### PR TITLE
Fix preferred/unpreferred agency matching

### DIFF
--- a/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
@@ -1147,7 +1147,7 @@ public class RoutingRequest implements Cloneable, Serializable {
     /** Check if route is preferred according to this request. */
     public long preferencesPenaltyForRoute(Route route) {
         long preferences_penalty = 0;
-        String agencyID = route.getId().getAgencyId();
+        String agencyID = route.getAgency().getId();
         if ((preferredRoutes != null && !preferredRoutes.equals(RouteMatcher.emptyMatcher())) ||
                 (preferredAgencies != null && !preferredAgencies.isEmpty())) {
             boolean isPreferedRoute = preferredRoutes != null && preferredRoutes.matches(route);

--- a/src/test/java/org/opentripplanner/routing/core/RoutingRequestTest.java
+++ b/src/test/java/org/opentripplanner/routing/core/RoutingRequestTest.java
@@ -14,6 +14,7 @@
 package org.opentripplanner.routing.core;
 
 import org.junit.Test;
+import org.onebusaway.gtfs.model.Agency;
 import org.onebusaway.gtfs.model.AgencyAndId;
 import org.onebusaway.gtfs.model.Route;
 import org.onebusaway.gtfs.model.Trip;
@@ -67,12 +68,14 @@ public class RoutingRequestTest {
     @Test
     public void testPreferencesPenaltyForRoute() {
         AgencyAndId agencyAndId = new AgencyAndId();
+        Agency agency = new Agency();
         Route route = new Route();
         Trip trip = new Trip();
         RoutingRequest routingRequest = new RoutingRequest();
 
         trip.setRoute(route);
         route.setId(agencyAndId);
+        route.setAgency(agency);
         assertEquals(0, routingRequest.preferencesPenaltyForRoute(trip.getRoute()));
     }
 }


### PR DESCRIPTION
The current code is actually matching on feed ID instead of the route's agency ID.