### PR TITLE
Add stop code in index API response

### DIFF
--- a/src/main/java/org/opentripplanner/index/model/StopShort.java
+++ b/src/main/java/org/opentripplanner/index/model/StopShort.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 public class StopShort {
 
     public AgencyAndId id;
+    public String code;
     public String name;
     public double lat;
     public double lon;
@@ -23,6 +24,7 @@ public class StopShort {
     
     public StopShort (Stop stop) {
         id = stop.getId();
+        code = stop.getCode();
         name = stop.getName();
         lat = stop.getLat();
         lon = stop.getLon();


### PR DESCRIPTION
Allows us to show the user-visible stop code when querying for the nearest stops.