### PR TITLE
Add getters for languages and translations

### DIFF
--- a/src/main/java/org/opentripplanner/util/TranslatedString.java
+++ b/src/main/java/org/opentripplanner/util/TranslatedString.java
@@ -1,10 +1,14 @@
 package org.opentripplanner.util;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Map.Entry;
 
 /**
  * This is for translated strings for which translations are read from OSM or GTFS alerts.
@@ -58,6 +62,20 @@ public class TranslatedString implements I18NString, Serializable {
             intern.put(translations, ret);
             return ret;
         }
+    }
+
+    /**
+     * @return The available languages
+     */
+    public Collection<String> getLanguages() {
+        return translations.keySet();
+    }
+
+    /**
+     * @return The available translations
+     */
+    public List<Entry<String,String>> getTranslations() {
+        return new ArrayList<Entry<String, String>>(translations.entrySet());
     }
 
     /**


### PR DESCRIPTION
Need to be able to iterate through available translations. Useful for exposing them through e.g. GraphQL API