### PR TITLE
fix to handling of &fromName=[<name>::]<lat>,<lng>

### DIFF
--- a/src/client/js/otp/modules/planner/PlannerModule.js
+++ b/src/client/js/otp/modules/planner/PlannerModule.js
@@ -220,6 +220,8 @@ otp.modules.planner.PlannerModule =
             this.startMarker.on('dragend', $.proxy(function() {
                 this.webapp.hideSplash();
                 this.startLatLng = this.startMarker.getLatLng();
+                // start flag has beenpicked up, clear any name that was set  
+		this.startName=null;
                 this.invokeHandlers("startChanged", [this.startLatLng]);
                 if(typeof this.userPlanTripStart == 'function') this.userPlanTripStart();
                 this.planTripFunction.apply(this);//planTrip();
@@ -251,6 +253,8 @@ otp.modules.planner.PlannerModule =
             this.endMarker.on('dragend', $.proxy(function() {
                 this.webapp.hideSplash();
                 this.endLatLng = this.endMarker.getLatLng();
+                // end flag has beenpicked up, clear any name that was set  
+		this.endName=null;
                 this.invokeHandlers("endChanged", [this.endLatLng]);
                 if(typeof this.userPlanTripStart == 'function') this.userPlanTripStart();
                 this.planTripFunction.apply(this);//this_.planTrip();
@@ -288,10 +292,10 @@ otp.modules.planner.PlannerModule =
     
     restoreMarkers : function(queryParams) {
       	this.startLatLng = otp.util.Geo.stringToLatLng(otp.util.Itin.getLocationPlace(queryParams.fromPlace));
-    	this.setStartPoint(this.startLatLng, false);
+    	this.setStartPoint(this.startLatLng, false,this.startName);
     	
       	this.endLatLng = otp.util.Geo.stringToLatLng(otp.util.Itin.getLocationPlace(queryParams.toPlace));
-    	this.setEndPoint(this.endLatLng, false);
+    	this.setEndPoint(this.endLatLng, false,this.endName);
     },
     
     planTrip : function(existingQueryParams, apiMethod) {
@@ -611,10 +615,10 @@ otp.modules.planner.PlannerModule =
     restorePlan : function(data){
     	
     	this.startLatLng = new L.LatLng(data.startLat, data.startLon);
-    	this.setStartPoint(this.startLatLng, false);
+    	this.setStartPoint(this.startLatLng, false,this.startName);
     	
     	this.endLatLng = new L.LatLng(data.endLat, data.endLon);
-    	this.setEndPoint(this.endLatLng, false);
+    	this.setEndPoint(this.endLatLng, false,this.endName);
     	
     	this.webapp.setBounds(new L.LatLngBounds([this.startLatLng, this.endLatLng]));
     	

--- a/src/client/js/otp/util/Itin.js
+++ b/src/client/js/otp/util/Itin.js
@@ -45,7 +45,22 @@ otp.util.Itin = {
         return locationStr.indexOf("::") != -1 ? 
             locationStr.split("::")[0] : null;
     },
-    
+
+    /** 
+     * Extracts the "lat,lng" from an OTP "name::lat,lng" or just "lat,lng"  if "name::" not present
+     *
+     * @param {string} locationStr an OTP GenericLocation string
+     * @return {{lat,lng}} the "lat" and "lng" component of an OTP location string "[name::]lat,lng". returns null if not present 
+     */
+    getLocationLatLng : function(locationStr) {
+        var location = locationStr.indexOf("::") != -1 ? 
+            locationStr.split("::")[1] : locationStr;
+	if (locationStr.indexOf(",") == -1) return null;
+
+        var [lat,lng]=location.split(",");
+	return {lat:lat,lng:lng};
+    },
+
     /**
      * Extracts the unqualified mode from an OTP "mode_qualifier" string
      *

--- a/src/client/js/otp/widgets/tripoptions/TripOptionsWidget.js
+++ b/src/client/js/otp/widgets/tripoptions/TripOptionsWidget.js
@@ -268,7 +268,11 @@ otp.widgets.tripoptions.LocationsSelector =
         if(data.queryParams.fromPlace) {
             console.log("rP: "+data.queryParams.fromPlace);
             var fromName = otp.util.Itin.getLocationName(data.queryParams.fromPlace);
+            var fromPlace = otp.util.Itin.getLocationPlace(data.queryParams.fromPlace);
+            var fromLatLng = otp.util.Itin.getLocationLatLng(data.queryParams.fromPlace);
+
             if(fromName) {
+		this.tripWidget.module.setStartPoint(fromLatLng,true,fromName);
                 $("#"+this.id+"-start").val(fromName);
                 this.tripWidget.module.startName = fromName;
             }
@@ -280,6 +284,9 @@ otp.widgets.tripoptions.LocationsSelector =
         
         if(data.queryParams.toPlace) {
             var toName = otp.util.Itin.getLocationName(data.queryParams.toPlace);
+            var toPlace = otp.util.Itin.getLocationPlace(data.queryParams.toPlace);
+            var toLatLng = otp.util.Itin.getLocationLatLng(data.queryParams.toPlace);
+
             if(toName) {
                 $("#"+this.id+"-end").val(toName);
                 this.tripWidget.module.endName = toName;


### PR DESCRIPTION
see issue #1553
There may be a bug with this. Upon an initial startup of the page to a trip planner I havent used for a session or more, I sometimes get a complaint that the planner isnt avaiable. I beleive that it's due to an initial call to the planner being cancelled as a result of the from/to names being set in the dialog, but I cant get to the bottom of it and of course it always works on a reload.