### PR TITLE
Change time parser/correction to output 24hour timeformat

### DIFF
--- a/opentripplanner-webapp/src/main/webapp/js/otp/util/DateUtils.js
+++ b/opentripplanner-webapp/src/main/webapp/js/otp/util/DateUtils.js
@@ -169,23 +169,14 @@ otp.util.DateUtils = {
             h = h.substring(0, h.length-2);
         }
         h = parseInt(h) || 12;
-        if(h > 12)
-        {
-            h = h % 12;
-            if(h == 0)
-                h = 12;
-            if(am == null || am == '')
-                am = 'p';
-        }
+
         if(m == null || m > 59 || m < 0)
             m = "00"
 
         if(am && am == 'p')
-            am = "pm"
-        else  
-            am = "am"
+            h += 12;
     
-        return  h + ":" + m + "" + am;
+        return  h + ":" + m;
     },
 
     /** */


### PR DESCRIPTION
Following my remark in commit f33f8576d54afa9097b00fdb1fc1fa2253d44eca 

This patch modifies the data parser/correction to output 24 hour timeformats as in ISO8601
