### PR TITLE
Removing test redundant for org.opentripplanner.openstreetmap.model.OSMWayTest.testMotorCarTagDeniedPermissions

### DIFF
--- a/src/test/java/org/opentripplanner/openstreetmap/model/OSMWayTest.java
+++ b/src/test/java/org/opentripplanner/openstreetmap/model/OSMWayTest.java
@@ -249,7 +249,7 @@ public class OSMWayTest {
      * but no remove permission if access is yes
      *
      * Support for motor_vehicle was added in #1881
-     */
+     */ @org.junit.Ignore
     @Test public void testMotorVehicleTagDeniedPermissions(){
         OSMWay way = new OSMWay();
         way.addTag("highway", "residential");


### PR DESCRIPTION
We are researchers working on identifying redundant tests in a test suite. Our analysis of finding redundant tests involve each test's dynamic code coverage and their potential fault-detection capability.

Through our analysis, we found that the tests org.opentripplanner.openstreetmap.model.OSMWayTest.testMotorCarTagDeniedPermissions, org.opentripplanner.openstreetmap.model.OSMWayTest.testMotorVehicleTagDeniedPermissions are redundant with respect to one another. In this pull request, we are proposing to keep only the test org.opentripplanner.openstreetmap.model.OSMWayTest.testMotorCarTagDeniedPermissions while adding @Ignore annotations to the remaining test. However, as we believe these tests are identical, any one of them can be kept while skipping the remaining test.

If you do not believe any of these tests should be ignored, we would greatly appreciate it if you could follow up on this pull request and let us know your reasons.