### PR TITLE
Add CUSTOM_MOTOR_VEHICLE to StreetTraversalPermission. Add tests.

### DIFF
--- a/opentripplanner-routing/src/main/java/org/opentripplanner/routing/edgetype/StreetTraversalPermission.java
+++ b/opentripplanner-routing/src/main/java/org/opentripplanner/routing/edgetype/StreetTraversalPermission.java
@@ -17,6 +17,8 @@ import java.util.Map;
 import java.util.HashMap;
 import java.util.EnumSet;
 
+import lombok.Getter;
+
 /**
  * Who can traverse a street in a single direction.
  * 
@@ -29,7 +31,10 @@ public enum StreetTraversalPermission {
     CAR(4),
     PEDESTRIAN_AND_CAR(4 | 1),
     BICYCLE_AND_CAR(4 | 2),
+    // This is a configurable motor vehicle that is not a vanilla car.
+    // e.g. truck, motor bike, etc.
     CUSTOM_MOTOR_VEHICLE(8),
+    ALL_DRIVING(8 | 4),
     ALL(8 | 4 | 2 | 1),
     CROSSHATCHED(16); // this street exists in both Beszel and Ul Qoma; traffic direction may depend on which city you're in.
 
@@ -40,14 +45,11 @@ public enum StreetTraversalPermission {
             lookup.put(s.getCode(), s);
     }
 
+    @Getter
     private int code;
 
     private StreetTraversalPermission(int code) {
         this.code = code;
-    }
-
-    public int getCode() {
-        return code;
     }
 
     public static StreetTraversalPermission get(int code) {

--- a/opentripplanner-routing/src/test/java/org/opentripplanner/routing/edgetype/StreetTraversalPermissionTest.java
+++ b/opentripplanner-routing/src/test/java/org/opentripplanner/routing/edgetype/StreetTraversalPermissionTest.java
@@ -1,0 +1,47 @@
+package org.opentripplanner.routing.edgetype;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class StreetTraversalPermissionTest {
+
+    @Test
+    public void testGetCode() {
+        StreetTraversalPermission perm1 = StreetTraversalPermission.ALL_DRIVING;
+        StreetTraversalPermission perm2 = StreetTraversalPermission.get(perm1.getCode());
+        assertEquals(perm1, perm2);
+        
+        StreetTraversalPermission perm3 = StreetTraversalPermission.BICYCLE;
+        assertFalse(perm1.equals(perm3));
+    }
+    
+    @Test
+    public void testAdd() {
+        StreetTraversalPermission perm1 = StreetTraversalPermission.CAR;
+        StreetTraversalPermission all_driving = perm1.add(StreetTraversalPermission.CUSTOM_MOTOR_VEHICLE);
+        assertEquals(StreetTraversalPermission.ALL_DRIVING, all_driving);
+    }
+
+    @Test
+    public void testRemove() {
+        StreetTraversalPermission perm1 = StreetTraversalPermission.CAR;
+        StreetTraversalPermission none = perm1.remove(StreetTraversalPermission.CAR);
+        assertEquals(StreetTraversalPermission.NONE, none);
+    }
+    
+    @Test
+    public void testAllows() {
+        StreetTraversalPermission perm1 = StreetTraversalPermission.ALL;
+        assertFalse(perm1.allows(StreetTraversalPermission.CROSSHATCHED));
+        assertTrue(perm1.allows(StreetTraversalPermission.CAR));
+        assertTrue(perm1.allows(StreetTraversalPermission.CUSTOM_MOTOR_VEHICLE));
+        assertTrue(perm1.allows(StreetTraversalPermission.BICYCLE));
+        assertTrue(perm1.allows(StreetTraversalPermission.PEDESTRIAN));
+        assertTrue(perm1.allows(StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE));
+        
+        StreetTraversalPermission perm = StreetTraversalPermission.ALL_DRIVING;
+        assertTrue(perm.allows(StreetTraversalPermission.CUSTOM_MOTOR_VEHICLE));
+        assertFalse(perm.allows(StreetTraversalPermission.BICYCLE));    
+    }
+}


### PR DESCRIPTION
Adds a StreetTraversalPermission for custom motor vehicles like trucks, motorbikes. This way we can configure the graph to allow/disallow these vehicles on certain roads.

Additionally:
1) Format StreetTraversalPermission.java
2) Add unit tests.
3) Make it more explicit that StreetTraversalPermission is a bitset.

Everything builds, tests all pass (including new ones).
Avi
