### PR TITLE
Add option "--disableFileCache" for development.

### DIFF
--- a/src/main/java/org/opentripplanner/standalone/CommandLineParameters.java
+++ b/src/main/java/org/opentripplanner/standalone/CommandLineParameters.java
@@ -106,6 +106,9 @@ public class CommandLineParameters implements Cloneable {
             description = "Path to directory containing local client files to serve.")
     public File clientDirectory = null;
 
+    @Parameter(names = {"--disableFileCache"}, description = "Disable http server static file cache. Handy for development.")
+    public boolean disableFileCache = false;
+
     @Parameter(names = {"--router"}, validateWith = RouterId.class,
             description = "One or more router IDs to build and/or serve, first one being the default.")
     public List<String> routerIds;

--- a/src/main/java/org/opentripplanner/standalone/GrizzlyServer.java
+++ b/src/main/java/org/opentripplanner/standalone/GrizzlyServer.java
@@ -95,7 +95,11 @@ public class GrizzlyServer {
         httpServer.getServerConfiguration().addHttpHandler(dynamicHandler, "/otp/");
 
         /* 2. A static content handler to serve the client JS apps etc. from the classpath. */
-        HttpHandler staticHandler = new CLStaticHttpHandler(GrizzlyServer.class.getClassLoader(), "/client/");
+        CLStaticHttpHandler staticHandler = new CLStaticHttpHandler(GrizzlyServer.class.getClassLoader(), "/client/");
+        if (params.disableFileCache) {
+            LOG.info("Disabling HTTP server static file cache.");
+            staticHandler.setFileCacheEnabled(false);
+        }
         httpServer.getServerConfiguration().addHttpHandler(staticHandler, "/");
 
         /*


### PR DESCRIPTION
This is handy when developing static client files, without this option you need to restart OTP grizzly server to see the file modification in the client browser.