### PR TITLE
OpenData/GBFS Bike Rental Updater

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -478,6 +478,27 @@ connect to a network resource is the `url` field.
             frequencySec: -1
 		},
 
+        // OpenData/GBFS bike rental updater  (SocialBicycles, and others - see https://github.com/NABSA/gbfs)
+        
+        // Bikes 
+        // - Fetches /free_bike_status.json and adds working bikes as 1 available to rent, but 0 available to dropoff
+        {
+                type: "bike-rental",
+                frequencySec: 100,
+                sourceType: "opendata-bikes",
+                url: "http://usf.socialbicycles.com/opendata/"
+        },
+
+        // Hubs
+        // - Fetches /station_information.json, and /station_status.json and adds working hubs
+        //   num_bikes_available and num_docks_available fields are set from the data
+        {
+                type: "bike-rental",
+                frequencySec: 100,
+                sourceType: "opendata-hubs",
+                url: "http://usf.socialbicycles.com/opendata/"
+        }
+
         // Bike parking availability
         {
             type: "bike-park"

--- a/src/main/java/org/opentripplanner/updater/bike_rental/BikeRentalUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/bike_rental/BikeRentalUpdater.java
@@ -110,6 +110,10 @@ public class BikeRentalUpdater extends PollingGraphUpdater {
                 source = new SanFranciscoBayAreaBikeRentalDataSource(networkName);
             } else if (sourceType.equals("share-bike")) {
                 source = new ShareBikeRentalDataSource();
+            } else if (sourceType.equals("opendata-bikes")) {
+               source = new OpenDataBikeRentalDataSource();
+            } else if (sourceType.equals("opendata-hubs")) {
+                source = new OpenDataBikeHubsDataSource();
             }
         }
 

