### PR TITLE
Table trip pattern fix

### DIFF
--- a/opentripplanner-routing/src/main/java/org/opentripplanner/routing/edgetype/TableTripPattern.java
+++ b/opentripplanner-routing/src/main/java/org/opentripplanner/routing/edgetype/TableTripPattern.java
@@ -132,7 +132,7 @@ public class TableTripPattern implements TripPattern, Serializable {
         }
     }
     
-    private Stop getStop(int stopIndex) {
+    public Stop getStop(int stopIndex) {
     	if (stopIndex == patternHops.length)
     		return patternHops[stopIndex - 1].getEndStop();
     	else

--- a/opentripplanner-routing/src/main/java/org/opentripplanner/routing/edgetype/Timetable.java
+++ b/opentripplanner-routing/src/main/java/org/opentripplanner/routing/edgetype/Timetable.java
@@ -162,7 +162,7 @@ public class Timetable implements Serializable {
         int index;
         TripTimes[][] tableIndex = boarding ? departuresIndex : arrivalsIndex;
         int stopOffset = boarding ? 0 : 1;
-        Stop currentStop = pattern.getStops().get(stopIndex + stopOffset);
+        Stop currentStop = pattern.getStop(stopIndex + stopOffset);
         if (tableIndex != null) {
             TripTimes[] sorted;
             // this timetable has been indexed, use binary search


### PR DESCRIPTION
Fix that lets all unit tests pass again. Also let Timetable.getNextTrip() use TableTripPattern.getStop() instead of TableTripPattern.getStops().get() because the latter is more efficient.
