### PR TITLE
Add feed id to gtfs feeds, resolves #1990

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -348,7 +348,7 @@ connect to a network resource is the `url` field.
             type: "real-time-alerts",
             frequencySec: 30,
             url: "http://developer.trimet.org/ws/V1/FeedSpecAlerts/appID/0123456789ABCDEF",
-            defaultAgencyId: "TriMet"
+            feedId: "TriMet"
         },
 
         // Polling bike rental updater.
@@ -381,7 +381,7 @@ connect to a network resource is the `url` field.
             // this is either http or file... shouldn't it default to http or guess from the presence of a URL?
             sourceType: "gtfs-http",
             url: "http://developer.trimet.org/ws/V1/TripUpdate/appID/0123456789ABCDEF",
-            defaultAgencyId: "TriMet"
+            feedId: "TriMet"
         },
 
         // Streaming differential GTFS-RT TripUpdates over websockets

--- a/src/main/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverter.java
+++ b/src/main/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverter.java
@@ -297,8 +297,6 @@ public abstract class GraphPathToTripPlanConverter {
 
         addPlaces(leg, states, edges, showIntermediateStops, requestedLocale);
 
-        if (leg.isTransitLeg()) addRealTimeData(leg, states);
-
         CoordinateArrayListSequence coordinates = makeCoordinates(edges);
         Geometry geometry = GeometryUtils.getGeometryFactory().createLineString(coordinates);
 
@@ -311,6 +309,7 @@ public abstract class GraphPathToTripPlanConverter {
         leg.rentedBike = states[0].isBikeRenting() && states[states.length - 1].isBikeRenting();
 
         addModeAndAlerts(graph, leg, states, requestedLocale);
+        if (leg.isTransitLeg()) addRealTimeData(leg, states);
 
         return leg;
     }

--- a/src/main/java/org/opentripplanner/calendar/impl/CalendarServiceDataFactoryImpl.java
+++ b/src/main/java/org/opentripplanner/calendar/impl/CalendarServiceDataFactoryImpl.java
@@ -1,0 +1,257 @@
+/**
+ * Copyright (C) 2011 Brian Ferris <bdferris@onebusaway.org>
+ * Copyright (C) 2012 Google, Inc.
+ * Copyright (C) 2013 Codemass, Inc. <aaron@codemass.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opentripplanner.calendar.impl;
+
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.TimeZone;
+
+import org.onebusaway.gtfs.impl.calendar.CalendarServiceImpl;
+import org.onebusaway.gtfs.impl.calendar.UnknownAgencyTimezoneException;
+import org.onebusaway.gtfs.model.Agency;
+import org.onebusaway.gtfs.model.AgencyAndId;
+import org.onebusaway.gtfs.model.ServiceCalendar;
+import org.onebusaway.gtfs.model.ServiceCalendarDate;
+import org.onebusaway.gtfs.model.calendar.CalendarServiceData;
+import org.onebusaway.gtfs.model.calendar.LocalizedServiceId;
+import org.onebusaway.gtfs.model.calendar.ServiceDate;
+import org.onebusaway.gtfs.services.GtfsRelationalDao;
+import org.onebusaway.gtfs.services.calendar.CalendarService;
+import org.onebusaway.gtfs.services.calendar.CalendarServiceDataFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * We perform initial date calculations in the timezone of the host jvm, which
+ * may be different than the timezone of an agency with the specified service
+ * id. To my knowledge, the calculation should work the same, which is to say I
+ * can't immediately think of any cases where the service dates would be
+ * computed incorrectly.
+ * 
+ * @author bdferris
+ */
+public class CalendarServiceDataFactoryImpl implements
+    CalendarServiceDataFactory {
+
+  private final Logger _log = LoggerFactory.getLogger(CalendarServiceDataFactoryImpl.class);
+
+  private GtfsRelationalDao _dao;
+
+  private int _excludeFutureServiceDatesInDays;
+
+  public static CalendarService createService(GtfsRelationalDao dao) {
+    CalendarServiceDataFactoryImpl factory = new CalendarServiceDataFactoryImpl(
+        dao);
+    return new CalendarServiceImpl(factory.createData());
+  }
+
+  public CalendarServiceDataFactoryImpl() {
+
+  }
+
+  public CalendarServiceDataFactoryImpl(GtfsRelationalDao dao) {
+    _dao = dao;
+  }
+
+  public void setGtfsDao(GtfsRelationalDao dao) {
+    _dao = dao;
+  }
+
+  public void setExcludeFutureServiceDatesInDays(
+      int excludeFutureServiceDatesInDays) {
+    _excludeFutureServiceDatesInDays = excludeFutureServiceDatesInDays;
+  }
+
+  @Override
+  public CalendarServiceData createData() {
+
+    CalendarServiceData data = new CalendarServiceData();
+
+    setTimeZonesForAgencies(data);
+
+    List<AgencyAndId> serviceIds = _dao.getAllServiceIds();
+
+    int index = 0;
+
+    for (AgencyAndId serviceId : serviceIds) {
+
+      index++;
+
+      _log.debug("serviceId=" + serviceId + " (" + index + "/"
+          + serviceIds.size() + ")");
+
+      TimeZone serviceIdTimeZone = data.getTimeZoneForAgencyId(serviceId.getAgencyId());
+      if (serviceIdTimeZone == null) {
+        serviceIdTimeZone = TimeZone.getDefault();
+      }
+
+      Set<ServiceDate> activeDates = getServiceDatesForServiceId(serviceId,
+          serviceIdTimeZone);
+
+      List<ServiceDate> serviceDates = new ArrayList<ServiceDate>(activeDates);
+      Collections.sort(serviceDates);
+
+      data.putServiceDatesForServiceId(serviceId, serviceDates);
+
+//      List<String> tripAgencyIds = _dao.getTripAgencyIdsReferencingServiceId(serviceId);
+
+//      Set<TimeZone> timeZones = new HashSet<TimeZone>();
+//      for (String tripAgencyId : tripAgencyIds) {
+//        TimeZone timeZone = data.getTimeZoneForAgencyId(tripAgencyId);
+//        timeZones.add(timeZone);
+//      }
+
+//      for (TimeZone timeZone : timeZones) {
+//
+//        List<Date> dates = new ArrayList<Date>(serviceDates.size());
+//        for (ServiceDate serviceDate : serviceDates)
+//          dates.add(serviceDate.getAsDate(timeZone));
+//
+//        LocalizedServiceId id = new LocalizedServiceId(serviceId, timeZone);
+//        data.putDatesForLocalizedServiceId(id, dates);
+//      }
+    }
+
+    return data;
+  }
+
+  public Set<ServiceDate> getServiceDatesForServiceId(AgencyAndId serviceId,
+      TimeZone serviceIdTimeZone) {
+    Set<ServiceDate> activeDates = new HashSet<ServiceDate>();
+    ServiceCalendar c = _dao.getCalendarForServiceId(serviceId);
+
+    if (c != null) {
+      addDatesFromCalendar(c, serviceIdTimeZone, activeDates);
+    }
+    for (ServiceCalendarDate cd : _dao.getCalendarDatesForServiceId(serviceId)) {
+      addAndRemoveDatesFromCalendarDate(cd, serviceIdTimeZone, activeDates);
+    }
+    return activeDates;
+  }
+
+  private void setTimeZonesForAgencies(CalendarServiceData data) {
+    for (Agency agency : _dao.getAllAgencies()) {
+      TimeZone timeZone = TimeZone.getTimeZone(agency.getTimezone());
+      if (timeZone.getID().equals("GMT")
+          && !agency.getTimezone().toUpperCase().equals("GMT")) {
+        throw new UnknownAgencyTimezoneException(agency.getName(),
+            agency.getTimezone());
+      }
+      data.putTimeZoneForAgencyId(agency.getId(), timeZone);
+    }
+  }
+
+  private void addDatesFromCalendar(ServiceCalendar calendar,
+      TimeZone timeZone, Set<ServiceDate> activeDates) {
+
+    /**
+     * We calculate service dates relative to noon so as to avoid any weirdness
+     * relative to DST.
+     */
+    Date startDate = getServiceDateAsNoon(calendar.getStartDate(), timeZone);
+    Date endDate = getServiceDateAsNoon(calendar.getEndDate(), timeZone);
+
+    java.util.Calendar c = java.util.Calendar.getInstance(timeZone);
+    c.setTime(startDate);
+
+    while (true) {
+      Date date = c.getTime();
+      if (date.after(endDate))
+        break;
+
+      int day = c.get(java.util.Calendar.DAY_OF_WEEK);
+      boolean active = false;
+
+      switch (day) {
+        case java.util.Calendar.MONDAY:
+          active = calendar.getMonday() == 1;
+          break;
+        case java.util.Calendar.TUESDAY:
+          active = calendar.getTuesday() == 1;
+          break;
+        case java.util.Calendar.WEDNESDAY:
+          active = calendar.getWednesday() == 1;
+          break;
+        case java.util.Calendar.THURSDAY:
+          active = calendar.getThursday() == 1;
+          break;
+        case java.util.Calendar.FRIDAY:
+          active = calendar.getFriday() == 1;
+          break;
+        case java.util.Calendar.SATURDAY:
+          active = calendar.getSaturday() == 1;
+          break;
+        case java.util.Calendar.SUNDAY:
+          active = calendar.getSunday() == 1;
+          break;
+      }
+
+      if (active) {
+        addServiceDate(activeDates, new ServiceDate(c), timeZone);
+      }
+
+      c.add(java.util.Calendar.DAY_OF_YEAR, 1);
+    }
+  }
+
+  private void addAndRemoveDatesFromCalendarDate(
+      ServiceCalendarDate calendarDate, TimeZone serviceIdTimeZone,
+      Set<ServiceDate> activeDates) {
+
+    ServiceDate serviceDate = calendarDate.getDate();
+    Date targetDate = calendarDate.getDate().getAsDate();
+    Calendar c = Calendar.getInstance();
+    c.setTime(targetDate);
+
+    switch (calendarDate.getExceptionType()) {
+      case ServiceCalendarDate.EXCEPTION_TYPE_ADD:
+        addServiceDate(activeDates, serviceDate, serviceIdTimeZone);
+        break;
+      case ServiceCalendarDate.EXCEPTION_TYPE_REMOVE:
+        activeDates.remove(serviceDate);
+        break;
+      default:
+        _log.warn("unknown CalendarDate exception type: "
+            + calendarDate.getExceptionType());
+        break;
+    }
+  }
+
+  private void addServiceDate(Set<ServiceDate> activeDates,
+      ServiceDate serviceDate, TimeZone timeZone) {
+    if (_excludeFutureServiceDatesInDays > 0) {
+      int days = (int) ((serviceDate.getAsDate().getTime() - System.currentTimeMillis()) / (24 * 60 * 60 * 1000));
+      if (days > _excludeFutureServiceDatesInDays)
+        return;
+    }
+
+    activeDates.add(new ServiceDate(serviceDate));
+  }
+
+  private static Date getServiceDateAsNoon(ServiceDate serviceDate,
+      TimeZone timeZone) {
+    Calendar c = serviceDate.getAsCalendar(timeZone);
+    c.add(Calendar.HOUR_OF_DAY, 12);
+    return c.getTime();
+  }
+}

--- a/src/main/java/org/opentripplanner/graph_builder/model/GtfsBundle.java
+++ b/src/main/java/org/opentripplanner/graph_builder/model/GtfsBundle.java
@@ -25,6 +25,7 @@ import org.onebusaway.csv_entities.CsvInputSource;
 import org.onebusaway.csv_entities.FileCsvInputSource;
 import org.onebusaway.csv_entities.ZipFileCsvInputSource;
 import org.opentripplanner.graph_builder.module.DownloadableGtfsInputSource;
+import org.opentripplanner.graph_builder.module.GtfsFeedId;
 import org.opentripplanner.util.HttpUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,7 +38,7 @@ public class GtfsBundle {
 
     private URL url;
 
-    private String defaultAgencyId;
+    private GtfsFeedId feedId;
 
     private CsvInputSource csvInputSource;
 
@@ -72,6 +73,7 @@ public class GtfsBundle {
     
     public GtfsBundle(File gtfsFile) {
         this.setPath(gtfsFile);
+        this.setFeedId(GtfsFeedId.createFromFile(gtfsFile));
     }
 
     public void setPath(File path) {
@@ -120,26 +122,21 @@ public class GtfsBundle {
         } else {
             src = "(no source)";
         }
+        if (feedId != null) {
+            src += " (" + feedId.getId() + ")";
+        }
         return "GTFS bundle at " + src;
     }
     
     /**
-     * So that you can load multiple gtfs feeds into the same database / system without entity id
-     * collisions, everything has an agency id, including entities like stops, shapes, and service
-     * ids that don't explicitly have an agency id (as opposed to routes + trips + stop times).
-     * However, the spec doesn't currently have a method to specify which agency a stop
-     * should be assigned to in the case of multiple agencies being specified in the same feed.  
-     * Routes (and thus everything belonging to them) do have an agency id, but stops don't.
-     * The defaultAgencyId allows you to define which agency will be used as the default
-     * when figuring out which agency a stop should be assigned to (also applies to shapes + service
-     * ids as well). If not specified, the first agency in the agency list will be used.
+     * So that we can load multiple gtfs feeds into the same database.
      */
-    public String getDefaultAgencyId() {
-        return defaultAgencyId;
+    public GtfsFeedId getFeedId() {
+        return feedId;
     }
 
-    public void setDefaultAgencyId(String defaultAgencyId) {
-        this.defaultAgencyId = defaultAgencyId;
+    public void setFeedId(GtfsFeedId feedId) {
+        this.feedId = feedId;
     }
 
     public Map<String, String> getAgencyIdMappings() {

--- a/src/main/java/org/opentripplanner/graph_builder/model/GtfsBundle.java
+++ b/src/main/java/org/opentripplanner/graph_builder/model/GtfsBundle.java
@@ -73,7 +73,6 @@ public class GtfsBundle {
     
     public GtfsBundle(File gtfsFile) {
         this.setPath(gtfsFile);
-        this.setFeedId(GtfsFeedId.createFromFile(gtfsFile));
     }
 
     public void setPath(File path) {
@@ -132,6 +131,14 @@ public class GtfsBundle {
      * So that we can load multiple gtfs feeds into the same database.
      */
     public GtfsFeedId getFeedId() {
+        if (feedId == null) {
+            try {
+                feedId = new GtfsFeedId.Builder().fromGtfsFeed(getCsvInputSource()).build();
+            } catch (IOException e) {
+                LOG.error("Failed to fetch feedId from feed_info.");
+                throw new RuntimeException(e);
+            }
+        }
         return feedId;
     }
 

--- a/src/main/java/org/opentripplanner/graph_builder/module/GtfsFeedId.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/GtfsFeedId.java
@@ -13,41 +13,111 @@
 
 package org.opentripplanner.graph_builder.module;
 
-import java.io.File;
+import com.csvreader.CsvReader;
+import org.apache.commons.io.IOUtils;
+import org.onebusaway.csv_entities.CsvInputSource;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringWriter;
 
 /**
- * Created by johan on 17/06/15.
+ * Represent a feed id in a GTFS feed.
  */
 public class GtfsFeedId {
-    private final String id;
-
-    public GtfsFeedId(String id) {
-        this.id = cleanId(id);
-    }
+    /**
+     * A counter that will increase for each created feed id.
+     */
+    private static int FEED_ID_COUNTER = 1;
 
     /**
-     * Cleans the id before it is set. This method ensures that the id is a valid id.
+     * The id for the feed
+     */
+    private final String id;
+
+    /**
+     * Constructs a new feed id.
+     *
+     * If the passed id is null or an empty string a unique feed id will be generated.
      *
      * @param id The feed id
-     * @return The cleaned id.
      */
-    protected String cleanId(String id) {
-        // 1. Underscore is used as an separator by OBA.
-        // 2. Colon is used as an separator in OTP.
-        return id.replaceAll("_", "")
-                .replaceAll(":", "");
+    private GtfsFeedId(String id) {
+        this.id = id;
     }
 
     public String getId() {
         return id;
     }
 
-    public static GtfsFeedId createFromFile(File path) {
-        String feedId = path.getName();
-        int pos = feedId.lastIndexOf('.');
-        if (pos > 0) {
-            feedId = feedId.substring(0, pos);
+
+    public static class Builder {
+
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            return this;
         }
-        return new GtfsFeedId(feedId);
+
+        /**
+         * Extracts a feed_id from the passed source for a GTFS feed.
+         * <p/>
+         * This will try to fetch the experimental feed_id field from the feed_info.txt file.
+         * <p/>
+         * If the feed does not contain a feed_info.txt or a feed_id field a default GtfsFeedId will be created.
+         *
+         * @param source the input source
+         * @return A GtfsFeedId
+         * @throws IOException
+         * @see <a href="http://developer.trimet.org/gtfs_ext.shtml">http://developer.trimet.org/gtfs_ext.shtml</a>
+         */
+        public Builder fromGtfsFeed(CsvInputSource source) {
+            try {
+                if (source.hasResource("feed_info.txt")) {
+                    InputStream feedInfoInputStream = source.getResource("feed_info.txt");
+                    StringWriter writer = new StringWriter();
+                    IOUtils.copy(feedInfoInputStream, writer, "UTF-8");
+                    String feedInfoCsv = writer.toString();
+                    CsvReader result = CsvReader.parse(feedInfoCsv);
+                    result.readHeaders();
+                    result.readRecord();
+                    this.id = result.get("feed_id");
+                }
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            return this;
+        }
+
+        /**
+         * Cleans the id before it is set. This method ensures that the id is a valid id.
+         *
+         * @param id The feed id
+         * @return The cleaned id.
+         */
+        protected String cleanId(String id) {
+            if (id == null || id.trim().length() == 0) {
+                return id;
+            }
+            // 1. Underscore is used as an separator by OBA.
+            // 2. Colon is used as an separator in OTP.
+            return id.replaceAll("_", "")
+                    .replaceAll(":", "");
+        }
+
+        /**
+         * Creates a new GtfsFeedId.
+         *
+         * @return A GtfsFeedId
+         */
+        public GtfsFeedId build() {
+            id = cleanId(id);
+            if (id == null || id.trim().length() == 0) {
+                id = String.valueOf(FEED_ID_COUNTER);
+            }
+            FEED_ID_COUNTER++;
+            return new GtfsFeedId(id);
+        }
     }
 }

--- a/src/main/java/org/opentripplanner/graph_builder/module/GtfsFeedId.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/GtfsFeedId.java
@@ -1,0 +1,53 @@
+/* This program is free software: you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public License
+ as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+package org.opentripplanner.graph_builder.module;
+
+import java.io.File;
+
+/**
+ * Created by johan on 17/06/15.
+ */
+public class GtfsFeedId {
+    private final String id;
+
+    public GtfsFeedId(String id) {
+        this.id = cleanId(id);
+    }
+
+    /**
+     * Cleans the id before it is set. This method ensures that the id is a valid id.
+     *
+     * @param id The feed id
+     * @return The cleaned id.
+     */
+    protected String cleanId(String id) {
+        // 1. Underscore is used as an separator by OBA.
+        // 2. Colon is used as an separator in OTP.
+        return id.replaceAll("_", "")
+                .replaceAll(":", "");
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public static GtfsFeedId createFromFile(File path) {
+        String feedId = path.getName();
+        int pos = feedId.lastIndexOf('.');
+        if (pos > 0) {
+            feedId = feedId.substring(0, pos);
+        }
+        return new GtfsFeedId(feedId);
+    }
+}

--- a/src/main/java/org/opentripplanner/graph_builder/module/GtfsModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/GtfsModule.java
@@ -155,11 +155,13 @@ public class GtfsModule implements GraphBuilderModule {
         store.open();
         LOG.info("reading {}", gtfsBundle.toString());
 
+        GtfsFeedId gtfsFeedId = gtfsBundle.getFeedId();
+
         GtfsReader reader = new GtfsReader();
         reader.setInputSource(gtfsBundle.getCsvInputSource());
         reader.setEntityStore(store);
         reader.setInternStrings(true);
-        reader.setDefaultAgencyId(gtfsBundle.getFeedId().getId());
+        reader.setDefaultAgencyId(gtfsFeedId.getId());
 
         if (LOG.isDebugEnabled())
             reader.addEntityHandler(counter);
@@ -180,7 +182,7 @@ public class GtfsModule implements GraphBuilderModule {
                     LOG.info("This Agency has the ID {}", agencyId);
                     // Somehow, when the agency's id field is missing, OBA replaces it with the agency's name.
                     // TODO Figure out how and why this is happening.
-                    if (agencyId == null || agencyIdsSeen.contains(agencyId)) {
+                    if (agencyId == null || agencyIdsSeen.contains(gtfsFeedId.getId() + agencyId)) {
                         // Loop in case generated name is already in use.
                         String generatedAgencyId = null;
                         while (generatedAgencyId == null || agencyIdsSeen.contains(generatedAgencyId)) {
@@ -192,7 +194,7 @@ public class GtfsModule implements GraphBuilderModule {
                         agency.setId(generatedAgencyId);
                         agencyId = generatedAgencyId;
                     }
-                    if (agencyId != null) agencyIdsSeen.add(agencyId);
+                    if (agencyId != null) agencyIdsSeen.add(gtfsFeedId.getId() + agencyId);
                 }
             }
         }

--- a/src/main/java/org/opentripplanner/gtfs/GtfsContext.java
+++ b/src/main/java/org/opentripplanner/gtfs/GtfsContext.java
@@ -15,8 +15,11 @@ package org.opentripplanner.gtfs;
 
 import org.onebusaway.gtfs.services.GtfsRelationalDao;
 import org.onebusaway.gtfs.services.calendar.CalendarService;
+import org.opentripplanner.graph_builder.module.GtfsFeedId;
 
 public interface GtfsContext {
+    public GtfsFeedId getFeedId();
+
     public GtfsRelationalDao getDao();
 
     public CalendarService getCalendarService();

--- a/src/main/java/org/opentripplanner/gtfs/GtfsLibrary.java
+++ b/src/main/java/org/opentripplanner/gtfs/GtfsLibrary.java
@@ -43,20 +43,15 @@ public class GtfsLibrary {
     }
 
     public static GtfsContext readGtfs(File path) throws IOException {
-
-        return readGtfs(GtfsFeedId.createFromFile(path), path);
-    }
-
-    public static GtfsContext readGtfs(GtfsFeedId feedId, File path) throws IOException {
-
         GtfsRelationalDaoImpl dao = new GtfsRelationalDaoImpl();
 
         GtfsReader reader = new GtfsReader();
         reader.setInputLocation(path);
         reader.setEntityStore(dao);
 
-        if (feedId != null)
-            reader.setDefaultAgencyId(feedId.getId());
+        GtfsFeedId feedId = new GtfsFeedId.Builder().fromGtfsFeed(reader.getInputSource()).build();
+
+        reader.setDefaultAgencyId(feedId.getId());
 
         reader.run();
 

--- a/src/main/java/org/opentripplanner/index/IndexAPI.java
+++ b/src/main/java/org/opentripplanner/index/IndexAPI.java
@@ -97,7 +97,7 @@ public class IndexAPI {
 
     @GET
     @Path("/feeds")
-    public Response getFeeds(String feedId) {
+    public Response getFeeds() {
         return Response.status(Status.OK).entity(index.agenciesForFeedId.keySet()).build();
     }
 

--- a/src/main/java/org/opentripplanner/routing/alertpatch/AlertPatch.java
+++ b/src/main/java/org/opentripplanner/routing/alertpatch/AlertPatch.java
@@ -127,11 +127,8 @@ public class AlertPatch implements Serializable {
             } else if (route != null) {
                tripPatterns = graph.index.patternsForRoute.get(route);
             } else {
-                // Find patterns for the agency.
-                Multimap<Agency, TripPattern> patternsForAgency = graph.index.agencyPatternsForFeedId.get(feedId);
-                if (patternsForAgency != null) {
-                    tripPatterns = patternsForAgency.get(agency);
-                }
+                // Find patterns for the feed.
+                tripPatterns = graph.index.patternsForFeedId.get(feedId);
             }
 
             if (tripPatterns != null) {
@@ -191,11 +188,8 @@ public class AlertPatch implements Serializable {
             } else if (route != null) {
                tripPatterns = graph.index.patternsForRoute.get(route);
             } else {
-                // Find patterns for the agency.
-                Multimap<Agency, TripPattern> patternsForAgency = graph.index.agencyPatternsForFeedId.get(feedId);
-                if (patternsForAgency != null) {
-                    tripPatterns = patternsForAgency.get(agency);
-                }
+                // Find patterns for the feed.
+                tripPatterns = graph.index.patternsForFeedId.get(feedId);
             }
 
             if (tripPatterns != null) {

--- a/src/main/java/org/opentripplanner/routing/alertpatch/AlertPatch.java
+++ b/src/main/java/org/opentripplanner/routing/alertpatch/AlertPatch.java
@@ -16,15 +16,13 @@ package org.opentripplanner.routing.alertpatch;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import com.google.common.collect.Multimap;
 import org.onebusaway.gtfs.model.Agency;
 import org.onebusaway.gtfs.model.AgencyAndId;
 import org.onebusaway.gtfs.model.Route;
@@ -38,6 +36,8 @@ import org.opentripplanner.routing.edgetype.TripPattern;
 import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.vertextype.TransitStop;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This adds a note to all boardings of a given route or stop (optionally, in a given direction)
@@ -47,6 +47,8 @@ import org.opentripplanner.routing.vertextype.TransitStop;
  */
 @XmlRootElement(name = "AlertPatch")
 public class AlertPatch implements Serializable {
+    private static final Logger LOG = LoggerFactory.getLogger(AlertPatch.class);
+
     private static final long serialVersionUID = 20140319L;
 
     private String id;
@@ -67,6 +69,11 @@ public class AlertPatch implements Serializable {
      * The headsign of the alert
      */
     private String direction;
+
+    /**
+     * The id of the feed this patch is intended for.
+     */
+    private String feedId;
 
     /**
      * Direction id of the GTFS trips this alert concerns, set to -1 if no direction.
@@ -99,37 +106,47 @@ public class AlertPatch implements Serializable {
     }
 
     public void apply(Graph graph) {
-        Agency agency = this.agency != null ? graph.index.agencyForId.get(this.agency) : null;
+        Agency agency = null;
+        if (feedId != null) {
+            Map<String, Agency> agencies = graph.index.agenciesForFeedId.get(feedId);
+            agency = this.agency != null ? agencies.get(this.agency) : null;
+        }
         Route route = this.route != null ? graph.index.routeForId.get(this.route) : null;
         Stop stop = this.stop != null ? graph.index.stopForId.get(this.stop) : null;
         Trip trip = this.trip != null ? graph.index.tripForId.get(this.trip) : null;
 
         if (route != null || trip != null || agency != null) {
-            Collection<TripPattern> tripPatterns;
+            Collection<TripPattern> tripPatterns = null;
 
-            if(trip != null) {
-                tripPatterns = new LinkedList<TripPattern>();
+            if (trip != null) {
+                tripPatterns = new LinkedList<>();
                 TripPattern tripPattern = graph.index.patternForTrip.get(trip);
-                if(tripPattern != null) {
+                if (tripPattern != null) {
                     tripPatterns.add(tripPattern);
                 }
             } else if (route != null) {
                tripPatterns = graph.index.patternsForRoute.get(route);
             } else {
-               tripPatterns = graph.index.patternsForAgency.get(agency);
+                // Find patterns for the agency.
+                Multimap<Agency, TripPattern> patternsForAgency = graph.index.agencyPatternsForFeedId.get(feedId);
+                if (patternsForAgency != null) {
+                    tripPatterns = patternsForAgency.get(agency);
+                }
             }
 
-            for (TripPattern tripPattern : tripPatterns) {
-                if (direction != null && ! direction.equals(tripPattern.getDirection())) {
-                    continue;
-                }
-                if (directionId != -1 && directionId == tripPattern.directionId) {
-                    continue;
-                }
-                for (int i = 0; i < tripPattern.stopPattern.stops.length; i++) {
-                    if (stop == null || stop.equals(tripPattern.stopPattern.stops[i])) {
-                        graph.addAlertPatch(tripPattern.boardEdges[i], this);
-                        graph.addAlertPatch(tripPattern.alightEdges[i], this);
+            if (tripPatterns != null) {
+                for (TripPattern tripPattern : tripPatterns) {
+                    if (direction != null && !direction.equals(tripPattern.getDirection())) {
+                        continue;
+                    }
+                    if (directionId != -1 && directionId == tripPattern.directionId) {
+                        continue;
+                    }
+                    for (int i = 0; i < tripPattern.stopPattern.stops.length; i++) {
+                        if (stop == null || stop.equals(tripPattern.stopPattern.stops[i])) {
+                            graph.addAlertPatch(tripPattern.boardEdges[i], this);
+                            graph.addAlertPatch(tripPattern.alightEdges[i], this);
+                        }
                     }
                 }
             }
@@ -153,13 +170,17 @@ public class AlertPatch implements Serializable {
     }
 
     public void remove(Graph graph) {
-        Agency agency = this.agency != null ? graph.index.agencyForId.get(this.agency) : null;
+        Agency agency = null;
+        if (feedId != null) {
+            Map<String, Agency> agencies = graph.index.agenciesForFeedId.get(feedId);
+            agency = this.agency != null ? agencies.get(this.agency) : null;
+        }
         Route route = this.route != null ? graph.index.routeForId.get(this.route) : null;
         Stop stop = this.stop != null ? graph.index.stopForId.get(this.stop) : null;
         Trip trip = this.trip != null ? graph.index.tripForId.get(this.trip) : null;
 
         if (route != null || trip != null || agency != null) {
-            Collection<TripPattern> tripPatterns;
+            Collection<TripPattern> tripPatterns = null;
 
             if(trip != null) {
                 tripPatterns = new LinkedList<TripPattern>();
@@ -170,20 +191,26 @@ public class AlertPatch implements Serializable {
             } else if (route != null) {
                tripPatterns = graph.index.patternsForRoute.get(route);
             } else {
-               tripPatterns = graph.index.patternsForAgency.get(agency);
+                // Find patterns for the agency.
+                Multimap<Agency, TripPattern> patternsForAgency = graph.index.agencyPatternsForFeedId.get(feedId);
+                if (patternsForAgency != null) {
+                    tripPatterns = patternsForAgency.get(agency);
+                }
             }
 
-            for (TripPattern tripPattern : tripPatterns) {
-                if (direction != null && ! direction.equals(tripPattern.getDirection())) {
-                    continue;
-                }
-                if (directionId != -1 && directionId != tripPattern.directionId) {
-                    continue;
-                }
-                for (int i = 0; i < tripPattern.stopPattern.stops.length; i++) {
-                    if (stop == null || stop.equals(tripPattern.stopPattern.stops[i])) {
-                        graph.removeAlertPatch(tripPattern.boardEdges[i], this);
-                        graph.removeAlertPatch(tripPattern.alightEdges[i], this);
+            if (tripPatterns != null) {
+                for (TripPattern tripPattern : tripPatterns) {
+                    if (direction != null && !direction.equals(tripPattern.getDirection())) {
+                        continue;
+                    }
+                    if (directionId != -1 && directionId != tripPattern.directionId) {
+                        continue;
+                    }
+                    for (int i = 0; i < tripPattern.stopPattern.stops.length; i++) {
+                        if (stop == null || stop.equals(tripPattern.stopPattern.stops[i])) {
+                            graph.removeAlertPatch(tripPattern.boardEdges[i], this);
+                            graph.removeAlertPatch(tripPattern.alightEdges[i], this);
+                        }
                     }
                 }
             }
@@ -277,6 +304,18 @@ public class AlertPatch implements Serializable {
         this.stop = stop;
     }
 
+    public String getFeedId() {
+        return feedId;
+    }
+
+    public void setFeedId(String feedId) {
+        this.feedId = feedId;
+    }
+
+    public boolean hasTrip() {
+        return trip != null;
+    }
+
     public boolean equals(Object o) {
         if (!(o instanceof AlertPatch)) {
             return false;
@@ -357,6 +396,15 @@ public class AlertPatch implements Serializable {
                 return false;
             }
         }
+        if (feedId == null) {
+            if (other.feedId != null) {
+                return false;
+            }
+        } else {
+            if (!feedId.equals(other.feedId)) {
+                return false;
+            }
+        }
         return true;
     }
 
@@ -367,6 +415,7 @@ public class AlertPatch implements Serializable {
                 (trip == null ? 0 : trip.hashCode()) +
                 (stop == null ? 0 : stop.hashCode()) +
                 (route == null ? 0 : route.hashCode()) +
-                (alert == null ? 0 : alert.hashCode()));
+                (alert == null ? 0 : alert.hashCode()) +
+                (feedId == null ? 0 : feedId.hashCode()));
     }
 }

--- a/src/main/java/org/opentripplanner/routing/core/RoutingContext.java
+++ b/src/main/java/org/opentripplanner/routing/core/RoutingContext.java
@@ -15,6 +15,7 @@ package org.opentripplanner.routing.core;
 
 import com.google.common.collect.Iterables;
 import com.vividsolutions.jts.geom.LineString;
+import org.onebusaway.gtfs.model.Agency;
 import org.onebusaway.gtfs.model.AgencyAndId;
 import org.onebusaway.gtfs.model.Stop;
 import org.onebusaway.gtfs.model.calendar.ServiceDate;
@@ -358,12 +359,14 @@ public class RoutingContext implements Cloneable {
             return;
         }
 
-        for (String agency : graph.getAgencyIds()) {
-            addIfNotExists(this.serviceDays, new ServiceDay(graph, serviceDate.previous(),
-                    calendarService, agency));
-            addIfNotExists(this.serviceDays, new ServiceDay(graph, serviceDate, calendarService, agency));
-            addIfNotExists(this.serviceDays, new ServiceDay(graph, serviceDate.next(),
-                    calendarService, agency));
+        for (String feedId : graph.getFeedIds()) {
+            for (Agency agency : graph.getAgencies(feedId)) {
+                addIfNotExists(this.serviceDays, new ServiceDay(graph, serviceDate.previous(),
+                        calendarService, agency.getId()));
+                addIfNotExists(this.serviceDays, new ServiceDay(graph, serviceDate, calendarService, agency.getId()));
+                addIfNotExists(this.serviceDays, new ServiceDay(graph, serviceDate.next(),
+                        calendarService, agency.getId()));
+            }
         }
     }
 

--- a/src/main/java/org/opentripplanner/routing/edgetype/TimetableSnapshot.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/TimetableSnapshot.java
@@ -74,7 +74,7 @@ public class TimetableSnapshot {
 
         @Override
         public int hashCode() {
-            int result = Objects.hash(tripId, serviceDate);
+            int result = Objects.hash(tripId, serviceDate, feedId);
             return result;
         }
 

--- a/src/main/java/org/opentripplanner/routing/edgetype/TimetableSnapshot.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/TimetableSnapshot.java
@@ -13,16 +13,9 @@
 
 package org.opentripplanner.routing.edgetype;
 
-import java.util.Comparator;
-import java.util.ConcurrentModificationException;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Objects;
-import java.util.Set;
-import java.util.SortedSet;
-import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 import org.onebusaway.gtfs.model.calendar.ServiceDate;
 import org.opentripplanner.routing.trippattern.TripTimes;
@@ -54,17 +47,23 @@ public class TimetableSnapshot {
     }
     
     /**
-     * Class to use as key in HashMap containing trip id and service date
+     * Class to use as key in HashMap containing feed id, trip id and service date
      */
     protected class TripIdAndServiceDate {
+        private final String feedId;
         private final String tripId;
         private final ServiceDate serviceDate;
         
-        public TripIdAndServiceDate(final String tripId, final ServiceDate serviceDate) {
+        public TripIdAndServiceDate(final String feedId, final String tripId, final ServiceDate serviceDate) {
+            this.feedId = feedId;
             this.tripId = tripId;
             this.serviceDate = serviceDate;
         }
-        
+
+        public String getFeedId() {
+            return feedId;
+        }
+
         public String getTripId() {
             return tripId;
         }
@@ -72,6 +71,7 @@ public class TimetableSnapshot {
         public ServiceDate getServiceDate() {
             return serviceDate;
         }
+
 
         @Override
         public int hashCode() {
@@ -89,7 +89,8 @@ public class TimetableSnapshot {
                 return false;
             TripIdAndServiceDate other = (TripIdAndServiceDate) obj;
             boolean result = Objects.equals(this.tripId, other.tripId) &&
-                    Objects.equals(this.serviceDate, other.serviceDate);
+                    Objects.equals(this.serviceDate, other.serviceDate) &&
+                    Objects.equals(this.feedId, other.feedId);
             return result;
         }
     }
@@ -102,11 +103,11 @@ public class TimetableSnapshot {
     // FIXME: this could be made into a flat hashtable with compound keys.
     private HashMap<TripPattern, SortedSet<Timetable>> timetables =
             new HashMap<TripPattern, SortedSet<Timetable>>();
-    
+
     /**
      * <p>
      * Map containing the last <b>added</b> trip pattern given a trip id (without agency) and a
-     * service date as a result of a call to {@link #update(TripPattern, TripTimes, ServiceDate)}
+     * service date as a result of a call to {@link #update(String feedId, TripPattern, TripTimes, ServiceDate)}
      * with trip times of a trip that didn't exist yet in the trip pattern.
      * </p>
      * <p>
@@ -154,15 +155,16 @@ public class TimetableSnapshot {
     
     /**
      * Get the last <b>added</b> trip pattern given a trip id (without agency) and a service date as
-     * a result of a call to {@link #update(TripPattern, TripTimes, ServiceDate)} with trip times of
+     * a result of a call to {@link #update(String feedId, TripPattern, TripTimes, ServiceDate)} with trip times of
      * a trip that didn't exist yet in the trip pattern.
-     * 
+     *
+     * @param feedId feed id the trip id belongs to
      * @param tripId trip id (without agency)
      * @param serviceDate service date
      * @return last added trip pattern; null if trip never was added to a trip pattern
      */
-    public TripPattern getLastAddedTripPattern(String tripId, ServiceDate serviceDate) {
-        TripIdAndServiceDate tripIdAndServiceDate = new TripIdAndServiceDate(tripId, serviceDate);
+    public TripPattern getLastAddedTripPattern(String feedId, String tripId, ServiceDate serviceDate) {
+        TripIdAndServiceDate tripIdAndServiceDate = new TripIdAndServiceDate(feedId, tripId, serviceDate);
         TripPattern pattern = lastAddedTripPattern.get(tripIdAndServiceDate);
         return pattern;
     }
@@ -176,7 +178,7 @@ public class TimetableSnapshot {
      * @param serviceDate service day for which this update is valid
      * @return whether or not the update was actually applied
      */
-    public boolean update(TripPattern pattern, TripTimes updatedTripTimes, ServiceDate serviceDate) {
+    public boolean update(String feedId, TripPattern pattern, TripTimes updatedTripTimes, ServiceDate serviceDate) {
         // Preconditions
         Preconditions.checkNotNull(pattern);
         Preconditions.checkNotNull(serviceDate);
@@ -216,7 +218,7 @@ public class TimetableSnapshot {
             tt.addTripTimes(updatedTripTimes);
             // Remember this pattern for the added trip id and service date
             String tripId = updatedTripTimes.trip.getId().getId();
-            TripIdAndServiceDate tripIdAndServiceDate = new TripIdAndServiceDate(tripId, serviceDate);
+            TripIdAndServiceDate tripIdAndServiceDate = new TripIdAndServiceDate(feedId, tripId, serviceDate);
             lastAddedTripPattern.put(tripIdAndServiceDate, pattern);
         } else {
             // Set updated trip times of trip
@@ -264,21 +266,46 @@ public class TimetableSnapshot {
     }
 
     /**
-     * Clear all data of snapshot 
+     * Clear all data of snapshot for the provided feed id
+     *
+     * @param feedId feed id to clear the snapshop for
      */
-    public void clear() {
+    public void clear(String feedId) {
         if (readOnly) {
             throw new ConcurrentModificationException("This TimetableSnapshot is read-only.");
         }
-        
-        // If this snapshot is not empty, it will be dirty after the clear action 
-        if (!timetables.isEmpty() || !lastAddedTripPattern.isEmpty()) {
+        // Clear all data from snapshot.
+        boolean timetableWasModified = clearTimetable(feedId);
+        boolean lastAddedWasModified = clearLastAddedTripPattern(feedId);
+
+        // If this snapshot was modified, it will be dirty after the clear actions.
+        if (timetableWasModified || lastAddedWasModified) {
             dirty = true;
         }
-        
-        // Clear all data from snapshot
-        timetables.clear();
-        lastAddedTripPattern.clear();
+    }
+
+    /**
+     * Clear timetable for all patterns matching the provided feed id.
+     *
+     * @param feedId feed id to clear out
+     * @return true if the timetable changed as a result of the call
+     */
+    protected boolean clearTimetable(String feedId) {
+        return timetables.keySet().removeAll(timetables.keySet().stream()
+                .filter(timeTable -> feedId.equals(timeTable.getFeedId()))
+                .collect(Collectors.toSet()));
+    }
+
+    /**
+     * Clear all last added trip patterns matching the provided feed id.
+     *
+     * @param feedId feed id to clear out
+     * @return true if the lastAddedTripPattern changed as a result of the call
+     */
+    protected boolean clearLastAddedTripPattern(String feedId) {
+        return lastAddedTripPattern.keySet().removeAll(lastAddedTripPattern.keySet().stream()
+                        .filter(lastAddedTripPattern -> feedId.equals(lastAddedTripPattern.getFeedId()))
+                        .collect(Collectors.toSet()));
     }
 
     /**

--- a/src/main/java/org/opentripplanner/routing/edgetype/TimetableSnapshot.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/TimetableSnapshot.java
@@ -15,7 +15,6 @@ package org.opentripplanner.routing.edgetype;
 
 import java.util.*;
 import java.util.Map.Entry;
-import java.util.stream.Collectors;
 
 import org.onebusaway.gtfs.model.calendar.ServiceDate;
 import org.opentripplanner.routing.trippattern.TripTimes;
@@ -291,9 +290,7 @@ public class TimetableSnapshot {
      * @return true if the timetable changed as a result of the call
      */
     protected boolean clearTimetable(String feedId) {
-        return timetables.keySet().removeAll(timetables.keySet().stream()
-                .filter(timeTable -> feedId.equals(timeTable.getFeedId()))
-                .collect(Collectors.toSet()));
+        return timetables.keySet().removeIf(tripPattern -> feedId.equals(tripPattern.getFeedId()));
     }
 
     /**
@@ -303,9 +300,7 @@ public class TimetableSnapshot {
      * @return true if the lastAddedTripPattern changed as a result of the call
      */
     protected boolean clearLastAddedTripPattern(String feedId) {
-        return lastAddedTripPattern.keySet().removeAll(lastAddedTripPattern.keySet().stream()
-                        .filter(lastAddedTripPattern -> feedId.equals(lastAddedTripPattern.getFeedId()))
-                        .collect(Collectors.toSet()));
+        return lastAddedTripPattern.keySet().removeIf(lastAddedTripPattern -> feedId.equals(lastAddedTripPattern.getFeedId()));
     }
 
     /**

--- a/src/main/java/org/opentripplanner/routing/edgetype/TripPattern.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/TripPattern.java
@@ -694,4 +694,18 @@ public class TripPattern implements Serializable {
         return freqs.get(0);
     }
 
+    /**
+     * Get the feed id this trip pattern belongs to.
+     *
+     * @return feed id for this trip pattern
+     */
+    public String getFeedId() {
+        if (code != null && code.length() > 0) {
+            // The key stored in patternForId is the pattern code that is constructed as.
+            // Agency:RouteId:DirectionId:PatternNumber, the first part is the feed id.
+            return code.substring(0, code.indexOf(':'));
+        }
+        // If we cant obtain the feed id from the code, we can get it from the route.
+        return route.getId().getAgencyId();
+    }
 }

--- a/src/main/java/org/opentripplanner/routing/edgetype/TripPattern.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/TripPattern.java
@@ -700,12 +700,7 @@ public class TripPattern implements Serializable {
      * @return feed id for this trip pattern
      */
     public String getFeedId() {
-        if (code != null && code.length() > 0) {
-            // The key stored in patternForId is the pattern code that is constructed as.
-            // Agency:RouteId:DirectionId:PatternNumber, the first part is the feed id.
-            return code.substring(0, code.indexOf(':'));
-        }
-        // If we cant obtain the feed id from the code, we can get it from the route.
+        // The feed id is the same as the agency id on the route, this allows us to obtain it from there.
         return route.getId().getAgencyId();
     }
 }

--- a/src/main/java/org/opentripplanner/routing/edgetype/factory/GTFSPatternHopFactory.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/factory/GTFSPatternHopFactory.java
@@ -42,6 +42,7 @@ import org.opentripplanner.common.geometry.PackedCoordinateSequence;
 import org.opentripplanner.common.geometry.SphericalDistanceLibrary;
 import org.opentripplanner.common.model.P2;
 import org.opentripplanner.graph_builder.annotation.*;
+import org.opentripplanner.graph_builder.module.GtfsFeedId;
 import org.opentripplanner.gtfs.GtfsContext;
 import org.opentripplanner.gtfs.GtfsLibrary;
 import org.opentripplanner.model.StopPattern;
@@ -274,6 +275,8 @@ public class GTFSPatternHopFactory {
 
     private static GeometryFactory _geometryFactory = GeometryUtils.getGeometryFactory();
 
+    private GtfsFeedId _feedId;
+
     private GtfsRelationalDao _dao;
 
     private CalendarService _calendarService;
@@ -295,11 +298,13 @@ public class GTFSPatternHopFactory {
     private double maxStopToShapeSnapDistance = 150;
 
     public GTFSPatternHopFactory(GtfsContext context) {
+        this._feedId = context.getFeedId();
         this._dao = context.getDao();
         this._calendarService = context.getCalendarService();
     }
     
     public GTFSPatternHopFactory() {
+        this._feedId = null;
         this._dao = null;
         this._calendarService = null;
     }
@@ -893,7 +898,7 @@ public class GTFSPatternHopFactory {
     
     private void loadAgencies(Graph graph) {
         for (Agency agency : _dao.getAllAgencies()) {
-            graph.addAgency(agency);
+            graph.addAgency(_feedId.getId(), agency);
         }
     }
 

--- a/src/main/java/org/opentripplanner/routing/graph/Graph.java
+++ b/src/main/java/org/opentripplanner/routing/graph/Graph.java
@@ -153,9 +153,9 @@ public class Graph implements Serializable {
 
     private transient List<GraphBuilderAnnotation> graphBuilderAnnotations = new LinkedList<GraphBuilderAnnotation>(); // initialize for tests
 
-    private Collection<String> agenciesIds = new HashSet<String>();
+    private Map<String, Collection<Agency>> agenciesForFeedId = new HashMap<>();
 
-    private Collection<Agency> agencies = new HashSet<Agency>();
+    private Collection<String> feedIds = new HashSet<>();
 
     private VertexComparatorFactory vertexComparatorFactory = new MortonVertexComparatorFactory();
 
@@ -883,17 +883,19 @@ public class Graph implements Serializable {
         return removed;
     }
 
-    public Collection<String> getAgencyIds() {
-        return agenciesIds;
+    public Collection<String> getFeedIds() {
+        return feedIds;
     }
 
-    public Collection<Agency> getAgencies() {
-        return agencies;
+    public Collection<Agency> getAgencies(String feedId) {
+        return agenciesForFeedId.get(feedId);
     }
 
-    public void addAgency(Agency agency) {
+    public void addAgency(String feedId, Agency agency) {
+        Collection<Agency> agencies = agenciesForFeedId.getOrDefault(feedId, new HashSet<>());
         agencies.add(agency);
-        agenciesIds.add(agency.getId());
+        this.agenciesForFeedId.put(feedId, agencies);
+        this.feedIds.add(feedId);
     }
 
     /**
@@ -904,14 +906,17 @@ public class Graph implements Serializable {
      */
     public TimeZone getTimeZone() {
         if (timeZone == null) {
-            Collection<String> agencyIds = this.getAgencyIds();
-            if (agencyIds.size() == 0) {
+            Collection<Agency> agencies = null;
+            if (agenciesForFeedId.entrySet().size() > 0) {
+                agencies = agenciesForFeedId.entrySet().iterator().next().getValue();
+            }
+            if (agencies == null || agencies.size() == 0) {
                 timeZone = TimeZone.getTimeZone("GMT");
                 LOG.warn("graph contains no agencies (yet); API request times will be interpreted as GMT.");
             } else {
                 CalendarService cs = this.getCalendarService();
-                for (String agencyId : agencyIds) {
-                    TimeZone tz = cs.getTimeZoneForAgencyId(agencyId);
+                for (Agency agency : agencies) {
+                    TimeZone tz = cs.getTimeZoneForAgencyId(agency.getId());
                     if (timeZone == null) {
                         LOG.debug("graph time zone set to {}", tz);
                         timeZone = tz;

--- a/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
+++ b/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
@@ -60,7 +60,7 @@ public class GraphIndex {
     public final Map<String, TripPattern> patternForId = Maps.newHashMap();
     public final Map<Stop, TransitStop> stopVertexForStop = Maps.newHashMap();
     public final Map<Trip, TripPattern> patternForTrip = Maps.newHashMap();
-    public final Map<String, Multimap<Agency, TripPattern>> agencyPatternsForFeedId = Maps.newHashMap();
+    public final Multimap<String, TripPattern> patternsForFeedId = ArrayListMultimap.create();
     public final Multimap<Route, TripPattern> patternsForRoute = ArrayListMultimap.create();
     public final Multimap<Stop, TripPattern> patternsForStop = ArrayListMultimap.create();
     public final Multimap<String, Stop> stopsForParentStation = ArrayListMultimap.create();
@@ -130,14 +130,7 @@ public class GraphIndex {
             // The key stored in patternForId is the pattern code that is constructed as.
             // Agency:RouteId:DirectionId:PatternNumber, the first part is the feed id.
             String feedId = pattern.code.substring(0, pattern.code.indexOf(':'));
-            Multimap<Agency, TripPattern> patternsForAgency;
-            if (!agencyPatternsForFeedId.containsKey(feedId)) {
-                patternsForAgency = ArrayListMultimap.create();
-            } else {
-                patternsForAgency = agencyPatternsForFeedId.get(feedId);
-            }
-            patternsForAgency.put(pattern.route.getAgency(), pattern);
-            agencyPatternsForFeedId.put(feedId, patternsForAgency);
+            patternsForFeedId.put(feedId, pattern);
 
             patternsForRoute.put(pattern.route, pattern);
 

--- a/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
+++ b/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
@@ -127,11 +127,7 @@ public class GraphIndex {
             stopSpatialIndex.insert(envelope, stopVertex);
         }
         for (TripPattern pattern : patternForId.values()) {
-            // The key stored in patternForId is the pattern code that is constructed as.
-            // Agency:RouteId:DirectionId:PatternNumber, the first part is the feed id.
-            String feedId = pattern.code.substring(0, pattern.code.indexOf(':'));
-            patternsForFeedId.put(feedId, pattern);
-
+            patternsForFeedId.put(pattern.getFeedId(), pattern);
             patternsForRoute.put(pattern.route, pattern);
 
             for (Trip trip : pattern.getTrips()) {

--- a/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
+++ b/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
@@ -38,12 +38,7 @@ import org.opentripplanner.routing.vertextype.TransitStop;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.BitSet;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 /**
  * This class contains all the transient indexes of graph elements -- those that are not
@@ -57,7 +52,7 @@ public class GraphIndex {
 
     // TODO: consistently key on model object or id string
     public final Map<String, Vertex> vertexForId = Maps.newHashMap();
-    public final Map<String, Agency> agencyForId = Maps.newHashMap();
+    public final Map<String, Map<String, Agency>> agenciesForFeedId = Maps.newHashMap();
     public final Map<AgencyAndId, Stop> stopForId = Maps.newHashMap();
     public final Map<AgencyAndId, Trip> tripForId = Maps.newHashMap();
     public final Map<AgencyAndId, Route> routeForId = Maps.newHashMap();
@@ -65,7 +60,7 @@ public class GraphIndex {
     public final Map<String, TripPattern> patternForId = Maps.newHashMap();
     public final Map<Stop, TransitStop> stopVertexForStop = Maps.newHashMap();
     public final Map<Trip, TripPattern> patternForTrip = Maps.newHashMap();
-    public final Multimap<Agency, TripPattern> patternsForAgency = ArrayListMultimap.create();
+    public final Map<String, Multimap<Agency, TripPattern>> agencyPatternsForFeedId = Maps.newHashMap();
     public final Multimap<Route, TripPattern> patternsForRoute = ArrayListMultimap.create();
     public final Multimap<Stop, TripPattern> patternsForStop = ArrayListMultimap.create();
     public final Multimap<String, Stop> stopsForParentStation = ArrayListMultimap.create();
@@ -84,11 +79,6 @@ public class GraphIndex {
     public Multimap<StopCluster, ProfileTransfer> transfersFromStopCluster;
     private HashGridSpatialIndex<StopCluster> stopClusterSpatialIndex = null;
 
-    /* Extra indices for applying realtime updates (lazy-initialized). */
-    public Map<String, Route> routeForIdWithoutAgency = null;
-    public Map<String, Trip> tripForIdWithoutAgency = null;
-    public Map<String, Stop> stopForIdWithoutAgency = null;
-
     /* This is a workaround, and should probably eventually be removed. */
     public Graph graph;
 
@@ -100,9 +90,15 @@ public class GraphIndex {
 
     public GraphIndex (Graph graph) {
         LOG.info("Indexing graph...");
-        for (Agency a : graph.getAgencies()) {
-            agencyForId.put(a.getId(), a);
+
+        for (String feedId : graph.getFeedIds()) {
+            for (Agency agency : graph.getAgencies(feedId)) {
+                Map<String, Agency> agencyForId = agenciesForFeedId.getOrDefault(feedId, new HashMap<>());
+                agencyForId.put(agency.getId(), agency);
+                this.agenciesForFeedId.put(feedId, agencyForId);
+            }
         }
+
         Collection<Edge> edges = graph.getEdges();
         /* We will keep a separate set of all vertices in case some have the same label. 
          * Maybe we should just guarantee unique labels. */
@@ -131,8 +127,20 @@ public class GraphIndex {
             stopSpatialIndex.insert(envelope, stopVertex);
         }
         for (TripPattern pattern : patternForId.values()) {
+            // The key stored in patternForId is the pattern code that is constructed as.
+            // Agency:RouteId:DirectionId:PatternNumber, the first part is the feed id.
+            String feedId = pattern.code.substring(0, pattern.code.indexOf(':'));
+            Multimap<Agency, TripPattern> patternsForAgency;
+            if (!agencyPatternsForFeedId.containsKey(feedId)) {
+                patternsForAgency = ArrayListMultimap.create();
+            } else {
+                patternsForAgency = agencyPatternsForFeedId.get(feedId);
+            }
             patternsForAgency.put(pattern.route.getAgency(), pattern);
+            agencyPatternsForFeedId.put(feedId, patternsForAgency);
+
             patternsForRoute.put(pattern.route, pattern);
+
             for (Trip trip : pattern.getTrips()) {
                 patternForTrip.put(trip, pattern);
                 tripForId.put(trip.getId(), trip);

--- a/src/main/java/org/opentripplanner/updater/GtfsRealtimeFuzzyTripMatcher.java
+++ b/src/main/java/org/opentripplanner/updater/GtfsRealtimeFuzzyTripMatcher.java
@@ -28,7 +28,7 @@ public class GtfsRealtimeFuzzyTripMatcher {
         this.index = index;
     }
 
-    public TripDescriptor match(String agency, TripDescriptor trip) {
+    public TripDescriptor match(String feedId, TripDescriptor trip) {
         if (trip.hasTripId()) {
             // trip_id already exists
             return trip;
@@ -40,7 +40,7 @@ public class GtfsRealtimeFuzzyTripMatcher {
             return trip;
         }
 
-        AgencyAndId routeId = new AgencyAndId(agency, trip.getRouteId());
+        AgencyAndId routeId = new AgencyAndId(feedId, trip.getRouteId());
         int time = StopTimeFieldMappingFactory.getStringAsSeconds(trip.getStartTime());
         ServiceDate date;
         try {

--- a/src/main/java/org/opentripplanner/updater/alerts/GtfsRealtimeAlertsUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/alerts/GtfsRealtimeAlertsUpdater.java
@@ -39,7 +39,7 @@ import com.google.transit.realtime.GtfsRealtime.FeedMessage;
  * myalert.frequencySec = 60
  * myalert.url = http://host.tld/path
  * myalert.earlyStartSec = 3600
- * myalert.defaultAgencyId = TA
+ * myalert.feedId = TA
  * </pre>
  */
 public class GtfsRealtimeAlertsUpdater extends PollingGraphUpdater {
@@ -51,7 +51,7 @@ public class GtfsRealtimeAlertsUpdater extends PollingGraphUpdater {
 
     private String url;
 
-    private String defaultAgencyId;
+    private String feedId;
 
     private GtfsRealtimeFuzzyTripMatcher fuzzyTripMatcher;
 
@@ -77,7 +77,7 @@ public class GtfsRealtimeAlertsUpdater extends PollingGraphUpdater {
         }
         this.url = url;
         this.earlyStart = config.path("earlyStartSec").asInt(0);
-        this.defaultAgencyId = config.path("defaultAgencyId").asText();
+        this.feedId = config.path("feedId").asText();
         if (config.path("fuzzyTripMatching").asBoolean(false)) {
             this.fuzzyTripMatcher = new GtfsRealtimeFuzzyTripMatcher(graph.index);
         }
@@ -90,7 +90,7 @@ public class GtfsRealtimeAlertsUpdater extends PollingGraphUpdater {
             updateHandler = new AlertsUpdateHandler();
         }
         updateHandler.setEarlyStart(earlyStart);
-        updateHandler.setDefaultAgencyId(defaultAgencyId);
+        updateHandler.setFeedId(feedId);
         updateHandler.setAlertPatchService(alertPatchService);
         updateHandler.setFuzzyTripMatcher(fuzzyTripMatcher);
     }

--- a/src/main/java/org/opentripplanner/updater/stoptime/GtfsRealtimeFileTripUpdateSource.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/GtfsRealtimeFileTripUpdateSource.java
@@ -46,11 +46,11 @@ public class GtfsRealtimeFileTripUpdateSource implements TripUpdateSource, JsonC
     /**
      * Default agency id that is used for the trip ids in the TripUpdates
      */
-    private String agencyId;
+    private String feedId;
 
     @Override
     public void configure(Graph graph, JsonNode config) throws Exception {
-        this.agencyId = config.path("defaultAgencyId").asText();
+        this.feedId = config.path("feedId").asText();
         this.file = new File(config.path("file").asText(""));
     }
 
@@ -97,7 +97,7 @@ public class GtfsRealtimeFileTripUpdateSource implements TripUpdateSource, JsonC
     }
 
     @Override
-    public String getAgencyId() {
-        return this.agencyId;
+    public String getFeedId() {
+        return this.feedId;
     }
 }

--- a/src/main/java/org/opentripplanner/updater/stoptime/GtfsRealtimeHttpTripUpdateSource.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/GtfsRealtimeHttpTripUpdateSource.java
@@ -39,11 +39,11 @@ public class GtfsRealtimeHttpTripUpdateSource implements TripUpdateSource, JsonC
      * previous updates should be disregarded
      */
     private boolean fullDataset = true;
-    
+
     /**
-     * Default agency id that is used for the trip ids in the TripUpdates
+     * Feed id that is used to match trip ids in the TripUpdates
      */
-    private String agencyId;
+    private String feedId;
 
     private String url;
 
@@ -54,7 +54,7 @@ public class GtfsRealtimeHttpTripUpdateSource implements TripUpdateSource, JsonC
             throw new IllegalArgumentException("Missing mandatory 'url' parameter");
         }
         this.url = url;
-        this.agencyId = config.path("defaultAgencyId").asText();
+        this.feedId = config.path("feedId").asText();
     }
 
     @Override
@@ -100,7 +100,7 @@ public class GtfsRealtimeHttpTripUpdateSource implements TripUpdateSource, JsonC
     }
 
     @Override
-    public String getAgencyId() {
-        return this.agencyId;
+    public String getFeedId() {
+        return this.feedId;
     }
 }

--- a/src/main/java/org/opentripplanner/updater/stoptime/PollingStoptimeUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/PollingStoptimeUpdater.java
@@ -34,7 +34,7 @@ import com.google.transit.realtime.GtfsRealtime.TripUpdate;
  * rt.frequencySec = 60
  * rt.sourceType = gtfs-http
  * rt.url = http://host.tld/path
- * rt.defaultAgencyId = TA
+ * rt.feedId = TA
  * </pre>
  *
  */
@@ -67,9 +67,9 @@ public class PollingStoptimeUpdater extends PollingGraphUpdater {
     private Boolean purgeExpiredData;
 
     /**
-     * Default agency id that is used for the trip ids in the TripUpdates
+     * Feed id that is used for the trip ids in the TripUpdates
      */
-    private String agencyId;
+    private String feedId;
 
     /**
      * Set only if we should attempt to match the trip_id from other data in TripDescriptor
@@ -84,7 +84,7 @@ public class PollingStoptimeUpdater extends PollingGraphUpdater {
     @Override
     public void configurePolling(Graph graph, JsonNode config) throws Exception {
         // Create update streamer from preferences
-        agencyId = config.path("defaultAgencyId").asText("");
+        feedId = config.path("feedId").asText("");
         String sourceType = config.path("sourceType").asText();
         if (sourceType != null) {
             if (sourceType.equals("gtfs-http")) {
@@ -162,7 +162,7 @@ public class PollingStoptimeUpdater extends PollingGraphUpdater {
         if (updates != null) {
             // Handle trip updates via graph writer runnable
             TripUpdateGraphWriterRunnable runnable =
-                    new TripUpdateGraphWriterRunnable(fullDataset, updates, agencyId);
+                    new TripUpdateGraphWriterRunnable(fullDataset, updates, feedId);
             updaterManager.execute(runnable);
         }
     }

--- a/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
@@ -171,9 +171,6 @@ public class TimetableSnapshotSource {
      * Method to apply a trip update list to the most recent version of the timetable snapshot. A
      * GTFS-RT feed is always applied against a single static feed (indicated by feedId).
      * 
-     * However, multi-feed support is not completed and we currently assume there is only one static
-     * feed when matching IDs.
-     * 
      * @param graph graph to update (needed for adding/changing stop patterns)
      * @param fullDataset true iff the list with updates represent all updates that are active right
      *        now, i.e. all previous updates should be disregarded
@@ -195,7 +192,7 @@ public class TimetableSnapshotSource {
                 buffer.clear();
             }
 
-            LOG.debug("message contains {} trip updates", updates.size());
+            LOG.info("message contains {} trip updates", updates.size());
             int uIndex = 0;
             for (TripUpdate tripUpdate : updates) {
                 if (fuzzyTripMatcher != null && tripUpdate.hasTrip()) {
@@ -321,9 +318,9 @@ public class TimetableSnapshotSource {
 
     private boolean handleScheduledTrip(TripUpdate tripUpdate, String feedId, ServiceDate serviceDate) {
         TripDescriptor tripDescriptor = tripUpdate.getTrip();
-        // This does not include Agency ID or feed ID, trips are feed-unique and we currently assume a single static feed.
+        // This does not include Agency ID or feed ID.
         String tripId = tripDescriptor.getTripId();
-        TripPattern pattern = getPatternForTripId(tripId);
+        TripPattern pattern = getPatternForTripId(feedId, tripId);
 
         if (pattern == null) {
             LOG.warn("No pattern found for tripId {}, skipping TripUpdate.", tripId);
@@ -376,7 +373,7 @@ public class TimetableSnapshotSource {
         
         // Check whether trip id already exists in graph
         String tripId = tripDescriptor.getTripId();
-        Trip trip = getTripForTripId(tripId);
+        Trip trip = getTripForTripId(feedId, tripId);
         if (trip != null) {
             // TODO: should we support this and add a new instantiation of this trip (making it
             // frequency based)?
@@ -398,7 +395,7 @@ public class TimetableSnapshotSource {
         }
         
         // Check whether all stop times are available and all stops exist
-        List<Stop> stops = checkNewStopTimeUpdatesAndFindStops(tripUpdate);
+        List<Stop> stops = checkNewStopTimeUpdatesAndFindStops(feedId, tripUpdate);
         if (stops == null) {
             return false;
         }
@@ -414,11 +411,12 @@ public class TimetableSnapshotSource {
     /**
      * Check stop time updates of trip update that results in a new trip (ADDED or MODIFIED) and
      * find all stops of that trip.
-     * 
+     *
+     * @param feedId feed id this trip update is intented for
      * @param tripUpdate trip update
      * @return stops when stop time updates are correct; null if there are errors
      */
-    private List<Stop> checkNewStopTimeUpdatesAndFindStops(final TripUpdate tripUpdate) {
+    private List<Stop> checkNewStopTimeUpdatesAndFindStops(final String feedId, final TripUpdate tripUpdate) {
         Integer previousStopSequence = null;
         Long previousTime = null;
         List<StopTimeUpdate> stopTimeUpdates = tripUpdate.getStopTimeUpdateList();
@@ -452,7 +450,7 @@ public class TimetableSnapshotSource {
             // Find stops
             if (stopTimeUpdate.hasStopId()) {
                 // Find stop
-                Stop stop = getStopForStopId(stopTimeUpdate.getStopId());
+                Stop stop = getStopForStopId(feedId, stopTimeUpdate.getStopId());
                 if (stop != null) {
                     // Remember stop
                     stops.add(stop);
@@ -562,7 +560,7 @@ public class TimetableSnapshotSource {
         Route route = null;
         if (tripUpdate.getTrip().hasRouteId()) {
             // Try to find route
-            route = getRouteForRouteId(tripUpdate.getTrip().getRouteId());
+            route = getRouteForRouteId(feedId, tripUpdate.getTrip().getRouteId());
         }
         
         if (route == null) {
@@ -723,10 +721,10 @@ public class TimetableSnapshotSource {
      * @param serviceDate service date
      * @return true if scheduled trip was cancelled
      */
-    private boolean cancelScheduledTrip(String tripId, final ServiceDate serviceDate) {
+    private boolean cancelScheduledTrip(String feedId, String tripId, final ServiceDate serviceDate) {
         boolean success = false;
         
-        TripPattern pattern = getPatternForTripId(tripId);
+        TripPattern pattern = getPatternForTripId(feedId, tripId);
         if (pattern != null) {
             // Cancel scheduled trip times for this trip in this pattern
             Timetable timetable = pattern.scheduledTimetable;
@@ -807,7 +805,7 @@ public class TimetableSnapshotSource {
         
         // Check whether trip id already exists in graph
         String tripId = tripDescriptor.getTripId();
-        Trip trip = getTripForTripId(tripId);
+        Trip trip = getTripForTripId(feedId, tripId);
         if (trip == null) {
             // TODO: should we support this and consider it an ADDED trip?
             LOG.warn("Graph does not contain trip id of MODIFIED trip, skipping.");
@@ -836,7 +834,7 @@ public class TimetableSnapshotSource {
         }
         
         // Check whether all stop times are available and all stops exist
-        List<Stop> stops = checkNewStopTimeUpdatesAndFindStops(tripUpdate);
+        List<Stop> stops = checkNewStopTimeUpdatesAndFindStops(feedId, tripUpdate);
         if (stops == null) {
             return false;
         }
@@ -870,7 +868,7 @@ public class TimetableSnapshotSource {
         
         // Cancel scheduled trip
         String tripId = tripUpdate.getTrip().getTripId();
-        cancelScheduledTrip(tripId, serviceDate);
+        cancelScheduledTrip(feedId, tripId, serviceDate);
         
         // Check whether trip id has been used for previously ADDED/MODIFIED trip message and cancel
         // previously created trip
@@ -886,7 +884,7 @@ public class TimetableSnapshotSource {
         if (tripUpdate.getTrip().hasTripId()) {
             // Try to cancel scheduled trip
             String tripId = tripUpdate.getTrip().getTripId();
-            boolean cancelScheduledSuccess = cancelScheduledTrip(tripId, serviceDate); 
+            boolean cancelScheduledSuccess = cancelScheduledTrip(feedId, tripId, serviceDate);
             
             // Try to cancel previously added trip
             boolean cancelPreviouslyAddedSuccess = cancelPreviouslyAddedTrip(tripId, serviceDate);
@@ -918,80 +916,52 @@ public class TimetableSnapshotSource {
         return buffer.purgeExpiredData(previously);
     }
 
-    private TripPattern getPatternForTripId(String tripIdWithoutAgency) {
-        Trip trip = getTripForTripId(tripIdWithoutAgency);
+    /**
+     * Retrieve a trip pattern given a feed id and trid id.
+     *
+     * @param feedId feed id for the trip id
+     * @param tripId trip id without agency
+     * @return trip pattern or null if no trip pattern was found
+     */
+    private TripPattern getPatternForTripId(String feedId, String tripId) {
+        Trip trip = graphIndex.tripForId.get(new AgencyAndId(feedId, tripId));
         TripPattern pattern = graphIndex.patternForTrip.get(trip);
         return pattern;
     }
 
     /**
      * Retrieve route given a route id without an agency
-     * 
+     *
+     * @param feedId feed id for the route id
      * @param routeId route id without the agency
      * @return route or null if route can't be found in graph index
      */
-    private Route getRouteForRouteId(String routeId) {
-        /* Lazy-initialize a separate index that ignores agency IDs.
-         * Stopgap measure assuming no cross-feed ID conflicts, until we get GTFS loader replaced. */
-        if (graphIndex.routeForIdWithoutAgency == null) {
-            Map<String, Route> map = Maps.newHashMap();
-            for (Route route : graphIndex.routeForId.values()) {
-                Route previousValue = map.put(route.getId().getId(), route);
-                if (previousValue != null) {
-                    LOG.warn("Duplicate route id detected when agency is ignored for "
-                            + "realtime updates: {}", route.getId().getId());
-                }
-            }
-            graphIndex.routeForIdWithoutAgency = map;
-        }
-        Route route = graphIndex.routeForIdWithoutAgency.get(routeId);
+    private Route getRouteForRouteId(String feedId, String routeId) {
+        Route route = graphIndex.routeForId.get(new AgencyAndId(feedId, routeId));
         return route;
     }
     
     /**
      * Retrieve trip given a trip id without an agency
-     * 
+     *
+     * @param feedId feed id for the trip id
      * @param tripId trip id without the agency
      * @return trip or null if trip can't be found in graph index
      */
-    private Trip getTripForTripId(String tripId) {
-        /* Lazy-initialize a separate index that ignores agency IDs.
-         * Stopgap measure assuming no cross-feed ID conflicts, until we get GTFS loader replaced. */
-        if (graphIndex.tripForIdWithoutAgency == null) {
-            Map<String, Trip> map = Maps.newHashMap();
-            for (Trip trip : graphIndex.tripForId.values()) {
-                Trip previousValue = map.put(trip.getId().getId(), trip);
-                if (previousValue != null) {
-                    LOG.warn("Duplicate trip id detected when agency is ignored for realtime"
-                            + "updates: {}", trip.getId().getId());
-                }
-            }
-            graphIndex.tripForIdWithoutAgency = map;
-        }
-        Trip trip = graphIndex.tripForIdWithoutAgency.get(tripId);
+    private Trip getTripForTripId(String feedId, String tripId) {
+        Trip trip = graphIndex.tripForId.get(new AgencyAndId(feedId, tripId));
         return trip;
     }
 
     /**
-     * Retrieve stop given a stop id without an agency
-     * 
+     * Retrieve stop given a feed id and stop id.
+     *
+     * @param feedId feed id for the stop id
      * @param stopId trip id without the agency
      * @return stop or null if stop doesn't exist
      */
-    private Stop getStopForStopId(String stopId) {
-        /* Lazy-initialize a separate index that ignores agency IDs.
-         * Stopgap measure assuming no cross-feed ID conflicts, until we get GTFS loader replaced. */
-        if (graphIndex.stopForIdWithoutAgency == null) {
-            Map<String, Stop> map = Maps.newHashMap();
-            for (Stop stop : graphIndex.stopForId.values()) {
-                Stop previousValue = map.put(stop.getId().getId(), stop);
-                if (previousValue != null) {
-                    LOG.warn("Duplicate stop id detected when agency is ignored for realtime updates: {}", stopId);
-                }
-            }
-            graphIndex.stopForIdWithoutAgency = map;
-        }
-        Stop stop = graphIndex.stopForIdWithoutAgency.get(stopId);
+    private Stop getStopForStopId(String feedId, String stopId) {
+        Stop stop = graphIndex.stopForId.get(new AgencyAndId(feedId, stopId));
         return stop;
     }
     

--- a/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
@@ -192,7 +192,7 @@ public class TimetableSnapshotSource {
                 buffer.clear(feedId);
             }
 
-            LOG.info("message contains {} trip updates", updates.size());
+            LOG.debug("message contains {} trip updates", updates.size());
             int uIndex = 0;
             for (TripUpdate tripUpdate : updates) {
                 if (fuzzyTripMatcher != null && tripUpdate.hasTrip()) {

--- a/src/main/java/org/opentripplanner/updater/stoptime/TripUpdateSource.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/TripUpdateSource.java
@@ -31,5 +31,5 @@ public interface TripUpdateSource {
      */
     public boolean getFullDatasetValueOfLastUpdates();
 
-    public String getAgencyId();
+    public String getFeedId();
 }

--- a/src/test/java/org/opentripplanner/GtfsTest.java
+++ b/src/test/java/org/opentripplanner/GtfsTest.java
@@ -28,6 +28,7 @@ import org.opentripplanner.api.model.Leg;
 import org.opentripplanner.api.model.TripPlan;
 import org.opentripplanner.api.resource.GraphPathToTripPlanConverter;
 import org.opentripplanner.common.model.GenericLocation;
+import org.opentripplanner.graph_builder.module.GtfsFeedId;
 import org.opentripplanner.graph_builder.module.GtfsModule;
 import org.opentripplanner.graph_builder.model.GtfsBundle;
 import org.opentripplanner.routing.core.RoutingRequest;
@@ -54,6 +55,7 @@ public abstract class GtfsTest extends TestCase {
     TimetableSnapshotSource timetableSnapshotSource;
     AlertPatchServiceImpl alertPatchServiceImpl;
     public Router router;
+    private GtfsFeedId feedId;
 
     public abstract String getFeedName();
 
@@ -67,8 +69,11 @@ public abstract class GtfsTest extends TestCase {
         File gtfs = new File("src/test/resources/" + getFeedName());
         File gtfsRealTime = new File("src/test/resources/" + getFeedName() + ".pb");
         GtfsBundle gtfsBundle = new GtfsBundle(gtfs);
+        feedId = new GtfsFeedId("FEED");
+        gtfsBundle.setFeedId(feedId);
         List<GtfsBundle> gtfsBundleList = Collections.singletonList(gtfsBundle);
         GtfsModule gtfsGraphBuilderImpl = new GtfsModule(gtfsBundleList);
+
 
         alertsUpdateHandler = new AlertsUpdateHandler();
         graph = new Graph();
@@ -77,7 +82,7 @@ public abstract class GtfsTest extends TestCase {
         gtfsBundle.setTransfersTxtDefinesStationPaths(true);
         gtfsGraphBuilderImpl.buildGraph(graph, null);
         // Set the agency ID to be used for tests to the first one in the feed.
-        agencyId = graph.getAgencyIds().iterator().next();
+        agencyId = graph.getAgencies(feedId.getId()).iterator().next().getId();
         System.out.printf("Set the agency ID for this test to %s\n", agencyId);
         graph.index(new DefaultStreetVertexIndexFactory());
         timetableSnapshotSource = new TimetableSnapshotSource(graph);
@@ -85,7 +90,7 @@ public abstract class GtfsTest extends TestCase {
         graph.timetableSnapshotSource = (timetableSnapshotSource);
         alertPatchServiceImpl = new AlertPatchServiceImpl(graph);
         alertsUpdateHandler.setAlertPatchService(alertPatchServiceImpl);
-        alertsUpdateHandler.setDefaultAgencyId("MMRI");
+        alertsUpdateHandler.setFeedId(feedId.getId());
 
         try {
             final boolean fullDataset = false;
@@ -96,7 +101,7 @@ public abstract class GtfsTest extends TestCase {
             for (FeedEntity feedEntity : feedEntityList) {
                 updates.add(feedEntity.getTripUpdate());
             }
-            timetableSnapshotSource.applyTripUpdates(graph, fullDataset, updates, agencyId);
+            timetableSnapshotSource.applyTripUpdates(graph, fullDataset, updates, feedId.getId());
             alertsUpdateHandler.update(feedMessage);
         } catch (Exception exception) {}
     }
@@ -118,13 +123,13 @@ public abstract class GtfsTest extends TestCase {
         routingRequest.setArriveBy(dateTime < 0);
         routingRequest.dateTime = Math.abs(dateTime);
         if (fromVertex != null && !fromVertex.isEmpty()) {
-            routingRequest.from = (new GenericLocation(null, agencyId + ":" + fromVertex));
+            routingRequest.from = (new GenericLocation(null, feedId.getId() + ":" + fromVertex));
         }
         if (toVertex != null && !toVertex.isEmpty()) {
-            routingRequest.to = new GenericLocation(null, agencyId + ":" + toVertex);
+            routingRequest.to = new GenericLocation(null, feedId.getId() + ":" + toVertex);
         }
         if (onTripId != null && !onTripId.isEmpty()) {
-            routingRequest.startingTransitTripId = (new AgencyAndId(agencyId, onTripId));
+            routingRequest.startingTransitTripId = (new AgencyAndId(feedId.getId(), onTripId));
         }
         routingRequest.setRoutingContext(graph);
         routingRequest.setWheelchairAccessible(wheelchairAccessible);
@@ -132,10 +137,10 @@ public abstract class GtfsTest extends TestCase {
         routingRequest.setModes(new TraverseModeSet(TraverseMode.WALK, mode));
         // TODO route matcher still using underscores because it's quite nonstandard and should be eliminated from the 1.0 release rather than reworked
         if (excludedRoute != null && !excludedRoute.isEmpty()) {
-            routingRequest.setBannedRoutes(agencyId + "__" + excludedRoute);
+            routingRequest.setBannedRoutes(feedId.getId() + "__" + excludedRoute);
         }
         if (excludedStop != null && !excludedStop.isEmpty()) {
-            routingRequest.setBannedStopsHard(agencyId + ":" + excludedStop);
+            routingRequest.setBannedStopsHard(feedId.getId() + ":" + excludedStop);
         }
         routingRequest.setOtherThanPreferredRoutesPenalty(0);
         // The walk board cost is set low because it interferes with test 2c1.
@@ -160,9 +165,9 @@ public abstract class GtfsTest extends TestCase {
         assertEquals(startTime, leg.startTime.getTimeInMillis());
         assertEquals(endTime, leg.endTime.getTimeInMillis());
         assertEquals(toStopId, leg.to.stopId.getId());
-        assertEquals(agencyId, leg.to.stopId.getAgencyId());
+        assertEquals(feedId.getId(), leg.to.stopId.getAgencyId());
         if (fromStopId != null) {
-            assertEquals(agencyId, leg.from.stopId.getAgencyId());
+            assertEquals(feedId.getId(), leg.from.stopId.getAgencyId());
             assertEquals(fromStopId, leg.from.stopId.getId());
         } else {
             assertNull(leg.from.stopId);

--- a/src/test/java/org/opentripplanner/GtfsTest.java
+++ b/src/test/java/org/opentripplanner/GtfsTest.java
@@ -69,7 +69,7 @@ public abstract class GtfsTest extends TestCase {
         File gtfs = new File("src/test/resources/" + getFeedName());
         File gtfsRealTime = new File("src/test/resources/" + getFeedName() + ".pb");
         GtfsBundle gtfsBundle = new GtfsBundle(gtfs);
-        feedId = new GtfsFeedId("FEED");
+        feedId = new GtfsFeedId.Builder().id("FEED").build();
         gtfsBundle.setFeedId(feedId);
         List<GtfsBundle> gtfsBundleList = Collections.singletonList(gtfsBundle);
         GtfsModule gtfsGraphBuilderImpl = new GtfsModule(gtfsBundleList);

--- a/src/test/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverterTest.java
+++ b/src/test/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverterTest.java
@@ -94,13 +94,7 @@ import org.opentripplanner.updater.stoptime.TimetableSnapshotSource;
 import org.opentripplanner.util.NonLocalizedString;
 import org.opentripplanner.util.model.EncodedPolylineBean;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Locale;
-import java.util.Set;
-import java.util.SimpleTimeZone;
-import java.util.TimeZone;
+import java.util.*;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
@@ -171,6 +165,8 @@ public class GraphPathToTripPlanConverterTest {
         // This set of requested traverse modes implies that bike rental is a possibility.
         RoutingRequest options = new RoutingRequest("BICYCLE_RENT,TRANSIT");
 
+        String feedId = "FEED";
+
         Graph graph = new Graph();
 
         // Vertices for leg 0
@@ -189,42 +185,42 @@ public class GraphPathToTripPlanConverterTest {
         Stop ferryStopDepart = new Stop();
         Stop ferryStopArrive = new Stop();
 
-        trainStopDepart.setId(new AgencyAndId("Train", "Depart"));
+        trainStopDepart.setId(new AgencyAndId(feedId, "Depart"));
         trainStopDepart.setName("Train stop depart");
         trainStopDepart.setLon(1);
         trainStopDepart.setLat(1);
         trainStopDepart.setCode("Train depart code");
         trainStopDepart.setPlatformCode("Train depart platform");
         trainStopDepart.setZoneId("Train depart zone");
-        trainStopDwell.setId(new AgencyAndId("Train", "Dwell"));
+        trainStopDwell.setId(new AgencyAndId(feedId, "Dwell"));
         trainStopDwell.setName("Train stop dwell");
         trainStopDwell.setLon(45);
         trainStopDwell.setLat(23);
         trainStopDwell.setCode("Train dwell code");
         trainStopDwell.setPlatformCode("Train dwell platform");
         trainStopDwell.setZoneId("Train dwell zone");
-        trainStopInterline.setId(new AgencyAndId("Train", "Interline"));
+        trainStopInterline.setId(new AgencyAndId(feedId, "Interline"));
         trainStopInterline.setName("Train stop interline");
         trainStopInterline.setLon(89);
         trainStopInterline.setLat(45);
         trainStopInterline.setCode("Train interline code");
         trainStopInterline.setPlatformCode("Train interline platform");
         trainStopInterline.setZoneId("Train interline zone");
-        trainStopArrive.setId(new AgencyAndId("Train", "Arrive"));
+        trainStopArrive.setId(new AgencyAndId(feedId, "Arrive"));
         trainStopArrive.setName("Train stop arrive");
         trainStopArrive.setLon(133);
         trainStopArrive.setLat(67);
         trainStopArrive.setCode("Train arrive code");
         trainStopArrive.setPlatformCode("Train arrive platform");
         trainStopArrive.setZoneId("Train arrive zone");
-        ferryStopDepart.setId(new AgencyAndId("Ferry", "Depart"));
+        ferryStopDepart.setId(new AgencyAndId(feedId, "Depart"));
         ferryStopDepart.setName("Ferry stop depart");
         ferryStopDepart.setLon(135);
         ferryStopDepart.setLat(67);
         ferryStopDepart.setCode("Ferry depart code");
         ferryStopDepart.setPlatformCode("Ferry depart platform");
         ferryStopDepart.setZoneId("Ferry depart zone");
-        ferryStopArrive.setId(new AgencyAndId("Ferry", "Arrive"));
+        ferryStopArrive.setId(new AgencyAndId(feedId, "Arrive"));
         ferryStopArrive.setName("Ferry stop arrive");
         ferryStopArrive.setLon(179);
         ferryStopArrive.setLat(89);
@@ -260,21 +256,21 @@ public class GraphPathToTripPlanConverterTest {
         Route secondRoute = new Route();
         Route thirdRoute = new Route();
 
-        firstRoute.setId(new AgencyAndId("Train", "A"));
+        firstRoute.setId(new AgencyAndId(feedId, "A"));
         firstRoute.setAgency(trainAgency);
         firstRoute.setShortName("A");
         firstRoute.setLongName("'A' Train");
         firstRoute.setType(2);
         firstRoute.setColor("White");
         firstRoute.setTextColor("Black");
-        secondRoute.setId(new AgencyAndId("Train", "B"));
+        secondRoute.setId(new AgencyAndId(feedId, "B"));
         secondRoute.setAgency(trainAgency);
         secondRoute.setShortName("B");
         secondRoute.setLongName("Another Train");
         secondRoute.setType(2);
         secondRoute.setColor("Cyan");
         secondRoute.setTextColor("Yellow");
-        thirdRoute.setId(new AgencyAndId("Ferry", "C"));
+        thirdRoute.setId(new AgencyAndId(feedId, "C"));
         thirdRoute.setAgency(ferryAgency);
         thirdRoute.setShortName("C");
         thirdRoute.setLongName("Ferry Cross the Mersey");
@@ -287,19 +283,19 @@ public class GraphPathToTripPlanConverterTest {
         Trip secondTrip = new Trip();
         Trip thirdTrip = new Trip();
 
-        firstTrip.setId(new AgencyAndId("Train", "A"));
+        firstTrip.setId(new AgencyAndId(feedId, "A"));
         firstTrip.setTripShortName("A");
         firstTrip.setBlockId("Alock");
         firstTrip.setRoute(firstRoute);
         BikeAccess.setForTrip(firstTrip, BikeAccess.ALLOWED);
         firstTrip.setTripHeadsign("Street Fighting Man");
-        secondTrip.setId(new AgencyAndId("Train", "B"));
+        secondTrip.setId(new AgencyAndId(feedId, "B"));
         secondTrip.setTripShortName("B");
         secondTrip.setBlockId("Block");
         secondTrip.setRoute(secondRoute);
         BikeAccess.setForTrip(secondTrip, BikeAccess.ALLOWED);
         secondTrip.setTripHeadsign("No Expectations");
-        thirdTrip.setId(new AgencyAndId("Ferry", "C"));
+        thirdTrip.setId(new AgencyAndId(feedId, "C"));
         thirdTrip.setTripShortName("C");
         thirdTrip.setBlockId("Clock");
         thirdTrip.setRoute(thirdRoute);
@@ -605,8 +601,8 @@ public class GraphPathToTripPlanConverterTest {
         CalendarServiceData calendarServiceData = new CalendarServiceDataStub(graph.serviceCodes.keySet());
         CalendarServiceImpl calendarServiceImpl = new CalendarServiceImpl(calendarServiceData);
 
-        calendarServiceData.putTimeZoneForAgencyId("Train", timeZone);
-        calendarServiceData.putTimeZoneForAgencyId("Ferry", timeZone);
+        calendarServiceData.putTimeZoneForAgencyId(feedId, timeZone);
+        calendarServiceData.putTimeZoneForAgencyId(feedId, timeZone);
 
         FareServiceStub fareServiceStub = new FareServiceStub();
 
@@ -656,7 +652,6 @@ public class GraphPathToTripPlanConverterTest {
         timetableSnapshotSource.getTimetableSnapshot().update(thirdTripPattern, updatedTripTimes, serviceDate);
 
         // Further graph initialization
-        String feedId = "FEED";
 
         graph.putService(CalendarServiceData.class, calendarServiceData);
         graph.putService(FareService.class, fareServiceStub);
@@ -666,7 +661,7 @@ public class GraphPathToTripPlanConverterTest {
         graph.addAlertPatch(e29, alertPatch);
 
         // Routing context creation and initialization
-        ServiceDay serviceDay = new ServiceDay(graph, 0, calendarServiceImpl, null);
+        ServiceDay serviceDay = new ServiceDay(graph, 0, calendarServiceImpl, feedId);
 
         // Temporary graph objects for onboard depart tests
         OnboardDepartVertex onboardDepartVertex = new OnboardDepartVertex("Onboard", 23.0, 12.0);
@@ -1712,44 +1707,44 @@ public class GraphPathToTripPlanConverterTest {
         assertNull(stopIds[0][0]);
 
         if (type == Type.FORWARD || type == Type.BACKWARD) {
-            assertEquals("Train", stopIds[0][1].getAgencyId());
+            assertEquals("FEED", stopIds[0][1].getAgencyId());
             assertEquals("Depart", stopIds[0][1].getId());
         } else if (type == Type.ONBOARD) {
             assertNull(stopIds[0][1]);
         }
 
         if (type == Type.FORWARD || type == Type.BACKWARD) {
-            assertEquals("Train", stopIds[1][0].getAgencyId());
+            assertEquals("FEED", stopIds[1][0].getAgencyId());
             assertEquals("Depart", stopIds[1][0].getId());
         } else if (type == Type.ONBOARD) {
             assertNull(stopIds[1][0]);
         }
 
-        assertEquals("Train", stopIds[1][1].getAgencyId());
+        assertEquals("FEED", stopIds[1][1].getAgencyId());
         assertEquals("Dwell", stopIds[1][1].getId());
 
-        assertEquals("Train", stopIds[1][2].getAgencyId());
+        assertEquals("FEED", stopIds[1][2].getAgencyId());
         assertEquals("Interline", stopIds[1][2].getId());
 
-        assertEquals("Train", stopIds[2][0].getAgencyId());
+        assertEquals("FEED", stopIds[2][0].getAgencyId());
         assertEquals("Interline", stopIds[2][0].getId());
 
-        assertEquals("Train", stopIds[2][1].getAgencyId());
+        assertEquals("FEED", stopIds[2][1].getAgencyId());
         assertEquals("Arrive", stopIds[2][1].getId());
 
-        assertEquals("Train", stopIds[3][0].getAgencyId());
+        assertEquals("FEED", stopIds[3][0].getAgencyId());
         assertEquals("Arrive", stopIds[3][0].getId());
 
-        assertEquals("Ferry", stopIds[3][1].getAgencyId());
+        assertEquals("FEED", stopIds[3][1].getAgencyId());
         assertEquals("Depart", stopIds[3][1].getId());
 
-        assertEquals("Ferry", stopIds[4][0].getAgencyId());
+        assertEquals("FEED", stopIds[4][0].getAgencyId());
         assertEquals("Depart", stopIds[4][0].getId());
 
-        assertEquals("Ferry", stopIds[4][1].getAgencyId());
+        assertEquals("FEED", stopIds[4][1].getAgencyId());
         assertEquals("Arrive", stopIds[4][1].getId());
 
-        assertEquals("Ferry", stopIds[5][0].getAgencyId());
+        assertEquals("FEED", stopIds[5][0].getAgencyId());
         assertEquals("Arrive", stopIds[5][0].getId());
 
         assertNull(stopIds[5][1]);

--- a/src/test/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverterTest.java
+++ b/src/test/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverterTest.java
@@ -656,10 +656,12 @@ public class GraphPathToTripPlanConverterTest {
         timetableSnapshotSource.getTimetableSnapshot().update(thirdTripPattern, updatedTripTimes, serviceDate);
 
         // Further graph initialization
+        String feedId = "FEED";
+
         graph.putService(CalendarServiceData.class, calendarServiceData);
         graph.putService(FareService.class, fareServiceStub);
-        graph.addAgency(trainAgency);
-        graph.addAgency(ferryAgency);
+        graph.addAgency(feedId, trainAgency);
+        graph.addAgency(feedId, ferryAgency);
         graph.timetableSnapshotSource = (timetableSnapshotSource);
         graph.addAlertPatch(e29, alertPatch);
 

--- a/src/test/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverterTest.java
+++ b/src/test/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverterTest.java
@@ -649,7 +649,7 @@ public class GraphPathToTripPlanConverterTest {
 
         TripTimes updatedTripTimes = thirdTripPattern.scheduledTimetable.createUpdatedTripTimes(tripUpdate,
                 timeZone, serviceDate);
-        timetableSnapshotSource.getTimetableSnapshot().update(thirdTripPattern, updatedTripTimes, serviceDate);
+        timetableSnapshotSource.getTimetableSnapshot().update(feedId, thirdTripPattern, updatedTripTimes, serviceDate);
 
         // Further graph initialization
 

--- a/src/test/java/org/opentripplanner/graph_builder/module/GtfsGraphBuilderModuleTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/GtfsGraphBuilderModuleTest.java
@@ -109,7 +109,7 @@ public class GtfsGraphBuilderModuleTest {
 
     private static List<GtfsBundle> getGtfsAsBundleList (MockGtfs gtfs) {
         GtfsBundle bundle = new GtfsBundle();
-        bundle.setFeedId(new GtfsFeedId("FEED"));
+        bundle.setFeedId(new GtfsFeedId.Builder().id("FEED").build());
         bundle.setPath(gtfs.getPath());
         List<GtfsBundle> list = Lists.newArrayList();
         list.add(bundle);

--- a/src/test/java/org/opentripplanner/graph_builder/module/GtfsGraphBuilderModuleTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/GtfsGraphBuilderModuleTest.java
@@ -54,13 +54,17 @@ public class GtfsGraphBuilderModuleTest {
         _builder.buildGraph(graph, _extra);
         graph.index(new DefaultStreetVertexIndexFactory());
 
-        Trip trip = graph.index.tripForId.get(new AgencyAndId("a0", "t0"));
+        // Feed id is used instead of the agency id for OBA entities.
+        GtfsBundle gtfsBundle = bundleList.get(0);
+        GtfsFeedId feedId = gtfsBundle.getFeedId();
+
+        Trip trip = graph.index.tripForId.get(new AgencyAndId(feedId.getId(), "t0"));
         TripPattern pattern = graph.index.patternForTrip.get(trip);
         List<Trip> trips = pattern.getTrips();
         assertEquals(BikeAccess.UNKNOWN,
-                BikeAccess.fromTrip(withId(trips, new AgencyAndId("a0", "t0"))));
+                BikeAccess.fromTrip(withId(trips, new AgencyAndId(feedId.getId(), "t0"))));
         assertEquals(BikeAccess.ALLOWED,
-                BikeAccess.fromTrip(withId(trips, new AgencyAndId("a0", "t1"))));
+                BikeAccess.fromTrip(withId(trips, new AgencyAndId(feedId.getId(), "t1"))));
     }
 
     @Test
@@ -79,13 +83,17 @@ public class GtfsGraphBuilderModuleTest {
         _builder.buildGraph(graph, _extra);
         graph.index(new DefaultStreetVertexIndexFactory());
 
-        Trip trip = graph.index.tripForId.get(new AgencyAndId("a0", "t0"));
+        // Feed id is used instead of the agency id for OBA entities.
+        GtfsBundle gtfsBundle = bundleList.get(0);
+        GtfsFeedId feedId = gtfsBundle.getFeedId();
+
+        Trip trip = graph.index.tripForId.get(new AgencyAndId(feedId.getId(), "t0"));
         TripPattern pattern = graph.index.patternForTrip.get(trip);
         List<Trip> trips = pattern.getTrips();
         assertEquals(BikeAccess.ALLOWED,
-                BikeAccess.fromTrip(withId(trips, new AgencyAndId("a0", "t0"))));
+                BikeAccess.fromTrip(withId(trips, new AgencyAndId(feedId.getId(), "t0"))));
         assertEquals(BikeAccess.NOT_ALLOWED,
-                BikeAccess.fromTrip(withId(trips, new AgencyAndId("a0", "t1"))));
+                BikeAccess.fromTrip(withId(trips, new AgencyAndId(feedId.getId(), "t1"))));
     }
 
     private MockGtfs getSimpleGtfs() throws IOException {
@@ -101,6 +109,7 @@ public class GtfsGraphBuilderModuleTest {
 
     private static List<GtfsBundle> getGtfsAsBundleList (MockGtfs gtfs) {
         GtfsBundle bundle = new GtfsBundle();
+        bundle.setFeedId(new GtfsFeedId("FEED"));
         bundle.setPath(gtfs.getPath());
         List<GtfsBundle> list = Lists.newArrayList();
         list.add(bundle);

--- a/src/test/java/org/opentripplanner/routing/algorithm/TestAStar.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/TestAStar.java
@@ -42,14 +42,15 @@ public class TestAStar extends TestCase {
         factory.run(gg);
         gg.putService(CalendarServiceData.class, GtfsLibrary.createCalendarServiceData(context.getDao()));
         RoutingRequest options = new RoutingRequest();
-        
+
         ShortestPathTree spt;
         GraphPath path = null;
 
+        String feedId = gg.getFeedIds().iterator().next();
         options.dateTime = TestUtils.dateInSeconds("America/Los_Angeles", 2009, 8, 7, 12, 0, 0);
-        options.setRoutingContext(gg, "Caltrain:Millbrae Caltrain", "Caltrain:Mountain View Caltrain");
+        options.setRoutingContext(gg, feedId + ":Millbrae Caltrain", feedId + ":Mountain View Caltrain");
         spt = aStar.getShortestPathTree(options);
-        path = spt.getPath(gg.getVertex("Caltrain:Mountain View Caltrain"), true);
+        path = spt.getPath(gg.getVertex(feedId + ":Mountain View Caltrain"), true);
 
         long endTime = TestUtils.dateInSeconds("America/Los_Angeles", 2009, 8, 7, 13, 29, 0);
 
@@ -58,9 +59,9 @@ public class TestAStar extends TestCase {
         /* test backwards traversal */
         options.setArriveBy(true);
         options.dateTime = endTime;
-        options.setRoutingContext(gg, "Caltrain:Millbrae Caltrain", "Caltrain:Mountain View Caltrain");
+        options.setRoutingContext(gg, feedId + ":Millbrae Caltrain", feedId + ":Mountain View Caltrain");
         spt = aStar.getShortestPathTree(options);
-        path = spt.getPath(gg.getVertex("Caltrain:Millbrae Caltrain"), true);
+        path = spt.getPath(gg.getVertex(feedId + ":Millbrae Caltrain"), true);
 
         long expectedStartTime = TestUtils.dateInSeconds("America/Los_Angeles", 2009, 8, 7, 12, 39, 0);
 
@@ -71,8 +72,9 @@ public class TestAStar extends TestCase {
     public void testMaxTime() {
 
         Graph graph = ConstantsForTests.getInstance().getPortlandGraph();
-        Vertex start = graph.getVertex("TriMet:8371");
-        Vertex end = graph.getVertex("TriMet:8374");
+        String feedId = graph.getFeedIds().iterator().next();
+        Vertex start = graph.getVertex(feedId + ":8371");
+        Vertex end = graph.getVertex(feedId + ":8374");
 
         RoutingRequest options = new RoutingRequest();
         long startTime = TestUtils.dateInSeconds("America/Los_Angeles", 2009, 11, 1, 12, 34, 25);

--- a/src/test/java/org/opentripplanner/routing/algorithm/TestBanning.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/TestBanning.java
@@ -39,9 +39,10 @@ public class TestBanning extends TestCase {
 
         Graph graph = ConstantsForTests.getInstance().getPortlandGraph();
 
+        String feedId = graph.getFeedIds().iterator().next();
         RoutingRequest options = new RoutingRequest();
-        Vertex start = graph.getVertex("TriMet:8371");
-        Vertex end = graph.getVertex("TriMet:8374");
+        Vertex start = graph.getVertex(feedId + ":8371");
+        Vertex end = graph.getVertex(feedId + ":8374");
         options.dateTime = TestUtils.dateInSeconds("America/Los_Angeles", 2009, 11, 1, 12, 34, 25);
         // must set routing context _after_ options is fully configured (time)
         options.setRoutingContext(graph, start, end);
@@ -56,7 +57,7 @@ public class TestBanning extends TestCase {
         for (int i = 0; i < maxLines.length; ++i) {
             String lineName = maxLines[i][0];
             String lineId = maxLines[i][1];
-            String routeSpecStr = "TriMet_" + (lineName != null ? lineName : "")
+            String routeSpecStr = feedId + "_" + (lineName != null ? lineName : "")
                     + (lineId != null ? "_" + lineId : "");
                 options.setBannedRoutes(routeSpecStr);
             spt = aStar.getShortestPathTree(options);
@@ -102,6 +103,7 @@ public class TestBanning extends TestCase {
     public void doTestBannedTrips(boolean partial, int seed) {
 
         Graph graph = ConstantsForTests.getInstance().getPortlandGraph();
+        String feedId = graph.getFeedIds().iterator().next();
         Random rand = new Random(seed);
 
         for (int i = 0; i < 20; i++) {
@@ -111,9 +113,9 @@ public class TestBanning extends TestCase {
             Vertex start = null;
             Vertex end = null;
             while (start == null)
-                start = graph.getVertex("TriMet:" + rand.nextInt(10000));
+                start = graph.getVertex(feedId + ":" + rand.nextInt(10000));
             while (end == null)
-                end = graph.getVertex("TriMet:" + rand.nextInt(10000));
+                end = graph.getVertex(feedId + ":" + rand.nextInt(10000));
             options.setRoutingContext(graph, start, end);
             ShortestPathTree spt = null;
             int n = rand.nextInt(5) + 3;

--- a/src/test/java/org/opentripplanner/routing/algorithm/TestFares.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/TestFares.java
@@ -44,14 +44,15 @@ public class TestFares extends TestCase {
         factory.run(gg);
         gg.putService(CalendarServiceData.class, GtfsLibrary.createCalendarServiceData(context.getDao()));
         RoutingRequest options = new RoutingRequest();
+        String feedId = gg.getFeedIds().iterator().next();
         long startTime = TestUtils.dateInSeconds("America/Los_Angeles", 2009, 8, 7, 12, 0, 0);
         options.dateTime = startTime;
-        options.setRoutingContext(gg, "Caltrain:Millbrae Caltrain", "Caltrain:Mountain View Caltrain");
+        options.setRoutingContext(gg, feedId + ":Millbrae Caltrain", feedId + ":Mountain View Caltrain");
         ShortestPathTree spt;
         GraphPath path = null;
         spt = aStar.getShortestPathTree(options);
 
-        path = spt.getPath(gg.getVertex("Caltrain:Mountain View Caltrain"), true);
+        path = spt.getPath(gg.getVertex(feedId + ":Mountain View Caltrain"), true);
 
         FareService fareService = gg.getService(FareService.class);
         
@@ -62,16 +63,17 @@ public class TestFares extends TestCase {
     public void testPortland() throws Exception {
 
         Graph gg = ConstantsForTests.getInstance().getPortlandGraph();
+        String feedId = gg.getFeedIds().iterator().next();
         RoutingRequest options = new RoutingRequest();
         ShortestPathTree spt;
         GraphPath path = null;
         long startTime = TestUtils.dateInSeconds("America/Los_Angeles", 2009, 11, 1, 12, 0, 0);
         options.dateTime = startTime;
-        options.setRoutingContext(gg, "TriMet:10579", "TriMet:8371");
+        options.setRoutingContext(gg, feedId + ":10579", feedId + ":8371");
         // from zone 3 to zone 2
         spt = aStar.getShortestPathTree(options);
 
-        path = spt.getPath(gg.getVertex("TriMet:8371"), true);
+        path = spt.getPath(gg.getVertex(feedId + ":8371"), true);
         assertNotNull(path);
 
         FareService fareService = gg.getService(FareService.class);
@@ -82,10 +84,10 @@ public class TestFares extends TestCase {
 
         startTime = TestUtils.dateInSeconds("America/Los_Angeles", 2009, 11, 1, 14, 0, 0);
         options.dateTime = startTime;
-        options.setRoutingContext(gg, "TriMet:8389", "TriMet:1252");
+        options.setRoutingContext(gg, feedId + ":8389", feedId + ":1252");
         spt = aStar.getShortestPathTree(options);
 
-        path = spt.getPath(gg.getVertex("TriMet:1252"), true);
+        path = spt.getPath(gg.getVertex(feedId + ":1252"), true);
         assertNotNull(path);
         cost = fareService.getCost(path);
         
@@ -95,10 +97,10 @@ public class TestFares extends TestCase {
         options.maxTransfers = 5;
         startTime = TestUtils.dateInSeconds("America/Los_Angeles", 2009, 11, 1, 14, 0, 0);
         options.dateTime = startTime;
-        options.setRoutingContext(gg, "TriMet:10428", "TriMet:4231");
+        options.setRoutingContext(gg, feedId + ":10428", feedId + ":4231");
         spt = aStar.getShortestPathTree(options);
 
-        path = spt.getPath(gg.getVertex("TriMet:4231"), true);
+        path = spt.getPath(gg.getVertex(feedId + ":4231"), true);
         assertNotNull(path);
         cost = fareService.getCost(path);
         //

--- a/src/test/java/org/opentripplanner/routing/algorithm/TestGraphPath.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/TestGraphPath.java
@@ -49,9 +49,11 @@ public class TestGraphPath extends TestCase {
 
     public void testGraphPathOptimize() throws Exception {
 
-        Vertex stop_a = graph.getVertex("agency:A");
-        Vertex stop_c = graph.getVertex("agency:C");
-        Vertex stop_e = graph.getVertex("agency:E");
+        String feedId = graph.getFeedIds().iterator().next();
+
+        Vertex stop_a = graph.getVertex(feedId + ":A");
+        Vertex stop_c = graph.getVertex(feedId + ":C");
+        Vertex stop_e = graph.getVertex(feedId + ":E");
 
         ShortestPathTree spt;
         GraphPath path;

--- a/src/test/java/org/opentripplanner/routing/core/RoutingContextTest.java
+++ b/src/test/java/org/opentripplanner/routing/core/RoutingContextTest.java
@@ -14,6 +14,7 @@
 package org.opentripplanner.routing.core;
 
 import org.junit.Test;
+import org.onebusaway.gtfs.model.Agency;
 import org.onebusaway.gtfs.model.calendar.ServiceDate;
 import org.onebusaway.gtfs.services.calendar.CalendarService;
 import org.opentripplanner.routing.graph.Graph;
@@ -31,14 +32,20 @@ public class RoutingContextTest {
     @Test
     public void testSetServiceDays() throws Exception {
 
+        String feedId = "FEED";
         String agencyId = "AGENCY";
+
+        Agency agency = new Agency();
+        agency.setId(agencyId);
+
         Graph graph = mock(Graph.class);
         RoutingRequest routingRequest = mock(RoutingRequest.class);
         CalendarService calendarService = mock(CalendarService.class);
 
         when(graph.getTimeZone()).thenReturn(TimeZone.getTimeZone("Europe/Budapest"));
         when(graph.getCalendarService()).thenReturn(calendarService);
-        when(graph.getAgencyIds()).thenReturn(Collections.<String>singletonList(agencyId));
+        when(graph.getFeedIds()).thenReturn(Collections.singletonList("FEED"));
+        when(graph.getAgencies(feedId)).thenReturn(Collections.singletonList(agency));
         when(calendarService.getTimeZoneForAgencyId(agencyId)).thenReturn(TimeZone.getTimeZone("Europe/Budapest"));
 
         when(routingRequest.getSecondsSinceEpoch())

--- a/src/test/java/org/opentripplanner/routing/core/TestOnBoardRouting.java
+++ b/src/test/java/org/opentripplanner/routing/core/TestOnBoardRouting.java
@@ -74,6 +74,7 @@ public class TestOnBoardRouting extends TestCase {
     @SuppressWarnings("deprecation")
     public void testOnBoardRouting() throws Exception {
 
+        String feedId = graph.getFeedIds().iterator().next();
         // Seed the random generator to make consistent set of tests
         Random rand = new Random(42);
 
@@ -87,8 +88,8 @@ public class TestOnBoardRouting extends TestCase {
             Vertex origin, destination;
             do {
                 /* See FAKE_GTFS for available locations */
-                origin = graph.getVertex("agency:" + (char) (65 + rand.nextInt(20)));
-                destination = graph.getVertex("agency:" + (char) (65 + rand.nextInt(20)));
+                origin = graph.getVertex(feedId + ":" + (char) (65 + rand.nextInt(20)));
+                destination = graph.getVertex(feedId + ":" + (char) (65 + rand.nextInt(20)));
             } while (origin.equals(destination));
 
             /* ...at a random date/time */

--- a/src/test/java/org/opentripplanner/routing/core/TestTransfers.java
+++ b/src/test/java/org/opentripplanner/routing/core/TestTransfers.java
@@ -64,6 +64,8 @@ import com.google.transit.realtime.GtfsRealtime.TripUpdate.StopTimeUpdate.Schedu
  * This is a singleton class to hold graph data between test runs, since loading it is slow.
  */
 class Context {
+    public String feedId;
+
     public Graph graph;
 
     public AStar aStar;
@@ -90,14 +92,15 @@ class Context {
         graph.putService(CalendarServiceData.class,
                 GtfsLibrary.createCalendarServiceData(context.getDao()));
 
+        feedId = context.getFeedId().getId();
         // Add simple transfer to make transfer possible between N-K and F-H
-        createSimpleTransfer("agency:K", "agency:F", 100);
+        createSimpleTransfer(feedId + ":K", feedId + ":F", 100);
 
         // Add simple transfer to make transfer possible between O-P and U-V
-        createSimpleTransfer("agency:P", "agency:U", 100);
+        createSimpleTransfer(feedId + ":P", feedId + ":U", 100);
 
         // Add simple transfer to make transfer possible between U-V and I-J
-        createSimpleTransfer("agency:V", "agency:I", 100);
+        createSimpleTransfer(feedId + ":V", feedId + ":I", 100);
 
         // Create dummy TimetableSnapshot
         TimetableSnapshot snapshot = new TimetableSnapshot();
@@ -131,10 +134,13 @@ public class TestTransfers extends TestCase {
 
     private AStar aStar;
 
+    private String feedId;
+
     public void setUp() throws Exception {
-        // Get graph and a star from singleton class
+        // Get graph, a star & feed id from singleton class
         graph = Context.getInstance().graph;
         aStar = Context.getInstance().aStar;
+        feedId = Context.getInstance().feedId;
     }
 
     /**
@@ -226,8 +232,8 @@ public class TestTransfers extends TestCase {
         when(graph.getTransferTable()).thenReturn(table);
 
         // Compute a normal path between two stops
-        Vertex origin = graph.getVertex("agency:N");
-        Vertex destination = graph.getVertex("agency:H");
+        Vertex origin = graph.getVertex(feedId + ":N");
+        Vertex destination = graph.getVertex(feedId + ":H");
 
         // Set options like time and routing context
         RoutingRequest options = new RoutingRequest();
@@ -245,9 +251,9 @@ public class TestTransfers extends TestCase {
 
         // Add transfer to table, transfer time was 27600 seconds
         Stop stopK = new Stop();
-        stopK.setId(new AgencyAndId("agency", "K"));
+        stopK.setId(new AgencyAndId(feedId, "K"));
         Stop stopF = new Stop();
-        stopF.setId(new AgencyAndId("agency", "F"));
+        stopF.setId(new AgencyAndId(feedId, "F"));
         table.addTransferTime(stopK, stopF, null, null, null, null, 27601);
 
         // Plan journey
@@ -267,8 +273,8 @@ public class TestTransfers extends TestCase {
         when(graph.getTransferTable()).thenReturn(table);
 
         // Compute a normal path between two stops
-        Vertex origin = graph.getVertex("agency:N");
-        Vertex destination = graph.getVertex("agency:H");
+        Vertex origin = graph.getVertex(feedId + ":N");
+        Vertex destination = graph.getVertex(feedId + ":H");
 
         // Set options like time and routing context
         RoutingRequest options = new RoutingRequest();
@@ -287,9 +293,9 @@ public class TestTransfers extends TestCase {
 
         // Add transfer to table, transfer time was 27600 seconds
         Stop stopK = new Stop();
-        stopK.setId(new AgencyAndId("agency", "K"));
+        stopK.setId(new AgencyAndId(feedId, "K"));
         Stop stopF = new Stop();
-        stopF.setId(new AgencyAndId("agency", "F"));
+        stopF.setId(new AgencyAndId(feedId, "F"));
         table.addTransferTime(stopK, stopF, null, null, null, null, 27601);
 
         // Plan journey
@@ -309,8 +315,8 @@ public class TestTransfers extends TestCase {
         when(graph.getTransferTable()).thenReturn(table);
 
         // Compute a normal path between two stops
-        Vertex origin = graph.getVertex("agency:O");
-        Vertex destination = graph.getVertex("agency:V");
+        Vertex origin = graph.getVertex(feedId + ":O");
+        Vertex destination = graph.getVertex(feedId + ":V");
 
         // Set options like time and routing context
         RoutingRequest options = new RoutingRequest();
@@ -337,9 +343,9 @@ public class TestTransfers extends TestCase {
         // Add transfer to table such that the next trip will be chosen
         // (there are 3600 seconds between trips), transfer time was 75 seconds
         Stop stopP = new Stop();
-        stopP.setId(new AgencyAndId("agency", "P"));
+        stopP.setId(new AgencyAndId(feedId, "P"));
         Stop stopU = new Stop();
-        stopU.setId(new AgencyAndId("agency", "U"));
+        stopU.setId(new AgencyAndId(feedId, "U"));
         table.addTransferTime(stopP, stopU, null, null, null, null, 3675);
 
         // Plan journey
@@ -369,8 +375,8 @@ public class TestTransfers extends TestCase {
         when(graph.getTransferTable()).thenReturn(table);
 
         // Compute a normal path between two stops
-        Vertex origin = graph.getVertex("agency:U");
-        Vertex destination = graph.getVertex("agency:J");
+        Vertex origin = graph.getVertex(feedId + ":U");
+        Vertex destination = graph.getVertex(feedId + ":J");
 
         // Set options like time and routing context
         RoutingRequest options = new RoutingRequest();
@@ -400,9 +406,9 @@ public class TestTransfers extends TestCase {
         // Add transfer to table such that the next trip will be chosen
         // (there are 3600 seconds between trips), transfer time was 75 seconds
         Stop stopV = new Stop();
-        stopV.setId(new AgencyAndId("agency", "V"));
+        stopV.setId(new AgencyAndId(feedId, "V"));
         Stop stopI = new Stop();
-        stopI.setId(new AgencyAndId("agency", "I"));
+        stopI.setId(new AgencyAndId(feedId, "I"));
         table.addTransferTime(stopV, stopI, null, null, null, null, 3675);
 
         // Plan journey
@@ -434,8 +440,8 @@ public class TestTransfers extends TestCase {
         when(graph.getTransferTable()).thenReturn(table);
 
         // Compute a normal path between two stops
-        Vertex origin = graph.getVertex("agency:N");
-        Vertex destination = graph.getVertex("agency:H");
+        Vertex origin = graph.getVertex(feedId + ":N");
+        Vertex destination = graph.getVertex(feedId + ":H");
 
         // Set options like time and routing context
         RoutingRequest options = new RoutingRequest();
@@ -453,9 +459,9 @@ public class TestTransfers extends TestCase {
 
         // Add forbidden transfer to table
         Stop stopK = new Stop();
-        stopK.setId(new AgencyAndId("agency", "K"));
+        stopK.setId(new AgencyAndId(feedId, "K"));
         Stop stopF = new Stop();
-        stopF.setId(new AgencyAndId("agency", "F"));
+        stopF.setId(new AgencyAndId(feedId, "F"));
         table.addTransferTime(stopK, stopF, null, null, null, null,
                 StopTransfer.FORBIDDEN_TRANSFER);
 
@@ -475,8 +481,8 @@ public class TestTransfers extends TestCase {
         when(graph.getTransferTable()).thenReturn(table);
 
         // Compute a normal path between two stops
-        Vertex origin = graph.getVertex("agency:U");
-        Vertex destination = graph.getVertex("agency:J");
+        Vertex origin = graph.getVertex(feedId + ":U");
+        Vertex destination = graph.getVertex(feedId + ":J");
 
         // Set options like time and routing context
         RoutingRequest options = new RoutingRequest();
@@ -495,9 +501,9 @@ public class TestTransfers extends TestCase {
 
         // Add forbidden transfer to table
         Stop stopV = new Stop();
-        stopV.setId(new AgencyAndId("agency", "V"));
+        stopV.setId(new AgencyAndId(feedId, "V"));
         Stop stopI = new Stop();
-        stopI.setId(new AgencyAndId("agency", "I"));
+        stopI.setId(new AgencyAndId(feedId, "I"));
         table.addTransferTime(stopV, stopI, null, null, null, null,
                 StopTransfer.FORBIDDEN_TRANSFER);
 
@@ -519,8 +525,8 @@ public class TestTransfers extends TestCase {
         when(graph.getTransferTable()).thenReturn(table);
 
         // Compute a normal path between two stops
-        Vertex origin = graph.getVertex("agency:N");
-        Vertex destination = graph.getVertex("agency:H");
+        Vertex origin = graph.getVertex(feedId + ":N");
+        Vertex destination = graph.getVertex(feedId + ":H");
 
         // Set options like time and routing context
         RoutingRequest options = new RoutingRequest();
@@ -538,13 +544,13 @@ public class TestTransfers extends TestCase {
 
         // Add timed transfer to table
         Stop stopK = new Stop();
-        stopK.setId(new AgencyAndId("agency", "K"));
+        stopK.setId(new AgencyAndId(feedId, "K"));
         Stop stopF = new Stop();
-        stopF.setId(new AgencyAndId("agency", "F"));
+        stopF.setId(new AgencyAndId(feedId, "F"));
         table.addTransferTime(stopK, stopF, null, null, null, null, StopTransfer.TIMED_TRANSFER);
         // Don't forget to also add a TimedTransferEdge
-        Vertex fromVertex = graph.getVertex("agency:K_arrive");
-        Vertex toVertex = graph.getVertex("agency:F_depart");
+        Vertex fromVertex = graph.getVertex(feedId + ":K_arrive");
+        Vertex toVertex = graph.getVertex(feedId + ":F_depart");
         TimedTransferEdge timedTransferEdge = new TimedTransferEdge(fromVertex, toVertex);
 
         // Plan journey

--- a/src/test/java/org/opentripplanner/routing/edgetype/TimetableSnapshotTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/TimetableSnapshotTest.java
@@ -85,7 +85,7 @@ public class TimetableSnapshotTest {
     private boolean updateResolver(TimetableSnapshot resolver, TripPattern pattern, TripUpdate tripUpdate, String feedId, ServiceDate serviceDate) {
         TripTimes updatedTripTimes = pattern.scheduledTimetable.createUpdatedTripTimes(tripUpdate,
                 timeZone, serviceDate);
-        return resolver.update(pattern, updatedTripTimes, serviceDate);
+        return resolver.update(feedId, pattern, updatedTripTimes, serviceDate);
     }
 
     @Test

--- a/src/test/java/org/opentripplanner/routing/edgetype/TimetableTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/TimetableTest.java
@@ -95,10 +95,12 @@ public class TimetableTest {
         StopTimeUpdate.Builder stopTimeUpdateBuilder;
         StopTimeEvent.Builder stopTimeEventBuilder;
 
+        String feedId = graph.getFeedIds().iterator().next();
+
         int trip_1_1_index = timetable.getTripIndex(new AgencyAndId("agency", "1.1"));
 
-        Vertex stop_a = graph.getVertex("agency:A");
-        Vertex stop_c = graph.getVertex("agency:C");
+        Vertex stop_a = graph.getVertex(feedId + ":A");
+        Vertex stop_c = graph.getVertex(feedId + ":C");
         RoutingRequest options = new RoutingRequest();
 
         ShortestPathTree spt;

--- a/src/test/java/org/opentripplanner/routing/edgetype/factory/GTFSPatternHopFactoryTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/factory/GTFSPatternHopFactoryTest.java
@@ -40,7 +40,7 @@ public class GTFSPatternHopFactoryTest {
         gtfs.putLines("frequencies.txt", "trip_id,start_time,end_time,headway_secs",
                 "t0,09:00:00,17:00:00,300");
 
-        GtfsFeedId feedId = new GtfsFeedId("FEED");
+        GtfsFeedId feedId = new GtfsFeedId.Builder().id("FEED").build();
         GTFSPatternHopFactory factory = new GTFSPatternHopFactory(GtfsLibrary.createContext(feedId, gtfs
                 .read()));
         Graph graph = new Graph();

--- a/src/test/java/org/opentripplanner/routing/edgetype/factory/GTFSPatternHopFactoryTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/factory/GTFSPatternHopFactoryTest.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 
 import org.junit.Test;
 import org.onebusaway.gtfs.services.MockGtfs;
+import org.opentripplanner.graph_builder.module.GtfsFeedId;
 import org.opentripplanner.gtfs.GtfsLibrary;
 import org.opentripplanner.routing.edgetype.TransitBoardAlight;
 import org.opentripplanner.routing.edgetype.TripPattern;
@@ -39,7 +40,8 @@ public class GTFSPatternHopFactoryTest {
         gtfs.putLines("frequencies.txt", "trip_id,start_time,end_time,headway_secs",
                 "t0,09:00:00,17:00:00,300");
 
-        GTFSPatternHopFactory factory = new GTFSPatternHopFactory(GtfsLibrary.createContext(gtfs
+        GtfsFeedId feedId = new GtfsFeedId("FEED");
+        GTFSPatternHopFactory factory = new GTFSPatternHopFactory(GtfsLibrary.createContext(feedId, gtfs
                 .read()));
         Graph graph = new Graph();
         factory.run(graph);

--- a/src/test/java/org/opentripplanner/routing/edgetype/loader/TestHopFactory.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/loader/TestHopFactory.java
@@ -43,18 +43,22 @@ public class TestHopFactory extends TestCase {
 
     private AStar aStar = new AStar();
 
+    private String feedId;
+
     public void setUp() throws Exception {
         GtfsContext context = GtfsLibrary.readGtfs(new File(ConstantsForTests.FAKE_GTFS));
         graph = new Graph();
         GTFSPatternHopFactory factory = new GTFSPatternHopFactory(context);
         factory.run(graph);
         graph.putService(CalendarServiceData.class, GtfsLibrary.createCalendarServiceData(context.getDao()));
+
+        feedId = context.getFeedId().getId();
     }
 
     public void testBoardAlight() throws Exception {
 
-        Vertex stop_a = graph.getVertex("agency:A_depart");
-        Vertex stop_b_depart = graph.getVertex("agency:B_depart");
+        Vertex stop_a = graph.getVertex(feedId + ":A_depart");
+        Vertex stop_b_depart = graph.getVertex(feedId + ":B_depart");
 
         assertEquals(1, stop_a.getDegreeOut());
         assertEquals(3, stop_b_depart.getDegreeOut());
@@ -81,8 +85,8 @@ public class TestHopFactory extends TestCase {
     }
 
     public void testDwell() throws Exception {
-        Vertex stop_a = graph.getVertex("agency:A_depart");
-        Vertex stop_c = graph.getVertex("agency:C_arrive");
+        Vertex stop_a = graph.getVertex(feedId + ":A_depart");
+        Vertex stop_c = graph.getVertex(feedId + ":C_arrive");
 
         RoutingRequest options = new RoutingRequest();
         options.dateTime = TestUtils.dateInSeconds("America/New_York", 2009, 8, 7, 8, 0, 0);
@@ -98,11 +102,11 @@ public class TestHopFactory extends TestCase {
 
     public void testRouting() throws Exception {
 
-        Vertex stop_a = graph.getVertex("agency:A");
-        Vertex stop_b = graph.getVertex("agency:B");
-        Vertex stop_c = graph.getVertex("agency:C");
-        Vertex stop_d = graph.getVertex("agency:D");
-        Vertex stop_e = graph.getVertex("agency:E");
+        Vertex stop_a = graph.getVertex(feedId + ":A");
+        Vertex stop_b = graph.getVertex(feedId + ":B");
+        Vertex stop_c = graph.getVertex(feedId + ":C");
+        Vertex stop_d = graph.getVertex(feedId + ":D");
+        Vertex stop_e = graph.getVertex(feedId + ":E");
 
         RoutingRequest options = new RoutingRequest();
         options.dateTime = TestUtils.dateInSeconds("America/New_York", 2009, 8, 7, 0, 0, 0); 

--- a/src/test/java/org/opentripplanner/routing/graph/GraphIndexTest.java
+++ b/src/test/java/org/opentripplanner/routing/graph/GraphIndexTest.java
@@ -41,10 +41,11 @@ public class GraphIndexTest extends GtfsTest {
         }
 
         /* Agencies */
+        String feedId = graph.getFeedIds().iterator().next();
         Agency agency;
-        agency = graph.index.agencyForId.get("azerty");
+        agency = graph.index.agenciesForFeedId.get(feedId).get("azerty");
         assertNull(agency);
-        agency = graph.index.agencyForId.get("agency");
+        agency = graph.index.agenciesForFeedId.get(feedId).get("agency");
         assertEquals(agency.getId(), "agency");
         assertEquals(agency.getName(), "Fake Agency");
 
@@ -78,9 +79,10 @@ public class GraphIndexTest extends GtfsTest {
     }
 
     public void testSpatialIndex() {
-        Stop stopJ = graph.index.stopForId.get(new AgencyAndId("agency", "J"));
-        Stop stopL = graph.index.stopForId.get(new AgencyAndId("agency", "L"));
-        Stop stopM = graph.index.stopForId.get(new AgencyAndId("agency", "M"));
+        String feedId = graph.getFeedIds().iterator().next();
+        Stop stopJ = graph.index.stopForId.get(new AgencyAndId(feedId, "J"));
+        Stop stopL = graph.index.stopForId.get(new AgencyAndId(feedId, "L"));
+        Stop stopM = graph.index.stopForId.get(new AgencyAndId(feedId, "M"));
         TransitStop stopvJ = graph.index.stopVertexForStop.get(stopJ);
         TransitStop stopvL = graph.index.stopVertexForStop.get(stopL);
         TransitStop stopvM = graph.index.stopVertexForStop.get(stopM);

--- a/src/test/java/org/opentripplanner/routing/impl/OnBoardDepartServiceImplTest.java
+++ b/src/test/java/org/opentripplanner/routing/impl/OnBoardDepartServiceImplTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.TimeZone;
 
@@ -125,6 +126,7 @@ public class OnBoardDepartServiceImplTest {
         TripTimes tripTimes = new TripTimes(trip, stopTimes, new Deduplicator());
         StopPattern stopPattern = new StopPattern(stopTimes);
         TripPattern tripPattern = new TripPattern(route, stopPattern);
+        TripPattern.generateUniqueIds(Arrays.asList(tripPattern));
 
         when(depart.getTripPattern()).thenReturn(tripPattern);
         when(dwell.getTripPattern()).thenReturn(tripPattern);
@@ -217,6 +219,7 @@ public class OnBoardDepartServiceImplTest {
         TripTimes tripTimes = new TripTimes(trip, stopTimes, new Deduplicator());
         StopPattern stopPattern = new StopPattern(stopTimes);
         TripPattern tripPattern = new TripPattern(route, stopPattern);
+        TripPattern.generateUniqueIds(Arrays.asList(tripPattern));
 
         when(depart.getTripPattern()).thenReturn(tripPattern);
 
@@ -292,6 +295,7 @@ public class OnBoardDepartServiceImplTest {
         TripTimes tripTimes = new TripTimes(trip, stopTimes, new Deduplicator());
         StopPattern stopPattern = new StopPattern(stopTimes);
         TripPattern tripPattern = new TripPattern(route, stopPattern);
+        TripPattern.generateUniqueIds(Arrays.asList(tripPattern));
 
         when(depart.getTripPattern()).thenReturn(tripPattern);
         when(dwell.getTripPattern()).thenReturn(tripPattern);

--- a/src/test/java/org/opentripplanner/updater/GtfsRealtimeFuzzyTripMatcherTest.java
+++ b/src/test/java/org/opentripplanner/updater/GtfsRealtimeFuzzyTripMatcherTest.java
@@ -6,13 +6,15 @@ import org.opentripplanner.GtfsTest;
 public class GtfsRealtimeFuzzyTripMatcherTest extends GtfsTest {
 
     public void testMatch() throws Exception {
+        String feedId = graph.getFeedIds().iterator().next();
+
         GtfsRealtimeFuzzyTripMatcher matcher = new GtfsRealtimeFuzzyTripMatcher(graph.index);
         TripDescriptor trip1 = TripDescriptor.newBuilder().setRouteId("1").setDirectionId(0).
                 setStartTime("06:47:00").setStartDate("20090915").build();
-        assertEquals("10W1020", matcher.match("TriMet", trip1).getTripId());
+        assertEquals("10W1020", matcher.match(feedId, trip1).getTripId());
         trip1 = TripDescriptor.newBuilder().setRouteId("4").setDirectionId(0).
                 setStartTime("00:02:00").setStartDate("20090915").build();
-        assertEquals("40W1890", matcher.match("TriMet", trip1).getTripId());
+        assertEquals("40W1890", matcher.match(feedId, trip1).getTripId());
         // Test matching with "real time", when schedule uses time grater than 24:00
         trip1 = TripDescriptor.newBuilder().setRouteId("4").setDirectionId(0).
                 setStartTime("12:00:00").setStartDate("20090915").build();

--- a/src/test/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSourceTest.java
+++ b/src/test/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSourceTest.java
@@ -444,7 +444,7 @@ public class TimetableSnapshotSourceTest {
         
         // New trip pattern 
         {
-            TripPattern newTripPattern = snapshot.getLastAddedTripPattern(modifiedTripId, serviceDate);
+            TripPattern newTripPattern = snapshot.getLastAddedTripPattern(feedId, modifiedTripId, serviceDate);
             assertNotNull("New trip pattern should be found", newTripPattern);
             
             Timetable newTimetableForToday = snapshot.resolve(newTripPattern, serviceDate);

--- a/src/test/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSourceTest.java
+++ b/src/test/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSourceTest.java
@@ -29,11 +29,10 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.onebusaway.gtfs.model.AgencyAndId;
-import org.onebusaway.gtfs.model.Stop;
-import org.onebusaway.gtfs.model.Trip;
+import org.onebusaway.gtfs.model.*;
 import org.onebusaway.gtfs.model.calendar.CalendarServiceData;
 import org.onebusaway.gtfs.model.calendar.ServiceDate;
+import org.onebusaway.gtfs.services.GtfsRelationalDao;
 import org.opentripplanner.ConstantsForTests;
 import org.opentripplanner.gtfs.GtfsContext;
 import org.opentripplanner.gtfs.GtfsLibrary;
@@ -53,6 +52,7 @@ import com.google.transit.realtime.GtfsRealtime.TripDescriptor;
 import com.google.transit.realtime.GtfsRealtime.TripUpdate;
 import com.google.transit.realtime.GtfsRealtime.TripUpdate.StopTimeEvent;
 import com.google.transit.realtime.GtfsRealtime.TripUpdate.StopTimeUpdate;
+import org.opentripplanner.updater.GtfsRealtimeFuzzyTripMatcher;
 
 public class TimetableSnapshotSourceTest {
 
@@ -61,12 +61,42 @@ public class TimetableSnapshotSourceTest {
     private static boolean fullDataset = false;
     private static GtfsContext context;
     private static ServiceDate serviceDate = new ServiceDate();
+    private static String feedId;
 
     private TimetableSnapshotSource updater;
 
     @BeforeClass
     public static void setUpClass() throws Exception {
         context = GtfsLibrary.readGtfs(new File(ConstantsForTests.FAKE_GTFS));
+
+        GtfsRelationalDao dao = context.getDao();
+
+        feedId = context.getFeedId().getId();
+
+        for (ShapePoint shapePoint : dao.getAllEntitiesForType(ShapePoint.class)) {
+            shapePoint.getShapeId().setAgencyId(feedId);
+        }
+        for (Route route : dao.getAllEntitiesForType(Route.class)) {
+            route.getId().setAgencyId(feedId);
+        }
+        for (Stop stop : dao.getAllEntitiesForType(Stop.class)) {
+            stop.getId().setAgencyId(feedId);
+        }
+        for (Trip trip : dao.getAllEntitiesForType(Trip.class)) {
+            trip.getId().setAgencyId(feedId);
+        }
+        for (ServiceCalendar serviceCalendar : dao.getAllEntitiesForType(ServiceCalendar.class)) {
+            serviceCalendar.getServiceId().setAgencyId(feedId);
+        }
+        for (ServiceCalendarDate serviceCalendarDate : dao.getAllEntitiesForType(ServiceCalendarDate.class)) {
+            serviceCalendarDate.getServiceId().setAgencyId(feedId);
+        }
+        for (FareAttribute fareAttribute : dao.getAllEntitiesForType(FareAttribute.class)) {
+            fareAttribute.getId().setAgencyId(feedId);
+        }
+        for (Pathway pathway : dao.getAllEntitiesForType(Pathway.class)) {
+            pathway.getId().setAgencyId(feedId);
+        }
 
         GTFSPatternHopFactory factory = new GTFSPatternHopFactory(context);
         factory.run(graph);
@@ -93,13 +123,13 @@ public class TimetableSnapshotSourceTest {
 
     @Test
     public void testGetSnapshot() throws InvalidProtocolBufferException {
-        updater.applyTripUpdates(graph, fullDataset, Arrays.asList(TripUpdate.parseFrom(cancellation)), "agency");
+        updater.applyTripUpdates(graph, fullDataset, Arrays.asList(TripUpdate.parseFrom(cancellation)), feedId);
 
         TimetableSnapshot snapshot = updater.getTimetableSnapshot();
         assertNotNull(snapshot);
         assertSame(snapshot, updater.getTimetableSnapshot());
 
-        updater.applyTripUpdates(graph, fullDataset, Arrays.asList(TripUpdate.parseFrom(cancellation)), "agency");
+        updater.applyTripUpdates(graph, fullDataset, Arrays.asList(TripUpdate.parseFrom(cancellation)), feedId);
         assertSame(snapshot, updater.getTimetableSnapshot());
 
         updater.maxSnapshotFrequency = (-1);
@@ -110,14 +140,14 @@ public class TimetableSnapshotSourceTest {
 
     @Test
     public void testHandleCanceledTrip() throws InvalidProtocolBufferException {
-        AgencyAndId tripId = new AgencyAndId("agency", "1.1");
-        AgencyAndId tripId2 = new AgencyAndId("agency", "1.2");
+        AgencyAndId tripId = new AgencyAndId(feedId, "1.1");
+        AgencyAndId tripId2 = new AgencyAndId(feedId, "1.2");
         Trip trip = graph.index.tripForId.get(tripId);
         TripPattern pattern = graph.index.patternForTrip.get(trip);
         int tripIndex = pattern.scheduledTimetable.getTripIndex(tripId);
         int tripIndex2 = pattern.scheduledTimetable.getTripIndex(tripId2);
 
-        updater.applyTripUpdates(graph, fullDataset, Arrays.asList(TripUpdate.parseFrom(cancellation)), "agency");
+        updater.applyTripUpdates(graph, fullDataset, Arrays.asList(TripUpdate.parseFrom(cancellation)), feedId);
 
         TimetableSnapshot snapshot = updater.getTimetableSnapshot();
         Timetable forToday = snapshot.resolve(pattern, serviceDate);
@@ -135,8 +165,8 @@ public class TimetableSnapshotSourceTest {
 
     @Test
     public void testHandleDelayedTrip() {
-        AgencyAndId tripId = new AgencyAndId("agency", "1.1");
-        AgencyAndId tripId2 = new AgencyAndId("agency", "1.2");
+        AgencyAndId tripId = new AgencyAndId(feedId, "1.1");
+        AgencyAndId tripId2 = new AgencyAndId(feedId, "1.2");
         Trip trip = graph.index.tripForId.get(tripId);
         TripPattern pattern = graph.index.patternForTrip.get(trip);
         int tripIndex = pattern.scheduledTimetable.getTripIndex(tripId);
@@ -166,7 +196,7 @@ public class TimetableSnapshotSourceTest {
 
         TripUpdate tripUpdate = tripUpdateBuilder.build();
 
-        updater.applyTripUpdates(graph, fullDataset, Arrays.asList(tripUpdate), "agency");
+        updater.applyTripUpdates(graph, fullDataset, Arrays.asList(tripUpdate), feedId);
 
         TimetableSnapshot snapshot = updater.getTimetableSnapshot();
         Timetable forToday = snapshot.resolve(pattern, serviceDate);
@@ -258,13 +288,13 @@ public class TimetableSnapshotSourceTest {
             
             tripUpdate = tripUpdateBuilder.build();
         }
-        
+
         // WHEN
-        updater.applyTripUpdates(graph, fullDataset, Arrays.asList(tripUpdate), "agency");
-        
+        updater.applyTripUpdates(graph, fullDataset, Arrays.asList(tripUpdate), feedId);
+
         // THEN
         // Find new pattern in graph starting from stop A
-        Stop stopA = graph.index.stopForId.get(new AgencyAndId("agency", "A"));
+        Stop stopA = graph.index.stopForId.get(new AgencyAndId(feedId, "A"));
         TransitStopDepart transitStopDepartA = graph.index.stopVertexForStop.get(stopA).departVertex;
         // Get trip pattern of last (most recently added) outgoing edge
         List<Edge> outgoingEdges = (List<Edge>) transitStopDepartA.getOutgoing();
@@ -283,16 +313,13 @@ public class TimetableSnapshotSourceTest {
     
     @Test
     public void testHandleModifiedTrip() throws ParseException {
-        // TODO
-        
         // GIVEN
         
         // Get service date of today because old dates will be purged after applying updates
         ServiceDate serviceDate = new ServiceDate(Calendar.getInstance());
         
         String modifiedTripId = "10.1";
-        String modifiedTripAgency = "agency";
-        
+
         TripUpdate tripUpdate;
         {
             TripDescriptor.Builder tripDescriptorBuilder = TripDescriptor.newBuilder();
@@ -386,16 +413,16 @@ public class TimetableSnapshotSourceTest {
             
             tripUpdate = tripUpdateBuilder.build();
         }
-        
+
         // WHEN
-        updater.applyTripUpdates(graph, fullDataset, Arrays.asList(tripUpdate), modifiedTripAgency);
+        updater.applyTripUpdates(graph, fullDataset, Arrays.asList(tripUpdate), feedId);
         
         // THEN
         TimetableSnapshot snapshot = updater.getTimetableSnapshot();
 
         // Original trip pattern 
         {
-            AgencyAndId tripId = new AgencyAndId(modifiedTripAgency, modifiedTripId);
+            AgencyAndId tripId = new AgencyAndId(feedId, modifiedTripId);
             Trip trip = graph.index.tripForId.get(tripId);
             TripPattern originalTripPattern = graph.index.patternForTrip.get(trip);
             
@@ -432,7 +459,7 @@ public class TimetableSnapshotSourceTest {
     
     @Test
     public void testPurgeExpiredData() throws InvalidProtocolBufferException {
-        AgencyAndId tripId = new AgencyAndId("agency", "1.1");
+        AgencyAndId tripId = new AgencyAndId(feedId, "1.1");
         ServiceDate previously = serviceDate.previous().previous(); // Just to be safe...
         Trip trip = graph.index.tripForId.get(tripId);
         TripPattern pattern = graph.index.patternForTrip.get(trip);
@@ -440,7 +467,7 @@ public class TimetableSnapshotSourceTest {
         updater.maxSnapshotFrequency = (0);
         updater.purgeExpiredData = (false);
 
-        updater.applyTripUpdates(graph, fullDataset, Arrays.asList(TripUpdate.parseFrom(cancellation)), "agency");
+        updater.applyTripUpdates(graph, fullDataset, Arrays.asList(TripUpdate.parseFrom(cancellation)), feedId);
         TimetableSnapshot snapshotA = updater.getTimetableSnapshot();
 
         updater.purgeExpiredData = (true);
@@ -457,7 +484,7 @@ public class TimetableSnapshotSourceTest {
 
         TripUpdate tripUpdate = tripUpdateBuilder.build();
 
-        updater.applyTripUpdates(graph, fullDataset, Arrays.asList(tripUpdate), "agency");
+        updater.applyTripUpdates(graph, fullDataset, Arrays.asList(tripUpdate), feedId);
         TimetableSnapshot snapshotB = updater.getTimetableSnapshot();
 
         assertNotSame(snapshotA, snapshotB);


### PR DESCRIPTION
This adds improved support for multiple GTFS feeds and multi agency feeds

There is currently an issue with the gtfs-rt updater for alerts with feeds that contains multiple agencies where we can't match stop id, route id or trip ids because lookups could not be done with the agency id within the entity selector.

There's currently an issue with the gtfs-rt stop time updater because it assumes stop id, route id and trip ids is unique within OTP, this is not always the case and in these situations the update would not be possible.

This PR resolves these issues by introducing a feed id as per @abyrd suggestion in #1990.

* Change to use a feed id instead of selecting a default agency id for feeds
* Change to re-index gtfs feeds using the feed id
* Change indexes that use agency id as key to group agencies with a feed id instead
* Change to use feedId instead of defaultAgency in gtfs-rt updaters, this makes entity selector for gtfs-rt alerts to work as expected
* Add support for multi agency feeds to the gtfs-rt updaters
* Change index api for agencies, these api now requires a feed id
* Add support for matching gtfs alert with a trip id