### PR TITLE
Fix for #1077 by removing the platform bonus

### DIFF
--- a/src/main/java/org/opentripplanner/routing/impl/CandidateEdge.java
+++ b/src/main/java/org/opentripplanner/routing/impl/CandidateEdge.java
@@ -223,10 +223,9 @@ public class CandidateEdge {
             // this is a hack, but there's not really a better way to do it
             myScore /= SIDEWALK_PREFERENCE;
         }
-        // apply strong preference to car edges and to platforms for the specified modes
-        // only apply for car modes -- TODO Check this.
-        if (modes.getCar() && edge.getPermission().allows(StreetTraversalPermission.CAR)
-                || (edge.getStreetClass() & platform) != 0) {
+        // apply strong preference to car edges
+        // only apply for car modes
+        if (modes.getCar() && edge.getPermission().allows(StreetTraversalPermission.CAR)) {
             // we're subtracting here because no matter how close we are to a
             // good non-car non-platform edge, we really want to avoid it in
             // case it's a Pedway or other weird and unlikely starting location.


### PR DESCRIPTION
The platform bonus is meant to snap to a nearby platform if it is close.
However, this can result in strange endpoint selection where a near road
is ignored in favor of a relatively far platform. Also note that the
platform condition "(edge.getStreetClass() & platform) != 0" was tested
for twice and also got weighted twice: once by dividing and once by
subtracting.
I added a test case which fails in the old behavior but succeeds in with
the code in this branch.