### PR TITLE
Use equals() when comparing Stop objects in index API.

### DIFF
--- a/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
+++ b/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
@@ -506,7 +506,7 @@ public class GraphIndex {
             ServiceDay sd = new ServiceDay(graph, serviceDate, calendarService, pattern.route.getAgency().getId());
             int sidx = 0;
             for (Stop currStop : pattern.stopPattern.stops) {
-                if (currStop == stop) {
+                if (currStop.equals(stop)) {
                     for (TripTimes t : tt.tripTimes) {
                         if (!sd.serviceRunning(t.serviceCode)) continue;
                         stopTimes.times.add(new TripTimeShort(t, sidx, stop, sd));


### PR DESCRIPTION
If stops are loaded from several GTFS-bundles the trip patterns may
contain several instances of Stop objects referring to the same
stop (same id and agencyId).

Comparing by object referance will only return stop times for
one of the bundles.