### PR TITLE
Check for null FareRule set in SeattleFareServiceFactory. fixes #2210

### DIFF
--- a/src/main/java/org/opentripplanner/routing/impl/SeattleFareServiceFactory.java
+++ b/src/main/java/org/opentripplanner/routing/impl/SeattleFareServiceFactory.java
@@ -13,6 +13,7 @@
 
 package org.opentripplanner.routing.impl;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -200,8 +201,12 @@ public class SeattleFareServiceFactory extends DefaultFareServiceFactory {
         }
 
         for (Map.Entry<String, Set<FareAttribute>> kv : fareAttributesPerAgency.entrySet()) {
-            super.fillFareRules(kv.getKey(), kv.getValue(), fareRulesPerAgency.get(kv.getKey()),
-                    regularFareRules);
+
+            Set<FareRule> fareRules = fareRulesPerAgency.get(kv.getKey());
+            if (fareRules == null)
+                fareRules = Collections.emptySet();
+
+            super.fillFareRules(kv.getKey(), kv.getValue(), fareRules, regularFareRules);
         }
     }
 


### PR DESCRIPTION
This fixes issue #2210. If the FareRule set is null, we create an empty set before passing it to DefaultFareServiceFactory.