### PR TITLE
Do not compare states with bike of distinct networks.

### DIFF
--- a/src/main/java/org/opentripplanner/routing/spt/DominanceFunction.java
+++ b/src/main/java/org/opentripplanner/routing/spt/DominanceFunction.java
@@ -5,6 +5,7 @@ import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.edgetype.StreetEdge;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * A class that determines when one search branch prunes another at the same Vertex, and ultimately which solutions
@@ -41,6 +42,12 @@ public abstract class DominanceFunction implements Serializable {
         // Does one state represent riding a rented bike and the other represent walking before/after rental?
         if (a.isBikeRenting() != b.isBikeRenting()) {
             return false;
+        }
+
+        // In case of bike renting, different networks (ie incompatible bikes) are not comparable
+        if (a.isBikeRenting()) {
+            if (!Objects.equals(a.getBikeRentalNetworks(), b.getBikeRentalNetworks()))
+                return false;
         }
 
         // Does one state represent driving a car and the other represent walking after the car was parked?


### PR DESCRIPTION
This was preventing computing a path using two different bike rental networks. We need to disable state comparison when in "bike rented state" and networks are not compatible.

For more details, see this thread:
https://groups.google.com/d/msg/opentripplanner-users/KlW9V_KdaDw/jRzIVdf3JC8J