### PR TITLE
Fix #1605: shared nodes between areas causing hang.

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/impl/osm/OSMDatabase.java
+++ b/src/main/java/org/opentripplanner/graph_builder/impl/osm/OSMDatabase.java
@@ -362,9 +362,9 @@ public class OSMDatabase implements OpenStreetMapContentHandler {
 
         /*
          * Create a spatial index for each segment of area outer rings. Note: The spatial index is
-         * temporary and store only areas, so it should not take that much memory. Note 2: For common
-         * nodes shared by different ways of different areas we only add them once, otherwise we could
-         * end-up looping on creating new intersections.
+         * temporary and store only areas, so it should not take that much memory. Note 2: For
+         * common nodes shared by different ways of different areas we only add them once, otherwise
+         * we could end-up looping on creating new intersections.
          */
         Set<P2<Long>> commonSegments = new HashSet<P2<Long>>();
         HashGridSpatialIndex<RingSegment> spndx = new HashGridSpatialIndex<>();
@@ -410,6 +410,7 @@ public class OSMDatabase implements OpenStreetMapContentHandler {
                 LineString seg = GeometryUtils.makeLineString(nA.lon, nA.lat, nB.lon, nB.lat);
 
                 for (RingSegment ringSegment : ringSegments) {
+
                     // Skip if both segments share a common node
                     if (ringSegment.nA.getId() == nA.getId()
                             || ringSegment.nA.getId() == nB.getId()


### PR DESCRIPTION
This should fix #1605.

The issue was caused by an infinite loop on handling common nodes between different areas. The code restart the way intersection loop when a node have been created to handle the case where the same segment intersect two segment of a ring. For some P+R areas however, two distinct areas share a common segment (2 nodes shared on two distinct way), causing this loop. We solve the issue by only intersecting with unshared segments. This is safe as topogically if a segment is shared between 2 P+R areas that means that the segment is not part of the outer ring (except if two P+R areas are overlapping, but that should not happen). And even in that pathological case, the only risk is missing some intersections, which is not critical.

Performance-wise I could not test on the whole of the NL (not enough memory on my dev machine: 8GB is not enough), but on a 1x1 degree extract containing Amsterdam, build time is 3.6 minutes and handling unconnected areas takes 9 seconds.
