### PR TITLE
Allow Passing Time Zone in Request

### DIFF
--- a/src/main/java/org/opentripplanner/api/common/RoutingResource.java
+++ b/src/main/java/org/opentripplanner/api/common/RoutingResource.java
@@ -77,15 +77,20 @@ public abstract class RoutingResource {
     /** The date that the trip should depart (or arrive, for requests where arriveBy is true). */
     @QueryParam("date")
     protected String date;
-    
+
     /** The time that the trip should depart (or arrive, for requests where arriveBy is true). */
     @QueryParam("time")
     protected String time;
-    
+
+    /** The timezone in which the date & time in the query should be interpreted */
+    @QueryParam("timeZone")
+    protected String timeZone;
+
+
     /** Whether the trip should depart or arrive at the specified date and time. */
     @QueryParam("arriveBy")
     protected Boolean arriveBy;
-    
+
     /** Whether the trip must be wheelchair accessible. */
     @QueryParam("wheelchair")
     protected Boolean wheelchair;
@@ -392,8 +397,10 @@ public abstract class RoutingResource {
 
         {
             //FIXME: move into setter method on routing request
-            TimeZone tz;
-            tz = router.graph.getTimeZone();
+            TimeZone defaultTz;
+            defaultTz = router.graph.getTimeZone();
+            if(timeZone != null) defaultTz =  TimeZone.getTimeZone(timeZone);
+            LOG.debug("using default timezone " + defaultTz.toString());
             if (date == null && time != null) { // Time was provided but not date
                 LOG.debug("parsing ISO datetime {}", time);
                 try {
@@ -402,15 +409,15 @@ public abstract class RoutingResource {
                     XMLGregorianCalendar xmlGregCal = df.newXMLGregorianCalendar(time);
                     GregorianCalendar gregCal = xmlGregCal.toGregorianCalendar();
                     if (xmlGregCal.getTimezone() == DatatypeConstants.FIELD_UNDEFINED) {
-                        gregCal.setTimeZone(tz);
+                        gregCal.setTimeZone(defaultTz);
                     }
                     Date d2 = gregCal.getTime();
                     request.setDateTime(d2);
                 } catch (DatatypeConfigurationException e) {
-                    request.setDateTime(date, time, tz);
+                    request.setDateTime(date, time, defaultTz);
                 }
             } else {
-                request.setDateTime(date, time, tz);
+                request.setDateTime(date, time, defaultTz);
             }
         }
 


### PR DESCRIPTION
This PR allows API consumers to specify the timezone in which their date/time parameters are interpreted. The current approach is to use the graph timezone exclusively. However, the graph timezone is non-deterministically determined during the graph build process and may change over repeated runs if GTFS files from multiple time zones are used as input to a graph. This may happen even in single-city OTP installations (for example if using the Amtrak GTFS file which specifies New York as the time zone in a west-coast US city graph build).

Allowing the user to specify the timezone is a non-intrusive change, as the default behavior specified above is maintained if the user opts not to specify. Per the getTimeZone [docs](https://docs.oracle.com/javase/7/docs/api/java/util/TimeZone.html#getTimeZone(java.lang.String)), if the user sends an invalid time zone as part of the request it will be interpreted as GMT.