### PR TITLE
Fix LEG_SWITCH bug

### DIFF
--- a/src/main/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverter.java
+++ b/src/main/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverter.java
@@ -132,10 +132,6 @@ public abstract class GraphPathToTripPlanConverter {
      * @return The generated itinerary
      */
     public static Itinerary generateItinerary(GraphPath path, boolean showIntermediateStops, Locale requestedLocale) {
-        if (path.states.size() < 2) {
-            throw new TrivialPathException();
-        }
-
         Itinerary itinerary = new Itinerary();
 
         State[] states = new State[path.states.size()];
@@ -223,6 +219,21 @@ public abstract class GraphPathToTripPlanConverter {
      * @return An array of arrays of states belonging to a single leg (i.e. a two-dimensional array)
      */
     private static State[][] sliceStates(State[] states) {
+        boolean trivial = true;
+
+        for (State state : states) {
+            TraverseMode traverseMode = state.getBackMode();
+
+            if (traverseMode != null && traverseMode != TraverseMode.LEG_SWITCH) {
+                trivial = false;
+                break;
+            }
+        }
+
+        if (trivial) {
+            throw new TrivialPathException();
+        }
+
         int[] legIndexPairs = {0, states.length - 1};
         List<int[]> legsIndexes = new ArrayList<int[]>();
 

--- a/src/test/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverterTest.java
+++ b/src/test/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverterTest.java
@@ -74,6 +74,7 @@ import org.opentripplanner.routing.edgetype.StreetWithElevationEdge;
 import org.opentripplanner.routing.edgetype.TimetableSnapshot;
 import org.opentripplanner.routing.edgetype.TransitBoardAlight;
 import org.opentripplanner.routing.edgetype.TripPattern;
+import org.opentripplanner.routing.error.TrivialPathException;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.location.StreetLocation;
 import org.opentripplanner.routing.services.FareService;
@@ -151,6 +152,46 @@ public class GraphPathToTripPlanConverterTest {
 
         assertEquals(1, itinerary.legs.size());
         assertEquals("WALK", itinerary.legs.get(0).mode);
+    }
+
+    /**
+     * Test that empty graph paths throw a TrivialPathException
+     */
+    @Test(expected = TrivialPathException.class)
+    public void testEmptyGraphPath() {
+        RoutingRequest options = new RoutingRequest();
+        Graph graph = new Graph();
+        ExitVertex vertex = new ExitVertex(graph, "Vertex", 0, 0);
+
+        options.rctx = new RoutingContext(options, graph, vertex, vertex);
+
+        GraphPath graphPath = new GraphPath(new State(options), false);
+
+        GraphPathToTripPlanConverter.generateItinerary(graphPath, false, locale);
+    }
+
+    /**
+     * Test that graph paths with only null and LEG_SWITCH modes throw a TrivialPathException
+     */
+    @Test(expected = TrivialPathException.class)
+    public void testLegSwitchOnlyGraphPath() {
+        RoutingRequest options = new RoutingRequest();
+        Graph graph = new Graph();
+
+        ExitVertex start = new ExitVertex(graph, "Start", 0, -90);
+        ExitVertex middle = new ExitVertex(graph, "Middle", 0, 0);
+        ExitVertex end = new ExitVertex(graph, "End", 0, 90);
+
+        FreeEdge depart = new FreeEdge(start, middle);
+        LegSwitchingEdge arrive = new LegSwitchingEdge(middle, end);
+
+        options.rctx = new RoutingContext(options, graph, start, end);
+
+        State intermediate = depart.traverse(new State(options));
+
+        GraphPath graphPath = new GraphPath(arrive.traverse(intermediate), false);
+
+        GraphPathToTripPlanConverter.generateItinerary(graphPath, false, locale);
     }
 
     /**


### PR DESCRIPTION
I discovered that OTP sometimes returns itineraries consisting of a single leg having a mode of LEG_SWITCH. LEG_SWITCH is an internal construct that should never be shown to the outside world. Upon further investigation, it turned out that issue was being caused by trying to plan from a street location connected directly to a stop to that stop's parent station. This gives a path consisting only of edges with modes null and LEG_SWITCH. Because these results aren't useful anyway (no actual walking directions are returned), I propose that we just act as if this is a trivial trip.

Forward ported from a GoAbout branch. I couldn't run the full test suite because I don't have Java 8 installed, but the new tests themselves certainly pass.