### PR TITLE
Fixes #1890 don't match the sources jar in the run script

### DIFF
--- a/otp
+++ b/otp
@@ -2,4 +2,4 @@
 # Run OTP in standalone mode with the supplied arguments.
 # Standalone OTP can build a graph, visualize a graph, run an OTP API server,
 # or any combination of these.
-java -Xmx6G -Xverify:none -jar `dirname $0`/target/otp*.jar "$@"
+java -Xmx6G -Xverify:none -jar `dirname $0`/target/otp*[!sources].jar "$@"

--- a/src/main/java/org/opentripplanner/standalone/OTPMain.java
+++ b/src/main/java/org/opentripplanner/standalone/OTPMain.java
@@ -130,7 +130,7 @@ public class OTPMain {
             /* Auto-register pre-existing graph on disk, with optional auto-scan. */
             GraphScanner graphScanner = new GraphScanner(graphService, params.graphDirectory, params.autoScan);
             graphScanner.basePath = params.graphDirectory;
-            if (params.routerIds.size() > 0) {
+            if (params.routerIds != null && params.routerIds.size() > 0) {
                 graphScanner.defaultRouterId = params.routerIds.get(0);
             }
             graphScanner.autoRegister = params.routerIds;


### PR DESCRIPTION
Tests pass, but they're not testing the otp script anyway. Confirmed that expected behavior now occurs when running ```./otp```