### PR TITLE
Fix bugs in park and ride search

### DIFF
--- a/src/main/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverter.java
+++ b/src/main/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverter.java
@@ -749,7 +749,10 @@ public abstract class GraphPathToTripPlanConverter {
             SimpleTransfer transferEdge = ((SimpleTransfer) states[1].getBackEdge());
             List<Edge> transferEdges = transferEdge.getEdges();
             if (transferEdges != null) {
-                State s = new State(transferEdges.get(0).getFromVertex(), states[0].getOptions());
+                // Create a new initial state. Some parameters may have change along the way, copy them from the first state
+                StateEditor se = new StateEditor(states[0].getOptions(), transferEdges.get(0).getFromVertex());
+                se.setNonTransitOptionsFromState(states[0]);
+                State s = se.makeState();
                 ArrayList<State> transferStates = new ArrayList<>();
                 transferStates.add(s);
                 for (Edge e : transferEdges) {

--- a/src/main/java/org/opentripplanner/graph_builder/linking/SimpleStreetSplitter.java
+++ b/src/main/java/org/opentripplanner/graph_builder/linking/SimpleStreetSplitter.java
@@ -518,9 +518,9 @@ public class SimpleStreetSplitter {
             TraverseModeSet modes = options.modes;
             if (modes.getCar())
                 // for park and ride we will start in car mode and walk to the end vertex
-                if(endVertex && (options.parkAndRide || options.kissAndRide)){
+                if (endVertex && (options.parkAndRide || options.kissAndRide)) {
                     nonTransitMode = TraverseMode.WALK;
-                }else{
+                } else {
                     nonTransitMode = TraverseMode.CAR;
                 }
             else if (modes.getWalk())

--- a/src/main/java/org/opentripplanner/graph_builder/linking/SimpleStreetSplitter.java
+++ b/src/main/java/org/opentripplanner/graph_builder/linking/SimpleStreetSplitter.java
@@ -517,7 +517,12 @@ public class SimpleStreetSplitter {
         if (options != null) {
             TraverseModeSet modes = options.modes;
             if (modes.getCar())
-                nonTransitMode = TraverseMode.CAR;
+                // for park and ride we will start in car mode and walk to the end vertex
+                if(endVertex && (options.parkAndRide || options.kissAndRide)){
+                    nonTransitMode = TraverseMode.WALK;
+                }else{
+                    nonTransitMode = TraverseMode.CAR;
+                }
             else if (modes.getWalk())
                 nonTransitMode = TraverseMode.WALK;
             else if (modes.getBicycle())

--- a/src/main/java/org/opentripplanner/routing/core/StateEditor.java
+++ b/src/main/java/org/opentripplanner/routing/core/StateEditor.java
@@ -421,6 +421,14 @@ public class StateEditor {
         child.stateData.bikeParked = state.stateData.bikeParked;
     }
 
+    public void setNonTransitOptionsFromState(State state){
+        cloneStateDataAsNeeded();
+        child.stateData.nonTransitMode = state.getNonTransitMode();
+        child.stateData.carParked = state.isCarParked();
+        child.stateData.bikeParked = state.isBikeParked();
+        child.stateData.usingRentedBike = state.isBikeRenting();
+    }
+
     /* PUBLIC GETTER METHODS */
 
     /*

--- a/src/test/java/org/opentripplanner/graph_builder/linking/SimpleStreetSplitterTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/linking/SimpleStreetSplitterTest.java
@@ -1,0 +1,43 @@
+package org.opentripplanner.graph_builder.linking;
+
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opentripplanner.common.model.GenericLocation;
+import org.opentripplanner.routing.core.RoutingRequest;
+import org.opentripplanner.routing.core.TraverseMode;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.routing.graph.Vertex;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+public class SimpleStreetSplitterTest {
+
+    private SimpleStreetSplitter spySimpleStreetSplitter;
+
+
+    @Before
+    public void buildSpy(){
+        Graph graph = new Graph();
+        SimpleStreetSplitter simpleStreetSplitter = new SimpleStreetSplitter(graph, null, null,false);
+        spySimpleStreetSplitter = spy(simpleStreetSplitter);
+    }
+
+    /**
+     * Tests that traverse mode WALK is used when getting closest end vertex for park and ride.
+     */
+    @Test
+    public void testFindEndVertexForParkAndRide(){
+        GenericLocation genericLocation = new GenericLocation(10,23);
+
+        RoutingRequest routingRequest = new RoutingRequest();
+        routingRequest.setMode(TraverseMode.CAR);
+        routingRequest.parkAndRide = true;
+
+        spySimpleStreetSplitter.getClosestVertex(genericLocation, routingRequest, true);
+        verify(spySimpleStreetSplitter).link(any(Vertex.class), eq(TraverseMode.WALK), eq(routingRequest));
+    }
+}

--- a/src/test/java/org/opentripplanner/routing/core/StateEditorTest.java
+++ b/src/test/java/org/opentripplanner/routing/core/StateEditorTest.java
@@ -13,11 +13,14 @@
 
 package org.opentripplanner.routing.core;
 
+import org.junit.Test;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.routing.impl.StreetVertexIndexServiceImpl;
+
 import static org.junit.Assert.assertEquals;
 
-import org.junit.Test;
-
 public class StateEditorTest {
+
     @Test
     public final void testIncrementTimeInSeconds() {
         RoutingRequest routingRequest = new RoutingRequest();
@@ -27,5 +30,32 @@ public class StateEditorTest {
         stateEditor.incrementTimeInSeconds(999999999);
 
         assertEquals(999999999, stateEditor.child.getTimeSeconds());
+    }
+
+    /**
+     * Test update of non transit options.
+     */
+    @Test
+    public final void testSetNonTransitOptionsFromState(){
+        RoutingRequest request = new RoutingRequest();
+        request.setMode(TraverseMode.CAR);
+        request.parkAndRide = true;
+        Graph graph = new Graph();
+        graph.streetIndex = new StreetVertexIndexServiceImpl(graph);
+        request.rctx = new RoutingContext(request, graph);
+        State state = new State(request);
+
+        state.stateData.carParked = true;
+        state.stateData.bikeParked = true;
+        state.stateData.usingRentedBike = false;
+        state.stateData.nonTransitMode = TraverseMode.WALK;
+
+        StateEditor se = new StateEditor(request, null);
+        se.setNonTransitOptionsFromState(state);
+        State updatedState = se.makeState();
+        assertEquals(TraverseMode.WALK, updatedState.getNonTransitMode());
+        assertEquals(true, updatedState.isCarParked());
+        assertEquals(true, updatedState.isBikeParked());
+        assertEquals(false, updatedState.isBikeRenting());
     }
 }


### PR DESCRIPTION
Solves #2421 
 
When finding the closest vertex to the destination for park
and ride , the traverse mode must be 'walk' and not 'car'.