### PR TITLE
remove/update deprecated HTTPClient code, adding missing ciphers for SSL

### DIFF
--- a/src/main/java/org/opentripplanner/util/HttpUtils.java
+++ b/src/main/java/org/opentripplanner/util/HttpUtils.java
@@ -16,6 +16,7 @@ package org.opentripplanner.util;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
@@ -24,14 +25,12 @@ import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpHead;
-import org.apache.http.impl.client.DefaultHttpClient;
-import org.apache.http.params.BasicHttpParams;
-import org.apache.http.params.HttpConnectionParams;
-import org.apache.http.params.HttpParams;
+import org.apache.http.config.SocketConfig;
+import org.apache.http.impl.client.HttpClientBuilder;
 
 public class HttpUtils {
     
-    private static final int TIMEOUT_CONNECTION = 5000;
+    private static final long TIMEOUT_CONNECTION = 5000;
     private static final int TIMEOUT_SOCKET = 5000;
 
     public static InputStream getData(String url) throws IOException {
@@ -72,12 +71,11 @@ public class HttpUtils {
     }
     
     private static HttpClient getClient() {
-        HttpParams httpParams = new BasicHttpParams();
-        HttpConnectionParams.setConnectionTimeout(httpParams, TIMEOUT_CONNECTION);
-        HttpConnectionParams.setSoTimeout(httpParams, TIMEOUT_SOCKET);
-        
-        DefaultHttpClient httpclient = new DefaultHttpClient();
-        httpclient.setParams(httpParams);
-        return httpclient;
+        HttpClient httpClient = HttpClientBuilder.create()
+                .setDefaultSocketConfig(SocketConfig.custom().setSoTimeout(TIMEOUT_SOCKET).build())
+                .setConnectionTimeToLive(TIMEOUT_CONNECTION, TimeUnit.MILLISECONDS)
+                .build();
+
+        return httpClient;
     }
 }


### PR DESCRIPTION
Replace deprecated `DefaultHTTPClient` with `HttpClientBuilder`.

Fixes #2450.