### PR TITLE
Fix Bike Rental and REST url for leaflet-client

### DIFF
--- a/otp-leaflet-client/src/main/webapp/js/otp/widgets/tripoptions/TripOptionsWidget.js
+++ b/otp-leaflet-client/src/main/webapp/js/otp/widgets/tripoptions/TripOptionsWidget.js
@@ -405,6 +405,7 @@ otp.widgets.tripoptions.ModeSelector =
         "BUSISH,WALK" : "Bus Only",
         "TRAINISH,WALK" : "Rail Only",
         "BICYCLE" : 'Bicycle Only',
+		"BICYCLE_RENT" : "Rented Bicycle",
         "WALK" : 'Walk Only',
         "TRANSIT,BICYCLE" : "Bicycle &amp; Transit",
         "CAR" : 'Drive Only',

--- a/otp-rest-servlet/src/main/webapp/WEB-INF/web.xml
+++ b/otp-rest-servlet/src/main/webapp/WEB-INF/web.xml
@@ -27,7 +27,7 @@
 
 	<filter-mapping>
 		<filter-name>jsonpCallbackFilter</filter-name>
-		<url-pattern>/ws/*</url-pattern>
+		<url-pattern>/*</url-pattern>
 	</filter-mapping>
 	
 	<!-- Enables Spring Security -->
@@ -62,7 +62,7 @@
 	</servlet>
 	<servlet-mapping>
 		<servlet-name>Jersey</servlet-name>
-		<url-pattern>/ws/*</url-pattern>
+		<url-pattern>/*</url-pattern>
 	</servlet-mapping>
 	<session-config>
 		<session-timeout>30</session-timeout>


### PR DESCRIPTION
I think the following patch is good -- it fixes some issues I was having deploying origin-0.11.x with a basic miami OSM extract graph and dynamic city-bikes API with routing.
- Remove /ws prefix from webapp URL as expected by leaflet-client

It looks like the leaflet-client expects a particular tomcat deployment and does NOT (by default) include the /ws/ prefix for API calls -- So, remove it from the WEB-INF web.xml filter-pattern (for rest-servlet) so that all you have to do is match your tomcat deployment to the expected (/otp/) and the leaflet-client will communicate with the rest-servlet.

Alternatively, we could correct the leaflet-client to expect /otp/ws/ 
- Add BICYCLE_RENT as an option (again) so bike rentals will be used.

For some reason, the BICYCLE_RENT option for rented bicycles was removed from the leaflet-client transitoptionswidget.js - so, this patch simply adds it back.  It looks like there may be some more work done with this in master/1.0.x to allow a more modular approach to enabling transit modes ("with bike share", etc), but until then it seems appropriate to add the available options so that even though a user correctly configures the graph and API endpoints (via graph.properties) OTP would never use bike rental stations because "allowedBikeRental" would be false within routing/edgetype/StreetBikeRentalLink.java.

I hope that is detailed enough and the patch(es) are helpful to the project!

Any comments and feedback is welcome.

Thanks
