### PR TITLE
Worst trip is not used in the RetryingPathServiceImpl

### DIFF
--- a/opentripplanner-routing/src/main/java/org/opentripplanner/routing/impl/RetryingPathServiceImpl.java
+++ b/opentripplanner-routing/src/main/java/org/opentripplanner/routing/impl/RetryingPathServiceImpl.java
@@ -19,6 +19,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
 
+import lombok.Setter;
 import org.onebusaway.gtfs.model.AgencyAndId;
 import org.opentripplanner.routing.core.RoutingRequest;
 import org.opentripplanner.routing.pathparser.BasicPathParser;
@@ -37,42 +38,38 @@ public class RetryingPathServiceImpl implements PathService {
 
     private static final Logger LOG = LoggerFactory.getLogger(RetryingPathServiceImpl.class);
 
-    private static final int MAX_TIME_FACTOR = 2;
-    private static final int MAX_WEIGHT_FACTOR = 2;
-
-    private static final double MAX_WALK_MULTIPLE = 16;
+    @Setter
+    private double maxTimeFactor = 2;
+    @Setter
+    private double maxWeightFactor = 2;
+    @Setter
+    private int maxWalkMultiple = 16;
 
     @Autowired
     private GraphService graphService;
     @Autowired
     private SPTService sptService;
 
+    /**
+     * Give up on searching for the first itinerary after this many seconds have elapsed.
+     * A negative or zero value means search forever.
+     */
+    @Setter
     private double firstPathTimeout = 0; // seconds
+    /**
+     * Stop searching for additional itineraries (beyond the first one) after this many seconds
+     * have elapsed, relative to the beginning of the search for the first itinerary.
+     * A negative or zero value means search forever.
+     * Setting this lower than the firstPathTimeout will avoid searching for additional
+     * itineraries when finding the first itinerary takes a long time. This helps keep overall
+     * response time down while assuring that the end user will get at least one response.
+     */
+    @Setter
     private double multiPathTimeout = 0; // seconds
-    
+
     /** Give up on searching for itineraries after this many seconds have elapsed. */
     public void setTimeout (double seconds) {
         firstPathTimeout = seconds;
-        multiPathTimeout = seconds;
-    }
-
-    /**
-     * Give up on searching for the first itinerary after this many seconds have elapsed.
-     * A negative or zero value means search forever. 
-     */
-    public void setFirstPathTimeout (double seconds) {
-        firstPathTimeout = seconds;
-    }
-    
-    /**
-     * Stop searching for additional itineraries (beyond the first one) after this many seconds 
-     * have elapsed, relative to the beginning of the search for the first itinerary. 
-     * A negative or zero value means search forever. 
-     * Setting this lower than the firstPathTimeout will avoid searching for additional
-     * itineraries when finding the first itinerary takes a long time. This helps keep overall 
-     * response time down while assuring that the end user will get at least one response.
-     */
-    public void setMultiPathTimeout (double seconds) {
         multiPathTimeout = seconds;
     }
 
@@ -90,7 +87,7 @@ public class RetryingPathServiceImpl implements PathService {
         }
 
         long searchBeginTime = System.currentTimeMillis();
-        
+
         // The list of options specifying various modes, banned routes, etc to try for multiple
         // itineraries
         Queue<RoutingRequest> optionQueue = new LinkedList<RoutingRequest>();
@@ -101,6 +98,7 @@ public class RetryingPathServiceImpl implements PathService {
         double initialMaxWalk = maxWalk;
         long maxTime = options.isArriveBy() ? 0 : Long.MAX_VALUE;
         RoutingRequest currOptions;
+        boolean firstRun = true;
         while (paths.size() < options.numItineraries) {
             currOptions = optionQueue.poll();
             if (currOptions == null) {
@@ -108,30 +106,31 @@ public class RetryingPathServiceImpl implements PathService {
                 break;
             }
             currOptions.setMaxWalkDistance(maxWalk);
-            
+            currOptions.worstTime = maxTime;
+            currOptions.maxWeight = maxWeight;
+
             // apply appropriate timeout
             double timeout = paths.isEmpty() ? firstPathTimeout : multiPathTimeout;
-            
-            // options.worstTime = maxTime;
-            //options.maxWeight = maxWeight;
+
+
             long subsearchBeginTime = System.currentTimeMillis();
-            
+
             LOG.debug("BEGIN SUBSEARCH");
             ShortestPathTree spt = sptService.getShortestPathTree(currOptions, timeout);
             if (spt == null) // timeout or other fail
                 break;
             List<GraphPath> somePaths = spt.getPaths();
-            LOG.debug("END SUBSEARCH ({} msec of {} msec total)", 
+            LOG.debug("END SUBSEARCH ({} msec of {} msec total)",
                     System.currentTimeMillis() - subsearchBeginTime,
                     System.currentTimeMillis() - searchBeginTime);
             if (somePaths == null) {
                 // search failed, likely due to timeout
                 // this could be signaled with an exception
-                LOG.warn("Aborting search. {} paths found, elapsed time {} sec", 
+                LOG.warn("Aborting search. {} paths found, elapsed time {} sec",
                         paths.size(), (System.currentTimeMillis() - searchBeginTime) / 1000.0);
                 break;
             }
-            if (maxWeight == Double.MAX_VALUE && maxWalk == Double.MAX_VALUE) {
+            if (firstRun) {
                 /* the worst trip we are willing to accept is at most twice as bad or twice as long */
                 if (somePaths.isEmpty()) {
                     // if there is no first path, there won't be any other paths
@@ -141,20 +140,21 @@ public class RetryingPathServiceImpl implements PathService {
                 long duration = path.getDuration();
                 LOG.debug("Setting max time and weight for subsequent searches.");
                 LOG.debug("First path start time:  {}", path.getStartTime());
-                maxTime = path.getStartTime() + 
-                		  MAX_TIME_FACTOR * (currOptions.isArriveBy() ? -duration : duration);
+                maxTime = (long)(path.getStartTime() +
+                        maxTimeFactor * (currOptions.isArriveBy() ? -duration : duration));
                 LOG.debug("First path duration:  {}", duration);
                 LOG.debug("Max time set to:  {}", maxTime);
-                maxWeight = path.getWeight() * MAX_WEIGHT_FACTOR;
+                maxWeight = path.getWeight() * maxWeightFactor;
                 LOG.debug("Max weight set to:  {}", maxWeight);
                 if (path.getWalkDistance() > maxWalk) {
                     maxWalk = path.getWalkDistance() * 1.25;
                 }
+                firstRun = false;
             }
             if (somePaths.isEmpty()) {
                 //try again doubling maxwalk
                 LOG.debug("No paths were found.");
-                if (maxWalk > initialMaxWalk * MAX_WALK_MULTIPLE || maxWalk >= Double.MAX_VALUE)
+                if (maxWalk > initialMaxWalk * maxWalkMultiple || maxWalk >= Double.MAX_VALUE)
                     break;
                 maxWalk *= 2;
                 LOG.debug("Doubled walk distance to {}", maxWalk);


### PR DESCRIPTION
While passing on RetryingPathServiceImpl class I've noticed that lines 133-150 are never accessed, consequently the parameters for the worst path are not applied.
I've also found that the line for updating maxTime and maxWeight are marked as note. 
This commit include:
A small fix for applying worst time and worst wight.
A change of the type of maxTimeFactor, maxWeightFactor and maxWalkMultiple to double. And a change in of the modifier from private static final to just private so it can be used as configurable parameters. 
