### PR TITLE
.gitignore was not specific enough, causing missing files in status.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,5 @@ gen-py/
 .idea/
 .sonar
 _site/
-otp
-otp-batch-analyst
+/otp
+/otp-batch-analyst


### PR DESCRIPTION
`otp` was probably meant for only the `/otp` in the root dir of the project. This caused me some issues when finding changed and added files in e.g. `src/client/js/otp` This might help with i18n.