### PR TITLE
update repository list to use conveyal repo instead of opengeo for branch 0.11.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -245,9 +245,9 @@
       <url>http://people.apache.org/repo/m1-ibiblio-rsync-repository/org.apache.axis2/</url>
     </repository>
     <repository>
-      <id>opengeo</id>
-      <name>OpenGeo Maven Repository</name>
-      <url>http://repo.opengeo.org/</url>
+      <id>conveyal</id>
+      <name>Conveyal Maven Repository</name>
+      <url>http://maven.conveyal.com/</url>
       <!-- Avoid downloading OTP snapshots from repo -->
       <releases><enabled>true</enabled></releases>
       <snapshots><enabled>false</enabled></snapshots>
@@ -460,9 +460,6 @@
     <jersey.version>1.17.1</jersey.version>
     <spring.version>3.0.5.RELEASE</spring.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <distribution_id>opengeo</distribution_id>
-    <distribution_name>OpenGeo Maven Repository</distribution_name>
-    <distribution_url>dav:http://repo.opengeo.org</distribution_url>
     <snapshot_distribution_id>opengeo</snapshot_distribution_id>
     <snapshot_distribution_name>OpenGeo Maven Repository</snapshot_distribution_name>
     <snapshot_distribution_url>dav:http://repo.opengeo.org</snapshot_distribution_url>


### PR DESCRIPTION
OpenGeo was moved to boundless spatial domain and some artifacts removed
