### PR TITLE
replaced link to 0.19 jar with 1.0 jar.

### DIFF
--- a/docs/Getting-OTP.md
+++ b/docs/Getting-OTP.md
@@ -3,7 +3,7 @@
 ## Pre-built JARs
 
 OpenTripPlanner is now distributed as a single stand-alone runnable JAR file. The JAR files for each release are
-published to the [Conveyal Maven repository](http://maven.conveyal.com/org/opentripplanner/otp/). Most users will want to navigate into the directory with the highest-numbered non-snapshot version and download the file whose name ends with `shaded.jar`. The latest release is the [0.19.0 shaded JAR](http://maven.conveyal.com.s3.amazonaws.com/org/opentripplanner/otp/0.19.0/otp-0.19.0-shaded.jar).
+published to the [Conveyal Maven repository](http://maven.conveyal.com/org/opentripplanner/otp/). Most users will want to navigate into the directory with the highest-numbered non-snapshot version and download the file whose name ends with `shaded.jar`. The latest release is the [1.0.0 shaded JAR](https://s3.amazonaws.com/maven.conveyal.com/org/opentripplanner/otp/1.0.0/otp-1.0.0-shaded.jar).
 
 ## Building from Source
 


### PR DESCRIPTION
Google still points here, so it is worth updating this link.