### PR TITLE
Compute isochrone feature collection synchronously

### DIFF
--- a/src/main/java/org/opentripplanner/api/resource/LIsochrone.java
+++ b/src/main/java/org/opentripplanner/api/resource/LIsochrone.java
@@ -149,7 +149,7 @@ public class LIsochrone extends RoutingResource {
      * Create a geotools feature collection from a list of isochrones in the OTPA internal format.
      * Once in a FeatureCollection, they can for example be exported as GeoJSON.
      */
-    public static SimpleFeatureCollection makeContourFeatures(List<IsochroneData> isochrones) {
+    public static synchronized SimpleFeatureCollection makeContourFeatures(List<IsochroneData> isochrones) {
         DefaultFeatureCollection featureCollection = new DefaultFeatureCollection(null,
                 contourSchema);
         SimpleFeatureBuilder fbuilder = new SimpleFeatureBuilder(contourSchema);


### PR DESCRIPTION
GeoTools [SimpleFeatureBuilder is not thread safe](http://docs.geotools.org/latest/javadocs/org/geotools/feature/simple/SimpleFeatureBuilder.html).
Compute isochrone features synchronously, to avoid concurrency issues with SimpleFeatureBuilder.

Should fix issues with computing multiple isochrones in rapid succession, such as #1436.