### PR TITLE
When creating backStreet AreaEdge, wheelchairAccessible is set twice …

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilder.java
@@ -454,7 +454,7 @@ public class WalkableAreaBuilder {
             }
 
             if (areaEntity.isTagFalse("wheelchair")) {
-                street.setWheelchairAccessible(false);
+                backStreet.setWheelchairAccessible(false);
             }
 
             backStreet.setStreetClass(cls);


### PR DESCRIPTION
…on 'street' instead of on both 'steet' and 'backStreet'
