### PR TITLE
Fix trip itinerary showing stop as #undefined

### DIFF
--- a/src/client/js/otp/modules/planner/ItinerariesWidget.js
+++ b/src/client/js/otp/modules/planner/ItinerariesWidget.js
@@ -553,8 +553,13 @@ otp.widgets.ItinerariesWidget =
                 this_.module.drawAllStartBubbles(this_.itineraries[this_.activeIndex]);
             });
 
+            var stopHtml = '<div class="otp-itin-leg-endpointDescSub">';
+            if( typeof leg.from.stopCode != 'undefined' ) {
+                stopHtml += _tr("Stop") + ' #'+leg.from.stopCode+ ' ';
+            }
+            stopHtml += '[<a href="#">' + _tr("Stop Viewer") +'</a>]</div>';
 
-            $('<div class="otp-itin-leg-endpointDescSub">' + _tr("Stop") + ' #'+leg.from.stopId.id+' [<a href="#">' + _tr("Stop Viewer") +'</a>]</div>')
+            $(stopHtml)
             .appendTo(legDiv)
             .click(function(evt) {
                 if(!this_.module.stopViewerWidget) {


### PR DESCRIPTION
stopId.id never exists, as stopId is a string. Furthermore since it's meant to be the internal ID and stopCode is the ID that users could understand, it makes more sense to use that instead.