--- a/src/main/java/org/opentripplanner/updater/bike_rental/OpenDataBikeHubsDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/bike_rental/OpenDataBikeHubsDataSource.java
@@ -1,0 +1,209 @@
+/* 
+ Copyright (C) 2016 University of South Florida.
+ All rights reserved.
+
+ This program is free software: you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public License
+ as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+package org.opentripplanner.updater.bike_rental;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.prefs.Preferences;
+import java.util.HashMap;
+
+import org.opentripplanner.updater.JsonConfigurable;
+import org.opentripplanner.routing.bike_rental.BikeRentalStation;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.util.HttpUtils;
+import org.opentripplanner.util.NonLocalizedString;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+
+/**
+ * Fetch Bike Rental JSON feeds and pass each record on to the specific rental subclass
+ *
+ * @see BikeRentalDataSource
+ */
+public final class OpenDataBikeHubsDataSource extends GenericJsonBikeRentalDataSource {
+
+    private static final Logger log = LoggerFactory.getLogger(OpenDataBikeHubsDataSource.class);
+
+    private String jsonParsePath;
+
+    ArrayList<BikeRentalStation> stations = new ArrayList<BikeRentalStation>();
+   
+    HashMap<String, BikeRentalStation> hubs = new HashMap<String, BikeRentalStation>();
+ 
+    public OpenDataBikeHubsDataSource() {
+    	jsonParsePath = "data/stations";
+    }
+
+    public boolean update() {
+	String url = getUrl();
+	// First get initial hub data (names, etc)
+        try {
+            InputStream data = HttpUtils.getData(url + "/station_information.json");
+            if (data == null) {
+                log.warn("Failed to get data from url " + url);
+                return false;
+            }
+            parseStationInformation(data);
+            data.close();
+        } catch (IllegalArgumentException e) {
+            log.warn("Error parsing bike rental feed from " + url, e);
+            return false;
+        } catch (JsonProcessingException e) {
+            log.warn("Error parsing bike rental feed from " + url + "(bad JSON of some sort)", e);
+            return false;
+        } catch (IOException e) {
+            log.warn("Error reading bike rental feed from " + url, e);
+            return false;
+        }
+
+	// Now get the hub status
+        try {
+            InputStream data = HttpUtils.getData(url + "/station_status.json");
+            if (data == null) {
+                log.warn("Failed to get data from url " + url);
+                return false;
+            }
+            parseJSON(data);
+            data.close();
+        } catch (IllegalArgumentException e) {
+            log.warn("Error parsing bike rental feed from " + url, e);
+            return false;
+        } catch (JsonProcessingException e) {
+            log.warn("Error parsing bike rental feed from " + url + "(bad JSON of some sort)", e);
+            return false;
+        } catch (IOException e) {
+            log.warn("Error reading bike rental feed from " + url, e);
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public synchronized List<BikeRentalStation> getStations() {
+        return stations;
+    }
+
+   private void parseStationInformation(InputStream dataStream) throws JsonProcessingException, IllegalArgumentException,
+      IOException {
+
+        String rentalString = convertStreamToString(dataStream);
+
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode rootNode = mapper.readTree(rentalString);
+
+        if (!jsonParsePath.equals("")) {
+            String delimiter = "/";
+            String[] parseElement = jsonParsePath.split(delimiter);
+            for(int i =0; i < parseElement.length ; i++) {
+                rootNode = rootNode.path(parseElement[i]);
+            }
+
+            if (rootNode.isMissingNode()) {
+                throw new IllegalArgumentException("Could not find jSON elements " + jsonParsePath);
+              }
+        }
+
+        for (int i = 0; i < rootNode.size(); i++) {
+            JsonNode node = rootNode.get(i);
+            if (node == null) {
+                continue;
+            }
+
+	    // get hub id, name, and x/y and save in local map
+            makeStation(node);
+	}
+     
+    }
+
+    private void parseJSON(InputStream dataStream) throws JsonProcessingException, IllegalArgumentException,
+      IOException {
+
+        ArrayList<BikeRentalStation> out = new ArrayList<BikeRentalStation>();
+
+        String rentalString = convertStreamToString(dataStream);
+
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode rootNode = mapper.readTree(rentalString);
+
+        if (!jsonParsePath.equals("")) {
+            String delimiter = "/";
+            String[] parseElement = jsonParsePath.split(delimiter);
+            for(int i =0; i < parseElement.length ; i++) {
+                rootNode = rootNode.path(parseElement[i]);
+            }
+
+            if (rootNode.isMissingNode()) {
+                throw new IllegalArgumentException("Could not find jSON elements " + jsonParsePath);
+              }
+        }
+
+        for (int i = 0; i < rootNode.size(); i++) {
+            JsonNode node = rootNode.get(i);
+            if (node == null) {
+                continue;
+            }
+            BikeRentalStation brstation = makeStation(node);
+            if (brstation != null) {
+                out.add(brstation);
+	    }
+        }
+        synchronized(this) {
+            stations = out;
+        }
+    }
+
+    private String convertStreamToString(java.io.InputStream is) {
+        java.util.Scanner s = new java.util.Scanner(is).useDelimiter("\\A");
+        return s.hasNext() ? s.next() : "";
+    }
+    
+    public BikeRentalStation makeStation(JsonNode stationNode) {
+
+        BikeRentalStation brStation = null;
+
+	if (stationNode.get("name") != null) {
+		brStation = new BikeRentalStation();
+	        brStation.id = String.valueOf(stationNode.get("station_id").textValue());
+ 	 	brStation.x = stationNode.get("lon").doubleValue();// / 1000000.0;
+		brStation.y = stationNode.get("lat").doubleValue();// / 1000000.0;
+	        brStation.name = new NonLocalizedString(stationNode.get("name").textValue());
+		hubs.put( brStation.id, brStation );
+		return null;
+ 	 }
+
+ 	 brStation = hubs.get( stationNode.get("station_id").textValue() );
+
+         brStation.bikesAvailable = stationNode.get("num_bikes_available").intValue();
+         brStation.spacesAvailable = stationNode.get("num_docks_available").intValue();
+
+	 if (stationNode.get("is_renting").intValue() != 1) 
+		return null; // don't add a broken or unavailable hub
+
+	return brStation;
+    }
+
+}

--- a/src/main/java/org/opentripplanner/updater/bike_rental/OpenDataBikeHubsDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/bike_rental/OpenDataBikeHubsDataSource.java
@@ -1,6 +1,5 @@
 /* 
  Copyright (C) 2016 University of South Florida.
- All rights reserved.
 
  This program is free software: you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public License

--- a/src/main/java/org/opentripplanner/updater/bike_rental/OpenDataBikeRentalDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/bike_rental/OpenDataBikeRentalDataSource.java
@@ -1,0 +1,83 @@
+/* 
+ Copyright (C) 2016 University of South Florida.
+ All rights reserved.
+
+ This program is free software: you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public License
+ as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+
+package org.opentripplanner.updater.bike_rental;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.prefs.Preferences;
+
+import org.opentripplanner.updater.JsonConfigurable;
+import org.opentripplanner.routing.bike_rental.BikeRentalStation;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.util.HttpUtils;
+import org.opentripplanner.util.NonLocalizedString;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+
+/**
+ * Fetch Bike Rental JSON feeds and pass each record on to the specific rental subclass
+ *
+ * @see BikeRentalDataSource
+ */
+public final class OpenDataBikeRentalDataSource extends GenericJsonBikeRentalDataSource {
+
+    private static final Logger log = LoggerFactory.getLogger(OpenDataBikeRentalDataSource.class);
+    private String url;
+
+    ArrayList<BikeRentalStation> stations = new ArrayList<BikeRentalStation>();
+
+    public OpenDataBikeRentalDataSource() {
+        super("data/bikes");
+    }
+
+    public void configure(Graph graph, JsonNode jsonNode) {
+        String url = jsonNode.path("url").asText();
+        if (url == null)
+            throw new IllegalArgumentException("Missing mandatory 'url' configuration.");
+        setUrl(url + "/free_bike_status.json");
+    }
+
+    public BikeRentalStation makeStation(JsonNode stationNode) {
+
+         BikeRentalStation brStation = new BikeRentalStation();
+
+         brStation.id = String.valueOf(stationNode.get("bike_id").textValue());
+         brStation.name =  new NonLocalizedString(stationNode.get("name").textValue());
+
+         brStation.x = stationNode.get("lon").doubleValue();// / 1000000.0;
+         brStation.y = stationNode.get("lat").doubleValue();// / 1000000.0;
+
+         brStation.bikesAvailable = 1;
+         brStation.spacesAvailable = 0;
+
+	 if (stationNode.get("is_reserved").intValue() != 0 || stationNode.get("is_disabled").intValue() != 0) 
+		return null; // don't add a broken or unavailable bike
+
+	return brStation;
+    }
+
+}

--- a/src/main/java/org/opentripplanner/updater/bike_rental/OpenDataBikeRentalDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/bike_rental/OpenDataBikeRentalDataSource.java
@@ -1,6 +1,5 @@
 /* 
  Copyright (C) 2016 University of South Florida.
- All rights reserved.
 
  This program is free software: you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public License


### PR DESCRIPTION
This PR partially implements the GBFS/Opendata specification as described in #2181.   It is currently used by the OTP deployment at USF (maps.usf.edu) for the SocialBicycles bikes on campus.

The code extends from the GenericJSON updater, and implements two classes to load the dynamic bikes and hub locations with capacities.  The decision to split it into two updaters was made because of the way the spec handles each individually, and to allow for situations where you may only want one or the other.

Currently implemented:
- Bike Rentals: /free_bike_status.json
  Ignoring bikes with is_disabled or is_reserved set.

NOTE: bikes_available is set to 1, and spaces_available 0 to force bike routing to pickup from a free bike, but only drop off at a hub - which is the requirement for our system.
- Hubs: /station_information.json, /station_status.json
  Using the num_bikes_available and num_docks_available fields
  Ignoring stations without is_renting

Future development may wish to implement the auto-discovery (gbfs.json) in the spec for the URLs instead of hard-coding.
- [ ] gbfs.json
- [ ] system_information.json
- [X] station_information.json
- [X] station_status.json
- [X] free_bike_status.json
- [ ] system_hours.json
- [ ] system_calendar.json
- [ ] system_regions.json
- [ ] system_pricing_plans.json
- [ ] system_alerts.json

To use this, you will need to add something like the following to your router-config.json:

```
{
    updaters: {
        type: "bike-rental",
        frequencySec: 100,
        sourceType: "opendata-bikes",
        url: "http://usf.socialbicycles.com/opendata/"
    },
    updaters: {
        type: "bike-rental",
        frequencySec: 100,
        sourceType: "opendata-hubs",
        url: "http://usf.socialbicycles.com/opendata/"
    }
}
```
