### PR TITLE
Use @InjectParam for Jersey, not @Autowired.

### DIFF
--- a/otp-core/src/main/java/org/opentripplanner/api/ws/BikeRental.java
+++ b/otp-core/src/main/java/org/opentripplanner/api/ws/BikeRental.java
@@ -29,8 +29,8 @@ import org.opentripplanner.routing.bike_rental.BikeRentalStation;
 import org.opentripplanner.routing.bike_rental.BikeRentalStationService;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.services.GraphService;
-import org.springframework.beans.factory.annotation.Autowired;
 
+import com.sun.jersey.api.core.InjectParam;
 import com.sun.jersey.api.spring.Autowire;
 import com.vividsolutions.jts.geom.Envelope;
 
@@ -38,9 +38,10 @@ import com.vividsolutions.jts.geom.Envelope;
 @XmlRootElement
 @Autowire
 public class BikeRental {
+
+    @InjectParam
     private GraphService graphService;
 
-    @Autowired
     public void setGraphService(GraphService graphService) {
         this.graphService = graphService;
     }


### PR DESCRIPTION
Cherry-picked from 0.11.x maintenance branch.

Maybe standalone DI should accept @Autowired for this? It may be broken only for standalone mode.
