### PR TITLE
Add shutdown hook to gracefully shut down Grizzly

### DIFF
--- a/src/main/java/org/opentripplanner/standalone/GrizzlyServer.java
+++ b/src/main/java/org/opentripplanner/standalone/GrizzlyServer.java
@@ -137,7 +137,8 @@ public class GrizzlyServer {
             LOG.info("Interrupted, shutting down.");
         }
 
-        // Clean up graceful shutdown hook.
+        // Clean up graceful shutdown hook before shutting down Grizzly.
         Runtime.getRuntime().removeShutdownHook(shutdownThread);
+        httpServer.shutdown();
     }
 }

--- a/src/main/java/org/opentripplanner/standalone/GrizzlyServer.java
+++ b/src/main/java/org/opentripplanner/standalone/GrizzlyServer.java
@@ -118,10 +118,15 @@ public class GrizzlyServer {
         // GraphService gs = (GraphService) iocFactory.getComponentProvider(GraphService.class).getInstance();
         // Graph graph = gs.getGraph();
         // httpServer.getServerConfiguration().addHttpHandler(new OTPHttpHandler(graph), "/test/*");
-        
+
+        // Add shutdown hook to gracefully shut down Grizzly.
+        // Signal handling (sun.misc.Signal) is potentially not available on all JVMs.
+        Thread shutdownThread = new Thread(httpServer::shutdown);
+        Runtime.getRuntime().addShutdownHook(shutdownThread);
+
         /* RELINQUISH CONTROL TO THE SERVER THREAD */
         try {
-            httpServer.start(); 
+            httpServer.start();
             LOG.info("Grizzly server running.");
             Thread.currentThread().join();
         } catch (BindException be) {
@@ -131,7 +136,8 @@ public class GrizzlyServer {
         } catch (InterruptedException ie) {
             LOG.info("Interrupted, shutting down.");
         }
-        httpServer.shutdown();
 
+        // Clean up graceful shutdown hook.
+        Runtime.getRuntime().removeShutdownHook(shutdownThread);
     }
 }


### PR DESCRIPTION
This PR moves the call to `HttpServer.shutdown` to a JVM shutdown hook, in order to gracefully shut down the Grizzly server in case a TERM signal is received.