### PR TITLE
Always pass agency information of alert

### DIFF
--- a/src/main/java/org/opentripplanner/updater/alerts/AlertsUpdateHandler.java
+++ b/src/main/java/org/opentripplanner/updater/alerts/AlertsUpdateHandler.java
@@ -147,9 +147,7 @@ public class AlertsUpdateHandler {
             if (stopId != null) {
                 patch.setStop(new AgencyAndId(agencyId, stopId));
             }
-            if(agencyId != null && routeId == null && tripId == null && stopId == null) {
-                patch.setAgencyId(agencyId);
-            }
+            patch.setAgencyId(agencyId);
             patch.setTimePeriods(periods);
             patch.setAlert(alertText);
 


### PR DESCRIPTION
Refactor/reorder AlertPatch code, so that in the case of agency getting passed, we only take it as "whole agency alert" if nothing else matches. Previously agency was only set if it was a "whole agency alert".

Also save the patterns for later use.
