### PR TITLE
Added API method in the Router API to save graph to disk

### DIFF
--- a/opentripplanner-routing/src/main/java/org/opentripplanner/routing/impl/GraphServiceAutoDiscoverImpl.java
+++ b/opentripplanner-routing/src/main/java/org/opentripplanner/routing/impl/GraphServiceAutoDiscoverImpl.java
@@ -14,6 +14,7 @@
 package org.opentripplanner.routing.impl;
 
 import java.io.File;
+import java.io.InputStream;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Timer;
@@ -130,6 +131,11 @@ public class GraphServiceAutoDiscoverImpl implements GraphService {
         return 0;
     }
 
+    @Override
+    public boolean save(String routerId, InputStream is) {
+    	return decorated.save(routerId, is);
+    }
+    
     /**
      * Based on the autoRegister list, automatically register all routerIds for which we can find a
      * graph file in a subdirectory of the resourceBase path. Also register and load the graph for
@@ -239,4 +245,5 @@ public class GraphServiceAutoDiscoverImpl implements GraphService {
                     + "You must place one or more graphs before routing.");
         }
     }
+
 }

--- a/opentripplanner-routing/src/main/java/org/opentripplanner/routing/impl/GraphServiceBeanImpl.java
+++ b/opentripplanner-routing/src/main/java/org/opentripplanner/routing/impl/GraphServiceBeanImpl.java
@@ -13,6 +13,7 @@
 
 package org.opentripplanner.routing.impl;
 
+import java.io.InputStream;
 import java.util.Arrays;
 import java.util.List;
 
@@ -33,7 +34,7 @@ public class GraphServiceBeanImpl implements GraphService {
     // 0-arg bean constructor
     public GraphServiceBeanImpl() {
     }
-    
+
     public GraphServiceBeanImpl(Graph graph) {
         this.graph = graph;
     }
@@ -85,6 +86,11 @@ public class GraphServiceBeanImpl implements GraphService {
     @Override
     public boolean reloadGraphs(boolean preEvict) {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean save(String routerId, InputStream is) {
+        return false;
     }
 
 }

--- a/opentripplanner-routing/src/main/java/org/opentripplanner/routing/impl/GraphServiceImpl.java
+++ b/opentripplanner-routing/src/main/java/org/opentripplanner/routing/impl/GraphServiceImpl.java
@@ -13,6 +13,7 @@
 
 package org.opentripplanner.routing.impl;
 
+import java.io.InputStream;
 import java.util.Collection;
 import java.util.List;
 
@@ -151,4 +152,9 @@ public class GraphServiceImpl implements GraphService {
         return decorated.evictAll();
     }
 
+    @Override
+    public boolean save(String routerId, InputStream is) {
+    	return decorated.save(routerId, is);
+    }
+    
 }

--- a/opentripplanner-routing/src/main/java/org/opentripplanner/routing/services/GraphService.java
+++ b/opentripplanner-routing/src/main/java/org/opentripplanner/routing/services/GraphService.java
@@ -13,6 +13,7 @@
 
 package org.opentripplanner.routing.services;
 
+import java.io.InputStream;
 import java.util.Collection;
 
 import org.onebusaway.gtfs.services.calendar.CalendarService;
@@ -92,5 +93,13 @@ public interface GraphService {
      * This is equivalent to calling evictGraph on every registered router ID.
      */
     public int evictAll();
-
+    
+    /**
+     * Save the graph data. 
+     * 
+     * @param routerId of the graph
+     * @param is graph data as input stream
+     * @return
+     */
+    public boolean save(String routerId, InputStream is);
 }

--- a/otp-rest-api/src/main/java/org/opentripplanner/api/ws/Routers.java
+++ b/otp-rest-api/src/main/java/org/opentripplanner/api/ws/Routers.java
@@ -13,6 +13,7 @@
 
 package org.opentripplanner.api.ws;
 
+import java.io.File;
 import java.io.InputStream;
 
 import javax.ws.rs.Consumes;
@@ -37,6 +38,7 @@ import org.opentripplanner.api.model.RouterList;
 import org.opentripplanner.api.ws.impl.StoredHullService;
 import org.opentripplanner.api.ws.services.HullService;
 import org.opentripplanner.common.geometry.GraphUtils;
+import org.opentripplanner.model.GraphBundle;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Graph.LoadLevel;
 import org.opentripplanner.routing.impl.GraphServiceImpl;
@@ -204,6 +206,28 @@ public class Routers {
             graph = Graph.load(is, level);
             graphService.registerGraph(routerId, graph);
             return Response.status(Status.CREATED).entity(graph.toString()).build();
+        } catch (Exception e) {
+            return Response.status(Status.BAD_REQUEST).entity(e.toString()).build();
+        }
+    }
+    
+    /** 
+     * Save the graph to disk to the specified routerId.
+     */
+    @Secured({ "ROLE_ROUTERS" })
+    @POST @Path("/save") @Produces({ MediaType.TEXT_PLAIN })
+    @Consumes(MediaType.APPLICATION_OCTET_STREAM)
+    public Response saveGraphOverWire (
+            @QueryParam("routerId") String routerId,
+            InputStream is) {
+        LOG.debug("save graph from POST data stream...");
+        try {
+        	boolean success = graphService.save(routerId, is);
+        	if (success) {
+        		return Response.status(201).entity("graph saved.").build();
+        	} else {
+        		return Response.status(404).entity("graph not saved or other error.").build();
+        	}
         } catch (Exception e) {
             return Response.status(Status.BAD_REQUEST).entity(e.toString()).build();
         }

--- a/otp-rest-api/src/test/java/org/opentripplanner/api/ws/TestRequest.java
+++ b/otp-rest-api/src/test/java/org/opentripplanner/api/ws/TestRequest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.reset;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -162,6 +163,10 @@ class SimpleGraphServiceImpl implements GraphService {
         throw new UnsupportedOperationException();
     }
 
+    @Override
+    public boolean save(String routerId, InputStream is) {
+    	return false;
+    }
 }
 
 /* This is a hack to hold context and graph data between test runs, since loading it is slow. */


### PR DESCRIPTION
Makes it possible to push a graph object over the wire and save it on hard disk. Reading the graph then allows OpenTripPlanner to use this graph object again when OpenTripPlanner restarts.
