### PR TITLE
Add "open area" as creative name for areas

### DIFF
--- a/opentripplanner-graph-builder/src/main/java/org/opentripplanner/graph_builder/impl/osm/DefaultWayPropertySetSource.java
+++ b/opentripplanner-graph-builder/src/main/java/org/opentripplanner/graph_builder/impl/osm/DefaultWayPropertySetSource.java
@@ -466,6 +466,7 @@ public class DefaultWayPropertySetSource implements WayPropertySetSource {
         createNames(props, "highway=cycleway", "bike path");
         createNames(props, "cycleway=track", "bike path");
         createNames(props, "highway=pedestrian", "path");
+        createNames(props, "highway=pedestrian;area=yes", "open area");
         createNames(props, "highway=path", "path");
         createNames(props, "highway=footway", "path");
         createNames(props, "highway=bridleway", "bridleway");


### PR DESCRIPTION
Rather than saying "path" when walking across an unnamed area, say "open area", as @novalis and I discussed on the mailing list earlier. A few caveats:
- I'm not sure how this will play with the multipolygon code
- I'm not sure if "open area" is the most clear possible name
- I want to make sure that I put the change in the right place

-Matt
