### PR TITLE
Implements the option --preFlight

### DIFF
--- a/src/main/java/org/opentripplanner/standalone/CommandLineParameters.java
+++ b/src/main/java/org/opentripplanner/standalone/CommandLineParameters.java
@@ -66,6 +66,10 @@ public class CommandLineParameters {
     @Parameter(names = { "-m", "--inMemory"},
     description = "pass the graph to the server in-memory after building it, without saving to disk")
     boolean inMemory;
+ 
+    @Parameter(names = { "--preFlight"},
+    description = "pass the graph to the server in-memory after building it, and saving to disk")
+    boolean preFlight;
     
     @Parameter(names = {"--noTransit"},
     description = "skip all transit input files (GTFS)")
@@ -153,7 +157,7 @@ public class CommandLineParameters {
 
     /** Set some convenience parameters based on other parameters' values. */
     public void infer () {
-        server |= ( inMemory || port != null );
+        server |= ( inMemory || preFlight || port != null );
         if (graphDirectory  == null) graphDirectory  = DEFAULT_GRAPH_DIRECTORY;
         if (routerIds == null) routerIds = Arrays.asList(DEFAULT_ROUTER_ID);
         if (cacheDirectory == null) cacheDirectory = DEFAULT_CACHE_DIRECTORY;

--- a/src/main/java/org/opentripplanner/standalone/OTPConfigurator.java
+++ b/src/main/java/org/opentripplanner/standalone/OTPConfigurator.java
@@ -79,7 +79,7 @@ public class OTPConfigurator {
     /** Create a cached GraphService that will be shared between all OTP components. */
     public void makeGraphService(Graph graph) {
         /* Hand off graph in memory to server in a single-graph in-memory GraphServiceImpl. */
-        if (graph != null && params.inMemory) {
+        if (graph != null && ( params.inMemory || params.preFlight) ) {
             try {
                 FileInputStream graphConfiguration = new FileInputStream(params.graphConfigFile);
                 Preferences config = new PropertiesPreferences(graphConfiguration);
@@ -212,7 +212,7 @@ public class OTPConfigurator {
             GraphBuilder elevationBuilder = new ElevationGraphBuilderImpl(gcf);
             graphBuilder.addGraphBuilder(elevationBuilder);
         }
-        graphBuilder.setSerializeGraph( ! params.inMemory);
+        graphBuilder.setSerializeGraph( ( ! params.inMemory ) || params.preFlight );
         return graphBuilder;
     }
 

--- a/src/main/java/org/opentripplanner/standalone/OTPMain.java
+++ b/src/main/java/org/opentripplanner/standalone/OTPMain.java
@@ -60,7 +60,7 @@ public class OTPMain {
         if (graphBuilder != null) {
             graphBuilder.run();
             // Inform configurator which graph is to be used for in-memory handoff.
-            if (params.inMemory) configurator.makeGraphService(graphBuilder.getGraph());
+            if (params.inMemory || params.preFlight) configurator.makeGraphService(graphBuilder.getGraph());
         }
         
         // start visualizer, if asked for


### PR DESCRIPTION
Currently --inMemory is able to load a GTFS file from disk, but explicitly won't write Graph.obj to disk. Our usecase is an instance of OpenTripPlanner running in preFlight mode. This mode will compile a graph upon startup, and when the service is accessibily will be used to evaluate the quality of the running instance. Once the running instance passes the criteria the Graph.obj will be deployed to its final location, where other instances are able to start from it.
