### PR TITLE
Improve stoptimes in the index API

### DIFF
--- a/src/main/java/org/opentripplanner/index/IndexAPI.java
+++ b/src/main/java/org/opentripplanner/index/IndexAPI.java
@@ -13,6 +13,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
 package org.opentripplanner.index;
 
+import java.text.ParseException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -33,6 +34,7 @@ import org.onebusaway.gtfs.model.AgencyAndId;
 import org.onebusaway.gtfs.model.Route;
 import org.onebusaway.gtfs.model.Stop;
 import org.onebusaway.gtfs.model.Trip;
+import org.onebusaway.gtfs.model.calendar.ServiceDate;
 import org.opentripplanner.common.geometry.DistanceLibrary;
 import org.opentripplanner.common.geometry.SphericalDistanceLibrary;
 import org.opentripplanner.gtfs.GtfsLibrary;
@@ -41,6 +43,7 @@ import org.opentripplanner.index.model.PatternShort;
 import org.opentripplanner.index.model.RouteShort;
 import org.opentripplanner.index.model.StopClusterDetail;
 import org.opentripplanner.index.model.StopShort;
+import org.opentripplanner.index.model.StopTimesInPattern;
 import org.opentripplanner.index.model.TripShort;
 import org.opentripplanner.index.model.TripTimeShort;
 import org.opentripplanner.profile.StopCluster;
@@ -206,6 +209,25 @@ public class IndexAPI {
         return Response.status(Status.OK).entity(index.stopTimesForStop(stop)).build();
     }
 
+    /** Return upcoming vehicle arrival/departure times at the given stop. */
+    @GET
+    @Path("/stops/{stopId}/stoptimes/{date}")
+    public Response getStoptimesForStopAndDate (@PathParam("stopId") String stopIdString,
+                                                @PathParam("date") String date) {
+        Stop stop = index.stopForId.get(GtfsLibrary.convertIdFromString(stopIdString));
+        if (stop == null) return Response.status(Status.NOT_FOUND).entity(MSG_404).build();
+        ServiceDate sd;
+        try {
+            sd = ServiceDate.parseString(date);
+        }
+        catch (ParseException e){
+            return Response.status(Status.BAD_REQUEST).entity(MSG_400).build();
+        }
+
+        List<StopTimesInPattern> ret = index.getStopTimesForStop(stop, sd);
+        return Response.status(Status.OK).entity(ret).build();
+    }
+    
    /** Return a list of all routes in the graph. */
    // with repeated hasStop parameters, replaces old routesBetweenStops
    @GET

