### PR TITLE
Bugfix in GraphIndex.stopTimesForStop

### DIFF
--- a/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
+++ b/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
@@ -59,6 +59,7 @@ import javax.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.Collection;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -411,7 +412,8 @@ public class GraphIndex {
         if (graph.timetableSnapshotSource != null) {
             snapshot = graph.timetableSnapshotSource.getTimetableSnapshot();
         }
-        ServiceDate[] serviceDates = {new ServiceDate().previous(), new ServiceDate(), new ServiceDate().next()};
+        Date date = new Date(startTime * 1000);
+        ServiceDate[] serviceDates = {new ServiceDate(date).previous(), new ServiceDate(date), new ServiceDate(date).next()};
 
         for (TripPattern pattern : patternsForStop.get(stop)) {
 


### PR DESCRIPTION
`GraphIndex.stopTimesForStop()` (called from the `/stops/{stopId}/stoptimes` API call) searches for times on the previous day, current day, and next day. This is incorrect if the `startTime` parameter is a time on future or past day. This commit fixes that behavior.