### PR TITLE
Improve linking

### DIFF
--- a/src/main/java/org/opentripplanner/standalone/OTPConfigurator.java
+++ b/src/main/java/org/opentripplanner/standalone/OTPConfigurator.java
@@ -166,7 +166,7 @@ public class OTPConfigurator {
             osmBuilder.setDefaultWayPropertySetSource(defaultWayPropertySetSource);
             osmBuilder.skipVisibility = params.skipVisibility;
             graphBuilder.addGraphBuilder(osmBuilder);
-            graphBuilder.addGraphBuilder(new PruneFloatingIslands());            
+            graphBuilder.addGraphBuilder(new PruneFloatingIslands());
         }
         if ( hasGTFS ) {
             List<GtfsBundle> gtfsBundles = Lists.newArrayList();


### PR DESCRIPTION
1. Always add transit stops to areas when part of the edge way
2. Support public transit stop relations, in order to add stops that are located within platform areas, but unlinked
3. Support routing in simple single way to area intersections
