### PR TITLE
Keep sort order when converting from path to trip plan

### DIFF
--- a/src/main/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverter.java
+++ b/src/main/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverter.java
@@ -83,7 +83,7 @@ public abstract class GraphPathToTripPlanConverter {
 
         // Convert GraphPaths to Itineraries, keeping track of the best non-transit (e.g. walk/bike-only) option time
         long bestNonTransitTime = Long.MAX_VALUE;
-        Set<Itinerary> itineraries = new HashSet<>();
+        List<Itinerary> itineraries = new ArrayList<>();
         for (GraphPath path : paths) {
             Itinerary itinerary = generateItinerary(path, request.showIntermediateStops, request.disableAlertFiltering, requestedLocale);
             itinerary = adjustItinerary(request, itinerary);
@@ -92,6 +92,9 @@ public abstract class GraphPathToTripPlanConverter {
             }
             itineraries.add(itinerary);
         }
+
+        //ensure no duplicates in list
+        itineraries = new ArrayList<>(new LinkedHashSet<>(itineraries));
 
         // Filter and add itineraries to plan
         for (Itinerary itinerary : itineraries) {


### PR DESCRIPTION
In method generatePlan() a set is used when converting the
paths to itineraries which randomizes the search result sort order.
The set is replaced by a list to keep the sort order. A second
line is added to ensure no duplicates as before
(not sure if it is necessary)