### PR TITLE
Add graph annotations when turn restrictions are skipped

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/annotation/TurnRestrictionBad.java
+++ b/src/main/java/org/opentripplanner/graph_builder/annotation/TurnRestrictionBad.java
@@ -17,23 +17,26 @@ public class TurnRestrictionBad extends GraphBuilderAnnotation {
 
     private static final long serialVersionUID = 1L;
 
-    public static final String FMT = "Bad turn restriction at relation %s";
-    public static final String HTMLFMT = "Bad turn restriction at relation <a href='http://www.openstreetmap.org/relation/%s'>%s</a>";
+    public static final String FMT = "Bad turn restriction at relation %s. Reason: %s";
+    public static final String HTMLFMT = "Bad turn restriction at relation <a href='http://www.openstreetmap.org/relation/%s'>%s</a>. Reason: %s";
     
     final long id;
-    
-    public TurnRestrictionBad(long id){
-    	this.id = id;
+
+    final String reason;
+
+    public TurnRestrictionBad(long relationOSMID, String reason) {
+        this.id = relationOSMID;
+        this.reason = reason;
     }
-    
+
     @Override
     public String getMessage() {
-        return String.format(FMT, id);
+        return String.format(FMT, id, reason);
     }
 
     @Override
     public String getHTMLMessage() {
-        return String.format(HTMLFMT, id, id);
+        return String.format(HTMLFMT, id, id, reason);
     }
 
 }

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/OSMDatabase.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/OSMDatabase.java
@@ -751,7 +751,8 @@ public class OSMDatabase implements OpenStreetMapContentHandler {
             }
         }
         if (from == -1 || to == -1 || via == -1) {
-            LOG.warn(addBuilderAnnotation(new TurnRestrictionBad(relation.getId())));
+            LOG.warn(addBuilderAnnotation(new TurnRestrictionBad(relation.getId(),
+                "One of from|via|to edges are empty in relation")));
             return;
         }
 
