### PR TITLE
Add dirname so that OTP can be run from any path.

### DIFF
--- a/otp
+++ b/otp
@@ -3,4 +3,4 @@
 # Run OTP in standalone mode with the supplied arguments.
 # Standalone OTP can build a graph, visualize a graph, run an OTP API server,
 # or any combination of these.
-java -Xmx6G -jar otp-core/target/otp.jar "$@"
+java -Xmx6G -jar `dirname $0`/otp-core/target/otp.jar "$@"


### PR DESCRIPTION
This allows the otp shell script to be run from any directory.
