### PR TITLE
Fix #1781. Removal of looping edges throws NPE.

### DIFF
--- a/src/main/java/org/opentripplanner/routing/graph/Graph.java
+++ b/src/main/java/org/opentripplanner/routing/graph/Graph.java
@@ -487,7 +487,11 @@ public class Graph implements Serializable {
             throw new IllegalStateException("attempting to remove vertex that is not in graph.");
         }
 
-        List<Edge> edges = new ArrayList<Edge>(vertex.getDegreeIn() + vertex.getDegreeOut());
+        /*
+         * Note: We have to handle the removal of looping edges (for example RentABikeOn/OffEdge),
+         * we use a set to prevent having multiple times the same edge.
+         */
+        Set<Edge> edges = new HashSet<Edge>(vertex.getDegreeIn() + vertex.getDegreeOut());
         edges.addAll(vertex.getIncoming());
         edges.addAll(vertex.getOutgoing());
 


### PR DESCRIPTION
Removing looping edges (for example RentABikeOn/OffEdge) is causing a NPE: the same edge was added multiple times in the list, the second loop iteration on the same edge was causing a NPE, due to `edge::hashCode()` function relying on from/to vertex to be non-null.