### PR TITLE
Fix 1847

### DIFF
--- a/src/main/java/org/opentripplanner/api/resource/Routers.java
+++ b/src/main/java/org/opentripplanner/api/resource/Routers.java
@@ -180,8 +180,11 @@ public class Routers {
         LOG.debug("Attempting to load graph '{}' from server's local filesystem.", routerId);
         GraphService graphService = otpServer.getGraphService();
         if (graphService.getRouterIds().contains(routerId)) {
-            graphService.reloadGraph(routerId, preEvict);
-            return Response.status(201).entity("graph already registered, reloaded.\n").build();
+            boolean success = graphService.reloadGraph(routerId, preEvict);
+            if (success)
+                return Response.status(201).entity("graph already registered, reloaded.\n").build();
+            else
+                return Response.status(404).entity("graph already registered, but reload failed.\n").build();
         } else {
             boolean success = graphService.registerGraph(routerId, graphService
                     .getGraphSourceFactory().createGraphSource(routerId));

--- a/src/main/java/org/opentripplanner/api/resource/Routers.java
+++ b/src/main/java/org/opentripplanner/api/resource/Routers.java
@@ -170,8 +170,6 @@ public class Routers {
      * @param preEvict before reloading each graph, evict the existing graph. This will prevent 
      * memory usage from increasing during the reload, but routing will be unavailable on this 
      * routerId for the duration of the operation.
-     *
-     *                FIXME @param upload read the graph from the PUT data stream instead of from disk.
      */
     @RolesAllowed({ "ROUTERS" })
     @PUT @Path("{routerId}") @Produces({ MediaType.TEXT_PLAIN })

--- a/src/main/java/org/opentripplanner/api/resource/Routers.java
+++ b/src/main/java/org/opentripplanner/api/resource/Routers.java
@@ -159,9 +159,10 @@ public class Routers {
      */
     @RolesAllowed({ "ROUTERS" })
     @PUT @Produces({ MediaType.APPLICATION_JSON })
-    public Response reloadGraphs(@QueryParam("path") String path, 
-            @QueryParam("preEvict") @DefaultValue("true") boolean preEvict) {
-        otpServer.getGraphService().reloadGraphs(preEvict);
+    public Response reloadGraphs(@QueryParam("path") String path,
+            @QueryParam("preEvict") @DefaultValue("true") boolean preEvict,
+            @QueryParam("force") @DefaultValue("true") boolean force) {
+        otpServer.getGraphService().reloadGraphs(preEvict, force);
         return Response.status(Status.OK).build();
     }
 
@@ -178,7 +179,7 @@ public class Routers {
         LOG.debug("Attempting to load graph '{}' from server's local filesystem.", routerId);
         GraphService graphService = otpServer.getGraphService();
         if (graphService.getRouterIds().contains(routerId)) {
-            boolean success = graphService.reloadGraph(routerId, preEvict);
+            boolean success = graphService.reloadGraph(routerId, preEvict, false);
             if (success)
                 return Response.status(201).entity("graph already registered, reloaded.\n").build();
             else

--- a/src/main/java/org/opentripplanner/routing/impl/InputStreamGraphSource.java
+++ b/src/main/java/org/opentripplanner/routing/impl/InputStreamGraphSource.java
@@ -28,7 +28,6 @@ import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Graph.LoadLevel;
 import org.opentripplanner.routing.services.GraphSource;
 import org.opentripplanner.routing.services.StreetVertexIndexFactory;
-import org.opentripplanner.standalone.OTPMain;
 import org.opentripplanner.standalone.Router;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/org/opentripplanner/routing/impl/InputStreamGraphSource.java
+++ b/src/main/java/org/opentripplanner/routing/impl/InputStreamGraphSource.java
@@ -124,6 +124,7 @@ public class InputStreamGraphSource implements GraphSource {
             if (preEvict) {
                 synchronized (preEvictMutex) {
                     if (router != null) {
+                        LOG.info("Reloading '{}': pre-evicting router", routerId);
                         router.shutdown();
                     }
                     /*
@@ -139,6 +140,7 @@ public class InputStreamGraphSource implements GraphSource {
                 if (newRouter != null) {
                     // Load OK
                     if (router != null) {
+                        LOG.info("Reloading '{}': post-evicting router", routerId);
                         router.shutdown();
                     }
                     router = newRouter; // Assignment in java is atomic

--- a/src/main/java/org/opentripplanner/routing/impl/MemoryGraphSource.java
+++ b/src/main/java/org/opentripplanner/routing/impl/MemoryGraphSource.java
@@ -13,9 +13,6 @@
 
 package org.opentripplanner.routing.impl;
 
-import java.util.Properties;
-import java.util.prefs.Preferences;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.MissingNode;
 import org.opentripplanner.routing.graph.Graph;

--- a/src/main/java/org/opentripplanner/routing/services/GraphService.java
+++ b/src/main/java/org/opentripplanner/routing/services/GraphService.java
@@ -137,12 +137,12 @@ public class GraphService {
      * Reload all registered graphs from wherever they came from. See reloadGraph().
      * @return whether the operation completed successfully (all reloads are successful).
      */
-    public boolean reloadGraphs(boolean preEvict) {
+    public boolean reloadGraphs(boolean preEvict, boolean force) {
         boolean allSucceeded = true;
         synchronized (graphSources) {
             Collection<String> routerIds = getRouterIds();
             for (String routerId : routerIds) {
-                allSucceeded &= reloadGraph(routerId, preEvict);
+                allSucceeded &= reloadGraph(routerId, preEvict, force);
             }
         }
         return allSucceeded;
@@ -155,15 +155,17 @@ public class GraphService {
      * @param preEvict When true, release the existing graph (if any) before loading. This will
      *        halve the amount of memory needed for the operation, but routing will be unavailable
      *        for that graph during the load process
+     * @param force When true, force a reload. If false, only check if the source has been modified,
+     *        and reload if so.
      * @return True if the reload is successful, false otherwise.
      */
-    public boolean reloadGraph(String routerId, boolean preEvict) {
+    public boolean reloadGraph(String routerId, boolean preEvict, boolean force) {
         synchronized (graphSources) {
             GraphSource graphSource = graphSources.get(routerId);
             if (graphSource == null) {
                 return false;
             }
-            boolean success = graphSource.reload(true, preEvict);
+            boolean success = graphSource.reload(force, preEvict);
             if (!success) {
                 evictRouter(routerId);
             }

--- a/src/main/java/org/opentripplanner/routing/services/GraphSource.java
+++ b/src/main/java/org/opentripplanner/routing/services/GraphSource.java
@@ -65,7 +65,8 @@ public interface GraphSource {
      * @param preEvict True to evict the old version *before* loading the new one. In that case the
      *        implementation have to take care of making the getGraph() call wait while the new
      *        graph is being loaded and not return null.
-     * @return False if a new graph has not been reloaded and this graph must be evicted.
+     * @return False if a new graph has not been reloaded and we could not keep the previous one: it
+     *         should be evicted.
      */
     public boolean reload(boolean force, boolean preEvict);
 

--- a/src/main/java/org/opentripplanner/standalone/OTPServer.java
+++ b/src/main/java/org/opentripplanner/standalone/OTPServer.java
@@ -8,8 +8,6 @@ import org.opentripplanner.analyst.DiskBackedPointSetCache;
 import org.opentripplanner.analyst.PointSetCache;
 import org.opentripplanner.analyst.SurfaceCache;
 import org.opentripplanner.routing.error.GraphNotFoundException;
-import org.opentripplanner.routing.impl.GraphScanner;
-import org.opentripplanner.routing.impl.InputStreamGraphSource;
 import org.opentripplanner.routing.services.GraphService;
 import org.opentripplanner.scripting.impl.ScriptingService;
 import org.slf4j.Logger;

--- a/src/main/java/org/opentripplanner/standalone/Router.java
+++ b/src/main/java/org/opentripplanner/standalone/Router.java
@@ -1,12 +1,9 @@
 package org.opentripplanner.standalone;
 
-import java.util.prefs.Preferences;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import org.opentripplanner.analyst.request.*;
 import org.opentripplanner.inspector.TileRendererManager;
 import org.opentripplanner.reflect.ReflectiveInitializer;
-import org.opentripplanner.routing.algorithm.TraverseVisitor;
 import org.opentripplanner.routing.core.RoutingRequest;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.updater.GraphUpdaterConfigurator;

--- a/src/test/java/org/opentripplanner/routing/impl/GraphServiceTest.java
+++ b/src/test/java/org/opentripplanner/routing/impl/GraphServiceTest.java
@@ -164,7 +164,7 @@ public class GraphServiceTest extends TestCase {
         graphSourceFactory.save("A", new ByteArrayInputStream(smallGraphData));
 
         // Force a reload, get again the graph
-        graphService.reloadGraphs(false);
+        graphService.reloadGraphs(false, true);
         graph = graphService.getRouter("A").graph;
 
         // Check if loaded graph is the one modified
@@ -175,7 +175,7 @@ public class GraphServiceTest extends TestCase {
         boolean deleted = new File(new File(basePath, "A"), InputStreamGraphSource.GRAPH_FILENAME)
                 .delete();
         assertTrue(deleted);
-        graphService.reloadGraphs(false);
+        graphService.reloadGraphs(false, true);
 
         // Check that the graph have been evicted
         assertEquals(0, graphService.getRouterIds().size());


### PR DESCRIPTION
This aims to fix #1847.

When calling `PUT /otp/routers/<routerId>` with an already registered router, we now reload the graph, instead of doing nothing.

We may want to have a dedicated "reload" end-point for this, but this solution probably make more sense. If the need arise we could refine the API.

**Warning**: this changes the semantics of the router registration API end-point. If any API client assume it's safe to register several times the same router ID, this would now reload the graph again and again which could degrade performances.

This PR also contains minor cosmetics fixes (unused imports warnings, code comment).