### PR TITLE
HTML annotations large number of annotations support

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/AnnotationsToHTML.java
+++ b/src/main/java/org/opentripplanner/graph_builder/AnnotationsToHTML.java
@@ -23,11 +23,11 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.logging.Level;
+
+import com.google.common.primitives.Ints;
+import org.opentripplanner.common.model.T2;
 import org.opentripplanner.graph_builder.annotation.GraphBuilderAnnotation;
 import org.opentripplanner.graph_builder.services.GraphBuilderModule;
 import org.opentripplanner.routing.graph.Graph;
@@ -76,11 +76,24 @@ public class AnnotationsToHTML implements GraphBuilderModule {
 
         Set<String> classes = annotations.keySet();
 
-        for (Map.Entry<String, Collection<String>> entry : annotations.asMap().entrySet()) {
-            LOG.info("Key: {} ({})", entry.getKey(), entry.getValue().size());
+
+
+        Map<String, Collection<String>> annotationsMap = annotations.asMap();
+        //saves list of annotation classes and counts
+        List<T2<String, Integer>> counts = new ArrayList<>(annotationsMap.size());
+        for (Map.Entry<String, Collection<String>> entry: annotationsMap.entrySet()) {
+            counts.add(new T2<>(entry.getKey(), entry.getValue().size()));
+        }
+
+        //Orders annotations and counts of annotations usages by number of usages
+        //from most used to the least
+        Collections.sort(counts, (o1, o2) -> Ints.compare(o2.second, o1.second));
+
+        for (T2<String, Integer> count : counts) {
+            LOG.info("Key: {} ({})", count.first, count.second);
 
             try {
-                HTMLWriter file_writer = new HTMLWriter(entry.getKey(), entry.getValue());
+                HTMLWriter file_writer = new HTMLWriter(count.first, annotationsMap.get(count.first));
                 file_writer.writeFile(classes);
 
             } catch (FileNotFoundException ex) {

--- a/src/main/java/org/opentripplanner/graph_builder/AnnotationsToHTML.java
+++ b/src/main/java/org/opentripplanner/graph_builder/AnnotationsToHTML.java
@@ -26,6 +26,7 @@ import java.io.PrintStream;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.logging.Level;
 import org.opentripplanner.graph_builder.annotation.GraphBuilderAnnotation;
 import org.opentripplanner.graph_builder.services.GraphBuilderModule;
@@ -73,12 +74,14 @@ public class AnnotationsToHTML implements GraphBuilderModule {
         }
         LOG.info("Creating Annotations log");
 
+        Set<String> classes = annotations.keySet();
+
         for (Map.Entry<String, Collection<String>> entry : annotations.asMap().entrySet()) {
             LOG.info("Key: {} ({})", entry.getKey(), entry.getValue().size());
 
             try {
                 HTMLWriter file_writer = new HTMLWriter(entry.getKey(), entry.getValue());
-                file_writer.writeFile();
+                file_writer.writeFile(classes);
 
             } catch (FileNotFoundException ex) {
                 LOG.error("Output folder not found:{} {}", outPath, ex);
@@ -108,15 +111,18 @@ public class AnnotationsToHTML implements GraphBuilderModule {
 
         private Multimap<String, String> lannotations;
 
+        private String current_class;
+
         public HTMLWriter(String key, Collection<String> annotations) throws FileNotFoundException {
             File newFile = new File(outPath, key +".html");
             FileOutputStream fileOutputStream = new FileOutputStream(newFile);
             this.out = new PrintStream(fileOutputStream);
             lannotations = ArrayListMultimap.create();
             lannotations.putAll(key, annotations);
+            current_class = key;
         }
 
-        private void writeFile() {
+        private void writeFile(Collection<String> classes) {
             println("<html><head><title>Graph report for " + outPath.getParentFile()
                 + "Graph.obj</title>");
             println("\t<meta charset=\"utf-8\">");
@@ -164,6 +170,16 @@ public class AnnotationsToHTML implements GraphBuilderModule {
             println("</head><body>");
             println("<h1>OpenTripPlanner annotations log</h1>");
             println("<h2>Graph report for " + outPath.getParentFile() + "Graph.obj</h2>");
+            println("<p>");
+            //adds links to the other HTML files
+            for (String htmlAnnotationClass: classes) {
+                if (htmlAnnotationClass.equals(current_class)) {
+                    println("<span>" + htmlAnnotationClass + "</span><br />");
+                } else {
+                    println("<a href=\"" + htmlAnnotationClass + ".html\">" + htmlAnnotationClass + "</a><br />");
+                }
+            }
+            println("</p>");
             println("<div id=\"buttons\"></div><ul id=\"log\"></ul>");
 
 

--- a/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
@@ -311,7 +311,7 @@ public class GraphBuilder implements Runnable {
         }
         graphBuilder.addModule(new EmbedConfig(builderConfig, routerConfig));
         if (builderParams.htmlAnnotations) {
-            graphBuilder.addModule(new AnnotationsToHTML(new File(params.build, "report.html")));
+            graphBuilder.addModule(new AnnotationsToHTML(params.build));
         }
         graphBuilder.serializeGraph = ( ! params.inMemory ) || params.preFlight;
         return graphBuilder;

--- a/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
@@ -311,7 +311,7 @@ public class GraphBuilder implements Runnable {
         }
         graphBuilder.addModule(new EmbedConfig(builderConfig, routerConfig));
         if (builderParams.htmlAnnotations) {
-            graphBuilder.addModule(new AnnotationsToHTML(params.build));
+            graphBuilder.addModule(new AnnotationsToHTML(params.build, builderParams.maxHtmlAnnotationsPerFile));
         }
         graphBuilder.serializeGraph = ( ! params.inMemory ) || params.preFlight;
         return graphBuilder;

--- a/src/main/java/org/opentripplanner/standalone/GraphBuilderParameters.java
+++ b/src/main/java/org/opentripplanner/standalone/GraphBuilderParameters.java
@@ -28,6 +28,12 @@ public class GraphBuilderParameters {
     public final boolean htmlAnnotations;
 
     /**
+     * If number of annotations is larger then specified number annotations will be split in multiple files.
+     * Since browsers have problems opening large HTML files.
+     */
+    public final int maxHtmlAnnotationsPerFile;
+
+    /**
      * Include all transit input files (GTFS) from scanned directory.
      */
     public final boolean transit;
@@ -131,6 +137,7 @@ public class GraphBuilderParameters {
         staticBikeRental = config.path("staticBikeRental").asBoolean(false);
         staticParkAndRide = config.path("staticParkAndRide").asBoolean(true);
         staticBikeParkAndRide = config.path("staticBikeParkAndRide").asBoolean(false);
+        maxHtmlAnnotationsPerFile = config.path("maxHtmlAnnotationsPerFile").asInt(1000);
     }
 
 }


### PR DESCRIPTION
I changed how annotations are created.
Each class of annotations now has its own file. But if multiple classes of annotations have low number of annotations they are still grouped in file called rest. So that there aren't a bunch of files with 1-5 annotations.

New build-config parameter is added "maxHtmlAnnotationsPerFile". And if number of annotations in one class is too large it is split in multiple files.
Value is by default 1000. @abyrd and @andreyz Please test it with files which have large number of annotations and please tell me what would be sensible default.

This is connected with #1510  and #2010.

WIP because if it works correctly I need to clean the code a little bit and add more comments and remove some logging.