### PR TITLE
Stop background threads after webapp stop/reload.

### DIFF
--- a/otp-core/src/main/java/org/opentripplanner/routing/impl/GraphServiceImpl.java
+++ b/otp-core/src/main/java/org/opentripplanner/routing/impl/GraphServiceImpl.java
@@ -18,6 +18,7 @@ import java.util.Collection;
 import java.util.List;
 
 import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
 
 import lombok.Setter;
 
@@ -106,6 +107,18 @@ public class GraphServiceImpl implements GraphService {
                     + "You must use the routers API to register one or more graphs before routing.");
         }
     }
+    
+    /**
+     * This is called when the bean gets deleted, that is mainly in case of webapp container
+     * application stop or reload. We teardown all loaded graph to stop their background real-time
+     * data updater thread.
+     */
+    @PreDestroy
+    private void teardown() {
+        LOG.info("Cleaning-up graphs...");
+        evictAll();
+        decorated.cleanupWebapp();
+    }
 
     @Override
     public Graph getGraph() {
@@ -156,5 +169,4 @@ public class GraphServiceImpl implements GraphService {
     public boolean save(String routerId, InputStream is) {
     	return decorated.save(routerId, is);
     }
-    
 }


### PR DESCRIPTION
When OTP is used within application containers such as Tomcat or Jetty, if the application is stopped or auto-reloaded, the various background updater threads are not stopped. This pull request attempt to solve this by registering @PreDestroy hooks to:
1) shutdown real-time threads (we use the existing GraphService::evictAll() which is supposed to do that)
2) shutdown background scan thread in the GraphServiceAutoDiscovery service
3) shutdown geotools threads that rely on client code to call them (WeakCollectionCleaner, DeferredAuthorityFactory)

Note: The big diff in GraphServiceFileImpl::evict() is only code auto-format.
