### PR TITLE
Optional stop clustering by parent station or geography

### DIFF
--- a/src/main/java/org/opentripplanner/routing/graph/Graph.java
+++ b/src/main/java/org/opentripplanner/routing/graph/Graph.java
@@ -197,6 +197,9 @@ public class Graph implements Serializable {
 
     /** A speed source for traffic data */
     public transient StreetSpeedSnapshotSource streetSpeedSource;
+    
+    /** Whether stop clustering should be based on parent stations */
+    public boolean clusterByParentStation = false;
 
     public Graph(Graph basedOn) {
         this();

--- a/src/main/java/org/opentripplanner/routing/graph/Graph.java
+++ b/src/main/java/org/opentripplanner/routing/graph/Graph.java
@@ -198,8 +198,8 @@ public class Graph implements Serializable {
     /** A speed source for traffic data */
     public transient StreetSpeedSnapshotSource streetSpeedSource;
     
-    /** Whether stop clustering should be based on parent stations */
-    public boolean clusterByParentStation = false;
+    /** How should we cluster stops? */
+    public String stopClusterMode;
 
     public Graph(Graph basedOn) {
         this();

--- a/src/main/java/org/opentripplanner/routing/graph/Graph.java
+++ b/src/main/java/org/opentripplanner/routing/graph/Graph.java
@@ -199,7 +199,7 @@ public class Graph implements Serializable {
     public transient StreetSpeedSnapshotSource streetSpeedSource;
     
     /** How should we cluster stops? */
-    public String stopClusterMode;
+    public String stopClusterMode = "proximity";
 
     public Graph(Graph basedOn) {
         this();

--- a/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
+++ b/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
@@ -604,9 +604,13 @@ public class GraphIndex {
 		LOG.info("Clustering stops by parent station...");
     	for (Stop stop : stopForId.values()) {
     		String ps = stop.getParentStation();
-    		if (ps == null || ps.isEmpty()) continue;
+    		if (ps == null || ps.isEmpty()) {
+    			continue;
+    		}
     		StopCluster cluster;
-    		if (stopClusterForId.containsKey(ps)) cluster = stopClusterForId.get(ps);		
+    		if (stopClusterForId.containsKey(ps)) {
+    			cluster = stopClusterForId.get(ps);		
+    		}
     		else {
     			cluster = new StopCluster(ps, stop.getName());   
     			stopClusterForId.put(ps, cluster); 

--- a/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
+++ b/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
@@ -563,10 +563,15 @@ public class GraphIndex {
      * stops -- no guessing is reasonable without that information.
      */
     public void clusterStops() {
-    	if (graph.clusterByParentStation) {
+    	switch (graph.stopClusterMode) {
+    	case "parentStation": 
     	    clusterByParentStation();
-    	} else {
+    	    break;   	    
+    	case "proximity":
     	    clusterByProximity();
+    	    break;    	    
+    	default:
+    	    clusterByProximity(); 
     	}
     }
     

--- a/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
+++ b/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
@@ -602,16 +602,18 @@ public class GraphIndex {
     
 	private void clusterByParentStation() {
 		LOG.info("Clustering stops by parent station...");
-    	for (Stop s0 : stopForId.values()) {
-    		String ps = s0.getParentStation();
-    		stopClusterForId.put(ps, new StopCluster(ps, s0.getName()));
+    	for (Stop stop : stopForId.values()) {
+    		String ps = stop.getParentStation();
+    		if (ps == null || ps.isEmpty()) continue;
+    		StopCluster cluster;
+    		if (stopClusterForId.containsKey(ps)) cluster = stopClusterForId.get(ps);		
+    		else {
+    			cluster = new StopCluster(ps, stop.getName());   
+    			stopClusterForId.put(ps, cluster); 
     		}
-    	for (Stop s0 : stopForId.values()) {
-    		String ps = s0.getParentStation();
-    		if(!stopClusterForId.containsKey(ps)) continue;
-    		StopCluster cluster = stopClusterForId.get(ps);
-    		cluster.children.add(s0);
-    		stopClusterForStop.put(s0, cluster);
+    		cluster.children.add(stop);
+    		stopClusterForStop.put(stop, cluster);
+    		   		
     	}
     	for (Map.Entry<String, StopCluster> cluster : stopClusterForId.entrySet()) {
     		cluster.getValue().computeCenter();

--- a/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
+++ b/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
@@ -78,6 +78,9 @@ public class GraphIndex {
 
     /** maximum distance to walk after leaving transit in Analyst */
     public static final int MAX_WALK_METERS = 3500;
+    
+    /** Should stop clusters be created by parent stations instead of by proximity?  */
+    public static final boolean CLUSTER_BY_PARENT_STATIONS = false;
 
     // TODO: consistently key on model object or id string
     public final Map<String, Vertex> vertexForId = Maps.newHashMap();
@@ -547,11 +550,13 @@ public class GraphIndex {
     }
 
     /**
+     * Stop clusters can be built in one of two ways, either by geographical proximity, or 
+     * according to a parent/child station topology, if it exists.
+     * 
+     * Some challenges faced by DC and Trimet:
      * FIXME OBA parentStation field is a string, not an AgencyAndId, so it has no agency/feed scope
      * But the DC regional graph has no parent stations pre-defined, so no use dealing with them for now.
      * However Trimet stops have "landmark" or Transit Center parent stations, so we don't use the parent stop field.
-     *
-     * Ideally in the future stop clusters will replicate and/or share implementation with GTFS parent stations.
      *
      * We can't use a similarity comparison, we need exact matches. This is because many street names differ by only
      * one letter or number, e.g. 34th and 35th or Avenue A and Avenue B.
@@ -560,36 +565,57 @@ public class GraphIndex {
      * stops -- no guessing is reasonable without that information.
      */
     public void clusterStops() {
-        int psIdx = 0; // unique index for next parent stop
-        LOG.info("Clustering stops by geographic proximity and name...");
-        // Each stop without a cluster will greedily claim other stops without clusters.
-        for (Stop s0 : stopForId.values()) {
-            if (stopClusterForStop.containsKey(s0)) continue; // skip stops that have already been claimed by a cluster
-            String s0normalizedName = StopNameNormalizer.normalize(s0.getName());
-            StopCluster cluster = new StopCluster(String.format("C%03d", psIdx++), s0normalizedName);
-            // LOG.info("stop {}", s0normalizedName);
-            // No need to explicitly add s0 to the cluster. It will be found in the spatial index query below.
-            Envelope env = new Envelope(new Coordinate(s0.getLon(), s0.getLat()));
-            env.expandBy(SphericalDistanceLibrary.metersToLonDegrees(CLUSTER_RADIUS, s0.getLat()),
-                    SphericalDistanceLibrary.metersToDegrees(CLUSTER_RADIUS));
-            for (TransitStop ts1 : stopSpatialIndex.query(env)) {
-                Stop s1 = ts1.getStop();
-                double geoDistance = SphericalDistanceLibrary.fastDistance(
-                        s0.getLat(), s0.getLon(), s1.getLat(), s1.getLon());
-                if (geoDistance < CLUSTER_RADIUS) {
-                    String s1normalizedName = StopNameNormalizer.normalize(s1.getName());
-                    // LOG.info("   --> {}", s1normalizedName);
-                    // LOG.info("       geodist {} stringdist {}", geoDistance, stringDistance);
-                    if (s1normalizedName.equals(s0normalizedName)) {
-                        // Create a bidirectional relationship between the stop and its cluster
-                        cluster.children.add(s1);
-                        stopClusterForStop.put(s1, cluster);
-                    }
-                }
-            }
-            cluster.computeCenter();
-            stopClusterForId.put(cluster.id, cluster);
-        }
+    	if (!CLUSTER_BY_PARENT_STATIONS) {
+	    int psIdx = 0; // unique index for next parent stop
+	    LOG.info("Clustering stops by geographic proximity and name...");
+	    // Each stop without a cluster will greedily claim other stops without clusters.
+	    for (Stop s0 : stopForId.values()) {
+	        if (stopClusterForStop.containsKey(s0)) continue; // skip stops that have already been claimed by a cluster
+	        String s0normalizedName = StopNameNormalizer.normalize(s0.getName());
+	        StopCluster cluster = new StopCluster(String.format("C%03d", psIdx++), s0normalizedName);
+	        // LOG.info("stop {}", s0normalizedName);
+	        // No need to explicitly add s0 to the cluster. It will be found in the spatial index query below.
+	        Envelope env = new Envelope(new Coordinate(s0.getLon(), s0.getLat()));
+	        env.expandBy(SphericalDistanceLibrary.metersToLonDegrees(CLUSTER_RADIUS, s0.getLat()),
+	                SphericalDistanceLibrary.metersToDegrees(CLUSTER_RADIUS));
+	        for (TransitStop ts1 : stopSpatialIndex.query(env)) {
+	            Stop s1 = ts1.getStop();
+	            double geoDistance = SphericalDistanceLibrary.fastDistance(
+	                    s0.getLat(), s0.getLon(), s1.getLat(), s1.getLon());
+	            if (geoDistance < CLUSTER_RADIUS) {
+	                String s1normalizedName = StopNameNormalizer.normalize(s1.getName());
+	                // LOG.info("   --> {}", s1normalizedName);
+	                // LOG.info("       geodist {} stringdist {}", geoDistance, stringDistance);
+	                if (s1normalizedName.equals(s0normalizedName)) {
+	                    // Create a bidirectional relationship between the stop and its cluster
+	                    cluster.children.add(s1);
+	                    stopClusterForStop.put(s1, cluster);
+	                }
+	            }
+	        }
+	        cluster.computeCenter();
+	        stopClusterForId.put(cluster.id, cluster);
+	    }
+    	}
+    	else {
+	        LOG.info("Clustering stops by parent station...");
+	    	Map<String, StopCluster> parentStopsMap = new HashMap();
+	    	for (Stop s0 : stopForId.values()) {
+	    		String ps = s0.getParentStation();
+	    		parentStopsMap.put(ps, new StopCluster(ps, s0.getName()));
+	    		}
+	    	for (Stop s0 : stopForId.values()) {
+	    		String ps = s0.getParentStation();
+	    		if(!parentStopsMap.containsKey(ps)) continue;
+	    		StopCluster cluster = parentStopsMap.get(ps);
+	    		cluster.children.add(s0);
+	    		stopClusterForStop.put(s0, cluster);
+	    	}
+	    	for (Map.Entry<String, StopCluster> cluster : parentStopsMap.entrySet()) {
+	    		cluster.getValue().computeCenter();
+	    		stopClusterForId.put(cluster.getKey(), cluster.getValue());
+	    	}
+    	}
     }
 
     public Response getGraphQLResponse(String query, Map<String, Object> variables) {

--- a/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
+++ b/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
@@ -563,8 +563,11 @@ public class GraphIndex {
      * stops -- no guessing is reasonable without that information.
      */
     public void clusterStops() {
-    	if (graph.clusterByParentStation) clusterByParentStation();
-    	else clusterByProximity();
+    	if (graph.clusterByParentStation) {
+    	    clusterByParentStation();
+    	} else {
+    	    clusterByProximity();
+    	}
     }
     
     private void clusterByProximity() {	
@@ -599,31 +602,27 @@ public class GraphIndex {
 	        stopClusterForId.put(cluster.id, cluster);
 	    }
     }
-    
-	private void clusterByParentStation() {
-		LOG.info("Clustering stops by parent station...");
+    private void clusterByParentStation() {
+        LOG.info("Clustering stops by parent station...");
     	for (Stop stop : stopForId.values()) {
-    		String ps = stop.getParentStation();
-    		if (ps == null || ps.isEmpty()) {
-    			continue;
-    		}
-    		StopCluster cluster;
-    		if (stopClusterForId.containsKey(ps)) {
-    			cluster = stopClusterForId.get(ps);		
-    		}
-    		else {
-    			cluster = new StopCluster(ps, stop.getName());   
-    			stopClusterForId.put(ps, cluster); 
-    		}
-    		cluster.children.add(stop);
-    		stopClusterForStop.put(stop, cluster);
-    		   		
+    	    String ps = stop.getParentStation();
+    	    if (ps == null || ps.isEmpty()) {
+    	        continue;
+    	    }
+    	    StopCluster cluster;
+    	    if (stopClusterForId.containsKey(ps)) {
+    	        cluster = stopClusterForId.get(ps);
+    	    } else {
+    	        cluster = new StopCluster(ps, stop.getName());
+    	        stopClusterForId.put(ps, cluster);
+	    }
+    	    cluster.children.add(stop);
+    	    stopClusterForStop.put(stop, cluster);    
     	}
     	for (Map.Entry<String, StopCluster> cluster : stopClusterForId.entrySet()) {
-    		cluster.getValue().computeCenter();
-    		
+    	    cluster.getValue().computeCenter();
     	}
-	}
+    }
     
     public Response getGraphQLResponse(String query, Map<String, Object> variables) {
         ExecutionResult executionResult = graphQL.execute(query, null, null, variables);

--- a/src/main/java/org/opentripplanner/standalone/Router.java
+++ b/src/main/java/org/opentripplanner/standalone/Router.java
@@ -153,8 +153,13 @@ public class Router {
         }
         
         JsonNode clusterByParentStation = config.get("clusterByParentStation");
-        if (clusterByParentStation != null && clusterByParentStation.isBoolean()) 
-        	graph.clusterByParentStation = clusterByParentStation.asBoolean();
+        if (clusterByParentStation != null) {
+            if(clusterByParentStation.isBoolean()) {
+                graph.clusterByParentStation = clusterByParentStation.asBoolean();   
+            } else { 
+                LOG.info("The parameter clusterByParentStation must have a boolean value. Setting to false.");
+            }
+        }
         
         /* Create Graph updater modules from JSON config. */
         GraphUpdaterConfigurator.setupGraph(this.graph, config);

--- a/src/main/java/org/opentripplanner/standalone/Router.java
+++ b/src/main/java/org/opentripplanner/standalone/Router.java
@@ -151,7 +151,11 @@ public class Router {
                 }
             }
         }
-
+        
+        JsonNode clusterByParentStation = config.get("clusterByParentStation");
+        if (clusterByParentStation != null && clusterByParentStation.isBoolean()) 
+        	graph.clusterByParentStation = clusterByParentStation.asBoolean();
+        
         /* Create Graph updater modules from JSON config. */
         GraphUpdaterConfigurator.setupGraph(this.graph, config);
 

--- a/src/main/java/org/opentripplanner/standalone/Router.java
+++ b/src/main/java/org/opentripplanner/standalone/Router.java
@@ -152,13 +152,11 @@ public class Router {
             }
         }
         
-        JsonNode clusterByParentStation = config.get("clusterByParentStation");
-        if (clusterByParentStation != null) {
-            if(clusterByParentStation.isBoolean()) {
-                graph.clusterByParentStation = clusterByParentStation.asBoolean();   
-            } else { 
-                LOG.info("The parameter clusterByParentStation must have a boolean value. Setting to false.");
-            }
+        JsonNode stopClusterMode = config.get("stopClusterMode");
+        if (stopClusterMode != null) {
+            graph.stopClusterMode = stopClusterMode.asText();    
+        } else {
+            graph.stopClusterMode = "proximity";
         }
         
         /* Create Graph updater modules from JSON config. */


### PR DESCRIPTION
As discussed in #2364, this PR introduces the possibility to cluster stops based on parent stations, rather than by geographical proximity. This has proved to work well in our test environment here in Oslo.