### PR TITLE
use URLDecoder.decode() to unescape test resource paths

### DIFF
--- a/src/test/java/org/opentripplanner/graph_builder/impl/osm/OpenStreetMapParserTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/impl/osm/OpenStreetMapParserTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.io.File;
 import java.util.zip.GZIPInputStream;
+import java.net.URLDecoder;
 
 import org.junit.Test;
 
@@ -42,7 +43,7 @@ public class OpenStreetMapParserTest {
     public void testAFBinaryParser() throws Exception {
         AnyFileBasedOpenStreetMapProviderImpl pr = new AnyFileBasedOpenStreetMapProviderImpl();
         OSMMap map = new OSMMap();
-        pr.setPath(new File(getClass().getResource("map.osm.pbf").getPath()));
+        pr.setPath(new File(URLDecoder.decode(getClass().getResource("map.osm.pbf").getPath(), "UTF-8")));
         pr.readOSM(map);
         testParser(map);
     }
@@ -51,7 +52,7 @@ public class OpenStreetMapParserTest {
     public void testAFXMLParser() throws Exception {
         AnyFileBasedOpenStreetMapProviderImpl pr = new AnyFileBasedOpenStreetMapProviderImpl();
         OSMMap map = new OSMMap();
-        pr.setPath(new File(getClass().getResource("map.osm.gz").getPath()));
+        pr.setPath(new File(URLDecoder.decode(getClass().getResource("map.osm.gz").getPath(), "UTF-8")));
         pr.readOSM(map);
         testParser(map);
     }
@@ -60,7 +61,7 @@ public class OpenStreetMapParserTest {
     public void testBinaryParser() throws Exception {
         BinaryFileBasedOpenStreetMapProviderImpl pr = new BinaryFileBasedOpenStreetMapProviderImpl();
         OSMMap map = new OSMMap();
-        pr.setPath(new File(getClass().getResource("map.osm.pbf").getPath()));
+        pr.setPath(new File(URLDecoder.decode(getClass().getResource("map.osm.pbf").getPath(), "UTF-8")));
         pr.readOSM(map);
         testParser(map);
     }
@@ -69,7 +70,7 @@ public class OpenStreetMapParserTest {
     public void testXMLParser() throws Exception {
         FileBasedOpenStreetMapProviderImpl pr = new FileBasedOpenStreetMapProviderImpl();
         OSMMap map = new OSMMap();
-        pr.setPath(new File(getClass().getResource("map.osm.gz").getPath()));
+        pr.setPath(new File(URLDecoder.decode(getClass().getResource("map.osm.gz").getPath(), "UTF-8")));
         pr.readOSM(map);
         testParser(map);
     }
@@ -78,7 +79,7 @@ public class OpenStreetMapParserTest {
     public void testStreamedXMLParser() throws Exception {
         StreamedFileBasedOpenStreetMapProviderImpl pr = new StreamedFileBasedOpenStreetMapProviderImpl();
         OSMMap map = new OSMMap();
-        pr.setPath(new File(getClass().getResource("map.osm.gz").getPath()));
+        pr.setPath(new File(URLDecoder.decode(getClass().getResource("map.osm.gz").getPath(), "UTF-8")));
         pr.readOSM(map);
         testParser(map);
     }

--- a/src/test/java/org/opentripplanner/graph_builder/impl/osm/TestOpenStreetMapGraphBuilder.java
+++ b/src/test/java/org/opentripplanner/graph_builder/impl/osm/TestOpenStreetMapGraphBuilder.java
@@ -17,6 +17,7 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
+import java.net.URLDecoder;
 
 import junit.framework.TestCase;
 
@@ -53,7 +54,7 @@ public class TestOpenStreetMapGraphBuilder extends TestCase {
         loader.setDefaultWayPropertySetSource(new DefaultWayPropertySetSource());
         FileBasedOpenStreetMapProviderImpl provider = new FileBasedOpenStreetMapProviderImpl();
 
-        File file = new File(getClass().getResource("map.osm.gz").getFile());
+        File file = new File(URLDecoder.decode(getClass().getResource("map.osm.gz").getFile(), "UTF-8"));
 
         provider.setPath(file);
         loader.setProvider(provider);
@@ -111,7 +112,7 @@ public class TestOpenStreetMapGraphBuilder extends TestCase {
         loader.setDefaultWayPropertySetSource(new DefaultWayPropertySetSource());
         FileBasedOpenStreetMapProviderImpl provider = new FileBasedOpenStreetMapProviderImpl();
 
-        File file = new File(getClass().getResource("NYC_small.osm.gz").getFile());
+        File file = new File(URLDecoder.decode(getClass().getResource("NYC_small.osm.gz").getFile(), "UTF-8"));
 
         provider.setPath(file);
         loader.setProvider(provider);

--- a/src/test/java/org/opentripplanner/graph_builder/impl/osm/TestUnroutable.java
+++ b/src/test/java/org/opentripplanner/graph_builder/impl/osm/TestUnroutable.java
@@ -29,6 +29,7 @@ import org.opentripplanner.routing.spt.ShortestPathTree;
 
 import java.io.File;
 import java.net.URL;
+import java.net.URLDecoder;
 import java.util.HashMap;
 
 /**
@@ -48,7 +49,7 @@ public class TestUnroutable extends TestCase {
         osmBuilder.setDefaultWayPropertySetSource(new DefaultWayPropertySetSource());
         AnyFileBasedOpenStreetMapProviderImpl provider = new AnyFileBasedOpenStreetMapProviderImpl();
         URL osmDataUrl = getClass().getResource("bridge_construction.osm.pbf");
-        File osmDataFile = new File(osmDataUrl.getFile());
+        File osmDataFile = new File(URLDecoder.decode(osmDataUrl.getFile(), "UTF-8"));
         provider.setPath(osmDataFile);
         osmBuilder.setProvider(provider);
         HashMap<Class<?>, Object> extra = Maps.newHashMap();

--- a/src/test/java/org/opentripplanner/graph_builder/impl/osm/TriangleInequalityTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/impl/osm/TriangleInequalityTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.*;
 
 import java.io.File;
 import java.util.HashMap;
+import java.net.URLDecoder;
 
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -47,7 +48,7 @@ public class TriangleInequalityTest {
     private Vertex end;
 
     @BeforeClass
-    public static void onlyOnce() {
+    public static void onlyOnce() throws Exception {
 
         extra = new HashMap<Class<?>, Object>();
         _graph = new Graph();
@@ -56,7 +57,7 @@ public class TriangleInequalityTest {
         loader.setDefaultWayPropertySetSource(new DefaultWayPropertySetSource());
         FileBasedOpenStreetMapProviderImpl provider = new FileBasedOpenStreetMapProviderImpl();
 
-        File file = new File(TriangleInequalityTest.class.getResource("NYC_small.osm.gz").getFile());
+        File file = new File(URLDecoder.decode(TriangleInequalityTest.class.getResource("NYC_small.osm.gz").getFile(), "UTF-8"));
 
         provider.setPath(file);
         loader.setProvider(provider);


### PR DESCRIPTION
This is a fix for the build error described [here](https://groups.google.com/forum/#!topic/opentripplanner-dev/Ys9s3bX9eMs) and [here](https://groups.google.com/forum/#!topic/opentripplanner-dev/WcvSXGvWp_E).

If the repository was installed on a path containing a folder with a space in the name, some test resources failed to open.

The fix is based on http://stackoverflow.com/questions/3263560/sysloader-getresource-problem-in-java.
