### PR TITLE
Fixed NullPointerException if clustering before graph creation

### DIFF
--- a/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
+++ b/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
@@ -563,16 +563,20 @@ public class GraphIndex {
      * stops -- no guessing is reasonable without that information.
      */
     public void clusterStops() {
-    	switch (graph.stopClusterMode) {
-    	case "parentStation": 
-    	    clusterByParentStation();
-    	    break;   	    
-    	case "proximity":
-    	    clusterByProximity();
-    	    break;    	    
-    	default:
-    	    clusterByProximity(); 
-    	}
+    	if (graph.stopClusterMode != null) {
+            switch (graph.stopClusterMode) {
+                case "parentStation":
+                    clusterByParentStation();
+                    break;
+                case "proximity":
+                    clusterByProximity();
+                    break;
+                default:
+                    clusterByProximity();
+            }
+        } else {
+            clusterByProximity();
+        }
     }
     
     private void clusterByProximity() {	


### PR DESCRIPTION
Seems we were too quick with merging #2383. Some tests perform clustering before the graph is built, and this reveals a NullPointerException, which is handled in this PR.