### PR TITLE
Add equals and hashCode to OSMLevel

### DIFF
--- a/src/main/java/org/opentripplanner/openstreetmap/model/OSMLevel.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/model/OSMLevel.java
@@ -179,4 +179,18 @@ public class OSMLevel implements Comparable<OSMLevel> {
         return this.floorNumber - other.floorNumber;
     }
 
+    @Override
+    public boolean equals(Object other) {
+        if (other == null)
+            return false;
+        if (!(other instanceof OSMLevel))
+            return false;
+        return this.floorNumber == ((OSMLevel)other).floorNumber;
+    }
+
+    @Override
+    public int hashCode(){
+        return this.floorNumber;
+    }
+
 }


### PR DESCRIPTION
Fixes containsKey for HashMaps with OSMLevel as key, which now works correctly and we don't get duplicate nodes for [some](http://www.openstreetmap.org/node/173248867) elevators.
