### PR TITLE
Removes redundant streetTraversalPermissions

### DIFF
--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetTraversalPermission.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetTraversalPermission.java
@@ -31,7 +31,6 @@ public enum StreetTraversalPermission {
     CAR(4),
     PEDESTRIAN_AND_CAR(4 | 1),
     BICYCLE_AND_CAR(4 | 2),
-    PEDESTRIAN_AND_BICYCLE_AND_CAR(4 | 2 | 1),
     ALL(4 | 2 | 1);
 
     private static final Map<Integer, StreetTraversalPermission> lookup = new HashMap<Integer, StreetTraversalPermission>();


### PR DESCRIPTION
ALL and PEDESTRIAN_AND_BICYCLE_AND_CAR both had values 4|2|1
since #1772. Fixes #1874