### PR TITLE
Fix IndexOutOfBounds for directionless transfers

### DIFF
--- a/src/main/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverter.java
+++ b/src/main/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverter.java
@@ -748,7 +748,7 @@ public abstract class GraphPathToTripPlanConverter {
         if (states.length == 2 && states[1].getBackEdge() instanceof SimpleTransfer) {
             SimpleTransfer transferEdge = ((SimpleTransfer) states[1].getBackEdge());
             List<Edge> transferEdges = transferEdge.getEdges();
-            if (transferEdges != null) {
+            if (transferEdges != null && transferEdges.size() > 0) {
                 // Create a new initial state. Some parameters may have change along the way, copy them from the first state
                 StateEditor se = new StateEditor(states[0].getOptions(), transferEdges.get(0).getFromVertex());
                 se.setNonTransitOptionsFromState(states[0]);


### PR DESCRIPTION
This is half a question to the maintainers as well. I don't have a solid reproduction case for this so I'm not sure if there's something I don't understand.

It sometimes happens that a transfer has no directions which causes transferEdges to be empty.

https://github.com/opentripplanner/OpenTripPlanner/blob/a2ef28523293054d381ab66738ba86bdc5a47be1/src/main/java/org/opentripplanner/graph_builder/module/NearbyStopFinder.java#L226

This handles a particular case for the geometry creation but not for the transfer edges, and I was thinking it might be the same kind of error?