### PR TITLE
Fixed map builder

### DIFF
--- a/src/main/java/org/opentripplanner/standalone/OTPConfigurator.java
+++ b/src/main/java/org/opentripplanner/standalone/OTPConfigurator.java
@@ -52,6 +52,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Lists;
+import org.opentripplanner.graph_builder.impl.map.MapBuilder;
 
 public class OTPConfigurator {
 
@@ -213,6 +214,7 @@ public class OTPConfigurator {
                 }
             } 
             if ( hasOSM ) {
+                graphBuilder.addGraphBuilder(new MapBuilder());
                 graphBuilder.addGraphBuilder(new TransitToTaggedStopsGraphBuilderImpl());
                 graphBuilder.addGraphBuilder(new TransitToStreetNetworkGraphBuilderImpl());
                 // The stops can be linked to each other once they have links to the street network.


### PR DESCRIPTION
I compared those mapbuilder with one in 0.11.x and geometries are the same.
I compared then with shapely.

What I don't like is:
##### How geometries are created.
Currently they are made when getGeometry() is called. I could move this to constructor but trips can also be added with add functions.
Geometries are created based on the code in StreetlesStopLinker which I'm not sure how it works.

##### Indexing of graph
For Mapbuilder transit index needs to be created
In 0.11 this was with `TransitIndexService transit = graph.getService(TransitIndexService.class);` but in master it seems that `index` graph function does this task so I added it in MapBuilder and removed transitIndex dependency.

I added Mapbuilder in standaloneOTP if OSM and GTFS files exist.