### PR TITLE
Add 700 route_type

### DIFF
--- a/opentripplanner-routing/src/main/java/org/opentripplanner/gtfs/GtfsLibrary.java
+++ b/opentripplanner-routing/src/main/java/org/opentripplanner/gtfs/GtfsLibrary.java
@@ -105,6 +105,7 @@ public class GtfsLibrary {
         case 2:
             return TraverseMode.RAIL;
         case 3:
+        case 700:
             return TraverseMode.BUS;
         case 4:
             return TraverseMode.FERRY;


### PR DESCRIPTION
As per Brian Ferris in the Google Changes, Google Transit supports the extension 700 route_type for regular bus service. Is used in the OpenVBB Berlin GTFS feed and probably will be in more feeds.
https://groups.google.com/d/msg/gtfs-changes/2LhXGnYwJng/IVod-mE0564J
