### PR TITLE
Add real time state to trip times

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -552,6 +552,12 @@
             <artifactId>gtfs-lib</artifactId>
             <!-- TODO: we set above to not download snapshots from the Conveyal Maven repo -->
             <version>0.1-SNAPSHOT</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-simple</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- Processing is used for the debug GUI (though we could probably use just Java2D) -->
         <dependency>

--- a/src/main/java/org/opentripplanner/routing/trippattern/RealTimeState.java
+++ b/src/main/java/org/opentripplanner/routing/trippattern/RealTimeState.java
@@ -1,0 +1,34 @@
+package org.opentripplanner.routing.trippattern;
+
+/**
+ * The real-time state of a trip
+ */
+public enum RealTimeState {
+
+    /**
+     * The trip information comes from the GTFS feed, i.e. no real-time update has been applied.
+     */
+    SCHEDULED,
+
+    /**
+     * The trip information has been updated, but the trip pattern stayed the same as the trip
+     * pattern of the scheduled trip.
+     */
+    UDPATED,
+
+    /**
+     * The trip has been canceled by a real-time update.
+     */
+    CANCELED,
+
+    /**
+     * The trip has been added using a real-time update, i.e. the trip was not present in the GTFS feed.
+     */
+    ADDED,
+
+    /**
+     * The trip information has been updated and resulted in a different trip pattern compared to
+     * the trip pattern of the scheduled trip.
+     */
+    MODIFIED;
+}

--- a/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
@@ -23,9 +23,6 @@ import java.util.Set;
 import java.util.TimeZone;
 import java.util.concurrent.locks.ReentrantLock;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Maps;
-
 import org.onebusaway.gtfs.model.Agency;
 import org.onebusaway.gtfs.model.AgencyAndId;
 import org.onebusaway.gtfs.model.Route;
@@ -35,15 +32,18 @@ import org.onebusaway.gtfs.model.Trip;
 import org.onebusaway.gtfs.model.calendar.ServiceDate;
 import org.opentripplanner.model.StopPattern;
 import org.opentripplanner.routing.edgetype.Timetable;
-import org.opentripplanner.routing.edgetype.TripPattern;
 import org.opentripplanner.routing.edgetype.TimetableSnapshot;
+import org.opentripplanner.routing.edgetype.TripPattern;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.GraphIndex;
+import org.opentripplanner.routing.trippattern.RealTimeState;
 import org.opentripplanner.routing.trippattern.TripTimes;
 import org.opentripplanner.updater.GtfsRealtimeFuzzyTripMatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
 import com.google.transit.realtime.GtfsRealtime.TripDescriptor;
 import com.google.transit.realtime.GtfsRealtime.TripUpdate;
 import com.google.transit.realtime.GtfsRealtime.TripUpdate.StopTimeUpdate;
