### PR TITLE
Decouple off-road dist param from grid size.

### DIFF
--- a/src/main/java/org/opentripplanner/analyst/request/IsoChroneRequest.java
+++ b/src/main/java/org/opentripplanner/analyst/request/IsoChroneRequest.java
@@ -31,6 +31,8 @@ public class IsoChroneRequest {
 
     public int precisionMeters = 200;
 
+    public int offRoadDistanceMeters = 150;
+
     public int maxTimeSec = 0;
 
     public Coordinate coordinateOrigin;

--- a/src/main/java/org/opentripplanner/analyst/request/IsoChroneSPTRendererAccSampling.java
+++ b/src/main/java/org/opentripplanner/analyst/request/IsoChroneSPTRendererAccSampling.java
@@ -50,12 +50,13 @@ public class IsoChroneSPTRendererAccSampling implements IsoChroneSPTRenderer {
     public List<IsochroneData> getIsochrones(IsoChroneRequest isoChroneRequest,
             RoutingRequest sptRequest) {
 
-        final double D0 = sampleGridRenderer.getOffRoadDistanceMeters(isoChroneRequest.precisionMeters);
+        final double offRoadDistanceMeters = isoChroneRequest.offRoadDistanceMeters;
 
         // 1. Create a sample grid from the SPT, using the TimeGridRenderer
         SampleGridRequest tgRequest = new SampleGridRequest();
         tgRequest.maxTimeSec = isoChroneRequest.maxTimeSec;
         tgRequest.precisionMeters = isoChroneRequest.precisionMeters;
+        tgRequest.offRoadDistanceMeters = isoChroneRequest.offRoadDistanceMeters;
         tgRequest.coordinateOrigin = isoChroneRequest.coordinateOrigin;
         ZSampleGrid<WTWD> sampleGrid = sampleGridRenderer.getSampleGrid(tgRequest, sptRequest);
 
@@ -101,7 +102,7 @@ public class IsoChroneSPTRendererAccSampling implements IsoChroneSPTRenderer {
             WTWD z0 = new WTWD();
             z0.w = 1.0;
             z0.wTime = cutoffSec;
-            z0.d = D0;
+            z0.d = offRoadDistanceMeters;
             IsochroneData isochrone = new IsochroneData(cutoffSec,
                     isolineBuilder.computeIsoline(z0));
             if (isoChroneRequest.includeDebugGeometry)

--- a/src/main/java/org/opentripplanner/analyst/request/SampleGridRenderer.java
+++ b/src/main/java/org/opentripplanner/analyst/request/SampleGridRenderer.java
@@ -15,9 +15,13 @@ package org.opentripplanner.analyst.request;
 
 import static org.apache.commons.math3.util.FastMath.toRadians;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.commons.math3.util.FastMath;
 import org.opentripplanner.common.geometry.AccumulativeGridSampler;
 import org.opentripplanner.common.geometry.AccumulativeGridSampler.AccumulativeMetric;
+import org.opentripplanner.common.geometry.ZSampleGrid.ZSamplePoint;
 import org.opentripplanner.common.geometry.IsolineBuilder;
 import org.opentripplanner.common.geometry.SparseMatrixZSampleGrid;
 import org.opentripplanner.common.geometry.SphericalDistanceLibrary;
@@ -68,12 +72,12 @@ public class SampleGridRenderer {
      */
     public ZSampleGrid<WTWD> getSampleGrid(SampleGridRequest spgRequest, RoutingRequest sptRequest) {
 
-        final double D0 = getOffRoadDistanceMeters(spgRequest.precisionMeters);
-        final double V0 = 1.00; // m/s, off-road walk speed
+        final double offRoadDistanceMeters = spgRequest.offRoadDistanceMeters;
+        final double offRoadWalkSpeedMps = 1.00; // m/s, off-road walk speed
 
         // 1. Compute the Shortest Path Tree.
         long t0 = System.currentTimeMillis();
-        long tOvershot = (long) (2 * D0 / V0);
+        long tOvershot = (long) (2 * offRoadDistanceMeters / offRoadWalkSpeedMps);
         sptRequest.worstTime = (sptRequest.dateTime + (sptRequest.arriveBy ? -spgRequest.maxTimeSec
                 - tOvershot : spgRequest.maxTimeSec + tOvershot));
         sptRequest.batch = (true);
@@ -94,7 +98,7 @@ public class SampleGridRenderer {
 
         SparseMatrixZSampleGrid<WTWD> sampleGrid = new SparseMatrixZSampleGrid<WTWD>(16,
                 spt.getVertexCount(), dX, dY, coordinateOrigin);
-        sampleSPT(spt, sampleGrid, gridSizeMeters * 0.7, gridSizeMeters, V0,
+        sampleSPT(spt, sampleGrid, gridSizeMeters, offRoadDistanceMeters, offRoadWalkSpeedMps,
                 sptRequest.getMaxWalkDistance(), spgRequest.maxTimeSec, cosLat);
         sptRequest.cleanup();
 
@@ -109,11 +113,15 @@ public class SampleGridRenderer {
      * Sample a SPT using a SPTWalker and an AccumulativeGridSampler.
      */
     public static void sampleSPT(final ShortestPathTree spt, ZSampleGrid<WTWD> sampleGrid,
-            final double d0, final double gridSizeMeters, final double offRoadSpeed,
+            final double gridSizeMeters, final double offRoadDistanceMeters, final double offRoadWalkSpeedMps,
             final double maxWalkDistance, final int maxTimeSec, final double cosLat) {
 
-        AccumulativeMetric<WTWD> accMetric = new WTWDAccumulativeMetric(cosLat, d0, offRoadSpeed, gridSizeMeters);
+        AccumulativeMetric<WTWD> accMetric = new WTWDAccumulativeMetric(cosLat, offRoadDistanceMeters, offRoadWalkSpeedMps, gridSizeMeters);
         final AccumulativeGridSampler<WTWD> gridSampler = new AccumulativeGridSampler<WTWD>(sampleGrid, accMetric);
+
+        // At which distance we split edges along the geometry during sampling.
+        // For best results, this should be slighly lower than the grid size.
+        double walkerSplitDistanceMeters = gridSizeMeters * 0.5;
 
         SPTWalker johnny = new SPTWalker(spt);
         johnny.walk(new SPTVisitor() {
@@ -144,19 +152,12 @@ public class SampleGridRenderer {
                             z.wBoardings = s1.getNumBoardings();
                             z.wWalkDist = s1.getWalkDistance() + d1;
                         }
-                        gridSampler.addSamplingPoint(c, z, offRoadSpeed);
+                        gridSampler.addSamplingPoint(c, z, offRoadWalkSpeedMps);
                     }
                 }
             }
-        }, d0);
+        }, walkerSplitDistanceMeters);
         gridSampler.close();
-    }
-
-    public double getOffRoadDistanceMeters(double precisionMeters) {
-        // Off-road max distance MUST be APPROX EQUALS to the grid precision
-        // TODO: Loosen this restriction (by adding more closing sample).
-        // Change the 0.8 magic factor here with caution.
-        return 0.8 * precisionMeters;
     }
 
     /**
@@ -232,15 +233,15 @@ public class SampleGridRenderer {
      */
     public static class WTWDAccumulativeMetric implements AccumulativeGridSampler.AccumulativeMetric<WTWD> {
 
-        private double cosLat, d0, offRoadSpeed, gridSizeMeters;
+        private double cosLat, offRoadDistanceMeters, offRoadSpeed, gridSizeMeters;
 
         /**
          * @param cosLat
          * @param d0 distance off road?
          */
-        public WTWDAccumulativeMetric (double cosLat, double d0, double offRoadSpeed, double gridSizeMeters) {
+        public WTWDAccumulativeMetric (double cosLat, double offRoadDistanceMeters, double offRoadSpeed, double gridSizeMeters) {
             this.cosLat = cosLat;
-            this.d0 = d0;
+            this.offRoadDistanceMeters = offRoadDistanceMeters;
             this.offRoadSpeed = offRoadSpeed;
             this.gridSizeMeters = gridSizeMeters;
         }
@@ -253,8 +254,12 @@ public class SampleGridRenderer {
             double d = SphericalDistanceLibrary.fastDistance(C0, Cs, cosLat);
             // additionnal time
             double dt = d / offRoadSpeed;
-            // t weight
-            double w = 1 / ((d + d0) * (d + d0));
+            /*
+             * Compute weight for time. The weight function to distance here is somehow arbitrary.
+             * It only purpose is to weight the samples when there is various samples within the
+             * same "cell", giving more weight to the closests samples to the cell center.
+             */
+            double w = 1 / ((d + gridSizeMeters) * (d + gridSizeMeters));
             if (zS == null) {
                 zS = new WTWD();
                 zS.d = Double.MAX_VALUE;
@@ -278,14 +283,21 @@ public class SampleGridRenderer {
          * based on the order where we close the samples.
          */
         @Override
-        public WTWD closeSample(WTWD zUp, WTWD zDown, WTWD zRight, WTWD zLeft){
+        public boolean closeSample(ZSamplePoint<WTWD> point){
             double dMin = Double.MAX_VALUE;
             double tMin = Double.MAX_VALUE;
             double bMin = Double.MAX_VALUE;
             double wdMin = Double.MAX_VALUE;
-            for (WTWD z : new WTWD[]{zUp, zDown, zRight, zLeft}) {
-                if (z == null)
-                    continue;
+            List<WTWD> zz = new ArrayList<>(4);
+            if (point.up() != null)
+                zz.add(point.up().getZ());
+            if (point.down() != null)
+                zz.add(point.down().getZ());
+            if (point.right() != null)
+                zz.add(point.right().getZ());
+            if (point.left() != null)
+                zz.add(point.left().getZ());
+            for (WTWD z : zz) {
                 if (z.d < dMin)
                     dMin = z.d;
                 double t = z.wTime / z.w;
@@ -308,7 +320,8 @@ public class SampleGridRenderer {
             z.wBoardings = bMin;
             z.wWalkDist = wdMin + gridSizeMeters;
             z.d = dMin + gridSizeMeters;
-            return z;
+            point.setZ(z);
+            return dMin > offRoadDistanceMeters;
         }
     }
 

--- a/src/main/java/org/opentripplanner/analyst/request/SampleGridRequest.java
+++ b/src/main/java/org/opentripplanner/analyst/request/SampleGridRequest.java
@@ -24,6 +24,8 @@ public class SampleGridRequest {
 
     public int precisionMeters = 200;
 
+    public int offRoadDistanceMeters = 150;
+
     public int maxTimeSec = 0;
 
     public Coordinate coordinateOrigin;

--- a/src/main/java/org/opentripplanner/api/resource/LIsochrone.java
+++ b/src/main/java/org/opentripplanner/api/resource/LIsochrone.java
@@ -84,6 +84,10 @@ public class LIsochrone extends RoutingResource {
     @DefaultValue("200")
     private Integer precisionMeters;
 
+    @QueryParam("offRoadDistanceMeters")
+    @DefaultValue("150")
+    private Integer offRoadDistanceMeters;
+
     @QueryParam("coordinateOrigin")
     private String coordinateOrigin = null;
 
@@ -170,10 +174,13 @@ public class LIsochrone extends RoutingResource {
             debug = false;
         if (precisionMeters < 10)
             throw new IllegalArgumentException("Too small precisionMeters: " + precisionMeters);
+        if (offRoadDistanceMeters < 10)
+            throw new IllegalArgumentException("Too small offRoadDistanceMeters: " + offRoadDistanceMeters);
 
         IsoChroneRequest isoChroneRequest = new IsoChroneRequest(cutoffSecList);
         isoChroneRequest.includeDebugGeometry = debug;
         isoChroneRequest.precisionMeters = precisionMeters;
+        isoChroneRequest.offRoadDistanceMeters = offRoadDistanceMeters;
         if (coordinateOrigin != null)
             isoChroneRequest.coordinateOrigin = new GenericLocation(null, coordinateOrigin)
                     .getCoordinate();

--- a/src/main/java/org/opentripplanner/api/resource/TimeGridWs.java
+++ b/src/main/java/org/opentripplanner/api/resource/TimeGridWs.java
@@ -70,6 +70,10 @@ public class TimeGridWs extends RoutingResource {
     @DefaultValue("200")
     private Integer precisionMeters;
 
+    @QueryParam("offRoadDistanceMeters")
+    @DefaultValue("150")
+    private Integer offRoadDistanceMeters;
+
     @QueryParam("coordinateOrigin")
     private String coordinateOrigin;
 
@@ -92,12 +96,15 @@ public class TimeGridWs extends RoutingResource {
 
         if (precisionMeters < 10)
             throw new IllegalArgumentException("Too small precisionMeters: " + precisionMeters);
+        if (offRoadDistanceMeters < 10)
+            throw new IllegalArgumentException("Too small offRoadDistanceMeters: " + offRoadDistanceMeters);
 
         // Build the request
         RoutingRequest sptRequest = buildRequest();
         SampleGridRequest tgRequest = new SampleGridRequest();
         tgRequest.maxTimeSec = maxTimeSec;
         tgRequest.precisionMeters = precisionMeters;
+        tgRequest.offRoadDistanceMeters = offRoadDistanceMeters;
         if (coordinateOrigin != null)
             tgRequest.coordinateOrigin = new GenericLocation(null, coordinateOrigin).getCoordinate();
 
@@ -129,9 +136,7 @@ public class TimeGridWs extends RoutingResource {
                 + sampleGrid.getXMin() * sampleGrid.getCellSize().x);
         String gridCellSzStr = String.format(Locale.US, "%.12f,%.12f", sampleGrid.getCellSize().y,
                 sampleGrid.getCellSize().x);
-
-        String offRoadDistStr = String.format(Locale.US, "%f",
-                router.sampleGridRenderer.getOffRoadDistanceMeters(precisionMeters));
+        String offRoadDistStr = String.format(Locale.US, "%d", offRoadDistanceMeters);
 
         PngChunkTEXT gridCornerChunk = new PngChunkTEXT(imgInfo);
         gridCornerChunk.setKeyVal(OTPA_GRID_CORNER, gridCornerStr);


### PR DESCRIPTION
Some changes made in #1440 were not merged back to master, but they can be useful. This modification is to decouple off-road distance to grid size in isochrone computation. We can now specify the two parameters independently. This has the side effect of making the "samples set closing" process more resilient (removing some "magic" constant).

Also replace "d0" by easier to read "offRoadDistanceMeters". Add a few comments.