### PR TITLE
Bugfix: access=private means OSM way should not be accessed.

### DIFF
--- a/src/main/java/org/opentripplanner/openstreetmap/model/OSMWithTags.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/model/OSMWithTags.java
@@ -207,7 +207,7 @@ public class OSMWithTags {
      */
     private boolean isTagDeniedAccess(String tagName) {
         String tagValue = getTag(tagName);
-        return "no".equals(tagValue) || "license".equals(tagValue);
+        return "no".equals(tagValue) || "license".equals(tagValue) || "private".equals(tagValue);
     }
 
     /**


### PR DESCRIPTION
See https://wiki.openstreetmap.org/wiki/Tag:access=private?uselang=en-US

This PR ensures that if an OSM way has the tag access=private, it is not used for routing.