### PR TITLE
Remove underscores from mode names

### DIFF
--- a/src/client/js/otp/util/Itin.js
+++ b/src/client/js/otp/util/Itin.js
@@ -190,7 +190,7 @@ otp.util.Itin = {
         'TRAM' : _tr('Light Rail'),
         //TRANSLATORS: Used for street-level cable cars where the cable runs
         //beneath the car.
-        'CABLE_CAR': _tr('Cable Car'),
+        'CABLECAR': _tr('Cable Car'),
         //TRANSLATORS: Any rail system designed for steep inclines.
         'FUNICULAR': _tr('Funicular'),
         //TRANSLATORS: Gondola, Suspended cable car. Typically used for aerial

--- a/src/main/java/com/conveyal/gtfs/model/Route.java
+++ b/src/main/java/com/conveyal/gtfs/model/Route.java
@@ -26,7 +26,7 @@ public class Route extends Entity { // implements Entity.Factory<Route>
     public static final int RAIL = 2;
     public static final int BUS = 3;
     public static final int FERRY = 4;
-    public static final int CABLE_CAR = 4;
+    public static final int CABLECAR = 4;
     public static final int GONDOLA = 4;
     public static final int FUNICULAR = 5;
 

--- a/src/main/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverter.java
+++ b/src/main/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverter.java
@@ -215,7 +215,7 @@ public abstract class GraphPathToTripPlanConverter {
 
     /**
      * Slice a {@link State} array at the leg boundaries. Leg switches occur when:
-     * 1. A LEG_SWITCH mode (which itself isn't part of any leg) is seen
+     * 1. A LEGSWITCH mode (which itself isn't part of any leg) is seen
      * 2. The mode changes otherwise, for instance from BICYCLE to WALK
      * 3. A PatternInterlineDwell edge (i.e. interlining) is seen
      *
@@ -234,10 +234,10 @@ public abstract class GraphPathToTripPlanConverter {
 
             Edge edge = states[i + 1].getBackEdge();
 
-            if (backMode == TraverseMode.LEG_SWITCH || forwardMode == TraverseMode.LEG_SWITCH) {
-                if (backMode != TraverseMode.LEG_SWITCH) {              // Start of leg switch
+            if (backMode == TraverseMode.LEGSWITCH || forwardMode == TraverseMode.LEGSWITCH) {
+                if (backMode != TraverseMode.LEGSWITCH) {              // Start of leg switch
                     legIndexPairs[1] = i;
-                } else if (forwardMode != TraverseMode.LEG_SWITCH) {    // End of leg switch
+                } else if (forwardMode != TraverseMode.LEGSWITCH) {    // End of leg switch
                     if (legIndexPairs[1] != states.length - 1) {
                         legsIndexes.add(legIndexPairs);
                     }
@@ -494,7 +494,7 @@ public abstract class GraphPathToTripPlanConverter {
                     itinerary.transitTime += state.getTimeDeltaSeconds();
                     break;
 
-                case LEG_SWITCH:
+                case LEGSWITCH:
                     itinerary.waitingTime += state.getTimeDeltaSeconds();
                     break;
 

--- a/src/main/java/org/opentripplanner/gtfs/GtfsLibrary.java
+++ b/src/main/java/org/opentripplanner/gtfs/GtfsLibrary.java
@@ -141,7 +141,7 @@ public class GtfsLibrary {
         case 4:
             return TraverseMode.FERRY;
         case 5:
-            return TraverseMode.CABLE_CAR;
+            return TraverseMode.CABLECAR;
         case 6:
             return TraverseMode.GONDOLA;
         case 7:

--- a/src/main/java/org/opentripplanner/routing/core/TraverseMode.java
+++ b/src/main/java/org/opentripplanner/routing/core/TraverseMode.java
@@ -24,8 +24,8 @@ import java.util.Set;
 public enum TraverseMode {
     WALK, BICYCLE, CAR,
     TRAM, SUBWAY, RAIL, BUS, FERRY,
-    CABLE_CAR, GONDOLA, FUNICULAR,
-    TRANSIT, TRAINISH, BUSISH, LEG_SWITCH;
+    CABLECAR, GONDOLA, FUNICULAR,
+    TRANSIT, TRAINISH, BUSISH, LEGSWITCH;
 
     private static HashMap <Set<TraverseMode>, Set<TraverseMode>> setMap = 
             new HashMap <Set<TraverseMode>, Set<TraverseMode>>();
@@ -46,7 +46,7 @@ public enum TraverseMode {
 
     public boolean isTransit() {
         return this == TRAM || this == SUBWAY || this == RAIL || this == BUS || this == FERRY
-                || this == CABLE_CAR || this == GONDOLA || this == FUNICULAR || this == TRANSIT
+                || this == CABLECAR || this == GONDOLA || this == FUNICULAR || this == TRANSIT
                 || this == TRAINISH || this == BUSISH;
     }
 

--- a/src/main/java/org/opentripplanner/routing/core/TraverseModeSet.java
+++ b/src/main/java/org/opentripplanner/routing/core/TraverseModeSet.java
@@ -45,7 +45,7 @@ public class TraverseModeSet implements Cloneable, Serializable {
 
     private static final int MODE_FERRY = 256;
 
-    private static final int MODE_CABLE_CAR = 512;
+    private static final int MODE_CABLECAR = 512;
 
     private static final int MODE_GONDOLA = 1024;
 
@@ -53,7 +53,7 @@ public class TraverseModeSet implements Cloneable, Serializable {
     
     private static final int MODE_TRAINISH = MODE_TRAM | MODE_RAIL | MODE_SUBWAY | MODE_FUNICULAR | MODE_GONDOLA;
 
-    private static final int MODE_BUSISH = MODE_CABLE_CAR | MODE_BUS;
+    private static final int MODE_BUSISH = MODE_CABLECAR | MODE_BUS;
 
     private static final int MODE_TRANSIT = MODE_TRAINISH | MODE_BUSISH | MODE_FERRY;
     
@@ -101,8 +101,8 @@ public class TraverseModeSet implements Cloneable, Serializable {
             return MODE_BUS;
         case TRAM:
             return MODE_TRAM;
-        case CABLE_CAR:
-            return MODE_CABLE_CAR;
+        case CABLECAR:
+            return MODE_CABLECAR;
         case GONDOLA:
             return MODE_GONDOLA;
         case FERRY:
@@ -177,7 +177,7 @@ public class TraverseModeSet implements Cloneable, Serializable {
     }
     
     public boolean getCableCar() {
-        return (modes & MODE_CABLE_CAR) != 0;
+        return (modes & MODE_CABLECAR) != 0;
     }
 
     public boolean getFunicular() {
@@ -259,9 +259,9 @@ public class TraverseModeSet implements Cloneable, Serializable {
 
     public void setCableCar(boolean cableCar) {
         if (cableCar) {
-            modes |= MODE_CABLE_CAR;
+            modes |= MODE_CABLECAR;
         } else {
-            modes &= ~MODE_CABLE_CAR;
+            modes &= ~MODE_CABLECAR;
         }
     }
 

--- a/src/main/java/org/opentripplanner/routing/edgetype/BikeParkEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/BikeParkEdge.java
@@ -67,7 +67,7 @@ public class BikeParkEdge extends Edge {
         StateEditor s0e = s0.edit(this);
         s0e.incrementWeight(options.bikeParkCost);
         s0e.incrementTimeInSeconds(options.bikeParkTime);
-        s0e.setBackMode(TraverseMode.LEG_SWITCH);
+        s0e.setBackMode(TraverseMode.LEGSWITCH);
         s0e.setBikeParked(false);
         State s1 = s0e.makeState();
         return s1;
@@ -90,7 +90,7 @@ public class BikeParkEdge extends Edge {
         StateEditor s0e = s0.edit(this);
         s0e.incrementWeight(options.bikeParkCost);
         s0e.incrementTimeInSeconds(options.bikeParkTime);
-        s0e.setBackMode(TraverseMode.LEG_SWITCH);
+        s0e.setBackMode(TraverseMode.LEGSWITCH);
         s0e.setBikeParked(true);
         State s1 = s0e.makeState();
         return s1;

--- a/src/main/java/org/opentripplanner/routing/edgetype/LegSwitchingEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/LegSwitchingEdge.java
@@ -36,7 +36,7 @@ public class LegSwitchingEdge extends Edge {
 	@Override
 	public State traverse(State s0) {
 		StateEditor editor = s0.edit(this);
-		editor.setBackMode(TraverseMode.LEG_SWITCH);
+		editor.setBackMode(TraverseMode.LEGSWITCH);
 		return editor.makeState();
 	}
 

--- a/src/main/java/org/opentripplanner/routing/edgetype/ParkAndRideEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/ParkAndRideEdge.java
@@ -63,7 +63,7 @@ public class ParkAndRideEdge extends Edge {
             s1.incrementWeight(time);
             s1.incrementTimeInSeconds(time);
             s1.setCarParked(false);
-            s1.setBackMode(TraverseMode.LEG_SWITCH);
+            s1.setBackMode(TraverseMode.LEGSWITCH);
             return s1.makeState();
         } else {
             /*
@@ -80,7 +80,7 @@ public class ParkAndRideEdge extends Edge {
             s1.incrementWeight(time);
             s1.incrementTimeInSeconds(time);
             s1.setCarParked(true);
-            s1.setBackMode(TraverseMode.LEG_SWITCH);
+            s1.setBackMode(TraverseMode.LEGSWITCH);
             return s1.makeState();
         }
     }

--- a/src/main/java/org/opentripplanner/routing/edgetype/PreAlightEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/PreAlightEdge.java
@@ -111,7 +111,7 @@ public class PreAlightEdge extends FreeEdge implements StationEdge {
     }
 
     public TraverseMode getMode() {
-        return TraverseMode.LEG_SWITCH;
+        return TraverseMode.LEGSWITCH;
     }
 
     public State optimisticTraverse(State s0) {

--- a/src/main/java/org/opentripplanner/routing/edgetype/PreBoardEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/PreBoardEdge.java
@@ -110,7 +110,7 @@ public class PreBoardEdge extends FreeEdge implements StationEdge {
     }
 
     public TraverseMode getMode() {
-        return TraverseMode.LEG_SWITCH;
+        return TraverseMode.LEGSWITCH;
     }
 
     public State optimisticTraverse(State s0) {

--- a/src/main/java/org/opentripplanner/routing/edgetype/StationStopEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StationStopEdge.java
@@ -50,7 +50,7 @@ public class StationStopEdge extends Edge {
     @Override
     public State traverse(State s0) {
         StateEditor s1 = s0.edit(this);
-        s1.setBackMode(TraverseMode.LEG_SWITCH);
+        s1.setBackMode(TraverseMode.LEGSWITCH);
         s1.incrementWeight(1);
         // Increment weight, but not time. See Javadoc on this class.
         return s1.makeState();

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetTransitLink.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetTransitLink.java
@@ -67,7 +67,7 @@ public class StreetTransitLink extends Edge {
     }
 
     public TraverseMode getMode() {
-        return TraverseMode.LEG_SWITCH;
+        return TraverseMode.LEGSWITCH;
     }
 
     public String getName() {
@@ -105,14 +105,14 @@ public class StreetTransitLink extends Edge {
         }
         s1.incrementTimeInSeconds(transitStop.getStreetToStopTime() + STL_TRAVERSE_COST);
         s1.incrementWeight(STL_TRAVERSE_COST + transitStop.getStreetToStopTime());
-        s1.setBackMode(TraverseMode.LEG_SWITCH);
+        s1.setBackMode(TraverseMode.LEGSWITCH);
         return s1.makeState();
     }
 
     public State optimisticTraverse(State s0) {
         StateEditor s1 = s0.edit(this);
         s1.incrementWeight(STL_TRAVERSE_COST);
-        s1.setBackMode(TraverseMode.LEG_SWITCH);
+        s1.setBackMode(TraverseMode.LEGSWITCH);
         return s1.makeState();
     }
     

--- a/src/main/java/org/opentripplanner/routing/edgetype/TransitBoardAlight.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/TransitBoardAlight.java
@@ -106,7 +106,7 @@ public class TransitBoardAlight extends TablePatternEdge implements OnboardEdge 
     }
 
     public TraverseMode getMode() {
-        return TraverseMode.LEG_SWITCH;
+        return TraverseMode.LEGSWITCH;
     }
 
     public String getName() {

--- a/src/main/java/org/opentripplanner/routing/impl/CandidateEdge.java
+++ b/src/main/java/org/opentripplanner/routing/impl/CandidateEdge.java
@@ -201,7 +201,7 @@ public class CandidateEdge {
             out |= StreetEdge.CLASS_TRAIN_PLATFORM;
         }
         if (mode.getBusish() ) { 
-            // includes CABLE_CAR
+            // includes CABLECAR
             out |= StreetEdge.CLASS_OTHER_PLATFORM;
         }
         return out;

--- a/src/main/java/org/opentripplanner/routing/impl/SFBayFareServiceImpl.java
+++ b/src/main/java/org/opentripplanner/routing/impl/SFBayFareServiceImpl.java
@@ -41,7 +41,7 @@ public class SFBayFareServiceImpl extends DefaultFareServiceImpl {
     public static final int SFMTA_TRANSFER_DURATION = 60 * 90;
     public static final int BART_TRANSFER_DURATION =  60 * 60;
     public static final float SFMTA_BASE_FARE = 2.00f;
-    public static final float CABLE_CAR_FARE = 5.00f;
+    public static final float CABLECAR_FARE = 5.00f;
     public static final float AIRBART_FARE = 3.00f;
     public static final float SFMTA_BART_TRANSFER_FARE = 1.75f;
     public static final Set<String> SFMTA_BART_TRANSFER_STOPS = new HashSet<String>(Arrays.asList(
@@ -72,9 +72,9 @@ public class SFBayFareServiceImpl extends DefaultFareServiceImpl {
                     bartBlock = null;
                 }
                 if (agencyId.equals("SFMTA")) {
-                    if (ride.classifier == TraverseMode.CABLE_CAR) {
+                    if (ride.classifier == TraverseMode.CABLECAR) {
                         // no transfers issued or accepted
-                        cost += CABLE_CAR_FARE;
+                        cost += CABLECAR_FARE;
                     } else if (sfmtaTransferIssued == null || 
                         sfmtaTransferIssued + SFMTA_TRANSFER_DURATION < ride.endTime) {
                         sfmtaTransferIssued = ride.startTime;

--- a/src/test/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverterTest.java
+++ b/src/test/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverterTest.java
@@ -119,8 +119,8 @@ public class GraphPathToTripPlanConverterTest {
     }
 
     /**
-     * Test that a LEG_SWITCH mode at the end of a graph path does not generate an extra leg.
-     * Also test that such a LEG_SWITCH mode does not show up as part of the itinerary.
+     * Test that a LEGSWITCH mode at the end of a graph path does not generate an extra leg.
+     * Also test that such a LEGSWITCH mode does not show up as part of the itinerary.
      */
     @Test
     public void testEndWithLegSwitch() {


### PR DESCRIPTION
Apparently the mode CABLE_CAR has been unusable in OTP for approximately a year now, at least when specified by itself (it'll still work as part of BUSISH or TRANSIT), as that gives a 404 error (not even our own error object with a code of 404, but an actual HTTP status code of 404).

The reason is that it contains an underscore and we're using underscores for qualified modes now, which means CABLE_CAR can't be parsed correctly anymore. I changed it into CABLECAR to fix this issue, also changing LEG_SWITCH to LEGSWITCH for consistency, even though that should be a strictly internal value.

Since this is technically an API change, I'm creating a pull request instead of just pushing the change. Although I doubt it, there might still be third-party clients that rely on the old spelling.