### PR TITLE
Fix NPE in DCFareCalculator

### DIFF
--- a/src/main/java/org/opentripplanner/profile/DCFareCalculator.java
+++ b/src/main/java/org/opentripplanner/profile/DCFareCalculator.java
@@ -109,6 +109,8 @@ public class DCFareCalculator {
         // automatically compose string using 'free' or 'discounted' and route name
         private void calcFare() {
             RideType prevType = (prev == null) ? null : prev.type;
+            if (type == null)
+                return;
             switch (type) {
             case METRO_RAIL:
                 fare = METRORAIL.lookup(from, to);


### PR DESCRIPTION
This is used for all profile requests, and should not give a null pointer exception if the fare is unknown.