@@ -770,21 +771,29 @@ public class OSMDatabase implements OpenStreetMapContentHandler {
 
         TurnRestrictionTag tag;
         if (relation.isTag("restriction", "no_right_turn")) {
-            tag = new TurnRestrictionTag(via, TurnRestrictionType.NO_TURN, Direction.RIGHT);
+            tag = new TurnRestrictionTag(via, TurnRestrictionType.NO_TURN, Direction.RIGHT,
+                relation.getId());
         } else if (relation.isTag("restriction", "no_left_turn")) {
-            tag = new TurnRestrictionTag(via, TurnRestrictionType.NO_TURN, Direction.LEFT);
+            tag = new TurnRestrictionTag(via, TurnRestrictionType.NO_TURN, Direction.LEFT,
+                relation.getId());
         } else if (relation.isTag("restriction", "no_straight_on")) {
-            tag = new TurnRestrictionTag(via, TurnRestrictionType.NO_TURN, Direction.STRAIGHT);
+            tag = new TurnRestrictionTag(via, TurnRestrictionType.NO_TURN, Direction.STRAIGHT,
+                relation.getId());
         } else if (relation.isTag("restriction", "no_u_turn")) {
-            tag = new TurnRestrictionTag(via, TurnRestrictionType.NO_TURN, Direction.U);
+            tag = new TurnRestrictionTag(via, TurnRestrictionType.NO_TURN, Direction.U,
+                relation.getId());
         } else if (relation.isTag("restriction", "only_straight_on")) {
-            tag = new TurnRestrictionTag(via, TurnRestrictionType.ONLY_TURN, Direction.STRAIGHT);
+            tag = new TurnRestrictionTag(via, TurnRestrictionType.ONLY_TURN, Direction.STRAIGHT,
+                relation.getId());
         } else if (relation.isTag("restriction", "only_right_turn")) {
-            tag = new TurnRestrictionTag(via, TurnRestrictionType.ONLY_TURN, Direction.RIGHT);
+            tag = new TurnRestrictionTag(via, TurnRestrictionType.ONLY_TURN, Direction.RIGHT,
+                relation.getId());
         } else if (relation.isTag("restriction", "only_left_turn")) {
-            tag = new TurnRestrictionTag(via, TurnRestrictionType.ONLY_TURN, Direction.LEFT);
+            tag = new TurnRestrictionTag(via, TurnRestrictionType.ONLY_TURN, Direction.LEFT,
+                relation.getId());
         } else if (relation.isTag("restriction", "only_u_turn")) {
-            tag = new TurnRestrictionTag(via, TurnRestrictionType.ONLY_TURN, Direction.U);
+            tag = new TurnRestrictionTag(via, TurnRestrictionType.ONLY_TURN, Direction.U,
+                relation.getId());
         } else {
             LOG.warn(addBuilderAnnotation(new TurnRestrictionUnknown(relation.getId(), relation.getTag("restriction"))));
             return;

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModule.java
@@ -23,10 +23,7 @@ import org.opentripplanner.common.geometry.GeometryUtils;
 import org.opentripplanner.common.geometry.SphericalDistanceLibrary;
 import org.opentripplanner.common.model.P2;
 import org.opentripplanner.common.model.T2;
-import org.opentripplanner.graph_builder.annotation.GraphBuilderAnnotation;
-import org.opentripplanner.graph_builder.annotation.Graphwide;
-import org.opentripplanner.graph_builder.annotation.ParkAndRideUnlinked;
-import org.opentripplanner.graph_builder.annotation.StreetCarSpeedZero;
+import org.opentripplanner.graph_builder.annotation.*;
 import org.opentripplanner.graph_builder.module.extra_elevation_data.ElevationPoint;
 import org.opentripplanner.graph_builder.services.DefaultStreetEdgeFactory;
 import org.opentripplanner.graph_builder.services.GraphBuilderModule;
@@ -781,20 +778,28 @@ public class OpenStreetMapModule implements GraphBuilderModule {
             for (Long fromWay : osmdb.getTurnRestrictionWayIds()) {
                 for (TurnRestrictionTag restrictionTag : osmdb.getFromWayTurnRestrictions(fromWay)) {
                     if (restrictionTag.possibleFrom.isEmpty()) {
-                        LOG.debug("No from edge found for " + restrictionTag);
+                        graph.addBuilderAnnotation(new TurnRestrictionBad(restrictionTag.relationOSMID,
+                            "No from edge found"));
                         continue;
                     }
                     if (restrictionTag.possibleTo.isEmpty()) {
-                        LOG.debug("No to edge found for " + restrictionTag);
+                        graph.addBuilderAnnotation(
+                            new TurnRestrictionBad(restrictionTag.relationOSMID,
+                                "No to edge found"));
                         continue;
                     }
                     for (StreetEdge from : restrictionTag.possibleFrom) {
                         if (from == null) {
-                            LOG.warn("from-edge is null in turn " + restrictionTag);
+                            graph.addBuilderAnnotation(
+                                new TurnRestrictionBad(restrictionTag.relationOSMID,
+                                    "from-edge is null"));
                             continue;
                         }
                         for (StreetEdge to : restrictionTag.possibleTo) {
                             if (from == null || to == null) {
+                                graph.addBuilderAnnotation(
+                                    new TurnRestrictionBad(restrictionTag.relationOSMID,
+                                        "to-edge is null"));
                                 continue;
                             }
                             int angleDiff = from.getOutAngle() - to.getInAngle();
@@ -804,20 +809,35 @@ public class OpenStreetMapModule implements GraphBuilderModule {
                             switch (restrictionTag.direction) {
                             case LEFT:
                                 if (angleDiff >= 160) {
+                                    graph.addBuilderAnnotation(
+                                        new TurnRestrictionBad(restrictionTag.relationOSMID,
+                                            "Left turn restriction is not on edges which turn left"));
                                     continue; // not a left turn
                                 }
                                 break;
                             case RIGHT:
-                                if (angleDiff <= 200)
+                                if (angleDiff <= 200) {
+                                    graph.addBuilderAnnotation(
+                                        new TurnRestrictionBad(restrictionTag.relationOSMID,
+                                            "Right turn restriction is not on edges which turn right"));
                                     continue; // not a right turn
+                                }
                                 break;
                             case U:
-                                if ((angleDiff <= 150 || angleDiff > 210))
+                                if ((angleDiff <= 150 || angleDiff > 210)) {
+                                    graph.addBuilderAnnotation(
+                                        new TurnRestrictionBad(restrictionTag.relationOSMID,
+                                            "U-turn restriction is not on U-turn"));
                                     continue; // not a U turn
+                                }
                                 break;
                             case STRAIGHT:
-                                if (angleDiff >= 30 && angleDiff < 330)
+                                if (angleDiff >= 30 && angleDiff < 330) {
+                                    graph.addBuilderAnnotation(
+                                        new TurnRestrictionBad(restrictionTag.relationOSMID,
+                                            "Straight turn restriction is not on edges which go straight"));
                                     continue; // not straight
+                                }
                                 break;
                             }
                             TurnRestriction restriction = new TurnRestriction();

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/TurnRestrictionTag.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/TurnRestrictionTag.java
@@ -32,6 +32,9 @@ class TurnRestrictionTag {
 
     long via;
 
+    //Used only for graph annotations so that it can be visualized which annotations are problematic
+    long relationOSMID;
+
     TurnRestrictionType type;
 
     Direction direction;
@@ -44,10 +47,11 @@ class TurnRestrictionTag {
 
     public TraverseModeSet modes;
 
-    TurnRestrictionTag(long via, TurnRestrictionType type, Direction direction) {
+    TurnRestrictionTag(long via, TurnRestrictionType type, Direction direction, long relationOSMID) {
         this.via = via;
         this.type = type;
         this.direction = direction;
+        this.relationOSMID = relationOSMID;
     }
 
     @Override


### PR DESCRIPTION
Previously if turn restrictions weren't created because from/to edges
were missing or edges weren't the correct angle they were silently
ignored. This commit adds those skipped turn restrictions to log and
adds them to graph annotations

Fixes #2159