### PR TITLE
Fix NPE when handling bad date in request

### DIFF
--- a/src/main/java/org/opentripplanner/api/resource/PlannerResource.java
+++ b/src/main/java/org/opentripplanner/api/resource/PlannerResource.java
@@ -104,41 +104,44 @@ public class PlannerResource extends RoutingResource {
             }
         }
 
-        /* Populate up the elevation metadata */
-        response.elevationMetadata = new ElevationMetadata();
-        response.elevationMetadata.ellipsoidToGeoidDifference = router.graph.ellipsoidToGeoidDifference;
-        response.elevationMetadata.geoidElevation = request.geoidElevation;
+        if (request != null && router != null) {
+            // If there were no errors in the request, handle elevation data and logging (if enabled).
+            /* Populate up the elevation metadata */
+            response.elevationMetadata = new ElevationMetadata();
+            response.elevationMetadata.ellipsoidToGeoidDifference = router.graph.ellipsoidToGeoidDifference;
+            response.elevationMetadata.geoidElevation = request.geoidElevation;
 
-        /* Log this request if such logging is enabled. */
-        if (request != null && router != null && router.requestLogger != null) {
-            StringBuilder sb = new StringBuilder();
-            String clientIpAddress = grizzlyRequest.getRemoteAddr();
-            //sb.append(LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME));
-            sb.append(clientIpAddress);
-            sb.append(' ');
-            sb.append(request.arriveBy ? "ARRIVE" : "DEPART");
-            sb.append(' ');
-            sb.append(LocalDateTime.ofInstant(Instant.ofEpochSecond(request.dateTime), ZoneId.systemDefault()));
-            sb.append(' ');
-            sb.append(request.modes.getAsStr());
-            sb.append(' ');
-            sb.append(request.from.lat);
-            sb.append(' ');
-            sb.append(request.from.lng);
-            sb.append(' ');
-            sb.append(request.to.lat);
-            sb.append(' ');
-            sb.append(request.to.lng);
-            sb.append(' ');
-            if (paths != null) {
-                for (GraphPath path : paths) {
-                    sb.append(path.getDuration());
-                    sb.append(' ');
-                    sb.append(path.getTrips().size());
-                    sb.append(' ');
+            if (router.requestLogger != null) {
+                /* Log this request if such logging is enabled. */
+                StringBuilder sb = new StringBuilder();
+                String clientIpAddress = grizzlyRequest.getRemoteAddr();
+                //sb.append(LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME));
+                sb.append(clientIpAddress);
+                sb.append(' ');
+                sb.append(request.arriveBy ? "ARRIVE" : "DEPART");
+                sb.append(' ');
+                sb.append(LocalDateTime.ofInstant(Instant.ofEpochSecond(request.dateTime), ZoneId.systemDefault()));
+                sb.append(' ');
+                sb.append(request.modes.getAsStr());
+                sb.append(' ');
+                sb.append(request.from.lat);
+                sb.append(' ');
+                sb.append(request.from.lng);
+                sb.append(' ');
+                sb.append(request.to.lat);
+                sb.append(' ');
+                sb.append(request.to.lng);
+                sb.append(' ');
+                if (paths != null) {
+                    for (GraphPath path : paths) {
+                        sb.append(path.getDuration());
+                        sb.append(' ');
+                        sb.append(path.getTrips().size());
+                        sb.append(' ');
+                    }
                 }
+                router.requestLogger.info(sb.toString());
             }
-            router.requestLogger.info(sb.toString());
         }
         return response;
     }

--- a/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
@@ -713,11 +713,13 @@ public class RoutingRequest implements Cloneable, Serializable {
     }
 
     public void setDateTime(Date dateTime) {
-        this.dateTime = dateTime.getTime() / 1000;
+        if (dateTime == null) throw new IllegalArgumentException("Date or time parameter is invalid.");
+        else this.dateTime = dateTime.getTime() / 1000;
     }
 
     public void setDateTime(String date, String time, TimeZone tz) {
         Date dateObject = DateUtils.toDate(date, time, tz);
+
         setDateTime(dateObject);
     }
 


### PR DESCRIPTION
This PR fixes #2536.  If a bogus date is provided (which causes a `null` `Date` object and the request to fail), an `IllegalArgumentException` is now thrown which filters up as a `BOGUS_PARAMETER` OTP planner error.