### PR TITLE
Removed Busish + Trainish modes (fixes #2218)

### DIFF
--- a/src/client/js/otp/config.js
+++ b/src/client/js/otp/config.js
@@ -285,10 +285,10 @@ otp.config.modes = {
         "TRANSIT,WALK"        : _tr("Transit"), 
     //TRANSLATORS: Travel by: mode of transport (Used in selection in Travel
     //Options widgets)
-        "BUSISH,WALK"         : _tr("Bus Only"), 
+        "BUS,WALK"         : _tr("Bus Only"), 
     //TRANSLATORS: Travel by: mode of transport (Used in selection in Travel
     //Options widgets)
-        "TRAINISH,WALK"       : _tr("Rail Only"), 
+        "TRAM,RAIL,SUBWAY,FUNICULAR,GONDOLA,WALK"       : _tr("Rail Only"), 
     //TRANSLATORS: Travel by: mode of transport (Used in selection in Travel
     //Options widgets)
         "AIRPLANE,WALK"       : _tr("Airplane Only"),

--- a/src/client/js/otp/util/Itin.js
+++ b/src/client/js/otp/util/Itin.js
@@ -70,7 +70,7 @@ otp.util.Itin = {
     },
 
     isTransit : function(mode) {
-        return mode === "TRANSIT" || mode === "SUBWAY" || mode === "RAIL" || mode === "BUS" || mode === "TRAM" || mode === "GONDOLA" || mode === "TRAINISH" || mode === "BUSISH" || mode === "AIRPLANE";
+        return mode === "TRANSIT" || mode === "SUBWAY" || mode === "RAIL" || mode === "BUS" || mode === "TRAM" || mode === "GONDOLA" || mode === "AIRPLANE";
     },
 
     includesTransit : function(mode) {

--- a/src/main/java/org/opentripplanner/api/resource/SIsochrone.java
+++ b/src/main/java/org/opentripplanner/api/resource/SIsochrone.java
@@ -166,8 +166,7 @@ public class SIsochrone extends RoutingResource {
         // set the switch-time for shed/area calculation, i.e. to decide if the hull is calculated based on points or on edges
         TraverseModeSet modes = sptRequestA.modes;
         LOG.debug("mode(s): " + modes);
-        if ((modes.contains(TraverseMode.TRANSIT)) || (modes.contains(TraverseMode.BUSISH))
-                || (modes.contains(TraverseMode.TRAINISH))) {
+        if (modes.contains(TraverseMode.TRANSIT)) {
             shedCalcMethodSwitchTimeInSec = 60 * 20; // 20min (use 20min for transit, since buses may not come all the time)
         } else if (modes.contains(TraverseMode.CAR)) {
             shedCalcMethodSwitchTimeInSec = 60 * 10; // 10min

--- a/src/main/java/org/opentripplanner/routing/core/TraverseMode.java
+++ b/src/main/java/org/opentripplanner/routing/core/TraverseMode.java
@@ -25,7 +25,7 @@ public enum TraverseMode {
     WALK, BICYCLE, CAR,
     TRAM, SUBWAY, RAIL, BUS, FERRY,
     CABLE_CAR, GONDOLA, FUNICULAR,
-    TRANSIT, TRAINISH, BUSISH, LEG_SWITCH,
+    TRANSIT, LEG_SWITCH,
     AIRPLANE;
 
     private static HashMap <Set<TraverseMode>, Set<TraverseMode>> setMap = 
@@ -48,7 +48,7 @@ public enum TraverseMode {
     public boolean isTransit() {
         return this == TRAM || this == SUBWAY || this == RAIL || this == BUS || this == FERRY
                 || this == CABLE_CAR || this == GONDOLA || this == FUNICULAR || this == TRANSIT
-                || this == TRAINISH || this == BUSISH || this == AIRPLANE;
+                || this == AIRPLANE;
     }
 
     public boolean isOnStreetNonTransit() {

--- a/src/main/java/org/opentripplanner/routing/core/TraverseModeSet.java
+++ b/src/main/java/org/opentripplanner/routing/core/TraverseModeSet.java
@@ -53,12 +53,9 @@ public class TraverseModeSet implements Cloneable, Serializable {
 
     private static final int MODE_AIRPLANE = 4096;
 
-    private static final int MODE_TRAINISH = MODE_TRAM | MODE_RAIL | MODE_SUBWAY | MODE_FUNICULAR | MODE_GONDOLA;
-
-    private static final int MODE_BUSISH = MODE_CABLE_CAR | MODE_BUS;
-
-    private static final int MODE_TRANSIT = MODE_TRAINISH | MODE_BUSISH | MODE_FERRY | MODE_AIRPLANE;
-    
+    private static final int MODE_TRANSIT = MODE_TRAM | MODE_RAIL | MODE_SUBWAY | MODE_FUNICULAR
+            | MODE_GONDOLA | MODE_CABLE_CAR | MODE_BUS | MODE_FERRY | MODE_AIRPLANE;
+ 
     private static final int MODE_ALL = MODE_TRANSIT | MODE_WALK | MODE_BICYCLE;
 
     private int modes = 0;
@@ -117,10 +114,6 @@ public class TraverseModeSet implements Cloneable, Serializable {
             return MODE_RAIL;
         case AIRPLANE:
             return MODE_AIRPLANE;
-        case TRAINISH:
-            return MODE_TRAINISH;
-        case BUSISH:
-            return MODE_BUSISH;
         case TRANSIT:
             return MODE_TRANSIT;
         }
@@ -158,14 +151,6 @@ public class TraverseModeSet implements Cloneable, Serializable {
     
     public boolean getTram() {
         return (modes & MODE_TRAM) != 0;
-    }
-    
-    public boolean getTrainish() {
-        return (modes & MODE_TRAINISH) != 0;
-    }
-    
-    public boolean getBusish() {
-        return (modes & MODE_BUSISH) != 0;
     }
     
     public boolean getBus() {
@@ -231,14 +216,6 @@ public class TraverseModeSet implements Cloneable, Serializable {
             modes &= ~MODE_TRAM;
         }
     }
-
-    public void setTrainish(boolean trainish) {
-        if (trainish) {
-            modes |= MODE_TRAINISH;
-        } else {
-            modes &= ~MODE_TRAINISH;
-        }
-    }
     
     public void setBus(boolean bus) {
         if (bus) {
@@ -247,15 +224,7 @@ public class TraverseModeSet implements Cloneable, Serializable {
             modes &= ~MODE_BUS;
         }
     }
-
-    public void setBusish(boolean busish) {
-        if (busish) {
-            modes |= MODE_BUSISH;
-        } else {
-            modes &= ~MODE_BUSISH;
-        }
-    }
-    
+   
     public void setFerry(boolean ferry) {
         if (ferry) {
             modes |= MODE_FERRY;
@@ -333,11 +302,6 @@ public class TraverseModeSet implements Cloneable, Serializable {
         retval.modes = modes;
         retval.setTransit(false);
         return retval;
-    }
-
-    /** Returns true if any the trip may use some train-like (train, subway, tram) mode */
-    public boolean getTraininsh() {
-        return (modes & (MODE_TRAINISH)) != 0;
     }
 
     public List<TraverseMode> getModes() {

--- a/src/main/java/org/opentripplanner/routing/impl/CandidateEdge.java
+++ b/src/main/java/org/opentripplanner/routing/impl/CandidateEdge.java
@@ -197,10 +197,11 @@ public class CandidateEdge {
      */
     private int calcPlatform(TraverseModeSet mode) {
         int out = 0;
-        if (mode.getTrainish()) {
+        if (mode.getTram() | mode.getRail() | mode.getSubway() | mode.getFunicular()
+                | mode.getGondola()) {
             out |= StreetEdge.CLASS_TRAIN_PLATFORM;
         }
-        if (mode.getBusish() ) { 
+        if (mode.getBus() | mode.getCableCar()) {
             // includes CABLE_CAR
             out |= StreetEdge.CLASS_OTHER_PLATFORM;
         }

--- a/src/main/java/org/opentripplanner/visualizer/GraphVisualizer.java
+++ b/src/main/java/org/opentripplanner/visualizer/GraphVisualizer.java
@@ -1366,8 +1366,13 @@ public class GraphVisualizer extends JFrame implements VertexSelectionListener {
         modeSet.setWalk(walkCheckBox.isSelected());
         modeSet.setBicycle(bikeCheckBox.isSelected());
         modeSet.setFerry(ferryCheckBox.isSelected());
-        modeSet.setTrainish(trainCheckBox.isSelected());
-        modeSet.setBusish(busCheckBox.isSelected());
+        modeSet.setRail(trainCheckBox.isSelected());
+        modeSet.setTram(trainCheckBox.isSelected());
+        modeSet.setSubway(trainCheckBox.isSelected());
+        modeSet.setFunicular(trainCheckBox.isSelected());
+        modeSet.setGondola(trainCheckBox.isSelected());
+        modeSet.setBus(busCheckBox.isSelected());
+        modeSet.setCableCar(busCheckBox.isSelected());
         modeSet.setCar(carCheckBox.isSelected());
         // must set generic transit mode last, and only when it is checked
         // otherwise 'false' will clear trainish and busish

--- a/src/test/java/org/opentripplanner/routing/core/TraverseModeSetTest.java
+++ b/src/test/java/org/opentripplanner/routing/core/TraverseModeSetTest.java
@@ -25,7 +25,11 @@ public class TraverseModeSetTest {
         
         assertTrue(modeSet.getCar());
         assertFalse(modeSet.isTransit());
-        assertFalse(modeSet.getTrainish());
+        assertFalse(modeSet.getRail());
+        assertFalse(modeSet.getTram());
+        assertFalse(modeSet.getSubway());
+        assertFalse(modeSet.getFunicular());
+        assertFalse(modeSet.getGondola());
         assertFalse(modeSet.getWalk());
         assertFalse(modeSet.getBicycle());        
     }
@@ -37,7 +41,11 @@ public class TraverseModeSetTest {
         assertTrue(modeSet.getWalk());
         assertFalse(modeSet.getCar());
         assertFalse(modeSet.isTransit());
-        assertFalse(modeSet.getTrainish());
+        assertFalse(modeSet.getRail());
+        assertFalse(modeSet.getTram());
+        assertFalse(modeSet.getSubway());
+        assertFalse(modeSet.getFunicular());
+        assertFalse(modeSet.getGondola());
         assertFalse(modeSet.getBicycle());
     }
     
@@ -49,7 +57,11 @@ public class TraverseModeSetTest {
         assertFalse(modeSet.getWalk());
         assertFalse(modeSet.getCar());
         assertFalse(modeSet.isTransit());
-        assertFalse(modeSet.getTrainish());
+        assertFalse(modeSet.getRail());
+        assertFalse(modeSet.getTram());
+        assertFalse(modeSet.getSubway());
+        assertFalse(modeSet.getFunicular());
+        assertFalse(modeSet.getGondola());
         assertFalse(modeSet.getWalk());
     }
 

--- a/src/test/java/org/opentripplanner/routing/edgetype/StreetTraversalPermissionTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/StreetTraversalPermissionTest.java
@@ -54,8 +54,7 @@ public class StreetTraversalPermissionTest {
         assertTrue(perm1.allows(TraverseMode.WALK));
 
         // StreetTraversalPermission is not used for public transit.
-        assertFalse(perm1.allows(TraverseMode.BUS));
-        assertFalse(perm1.allows(TraverseMode.TRAINISH));
+        assertFalse(perm1.allows(TraverseMode.TRANSIT));
     }
 
     @Test
@@ -63,7 +62,7 @@ public class StreetTraversalPermissionTest {
         StreetTraversalPermission perm1 = StreetTraversalPermission.BICYCLE_AND_CAR;
         assertTrue(perm1.allows(TraverseModeSet.allModes()));
         assertTrue(perm1.allows(new TraverseModeSet(TraverseMode.CAR, TraverseMode.BICYCLE)));
-        assertTrue(perm1.allows(new TraverseModeSet(TraverseMode.BICYCLE, TraverseMode.TRAINISH, TraverseMode.FERRY)));
+        assertTrue(perm1.allows(new TraverseModeSet(TraverseMode.BICYCLE, TraverseMode.RAIL, TraverseMode.FERRY)));
         assertFalse(perm1.allows(new TraverseModeSet(TraverseMode.WALK)));
     }
 

--- a/src/test/java/org/opentripplanner/routing/edgetype/loader/TestPatternHopFactory.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/loader/TestPatternHopFactory.java
@@ -386,7 +386,7 @@ public class TestPatternHopFactory extends TestCase {
         ShortestPathTree spt;
 
         RoutingRequest options = new RoutingRequest();
-        options.setModes(new TraverseModeSet("TRAINISH"));
+        options.setModes(new TraverseModeSet("TRAM,RAIL,SUBWAY,FUNICULAR,GONDOLA"));
         options.dateTime = TestUtils.dateInSeconds("America/New_York", 2009, 8, 0, 0, 0, 0);
         options.setRoutingContext(graph, stop_a, stop_b);
         spt = aStar.getShortestPathTree(options );
@@ -394,7 +394,7 @@ public class TestPatternHopFactory extends TestCase {
         //a to b is bus only
         assertNull(spt.getPath(stop_b, false));
         
-        options.setModes(new TraverseModeSet("TRAINISH,BUSISH"));
+        options.setModes(new TraverseModeSet("TRAM,RAIL,SUBWAY,FUNICULAR,GONDOLA,CABLE_CAR,BUS"));
         spt = aStar.getShortestPathTree(options);
 
         assertNotNull(spt.getPath(stop_b, false));


### PR DESCRIPTION
I removed the Busish and Trainish modes in the code as was proposed by @abyrd in issue #2218.

Regarding the questions about the Cable Car I had:
* The modes Bus + Walk are used if you select the "Bus only" option. Cable Car was removed here. If this change should be reverted, please let me now so I can fix it.
* The Cable Car mode receives the StreetEdge.CLASS_OTHER_PLATFORM platform class (originally also the case)
* The Cable Car mode options haven't been tested since I'm not able to find a suitable map or GTFS feed which uses this mode