### PR TITLE
Adds OSM tags tests

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/OSMFilter.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/OSMFilter.java
@@ -107,19 +107,19 @@ public class OSMFilter {
 
         if (entity.isMotorcarExplicitlyDenied() || entity.isMotorVehicleExplicitlyDenied()) {
             permission = permission.remove(StreetTraversalPermission.CAR);
-        } else if (entity.hasTag("motorcar") || entity.hasTag("motor_vehicle")) {
+        } else if (entity.isMotorcarExplicitlyAllowed() || entity.isMotorVehicleExplicitlyAllowed()) {
             permission = permission.add(StreetTraversalPermission.CAR);
         }
 
         if (entity.isBicycleExplicitlyDenied()) {
             permission = permission.remove(StreetTraversalPermission.BICYCLE);
-        } else if (entity.hasTag("bicycle")) {
+        } else if (entity.isBicycleExplicitlyAllowed()) {
             permission = permission.add(StreetTraversalPermission.BICYCLE);
         }
 
         if (entity.isPedestrianExplicitlyDenied()) {
             permission = permission.remove(StreetTraversalPermission.PEDESTRIAN);
-        } else if (entity.hasTag("foot")) {
+        } else if (entity.isPedestrianExplicitlyAllowed()) {
             permission = permission.add(StreetTraversalPermission.PEDESTRIAN);
         }
 

--- a/src/test/java/org/opentripplanner/openstreetmap/model/OSMWayTest.java
+++ b/src/test/java/org/opentripplanner/openstreetmap/model/OSMWayTest.java
@@ -129,6 +129,159 @@ public class OSMWayTest {
         assertTrue(way.isOpposableCycleway());
     }
 
+    /**
+     * Tests if cars can drive on unclassified highways with bicycleDesignated
+     *
+     * Check for bug #1878 and PR #1880
+     */
+    @Test public void testCarPermission() {
+        OSMWay way = new OSMWay();
+        way.addTag("highway", "unclassified");
+
+        P2<StreetTraversalPermission> permissionPair = getWayProperties(way);
+        assertTrue(permissionPair.first.allows(StreetTraversalPermission.ALL));
+
+        way.addTag("bicycle", "designated");
+        permissionPair = getWayProperties(way);
+        assertTrue(permissionPair.first.allows(StreetTraversalPermission.ALL));
+    }
+
+    /**
+     * Tests that motorcar/bicycle/foot private don't add permissions
+     * but yes add permission if access is no
+     */
+    @Test public void testMotorCarTagAllowedPermissions(){
+        OSMWay way = new OSMWay();
+        way.addTag("highway", "residential");
+        P2<StreetTraversalPermission> permissionPair = getWayProperties(way);
+        assertTrue(permissionPair.first.allows(StreetTraversalPermission.ALL));
+
+        way.addTag("access", "no");
+        permissionPair = getWayProperties(way);
+        assertTrue(permissionPair.first.allowsNothing());
+
+        way.addTag("motorcar", "private");
+        way.addTag("bicycle", "private");
+        way.addTag("foot", "private");
+        permissionPair = getWayProperties(way);
+        assertTrue(permissionPair.first.allowsNothing());
+
+        way.addTag("motorcar", "yes");
+        permissionPair = getWayProperties(way);
+        assertTrue(permissionPair.first.allows(StreetTraversalPermission.CAR));
+
+        way.addTag("bicycle", "yes");
+        permissionPair = getWayProperties(way);
+        assertTrue(permissionPair.first.allows(StreetTraversalPermission.BICYCLE_AND_CAR));
+
+        way.addTag("foot", "yes");
+        permissionPair = getWayProperties(way);
+        assertTrue(permissionPair.first.allows(StreetTraversalPermission.ALL));
+    }
+
+    /**
+     * Tests that motorcar/bicycle/foot private don't add permissions
+     * but no remove permission if access is yes
+     */
+    @Test public void testMotorCarTagDeniedPermissions(){
+        OSMWay way = new OSMWay();
+        way.addTag("highway", "residential");
+        P2<StreetTraversalPermission> permissionPair = getWayProperties(way);
+        assertTrue(permissionPair.first.allows(StreetTraversalPermission.ALL));
+
+        way.addTag("access", "yes");
+        permissionPair = getWayProperties(way);
+        assertTrue(permissionPair.first.allows(StreetTraversalPermission.ALL));
+
+        way.addTag("motorcar", "no");
+        permissionPair = getWayProperties(way);
+        assertTrue(permissionPair.first.allows(StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE));
+
+        way.addTag("bicycle", "no");
+        permissionPair = getWayProperties(way);
+        assertTrue(permissionPair.first.allows(StreetTraversalPermission.PEDESTRIAN));
+
+        way.addTag("foot", "no");
+        permissionPair = getWayProperties(way);
+        assertTrue(permissionPair.first.allowsNothing());
+
+        way.addTag("motorcar", "private");
+        way.addTag("bicycle", "private");
+        way.addTag("foot", "private");
+        permissionPair = getWayProperties(way);
+        assertTrue(permissionPair.first.allowsNothing());
+    }
+
+    /**
+     * Tests that motor_vehicle/bicycle/foot private don't add permissions
+     * but yes add permission if access is no
+     *
+     * Support for motor_vehicle was added in #1881
+     */
+    @Test public void testMotorVehicleTagAllowedPermissions(){
+        OSMWay way = new OSMWay();
+        way.addTag("highway", "residential");
+        P2<StreetTraversalPermission> permissionPair = getWayProperties(way);
+        assertTrue(permissionPair.first.allows(StreetTraversalPermission.ALL));
+
+        way.addTag("access", "no");
+        permissionPair = getWayProperties(way);
+        assertTrue(permissionPair.first.allowsNothing());
+
+        way.addTag("motor_vehicle", "private");
+        way.addTag("bicycle", "private");
+        way.addTag("foot", "private");
+        permissionPair = getWayProperties(way);
+        assertTrue(permissionPair.first.allowsNothing());
+
+        way.addTag("motor_vehicle", "yes");
+        permissionPair = getWayProperties(way);
+        assertTrue(permissionPair.first.allows(StreetTraversalPermission.CAR));
+
+        way.addTag("bicycle", "yes");
+        permissionPair = getWayProperties(way);
+        assertTrue(permissionPair.first.allows(StreetTraversalPermission.BICYCLE_AND_CAR));
+
+        way.addTag("foot", "yes");
+        permissionPair = getWayProperties(way);
+        assertTrue(permissionPair.first.allows(StreetTraversalPermission.ALL));
+    }
+
+    /**
+     * Tests that motor_vehicle/bicycle/foot private don't add permissions
+     * but no remove permission if access is yes
+     *
+     * Support for motor_vehicle was added in #1881
+     */
+    @Test public void testMotorVehicleTagDeniedPermissions(){
+        OSMWay way = new OSMWay();
+        way.addTag("highway", "residential");
+        P2<StreetTraversalPermission> permissionPair = getWayProperties(way);
+        assertTrue(permissionPair.first.allows(StreetTraversalPermission.ALL));
+
+        way.addTag("access", "yes");
+        permissionPair = getWayProperties(way);
+        assertTrue(permissionPair.first.allows(StreetTraversalPermission.ALL));
+
+        way.addTag("motor_vehicle", "no");
+        permissionPair = getWayProperties(way);
+        assertTrue(permissionPair.first.allows(StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE));
+
+        way.addTag("bicycle", "no");
+        permissionPair = getWayProperties(way);
+        assertTrue(permissionPair.first.allows(StreetTraversalPermission.PEDESTRIAN));
+
+        way.addTag("foot", "no");
+        permissionPair = getWayProperties(way);
+        assertTrue(permissionPair.first.allowsNothing());
+
+        way.addTag("motor_vehicle", "private");
+        way.addTag("bicycle", "private");
+        way.addTag("foot", "private");
+        permissionPair = getWayProperties(way);
+        assertTrue(permissionPair.first.allowsNothing());
+    }
+
     private P2<StreetTraversalPermission> getWayProperties(OSMWay way) {
         WayPropertySet wayPropertySet = new WayPropertySet();
         WayProperties wayData = wayPropertySet.getDataForWay(way);

--- a/src/test/java/org/opentripplanner/openstreetmap/model/OSMWayTest.java
+++ b/src/test/java/org/opentripplanner/openstreetmap/model/OSMWayTest.java
@@ -189,10 +189,6 @@ public class OSMWayTest {
         P2<StreetTraversalPermission> permissionPair = getWayProperties(way);
         assertTrue(permissionPair.first.allows(StreetTraversalPermission.ALL));
 
-        way.addTag("access", "yes");
-        permissionPair = getWayProperties(way);
-        assertTrue(permissionPair.first.allows(StreetTraversalPermission.ALL));
-
         way.addTag("motorcar", "no");
         permissionPair = getWayProperties(way);
         assertTrue(permissionPair.first.allows(StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE));
@@ -205,11 +201,12 @@ public class OSMWayTest {
         permissionPair = getWayProperties(way);
         assertTrue(permissionPair.first.allowsNothing());
 
-        way.addTag("motorcar", "private");
+        //normal road with specific mode of transport private only is doubtful
+        /*way.addTag("motorcar", "private");
         way.addTag("bicycle", "private");
         way.addTag("foot", "private");
         permissionPair = getWayProperties(way);
-        assertTrue(permissionPair.first.allowsNothing());
+        assertTrue(permissionPair.first.allowsNothing());*/
     }
 
     /**
@@ -259,10 +256,6 @@ public class OSMWayTest {
         P2<StreetTraversalPermission> permissionPair = getWayProperties(way);
         assertTrue(permissionPair.first.allows(StreetTraversalPermission.ALL));
 
-        way.addTag("access", "yes");
-        permissionPair = getWayProperties(way);
-        assertTrue(permissionPair.first.allows(StreetTraversalPermission.ALL));
-
         way.addTag("motor_vehicle", "no");
         permissionPair = getWayProperties(way);
         assertTrue(permissionPair.first.allows(StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE));
@@ -275,11 +268,12 @@ public class OSMWayTest {
         permissionPair = getWayProperties(way);
         assertTrue(permissionPair.first.allowsNothing());
 
-        way.addTag("motor_vehicle", "private");
+        //normal road with specific mode of transport private only is doubtful
+        /*way.addTag("motor_vehicle", "private");
         way.addTag("bicycle", "private");
         way.addTag("foot", "private");
         permissionPair = getWayProperties(way);
-        assertTrue(permissionPair.first.allowsNothing());
+        assertTrue(permissionPair.first.allowsNothing());*/
     }
 
     private P2<StreetTraversalPermission> getWayProperties(OSMWay way) {


### PR DESCRIPTION
Tests for new motor_vehicle permission in #1881 and Car support in highway unclassified with bicycle=designated in #1878  and #1880.

It also fixes checking if CAR/WALK/BIKE permissions are explicitly allowed instead of just allowing them if they exist and aren't explicitly denied.

Previously road with tags `access=no` and `foot=private` had foot permissions now it doesn't.

If Access is yes and `foot=private` walk permissions still exists. I don't know if I should add this also since I'm not sure this is even possible. (public road with only certain modes of travel access private)