### PR TITLE
adapt client to new Index API

### DIFF
--- a/src/client/index.html
+++ b/src/client/index.html
@@ -11,7 +11,7 @@
 <!--  Mobile Viewport Fix -->
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-  
+
 <!-- Google WebFonts -->
 <link href='http://fonts.googleapis.com/css?family=Dancing+Script:700' rel='stylesheet' type='text/css'>
 
@@ -96,6 +96,7 @@
 <script src="js/otp/core/GeocoderBuiltin.js?v=1"></script>
 <script src="js/otp/core/SOLRGeocoder.js?v=1"></script>
 <script src="js/otp/core/TransitIndex.js?v=1"></script>
+<script src="js/otp/core/IndexApi.js?v=1"></script>
 <script src="js/otp/core/TrinetSessionManager.js?v=1"></script>
 
 <script src="js/otp/widgets/Widget.js?v=1"></script>
@@ -199,12 +200,12 @@ $(document).ready(function() {
             $('<div style="display:none;"></div>').appendTo($("body")).html(html);
             loadedTemplates++;
             if(loadedTemplates == templateUrls.length) {
-                ich.grabTemplates();                   
+                ich.grabTemplates();
                 new otp.core.Webapp();
             }
         });
     }
-        
+
 });
 
 
@@ -215,7 +216,7 @@ $(document).ready(function() {
 <body>
 
 <header id="branding" role="banner" class="clearfix">
-  
+
   <!--<hgroup id="logo">
     <div class="ribbon">
       <h1 id="site-title"><span><a href="/" title="cibi.me" rel="home">cibi.me</a></span></h1>
@@ -227,7 +228,7 @@ $(document).ready(function() {
 
  <!--
   <div class="search">
-    
+
     <input type="text" name="location_search" placeholder="Search for a location&hellip;" />
   </div>
  -->

--- a/src/client/js/otp/core/IndexApi.js
+++ b/src/client/js/otp/core/IndexApi.js
@@ -1,0 +1,283 @@
+/* This program is free software: you can redistribute it and/or
+   modify it under the teMap.jsrms of the GNU Lesser General Public License
+   as published by the Free Software Foundation, either version 3 of
+   the License, or (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+otp.namespace("otp.core");
+
+otp.core.IndexApi = otp.Class({
+
+    webapp          : null,
+
+    agencies        : null,
+    routes          : null,
+
+    initialize : function(webapp) {
+        this.webapp = webapp;
+    },
+
+    loadAgencies : function(callbackTarget, callback) {
+        var this_ = this;
+        if(this.agencies) {
+            if(callback) callback.call(callbackTarget);
+            return;
+        }
+
+        var url = otp.config.hostname + '/' + otp.config.restService + '/index/agencies';
+        $.ajax(url, {
+            //dataType:   'jsonp', //defaults to "Intelligent Guess" jQuery will try to infer it based on the MIME type of the response
+            /* no parameter to send...
+            data: {
+                extended: 'true',
+            },
+            */
+            success: function(data) {
+                this_.agencies = {};
+
+                for(var i=0; i<data.length; i++) {
+                    var agencyData = data[i];
+                    this_.agencies[agencyData.id] = {
+                        index : i,
+                        agencyData : agencyData,
+                    };
+                }
+
+                if(callback) callback.call(callbackTarget);
+            }
+        });
+    },
+
+    loadRoutes : function(callbackTarget, callback) {
+        var this_ = this;
+        if(this.routes) {
+            if(callback) callback.call(callbackTarget);
+            return;
+        }
+
+        var url = otp.config.hostname + '/' + otp.config.restService + '/index/routes';
+        $.ajax(url, {
+            /*dataType:   'jsonp',
+
+            data: {
+                extended: 'true',
+            },
+*/
+            success: function(data) {
+                if(_.isEmpty(data)) {
+                    console.log("Error: routes call returned no route data. OTP Message: "+data.message);
+                    return;
+                }
+                var sortedRoutes = data;
+                sortedRoutes.sort(function(a,b) {
+                    a = a.shortName || a.longName;
+                    b = b.shortName || b.longName;
+                    if(otp.util.Text.isNumber(a) && otp.util.Text.isNumber(b)) {
+                        if(parseFloat(a) < parseFloat(b)) return -1;
+                        if(parseFloat(a) > parseFloat(b)) return 1;
+                        return 0;
+                    }
+                    if(a < b) return -1;
+                    if(a > b) return 1;
+                    return 0;
+                });
+
+                var routes = { };
+                for(var i=0; i<sortedRoutes.length; i++) {
+                    var routeData = sortedRoutes[i];
+                    var agencyAndId = routeData.id;//.agencyId+"_"+routeData.id.id;
+                    routes[agencyAndId] = {
+                        index : i,
+                        routeData : routeData,
+                        variants : null
+                    };
+                }
+                this_.routes = routes;
+                if(callback) callback.call(callbackTarget);
+            }
+        });
+    },
+
+    loadVariants : function(agencyAndId, callbackTarget, callback) {
+        var this_ = this;
+        //console.log("loadVariants: "+agencyAndId);
+        var route = this.routes[agencyAndId];
+        if(route.variants) {
+            if(callback) callback.call(callbackTarget, route.variants);
+            return;
+        }
+
+        var url = otp.config.hostname + '/' + otp.config.restService + '/transit/routeData';
+        $.ajax(url, {
+            data: {
+                agency : route.routeData.id.agencyId,
+                id : route.routeData.id.id
+
+            },
+            dataType:   'jsonp',
+
+            success: function(data) {
+                //console.log(data);
+                route.variants = {};
+                for(var i=0; i<data.routeData[0].variants.length; i++) {
+                    route.variants[data.routeData[0].variants[i].name] = data.routeData[0].variants[i];
+                    data.routeData[0].variants[i].index = i;
+                }
+                if(callback && callbackTarget) {
+                    callback.call(callbackTarget, route.variants);
+                }
+            }
+        });
+
+    },
+
+    readVariantForTrip : function(tripAgency, tripId, callbackTarget, callback) {
+
+        var url = otp.config.hostname + '/' + otp.config.restService + '/transit/variantForTrip';
+        $.ajax(url, {
+            data: {
+                tripAgency : tripAgency,
+                tripId : tripId
+            },
+            dataType:   'jsonp',
+
+            success: function(data) {
+                //console.log("vFT result:");
+                //console.log(data);
+                callback.call(callbackTarget, data);
+            }
+        });
+
+        /*var route = this.routes[agencyAndId];
+        console.log("looking for trip "+tripId+" in "+agencyAndId);
+
+        if(!route.variants) {
+            console.log("ERROR: transitIndex.routes.["+agencyAndId+"].variants null in TransitIndex.getVariantForTrip()");
+            return;
+        }
+
+        for(var vi=0; vi<route.variants.length; vi++) {
+            var variant = route.variants[vi];
+            console.log("searching variant "+vi);
+            //console.log(variant);
+            for(var ti=0; ti<variant.trips.length; ti++) {
+                var trip = variant.trips[ti];
+                console.log(" - "+trip.id)
+                if(trip.id == tripId) return variant;
+            }
+        }
+
+        console.log("cound not find trip "+tripId);
+        return null;*/
+    },
+
+
+    runStopTimesQuery : function(agencyId, stopId, startTime, endTime, callbackTarget, callback) {
+
+        if(otp.config.useLegacyMillisecondsApi) {
+            startTime *= 1000;
+            endTime *= 1000;
+        }
+
+        var params = {
+            agency: agencyId,
+            id: stopId,
+            startTime : startTime, //new TransitIndex API uses seconds
+            endTime : endTime, // new TransitIndex API uses seconds
+            extended : true,
+        };
+        if(otp.config.routerId !== undefined) {
+            params.routerId = otp.config.routerId;
+        }
+
+        var url = otp.config.hostname + '/' + otp.config.restService + '/transit/stopTimesForStop';
+        $.ajax(url, {
+            data:       params,
+            dataType:   'jsonp',
+
+            success: function(data) {
+                callback.call(callbackTarget, data);
+            }
+        });
+    },
+
+    loadStopsInRectangle : function(agencyId, bounds, callbackTarget, callback) {
+        var params = {
+            leftUpLat : bounds.getNorthWest().lat,
+            leftUpLon : bounds.getNorthWest().lng,
+            rightDownLat : bounds.getSouthEast().lat,
+            rightDownLon : bounds.getSouthEast().lng,
+            extended : true
+        };
+        if(agencyId !== null) {
+            params.agency = agencyId;
+        }
+        if(typeof otp.config.routerId !== 'undefined') {
+            params.routerId = otp.config.routerId;
+        }
+
+        var url = otp.config.hostname + '/' + otp.config.restService + '/transit/stopsInRectangle';
+        $.ajax(url, {
+            data:       params,
+            dataType:   'jsonp',
+
+            success: function(data) {
+                callback.call(callbackTarget, data);
+            }
+        });
+    },
+
+    loadStopsById : function(agencyId, id, callbackTarget, callback) {
+        var params = {
+            id : id,
+            extended : true
+        };
+        if(agencyId !== null) {
+            params.agency = agencyId;
+        }
+        if(typeof otp.config.routerId !== 'undefined') {
+            params.routerId = otp.config.routerId;
+        }
+
+        var url = otp.config.hostname + '/' + otp.config.restService + '/transit/stopData';
+        $.ajax(url, {
+            data:       params,
+            dataType:   'jsonp',
+
+            success: function(data) {
+                callback.call(callbackTarget, data);
+            }
+        });
+    },
+
+    loadStopsByName : function(agencyId, name, callbackTarget, callback) {
+        var params = {
+            name: name,
+            extended : true
+        };
+        if(agencyId !== null) {
+            params.agency = agencyId;
+        }
+        if(typeof otp.config.routerId !== 'undefined') {
+            params.routerId = otp.config.routerId;
+        }
+
+        var url = otp.config.hostname + '/' + otp.config.restService + '/transit/stopsByName';
+        $.ajax(url, {
+            data:       params,
+            dataType:   'jsonp',
+
+            success: function(data) {
+                callback.call(callbackTarget, data);
+            }
+        });
+    },
+});

