### PR TITLE
Ability to plan trip using GTFS route types

### DIFF
--- a/src/main/java/org/opentripplanner/api/common/RoutingResource.java
+++ b/src/main/java/org/opentripplanner/api/common/RoutingResource.java
@@ -353,6 +353,12 @@ public abstract class RoutingResource {
     @QueryParam("disableAlertFiltering")
     private Boolean disableAlertFiltering;
 
+    /**
+     * The comma-separated list of allowed GTFS route types.
+     */
+    @QueryParam("routeTypes")
+    private String routeTypes;
+
     /* 
      * somewhat ugly bug fix: the graphService is only needed here for fetching per-graph time zones. 
      * this should ideally be done when setting the routing context, but at present departure/
@@ -575,6 +581,9 @@ public abstract class RoutingResource {
 
         if (maxHours != null)
             request.maxHours = maxHours;
+
+        if(routeTypes != null)
+            request.setRouteTypes(routeTypes);
 
         if (disableAlertFiltering != null)
             request.disableAlertFiltering = disableAlertFiltering;

--- a/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
@@ -109,6 +109,9 @@ public class RoutingRequest implements Cloneable, Serializable {
     /** The maximum duration of a returned itinerary, in hours. */
     public double maxHours = Double.MAX_VALUE;
 
+    /** Set of allowed GTFS route types. */
+    public HashSet<Integer> routeTypes = new HashSet<Integer>();
+
     /** The set of TraverseModes that a user is willing to use. Defaults to WALK | TRANSIT. */
     public TraverseModeSet modes = new TraverseModeSet("TRANSIT,WALK"); // defaults in constructor overwrite this
 
@@ -786,6 +789,17 @@ public class RoutingRequest implements Cloneable, Serializable {
         bikeWalkingOptions.triangleTimeFactor = triangleTimeFactor;
     }
 
+    public void setRouteTypes(String s) {
+        if (s == null || s.equals(""))
+            return;
+        HashSet<String> types = new HashSet<String>(Arrays.asList(s.split(",")));
+        if (types.size() > 0) {
+            routeTypes = new HashSet<Integer>(types.size());
+            for (String type : types)
+                routeTypes.add(Integer.parseInt(type));
+        }
+    }
+
     public NamedPlace getFromPlace() {
         return this.from.getNamedPlace();
     }
@@ -1142,6 +1156,13 @@ public class RoutingRequest implements Cloneable, Serializable {
         }
 
         return false;
+    }
+
+    /**
+     * Check if trip route type matches for this plan.
+     */
+    public boolean tripRouteTypeMatches(Trip trip) {
+        return routeTypes == null || routeTypes.contains(trip.getRoute().getType());
     }
 
     /** Check if route is preferred according to this request. */

--- a/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
@@ -1162,7 +1162,7 @@ public class RoutingRequest implements Cloneable, Serializable {
      * Check if trip route type matches for this plan.
      */
     public boolean tripRouteTypeMatches(Trip trip) {
-        return routeTypes == null || routeTypes.contains(trip.getRoute().getType());
+        return routeTypes == null || routeTypes.size() == 0 || routeTypes.contains(trip.getRoute().getType());
     }
 
     /** Check if route is preferred according to this request. */

--- a/src/main/java/org/opentripplanner/routing/edgetype/TransitBoardAlight.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/TransitBoardAlight.java
@@ -294,6 +294,9 @@ public class TransitBoardAlight extends TablePatternEdge implements OnboardEdge 
             // FIXME this should be done WHILE searching for a trip.
             if (options.tripIsBanned(trip)) return null;
 
+            /* check if route type matches (if requested). */
+            if(!options.tripRouteTypeMatches(trip)) return null;
+
             /* Check if route is preferred by the user. */
             long preferences_penalty = options.preferencesPenaltyForRoute(getPattern().route);
             


### PR DESCRIPTION
Sometimes it is necessary to filter trips by GTFS route type.

We are developing route planner service and we want to allow users to select specific transport types, because people buy monthly tickets for specific transport types.
It becomes problematic because trolleybus and bus services both are under BUS TraverseMode.

With my modifications you can specify GTFS route types using comma separated list:
<pre>
...&routeTypes=100,800
</pre>