### PR TITLE
Configurable HTTP timeout from JSON config

### DIFF
--- a/src/main/java/org/opentripplanner/updater/alerts/GtfsRealtimeAlertsUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/alerts/GtfsRealtimeAlertsUpdater.java
@@ -40,6 +40,9 @@ import com.google.transit.realtime.GtfsRealtime.FeedMessage;
  * myalert.url = http://host.tld/path
  * myalert.earlyStartSec = 3600
  * myalert.feedId = TA
+ * myalert.connectionTimeoutMills = 3000
+ * myalert.connectionRequestTimeoutMills = 10000
+ * myalert.socketTimeoutMills = 3000
  * </pre>
  */
 public class GtfsRealtimeAlertsUpdater extends PollingGraphUpdater {
@@ -61,6 +64,12 @@ public class GtfsRealtimeAlertsUpdater extends PollingGraphUpdater {
 
     private AlertsUpdateHandler updateHandler = null;
 
+    private int connectionTimeout;
+
+    private int connectionRequestTimeout;
+
+    private int socketTimeout;
+
     @Override
     public void setGraphUpdaterManager(GraphUpdaterManager updaterManager) {
         this.updaterManager = updaterManager;
@@ -81,6 +90,9 @@ public class GtfsRealtimeAlertsUpdater extends PollingGraphUpdater {
         if (config.path("fuzzyTripMatching").asBoolean(false)) {
             this.fuzzyTripMatcher = new GtfsRealtimeFuzzyTripMatcher(graph.index);
         }
+        this.connectionTimeout = config.path("connectionTimeoutMills").asInt();
+        this.connectionRequestTimeout = config.path("connectionRequestTimeoutMills").asInt();
+        this.socketTimeout = config.path("socketTimeoutMills").asInt();
         LOG.info("Creating real-time alert updater running every {} seconds : {}", frequencySec, url);
     }
 
@@ -98,7 +110,7 @@ public class GtfsRealtimeAlertsUpdater extends PollingGraphUpdater {
     @Override
     protected void runPolling() {
         try {
-            InputStream data = HttpUtils.getData(url);
+            InputStream data = HttpUtils.getData(url, connectionTimeout, connectionRequestTimeout, socketTimeout);
             if (data == null) {
                 throw new RuntimeException("Failed to get data from url " + url);
             }

--- a/src/main/java/org/opentripplanner/updater/stoptime/GtfsRealtimeHttpTripUpdateSource.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/GtfsRealtimeHttpTripUpdateSource.java
@@ -31,8 +31,7 @@ import com.google.transit.realtime.GtfsRealtime.FeedMessage;
 import com.google.transit.realtime.GtfsRealtime.TripUpdate;
 
 public class GtfsRealtimeHttpTripUpdateSource implements TripUpdateSource, JsonConfigurable {
-    private static final Logger LOG =
-            LoggerFactory.getLogger(GtfsRealtimeHttpTripUpdateSource.class);
+    private static final Logger LOG = LoggerFactory.getLogger(GtfsRealtimeHttpTripUpdateSource.class);
 
     /**
      * True iff the last list with updates represent all updates that are active right now, i.e. all
@@ -47,6 +46,12 @@ public class GtfsRealtimeHttpTripUpdateSource implements TripUpdateSource, JsonC
 
     private String url;
 
+    private int connectionTimeout;
+
+    private int connectionRequestTimeout;
+
+    private int socketTimeout;
+
     @Override
     public void configure(Graph graph, JsonNode config) throws Exception {
         String url = config.path("url").asText();
@@ -55,6 +60,9 @@ public class GtfsRealtimeHttpTripUpdateSource implements TripUpdateSource, JsonC
         }
         this.url = url;
         this.feedId = config.path("feedId").asText();
+        this.connectionTimeout = config.path("connectionTimeoutMills").asInt();
+        this.connectionRequestTimeout = config.path("connectionRequestTimeoutMills").asInt();
+        this.socketTimeout = config.path("socketTimeoutMills").asInt();
     }
 
     @Override
@@ -64,7 +72,7 @@ public class GtfsRealtimeHttpTripUpdateSource implements TripUpdateSource, JsonC
         List<TripUpdate> updates = null;
         fullDataset = true;
         try {
-            InputStream is = HttpUtils.getData(url);
+            InputStream is = HttpUtils.getData(url, connectionTimeout, connectionRequestTimeout, socketTimeout);
             if (is != null) {
                 // Decode message
                 feedMessage = FeedMessage.PARSER.parseFrom(is);

--- a/src/main/java/org/opentripplanner/util/HttpUtils.java
+++ b/src/main/java/org/opentripplanner/util/HttpUtils.java
@@ -65,7 +65,7 @@ public class HttpUtils {
 
     public static void testUrl(String url) throws IOException {
         HttpHead head = new HttpHead(url);
-        HttpClient httpclient = getClient(0, 0, 0);
+        HttpClient httpclient = getClient(TIMEOUT_CONNECTION, TIMEOUT_CONNECTION_REQUEST, TIMEOUT_SOCKET);
         HttpResponse response = httpclient.execute(head);
 
         StatusLine status = response.getStatusLine();


### PR DESCRIPTION
Some feeds my not respond within the default 5 seconds. To compensate for slow feeds it would be good to allow overwriting default timeout values of feeds configured in router-config.json

