### PR TITLE
Fix "unbuilt" highways being included for routing

### DIFF
--- a/opentripplanner-graph-builder/src/main/java/org/opentripplanner/graph_builder/impl/osm/OpenStreetMapGraphBuilderImpl.java
+++ b/opentripplanner-graph-builder/src/main/java/org/opentripplanner/graph_builder/impl/osm/OpenStreetMapGraphBuilderImpl.java
@@ -1882,7 +1882,7 @@ public class OpenStreetMapGraphBuilderImpl implements GraphBuilder {
             
             String highway = way.getTag("highway");
             if (highway != null && (highway.equals("conveyer") || highway.equals("proposed") || 
-                highway.equals("raceway")))
+                highway.equals("raceway") || highway.equals("unbuilt")))
                 return false;
             
             if (way.isGeneralAccessDenied()) {


### PR DESCRIPTION
Some OSM node taged "unbuilt" were included in the graph, it should not be. 
