### PR TITLE
Microoptimalization: Less costly / lazy init of RoutingRequest instances

### DIFF
--- a/src/main/java/org/opentripplanner/api/common/RoutingResource.java
+++ b/src/main/java/org/opentripplanner/api/common/RoutingResource.java
@@ -507,7 +507,7 @@ public abstract class RoutingResource {
 
         HashMap<AgencyAndId, BannedStopSet> bannedTripMap = makeBannedTripMap(bannedTrips);
         if (bannedTripMap != null)
-            request.bannedTrips = bannedTripMap;
+            request.setBannedTrips(bannedTripMap);
 
         if (bannedStops != null)
             request.setBannedStops(bannedStops);

--- a/src/main/java/org/opentripplanner/routing/impl/GraphPathFinder.java
+++ b/src/main/java/org/opentripplanner/routing/impl/GraphPathFinder.java
@@ -332,7 +332,7 @@ public class GraphPathFinder {
         reversedOptions.rctx.remainingWeightHeuristic = remainingWeightHeuristic;
         reversedOptions.maxTransfers = 4;
         reversedOptions.longDistance = true;
-        reversedOptions.bannedTrips = options.bannedTrips;
+        reversedOptions.setBannedTrips(options.getBannedTrips());
         return reversedOptions;
     }
 

--- a/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
+++ b/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
@@ -327,7 +327,7 @@ public class TripTimes implements Serializable, Comparable<TripTimes>, Cloneable
      */
     public boolean tripAcceptable(final State state0, final int stopIndex) {
         final RoutingRequest options = state0.getOptions();
-        final BannedStopSet banned = options.bannedTrips.get(trip.getId());
+        final BannedStopSet banned = options.getBannedTrip(trip.getId());
         if (banned != null && banned.contains(stopIndex)) {
             return false;
         }

--- a/src/test/java/org/opentripplanner/routing/algorithm/TestBanning.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/TestBanning.java
@@ -144,7 +144,7 @@ public class TestBanning extends TestCase {
                 }
                 // Used trips should not contains a banned trip
                 for (T2<AgencyAndId, BannedStopSet> usedTripDef : usedTripDefs) {
-                    BannedStopSet bannedStopSet = options.bannedTrips.get(usedTripDef.first);
+                    BannedStopSet bannedStopSet = options.getBannedTrip(usedTripDef.first);
                     if (bannedStopSet != null) {
                         for (Integer stopIndex : usedTripDef.second) {
                             assertFalse(bannedStopSet.contains(stopIndex));
@@ -158,9 +158,9 @@ public class TestBanning extends TestCase {
                         usedTripDefs);
                 T2<AgencyAndId, BannedStopSet> tripDefToBan = usedTripDefsList.get(rand
                         .nextInt(usedTripDefs.size()));
-                options.bannedTrips.put(tripDefToBan.first, tripDefToBan.second);
+                options.banTrip(tripDefToBan.first, tripDefToBan.second);
             }
-            options.bannedTrips.clear();
+            options.clearBannedTrips();
         }
     }
 }


### PR DESCRIPTION
Roughly halves the cost of constructing RoutingRequest.

- [ ] **issue**: None - should I open a generic issue on Trip Planning performance? 
- [ ] **roadmap**: Where is the roadmap located? Links seems not to be working.
- [x] **tests**: Tested as part of existing tests
- [x] **formatting**.

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **before merging**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)