### PR TITLE
Add "--clientFiles" option to serve local files by http.

### DIFF
--- a/src/main/java/org/opentripplanner/standalone/CommandLineParameters.java
+++ b/src/main/java/org/opentripplanner/standalone/CommandLineParameters.java
@@ -152,6 +152,10 @@ public class CommandLineParameters implements Cloneable {
             description = "Path to directory containing PointSets. Defaults to BASE_PATH/pointsets.")
     public File pointSetDirectory;
 
+    @Parameter(names = {"--clientFiles"}, validateWith = ReadableDirectory.class,
+            description = "Path to directory containing local client files to serve.")
+    public File clientDirectory = null;
+
     @Parameter(names = {"--router"}, validateWith = RouterId.class,
             description = "One or more router IDs to build and/or serve, first one being the default.")
     public List<String> routerIds;

--- a/src/main/java/org/opentripplanner/standalone/GrizzlyServer.java
+++ b/src/main/java/org/opentripplanner/standalone/GrizzlyServer.java
@@ -9,6 +9,7 @@ import org.glassfish.grizzly.http.server.CLStaticHttpHandler;
 import org.glassfish.grizzly.http.server.HttpHandler;
 import org.glassfish.grizzly.http.server.HttpServer;
 import org.glassfish.grizzly.http.server.NetworkListener;
+import org.glassfish.grizzly.http.server.StaticHttpHandler;
 import org.glassfish.grizzly.ssl.SSLContextConfigurator;
 import org.glassfish.grizzly.ssl.SSLEngineConfigurator;
 import org.glassfish.grizzly.threadpool.ThreadPoolConfig;
@@ -96,6 +97,17 @@ public class GrizzlyServer {
         /* 2. A static content handler to serve the client JS apps etc. from the classpath. */
         HttpHandler staticHandler = new CLStaticHttpHandler(GrizzlyServer.class.getClassLoader(), "/client/");
         httpServer.getServerConfiguration().addHttpHandler(staticHandler, "/");
+
+        /*
+         * 3. A static content handler to serve local files from the filesystem, under the "local"
+         * path.
+         */
+        if (params.clientDirectory != null) {
+            StaticHttpHandler localHandler = new StaticHttpHandler(
+                    params.clientDirectory.getAbsolutePath());
+            localHandler.setFileCacheEnabled(false);
+            httpServer.getServerConfiguration().addHttpHandler(localHandler, "/local");
+        }
 
         /* 3. Test alternate method (no Jersey). */
         // As in servlets, * is needed in base path to identify the "rest" of the path.


### PR DESCRIPTION
This is a proposal to serve external files (in the file system) on a "/local" URL, adding a non-cached Grizzly static http handler.

I'm not sure about the name of the option "--clientFiles", maybe another name could be better. The same for the URL path "/local", and whether this change is properly implemented (maybe there could be a better way). Another option would be to serve them in the root context if the option is enabled, disabling the default embedded (classpath) files.