### PR TITLE
Router compact legs NPE fix in AStar search. Bug fix on #2449

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/AStar.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/AStar.java
@@ -360,7 +360,7 @@ public class AStar {
     }
 
     public List<GraphPath> getPathsToTarget() {
-        if(runState == null) {
+        if (runState == null) {
             return Collections.emptyList();
         }
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/AStar.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/AStar.java
@@ -360,6 +360,10 @@ public class AStar {
     }
 
     public List<GraphPath> getPathsToTarget() {
+        if(runState == null) {
+            return Collections.emptyList();
+        }
+
         List<GraphPath> ret = new LinkedList<>();
         for (State s : runState.targetAcceptedStates) {
             if (s.isFinal()) {


### PR DESCRIPTION
The PR 'Compact legs by reversed search #2449' cased a null pointer exception (npe) in the AStar class as reported by @vesameskanen. Please see the discussion in PR #2449 for details.

The NPE is occuring when the timeout is reached at the initialization point in time, and the runState is set to null:
```java
// Since initial states can be multiple, heuristic cannot depend on the initial state.
// Initializing the bidirectional heuristic is a pretty complicated operation that involves searching through
// the streets around the origin and destination.
runState.heuristic.initialize(runState.options, abortTime);
if (abortTime < Long.MAX_VALUE  && System.currentTimeMillis() > abortTime) {
    LOG.warn("Timeout during initialization of goal direction heuristic.");
    options.rctx.debugOutput.timedOut = true;
    runState = null; // Search timed out
    return;
}
(AStar.java:120)
```
Later when the `getPathsToTarget()`is called, the result is a NPE. 

My approach to fix this was to do a check in the `getPathsToTarget()` method and return an empty list when runState is null. 

This is not a robust solution - it enforces the AStar logic to make sure the runState is not null everywhere. Perhaps a better way would be to throw some kind of TimeOutException when a timeout is detected and handle this at an higher level. But, I have to say that with my limited experience with OTP, I am not comfortable to such change. Any comments on this is encouraged.
