### PR TITLE
Improves getIntersectionAt

### DIFF
--- a/src/main/java/org/opentripplanner/routing/impl/StreetVertexIndexServiceImpl.java
+++ b/src/main/java/org/opentripplanner/routing/impl/StreetVertexIndexServiceImpl.java
@@ -315,10 +315,24 @@ public class StreetVertexIndexServiceImpl implements StreetVertexIndexService {
                 }
                 TemporaryStreetLocation closest = new TemporaryStreetLocation(
                         "corner " + Math.random(), coord, calculatedName, endVertex);
+
+                //This searches for all the vertices that are at the same coordinate as found intersection
+                //since found street splits can be problematic, because they split the street only in one direction
+                List <Vertex> verticesOnSameLoc = getVerticesForEnvelope(new Envelope(intersection.getCoordinate()));
                 if (endVertex) {
                     new TemporaryFreeEdge(intersection, closest);
+                    for (Vertex vertex: verticesOnSameLoc) {
+                        if (!intersection.equals(vertex)) {
+                            new TemporaryFreeEdge(vertex, closest);
+                        }
+                    }
                 } else {
                     new TemporaryFreeEdge(closest, intersection);
+                    for (Vertex vertex: verticesOnSameLoc) {
+                        if (!intersection.equals(vertex)) {
+                            new TemporaryFreeEdge(closest, vertex);
+                        }
+                    }
                 }
 
                 return closest;

