### PR TITLE
Add --version flag to output current version

### DIFF
--- a/src/main/java/org/opentripplanner/common/MavenVersion.java
+++ b/src/main/java/org/opentripplanner/common/MavenVersion.java
@@ -20,8 +20,6 @@ import java.util.Properties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Strings;
-
 public class MavenVersion implements Serializable {
 
     private static final Logger LOG = LoggerFactory.getLogger(MavenVersion.class);
@@ -113,28 +111,9 @@ public class MavenVersion implements Serializable {
         return String.format("%s => %s UID=%d", version, this.toString(), getUID());
     }
 
-    public String getVersion(String fragment) {
-        String f = Strings.isNullOrEmpty(fragment) ? "all" : fragment;
-
-        switch (f) {
-            case "version":
-                return version;
-            case "major":
-                return String.valueOf(major);
-            case "minor":
-                return String.valueOf(minor);
-            case "incremental":
-                return String.valueOf(incremental);
-            case "qualifier":
-                return qualifier;
-            case "commit":
-                return commit;
-
-            case "all":
-            default:
-                String format = "version: %s\nmajor: %s\nminor: %s\npatch: %s\nqualifier: %s\ncommit: %s\n";
-                return String.format(format, version, major, minor, incremental, qualifier, commit);
-        }
+    public String getVersion() {
+        String format = "version: %s\nmajor: %s\nminor: %s\npatch: %s\nqualifier: %s\ncommit: %s\n";
+        return String.format(format, version, major, minor, incremental, qualifier, commit);
     }
 
     public int hashCode () {

--- a/src/main/java/org/opentripplanner/common/MavenVersion.java
+++ b/src/main/java/org/opentripplanner/common/MavenVersion.java
@@ -20,6 +20,8 @@ import java.util.Properties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Strings;
+
 public class MavenVersion implements Serializable {
 
     private static final Logger LOG = LoggerFactory.getLogger(MavenVersion.class);
@@ -109,6 +111,30 @@ public class MavenVersion implements Serializable {
 
     public String toStringVerbose() {
         return String.format("%s => %s UID=%d", version, this.toString(), getUID());
+    }
+
+    public String getVersion(String fragment) {
+        String f = Strings.isNullOrEmpty(fragment) ? "all" : fragment;
+
+        switch (f) {
+            case "version":
+                return version;
+            case "major":
+                return String.valueOf(major);
+            case "minor":
+                return String.valueOf(minor);
+            case "incremental":
+                return String.valueOf(incremental);
+            case "qualifier":
+                return qualifier;
+            case "commit":
+                return commit;
+
+            case "all":
+            default:
+                String format = "version: %s\nmajor: %s\nminor: %s\npatch: %s\nqualifier: %s\ncommit: %s\n";
+                return String.format(format, version, major, minor, incremental, qualifier, commit);
+        }
     }
 
     public int hashCode () {

--- a/src/main/java/org/opentripplanner/standalone/CommandLineParameters.java
+++ b/src/main/java/org/opentripplanner/standalone/CommandLineParameters.java
@@ -35,7 +35,6 @@ public class CommandLineParameters implements Cloneable {
     private static final int    DEFAULT_SECURE_PORT = 8081;
     private static final String DEFAULT_BASE_PATH   = "/var/otp";
     private static final String DEFAULT_ROUTER_ID   = "";
-    private static final String DEFAULT_VERSION_FRAGMENT = "all";
 
     /* Options for the command itself, rather than build or server sub-tasks. */
 
@@ -72,11 +71,6 @@ public class CommandLineParameters implements Cloneable {
     @Parameter(names = { "--version", },
             description = "Print the version, and then exit.")
     public boolean version = false;
-
-    @Parameter(names = { "--version-fragment" },
-            description = "Print the a fragment of the version, and then exit. Use one of [`version`, `major`, `minor`, `incremental`, " +
-                    "`qualifier`, `commit` ] to specify which fragment")
-    public String versionFragment = DEFAULT_VERSION_FRAGMENT;
 
     /* Options for the server sub-task. */
 

--- a/src/main/java/org/opentripplanner/standalone/CommandLineParameters.java
+++ b/src/main/java/org/opentripplanner/standalone/CommandLineParameters.java
@@ -4,8 +4,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import jersey.repackaged.com.google.common.collect.Lists;
@@ -37,6 +35,7 @@ public class CommandLineParameters implements Cloneable {
     private static final int    DEFAULT_SECURE_PORT = 8081;
     private static final String DEFAULT_BASE_PATH   = "/var/otp";
     private static final String DEFAULT_ROUTER_ID   = "";
+    private static final String DEFAULT_VERSION_FRAGMENT = "all";
 
     /* Options for the command itself, rather than build or server sub-tasks. */
 
@@ -69,6 +68,15 @@ public class CommandLineParameters implements Cloneable {
     @Parameter(names = {"--preFlight"},
             description = "Pass the graph to the server in-memory after building it, and saving to disk.")
     public boolean preFlight;
+
+    @Parameter(names = { "--version", },
+            description = "Print the version, and then exit.")
+    public boolean outputVersion = false;
+
+    @Parameter(names = { "--version-fragment", },
+            description = "Print the a fragment of the version, and then exit. Use one of [`version`, `major`, `minor`, `incremental`, " +
+                    "`qualifier`, `commit` ] to specify which fragment")
+    public String version = DEFAULT_VERSION_FRAGMENT;
 
     /* Options for the server sub-task. */
 

--- a/src/main/java/org/opentripplanner/standalone/CommandLineParameters.java
+++ b/src/main/java/org/opentripplanner/standalone/CommandLineParameters.java
@@ -71,12 +71,12 @@ public class CommandLineParameters implements Cloneable {
 
     @Parameter(names = { "--version", },
             description = "Print the version, and then exit.")
-    public boolean outputVersion = false;
+    public boolean version = false;
 
-    @Parameter(names = { "--version-fragment", },
+    @Parameter(names = { "--version-fragment" },
             description = "Print the a fragment of the version, and then exit. Use one of [`version`, `major`, `minor`, `incremental`, " +
                     "`qualifier`, `commit` ] to specify which fragment")
-    public String version = DEFAULT_VERSION_FRAGMENT;
+    public String versionFragment = DEFAULT_VERSION_FRAGMENT;
 
     /* Options for the server sub-task. */
 

--- a/src/main/java/org/opentripplanner/standalone/OTPMain.java
+++ b/src/main/java/org/opentripplanner/standalone/OTPMain.java
@@ -78,7 +78,7 @@ public class OTPMain {
                 mavenVersionLogger.setLevel(Level.OFF);
 
                 MavenVersion version = MavenVersion.VERSION;
-                System.out.println(version.getVersion(params.versionFragment));
+                System.out.println(version.getVersion());
                 System.exit(0);
             }
 

--- a/src/main/java/org/opentripplanner/standalone/OTPMain.java
+++ b/src/main/java/org/opentripplanner/standalone/OTPMain.java
@@ -13,13 +13,17 @@
 
 package org.opentripplanner.standalone;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.MissingNode;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+
+import org.opentripplanner.common.MavenVersion;
 import org.opentripplanner.graph_builder.GraphBuilder;
 import org.opentripplanner.routing.graph.Graph;
-import org.opentripplanner.routing.impl.*;
+import org.opentripplanner.routing.impl.DefaultStreetVertexIndexFactory;
+import org.opentripplanner.routing.impl.GraphScanner;
+import org.opentripplanner.routing.impl.InputStreamGraphSource;
+import org.opentripplanner.routing.impl.MemoryGraphSource;
 import org.opentripplanner.routing.services.GraphService;
 import org.opentripplanner.scripting.impl.BSFOTPScript;
 import org.opentripplanner.scripting.impl.OTPScript;
@@ -27,12 +31,14 @@ import org.opentripplanner.visualizer.GraphVisualizer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import ch.qos.logback.classic.Level;
+
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterException;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.MissingNode;
 
 /**
  * This is the main entry point to OpenTripPlanner. It allows both building graphs and starting up an OTP server
@@ -64,6 +70,18 @@ public class OTPMain {
                 jc.usage();
                 System.exit(0);
             }
+
+            if (params.outputVersion) {
+                // Disable logging, we don't want to see anything else than the intended output below.
+                ch.qos.logback.classic.Logger mavenVersionLogger =
+                        (ch.qos.logback.classic.Logger)LoggerFactory.getLogger(MavenVersion.class);
+                mavenVersionLogger.setLevel(Level.OFF);
+
+                MavenVersion version = MavenVersion.VERSION;
+                System.out.println(version.getVersion(params.version));
+                System.exit(0);
+            }
+
             params.infer();
         } catch (ParameterException pex) {
             LOG.error("Parameter error: {}", pex.getMessage());

--- a/src/main/java/org/opentripplanner/standalone/OTPMain.java
+++ b/src/main/java/org/opentripplanner/standalone/OTPMain.java
@@ -71,14 +71,14 @@ public class OTPMain {
                 System.exit(0);
             }
 
-            if (params.outputVersion) {
+            if (params.version) {
                 // Disable logging, we don't want to see anything else than the intended output below.
                 ch.qos.logback.classic.Logger mavenVersionLogger =
                         (ch.qos.logback.classic.Logger)LoggerFactory.getLogger(MavenVersion.class);
                 mavenVersionLogger.setLevel(Level.OFF);
 
                 MavenVersion version = MavenVersion.VERSION;
-                System.out.println(version.getVersion(params.version));
+                System.out.println(version.getVersion(params.versionFragment));
                 System.exit(0);
             }
 

--- a/src/main/java/org/opentripplanner/standalone/OTPMain.java
+++ b/src/main/java/org/opentripplanner/standalone/OTPMain.java
@@ -31,8 +31,6 @@ import org.opentripplanner.visualizer.GraphVisualizer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import ch.qos.logback.classic.Level;
-
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterException;
 import com.fasterxml.jackson.core.JsonParser;
@@ -72,11 +70,6 @@ public class OTPMain {
             }
 
             if (params.version) {
-                // Disable logging, we don't want to see anything else than the intended output below.
-                ch.qos.logback.classic.Logger mavenVersionLogger =
-                        (ch.qos.logback.classic.Logger)LoggerFactory.getLogger(MavenVersion.class);
-                mavenVersionLogger.setLevel(Level.OFF);
-
                 MavenVersion version = MavenVersion.VERSION;
                 System.out.println(version.getVersion());
                 System.exit(0);


### PR DESCRIPTION
Fixes #1766

Adds a new flag to enable version output of the current `otp.jar`.

`--version` enables output of version and prints all version bits by default.

```
$ java -jar otp.jar --version
version: 1.0.0-SNAPSHOT
major: 1
minor: 0
patch: 0
qualifier: SNAPSHOT
commit: 5baeb0da96f679cfb7c6d7b8dea192a127f83b35
```
