### PR TITLE
Move TurnRestriction List from StreetEdge to Graph

### DIFF
--- a/src/main/java/org/opentripplanner/common/StreetUtils.java
+++ b/src/main/java/org/opentripplanner/common/StreetUtils.java
@@ -165,7 +165,7 @@ public class StreetUtils {
                     if (permission == StreetTraversalPermission.NONE) {
                         // TODO Shouldn't we have a graph.removeEdge()?
                         graph.streetNotesService.removeStaticNotes(pse);
-                        pse.detach();
+                        pse.detach(graph);
                     } else {
                         pse.setPermission(permission);
                     }
@@ -186,7 +186,7 @@ public class StreetUtils {
             edges.addAll(v.getIncoming());
             for (Edge e : edges) {
                 if (e instanceof StreetTransitLink) {
-                    e.detach();
+                    e.detach(graph);
                 }
             }
         }

--- a/src/main/java/org/opentripplanner/graph_builder/impl/osm/OpenStreetMapGraphBuilderImpl.java
+++ b/src/main/java/org/opentripplanner/graph_builder/impl/osm/OpenStreetMapGraphBuilderImpl.java
@@ -750,7 +750,7 @@ public class OpenStreetMapGraphBuilderImpl implements GraphBuilder {
                             restriction.type = restrictionTag.type;
                             restriction.modes = restrictionTag.modes;
                             restriction.time = restrictionTag.time;
-                            from.addTurnRestriction(restriction);
+                            graph.addTurnRestriction(from, restriction);
                         }
                     }
                 }

--- a/src/main/java/org/opentripplanner/graph_builder/impl/osm/WalkableAreaBuilder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/impl/osm/WalkableAreaBuilder.java
@@ -275,6 +275,7 @@ public class WalkableAreaBuilder {
             mode = TraverseMode.CAR;
         }
         RoutingRequest options = new RoutingRequest(mode);
+        options.setDummyRoutingContext(graph);
         GenericDijkstra search = new GenericDijkstra(options);
         search.setSkipEdgeStrategy(new ListedEdgesOnly(edges));
         Set<Edge> usedEdges = new HashSet<Edge>();
@@ -293,7 +294,7 @@ public class WalkableAreaBuilder {
         for (Edge edge : edges) {
             if (!usedEdges.contains(edge)) {
                 graph.streetNotesService.removeStaticNotes(edge);
-                edge.detach();
+                edge.detach(graph);
             }
         }
     }

