### PR TITLE
Compact legs by reversed search

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/AStar.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/AStar.java
@@ -368,11 +368,4 @@ public class AStar {
         }
         return ret;
     }
-
-    public State getTragetAcceptedState(){
-        if(!runState.targetAcceptedStates.isEmpty() ){
-            return runState.targetAcceptedStates.get(0);
-        }
-        return null;
-    }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/AStar.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/AStar.java
@@ -368,4 +368,11 @@ public class AStar {
         }
         return ret;
     }
+
+    public State getTragetAcceptedState(){
+        if(!runState.targetAcceptedStates.isEmpty() ){
+            return runState.targetAcceptedStates.get(0);
+        }
+        return null;
+    }
 }

--- a/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
@@ -345,6 +345,11 @@ public class RoutingRequest implements Cloneable, Serializable {
     public boolean reverseOptimizeOnTheFly = false;
 
     /**
+     * When true, do a full reversed search to compact the legs of the GraphPath.
+     */
+    public boolean compactLegsByReversedSearch = false;
+
+    /**
      * If true, cost turns as they would be in a country where driving occurs on the right; otherwise, cost them as they would be in a country where
      * driving occurs on the left.
      */

--- a/src/main/java/org/opentripplanner/routing/core/StateData.java
+++ b/src/main/java/org/opentripplanner/routing/core/StateData.java
@@ -117,4 +117,8 @@ public class StateData implements Cloneable {
         }
     }
 
+    public int getNumBooardings(){
+        return numBoardings;
+    }
+
 }

--- a/src/main/java/org/opentripplanner/routing/impl/GraphPathFinder.java
+++ b/src/main/java/org/opentripplanner/routing/impl/GraphPathFinder.java
@@ -167,7 +167,9 @@ public class GraphPathFinder {
             }
 
             // Do a full reversed search to compact the legs