@@ -57,7 +57,7 @@ public class TimetableSnapshotSource {
     private static final Logger LOG = LoggerFactory.getLogger(TimetableSnapshotSource.class);
 
     /**
-     * Number of milliseconds per second 
+     * Number of milliseconds per second
      */
     private static final int MILLIS_PER_SECOND = 1000;
 
@@ -88,17 +88,17 @@ public class TimetableSnapshotSource {
      * only be modified by a thread that holds a lock on {@link #bufferLock}. All public methods that
      * might modify this buffer will correctly acquire the lock.
      */
-    private TimetableSnapshot buffer = new TimetableSnapshot();
-    
+    private final TimetableSnapshot buffer = new TimetableSnapshot();
+
     /**
      * Lock to indicate that buffer is in use
      */
     private final ReentrantLock bufferLock = new ReentrantLock(true);
-    
+
     /**
      * A synchronized cache of trip patterns that are added to the graph due to GTFS-realtime messages.
      */
-    private TripPatternCache tripPatternCache = new TripPatternCache();
+    private final TripPatternCache tripPatternCache = new TripPatternCache();
 
     /** Should expired realtime data be purged from the graph. */
     public boolean purgeExpiredData = true;
@@ -109,16 +109,16 @@ public class TimetableSnapshotSource {
 
     private final TimeZone timeZone;
 
-    private GraphIndex graphIndex;
-    
-    private Agency dummyAgency;
+    private final GraphIndex graphIndex;
+
+    private final Agency dummyAgency;
 
     public GtfsRealtimeFuzzyTripMatcher fuzzyTripMatcher;
 
-    public TimetableSnapshotSource(Graph graph) {
+    public TimetableSnapshotSource(final Graph graph) {
         timeZone = graph.getTimeZone();
         graphIndex = graph.index;
-        
+
         // Create dummy agency for added trips
         dummyAgency = new Agency();
         dummyAgency.setId("");
@@ -133,7 +133,7 @@ public class TimetableSnapshotSource {
      */
     public TimetableSnapshot getTimetableSnapshot() {
         TimetableSnapshot snapshotToReturn;
-        
+
         // Try to get a lock on the buffer
         if (bufferLock.tryLock()) {
             // Make a new snapshot if necessary
@@ -147,12 +147,12 @@ public class TimetableSnapshotSource {
             // are applied at this moment, just return the current snapshot
             snapshotToReturn = snapshot;
         }
-        
+
         return snapshotToReturn;
     }
 
-    private TimetableSnapshot getTimetableSnapshot(boolean force) {
-        long now = System.currentTimeMillis();
+    private TimetableSnapshot getTimetableSnapshot(final boolean force) {
+        final long now = System.currentTimeMillis();
         if (force || now - lastSnapshotTime > maxSnapshotFrequency) {
             if (force || buffer.isDirty()) {
                 LOG.debug("Committing {}", buffer.toString());
@@ -170,22 +170,22 @@ public class TimetableSnapshotSource {
     /**
      * Method to apply a trip update list to the most recent version of the timetable snapshot. A
      * GTFS-RT feed is always applied against a single static feed (indicated by feedId).
-     * 
+     *
      * However, multi-feed support is not completed and we currently assume there is only one static
      * feed when matching IDs.
-     * 
+     *
      * @param graph graph to update (needed for adding/changing stop patterns)
      * @param fullDataset true iff the list with updates represent all updates that are active right
      *        now, i.e. all previous updates should be disregarded
      * @param updates GTFS-RT TripUpdate's that should be applied atomically
      * @param feedId
      */
-    public void applyTripUpdates(Graph graph, boolean fullDataset, final List<TripUpdate> updates, final String feedId) {
+    public void applyTripUpdates(final Graph graph, final boolean fullDataset, final List<TripUpdate> updates, final String feedId) {
         if (updates == null) {
             LOG.warn("updates is null");
             return;
         }
-        
+
         // Acquire lock on buffer
         bufferLock.lock();
 
@@ -199,7 +199,7 @@ public class TimetableSnapshotSource {
             int uIndex = 0;
             for (TripUpdate tripUpdate : updates) {
                 if (fuzzyTripMatcher != null && tripUpdate.hasTrip()) {
-                    TripDescriptor trip = fuzzyTripMatcher.match(feedId, tripUpdate.getTrip());
+                    final TripDescriptor trip = fuzzyTripMatcher.match(feedId, tripUpdate.getTrip());
                     tripUpdate = tripUpdate.toBuilder().setTrip(trip).build();
                 }
 
@@ -209,12 +209,12 @@ public class TimetableSnapshotSource {
                 }
 
                 ServiceDate serviceDate = new ServiceDate();
-                TripDescriptor tripDescriptor = tripUpdate.getTrip();
+                final TripDescriptor tripDescriptor = tripUpdate.getTrip();
 
                 if (tripDescriptor.hasStartDate()) {
                     try {
                         serviceDate = ServiceDate.parseString(tripDescriptor.getStartDate());
-                    } catch (ParseException e) {
+                    } catch (final ParseException e) {
                         LOG.warn("Failed to parse start date in gtfs-rt trip update: \n{}", tripUpdate);
                         continue;
                     }
@@ -267,7 +267,7 @@ public class TimetableSnapshotSource {
             // Purge data if necessary (and force new snapshot if anything was purged)
             // Make sure that the public (locking) getTimetableSnapshot function is not called.
             if (purgeExpiredData) {
-                boolean modified = purgeExpiredData();
+                final boolean modified = purgeExpiredData();
                 getTimetableSnapshot(modified);
             } else {
                 getTimetableSnapshot(false);
@@ -280,26 +280,26 @@ public class TimetableSnapshotSource {
 
     /**
      * Determine how the trip update should be handled.
-     * 
+     *
      * @param tripUpdate trip update
      * @return TripDescriptor.ScheduleRelationship indicating how the trip update should be handled
      */
     private TripDescriptor.ScheduleRelationship determineTripScheduleRelationship(final TripUpdate tripUpdate) {
         // Assume default value
-        TripDescriptor.ScheduleRelationship tripScheduleRelationship = TripDescriptor.ScheduleRelationship.SCHEDULED; 
-        
+        TripDescriptor.ScheduleRelationship tripScheduleRelationship = TripDescriptor.ScheduleRelationship.SCHEDULED;
+
         // If trip update contains schedule relationship, use it
         if (tripUpdate.hasTrip() && tripUpdate.getTrip().hasScheduleRelationship()) {
             tripScheduleRelationship = tripUpdate.getTrip().getScheduleRelationship();
         }
-        
+
         if (tripScheduleRelationship.equals(TripDescriptor.ScheduleRelationship.SCHEDULED)) {
             // Loop over stops to check whether there are ADDED or SKIPPED stops
             boolean hasModifiedStops = false;
-            for (StopTimeUpdate stopTimeUpdate : tripUpdate.getStopTimeUpdateList()) {
+            for (final StopTimeUpdate stopTimeUpdate : tripUpdate.getStopTimeUpdateList()) {
                 // Check schedule relationship
                 if (stopTimeUpdate.hasScheduleRelationship()) {
-                    StopTimeUpdate.ScheduleRelationship stopScheduleRelationship = stopTimeUpdate
+                    final StopTimeUpdate.ScheduleRelationship stopScheduleRelationship = stopTimeUpdate
                             .getScheduleRelationship();
                     if (stopScheduleRelationship.equals(StopTimeUpdate.ScheduleRelationship.SKIPPED)
                             // TODO: uncomment next line when StopTimeUpdate.ScheduleRelationship.ADDED exists
@@ -309,21 +309,21 @@ public class TimetableSnapshotSource {
                     }
                 }
             }
-            
+
             // If stops are modified, handle trip update like a modified trip
             if (hasModifiedStops) {
                 tripScheduleRelationship = TripDescriptor.ScheduleRelationship.MODIFIED;
             }
         }
-        
+
         return tripScheduleRelationship;
     }
 
-    private boolean handleScheduledTrip(TripUpdate tripUpdate, String feedId, ServiceDate serviceDate) {
-        TripDescriptor tripDescriptor = tripUpdate.getTrip();
+    private boolean handleScheduledTrip(final TripUpdate tripUpdate, final String feedId, final ServiceDate serviceDate) {
+        final TripDescriptor tripDescriptor = tripUpdate.getTrip();
         // This does not include Agency ID or feed ID, trips are feed-unique and we currently assume a single static feed.
-        String tripId = tripDescriptor.getTripId();
-        TripPattern pattern = getPatternForTripId(tripId);
+        final String tripId = tripDescriptor.getTripId();
+        final TripPattern pattern = getPatternForTripId(tripId);
 
         if (pattern == null) {
             LOG.warn("No pattern found for tripId {}, skipping TripUpdate.", tripId);
@@ -336,21 +336,24 @@ public class TimetableSnapshotSource {
         }
 
         // Apply update on the *scheduled* time table and set the updated trip times in the buffer
-        TripTimes updatedTripTimes = pattern.scheduledTimetable.createUpdatedTripTimes(tripUpdate,
+        final TripTimes updatedTripTimes = pattern.scheduledTimetable.createUpdatedTripTimes(tripUpdate,
                 timeZone, serviceDate);
-        
+
         if (updatedTripTimes == null) {
             return false;
         }
-        
-        boolean success = buffer.update(pattern, updatedTripTimes, serviceDate); 
+
+        // Make sure that updated trip times have the correct real time state
+        updatedTripTimes.setRealTimeState(RealTimeState.UDPATED);
+
+        final boolean success = buffer.update(pattern, updatedTripTimes, serviceDate);
         return success;
     }
 
     /**
      * Validate and handle GTFS-RT TripUpdate message containing an ADDED trip.
-     * 
-     * @param graph graph to update 
+     *
+     * @param graph graph to update
      * @param tripUpdate GTFS-RT TripUpdate message
      * @param feedId
      * @param serviceDate
@@ -362,83 +365,83 @@ public class TimetableSnapshotSource {
         Preconditions.checkNotNull(graph);
         Preconditions.checkNotNull(tripUpdate);
         Preconditions.checkNotNull(serviceDate);
-        
+
         //
         // Validate added trip
         //
-        
+
         // Check whether trip id of ADDED trip is available
-        TripDescriptor tripDescriptor = tripUpdate.getTrip();
+        final TripDescriptor tripDescriptor = tripUpdate.getTrip();
         if (!tripDescriptor.hasTripId()) {
             LOG.warn("No trip id found for ADDED trip, skipping.");
             return false;
         }
-        
+
         // Check whether trip id already exists in graph
-        String tripId = tripDescriptor.getTripId();
-        Trip trip = getTripForTripId(tripId);
+        final String tripId = tripDescriptor.getTripId();
+        final Trip trip = getTripForTripId(tripId);
         if (trip != null) {
             // TODO: should we support this and add a new instantiation of this trip (making it
             // frequency based)?
             LOG.warn("Graph already contains trip id of ADDED trip, skipping.");
             return false;
         }
-        
+
         // Check whether a start date exists
         if (!tripDescriptor.hasStartDate()) {
             // TODO: should we support this and apply update to all days?
             LOG.warn("ADDED trip doesn't have a start date in TripDescriptor, skipping.");
             return false;
         }
-        
+
         // Check whether at least two stop updates exist
         if (tripUpdate.getStopTimeUpdateCount() < 2) {
             LOG.warn("ADDED trip has less then two stops, skipping.");
             return false;
         }
-        
+
         // Check whether all stop times are available and all stops exist
-        List<Stop> stops = checkNewStopTimeUpdatesAndFindStops(tripUpdate);
+        final List<Stop> stops = checkNewStopTimeUpdatesAndFindStops(tripUpdate);
         if (stops == null) {
             return false;
         }
-        
+
         //
         // Handle added trip
         //
-        
-        boolean success = handleAddedTrip(graph, tripUpdate, stops, feedId, serviceDate);
+
+        final boolean success = handleAddedTrip(graph, tripUpdate, stops, feedId, serviceDate);
         return success;
     }
 
     /**
      * Check stop time updates of trip update that results in a new trip (ADDED or MODIFIED) and
      * find all stops of that trip.
-     * 
+     *
      * @param tripUpdate trip update
      * @return stops when stop time updates are correct; null if there are errors
      */
     private List<Stop> checkNewStopTimeUpdatesAndFindStops(final TripUpdate tripUpdate) {
         Integer previousStopSequence = null;
         Long previousTime = null;
-        List<StopTimeUpdate> stopTimeUpdates = tripUpdate.getStopTimeUpdateList();
-        List<Stop> stops = new ArrayList<>(stopTimeUpdates.size()); 
+        final List<StopTimeUpdate> stopTimeUpdates = tripUpdate.getStopTimeUpdateList();
+        final List<Stop> stops = new ArrayList<>(stopTimeUpdates.size());
         for (int index = 0; index < stopTimeUpdates.size(); ++index) {
-            StopTimeUpdate stopTimeUpdate = stopTimeUpdates.get(index);
-            
+            final StopTimeUpdate stopTimeUpdate = stopTimeUpdates.get(index);
+
             // Determine whether stop is skipped
-            boolean skippedStop = isStopSkipped(stopTimeUpdate);
-            
+            final boolean skippedStop = isStopSkipped(stopTimeUpdate);
+
             // Check stop sequence
             if (stopTimeUpdate.hasStopSequence()) {
-                Integer stopSequence = stopTimeUpdate.getStopSequence();
-                
+                final Integer stopSequence = stopTimeUpdate.getStopSequence();
+
                 // Check non-negative
                 if (stopSequence < 0) {
                     LOG.warn("Trip update contains negative stop sequence, skipping.");
                     return null;
                 }
-                
+
                 // Check whether sequence is increasing
                 if (previousStopSequence != null && previousStopSequence > stopSequence) {
                     LOG.warn("Trip update contains decreasing stop sequence, skipping.");
@@ -448,11 +451,11 @@ public class TimetableSnapshotSource {
             } else {
                 // Allow missing stop sequences for ADDED and MODIFIED trips
             }
-            
+
             // Find stops
             if (stopTimeUpdate.hasStopId()) {
                 // Find stop
-                Stop stop = getStopForStopId(stopTimeUpdate.getStopId());
+                final Stop stop = getStopForStopId(stopTimeUpdate.getStopId());
                 if (stop != null) {
                     // Remember stop
                     stops.add(stop);
@@ -468,13 +471,13 @@ public class TimetableSnapshotSource {
                 LOG.warn("Trip update misses some stop ids, skipping.");
                 return null;
             }
-            
+
             // Only check arrival and departure times for non-skipped stops
             if (!skippedStop) {
                 // Check arrival time
                 if (stopTimeUpdate.hasArrival() && stopTimeUpdate.getArrival().hasTime()) {
                     // Check for increasing time
-                    Long time = stopTimeUpdate.getArrival().getTime();
+                    final Long time = stopTimeUpdate.getArrival().getTime();
                     if (previousTime != null && previousTime > time) {
                         LOG.warn("Trip update contains decreasing times, skipping.");
                         return null;
@@ -484,20 +487,20 @@ public class TimetableSnapshotSource {
                     // Only first non-skipped stop is allowed to miss arrival time
                     // TODO: should we support only requiring an arrival time on the last stop and interpolate?
                     for (int earlierIndex = 0; earlierIndex < index; earlierIndex++) {
-                        StopTimeUpdate earlierStopTimeUpdate = stopTimeUpdates.get(earlierIndex);
+                        final StopTimeUpdate earlierStopTimeUpdate = stopTimeUpdates.get(earlierIndex);
                         // Determine whether earlier stop is skipped
-                        boolean earlierSkippedStop = isStopSkipped(earlierStopTimeUpdate);
+                        final boolean earlierSkippedStop = isStopSkipped(earlierStopTimeUpdate);
                         if (!earlierSkippedStop) {
                             LOG.warn("Trip update misses arrival time, skipping.");
                             return null;
                         }
                     }
                 }
-                
+
                 // Check departure time
                 if (stopTimeUpdate.hasDeparture() && stopTimeUpdate.getDeparture().hasTime()) {
                     // Check for increasing time
-                    Long time = stopTimeUpdate.getDeparture().getTime();
+                    final Long time = stopTimeUpdate.getDeparture().getTime();
                     if (previousTime != null && previousTime > time) {
                         LOG.warn("Trip update contains decreasing times, skipping.");
                         return null;
@@ -505,11 +508,11 @@ public class TimetableSnapshotSource {
                     previousTime = time;
                 } else {
                     // Only last non-skipped stop is allowed to miss departure time
-                    // TODO: should we support only requiring a departure time on the first stop and interpolate? 
+                    // TODO: should we support only requiring a departure time on the first stop and interpolate?
                     for (int laterIndex = stopTimeUpdates.size() - 1; laterIndex > index; laterIndex--) {
-                        StopTimeUpdate laterStopTimeUpdate = stopTimeUpdates.get(laterIndex);
+                        final StopTimeUpdate laterStopTimeUpdate = stopTimeUpdates.get(laterIndex);
                         // Determine whether later stop is skipped
-                        boolean laterSkippedStop = isStopSkipped(laterStopTimeUpdate);
+                        final boolean laterSkippedStop = isStopSkipped(laterStopTimeUpdate);
                         if (!laterSkippedStop) {
                             LOG.warn("Trip update misses departure time, skipping.");
                             return null;
@@ -523,19 +526,19 @@ public class TimetableSnapshotSource {
 
     /**
      * Determine whether stop time update represents a SKIPPED stop.
-     * 
+     *
      * @param stopTimeUpdate stop time update
      * @return true iff stop is SKIPPED; false otherwise
      */
-    private boolean isStopSkipped(StopTimeUpdate stopTimeUpdate) {
-        boolean isSkipped = stopTimeUpdate.hasScheduleRelationship() &&
-                stopTimeUpdate.getScheduleRelationship().equals(StopTimeUpdate.ScheduleRelationship.SKIPPED); 
+    private boolean isStopSkipped(final StopTimeUpdate stopTimeUpdate) {
+        final boolean isSkipped = stopTimeUpdate.hasScheduleRelationship() &&
+                stopTimeUpdate.getScheduleRelationship().equals(StopTimeUpdate.ScheduleRelationship.SKIPPED);
         return isSkipped;
     }
 
     /**
      * Handle GTFS-RT TripUpdate message containing an ADDED trip.
-     * 
+     *
      * @param graph graph to update
      * @param tripUpdate GTFS-RT TripUpdate message
      * @param stops the stops of each StopTimeUpdate in the TripUpdate message
@@ -549,22 +552,22 @@ public class TimetableSnapshotSource {
         Preconditions.checkNotNull(stops);
         Preconditions.checkArgument(tripUpdate.getStopTimeUpdateCount() == stops.size(),
                 "number of stop should match the number of stop time updates");
-        
+
         // Check whether trip id has been used for previously ADDED trip message and cancel
         // previously created trip
-        String tripId = tripUpdate.getTrip().getTripId();
+        final String tripId = tripUpdate.getTrip().getTripId();
         cancelPreviouslyAddedTrip(tripId, serviceDate);
-        
+
         //
         // Create added trip
         //
-        
+
         Route route = null;
         if (tripUpdate.getTrip().hasRouteId()) {
             // Try to find route
             route = getRouteForRouteId(tripUpdate.getTrip().getRouteId());
         }
-        
+
         if (route == null) {
             // Create new Route
             route = new Route();
@@ -580,15 +583,15 @@ public class TimetableSnapshotSource {
             // Create route name
             route.setLongName(tripId);
         }
-        
+
         // Create new Trip
-        Trip trip = new Trip();
+        final Trip trip = new Trip();
         // TODO: which Agency ID to use? Currently use feed id.
         trip.setId(new AgencyAndId(feedId, tripUpdate.getTrip().getTripId()));
         trip.setRoute(route);
-        
+
         // Find service ID running on this service date
-        Set<AgencyAndId> serviceIds = graph.getCalendarService().getServiceIdsOnDate(serviceDate);
+        final Set<AgencyAndId> serviceIds = graph.getCalendarService().getServiceIdsOnDate(serviceDate);
         if (serviceIds.isEmpty()) {
             // No service id exists: return error for now
             LOG.warn("ADDED trip has service date for which no service id is available, skipping.");
@@ -597,50 +600,53 @@ public class TimetableSnapshotSource {
             // Just use first service id of set
             trip.setServiceId(serviceIds.iterator().next());
         }
-        
-        boolean success = addTripToGraphAndBuffer(graph, trip, tripUpdate, stops, serviceDate); 
+
+        final boolean success = addTripToGraphAndBuffer(graph, trip, tripUpdate, stops, serviceDate,
+                RealTimeState.ADDED);
         return success;
     }
 
     /**
      * Add a (new) trip to the graph and the buffer
+     *
      * @param graph graph
      * @param trip trip
      * @param tripUpdate trip update containing stop time updates
      * @param stops list of stops corresponding to stop time updates
      * @param serviceDate service date of trip
-     * 
+     * @param realTimeState real-time state of new trip
      * @return true iff successful
      */
-    private boolean addTripToGraphAndBuffer(final Graph graph, Trip trip,
-            final TripUpdate tripUpdate, final List<Stop> stops, final ServiceDate serviceDate) {
+    private boolean addTripToGraphAndBuffer(final Graph graph, final Trip trip,
+            final TripUpdate tripUpdate, final List<Stop> stops, final ServiceDate serviceDate,
+            final RealTimeState realTimeState) {
         // Preconditions
         Preconditions.checkNotNull(stops);
         Preconditions.checkArgument(tripUpdate.getStopTimeUpdateCount() == stops.size(),
                 "number of stop should match the number of stop time updates");
-        
-        // Calculate seconds since epoch on GTFS midnight (noon minus 12h) of service date 
-        Calendar serviceCalendar = serviceDate.getAsCalendar(timeZone);
+
+        // Calculate seconds since epoch on GTFS midnight (noon minus 12h) of service date
+        final Calendar serviceCalendar = serviceDate.getAsCalendar(timeZone);
         final long midnightSecondsSinceEpoch = serviceCalendar.getTimeInMillis() / MILLIS_PER_SECOND;
-        
+
         // Create StopTimes
-        List<StopTime> stopTimes = new ArrayList<>(tripUpdate.getStopTimeUpdateCount());
+        final List<StopTime> stopTimes = new ArrayList<>(tripUpdate.getStopTimeUpdateCount());
         for (int index = 0; index < tripUpdate.getStopTimeUpdateCount(); ++index) {
-            StopTimeUpdate stopTimeUpdate = tripUpdate.getStopTimeUpdate(index);
-            Stop stop = stops.get(index);
-            
+            final StopTimeUpdate stopTimeUpdate = tripUpdate.getStopTimeUpdate(index);
+            final Stop stop = stops.get(index);
+
             // Determine whether stop is skipped
-            boolean skippedStop = isStopSkipped(stopTimeUpdate);
-            
+            final boolean skippedStop = isStopSkipped(stopTimeUpdate);
+
             // Only create stop time for non-skipped stops
             if (!skippedStop) {
                 // Create stop time
-                StopTime stopTime = new StopTime();
+                final StopTime stopTime = new StopTime();
                 stopTime.setTrip(trip);
                 stopTime.setStop(stop);
                 // Set arrival time
                 if (stopTimeUpdate.hasArrival() && stopTimeUpdate.getArrival().hasTime()) {
-                    long arrivalTime = stopTimeUpdate.getArrival().getTime() - midnightSecondsSinceEpoch;
+                    final long arrivalTime = stopTimeUpdate.getArrival().getTime() - midnightSecondsSinceEpoch;
                     if (arrivalTime < 0 || arrivalTime > MAX_ARRIVAL_DEPARTURE_TIME) {
                         LOG.warn("ADDED trip has invalid arrival time (compared to start date in "
                                 + "TripDescriptor), skipping.");
@@ -650,7 +656,7 @@ public class TimetableSnapshotSource {
                 }
                 // Set departure time
                 if (stopTimeUpdate.hasDeparture() && stopTimeUpdate.getDeparture().hasTime()) {
-                    long departureTime = stopTimeUpdate.getDeparture().getTime() - midnightSecondsSinceEpoch;
+                    final long departureTime = stopTimeUpdate.getDeparture().getTime() - midnightSecondsSinceEpoch;
                     if (departureTime < 0 || departureTime > MAX_ARRIVAL_DEPARTURE_TIME) {
                         LOG.warn("ADDED trip has invalid departure time (compared to start date in "
                                 + "TripDescriptor), skipping.");
@@ -663,117 +669,120 @@ public class TimetableSnapshotSource {
                     stopTime.setStopSequence(stopTimeUpdate.getStopSequence());
                 }
                 // Set pickup type
-                // Set different pickup type for last stop 
+                // Set different pickup type for last stop
                 if (index == tripUpdate.getStopTimeUpdateCount() - 1) {
                     stopTime.setPickupType(1); // No pickup available
                 } else {
                     stopTime.setPickupType(0); // Regularly scheduled pickup
                 }
                 // Set drop off type
-                // Set different drop off type for first stop 
+                // Set different drop off type for first stop
                 if (index == 0) {
                     stopTime.setDropOffType(1); // No drop off available
                 } else {
                     stopTime.setDropOffType(0); // Regularly scheduled drop off
                 }
-                
+
                 // Add stop time to list
                 stopTimes.add(stopTime);
             }
         }
-        
+
         // TODO: filter/interpolate stop times like in GTFSPatternHopFactory?
-        
+
         // Create StopPattern
-        StopPattern stopPattern = new StopPattern(stopTimes);
+        final StopPattern stopPattern = new StopPattern(stopTimes);
 
         // Get cached trip pattern or create one if it doesn't exist yet
-        TripPattern pattern = tripPatternCache.getOrCreateTripPattern(stopPattern, trip.getRoute(), graph);
-        
+        final TripPattern pattern = tripPatternCache.getOrCreateTripPattern(stopPattern, trip.getRoute(), graph);
+
         // Add service code to bitset of pattern if needed (using copy on write)
-        int serviceCode = graph.serviceCodes.get(trip.getServiceId());
+        final int serviceCode = graph.serviceCodes.get(trip.getServiceId());
         if (!pattern.getServices().get(serviceCode)) {
-            BitSet services = (BitSet) pattern.getServices().clone();
+            final BitSet services = (BitSet) pattern.getServices().clone();
             services.set(serviceCode);
             pattern.setServices(services);
         }
-        
+
         // Create new trip times
-        TripTimes newTripTimes = new TripTimes(trip, stopTimes, graph.deduplicator);
-        
+        final TripTimes newTripTimes = new TripTimes(trip, stopTimes, graph.deduplicator);
+
         // Update all times to mark trip times as realtime
         // TODO: should we incorporate the delay field if present?
         for (int stopIndex = 0; stopIndex < newTripTimes.getNumStops(); stopIndex++) {
             newTripTimes.updateArrivalTime(stopIndex, newTripTimes.getScheduledArrivalTime(stopIndex));
             newTripTimes.updateDepartureTime(stopIndex, newTripTimes.getScheduledDepartureTime(stopIndex));
         }
-        
+
         // Set service code of new trip times
         newTripTimes.serviceCode = serviceCode;
-        
+
+        // Make sure that updated trip times have the correct real time state
+        newTripTimes.setRealTimeState(realTimeState);
+
         // Add new trip times to the buffer
-        boolean success = buffer.update(pattern, newTripTimes, serviceDate);
+        final boolean success = buffer.update(pattern, newTripTimes, serviceDate);
         return success;
     }
 
     /**
      * Cancel scheduled trip in buffer given trip id (without agency id) on service date
-     * 
+     *
      * @param tripId trip id without agency id
      * @param serviceDate service date
      * @return true if scheduled trip was cancelled
      */
-    private boolean cancelScheduledTrip(String tripId, final ServiceDate serviceDate) {
+    private boolean cancelScheduledTrip(final String tripId, final ServiceDate serviceDate) {
         boolean success = false;
-        
-        TripPattern pattern = getPatternForTripId(tripId);
+
+        final TripPattern pattern = getPatternForTripId(tripId);
         if (pattern != null) {
             // Cancel scheduled trip times for this trip in this pattern
-            Timetable timetable = pattern.scheduledTimetable;
-            int tripIndex = timetable.getTripIndex(tripId);
+            final Timetable timetable = pattern.scheduledTimetable;
+            final int tripIndex = timetable.getTripIndex(tripId);
             if (tripIndex == -1) {
                 LOG.warn("Could not cancel scheduled trip {}", tripId);
             } else {
-                TripTimes newTripTimes = new TripTimes(timetable.getTripTimes(tripIndex));
+                final TripTimes newTripTimes = new TripTimes(timetable.getTripTimes(tripIndex));
                 newTripTimes.cancel();
                 buffer.update(pattern, newTripTimes, serviceDate);
                 success = true;
             }
         }
-        
+
         return success;
     }
 
     /**
      * Cancel previously added trip from buffer if there is a previously added trip with given trip
      * id (without agency id) on service date
-     * 
+     *
      * @param tripId trip id without agency id
      * @param serviceDate service date
      * @return true if a previously added trip was cancelled
      */
-    private boolean cancelPreviouslyAddedTrip(String tripId, final ServiceDate serviceDate) {
+    private boolean cancelPreviouslyAddedTrip(final String tripId, final ServiceDate serviceDate) {
         boolean success = false;
-        
-        TripPattern pattern = buffer.getLastAddedTripPattern(tripId, serviceDate);
+
+        final TripPattern pattern = buffer.getLastAddedTripPattern(tripId, serviceDate);
         if (pattern != null) {
             // Cancel trip times for this trip in this pattern
-            Timetable timetable = buffer.resolve(pattern, serviceDate);
-            int tripIndex = timetable.getTripIndex(tripId);
+            final Timetable timetable = buffer.resolve(pattern, serviceDate);
+            final int tripIndex = timetable.getTripIndex(tripId);
             if (tripIndex == -1) {
                 LOG.warn("Could not cancel previously added trip {}", tripId);
             } else {
-                TripTimes newTripTimes = new TripTimes(timetable.getTripTimes(tripIndex));
+                final TripTimes newTripTimes = new TripTimes(timetable.getTripTimes(tripIndex));
                 newTripTimes.cancel();
                 buffer.update(pattern, newTripTimes, serviceDate);
                 success = true;
             }
         }
-        
+
         return success;
     }
-    
-    private boolean handleUnscheduledTrip(TripUpdate tripUpdate, String feedId, ServiceDate serviceDate) {
+
+    private boolean handleUnscheduledTrip(final TripUpdate tripUpdate, final String feedId, final ServiceDate serviceDate) {
         // TODO: Handle unscheduled trip
         LOG.warn("Unscheduled trips are currently unsupported. Skipping TripUpdate.");
         return false;
@@ -781,39 +790,39 @@ public class TimetableSnapshotSource {
 
     /**
      * Validate and handle GTFS-RT TripUpdate message containing a MODIFIED trip.
-     * 
-     * @param graph graph to update 
+     *
+     * @param graph graph to update
      * @param tripUpdate GTFS-RT TripUpdate message
      * @param feedId
      * @param serviceDate
      * @return true iff successful
      */
-    private boolean validateAndHandleModifiedTrip(Graph graph, TripUpdate tripUpdate, String feedId, ServiceDate serviceDate) {
+    private boolean validateAndHandleModifiedTrip(final Graph graph, final TripUpdate tripUpdate, final String feedId, final ServiceDate serviceDate) {
         // Preconditions
         Preconditions.checkNotNull(graph);
         Preconditions.checkNotNull(tripUpdate);
         Preconditions.checkNotNull(serviceDate);
-        
+
         //
         // Validate modified trip
         //
-        
+
         // Check whether trip id of MODIFIED trip is available
-        TripDescriptor tripDescriptor = tripUpdate.getTrip();
+        final TripDescriptor tripDescriptor = tripUpdate.getTrip();
         if (!tripDescriptor.hasTripId()) {
             LOG.warn("No trip id found for MODIFIED trip, skipping.");
             return false;
         }
-        
+
         // Check whether trip id already exists in graph
-        String tripId = tripDescriptor.getTripId();
-        Trip trip = getTripForTripId(tripId);
+        final String tripId = tripDescriptor.getTripId();
+        final Trip trip = getTripForTripId(tripId);
         if (trip == null) {
             // TODO: should we support this and consider it an ADDED trip?
             LOG.warn("Graph does not contain trip id of MODIFIED trip, skipping.");
             return false;
         }
-        
+
         // Check whether a start date exists
         if (!tripDescriptor.hasStartDate()) {
             // TODO: should we support this and apply update to all days?
@@ -821,38 +830,38 @@ public class TimetableSnapshotSource {
             return false;
         } else {
             // Check whether service date is served by trip
-            Set<AgencyAndId> serviceIds = graph.getCalendarService().getServiceIdsOnDate(serviceDate);
+            final Set<AgencyAndId> serviceIds = graph.getCalendarService().getServiceIdsOnDate(serviceDate);
             if (!serviceIds.contains(trip.getServiceId())) {
                 // TODO: should we support this and change service id of trip?
                 LOG.warn("MODIFIED trip has a service date that is not served by trip, skipping.");
                 return false;
             }
         }
-        
+
         // Check whether at least two stop updates exist
         if (tripUpdate.getStopTimeUpdateCount() < 2) {
             LOG.warn("MODIFIED trip has less then two stops, skipping.");
             return false;
         }
-        
+
         // Check whether all stop times are available and all stops exist
-        List<Stop> stops = checkNewStopTimeUpdatesAndFindStops(tripUpdate);
+        final List<Stop> stops = checkNewStopTimeUpdatesAndFindStops(tripUpdate);
         if (stops == null) {
             return false;
         }
-        
+
         //
         // Handle modified trip
         //
-        
-        boolean success = handleModifiedTrip(graph, trip, tripUpdate, stops, feedId, serviceDate);
-        
+
+        final boolean success = handleModifiedTrip(graph, trip, tripUpdate, stops, feedId, serviceDate);
+
         return success;
     }
 
     /**
      * Handle GTFS-RT TripUpdate message containing a MODIFIED trip.
-     * 
+     *
      * @param graph graph to update
      * @param trip trip that is modified
      * @param tripUpdate GTFS-RT TripUpdate message
@@ -861,36 +870,37 @@ public class TimetableSnapshotSource {
      * @param serviceDate service date for modified trip
      * @return true iff successful
      */
-    private boolean handleModifiedTrip(Graph graph, Trip trip, TripUpdate tripUpdate, List<Stop> stops,
-            String feedId, ServiceDate serviceDate) {
+    private boolean handleModifiedTrip(final Graph graph, final Trip trip, final TripUpdate tripUpdate, final List<Stop> stops,
+            final String feedId, final ServiceDate serviceDate) {
         // Preconditions
         Preconditions.checkNotNull(stops);
         Preconditions.checkArgument(tripUpdate.getStopTimeUpdateCount() == stops.size(),
                 "number of stop should match the number of stop time updates");
-        
+
         // Cancel scheduled trip
-        String tripId = tripUpdate.getTrip().getTripId();
+        final String tripId = tripUpdate.getTrip().getTripId();
         cancelScheduledTrip(tripId, serviceDate);
-        
+
         // Check whether trip id has been used for previously ADDED/MODIFIED trip message and cancel
         // previously created trip
         cancelPreviouslyAddedTrip(tripId, serviceDate);
-        
+
         // Add new trip
-        boolean success = addTripToGraphAndBuffer(graph, trip, tripUpdate, stops, serviceDate); 
+        final boolean success = addTripToGraphAndBuffer(graph, trip, tripUpdate, stops, serviceDate,
+                RealTimeState.MODIFIED);
         return success;
     }
 
-    private boolean handleCanceledTrip(TripUpdate tripUpdate, String feedId, ServiceDate serviceDate) {
+    private boolean handleCanceledTrip(final TripUpdate tripUpdate, final String feedId, final ServiceDate serviceDate) {
         boolean success = false;
         if (tripUpdate.getTrip().hasTripId()) {
             // Try to cancel scheduled trip
-            String tripId = tripUpdate.getTrip().getTripId();
-            boolean cancelScheduledSuccess = cancelScheduledTrip(tripId, serviceDate); 
-            
+            final String tripId = tripUpdate.getTrip().getTripId();
+            final boolean cancelScheduledSuccess = cancelScheduledTrip(tripId, serviceDate);
+
             // Try to cancel previously added trip
-            boolean cancelPreviouslyAddedSuccess = cancelPreviouslyAddedTrip(tripId, serviceDate);
-            
+            final boolean cancelPreviouslyAddedSuccess = cancelPreviouslyAddedTrip(tripId, serviceDate);
+
             if (cancelScheduledSuccess || cancelPreviouslyAddedSuccess) {
                 success = true;
             } else {
@@ -899,13 +909,13 @@ public class TimetableSnapshotSource {
         } else {
             LOG.warn("No trip id in CANCELED trip update, skipping TripUpdate.");
         }
-        
+
         return success;
     }
 
     private boolean purgeExpiredData() {
-        ServiceDate today = new ServiceDate();
-        ServiceDate previously = today.previous().previous(); // Just to be safe...
+        final ServiceDate today = new ServiceDate();
+        final ServiceDate previously = today.previous().previous(); // Just to be safe...
 
         if(lastPurgeDate != null && lastPurgeDate.compareTo(previously) > 0) {
             return false;
@@ -918,25 +928,25 @@ public class TimetableSnapshotSource {
         return buffer.purgeExpiredData(previously);
     }
 
-    private TripPattern getPatternForTripId(String tripIdWithoutAgency) {
-        Trip trip = getTripForTripId(tripIdWithoutAgency);
-        TripPattern pattern = graphIndex.patternForTrip.get(trip);
+    private TripPattern getPatternForTripId(final String tripIdWithoutAgency) {
+        final Trip trip = getTripForTripId(tripIdWithoutAgency);
+        final TripPattern pattern = graphIndex.patternForTrip.get(trip);
         return pattern;
     }
 
     /**
      * Retrieve route given a route id without an agency
-     * 
+     *
      * @param routeId route id without the agency
      * @return route or null if route can't be found in graph index
      */
-    private Route getRouteForRouteId(String routeId) {
+    private Route getRouteForRouteId(final String routeId) {
         /* Lazy-initialize a separate index that ignores agency IDs.
          * Stopgap measure assuming no cross-feed ID conflicts, until we get GTFS loader replaced. */
         if (graphIndex.routeForIdWithoutAgency == null) {
-            Map<String, Route> map = Maps.newHashMap();
-            for (Route route : graphIndex.routeForId.values()) {
-                Route previousValue = map.put(route.getId().getId(), route);
+            final Map<String, Route> map = Maps.newHashMap();
+            for (final Route route : graphIndex.routeForId.values()) {
+                final Route previousValue = map.put(route.getId().getId(), route);
                 if (previousValue != null) {
                     LOG.warn("Duplicate route id detected when agency is ignored for "
                             + "realtime updates: {}", route.getId().getId());
@@ -944,23 +954,23 @@ public class TimetableSnapshotSource {
             }
             graphIndex.routeForIdWithoutAgency = map;
         }
-        Route route = graphIndex.routeForIdWithoutAgency.get(routeId);
+        final Route route = graphIndex.routeForIdWithoutAgency.get(routeId);
         return route;
     }
-    
+
     /**
      * Retrieve trip given a trip id without an agency
-     * 
+     *
      * @param tripId trip id without the agency
      * @return trip or null if trip can't be found in graph index
      */
-    private Trip getTripForTripId(String tripId) {
+    private Trip getTripForTripId(final String tripId) {
         /* Lazy-initialize a separate index that ignores agency IDs.
          * Stopgap measure assuming no cross-feed ID conflicts, until we get GTFS loader replaced. */
         if (graphIndex.tripForIdWithoutAgency == null) {
-            Map<String, Trip> map = Maps.newHashMap();
-            for (Trip trip : graphIndex.tripForId.values()) {
-                Trip previousValue = map.put(trip.getId().getId(), trip);
+            final Map<String, Trip> map = Maps.newHashMap();
+            for (final Trip trip : graphIndex.tripForId.values()) {
+                final Trip previousValue = map.put(trip.getId().getId(), trip);
                 if (previousValue != null) {
                     LOG.warn("Duplicate trip id detected when agency is ignored for realtime"
                             + "updates: {}", trip.getId().getId());
@@ -968,31 +978,31 @@ public class TimetableSnapshotSource {
             }
             graphIndex.tripForIdWithoutAgency = map;
         }
-        Trip trip = graphIndex.tripForIdWithoutAgency.get(tripId);
+        final Trip trip = graphIndex.tripForIdWithoutAgency.get(tripId);
         return trip;
     }
 
     /**
      * Retrieve stop given a stop id without an agency
-     * 
+     *
      * @param stopId trip id without the agency
      * @return stop or null if stop doesn't exist
      */
-    private Stop getStopForStopId(String stopId) {
+    private Stop getStopForStopId(final String stopId) {
         /* Lazy-initialize a separate index that ignores agency IDs.
          * Stopgap measure assuming no cross-feed ID conflicts, until we get GTFS loader replaced. */
         if (graphIndex.stopForIdWithoutAgency == null) {
-            Map<String, Stop> map = Maps.newHashMap();
-            for (Stop stop : graphIndex.stopForId.values()) {
-                Stop previousValue = map.put(stop.getId().getId(), stop);
+            final Map<String, Stop> map = Maps.newHashMap();
+            for (final Stop stop : graphIndex.stopForId.values()) {
+                final Stop previousValue = map.put(stop.getId().getId(), stop);
                 if (previousValue != null) {
                     LOG.warn("Duplicate stop id detected when agency is ignored for realtime updates: {}", stopId);
                 }
             }
             graphIndex.stopForIdWithoutAgency = map;
         }
-        Stop stop = graphIndex.stopForIdWithoutAgency.get(stopId);
+        final Stop stop = graphIndex.stopForIdWithoutAgency.get(stopId);
         return stop;
     }
-    
+
 }

--- a/src/test/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSourceTest.java
+++ b/src/test/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSourceTest.java
@@ -37,14 +37,15 @@ import org.onebusaway.gtfs.model.calendar.ServiceDate;
 import org.opentripplanner.ConstantsForTests;
 import org.opentripplanner.gtfs.GtfsContext;
 import org.opentripplanner.gtfs.GtfsLibrary;
-import org.opentripplanner.routing.edgetype.TransitBoardAlight;
-import org.opentripplanner.routing.edgetype.TripPattern;
 import org.opentripplanner.routing.edgetype.Timetable;
 import org.opentripplanner.routing.edgetype.TimetableSnapshot;
+import org.opentripplanner.routing.edgetype.TransitBoardAlight;
+import org.opentripplanner.routing.edgetype.TripPattern;
 import org.opentripplanner.routing.edgetype.factory.GTFSPatternHopFactory;
 import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.impl.DefaultStreetVertexIndexFactory;
+import org.opentripplanner.routing.trippattern.RealTimeState;
 import org.opentripplanner.routing.trippattern.TripTimes;
 import org.opentripplanner.routing.vertextype.TransitStopDepart;
 
@@ -68,16 +69,16 @@ public class TimetableSnapshotSourceTest {
     public static void setUpClass() throws Exception {
         context = GtfsLibrary.readGtfs(new File(ConstantsForTests.FAKE_GTFS));
 
-        GTFSPatternHopFactory factory = new GTFSPatternHopFactory(context);
+        final GTFSPatternHopFactory factory = new GTFSPatternHopFactory(context);
         factory.run(graph);
         graph.index(new DefaultStreetVertexIndexFactory());
 
-        TripDescriptor.Builder tripDescriptorBuilder = TripDescriptor.newBuilder();
+        final TripDescriptor.Builder tripDescriptorBuilder = TripDescriptor.newBuilder();
 
         tripDescriptorBuilder.setTripId("1.1");
         tripDescriptorBuilder.setScheduleRelationship(TripDescriptor.ScheduleRelationship.CANCELED);
 
-        TripUpdate.Builder tripUpdateBuilder = TripUpdate.newBuilder();
+        final TripUpdate.Builder tripUpdateBuilder = TripUpdate.newBuilder();
 
         tripUpdateBuilder.setTrip(tripDescriptorBuilder);
 
@@ -95,7 +96,7 @@ public class TimetableSnapshotSourceTest {
     public void testGetSnapshot() throws InvalidProtocolBufferException {
         updater.applyTripUpdates(graph, fullDataset, Arrays.asList(TripUpdate.parseFrom(cancellation)), "agency");
 
-        TimetableSnapshot snapshot = updater.getTimetableSnapshot();
+        final TimetableSnapshot snapshot = updater.getTimetableSnapshot();
         assertNotNull(snapshot);
         assertSame(snapshot, updater.getTimetableSnapshot());
 
@@ -103,362 +104,378 @@ public class TimetableSnapshotSourceTest {
         assertSame(snapshot, updater.getTimetableSnapshot());
 
         updater.maxSnapshotFrequency = (-1);
-        TimetableSnapshot newSnapshot = updater.getTimetableSnapshot();
+        final TimetableSnapshot newSnapshot = updater.getTimetableSnapshot();
         assertNotNull(newSnapshot);
         assertNotSame(snapshot, newSnapshot);
     }
 
     @Test
     public void testHandleCanceledTrip() throws InvalidProtocolBufferException {
-        AgencyAndId tripId = new AgencyAndId("agency", "1.1");
-        AgencyAndId tripId2 = new AgencyAndId("agency", "1.2");
-        Trip trip = graph.index.tripForId.get(tripId);
-        TripPattern pattern = graph.index.patternForTrip.get(trip);
-        int tripIndex = pattern.scheduledTimetable.getTripIndex(tripId);
-        int tripIndex2 = pattern.scheduledTimetable.getTripIndex(tripId2);
+        final AgencyAndId tripId = new AgencyAndId("agency", "1.1");
+        final AgencyAndId tripId2 = new AgencyAndId("agency", "1.2");
+        final Trip trip = graph.index.tripForId.get(tripId);
+        final TripPattern pattern = graph.index.patternForTrip.get(trip);
+        final int tripIndex = pattern.scheduledTimetable.getTripIndex(tripId);
+        final int tripIndex2 = pattern.scheduledTimetable.getTripIndex(tripId2);
 
         updater.applyTripUpdates(graph, fullDataset, Arrays.asList(TripUpdate.parseFrom(cancellation)), "agency");
 
-        TimetableSnapshot snapshot = updater.getTimetableSnapshot();
-        Timetable forToday = snapshot.resolve(pattern, serviceDate);
-        Timetable schedule = snapshot.resolve(pattern, null);
+        final TimetableSnapshot snapshot = updater.getTimetableSnapshot();
+        final Timetable forToday = snapshot.resolve(pattern, serviceDate);
+        final Timetable schedule = snapshot.resolve(pattern, null);
         assertNotSame(forToday, schedule);
         assertNotSame(forToday.getTripTimes(tripIndex), schedule.getTripTimes(tripIndex));
         assertSame(forToday.getTripTimes(tripIndex2), schedule.getTripTimes(tripIndex2));
 
-        TripTimes tripTimes = forToday.getTripTimes(tripIndex);
+        final TripTimes tripTimes = forToday.getTripTimes(tripIndex);
         for (int i = 0; i < tripTimes.getNumStops(); i++) {
             assertEquals(TripTimes.UNAVAILABLE, tripTimes.getDepartureTime(i));
             assertEquals(TripTimes.UNAVAILABLE, tripTimes.getArrivalTime(i));
         }
+        assertEquals(RealTimeState.CANCELED, tripTimes.getRealTimeState());
     }
 
     @Test
     public void testHandleDelayedTrip() {
-        AgencyAndId tripId = new AgencyAndId("agency", "1.1");
-        AgencyAndId tripId2 = new AgencyAndId("agency", "1.2");
-        Trip trip = graph.index.tripForId.get(tripId);
-        TripPattern pattern = graph.index.patternForTrip.get(trip);
-        int tripIndex = pattern.scheduledTimetable.getTripIndex(tripId);
-        int tripIndex2 = pattern.scheduledTimetable.getTripIndex(tripId2);
+        final AgencyAndId tripId = new AgencyAndId("agency", "1.1");
+        final AgencyAndId tripId2 = new AgencyAndId("agency", "1.2");
+        final Trip trip = graph.index.tripForId.get(tripId);
+        final TripPattern pattern = graph.index.patternForTrip.get(trip);
+        final int tripIndex = pattern.scheduledTimetable.getTripIndex(tripId);
+        final int tripIndex2 = pattern.scheduledTimetable.getTripIndex(tripId2);
 
-        TripDescriptor.Builder tripDescriptorBuilder = TripDescriptor.newBuilder();
+        final TripDescriptor.Builder tripDescriptorBuilder = TripDescriptor.newBuilder();
 
         tripDescriptorBuilder.setTripId("1.1");
         tripDescriptorBuilder.setScheduleRelationship(
                TripDescriptor.ScheduleRelationship.SCHEDULED);
 
-        TripUpdate.Builder tripUpdateBuilder = TripUpdate.newBuilder();
+        final TripUpdate.Builder tripUpdateBuilder = TripUpdate.newBuilder();
 
         tripUpdateBuilder.setTrip(tripDescriptorBuilder);
 
-        StopTimeUpdate.Builder stopTimeUpdateBuilder = tripUpdateBuilder.addStopTimeUpdateBuilder();
+        final StopTimeUpdate.Builder stopTimeUpdateBuilder = tripUpdateBuilder.addStopTimeUpdateBuilder();
 
         stopTimeUpdateBuilder.setScheduleRelationship(
                 StopTimeUpdate.ScheduleRelationship.SCHEDULED);
         stopTimeUpdateBuilder.setStopSequence(2);
 
-        StopTimeEvent.Builder arrivalBuilder = stopTimeUpdateBuilder.getArrivalBuilder();
-        StopTimeEvent.Builder departureBuilder = stopTimeUpdateBuilder.getDepartureBuilder();
+        final StopTimeEvent.Builder arrivalBuilder = stopTimeUpdateBuilder.getArrivalBuilder();
+        final StopTimeEvent.Builder departureBuilder = stopTimeUpdateBuilder.getDepartureBuilder();
 
         arrivalBuilder.setDelay(1);
         departureBuilder.setDelay(1);
 
-        TripUpdate tripUpdate = tripUpdateBuilder.build();
+        final TripUpdate tripUpdate = tripUpdateBuilder.build();
 
         updater.applyTripUpdates(graph, fullDataset, Arrays.asList(tripUpdate), "agency");
 
-        TimetableSnapshot snapshot = updater.getTimetableSnapshot();
-        Timetable forToday = snapshot.resolve(pattern, serviceDate);
-        Timetable schedule = snapshot.resolve(pattern, null);
+        final TimetableSnapshot snapshot = updater.getTimetableSnapshot();
+        final Timetable forToday = snapshot.resolve(pattern, serviceDate);
+        final Timetable schedule = snapshot.resolve(pattern, null);
         assertNotSame(forToday, schedule);
         assertNotSame(forToday.getTripTimes(tripIndex), schedule.getTripTimes(tripIndex));
         assertSame(forToday.getTripTimes(tripIndex2), schedule.getTripTimes(tripIndex2));
         assertEquals(1, forToday.getTripTimes(tripIndex).getArrivalDelay(1));
         assertEquals(1, forToday.getTripTimes(tripIndex).getDepartureDelay(1));
+
+        assertEquals(RealTimeState.SCHEDULED, schedule.getTripTimes(tripIndex).getRealTimeState());
+        assertEquals(RealTimeState.UDPATED, forToday.getTripTimes(tripIndex).getRealTimeState());
+
+        assertEquals(RealTimeState.SCHEDULED, schedule.getTripTimes(tripIndex2).getRealTimeState());
+        assertEquals(RealTimeState.SCHEDULED, forToday.getTripTimes(tripIndex2).getRealTimeState());
     }
 
     @Test
     public void testHandleAddedTrip() throws ParseException {
         // GIVEN
-        
+
         // Get service date of today because old dates will be purged after applying updates
-        ServiceDate serviceDate = new ServiceDate(Calendar.getInstance());
-        
-        String addedTripId = "added_trip";
-        
+        final ServiceDate serviceDate = new ServiceDate(Calendar.getInstance());
+
+        final String addedTripId = "added_trip";
+
         TripUpdate tripUpdate;
         {
-            TripDescriptor.Builder tripDescriptorBuilder = TripDescriptor.newBuilder();
-            
+            final TripDescriptor.Builder tripDescriptorBuilder = TripDescriptor.newBuilder();
+
             tripDescriptorBuilder.setTripId(addedTripId);
             tripDescriptorBuilder.setScheduleRelationship(TripDescriptor.ScheduleRelationship.ADDED);
             tripDescriptorBuilder.setStartDate(serviceDate.getAsString());
-            
-            Calendar calendar = serviceDate.getAsCalendar(graph.getTimeZone());
-            long midnightSecondsSinceEpoch = calendar.getTimeInMillis() / 1000;
-            
-            TripUpdate.Builder tripUpdateBuilder = TripUpdate.newBuilder();
-            
+
+            final Calendar calendar = serviceDate.getAsCalendar(graph.getTimeZone());
+            final long midnightSecondsSinceEpoch = calendar.getTimeInMillis() / 1000;
+
+            final TripUpdate.Builder tripUpdateBuilder = TripUpdate.newBuilder();
+
             tripUpdateBuilder.setTrip(tripDescriptorBuilder);
-            
+
             { // Stop A
-                StopTimeUpdate.Builder stopTimeUpdateBuilder = tripUpdateBuilder.addStopTimeUpdateBuilder();
+                final StopTimeUpdate.Builder stopTimeUpdateBuilder = tripUpdateBuilder.addStopTimeUpdateBuilder();
                 stopTimeUpdateBuilder.setScheduleRelationship(StopTimeUpdate.ScheduleRelationship.SCHEDULED);
                 stopTimeUpdateBuilder.setStopId("A");
-                
+
                 { // Arrival
-                    StopTimeEvent.Builder arrivalBuilder = stopTimeUpdateBuilder.getArrivalBuilder();
+                    final StopTimeEvent.Builder arrivalBuilder = stopTimeUpdateBuilder.getArrivalBuilder();
                     arrivalBuilder.setTime(midnightSecondsSinceEpoch + (8 * 3600) + (30 * 60));
                     arrivalBuilder.setDelay(0);
                 }
-                
+
                 { // Departure
-                    StopTimeEvent.Builder departureBuilder = stopTimeUpdateBuilder.getDepartureBuilder();
+                    final StopTimeEvent.Builder departureBuilder = stopTimeUpdateBuilder.getDepartureBuilder();
                     departureBuilder.setTime(midnightSecondsSinceEpoch + (8 * 3600) + (30 * 60));
                     departureBuilder.setDelay(0);
                 }
             }
-            
+
             { // Stop C
-                StopTimeUpdate.Builder stopTimeUpdateBuilder = tripUpdateBuilder.addStopTimeUpdateBuilder();
+                final StopTimeUpdate.Builder stopTimeUpdateBuilder = tripUpdateBuilder.addStopTimeUpdateBuilder();
                 stopTimeUpdateBuilder.setScheduleRelationship(StopTimeUpdate.ScheduleRelationship.SCHEDULED);
                 stopTimeUpdateBuilder.setStopId("C");
-                
+
                 { // Arrival
-                    StopTimeEvent.Builder arrivalBuilder = stopTimeUpdateBuilder.getArrivalBuilder();
+                    final StopTimeEvent.Builder arrivalBuilder = stopTimeUpdateBuilder.getArrivalBuilder();
                     arrivalBuilder.setTime(midnightSecondsSinceEpoch + (8 * 3600) + (40 * 60));
                     arrivalBuilder.setDelay(0);
                 }
-                
+
                 { // Departure
-                    StopTimeEvent.Builder departureBuilder = stopTimeUpdateBuilder.getDepartureBuilder();
+                    final StopTimeEvent.Builder departureBuilder = stopTimeUpdateBuilder.getDepartureBuilder();
                     departureBuilder.setTime(midnightSecondsSinceEpoch + (8 * 3600) + (45 * 60));
                     departureBuilder.setDelay(0);
                 }
             }
-            
+
             { // Stop E
-                StopTimeUpdate.Builder stopTimeUpdateBuilder = tripUpdateBuilder.addStopTimeUpdateBuilder();
+                final StopTimeUpdate.Builder stopTimeUpdateBuilder = tripUpdateBuilder.addStopTimeUpdateBuilder();
                 stopTimeUpdateBuilder.setScheduleRelationship(StopTimeUpdate.ScheduleRelationship.SCHEDULED);
                 stopTimeUpdateBuilder.setStopId("E");
-                
+
                 { // Arrival
-                    StopTimeEvent.Builder arrivalBuilder = stopTimeUpdateBuilder.getArrivalBuilder();
+                    final StopTimeEvent.Builder arrivalBuilder = stopTimeUpdateBuilder.getArrivalBuilder();
                     arrivalBuilder.setTime(midnightSecondsSinceEpoch + (8 * 3600) + (55 * 60));
                     arrivalBuilder.setDelay(0);
                 }
-                
+
                 { // Departure
-                    StopTimeEvent.Builder departureBuilder = stopTimeUpdateBuilder.getDepartureBuilder();
+                    final StopTimeEvent.Builder departureBuilder = stopTimeUpdateBuilder.getDepartureBuilder();
                     departureBuilder.setTime(midnightSecondsSinceEpoch + (8 * 3600) + (55 * 60));
                     departureBuilder.setDelay(0);
                 }
             }
-            
+
             tripUpdate = tripUpdateBuilder.build();
         }
-        
+
         // WHEN
         updater.applyTripUpdates(graph, fullDataset, Arrays.asList(tripUpdate), "agency");
-        
+
         // THEN
         // Find new pattern in graph starting from stop A
-        Stop stopA = graph.index.stopForId.get(new AgencyAndId("agency", "A"));
-        TransitStopDepart transitStopDepartA = graph.index.stopVertexForStop.get(stopA).departVertex;
+        final Stop stopA = graph.index.stopForId.get(new AgencyAndId("agency", "A"));
+        final TransitStopDepart transitStopDepartA = graph.index.stopVertexForStop.get(stopA).departVertex;
         // Get trip pattern of last (most recently added) outgoing edge
-        List<Edge> outgoingEdges = (List<Edge>) transitStopDepartA.getOutgoing();
-        TripPattern tripPattern = ((TransitBoardAlight) outgoingEdges.get(outgoingEdges.size() - 1)).getPattern();
+        final List<Edge> outgoingEdges = (List<Edge>) transitStopDepartA.getOutgoing();
+        final TripPattern tripPattern = ((TransitBoardAlight) outgoingEdges.get(outgoingEdges.size() - 1)).getPattern();
         assertNotNull("Added trip pattern should be found", tripPattern);
-        
-        TimetableSnapshot snapshot = updater.getTimetableSnapshot();
-        Timetable forToday = snapshot.resolve(tripPattern, serviceDate);
-        Timetable schedule = snapshot.resolve(tripPattern, null);
-        
+
+        final TimetableSnapshot snapshot = updater.getTimetableSnapshot();
+        final Timetable forToday = snapshot.resolve(tripPattern, serviceDate);
+        final Timetable schedule = snapshot.resolve(tripPattern, null);
+
         assertNotSame(forToday, schedule);
-        
-        assertTrue("Added trip should be found in time table for service date", forToday.getTripIndex(addedTripId) > -1);
-        assertEquals("Added trip should not be found in scheduled time table", -1, schedule.getTripIndex(addedTripId));
+
+        final int forTodayAddedTripIndex = forToday.getTripIndex(addedTripId);
+        assertTrue("Added trip should be found in time table for service date", forTodayAddedTripIndex > -1);
+        assertEquals(RealTimeState.ADDED, forToday.getTripTimes(forTodayAddedTripIndex).getRealTimeState());
+
+        final int scheduleTripIndex = schedule.getTripIndex(addedTripId);
+        assertEquals("Added trip should not be found in scheduled time table", -1, scheduleTripIndex);
     }
-    
+
     @Test
     public void testHandleModifiedTrip() throws ParseException {
         // TODO
-        
+
         // GIVEN
-        
+
         // Get service date of today because old dates will be purged after applying updates
-        ServiceDate serviceDate = new ServiceDate(Calendar.getInstance());
-        
-        String modifiedTripId = "10.1";
-        String modifiedTripAgency = "agency";
-        
+        final ServiceDate serviceDate = new ServiceDate(Calendar.getInstance());
+
+        final String modifiedTripId = "10.1";
+        final String modifiedTripAgency = "agency";
+
         TripUpdate tripUpdate;
         {
-            TripDescriptor.Builder tripDescriptorBuilder = TripDescriptor.newBuilder();
-            
+            final TripDescriptor.Builder tripDescriptorBuilder = TripDescriptor.newBuilder();
+
             tripDescriptorBuilder.setTripId(modifiedTripId);
             tripDescriptorBuilder.setScheduleRelationship(TripDescriptor.ScheduleRelationship.MODIFIED);
             tripDescriptorBuilder.setStartDate(serviceDate.getAsString());
-            
-            Calendar calendar = serviceDate.getAsCalendar(graph.getTimeZone());
-            long midnightSecondsSinceEpoch = calendar.getTimeInMillis() / 1000;
-            
-            TripUpdate.Builder tripUpdateBuilder = TripUpdate.newBuilder();
-            
+
+            final Calendar calendar = serviceDate.getAsCalendar(graph.getTimeZone());
+            final long midnightSecondsSinceEpoch = calendar.getTimeInMillis() / 1000;
+
+            final TripUpdate.Builder tripUpdateBuilder = TripUpdate.newBuilder();
+
             tripUpdateBuilder.setTrip(tripDescriptorBuilder);
-            
+
             { // Stop O
-                StopTimeUpdate.Builder stopTimeUpdateBuilder = tripUpdateBuilder.addStopTimeUpdateBuilder();
+                final StopTimeUpdate.Builder stopTimeUpdateBuilder = tripUpdateBuilder.addStopTimeUpdateBuilder();
                 stopTimeUpdateBuilder.setScheduleRelationship(StopTimeUpdate.ScheduleRelationship.SCHEDULED);
                 stopTimeUpdateBuilder.setStopId("O");
                 stopTimeUpdateBuilder.setStopSequence(10);
-                
+
                 { // Arrival
-                    StopTimeEvent.Builder arrivalBuilder = stopTimeUpdateBuilder.getArrivalBuilder();
+                    final StopTimeEvent.Builder arrivalBuilder = stopTimeUpdateBuilder.getArrivalBuilder();
                     arrivalBuilder.setTime(midnightSecondsSinceEpoch + (12 * 3600) + (30 * 60));
                     arrivalBuilder.setDelay(0);
                 }
-                
+
                 { // Departure
-                    StopTimeEvent.Builder departureBuilder = stopTimeUpdateBuilder.getDepartureBuilder();
+                    final StopTimeEvent.Builder departureBuilder = stopTimeUpdateBuilder.getDepartureBuilder();
                     departureBuilder.setTime(midnightSecondsSinceEpoch + (12 * 3600) + (30 * 60));
                     departureBuilder.setDelay(0);
                 }
             }
-            
+
             { // Stop C
-                StopTimeUpdate.Builder stopTimeUpdateBuilder = tripUpdateBuilder.addStopTimeUpdateBuilder();
+                final StopTimeUpdate.Builder stopTimeUpdateBuilder = tripUpdateBuilder.addStopTimeUpdateBuilder();
                 stopTimeUpdateBuilder.setScheduleRelationship(StopTimeUpdate.ScheduleRelationship.SCHEDULED);
                 stopTimeUpdateBuilder.setStopId("C");
                 stopTimeUpdateBuilder.setStopSequence(30);
-                
+
                 { // Arrival
-                    StopTimeEvent.Builder arrivalBuilder = stopTimeUpdateBuilder.getArrivalBuilder();
+                    final StopTimeEvent.Builder arrivalBuilder = stopTimeUpdateBuilder.getArrivalBuilder();
                     arrivalBuilder.setTime(midnightSecondsSinceEpoch + (12 * 3600) + (40 * 60));
                     arrivalBuilder.setDelay(0);
                 }
-                
+
                 { // Departure
-                    StopTimeEvent.Builder departureBuilder = stopTimeUpdateBuilder.getDepartureBuilder();
+                    final StopTimeEvent.Builder departureBuilder = stopTimeUpdateBuilder.getDepartureBuilder();
                     departureBuilder.setTime(midnightSecondsSinceEpoch + (12 * 3600) + (45 * 60));
                     departureBuilder.setDelay(0);
                 }
             }
-            
+
             { // Stop D
-                StopTimeUpdate.Builder stopTimeUpdateBuilder = tripUpdateBuilder.addStopTimeUpdateBuilder();
+                final StopTimeUpdate.Builder stopTimeUpdateBuilder = tripUpdateBuilder.addStopTimeUpdateBuilder();
                 stopTimeUpdateBuilder.setScheduleRelationship(StopTimeUpdate.ScheduleRelationship.SKIPPED);
                 stopTimeUpdateBuilder.setStopId("D");
                 stopTimeUpdateBuilder.setStopSequence(40);
-                
+
                 { // Arrival
-                    StopTimeEvent.Builder arrivalBuilder = stopTimeUpdateBuilder.getArrivalBuilder();
+                    final StopTimeEvent.Builder arrivalBuilder = stopTimeUpdateBuilder.getArrivalBuilder();
                     arrivalBuilder.setTime(midnightSecondsSinceEpoch + (12 * 3600) + (50 * 60));
                     arrivalBuilder.setDelay(0);
                 }
-                
+
                 { // Departure
-                    StopTimeEvent.Builder departureBuilder = stopTimeUpdateBuilder.getDepartureBuilder();
+                    final StopTimeEvent.Builder departureBuilder = stopTimeUpdateBuilder.getDepartureBuilder();
                     departureBuilder.setTime(midnightSecondsSinceEpoch + (12 * 3600) + (51 * 60));
                     departureBuilder.setDelay(0);
                 }
             }
-            
+
             { // Stop P
-                StopTimeUpdate.Builder stopTimeUpdateBuilder = tripUpdateBuilder.addStopTimeUpdateBuilder();
+                final StopTimeUpdate.Builder stopTimeUpdateBuilder = tripUpdateBuilder.addStopTimeUpdateBuilder();
                 stopTimeUpdateBuilder.setScheduleRelationship(StopTimeUpdate.ScheduleRelationship.SCHEDULED);
                 stopTimeUpdateBuilder.setStopId("P");
                 stopTimeUpdateBuilder.setStopSequence(50);
-                
+
                 { // Arrival
-                    StopTimeEvent.Builder arrivalBuilder = stopTimeUpdateBuilder.getArrivalBuilder();
+                    final StopTimeEvent.Builder arrivalBuilder = stopTimeUpdateBuilder.getArrivalBuilder();
                     arrivalBuilder.setTime(midnightSecondsSinceEpoch + (12 * 3600) + (55 * 60));
                     arrivalBuilder.setDelay(0);
                 }
-                
+
                 { // Departure
-                    StopTimeEvent.Builder departureBuilder = stopTimeUpdateBuilder.getDepartureBuilder();
+                    final StopTimeEvent.Builder departureBuilder = stopTimeUpdateBuilder.getDepartureBuilder();
                     departureBuilder.setTime(midnightSecondsSinceEpoch + (12 * 3600) + (55 * 60));
                     departureBuilder.setDelay(0);
                 }
             }
-            
+
             tripUpdate = tripUpdateBuilder.build();
         }
-        
+
         // WHEN
         updater.applyTripUpdates(graph, fullDataset, Arrays.asList(tripUpdate), modifiedTripAgency);
-        
+
         // THEN
-        TimetableSnapshot snapshot = updater.getTimetableSnapshot();
+        final TimetableSnapshot snapshot = updater.getTimetableSnapshot();
 
-        // Original trip pattern 
+        // Original trip pattern
         {
-            AgencyAndId tripId = new AgencyAndId(modifiedTripAgency, modifiedTripId);
-            Trip trip = graph.index.tripForId.get(tripId);
-            TripPattern originalTripPattern = graph.index.patternForTrip.get(trip);
-            
-            Timetable originalTimetableForToday = snapshot.resolve(originalTripPattern, serviceDate);
-            Timetable originalTimetableScheduled = snapshot.resolve(originalTripPattern, null);
-            
+            final AgencyAndId tripId = new AgencyAndId(modifiedTripAgency, modifiedTripId);
+            final Trip trip = graph.index.tripForId.get(tripId);
+            final TripPattern originalTripPattern = graph.index.patternForTrip.get(trip);
+
+            final Timetable originalTimetableForToday = snapshot.resolve(originalTripPattern, serviceDate);
+            final Timetable originalTimetableScheduled = snapshot.resolve(originalTripPattern, null);
+
             assertNotSame(originalTimetableForToday, originalTimetableScheduled);
-            
-            int originalTripIndexScheduled = originalTimetableScheduled.getTripIndex(modifiedTripId);
-            assertTrue("Original trip should be found in scheduled time table", originalTripIndexScheduled > -1);
-            TripTimes originalTripTimesScheduled = originalTimetableScheduled.getTripTimes(originalTripIndexScheduled);
-            assertFalse("Original trip times should not be canceled in scheduled time table", originalTripTimesScheduled.isCanceled());
 
-            int originalTripIndexForToday = originalTimetableForToday.getTripIndex(modifiedTripId);
+            final int originalTripIndexScheduled = originalTimetableScheduled.getTripIndex(modifiedTripId);
+            assertTrue("Original trip should be found in scheduled time table", originalTripIndexScheduled > -1);
+            final TripTimes originalTripTimesScheduled = originalTimetableScheduled.getTripTimes(originalTripIndexScheduled);
+            assertFalse("Original trip times should not be canceled in scheduled time table", originalTripTimesScheduled.isCanceled());
+            assertEquals(RealTimeState.SCHEDULED, originalTripTimesScheduled.getRealTimeState());
+
+            final int originalTripIndexForToday = originalTimetableForToday.getTripIndex(modifiedTripId);
             assertTrue("Original trip should be found in time table for service date", originalTripIndexForToday > -1);
-            TripTimes originalTripTimesForToday = originalTimetableForToday.getTripTimes(originalTripIndexForToday);
+            final TripTimes originalTripTimesForToday = originalTimetableForToday.getTripTimes(originalTripIndexForToday);
             assertTrue("Original trip times should be canceled in time table for service date", originalTripTimesForToday.isCanceled());
+            assertEquals(RealTimeState.CANCELED, originalTripTimesForToday.getRealTimeState());
         }
-        
-        // New trip pattern 
+
+        // New trip pattern
         {
-            TripPattern newTripPattern = snapshot.getLastAddedTripPattern(modifiedTripId, serviceDate);
+            final TripPattern newTripPattern = snapshot.getLastAddedTripPattern(modifiedTripId, serviceDate);
             assertNotNull("New trip pattern should be found", newTripPattern);
-            
-            Timetable newTimetableForToday = snapshot.resolve(newTripPattern, serviceDate);
-            Timetable newTimetableScheduled = snapshot.resolve(newTripPattern, null);
-            
+
+            final Timetable newTimetableForToday = snapshot.resolve(newTripPattern, serviceDate);
+            final Timetable newTimetableScheduled = snapshot.resolve(newTripPattern, null);
+
             assertNotSame(newTimetableForToday, newTimetableScheduled);
-            
-            assertTrue("New trip should be found in time table for service date", newTimetableForToday.getTripIndex(modifiedTripId) > -1);
+
+            final int newTimetableForTodayModifiedTripIndex = newTimetableForToday.getTripIndex(modifiedTripId);
+            assertTrue("New trip should be found in time table for service date", newTimetableForTodayModifiedTripIndex > -1);
+            assertEquals(RealTimeState.MODIFIED, newTimetableForToday.getTripTimes(newTimetableForTodayModifiedTripIndex).getRealTimeState());
+
             assertEquals("New trip should not be found in scheduled time table", -1, newTimetableScheduled.getTripIndex(modifiedTripId));
         }
     }
-    
+
     @Test
     public void testPurgeExpiredData() throws InvalidProtocolBufferException {
-        AgencyAndId tripId = new AgencyAndId("agency", "1.1");
-        ServiceDate previously = serviceDate.previous().previous(); // Just to be safe...
-        Trip trip = graph.index.tripForId.get(tripId);
-        TripPattern pattern = graph.index.patternForTrip.get(trip);
+        final AgencyAndId tripId = new AgencyAndId("agency", "1.1");
+        final ServiceDate previously = serviceDate.previous().previous(); // Just to be safe...
+        final Trip trip = graph.index.tripForId.get(tripId);
+        final TripPattern pattern = graph.index.patternForTrip.get(trip);
 
         updater.maxSnapshotFrequency = (0);
         updater.purgeExpiredData = (false);
 
         updater.applyTripUpdates(graph, fullDataset, Arrays.asList(TripUpdate.parseFrom(cancellation)), "agency");
-        TimetableSnapshot snapshotA = updater.getTimetableSnapshot();
+        final TimetableSnapshot snapshotA = updater.getTimetableSnapshot();
 
         updater.purgeExpiredData = (true);
 
-        TripDescriptor.Builder tripDescriptorBuilder = TripDescriptor.newBuilder();
+        final TripDescriptor.Builder tripDescriptorBuilder = TripDescriptor.newBuilder();
 
         tripDescriptorBuilder.setTripId("1.1");
         tripDescriptorBuilder.setScheduleRelationship(TripDescriptor.ScheduleRelationship.CANCELED);
         tripDescriptorBuilder.setStartDate(previously.getAsString());
 
-        TripUpdate.Builder tripUpdateBuilder = TripUpdate.newBuilder();
+        final TripUpdate.Builder tripUpdateBuilder = TripUpdate.newBuilder();
 
         tripUpdateBuilder.setTrip(tripDescriptorBuilder);
 
-        TripUpdate tripUpdate = tripUpdateBuilder.build();
+        final TripUpdate tripUpdate = tripUpdateBuilder.build();
 
         updater.applyTripUpdates(graph, fullDataset, Arrays.asList(tripUpdate), "agency");
-        TimetableSnapshot snapshotB = updater.getTimetableSnapshot();
+        final TimetableSnapshot snapshotB = updater.getTimetableSnapshot();
 
         assertNotSame(snapshotA, snapshotB);
 


### PR DESCRIPTION
As discussed in #1722, add the enum RealTimeState to the TripTimes object.

Note that for example a MODIFIED GTFS-RT trip update may result in one TripTimes object getting the real-time state CANCELED and another TripTimes object getting the real-time state MODIFIED.