### PR TITLE
  Time format localization bug & fix master branch

### DIFF
--- a/src/client/js/otp/modules/planner/IconFactory.js
+++ b/src/client/js/otp/modules/planner/IconFactory.js
@@ -317,7 +317,10 @@ otp.modules.planner.IconFactory = otp.Class({
         html += '<img src="'+otp.config.resourcePath+'images/mode/'+mode+'.png">';
         if(isOrigin) html += '<img src="'+otp.config.resourcePath+'images/mode/arrow.png" style="margin-left:2px;">';
         html += '</div>';
-        html +=  otp.util.Time.formatItinTime(time, "h:mm");
+        //Removes AM/PM at the end of time if it exists (Time is too long
+        //otherwise)
+        var time_format = (otp.config.locale.time.time_format.slice(-1) === 'a') ? otp.config.locale.time.time_format.slice(0, -1) : otp.config.locale.time.time_format;
+        html +=  otp.util.Time.formatItinTime(time, time_format);
         
         if(quadrant === 'nw') anchor = [32,44];
         if(quadrant === 'ne') anchor = [0,44];

--- a/src/client/js/otp/modules/planner/PlannerModule.js
+++ b/src/client/js/otp/modules/planner/PlannerModule.js
@@ -17,8 +17,8 @@ otp.namespace("otp.modules.planner");
 otp.modules.planner.defaultQueryParams = {
     startPlace                      : null,
     endPlace                        : null,
-    time                            : moment().format("h:mma"),
-    date                            : moment().format("MM-DD-YYYY"),
+    time                            : moment().format(otp.config.locale.time.time_format),
+    date                            : moment().format(otp.config.locale.time.date_format),
     arriveBy                        : false,
     mode                            : "TRANSIT,WALK",
     maxWalkDistance                 : 804.672, // 1/2 mi.

--- a/src/client/js/otp/util/Time.js
+++ b/src/client/js/otp/util/Time.js
@@ -48,7 +48,11 @@ otp.util.Time = {
 
     correctAmPmTimeString : function(time, format) {
         // step 0: leave if we don't have what we need...
-        if(otp.config.timeFormat && otp.config.timeFormat.slice(-1) !== 'a') return time;
+        if(otp.config.locale.time.time_format && otp.config.locale.time.time_format.slice(-1) !== 'a') {
+            //It should always return 12 hour am/pm time because that is what
+            //server expects
+            return moment(time, otp.config.locale.time.time_format).format("h:mma");
+        }
         if(time == null || time.length < 1) return time;
 
 

--- a/src/client/js/otp/widgets/tripoptions/TripOptionsWidget.js
+++ b/src/client/js/otp/widgets/tripoptions/TripOptionsWidget.js
@@ -379,11 +379,11 @@ otp.widgets.tripoptions.TimeSelector =
         //var m = moment(data.queryParams.date+" "+data.queryParams.time, "MM-DD-YYYY h:mma");
         //$('#'+this.id+'-picker').datepicker("setDate", new Date(m));
         if(data.queryParams.date) {
-            $('#'+this.id+'-date').datepicker("setDate", new Date(moment(data.queryParams.date, "MM-DD-YYYY")));
+            $('#'+this.id+'-date').datepicker("setDate", new Date(moment(data.queryParams.date, otp.config.locale.time.date_format)));
             this.tripWidget.module.date = data.queryParams.date;
         }
         if(data.queryParams.time) {
-            $('#'+this.id+'-time').val(moment(data.queryParams.time, "h:mma").format(otp.config.locale.time.time_format));
+            $('#'+this.id+'-time').val(moment(data.queryParams.time, otp.config.locale.time.time_format).format(otp.config.locale.time.time_format));
             this.tripWidget.module.time = data.queryParams.time;
         }
         if(data.queryParams.arriveBy === true || data.queryParams.arriveBy === "true") {


### PR DESCRIPTION
I fixed hardcoded time formats (#1385) and now when I started using them I found a bug.
I forgot to make time format in popup bubble configurable.
And time and date is wrong if localization is not using 12 hour time and mm-dd-YYYY. Date problem only shows up if datepicker is localized. (Which is currently never).