--- a/src/main/java/org/opentripplanner/index/model/TripTimeShort.java
+++ b/src/main/java/org/opentripplanner/index/model/TripTimeShort.java
@@ -24,6 +24,7 @@ public class TripTimeShort {
     public boolean timepoint = false;
     public boolean realtime = false;
     public long serviceDay;
+    public AgencyAndId tripId;
 
     /**
      * This is stop-specific, so the index i is a stop index, not a hop index.
@@ -42,6 +43,7 @@ public class TripTimeShort {
 
     public TripTimeShort(TripTimes tt, int i, Stop stop, ServiceDay sd) {
         this(tt, i, stop);
+        tripId = tt.trip.getId();
         serviceDay = sd.time(0);
     }
 

--- a/src/main/java/org/opentripplanner/index/model/TripTimeShort.java
+++ b/src/main/java/org/opentripplanner/index/model/TripTimeShort.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.onebusaway.gtfs.model.AgencyAndId;
 import org.onebusaway.gtfs.model.Stop;
 import org.onebusaway.gtfs.model.Trip;
+import org.opentripplanner.routing.core.ServiceDay;
 import org.opentripplanner.routing.edgetype.Timetable;
 import org.opentripplanner.routing.trippattern.TripTimes;
 
@@ -21,6 +22,8 @@ public class TripTimeShort {
     public int arrivalDelay = UNDEFINED ;
     public int departureDelay = UNDEFINED ;
     public boolean timepoint = false;
+    public boolean realtime = false;
+    public long serviceDay;
 
     /**
      * This is stop-specific, so the index i is a stop index, not a hop index.
@@ -34,6 +37,12 @@ public class TripTimeShort {
         realtimeDeparture  = tt.getDepartureTime(i);
         departureDelay     = tt.getDepartureDelay(i);
         timepoint          = tt.isTimepoint(i);
+        realtime           = !tt.isScheduled();
+    }
+
+    public TripTimeShort(TripTimes tt, int i, Stop stop, ServiceDay sd) {
+        this(tt, i, stop);
+        serviceDay = sd.time(0);
     }
 
     /**

--- a/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
+++ b/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
@@ -329,7 +329,10 @@ public class GraphIndex {
 
         long now = System.currentTimeMillis()/1000;
         List<StopTimesInPattern> ret = new ArrayList<>();
-        TimetableResolver timetableResolver = graph.timetableSnapshotSource.getTimetableSnapshot();
+        TimetableResolver timetableResolver = null;
+        if (graph.timetableSnapshotSource != null) {
+            timetableResolver = graph.timetableSnapshotSource.getTimetableSnapshot();
+        }
         ServiceDate[] serviceDates = {new ServiceDate().previous(), new ServiceDate(), new ServiceDate().next()};
 
         for (TripPattern pattern : patternsForStop.get(stop)) {
@@ -347,7 +350,12 @@ public class GraphIndex {
             // Loop through all possible days
             for (ServiceDate serviceDate : serviceDates) {
                 ServiceDay sd = new ServiceDay(graph, serviceDate, calendarService, pattern.route.getAgency().getId());
-                Timetable tt = timetableResolver.resolve(pattern, serviceDate);
+                Timetable tt;
+                if (timetableResolver != null){
+                    tt = timetableResolver.resolve(pattern, serviceDate);
+                } else {
+                    tt = pattern.scheduledTimetable;
+                }
 
                 if (!tt.temporallyViable(sd, now, timeRange, true)) continue;
 

--- a/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
+++ b/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
@@ -1,11 +1,13 @@
 package org.opentripplanner.routing.graph;
 
+import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.lucene.util.PriorityQueue;
 import org.joda.time.LocalDate;
 import org.onebusaway.gtfs.model.Agency;
 import org.onebusaway.gtfs.model.AgencyAndId;
@@ -30,6 +32,7 @@ import org.opentripplanner.routing.core.ServiceDay;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.edgetype.TablePatternEdge;
 import org.opentripplanner.routing.edgetype.Timetable;
+import org.opentripplanner.routing.edgetype.TimetableResolver;
 import org.opentripplanner.routing.edgetype.TripPattern;
 import org.opentripplanner.routing.trippattern.TripTimes;
 import org.opentripplanner.routing.vertextype.TransitStop;
@@ -298,36 +301,110 @@ public class GraphIndex {
     }
 
     /**
-     * Fetch upcoming vehicle arrivals at a stop.
-     * This is a rather convoluted process because all of the departure search functions currently assume the
-     * existence of a State and a routing context. It would be nice to have another function that gives
-     * all departures within a time window at a stop, being careful to get a mix of all patterns passing through
-     * that stop. In fact, such a function could replace the current boarding logic if we want to allow boarding
-     * more than one trip on the same route at once (return more than one state).
-     * The current implementation is a sketch and does not adequately
+     * Fetch upcoming vehicle departures from a stop.
+     * Fetches two departures for each pattern during the next 24 hours as default
+     *
+     * @param stop
+     * @return
      */
     public Collection<StopTimesInPattern> stopTimesForStop(Stop stop) {
-        List<StopTimesInPattern> ret = Lists.newArrayList();
-        RoutingRequest req = new RoutingRequest();
-        req.setRoutingContext(graph, (Vertex)null, (Vertex)null);
-        State state = new State(req);
+        return getStopTimesForStop(stop, 24*60*60, 2);
+    }
+
+    /**
+     * Fetch upcoming vehicle departures from a stop.
+     * It goes though all patterns passing the stop for the previous, current and next service date.
+     * It uses a priority queue to keep track of the next departures. The queue is shared between all dates, as services
+     * from the previous service date can visit the stop later than the current service date's services. This happens
+     * eg. with sleeper trains.
+     *
+     * TODO: Add frequency based trips
+     *
+     * @param stop
+     * @param timeRange
+     * @param numberOfDepartures
+     * @return
+     */
+    public List<StopTimesInPattern> getStopTimesForStop(Stop stop, int timeRange, int numberOfDepartures) {
+
+        long now = System.currentTimeMillis()/1000;
+        List<StopTimesInPattern> ret = new ArrayList<>();
+        TimetableResolver timetableResolver = graph.timetableSnapshotSource.getTimetableSnapshot();
+        ServiceDate[] serviceDates = {new ServiceDate().previous(), new ServiceDate(), new ServiceDate().next()};
+
         for (TripPattern pattern : patternsForStop.get(stop)) {
-            StopTimesInPattern times = new StopTimesInPattern(pattern);
-            // Should actually be getUpdatedTimetable
-            Timetable table = pattern.scheduledTimetable;
-            // A Stop may occur more than once in a pattern, so iterate over all Stops.
+
+            // Use the Lucene PriorityQueue, which has a fixed size
+            PriorityQueue<TripTimeShort> pq = new PriorityQueue<TripTimeShort>(numberOfDepartures) {
+                @Override
+                protected boolean lessThan(TripTimeShort tripTimeShort, TripTimeShort t1) {
+                    // Calculate exact timestamp
+                    return (tripTimeShort.serviceDay + tripTimeShort.realtimeDeparture) >
+                            (t1.serviceDay + t1.realtimeDeparture);
+                }
+            };
+
+            // Loop through all possible days
+            for (ServiceDate serviceDate : serviceDates) {
+                ServiceDay sd = new ServiceDay(graph, serviceDate, calendarService, pattern.route.getAgency().getId());
+                Timetable tt = timetableResolver.resolve(pattern, serviceDate);
+
+                if (!tt.temporallyViable(sd, now, timeRange, true)) continue;
+
+                int secondsSinceMidnight = sd.secondsSinceMidnight(now);
+                int sidx = 0;
+                for (Stop currStop : pattern.stopPattern.stops) {
+                    if (currStop == stop) {
+                        for (TripTimes t : tt.tripTimes) {
+                            if (!sd.serviceRunning(t.serviceCode)) continue;
+                            if (t.getDepartureTime(sidx) != -1 &&
+                                    t.getDepartureTime(sidx) >= secondsSinceMidnight) {
+                                pq.insertWithOverflow(new TripTimeShort(t, sidx, stop, sd));
+                            }
+                        }
+                    }
+                    sidx++;
+                }
+            }
+
+            if (pq.size() != 0) {
+                StopTimesInPattern stopTimes = new StopTimesInPattern(pattern);
+                while (pq.size() != 0) {
+                    stopTimes.times.add(0, pq.pop());
+                }
+                ret.add(stopTimes);
+            }
+        }
+        return ret;
+    }
+
+    /**
+     * Get a list of all trips that pass through a stop during a single ServiceDate. Useful when creating complete stop
+     * timetables for a single day.
+     *
+     * @param stop
+     * @param serviceDate
+     * @return
+     */
+    public List<StopTimesInPattern> getStopTimesForStop(Stop stop, ServiceDate serviceDate) {
+        List<StopTimesInPattern> ret = new ArrayList<>();
+        TimetableResolver timetableResolver = graph.timetableSnapshotSource.getTimetableSnapshot();
+        Collection<TripPattern> patterns = patternsForStop.get(stop);
+        for (TripPattern pattern : patterns) {
+            StopTimesInPattern stopTimes = new StopTimesInPattern(pattern);
+            Timetable tt = timetableResolver.resolve(pattern, serviceDate);
+            ServiceDay sd = new ServiceDay(graph, serviceDate, calendarService, pattern.route.getAgency().getId());
             int sidx = 0;
-            for (Stop currStop : table.pattern.stopPattern.stops) {
-                if (currStop != stop) continue;
-                for (ServiceDay sd : req.rctx.serviceDays) {
-                    TripTimes tt = table.getNextTrip(state, sd, sidx, true);
-                    if (tt != null) {
-                        times.times.add(new TripTimeShort(tt, sidx, stop));
+            for (Stop currStop : pattern.stopPattern.stops) {
+                if (currStop == stop) {
+                    for (TripTimes t : tt.tripTimes) {
+                        if (!sd.serviceRunning(t.serviceCode)) continue;
+                        stopTimes.times.add(new TripTimeShort(t, sidx, stop));
                     }
                 }
                 sidx++;
             }
-            if ( ! times.times.isEmpty()) ret.add(times);
+            ret.add(stopTimes);
         }
         return ret;
     }


### PR DESCRIPTION
Currently the stop times for a single stop is quite in a dire state. 
- It doesn't return the correct times, but times for the first stop
- It returns one stoptime each for the previous, current and next service date
- It does not return real-time stoptimes
- It does not return any indication for which service date the stoptime is for.

This branch reworks how the stoptimes are fetched. Instead of using getNextTrip in Timetable, it iterates through all trip patterns that pass along the stop and adds all stoptimes for the previous, current and next service dates, which have not yet happened into a priority queue and fetches the N soonest departures for the pattern.