### PR TITLE
Add error code for when no graph could be found

### DIFF
--- a/otp-core/src/main/java/org/opentripplanner/api/common/Message.java
+++ b/otp-core/src/main/java/org/opentripplanner/api/common/Message.java
@@ -24,6 +24,7 @@ public enum Message {
     // id field is loosely based on HTTP error codes http://en.wikipedia.org/wiki/List_of_HTTP_status_codes
     PLAN_OK(200),
     SYSTEM_ERROR(500),
+    GRAPH_UNAVAILABLE(503),
 
     OUTSIDE_BOUNDS(400),
     PATH_NOT_FOUND(404),

--- a/otp-core/src/main/java/org/opentripplanner/api/model/error/PlannerError.java
+++ b/otp-core/src/main/java/org/opentripplanner/api/model/error/PlannerError.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.opentripplanner.api.common.Message;
 import org.opentripplanner.api.ws.LocationNotAccessible;
+import org.opentripplanner.routing.error.GraphNotFoundException;
 import org.opentripplanner.routing.error.PathNotFoundException;
 import org.opentripplanner.routing.error.TransitTimesException;
 import org.opentripplanner.routing.error.TrivialPathException;
@@ -39,6 +40,7 @@ public class PlannerError {
         messages.put(LocationNotAccessible.class,   Message.LOCATION_NOT_ACCESSIBLE);
         messages.put(TransitTimesException.class,   Message.NO_TRANSIT_TIMES);
         messages.put(TrivialPathException.class,    Message.TOO_CLOSE);
+        messages.put(GraphNotFoundException.class,    Message.GRAPH_UNAVAILABLE);
     }
     
     private int    id;

--- a/otp-core/src/main/java/org/opentripplanner/routing/core/RoutingContext.java
+++ b/otp-core/src/main/java/org/opentripplanner/routing/core/RoutingContext.java
@@ -32,6 +32,7 @@ import org.opentripplanner.routing.algorithm.strategies.TrivialRemainingWeightHe
 import org.opentripplanner.routing.edgetype.PartialPlainStreetEdge;
 import org.opentripplanner.routing.edgetype.PlainStreetEdge;
 import org.opentripplanner.routing.edgetype.TimetableResolver;
+import org.opentripplanner.routing.error.GraphNotFoundException;
 import org.opentripplanner.routing.error.TransitTimesException;
 import org.opentripplanner.routing.error.VertexNotFoundException;
 import org.opentripplanner.routing.graph.Edge;
@@ -210,6 +211,9 @@ public class RoutingContext implements Cloneable {
      */
     private RoutingContext(RoutingRequest routingRequest, Graph graph, Vertex from, Vertex to,
             boolean findPlaces) {
+        if (graph == null) {
+            throw new GraphNotFoundException();
+        }
         this.opt = routingRequest;
         this.graph = graph;
         this.debug.startedCalculating();

--- a/otp-core/src/main/java/org/opentripplanner/routing/error/GraphNotFoundException.java
+++ b/otp-core/src/main/java/org/opentripplanner/routing/error/GraphNotFoundException.java
@@ -1,0 +1,24 @@
+/* This program is free software: you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public License
+ as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+package org.opentripplanner.routing.error;
+
+/**
+ * Indicates that there is no graph currently available.
+ * This might be thrown if a new graph is registered and the old one is evicted before registering.
+ */
+public class GraphNotFoundException extends RuntimeException {
+    
+    private static final long serialVersionUID = 1L;
+
+}

--- a/otp-core/src/main/java/org/opentripplanner/routing/impl/GraphServiceFileImpl.java
+++ b/otp-core/src/main/java/org/opentripplanner/routing/impl/GraphServiceFileImpl.java
@@ -33,6 +33,7 @@ import lombok.Setter;
 
 import org.opentripplanner.updater.GraphUpdaterConfigurator;
 import org.opentripplanner.updater.PropertiesPreferences;
+import org.opentripplanner.routing.error.GraphNotFoundException;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Graph.LoadLevel;
 import org.opentripplanner.routing.services.GraphService;
@@ -98,7 +99,7 @@ public class GraphServiceFileImpl implements GraphService {
         synchronized (graphs) {
             if (!graphs.containsKey(routerId)) {
                 LOG.error("no graph registered with the routerId '{}'", routerId);
-                return null;
+                throw new GraphNotFoundException();
             } else {
                 return graphs.get(routerId);
             }

--- a/otp-core/src/main/resources/Message.properties
+++ b/otp-core/src/main/resources/Message.properties
@@ -5,6 +5,7 @@
 # PLANNER ERROR MESSAGES
 PLAN_OK      = Success
 SYSTEM_ERROR = We're sorry. The trip planner is temporarily unavailable. Please try again later.
+GRAPH_UNAVAILABLE = We're sorry. The trip planner is temporarily unavailable. Please try again later.
 
 OUTSIDE_BOUNDS            = Trip is not possible.  You might be trying to plan a trip outside the map data boundary.
 REQUEST_TIMEOUT           = The trip planner is taking way too long to process your request. Please try again later.

--- a/otp-core/src/main/resources/Message_es.properties
+++ b/otp-core/src/main/resources/Message_es.properties
@@ -5,6 +5,7 @@
 # PLANNER ERROR MESSAGES
 PLAN_OK      = ES-Success
 SYSTEM_ERROR = ES-We're sorry. The trip planner is temporarily unavailable. Please try again later.
+GRAPH_UNAVAILABLE = ES-We're sorry. The trip planner is temporarily unavailable. Please try again later.
 
 OUTSIDE_BOUNDS            = ES-los trip is not possible.  You might be trying to plan a trip outside the map data boundary.
 REQUEST_TIMEOUT           = ES-los trip planner is taking way too long to process your request. Please try again later.

--- a/otp-core/src/main/resources/Message_fr.properties
+++ b/otp-core/src/main/resources/Message_fr.properties
@@ -5,6 +5,7 @@
 # PLANNER ERROR MESSAGES
 PLAN_OK      = Succès
 SYSTEM_ERROR = Désolé: le calculateur d'itinéraires est temporairement indisponible. Veuillez recommencer ultérieurement.
+GRAPH_UNAVAILABLE = Désolé: le calculateur d'itinéraires est temporairement indisponible. Veuillez recommencer ultérieurement.
 
 OUTSIDE_BOUNDS            = Impossible de calculer un itinéraire. Vous essayez de planifier un itinéraire hors des limites de la zone couverte.
 REQUEST_TIMEOUT           = Le calculateur d'itinéraires prend trop de temps pour gérer votre demande. Veuillez recommencer ultérieurement.

--- a/otp-core/src/main/resources/Message_nl.properties
+++ b/otp-core/src/main/resources/Message_nl.properties
@@ -5,6 +5,7 @@
 # PLANNER ERROR MESSAGES
 PLAN_OK      = Succes
 SYSTEM_ERROR = Onze excuses. De routeplanner is momenteel niet beschikbaar. Probeer later opnieuw.
+GRAPH_UNAVAILABLE = Onze excuses. De routeplanner is momenteel niet beschikbaar. Probeer later opnieuw.
 
 OUTSIDE_BOUNDS            = Deze reis is niet mogelijk. Mogelijk probeert u een reis te plannen buiten het beschikbare gebied
 REQUEST_TIMEOUT           = De routeplanner is te lang bezig met uw verzoek. Probeer later opnieuw.


### PR DESCRIPTION
Specific error for case where graph could not be found (due to no graph at startup or due to preEvict = true when registering)
