### PR TITLE
Flatten profile requests

### DIFF
--- a/src/main/java/org/opentripplanner/analyst/TimeSurface.java
+++ b/src/main/java/org/opentripplanner/analyst/TimeSurface.java
@@ -86,8 +86,8 @@ public class TimeSurface implements Serializable {
     /** Make a max or min timesurface from propagated times in a ProfileRouter. */
     public TimeSurface (AnalystProfileRouterPrototype profileRouter) {
         ProfileRequest req = profileRouter.request;
-        lon = req.from.lon;
-        lat = req.from.lat;
+        lon = req.fromLon;
+        lat = req.fromLat;
         id = makeUniqueId();
         dateTime = req.fromTime; // FIXME
         routerId = profileRouter.graph.routerId;

--- a/src/main/java/org/opentripplanner/api/resource/ProfileResource.java
+++ b/src/main/java/org/opentripplanner/api/resource/ProfileResource.java
@@ -86,8 +86,10 @@ public class ProfileResource {
         QueryParameter.checkRangeInclusive(suboptimalMinutes, 0, 30);
 
         ProfileRequest req = new ProfileRequest();
-        req.from         = from;
-        req.to           = to;
+        req.fromLat      = from.lat;
+        req.fromLon      = from.lon;
+        req.toLat        = to.lat;
+        req.toLon        = to.lon;
         req.fromTime     = fromTime.toSeconds();
         req.toTime       = toTime.toSeconds();
         req.walkSpeed    = walkSpeed;

--- a/src/main/java/org/opentripplanner/profile/AnalystProfileRouterPrototype.java
+++ b/src/main/java/org/opentripplanner/profile/AnalystProfileRouterPrototype.java
@@ -208,7 +208,7 @@ public class AnalystProfileRouterPrototype {
      */
     private TObjectIntMap<Stop> findClosestStops(final TraverseMode mode) {
         RoutingRequest rr = new RoutingRequest(mode);
-        GenericLocation gl = new GenericLocation(request.from.lat, request.from.lon);
+        GenericLocation gl = new GenericLocation(request.fromLat, request.fromLon);
         rr.from = gl;
         // FIXME destination must be set, even though this is meaningless for one-to-many
         rr.to = gl;

--- a/src/main/java/org/opentripplanner/profile/ProfileRequest.java
+++ b/src/main/java/org/opentripplanner/profile/ProfileRequest.java
@@ -10,12 +10,15 @@ import javax.ws.rs.DefaultValue;
 import javax.ws.rs.QueryParam;
 
 /**
- * All the modifiable paramters for profile routing.
+ * All the modifiable parameters for profile routing.
  */
 public class ProfileRequest implements Serializable {
 
-    public LatLon from;
-    public LatLon to;
+    public double fromLat;
+    public double fromLon;
+    public double toLat;
+    public double toLon;
+    
     public int    fromTime;
     public int    toTime;
 
@@ -49,8 +52,10 @@ public class ProfileRequest implements Serializable {
     
     public ProfileRequest clone () {
         ProfileRequest ret = new ProfileRequest();
-        ret.from = from;
-        ret.to = to;
+        ret.fromLat = fromLat;
+        ret.fromLon = fromLon;
+        ret.toLat = toLat;
+        ret.toLon = toLon;
         ret.fromTime = fromTime;
         ret.toTime = toTime;
         

--- a/src/main/java/org/opentripplanner/profile/ProfileRouter.java
+++ b/src/main/java/org/opentripplanner/profile/ProfileRouter.java
@@ -425,9 +425,9 @@ public class ProfileRouter {
             rr.parkAndRide = true; // allow car->walk transition only at tagged park and ride facilities.
             rr.modes.setWalk(true); // need to walk after dropping the car off
         }
-        rr.from = (new GenericLocation(request.from.lat, request.from.lon));
+        rr.from = (new GenericLocation(request.fromLat, request.fromLon));
         // FIXME requires destination to be set, not necesary for analyst
-        rr.to = new GenericLocation(request.to.lat, request.to.lon);
+        rr.to = new GenericLocation(request.toLat, request.toLon);
         rr.setArriveBy(dest);
         rr.setRoutingContext(graph);
         // Set batch after context, so both origin and dest vertices will be found.
@@ -491,8 +491,8 @@ public class ProfileRouter {
     private void findStreetOption(TraverseMode mode) {
         // Make a normal OTP routing request so we can traverse edges and use GenericAStar
         RoutingRequest rr = new RoutingRequest(mode);
-        rr.from = (new GenericLocation(request.from.lat, request.from.lon));
-        rr.to = new GenericLocation(request.to.lat, request.to.lon);
+        rr.from = (new GenericLocation(request.fromLat, request.fromLon));
+        rr.to = new GenericLocation(request.toLat, request.toLon);
         rr.setArriveBy(false);
         rr.setRoutingContext(graph);
         // This is not a batch search, it is a point-to-point search with goal direction.


### PR DESCRIPTION
QueryParameters are not serializable, and we need to pass serialized profile requests around in OTPA-cluster.