### PR TITLE
Utility function to find maximum in array of int primitives

### DIFF
--- a/src/main/java/org/opentripplanner/util/ArrayUtils.java
+++ b/src/main/java/org/opentripplanner/util/ArrayUtils.java
@@ -28,4 +28,14 @@ public class ArrayUtils {
         }
         return false;
     }
+    
+    public static int maxValue(int[] ints) {
+    	int max = ints[0];
+    	for (int ktr = 0; ktr < ints.length; ktr++) {
+    		if (ints[ktr] > max) {
+    			max = ints[ktr];
+    		}
+    	}
+    	return max;
+    }
 }


### PR DESCRIPTION
Just a convenience utility to avoid dependency on Apache ArrayUtils. We use this in batch processing to set EarliestArrivalSearch.maxDuration to the max value in an array of cumulative opportunity thresholds we are interested in.