### PR TITLE
Fix tests

### DIFF
--- a/otp-core/src/main/java/org/opentripplanner/graph_builder/model/GtfsBundle.java
+++ b/otp-core/src/main/java/org/opentripplanner/graph_builder/model/GtfsBundle.java
@@ -59,7 +59,7 @@ public class GtfsBundle {
      * ending paths (itineraries) at them. 
      */
     @Getter @Setter
-    private boolean linkStopsToParentStations = true;
+    private boolean linkStopsToParentStations = false;
 
     private Map<String, String> agencyIdMappings = new HashMap<String, String>();
 

--- a/otp-core/src/main/java/org/opentripplanner/standalone/CommandLineParameters.java
+++ b/otp-core/src/main/java/org/opentripplanner/standalone/CommandLineParameters.java
@@ -74,6 +74,10 @@ public class CommandLineParameters {
     description = "use transfers.txt file for the gtfsBundle (GTFS)")
     boolean useTransfersTxt;
     
+    @Parameter(names = {"--noParentStopLinking"},
+    description = "skip linking of stops to parent stops (GTFS)")
+    boolean noParentStopLinking;
+
     @Parameter(names = {"--parentStationTransfers"},
     description = "create direct transfers between the constituent stops of each parent station")
     boolean parentStationTransfers = false;

--- a/otp-core/src/main/java/org/opentripplanner/standalone/OTPConfigurator.java
+++ b/otp-core/src/main/java/org/opentripplanner/standalone/OTPConfigurator.java
@@ -206,7 +206,9 @@ public class OTPConfigurator {
             for (File gtfsFile : gtfsFiles) {
                 GtfsBundle gtfsBundle = new GtfsBundle(gtfsFile);
                 gtfsBundle.setTransfersTxtDefinesStationPaths(params.useTransfersTxt);
-                gtfsBundle.setLinkStopsToParentStations(true);
+                if (!params.noParentStopLinking) {
+                    gtfsBundle.setLinkStopsToParentStations(true);
+                }
                 gtfsBundle.setParentStationTransfers(params.parentStationTransfers);
                 gtfsBundles.add(gtfsBundle);
             }


### PR DESCRIPTION
I've had to re-enable the option to skip linking of stops to parent stops, because two Beter Benutten MMRI tests didn't pass anymore, despite trying all reasonable combinations of command line options.
