### PR TITLE
 Allow easier usage of OTP-standalone

### DIFF
--- a/otp-standalone/src/main/java/org/opentripplanner/standalone/GrizzlyServer.java
+++ b/otp-standalone/src/main/java/org/opentripplanner/standalone/GrizzlyServer.java
@@ -64,7 +64,7 @@ public class GrizzlyServer {
         //    This is a filesystem path, not classpath.
         //    Files are relative to the project dir, so
         //    from ./ we can reach e.g. target/classes/data-sources.xml
-        final String clientPath = "../opentripplanner-webapp/target/opentripplanner-webapp/";
+        final String clientPath = "../opentripplanner-webapp/src/main/webapp/";
         httpServer.getServerConfiguration().addHttpHandler(new StaticHttpHandler(clientPath), "/");
         
         /* RELINQUISH CONTROL TO THE SERVER THREAD */


### PR DESCRIPTION
Right now, the OTP webapp needs to be built (which is apparently just a copy operation) in order to use the standalone version of OTP. When running OTP inside Eclipse, it's more convenient to be able to serve up the webapp source directly, which is what this patch is aimed at.
