### PR TITLE
Actually use different stair reluctance when walking with bike

### DIFF
--- a/src/main/java/org/opentripplanner/api/common/RoutingResource.java
+++ b/src/main/java/org/opentripplanner/api/common/RoutingResource.java
@@ -513,7 +513,10 @@ public abstract class RoutingResource {
             request.setOptimize(optimize);
 
         /* Temporary code to get bike/car parking and renting working. */
-        if (modes != null) modes.applyToRoutingRequest(request);
+        if (modes != null) {
+            modes.applyToRoutingRequest(request);
+            request.setModes(request.modes);
+        }
 
         if (request.allowBikeRental && bikeSpeed == null) {
             //slower bike speed for bike sharing, based on empirical evidence from DC.


### PR DESCRIPTION
Previously they weren't used so OTP sometimes preferred walking down/up
the stairs with bike which is hard.
Fixes #1768

I noticed that bikeWalking options aren't applied at all in building routing request in RoutingResource.

Correct bikeWalking options are made only when [setModes](https://github.com/opentripplanner/OpenTripPlanner/blob/master/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java#L485) is called on routingRequest. But this function is never called when request is build in planner request, because modes are set with setMode one by one from list of qualified modes in [applyToRoutingRequest](https://github.com/opentripplanner/OpenTripPlanner/blob/master/src/main/java/org/opentripplanner/api/parameter/QualifiedModeSet.java#L47).

The result is that bikeWalking options just has the same options as routingRequest.

If I change building routing request so that correct bikeWalking options are applied I get correct routing in my case. (bike avoids stairs and instead routes around them)
