### PR TITLE
Expose query parameters for the StopTime Index API

### DIFF
--- a/src/main/java/org/opentripplanner/index/IndexAPI.java
+++ b/src/main/java/org/opentripplanner/index/IndexAPI.java
@@ -51,6 +51,7 @@ import org.opentripplanner.util.model.EncodedPolylineBean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -226,13 +227,22 @@ public class IndexAPI {
        return Response.status(Status.OK).entity(PatternShort.list(patterns)).build();
    }
 
-    /** Return upcoming vehicle arrival/departure times at the given stop. */
+    /** Return upcoming vehicle arrival/departure times at the given stop.
+     *
+     * @param stopIdString Stop ID in Agency:Stop ID format
+     * @param startTime Start time for the search. Seconds from UNIX epoch
+     * @param timeRange Searches forward for timeRange seconds from startTime
+     * @param numberOfDepartures Number of departures to fetch per pattern
+     */
     @GET
     @Path("/stops/{stopId}/stoptimes")
-    public Response getStoptimesForStop (@PathParam("stopId") String stopIdString) {
+    public Response getStoptimesForStop (@PathParam("stopId") String stopIdString,
+                                         @QueryParam("startTime") long startTime,
+                                         @QueryParam("timeRange") @DefaultValue("86400") int timeRange,
+                                         @QueryParam("numberOfDepartures") @DefaultValue("2") int numberOfDepartures) {
         Stop stop = index.stopForId.get(GtfsLibrary.convertIdFromString(stopIdString));
         if (stop == null) return Response.status(Status.NOT_FOUND).entity(MSG_404).build();
-        return Response.status(Status.OK).entity(index.stopTimesForStop(stop)).build();
+        return Response.status(Status.OK).entity(index.stopTimesForStop(stop, startTime, timeRange, numberOfDepartures)).build();
     }
 
     /**

--- a/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
+++ b/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
@@ -306,7 +306,7 @@ public class GraphIndex {
      * @return
      */
     public Collection<StopTimesInPattern> stopTimesForStop(Stop stop) {
-        return getStopTimesForStop(stop, 24 * 60 * 60, 2);
+        return stopTimesForStop(stop, System.currentTimeMillis()/1000, 24 * 60 * 60, 2);
     }
 
     /**
@@ -318,14 +318,17 @@ public class GraphIndex {
      *
      * TODO: Add frequency based trips
      *
-     * @param stop
-     * @param timeRange
-     * @param numberOfDepartures
+     * @param stop Stop object to perform the search for
+     * @param startTime Start time for the search. Seconds from UNIX epoch
+     * @param timeRange Searches forward for timeRange seconds from startTime
+     * @param numberOfDepartures Number of departures to fetch per pattern
      * @return
      */
-    public List<StopTimesInPattern> getStopTimesForStop(Stop stop, int timeRange, int numberOfDepartures) {
+    public List<StopTimesInPattern> stopTimesForStop(Stop stop, long startTime, int timeRange, int numberOfDepartures) {
 
-        long now = System.currentTimeMillis()/1000;
+        if (startTime == 0) {
+            startTime = System.currentTimeMillis() / 1000;
+        }
         List<StopTimesInPattern> ret = new ArrayList<>();
         TimetableSnapshot snapshot = null;
         if (graph.timetableSnapshotSource != null) {
@@ -355,9 +358,9 @@ public class GraphIndex {
                     tt = pattern.scheduledTimetable;
                 }
 
-                if (!tt.temporallyViable(sd, now, timeRange, true)) continue;
+                if (!tt.temporallyViable(sd, startTime, timeRange, true)) continue;
 
-                int secondsSinceMidnight = sd.secondsSinceMidnight(now);
+                int secondsSinceMidnight = sd.secondsSinceMidnight(startTime);
                 int sidx = 0;
                 for (Stop currStop : pattern.stopPattern.stops) {
                     if (currStop == stop) {
@@ -403,8 +406,8 @@ public class GraphIndex {
      * Get a list of all trips that pass through a stop during a single ServiceDate. Useful when creating complete stop
      * timetables for a single day.
      *
-     * @param stop
-     * @param serviceDate
+     * @param stop Stop object to perform the search for
+     * @param serviceDate Return all departures for the specified date
      * @return
      */
     public List<StopTimesInPattern> getStopTimesForStop(Stop stop, ServiceDate serviceDate) {


### PR DESCRIPTION
Currently there is no way to search for stopTimes at a specific time in the future for a specific stop. This PR adds the ability to configure the query parameters for the /stops/{stopId}/stoptimes API endpoint.