--- a/src/main/java/org/opentripplanner/routing/core/RoutingContext.java
+++ b/src/main/java/org/opentripplanner/routing/core/RoutingContext.java
@@ -421,11 +421,11 @@ public class RoutingContext implements Cloneable {
     public int destroy() {
         int nRemoved = 0;
         if (origin != null)
-            nRemoved += origin.removeTemporaryEdges();
+            nRemoved += origin.removeTemporaryEdges(graph);
         if (target != null)
-            nRemoved += target.removeTemporaryEdges();
+            nRemoved += target.removeTemporaryEdges(graph);
         for (Vertex v : intermediateVertices)
-            nRemoved += v.removeTemporaryEdges();
+            nRemoved += v.removeTemporaryEdges(graph);
         return nRemoved;
     }
 

--- a/src/main/java/org/opentripplanner/routing/edgetype/AreaEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/AreaEdge.java
@@ -13,6 +13,7 @@
 
 package org.opentripplanner.routing.edgetype;
 
+import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.vertextype.IntersectionVertex;
 
 import com.vividsolutions.jts.geom.LineString;
@@ -33,9 +34,9 @@ public class AreaEdge extends StreetWithElevationEdge {
         return area;
     }
     
-    public int detach() {
+    public int detach(Graph graph) {
         area.removeEdge(this);
-        return super.detach();
+        return super.detach(graph);
     }
 
     public void setArea(AreaEdgeList area) {

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
@@ -31,6 +31,7 @@ import org.opentripplanner.routing.core.StateEditor;
 import org.opentripplanner.routing.core.TraverseMode;
 import org.opentripplanner.routing.core.TraverseModeSet;
 import org.opentripplanner.routing.graph.Edge;
+import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.util.ElevationUtils;
 import org.opentripplanner.routing.vertextype.IntersectionVertex;
 import org.opentripplanner.routing.vertextype.StreetVertex;
@@ -107,8 +108,6 @@ public class StreetEdge extends Edge implements Cloneable {
      * this street segment.
      */
     private float carSpeed;
-
-    private List<TurnRestriction> turnRestrictions = Collections.emptyList();
 
     /**
      * The angle at the start of the edge geometry.
@@ -530,18 +529,6 @@ public class StreetEdge extends Edge implements Cloneable {
                 + " permission=" + this.getPermission() + ")";
     }
 
-    /** Returns true if there are any turn restrictions defined. */
-    public boolean hasExplicitTurnRestrictions() {
-        return this.turnRestrictions != null && this.turnRestrictions.size() > 0;
-    }
-
-    public void addTurnRestriction(TurnRestriction turnRestriction) {
-        if (turnRestrictions.isEmpty()) {
-            turnRestrictions = new ArrayList<TurnRestriction>();
-        }
-        turnRestrictions.add(turnRestriction);
-    }
-
     @Override
     public StreetEdge clone() {
         try {
@@ -552,7 +539,8 @@ public class StreetEdge extends Edge implements Cloneable {
     }
     
     public boolean canTurnOnto(Edge e, State state, TraverseMode mode) {
-        for (TurnRestriction restriction : turnRestrictions) {
+        Graph graph = state.getOptions().rctx.graph;
+        for (TurnRestriction restriction : graph.getTurnRestrictions(this)) {
             /* FIXME: This is wrong for trips that end in the middle of restriction.to
              */
 
@@ -573,20 +561,19 @@ public class StreetEdge extends Edge implements Cloneable {
         return true;
     }
 
-    protected boolean detachFrom() {
+    protected boolean detachFrom(Graph graph) {
         if (fromv != null) {
             for (Edge e : fromv.getIncoming()) {
-                if (!(e instanceof StreetEdge)) continue;
-                StreetEdge pse = (StreetEdge) e;
-                ArrayList<TurnRestriction> restrictions = new ArrayList<TurnRestriction>(pse.turnRestrictions);
-                for (TurnRestriction restriction : restrictions) {
-                    if (restriction.to == this) {
-                        pse.turnRestrictions.remove(restriction);
+                if (e instanceof StreetEdge) {
+                    for (TurnRestriction restriction : graph.getTurnRestrictions(e)) {
+                        if (restriction.to == this) {
+                            graph.removeTurnRestriction(e, restriction);
+                        }
                     }
                 }
             }
         }
-        return super.detachFrom();
+        return super.detachFrom(graph);
     }
 
 	@Override
@@ -699,10 +686,6 @@ public class StreetEdge extends Edge implements Cloneable {
 
 	public void setSlopeOverride(boolean slopeOverride) {
 	    flags = BitSetUtils.set(flags, SLOPEOVERRIDE_FLAG_INDEX, slopeOverride);
-	}
-
-	public List<TurnRestriction> getTurnRestrictions() {
-		return this.turnRestrictions;
 	}
 
     /**

--- a/src/main/java/org/opentripplanner/routing/graph/Edge.java
+++ b/src/main/java/org/opentripplanner/routing/graph/Edge.java
@@ -100,28 +100,6 @@ public abstract class Edge implements Serializable {
                 this.getToVertex() == e.getFromVertex());
     }
     
-    public void attachFrom(Vertex fromv) {
-        detachFrom();
-        if (fromv == null)
-            throw new IllegalStateException("attaching to fromv null");
-        this.fromv = fromv;
-        fromv.addOutgoing(this);
-    }
-
-    public void attachTo(Vertex tov) {
-        detachTo();
-        if (tov == null)
-            throw new IllegalStateException("attaching to tov null");
-        this.tov = tov;
-        tov.addIncoming(this);
-    }
-
-    /** Attach this edge to new endpoint vertices, keeping edgelists coherent */
-    public void attach(Vertex fromv, Vertex tov) {
-        attachFrom(fromv);
-        attachTo(tov);
-    }
-
     /**
      * Get a direction on paths where it matters, or null
      * 
@@ -131,7 +109,7 @@ public abstract class Edge implements Serializable {
         return null;
     }
 
-    protected boolean detachFrom() {
+    protected boolean detachFrom(Graph graph) {
         boolean detached = false;
         if (fromv != null) {
             detached = fromv.removeOutgoing(this);
@@ -140,7 +118,7 @@ public abstract class Edge implements Serializable {
         return detached;
     }
 
-    protected boolean detachTo() {
+    protected boolean detachTo(Graph graph) {
         boolean detached = false;
         if (tov != null) {
             detached = tov.removeIncoming(this);
@@ -154,12 +132,12 @@ public abstract class Edge implements Serializable {
      * 
      * @return
      */
-    public int detach() {
+    public int detach(Graph graph) {
         int nDetached = 0;
-        if (detachFrom()) {
+        if (detachFrom(graph)) {
             ++nDetached;
         }
-        if (detachTo()) {
+        if (detachTo(graph)) {
             ++nDetached;
         }
         return nDetached;

--- a/src/main/java/org/opentripplanner/routing/graph/Vertex.java
+++ b/src/main/java/org/opentripplanner/routing/graph/Vertex.java
@@ -365,7 +365,7 @@ public abstract class Vertex implements Serializable, Cloneable {
      * edge lists, usually by simply calling detach() on them.
      * @return the number of edges affected by the cleanup.
      */
-    public int removeTemporaryEdges() {
+    public int removeTemporaryEdges(Graph graph) {
         // do nothing, signal 0 other objects affected
         return 0;
     }

--- a/src/main/java/org/opentripplanner/routing/location/StreetLocation.java
+++ b/src/main/java/org/opentripplanner/routing/location/StreetLocation.java
@@ -227,8 +227,8 @@ public class StreetLocation extends StreetVertex {
         newRight.setNoThruTraffic(street.isNoThruTraffic());
         
         // Copy turn restrictions onto the outgoing half-edge.
-        for (TurnRestriction turnRestriction : street.getTurnRestrictions()) {
-            newRight.addTurnRestriction(turnRestriction);
+        for (TurnRestriction turnRestriction : graph.getTurnRestrictions(street)) {
+            graph.addTurnRestriction(newRight, turnRestriction);
         }
         base.extra.add(newLeft);
         base.extra.add(newRight);
@@ -281,12 +281,12 @@ public class StreetLocation extends StreetVertex {
     }
 
     @Override
-    public int removeTemporaryEdges() {
+    public int removeTemporaryEdges(Graph graph) {
         int nRemoved = 0;
         for (Edge e : getExtra()) {            
             graph.removeTemporaryEdge(e);
             // edges might already be detached
-            if (e.detach() != 0) nRemoved += 1;
+            if (e.detach(graph) != 0) nRemoved += 1;
         }
         return nRemoved;
     }
@@ -300,7 +300,7 @@ public class StreetLocation extends StreetVertex {
      */
     @Override
     public void finalize() {
-        if (removeTemporaryEdges() > 0)
+        if (removeTemporaryEdges(graph) > 0)
             LOG.error("Temporary edges were removed by finalizer: this is a memory leak.");
     }
 

--- a/src/main/java/org/opentripplanner/routing/spt/BasicShortestPathTree.java
+++ b/src/main/java/org/opentripplanner/routing/spt/BasicShortestPathTree.java
@@ -25,6 +25,7 @@ import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.core.RoutingRequest;
 import org.opentripplanner.routing.edgetype.StreetEdge;
 import org.opentripplanner.routing.graph.Edge;
+import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
 
 /**
@@ -73,6 +74,7 @@ public class BasicShortestPathTree extends AbstractShortestPathTree {
 
     @Override
     public boolean add(State state) {
+        Graph graph = state.getOptions().rctx.graph;
         Vertex here = state.getVertex();
         State existing = states.get(here);
         if (existing == null || state.betterThan(existing)) {
@@ -80,16 +82,11 @@ public class BasicShortestPathTree extends AbstractShortestPathTree {
             return true;
         } else {
             final Edge backEdge = existing.getBackEdge();
-            if (backEdge instanceof StreetEdge) {
-                StreetEdge pseBack = (StreetEdge) backEdge;
-                if (pseBack.hasExplicitTurnRestrictions()) {
-                    // If the previous back edge had turn restrictions, we need to continue
-                    // the search because the previous path may be prevented by from reaching the end by turn restrictions.
-                    return true;
-                }
-            }
+            // If the previous back edge had turn restrictions, we need to continue
+            // the search because the previous path may be prevented by from reaching the end by
+            // turn restrictions.
 
-            return false;
+            return !graph.getTurnRestrictions(backEdge).isEmpty();
         }
     }
 
@@ -109,15 +106,15 @@ public class BasicShortestPathTree extends AbstractShortestPathTree {
 
     @Override
     public boolean visit(State s) {
+        final Graph graph = s.getOptions().rctx.graph;
         final State existing = states.get(s.getVertex());
         final Edge backEdge = existing.getBackEdge();
-        if (backEdge instanceof StreetEdge) {
-            StreetEdge pseBack = (StreetEdge) backEdge;
-            if (pseBack.hasExplicitTurnRestrictions()) {
-                // If the previous back edge had turn restrictions, we need to continue
-                // the search because the previous path may be prevented by from reaching the end by turn restrictions.
-                return true;
-            }
+        if (!graph.getTurnRestrictions(backEdge).isEmpty()) {
+            // If the previous back edge had turn restrictions, we need to continue
+            // the search because the previous path may be prevented by from reaching the end by
+            // turn restrictions.
+
+            return true;
         }
         return (s == existing);
     }

--- a/src/main/java/org/opentripplanner/routing/spt/MultiShortestPathTree.java
+++ b/src/main/java/org/opentripplanner/routing/spt/MultiShortestPathTree.java
@@ -25,6 +25,7 @@ import org.opentripplanner.common.MavenVersion;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.core.RoutingRequest;
 import org.opentripplanner.routing.edgetype.StreetEdge;
+import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
 
 public class MultiShortestPathTree extends AbstractShortestPathTree {
@@ -87,8 +88,9 @@ public class MultiShortestPathTree extends AbstractShortestPathTree {
         if (thisState.isCarParked() != other.isCarParked())
             return false;
 
+        Graph graph = thisState.getOptions().rctx.graph;
         if (thisState.backEdge != other.getBackEdge() && ((thisState.backEdge instanceof StreetEdge)
-                && (!((StreetEdge) thisState.backEdge).getTurnRestrictions().isEmpty())))
+                && (!graph.getTurnRestrictions(thisState.backEdge).isEmpty())))
             return false;
 
         if (thisState.routeSequenceSubset(other)) {

--- a/src/main/java/org/opentripplanner/routing/vertextype/OnboardDepartVertex.java
+++ b/src/main/java/org/opentripplanner/routing/vertextype/OnboardDepartVertex.java
@@ -14,6 +14,7 @@
 package org.opentripplanner.routing.vertextype;
 
 import org.opentripplanner.routing.graph.Edge;
+import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
 
 /**
@@ -31,11 +32,11 @@ public class OnboardDepartVertex extends Vertex {
     }
 
     @Override
-    public int removeTemporaryEdges() {
+    public int removeTemporaryEdges(Graph graph) {
         // We can remove all
         int nRemoved = 0;
         for (Edge e : getOutgoing()) {
-            if (e.detach() != 0)
+            if (e.detach(graph) != 0)
                 nRemoved += 1;
         }
         if (!getIncoming().isEmpty())

--- a/src/test/java/org/opentripplanner/api/resource/TestRequest.java
+++ b/src/test/java/org/opentripplanner/api/resource/TestRequest.java
@@ -693,7 +693,7 @@ public class TestRequest extends TestCase {
         applyUpdateToTripPattern(pattern, "120W1320", "9756", 22, 41820, 41820,
                 ScheduleRelationship.SCHEDULED, 0, serviceDate);
         // Remove the timed transfer from the graph
-        timedTransferEdge.detach();
+        timedTransferEdge.detach(graph);
         // Revert the graph, thus using the original transfer table again
         reset(graph);
     }
@@ -761,7 +761,7 @@ public class TestRequest extends TestCase {
         applyUpdateToTripPattern(pattern, "120W1320", "9756", 22, 41820, 41820,
                 ScheduleRelationship.SCHEDULED, 0, serviceDate);
         // Remove the timed transfer from the graph
-        timedTransferEdge.detach();
+        timedTransferEdge.detach(graph);
         // Revert the graph, thus using the original transfer table again
         reset(graph);
     }

--- a/src/test/java/org/opentripplanner/graph_builder/impl/map/TestStreetMatcher.java
+++ b/src/test/java/org/opentripplanner/graph_builder/impl/map/TestStreetMatcher.java
@@ -246,11 +246,6 @@ public class TestStreetMatcher {
         }
 
         @Override
-        public List<TurnRestriction> getTurnRestrictions() {
-            return Collections.emptyList();
-        }
-
-        @Override
         public float getCarSpeed() {
             return 11.2f;
         }

--- a/src/test/java/org/opentripplanner/graph_builder/impl/osm/TestOpenStreetMapGraphBuilder.java
+++ b/src/test/java/org/opentripplanner/graph_builder/impl/osm/TestOpenStreetMapGraphBuilder.java
@@ -158,7 +158,7 @@ public class TestOpenStreetMapGraphBuilder extends TestCase {
             // Check turn restriction consistency.
             // NOTE(flamholz): currently there don't appear to be any turn restrictions
             // in the OSM file we are loading.
-            for (TurnRestriction tr : se.getTurnRestrictions()) {                
+            for (TurnRestriction tr : gg.getTurnRestrictions(se)) {
                 // All turn restrictions should apply equally to
                 // CAR and CUSTOM_MOTOR_VEHICLE.
                 TraverseModeSet modes = tr.modes;

--- a/src/test/java/org/opentripplanner/routing/algorithm/TurnCostTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/TurnCostTest.java
@@ -250,7 +250,7 @@ public class TurnCostTest {
         TurnRestrictionType rType = TurnRestrictionType.NO_TURN;
         TraverseModeSet restrictedModes = new TraverseModeSet(TraverseMode.CAR, TraverseMode.CUSTOM_MOTOR_VEHICLE);
         TurnRestriction restrict = new TurnRestriction(from, to, rType, restrictedModes);
-        from.addTurnRestriction(restrict);
+        _graph.addTurnRestriction(from, restrict);
     }
 
 }

--- a/src/test/java/org/opentripplanner/routing/algorithm/TurnRestrictionTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/TurnRestrictionTest.java
@@ -100,8 +100,8 @@ public class TurnRestrictionTest {
 
     @Test
     public void testHasExplicitTurnRestrictions() {
-        assertTrue(this.maple_main1.hasExplicitTurnRestrictions());
-        assertFalse(this.broad1_2.hasExplicitTurnRestrictions());
+        assertFalse(_graph.getTurnRestrictions(maple_main1).isEmpty());
+        assertTrue(_graph.getTurnRestrictions(broad1_2).isEmpty());
     }
     
     @Test
@@ -241,7 +241,7 @@ public class TurnRestrictionTest {
         TurnRestrictionType rType = TurnRestrictionType.NO_TURN;
         TraverseModeSet restrictedModes = new TraverseModeSet(TraverseMode.CAR, TraverseMode.CUSTOM_MOTOR_VEHICLE);
         TurnRestriction restrict = new TurnRestriction(from, to, rType, restrictedModes);
-        from.addTurnRestriction(restrict);
+        _graph.addTurnRestriction(from, restrict);
     }
 
 }

--- a/src/test/java/org/opentripplanner/routing/core/TestOnBoardRouting.java
+++ b/src/test/java/org/opentripplanner/routing/core/TestOnBoardRouting.java
@@ -204,7 +204,7 @@ public class TestOnBoardRouting extends TestCase {
             assertTrue(numBoardings2 < numBoardings1);
 
             /* Cleanup edges */
-            int nRemoved = onboardOrigin.removeTemporaryEdges();
+            int nRemoved = onboardOrigin.removeTemporaryEdges(graph);
             assertEquals(1, nRemoved);
 
             n++;

--- a/src/test/java/org/opentripplanner/routing/core/TestTransfers.java
+++ b/src/test/java/org/opentripplanner/routing/core/TestTransfers.java
@@ -581,7 +581,7 @@ public class TestTransfers extends TestCase {
         applyUpdateToTripPattern(pattern, "4.2", "F", 1, 82800, 82800,
                 ScheduleRelationship.SCHEDULED, 0, serviceDate);
         // Remove the timed transfer from the graph
-        timedTransferEdge.detach();
+        timedTransferEdge.detach(graph);
         // Revert the graph, thus using the original transfer table again
         reset(graph);
     }

--- a/src/test/java/org/opentripplanner/routing/edgetype/PlainStreetEdgeTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/PlainStreetEdgeTest.java
@@ -45,6 +45,7 @@ public class PlainStreetEdgeTest {
         v2 = vertex("maple_2nd", 1.0, 2.0);
         
         proto = new RoutingRequest();
+        proto.setDummyRoutingContext(_graph);
         proto.carSpeed = 15.0f;
         proto.walkSpeed = 1.0;
         proto.bikeSpeed = 5.0f;
@@ -278,7 +279,7 @@ public class PlainStreetEdgeTest {
         State state = new State(v2, 0, proto.clone());
 
         state.getOptions().setArriveBy(true);
-        e1.addTurnRestriction(new TurnRestriction(e1, e0, null, TraverseModeSet.allModes()));
+        _graph.addTurnRestriction(e1, new TurnRestriction(e1, e0, null, TraverseModeSet.allModes()));
 
         assertNotNull(e0.traverse(e1.traverse(state)));
     }


### PR DESCRIPTION
I moved the List of TurnRestriction objects inside each StreetEdge to a private Map inside Graph. This is meant to reduce the memory footprint as part of issue #1527.

I used a NY state OSM extract from Geofabrik to see what the effects were.

Before I made my changes, the sizes were as follows:
Graph size on disk: 256.691.161 bytes
Approximate OTP memory consumption after loading the graph from disk: 671 MB

After I made my changes, the sizes were reduced to:
Graph size on disk: 245.908.938 bytes
Approximate OTP memory consumption after loading the graph from disk: 654 MB

That implies a 2.6% reduction in memory usage and a 4.4% reduction in graph size on disk. Of course these numbers will be different for different OSM extracts, but I do not believe the graph size could increase under any realistic scenario.

This pull requests doesn't make any tests fail and there do not seem to be (nor should there be) any changes to OTP's functionality. While I was adapting the code to the changes I made, I removed some dead code in the process. I did not check whether the TurnRestriction removal code in StreetEdge's detachFrom() is really necessary or can be removed altogether.
