### PR TITLE
Real-time: fix NPE when using frequency-based trip.

### DIFF
--- a/otp-rest-api/src/main/java/org/opentripplanner/api/ws/PlanGenerator.java
+++ b/otp-rest-api/src/main/java/org/opentripplanner/api/ws/PlanGenerator.java
@@ -384,7 +384,7 @@ public class PlanGenerator {
                         leg = makeLeg(itinerary, state);
                         leg.from.stopIndex = ((OnBoardForwardEdge)backEdge).getStopIndex();
                         TripTimes tt = state.getTripTimes();
-                        if ( ! tt.isScheduled()) {
+                        if (tt != null && !tt.isScheduled()) {
                             leg.realTime = true;
                             leg.departureDelay = tt.getDepartureDelay(leg.from.stopIndex);
                         }


### PR DESCRIPTION
State tripTimes used for real-time delay can be null for a frequency-based trip.
