### PR TITLE
Add equals() and hashCode() to PointFeature.

### DIFF
--- a/src/main/java/org/opentripplanner/analyst/PointFeature.java
+++ b/src/main/java/org/opentripplanner/analyst/PointFeature.java
@@ -161,5 +161,24 @@ public class PointFeature implements Serializable {
     public int getProperty(String id) {
         return this.properties.get(id);
     }
-
+    
+    public boolean equals (Object o) {
+        if (o instanceof PointFeature) {
+            PointFeature f = (PointFeature) o;
+            return f.lat == this.lat &&
+                    f.lon == this.lon &&
+                    (f.geom == this.geom || f.geom != null && f.geom.equals(this.geom)) &&
+                    (f.id == this.id || f.id != null && f.id.equals(this.id)) &&
+                    this.properties.equals(f.properties);
+        }
+        
+        return false; 
+    }
+    
+    public int hashCode () {
+        return (int) (this.lat * 1000) + (int) (this.lon * 1000) +
+                (this.geom != null ? this.geom.hashCode() : 0) + 
+                (this.id != null ? this.id.hashCode() : 0) +
+                this.properties.hashCode();
+    }
 }

--- a/src/main/java/org/opentripplanner/analyst/PointFeature.java
+++ b/src/main/java/org/opentripplanner/analyst/PointFeature.java
@@ -166,8 +166,9 @@ public class PointFeature implements Serializable {
      * Compare to another object.
      * 
      * We can't use identity equality, because point features may be serialized and deserialized
-     * (for example, during message passing in otpa-cluster) and thus the same PointFeature may
-     * exist in memory more than once.
+     * and thus the same PointFeature may exist in memory more than once. For example, PointFeatures
+     * are compared inside the conveyal/otpa-cluster project to figure out which origins have
+     * returned from the compute cluster. 
      */
     public boolean equals (Object o) {
         if (o instanceof PointFeature) {
@@ -184,6 +185,7 @@ public class PointFeature implements Serializable {
     
     /**
      * Hash the relevant features of this PointFeature for efficient use in HashSets, etc.
+     * PointFeatures are put in HashSets in the conveyal/otpa-cluster project.
      */
     public int hashCode () {
         return (int) (this.lat * 1000) + (int) (this.lon * 1000) +

--- a/src/main/java/org/opentripplanner/analyst/PointFeature.java
+++ b/src/main/java/org/opentripplanner/analyst/PointFeature.java
@@ -162,6 +162,13 @@ public class PointFeature implements Serializable {
         return this.properties.get(id);
     }
     
+    /**
+     * Compare to another object.
+     * 
+     * We can't use identity equality, because point features may be serialized and deserialized
+     * (for example, during message passing in otpa-cluster) and thus the same PointFeature may
+     * exist in memory more than once.
+     */
     public boolean equals (Object o) {
         if (o instanceof PointFeature) {
             PointFeature f = (PointFeature) o;
@@ -175,6 +182,9 @@ public class PointFeature implements Serializable {
         return false; 
     }
     
+    /**
+     * Hash the relevant features of this PointFeature for efficient use in HashSets, etc.
+     */
     public int hashCode () {
         return (int) (this.lat * 1000) + (int) (this.lon * 1000) +
                 (this.geom != null ? this.geom.hashCode() : 0) + 


### PR DESCRIPTION
So that we don't use memory address equality. PointFeatures are compared inside the conveyal/otpa-cluster project to figure out which origins have returned from the compute cluster.