-            newPaths = compactLegsByReversedSearch(aStar, originalReq, options, newPaths, timeout, reversedSearchHeuristic);
+            if(options.compactLegsByReversedSearch){
+                newPaths = compactLegsByReversedSearch(aStar, originalReq, options, newPaths, timeout, reversedSearchHeuristic);
+            }
 
             // Find all trips used in this path and ban them for the remaining searches
             for (GraphPath path : newPaths) {

--- a/src/main/java/org/opentripplanner/routing/impl/GraphPathFinder.java
+++ b/src/main/java/org/opentripplanner/routing/impl/GraphPathFinder.java
@@ -25,6 +25,7 @@ import org.opentripplanner.routing.algorithm.strategies.TrivialRemainingWeightHe
 import org.opentripplanner.routing.core.RoutingRequest;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.edgetype.LegSwitchingEdge;
+import org.opentripplanner.routing.edgetype.TransitBoardAlight;
 import org.opentripplanner.routing.error.PathNotFoundException;
 import org.opentripplanner.routing.error.VertexNotFoundException;
 import org.opentripplanner.routing.graph.Edge;
@@ -35,10 +36,7 @@ import org.opentripplanner.standalone.Router;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -82,6 +80,8 @@ public class GraphPathFinder {
      */
     public List<GraphPath> getPaths(RoutingRequest options) {
 
+        RoutingRequest originalReq = options.clone();
+
         if (options == null) {
             LOG.error("PathService was passed a null routing request.");
             return null;
@@ -120,6 +120,8 @@ public class GraphPathFinder {
         }
         options.rctx.remainingWeightHeuristic = heuristic;
 
+        RemainingWeightHeuristic backheuristic = new InterleavedBidirectionalHeuristic();
+
         /* In RoutingRequest, maxTransfers defaults to 2. Over long distances, we may see
          * itineraries with far more transfers. We do not expect transfer limiting to improve
          * search times on the LongDistancePathService, so we set it to the maximum we ever expect
@@ -136,7 +138,7 @@ public class GraphPathFinder {
         if (options.maxWalkDistance == Double.MAX_VALUE) options.maxWalkDistance = DEFAULT_MAX_WALK;
         if (options.maxWalkDistance > CLAMP_MAX_WALK) options.maxWalkDistance = CLAMP_MAX_WALK;
         long searchBeginTime = System.currentTimeMillis();
-        LOG.debug("BEGIN SEARCH");
+        LOG.info("BEGIN SEARCH");
         List<GraphPath> paths = Lists.newArrayList();
         while (paths.size() < options.numItineraries) {
             // TODO pull all this timeout logic into a function near org.opentripplanner.util.DateUtils.absoluteTimeout()
@@ -153,17 +155,23 @@ public class GraphPathFinder {
                 options.rctx.aborted = true;
                 break;
             }
+            // Don't dig through the SPT object, just ask the A star algorithm for the states that reached the target.
             aStar.getShortestPathTree(options, timeout);
             if (options.rctx.aborted) {
                 break; // Search timed out or was gracefully aborted for some other reason.
             }
-            // Don't dig through the SPT object, just ask the A star algorithm for the states that reached the target.
             List<GraphPath> newPaths = aStar.getPathsToTarget();
             if (newPaths.isEmpty()) {
                 break;
             }
+
+            // Do a full reversed search to compact the legs
+            newPaths = compactLegsByReverseSearch(aStar, originalReq, options, newPaths, timeout, backheuristic);
+
             // Find all trips used in this path and ban them for the remaining searches
             for (GraphPath path : newPaths) {
+                LOG.info("PATH depTime: " + new Date(path.getStartTime() * 1000));
+                LOG.info("PATH arrTime: " + new Date(path.getEndTime() * 1000));
                 // path.dump();
                 List<AgencyAndId> tripIds = path.getTrips();
                 for (AgencyAndId tripId : tripIds) {
@@ -179,11 +187,72 @@ public class GraphPathFinder {
                     .filter(path -> path.getDuration() < options.maxHours * 60 * 60)
                     .collect(Collectors.toList()));
 
-            LOG.debug("we have {} paths", paths.size());
+            LOG.info("we have {} paths", paths.size());
         }
-        LOG.debug("END SEARCH ({} msec)", System.currentTimeMillis() - searchBeginTime);
+        LOG.info("END SEARCH ({} msec)", System.currentTimeMillis() - searchBeginTime);
         Collections.sort(paths, new PathComparator(options.arriveBy));
         return paths;
+    }
+
+    private List<GraphPath> compactLegsByReverseSearch(AStar aStar, RoutingRequest originalReq, RoutingRequest options, List<GraphPath> newPaths, double timeout, RemainingWeightHeuristic remainingWeightHeuristic){
+        State tragetAcceptedState = aStar.getTragetAcceptedState();
+        if(tragetAcceptedState.stateData.getNumBooardings() > 1) {
+            long arrDepTime = tragetAcceptedState.getTimeSeconds();
+
+            // find last trip endpoint
+            State orig = newPaths.get(0).states.getLast();
+            Vertex endpoint = null;
+            long endpointTime = arrDepTime;
+            while (endpoint== null) {
+                if(orig.backEdge instanceof TransitBoardAlight){
+                    endpoint = orig.backEdge.getToVertex();
+                    endpointTime = orig.getTimeSeconds();
+                }
+                orig = orig.getBackState();
+            }
+
+            // find the path from endpoint to destination
+            arrDepTime = options.arriveBy ? endpointTime : arrDepTime;
+            RoutingRequest reversedFromEndpoint = createReversedRequest(originalReq, options, endpoint, options.rctx.toVertex, arrDepTime, remainingWeightHeuristic);
+            reversedFromEndpoint.maxWalkDistance = CLAMP_MAX_WALK;
+            aStar.getShortestPathTree(reversedFromEndpoint, timeout);
+            List<GraphPath> pathsToTarget = aStar.getPathsToTarget();
+            List<GraphPath> walkPaths = Collections.singletonList(pathsToTarget.get(0));
+
+            // do the reversed search to endpoint
+            arrDepTime = options.arriveBy ? arrDepTime : endpointTime;
+            RoutingRequest reversedToEndpoint = createReversedRequest(originalReq, options, options.rctx.fromVertex, endpoint, arrDepTime, remainingWeightHeuristic);
+            aStar.getShortestPathTree(reversedToEndpoint, timeout);
+
+            State revTargetAcceptedState = aStar.getTragetAcceptedState();
+            if(revTargetAcceptedState == null){
+                return newPaths;
+            }
+            if((!options.arriveBy && revTargetAcceptedState.getTimeInMillis() > options.dateTime * 1000) ||
+                    (options.arriveBy && revTargetAcceptedState.getTimeInMillis() < options.dateTime * 1000)){
+                List<GraphPath> newRevPaths = aStar.getPathsToTarget();
+                if (newRevPaths.isEmpty()) {
+                    return newPaths;
+                }else{
+                    newRevPaths.addAll(walkPaths);
+                    return Collections.singletonList(joinPaths(newRevPaths));
+                }
+            }
+        }
+        return newPaths;
+    }
+
+    public RoutingRequest createReversedRequest(RoutingRequest originalReq, RoutingRequest options, Vertex fromVertex, Vertex toVertex, long dateTime, RemainingWeightHeuristic remainingWeightHeuristic){
+        RoutingRequest reversedOptions = originalReq.clone();
+        reversedOptions.dateTime = dateTime;
+        reversedOptions.setArriveBy(!originalReq.arriveBy);
+        reversedOptions.setRoutingContext(router.graph, fromVertex, toVertex);
+        reversedOptions.dominanceFunction = new DominanceFunction.MinimumWeight();
+        reversedOptions.rctx.remainingWeightHeuristic = remainingWeightHeuristic;
+        reversedOptions.maxTransfers = 4;
+        reversedOptions.longDistance = true;
+        reversedOptions.bannedTrips = options.bannedTrips;
+        return reversedOptions;
     }
 
     /* Try to find N paths through the Graph */


### PR DESCRIPTION
This PR aims to solve the issues described in #1361.

A full  reversed search is made to compact the legs. Enabling the reversed search will of course influence performance, since an additional search is made. However, performance has not been an issue after running this patch for the graph in Norway (Oslo and national graphs) for a couple of months. 

