### PR TITLE
Fixes BusRouteStreetMatcher matching when trip geometry is generated

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/impl/map/BusRouteStreetMatcher.java
+++ b/src/main/java/org/opentripplanner/graph_builder/impl/map/BusRouteStreetMatcher.java
@@ -71,7 +71,13 @@ public class BusRouteStreetMatcher implements GraphBuilder {
             for (TripPattern pattern : graph.index.patternsForRoute.get(route)) {
                 if (pattern.mode == TraverseMode.BUS) {
                     /* we can only match geometry to streets on bus routes */
-                    log.info("Matching {}", pattern);
+                    log.debug("Matching {}", pattern);
+                    //If there are no shapes in GTFS pattern geometry is generated
+                    //generated geometry is useless for street matching
+                    //that is why pattern.geometry is null in that case
+                    if (pattern.geometry == null) {
+                        continue;
+                    }
                     List<Edge> edges = matcher.match(pattern.geometry);
                     if (edges == null || edges.isEmpty()) {
                         log.warn("Could not match to street network: {}", pattern);

--- a/src/main/java/org/opentripplanner/routing/edgetype/factory/GTFSPatternHopFactory.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/factory/GTFSPatternHopFactory.java
@@ -438,9 +438,11 @@ public class GTFSPatternHopFactory {
                 for (int i = 0; i < tripPattern.hopEdges.length; i++) {
                     tripPattern.hopEdges[i].setGeometry(geom[i]);
                 }
+                // Make a geometry for the whole TripPattern from all its constituent hops.
+                // This happens only if geometry is found in geometriesByTripPattern,
+                // because that means that geometry was created from shapes instead "as crow flies"
+                tripPattern.makeGeometry();
             }
-            // Make a geometry for the whole TripPattern from all its constituent hops.
-            tripPattern.makeGeometry();
             tripPattern.setServiceCodes(graph.serviceCodes); // TODO this could be more elegant
         }
 


### PR DESCRIPTION
makeGeometry in TripPattern now doesn't creates geometry if it isn't created from shape files,
same with BusRouteStreetMatcher.

This improves BusRouteStreetMatcher, because matching was very weird previously when geometry wasn't created from shapefiles. I don't know if geometry is used anywhere else where it is needed even if it is as crow flies.
