### PR TITLE
Add Vehicle Positions GTFS-RT updater 

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -389,7 +389,21 @@ updated from minute to minute.
 departure times for the remainder of the trip.
 
 - **VehiclePositions** give the location of some or all vehicles currently in service, in terms of geographic coordinates
-or position relative to their scheduled stops.
+or position relative to their scheduled stops. The data from the updater is exposed in the /vehicle_positions endpoint as a list of vehicles.
+
+The format of the data looks like this: 
+```XML
+<vehicles>
+    <id>1331</id>
+    <agencyId>USF Bull Runner</agencyId>
+    <lat>28.067890167236328</lat>
+    <lon>-82.41658020019531</lon>
+    <bearing>270.0</bearing>
+    <routeId>A</routeId>
+    <lastUpdate>1473996577562</lastUpdate>
+    <occupancyStatus>MANY_SEATS_AVAILABLE</occupancyStatus>
+</vehicles>
+```
 
 ### Bicycle rental systems
 
@@ -492,6 +506,15 @@ connect to a network resource is the `url` field.
             url: "http://developer.trimet.org/ws/V1/TripUpdate/appID/0123456789ABCDEF",
             feedId: "TriMet"
         },
+
+        // Vehicle Positions (GTFS-RT)
+        {
+            type: "vehicle-position-updater",
+            frequencySec: 5,
+            defaultAgencyId: "USF Bull Runner",
+            sourceType: "gtfs-http",
+            url: "http://mobullity.forest.usf.edu:8088/vehicle-positions"
+        }
 
         // Streaming differential GTFS-RT TripUpdates over websockets
         {

--- a/src/main/java/org/opentripplanner/api/resource/VehiclePositions.java
+++ b/src/main/java/org/opentripplanner/api/resource/VehiclePositions.java
@@ -1,0 +1,80 @@
+/* 
+ Copyright (C) 2016 University of South Florida.
+ All rights reserved.
+
+ This program is free software: you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public License
+ as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+*/
+
+package org.opentripplanner.api.resource;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.opentripplanner.api.model.transit.AgencyList;
+import org.opentripplanner.updater.vehiclepositions.GtfsRealtimeHttpVehiclePositionSource;
+import org.opentripplanner.updater.vehiclepositions.PollingVehiclePositionsUpdater;
+import org.opentripplanner.updater.vehiclepositions.Vehicle;
+import org.opentripplanner.updater.vehiclepositions.VehiclePositionSource;
+
+import com.google.transit.realtime.GtfsRealtime.Position;
+import com.google.transit.realtime.GtfsRealtime.VehiclePosition;
+
+@Path("/vehicle_positions")
+@XmlRootElement
+public class VehiclePositions {
+	
+    @GET
+    @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.TEXT_XML })
+    	public VehiclePositionsList getVehiclePositions(
+    			@QueryParam("routeid") String routeId,
+    			@QueryParam("agencyid") String agencyId){
+    		
+    		List<String> vehicleIds = org.opentripplanner.updater.vehiclepositions.PollingVehiclePositionsUpdater.vehicleIds;
+    		Map<String,Vehicle> vehiclesById = org.opentripplanner.updater.vehiclepositions.PollingVehiclePositionsUpdater.vehiclesById;
+    		
+    		//if null returns new empty list:
+    		if(vehicleIds == null){return new VehiclePositionsList();}
+    	
+    		//sets data list to vehicles
+    		List<Vehicle> vehicles = new ArrayList<Vehicle>();
+    		for (int x = 0; x < vehicleIds.size(); x++){
+    			//getting info from the updater
+    			String vehicleId = vehicleIds.get(x);
+    			Vehicle v = vehiclesById.get(vehicleId);
+    			if(routeId != null && agencyId != null){
+    				if (v.routeId.equals(routeId) && v.agencyId.equals(agencyId)){vehicles.add(v);}
+    			}
+    			else if(routeId != null){
+    				if(v.routeId.equals(routeId)){
+    					vehicles.add(v);
+    					}
+    			}
+    			else if(agencyId != null){
+    				if (v.agencyId.equals(agencyId)){vehicles.add(v);}
+    			}
+    			else{vehicles.add(v);}
+    		}
+    		
+    		VehiclePositionsList vehicleList = new VehiclePositionsList();
+    		vehicleList.vehicles = vehicles;
+    		return vehicleList;
+    }
+}

