### PR TITLE
Graph builder: Support DEM files in GeoTIFF format [master branch]

### DIFF
--- a/src/main/java/org/opentripplanner/standalone/OTPConfigurator.java
+++ b/src/main/java/org/opentripplanner/standalone/OTPConfigurator.java
@@ -181,7 +181,7 @@ public class OTPConfigurator {
             }
             OpenStreetMapGraphBuilderImpl osmBuilder = new OpenStreetMapGraphBuilderImpl(osmProviders);
             DefaultStreetEdgeFactory streetEdgeFactory = new DefaultStreetEdgeFactory();
-            streetEdgeFactory.useElevationData = params.elevation;
+            streetEdgeFactory.useElevationData = params.elevation || (demFile != null);
             osmBuilder.edgeFactory = streetEdgeFactory;
             DefaultWayPropertySetSource defaultWayPropertySetSource = new DefaultWayPropertySetSource();
             osmBuilder.setDefaultWayPropertySetSource(defaultWayPropertySetSource);


### PR DESCRIPTION
Detects a GeoTIFF file in the input data directory, and uses it as elevation data when building the graph.
The explicit --elevation command line parameter will take precedence over this default behavior.
