### PR TITLE
Add realtimeState to TripTimeShort and GraphQL

### DIFF
--- a/src/main/java/org/opentripplanner/index/IndexGraphQLSchema.java
+++ b/src/main/java/org/opentripplanner/index/IndexGraphQLSchema.java
@@ -33,6 +33,7 @@ import org.opentripplanner.profile.StopCluster;
 import org.opentripplanner.routing.edgetype.SimpleTransfer;
 import org.opentripplanner.routing.edgetype.TripPattern;
 import org.opentripplanner.routing.graph.GraphIndex;
+import org.opentripplanner.routing.trippattern.RealTimeState;
 import org.opentripplanner.routing.vertextype.TransitVertex;
 import org.opentripplanner.updater.GtfsRealtimeFuzzyTripMatcher;
 
@@ -62,6 +63,19 @@ public class IndexGraphQLSchema {
         .value("NO_INFORMATION", 0, "There is no bike information for the trip.")
         .value("ALLOWED", 1, "The vehicle being used on this particular trip can accommodate at least one bicycle.")
         .value("NOT_ALLOWED", 2, "No bicycles are allowed on this trip.")
+        .build();
+
+    public static GraphQLEnumType realtimeStateEnum = GraphQLEnumType.newEnum()
+        .name("RealtimeState")
+        .value("SCHEDULED", RealTimeState.SCHEDULED, "The trip information comes from the GTFS feed, i.e. no real-time update has been applied.")
+
+        .value("UPDATED", RealTimeState.UDPATED, "The trip information has been updated, but the trip pattern stayed the same as the trip pattern of the scheduled trip.")
+
+        .value("CANCELED", RealTimeState.CANCELED, "The trip has been canceled by a real-time update.")
+
+        .value("ADDED", RealTimeState.ADDED, "The trip has been added using a real-time update, i.e. the trip was not present in the GTFS feed.")
+
+        .value("MODIFIED", RealTimeState.MODIFIED, "The trip information has been updated and resulted in a different trip pattern compared to the trip pattern of the scheduled trip.")
         .build();
 
     private final GtfsRealtimeFuzzyTripMatcher fuzzyTripMatcher;
@@ -423,6 +437,11 @@ public class IndexGraphQLSchema {
                 .name("realtime")
                 .type(Scalars.GraphQLBoolean)
                 .dataFetcher(environment -> ((TripTimeShort) environment.getSource()).realtime)
+                .build())
+            .field(GraphQLFieldDefinition.newFieldDefinition()
+                .name("realtimeState")
+                .type(realtimeStateEnum)
+                .dataFetcher(environment -> ((TripTimeShort) environment.getSource()).realtimeState)
                 .build())
             .field(GraphQLFieldDefinition.newFieldDefinition()
                 .name("serviceDay")

--- a/src/main/java/org/opentripplanner/index/model/TripTimeShort.java
+++ b/src/main/java/org/opentripplanner/index/model/TripTimeShort.java
@@ -7,6 +7,7 @@ import org.onebusaway.gtfs.model.Stop;
 import org.onebusaway.gtfs.model.Trip;
 import org.opentripplanner.routing.core.ServiceDay;
 import org.opentripplanner.routing.edgetype.Timetable;
+import org.opentripplanner.routing.trippattern.RealTimeState;
 import org.opentripplanner.routing.trippattern.TripTimes;
 
 import com.beust.jcommander.internal.Lists;
@@ -23,6 +24,7 @@ public class TripTimeShort {
     public int departureDelay = UNDEFINED ;
     public boolean timepoint = false;
     public boolean realtime = false;
+    public RealTimeState realtimeState = RealTimeState.SCHEDULED ;
     public long serviceDay;
     public AgencyAndId tripId;
 
@@ -39,6 +41,7 @@ public class TripTimeShort {
         departureDelay     = tt.getDepartureDelay(i);
         timepoint          = tt.isTimepoint(i);
         realtime           = !tt.isScheduled();
+        realtimeState      = tt.getRealTimeState();
     }
 
     public TripTimeShort(TripTimes tt, int i, Stop stop, ServiceDay sd) {


### PR DESCRIPTION
Canceled trips are taken into account in itinerary searches, but are not marked as such in REST or GraphQL APIs. This commit adds the API support for showing the realtime state.