--- a/src/main/java/org/opentripplanner/api/resource/VehiclePositions.java
+++ b/src/main/java/org/opentripplanner/api/resource/VehiclePositions.java
@@ -1,6 +1,5 @@
 /* 
  Copyright (C) 2016 University of South Florida.
- All rights reserved.
 
  This program is free software: you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public License

--- a/src/main/java/org/opentripplanner/api/resource/VehiclePositionsList.java
+++ b/src/main/java/org/opentripplanner/api/resource/VehiclePositionsList.java
@@ -1,0 +1,32 @@
+/* 
+ Copyright (C) 2016 University of South Florida.
+ All rights reserved.
+
+ This program is free software: you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public License
+ as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+*/
+
+package org.opentripplanner.api.resource;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElements;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.opentripplanner.updater.vehiclepositions.Vehicle;
+
+@XmlRootElement(name="VehiclePositionsList")
+public class VehiclePositionsList {
+    @XmlElements(value = { @XmlElement(name="vehicle") })
+    public List<Vehicle> vehicles = new ArrayList<Vehicle>();
+}

--- a/src/main/java/org/opentripplanner/api/resource/VehiclePositionsList.java
+++ b/src/main/java/org/opentripplanner/api/resource/VehiclePositionsList.java
@@ -1,6 +1,5 @@
 /* 
  Copyright (C) 2016 University of South Florida.
- All rights reserved.
 
  This program is free software: you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public License

--- a/src/main/java/org/opentripplanner/standalone/OTPApplication.java
+++ b/src/main/java/org/opentripplanner/standalone/OTPApplication.java
@@ -96,7 +96,8 @@ public class OTPApplication extends Application {
             RepeatedRaptorTestResource.class,
             /* Features and Filters: extend Jersey, manipulate requests and responses. */
             CorsFilter.class,
