### PR TITLE
Rework embedded router config

### DIFF
--- a/src/main/java/org/opentripplanner/api/resource/Routers.java
+++ b/src/main/java/org/opentripplanner/api/resource/Routers.java
@@ -55,6 +55,8 @@ import org.opentripplanner.standalone.Router;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Files;
 
@@ -213,7 +215,9 @@ public class Routers {
         try {
             graph = Graph.load(is, level);
             GraphService graphService = otpServer.getGraphService();
-            graphService.registerGraph(routerId, new MemoryGraphSource(routerId, graph));
+            ObjectMapper mapper = new ObjectMapper();
+            JsonNode routerJsonConf = mapper.readTree(graph.routerConfig);
+            graphService.registerGraph(routerId, new MemoryGraphSource(routerId, graph, routerJsonConf));
             return Response.status(Status.CREATED).entity(graph.toString() + "\n").build();
         } catch (Exception e) {
             return Response.status(Status.BAD_REQUEST).entity(e.toString() + "\n").build();

--- a/src/main/java/org/opentripplanner/api/resource/Routers.java
+++ b/src/main/java/org/opentripplanner/api/resource/Routers.java
@@ -55,8 +55,6 @@ import org.opentripplanner.standalone.Router;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Files;
 
@@ -215,9 +213,7 @@ public class Routers {
         try {
             graph = Graph.load(is, level);
             GraphService graphService = otpServer.getGraphService();
-            ObjectMapper mapper = new ObjectMapper();
-            JsonNode routerJsonConf = mapper.readTree(graph.routerConfig);
-            graphService.registerGraph(routerId, new MemoryGraphSource(routerId, graph, routerJsonConf));
+            graphService.registerGraph(routerId, new MemoryGraphSource(routerId, graph));
             return Response.status(Status.CREATED).entity(graph.toString() + "\n").build();
         } catch (Exception e) {
             return Response.status(Status.BAD_REQUEST).entity(e.toString() + "\n").build();

--- a/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
@@ -76,9 +76,6 @@ public class GraphBuilder implements Runnable {
     
     private Graph graph = new Graph();
 
-    /* The router configuration JSON that was discovered during the graph build and will be embedded (if any). */
-    public JsonNode routerConfig;
-
     /** Should the graph be serialized to disk after being created or not? */
     public boolean serializeGraph = true;
 
@@ -200,7 +197,7 @@ public class GraphBuilder implements Runnable {
         builderConfig = OTPMain.loadJson(new File(dir, BUILDER_CONFIG_FILENAME));
         GraphBuilderParameters builderParams = new GraphBuilderParameters(builderConfig);
         // Load the router config JSON to fail fast, but we will only apply it later when a router starts up
-        graphBuilder.routerConfig = OTPMain.loadJson(new File(dir, Router.ROUTER_CONFIG_FILENAME));
+        routerConfig = OTPMain.loadJson(new File(dir, Router.ROUTER_CONFIG_FILENAME));
         LOG.info(ReflectionLibrary.dumpFields(builderParams));
         for (File file : dir.listFiles()) {
             switch (InputFileType.forFile(file)) {

--- a/src/main/java/org/opentripplanner/routing/impl/MemoryGraphSource.java
+++ b/src/main/java/org/opentripplanner/routing/impl/MemoryGraphSource.java
@@ -13,31 +13,33 @@
 
 package org.opentripplanner.routing.impl;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.MissingNode;
+import java.io.IOException;
+
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.services.GraphSource;
 import org.opentripplanner.standalone.Router;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * An implementation of GraphSource that store a transient graph in memory.
  */
 public class MemoryGraphSource implements GraphSource {
 
+    private static final Logger LOG = LoggerFactory.getLogger(MemoryGraphSource.class);
+
     private Router router;
 
-    private JsonNode config;
-
-    /** Create an in-memory graph source with no runtime router configuration. */
+    /**
+     * Create an in-memory graph source. If the graph contains an embedded runtime-server
+     * configuration, it will be used.
+     */
     public MemoryGraphSource(String routerId, Graph graph) {
-        this(routerId, graph, MissingNode.getInstance());
-    }
-
-    /** Create an in-memory graph source with the specififed runtime router configuration JSON. */
-    public MemoryGraphSource(String routerId, Graph graph, JsonNode config) {
         router = new Router(routerId, graph);
         router.graph.routerId = routerId;
-        this.config = config;
         // We will start up the router later on (updaters and runtime configuration options)
     }
 
@@ -51,8 +53,17 @@ public class MemoryGraphSource implements GraphSource {
         // "Reloading" does not make sense for memory-graph, but we want to support mixing in-memory and file-based graphs.
         // Start up graph updaters and apply runtime configuration options
         // TODO will the updaters be started repeatedly due to reload calls?
-        router.startup(config);
-        return true;
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode routerJsonConf;
+        try {
+            routerJsonConf = mapper.readTree(router.graph.routerConfig);
+            router.startup(routerJsonConf);
+            return true;
+        } catch (IOException e) {
+            LOG.error("Can't startup graph: error with embed config (" + router.graph.routerConfig
+                    + ")", e);
+            return false;
+        }
     }
 
     @Override

--- a/src/main/java/org/opentripplanner/standalone/OTPMain.java
+++ b/src/main/java/org/opentripplanner/standalone/OTPMain.java
@@ -116,7 +116,7 @@ public class OTPMain {
                     Graph graph = graphBuilder.getGraph();
                     graph.index(new DefaultStreetVertexIndexFactory());
                     // FIXME set true router IDs
-                    graphService.registerGraph("", new MemoryGraphSource("", graph, graphBuilder.routerConfig));
+                    graphService.registerGraph("", new MemoryGraphSource("", graph));
                 }
             } else {
                 LOG.error("An error occurred while building the graph. Exiting.");


### PR DESCRIPTION
Fix #2184. Solves also the following:

* Allow the use of embeded router-config when posting a graph over the API.
* Allow the use of router-config.json when posting a ZIP to build over the API.
* Simplify code a bit.

Tested the following scenario, with and without a router-config.json file present:
* Graph building in a file, then startup (most common use)
* Graph building in memory and serving right away (--inMemory option)
* Graph building offline and posting a graph via API
* Zipping data with router-config and posting a zip via API