### PR TITLE
Make analyst widget's button row non-draggable

### DIFF
--- a/otp-leaflet-client/src/main/webapp/js/otp/modules/analyst/AnalystModule.js
+++ b/otp-leaflet-client/src/main/webapp/js/otp/modules/analyst/AnalystModule.js
@@ -57,7 +57,7 @@ otp.modules.analyst.AnalystModule =
 
         modeSelector.refreshModeControls();
 
-        var buttonRow = $('<div style="text-align: center; margin-top: 6px;"></div>')
+        var buttonRow = $('<div class="notDraggable" style="text-align: center; margin-top: 6px;"></div>')
         .appendTo(this.optionsWidget.$());
         
         $('<button>Refresh</button>').button().click(function() {


### PR DESCRIPTION
This fixes a bug where changing walk distance and clicking refresh in the analyst does not get the new value. Also, you can drag the widget while pressing the button, which is probably not intended.
