### PR TITLE
Re #2753 Upgrade Apache Deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -700,7 +700,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.0</version>
+            <version>1.17</version>
         </dependency>
         <dependency>
             <groupId>commons-discovery</groupId>
@@ -734,12 +734,17 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5</version>
+            <version>4.5.5</version>
+        </dependency>
+        <dependency>
+          <groupId>commons-codec</groupId>
+          <artifactId>commons-codec</artifactId>
+          <version>1.11</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-math3</artifactId>
-            <version>3.0</version>
+            <version>3.6.1</version>
         </dependency>
 
         <!-- Lucene for sophisticated text search -->


### PR DESCRIPTION
- Upgrades Commons, HTTP Components & Math to latest versions (no compatibility issues)
- Explicitly adds Commons Codec w/version greater than 1.4 to fix the issue I was encountering [c.f. this SO answer](https://stackoverflow.com/questions/7688644/java-lang-nosuchmethoderror-org-apache-commons-codec-binary-base64-encodebase64).

I found that these changes fixed my issue in #2573 