### PR TITLE
CSVPopulation projection support.

### DIFF
--- a/otp-core/src/main/java/org/opentripplanner/analyst/batch/CSVPopulation.java
+++ b/otp-core/src/main/java/org/opentripplanner/analyst/batch/CSVPopulation.java
@@ -51,7 +51,7 @@ public class CSVPopulation extends BasicPopulation {
     public int inputCol = 3;
     
     @Setter
-    public String inputCrs = "EPSG:4326";
+    public String crs = null;
 
     @Setter
     public boolean skipHeaders = true;
@@ -70,8 +70,8 @@ public class CSVPopulation extends BasicPopulation {
             boolean transform = false;
             CoordinateReferenceSystem destCrs = CRS.decode("EPSG:4326");
             Boolean latLon = null;
-            if (inputCrs != null) {
-                CoordinateReferenceSystem sourceCrs = CRS.decode(inputCrs);
+            if (crs != null) {
+                CoordinateReferenceSystem sourceCrs = CRS.decode(crs);
 
                 // make sure coordinates come out in the right order
                 // lat,lon: geotools default

--- a/otp-core/src/test/java/org/opentripplanner/analyst/batch/CSVPopulationTest.java
+++ b/otp-core/src/test/java/org/opentripplanner/analyst/batch/CSVPopulationTest.java
@@ -45,7 +45,7 @@ public class CSVPopulationTest {
         pop.setYCol(3);
         pop.setInputCol(1);
         pop.setLabelCol(0);
-        pop.setInputCrs("EPSG:2229"); // State Plane CA Zone 5, US Survey Feet
+        pop.setCrs("EPSG:2229"); // State Plane CA Zone 5, US Survey Feet
 
         pop.createIndividuals();
 
@@ -83,7 +83,7 @@ public class CSVPopulationTest {
         pop.setLatCol(3);
         pop.setInputCol(1);
         pop.setLabelCol(0);
-        pop.setInputCrs("EPSG:4326");
+        pop.setCrs("EPSG:4326");
 
         pop.createIndividuals();
 


### PR DESCRIPTION
This patch allows CSV files with projections other than WGS 84 to be used as population sources. It does this by adding an optional crs parameter to CSVPopulation. If this parameter is left out, the code behaves as it did before (that is, it is backwards-compatible); if it is present and something other than WGS 84, the individuals are reprojected. It also adds xCol and yCol parameters (which are the same as lonCol and latCol) for more idiomatic specification of non-geographic coordinate systems.
