### PR TITLE
Fixes #1892 check for routerIds before checking their length to prevent NPE

### DIFF
--- a/src/main/java/org/opentripplanner/standalone/OTPMain.java
+++ b/src/main/java/org/opentripplanner/standalone/OTPMain.java
@@ -130,7 +130,7 @@ public class OTPMain {
             /* Auto-register pre-existing graph on disk, with optional auto-scan. */
             GraphScanner graphScanner = new GraphScanner(graphService, params.graphDirectory, params.autoScan);
             graphScanner.basePath = params.graphDirectory;
-            if (params.routerIds.size() > 0) {
+            if (params.routerIds != null && params.routerIds.size() > 0) {
                 graphScanner.defaultRouterId = params.routerIds.get(0);
             }
             graphScanner.autoRegister = params.routerIds;


### PR DESCRIPTION
Tests all pass.

After adding in this commit, autoscan appears to work as intended when specified on the command line.