### PR TITLE
DREAL project fixes and javascript library

### DIFF
--- a/src/main/java/org/opentripplanner/analyst/request/SampleGridRenderer.java
+++ b/src/main/java/org/opentripplanner/analyst/request/SampleGridRenderer.java
@@ -115,7 +115,7 @@ public class SampleGridRenderer {
      * @return
      */
     public static void sampleSPT(final ShortestPathTree spt, ZSampleGrid<WTWD> sampleGrid,
-            final double d0, final double gridSizeMeters, final double v0,
+            final double d0, final double gridSizeMeters, final double offRoadSpeed,
             final double maxWalkDistance, final int maxTimeSec, final double cosLat) {
 
         final DistanceLibrary distanceLibrary = SphericalDistanceLibrary.getInstance();
@@ -188,7 +188,7 @@ public class SampleGridRenderer {
                  * The computations below are approximation, but we are on the edge anyway and the
                  * current sample does not correspond to any computed value.
                  */
-                z.wTime = tMin + gridSizeMeters / v0;
+                z.wTime = tMin + gridSizeMeters / offRoadSpeed;
                 z.wBoardings = bMin;
                 z.wWalkDist = wdMin + gridSizeMeters;
                 z.d = dMin + gridSizeMeters;
@@ -207,13 +207,13 @@ public class SampleGridRenderer {
 
             @Override
             public final void visit(Edge e, Coordinate c, State s0, State s1, double d0, double d1,
-                    double speed) {
+                    double speedAlongEdge) {
                 double wd0 = s0.getWalkDistance() + d0;
                 double wd1 = s0.getWalkDistance() + d1;
                 double t0 = wd0 > maxWalkDistance ? Double.POSITIVE_INFINITY : s0.getActiveTime()
-                        + d0 / speed;
+                        + d0 / speedAlongEdge;
                 double t1 = wd1 > maxWalkDistance ? Double.POSITIVE_INFINITY : s1.getActiveTime()
-                        + d1 / speed;
+                        + d1 / speedAlongEdge;
                 if (t0 < maxTimeSec || t1 < maxTimeSec) {
                     if (!Double.isInfinite(t0) || !Double.isInfinite(t1)) {
                         WTWD z = new WTWD();
@@ -228,7 +228,7 @@ public class SampleGridRenderer {
                             z.wBoardings = s1.getNumBoardings();
                             z.wWalkDist = s1.getWalkDistance() + d1;
                         }
-                        gridSampler.addSamplingPoint(c, z, speed);
+                        gridSampler.addSamplingPoint(c, z, offRoadSpeed);
                     }
                 }
             }

--- a/src/main/java/org/opentripplanner/analyst/request/SampleGridRenderer.java
+++ b/src/main/java/org/opentripplanner/analyst/request/SampleGridRenderer.java
@@ -29,6 +29,9 @@ import org.opentripplanner.routing.edgetype.StreetEdge;
 import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.impl.SPTServiceFactory;
+import org.opentripplanner.routing.pathparser.BasicPathParser;
+import org.opentripplanner.routing.pathparser.NoThruTrafficPathParser;
+import org.opentripplanner.routing.pathparser.PathParser;
 import org.opentripplanner.routing.spt.SPTWalker;
 import org.opentripplanner.routing.spt.SPTWalker.SPTVisitor;
 import org.opentripplanner.routing.spt.ShortestPathTree;
@@ -78,6 +81,8 @@ public class SampleGridRenderer {
                 - tOvershot : spgRequest.maxTimeSec + tOvershot));
         sptRequest.batch = (true);
         sptRequest.setRoutingContext(graph);
+        sptRequest.rctx.pathParsers = new PathParser[] { new BasicPathParser(),
+                new NoThruTrafficPathParser() };
         final ShortestPathTree spt = sptServiceFactory.instantiate().getShortestPathTree(sptRequest);
 
         // 3. Create a sample grid based on the SPT.

--- a/src/main/java/org/opentripplanner/routing/spt/SPTWalker.java
+++ b/src/main/java/org/opentripplanner/routing/spt/SPTWalker.java
@@ -80,13 +80,20 @@ public class SPTWalker {
     public void walk(SPTVisitor visitor, double d0) {
         int nTotal = 0, nSkippedDupEdge = 0, nSkippedNoGeometry = 0;
         Collection<? extends State> allStates = spt.getAllStates();
-        Set<Edge> processedEdges = new HashSet<Edge>(allStates.size());
-        for (State s0 : allStates) {
+        Set<Vertex> allVertices = new HashSet<Vertex>(spt.getVertexCount());
+        for (State s : allStates) {
+            allVertices.add(s.getVertex());
+        }
+        Set<Edge> processedEdges = new HashSet<Edge>(allVertices.size());
+        for (Vertex v : allVertices) {
+            State s0 = spt.getState(v);
+            if (s0 == null || !s0.isFinal())
+                continue;
             for (Edge e : s0.getVertex().getIncoming()) {
                 // Take only street
                 if (e != null && visitor.accept(e)) {
                     State s1 = spt.getState(e.getFromVertex());
-                    if (s1 == null)
+                    if (s1 == null || !s1.isFinal())
                         continue;
                     if (e.getFromVertex() != null && e.getToVertex() != null) {
                         // Hack alert: e.hashCode() throw NPE
@@ -166,7 +173,7 @@ public class SPTWalker {
                 }
             }
         }
-        LOG.info("SPTWalker: Generated {} points ({} dup edges, {} no geometry) from {} states.",
-                nTotal, nSkippedDupEdge, nSkippedNoGeometry, allStates.size());
+        LOG.info("SPTWalker: Generated {} points ({} dup edges, {} no geometry) from {} vertices / {} states.",
+                nTotal, nSkippedDupEdge, nSkippedNoGeometry, allVertices.size(), allStates.size());
     }
 }


### PR DESCRIPTION
This pull request contains some changes made for the DREAL PACA project that could be merged back to master:

- Javascript OTPA client library.
- TimeGrid API upgrade for use with new OTPServer stuff.
- Correct a few bugs in the SPTWalker (in case of multi-states SPT, the process was dependent on the vertex states list order). Sample only final states.
- Enable path parsers in the SPT sampling process.
- Distinguish between offroad speed and average speed along edge in the SPT sampler. The two speeds can be different (offroad is a walk speed, average speed along edge can be faster or way slower), this was causing subtle issues in some rare occurences.
- Skip trips w/o services (caused by some invalid GTFS files). Do not try to process them as they will throw a NPE later on.