### PR TITLE
Added headsign attribute for stoptimes in GraphQL

### DIFF
--- a/src/main/java/org/opentripplanner/index/IndexGraphQLSchema.java
+++ b/src/main/java/org/opentripplanner/index/IndexGraphQLSchema.java
@@ -133,6 +133,7 @@ public class IndexGraphQLSchema {
     public IndexGraphQLSchema(GraphIndex index) {
 
         fuzzyTripMatcher = new GtfsRealtimeFuzzyTripMatcher(index);
+        index.clusterStopsAsNeeded();
 
         stopAtDistanceType = GraphQLObjectType.newObject()
             .name("stopAtDistance")

--- a/src/main/java/org/opentripplanner/index/IndexGraphQLSchema.java
+++ b/src/main/java/org/opentripplanner/index/IndexGraphQLSchema.java
@@ -454,6 +454,11 @@ public class IndexGraphQLSchema {
                 .dataFetcher(environment -> index.tripForId
                     .get(((TripTimeShort) environment.getSource()).tripId))
                 .build())
+            .field(GraphQLFieldDefinition.newFieldDefinition()
+               	.name("headsign")
+              	.type(Scalars.GraphQLString)
+              	.dataFetcher(environment -> ((TripTimeShort) environment.getSource()).headsign)
+              	.build())
             .build();
 
         tripType = GraphQLObjectType.newObject()


### PR DESCRIPTION
As discussed in #2224 , the headsign element is missing from GraphQL. Added by this PR.

Partly replaces PR #2358, which contained too much clutter.