--- a/src/client/js/otp/core/IndexApi.js
+++ b/src/client/js/otp/core/IndexApi.js
@@ -34,12 +34,6 @@ otp.core.IndexApi = otp.Class({
 
         var url = otp.config.hostname + '/' + otp.config.restService + '/index/agencies';
         $.ajax(url, {
-            //dataType:   'jsonp', //defaults to "Intelligent Guess" jQuery will try to infer it based on the MIME type of the response
-            /* no parameter to send...
-            data: {
-                extended: 'true',
-            },
-            */
             success: function(data) {
                 this_.agencies = {};
 
@@ -65,12 +59,6 @@ otp.core.IndexApi = otp.Class({
 
         var url = otp.config.hostname + '/' + otp.config.restService + '/index/routes';
         $.ajax(url, {
-            /*dataType:   'jsonp',
-
-            data: {
-                extended: 'true',
-            },
-*/
             success: function(data) {
                 if(_.isEmpty(data)) {
                     console.log("Error: routes call returned no route data. OTP Message: "+data.message);
@@ -93,7 +81,7 @@ otp.core.IndexApi = otp.Class({
                 var routes = { };
                 for(var i=0; i<sortedRoutes.length; i++) {
                     var routeData = sortedRoutes[i];
-                    var agencyAndId = routeData.id;//.agencyId+"_"+routeData.id.id;
+                    var agencyAndId = routeData.id;
                     routes[agencyAndId] = {
                         index : i,
                         routeData : routeData,
@@ -186,15 +174,14 @@ otp.core.IndexApi = otp.Class({
             startTime : startTime,
             endTime : endTime,
             extended : true,
-        }; */
+        };
         if(otp.config.routerId !== undefined) {
             params.routerId = otp.config.routerId;
         }
-
+        */
         var url = otp.config.hostname + '/' + otp.config.restService + '/index/stops/' +stopId +'/stoptimes';
         $.ajax(url, {
             //data:       params,
-            //dataType:   'jsonp',
 
             success: function(data) {
                 callback.call(callbackTarget, data);

--- a/src/client/js/otp/core/IndexApi.js
+++ b/src/client/js/otp/core/IndexApi.js
@@ -151,7 +151,7 @@ otp.core.IndexApi = otp.Class({
         var variantData = {};
         // since the new index api does not provide variant/pattern for trip (yet)
         // we have to iterate on route's patterns searching for the current trip.
-        _.each(route.variants,function(pattern) {
+        _.each(route.variants, function(pattern) {
             var tripIds = _.pluck(pattern.trips, 'id');
             if (_.contains(tripIds, agency_Tripid)) {
                 variantData = pattern;
@@ -179,7 +179,7 @@ otp.core.IndexApi = otp.Class({
             params.routerId = otp.config.routerId;
         }
         */
-        var url = otp.config.hostname + '/' + otp.config.restService + '/index/stops/' +stopId +'/stoptimes';
+        var url = otp.config.hostname + '/' + otp.config.restService + '/index/stops/' + stopId + '/stoptimes';
         $.ajax(url, {
             //data:       params,
 
@@ -201,6 +201,16 @@ otp.core.IndexApi = otp.Class({
         $.ajax(url, {
             data:       params,
 
+            success: function(data) {
+                callback.call(callbackTarget, data);
+            }
+        });
+    },
+
+    loadRoutesForStop : function(agencyId, callbackTarget, callback) {
+
+        var url = otp.config.hostname + '/' + otp.config.restService + '/index/stops/' + agencyId + '/routes';
+        $.ajax(url, {
             success: function(data) {
                 callback.call(callbackTarget, data);
             }

--- a/src/client/js/otp/core/Webapp.js
+++ b/src/client/js/otp/core/Webapp.js
@@ -2,14 +2,14 @@
    modify it under the terms of the GNU Lesser General Public License
    as published by the Free Software Foundation, either version 3 of
    the License, or (at your option) any later version.
-   
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-   
+
    You should have received a copy of the GNU General Public License
-   along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 otp.namespace("otp.core");
@@ -17,30 +17,30 @@ otp.namespace("otp.core");
 otp.core.Webapp = otp.Class({
 
     map     : null,
-    
+
     modules : [ ],
     moduleMenu : null,
-    
+
     activeModule : null,
-    
+
     widgetManager   : null,
     infoWidgets     : { },
 
     geocoders : [ ],
-    
-    transitIndex : null,
-    
+
+    indexApi : null,
+
     urlParams : null,
 
     initialize : function() {
 
 
         // misc. housekeeping
-        
+
         if(typeof console == 'undefined') console = { log: function(str) {} };
         $.support.cors = true;
         var this_ = this;
-        
+
         otp.config.resourcePath = otp.config.resourcePath || "";
 
 
@@ -64,14 +64,14 @@ otp.core.Webapp = otp.Class({
 
         while (match = search.exec(query))
             this.urlParams[decode(match[1])] = decode(match[2]);
-            
-        
+
+
         // init siteUrl, if necessary
-        
+
         if(typeof otp.config.siteUrl === 'undefined') {
             otp.config.siteUrl = window.location.protocol + '//' + window.location.host + window.location.pathname;
         }
-            
+
         // Set Debug options
         if (this.urlParams.debug === 'false') {
             otp.debug.disable();
@@ -94,10 +94,10 @@ otp.core.Webapp = otp.Class({
 
 
         // set the logo & title
-        
+
         if(otp.config.showLogo) {
           //$('<div id="logo"><a href="'+otp.config.siteURL+'"><img src="'+otp.config.logoGraphic+'" style="height:100%"></a></div>').appendTo('#branding');
-            $(Mustache.render(otp.templates.img, { 
+            $(Mustache.render(otp.templates.img, {
                 src : otp.config.logoGraphic,
                 style : 'height:100%',
                 wrapLink : true,
@@ -112,39 +112,39 @@ otp.core.Webapp = otp.Class({
             .appendTo('#branding');          */
 
         }
-        
+
         if(otp.config.siteName !== undefined) {
             document.title = otp.config.siteName;
             if(otp.config.showTitle) {
                 $("<div id='site-title'><a href='"+otp.config.siteURL+"'>"+otp.config.siteName+"</a></div>").appendTo('#branding');
             }
         }
-        
+
         // create the Webapp-owned objects
-        
-        this.map = new otp.core.Map(this);        
-        this.transitIndex = new otp.core.TransitIndex(this);
+
+        this.map = new otp.core.Map(this);
+        this.indexApi = new otp.core.IndexApi(this);
         this.widgetManager = new otp.widgets.WidgetManager();
-        
-        
+
+
         if(otp.config.geocoders) {
             for(var i=0; i<otp.config.geocoders.length; i++) {
                 var gcConfig = otp.config.geocoders[i];
                 console.log('init geocoder: '+gcConfig.name);
                 //var geocoder = window[gcConfig.classname](gcConfig.url, gcConfig.addressParam);
-                
+
                 var gcClass = this.stringToFunction(gcConfig.className);
                 var geocoder = new gcClass(gcConfig.url, gcConfig.addressParam);
                 geocoder.name = gcConfig.name;
                 //console.log(geocoder);
-                
+
                 this.geocoders.push(geocoder);
                 //var geocoder = new otp.core.Geocoder(otp.config.geocoder.url, otp.config.geocoder.addressParam);
             }
         }
-       
+
         // initialize the AddThis widget
-        
+
         if(otp.config.showAddThis) {
             var addThisHtml = '<div id="addthis" class="addthis_toolbox addthis_default_style"\n';
             addThisHtml += 'addthis:url="'+otp.config.siteURL+'"\n';
@@ -157,18 +157,18 @@ otp.core.Webapp = otp.Class({
             addThisHtml += '<a class="addthis_button_compact"></a>\n';
             addThisHtml += '<a class="addthis_counter addthis_bubble_style"></a>\n';
             addThisHtml += '</div>';
-            
+
             $(addThisHtml).appendTo('#branding');
-            
+
             addthis_config = {
 		         pubid: otp.config.addThisPubId,
 		         data_track_clickback: false
 		    };
 		    $.getScript("http://s7.addthis.com/js/250/addthis_widget.js#pubid="+otp.config.addThisPubId);
-        }		
-        
+        }
+
         // create the widget manager menu & icon
-        
+
         this.widgetManagerMenu = new otp.core.WidgetManagerMenu(this);
 
         var widgetManagerIcon = $('<div id="otp-widgetManager"></div>')
@@ -176,20 +176,20 @@ otp.core.Webapp = otp.Class({
         .click(function(event) {
             this_.widgetManagerMenu.show(); // showWidgetManagerMenu();
         });
-        
-        
+
+
         // create the info widgets and links along header bar
-        
+
         if(otp.config.infoWidgets !== undefined && otp.config.infoWidgets.length > 0) {
             var nav = $('<nav id="main-menu" role="article">').appendTo('#branding');
             var ul = $('<ul>').appendTo(nav);
-            
+
             for(var i=0; i<otp.config.infoWidgets.length; i++) {
-            
+
                 if(otp.config.infoWidgets[i] == undefined) continue;
-    
-                var id = "otp-infoWidget-"+i;            
-                
+
+                var id = "otp-infoWidget-"+i;
+
                 var options = {};
                 if(_.has(otp.config.infoWidgets[i], 'title')) options.title = otp.config.infoWidgets[i].title;
                 if(_.has(otp.config.infoWidgets[i], 'cssClass')) options.cssClass = otp.config.infoWidgets[i].cssClass;
@@ -198,35 +198,35 @@ otp.core.Webapp = otp.Class({
                    options.content = otp.config.languageChooser();
                    otp.config.infoWidgets[i].content = options.content;
                 }
-                
+
                 this.infoWidgets[id] = new otp.widgets.InfoWidget(otp.config.infoWidgets[i].styleId,
                                                                   this, options, otp.config.infoWidgets[i].content);
-                
+
                 $("<li id='"+id+"'><a href='#'>"+otp.config.infoWidgets[i].title+"</a></li>").appendTo(ul).click(function(e) {
                     e.preventDefault();
                     var widget = this_.infoWidgets[this.id];
                     if(!widget.isOpen) widget.show();
                     widget.bringToFront();
                 });
-            
+
             }
         }
 
 
 
         // create the module selector
-        
+
         if(otp.config.showModuleSelector && otp.config.modules.length > 1) {
 
             var selector = $('<select id="otp_moduleSelector"></select>').appendTo('#branding');
             selector.change(function() {
                 this_.setActiveModule(this_.modules[this.selectedIndex]);
             });
-                       
+
         }
 
-        // initialize the modules 
-        
+        // initialize the modules
+
         var authModules = [];
         if(this.urlParams['module'])
             console.log("startup module: "+this.urlParams['module'])
@@ -236,11 +236,11 @@ otp.core.Webapp = otp.Class({
                 var modConfig = otp.config.modules[i];
                 var modClass = this.stringToFunction(modConfig.className);
                 var id =  modConfig.id || 'module'+i;
-                var options = modConfig.options || {}; 
+                var options = modConfig.options || {};
                 var module = new modClass(this, id, options);
                 module.config = modConfig;
                 if(modConfig.defaultBaseLayer) module.defaultBaseLayer = modConfig.defaultBaseLayer;
-                
+
                 if(module.requiresAuth) {
                     authModules.push(module);
                     continue;
@@ -257,13 +257,13 @@ otp.core.Webapp = otp.Class({
             }
             if(!defaultModule) defaultModule = this.modules[0];
             if(defaultModule) this_.setActiveModule(defaultModule);
-        }                
+        }
 
 
 
         // create the session manager, if needed
         if(authModules.length > 0) {
-            
+
             var verifyLoginUrl, redirectUrl;
             for(var i = 0; i < authModules.length; i++) {
                 var authModule = authModules[i];
@@ -288,26 +288,26 @@ otp.core.Webapp = otp.Class({
                             setActive = true;
                         }
                     }
-                } 
-            }, this));            
+                }
+            }, this));
         }
 
 
         // add the spinner
-        
+
         $(Mustache.render(otp.templates.img, {
             src: 'images/spinner.gif',
             wrapDiv: true,
             divId: 'otp-spinner'
         }));
-                
+
         // retrieve a saved trip, if applicable
 		//if(window.location.hash !== "")
 		//	otp.util.DataStorage.retrieve(window.location.hash.replace("#", ""), this.activeModule);
-			
-		
+
+
     },
-    
+
     addModule : function(module) {
         makeActive = typeof makeActive !== 'undefined' ? makeActive : false;
         this.modules.push(module);
@@ -316,30 +316,30 @@ otp.core.Webapp = otp.Class({
         var selector = $('#otp_moduleSelector');
         $('<option>'+module.moduleName+'</option>').appendTo(selector);
     },
-    
-    loadedTemplates: {}, 
+
+    loadedTemplates: {},
 
     setActiveModule : function(module) {
         var this_ = this;
         //console.log("set active module: "+module.moduleName);
         if(this.activeModule != null) {
             this.activeModule.deselected();
-            
+
             for(var i = 0; i < this.activeModule.widgets.length; i++) {
                 this.activeModule.widgets[i].hide();
             }
         }
-        
+
         $('#otp_toptitle').html(module.moduleName);
-        
+
         for(var i = 0; i < module.widgets.length; i++) {
             if(module.widgets[i].isOpen) {
                 console.log(" - showing widget: "+module.widgets[i].id);
                 module.widgets[i].show();
             }
-        }        
-        
-        if(!module.activated) {        
+        }
+
+        if(!module.activated) {
             if(module.templateFiles && module.templateFiles.length > 0) {
                 var loadedTemplateCount = 0;
                 for(var i = 0; i < module.templateFiles.length; i++) {
@@ -362,64 +362,64 @@ otp.core.Webapp = otp.Class({
             }
             else {
                 this.activateModule(module);
-            }         
+            }
         }
         else {
             this.moduleSelected(module);
         }
 
     },
-    
+
     activateModule : function(module) {
         module.activate();
         if(_.has(this.urlParams, 'module') && this.urlParams.module == module.id) module.restore();
         this.moduleSelected(module);
         module.activated = true;
     },
-    
+
     moduleSelected : function(module) {
         module.selected();
-        this.map.activeModuleChanged(this.activeModule, module);    
+        this.map.activeModuleChanged(this.activeModule, module);
         this.activeModule = module;
         var moduleIndex = this.modules.indexOf(this.activeModule);
         $('#otp_moduleSelector option:eq('+moduleIndex+')').prop('selected', true);
     },
-          
-          
+
+
     hideSplash : function() {
     	$("#splash-text").hide();
     	for(widgetId in this.infoWidgets) {
         	this.infoWidgets[widgetId].hide();
     	}
     },
-        
+
     setBounds : function(bounds)
     {
     	this.map.lmap.fitBounds(bounds);
     },
-        
-   
+
+
     mapClicked : function(event) {
         $(this.moduleMenu).hide();
         this.hideSplash();
         this.activeModule.handleClick(event);
     },
-    
+
     mapBoundsChanged : function(event) {
         if(this.activeModule) this.activeModule.mapBoundsChanged(event);
     },
-    
+
     addWidget : function(widget) {
         //this.widgets.push(widget);
         this.widgetManager.addWidget(widget);
     },
-    
+
     getWidgetManager : function() {
         return this.widgetManager;
     },
-    
+
     // TODO: move to Util library
-    
+
     stringToFunction : function(str) {
         var arr = str.split(".");
 
@@ -437,4 +437,3 @@ otp.core.Webapp = otp.Class({
 
     CLASS_NAME : "otp.core.Webapp"
 });
-

--- a/src/client/js/otp/layers/StopsLayer.js
+++ b/src/client/js/otp/layers/StopsLayer.js
@@ -2,14 +2,14 @@
    modify it under the terms of the GNU Lesser General Public License
    as published by the Free Software Foundation, either version 3 of
    the License, or (at your option) any later version.
-   
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-   
+
    You should have received a copy of the GNU General Public License
-   along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 otp.namespace("otp.layers");
@@ -24,38 +24,38 @@ var StopIcon20 = L.Icon.extend({
     }
 });
 
-otp.layers.StopsLayer = 
+otp.layers.StopsLayer =
     otp.Class(L.LayerGroup, {
-   
+
     module : null,
-    
+
     minimumZoomForStops : 15,
-    
+
     initialize : function(module) {
         L.LayerGroup.prototype.initialize.apply(this);
         this.module = module;
 
         this.stopsLookup = {};
-        
+
         this.module.addLayer("stops", this);
         this.module.webapp.map.lmap.on('dragend zoomend', $.proxy(this.refresh, this));
     },
-    
+
     refresh : function() {
-        this.clearLayers();                
+        this.clearLayers();
         var lmap = this.module.webapp.map.lmap;
         if(lmap.getZoom() >= this.minimumZoomForStops) {
-            this.module.webapp.transitIndex.loadStopsInRectangle(null, lmap.getBounds(), this, function(data) {
+            this.module.webapp.indexApi.loadStopsInRectangle(null, lmap.getBounds(), this, function(data) {
                 this.stopsLookup = {};
-                for(var i = 0; i < data.stops.length; i++) {
-                    var agencyAndId = data.stops[i].id.agencyId + "_" + data.stops[i].id.id;
-                    this.stopsLookup[agencyAndId] = data.stops[i];
+                for(var i = 0; i < data.length; i++) {
+                    var agencyAndId = data[i].id;
+                    this.stopsLookup[agencyAndId] = data[i];
                 }
                 this.updateStops();
             });
         }
     },
-    
+
     updateStops : function(stops) {
         var stops = _.values(this.stopsLookup);
         var this_ = this;
@@ -67,7 +67,7 @@ otp.layers.StopsLayer =
         //TRANSLATORS: Plan Trip [From Stop| To Stop] Used in stoplayer popup
         var to_stop_trans = _tr('To Stop');
         var routes_stop_trans = _tr('Routes Serving Stop');
-        
+
         for(var i=0; i<stops.length; i++) {
 
             var stop = stops[i];
@@ -79,9 +79,9 @@ otp.layers.StopsLayer =
                 stop.titleLink = 'http://www.trimet.org/go/cgi-bin/cstops.pl?action=entry&resptype=U&lang=en&noCat=Landmark&Loc=' + stop.id.id;
             }
             //console.log(stop);
-            
+
             var icon = new StopIcon20();
-            
+
             var context = _.clone(stop);
             context.agencyStopLinkText = otp.config.agencyStopLinkText || "Agency Stop URL";
             context.stop_viewer = stop_viewer_trans;
@@ -95,10 +95,10 @@ otp.layers.StopsLayer =
                 var thisStop = $(this).data('stop');
                 this_.module.stopViewerWidget.show();
                 this_.module.stopViewerWidget.setActiveTime(moment().add("hours", -otp.config.timeOffset).unix()*1000);
-                this_.module.stopViewerWidget.setStop(thisStop.id.agencyId, thisStop.id.id, thisStop.stopName);
+                this_.module.stopViewerWidget.setStop(thisStop.id, thisStop.name);
                 this_.module.stopViewerWidget.bringToFront();
             });
-            
+
             popupContent.find('.planFromLink').data('stop', stop).click(function() {
                 var thisStop = $(this).data('stop');
                 this_.module.setStartPoint(new L.LatLng(thisStop.lat, thisStop.lon), false, thisStop.stopName);
@@ -121,12 +121,12 @@ otp.layers.StopsLayer =
                     //routeList.append('<div>'+agencyAndId+'</div>');
                 }
             }
-                    
+
             L.marker([stop.lat, stop.lon], {
                 icon : icon,
             }).addTo(this)
             .bindPopup(popupContent.get(0));
-            
+
         }
     },
 });

--- a/src/client/js/otp/layers/StopsLayer.js
+++ b/src/client/js/otp/layers/StopsLayer.js
@@ -32,6 +32,7 @@ otp.layers.StopsLayer =
     minimumZoomForStops : 15,
 
     initialize : function(module) {
+        var this_ = this;
         L.LayerGroup.prototype.initialize.apply(this);
         this.module = module;
 
@@ -39,6 +40,13 @@ otp.layers.StopsLayer =
 
         this.module.addLayer("stops", this);
         this.module.webapp.map.lmap.on('dragend zoomend', $.proxy(this.refresh, this));
+        this.module.webapp.map.lmap.on('popupopen', function (e) {
+            this_.module.webapp.indexApi.loadRoutesForStop(e.popup._source._stopId, this_, function(data) {
+                _.each(data, function(route) {
+                    ich['otp-stopsLayer-popupRoute'](route).appendTo($('.routeList'));
+                });
+            });
+        });
     },
 
     refresh : function() {
@@ -110,22 +118,24 @@ otp.layers.StopsLayer =
                 this_.module.setEndPoint(new L.LatLng(thisStop.lat, thisStop.lon), false, thisStop.stopName);
                 this_.module.webapp.map.lmap.closePopup();
             });
-
+            /*
             if(stop.routes) {
                 var routeList = popupContent.find('.routeList');
                 for(var r = 0; r < stop.routes.length; r++) {
                     var agencyAndId = stop.routes[r].agencyId + '_' + stop.routes[r].id;
-                    var routeData = this.module.webapp.transitIndex.routes[agencyAndId].routeData;
+                    //var routeData = this.module.webapp.indexApi.routes[agencyAndId].routeData;
                     ich['otp-stopsLayer-popupRoute'](routeData).appendTo(routeList);
                     // TODO: click opens RouteViewer
                     //routeList.append('<div>'+agencyAndId+'</div>');
                 }
             }
-
-            L.marker([stop.lat, stop.lon], {
+            */
+            m = L.marker([stop.lat, stop.lon], {
                 icon : icon,
-            }).addTo(this)
-            .bindPopup(popupContent.get(0));
+            });
+            m._stopId = stop.id;
+            m.addTo(this)
+             .bindPopup(popupContent.get(0));
 
         }
     },

--- a/src/client/js/otp/layers/layers-templates.html
+++ b/src/client/js/otp/layers/layers-templates.html
@@ -3,10 +3,12 @@
     <div>
         <div style="font-weight: bold; font-size: 16px;">
             {{#titleLink}}<a href="{{titleLink}}" target="_blank">{{/titleLink}}
-            {{stopName}}
+            {{name}}
             {{#titleLink}}</a>{{/titleLink}}
         </div>
+        <!-- to be provided by index api
         <div style="font-style: italic; font-size: 11px;">{{stopDesc}}</div>
+        -->
         <div style="font-size: 10px;">
             [
 			<a href="#" class="stopViewerLink">{{stop_viewer}}</a>
@@ -16,11 +18,12 @@
             ]
         </div>
 		<div style="margin-top: 6px;"><b>{{plan_trip}}</b>: [ <a href="#" class="planFromLink">{{from_stop}}</a> | <a href="#" class="planToLink">{{to_stop}}</a> ]</div>
-        
+        <!--  TODO: new index api will expose routeList
         <div style="margin-top: 6px;" >
 			<b>{{routes_on_stop}}</b>:
             <ul class="routeList"/>
         </div>
+        -->
     </div>
 </script>
 

--- a/src/client/js/otp/layers/layers-templates.html
+++ b/src/client/js/otp/layers/layers-templates.html
@@ -18,20 +18,18 @@
             ]
         </div>
 		<div style="margin-top: 6px;"><b>{{plan_trip}}</b>: [ <a href="#" class="planFromLink">{{from_stop}}</a> | <a href="#" class="planToLink">{{to_stop}}</a> ]</div>
-        <!--  TODO: new index api will expose routeList
         <div style="margin-top: 6px;" >
 			<b>{{routes_on_stop}}</b>:
             <ul class="routeList"/>
         </div>
-        -->
     </div>
 </script>
 
 <script id="otp-stopsLayer-popupRoute" type="text/html">
     <li style="margin: 0px;">
-        {{#routeShortName}}
-            ({{routeShortName}})
-        {{/routeShortName}}
-        {{routeLongName}}
+        {{#shortName}}
+            ({{shortName}})
+        {{/shortName}}
+        {{longName}}
     </li>
 </script>

--- a/src/client/js/otp/modules/planner/ItinerariesWidget.js
+++ b/src/client/js/otp/modules/planner/ItinerariesWidget.js
@@ -2,29 +2,29 @@
    modify it under the terms of the GNU Lesser General Public License
    as published by the Free Software Foundation, either version 3 of
    the License, or (at your option) any later version.
-   
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-   
+
    You should have received a copy of the GNU General Public License
-   along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 otp.namespace("otp.widgets");
 
-otp.widgets.ItinerariesWidget = 
+otp.widgets.ItinerariesWidget =
     otp.Class(otp.widgets.Widget, {
 
     module : null,
-    
+
     itinsAccord : null,
     footer : null,
-    
+
     itineraries : null,
     activeIndex : 0,
-    
+
     // set to true by next/previous/etc. to indicate to only refresh the currently active itinerary
     refreshActiveOnly : false,
     showButtonRow : true,
@@ -32,8 +32,8 @@ otp.widgets.ItinerariesWidget =
     showPrintLink : true,
     showEmailLink : true,
     showSearchLink : false,
-    
-    
+
+
     initialize : function(id, module) {
         this.module = module;
 
@@ -50,7 +50,7 @@ otp.widgets.ItinerariesWidget =
         //this.minimizable = true;
         //this.addHeader("X Itineraries Returned");
     },
-    
+
     activeItin : function() {
         return this.itineraries[this.activeIndex];
     },
@@ -58,16 +58,16 @@ otp.widgets.ItinerariesWidget =
     updatePlan : function(plan) {
         this.updateItineraries(plan.itineraries, plan.queryParams);
     },
-        
+
     updateItineraries : function(itineraries, queryParams, itinIndex) {
-        
+
         var this_ = this;
         var divId = this.id+"-itinsAccord";
 
         if(this.minimized) this.unminimize();
-        
+
         if(this.refreshActiveOnly == true) { // if only refreshing one itinerary; e.g. if next/prev was used
-        
+
             // swap the old itinerary for the new one in both the TripPlan object and the local array
             var newItin = itineraries[0];
             var oldItin = this.itineraries[this.activeIndex];
@@ -89,14 +89,14 @@ otp.widgets.ItinerariesWidget =
             this.renderItinerary(newItin, this.activeIndex, alerts).appendTo(itinContainer);
             this.refreshActiveOnly = false;
             return;
-        }            
-        
+        }
+
         this.itineraries = itineraries;
 
         this.clear();
         //TRANSLATORS: widget title
         this.setTitle(ngettext("%d Itinerary Returned", "%d Itineraries Returned", this.itineraries.length));
-        
+
         var html = "<div id='"+divId+"' class='otp-itinsAccord'></div>";
         this.itinsAccord = $(html).appendTo(this.$());
 
@@ -105,20 +105,20 @@ otp.widgets.ItinerariesWidget =
             this.renderButtonRow();
         }
         if(this.showSearchLink) {
-            var link = this.constructLink(queryParams, 
+            var link = this.constructLink(queryParams,
                                           jQuery.isFunction(this.module.getAdditionalUrlParams) ?
                                               this.module.getAdditionalUrlParams() : null);
                                           //TODO: Where does this link?
             $('<div class="otp-itinsWidget-searchLink">[<a href="'+link+'">'+_tr("Link to search")+'</a>]</div>').appendTo(this.footer);
         }
-        
+
         var header;
         for(var i=0; i<this.itineraries.length; i++) {
             var itin = this.itineraries[i];
             //$('<h3><span id='+divId+'-headerContent-'+i+'>'+this.headerContent(itin, i)+'<span></h3>').appendTo(this.itinsAccord).click(function(evt) {
-            //$('<h3>'+this.headerContent(itin, i)+'</h3>').appendTo(this.itinsAccord).click(function(evt) {            
-            
-            var headerDivId = divId+'-headerContent-'+i; 
+            //$('<h3>'+this.headerContent(itin, i)+'</h3>').appendTo(this.itinsAccord).click(function(evt) {
+
+            var headerDivId = divId+'-headerContent-'+i;
             $('<h3><div id='+headerDivId+'></div></h3>')
             .appendTo(this.itinsAccord)
             .data('itin', itin)
@@ -127,19 +127,19 @@ otp.widgets.ItinerariesWidget =
                 var itin = $(this).data('itin');
                 this_.module.drawItinerary(itin);
                 this_.activeIndex = $(this).data('index');
-            });            
-            
+            });
+
             $('<div id="'+divId+'-'+i+'"></div>')
             .appendTo(this.itinsAccord)
             .append(this.renderItinerary(itin, i));
         }
         this.activeIndex = parseInt(itinIndex) || 0;
-        
+
         this.itinsAccord.accordion({
             active: this.activeIndex,
             heightStyle: "fill"
         });
-        
+
         // headers must be rendered after accordion is laid out to work around chrome layout bug
         /*for(var i=0; i<this.itineraries.length; i++) {
             var header = $("#"+divId+'-headerContent-'+i);
@@ -147,23 +147,23 @@ otp.widgets.ItinerariesWidget =
         }*/
         this.renderHeaders();
         this_.itinsAccord.accordion("resize");
-        
+
         this.$().resize(function(){
             this_.itinsAccord.accordion("resize");
             this_.renderHeaders();
         });
 
         this.$().draggable({ cancel: "#"+divId });
-        
+
     },
-    
+
     clear : function() {
         if(this.itinsAccord !== null) this.itinsAccord.remove();
         if(this.footer !== null) this.footer.remove();
     },
-    
+
     renderButtonRow : function() {
-    
+
         var serviceBreakTime = "03:00am";
         var this_ = this;
         var buttonRow = $("<div class='otp-itinsButtonRow'></div>").appendTo(this.footer);
@@ -188,7 +188,7 @@ otp.widgets.ItinerariesWidget =
             var params = itin.tripPlan.queryParams;
             var newEndTime = itin.itinData.endTime - 90000;
             var stopId = itin.getFirstStopID();
-            _.extend(params, { 
+            _.extend(params, {
                 startTransitStopId :  stopId,
                 time : otp.util.Time.formatItinTime(newEndTime, "h:mma"),
                 date : otp.util.Time.formatItinTime(newEndTime, "MM-DD-YYYY"),
@@ -230,23 +230,23 @@ otp.widgets.ItinerariesWidget =
             this_.module.planTripFunction.call(this_.module, params);
         });
     },
-    
+
     // returns HTML text
     headerContent : function(itin, index) {
         // show number of this itinerary (e.g. "1.")
         //var html= '<div class="otp-itinsAccord-header-number">'+(index+1)+'.</div>';
-        
+
         /*
-        // show iconographic trip leg summary  
+        // show iconographic trip leg summary
         html += '<div class="otp-itinsAccord-header-icons">'+itin.getIconSummaryHTML()+'</div>';
-        
+
         // show trip duration
         html += '<div class="otp-itinsAccord-header-duration">('+itin.getDurationStr()+')</div>';
-    
+
         if(itin.groupSize) {
             html += '<div class="otp-itinsAccord-header-groupSize">[Group size: '+itin.groupSize+']</div>';
         } */
-        
+
         var div = $('<div style="position: relative; height: 20px; background: yellow;"></div>');
         div.append('<div style="position:absolute; width: 20px; height: 20px; background: red;">'+(index+1)+'</div>');
         console.log("header div width: "+div.width());
@@ -259,14 +259,14 @@ otp.widgets.ItinerariesWidget =
         for(var i=0; i<this.itineraries.length; i++) {
             var header = $("#"+this.id+'-itinsAccord-headerContent-'+i);
             this.renderHeaderContent(this.itineraries[i], i, header);
-        }    
+        }
     },
 
     renderHeaderContent : function(itin, index, parentDiv) {
         parentDiv.empty();
         var div = $('<div style="position: relative; height: 20px;"></div>').appendTo(parentDiv);
         div.append('<div class="otp-itinsAccord-header-number">'+(index+1)+'.</div>');
-        
+
         var maxSpan = itin.tripPlan.latestEndTime - itin.tripPlan.earliestStartTime;
         var startPct = (itin.itinData.startTime - itin.tripPlan.earliestStartTime) / maxSpan;
         var itinSpan = itin.getEndTime() - itin.getStartTime();
@@ -277,24 +277,24 @@ otp.widgets.ItinerariesWidget =
         var widthPx = pxSpan * (itinSpan / maxSpan);
 
         div.append('<div style="position:absolute; width: '+(widthPx+5)+'px; height: 2px; left: '+(leftPx-2)+'px; top: 9px; background: black;" />');
-        
+
         var timeStr = otp.util.Time.formatItinTime(itin.getStartTime(), otp.config.locale.time.time_format);
 	/*timeStr = timeStr.substring(0, timeStr.length - 1);*/
         div.append('<div class="otp-itinsAccord-header-time" style="left: '+(leftPx-32)+'px;">' + timeStr + '</div>');
-        
+
         var timeStr = otp.util.Time.formatItinTime(itin.getEndTime(), otp.config.locale.time.time_format);
 	/*timeStr = timeStr.substring(0, timeStr.length - 1);*/
         div.append('<div class="otp-itinsAccord-header-time" style="left: '+(leftPx+widthPx+2)+'px;">' + timeStr + '</div>');
-        
+
         for(var l=0; l<itin.itinData.legs.length; l++) {
             var leg = itin.itinData.legs[l];
             var startPct = (leg.startTime - itin.tripPlan.earliestStartTime) / maxSpan;
             var endPct = (leg.endTime - itin.tripPlan.earliestStartTime) / maxSpan;
             var leftPx = startPx + startPct * pxSpan + 1;
             var widthPx = pxSpan * (leg.endTime - leg.startTime) / maxSpan - 1;
-    
+
             //div.append('<div class="otp-itinsAccord-header-segment" style="width: '+widthPx+'px; left: '+leftPx+'px; background: '+this.getModeColor(leg.mode)+' url(images/mode/'+leg.mode.toLowerCase()+'.png) center no-repeat;"></div>');
-            
+
             var showRouteLabel = widthPx > 40 && otp.util.Itin.isTransit(leg.mode) && leg.routeShortName && leg.routeShortName.length <= 6;
             var segment = $('<div class="otp-itinsAccord-header-segment" />')
             .css({
@@ -307,12 +307,12 @@ otp.widgets.ItinerariesWidget =
             if(showRouteLabel) segment.append('<div style="margin-left:'+(widthPx/2+9)+'px;">'+leg.routeShortName+'</div>');
 
         }
-        
+
         if(itin.groupSize) {
             var segment = $('<div class="otp-itinsAccord-header-groupSize">'+itin.groupSize+'</div>')
             .appendTo(div);
         }
-        
+
     },
 
     getModeColor : function(mode) {
@@ -324,14 +324,14 @@ otp.widgets.ItinerariesWidget =
         if(mode === "TRAM") return '#f00';
         return '#aaa';
     },
-    
-        
+
+
     municoderResultId : 0,
-    
+
     // returns jQuery object
     renderItinerary : function(itin, index, alerts) {
         var this_ = this;
-        
+
         // render legs
         var divId = this.module.id+"-itinAccord-"+index;
         var accordHtml = "<div id='"+divId+"' class='otp-itinAccord'></div>";
@@ -363,7 +363,7 @@ otp.widgets.ItinerariesWidget =
 
             if(leg.mode === "WALK" || leg.mode === "BICYCLE") {
                 headerHtml += " "+otp.util.Itin.distanceString(leg.distance)+ pgettext("direction", " to ")+leg.to.name;
-                
+
                 if(otp.config.municoderHostname) {
                     var spanId = this.newMunicoderRequest(leg.to.lat, leg.to.lon);
                     headerHtml += '<span id="'+spanId+'"></span>';
@@ -383,12 +383,12 @@ otp.widgets.ItinerariesWidget =
                     headsign>. Used in showing itinerary*/
                     headerHtml +=  pgettext("bus_direction", " to ") + leg.headsign;
                 }
-                
+
                 if(leg.alerts) {
                     headerHtml += '&nbsp;&nbsp;<img src="images/alert.png" style="vertical-align: -20%;" />';
                 }
             }
-            
+
             $("<h3>"+headerHtml+"</h3>").appendTo(legDiv).data('leg', leg).hover(function(evt) {
                 //var arr = evt.target.id.split('-');
                 //var index = parseInt(arr[arr.length-1]);
@@ -402,11 +402,11 @@ otp.widgets.ItinerariesWidget =
                 this_.module.pathMarkerLayer.clearLayers();
                 this_.module.drawAllStartBubbles(itin);
             });
-            this_.renderLeg(leg, 
+            this_.renderLeg(leg,
                             l>0 ? itin.itinData.legs[l-1] : null, // previous
                             l+1 < itin.itinData.legs.length ? itin.itinData.legs[l+1] : null // next
             ).appendTo(legDiv);
-            
+
             $(legDiv).accordion({
                 header : 'h3',
                 active: otp.util.Itin.isTransit(leg.mode) ? 0 : false,
@@ -414,7 +414,7 @@ otp.widgets.ItinerariesWidget =
                 collapsible: true
             });
         }
-        
+
         //itinAccord.accordion({
         /*console.log('#' + divId + ' > div')
         $('#' + divId + ' > div').accordion({
@@ -432,12 +432,12 @@ otp.widgets.ItinerariesWidget =
             //TRANSLATORS: Shown as alert text before showing itinerary.
             alerts.push(_tr("Total walk distance for this trip exceeds specified maximum"));
         }
-        
+
         for(var i = 0; i < alerts.length; i++) {
             itinDiv.append("<div class='otp-itinAlertRow'>"+alerts[i]+"</div>");
         }
-        
-        // add start and end time rows and the main leg accordion display 
+
+        // add start and end time rows and the main leg accordion display
         //TRANSLATORS: Start: Time and date (Shown before path itinerary)
         itinDiv.append("<div class='otp-itinStartRow'><b>" + pgettext('template', "Start") + "</b>: "+itin.getStartTimeStr()+"</div>");
         itinDiv.append(itinAccord);
@@ -452,48 +452,48 @@ otp.widgets.ItinerariesWidget =
         .append('<div class="otp-itinTripSummaryLabel">' + _tr("Travel") + '</div><div class="otp-itinTripSummaryText">'+itin.getStartTimeStr()+'</div>')
         //TRANSLATORS: Time: minutes How long is this trip
         .append('<div class="otp-itinTripSummaryLabel">' + _tr("Time") + '</div><div class="otp-itinTripSummaryText">'+itin.getDurationStr()+'</div>');
-        
+
         var walkDistance = itin.getModeDistance("WALK");
         if(walkDistance > 0) {
             //FIXME: If translation is longer transfers jumps to the right and
             //it is ugly
 
             //TRANSLATORS: Total foot distance for trip
-            tripSummary.append('<div class="otp-itinTripSummaryLabel">' + _tr("Total Walk") + '</div><div class="otp-itinTripSummaryText">' + 
+            tripSummary.append('<div class="otp-itinTripSummaryLabel">' + _tr("Total Walk") + '</div><div class="otp-itinTripSummaryText">' +
                 otp.util.Itin.distanceString(walkDistance) + '</div>')
         }
 
         var bikeDistance = itin.getModeDistance("BICYCLE");
         if(bikeDistance > 0) {
             //TRANSLATORS: Total distance on a bike for this trip
-            tripSummary.append('<div class="otp-itinTripSummaryLabel">' + _tr("Total Bike") + '</div><div class="otp-itinTripSummaryText">' + 
+            tripSummary.append('<div class="otp-itinTripSummaryLabel">' + _tr("Total Bike") + '</div><div class="otp-itinTripSummaryText">' +
                 otp.util.Itin.distanceString(bikeDistance) + '</div>')
         }
-        
+
         if(itin.hasTransit) {
             //TRANSLATORS: how many public transit transfers in a trip
             tripSummary.append('<div class="otp-itinTripSummaryLabel">' + _tr("Transfers") + '</div><div class="otp-itinTripSummaryText">'+itin.itinData.transfers+'</div>')
             /*if(itin.itinData.walkDistance > 0) {
-                tripSummary.append('<div class="otp-itinTripSummaryLabel">' + _tr("Total Walk") + '</div><div class="otp-itinTripSummaryText">' + 
+                tripSummary.append('<div class="otp-itinTripSummaryLabel">' + _tr("Total Walk") + '</div><div class="otp-itinTripSummaryText">' +
                     otp.util.Itin.distanceString(itin.itinData.walkDistance) + '</div>')
             }*/
            //TRANSLATORS: cost of trip
             tripSummary.append('<div class="otp-itinTripSummaryLabel">' + _tr("Fare") +'</div><div class="otp-itinTripSummaryText">'+itin.getFareStr()+'</div>');
         }
-        
-        
-        
+
+
+
         var tripSummaryFooter = $('<div class="otp-itinTripSummaryFooter" />');
-        
+
         //TRANSLATORS: Valid date time; When is this trip correct
         tripSummaryFooter.append(_tr('Valid') + ' ' + moment().format(otp.config.locale.time.format));
-        
+
         var itinLink = this.constructLink(itin.tripPlan.queryParams, { itinIndex : index });
         if(this.showItineraryLink) {
             //TRANSLATORS: Links to this itinerary
             tripSummaryFooter.append(' | <a href="'+itinLink+'">' + _tr("Link to Itinerary") + '</a>');
         }
-        
+
         if(this.showPrintLink) {
             tripSummaryFooter.append(' | ');
             $('<a href="#">' + _tr('Print') +'</a>').click(function(evt) {
@@ -501,7 +501,7 @@ otp.widgets.ItinerariesWidget =
 
                 var printWindow = window.open('','OpenTripPlanner Results','toolbar=yes, scrollbars=yes, height=500, width=800');
                 printWindow.document.write(itin.getHtmlNarrative());
-                
+
             }).appendTo(tripSummaryFooter);
         }
         if(this.showEmailLink) {
@@ -511,11 +511,11 @@ otp.widgets.ItinerariesWidget =
             //TRANSLATORS: Link to send trip by email
             tripSummaryFooter.append(' | <a href="mailto:?subject='+encodeURIComponent(subject)+'&body='+encodeURIComponent(body)+'" target="_blank">' + _tr("Email") + '</a>');
         }
-        
+
         tripSummary.append(tripSummaryFooter)
         .appendTo(itinDiv);
 
-       
+
         return itinDiv;
     },
 
@@ -523,7 +523,7 @@ otp.widgets.ItinerariesWidget =
         var this_ = this;
         if(otp.util.Itin.isTransit(leg.mode)) {
             var legDiv = $('<div></div>');
-            
+
             // show the start time and stop
 
             // prevaricate if this is a nonstruct frequency trip
@@ -533,7 +533,7 @@ otp.widgets.ItinerariesWidget =
             } else {
                 $('<div class="otp-itin-leg-leftcol">'+otp.util.Time.formatItinTime(leg.startTime, otp.config.locale.time.time_format)+"</div>").appendTo(legDiv);
             }
-            
+
             //TRANSLATORS: Depart station / Board at station in itinerary
             var startHtml = '<div class="otp-itin-leg-endpointDesc">' + (leg.interlineWithPreviousLeg ? "<b>" + pgettext("itinerary", "Depart") + "</b> " : _tr("<b>Board</b> at ")) +leg.from.name;
             if(otp.config.municoderHostname) {
@@ -541,18 +541,18 @@ otp.widgets.ItinerariesWidget =
                 startHtml += '<span id="'+spanId+'"></span>';
             }
             startHtml += '</div>';
-            
+
             $(startHtml).appendTo(legDiv)
             .click(function(evt) {
                 this_.module.webapp.map.lmap.panTo(new L.LatLng(leg.from.lat, leg.from.lon));
             }).hover(function(evt) {
                 this_.module.pathMarkerLayer.clearLayers();
-                this_.module.drawStartBubble(leg, true);            
+                this_.module.drawStartBubble(leg, true);
             }, function(evt) {
                 this_.module.pathMarkerLayer.clearLayers();
                 this_.module.drawAllStartBubbles(this_.itineraries[this_.activeIndex]);
             });
-            
+
 
             $('<div class="otp-itin-leg-endpointDescSub">' + _tr("Stop") + ' #'+leg.from.stopId.id+' [<a href="#">' + _tr("Stop Viewer") +'</a>]</div>')
             .appendTo(legDiv)
@@ -563,12 +563,12 @@ otp.widgets.ItinerariesWidget =
                 }
                 this_.module.stopViewerWidget.show();
                 this_.module.stopViewerWidget.setActiveTime(leg.startTime);
-                this_.module.stopViewerWidget.setStop(leg.from.stopId.agencyId, leg.from.stopId.id, leg.from.name);
+                this_.module.stopViewerWidget.setStop(leg.from.stopId, leg.from.name);
                 this_.module.stopViewerWidget.bringToFront();
             });
 
 
-            $('<div class="otp-itin-leg-buffer"></div>').appendTo(legDiv);            
+            $('<div class="otp-itin-leg-buffer"></div>').appendTo(legDiv);
 
             // show the "time in transit" line
 
@@ -588,24 +588,24 @@ otp.widgets.ItinerariesWidget =
                 this_.module.tripViewerWidget.update(leg);
                 this_.module.tripViewerWidget.bringToFront();
             });
-            
+
             // show the intermediate stops, if applicable -- REPLACED BY TRIP VIEWER
-            
+
             /*if(this.module.showIntermediateStops) {
 
-                $('<div class="otp-itin-leg-buffer"></div>').appendTo(legDiv);            
+                $('<div class="otp-itin-leg-buffer"></div>').appendTo(legDiv);
                 var intStopsDiv = $('<div class="otp-itin-leg-intStops"></div>').appendTo(legDiv);
-                
+
                 var intStopsListDiv = $('<div class="otp-itin-leg-intStopsList"></div>')
-                
+
                 $('<div class="otp-itin-leg-intStopsHeader">'+leg.intermediateStops.length+' Intermediate Stops</div>')
                 .appendTo(intStopsDiv)
                 .click(function(event) {
                     intStopsListDiv.toggle();
                 });
-                
+
                 intStopsListDiv.appendTo(intStopsDiv);
-                
+
                 for(var i=0; i < leg.intermediateStops.length; i++) {
                     var stop = leg.intermediateStops[i];
                     $('<div class="otp-itin-leg-intStopsListItem">'+(i+1)+'. '+stop.name+' (ID #'+stop.stopId.id+')</div>').
@@ -624,21 +624,21 @@ otp.widgets.ItinerariesWidget =
                     }, function(evt) {
                         $(this).css('color', 'black');
                         this_.module.webapp.map.lmap.closePopup();
-                    });                    
+                    });
                 }
                 intStopsListDiv.hide();
             }*/
 
             // show the end time and stop
 
-            $('<div class="otp-itin-leg-buffer"></div>').appendTo(legDiv);            
+            $('<div class="otp-itin-leg-buffer"></div>').appendTo(legDiv);
 
             if( leg.isNonExactFrequency === true ) {
-            	$('<div class="otp-itin-leg-leftcol">' + _tr('late as') + ' ' + otp.util.Time.formatItinTime(leg.endTime, otp.config.locale.time.time_format)+"</div>").appendTo(legDiv);   
+            	$('<div class="otp-itin-leg-leftcol">' + _tr('late as') + ' ' + otp.util.Time.formatItinTime(leg.endTime, otp.config.locale.time.time_format)+"</div>").appendTo(legDiv);
             } else {
-                $('<div class="otp-itin-leg-leftcol">'+otp.util.Time.formatItinTime(leg.endTime, otp.config.locale.time.time_format)+"</div>").appendTo(legDiv);   
+                $('<div class="otp-itin-leg-leftcol">'+otp.util.Time.formatItinTime(leg.endTime, otp.config.locale.time.time_format)+"</div>").appendTo(legDiv);
             }
-            
+
             //TRANSLATORS: Stay on board/Alight [at stop name]
             var endAction = (nextLeg && nextLeg.interlineWithPreviousLeg) ? _tr("Stay on board") : _tr("Alight");
             //TRANSLATORS: [Stay on board/Alight] at [stop name]
@@ -648,13 +648,13 @@ otp.widgets.ItinerariesWidget =
                 endHtml += '<span id="'+spanId+'"></span>';
             }
             endHtml += '</div>';
-            
+
             $(endHtml).appendTo(legDiv)
             .click(function(evt) {
                 this_.module.webapp.map.lmap.panTo(new L.LatLng(leg.to.lat, leg.to.lon));
             }).hover(function(evt) {
                 this_.module.pathMarkerLayer.clearLayers();
-                this_.module.drawEndBubble(leg, true);            
+                this_.module.drawEndBubble(leg, true);
             }, function(evt) {
                 this_.module.pathMarkerLayer.clearLayers();
                 this_.module.drawAllStartBubbles(this_.itineraries[this_.activeIndex]);
@@ -662,14 +662,14 @@ otp.widgets.ItinerariesWidget =
 
 
             // render any alerts
-            
+
             if(leg.alerts) {
                 for(var i = 0; i < leg.alerts.length; i++) {
                     var alert = leg.alerts[i];
-                    
+
                     var alertDiv = ich['otp-planner-alert']({ alert: alert, leg: leg }).appendTo(legDiv);
                     alertDiv.find('.otp-itin-alert-description').hide();
-                    
+
                     alertDiv.find('.otp-itin-alert-toggleButton').data('div', alertDiv).click(function() {
                         var div = $(this).data('div');
                         var desc = div.find('.otp-itin-alert-description');
@@ -683,9 +683,9 @@ otp.widgets.ItinerariesWidget =
                             toggle.html("&#x25B2;");
                         }
                     });
-                } 
+                }
             }
-                        
+
             return legDiv;
         }
         else if (leg.steps) { // walk / bike / car
@@ -694,16 +694,16 @@ otp.widgets.ItinerariesWidget =
                 for(var i=0; i<leg.steps.length; i++) {
                     var step = leg.steps[i];
                     var text = otp.util.Itin.getLegStepText(step);
-                    
+
                     var html = '<div id="foo-'+i+'" class="otp-itin-step-row">';
                     html += '<div class="otp-itin-step-icon">';
                     if(step.relativeDirection)
                         html += '<img src="'+otp.config.resourcePath+'images/directions/' +
                             step.relativeDirection.toLowerCase()+'.png">';
-                    html += '</div>';                
+                    html += '</div>';
                     var distArr= otp.util.Itin.distanceString(step.distance).split(" ");
                     html += '<div class="otp-itin-step-dist">' +
-                        '<span style="font-weight:bold; font-size: 1.2em;">' + 
+                        '<span style="font-weight:bold; font-size: 1.2em;">' +
                         distArr[0]+'</span><br>'+distArr[1]+'</div>';
                     html += '<div class="otp-itin-step-text">'+text+'</div>';
                     html += '<div style="clear:both;"></div></div>';
@@ -727,28 +727,28 @@ otp.widgets.ItinerariesWidget =
                     });
                 }
             }
-            return legDiv;                        
+            return legDiv;
         }
         return $("<div>Leg details go here</div>");
     },
-    
+
     constructLink : function(queryParams, additionalParams) {
         additionalParams = additionalParams ||  { };
-        return otp.config.siteUrl + '?module=' + this.module.id + "&" +  
+        return otp.config.siteUrl + '?module=' + this.module.id + "&" +
             otp.util.Text.constructUrlParamString(_.extend(_.clone(queryParams), additionalParams));
     },
-        
+
     newMunicoderRequest : function(lat, lon) {
-    
+
         this.municoderResultId++;
         var spanId = 'otp-municoderResult-'+this.municoderResultId;
 
-        console.log("muniReq");        
+        console.log("muniReq");
         $.ajax(otp.config.municoderHostname+"/opentripplanner-municoder/municoder", {
-        
-            data : { location : lat+","+lon },           
+
+            data : { location : lat+","+lon },
             dataType:   'jsonp',
-                
+
             success: function(data) {
                 if(data.name) {
                     $('#'+spanId).html(", "+data.name);
@@ -758,7 +758,5 @@ otp.widgets.ItinerariesWidget =
         return spanId;
     }
 
-    
-});
 
-    
+});

--- a/src/client/js/otp/util/Itin.js
+++ b/src/client/js/otp/util/Itin.js
@@ -2,14 +2,14 @@
    modify it under the terms of the GNU Lesser General Public License
    as published by the Free Software Foundation, either version 3 of
    the License, or (at your option) any later version.
-   
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-   
+
    You should have received a copy of the GNU General Public License
-   along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 otp.namespace("otp.util");
@@ -17,35 +17,35 @@ otp.namespace("otp.util");
 /**
  * Utility routines for OTP itinerary-based operations
  */
- 
+
 otp.util.Itin = {
 
-    /** 
+    /**
      * Extracts the "place" from an OTP "name::place" string, where "place" is
      * a latitude,longitude string or a vertex ID.
      *
      * @param {string} locationStr an OTP GenericLocation string
-     * @return {string} the "place" component of an OTP location string 
+     * @return {string} the "place" component of an OTP location string
      */
-     
+
     getLocationPlace : function(locationStr) {
-        return locationStr.indexOf("::") != -1 ? 
+        return locationStr.indexOf("::") != -1 ?
             locationStr.split("::")[1] : locationStr;
     },
 
 
-    /** 
+    /**
      * Extracts the "name" from an OTP "name::place" string, if present
      *
      * @param {string} locationStr an OTP GenericLocation string
-     * @return {string} the "name" component of an OTP location string, null if not present 
+     * @return {string} the "name" component of an OTP location string, null if not present
      */
 
     getLocationName : function(locationStr) {
-        return locationStr.indexOf("::") != -1 ? 
+        return locationStr.indexOf("::") != -1 ?
             locationStr.split("::")[0] : null;
     },
-    
+
     /**
      * Extracts the unqualified mode from an OTP "mode_qualifier" string
      *
@@ -72,7 +72,7 @@ otp.util.Itin = {
     isTransit : function(mode) {
         return mode === "TRANSIT" || mode === "SUBWAY" || mode === "RAIL" || mode === "BUS" || mode === "TRAM" || mode === "GONDOLA" || mode === "TRAINISH" || mode === "BUSISH";
     },
-    
+
     includesTransit : function(mode) {
         var modeArr = mode.split(",");
         for(var i = 0; i < modeArr.length; i++) {
@@ -80,7 +80,7 @@ otp.util.Itin = {
         }
         return false;
     },
-    
+
     includesWalk : function(mode) {
         var modeArr = mode.split(",");
         for(var i = 0; i < modeArr.length; i++) {
@@ -107,7 +107,7 @@ otp.util.Itin = {
 
     absoluteDirectionStrings : {
         // note: keep these lower case (and uppercase via template / code if needed)
-        //TRANSLATORS: Start on [street name] heading [Absolute direction] used in travel plan generation 
+        //TRANSLATORS: Start on [street name] heading [Absolute direction] used in travel plan generation
         'NORTH': _tr('north'),
         'NORTHEAST': _tr('northeast'),
         'EAST': _tr('east'),
@@ -117,15 +117,15 @@ otp.util.Itin = {
         'WEST': _tr('west'),
         'NORTHWEST': _tr('northwest'),
     },
-    
-    /** 
+
+    /**
      * Returns localized absolute direction string
      *
      * @param {string} dir a absolute direction string from a server
      * @return {string} localized absolute direction string
      */
 
-    getLocalizedAbsoluteDirectionString : function(dir) { 
+    getLocalizedAbsoluteDirectionString : function(dir) {
         if (dir in this.absoluteDirectionStrings) return this.absoluteDirectionStrings[dir];
         // This is used if dir isn't found in directionStrings
         // This shouldn't happen
@@ -141,7 +141,7 @@ otp.util.Itin = {
         //on /on to [streetname]
         'HARD_LEFT': _tr("hard left"),
         'LEFT': _tr("left"),
-        'SLIGHTLY_LEFT': _tr("slight left"), 
+        'SLIGHTLY_LEFT': _tr("slight left"),
         'CONTINUE': _tr("continue"),
         'SLIGHTLY_RIGHT': _tr("slight right"),
         'RIGHT': _tr("right"),
@@ -154,24 +154,24 @@ otp.util.Itin = {
     },
 
 
-    /** 
+    /**
      * Returns localized relative direction string
      *
      * @param {string} dir a relative direction string from a server
      * @return {string} localized direction string
      */
 
-    getLocalizedRelativeDirectionString : function(dir) { 
+    getLocalizedRelativeDirectionString : function(dir) {
         if (dir in this.relativeDirectionStrings) return this.relativeDirectionStrings[dir];
         // This is used if dir isn't found in directionStrings
         // This shouldn't happen
         return dir.toLowerCase().replace('_',' ').replace('ly','');
     },
-    
+
     distanceString : function(m) {
         return otp.util.Geo.distanceString(m);
     },
-    
+
     modeStrings : {
         //TRANSLATORS: Walk distance to place (itinerary header)
         'WALK': _tr('Walk'),
@@ -197,12 +197,12 @@ otp.util.Itin = {
         //cable cars where the car is suspended from the cable.
         'GONDOLA' : _tr('Aerial Tram'),
     },
-    
+
     modeString : function(mode) {
         if(mode in this.modeStrings) return this.modeStrings[mode];
         return mode;
     },
-    
+
     getLegStepText : function(step, asHtml) {
         asHtml = (typeof asHtml === "undefined") ? true : asHtml;
         var text = '';
@@ -241,14 +241,14 @@ otp.util.Itin = {
         }
         return text;
     },
-    
+
     getRouteDisplayString : function(routeData) {
-        var str = routeData.routeShortName ? '('+routeData.routeShortName+') ' : '';
-        str += routeData.routeLongName;
+        var str = routeData.shortName ? '('+routeData.shortName+') ' : '';
+        str += routeData.longName;
         return str;
     },
-    
+
     getRouteShortReference : function(routeData) {
         return routeData.routeShortName || routeData.id.id;
-    },    
+    },
 }

--- a/src/client/js/otp/widgets/transit/RouteBasedWidget.js
+++ b/src/client/js/otp/widgets/transit/RouteBasedWidget.js
@@ -2,39 +2,39 @@
    modify it under the terms of the GNU Lesser General Public License
    as published by the Free Software Foundation, either version 3 of
    the License, or (at your option) any later version.
-   
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-   
+
    You should have received a copy of the GNU General Public License
-   along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 otp.namespace("otp.widgets.transit");
 
-otp.widgets.transit.RouteBasedWidget = 
+otp.widgets.transit.RouteBasedWidget =
     otp.Class(otp.widgets.Widget, {
 
     module : null,
 
     agency_id : null,
-    
+
     activeLeg : null,
     timeIndex : null,
-    
+
     routeLookup : [], // for retrieving route obj from numerical index in <select> element
-    
+
     lastSize : null,
-    //variantIndexLookup : null, 
-    
+    //variantIndexLookup : null,
+
     initialize : function(id, module, options) {
-    
+
         otp.widgets.Widget.prototype.initialize.call(this, id, module, options);
-        
+
         this.module = module;
-        
+
         var this_ = this;
 
         var routeSelectDiv = $('<div class="otp-tripViewer-select notDraggable" />').appendTo(this.mainDiv);
@@ -46,7 +46,7 @@ otp.widgets.transit.RouteBasedWidget =
             this_.newRouteSelected();
         });
 
-        _.each(module.webapp.transitIndex.routes, function(route, key) {
+        _.each(module.webapp.indexApi.routes, function(route, key) {
             var optionHtml = '<option>';
             if(route.routeData.routeShortName) optionHtml += '('+route.routeData.routeShortName+') ';
             if(route.routeData.routeLongName) optionHtml += route.routeData.routeLongName;
@@ -65,9 +65,9 @@ otp.widgets.transit.RouteBasedWidget =
         .change(function() {
             this_.newVariantSelected();
         });
-        
+
     },
-    
+
     newRouteSelected : function() {
         this.agency_id = null;
         this.activeLeg = null;
@@ -75,60 +75,60 @@ otp.widgets.transit.RouteBasedWidget =
         this.agency_id = route.routeData.id.agencyId + "_" + route.routeData.id.id;
         this.variantSelect.empty();
         this.clear() //stopList.empty();
-        this.checkAndLoadVariants();     
+        this.checkAndLoadVariants();
     },
-    
+
     newVariantSelected : function() {
         this.activeLeg = null;
         var variantName = this.variantSelect.val();
         //console.log("new variant selected: "+variantName);
         this.clear() //stopList.empty();
-        this.setActiveVariant(this.module.webapp.transitIndex.routes[this.agency_id].variants[variantName]);
+        this.setActiveVariant(this.module.webapp.indexApi.routes[this.agency_id].variants[variantName]);
     },
-    
+
     update : function(leg) {
         //this.clearTimes();
         this.activeLeg = leg;
         this.activeTime = leg.startTime;
         //this.times = times;
 
-        this.agency_id = leg.agencyId + "_" + leg.routeId;
-        
-        var tiRouteInfo = this.module.webapp.transitIndex.routes[this.agency_id];
+        this.agency_id = leg.agencyId + ":" + leg.routeId;
+
+        var tiRouteInfo = this.module.webapp.indexApi.routes[this.agency_id];
         $('#'+this.id+'-routeSelect option:eq('+tiRouteInfo.index+')').prop('selected', true);
-        
-        this.checkAndLoadVariants();      
+
+        this.checkAndLoadVariants();
     },
-        
+
     checkAndLoadVariants : function() {
-        var tiRouteInfo = this.module.webapp.transitIndex.routes[this.agency_id];
+        var tiRouteInfo = this.module.webapp.indexApi.routes[this.agency_id];
         if(tiRouteInfo.variants != null) {
             //console.log("variants exist");
             this.updateVariants();
         }
         else {
-            this.module.webapp.transitIndex.loadVariants(this.agency_id, this, this.updateVariants);
+            this.module.webapp.indexApi.loadVariants(this.agency_id, this, this.updateVariants);
         }
     },
 
     updateVariants : function() {
         var this_ = this;
-        var route = this.module.webapp.transitIndex.routes[this.agency_id];
+        var route = this.module.webapp.indexApi.routes[this.agency_id];
 
         if(!route.variants) {
-            console.log("ERROR: transitIndex.routes.["+this.agency_id+"].variants null in StopViewerWidget.updateVariants()");
+            console.log("ERROR: indexApi.routes.["+this.agency_id+"].variants null in StopViewerWidget.updateVariants()");
             return;
         }
-        
+
         if(this.activeLeg) {
-            this.module.webapp.transitIndex.readVariantForTrip(this.activeLeg.agencyId, this.activeLeg.tripId, this, this.setActiveVariant);
+            this.module.webapp.indexApi.readVariantForTrip(this.activeLeg.agencyId, this.activeLeg.tripId, this, this.setActiveVariant);
         }
 
         this.variantSelect.empty();
         _.each(route.variants, function(variant) {
             $('<option>'+variant.name+'</option>').appendTo(this_.variantSelect);
         });
-        
+
         if(!this.activeLeg) {
             this.newVariantSelected();
         }
@@ -136,19 +136,19 @@ otp.widgets.transit.RouteBasedWidget =
 
     setActiveVariant : function(variantData) {
         var this_ = this;
-        var route = this.module.webapp.transitIndex.routes[this.agency_id];
+        var route = this.module.webapp.indexApi.routes[this.agency_id];
         this.activeVariant = route.variants[variantData.name];
         $('#'+this.id+'-variantSelect option:eq('+(this.activeVariant.index)+')').prop('selected', true);
-        
+
         this.variantSelected(variantData);
     },
-    
+
     // functions to be implemented by subclasses:
-    
+
     clear : function() {
     },
-    
+
     variantSelected : function() {
     },
-        
+
 });

--- a/src/client/js/otp/widgets/transit/RouteBasedWidget.js
+++ b/src/client/js/otp/widgets/transit/RouteBasedWidget.js
@@ -48,8 +48,8 @@ otp.widgets.transit.RouteBasedWidget =
 
         _.each(module.webapp.indexApi.routes, function(route, key) {
             var optionHtml = '<option>';
-            if(route.routeData.routeShortName) optionHtml += '('+route.routeData.routeShortName+') ';
-            if(route.routeData.routeLongName) optionHtml += route.routeData.routeLongName;
+            if(route.routeData.shortName) optionHtml += '('+route.routeData.shortName+') ';
+            if(route.routeData.longName) optionHtml += route.routeData.longName;
             optionHtml += '</option>';
             this_.routeSelect.append($(optionHtml));
             this_.routeLookup.push(route);
@@ -72,7 +72,7 @@ otp.widgets.transit.RouteBasedWidget =
         this.agency_id = null;
         this.activeLeg = null;
         var route = this.routeLookup[this.routeSelect.prop("selectedIndex")]
-        this.agency_id = route.routeData.id.agencyId + "_" + route.routeData.id.id;
+        this.agency_id = route.routeData.id;
         this.variantSelect.empty();
         this.clear() //stopList.empty();
         this.checkAndLoadVariants();
@@ -80,10 +80,10 @@ otp.widgets.transit.RouteBasedWidget =
 
     newVariantSelected : function() {
         this.activeLeg = null;
-        var variantName = this.variantSelect.val();
-        //console.log("new variant selected: "+variantName);
+        var variantId = this.variantSelect.val();
+        //console.log("new variant selected: "+variantId);
         this.clear() //stopList.empty();
-        this.setActiveVariant(this.module.webapp.indexApi.routes[this.agency_id].variants[variantName]);
+        this.setActiveVariant(this.module.webapp.indexApi.routes[this.agency_id].variants[variantId]);
     },
 
     update : function(leg) {
@@ -116,18 +116,19 @@ otp.widgets.transit.RouteBasedWidget =
         var route = this.module.webapp.indexApi.routes[this.agency_id];
 
         if(!route.variants) {
-            console.log("ERROR: indexApi.routes.["+this.agency_id+"].variants null in StopViewerWidget.updateVariants()");
+            console.log("ERROR: indexApi.routes.["+this.agency_id+"].variants null in RouteBasedWidget.updateVariants()");
             return;
-        }
-
-        if(this.activeLeg) {
-            this.module.webapp.indexApi.readVariantForTrip(this.activeLeg.agencyId, this.activeLeg.tripId, this, this.setActiveVariant);
         }
 
         this.variantSelect.empty();
         _.each(route.variants, function(variant) {
-            $('<option>'+variant.name+'</option>').appendTo(this_.variantSelect);
+            $('<option value='+ variant.id +'>'+variant.desc+'</option>').appendTo(this_.variantSelect);
         });
+
+        if(this.activeLeg) {
+            this.module.webapp.indexApi.readVariantForTrip(this.activeLeg.agencyId,  this.activeLeg.routeId, this.activeLeg.tripId, this, this.setActiveVariant);
+        }
+
 
         if(!this.activeLeg) {
             this.newVariantSelected();
@@ -137,8 +138,8 @@ otp.widgets.transit.RouteBasedWidget =
     setActiveVariant : function(variantData) {
         var this_ = this;
         var route = this.module.webapp.indexApi.routes[this.agency_id];
-        this.activeVariant = route.variants[variantData.name];
-        $('#'+this.id+'-variantSelect option:eq('+(this.activeVariant.index)+')').prop('selected', true);
+        this.activeVariant = route.variants[variantData.id];
+        $('#'+this.id+'-variantSelect option:eq('+this.activeVariant.index+')').prop('selected', true);
 
         this.variantSelected(variantData);
     },

--- a/src/client/js/otp/widgets/transit/StopFinderWidget.js
+++ b/src/client/js/otp/widgets/transit/StopFinderWidget.js
@@ -2,30 +2,30 @@
    modify it under the terms of the GNU Lesser General Public License
    as published by the Free Software Foundation, either version 3 of
    the License, or (at your option) any later version.
-   
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-   
+
    You should have received a copy of the GNU General Public License
-   along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 otp.namespace("otp.widgets.transit");
 
-otp.widgets.transit.StopFinderWidget = 
+otp.widgets.transit.StopFinderWidget =
     otp.Class(otp.widgets.Widget, {
 
     module : null,
 
     agency_id : null,
-    
+
     timeIndex : null,
-    
-        
+
+
     initialize : function(id, module, stopViewer) {
-    
+
         otp.widgets.Widget.prototype.initialize.call(this, id, module, {
             //TRANSLATORS: Widget title
             title : _tr('Stop Finder'),
@@ -35,10 +35,10 @@ otp.widgets.transit.StopFinderWidget =
             openInitially : false,
             persistOnClose : true,
         });
-        
+
         this.module = module;
         this.stopViewer = stopViewer;
-        
+
         var this_ = this;
 
         this.activeTime = moment();
@@ -53,12 +53,12 @@ otp.widgets.transit.StopFinderWidget =
             //TRANSLATORS: Search for Stops by ID/by Name
             search: _tr('Search')
         }
-          
+
         ich['otp-stopFinder'](translated_template).appendTo(this.mainDiv);
 
         this.agencySelect = this.mainDiv.find('.otp-stopFinder-agencySelect');
-        this.module.webapp.transitIndex.loadAgencies(this, function() {
-            for(var agencyId in this.module.webapp.transitIndex.agencies) {
+        this.module.webapp.indexApi.loadAgencies(this, function() {
+            for(var agencyId in this.module.webapp.indexApi.agencies) {
                 $("<option />").html(agencyId).appendTo(this_.agencySelect);
             }
         });
@@ -84,7 +84,7 @@ otp.widgets.transit.StopFinderWidget =
         });
 
         this.center();
-    },    
+    },
 
     updateStops : function(stops) {
         this.stopList.empty();

--- a/src/client/js/otp/widgets/transit/StopFinderWidget.js
+++ b/src/client/js/otp/widgets/transit/StopFinderWidget.js
@@ -69,7 +69,7 @@ otp.widgets.transit.StopFinderWidget =
             var agencyId = this_.agencySelect.val();
             var id = this_.mainDiv.find('.otp-stopFinder-idField').val();
             if(!id || id.length === 0) return;
-            this_.module.webapp.transitIndex.loadStopsById(agencyId, id, this, function(data) {
+            this_.module.webapp.indexApi.loadStopsById(agencyId, id, this, function(data) {
                 this_.updateStops(data.stops);
             });
         });
@@ -78,7 +78,7 @@ otp.widgets.transit.StopFinderWidget =
             var agencyId = this_.agencySelect.val();
             var name = this_.mainDiv.find('.otp-stopFinder-nameField').val();
             if(!name || name.length === 0) return;
-            this_.module.webapp.transitIndex.loadStopsByName(agencyId, name, this, function(data) {
+            this_.module.webapp.indexApi.loadStopsByName(agencyId, name, this, function(data) {
                 this_.updateStops(data.stops);
             });
         });
@@ -106,7 +106,7 @@ otp.widgets.transit.StopFinderWidget =
                 .click(function() {
                     var s = $(this).data('stop');
                     this_.stopViewer.show();
-                    this_.stopViewer.setStop(s.id.agencyId, s.id.id, s.stopName);
+                    this_.stopViewer.setStop(s.id, s.stopName);
                     this_.stopViewer.bringToFront();
                 });
         }

--- a/src/client/js/otp/widgets/transit/StopViewerWidget.js
+++ b/src/client/js/otp/widgets/transit/StopViewerWidget.js
@@ -2,30 +2,30 @@
    modify it under the terms of the GNU Lesser General Public License
    as published by the Free Software Foundation, either version 3 of
    the License, or (at your option) any later version.
-   
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-   
+
    You should have received a copy of the GNU General Public License
-   along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 otp.namespace("otp.widgets.transit");
 
-otp.widgets.transit.StopViewerWidget = 
+otp.widgets.transit.StopViewerWidget =
     otp.Class(otp.widgets.Widget, {
 
     module : null,
 
     agency_id : null,
-    
+
     timeIndex : null,
-    
-        
+
+
     initialize : function(id, module) {
-    
+
         otp.widgets.Widget.prototype.initialize.call(this, id, module, {
             //TRANSLATORS: widget title
             title : _tr('Stop Viewer'),
@@ -35,15 +35,15 @@ otp.widgets.transit.StopViewerWidget =
             openInitially : false,
             persistOnClose : true,
         });
-        
+
         this.module = module;
-        
+
         var this_ = this;
 
         this.activeTime = moment().unix() * 1000;
-        
+
         this.stopFinder = new otp.widgets.transit.StopFinderWidget(this.module.id + "-stopFinder", this.module, this);
-        
+
         var translated_template = {
             //TRANSLATORS: Date: date chooser (In stop viewer)
             date: _tr('Date'),
@@ -55,10 +55,10 @@ otp.widgets.transit.StopViewerWidget =
         }
 
         ich['otp-stopViewer'](translated_template).appendTo(this.mainDiv);
-        
+
         this.timeList = this.mainDiv.find(".otp-stopViewer-timeList");
         this.stopInfo = this.mainDiv.find(".otp-stopViewer-stopInfo");
-        
+
         var currentDate = new Date();
         this.datePicker = this.mainDiv.find(".otp-stopViewer-dateInput");
         this.datePicker.datepicker({
@@ -71,12 +71,12 @@ otp.widgets.transit.StopViewerWidget =
             }
         });
         this.datePicker.datepicker("setDate", currentDate);
-        
+
         this.mainDiv.find(".otp-stopViewer-findButton").click(function() {
             this_.stopFinder.show();
             this_.stopFinder.bringToFront();
         });
-        
+
     },
 
     clearTimes : function() {
@@ -84,31 +84,43 @@ otp.widgets.transit.StopViewerWidget =
         this.timeIndex = null;
         this.timeList.empty();
     },
-            
-    setStop : function(agencyId, stopId, stopName) {
-        this.agencyId = agencyId;
+
+    setStop : function(stopId, stopName) {
         this.stopId = stopId;
         this.clearTimes();
         //TRANSLATORS: Public transport <Stop> (stop name)
-        this.stopInfo.html("<b>" + _tr("Stop") + ":</b> " + stopName + " (" + agencyId + " #" + stopId + ")");
+        this.stopInfo.html("<b>" + _tr("Stop") + ":</b> " + stopName + " ("  + stopId + ")");
         this.runTimesQuery();
     },
-    
+
     runTimesQuery : function() {
         var this_ = this;
         var startTime = moment(this.datePicker.val(), otp.config.locale.time.date_format).add("hours", -otp.config.timeOffset).unix();
-        this.module.webapp.transitIndex.runStopTimesQuery(this.agencyId, this.stopId, startTime+10800, startTime+97200, this, function(data) {
+        this.module.webapp.indexApi.runStopTimesQuery(this.agencyId, this.stopId, startTime+10800, startTime+97200, this, function(data) {
             this_.times = [];
+            /*
             for(var i=0; i < data.stopTimes.length; i++) {
                 var time = data.stopTimes[i];
                 if(time.phase == "departure") {
                     this_.times.push(time);
                 }
-            }
+            }*/
+            // here we are rearranging a bit the stoptimes, flatting and sorting;
+            _.each(data, function(stopTime){
+                var routeId = stopTime.pattern.id.substring(0,stopTime.pattern.id.lastIndexOf(':'));
+                var pushTime = {};
+                pushTime.routeShortName = this_.module.webapp.indexApi.routes[routeId].routeData.shortName;
+                pushTime.routeLongName = this_.module.webapp.indexApi.routes[routeId].routeData.longName;
+                _.each(stopTime.times,function(time){
+                    pushTime.time = time.realtimeDeparture;
+                    this_.times.push(pushTime);
+                });
+            });
+            this_.times.sort(function(a,b){return a.time-b.time});
             this_.updateTimes();
-        });        
+        });
     },
-      
+
     updateTimes : function() {
         var minDiff = 1000000000;
         var bestIndex = 0;
@@ -135,10 +147,10 @@ otp.widgets.transit.StopViewerWidget =
         }
         this.timeList.scrollTop(((bestIndex/this.times.length) * this.timeList[0].scrollHeight) - this.timeList.height()/2 + $(this.timeList.find(".otp-stopViewer-timeListItem")[0]).height()/2);
     },
-    
+
     setActiveTime : function(activeTime) {
         this.activeTime = activeTime;
         this.datePicker.datepicker("setDate", new Date(activeTime));
     },
-    
+
 });

--- a/src/client/js/otp/widgets/transit/TripViewerWidget.js
+++ b/src/client/js/otp/widgets/transit/TripViewerWidget.js
@@ -2,79 +2,78 @@
    modify it under the terms of the GNU Lesser General Public License
    as published by the Free Software Foundation, either version 3 of
    the License, or (at your option) any later version.
-   
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-   
+
    You should have received a copy of the GNU General Public License
-   along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 otp.namespace("otp.widgets.transit");
 
-otp.widgets.transit.TripViewerWidget = 
+otp.widgets.transit.TripViewerWidget =
     otp.Class(otp.widgets.transit.RouteBasedWidget, {
 
     module : null,
 
     agency_id : null,
-    
+
     activeLeg : null,
     timeIndex : null,
-    
+
     routeLookup : [], // for retrieving route obj from numerical index in <select> element
-    
+
     lastSize : null,
-    //variantIndexLookup : null, 
-    
+    //variantIndexLookup : null,
+
     initialize : function(id, module) {
-    
+
         otp.widgets.transit.RouteBasedWidget.prototype.initialize.call(this, id, module, {
             title : _tr('Trip Viewer'),
             cssClass : 'otp-tripViewer',
             closeable : true,
             openInitially : false,
-            persistOnClose : true, 
+            persistOnClose : true,
         });
-        
+
         this.module = module;
-        
+
         var this_ = this;
 
         this.stopList = $('<div class="otp-tripViewer-stopList notDraggable" />').appendTo(this.mainDiv);
 
         this.scheduleLink = $('<div class="otp-tripViewer-scheduleLink notDraggable" />').appendTo(this.mainDiv);
-        
+
         console.log("added sched link");
         this.mainDiv.resizable({
             minWidth: 200,
             alsoResize: this.stopList,
         });
-        
+
     },
-    
-        
+
+
     clear : function() {
         this.stopList.empty();
     },
-    
+
     variantSelected : function(variantData) {
-        console.log("var sel");
-        console.log(variantData);
+        //console.log("var sel");
+        //console.log(variantData);
         var this_ = this;
-    
         this.stopList.empty();
         var selectedStopIndex = 0;
         for(var i=0; i<this.activeVariant.stops.length; i++) {
             var stop = this.activeVariant.stops[i];
 
             var row = $('<div class="otp-tripViewer-stopRow" />').appendTo(this.stopList);
-            
+
             var stopIcon = $('<div style="width: 30px; height: 32px; overflow: hidden; float:left; margin-left: 2px;" />').appendTo(row);
-            
-            // use the appropriate line/stop graphic          
+
+            // use the appropriate line/stop graphic
             var lineImg;
             if(i == 0) {
                 lineImg = $('<img src="images/widget-trip-stop-first.png" />');
@@ -98,20 +97,20 @@ otp.widgets.transit.TripViewerWidget =
             }
 
             lineImg.appendTo(stopIcon);
-            
-            // set up the stop name and id/links content            
+
+            // set up the stop name and id/links content
             var stopText = $('<div style="margin-left: 40px" />').appendTo(row);
             $('<div class="otp-tripViewer-stopRow-name"><b>'+(i+1)+'.</b> '+stop.name+'</div>').appendTo(stopText);
             var idLine = $('<div class="otp-tripViewer-stopRow-idLine" />').appendTo(stopText);
             var idHtml = '<span><i>';
             if(stop.url) idHtml += '<a href="'+stop.url+'" target="_blank">';
-            idHtml += stop.id.agencyId+' #'+stop.id.id;
+            idHtml += stop.id; //.agencyId+' #'+stop.id.id;
             if(stop.url) idHtml += '</a>';
             idHtml += '</i></span>'
             $(idHtml).appendTo(idLine);
-           
+
             //TRANSLATORS: Recenter map on this stop (Shown at each stop in
-            //Trip viewer 
+            //Trip viewer
             $('<span>&nbsp;[<a href="#">' + _tr('Recenter') + '</a>]</span>').appendTo(idLine)
             .data("stop", stop)
             .click(function(evt) {
@@ -130,15 +129,15 @@ otp.widgets.transit.TripViewerWidget =
                 }
                 this_.module.stopViewerWidget.show();
                 //this_.module.stopViewerWidget.activeTime = leg.startTime;
-                this_.module.stopViewerWidget.setStop(stop.id.agencyId, stop.id.id, stop.name);
+                this_.module.stopViewerWidget.setStop(stop.id, stop.name);
                 this_.module.stopViewerWidget.bringToFront();
             });
-            
+
             // highlight the boarded stops
             if(this.activeLeg && i >= this.activeLeg.from.stopIndex && i <= this.activeLeg.to.stopIndex) {
                 stopIcon.css({ background : '#bbb' });
             }
-            
+
             // set up hover functionality (open popup over stop)
             row.data("stop", stop).hover(function(evt) {
                 var stop = $(this).data("stop");
@@ -151,17 +150,17 @@ otp.widgets.transit.TripViewerWidget =
             }, function(evt) {
                 this_.module.webapp.map.lmap.closePopup();
             });
-            
+
         }
-        
+
         // scroll to the boarded segment, if applicable
         if(this.activeLeg) {
             var scrollY = this.stopList[0].scrollHeight * this.activeLeg.from.stopIndex / (this.activeVariant.stops.length - 1);
             this.stopList.scrollTop(scrollY);
         }
-        
+
         // update the route link
-        
+
         var url = variantData.route.url;
         var html = "";
         if(url) html += 'Link to: <a href="' + url + '" target="_blank">Route Info</a>';
@@ -177,9 +176,9 @@ otp.widgets.transit.TripViewerWidget =
             var rte = url.substring(29, 32);
             html += ' | <a href="http://trimet.org/schedules/' + day + '/t1' + rte + '_' + variantData.direction + '.htm" target="_blank">Timetable</a>';
         }
-        
+
         this.scheduleLink.html(html);
-        
+
     },
-    
+
 });

--- a/src/client/js/otp/widgets/transit/widgets-transit-templates.html
+++ b/src/client/js/otp/widgets/transit/widgets-transit-templates.html
@@ -1,7 +1,7 @@
 <script id="otp-stopViewer" type="text/html">
 
     <div class="otp-stopViewer-container notDraggable">
-        <div class="otp-stopViewer-stopInfo"> 
+        <div class="otp-stopViewer-stopInfo">
 			{{no_stops_selected}}
         </div>
 
@@ -23,10 +23,10 @@
             {{formattedTime}}
         </div>
         <div class="otp-stopViewer-routeRow">
-            {{#trip.route.shortName}}
-                ({{trip.route.shortName}}) 
-            {{/trip.route.shortName}}
-            {{trip.route.longName}}
+            {{#routeShortName}}
+                ({{routeShortName}})
+            {{/routeShortName}}
+            {{routeLongName}}
         </div>
 
         {{#direction}}
@@ -34,12 +34,12 @@
 				{{to}}{{direction}}
             </div>
         {{/direction}}
-        
+
         {{#trip.blockId}}
             <div class="otp-stopViewer-blockRow">
 				{{block}} {{trip.blockId}}
             </div>
-        {{/trip.blockId}}            
+        {{/trip.blockId}}
     </div>
 </script>
 

--- a/src/client/js/otp/widgets/tripoptions/RoutesSelectorWidget.js
+++ b/src/client/js/otp/widgets/tripoptions/RoutesSelectorWidget.js
@@ -2,31 +2,31 @@
    modify it under the terms of the GNU Lesser General Public License
    as published by the Free Software Foundation, either version 3 of
    the License, or (at your option) any later version.
-   
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-   
+
    You should have received a copy of the GNU General Public License
-   along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 otp.namespace("otp.widgets");
 
-otp.widgets.RoutesSelectorWidget = 
+otp.widgets.RoutesSelectorWidget =
     otp.Class(otp.widgets.Widget, {
 
     routesControl : null,
-    
+
     routeData : [],
     selectedRouteIndices : [],
     selectedRouteIds : null, // agencyAndId format
-    
+
     restoredRouteIds : null, // agencyAndId format
-    
+
     initializedRoutes : false,
-    
+
     initialize : function(id, routesControl, name) {
         var this_ = this;
         otp.widgets.Widget.prototype.initialize.call(this, id, routesControl.tripWidget.owner, {
@@ -35,7 +35,7 @@ otp.widgets.RoutesSelectorWidget =
         });
 
         this.routesControl = routesControl;
-        this.ti = this.routesControl.tripWidget.module.webapp.transitIndex;
+        this.indexApi = this.routesControl.tripWidget.module.webapp.indexApi;
 
         this.selectedRouteIds = [];
 
@@ -51,7 +51,7 @@ otp.widgets.RoutesSelectorWidget =
             //widget
             close : _tr("Close")
         }).appendTo(this.$());
-        
+
         this.selectedList = $('#'+this_.id+'-selectedList');
         this.routeList = $('#'+this_.id+'-routeList');
 
@@ -68,36 +68,36 @@ otp.widgets.RoutesSelectorWidget =
         $('#'+this.id+'-saveButton').button().click(function() {
             var paramStr = '', displayStr = '';
             for(var i = 0; i < this_.selectedRouteIds.length; i++) {
-                var route = this_.ti.routes[this_.selectedRouteIds[i]].routeData;
+                var route = this_.indexApi.routes[this_.selectedRouteIds[i]].routeData;
 
                 paramStr += route.id.agencyId+"__"+route.id.id + (i < this_.selectedRouteIds.length-1 ? ',' : '');
-                displayStr += (route.routeShortName || route.routeLongName) + (i < this_.selectedRouteIds.length-1 ? ', ' : '');
+                displayStr += (route.shortName || route.longName) + (i < this_.selectedRouteIds.length-1 ? ', ' : '');
             }
             this_.hide();
-            
+
             this_.routesControl.setRoutes(paramStr, displayStr);
         });
 
         $('#'+this.id+'-closeButton').button().click(function() {
             this_.close();
         });
-        
+
         this.center();
     },
-    
+
     selectRoute : function(agencyAndId) {
         if(!agencyAndId || _.contains(this.selectedRouteIds, agencyAndId)) return;
-        this.selectedList.append('<option value="'+agencyAndId+'">'+otp.util.Itin.getRouteDisplayString(this.ti.routes[agencyAndId].routeData)+'</option>');                
+        this.selectedList.append('<option value="'+agencyAndId+'">'+otp.util.Itin.getRouteDisplayString(this.indexApi.routes[agencyAndId].routeData)+'</option>');
         this.selectedRouteIds.push(agencyAndId);
     },
-    
+
     updateRouteList : function() {
         if(this.initializedRoutes) return;
         var this_ = this;
-        
+
         this.routeList.empty();
 
-        this.ti.loadRoutes(this, function() {
+        this.indexApi.loadRoutes(this, function() {
             this_.restoreSelected();
             this_.initializedRoutes = true;
         });
@@ -107,19 +107,19 @@ otp.widgets.RoutesSelectorWidget =
     restoreSelected : function() {
         this.clearSelected();
         var i = 0;
-        for(agencyAndId in this.ti.routes) {
-            var route = this.ti.routes[agencyAndId].routeData;
+        for(agencyAndId in this.indexApi.routes) {
+            var route = this.indexApi.routes[agencyAndId].routeData;
             this.routeList.append('<option value="'+agencyAndId+'">'+otp.util.Itin.getRouteDisplayString(route)+'</option>');
             if(_.contains(this.restoredRouteIds, agencyAndId)) {
                 this.selectRoute(agencyAndId);
             }
             i++;
-        }        
+        }
     },
-    
+
     clearSelected : function() {
         this.selectedList.empty();
         this.selectedRouteIds = [];
     }
-    
+
 });

--- a/src/client/js/otp/widgets/tripoptions/RoutesSelectorWidget.js
+++ b/src/client/js/otp/widgets/tripoptions/RoutesSelectorWidget.js
@@ -69,8 +69,8 @@ otp.widgets.RoutesSelectorWidget =
             var paramStr = '', displayStr = '';
             for(var i = 0; i < this_.selectedRouteIds.length; i++) {
                 var route = this_.indexApi.routes[this_.selectedRouteIds[i]].routeData;
-
-                paramStr += route.id.agencyId+"__"+route.id.id + (i < this_.selectedRouteIds.length-1 ? ',' : '');
+                //format expected: agency_routename or agency__routeid, so, in our case, two underscores 
+                paramStr += route.id.replace(":", "__") + (i < this_.selectedRouteIds.length-1 ? ',' : '');
                 displayStr += (route.shortName || route.longName) + (i < this_.selectedRouteIds.length-1 ? ', ' : '');
             }
             this_.hide();

--- a/src/client/js/otp/widgets/tripoptions/TripOptionsWidget.js
+++ b/src/client/js/otp/widgets/tripoptions/TripOptionsWidget.js
@@ -2,31 +2,31 @@
    modify it under the terms of the GNU Lesser General Public License
    as published by the Free Software Foundation, either version 3 of
    the License, or (at your option) any later version.
-   
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-   
+
    You should have received a copy of the GNU General Public License
-   along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 otp.namespace("otp.widgets.tripoptions");
 
-otp.widgets.tripoptions.TripOptionsWidget = 
+otp.widgets.tripoptions.TripOptionsWidget =
     otp.Class(otp.widgets.Widget, {
-    
+
     //planTripCallback : null,
     controls : null,
     module : null,
 
     scrollPanel : null,
-    
+
     autoPlan : false,
-            
+
     initialize : function(id, module, options) {
-    
+
         options = options || {};
         //TRANSLATORS: Widget title
         if(!_.has(options, 'title')) options['title'] = _tr("Travel Options");
@@ -34,15 +34,15 @@ otp.widgets.tripoptions.TripOptionsWidget =
         otp.widgets.Widget.prototype.initialize.call(this, id, module, options);
 
         this.mainDiv.addClass('otp-tripOptionsWidget');
-        
+
         //this.planTripCallback = planTripCallback;
         this.module = module;
-        
+
         this.controls = {};
     },
 
     addControl : function(id, control, scrollable) {
-    
+
         if(scrollable) {
             if(this.scrollPanel == null) this.initScrollPanel();
             control.$().appendTo(this.scrollPanel);
@@ -54,7 +54,7 @@ otp.widgets.tripoptions.TripOptionsWidget =
         control.doAfterLayout();
         this.controls[id] = control;
     },
-    
+
     initScrollPanel : function() {
         this.scrollPanel = $('<div id="'+this.id+'-scollPanel" class="notDraggable" style="overflow: auto;"></div>').appendTo(this.$());
         this.$().resizable({
@@ -62,7 +62,7 @@ otp.widgets.tripoptions.TripOptionsWidget =
             alsoResize: this.scrollPanel
         });
     },
-    
+
     addSeparator : function(scrollable) {
         var hr = $("<hr />")
         if(scrollable) {
@@ -73,7 +73,7 @@ otp.widgets.tripoptions.TripOptionsWidget =
             hr.appendTo(this.$());
         }
     },
-    
+
     addVerticalSpace : function(pixels, scrollable) {
         var vSpace = $('<div style="height: '+pixels+'px;"></div>');
         if(scrollable) {
@@ -87,7 +87,7 @@ otp.widgets.tripoptions.TripOptionsWidget =
 
     restorePlan : function(data) {
 	    if(data == null) return;
-	    
+
 	    for(var id in this.controls) {
             this.controls[id].restorePlan(data);
         }
@@ -105,21 +105,21 @@ otp.widgets.tripoptions.TripOptionsWidget =
         }
         this.applyQueryParams(params);
     },
-    
+
     newItinerary : function(itin) {
         for(var id in this.controls) {
             this.controls[id].newItinerary(itin);
         }
     },
-    
+
     inputChanged : function(params) {
         if(params) _.extend(this.module, params);
         if(this.autoPlan) {
             this.module.planTrip();
         }
     },
-    
-    
+
+
     CLASS_NAME : "otp.widgets.TripWidget"
 });
 
@@ -127,29 +127,29 @@ otp.widgets.tripoptions.TripOptionsWidget =
 //** CONTROL CLASSES **//
 
 otp.widgets.tripoptions.TripOptionsWidgetControl = otp.Class({
-    
+
     div :   null,
     tripWidget : null,
-    
+
     initialize : function(tripWidget) {
         this.tripWidget = tripWidget;
         this.div = document.createElement('div');
         //this.div.className()
     },
-    
+
     setContent : function(content) {
         this.div.innerHTML = content;
     },
-        
+
     doAfterLayout : function() {
     },
-    
+
     restorePlan : function(data) {
     },
-    
+
     newItinerary : function(itin) {
     },
-    
+
     isApplicableForMode : function(mode) {
         return false;
     },
@@ -161,21 +161,21 @@ otp.widgets.tripoptions.TripOptionsWidgetControl = otp.Class({
 
 //** LocationsSelector **//
 
-otp.widgets.tripoptions.LocationsSelector = 
+otp.widgets.tripoptions.LocationsSelector =
     otp.Class(otp.widgets.tripoptions.TripOptionsWidgetControl, {
-    
+
     id           :  null,
     geocoders    :  null,
-    
+
     activeIndex  :  0,
-    
+
     initialize : function(tripWidget, geocoders) {
         console.log("init loc");
         this.geocoders = geocoders;
-        
+
         otp.widgets.tripoptions.TripOptionsWidgetControl.prototype.initialize.apply(this, arguments);
         this.id = tripWidget.id+"-locSelector";
-        
+
         ich['otp-tripOptions-locations']({
             widgetId : this.id,
             showGeocoders : (this.geocoders && this.geocoders.length > 1),
@@ -185,7 +185,7 @@ otp.widgets.tripoptions.LocationsSelector =
             end: _tr("End"),
             geocoder: _tr("Geocoder")
         }).appendTo(this.$());
-        
+
         this.tripWidget.module.on("startChanged", $.proxy(function(latlng, name) {
             $("#"+this.id+"-start").val(name || '(' + latlng.lat.toFixed(5) + ', ' + latlng.lng.toFixed(5) + ')');
         }, this));
@@ -198,11 +198,11 @@ otp.widgets.tripoptions.LocationsSelector =
 
     doAfterLayout : function() {
         var this_ = this;
-        
+
         this.startInput = this.initInput($("#"+this.id+"-start"), this.tripWidget.module.setStartPoint);
         this.endInput = this.initInput($("#"+this.id+"-end"), this.tripWidget.module.setEndPoint);
 
-        
+
         $("#"+this.id+"-startDropdown").click($.proxy(function() {
             $("#"+this.id+"-start").autocomplete("widget").show();
         }, this));
@@ -210,7 +210,7 @@ otp.widgets.tripoptions.LocationsSelector =
         $("#"+this.id+"-endDropdown").click($.proxy(function() {
             $("#"+this.id+"-end").autocomplete("widget").show();
         }, this));
-                
+
 
         $("#"+this.id+"-reverseButton").click($.proxy(function() {
             var module = this.tripWidget.module;
@@ -220,9 +220,9 @@ otp.widgets.tripoptions.LocationsSelector =
             module.setStartPoint(endLatLng, false, endName);
             module.setEndPoint(startLatLng, false, startName);
             this_.tripWidget.inputChanged();
-            
+
         }, this));
-        
+
         if(this.geocoders.length > 1) {
             var selector = $("#"+this.id+"-selector");
             selector.change(function() {
@@ -230,7 +230,7 @@ otp.widgets.tripoptions.LocationsSelector =
             });
         }
     },
-        
+
     initInput : function(input, setterFunction) {
         var this_ = this;
         input.autocomplete({
@@ -255,7 +255,7 @@ otp.widgets.tripoptions.LocationsSelector =
         });
         return input;
     },
-    
+
     getResultLookup : function(results) {
         var resultLookup = {};
         for(var i=0; i<results.length; i++) {
@@ -263,7 +263,7 @@ otp.widgets.tripoptions.LocationsSelector =
         }
         return resultLookup;
     },
-    
+
     restorePlan : function(data) {
         if(data.queryParams.fromPlace) {
             console.log("rP: "+data.queryParams.fromPlace);
@@ -277,7 +277,7 @@ otp.widgets.tripoptions.LocationsSelector =
             $("#"+this.id+"-start").val('');
             this.tripWidget.module.startName = null;
         }
-        
+
         if(data.queryParams.toPlace) {
             var toName = otp.util.Itin.getLocationName(data.queryParams.toPlace);
             if(toName) {
@@ -289,19 +289,19 @@ otp.widgets.tripoptions.LocationsSelector =
             $("#"+this.id+"-end").val('');
             this.tripWidget.module.endName = null;
         }
-    }    
-        
+    }
+
 });
 
 
 //** TimeSelector **//
 
-otp.widgets.tripoptions.TimeSelector = 
+otp.widgets.tripoptions.TimeSelector =
     otp.Class(otp.widgets.tripoptions.TripOptionsWidgetControl, {
-    
+
     id          :  null,
-    epoch       : null,   
-    
+    epoch       : null,
+
     initialize : function(tripWidget) {
         otp.widgets.tripoptions.TripOptionsWidgetControl.prototype.initialize.apply(this, arguments);
         this.id = tripWidget.id+"-timeSelector";
@@ -317,8 +317,8 @@ otp.widgets.tripoptions.TimeSelector =
             //TRANSLATORS: on button that sets time and date of arrival/departure to now
             now      : _tr("Now")
         }).appendTo(this.$());
-    
-        this.epoch = moment().unix();    
+
+        this.epoch = moment().unix();
     },
 
     doAfterLayout : function() {
@@ -337,7 +337,7 @@ otp.widgets.tripoptions.TimeSelector =
             }
         });
         $('#'+this.id+'-date').datepicker("setDate", new Date());
-        
+
         $('#'+this.id+'-time').val(moment().format(otp.config.locale.time.time_format))
         .keyup(function() {
             if(otp.config.locale.time.time_format.toLowerCase().charAt(otp.config.locale.time.time_format.length-1) === 'a') {
@@ -357,15 +357,15 @@ otp.widgets.tripoptions.TimeSelector =
                         }
                     }
                 }
-            }            
+            }
             this_.tripWidget.inputChanged({
                 time : $(this).val(),
             });
-            
+
         });
-        
+
         $("#"+this.id+'-nowButton').click(function() {
-            $('#'+this_.id+'-date').datepicker("setDate", new Date());        
+            $('#'+this_.id+'-date').datepicker("setDate", new Date());
             $('#'+this_.id+'-time').val(moment().format(otp.config.locale.time.time_format))
             this_.tripWidget.inputChanged({
                 time : $('#'+this_.id+'-time').val(),
@@ -374,7 +374,7 @@ otp.widgets.tripoptions.TimeSelector =
         });
 
     },
-    
+
     getDate : function() {
         return $('#'+this.id+'-date').val();
     },
@@ -396,14 +396,14 @@ otp.widgets.tripoptions.TimeSelector =
         }
         if(data.queryParams.arriveBy === true || data.queryParams.arriveBy === "true") {
             this.tripWidget.module.arriveBy = true;
-            $('#'+this.id+'-depArr option:eq(1)').prop('selected', true);  
+            $('#'+this.id+'-depArr option:eq(1)').prop('selected', true);
         }
         else {
             this.tripWidget.module.arriveBy = false;
-            $('#'+this.id+'-depArr option:eq(0)').prop('selected', true);  
+            $('#'+this.id+'-depArr option:eq(0)').prop('selected', true);
         }
     }
-        
+
 });
 
 
@@ -454,16 +454,16 @@ otp.widgets.tripoptions.WheelChairSelector =
 
 //** ModeSelector **//
 
-otp.widgets.tripoptions.ModeSelector = 
+otp.widgets.tripoptions.ModeSelector =
     otp.Class(otp.widgets.tripoptions.TripOptionsWidgetControl, {
-    
+
     id           :  null,
 
     modes        : otp.config.modes,
-    
+
     optionLookup : null,
     modeControls : null,
-           
+
     initialize : function(tripWidget) {
         otp.widgets.tripoptions.TripOptionsWidgetControl.prototype.initialize.apply(this, arguments);
         this.id = tripWidget.id+"-modeSelector";
@@ -474,12 +474,12 @@ otp.widgets.tripoptions.ModeSelector =
         var html = "<div class='notDraggable'>" + _tr("Travel by") + ": ";
         html += '<select id="'+this.id+'">';
         _.each(this.modes, function(text, key) {
-            html += '<option>'+text+'</option>';            
+            html += '<option>'+text+'</option>';
         });
         html += '</select>';
         html += '<div id="'+this.id+'-widgets" style="overflow: hidden;"></div>';
         html += "</div>";
-        
+
         $(html).appendTo(this.$());
         //this.setContent(content);
     },
@@ -498,19 +498,19 @@ otp.widgets.tripoptions.ModeSelector =
         var i = 0;
         for(mode in this.modes) {
             if(mode === data.queryParams.mode) {
-                this.tripWidget.module.mode = data.queryParams.mode; 
-                $('#'+this.id+' option:eq('+i+')').prop('selected', true);    
+                this.tripWidget.module.mode = data.queryParams.mode;
+                $('#'+this.id+' option:eq('+i+')').prop('selected', true);
             }
             i++;
         }
-        
+
         for(i = 0; i < this.modeControls.length; i++) {
             this.modeControls[i].restorePlan(data);
         }
     },
-    
+
     controlPadding : "8px",
-    
+
     refreshModeControls : function() {
         var container = $("#"+this.id+'-widgets');
         container.empty();
@@ -524,19 +524,19 @@ otp.widgets.tripoptions.ModeSelector =
             }
         }
     },
-    
+
     addModeControl : function(widget) {
         this.modeControls.push(widget);
     }
-        
+
 });
 
 
 //** MaxWalkSelector **//
 
-otp.widgets.tripoptions.MaxDistanceSelector = 
+otp.widgets.tripoptions.MaxDistanceSelector =
     otp.Class(otp.widgets.tripoptions.TripOptionsWidgetControl, {
-    
+
     id           :  null,
     presets      : null,
     distSuffix   : null,
@@ -552,7 +552,7 @@ otp.widgets.tripoptions.MaxDistanceSelector =
         var presets;
 
         otp.widgets.tripoptions.TripOptionsWidgetControl.prototype.initialize.apply(this, arguments);
-        
+
         // Set it up the system correctly ones, so we don't need to later on
         if (otp.config.metric) {
             this.presets = presets = this.metricPresets;
@@ -595,7 +595,7 @@ otp.widgets.tripoptions.MaxDistanceSelector =
 
             this_.setDistance(meters);
         });
-        
+
         $('#'+this.id+'-presets').change(function() {
             var presetVal = this_.presets[this.selectedIndex-1];
 
@@ -605,8 +605,8 @@ otp.widgets.tripoptions.MaxDistanceSelector =
             if (!otp.config.metric) { presetVal = otp.util.Imperial.metersToMiles(presetVal); } // Output in miles
 
             // Show the value in miles/meters
-            $('#'+this_.id+'-value').val(presetVal.toFixed(2));    
-            $('#'+this_.id+'-presets option:eq(0)').prop('selected', true);    
+            $('#'+this_.id+'-value').val(presetVal.toFixed(2));
+            $('#'+this_.id+'-presets option:eq(0)').prop('selected', true);
         });
     },
 
@@ -618,7 +618,7 @@ otp.widgets.tripoptions.MaxDistanceSelector =
 
         if (!otp.config.metric) { meters = otp.util.Imperial.metersToMiles(meters); }
 
-        $('#'+this.id+'-value').val(meters.toFixed(2));  
+        $('#'+this.id+'-value').val(meters.toFixed(2));
         this.tripWidget.module.maxWalkDistance = parseFloat(data.queryParams.maxWalkDistance);
     },
 
@@ -630,7 +630,7 @@ otp.widgets.tripoptions.MaxDistanceSelector =
 
 });
 
-otp.widgets.tripoptions.MaxWalkSelector = 
+otp.widgets.tripoptions.MaxWalkSelector =
     otp.Class(otp.widgets.tripoptions.MaxDistanceSelector, {
 
     // miles (0.1, 0.2, 0.25, 0.3, 0.4, 0.5, 0.75, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5)
@@ -639,21 +639,21 @@ otp.widgets.tripoptions.MaxWalkSelector =
     // meters
     metricPresets      : [100, 200, 300, 400, 500, 750, 1000, 1500, 2000, 2500, 5000, 7500, 10000],
 
-    //TRANSLATORS: label for choosing how much should person's trip on foot be 
+    //TRANSLATORS: label for choosing how much should person's trip on foot be
     label       : _tr("Maximum walk")+":",
 
     initialize : function(tripWidget) {
         this.id = tripWidget.id+"-maxWalkSelector";
         otp.widgets.tripoptions.MaxDistanceSelector.prototype.initialize.apply(this, arguments);
     },
-    
+
     isApplicableForMode : function(mode) {
         return otp.util.Itin.includesTransit(mode) && otp.util.Itin.includesWalk(mode);
     },
 
 });
 
-otp.widgets.tripoptions.MaxBikeSelector = 
+otp.widgets.tripoptions.MaxBikeSelector =
     otp.Class(otp.widgets.tripoptions.MaxDistanceSelector, {
 
     // miles (0.1, 0.25, 0.5, 0.75, 1, 2, 3, 4, 5, 10, 15, 20, 30, 40, 100)
@@ -662,14 +662,14 @@ otp.widgets.tripoptions.MaxBikeSelector =
     // meters
     metricPresets      : [100, 300, 750, 1000, 1500, 2500, 5000, 7500, 10000],
 
-    //TRANSLATORS: label for choosing how much should person's trip on bicycle be 
+    //TRANSLATORS: label for choosing how much should person's trip on bicycle be
     label       : _tr("Maximum bike")+":",
 
     initialize : function(tripWidget) {
         this.id = tripWidget.id+"-maxBikeSelector";
         otp.widgets.tripoptions.MaxDistanceSelector.prototype.initialize.apply(this, arguments);
     },
-    
+
     isApplicableForMode : function(mode) {
         return otp.util.Itin.includesTransit(mode) && otp.util.Itin.includesBicycle(mode);
     },
@@ -678,20 +678,20 @@ otp.widgets.tripoptions.MaxBikeSelector =
 
 //** PreferredRoutes **//
 
-otp.widgets.tripoptions.PreferredRoutes = 
+otp.widgets.tripoptions.PreferredRoutes =
     otp.Class(otp.widgets.tripoptions.TripOptionsWidgetControl, {
-    
+
     id           :  null,
-    
+
     selectorWidget : null,
-    
+
     lastSliderValue : null,
-       
+
     initialize : function(tripWidget) {
         var this_ = this;
         otp.widgets.tripoptions.TripOptionsWidgetControl.prototype.initialize.apply(this, arguments);
         this.id = tripWidget.id+"-preferredRoutes";
-        
+
         ich['otp-tripOptions-preferredRoutes']({
             widgetId : this.id,
             //TRANSLATORS: label Preferred Routes: (routes/None)
@@ -704,7 +704,7 @@ otp.widgets.tripoptions.PreferredRoutes =
             //transport routes
             weight: _tr("Weight")
         }).appendTo(this.$());
-        
+
         //TRANSLATORS: widget title
         this.selectorWidget = new otp.widgets.RoutesSelectorWidget(this.id+"-selectorWidget", this, _tr("Preferred Routes"));
     },
@@ -718,7 +718,7 @@ otp.widgets.tripoptions.PreferredRoutes =
             if(this_.selectorWidget.isMinimized) this_.selectorWidget.unminimize();
             this_.selectorWidget.bringToFront();
         });
-        
+
         $('#'+this.id+'-weightSlider').slider({
             min : 0,
             max : 57600,
@@ -739,11 +739,11 @@ otp.widgets.tripoptions.PreferredRoutes =
         });
         $('#'+this.id+'-list').html(displayStr);
     },
-    
+
     restorePlan : function(planData) {
         if(planData.queryParams.preferredRoutes) {
             var this_ = this;
-            
+
             var restoredIds = [];
             var preferredRoutesArr = planData.queryParams.preferredRoutes.split(',');
 
@@ -758,18 +758,18 @@ otp.widgets.tripoptions.PreferredRoutes =
             if(this.selectorWidget.initializedRoutes) this.selectorWidget.restoreSelected();
 
             this.tripWidget.module.preferredRoutes = planData.queryParams.preferredRoutes;
-            
+
             // resolve the IDs to user-friendly names
-            var ti = this.tripWidget.module.webapp.transitIndex;
-            ti.loadRoutes(this, function() {
+            var indexApi = this.tripWidget.module.webapp.indexApi;
+            indexApi.loadRoutes(this, function() {
                 var routeNames = [];
                 for(var i = 0; i < restoredIds.length; i++) {
-                    var route = ti.routes[restoredIds[i]].routeData;
-                    routeNames.push(route.routeShortName || route.routeLongName);
+                    var route = indexApi.routes[restoredIds[i]].routeData;
+                    routeNames.push(route.shortName || route.longName);
                 }
                 $('#'+this_.id+'-list').html(routeNames.join(', '));
             });
-            
+
         }
         else { // none specified
             this.selectorWidget.clearSelected();
@@ -782,28 +782,28 @@ otp.widgets.tripoptions.PreferredRoutes =
             $('#'+this.id+'-weightSlider').slider('value', this.lastSliderValue);
         }
     },
-    
+
     isApplicableForMode : function(mode) {
         return otp.util.Itin.includesTransit(mode);
-    }      
-        
+    }
+
 });
 
 
 //** BannedRoutes **//
 
-otp.widgets.tripoptions.BannedRoutes = 
+otp.widgets.tripoptions.BannedRoutes =
     otp.Class(otp.widgets.tripoptions.TripOptionsWidgetControl, {
-    
+
     id           :  null,
-    
+
     selectorWidget : null,
-       
+
     initialize : function(tripWidget) {
         var this_ = this;
         otp.widgets.tripoptions.TripOptionsWidgetControl.prototype.initialize.apply(this, arguments);
         this.id = tripWidget.id+"-bannedRoutes";
-        
+
         var html = '<div class="notDraggable">';
         //TRANSLATORS: buton edit Banned public transport routes
         var html = '<div style="float:right; font-size: 12px;"><button id="'+this.id+'-button">' + _tr("Edit") + '…</button></div>';
@@ -811,7 +811,7 @@ otp.widgets.tripoptions.BannedRoutes =
         //(Routes you don't want to take)
         html += _tr("Banned routes") + ': <span id="'+this.id+'-list">('+_tr("None")+')</span>';
         html += '<div style="clear:both;"></div></div>';
-        
+
         $(html).appendTo(this.$());
 
         //TRANSLATORS: Widget title
@@ -834,11 +834,11 @@ otp.widgets.tripoptions.BannedRoutes =
         });
         $('#'+this.id+'-list').html(displayStr);
     },
-    
+
     restorePlan : function(planData) {
         if(planData.queryParams.bannedRoutes) {
             var this_ = this;
-            
+
             var restoredIds = [];
             var bannedRoutesArr = planData.queryParams.bannedRoutes.split(',');
 
@@ -853,18 +853,18 @@ otp.widgets.tripoptions.BannedRoutes =
             if(this.selectorWidget.initializedRoutes) this.selectorWidget.restoreSelected();
 
             this.tripWidget.module.bannedRoutes = planData.queryParams.bannedRoutes;
-            
+
             // resolve the IDs to user-friendly names
-            var ti = this.tripWidget.module.webapp.transitIndex;
-            ti.loadRoutes(this, function() {
+            var indexApi = this.tripWidget.module.webapp.indexApi;
+            indexApi.loadRoutes(this, function() {
                 var routeNames = [];
                 for(var i = 0; i < restoredIds.length; i++) {
-                    var route = ti.routes[restoredIds[i]].routeData;
-                    routeNames.push(route.routeShortName || route.routeLongName);
+                    var route = indexApi.routes[restoredIds[i]].routeData;
+                    routeNames.push(route.shortName || route.longName);
                 }
                 $('#'+this_.id+'-list').html(routeNames.join(', '));
             });
-            
+
         }
         else { // none specified
             this.selectorWidget.clearSelected();
@@ -873,30 +873,30 @@ otp.widgets.tripoptions.BannedRoutes =
             this.tripWidget.module.bannedRoutes = null;
         }
     },
-    
+
     isApplicableForMode : function(mode) {
         return otp.util.Itin.includesTransit(mode);
-    }      
-        
+    }
+
 });
 
 
 //** BikeTriangle **//
 
-otp.widgets.tripoptions.BikeTriangle = 
+otp.widgets.tripoptions.BikeTriangle =
     otp.Class(otp.widgets.tripoptions.TripOptionsWidgetControl, {
-    
+
     id           :  null,
     bikeTriangle :  null,
-       
+
     initialize : function(tripWidget) {
         otp.widgets.tripoptions.TripOptionsWidgetControl.prototype.initialize.apply(this, arguments);
         this.id = tripWidget.id+"-bikeTriangle";
-        
+
         var content = '';
         //content += '<h6 class="drag-to-change">Drag to Change Trip:</h6>';
         content += '<div id="'+this.id+'" class="otp-bikeTriangle notDraggable"></div>';
-        
+
         this.setContent(content);
     },
 
@@ -909,9 +909,9 @@ otp.widgets.tripoptions.BikeTriangle =
                 optimize : "TRIANGLE",
                 triangleTimeFactor : formData.triangleTimeFactor,
                 triangleSlopeFactor : formData.triangleSlopeFactor,
-                triangleSafetyFactor : formData.triangleSafetyFactor,                
+                triangleSafetyFactor : formData.triangleSafetyFactor,
             });
-            
+
         };
     },
 
@@ -922,34 +922,34 @@ otp.widgets.tripoptions.BikeTriangle =
                                         planData.queryParams.triangleSafetyFactor);
         }
     },
-    
+
     isApplicableForMode : function(mode) {
         return otp.util.Itin.includesAnyBicycle(mode);
-    }      
-        
+    }
+
 });
 
 
 //** BikeType **//
 
-otp.widgets.tripoptions.BikeType = 
+otp.widgets.tripoptions.BikeType =
     otp.Class(otp.widgets.tripoptions.TripOptionsWidgetControl, {
 
     id           :  null,
-       
+
     initialize : function(tripWidget) {
         otp.widgets.tripoptions.TripOptionsWidgetControl.prototype.initialize.apply(this, arguments);
         this.id = tripWidget.id+"-bikeType";
         this.$().addClass('notDraggable');
 
-        var content = '';        
+        var content = '';
         //TRANSLATORS: In Bike share planner radio button: <Use>: My Own Bike A shared bike
         content += _tr('Use') + ': ';
         //TRANSLATORS: In Bike share planner radio button: Use: <My Own Bike> A shared bike
         content += '<input id="'+this.id+'-myOwnBikeRBtn" type="radio" name="bikeType" value="my_bike" checked> ' + _tr("My Own Bike") + '&nbsp;&nbsp;';
         //TRANSLATORS: In Bike share planner radio button: Use: My Own Bike <A Shared bike>
         content += '<input id="'+this.id+'-sharedBikeRBtn" type="radio" name="bikeType" value="shared_bike"> ' + _tr("A Shared Bike");
-        
+
         this.setContent(content);
     },
 
@@ -972,7 +972,7 @@ otp.widgets.tripoptions.BikeType =
             });
         });
     },
-    
+
     restorePlan : function(planData) {
         if(planData.queryParams.mode === "BICYCLE") {
             $('#'+this.id+'-myOwnBikeRBtn').attr('checked', 'checked');
@@ -981,43 +981,43 @@ otp.widgets.tripoptions.BikeType =
             $('#'+this.id+'-sharedBikeRBtn').attr('checked', 'checked');
         }
     },
-    
+
     isApplicableForMode : function(mode) {
         return otp.util.Itin.includesBicycle(mode) && otp.util.Itin.includesWalk(mode);
-    }    
-        
+    }
+
 });
 
 
 //** TripSummary **//
 
-otp.widgets.tripoptions.TripSummary = 
+otp.widgets.tripoptions.TripSummary =
     otp.Class(otp.widgets.tripoptions.TripOptionsWidgetControl, {
-       
+
     id  : null,
-    
+
     initialize : function(tripWidget) {
         otp.widgets.tripoptions.TripOptionsWidgetControl.prototype.initialize.apply(this, arguments);
         this.id = tripWidget.id+"-tripSummary";
-        
-                
+
+
         var content = '';
         content += '<div id="'+this.id+'-distance" class="otp-tripSummary-distance"></div>';
         content += '<div id="'+this.id+'-duration" class="otp-tripSummary-duration"></div>';
-        content += '<div id="'+this.id+'-timeSummary" class="otp-tripSummary-timeSummary"></div>';    
+        content += '<div id="'+this.id+'-timeSummary" class="otp-tripSummary-timeSummary"></div>';
         this.setContent(content);
     },
 
     newItinerary : function(itin) {
     	var dist = 0;
-    	
+
     	for(var i=0; i < itin.legs.length; i++) {
     		dist += itin.legs[i].distance;
         }
-    	
+
         $("#"+this.id+"-distance").html(otp.util.Geo.distanceString(dist));
-        $("#"+this.id+"-duration").html(otp.util.Time.secsToHrMin(itin.duration));	
-        
+        $("#"+this.id+"-duration").html(otp.util.Time.secsToHrMin(itin.duration));
+
         var timeByMode = { };
         for(var i=0; i < itin.legs.length; i++) {
             if(itin.legs[i].mode in timeByMode) {
@@ -1027,14 +1027,14 @@ otp.widgets.tripoptions.TripSummary =
                 timeByMode[itin.legs[i].mode] = itin.legs[i].duration;
             }
         }
-        
+
         var summaryStr = "";
         for(mode in timeByMode) {
             summaryStr += otp.util.Time.secsToHrMin(timeByMode[mode]) + " " + this.getModeName(mode) + " / ";
         }
         summaryStr = summaryStr.slice(0, -3);
-        $("#"+this.id+"-timeSummary").html(summaryStr);	
-    },    
+        $("#"+this.id+"-timeSummary").html(summaryStr);
+    },
 
     getModeName : function(mode) {
         switch(mode) {
@@ -1050,50 +1050,50 @@ otp.widgets.tripoptions.TripSummary =
 
 //** AddThis **//
 
-otp.widgets.tripoptions.AddThis = 
+otp.widgets.tripoptions.AddThis =
     otp.Class(otp.widgets.tripoptions.TripOptionsWidgetControl, {
-       
+
     initialize : function(tripWidget) {
         otp.widgets.tripoptions.TripOptionsWidgetControl.prototype.initialize.apply(this, arguments);
-        
+
         var content = '';
         content += '<h6 id="share-route-header">Share this Trip:</h6>';
         content += '<div id="share-route"></div>';
 
         this.setContent(content);
     },
-    
+
     doAfterLayout : function() {
         // Copy our existing share widget from the header and customize it for route sharing.
         // The url to share is set in PlannerModule.js in the newTrip() callback that is called
         // once a new route is loaded from the server.
         var addthisElement = $(".addthis_toolbox").clone();
         addthisElement.find(".addthis_counter").remove();
-        
+
         // give this addthis toolbox a unique class so we can activate it alone in Webapp.js
         addthisElement.addClass("addthis_toolbox_route");
         addthisElement.appendTo("#share-route");
         addthisElement.attr("addthis:title", "Check out my trip planned on "+otp.config.siteName);
-        addthisElement.attr("addthis:description", otp.config.siteDescription);    
+        addthisElement.attr("addthis:description", otp.config.siteDescription);
     }
 });
 
 
 //** Submit **//
 
-otp.widgets.tripoptions.Submit = 
+otp.widgets.tripoptions.Submit =
     otp.Class(otp.widgets.tripoptions.TripOptionsWidgetControl, {
-       
+
     initialize : function(tripWidget) {
         otp.widgets.tripoptions.TripOptionsWidgetControl.prototype.initialize.apply(this, arguments);
         this.id = tripWidget.id+"-submit";
-        
+
         //TRANSLATORS: button to send query for trip planning
         $('<div class="notDraggable" style="text-align:center;"><button id="'+this.id+'-button">' + _tr("Plan Your Trip") + '</button></div>').appendTo(this.$());
         //console.log(this.id+'-button')
-        
+
     },
-    
+
     doAfterLayout : function() {
         var this_ = this;
         $('#'+this.id+'-button').button().click(function() {
@@ -1106,18 +1106,18 @@ otp.widgets.tripoptions.Submit =
 
 //** Group Trip **//
 
-otp.widgets.tripoptions.GroupTripOptions = 
+otp.widgets.tripoptions.GroupTripOptions =
     otp.Class(otp.widgets.tripoptions.TripOptionsWidgetControl, {
 
-       
+
     initialize : function(tripWidget, label) {
         otp.widgets.tripoptions.TripOptionsWidgetControl.prototype.initialize.apply(this, arguments);
         this.id = tripWidget.id+"-groupTripOptions";
-        
+
         label = label || "Group size: ";
         var html = '<div class="notDraggable">'+label+'<input id="'+this.id+'-value" type="text" style="width:30px;" value="100" />';
         html += "</div>";
-              
+
         $(html).appendTo(this.$());
     },
 
@@ -1138,24 +1138,24 @@ otp.widgets.tripoptions.GroupTripOptions =
             this.tripWidget.module.groupSize = parseInt(data.queryParams['groupSize']);
         }
     },
- 
+
     isApplicableForMode : function(mode) {
         return otp.util.Itin.includesTransit(mode);
-    }       
+    }
 });
 
-/*otp.widgets.TW_GroupTripSubmit = 
+/*otp.widgets.TW_GroupTripSubmit =
     otp.Class(otp.widgets.tripoptions.TripOptionsWidgetControl, {
-       
+
     initialize : function(tripWidget) {
         otp.widgets.tripoptions.TripOptionsWidgetControl.prototype.initialize.apply(this, arguments);
         this.id = tripWidget.id+"-gtSubmit";
 
         $('<div class="notDraggable" style="text-align:center;"><button id="'+this.id+'-button">Plan Trip</button></div>').appendTo(this.$());
         //console.log(this.id+'-button')
-        
+
     },
-    
+
     doAfterLayout : function() {
         var this_ = this;
         $('#'+this.id+'-button').button().click(function() {

--- a/src/main/java/org/opentripplanner/api/common/RoutingResource.java
+++ b/src/main/java/org/opentripplanner/api/common/RoutingResource.java
@@ -158,7 +158,8 @@ public abstract class RoutingResource {
      */
     @DefaultValue("") @QueryParam("preferredRoutes") protected List<String> preferredRoutes;
 
-    /** The maximum number of possible itineraries to return. */
+    /** Penalty added for using every route that is not preferred if user set any route as preferred, i.e. number of seconds that we are willing
+     * to wait for preferred route. */
     @DefaultValue("-1") @QueryParam("otherThanPreferredRoutesPenalty") protected List<Integer> otherThanPreferredRoutesPenalty;
     
     /** The comma-separated list of preferred agencies. */


### PR DESCRIPTION
This tries to address #1509,
with minimal implementation to adapt the client code to the new Index API.

I tried to reflect the new api name also in client code (IndexApi.js instead of TransitIndex.js) but we can also directly refactor the TransitIndex.js.
Get rid of several agencyId as new object identifiers already include it in the form agencyId:objectId

Other changes should leverage on enhancements from the Api side, e.g.:
- routeList on Stop, to show in the popup
- pattern name, more concise than pattern description
- pattern on Trip, to avoid iterating on route patterns trips searching for which pattern the trip belongs to
- findById and findByName endpoints (maybe /index/stops?name=abc*  or some other RESTFul uri)

but I think is worth waiting for the ongoing GTFS rework.

PS: the PR seems polluted by a lot of whitespace changes; this is due to my Atom editor which is trimming all whitespace line endings. sorry for that.
