### PR TITLE
fixes #1419 with last xhr check and request delay

### DIFF
--- a/src/client/js/otp/core/Geocoder.js
+++ b/src/client/js/otp/core/Geocoder.js
@@ -30,10 +30,11 @@ otp.core.Geocoder = otp.Class({
         var params = { }; 
         params[this.addressParam] = address;
         
-        $.ajax(this.url, {
+        lastXhr = $.ajax(this.url, {
             data : params,
             
             success: function(data) {
+              if (xhr === lastXhr){
                 if((typeof data) == "string") data = jQuery.parseXML(data);
                 var results = [];
                 $(data).find("geocoderResults").find("results").find("result").each(function () {
@@ -49,6 +50,7 @@ otp.core.Geocoder = otp.Class({
                 });
                 
                 setResultsCallback.call(this, results);
+              }
             }
         });        
     } 

--- a/src/client/js/otp/widgets/tripoptions/TripOptionsWidget.js
+++ b/src/client/js/otp/widgets/tripoptions/TripOptionsWidget.js
@@ -232,6 +232,7 @@ otp.widgets.tripoptions.LocationsSelector =
     initInput : function(input, setterFunction) {
         var this_ = this;
         input.autocomplete({
+            delay: 500, // 500ms between requests.
             source: function(request, response) {
                 this_.geocoders[this_.activeIndex].geocode(request.term, function(results) {
                     console.log("got results "+results.length);


### PR DESCRIPTION
Fixes #1419.

This pr adds a `lastXhr` object which stores the last ajax request which it uses to check against the incoming responses.

It also increases the autocomplete request delay to 500 ms from the default 300 ms to reduce the number of responses.
