### PR TITLE
Unclassified road with bike=designated was missing CAR permission

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/DefaultWayPropertySetSource.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/DefaultWayPropertySetSource.java
@@ -346,6 +346,8 @@ public class DefaultWayPropertySetSource implements WayPropertySetSource {
                 0.84, 0.84);
         setProperties(props, "highway=residential;bicycle=designated",
                 StreetTraversalPermission.ALL, 0.95, 0.95);
+        setProperties(props, "highway=unclassified;bicycle=designated",
+                StreetTraversalPermission.ALL, 0.95, 0.95);
         setProperties(props, "highway=residential_link;bicycle=designated",
                 StreetTraversalPermission.ALL, 0.95, 0.95);
         setProperties(props, "highway=tertiary;bicycle=designated", StreetTraversalPermission.ALL,


### PR DESCRIPTION
This adds car permission to roads which are Unclassified and have
bike=designated. 

This fixes #1878 because it changes permissions for road so that it has a car permission. But it adds new problem.
Now this [road](http://www.openstreetmap.org/way/114741006) is usable by car even though it has `motor_vehicle=no` [osm tag](https://wiki.openstreetmap.org/wiki/Key:motor_vehicle). This tag isn't supported in OTP only `motorcar` [OSM tag](https://wiki.openstreetmap.org/wiki/Key:motorcar) is. Should I add support for this tag in this PR or new one?