### PR TITLE
Added HTML report for stops with a snap distance over 20m

### DIFF
--- a/src/main/java/org/opentripplanner/common/geometry/SphericalDistanceLibrary.java
+++ b/src/main/java/org/opentripplanner/common/geometry/SphericalDistanceLibrary.java
@@ -149,11 +149,11 @@ public abstract class SphericalDistanceLibrary {
      */
     public static final double fastDistance(double lat1, double lon1, double lat2, double lon2,
             double radius) {
-    	if (abs(lat1 - lat2) > MAX_LAT_DELTA_DEG
-    			|| abs(lon1 - lon2) > MAX_LON_DELTA_DEG)
-    		return distance(lat1, lon1, lat2, lon2, radius);
+        if (abs(lat1 - lat2) > MAX_LAT_DELTA_DEG
+                || abs(lon1 - lon2) > MAX_LON_DELTA_DEG)
+            return distance(lat1, lon1, lat2, lon2, radius);
 
-    	double dLat = toRadians(lat2 - lat1);
+        double dLat = toRadians(lat2 - lat1);
         double dLon = toRadians(lon2 - lon1) * cos(toRadians((lat1 + lat2) / 2));
         return radius * sqrt(dLat * dLat + dLon * dLon) * MAX_ERR_INV;
     }
@@ -169,6 +169,10 @@ public abstract class SphericalDistanceLibrary {
      */
     public static double metersToDegrees(double distanceMeters) {
         return 360 * distanceMeters / (2 * Math.PI * RADIUS_OF_EARTH_IN_M);
+    }
+
+    public static double degreesToMeters(double distanceDegrees) {
+        return (2 * Math.PI * RADIUS_OF_EARTH_IN_M) * distanceDegrees / 360;
     }
 
     /**

--- a/src/main/java/org/opentripplanner/graph_builder/annotation/StopLinkedTooFar.java
+++ b/src/main/java/org/opentripplanner/graph_builder/annotation/StopLinkedTooFar.java
@@ -1,0 +1,48 @@
+/* This program is free software: you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public License
+ as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+package org.opentripplanner.graph_builder.annotation;
+
+import org.opentripplanner.routing.graph.Vertex;
+import org.opentripplanner.routing.vertextype.TransitStop;
+
+public class StopLinkedTooFar extends GraphBuilderAnnotation {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final String FMT = "Stop %s is far away from nearest street. Snap distance is %s.";
+    public static final String HTMLFMT = "Stop <a href=\"http://www.openstreetmap.org/?mlat=%s&mlon=%s&layers=T\">\"%s\" (%s)</a> is far away from nearest street. Snap distance is %s.";
+
+    final TransitStop stop;
+    final int distance;
+
+    public StopLinkedTooFar(TransitStop stop, int distance) {
+        this.stop = stop;
+        this.distance = distance;
+    }
+
+    @Override
+    public String getMessage() {
+        return String.format(FMT, stop, Integer.toString(distance));
+    }
+
+    @Override
+    public String getHTMLMessage() {
+        return String.format(HTMLFMT, stop.getStop().getLat(), stop.getStop().getLon(), stop.getName(), stop.getStopId(), Integer.toString(distance));
+    }
+
+    @Override
+    public Vertex getReferencedVertex() {
+        return this.stop;
+    }
+}

--- a/src/main/java/org/opentripplanner/graph_builder/linking/SimpleStreetSplitter.java
+++ b/src/main/java/org/opentripplanner/graph_builder/linking/SimpleStreetSplitter.java
@@ -19,6 +19,7 @@ import org.opentripplanner.common.model.P2;
 import org.opentripplanner.graph_builder.annotation.BikeParkUnlinked;
 import org.opentripplanner.graph_builder.annotation.BikeRentalStationUnlinked;
 import org.opentripplanner.graph_builder.annotation.StopUnlinked;
+import org.opentripplanner.graph_builder.annotation.StopLinkedTooFar;
 import org.opentripplanner.routing.core.RoutingRequest;
 import org.opentripplanner.routing.core.TraverseMode;
 import org.opentripplanner.routing.core.TraverseModeSet;
@@ -68,6 +69,8 @@ public class SimpleStreetSplitter {
     private static final Logger LOG = LoggerFactory.getLogger(SimpleStreetSplitter.class);
 
     public static final int MAX_SEARCH_RADIUS_METERS = 1000;
+
+    public static final int MIN_SNAP_DISTANCE_WARNING = 20;
 
     /** if there are two ways and the distances to them differ by less than this value, we link to both of them */
     public static final double DUPLICATE_WAY_EPSILON_METERS = 0.001;
@@ -196,6 +199,13 @@ public class SimpleStreetSplitter {
                 return 1;
             return 0;
         });
+
+        if (!candidateEdges.isEmpty() && vertex instanceof TransitStop) {
+            int distance = (int)SphericalDistanceLibrary.degreesToMeters(distances.get(candidateEdges.get(0).getId()));
+            if (distance > MIN_SNAP_DISTANCE_WARNING) {
+                LOG.info(String.format(graph.addBuilderAnnotation(new StopLinkedTooFar((TransitStop)vertex, distance))));
+            }
+        }
 
         // find the closest candidate edges
         if (candidateEdges.isEmpty() || distances.get(candidateEdges.get(0).getId()) > radiusDeg) {


### PR DESCRIPTION
Currently only stops that are not linked (because they are more than 1000m from a walkable edge) are reported. However, we have found it is also useful to report stops that are linked, but the distance is still significant. This can help us discover errors in stop coordinates or incomplete parts of the OSM network.