### PR TITLE
Throws trivialPath exception if start/end point is at the same edge

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/linking/OriginDestinationLinker.java
+++ b/src/main/java/org/opentripplanner/graph_builder/linking/OriginDestinationLinker.java
@@ -35,6 +35,7 @@ public class OriginDestinationLinker extends SimpleStreetSplitter {
         super(graph);
     }
 
+    //Will throw ThrivialPathException if origin and destination Location are on the same edge
     public Vertex getClosestVertex(GenericLocation location, RoutingRequest options,
         boolean endVertex) {
         if (endVertex) {
@@ -59,7 +60,7 @@ public class OriginDestinationLinker extends SimpleStreetSplitter {
                 nonTransitMode = TraverseMode.BICYCLE;
         }
 
-        if(!link(closest, nonTransitMode)) {
+        if(!link(closest, nonTransitMode, options)) {
             LOG.warn("Couldn't link {}", location);
         }
         return closest;

--- a/src/main/java/org/opentripplanner/graph_builder/linking/SimpleStreetSplitter.java
+++ b/src/main/java/org/opentripplanner/graph_builder/linking/SimpleStreetSplitter.java
@@ -19,6 +19,7 @@ import org.opentripplanner.common.model.P2;
 import org.opentripplanner.graph_builder.annotation.BikeParkUnlinked;
 import org.opentripplanner.graph_builder.annotation.BikeRentalStationUnlinked;
 import org.opentripplanner.graph_builder.annotation.StopUnlinked;
+import org.opentripplanner.routing.core.RoutingRequest;
 import org.opentripplanner.routing.core.TraverseMode;
 import org.opentripplanner.routing.core.TraverseModeSet;
 import org.opentripplanner.routing.edgetype.StreetBikeParkLink;
@@ -105,11 +106,11 @@ public class SimpleStreetSplitter {
 
     /** Link this vertex into the graph to the closest walkable edge */
     public boolean link (Vertex vertex) {
-        return link(vertex, TraverseMode.WALK);
+        return link(vertex, TraverseMode.WALK, null);
     }
 
     /** Link this vertex into the graph */
-    public boolean link(Vertex vertex, TraverseMode traverseMode) {
+    public boolean link(Vertex vertex, TraverseMode traverseMode, RoutingRequest options) {
         // find nearby street edges
         // TODO: we used to use an expanding-envelope search, which is more efficient in
         // dense areas. but first let's see how inefficient this is. I suspect it's not too
@@ -190,14 +191,14 @@ public class SimpleStreetSplitter {
                 distances.get(candidateEdges.get(i).getId()) - distances.get(candidateEdges.get(i - 1).getId()) < duplicateDeg);
 
         for (StreetEdge edge : bestEdges) {
-            link(vertex, edge, xscale);
+            link(vertex, edge, xscale, options);
         }
 
         return true;
     }
 
     /** split the edge and link in the transit stop */
-    private void link (Vertex tstop, StreetEdge edge, double xscale) {
+    private void link(Vertex tstop, StreetEdge edge, double xscale, RoutingRequest options) {
         // TODO: we've already built this line string, we should save it
         LineString orig = edge.getGeometry();
         LineString transformed = equirectangularProject(orig, xscale);
@@ -230,6 +231,11 @@ public class SimpleStreetSplitter {
                 temporaryVertex = (TemporaryVertex) tstop;
                 endVertex = temporaryVertex.isEndVertex();
 
+            }
+            //This throws runtime TrivialPathException if same edge is split in origin and destination link
+            //It is only used in origin/destination linking since otherwise options is null
+            if (options != null) {
+                options.canSplitEdge(edge);
             }
             // split the edge, get the split vertex
             SplitterVertex v0 = split(edge, ll, temporaryVertex != null, endVertex);

--- a/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
@@ -415,7 +415,11 @@ public class RoutingRequest implements Cloneable, Serializable {
     /** Accept only paths that use transit (no street-only paths). */
     public boolean onlyTransitTrips = false;
 
-    private StreetEdge splittedEdge = null;
+    /** Saves split edge which can be split on origin/destination search
+     *
+     * This is used so that TrivialPathException is thrown if origin and destination search would split the same edge
+     */
+    private StreetEdge splitEdge = null;
 
     /* CONSTRUCTORS */
 
@@ -1189,10 +1193,10 @@ public class RoutingRequest implements Cloneable, Serializable {
      * @param edge
      */
     public void canSplitEdge(StreetEdge edge) {
-        if (splittedEdge == null) {
-            splittedEdge = edge;
+        if (splitEdge == null) {
+            splitEdge = edge;
         } else {
-            if (splittedEdge.equals(edge)) {
+            if (splitEdge.equals(edge)) {
                 throw new TrivialPathException();
             }
         }

--- a/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
@@ -21,6 +21,8 @@ import org.opentripplanner.api.parameter.QualifiedModeSet;
 import org.opentripplanner.common.MavenVersion;
 import org.opentripplanner.common.model.GenericLocation;
 import org.opentripplanner.common.model.NamedPlace;
+import org.opentripplanner.routing.edgetype.StreetEdge;
+import org.opentripplanner.routing.error.TrivialPathException;
 import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
@@ -412,6 +414,8 @@ public class RoutingRequest implements Cloneable, Serializable {
 
     /** Accept only paths that use transit (no street-only paths). */
     public boolean onlyTransitTrips = false;
+
+    private StreetEdge splittedEdge = null;
 
     /* CONSTRUCTORS */
 
@@ -1174,5 +1178,24 @@ public class RoutingRequest implements Cloneable, Serializable {
     /** Create a new ShortestPathTree instance using the DominanceFunction specified in this RoutingRequest. */
     public ShortestPathTree getNewShortestPathTree() {
         return this.dominanceFunction.getNewShortestPathTree(this);
+    }
+
+    /**
+     * Does nothing if different edge is split in origin/destination search
+     *
+     * But throws TrivialPathException if same edge is split in origin/destination search.
+     *
+     * used in {@link org.opentripplanner.graph_builder.linking.OriginDestinationLinker} in {@link org.opentripplanner.graph_builder.linking.SimpleStreetSplitter#link(Vertex, StreetEdge, double, RoutingRequest)}
+     * @param edge
+     */
+    public void canSplitEdge(StreetEdge edge) {
+        if (splittedEdge == null) {
+            splittedEdge = edge;
+        } else {
+            if (splittedEdge.equals(edge)) {
+                throw new TrivialPathException();
+            }
+        }
+
     }
 }

--- a/src/test/java/org/opentripplanner/routing/TestHalfEdges.java
+++ b/src/test/java/org/opentripplanner/routing/TestHalfEdges.java
@@ -18,6 +18,10 @@ import com.vividsolutions.jts.geom.GeometryFactory;
 import com.vividsolutions.jts.geom.LineString;
 import com.vividsolutions.jts.linearref.LinearLocation;
 import junit.framework.TestCase;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.onebusaway.gtfs.model.AgencyAndId;
 import org.onebusaway.gtfs.model.Stop;
 import org.opentripplanner.common.geometry.GeometryUtils;
@@ -32,6 +36,7 @@ import org.opentripplanner.routing.core.TraverseModeSet;
 import org.opentripplanner.routing.edgetype.StreetEdge;
 import org.opentripplanner.routing.edgetype.StreetTraversalPermission;
 import org.opentripplanner.routing.edgetype.TemporaryFreeEdge;
+import org.opentripplanner.routing.error.TrivialPathException;
 import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
@@ -50,9 +55,11 @@ import java.util.HashMap;
 import java.util.Set;
 
 import static com.google.common.collect.Iterables.filter;
+import static org.junit.Assert.*;
+
 import org.opentripplanner.util.NonLocalizedString;
 
-public class TestHalfEdges extends TestCase {
+public class TestHalfEdges {
 
     Graph graph;
 
@@ -74,6 +81,10 @@ public class TestHalfEdges extends TestCase {
         return factory.createLineString(cs);
     }
 
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
+    @Before
     public void setUp() {
         graph = new Graph();
         // a 0.1 degree x 0.1 degree square
@@ -130,6 +141,7 @@ public class TestHalfEdges extends TestCase {
         graph.hasTransit = true;
     }
 
+    @Test
     public void testHalfEdges() {
         // the shortest half-edge from the start vertex takes you down, but the shortest total path
         // is up and over
@@ -263,7 +275,8 @@ public class TestHalfEdges extends TestCase {
         assertEquals(nVertices, graph.getVertices().size());
         assertEquals(nEdges, graph.getEdges().size());
     }
-    
+
+    @Test
     public void testRouteToSameEdge() {
         RoutingRequest options = new RoutingRequest();
 
@@ -279,7 +292,7 @@ public class TestHalfEdges extends TestCase {
                 filter(turns, StreetEdge.class),
                 new LinearLocation(0, 0.8).getCoordinate(left.getGeometry()), true);
 
-        assertEquals(start.getX(), end.getX());
+        assertEquals(start.getX(), end.getX(), 0.0001);
         assertTrue(start.getY() < end.getY());
 
         Collection<Edge> edges = end.getIncoming();
@@ -298,6 +311,7 @@ public class TestHalfEdges extends TestCase {
         options.cleanup();
     }
 
+    @Test
     public void testRouteToSameEdgeBackwards() {
         RoutingRequest options = new RoutingRequest();
 
@@ -313,7 +327,7 @@ public class TestHalfEdges extends TestCase {
                 filter(turns, StreetEdge.class),
                 new LinearLocation(0, 0.4).getCoordinate(left.getGeometry()), true);
 
-        assertEquals(start.getX(), end.getX());
+        assertEquals(start.getX(), end.getX(),0.001);
         assertTrue(start.getY() > end.getY());
 
         Collection<Edge> edges = end.getIncoming();
@@ -335,6 +349,7 @@ public class TestHalfEdges extends TestCase {
      * Test that alerts on split streets are preserved, i.e. if there are alerts on the street that is split the same alerts should be present on the
      * new street.
      */
+    @Test
     public void testStreetSplittingAlerts() {
         HashSet<Edge> turns = new HashSet<Edge>();
         turns.add(left);
@@ -403,6 +418,7 @@ public class TestHalfEdges extends TestCase {
         start.dispose();
     }
 
+    @Test
     public void testStreetLocationFinder() {
         StreetVertexIndexServiceImpl finder = new StreetVertexIndexServiceImpl(graph);
         // test that the local stop finder finds stops
@@ -435,15 +451,15 @@ public class TestHalfEdges extends TestCase {
         end.dispose();
         assertEquals(2, edges.size());
 
-        /*
 
         // test that it is possible to travel between two splits on the same street
         RoutingRequest walking = new RoutingRequest(TraverseMode.WALK);
         start = (TemporaryStreetLocation) finder.getVertexForLocation(
                 new GenericLocation(40.004, -74.0), walking, false);
+        exception.expect(TrivialPathException.class);
         end = (TemporaryStreetLocation) finder.getVertexForLocation(
                 new GenericLocation(40.008, -74.0), walking, true);
-        assertNotNull(end);
+         /*assertNotNull(end);
         // The visibility for temp edges for start and end is set in the setRoutingContext call
         walking.setRoutingContext(graph, start, end);
         ShortestPathTree spt = aStar.getShortestPathTree(walking);
@@ -451,10 +467,11 @@ public class TestHalfEdges extends TestCase {
         for (State s : path.states) {
             assertFalse(s.getBackEdge() == top);
         }
-        walking.cleanup();
-        */
+        walking.cleanup();*/
+
     }
 
+    @Test
     public void testNetworkLinker() {
         int numVerticesBefore = graph.getVertices().size();
         StreetLinkerModule ttsnm = new StreetLinkerModule();


### PR DESCRIPTION
When edges are split in origin/destination point request this is saved in RoutingRequest and if both requests would split same edge TrivialPathException is thrown.