### PR TITLE
Add routeId attribute in Leg

### DIFF
--- a/opentripplanner-api-webapp/src/main/java/org/opentripplanner/api/model/Leg.java
+++ b/opentripplanner-api-webapp/src/main/java/org/opentripplanner/api/model/Leg.java
@@ -77,6 +77,13 @@ public class Leg {
      */
     @XmlAttribute
     public String routeColor = null;
+    
+    /**
+     * For transit legs, the ID of the route.
+     * For non-transit legs, null.
+     */
+    @XmlAttribute
+    public String routeId = null;
 
     /**
      * For transit leg, the route's text color (if one exists). For non-transit legs, null.

--- a/opentripplanner-api-webapp/src/main/java/org/opentripplanner/api/ws/PlanGenerator.java
+++ b/opentripplanner-api-webapp/src/main/java/org/opentripplanner/api/ws/PlanGenerator.java
@@ -445,6 +445,7 @@ public class PlanGenerator {
             leg.routeLongName = trip.getRoute().getLongName();
             leg.routeColor = trip.getRoute().getColor();
             leg.routeTextColor = trip.getRoute().getTextColor();
+            leg.routeId = trip.getRoute().getId().getId();
             if (transitIndex != null) {
                 Agency agency = transitIndex.getAgency(leg.agencyId);
                 leg.agencyName = agency.getName();


### PR DESCRIPTION
Small pull request, just to get my feet wet. 

I needed to use the routeId of a transit leg and it was missing. TripsId and agencyId was there, but not routeId. So I added it!
