### PR TITLE
Nicer names when changing modes

### DIFF
--- a/src/main/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverter.java
+++ b/src/main/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverter.java
@@ -34,6 +34,7 @@ import org.opentripplanner.routing.error.TrivialPathException;
 import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
+import org.opentripplanner.routing.location.TemporaryStreetLocation;
 import org.opentripplanner.routing.services.FareService;
 import org.opentripplanner.routing.spt.GraphPath;
 import org.opentripplanner.routing.trippattern.TripTimes;
@@ -637,7 +638,15 @@ public abstract class GraphPathToTripPlanConverter {
     private static Place makePlace(State state, Vertex vertex, Edge edge, Stop stop, TripTimes tripTimes, Locale requestedLocale) {
         // If no edge was given, it means we're at the end of this leg and need to work around that.
         boolean endOfLeg = (edge == null);
-        Place place = new Place(vertex.getX(), vertex.getY(), vertex.getName(requestedLocale),
+        String name = vertex.getName(requestedLocale);
+
+        //This gets nicer names instead of osm:node:id when changing mode of transport
+        //Names are generated from all the streets in a corner, same as names in origin and destination
+        //We use name in TemporaryStreetLocation since this name generation already happened when temporary location was generated
+        if (vertex instanceof StreetVertex && !(vertex instanceof TemporaryStreetLocation)) {
+            name = ((StreetVertex) vertex).getIntersectionName(requestedLocale).toString(requestedLocale);
+        }
+        Place place = new Place(vertex.getX(), vertex.getY(), name,
                 makeCalendar(state), makeCalendar(state));
 
         if (endOfLeg) edge = state.getBackEdge();

--- a/src/main/java/org/opentripplanner/routing/impl/StreetVertexIndexServiceImpl.java
+++ b/src/main/java/org/opentripplanner/routing/impl/StreetVertexIndexServiceImpl.java
@@ -322,23 +322,9 @@ public class StreetVertexIndexServiceImpl implements StreetVertexIndexService {
                 // Coordinate is at an intersection or street endpoint, and has traversible edges.
                 if (!location.hasName()) {
                     LOG.debug("found intersection {}. not splitting.", intersection);
-                    // generate names for corners when no name was given
-                    Set<String> uniqueNameSet = new HashSet<String>();
-                    for (Edge e : intersection.getOutgoing()) {
-                        if (e instanceof StreetEdge) {
-                            uniqueNameSet.add(e.getName(locale));
-                        }
-                    }
-                    List<String> uniqueNames = new ArrayList<String>(uniqueNameSet);
 
-                    if (uniqueNames.size() > 1) {
-                        calculatedName = new LocalizedString("corner", new String[]{uniqueNames.get(0),
-                                uniqueNames.get(1)});
-                    } else if (uniqueNames.size() == 1) {
-                        calculatedName = new NonLocalizedString(uniqueNames.get(0));
-                    } else {
-                        calculatedName = new LocalizedString("unnamedStreet", (String[]) null);
-                    }
+                    calculatedName = intersection.getIntersectionName(locale);
+
                 }
                 TemporaryStreetLocation closest = new TemporaryStreetLocation(
                         "corner " + Math.random(), coord, calculatedName, endVertex);

--- a/src/main/java/org/opentripplanner/routing/impl/StreetVertexIndexServiceImpl.java
+++ b/src/main/java/org/opentripplanner/routing/impl/StreetVertexIndexServiceImpl.java
@@ -57,7 +57,6 @@ import com.vividsolutions.jts.geom.LineString;
 import com.vividsolutions.jts.index.SpatialIndex;
 import com.vividsolutions.jts.index.strtree.STRtree;
 import org.opentripplanner.util.I18NString;
-import org.opentripplanner.util.LocalizedString;
 import org.opentripplanner.util.NonLocalizedString;
 import org.opentripplanner.util.ResourceBundleSingleton;
 

--- a/src/main/java/org/opentripplanner/routing/vertextype/StreetVertex.java
+++ b/src/main/java/org/opentripplanner/routing/vertextype/StreetVertex.java
@@ -13,11 +13,17 @@
 
 package org.opentripplanner.routing.vertextype;
 
+import org.opentripplanner.routing.edgetype.StreetEdge;
+import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
 
 import com.vividsolutions.jts.geom.Coordinate;
 import org.opentripplanner.util.I18NString;
+import org.opentripplanner.util.LocalizedString;
+import org.opentripplanner.util.NonLocalizedString;
+
+import java.util.*;
 
 /**
  * Abstract base class for vertices in the street layer of the graph.
@@ -35,5 +41,37 @@ public abstract class StreetVertex extends Vertex {
     public StreetVertex(Graph g, String label, double x, double y, I18NString streetName) {
         super(g, label, x, y, streetName);
     }
-    
+
+    /**
+     * Creates intersection name out of all outgoing names
+     *
+     * This can be:
+     *  - name of the street if it is only 1
+     *  - unnamedStreed (localized in requested language) if it doesn't have a name
+     *  - corner of 0 and 1 (localized corner of zero and first street in the corner)
+     *
+     * @param locale Wanted locale
+     * @return already localized street names and non-localized corner of x and unnamedStreet
+     */
+    public I18NString getIntersectionName(Locale locale) {
+        I18NString calculatedName = null;
+        // generate names for corners when no name was given
+        Set<String> uniqueNameSet = new HashSet<String>();
+        for (Edge e : getOutgoing()) {
+            if (e instanceof StreetEdge) {
+                uniqueNameSet.add(e.getName(locale));
+            }
+        }
+        List<String> uniqueNames = new ArrayList<String>(uniqueNameSet);
+
+        if (uniqueNames.size() > 1) {
+            calculatedName = new LocalizedString("corner", new String[]{uniqueNames.get(0),
+                uniqueNames.get(1)});
+        } else if (uniqueNames.size() == 1) {
+            calculatedName = new NonLocalizedString(uniqueNames.get(0));
+        } else {
+            calculatedName = new LocalizedString("unnamedStreet", (String[]) null);
+        }
+        return calculatedName;
+    }
 }


### PR DESCRIPTION
Now corner generation code is used on each from/to vertex in each leg not only origin and destination. This makes nicer names. And osm:node:id isn't shown anymore in  client.

This fixes #1950 and #1957.

But it can show some interesting instructions:
> 1. CYCLE 317 feet to corner of path and steps
>2. WALK 101 feet to corner of underpass and steps
![weird_path](https://cloud.githubusercontent.com/assets/1055967/7861188/dd4d24c6-054e-11e5-9178-4a1010815e79.png)

It is not exactly a corner of path and steps. And it just sounds weird to have a corner of steps and x.