### PR TITLE
Fix createStationTransfers with location_type=2 stops

### DIFF
--- a/opentripplanner-routing/src/main/java/org/opentripplanner/routing/edgetype/factory/GTFSPatternHopFactory.java
+++ b/opentripplanner-routing/src/main/java/org/opentripplanner/routing/edgetype/factory/GTFSPatternHopFactory.java
@@ -1531,14 +1531,18 @@ public class GTFSPatternHopFactory {
                 Vertex stopArriveVertex = context.stopArriveNodes.get(stop);
                 Vertex parentStopArriveVertex = context.stopArriveNodes.get(parentStop);
 
-                new FreeEdge(parentStopArriveVertex, stopArriveVertex);
-                new FreeEdge(stopArriveVertex, parentStopArriveVertex);
+                if (stopArriveVertex != null && parentStopArriveVertex != null) {
+                    new FreeEdge(parentStopArriveVertex, stopArriveVertex);
+                    new FreeEdge(stopArriveVertex, parentStopArriveVertex);
+                }
 
                 Vertex stopDepartVertex = context.stopDepartNodes.get(stop);
                 Vertex parentStopDepartVertex = context.stopDepartNodes.get(parentStop);
 
-                new FreeEdge(parentStopDepartVertex, stopDepartVertex);
-                new FreeEdge(stopDepartVertex, parentStopDepartVertex);
+                if (stopDepartVertex != null && parentStopDepartVertex != null) {
+                    new FreeEdge(parentStopDepartVertex, stopDepartVertex);
+                    new FreeEdge(stopDepartVertex, parentStopDepartVertex);
+                }
 
                 // TODO: provide a cost for these edges when stations and
                 // stops have different locations 


### PR DESCRIPTION
A stop with location_type=2 (station entrance) does not have any arrive/depart vertex, causing crashes at the graph building stage. 
