### PR TITLE
Re #2374. Allow Cars on highway=*;bicycle=designated

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/DefaultWayPropertySetSource.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/DefaultWayPropertySetSource.java
@@ -341,7 +341,7 @@ public class DefaultWayPropertySetSource implements WayPropertySetSource {
 
         /* bicycle=designated, but no bike infrastructure is present */
         setProperties(props, "highway=*;bicycle=designated",
-                StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE, 0.97, 0.97);
+                StreetTraversalPermission.ALL, 0.97, 0.97);
         setProperties(props, "highway=service;bicycle=designated", StreetTraversalPermission.ALL,
                 0.84, 0.84);
         setProperties(props, "highway=residential;bicycle=designated",


### PR DESCRIPTION
If you're interested, this is in response to #2374 where I was unable to route on a highway=living_street. This PR opens up highway=* to allow all modes as the default, with specific exceptions for e.g. highway=cycleway or highway=footpath already covered in the file. 

The file comments indicate that it's meant to be Portland specific, whereas my problem was in California. Feel free to reject as irrelevant. Thanks for looking.