### PR TITLE
Added transit start and end timestamps to the BuildInfo object

### DIFF
--- a/src/main/java/org/opentripplanner/api/model/RouterInfo.java
+++ b/src/main/java/org/opentripplanner/api/model/RouterInfo.java
@@ -54,6 +54,12 @@ public class RouterInfo {
     @XmlElement
     public Date buildTime;
 
+    @XmlElement
+    public long transitServiceStarts;
+
+    @XmlElement
+    public long transitServiceEnds;
+
     public HashSet<TraverseMode> transitModes;
 
     private WorldEnvelope envelope;
@@ -71,6 +77,8 @@ public class RouterInfo {
         this.routerId = routerId;
         this.polygon = graph.getConvexHull();
         this.buildTime = graph.buildTime;
+        this.transitServiceStarts = graph.getTransitServiceStarts();
+        this.transitServiceEnds = graph.getTransitServiceEnds();
         this.transitModes = graph.getTransitModes();
         this.envelope = graph.getEnvelope();
         addCenter(graph.getCenter());

--- a/src/main/java/org/opentripplanner/routing/graph/Graph.java
+++ b/src/main/java/org/opentripplanner/routing/graph/Graph.java
@@ -1048,4 +1048,12 @@ public class Graph implements Serializable {
     public Optional<Coordinate> getCenter() {
         return Optional.ofNullable(center);
     }
+
+    public long getTransitServiceStarts() {
+        return transitServiceStarts;
+    }
+
+    public long getTransitServiceEnds() {
+        return transitServiceEnds;
+    }
 }

--- a/src/test/java/org/opentripplanner/api/resource/RoutersTest.java
+++ b/src/test/java/org/opentripplanner/api/resource/RoutersTest.java
@@ -1,6 +1,9 @@
 package org.opentripplanner.api.resource;
 
 import org.junit.Test;
+import org.onebusaway.gtfs.model.AgencyAndId;
+import org.onebusaway.gtfs.model.calendar.CalendarServiceData;
+import org.onebusaway.gtfs.model.calendar.ServiceDate;
 import org.opentripplanner.api.model.RouterInfo;
 import org.opentripplanner.api.model.RouterList;
 import org.opentripplanner.routing.graph.Graph;
@@ -11,7 +14,11 @@ import org.opentripplanner.standalone.CommandLineParameters;
 import org.opentripplanner.standalone.OTPServer;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class RoutersTest {
     @Test
@@ -48,5 +55,36 @@ public class RoutersTest {
         assertEquals("", defaultRouter.routerId);
         assertEquals("A", otherRouter.routerId);
         assertTrue(otherRouter.polygon.getArea() > 0);
+    }
+    
+    @Test
+    public void getRouterInfoReturnsFirstAndLastValidDateForGraph() {
+
+        final CalendarServiceData calendarService = new CalendarServiceData();
+        final List<ServiceDate> serviceDates = new ArrayList<ServiceDate>() {
+            {
+                add(new ServiceDate(2015, 10, 1));
+                add(new ServiceDate(2015, 11, 1));
+            }
+        };
+
+        calendarService.putServiceDatesForServiceId(new AgencyAndId("NA", "1"), serviceDates);
+
+        final Graph graph = new Graph();
+        graph.updateTransitFeedValidity(calendarService);
+        graph.expandToInclude(0, 100);
+
+        OTPServer otpServer = new OTPServer(new CommandLineParameters(), new GraphService());
+        otpServer.getGraphService().registerGraph("A", new MemoryGraphSource("A", graph));
+
+        Routers routerApi = new Routers();
+        routerApi.otpServer = otpServer;
+
+        RouterInfo info = routerApi.getGraphId("A");
+
+        assertNotNull(info.transitServiceStarts);
+        assertNotNull(info.transitServiceEnds);
+
+        assertTrue(info.transitServiceStarts < info.transitServiceEnds);
     }
 }


### PR DESCRIPTION
Added the transitServiceStarts and transitServiceEnds timestamps to the BuildInfo object. This info will then be available for the users through the API. Very useful when the user needs to know the date range supported by the currently running graph. 