### PR TITLE
Fix banning of agencies in multi agency feeds, resolves #2057

### DIFF
--- a/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
@@ -1077,7 +1077,7 @@ public class RoutingRequest implements Cloneable, Serializable {
     public boolean tripIsBanned(Trip trip) {
         /* check if agency is banned for this plan */
         if (bannedAgencies != null) {
-            if (bannedAgencies.contains(trip.getId().getAgencyId())) {
+            if (bannedAgencies.contains(trip.getRoute().getAgency().getId())) {
                 return true;
             }
         }


### PR DESCRIPTION
Change to lookup the agency id through the route instead of the trips id field which contains the feed id in multi agency feeds.

As explained in #2057 and related to the migration to a proper feed id in #1999 