### PR TITLE
Adds support for OSM tag motor_vehicle

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/OSMFilter.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/OSMFilter.java
@@ -53,7 +53,7 @@ public class OSMFilter {
         if (way.isGeneralAccessDenied()) {
             // There are exceptions.
             return (way.isMotorcarExplicitlyAllowed() || way.isBicycleExplicitlyAllowed() || way
-                    .isPedestrianExplicitlyAllowed());
+                    .isPedestrianExplicitlyAllowed() || way.isMotorVehicleExplicitlyAllowed());
         }
 
         return true;
@@ -92,7 +92,7 @@ public class OSMFilter {
         if (entity.isGeneralAccessDenied()) {
             // this can actually be overridden
             permission = StreetTraversalPermission.NONE;
-            if (entity.isMotorcarExplicitlyAllowed()) {
+            if (entity.isMotorcarExplicitlyAllowed() || entity.isMotorVehicleExplicitlyAllowed()) {
                 permission = permission.add(StreetTraversalPermission.CAR);
             }
             if (entity.isBicycleExplicitlyAllowed()) {
@@ -105,9 +105,9 @@ public class OSMFilter {
             permission = def;
         }
 
-        if (entity.isMotorcarExplicitlyDenied()) {
+        if (entity.isMotorcarExplicitlyDenied() || entity.isMotorVehicleExplicitlyDenied()) {
             permission = permission.remove(StreetTraversalPermission.CAR);
-        } else if (entity.hasTag("motorcar")) {
+        } else if (entity.hasTag("motorcar") || entity.hasTag("motor_vehicle")) {
             permission = permission.add(StreetTraversalPermission.CAR);
         }
 

--- a/src/main/java/org/opentripplanner/openstreetmap/model/OSMWithTags.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/model/OSMWithTags.java
@@ -231,6 +231,25 @@ public class OSMWithTags {
     }
 
     /**
+     * Returns true if cars/motorcycles/HGV are explicitly denied access.
+     *
+     * @return
+     */
+    public boolean isMotorVehicleExplicitlyDenied() {
+        return isTagDeniedAccess("motor_vehicle");
+    }
+
+    /**
+     * Returns true if cars/motorcycles/HGV are explicitly allowed.
+     *
+     * @return
+     */
+    public boolean isMotorVehicleExplicitlyAllowed() {
+        return doesTagAllowAccess("motor_vehicle");
+    }
+
+
+    /**
      * Returns true if bikes are explicitly denied access.
      * 
      * bicycle is denied if bicycle:no, bicycle:license or bicycle:use_sidepath


### PR DESCRIPTION
It is checked everywhere where support for motorcar is checked.
https://wiki.openstreetmap.org/wiki/Key:motor_vehicle. Fixes some problems which were made visible in #1880 .