### PR TITLE
Fix bug when stopClusters weren't lazy initialized everywhere

### DIFF
--- a/src/main/java/org/opentripplanner/index/IndexAPI.java
+++ b/src/main/java/org/opentripplanner/index/IndexAPI.java
@@ -548,6 +548,7 @@ public class IndexAPI {
     @GET
     @Path("/clusters")
     public Response getAllStopClusters () {
+        index.clusterStopsAsNeeded();
         // use 'detail' field common to all API methods in this class
         List<StopClusterDetail> scl = StopClusterDetail.list(index.stopClusterForId.values(), detail);
         return Response.status(Status.OK).entity(scl).build();
@@ -557,6 +558,7 @@ public class IndexAPI {
     @GET
     @Path("/clusters/{clusterId}")
     public Response getStopCluster (@PathParam("clusterId") String clusterIdString) {
+        index.clusterStopsAsNeeded();
         StopCluster cluster = index.stopClusterForId.get(clusterIdString);
         if (cluster != null) {
             return Response.status(Status.OK).entity(new StopClusterDetail(cluster, true)).build();


### PR DESCRIPTION
Fixes #2162. In Index API call for all clusters and for specific stop
clusters. Stop clusters were not lazy initialized.

They should be according to code comments and they were in profile
routing and lucene search.