### PR TITLE
Elevation should accept tiffs with different CRS

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -18,6 +18,7 @@ import com.vividsolutions.jts.geom.Geometry;
 import org.geotools.coverage.grid.GridCoverage2D;
 import org.geotools.coverage.grid.Interpolator2D;
 import org.geotools.geometry.DirectPosition2D;
+import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.opengis.coverage.Coverage;
 import org.opentripplanner.common.geometry.PackedCoordinateSequence;
 import org.opentripplanner.common.geometry.SphericalDistanceLibrary;
@@ -430,7 +431,7 @@ public class ElevationModule implements GraphBuilderModule {
     private double getElevation(double x, double y) {
         double values[] = new double[1];
         try {
-            coverage.evaluate(new DirectPosition2D(x, y), values);
+            coverage.evaluate(new DirectPosition2D(DefaultGeographicCRS.WGS84, x, y), values);
         } catch (org.opengis.coverage.PointOutsideCoverageException e) {
             // skip this for now
         }

--- a/src/main/java/org/opentripplanner/standalone/OTPMain.java
+++ b/src/main/java/org/opentripplanner/standalone/OTPMain.java
@@ -58,6 +58,10 @@ public class OTPMain {
     /** ENTRY POINT: This is the main method that is called when running otp.jar from the command line. */
     public static void main(String[] args) {
 
+        //This is needed so that conversion from WGS84 to coordinate system of elevation coordinate system is correct
+        //More info:http://docs.geotools.org/latest/userguide/library/referencing/order.html
+        System.setProperty("org.geotools.referencing.forceXY", "true");
+
         /* Parse and validate command line parameters. */
         CommandLineParameters params = new CommandLineParameters();
         try {


### PR DESCRIPTION
When getting elevation data from GeoTIFF coordinate system for coordinates
is specified now. Because latitude/longitude order is not
specifically defined See:
http://docs.geotools.org/latest/userguide/library/referencing/order.html
It is necessary to set forceXY property on OTP startup. This makes
correct order of latitude longitude so that conversion from OSM WGS84
-> elevation coordinate system -> GeoTIFF pixels works.

Tested with ETRS89, WGS84 and US elevations. All seem to be correctly converted.

Fixes #1930