### PR TITLE
Load embedded config for existing graphs

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/module/EmbedConfig.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/EmbedConfig.java
@@ -1,7 +1,9 @@
 package org.opentripplanner.graph_builder.module;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import org.opentripplanner.graph_builder.services.GraphBuilderModule;
 import org.opentripplanner.routing.graph.Graph;
 
@@ -26,10 +28,9 @@ public class EmbedConfig implements GraphBuilderModule {
 
     @Override
     public void buildGraph(Graph graph, HashMap<Class<?>, Object> extra) {
-        ObjectMapper mapper = new ObjectMapper();
         try {
-            graph.builderConfig = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(builderConfig);
-            graph.routerConfig = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(routerConfig);
+            graph.builderConfig = serializedConfiguration(builderConfig);
+            graph.routerConfig = serializedConfiguration(routerConfig);
         } catch (Exception ex) {
             throw new RuntimeException(ex);
         }
@@ -38,6 +39,12 @@ public class EmbedConfig implements GraphBuilderModule {
     @Override
     public void checkInputs() {
 
+    }
+
+    private String serializedConfiguration(JsonNode config) throws JsonProcessingException{
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectWriter writer = mapper.writerWithDefaultPrettyPrinter();
+        return config.isMissingNode() ? null : writer.writeValueAsString(config);
     }
 
 }

--- a/src/main/java/org/opentripplanner/routing/impl/InputStreamGraphSource.java
+++ b/src/main/java/org/opentripplanner/routing/impl/InputStreamGraphSource.java
@@ -223,12 +223,14 @@ public class InputStreamGraphSource implements GraphSource {
         // Even if a config file is not present on disk one could be bundled inside.
         try (InputStream is = streams.getConfigInputStream()) {
             JsonNode config = MissingNode.getInstance();
+            // TODO reuse the exact same JSON loader from OTPConfigurator
+            ObjectMapper mapper = new ObjectMapper();
+            mapper.configure(JsonParser.Feature.ALLOW_COMMENTS, true);
+            mapper.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true);
             if (is != null) {
-                // TODO reuse the exact same JSON loader from OTPConfigurator
-                ObjectMapper mapper = new ObjectMapper();
-                mapper.configure(JsonParser.Feature.ALLOW_COMMENTS, true);
-                mapper.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true);
                 config = mapper.readTree(is);
+            } else if (newGraph.routerConfig != null) {
+                config = mapper.readTree(newGraph.routerConfig);
             }
             Router newRouter = new Router(routerId, newGraph);
             newRouter.startup(config);

--- a/src/main/java/org/opentripplanner/routing/services/GraphService.java
+++ b/src/main/java/org/opentripplanner/routing/services/GraphService.java
@@ -13,6 +13,14 @@
 
 package org.opentripplanner.routing.services;
 
+import org.geotools.referencing.factory.DeferredAuthorityFactory;
+import org.geotools.util.WeakCollectionCleaner;
+import org.opentripplanner.routing.error.GraphNotFoundException;
+import org.opentripplanner.standalone.Router;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.PreDestroy;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -22,15 +30,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import javax.annotation.PreDestroy;
-
-import org.geotools.referencing.factory.DeferredAuthorityFactory;
-import org.geotools.util.WeakCollectionCleaner;
-import org.opentripplanner.routing.error.GraphNotFoundException;
-import org.opentripplanner.standalone.Router;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A GraphService maps RouterIds to Graphs.

--- a/src/test/java/org/opentripplanner/routing/impl/GraphServiceTest.java
+++ b/src/test/java/org/opentripplanner/routing/impl/GraphServiceTest.java
@@ -13,19 +13,11 @@
 
 package org.opentripplanner.routing.impl;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.ObjectOutputStream;
-
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import junit.framework.TestCase;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
+import com.fasterxml.jackson.databind.node.MissingNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import junit.framework.TestCase;
 import org.junit.Test;
 import org.opentripplanner.graph_builder.module.EmbedConfig;
 import org.opentripplanner.routing.edgetype.StreetEdge;
@@ -35,6 +27,9 @@ import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.services.GraphService;
 import org.opentripplanner.routing.vertextype.IntersectionVertex;
 import org.opentripplanner.routing.vertextype.StreetVertex;
+
+import java.io.*;
+
 
 public class GraphServiceTest extends TestCase {
 
@@ -253,9 +248,10 @@ public class GraphServiceTest extends TestCase {
     @Test
     public final void testGraphServiceMemoryRouterConfig () throws IOException {
         ObjectMapper mapper = new ObjectMapper();
-        ObjectNode config = mapper.createObjectNode();
-        config.put("timeout", 8);
-        EmbedConfig embedConfig = new EmbedConfig(null, config);
+        JsonNode buildConfig = MissingNode.getInstance();
+        ObjectNode routerConfig = mapper.createObjectNode();
+        routerConfig.put("timeout", 8);
+        EmbedConfig embedConfig = new EmbedConfig(buildConfig, routerConfig);
         embedConfig.buildGraph(emptyGraph, null);
 
         GraphService graphService = new GraphService();
@@ -267,8 +263,8 @@ public class GraphServiceTest extends TestCase {
         assertEquals(emptyGraph, graph);
         assertEquals("A", emptyGraph.routerId);
 
-        JsonNode routerConfig = mapper.readTree(graph.routerConfig);
-        assertEquals(routerConfig, config);
-        assertEquals(routerConfig.get("timeout"), config.get("timeout"));
+        JsonNode graphRouterConfig = mapper.readTree(graph.routerConfig);
+        assertEquals(graphRouterConfig, routerConfig);
+        assertEquals(graphRouterConfig.get("timeout"), routerConfig.get("timeout"));
     }
 }


### PR DESCRIPTION
I recently discovered that the embedded configurations (`build` and `router`) are not loaded in OTP, if an existing graph is posted to the server via `POST /routers/save?routerId=myRouter @graph.obj`.

This PR fixes this missing feature by loading the `routerConfig` if the respective file `router-config.json` is not found on the file system but is embedded to the graph already.
