### PR TITLE
Add timeout to interleaved bidirectional weight heuristic

### DIFF
--- a/otp-core/src/main/java/org/opentripplanner/routing/algorithm/GenericAStar.java
+++ b/otp-core/src/main/java/org/opentripplanner/routing/algorithm/GenericAStar.java
@@ -109,7 +109,12 @@ public class GenericAStar implements SPTService { // maybe this should be wrappe
 
         // heuristic calc could actually be done when states are constructed, inside state
         State initialState = new State(options);
-        heuristic.initialize(initialState, rctx.target);
+        heuristic.initialize(initialState, rctx.target, abortTime);
+        if (abortTime < Long.MAX_VALUE  && System.currentTimeMillis() > abortTime) {
+            LOG.warn("Timeout during initialization of interleaved bidirectional heuristic.");
+            options.rctx.debug.timedOut = true;
+            return null; // Search timed out
+        }
         options.rctx.debug.finishedPrecalculating();
         spt.add(initialState);
 

--- a/otp-core/src/main/java/org/opentripplanner/routing/algorithm/strategies/DefaultRemainingWeightHeuristic.java
+++ b/otp-core/src/main/java/org/opentripplanner/routing/algorithm/strategies/DefaultRemainingWeightHeuristic.java
@@ -46,7 +46,7 @@ public class DefaultRemainingWeightHeuristic implements RemainingWeightHeuristic
     private double targetY;
 
     @Override
-    public void initialize(State s, Vertex target) {
+    public void initialize(State s, Vertex target, long abortTime) {
         this.options = s.getOptions();
         this.useTransit = options.getModes().isTransit();
         this.maxSpeed = getMaxSpeed(options);

--- a/otp-core/src/main/java/org/opentripplanner/routing/algorithm/strategies/InterleavedBidirectionalHeuristic.java
+++ b/otp-core/src/main/java/org/opentripplanner/routing/algorithm/strategies/InterleavedBidirectionalHeuristic.java
@@ -95,7 +95,7 @@ public class InterleavedBidirectionalHeuristic implements RemainingWeightHeurist
      */
     
     @Override
-    public void initialize(State s, Vertex target) {
+    public void initialize(State s, Vertex target, long abortTime) {
         if (target == this.target) {
             LOG.debug("reusing existing heuristic");
             return;
@@ -110,12 +110,15 @@ public class InterleavedBidirectionalHeuristic implements RemainingWeightHeurist
         // make sure distance table is initialized before starting thread
         LOG.debug("initializing heuristic computation thread");
         // forward street search first, sets values around origin to 0
-        streetSearch(options, false); // ~30 msec
+        List<State> search = streetSearch(options, false, abortTime); // ~30 msec
+        if (search == null) return; // Search timed out
         LOG.info("end foreward street search {}", System.currentTimeMillis());
         // create a new priority queue
         q = new BinHeap<Vertex>();
         // enqueue states for each stop within walking distance of the destination
-        for (State stopState : streetSearch(options, true)) { // backward street search
+        search = streetSearch(options, true, abortTime);
+        if (search == null) return; // Search timed out
+        for (State stopState : search) { // backward street search
             q.insert(stopState.getVertex(), stopState.getWeight());
         }
         LOG.info("end backward street search {}", System.currentTimeMillis());
@@ -235,7 +238,7 @@ public class InterleavedBidirectionalHeuristic implements RemainingWeightHeurist
     
     */
 
-    private List<State> streetSearch (RoutingRequest rr, boolean fromTarget) {
+    private List<State> streetSearch (RoutingRequest rr, boolean fromTarget, long abortTime) {
         rr = rr.clone();
         if (fromTarget)
             rr.setArriveBy( ! rr.isArriveBy());
@@ -246,6 +249,13 @@ public class InterleavedBidirectionalHeuristic implements RemainingWeightHeurist
         State initState = new State(initVertex, rr);
         pq.insert(initState, 0);
         while ( ! pq.empty()) {
+            /**
+             * Terminate the search prematurely if we've hit our computation wall.
+             */
+            if (abortTime < Long.MAX_VALUE  && System.currentTimeMillis() > abortTime) {
+                return null;
+            }
+
             State s = pq.extract_min();
             Double w = s.getWeight();
             Vertex v = s.getVertex();

--- a/otp-core/src/main/java/org/opentripplanner/routing/algorithm/strategies/RemainingWeightHeuristic.java
+++ b/otp-core/src/main/java/org/opentripplanner/routing/algorithm/strategies/RemainingWeightHeuristic.java
@@ -28,7 +28,7 @@ public interface RemainingWeightHeuristic extends Serializable {
      * Perform any one-time setup and pre-computation that will be needed by later calls to 
      * computeForwardWeight/computeReverseWeight. 
      */
-    public void initialize(State s, Vertex target);
+    public void initialize(State s, Vertex target, long abortTime);
 
     public double computeForwardWeight(State s, Vertex target);
 

--- a/otp-core/src/main/java/org/opentripplanner/routing/algorithm/strategies/TrivialRemainingWeightHeuristic.java
+++ b/otp-core/src/main/java/org/opentripplanner/routing/algorithm/strategies/TrivialRemainingWeightHeuristic.java
@@ -29,7 +29,7 @@ public class TrivialRemainingWeightHeuristic implements RemainingWeightHeuristic
     private static final long serialVersionUID = 1L;
 
     @Override
-    public void initialize(State s, Vertex target) {}
+    public void initialize(State s, Vertex target, long abortTime) {}
 
     @Override
     public double computeForwardWeight(State s, Vertex target) {

--- a/otp-core/src/main/java/org/opentripplanner/routing/impl/MultiObjectivePathServiceImpl.java
+++ b/otp-core/src/main/java/org/opentripplanner/routing/impl/MultiObjectivePathServiceImpl.java
@@ -146,6 +146,9 @@ public class MultiObjectivePathServiceImpl implements PathService {
             options.setMaxWalkDistance(maxWalk);
             
             // cap search / heuristic weight
+            long startTime = System.currentTimeMillis();
+            long endTime = startTime + (int)(_timeouts[0] * 1000);
+            LOG.debug("starttime {} endtime {}", startTime, endTime);
             final double AVG_TRANSIT_SPEED = 25; // m/sec 
             double cutoff = (distanceLibrary.distance(originVertex.getCoordinate(),
                     targetVertex.getCoordinate()) * 1.5) / AVG_TRANSIT_SPEED; // wait time is irrelevant in the heuristic
@@ -154,7 +157,7 @@ public class MultiObjectivePathServiceImpl implements PathService {
             
             State origin = new State(options);
             // (used to) initialize heuristic outside loop so table can be reused
-            heuristic.initialize(origin, targetVertex);
+            heuristic.initialize(origin, targetVertex, endTime);
             
             options.maxWeight = cutoff + 30 * 60 * options.waitReluctance;
             
@@ -162,9 +165,6 @@ public class MultiObjectivePathServiceImpl implements PathService {
             HashMap<Vertex, List<State>> states = new HashMap<Vertex, List<State>>();
             pq.reset();
             pq.insert(origin, 0);
-            long startTime = System.currentTimeMillis();
-            long endTime = startTime + (int)(_timeouts[0] * 1000);
-            LOG.debug("starttime {} endtime {}", startTime, endTime); 
             QUEUE: while ( ! pq.empty()) {
                 
                 if (System.currentTimeMillis() > endTime) {

--- a/otp-core/src/main/java/org/opentripplanner/routing/impl/raptor/TargetBound.java
+++ b/otp-core/src/main/java/org/opentripplanner/routing/impl/raptor/TargetBound.java
@@ -318,7 +318,7 @@ public class TargetBound implements SearchTerminationStrategy, SkipTraverseResul
     public void reset() {}
 
     @Override
-    public void initialize(State s, Vertex target) {}
+    public void initialize(State s, Vertex target, long abortTime) {}
 
     public double getTimeBoundFactor() {
         return timeBoundFactor;


### PR DESCRIPTION
It has been observed that setting maxWalkDistance too high causes problems inside the interleaved bidirectional weight heuristic. While this probably means there's a bug in there that needs to be fixed, it also exposed the problem that the initialization of the heuristic is implemented without any kind of timeout. This pull request adds such a timeout to the interleaved bidirectional weight heuristic. Presumably, the other heuristics don't need such a timeout, although the interface to add one is now in place.
