### PR TITLE
Workaround for Leaflet L.Icon.Default.imagePath detection

### DIFF
--- a/src/client/index.html
+++ b/src/client/index.html
@@ -28,8 +28,14 @@
 <link rel="stylesheet" href="js/otp/widgets/transit/widgets-transit-style.css?v=1" />
 <link rel="stylesheet" href="style.css?v=1" />
 
-<!--Loads jquery, underscore, leaflet, json2, momentjs and raphael makes 7 requests less-->
-<script src="//cdn.jsdelivr.net/g/jquery@1.9.1,underscorejs@1.4.2,leaflet@0.7.3,json2@0.1,momentjs@1.7.2,raphael@2.1.2"></script>
+<!--Loads jquery, underscore, json2, momentjs and raphael makes 7 requests less-->
+<script src="//cdn.jsdelivr.net/g/jquery@1.9.1,underscorejs@1.4.2,json2@0.1,momentjs@1.7.2,raphael@2.1.2"></script>
+
+<!--
+leaflet cannot be loaded with other scripts. it breaks the L.Icon.Default.imagePath regular expression
+Analyst's webinterface was broken by that
+-->
+<script src="//cdn.jsdelivr.net/leaflet/0.7.3/leaflet.js"></script>
 
 <!-- jquery-ui -->
 <script src="js/lib/jquery-ui/js/jquery-ui-1.9.1.custom.min.js"></script>


### PR DESCRIPTION
leaflet cannot be loaded with other scripts. 
It breaks the L.Icon.Default.imagePath regular expression
Analyst's webinterface was broken by that