### PR TITLE
This makes max interline distance configurable

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
@@ -260,6 +260,7 @@ public class GraphBuilder implements Runnable {
                 }
                 gtfsBundle.parentStationTransfers = builderParams.stationTransfers;
                 gtfsBundle.subwayAccessTime = (int)(builderParams.subwayAccessTime * 60);
+                gtfsBundle.maxInterlineDistance = builderParams.maxInterlineDistance;
                 gtfsBundles.add(gtfsBundle);
             }
             GtfsModule gtfsModule = new GtfsModule(gtfsBundles);

--- a/src/main/java/org/opentripplanner/graph_builder/model/GtfsBundle.java
+++ b/src/main/java/org/opentripplanner/graph_builder/model/GtfsBundle.java
@@ -64,6 +64,8 @@ public class GtfsBundle {
 
     private double maxStopToShapeSnapDistance = 150;
 
+    public int maxInterlineDistance;
+
     public Boolean useCached = null; // null means use global default from GtfsGB || true
 
     public File cacheDirectory = null; // null means use default from GtfsGB || system temp dir 

--- a/src/main/java/org/opentripplanner/graph_builder/module/GtfsModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/GtfsModule.java
@@ -118,6 +118,7 @@ public class GtfsModule implements GraphBuilderModule {
                 service.addData(data, dao);
 
                 hf.subwayAccessTime = gtfsBundle.subwayAccessTime;
+                hf.maxInterlineDistance = gtfsBundle.maxInterlineDistance;
                 hf.run(graph);
 
                 if (gtfsBundle.doesTransfersTxtDefineStationPaths()) {

--- a/src/main/java/org/opentripplanner/routing/edgetype/factory/GTFSPatternHopFactory.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/factory/GTFSPatternHopFactory.java
@@ -310,6 +310,8 @@ public class GTFSPatternHopFactory {
 
     private double maxStopToShapeSnapDistance = 150;
 
+    public int maxInterlineDistance = 200;
+
     public GTFSPatternHopFactory(GtfsContext context) {
         this._feedId = context.getFeedId();
         this._dao = context.getDao();
@@ -562,7 +564,7 @@ public class GTFSPatternHopFactory {
                     Stop toStop   = currPattern.getStop(0);
                     double teleportationDistance = SphericalDistanceLibrary.fastDistance(
                                         fromStop.getLat(), fromStop.getLon(), toStop.getLat(), toStop.getLon());
-                    if (teleportationDistance > 200) {
+                    if (teleportationDistance > maxInterlineDistance) {
                         // FIXME Trimet data contains a lot of these -- in their data, two trips sharing a block ID just
                         // means that they are served by the same vehicle, not that interlining is automatically allowed.
                         // see #1654

--- a/src/main/java/org/opentripplanner/standalone/GraphBuilderParameters.java
+++ b/src/main/java/org/opentripplanner/standalone/GraphBuilderParameters.java
@@ -113,6 +113,11 @@ public class GraphBuilderParameters {
     public boolean staticBikeParkAndRide = false;
 
     /**
+     * Maximal distance between stops in meters that will connect consecutive trips that are made with same vehicle
+     */
+    public int maxInterlineDistance = 200;
+
+    /**
      * Set all parameters from the given Jackson JSON tree, applying defaults.
      * Supplying MissingNode.getInstance() will cause all the defaults to be applied.
      * This could be done automatically with the "reflective query scraper" but it's less type safe and less clear.
@@ -138,6 +143,7 @@ public class GraphBuilderParameters {
         staticParkAndRide = config.path("staticParkAndRide").asBoolean(true);
         staticBikeParkAndRide = config.path("staticBikeParkAndRide").asBoolean(false);
         maxHtmlAnnotationsPerFile = config.path("maxHtmlAnnotationsPerFile").asInt(1000);
+        maxInterlineDistance = config.path("maxInterlineDistance").asInt(200);
     }
 
 }


### PR DESCRIPTION
This is distance between stops that are considered a trip which can be
made without transfers between last stop of one trippattern and first
stop on next. It is made with same vehicle. Previously it was
hardcodded as 200 m now it is configurable

And should be quickfix for #2226.