### PR TITLE
Clear timezone liberally during graph building, workaround for #1635.

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/impl/GtfsGraphBuilderImpl.java
+++ b/src/main/java/org/opentripplanner/graph_builder/impl/GtfsGraphBuilderImpl.java
@@ -120,6 +120,12 @@ public class GtfsGraphBuilderImpl implements GraphBuilder {
 
     @Override
     public void buildGraph(Graph graph, HashMap<Class<?>, Object> extra) {
+        // we're about to add another agency to the graph, so clear the cached timezone
+        // in case it should change
+        // OTP doesn't currently support multiple time zones in a single graph;
+        // at least this way we catch the error and log it instead of silently ignoring
+        // because the time zone from the first agency is cached
+        graph.clearTimeZone();
 
         MultiCalendarServiceImpl service = new MultiCalendarServiceImpl();
         GtfsStopContext stopContext = new GtfsStopContext();

--- a/src/main/java/org/opentripplanner/graph_builder/impl/osm/OpenStreetMapGraphBuilderImpl.java
+++ b/src/main/java/org/opentripplanner/graph_builder/impl/osm/OpenStreetMapGraphBuilderImpl.java
@@ -416,6 +416,11 @@ public class OpenStreetMapGraphBuilderImpl implements GraphBuilder {
             for (AreaGroup group : areaGroups) {
                 walkableAreaBuilder.build(group);
             }
+            
+            // running a request caches the timezone; we need to clear it now so that when agencies are loaded
+            // the graph time zone is set to the agency time zone.
+            graph.clearTimeZone();
+            
             LOG.info("Done building visibility graphs for walkable areas.");
         }
 

--- a/src/main/java/org/opentripplanner/routing/graph/Graph.java
+++ b/src/main/java/org/opentripplanner/routing/graph/Graph.java
@@ -855,7 +855,7 @@ public class Graph implements Serializable {
             Collection<String> agencyIds = this.getAgencyIds();
             if (agencyIds.size() == 0) {
                 timeZone = TimeZone.getTimeZone("GMT");
-                LOG.warn("graph contains no agencies; API request times will be interpreted as GMT.");
+                LOG.warn("graph contains no agencies (yet); API request times will be interpreted as GMT.");
             } else {
                 CalendarService cs = this.getCalendarService();
                 for (String agencyId : agencyIds) {
@@ -870,6 +870,14 @@ public class Graph implements Serializable {
             }
         }
         return timeZone;
+    }
+    
+    /**
+     * The timezone is cached by the graph. If you've done something to the graph that has the
+     * potential to change the time zone, you should call this to ensure it is reset. 
+     */
+    public void clearTimeZone () {
+        this.timeZone = null;
     }
 
     public void summarizeBuilderAnnotations() {


### PR DESCRIPTION
Clear the timezone after building walkable areas. Also clear before adding an agency, so agencies with noncompliant timezones are detected by getTimeZone.
