### PR TITLE
Deploy builds to s3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 # OpenTripPlanner requires Java 8 and Travis doesn't (yet) support OpenJDK 8
 jdk:
   - oraclejdk8
-  
+
 # Replace Travis's default Maven installation step with a no-op.
 # This avoids redundantly pre-running 'mvn install -DskipTests' every time.
 install: true
@@ -42,3 +42,24 @@ notifications:
 # Decrypt and import the artifact signing certificate before running the build
 before_install:
   - if [[ "$TRAVIS_PULL_REQUEST" = "false" ]]; then openssl aes-256-cbc -K $encrypted_9918733fe303_key -iv $encrypted_9918733fe303_iv -in maven-artifact-signing-key.asc.enc -out maven-artifact-signing-key.asc -d && gpg --import --batch maven-artifact-signing-key.asc; fi
+before_deploy:
+# Get branch name of current branch for use in jar name: https://graysonkoonce.com/getting-the-current-branch-name-during-a-pull-request-in-travis-ci/
+- export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
+# Copy shaded jar over to deploy dir as git-described jar (either version or version+commit) and branch-specific jar.
+- mkdir deploy
+- cp target/*-shaded.jar deploy/$(git describe --always).jar
+- cp target/*-shaded.jar deploy/otp-latest-$BRANCH.jar
+deploy:
+  provider: s3
+  skip_cleanup: true
+  # AWS CI user: opentripplanner-ci
+  access_key_id: AKIAJEQQINNZK2IDHMJQ
+  secret_access_key:
+    secure: CCRXXGZ0RXSUQaVKHFlZjleEygesT3ec/rHUf28l7lw1XxOZBZulONqydL45OIQUM26JYge2SK+rMJfcN38qPVHXVbYQgGdcKnCQN76Kxj3MoNbMXrrvaKPZZq6jP0TOTHUTIh4TGO5Bu5nM6fV7zcySCFchC6yMF9EC90jDDns=
+  # Upload jars found in local directory to s3 bucket
+  local-dir: deploy
+  bucket: opentripplanner-builds
+  acl: public_read
+  on:
+    repo: opentripplanner/opentripplanner
+    all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,5 +61,5 @@ deploy:
   bucket: opentripplanner-builds
   acl: public_read
   on:
-    repo: opentripplanner/opentripplanner
+    repo: opentripplanner/OpenTripPlanner
     all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ before_deploy:
 - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
 # Copy shaded jar over to deploy dir as git-described jar (either version or version+commit) and branch-specific jar.
 - mkdir deploy
-- cp target/*-shaded.jar deploy/$(git describe --always).jar
+- cp target/*-shaded.jar deploy/otp-$(git describe --always).jar
 - cp target/*-shaded.jar deploy/otp-latest-$BRANCH.jar
 deploy:
   provider: s3


### PR DESCRIPTION
This PR adds a deploy stage to the continuous integration process that uploads the shaded jar file for any successful CI performed on the primary repo (i.e., PR builds from forks will not be uploaded). The jar files uploaded are:
- `otp-${git-description}.jar` (e.g. `otp-v1.3.0-54-g169c39d.jar`) and
- `otp-latest-${branch-name}.jar` (e.g., `otp-latest-deploy-builds-to-s3.jar `)

To be completed by pull request submitter:

- [ ] **issue**: N/A
- [ ] **roadmap**: (Not currently listed on roadmap -- needs discussion from PLC)
- [ ] **tests**: N/A, this is a new stage in Travis CI. However, success of the new S3 deploy stage has been confirmed: https://opentripplanner-builds.s3.amazonaws.com
- [ ] **formatting**: N/A (`yaml` file)

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **before merging**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)