### PR TITLE
Allow Reverse and Edit toolbar buttons to be hidden

### DIFF
--- a/opentripplanner-webapp/src/main/webapp/js/otp/config.js
+++ b/opentripplanner-webapp/src/main/webapp/js/otp/config.js
@@ -32,6 +32,8 @@ otp.config_defaults = {
             showStopCodes         : true,   // show stop codes as part of the itinerary
             showAgencyInfo        : true,   // show the 'service run by Yolobus' on each itinerary leg
             showFareInfo          : true,   // show the fare information in the itinerary
+            showReverseButton     : true,   // turn on/off itinerary reverse button
+            showEditButton        : true,   // turn on/off itinerary edit button
             showPrintButton       : true,   // turn on/off itinerary print button
             showLinksButton       : true,   // turn on/off itinerary links button
             useOptionDependencies : true,   // trip form changes based on mode and optimize flags (e.g., bike mode has no wheelchair or walk distance forms etc...) 

--- a/opentripplanner-webapp/src/main/webapp/js/otp/planner/TripTab.js
+++ b/opentripplanner-webapp/src/main/webapp/js/otp/planner/TripTab.js
@@ -116,23 +116,31 @@ otp.planner.TripTab = {
         if(z.length > 0)
         {
             // step D++: add buttons to the tab 
-            var r = new Ext.Toolbar.Button({
-                text:    this.locale.buttons.reverse,
-                iconCls: 'reverse-button',
-                tooltip: this.locale.buttons.reverseTip,
-                scope:   this,
-                handler: this.reverseCB
-            });
+            var buttons = [];
 
-            var e = new Ext.Toolbar.Button({
-                text:    this.locale.buttons.edit,
-                iconCls: 'edit-button',
-                tooltip: this.locale.buttons.editTip,
-                scope:   this,
-                handler: this.editCB
-            });
+            if(this.planner.options.showReverseButton)
+            {
+                var r = new Ext.Toolbar.Button({
+                    text:    this.locale.buttons.reverse,
+                    iconCls: 'reverse-button',
+                    tooltip: this.locale.buttons.reverseTip,
+                    scope:   this,
+                    handler: this.reverseCB
+                });
+                buttons.push(r);
+            }
 
-            var buttons = [r, e];
+            if(this.planner.options.showEditButton)
+            {
+                var e = new Ext.Toolbar.Button({
+                    text:    this.locale.buttons.edit,
+                    iconCls: 'edit-button',
+                    tooltip: this.locale.buttons.editTip,
+                    scope:   this,
+                    handler: this.editCB
+                });
+                buttons.push(e);
+            }
 
             if(this.planner.options.showPrintButton)
             {

--- a/opentripplanner-webapp/src/main/webapp/js/otp/planner/Utils.js
+++ b/opentripplanner-webapp/src/main/webapp/js/otp/planner/Utils.js
@@ -301,7 +301,7 @@ otp.planner.Utils = {
             autoScroll:   true,
             border:       false,
             buttonAlign: 'center',
-            buttons:      buttons,
+            buttons:      buttons.length > 0 ? buttons : null,
             items:        [itinTree, detailsTree]
         });
         


### PR DESCRIPTION
Hiding all (4) toolbar buttons will hide the toolbar itself (which would appear empty otherwise).
