### PR TITLE
Add a configuration option alwaysIncremental

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -408,7 +408,11 @@ connect to a network resource is the `url` field.
             // this is either http or file... shouldn't it default to http or guess from the presence of a URL?
             sourceType: "gtfs-http",
             url: "http://developer.trimet.org/ws/V1/TripUpdate/appID/0123456789ABCDEF",
-            defaultAgencyId: "TriMet"
+            defaultAgencyId: "TriMet",
+            // Defaults to false, if omitted. Makes the feed always incremental even when it states
+            // that it contains a full dataset.
+            // Useful with multiple realtime feeds to prevent last feed from clearing previous feeds.
+            alwaysIncremental: true
         },
 
         // Streaming differential GTFS-RT TripUpdates over websockets

--- a/src/main/java/org/opentripplanner/updater/stoptime/GtfsRealtimeFileTripUpdateSource.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/GtfsRealtimeFileTripUpdateSource.java
@@ -42,7 +42,15 @@ public class GtfsRealtimeFileTripUpdateSource implements TripUpdateSource, JsonC
      * previous updates should be disregarded
      */
     private boolean fullDataset = true;
-    
+
+    /**
+     * True iff updates from this realtime feed should always be considered incremental,
+     * i.e. missing entities will not delete previous realtime data,
+     * even if the feed itself says it contains the full dataset.
+     * Useful when there are several realtime feeds.
+     */
+    private boolean alwaysIncremental = true;
+
     /**
      * Default agency id that is used for the trip ids in the TripUpdates
      */
@@ -52,6 +60,10 @@ public class GtfsRealtimeFileTripUpdateSource implements TripUpdateSource, JsonC
     public void configure(Graph graph, JsonNode config) throws Exception {
         this.agencyId = config.path("defaultAgencyId").asText();
         this.file = new File(config.path("file").asText(""));
+        if (config.path("alwaysIncremental").asBoolean(false)) {
+            LOG.debug("Setting alwaysIncremental for source " + file);
+            this.alwaysIncremental = true;
+        }
     }
 
     @Override
@@ -89,6 +101,9 @@ public class GtfsRealtimeFileTripUpdateSource implements TripUpdateSource, JsonC
 
     @Override
     public boolean getFullDatasetValueOfLastUpdates() {
+        if (this.alwaysIncremental) {
+            return false;
+        }
         return fullDataset;
     }
     

--- a/src/main/java/org/opentripplanner/updater/stoptime/GtfsRealtimeHttpTripUpdateSource.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/GtfsRealtimeHttpTripUpdateSource.java
@@ -39,7 +39,15 @@ public class GtfsRealtimeHttpTripUpdateSource implements TripUpdateSource, JsonC
      * previous updates should be disregarded
      */
     private boolean fullDataset = true;
-    
+
+    /**
+     * True iff updates from this realtime feed should always be considered incremental,
+     * i.e. missing entities will not delete previous realtime data,
+     * even if the feed itself says it contains the full dataset.
+     * Useful when there are several realtime feeds.
+     */
+    private boolean alwaysIncremental = true;
+
     /**
      * Default agency id that is used for the trip ids in the TripUpdates
      */
@@ -55,6 +63,10 @@ public class GtfsRealtimeHttpTripUpdateSource implements TripUpdateSource, JsonC
         }
         this.url = url;
         this.agencyId = config.path("defaultAgencyId").asText();
+        if (config.path("alwaysIncremental").asBoolean(false)) {
+            LOG.debug("Setting alwaysIncremental for source " + url);
+            this.alwaysIncremental = true;
+        }
     }
 
     @Override
@@ -92,6 +104,9 @@ public class GtfsRealtimeHttpTripUpdateSource implements TripUpdateSource, JsonC
 
     @Override
     public boolean getFullDatasetValueOfLastUpdates() {
+        if (this.alwaysIncremental) {
+            return false;
+        }
         return fullDataset;
     }
     

--- a/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
@@ -192,6 +192,7 @@ public class TimetableSnapshotSource {
         try {
             if (fullDataset) {
                 // Remove all updates from the buffer
+                LOG.debug("Clearing all realtime updates");
                 buffer.clear();
             }
 


### PR DESCRIPTION
that helps with multiple GTFS realtime feeds. Without this parameter the last feed that finishes processing will clear realtime data from every previous feed.