### PR TITLE
Fix maven build, since tomcat 6.0.35 is apparently not available for download

### DIFF
--- a/opentripplanner-integration/pom.xml
+++ b/opentripplanner-integration/pom.xml
@@ -12,7 +12,7 @@
     </parent>
 
     <properties>
-        <tomcat.version>6.0.35</tomcat.version>
+        <tomcat.version>6.0.36</tomcat.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
I don't know exactly why, but tomcat 6.0.35 is not available for download (http://www.apache.org/dist/tomcat/tomcat-6/v6.0.35/bin/apache-tomcat-6.0.35.zip). Switch to 6.0.36 fix that.
