### PR TITLE
Addresses #2636: Update onebusaway-gtfs to latest version from OBA project

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.4 (in progress)
+
+- Update onebusaway-gtfs to latest version from OBA project (#2636)
+
 ## 1.3 (2018-08-03)
 
 - Fix stop linking to only one edge of platform (#2472)

--- a/pom.xml
+++ b/pom.xml
@@ -439,6 +439,11 @@
             <name>Conveyal Maven Repository</name>
             <url>https://maven.conveyal.com/</url>
         </repository>
+        <repository>
+            <id>onebusaway-releases</id>
+            <name>Onebusaway Releases Repo</name>
+            <url>http://nexus.onebusaway.org/content/repositories/releases/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -656,7 +661,7 @@
         <dependency>
             <groupId>org.onebusaway</groupId>
             <artifactId>onebusaway-gtfs</artifactId>
-            <version>1.3.5-conveyal-SNAPSHOT-2</version>
+            <version>1.3.41</version>
         </dependency>
         <!-- Processing is used for the debug GUI (though we could probably use just Java2D) -->
         <dependency>


### PR DESCRIPTION
This pull request updates the onebusaway-gtfs dependency to the latest version.

- [ ] **issue**: Addresses #2636 - short term update to onebusaway-gtfs dependency. Longer term, Conveyal GTFS-lib may be used instead.
- [ ] **roadmap**: Not on the roadmap; will need to be discussed by PLC. That said, it's a nonfunctional version bump of an existing dependency,
- [ ] **tests**: Tests pass.
- [ ] **formatting**: Yes.

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **before merging**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)