### PR TITLE
Add recovery from fatal errors to standalone OTP

### DIFF
--- a/otp-standalone/src/main/java/org/opentripplanner/standalone/OTPMain.java
+++ b/otp-standalone/src/main/java/org/opentripplanner/standalone/OTPMain.java
@@ -57,7 +57,16 @@ public class OTPMain {
             jc.usage();
             System.exit(0);
         }
-        main.run();
+        while (true) {
+            try {
+                main.run();
+                return;
+            }
+            catch (Throwable throwable) {
+                LOG.error("An uncaught " + throwable.getClass().getSimpleName()
+                        + " occurred inside OTP. Restarting server.", throwable);
+            }
+        }
     }
     
     private void run() {


### PR DESCRIPTION
I've noticed that opentripplanner.nl is sometimes unavailable for extended periods of time after crashing due to problematic requests (which is a problem in itself, but we don't know the exact cause yet). My hypothesis is that fatal errors are going uncaught inside the standalone version of OTP. This pull request implements a catch-all error recovery approach, while still exiting normally if the run() method returns, so that startup errors can be handled separately.

If this is (or should be) covered by code elsewhere in the tree, feel free to handle this issue differently.
