### PR TITLE
Ignore exceptions reading OSM LinearRing data

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/Area.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/Area.java
@@ -35,7 +35,7 @@ import com.vividsolutions.jts.geom.Polygon;
  */
 class Area {
 
-    public class AreaConstructionException extends RuntimeException {
+    public static class AreaConstructionException extends RuntimeException {
         private static final long serialVersionUID = 1L;
     }
 

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/AreaGroup.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/AreaGroup.java
@@ -23,6 +23,7 @@ import java.util.Set;
 
 import org.opentripplanner.common.DisjointSet;
 import org.opentripplanner.common.geometry.GeometryUtils;
+import org.opentripplanner.graph_builder.module.osm.Ring.RingConstructionException;
 import org.opentripplanner.openstreetmap.model.OSMLevel;
 import org.opentripplanner.openstreetmap.model.OSMNode;
 import org.opentripplanner.openstreetmap.model.OSMWithTags;
@@ -134,7 +135,7 @@ class AreaGroup {
         for (Set<Area> areaSet : groups.sets()) {
             try {
                 out.add(new AreaGroup(areaSet));
-            } catch (AreaGroup.RingConstructionException e) {
+            } catch (RingConstructionException e) {
                 for (Area area : areaSet) {
                     LOG.debug("Failed to create merged area for "
                             + area
@@ -144,10 +145,6 @@ class AreaGroup {
             }
         }
         return out;
-    }
-
-    public class RingConstructionException extends RuntimeException {
-        private static final long serialVersionUID = 1L;
     }
 
     private Ring toRing(Polygon polygon, HashMap<Coordinate, OSMNode> nodeMap) {

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/OSMDatabase.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/OSMDatabase.java
@@ -663,7 +663,7 @@ public class OSMDatabase implements OpenStreetMapContentHandler {
             processedAreas.add(relation);
             try {
                 newArea(new Area(relation, outerWays, innerWays, nodesById));
-            } catch (Area.AreaConstructionException e) {
+            } catch (Area.AreaConstructionException|Ring.RingConstructionException e) {
                 continue;
             }
 

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/Ring.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/Ring.java
@@ -31,6 +31,11 @@ import com.vividsolutions.jts.geom.LinearRing;
 import com.vividsolutions.jts.geom.Polygon;
 
 public class Ring {
+
+    public static class RingConstructionException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
+    }
+
     public List<OSMNode> nodes;
 
     public VLPolygon geometry;
@@ -85,7 +90,12 @@ public class Ring {
         }
         GeometryFactory factory = GeometryUtils.getGeometryFactory();
 
-        LinearRing shell = factory.createLinearRing(toCoordinates(geometry));
+        LinearRing shell;
+        try {
+            shell = factory.createLinearRing(toCoordinates(geometry));
+        } catch (IllegalArgumentException e) {
+            throw new RingConstructionException();
+        }
 
         // we need to merge connected holes here, because JTS does not believe in
         // holes that touch at multiple points (and, weirdly, does not have a method


### PR DESCRIPTION
This PR makes the graph builder ignore problems with `LinearRing`s in OSM data. It handles them in the same way as other data problems in `Area`, `Ring`, etc., which is to say ignore them without logging.

This commit also moves `RingConstructionException` from `Area` to `Ring`, which seems a more logical location.

Fixes #2293.