### PR TITLE
Updated to 2.18 of Jersey to fix hanging threads in Grizzly. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -506,18 +506,18 @@
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-server</artifactId>
-            <version>2.17</version>
+            <version>2.18</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-multipart</artifactId>
-            <version>2.17</version>
+            <version>2.18</version>
         </dependency>
         <!-- Deploy Jersey apps in stand-alone Grizzly server instead of a servlet container. -->
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-grizzly2-http</artifactId>
-            <version>2.17</version>
+            <version>2.18</version>
         </dependency>
 
         <!-- Jackson modules. -->

--- a/src/test/java/org/opentripplanner/graph_builder/module/linking/LinkingTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/linking/LinkingTest.java
@@ -2,13 +2,13 @@ package org.opentripplanner.graph_builder.module.linking;
 
 import com.google.common.base.Predicate;
 import com.google.common.collect.Collections2;
+import com.google.common.collect.Iterables;
 import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.GeometryFactory;
 import com.vividsolutions.jts.geom.LineString;
 import gnu.trove.iterator.TObjectIntIterator;
 import gnu.trove.map.TObjectIntMap;
 import gnu.trove.map.hash.TObjectIntHashMap;
-import jersey.repackaged.com.google.common.collect.Iterables;
 import jersey.repackaged.com.google.common.collect.Maps;
 import org.junit.Test;
 import org.opentripplanner.common.geometry.GeometryUtils;


### PR DESCRIPTION
This commit fixes the issue described here: https://groups.google.com/forum/#!topic/opentripplanner-users/NVmdO1J00aI

The issue has been that the Grizzly kernel threads have locked up at 100% CPU after a while and in the end the server stops responding. This seems to be been caused by the issue described here: https://java.net/jira/browse/GRIZZLY-1712

By updating to 2.18 of Jersey we have no longer seen this behavior in our running instance of OTP.