### PR TITLE
Fix frequency time calculations

### DIFF
--- a/src/main/java/org/opentripplanner/routing/trippattern/FrequencyEntry.java
+++ b/src/main/java/org/opentripplanner/routing/trippattern/FrequencyEntry.java
@@ -85,9 +85,13 @@ public class FrequencyEntry implements Serializable {
         int end = endTime + stopOffset; // Latest a vehicle can pass by this stop.
         if(t < beg) return -1;
         if (exactTimes) {
-            for (int dep = end; dep > beg; dep -= headway) {
-                if (dep <= t) return dep;
+            // we can't start from end in case end - beg is not a multiple of headway
+            int arr;
+            for (arr = beg + headway; arr < end; arr += headway) {
+                if (arr > t) return arr - headway;
             }
+            // if t > end, return last valid arrival time
+            return arr - headway;
         } else {
             int dep = t - headway;
             if (dep > end) return end; // not quite right

--- a/src/main/java/org/opentripplanner/routing/trippattern/FrequencyEntry.java
+++ b/src/main/java/org/opentripplanner/routing/trippattern/FrequencyEntry.java
@@ -59,11 +59,11 @@ public class FrequencyEntry implements Serializable {
     }
 
     public int nextDepartureTime (int stop, int time) {
-        if (time > endTime) return -1;
         // Start time and end time are for the first stop in the trip. Find the time offset for this stop.
         int stopOffset = tripTimes.getDepartureTime(stop) - tripTimes.getDepartureTime(0);
         int beg = startTime + stopOffset; // First time a vehicle passes by this stop.
         int end = endTime + stopOffset; // Latest a vehicle can pass by this stop.
+        if (time > end) return -1;
         if (exactTimes) {
             for (int dep = beg; dep < end; dep += headway) {
                 if (dep >= time) return dep;
@@ -80,10 +80,10 @@ public class FrequencyEntry implements Serializable {
     }
 
     public int prevArrivalTime (int stop, int t) {
-        if (t < startTime) return -1;
         int stopOffset = tripTimes.getArrivalTime(stop) - tripTimes.getDepartureTime(0);
         int beg = startTime + stopOffset; // First time a vehicle passes by this stop.
         int end = endTime + stopOffset; // Latest a vehicle can pass by this stop.
+        if(t < beg) return -1;
         if (exactTimes) {
             for (int dep = end; dep > beg; dep -= headway) {
                 if (dep <= t) return dep;

--- a/src/main/java/org/opentripplanner/routing/trippattern/FrequencyEntry.java
+++ b/src/main/java/org/opentripplanner/routing/trippattern/FrequencyEntry.java
@@ -73,7 +73,8 @@ public class FrequencyEntry implements Serializable {
             // TODO it might work better to step forward until in range
             // this would work better for time window edges.
             if (dep < beg) return beg; // not quite right
-            if (dep < end) return dep;
+            if (dep <= end) return dep;
+            if (dep > end && time <= end) return end;
         }
         return -1;
     }
@@ -90,7 +91,8 @@ public class FrequencyEntry implements Serializable {
         } else {
             int dep = t - headway;
             if (dep > end) return end; // not quite right
-            if (dep > beg) return dep;
+            if (dep >= beg) return dep;
+            if (dep < beg && t >= beg) return beg;
         }
         return -1;
     }

--- a/src/test/java/org/opentripplanner/routing/trippattern/FrequencyEntryTest.java
+++ b/src/test/java/org/opentripplanner/routing/trippattern/FrequencyEntryTest.java
@@ -1,0 +1,178 @@
+/* This program is free software: you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public License
+ as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+package org.opentripplanner.routing.trippattern;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.junit.Test;
+import org.onebusaway.gtfs.model.AgencyAndId;
+import org.onebusaway.gtfs.model.Frequency;
+import org.onebusaway.gtfs.model.Stop;
+import org.onebusaway.gtfs.model.StopTime;
+import org.onebusaway.gtfs.model.Trip;
+
+public class FrequencyEntryTest {
+    private static final AgencyAndId tripId = new AgencyAndId("agency", "testtrip");
+
+    private static final AgencyAndId stop_a = new AgencyAndId("agency", "A"); // 0
+    private static final AgencyAndId stop_b = new AgencyAndId("agency", "B"); // 1
+    private static final AgencyAndId stop_c = new AgencyAndId("agency", "C"); // 2
+    private static final AgencyAndId stop_d = new AgencyAndId("agency", "D"); // 3
+    private static final AgencyAndId stop_e = new AgencyAndId("agency", "E"); // 4
+    private static final AgencyAndId stop_f = new AgencyAndId("agency", "F"); // 5
+    private static final AgencyAndId stop_g = new AgencyAndId("agency", "G"); // 6
+    private static final AgencyAndId stop_h = new AgencyAndId("agency", "H"); // 7
+
+    private static final AgencyAndId[] stops =
+        {stop_a, stop_b, stop_c, stop_d, stop_e, stop_f, stop_g, stop_h};
+
+    private static final TripTimes tripTimes;
+
+    static {
+        Trip trip = new Trip();
+        trip.setId(tripId);
+
+        List<StopTime> stopTimes = new LinkedList<StopTime>();
+
+        int time = 0;
+        for(int i = 0; i < stops.length; ++i) {
+            StopTime stopTime = new StopTime();
+
+            Stop stop = new Stop();
+            stop.setId(stops[i]);
+            stopTime.setStop(stop);
+            stopTime.setArrivalTime(time);
+            if(i != 0 && i != stops.length - 1) {
+                time += 10;
+            }
+            stopTime.setDepartureTime(time);
+            time += 50;
+            stopTime.setStopSequence(i);
+            stopTimes.add(stopTime);
+        }
+
+        tripTimes = new TripTimes(trip, stopTimes, new Deduplicator());
+    }
+
+    @Test
+    public void testInexactTimes() {
+        Frequency f = new Frequency();
+        f.setStartTime(100000);
+        f.setEndTime(150000);
+        f.setHeadwaySecs(100);
+        f.setExactTimes(0);
+
+        FrequencyEntry freqEntry = new FrequencyEntry(f, tripTimes);
+
+        // 1st stop 00:00:00, 00:00:00
+        // 6th stop 00:04:50, 00:05:00
+        // 8th stop 00:06:50, 06:50:00
+
+        // testing first trip departure
+        assertEquals(100000, freqEntry.nextDepartureTime(0, 90000));  // first stop, before begin
+        assertEquals(100100, freqEntry.nextDepartureTime(0, 100000)); // first stop, on begin
+        assertEquals(100300, freqEntry.nextDepartureTime(5, 100000)); // 6th stop, before begin
+        assertEquals(100150, freqEntry.nextDepartureTime(0, 100050)); // first stop, after begin
+        assertEquals(100350, freqEntry.nextDepartureTime(5, 100250)); // 6th stop, after begin
+
+        // testing last trip departure
+        assertEquals(150000, freqEntry.nextDepartureTime(0, 149900)); // first stop, before end
+        assertEquals(150000, freqEntry.nextDepartureTime(0, 150000)); // first stop, on end
+        assertEquals(-1,     freqEntry.nextDepartureTime(0, 150200)); // first stop, after end
+        assertEquals(150300, freqEntry.nextDepartureTime(5, 150200)); // 6th stop, before end
+        assertEquals(150300, freqEntry.nextDepartureTime(5, 150300)); // 6th stop, on end
+        assertEquals(-1,     freqEntry.nextDepartureTime(5, 150400)); // 6th stop, after end
+
+        // testing first trip arrival
+        assertEquals(-1,     freqEntry.prevArrivalTime(5,  90000)); // 6th stop, before begin
+        assertEquals(100290, freqEntry.prevArrivalTime(5, 100290)); // 6th stop, on begin
+        assertEquals(100290, freqEntry.prevArrivalTime(5, 100390)); // 6th stop, after begin
+        assertEquals(100350, freqEntry.prevArrivalTime(5, 100450)); // 6th stop, after begin
+        assertEquals(-1,     freqEntry.prevArrivalTime(7, 100400)); // 8th stop, before begin
+        assertEquals(100410, freqEntry.prevArrivalTime(7, 100500)); // 8th stop, after begin
+
+        // testing last trip arrival
+        assertEquals(150290, freqEntry.prevArrivalTime(5, 150390)); // 6th stop
+        assertEquals(150310, freqEntry.prevArrivalTime(7, 150410)); // 8th stop, on end
+        assertEquals(150410, freqEntry.prevArrivalTime(7, 151000)); // 8th stop, after end
+    }
+
+    @Test
+    public void testExactTimes() {
+        Frequency f = new Frequency();
+        f.setStartTime(100000);
+        f.setEndTime(150000);
+        f.setHeadwaySecs(100);
+        f.setExactTimes(1);
+
+        FrequencyEntry freqEntry = new FrequencyEntry(f, tripTimes);
+
+        // testing first trip departure
+        assertEquals(100000, freqEntry.nextDepartureTime(0, 90000));  // first stop, before begin
+        assertEquals(100000, freqEntry.nextDepartureTime(0, 100000)); // first stop, on begin
+        assertEquals(100300, freqEntry.nextDepartureTime(5, 100000)); // 6th stop, before begin
+        assertEquals(100100, freqEntry.nextDepartureTime(0, 100050)); // first stop, after begin
+        assertEquals(100300, freqEntry.nextDepartureTime(5, 100250)); // 6th stop, after begin
+
+        // testing last trip departure
+        assertEquals(149900, freqEntry.nextDepartureTime(0, 149900)); // first stop, on end
+        assertEquals(-1,     freqEntry.nextDepartureTime(0, 150000)); // first stop, after end
+        assertEquals(-1,     freqEntry.nextDepartureTime(0, 150200)); // first stop, after end
+        assertEquals(150200, freqEntry.nextDepartureTime(5, 150200)); // 6th stop, on end
+        assertEquals(-1,     freqEntry.nextDepartureTime(5, 150300)); // 6th stop, after end
+        assertEquals(-1,     freqEntry.nextDepartureTime(5, 150400)); // 6th stop, after end
+
+        // testing first trip arrival
+        assertEquals(-1,     freqEntry.prevArrivalTime(5,  90000)); // 6th stop, before begin
+        assertEquals(100290, freqEntry.prevArrivalTime(5, 100290)); // 6th stop, on begin
+        assertEquals(100390, freqEntry.prevArrivalTime(5, 100390)); // 6th stop, after begin
+        assertEquals(100390, freqEntry.prevArrivalTime(5, 100450)); // 6th stop, after begin
+        assertEquals(-1,     freqEntry.prevArrivalTime(7, 100400)); // 8th stop, before begin
+        assertEquals(100410, freqEntry.prevArrivalTime(7, 100500)); // 8th stop, after begin
+
+        // testing last trip arrival
+        assertEquals(150190, freqEntry.prevArrivalTime(5, 150390)); // 6th stop
+        assertEquals(150310, freqEntry.prevArrivalTime(7, 150410)); // 8th stop, on end
+        assertEquals(150310, freqEntry.prevArrivalTime(7, 151000)); // 8th stop, after end
+    }
+
+    @Test
+    public void testExactTimesWithExtra() {
+        // test if end - start is not a multiple of headway
+        Frequency f = new Frequency();
+        f.setStartTime(100000);
+        f.setEndTime(110050);
+        f.setHeadwaySecs(100);
+        f.setExactTimes(1);
+
+        FrequencyEntry freqEntry = new FrequencyEntry(f, tripTimes);
+
+        // check last departure time is correct
+        assertEquals(110000, freqEntry.nextDepartureTime(0, 109950));
+        assertEquals(110000, freqEntry.nextDepartureTime(0, 110000));
+        assertEquals(-1,     freqEntry.nextDepartureTime(0, 110050));
+
+        // check last arrival time is correct
+        assertEquals(110290, freqEntry.prevArrivalTime(5, 110300));
+        assertEquals(110410, freqEntry.prevArrivalTime(7, 110410));
+        assertEquals(110410, freqEntry.prevArrivalTime(7, 110500));
+    }
+
+}


### PR DESCRIPTION
This fixes an issue where planning a trip outside a frequency-based trip's schedule will result in a starting time prior to the requested time.

The problem happens when the itinerary is reverse-optimized, if the trip is the first trip of the day, prevArrivalTime will return nothing (-1) because headway will cause you to fall outside the beginning time. This makes the current trip invalid and it will actually use the next closest trip which is the last trip of the previous day. This error then propagates to all previous legs and we have a trip that starts before our requested time.

To fix it, I just added a check where if you are already within the schedule, but headway pushes you out, just snap to the edge instead of returning nothing. For nextDepartureTime, it's just the reverse.

I'm not 100% sure this is a correct fix, but both functions are only used in Timetable so the impact should be limited. All tests still pass, so I assume it's mostly ok.
