### PR TITLE
Fixes #1890 don't match the sources jar in the run script

### DIFF
--- a/otp
+++ b/otp
@@ -2,4 +2,4 @@
 # Run OTP in standalone mode with the supplied arguments.
 # Standalone OTP can build a graph, visualize a graph, run an OTP API server,
 # or any combination of these.
-java -Xmx6G -Xverify:none -jar `dirname $0`/target/otp*.jar "$@"
+java -Xmx6G -Xverify:none -jar `dirname $0`/target/otp*[!sources].jar "$@"


### PR DESCRIPTION
Resubmits PR 1891 which was done incorrectly.

This fixes the issue where cloning the repo and trying to compile and run fails because the otp script uses an overly-broad wildcard match which captures the sources.jar first on my machine. 

The fix is to exclude that jar from the match.