### PR TITLE
Correctly handle GTFS-rt alerts without a TimeRange

### DIFF
--- a/otp-core/src/main/java/org/opentripplanner/api/ws/PlanGenerator.java
+++ b/otp-core/src/main/java/org/opentripplanner/api/ws/PlanGenerator.java
@@ -551,12 +551,6 @@ public class PlanGenerator {
                     leg.addAlert(alert);
                 }
             }
-
-            if (edge != null) {
-                for (Patch patch : edge.getPatches()) {
-                    leg.addAlert(patch.getAlert());
-                }
-            }
         }
     }
 

--- a/otp-core/src/main/java/org/opentripplanner/routing/core/StateEditor.java
+++ b/otp-core/src/main/java/org/opentripplanner/routing/core/StateEditor.java
@@ -497,20 +497,20 @@ public class StateEditor {
 
         if (patches != null) {
             for (Patch patch : patches) {
-                active  = false;
-                display = patch.displayDuring(child.stateData.opt, child.getStartTimeSeconds(),
-                                              child.getTimeSeconds());
+                display = false;
+                active = patch.activeDuring(child.stateData.opt, child.getStartTimeSeconds(),
+                                            child.getTimeSeconds());
 
-                if(!display) {
-                    active = patch.activeDuring(child.stateData.opt, child.getStartTimeSeconds(),
-                                                child.getTimeSeconds());
+                if(!active) {
+                    display = patch.displayDuring(child.stateData.opt, child.getStartTimeSeconds(),
+                                                  child.getTimeSeconds());
                 }
 
                 if(display || active) {
                     if(!patch.filterTraverseResult(this, display))
                         return false;
+                }
             }
-        }
         }
 
         return true;

--- a/otp-core/src/test/java/org/opentripplanner/api/ws/PlanGeneratorTest.java
+++ b/otp-core/src/test/java/org/opentripplanner/api/ws/PlanGeneratorTest.java
@@ -106,6 +106,7 @@ import org.opentripplanner.util.model.EncodedPolylineBean;
 import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.GeometryFactory;
 import com.vividsolutions.jts.geom.LineString;
+import org.opentripplanner.routing.patch.TimePeriod;
 
 public class PlanGeneratorTest {
     private static final double[] DISTANCES = {3, 9996806.8, 3539050.5, 11, 2478638.8, 4, 2, 1, 0};
@@ -563,7 +564,7 @@ public class PlanGeneratorTest {
 
         // Alert for testing GTFS-RT
         AlertPatch patch = new AlertPatch();
-
+        patch.setTimePeriods(Collections.singletonList(new TimePeriod(0, Long.MAX_VALUE)));
         patch.setAlert(Alert.createSimpleAlerts(alertsExample));
 
         // Edge initialization that can't be done using the constructor


### PR DESCRIPTION
Updates the handling of GTFS-rt alerts lacking a TimeRange to match the specification, per the discussion in 801e9f893d1c576aac0c9917491045334ccfd18e.

The existing tests pass, but I didn't run the Beter Benutten MMRI tests.
