### PR TITLE
Fix OUTSIDE_BOUNDS no longer being returned

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/linking/SimpleStreetSplitter.java
+++ b/src/main/java/org/opentripplanner/graph_builder/linking/SimpleStreetSplitter.java
@@ -526,6 +526,7 @@ public class SimpleStreetSplitter {
 
         if(!link(closest, nonTransitMode, options)) {
             LOG.warn("Couldn't link {}", location);
+            return null;
         }
         return closest;
 


### PR DESCRIPTION
In OTP 1.0.0, selecting endpoints that are outside the map (like in the ocean) always return PATH_NOT_FOUND instead of OUTSIDE_BOUNDS (as it did in 0.19.0).

This seems to have occurred after the refactor of the origin/destination linker. OUTSIDE_BOUNDS is only returned if a VertexNotFoundException is thrown, but the new linker always returns (a potentially out of bounds) vertex. We got back the old behavior by returning null if linking fails.
