### PR TITLE
Use long instead of int to prevent overflow.

### DIFF
--- a/otp-core/src/main/java/org/opentripplanner/routing/core/StateEditor.java
+++ b/otp-core/src/main/java/org/opentripplanner/routing/core/StateEditor.java
@@ -251,10 +251,10 @@ public class StateEditor {
      * backward when traversing backward.
      */
     public void incrementTimeInSeconds(int seconds) {
-        incrementTimeInMilliseconds(seconds * 1000);
+        incrementTimeInMilliseconds(seconds * 1000l);
     }
     
-    public void incrementTimeInMilliseconds(int milliseconds) {
+    public void incrementTimeInMilliseconds(long milliseconds) {
         if (milliseconds < 0) {
             LOG.warn("A state's time is being incremented by a negative amount while traversing edge "
                     + child.getBackEdge());


### PR DESCRIPTION
Use long instead of int to prevent overflow, so we can support transport time longer than 30 days
