### PR TITLE
Dynamic list of supported travel by modes

### DIFF
--- a/src/main/java/org/opentripplanner/api/model/RouterInfo.java
+++ b/src/main/java/org/opentripplanner/api/model/RouterInfo.java
@@ -16,6 +16,7 @@ package org.opentripplanner.api.model;
 
 import java.util.Date;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -33,6 +34,8 @@ import com.vividsolutions.jts.geom.Coordinate;
 import org.opentripplanner.routing.bike_rental.BikeRentalStationService;
 import org.opentripplanner.routing.core.TraverseMode;
 import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.util.TravelOption;
+import org.opentripplanner.util.TravelOptionsMaker;
 import org.opentripplanner.util.WorldEnvelope;
 
 @XmlRootElement(name = "RouterInfo")
@@ -61,6 +64,8 @@ public class RouterInfo {
 
     public boolean hasParkRide;
 
+    public List<TravelOption> travelOptions;
+
 
     public RouterInfo(String routerId, Graph graph) {
         this.routerId = routerId;
@@ -71,6 +76,7 @@ public class RouterInfo {
         addCenter(graph.getCenter());
         service = graph.getService(BikeRentalStationService.class, false);
         hasParkRide = graph.hasParkRide;
+        travelOptions = TravelOptionsMaker.makeOptions(graph);
     }
 
     public boolean getHasBikeSharing() {

--- a/src/main/java/org/opentripplanner/api/model/RouterInfo.java
+++ b/src/main/java/org/opentripplanner/api/model/RouterInfo.java
@@ -30,12 +30,15 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 import com.vividsolutions.jts.geom.Coordinate;
+import org.opentripplanner.routing.bike_rental.BikeRentalStationService;
 import org.opentripplanner.routing.core.TraverseMode;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.util.WorldEnvelope;
 
 @XmlRootElement(name = "RouterInfo")
 public class RouterInfo {
+
+    private final BikeRentalStationService service;
 
     @XmlElement
     public String routerId;
@@ -56,6 +59,8 @@ public class RouterInfo {
 
     public double centerLongitude;
 
+    public boolean hasParkRide;
+
 
     public RouterInfo(String routerId, Graph graph) {
         this.routerId = routerId;
@@ -64,6 +69,25 @@ public class RouterInfo {
         this.transitModes = graph.getTransitModes();
         this.envelope = graph.getEnvelope();
         addCenter(graph.getCenter());
+        service = graph.getService(BikeRentalStationService.class, false);
+        hasParkRide = graph.hasParkRide;
+    }
+
+    public boolean getHasBikeSharing() {
+        if (service == null) {
+            return false;
+        }
+
+        //at least 2 bike sharing stations are needed for useful bike sharing
+        return service.getBikeRentalStations().size() > 1;
+    }
+
+    public boolean getHasBikePark() {
+        if (service == null) {
+            return false;
+        }
+
+        return !service.getBikeParks().isEmpty();
     }
 
     /**

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModule.java
@@ -343,6 +343,9 @@ public class OpenStreetMapModule implements GraphBuilderModule {
                 new RentABikeOnEdge(stationVertex, stationVertex, networkSet);
                 new RentABikeOffEdge(stationVertex, stationVertex, networkSet);
             }
+            if (n > 1) {
+                graph.hasBikeSharing = true;
+            }
             LOG.info("Created " + n + " bike rental stations.");
         }
 
@@ -379,6 +382,9 @@ public class OpenStreetMapModule implements GraphBuilderModule {
                     buildBikeParkAndRideForArea(area);
                     n++;
                 }
+            }
+            if (n > 0) {
+                graph.hasBikeRide = true;
             }
             LOG.info("Created {} bike P+R areas.", n);
         }
@@ -439,6 +445,9 @@ public class OpenStreetMapModule implements GraphBuilderModule {
             for (AreaGroup group : areaGroups) {
                 if (buildParkAndRideAreasForGroup(group))
                     n++;
+            }
+            if (n > 0) {
+                graph.hasParkRide = true;
             }
             LOG.info("Created {} P+R.", n);
         }

--- a/src/main/java/org/opentripplanner/routing/graph/Graph.java
+++ b/src/main/java/org/opentripplanner/routing/graph/Graph.java
@@ -186,6 +186,12 @@ public class Graph implements Serializable {
     /** List of transit modes that are availible in GTFS data used in this graph**/
     private HashSet<TraverseMode> transitModes = new HashSet<TraverseMode>();
 
+    public boolean hasBikeSharing = false;
+
+    public boolean hasParkRide = false;
+
+    public boolean hasBikeRide = false;
+
     /**
      * Manages all updaters of this graph. Is created by the GraphUpdaterConfigurator when there are
      * graph updaters defined in the configuration.

--- a/src/main/java/org/opentripplanner/util/TravelOption.java
+++ b/src/main/java/org/opentripplanner/util/TravelOption.java
@@ -1,15 +1,4 @@
-/* This program is free software: you can redistribute it and/or
- modify it under the terms of the GNU Lesser General Public License
- as published by the Free Software Foundation, either version 3 of
- the License, or (at your option) any later version.
 
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
 package org.opentripplanner.util;
 

--- a/src/main/java/org/opentripplanner/util/TravelOption.java
+++ b/src/main/java/org/opentripplanner/util/TravelOption.java
@@ -1,0 +1,72 @@
+/* This program is free software: you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public License
+ as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+package org.opentripplanner.util;
+
+import java.util.HashSet;
+import java.util.Objects;
+
+/**
+ * This class is used to send to client which Travel Options are possible on this server
+ *
+ * This options are used in client "Travel by" drop down.
+ *
+ * Each travel option consist of two variables:
+ * - value is a value which is sent to the server if this is chosen ("TRANSIT, WALK", "CAR", etc.)
+ * - name is a name with which client can nicely name this option even if specific value changes ("TRANSIT", "PARKRIDE", "TRANSIT_BICYCLE", etc.)
+ *
+ * Travel options are created from {@link org.opentripplanner.routing.graph.Graph} transitModes variable and based if park & ride, bike & ride, bike sharing is supported.
+ * List itself is created in {@link TravelOptionsMaker#makeOptions(HashSet, boolean, boolean, boolean)}
+ *
+ * @see TravelOptionsMaker#makeOptions(HashSet, boolean, boolean, boolean)
+ * * Created by mabu on 28.7.2015.
+ */
+public class TravelOption {
+    public String value;
+    public String name;
+
+    public TravelOption(String value, String name) {
+        this.value = value;
+        this.name = name;
+    }
+
+    /**
+     * Creates TravelOption where value and name are same
+     *
+     * @param value
+     */
+    public TravelOption(String value) {
+        this.value = value;
+        this.name = value;
+    }
+
+    @Override public String toString() {
+        return "TravelOption{" +
+            "value='" + value + '\'' +
+            ", name='" + name + '\'' +
+            '}';
+    }
+
+    @Override public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        TravelOption that = (TravelOption) o;
+        return Objects.equals(value, that.value) && Objects.equals(name, that.name);
+    }
+
+    @Override public int hashCode() {
+        return Objects.hash(value, name);
+    }
+}

--- a/src/main/java/org/opentripplanner/util/TravelOptionsMaker.java
+++ b/src/main/java/org/opentripplanner/util/TravelOptionsMaker.java
@@ -1,0 +1,94 @@
+/* This program is free software: you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public License
+ as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+package org.opentripplanner.util;
+
+import org.opentripplanner.routing.core.TraverseMode;
+import org.opentripplanner.routing.graph.Graph;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+
+/**
+ * Class which creates "Travel by" options list from supported transit modes and which extra modes are supported (bike sharing, bike & ride, park & ride)
+ *
+ * This list is then returned to the client which shows it in UI.
+ * Created by mabu on 28.7.2015.
+ */
+public final class TravelOptionsMaker {
+
+    private static List<TravelOption> staticTravelOptions;
+
+    static {
+        staticTravelOptions = new ArrayList<>(3);
+        staticTravelOptions.add(new TravelOption(TraverseMode.WALK.toString()));
+        staticTravelOptions.add(new TravelOption(TraverseMode.BICYCLE.toString()));
+        staticTravelOptions.add(new TravelOption(TraverseMode.CAR.toString()));
+    }
+
+    public static List<TravelOption> makeOptions(Graph graph) {
+        return makeOptions(graph.getTransitModes(), graph.hasBikeSharing, graph.hasBikeRide, graph.hasParkRide);
+    }
+
+    public static List<TravelOption> makeOptions(HashSet<TraverseMode> transitModes, boolean hasBikeSharing,
+        boolean hasBikeRide, boolean hasParkRide) {
+        List<TravelOption> travelOptions = new ArrayList<>(16);
+
+        //Adds Transit, and all the transit modes
+        if (!transitModes.isEmpty()) {
+            travelOptions.add(new TravelOption(
+                String.join(",", TraverseMode.TRANSIT.toString(), TraverseMode.WALK.toString()),
+                TraverseMode.TRANSIT.toString()));
+
+            for (TraverseMode transitMode: transitModes) {
+                travelOptions.add(new TravelOption(
+                    String.join(",", transitMode.toString(), TraverseMode.WALK.toString()),
+                    transitMode.toString()));
+            }
+        }
+
+        travelOptions.addAll(staticTravelOptions);
+
+        if (hasBikeSharing) {
+            travelOptions.add(new TravelOption(String.join(",", TraverseMode.WALK.toString(), "BICYCLE_RENT"), "BICYCLERENT"));
+        }
+
+        //If transit modes exists.
+        if (!transitModes.isEmpty()) {
+            //Adds bicycle transit mode
+            travelOptions.add(new TravelOption(
+                String.join(",", TraverseMode.TRANSIT.toString(), TraverseMode.BICYCLE.toString()),
+                String.join("_", TraverseMode.TRANSIT.toString(), TraverseMode.BICYCLE.toString())));
+            if (hasBikeSharing) {
+                travelOptions.add(new TravelOption(String.join(",", TraverseMode.TRANSIT.toString(),
+                    TraverseMode.WALK.toString(), "BICYCLE_RENT"), "TRANSIT_BICYCLERENT"));
+            }
+            if (hasParkRide) {
+                travelOptions.add(new TravelOption(String.join(",", "CAR_PARK", TraverseMode.WALK.toString(), TraverseMode.TRANSIT.toString()),
+                    "PARKRIDE"));
+            }
+            if (hasBikeRide) {
+                travelOptions.add(new TravelOption(String.join(",", "BICYCLE_PARK", TraverseMode.WALK.toString(), TraverseMode.TRANSIT.toString()),
+                    "BIKERIDE"));
+            }
+            travelOptions.add(new TravelOption(String.join(",", TraverseMode.CAR.toString(), TraverseMode.WALK.toString(), TraverseMode.TRANSIT.toString()),
+                "KISSRIDE"));
+        }
+
+
+
+        return  travelOptions;
+    }
+
+}

--- a/src/test/java/org/opentripplanner/util/TravelOptionsMakerTest.java
+++ b/src/test/java/org/opentripplanner/util/TravelOptionsMakerTest.java
@@ -1,0 +1,152 @@
+/* This program is free software: you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public License
+ as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+package org.opentripplanner.util;
+
+import static org.junit.Assert.assertEquals;
+
+
+import org.junit.Test;
+import org.opentripplanner.routing.core.TraverseMode;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+
+/**
+ * Created by mabu on 28.7.2015.
+ */
+public class TravelOptionsMakerTest {
+
+    @Test
+    public void testMakeOptions() throws Exception {
+        boolean hasParkRide = false;
+        boolean hasBikeRide = false;
+        boolean hasBikeShare = false;
+
+        HashSet<TraverseMode> transitModes = new HashSet<>();
+        transitModes.add(TraverseMode.BUS);
+
+        List<TravelOption> options = TravelOptionsMaker.makeOptions(transitModes, hasBikeShare, hasBikeRide, hasParkRide);
+
+        List<TravelOption> expected = new ArrayList<>();
+        expected.add(new TravelOption("TRANSIT,WALK", "TRANSIT"));
+        expected.add(new TravelOption("BUS,WALK", "BUS"));
+        expected.add(new TravelOption("WALK", "WALK"));
+        expected.add(new TravelOption("BICYCLE", "BICYCLE"));
+        expected.add(new TravelOption("CAR", "CAR"));
+        expected.add(new TravelOption("TRANSIT,BICYCLE", "TRANSIT_BICYCLE"));
+        expected.add(new TravelOption("CAR,WALK,TRANSIT", "KISSRIDE"));
+        assertEquals(expected, options);
+
+        transitModes.add(TraverseMode.RAIL);
+
+        hasBikeRide = true;
+
+        options = TravelOptionsMaker.makeOptions(transitModes, hasBikeShare, hasBikeRide, hasParkRide);
+        expected = new ArrayList<>();
+        expected.add(new TravelOption("TRANSIT,WALK", "TRANSIT"));
+        expected.add(new TravelOption("BUS,WALK", "BUS"));
+        expected.add(new TravelOption("RAIL,WALK", "RAIL"));
+        expected.add(new TravelOption("WALK", "WALK"));
+        expected.add(new TravelOption("BICYCLE", "BICYCLE"));
+        expected.add(new TravelOption("CAR", "CAR"));
+        expected.add(new TravelOption("TRANSIT,BICYCLE", "TRANSIT_BICYCLE"));
+        expected.add(new TravelOption("BICYCLE_PARK,WALK,TRANSIT", "BIKERIDE"));
+        expected.add(new TravelOption("CAR,WALK,TRANSIT", "KISSRIDE"));
+
+        assertEquals(expected, options);
+
+        hasBikeRide = false;
+
+        hasBikeShare = true;
+
+        options = TravelOptionsMaker.makeOptions(transitModes, hasBikeShare, hasBikeRide, hasParkRide);
+        expected = new ArrayList<>();
+        expected.add(new TravelOption("TRANSIT,WALK", "TRANSIT"));
+        expected.add(new TravelOption("BUS,WALK", "BUS"));
+        expected.add(new TravelOption("RAIL,WALK", "RAIL"));
+        expected.add(new TravelOption("WALK", "WALK"));
+        expected.add(new TravelOption("BICYCLE", "BICYCLE"));
+        expected.add(new TravelOption("CAR", "CAR"));
+        expected.add(new TravelOption("WALK,BICYCLE_RENT", "BICYCLERENT"));
+        expected.add(new TravelOption("TRANSIT,BICYCLE", "TRANSIT_BICYCLE"));
+        expected.add(new TravelOption("TRANSIT,WALK,BICYCLE_RENT", "TRANSIT_BICYCLERENT"));
+        expected.add(new TravelOption("CAR,WALK,TRANSIT", "KISSRIDE"));
+
+        assertEquals(expected, options);
+
+        hasBikeShare = false;
+        hasParkRide = true;
+
+        options = TravelOptionsMaker.makeOptions(transitModes, hasBikeShare, hasBikeRide, hasParkRide);
+        expected = new ArrayList<>();
+        expected.add(new TravelOption("TRANSIT,WALK", "TRANSIT"));
+        expected.add(new TravelOption("BUS,WALK", "BUS"));
+        expected.add(new TravelOption("RAIL,WALK", "RAIL"));
+        expected.add(new TravelOption("WALK", "WALK"));
+        expected.add(new TravelOption("BICYCLE", "BICYCLE"));
+        expected.add(new TravelOption("CAR", "CAR"));
+        expected.add(new TravelOption("TRANSIT,BICYCLE", "TRANSIT_BICYCLE"));
+        expected.add(new TravelOption("CAR_PARK,WALK,TRANSIT", "PARKRIDE"));
+        expected.add(new TravelOption("CAR,WALK,TRANSIT", "KISSRIDE"));
+
+        assertEquals(expected, options);
+
+        hasBikeShare = true;
+        hasParkRide = true;
+        hasBikeRide = true;
+
+        options = TravelOptionsMaker.makeOptions(transitModes, hasBikeShare, hasBikeRide, hasParkRide);
+        expected = new ArrayList<>();
+        expected.add(new TravelOption("TRANSIT,WALK", "TRANSIT"));
+        expected.add(new TravelOption("BUS,WALK", "BUS"));
+        expected.add(new TravelOption("RAIL,WALK", "RAIL"));
+        expected.add(new TravelOption("WALK", "WALK"));
+        expected.add(new TravelOption("BICYCLE", "BICYCLE"));
+        expected.add(new TravelOption("CAR", "CAR"));
+        expected.add(new TravelOption("WALK,BICYCLE_RENT", "BICYCLERENT"));
+        expected.add(new TravelOption("TRANSIT,BICYCLE", "TRANSIT_BICYCLE"));
+        expected.add(new TravelOption("TRANSIT,WALK,BICYCLE_RENT", "TRANSIT_BICYCLERENT"));
+        expected.add(new TravelOption("CAR_PARK,WALK,TRANSIT", "PARKRIDE"));
+        expected.add(new TravelOption("BICYCLE_PARK,WALK,TRANSIT", "BIKERIDE"));
+        expected.add(new TravelOption("CAR,WALK,TRANSIT", "KISSRIDE"));
+
+        assertEquals(expected, options);
+
+        transitModes = new HashSet<>();
+
+        options = TravelOptionsMaker.makeOptions(transitModes, hasBikeShare, hasBikeRide, hasParkRide);
+        expected = new ArrayList<>();
+        expected.add(new TravelOption("WALK", "WALK"));
+        expected.add(new TravelOption("BICYCLE", "BICYCLE"));
+        expected.add(new TravelOption("CAR", "CAR"));
+        expected.add(new TravelOption("WALK,BICYCLE_RENT", "BICYCLERENT"));
+
+        assertEquals(expected, options);
+
+        hasBikeRide = false;
+        hasParkRide = false;
+        hasBikeShare = false;
+
+        options = TravelOptionsMaker.makeOptions(transitModes, hasBikeShare, hasBikeRide, hasParkRide);
+        expected = new ArrayList<>();
+        expected.add(new TravelOption("WALK", "WALK"));
+        expected.add(new TravelOption("BICYCLE", "BICYCLE"));
+        expected.add(new TravelOption("CAR", "CAR"));
+
+        assertEquals(expected, options);
+
+
+    }
+}


### PR DESCRIPTION
This is server part of automatic list of travel by modes. The goal is for the client to only show supported travel by modes and extra options (bike sharing, park & ride, bike & ride) on specific server.

Some examples of transit travelBy options are: `"TRANSIT,WALK"`, Park & Ride `"CAR_PARK,WALK,TRANSIT"` which is quite complex, but bicycle needs only `"BICYCLE"`.

This can be solved in 2 ways.
One is to send to client which transit modes are supported and if P & R, B & R or bike sharing are supported and is up to the client to create correct list of those and to name them.

Another is to create a list of values to be send ("TRANSIT,WALK", "BICYCLE") and names for them on the server itself. This would be better kept in since with the rest of server code than combining it on client.

Currently there are 3 well known clients. OTP default, OTP.js, and android app.

I currently implemented second option. I added a method on a server which creates list of travel By options with correct values and short names. Client then uses those names to show correct description (which can be translated).

I added travelOptions list to RouterInfo which consists of list of values and names. Values are items which are send to the server and names are names to be used for naming.

I also added hasBikeSharing, hasBikePark and hasParkRide variables to routerInfo which can be used in the future to enable or disable specific modes.

I also added tests.