### PR TITLE
Add bannedAgencies parameter. Same as bannedRoutes, but will disable entire agency.

### DIFF
--- a/opentripplanner-api-webapp/src/main/java/org/opentripplanner/api/common/RoutingResource.java
+++ b/opentripplanner-api-webapp/src/main/java/org/opentripplanner/api/common/RoutingResource.java
@@ -124,6 +124,9 @@ public abstract class RoutingResource {
     /** The comma-separated list of banned routes.  The format is agency_route, so TriMet_100. */
     @DefaultValue("") @QueryParam("bannedRoutes") protected List<String> bannedRoutes;
     
+    /** The comma-separated list of banned agencies. */
+    @DefaultValue("") @QueryParam("bannedAgencies") protected List<String> bannedAgencies;
+    
     /** The comma-separated list of banned trips.  The format is agency_route[:stop*], so:
      * TriMet_24601 or TriMet_24601:0:1:2:17:18:19
      */
@@ -280,6 +283,7 @@ public abstract class RoutingResource {
         request.setPreferredRoutes(get(preferredRoutes, n, request.getPreferredRouteStr()));
         request.setUnpreferredRoutes(get(unpreferredRoutes, n, request.getUnpreferredRouteStr()));
         request.setBannedRoutes(get(bannedRoutes, n, request.getBannedRouteStr()));
+        request.setBannedAgencies(get(bannedAgencies, n, request.getBannedAgenciesStr()));
         HashMap<AgencyAndId, BannedStopSet> bannedTripMap = makeBannedTripMap(get(bannedTrips, n, null));
         if (bannedTripMap != null) {
             request.setBannedTrips(bannedTripMap);
@@ -353,8 +357,8 @@ public abstract class RoutingResource {
         request.setLocale(locale);
         return request;
     }
-    
-    private HashMap<AgencyAndId, BannedStopSet> makeBannedTripMap(String banned) {
+
+	private HashMap<AgencyAndId, BannedStopSet> makeBannedTripMap(String banned) {
         if (banned == null) {
             return null;
         }

--- a/opentripplanner-routing/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
+++ b/opentripplanner-routing/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
@@ -15,6 +15,7 @@ package org.opentripplanner.routing.core;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -170,6 +171,9 @@ public class RoutingRequest implements Cloneable, Serializable {
 
     /** Do not use certain named routes */
     public HashSet<RouteSpec> bannedRoutes = new HashSet<RouteSpec>();
+    
+    /** Do not use certain named agencies */
+    public HashSet<String> bannedAgencies = new HashSet<String>();
     
     /** Do not use certain trips */
     public HashMap<AgencyAndId, BannedStopSet> bannedTrips = new HashMap<AgencyAndId, BannedStopSet>();
@@ -430,6 +434,11 @@ public class RoutingRequest implements Cloneable, Serializable {
     public void setBannedRoutes(String s) {
         if (s != null && !s.equals(""))
             bannedRoutes = new HashSet<RouteSpec>(RouteSpec.listFromString(s));
+    }
+    
+    public void setBannedAgencies(String s) {
+        if (s != null && !s.equals(""))
+            bannedAgencies = new HashSet<String>(Arrays.asList(s.split(",")));
     }
     
     public final static int MIN_SIMILARITY = 1000;
@@ -851,6 +860,19 @@ public class RoutingRequest implements Cloneable, Serializable {
 
     public String getBannedRouteStr() {
         return getRouteSetStr(bannedRoutes);
+    }
+    
+    public String getBannedAgenciesStr() {
+    	StringBuilder builder = new StringBuilder();
+        for (String agency : bannedAgencies) {
+            builder.append(agency);
+            builder.append(",");
+        }
+        if (builder.length() > 0) {
+            // trim trailing comma
+            builder.setLength(builder.length() - 1);
+        }
+        return builder.toString();
     }
 
     public void setMaxWalkDistance(double maxWalkDistance) {

--- a/opentripplanner-routing/src/main/java/org/opentripplanner/routing/edgetype/FrequencyAlight.java
+++ b/opentripplanner-routing/src/main/java/org/opentripplanner/routing/edgetype/FrequencyAlight.java
@@ -129,6 +129,13 @@ public class FrequencyAlight extends Edge  implements OnBoardReverseEdge {
             if (bestWait < 0) {
                 return null;
             }
+            
+            /* check if agency is banned for this plan */
+            if (options.bannedAgencies != null) {
+            	if (options.bannedAgencies.contains(trip.getId().getAgencyId())) {
+            		return null;
+            	}
+            }
 
             /* check if route banned for this plan */
             if (options.bannedRoutes != null) {

--- a/opentripplanner-routing/src/main/java/org/opentripplanner/routing/edgetype/FrequencyBoard.java
+++ b/opentripplanner-routing/src/main/java/org/opentripplanner/routing/edgetype/FrequencyBoard.java
@@ -144,7 +144,14 @@ public class FrequencyBoard extends Edge implements OnBoardForwardEdge, PatternE
             if (bestWait < 0) {
                 return null;
             }
-
+            
+            /* check if agency is banned for this plan */
+            if (options.bannedAgencies != null) {
+            	if (options.bannedAgencies.contains(trip.getId().getAgencyId())) {
+            		return null;
+            	}
+            }
+            
             /* check if route banned for this plan */
             if (options.bannedRoutes != null) {
                 Route route = trip.getRoute();

--- a/opentripplanner-routing/src/main/java/org/opentripplanner/routing/edgetype/TransitBoardAlight.java
+++ b/opentripplanner-routing/src/main/java/org/opentripplanner/routing/edgetype/TransitBoardAlight.java
@@ -259,6 +259,13 @@ public class TransitBoardAlight extends TablePatternEdge implements OnBoardForwa
                 return null;
             }
             Trip trip = bestTripTimes.getTrip();
+            
+            /* check if agency is banned for this plan */
+            if (options.bannedAgencies != null) {
+            	if (options.bannedAgencies.contains(trip.getId().getAgencyId())) {
+            		return null;
+            	}
+            }
 
             /* check if route banned for this plan */
             if (options.bannedRoutes != null) {


### PR DESCRIPTION
Titles says it all. 

We originally used bannedRoutes and just adding all the routes for an agency, but we eventually got some error 414. 