--- a/src/main/java/org/opentripplanner/routing/impl/StreetVertexIndexServiceImpl.java
+++ b/src/main/java/org/opentripplanner/routing/impl/StreetVertexIndexServiceImpl.java
@@ -47,6 +47,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * Indexes all edges and transit vertices of the graph spatially. Has a variety of query methods
@@ -278,7 +279,7 @@ public class StreetVertexIndexServiceImpl implements StreetVertexIndexService {
 
         // first, check for intersections very close by
         Coordinate coord = location.getCoordinate();
-        StreetVertex intersection = getIntersectionAt(coord);
+        List<StreetVertex> intersections = getIntersectionsAt(coord);
         I18NString calculatedName = null;
         Locale locale;
         if (options == null) {
@@ -289,49 +290,41 @@ public class StreetVertexIndexServiceImpl implements StreetVertexIndexService {
         if (location.name != null) {
             calculatedName = new NonLocalizedString(location.name);
         }
-        if (intersection != null) {
+        if (intersections != null && !intersections.isEmpty()) {
             // We have an intersection vertex. Check that this vertex has edges we can traverse.
             boolean canEscape = false;
             if (options == null) {
                 canEscape = true; // Some tests do not supply options.
             } else {
                 TraversalRequirements reqs = new TraversalRequirements(options);
-                for (StreetEdge e : Iterables.filter ( options.arriveBy ?
-                        intersection.getIncoming() : intersection.getOutgoing(),
-                        StreetEdge.class)) {
-                    if (reqs.canBeTraversed(e)) {
-                        canEscape = true;
-                        break;
-                    }
-                }
-            }       
-            if (canEscape) { 
+                //Filters out vertices for which reqs.canBeTraversed doesn't returns true for at least one edge
+                List<StreetVertex> filteredIntersections = intersections.stream().filter(intersectionVertex -> {
+                    Collection<Edge> streetEdges = options.arriveBy ? intersectionVertex.getIncoming() : intersectionVertex.getOutgoing();
+                    return streetEdges.stream()
+                        .filter((StreetEdge.class)::isInstance)
+                        .anyMatch(e -> reqs.canBeTraversed((StreetEdge) e));
+                }).collect(Collectors.toList());
+                canEscape = !filteredIntersections.isEmpty();
+
+            }
+            if (canEscape) {
                 // Coordinate is at an intersection or street endpoint, and has traversible edges.
                 if (!location.hasName()) {
-                    LOG.debug("found intersection {}. not splitting.", intersection);
+                    LOG.debug("found intersections {}. not splitting.", intersections);
 
-                    calculatedName = intersection.getIntersectionName(locale);
+                    calculatedName = intersections.get(0).getIntersectionName(locale);
 
                 }
                 TemporaryStreetLocation closest = new TemporaryStreetLocation(
                         "corner " + Math.random(), coord, calculatedName, endVertex);
 
-                //This searches for all the vertices that are at the same coordinate as found intersection
-                //since found street splits can be problematic, because they split the street only in one direction
-                List <Vertex> verticesOnSameLoc = getVerticesForEnvelope(new Envelope(intersection.getCoordinate()));
                 if (endVertex) {
-                    new TemporaryFreeEdge(intersection, closest);
-                    for (Vertex vertex: verticesOnSameLoc) {
-                        if (!intersection.equals(vertex)) {
-                            new TemporaryFreeEdge(vertex, closest);
-                        }
+                    for (Vertex vertex: intersections) {
+                        new TemporaryFreeEdge(vertex, closest);
                     }
                 } else {
-                    new TemporaryFreeEdge(closest, intersection);
-                    for (Vertex vertex: verticesOnSameLoc) {
-                        if (!intersection.equals(vertex)) {
-                            new TemporaryFreeEdge(closest, vertex);
-                        }
+                    for (Vertex vertex: intersections) {
+                        new TemporaryFreeEdge(closest, vertex);
                     }
                 }
 
@@ -571,6 +564,43 @@ public class StreetVertexIndexServiceImpl implements StreetVertexIndexService {
             }
         }
         return nearest;
+    }
+
+    /**
+     * @param coordinate Location to search intersection at. Look in a MAX_CORNER_DISTANCE_METERS radius.
+     * @return The nearest intersections, null if none found. It returns multiple intersections only if they are all on same coordinate
+     */
+    public List<StreetVertex> getIntersectionsAt(Coordinate coordinate) {
+        double dLon = SphericalDistanceLibrary.metersToLonDegrees(MAX_CORNER_DISTANCE_METERS,
+            coordinate.y);
+        double dLat = SphericalDistanceLibrary.metersToDegrees(MAX_CORNER_DISTANCE_METERS);
+        Envelope envelope = new Envelope(coordinate);
+        envelope.expandBy(dLon, dLat);
+        List<Vertex> nearby = getVerticesForEnvelope(envelope);
+        //List with all the nearest vertices that are the same coordinate and nearest to search coordinate
+        List<StreetVertex> nearestVertices = new ArrayList<>();
+        double bestDistanceMeter = Double.POSITIVE_INFINITY;
+        for (Vertex v : nearby) {
+            if (v instanceof StreetVertex) {
+                //Vertices with same coordinates as currently closest are just added to the list
+                if (!nearestVertices.isEmpty() &&
+                    v.getCoordinate().equals(nearestVertices.get(0).getCoordinate())) {
+                    nearestVertices.add((StreetVertex) v);
+                    continue;
+                }
+                double distanceMeter = SphericalDistanceLibrary.fastDistance(coordinate, v.getCoordinate());
+                //When we found vertex which is closer then current bestDistance we need to replace
+                //the list of closest vertices with new vertex
+                if (distanceMeter < MAX_CORNER_DISTANCE_METERS) {
+                    if (distanceMeter < bestDistanceMeter) {
+                        bestDistanceMeter = distanceMeter;
+                        nearestVertices.clear();
+                        nearestVertices.add((StreetVertex) v);
+                    }
+                }
+            }
+        }
+        return nearestVertices;
     }
     
     @Override


### PR DESCRIPTION
so that it links to all vertices at same coordinate not just first it finds.
Problem was visible during origin/destination linking when closest intersection
 was split street vertex.

Since street splits split street edges only in one direction if closest
intersection is street split we can only route in direction edge was
splitted. This fix connect closest vertices to all the closest vertices at same
coordinate. This more nicely fixes #2153.