### PR TITLE
KCM transfers - use maximum fare of two adjacent legs 

### DIFF
--- a/src/main/java/org/opentripplanner/routing/impl/SeattleFareServiceFactory.java
+++ b/src/main/java/org/opentripplanner/routing/impl/SeattleFareServiceFactory.java
@@ -13,12 +13,19 @@
 
 package org.opentripplanner.routing.impl;
 
+import java.io.Serializable;
 import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Multimap;
 import org.onebusaway.gtfs.model.AgencyAndId;
 import org.onebusaway.gtfs.model.Trip;
 import org.onebusaway.gtfs.services.GtfsRelationalDao;
+import org.opentripplanner.gtfs.GtfsLibrary;
 import org.opentripplanner.routing.core.Fare.FareType;
 import org.opentripplanner.routing.core.FareRuleSet;
 import org.opentripplanner.routing.services.FareService;
@@ -32,6 +39,8 @@ public class SeattleFareServiceFactory extends DefaultFareServiceFactory {
     @SuppressWarnings("unused")
     private static final Logger LOG = LoggerFactory.getLogger(SeattleFareServiceFactory.class);
 
+    private Multimap<String, String> agenciesByFeed = ArrayListMultimap.create();
+
     @Override
     public FareService makeFareService() {
     	
@@ -39,13 +48,24 @@ public class SeattleFareServiceFactory extends DefaultFareServiceFactory {
     	fareService.addFareRules(FareType.regular, regularFareRules.values());
     	fareService.addFareRules(FareType.youth, regularFareRules.values());
     	fareService.addFareRules(FareType.senior, regularFareRules.values());
-    	
+
+        fareService.setFareAdditiveStrategy(new SeattleFareAdditiveStrategy(agenciesByFeed));
+
     	return fareService;
     }
     
     @Override
     public void configure(JsonNode config) {
-        // No config for the moment
+        if (config.has("useMaxFareStrategy")) {
+            Iterator<JsonNode> iter = config.get("useMaxFareStrategy").iterator();
+            while (iter.hasNext()) {
+                // feed:agency ie 97:1
+                AgencyAndId feedAndAgency = GtfsLibrary.convertIdFromString(iter.next().asText());
+                String feedId = feedAndAgency.getAgencyId();
+                String agencyId = feedAndAgency.getId();
+                agenciesByFeed.put(feedId, agencyId);
+            }
+        }
     }
     
     @Override
@@ -74,5 +94,37 @@ public class SeattleFareServiceFactory extends DefaultFareServiceFactory {
         		rule.addTrip(trip.getId());        	
         }
         	
+    }
+}
+
+class SeattleFareAdditiveStrategy implements FareAdditiveStrategy, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Multimap<String, String> agenciesByFeed;
+
+    SeattleFareAdditiveStrategy(Multimap<String, String> agenciesByFeed) {
+        this.agenciesByFeed = agenciesByFeed;
+    }
+
+    @Override
+    public float addFares(List<Ride> ride0, List<Ride> ride1, float cost0, float cost1) {
+        String feedId = ride0.get(0).firstStop.getId().getAgencyId();
+        String agencyId = ride0.get(0).agency;
+        if (agenciesByFeed.get(feedId).contains(agencyId)) {
+            for (Ride r : Iterables.concat(ride0, ride1)) {
+                if (!isCorrectAgency(r, feedId, agencyId)) {
+                    return cost0 + cost1;
+                }
+            }
+            return Math.max(cost0, cost1);
+        }
+        return cost0 + cost1;
+    }
+
+    private static boolean isCorrectAgency(Ride r, String feedId, String agencyId) {
+        String rideFeedId = r.firstStop.getId().getAgencyId();
+        String rideAgencyId = r.agency;
+        return feedId.equals(rideFeedId) && agencyId.equals(rideAgencyId);
     }
 }


### PR DESCRIPTION
For KCM, take the maximum of fares on adjacent legs, rather than adding them.

This was rewritten from my first pass to minimize changes to DefaultFareServiceImpl, & reuse SeattleFareServiceImpl.

Discussed on the mailing list here: https://groups.google.com/forum/#!topic/opentripplanner-dev/70siIXQPYxw