-            MultiPartFeature.class
+            MultiPartFeature.class,
+            VehiclePositions.class
         ));
         
         if (this.secure) {

--- a/src/main/java/org/opentripplanner/updater/GraphUpdaterConfigurator.java
+++ b/src/main/java/org/opentripplanner/updater/GraphUpdaterConfigurator.java
@@ -24,13 +24,16 @@ import org.opentripplanner.updater.stoptime.PollingStoptimeUpdater;
 import org.opentripplanner.updater.stoptime.WebsocketGtfsRealtimeUpdater;
 import org.opentripplanner.updater.street_notes.WinkkiPollingGraphUpdater;
 import org.opentripplanner.updater.traffic.OpenTrafficUpdater;
+
+import org.opentripplanner.updater.vehiclepositions.PollingVehiclePositionsUpdater;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Upon loading a Graph, configure/decorate it using a JSON tree from Jackson. This mainly involves starting
  * graph updater processes (GTFS-RT, bike rental, etc.), hence the class name.
- * 
+ *
  * When a Graph is loaded, one should call setupGraph() with the JSON tree containing configuration for the Graph.
  * That method creates "graph updaters" according to the given JSON, which should contain an array or object field
  * called "updaters". Each child element represents one updater.
@@ -56,7 +59,7 @@ public abstract class GraphUpdaterConfigurator {
         JsonNode embeddedConfig = null; // graph.routerConfig;
         LOG.info("Using configurations: " + (mainConfig == null ? "" : "[main]") + " "
                 + (embeddedConfig == null ? "" : "[embedded]"));
-        
+
         // Apply configuration
         // FIXME why are we returning the same updatermanager object that has been modified ? this method could just create it.
         updaterManager = applyConfigurationToGraph(graph, updaterManager, mainConfig);
@@ -83,6 +86,7 @@ public abstract class GraphUpdaterConfigurator {
             // For each sub-node, determine which kind of updater is being created.
             String type = configItem.path("type").asText();
             GraphUpdater updater = null;
+
             if (type != null) {
                 if (type.equals("bike-rental")) {
                     updater = new BikeRentalUpdater();
@@ -95,6 +99,9 @@ public abstract class GraphUpdaterConfigurator {
                 }
                 else if (type.equals("websocket-gtfs-rt-updater")) {
                     updater = new WebsocketGtfsRealtimeUpdater();
+                }
+                else if (type.equals("vehicle-position-updater")){
+                    updater = new PollingVehiclePositionsUpdater();
                 }
                 else if (type.equals("real-time-alerts")) {
                     updater = new GtfsRealtimeAlertsUpdater();

--- a/src/main/java/org/opentripplanner/updater/vehiclepositions/GtfsRealtimeHttpVehiclePositionSource.java
+++ b/src/main/java/org/opentripplanner/updater/vehiclepositions/GtfsRealtimeHttpVehiclePositionSource.java
@@ -1,0 +1,84 @@
+/* 
+ Copyright (C) 2016 University of South Florida.
+ All rights reserved.
+
+ This program is free software: you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public License
+ as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+*/
+
+package org.opentripplanner.updater.vehiclepositions;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.prefs.Preferences;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import org.opentripplanner.updater.JsonConfigurable;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.util.HttpUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.transit.realtime.GtfsRealtime.FeedEntity;
+import com.google.transit.realtime.GtfsRealtime.FeedMessage;
+import com.google.transit.realtime.GtfsRealtime.VehiclePosition;
+
+public class GtfsRealtimeHttpVehiclePositionSource implements VehiclePositionSource, JsonConfigurable {
+    private static final Logger LOG =
+            LoggerFactory.getLogger(GtfsRealtimeHttpVehiclePositionSource.class);
+
+    /**
+     * Default agency id that is used for the trip ids in the Vehicle Positions
+     */
+    public String agencyId;
+
+    public String url;
+
+    @Override
+    public void configure(Graph graph, JsonNode config) throws Exception {
+
+        String url = config.path("url").asText();
+        if (url == null) {
+            throw new IllegalArgumentException("Missing mandatory 'url' parameter");
+        }
+        this.url = url;
+        this.agencyId = config.path("defaultAgencyId").asText();
+    }
+
+    @Override
+    public List<VehiclePosition> getUpdates() {
+        FeedMessage feedMessage = null;
+        List<FeedEntity> feedEntityList = null;
+        List<VehiclePosition> updates = null;
+        try {
+            InputStream is = HttpUtils.getData(url);
+            if (is != null) {
+                feedMessage = FeedMessage.PARSER.parseFrom(is);
+                feedEntityList = feedMessage.getEntityList();
+                updates = new ArrayList<VehiclePosition>(feedEntityList.size());
+                for (FeedEntity feedEntity : feedEntityList) {
+                    updates.add(feedEntity.getVehicle());
+                }
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to parse gtfs-rt feed from " + url + ":", e);
+        }
+        return updates;
+    }
+
+    public String toString() {
+        return "GtfsRealtimeHttpUpdateStreamer(" + url + ")";
+    }
+}

--- a/src/main/java/org/opentripplanner/updater/vehiclepositions/GtfsRealtimeHttpVehiclePositionSource.java
+++ b/src/main/java/org/opentripplanner/updater/vehiclepositions/GtfsRealtimeHttpVehiclePositionSource.java
@@ -1,6 +1,5 @@
 /* 
  Copyright (C) 2016 University of South Florida.
- All rights reserved.
 
  This program is free software: you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public License

--- a/src/main/java/org/opentripplanner/updater/vehiclepositions/PollingVehiclePositionsUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/vehiclepositions/PollingVehiclePositionsUpdater.java
@@ -1,0 +1,194 @@
+/* 
+ Copyright (C) 2016 University of South Florida.
+ All rights reserved.
+
+ This program is free software: you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public License
+ as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+*/
+
+package org.opentripplanner.updater.vehiclepositions;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.prefs.Preferences;
+
+import org.opentripplanner.updater.JsonConfigurable;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.updater.GraphUpdaterManager;
+import org.opentripplanner.updater.PollingGraphUpdater;
+import org.opentripplanner.updater.stoptime.GtfsRealtimeFileTripUpdateSource;
+import org.opentripplanner.updater.stoptime.GtfsRealtimeHttpTripUpdateSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import com.google.transit.realtime.GtfsRealtime.Position;
+import com.google.transit.realtime.GtfsRealtime.VehiclePosition;
+
+/**
+ * Update OTP stop time tables from some (realtime) source
+ *
+ * Usage example ('rt' name is an example) in file 'Graph.properties':
+ *
+ * <pre>
+ * rt.type = stop-time-updater
+ * rt.frequencySec = 60
+ * rt.sourceType = gtfs-http
+ * rt.url = http://host.tld/path
+ * rt.defaultAgencyId = TA
+ * </pre>
+ *
+ */
+public class PollingVehiclePositionsUpdater extends PollingGraphUpdater {
+    private static final Logger LOG = LoggerFactory.getLogger(PollingVehiclePositionsUpdater.class);
+    
+    /**
+     * Hash Map for Vehicle Positions
+     */
+    public static List<String> vehicleIds = new ArrayList<String>();
+    public static Map<String, Vehicle> vehiclesById = new ConcurrentHashMap<String, Vehicle>();
+    
+    /**
+     * Parent update manager. Is used to execute graph writer runnables.
+     */
+    private GraphUpdaterManager updaterManager;
+
+    /**
+     * Update streamer
+     */
+    private VehiclePositionSource updateSource;
+
+    /**
+     * Property to set on the RealtimeDataSnapshotSource
+     */
+    private Integer logFrequency;
+
+    /**
+     * Property to set on the RealtimeDataSnapshotSource
+     */
+    private Integer maxSnapshotFrequency;
+
+    /**
+     * Property to set on the RealtimeDataSnapshotSource
+     */
+    private Boolean purgeExpiredData;
+
+    /**
+     * Default agency id that is used for the trip ids in the Vehicle Positions
+     */
+    private String agencyId;
+
+    @Override
+    public void setGraphUpdaterManager(GraphUpdaterManager updaterManager) {
+        this.updaterManager = updaterManager;
+    }
+
+    @Override
+    public void configurePolling(Graph graph, JsonNode config) throws Exception {
+    	// Create update streamer from preferences
+        agencyId = config.path("defaultAgencyId").asText();
+        String sourceType = config.path("sourceType").asText();
+        if (sourceType != null) {
+            if (sourceType.equals("gtfs-http")) {
+                updateSource = new GtfsRealtimeHttpVehiclePositionSource();
+            } 
+        }
+
+        // Configure update source
+        if (updateSource == null) {
+            throw new IllegalArgumentException(
+                    "Unknown update streamer source type: " + sourceType);
+        } else if (updateSource instanceof JsonConfigurable) {
+            ((JsonConfigurable) updateSource).configure(graph, config);
+        }
+
+        // Configure updater
+        int logFrequency = config.path("logFrequency").asInt(-1);
+        if (logFrequency >= 0) {
+            this.logFrequency = logFrequency;
+        }
+        int maxSnapshotFrequency = config.path("maxSnapshotFrequencyMs").asInt(-1);
+        if (maxSnapshotFrequency >= 0)
+            this.maxSnapshotFrequency = maxSnapshotFrequency;
+        String purgeExpiredData = config.path("purgeExpiredData").asText("");
+        if (!purgeExpiredData.isEmpty()) {
+            this.purgeExpiredData = config.path("purgeExpiredData").asBoolean(true);
+        }
+
+        LOG.info("Creating stop time updater running every {} seconds : {}",
+                frequencySec, updateSource);
+    }
+
+    @Override
+    public void setup() throws InterruptedException, ExecutionException {
+       
+    }
+
+    /**
+     * Repeatedly makes blocking calls to an UpdateStreamer to retrieve new stop time updates, and
+     * applies those updates to the graph.
+     */
+    @Override
+    public void runPolling() {
+        // Get update lists from update source and clear hashmap
+    	final List<VehiclePosition> updates = updateSource.getUpdates();
+        vehicleIds.clear();
+        vehiclesById.clear();
+        
+        if (updates != null && updates.size() > 0) {
+            //Handle vehicle position updates
+        	//create new runnable thread with method run to update hashmaps
+        	//print to console to test working
+        	new Thread(){
+        		public void run(){
+        			for(int x = 0; x < updates.size(); x++){
+        				
+        				//setting vehicle variables to set up hash map
+        				Position position = updates.get(x).getPosition();
+        				String vehicleId = updates.get(x).getVehicle().getId();
+        				String routeId = updates.get(x).getTrip().getRouteId();
+        				Vehicle v = new Vehicle();
+        				v.id = vehicleId;
+        				v.lat=position.getLatitude();
+        				v.lon=position.getLongitude();
+        				v.routeId=routeId;
+        				v.agencyId=agencyId;
+        				v.bearing=position.getBearing();
+        				v.lastUpdate=System.currentTimeMillis();
+        				
+        				//setting up the hash map
+        				Vehicle existing = vehiclesById.get(vehicleId);
+        				if (existing == null || existing.lat != v.lat || existing.lon != v.lon) {
+        					vehicleIds.add(vehicleId);
+        					vehiclesById.put(vehicleId, v);
+        				}
+        				else { v.lastUpdate=existing.lastUpdate; }
+        			}
+        		}
+        	}.start();
+        }
+    }
+
+    @Override
+    public void teardown() {
+    }
+
+    public String toString() {
+        String s = (updateSource == null) ? "NONE" : updateSource.toString();
+        return "Streaming vehicle position updater with update source = " + s;
+    }
+}

--- a/src/main/java/org/opentripplanner/updater/vehiclepositions/PollingVehiclePositionsUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/vehiclepositions/PollingVehiclePositionsUpdater.java
@@ -1,6 +1,5 @@
 /* 
  Copyright (C) 2016 University of South Florida.
- All rights reserved.
 
  This program is free software: you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public License

--- a/src/main/java/org/opentripplanner/updater/vehiclepositions/PollingVehiclePositionsUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/vehiclepositions/PollingVehiclePositionsUpdater.java
@@ -168,7 +168,8 @@ public class PollingVehiclePositionsUpdater extends PollingGraphUpdater {
         				v.agencyId=agencyId;
         				v.bearing=position.getBearing();
         				v.lastUpdate=System.currentTimeMillis();
-        				
+        				v.occupancyStatus=updates.get(x).getOccupancyStatus();
+	
         				//setting up the hash map
         				Vehicle existing = vehiclesById.get(vehicleId);
         				if (existing == null || existing.lat != v.lat || existing.lon != v.lon) {

--- a/src/main/java/org/opentripplanner/updater/vehiclepositions/Vehicle.java
+++ b/src/main/java/org/opentripplanner/updater/vehiclepositions/Vehicle.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2012 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opentripplanner.updater.vehiclepositions;
+
+import java.io.Serializable;
+
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+public class Vehicle implements Serializable{
+	private static final long serialVersionUID = 3333460609708083333L;
+
+    @XmlAttribute
+    @JsonSerialize	
+	public String id;
+    @XmlElement
+    @JsonSerialize	
+    public String agencyId;
+    @XmlElement
+    @JsonSerialize	
+    public double lat;
+    @XmlElement
+    @JsonSerialize	
+    public double lon;
+    @XmlElement
+    @JsonSerialize	
+    public float bearing;
+    @XmlElement
+    @JsonSerialize	
+    public String routeId;
+    @XmlElement
+    @JsonSerialize	
+    public long lastUpdate;  
+
+}

--- a/src/main/java/org/opentripplanner/updater/vehiclepositions/Vehicle.java
+++ b/src/main/java/org/opentripplanner/updater/vehiclepositions/Vehicle.java
@@ -21,9 +21,10 @@ import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.transit.realtime.GtfsRealtime.VehiclePosition.OccupancyStatus;
 
 public class Vehicle implements Serializable{
-	private static final long serialVersionUID = 3333460609708083333L;
+    private static final long serialVersionUID = 3333460609708084444L;
 
     @XmlAttribute
     @JsonSerialize	
@@ -46,5 +47,8 @@ public class Vehicle implements Serializable{
     @XmlElement
     @JsonSerialize	
     public long lastUpdate;  
+    @XmlElement
+    @JsonSerialize
+    public OccupancyStatus occupancyStatus;
 
 }

--- a/src/main/java/org/opentripplanner/updater/vehiclepositions/VehiclePositionSource.java
+++ b/src/main/java/org/opentripplanner/updater/vehiclepositions/VehiclePositionSource.java
@@ -1,0 +1,33 @@
+/* 
+ Copyright (C) 2016 University of South Florida.
+ All rights reserved.
+
+ This program is free software: you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public License
+ as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+*/
+
+package org.opentripplanner.updater.vehiclepositions;
+
+import java.util.List;
+
+import com.google.transit.realtime.GtfsRealtime.VehiclePosition;
+
+public interface VehiclePositionSource {
+    /**
+     * Wait for one message to arrive, and decode it into a List of VehiclePositions. Blocking call.
+     * @return a List<VehiclePosition> potentially containing VehiclePositions for several different vehicles,
+     *         or null if an exception occurred while processing the message
+     */
+    public List<VehiclePosition> getUpdates();
+
+}

--- a/src/main/java/org/opentripplanner/updater/vehiclepositions/VehiclePositionSource.java
+++ b/src/main/java/org/opentripplanner/updater/vehiclepositions/VehiclePositionSource.java
@@ -1,6 +1,5 @@
 /* 
  Copyright (C) 2016 University of South Florida.
- All rights reserved.
 
  This program is free software: you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public License


### PR DESCRIPTION
Originally developed by Tracy @TNWolf for CUTR @ the University of South Florida

This adds the related data structures and API interfaces necessary to pull vehicle positions from a 'GtfsRealtimeHttpVehiclePositionSource'.

Our deployment at USF is fed with a custom GTFSRT generator like: https://github.com/CUTR-at-USF/bullrunner-gtfs-realtime-generator which itself uses https://github.com/OneBusAway/onebusaway-gtfs-realtime-exporter/

This was designed to be used ideally in conjunction with the GTFS-RT trip updater in PR #1647, but it is still handy to have by itself for maintaining a consumable JSON api with the latest vehicle positions.

A sample router-config:

```
{
    updaters: [
    {
        type: "vehicle-position-updater",
        frequencySec: 5,
        defaultAgencyId: "USF Bull Runner",
        sourceType: "gtfs-http",
        url: "http://mobullity.forest.usf.edu:8088/vehicle-positions"
    }
    ]
}
```
