### PR TITLE
Fix scripting typo

### DIFF
--- a/src/client/scripting.html
+++ b/src/client/scripting.html
@@ -9,7 +9,7 @@
 <p>
 	Select a script file to run and click 'Run script'.
 	Check-out OTP server log to see console output and progress.
-	To automate this process, you can use <em>curl</em>: <code>curl --form "scriptfile=@myscript.py" localhost:8080/opt/scripting/run</code>.
+	To automate this process, you can use <em>curl</em>: <code>curl --form "scriptfile=@myscript.py" localhost:8080/otp/scripting/run</code>.
 </p>
 <body>
 	<form enctype='multipart/form-data' action="/otp/scripting/run"

--- a/src/main/java/org/opentripplanner/api/resource/ScriptResource.java
+++ b/src/main/java/org/opentripplanner/api/resource/ScriptResource.java
@@ -62,7 +62,7 @@ public class ScriptResource extends RoutingResource {
                     scriptContent);
             return Response.ok().entity(retval).build();
 
-        } catch (Exception e) {
+        } catch (Throwable e) {
             return Response.status(Status.INTERNAL_SERVER_ERROR).entity(e.toString())
                     .type(MediaType.TEXT_PLAIN).build();
         }


### PR DESCRIPTION
* Fix typo: `otp` vs `opt`
* Catch all `Throwable` for easier debug when something fails in scripting. 