### PR TITLE
fix #894 (NPEs in NED builder)

### DIFF
--- a/opentripplanner-graph-builder/src/main/java/org/opentripplanner/graph_builder/impl/ned/NEDGraphBuilderImpl.java
+++ b/opentripplanner-graph-builder/src/main/java/org/opentripplanner/graph_builder/impl/ned/NEDGraphBuilderImpl.java
@@ -153,8 +153,13 @@ public class NEDGraphBuilderImpl implements GraphBuilder {
         BinHeap<ElevationRepairState> pq = new BinHeap<ElevationRepairState>();
 
         // elevation for each vertex (known or interpolated)
-        @SuppressWarnings("unchecked")
-        HashMap<Vertex, Double> elevations = (HashMap<Vertex, Double>) knownElevations.clone();
+        // knownElevations will be null if there are no ElevationPoints in the data
+        // for instance, with the Shapefile loader.)
+        HashMap<Vertex, Double> elevations; 
+        if (knownElevations != null)
+            elevations = (HashMap<Vertex, Double>) knownElevations.clone();
+        else
+            elevations = new HashMap<Vertex, Double>();
 
         HashSet<Vertex> closed = new HashSet<Vertex>();
 


### PR DESCRIPTION
This allows use of the shapefile loader with NED data. There's a warning on the cast; I'm not sure how to fix that; before there was an @ SupressWarnings("unchecked") on the assignment, but I can't figure out where to put it (Eclipse proposed the whole function, but that seemed unwise).
