### PR TITLE
Fix #1755 - Avoid wrong agency assignment to Route and Trip entities

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/impl/GtfsGraphBuilderImpl.java
+++ b/src/main/java/org/opentripplanner/graph_builder/impl/GtfsGraphBuilderImpl.java
@@ -231,18 +231,13 @@ public class GtfsGraphBuilderImpl implements GraphBuilder {
                 reader.setDefaultAgencyId(defaultAgencyId); // not sure this is a good idea, setting it to the first-of-many IDs.
             }
         }
-
+        // NOTE for those entities which *do not have* an explicit relation to an agency we are setting the defaultAgencyId
+        // for those entities which *do have* an explicit relation to an agency (ie. routes and trips), this is not necessary
         for (ShapePoint shapePoint : store.getAllEntitiesForType(ShapePoint.class)) {
             shapePoint.getShapeId().setAgencyId(reader.getDefaultAgencyId());
         }
-        for (Route route : store.getAllEntitiesForType(Route.class)) {
-            route.getId().setAgencyId(reader.getDefaultAgencyId());
-        }
         for (Stop stop : store.getAllEntitiesForType(Stop.class)) {
             stop.getId().setAgencyId(reader.getDefaultAgencyId());
-        }
-        for (Trip trip : store.getAllEntitiesForType(Trip.class)) {
-            trip.getId().setAgencyId(reader.getDefaultAgencyId());
         }
         for (ServiceCalendar serviceCalendar : store.getAllEntitiesForType(ServiceCalendar.class)) {
             serviceCalendar.getServiceId().setAgencyId(reader.getDefaultAgencyId());


### PR DESCRIPTION
Route and Trip entities do not need to be assigned to the default
agency as they already have an explicit relation to their proper agency.