### PR TITLE
Return default OSM level for way if not found

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/OSMDatabase.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/OSMDatabase.java
@@ -160,7 +160,8 @@ public class OSMDatabase implements OpenStreetMapContentHandler {
     }
 
     public OSMLevel getLevelForWay(OSMWithTags way) {
-        return wayLevels.get(way);
+        OSMLevel level = wayLevels.get(way);
+        return level != null ? level : OSMLevel.DEFAULT;
     }
 
     public boolean isNodeSharedByMultipleAreas(Long nodeId) {


### PR DESCRIPTION
Fixes NullPointerException at OpenStreetMapModule.java:948 in expression `level.shortName`, where `level` can be `null`.

This exception prevented graph building process.
`