### PR TITLE
bug fix in the Route Matcher, the bug cause the routingContext to store ...

### DIFF
--- a/opentripplanner-routing/src/main/java/org/opentripplanner/routing/core/RouteMatcher.java
+++ b/opentripplanner-routing/src/main/java/org/opentripplanner/routing/core/RouteMatcher.java
@@ -48,7 +48,7 @@ public class RouteMatcher implements Cloneable, Serializable {
      * Return an empty matcher (which match no routes).
      */
     public static RouteMatcher emptyMatcher() {
-        return EMPTY_MATCHER;
+        return new RouteMatcher();
     }
 
     /**


### PR DESCRIPTION
...the ban routes between requests

the fix:
return new RouteMatcher instance of EMPTY_MATCHER that is static.
