### PR TITLE
Fix stoptimes visualization in StopViewerWidget 

### DIFF
--- a/src/client/js/otp/core/IndexApi.js
+++ b/src/client/js/otp/core/IndexApi.js
@@ -162,24 +162,10 @@ otp.core.IndexApi = otp.Class({
         callback.call(callbackTarget, variantData);
     },
 
-
-    runStopTimesQuery : function(agencyId, stopId, startTime, endTime, callbackTarget, callback) {
-
-        if(otp.config.useLegacyMillisecondsApi) {
-            startTime *= 1000;
-            endTime *= 1000;
-        }
-        /*
-        var params = {
-            startTime : startTime,
-            endTime : endTime,
-            extended : true,
-        };
-        if(otp.config.routerId !== undefined) {
-            params.routerId = otp.config.routerId;
-        }
-        */
-        var url = otp.config.hostname + '/' + otp.config.restService + '/index/stops/' + stopId + '/stoptimes';
+    //runStopTimesQuery : function(agencyId, stopId, startTime, endTime, callbackTarget, callback) {
+    runStopTimesQuery : function( stopId, date, callbackTarget, callback) {
+        date = moment(date).format('YYYYMMDD');
+        var url = otp.config.hostname + '/' + otp.config.restService + '/index/stops/' + stopId + '/stoptimes/' + date;
         $.ajax(url, {
             //data:       params,
 

--- a/src/client/js/otp/widgets/transit/StopViewerWidget.js
+++ b/src/client/js/otp/widgets/transit/StopViewerWidget.js
@@ -96,7 +96,8 @@ otp.widgets.transit.StopViewerWidget =
     runTimesQuery : function() {
         var this_ = this;
         var startTime = moment(this.datePicker.val(), otp.config.locale.time.date_format).add("hours", -otp.config.timeOffset).unix();
-        this.module.webapp.indexApi.runStopTimesQuery(this.agencyId, this.stopId, startTime+10800, startTime+97200, this, function(data) {
+        //this.module.webapp.indexApi.runStopTimesQuery(this.agencyId, this.stopId, startTime+10800, startTime+97200, this, function(data) {
+        this.module.webapp.indexApi.runStopTimesQuery(this.stopId, this.datePicker.datepicker("getDate"), this, function(data) {
             this_.times = [];
             /*
             for(var i=0; i < data.stopTimes.length; i++) {

--- a/src/client/js/otp/widgets/transit/StopViewerWidget.js
+++ b/src/client/js/otp/widgets/transit/StopViewerWidget.js
@@ -106,6 +106,7 @@ otp.widgets.transit.StopViewerWidget =
                     pushTime.routeShortName = this_.module.webapp.indexApi.routes[routeId].routeData.shortName;
                     pushTime.routeLongName = this_.module.webapp.indexApi.routes[routeId].routeData.longName;
                     pushTime.time = time.realtimeDeparture;
+                    pushTime.serviceDay = time.serviceDay;
                     this_.times.push(pushTime);
                 });
             });
@@ -133,13 +134,13 @@ otp.widgets.transit.StopViewerWidget =
             time.to = to_trans;
             time.block = block_trans;
             ich['otp-stopViewer-timeListItem'](time).appendTo(this.timeList);
-            var diff = Math.abs(this.activeTime - time.time*1000);
+            var diff = Math.abs(this.activeTime - (time.time + time.serviceDay)*1000);
             if(diff < minDiff) {
                 minDiff = diff;
                 bestIndex = i;
             }
         }
-        this.timeList.scrollTop(((bestIndex/this.times.length) * this.timeList[0].scrollHeight) - this.timeList.height()/2 + $(this.timeList.find(".otp-stopViewer-timeListItem")[0]).height()/2);
+        this.timeList.scrollTop(this.timeList.find(".otp-stopViewer-timeListItem")[bestIndex].offsetTop);
     },
 
     setActiveTime : function(activeTime) {

--- a/src/client/js/otp/widgets/transit/StopViewerWidget.js
+++ b/src/client/js/otp/widgets/transit/StopViewerWidget.js
@@ -95,7 +95,7 @@ otp.widgets.transit.StopViewerWidget =
 
     runTimesQuery : function() {
         var this_ = this;
-        var startTime = moment(this.datePicker.val(), otp.config.locale.time.date_format).add("hours", -otp.config.timeOffset).unix();
+        //var startTime = moment(this.datePicker.val(), otp.config.locale.time.date_format).add("hours", -otp.config.timeOffset).unix();
         this.module.webapp.indexApi.runStopTimesQuery(this.stopId, this.datePicker.datepicker("getDate"), this, function(data) {
             this_.times = [];
             // rearrange stoptimes, flattening and sorting;
@@ -126,7 +126,8 @@ otp.widgets.transit.StopViewerWidget =
 
         for(var i = 0; i < this.times.length; i++) {
             var time = this.times[i];
-            time.formattedTime = otp.util.Time.formatItinTime(time.time*1000, otp.config.locale.time.time_format);
+            //time.formattedTime = otp.util.Time.formatItinTime(time.time*1000, otp.config.locale.time.time_format);
+            time.formattedTime = moment.utc(time.time*1000).format(otp.config.locale.time.time_format);
             //FIXME: There is probably a better way to translate to and block
             //then in each call separately
             time.to = to_trans;

--- a/src/client/js/otp/widgets/transit/StopViewerWidget.js
+++ b/src/client/js/otp/widgets/transit/StopViewerWidget.js
@@ -96,23 +96,15 @@ otp.widgets.transit.StopViewerWidget =
     runTimesQuery : function() {
         var this_ = this;
         var startTime = moment(this.datePicker.val(), otp.config.locale.time.date_format).add("hours", -otp.config.timeOffset).unix();
-        //this.module.webapp.indexApi.runStopTimesQuery(this.agencyId, this.stopId, startTime+10800, startTime+97200, this, function(data) {
         this.module.webapp.indexApi.runStopTimesQuery(this.stopId, this.datePicker.datepicker("getDate"), this, function(data) {
             this_.times = [];
-            /*
-            for(var i=0; i < data.stopTimes.length; i++) {
-                var time = data.stopTimes[i];
-                if(time.phase == "departure") {
-                    this_.times.push(time);
-                }
-            }*/
-            // here we are rearranging a bit the stoptimes, flatting and sorting;
+            // rearrange stoptimes, flattening and sorting;
             _.each(data, function(stopTime){
                 var routeId = stopTime.pattern.id.substring(0,stopTime.pattern.id.lastIndexOf(':'));
-                var pushTime = {};
-                pushTime.routeShortName = this_.module.webapp.indexApi.routes[routeId].routeData.shortName;
-                pushTime.routeLongName = this_.module.webapp.indexApi.routes[routeId].routeData.longName;
                 _.each(stopTime.times,function(time){
+                    var pushTime = {};
+                    pushTime.routeShortName = this_.module.webapp.indexApi.routes[routeId].routeData.shortName;
+                    pushTime.routeLongName = this_.module.webapp.indexApi.routes[routeId].routeData.longName;
                     pushTime.time = time.realtimeDeparture;
                     this_.times.push(pushTime);
                 });

--- a/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
+++ b/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
@@ -428,7 +428,7 @@ public class GraphIndex {
                 if (currStop == stop) {
                     for (TripTimes t : tt.tripTimes) {
                         if (!sd.serviceRunning(t.serviceCode)) continue;
-                        stopTimes.times.add(new TripTimeShort(t, sidx, stop));
+                        stopTimes.times.add(new TripTimeShort(t, sidx, stop, sd));
                     }
                 }
                 sidx++;


### PR DESCRIPTION
Several fixes that basically leverage on last @hannesj improvement to the IndexAPI in f0086dfc5463037e1c085e1b0b6dc7d7bb369506
It is now possible to change  the date in the widget, visualize all stoptimes in the given date;
 the list automatically scrolls to the stoptime nearest the search time or the time given by the itinerary widget.

This also fixes #1791, by adding both serviceId and tripId to the Api response.

The most notable change is the one concerning the local timezone on stoptimes in a055bd4880ded1f63b3916acdd4d90b7557a1545  :

former code relies on the formatItinTime util function which in turn relies on the otp.config.timeOffset which is not always set; as a result I was getting wrong stoptimes, shifted by 1 hour.
But instead of warring about applying and then trying to subtract again the timezone,
since the stoptimes returned by the API (as in gtfs) are to be considered in local-time, we can directly use moment.utc(sec_from_midnight *1000).format(...) to get the correct times.

this should work fine at least while OTP is running on a single timezone, as discussed in this post: https://groups.google.com/d/msg/opentripplanner-dev/jqHDYKsL2vU/44rSJqvEvhgJ

When it will be able to span multiple timezone, the API will need to change also, perhaps returning absolute times with timezone included...