### PR TITLE
Improved Html annotations

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/AnnotationsToHTML.java
+++ b/src/main/java/org/opentripplanner/graph_builder/AnnotationsToHTML.java
@@ -264,7 +264,7 @@ public class AnnotationsToHTML implements GraphBuilderModule {
                 + "";
             println(css);
             println("</head><body>");
-            println("<h1>OpenTripPlanner annotations log</h1>");
+            println(String.format("<h1>OpenTripPlanner annotations log for %s</h1>", annotationClassName));
             println("<h2>Graph report for " + outPath.getParentFile() + "Graph.obj</h2>");
             println("<p>");
             //adds links to the other HTML files

--- a/src/main/java/org/opentripplanner/graph_builder/AnnotationsToHTML.java
+++ b/src/main/java/org/opentripplanner/graph_builder/AnnotationsToHTML.java
@@ -276,9 +276,11 @@ public class AnnotationsToHTML implements GraphBuilderModule {
                 while (currentCount <= htmlAnnotationClass.getCount()) {
                     label = label_name + currentCount;
                     if (label.equals(annotationClassName)) {
-                        println("<span>" + label + "</span><br />");
+                        println(String.format("<button class='pure-button pure-button-disabled button-%s'>%s</button>",
+                            label_name.toLowerCase(), label));
                     } else {
-                        println("<a href=\"" + label + ".html\">" + label + "</a><br />");
+                        println(String.format("<a class='pure-button button-%s' href=\"%s.html\">%s</a>",
+                            label_name.toLowerCase(), label, label));
                     }
                     currentCount++;
                 }

--- a/src/main/java/org/opentripplanner/graph_builder/AnnotationsToHTML.java
+++ b/src/main/java/org/opentripplanner/graph_builder/AnnotationsToHTML.java
@@ -284,59 +284,10 @@ public class AnnotationsToHTML implements GraphBuilderModule {
                 }
             }
             println("</p>");
-            println("<div id=\"buttons\"></div><ul id=\"log\"></ul>");
-
             if (!isIndexFile) {
-                println("\t<script>");
-
-                writeJson();
-                String js = "\t\tvar selected = {};\n"
-                        + "\n"
-                        + "\t\t//select/deselects filters and correctly styles buttons\n"
-                        + "\t\tfunction refilter(item) {\n"
-                        + "\t\t\tconsole.debug(item.data.name);\n"
-                        + "\t\t\tvar annotation = item.data.name;\n"
-                        + "\t\t\tvar keyLower = \"button-\"+annotation.toLowerCase();\n"
-                        + "\t\t\tif (annotation in selected) {\n"
-                        + "\t\t   \t\tdelete selected[annotation];\t\n"
-                        + "\t\t\t\t$(\"button.\"+keyLower).removeClass(keyLower);\n"
-                        + "\t\t\t} else {\n"
-                        + "\t\t\t\tselected[annotation] = true;\n"
-                        + "\t\t\t\t$(\"button:contains('\"+annotation+\"')\").addClass(keyLower);\n"
-                        + "\t\t\t}\n"
-                        + "\t\t\tresetView();\n"
-                        + "\n"
-                        + "\t\t}\n"
-                        + "\n"
-                        + "\t\t//draws list based on selected buttons\n"
-                        + "\t\tfunction resetView() {\n"
-                        + "\t\t\t$(\"#log\").empty();\n"
-                        + "\t\t\t$.each(data, function(key, value) {\n"
-                        + "\t\t\t\t//console.log(key);\n"
-                        + "\t\t\t\tif (key in selected) {\n"
-                        + "\t\t\t\t\tvar keyLower = \"button-\"+key.toLowerCase();\n"
-                        + "\t\t\t\t\t$.each(value, function(index, log) {\n"
-                        + "\t\t\t\t\t$(\"#log\").append(\"<li>\"+ \"<span class='pure-button \" + keyLower + \"'>\"+ key + \"</span>\" + log+\"</li>\");\n"
-                        + "\t\t\t\t\t});\n"
-                        + "\t\t\t\t}\n"
-                        + "\t\t\t});\n"
-                        + "\t\t}\n"
-                        + "\n"
-                        + "\t\t//creates buttons\n"
-                        + "\t\t$.each(data, function(key, value) {\n"
-                        + "\t\t\t//console.info(key);\n"
-                        + "\t\t\t//console.info(value);\n"
-                        + "\t\t\tvar keyLower = \"button-\"+key.toLowerCase();\n"
-                        + "\t\t\tselected[key] = true;\n"
-                        + "\t\t\tlen = value.length;\n"
-                        + "\t\t\t$(\"#buttons\").append(\"<button class='pure-button \" + keyLower + \"'>\"+key+ \" (\" + len + \")</button>\");\n"
-                        + "\t\t\t$(\".\"+keyLower).on(\"click\", {name: key}, refilter);\n"
-                        + "\t\t});\n"
-                        + "\n"
-                        + "\t\tresetView();\n"
-                        + "";
-                println(js);
-                println("\t</script>");
+                println("<ul id=\"log\">");
+                writeAnnotations();
+                println("</ul>");
             }
 
             println("</body></html>");
@@ -344,8 +295,22 @@ public class AnnotationsToHTML implements GraphBuilderModule {
             close();
         }
 
+        /**
+         * Writes annotations as LI html elements
+         */
+        private void writeAnnotations() {
+            String annotationFMT = "<li>%s</li>";
+            for (Map.Entry<String, String> annotation: writerAnnotations.entries()) {
+                print(String.format(annotationFMT, annotation.getValue()));
+            }
+        }
+
         private void println(String bodyhtml) {
             out.println(bodyhtml);
+        }
+
+        private void print(String bodyhtml) {
+            out.print(bodyhtml);
         }
 
         private void close() {

--- a/src/main/java/org/opentripplanner/graph_builder/AnnotationsToHTML.java
+++ b/src/main/java/org/opentripplanner/graph_builder/AnnotationsToHTML.java
@@ -133,7 +133,7 @@ public class AnnotationsToHTML implements GraphBuilderModule {
             LOG.error("Index file coudn't be created:{}", e);
         }
 
-        LOG.info("Annotated log is in {}", outPath);
+        LOG.info("Annotated logs are in {}", outPath);
 
 
     }
@@ -151,7 +151,7 @@ public class AnnotationsToHTML implements GraphBuilderModule {
         try {
             HTMLWriter file_writer;
             if (annotations.size() > 1.2*maxNumberOfAnnotationsPerFile) {
-                LOG.info("Number of annotations is very large. Splitting: {}", annotationClassName);
+                LOG.debug("Number of annotations is very large. Splitting: {}", annotationClassName);
                 List<List<String>> partitions = Lists.partition(annotations, maxNumberOfAnnotationsPerFile);
                 for (List<String> partition: partitions) {
                     classOccurences.add(annotationClassName);
@@ -199,7 +199,7 @@ public class AnnotationsToHTML implements GraphBuilderModule {
         private String annotationClassName;
 
         public HTMLWriter(String key, Collection<String> annotations) throws FileNotFoundException {
-            LOG.info("Making file: {}", key);
+            LOG.debug("Making file: {}", key);
             File newFile = new File(outPath, key +".html");
             FileOutputStream fileOutputStream = new FileOutputStream(newFile);
             this.out = new PrintStream(fileOutputStream);
@@ -210,7 +210,7 @@ public class AnnotationsToHTML implements GraphBuilderModule {
 
         public HTMLWriter(String filename, Multimap<String, String> curMap)
             throws FileNotFoundException {
-            LOG.info("Making file: {}", filename);
+            LOG.debug("Making file: {}", filename);
             File newFile = new File(outPath, filename +".html");
             FileOutputStream fileOutputStream = new FileOutputStream(newFile);
             this.out = new PrintStream(fileOutputStream);

--- a/src/main/java/org/opentripplanner/graph_builder/AnnotationsToHTML.java
+++ b/src/main/java/org/opentripplanner/graph_builder/AnnotationsToHTML.java
@@ -26,6 +26,7 @@ import java.util.*;
 import java.util.logging.Level;
 
 import com.google.common.primitives.Ints;
+import org.apache.commons.io.FileUtils;
 import org.opentripplanner.common.model.T2;
 import org.opentripplanner.graph_builder.annotation.GraphBuilderAnnotation;
 import org.opentripplanner.graph_builder.services.GraphBuilderModule;
@@ -77,9 +78,23 @@ public class AnnotationsToHTML implements GraphBuilderModule {
         }
 
         outPath = new File(outPath, "report");
-        if (!outPath.mkdir()) {
-            LOG.error("Failed to create HTML report directory: {}. HTML report won't be generated!", outPath.toString());
-            return;
+        if (outPath.exists()) {
+            //Removes all files from report directory
+            try {
+                FileUtils.cleanDirectory(outPath);
+            } catch (IOException e) {
+                LOG.error("Failed to clean HTML report directory: " + outPath.toString() + ". HTML report won't be generated!", e);
+                return;
+            }
+        } else {
+            //Creates report directory if it doesn't exist yet
+            try {
+                FileUtils.forceMkdir(outPath);
+            } catch (IOException e) {
+                e.printStackTrace();
+                LOG.error("Failed to create HTML report directory: " + outPath.toString() + ". HTML report won't be generated!", e);
+                return;
+            }
         }
 
 

--- a/src/main/java/org/opentripplanner/graph_builder/annotation/BikeParkUnlinked.java
+++ b/src/main/java/org/opentripplanner/graph_builder/annotation/BikeParkUnlinked.java
@@ -20,11 +20,17 @@ public class BikeParkUnlinked extends GraphBuilderAnnotation {
     private static final long serialVersionUID = 1L;
 
     private static final String FMT = "Bike park %s not near any streets; it will not be usable.";
+    private static final String HTMLFMT = "Bike park <a href=\"http://www.openstreetmap.org/?mlat=%s&mlon=%s&layers=T\">\"%s\"</a> not near any streets; it will not be usable.";
 
     final BikeParkVertex bikeParkVertex;
 
     public BikeParkUnlinked(BikeParkVertex bikeParkVertex) {
         this.bikeParkVertex = bikeParkVertex;
+    }
+
+    @Override
+    public String getHTMLMessage() {
+        return String.format(HTMLFMT, bikeParkVertex.getLat(), bikeParkVertex.getLon(), bikeParkVertex);
     }
 
     @Override

--- a/src/main/java/org/opentripplanner/graph_builder/annotation/BikeParkUnlinked.java
+++ b/src/main/java/org/opentripplanner/graph_builder/annotation/BikeParkUnlinked.java
@@ -20,7 +20,7 @@ public class BikeParkUnlinked extends GraphBuilderAnnotation {
     private static final long serialVersionUID = 1L;
 
     private static final String FMT = "Bike park %s not near any streets; it will not be usable.";
-    private static final String HTMLFMT = "Bike park <a href=\"http://www.openstreetmap.org/?mlat=%s&mlon=%s&layers=T\">\"%s\"</a> not near any streets; it will not be usable.";
+    private static final String HTMLFMT = "Bike park <a href=\"http://www.openstreetmap.org/?mlat=%s&mlon=%s\">\"%s\"</a> not near any streets; it will not be usable.";
 
     final BikeParkVertex bikeParkVertex;
 

--- a/src/main/java/org/opentripplanner/graph_builder/annotation/BikeRentalStationUnlinked.java
+++ b/src/main/java/org/opentripplanner/graph_builder/annotation/BikeRentalStationUnlinked.java
@@ -20,7 +20,7 @@ public class BikeRentalStationUnlinked extends GraphBuilderAnnotation {
     private static final long serialVersionUID = 1L;
 
     public static final String FMT = "Bike rental station %s not near any streets; it will not be usable.";
-    private static final String HTMLFMT = "Bike rental station <a href=\"http://www.openstreetmap.org/?mlat=%s&mlon=%s&layers=T\">\"%s\"</a> not near any streets; it will not be usable.";
+    private static final String HTMLFMT = "Bike rental station <a href=\"http://www.openstreetmap.org/?mlat=%s&mlon=%s\">\"%s\"</a> not near any streets; it will not be usable.";
     
     final BikeRentalStationVertex station;
     

--- a/src/main/java/org/opentripplanner/graph_builder/annotation/BikeRentalStationUnlinked.java
+++ b/src/main/java/org/opentripplanner/graph_builder/annotation/BikeRentalStationUnlinked.java
@@ -20,13 +20,19 @@ public class BikeRentalStationUnlinked extends GraphBuilderAnnotation {
     private static final long serialVersionUID = 1L;
 
     public static final String FMT = "Bike rental station %s not near any streets; it will not be usable.";
+    private static final String HTMLFMT = "Bike rental station <a href=\"http://www.openstreetmap.org/?mlat=%s&mlon=%s&layers=T\">\"%s\"</a> not near any streets; it will not be usable.";
     
     final BikeRentalStationVertex station;
     
     public BikeRentalStationUnlinked(BikeRentalStationVertex station){
     	this.station = station;
     }
-    
+
+    @Override
+    public String getHTMLMessage() {
+        return String.format(HTMLFMT, station.getLat(), station.getLon(), station);
+    }
+
     @Override
     public String getMessage() {
         return String.format(FMT, station);

--- a/src/main/java/org/opentripplanner/graph_builder/annotation/ConflictingBikeTags.java
+++ b/src/main/java/org/opentripplanner/graph_builder/annotation/ConflictingBikeTags.java
@@ -19,13 +19,25 @@ public class ConflictingBikeTags extends GraphBuilderAnnotation {
 
     public static final String FMT = "Conflicting tags bicycle:[yes|designated] and cycleway: " +
     		"dismount on way %s, assuming dismount";
+    public static final String HTMLFMT = "Conflicting tags bicycle:[yes|designated] and cycleway: " +
+        "dismount on way <a href=\"http://www.openstreetmap.org/way/%d\">\"%d\"</a>, assuming dismount";
     
     final long wayId;
     
     public ConflictingBikeTags(long wayId){
     	this.wayId = wayId;
     }
-    
+
+    @Override
+    public String getHTMLMessage() {
+        if (wayId > 0 ) {
+            return String.format(HTMLFMT, wayId, wayId);
+        // If way is lower then 0 it means it is temporary ID and so useless to link to OSM
+        } else {
+            return getMessage();
+        }
+    }
+
     @Override
     public String getMessage() {
         return String.format(FMT, wayId);

--- a/src/main/java/org/opentripplanner/graph_builder/annotation/GraphBuilderAnnotation.java
+++ b/src/main/java/org/opentripplanner/graph_builder/annotation/GraphBuilderAnnotation.java
@@ -55,7 +55,7 @@ public abstract class GraphBuilderAnnotation implements Serializable {
     public abstract String getMessage();
 
     public String getHTMLMessage() {
-        return this.getMessage();
+        return this.getMessage().replace("<", "&lt;").replace(">", "&gt;");
     }
 
     public Edge getReferencedEdge() {

--- a/src/main/java/org/opentripplanner/graph_builder/annotation/StopNotLinkedForTransfers.java
+++ b/src/main/java/org/opentripplanner/graph_builder/annotation/StopNotLinkedForTransfers.java
@@ -21,10 +21,17 @@ public class StopNotLinkedForTransfers extends GraphBuilderAnnotation {
 
     public static final String FMT = "Stop %s not near any other stops; no transfers are possible.";
 
+    public static final String HTMLFMT = "Stop <a href=\"http://www.openstreetmap.org/?mlat=%s&mlon=%s&layers=T\">\"%s (%s)\"</a> not near any other stops; no transfers are possible.";
+
     final TransitStop stop;
     
     public StopNotLinkedForTransfers(TransitStop stop){
     	this.stop = stop;
+    }
+
+    @Override
+    public String getHTMLMessage() {
+        return String.format(HTMLFMT, stop.getLat(), stop.getLon(), stop.getName(), stop.getStopId());
     }
 
     @Override

--- a/src/main/java/org/opentripplanner/graph_builder/annotation/StreetCarSpeedZero.java
+++ b/src/main/java/org/opentripplanner/graph_builder/annotation/StreetCarSpeedZero.java
@@ -18,15 +18,26 @@ public class StreetCarSpeedZero extends GraphBuilderAnnotation {
     private static final long serialVersionUID = 6872784791854835184L;
 
     public static final String FMT = "Way %s has car speed zero";
+    public static final String HTMLFMT = "Way <a href=\"http://www.openstreetmap.org/way/%d\">\"%d\"</a> has car speed zero";
     
-    final long way;
+    final long wayId;
     
-    public StreetCarSpeedZero(long way){
-    	this.way = way;
+    public StreetCarSpeedZero(long wayId){
+    	this.wayId = wayId;
     }
-    
+
+    @Override
+    public String getHTMLMessage() {
+        if (wayId > 0 ) {
+            return String.format(HTMLFMT, wayId, wayId);
+            // If way is lower then 0 it means it is temporary ID and so useless to link to OSM
+        } else {
+            return getMessage();
+        }
+    }
+
     @Override
     public String getMessage() {
-        return String.format(FMT, way);
+        return String.format(FMT, wayId);
     }
 }

--- a/src/main/java/org/opentripplanner/graph_builder/annotation/TurnRestrictionException.java
+++ b/src/main/java/org/opentripplanner/graph_builder/annotation/TurnRestrictionException.java
@@ -18,17 +18,24 @@ public class TurnRestrictionException extends GraphBuilderAnnotation {
     private static final long serialVersionUID = 1L;
 
     public static final String FMT = "Turn restriction with bicycle exception at node %s from %s";
+
+    public static final String HTMLFMT = "Turn restriction with bicycle exception at node <a href=\"http://www.openstreetmap.org/node/%d\">\"%d\"</a> from <a href=\"http://www.openstreetmap.org/way/%d\">\"%d\"</a>";
     
-    final long node, way;
+    final long nodeId, wayId;
     
-    public TurnRestrictionException(long node, long way){
-    	this.node = node;
-    	this.way = way;
+    public TurnRestrictionException(long nodeId, long wayId){
+    	this.nodeId = nodeId;
+    	this.wayId = wayId;
     }
-    
+
+    @Override
+    public String getHTMLMessage() {
+        return String.format(HTMLFMT, nodeId, nodeId, wayId, wayId);
+    }
+
     @Override
     public String getMessage() {
-        return String.format(FMT, node, way);
+        return String.format(FMT, nodeId, wayId);
     }
 
 }

--- a/src/main/java/org/opentripplanner/graph_builder/annotation/TurnRestrictionUnknown.java
+++ b/src/main/java/org/opentripplanner/graph_builder/annotation/TurnRestrictionUnknown.java
@@ -17,17 +17,26 @@ public class TurnRestrictionUnknown extends GraphBuilderAnnotation {
 
     private static final long serialVersionUID = 1L;
 
-    public static final String FMT = "Invalid turn restriction %s";
+    public static final String FMT = "Invalid turn restriction tag %s in turn restriction %d";
+
+    public static final String HTMLFMT = "Invalid turn restriction tag %s in  <a href=\"http://www.openstreetmap.org/relation/%d\">\"%d\"</a>";
     
     final String tagval;
+    final long relationId;
     
-    public TurnRestrictionUnknown(String tagval){
+    public TurnRestrictionUnknown(long relationId, String tagval){
+        this.relationId = relationId;
     	this.tagval = tagval;
     }
-    
+
+    @Override
+    public String getHTMLMessage() {
+        return String.format(FMT, tagval, relationId, relationId);
+    }
+
     @Override
     public String getMessage() {
-        return String.format(FMT, tagval);
+        return String.format(FMT, tagval, relationId);
     }
 
 }

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/OSMDatabase.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/OSMDatabase.java
@@ -809,7 +809,7 @@ public class OSMDatabase implements OpenStreetMapContentHandler {
         } else if (relation.isTag("restriction", "only_u_turn")) {
             tag = new TurnRestrictionTag(via, TurnRestrictionType.ONLY_TURN, Direction.U);
         } else {
-            LOG.warn(addBuilderAnnotation(new TurnRestrictionUnknown(relation.getTag("restriction"))));
+            LOG.warn(addBuilderAnnotation(new TurnRestrictionUnknown(relation.getId(), relation.getTag("restriction"))));
             return;
         }
         tag.modes = modes.clone();


### PR DESCRIPTION
Improves HTML annotations based on @abyrd ideas and fixes #2088:
- Annotations are moved to own folder
- Adds index file to annotations
- removes old annotation files before creating new ones
- Doesn't group different classes of annotations
- Adds support for HTML in annotations (all annotations are now supported):
     - BikeParkUnlinked
     - BikeRentalStationUnlinked
     - ConflictingBikeTags
     - StreetCarSpeedZero
     - TurnRestrictionException
     - TurnRestrictionUnknown
     - StopNotLinkedForTransfers
- escapes HTML tags in msg strings for annotations that don't support HTML messages
- annotations aren't created with Javascript anymore
- nicer list of annotations and title in HTML
- cleaned a code added some comments and renamed some variables


