### PR TITLE
fix issue #1029

### DIFF
--- a/opentripplanner-routing/src/main/java/org/opentripplanner/routing/edgetype/PreBoardEdge.java
+++ b/opentripplanner-routing/src/main/java/org/opentripplanner/routing/edgetype/PreBoardEdge.java
@@ -134,7 +134,6 @@ public class PreBoardEdge extends FreeEdge {
 
             StateEditor s1 = s0.edit(this);
             s1.setTime(board_after);
-            s1.setEverBoarded(true);
             long wait_cost = board_after - t0;
             s1.incrementWeight(wait_cost + transfer_penalty);
             s1.setBackMode(getMode());


### PR DESCRIPTION
I Think I solve the problem. I'm not sure it dose not creates new ones.
What is actually happens is that isEverBoarded is now changed only in PreAlightEdge and not in PreBoardEdge. 
I'm not sure if this very small fix does not creates trouble elsewhere, will be happy to hear some experts options.
