### PR TITLE
Adds support for list parameters in client querystring

### DIFF
--- a/src/client/js/otp/core/Webapp.js
+++ b/src/client/js/otp/core/Webapp.js
@@ -62,8 +62,23 @@ otp.core.Webapp = otp.Class({
             decode = function (s) { return decodeURIComponent(s.replace(pl, " ")); },
             query  = window.location.search.substring(1);
 
-        while (match = search.exec(query))
-            this.urlParams[decode(match[1])] = decode(match[2]);
+        //Parser URL query string
+        while (match = search.exec(query)) {
+            var currentKey = decode(match[1]);
+            //Same key already appeared in parameters
+            //We need to change values from string to to list of values
+            if (currentKey in this.urlParams) {
+                var tmpValues = this.urlParams[currentKey];
+                if ($.isArray(tmpValues)) {
+                    tmpValues.push(decode(match[2]));
+                } else {
+                    tmpValues = [tmpValues, decode(match[2])];
+                }
+                this.urlParams[currentKey] = tmpValues;
+            } else {
+                this.urlParams[currentKey] = decode(match[2]);
+            }
+        }
 
 
         // init siteUrl, if necessary

--- a/src/client/js/otp/modules/planner/PlannerModule.js
+++ b/src/client/js/otp/modules/planner/PlannerModule.js
@@ -376,6 +376,9 @@ otp.modules.planner.PlannerModule =
         this.currentRequest = $.ajax(url, {
             data:       queryParams,
             dataType:   'JSON',
+            //Sends arrays as &b=1&b=2 instead of b[]=1&b[]=2 which is what
+            //Jersey expects
+            traditional: true,
 
             success: function(data) {
                 $('#otp-spinner').hide();


### PR DESCRIPTION
Previously each parameter was saved only ones in client when parsing
querystrings.
This appears to be a problem when using intermediatePlaces.

Now each parameter is saved as before, but if it appears again list is
created from values and then send to server.

Fixes #1784.

I don't know how this parsing is used in analyst or if it maybe breaks something else.