### PR TITLE
Separate graph serialization/deserialization from Graph

### DIFF
--- a/src/main/java/org/opentripplanner/api/resource/Routers.java
+++ b/src/main/java/org/opentripplanner/api/resource/Routers.java
@@ -32,10 +32,10 @@ import org.opentripplanner.api.model.RouterList;
 import org.opentripplanner.graph_builder.GraphBuilder;
 import org.opentripplanner.routing.error.GraphNotFoundException;
 import org.opentripplanner.routing.graph.Graph;
-import org.opentripplanner.routing.graph.Graph.LoadLevel;
 import org.opentripplanner.routing.impl.DefaultStreetVertexIndexFactory;
 import org.opentripplanner.routing.impl.MemoryGraphSource;
 import org.opentripplanner.routing.services.GraphService;
+import org.opentripplanner.serializer.GraphSerializerService;
 import org.opentripplanner.standalone.CommandLineParameters;
 import org.opentripplanner.standalone.OTPServer;
 import org.opentripplanner.standalone.Router;
@@ -89,6 +89,8 @@ import com.google.common.io.Files;
 public class Routers {
 
     private static final Logger LOG = LoggerFactory.getLogger(Routers.class);
+
+    private final GraphSerializerService graphSerializerService = new GraphSerializerService();
 
     @Context OTPServer otpServer;
 
@@ -189,7 +191,6 @@ public class Routers {
     public Response postGraphOverWire (
             @PathParam("routerId") String routerId, 
             @QueryParam("preEvict") @DefaultValue("true") boolean preEvict, 
-            @QueryParam("loadLevel") @DefaultValue("FULL") LoadLevel level,
             InputStream is) {
         if (preEvict) {
             LOG.debug("pre-evicting graph");
@@ -198,7 +199,7 @@ public class Routers {
         LOG.debug("deserializing graph from POST data stream...");
         Graph graph;
         try {
-            graph = Graph.load(is, level);
+            graph = graphSerializerService.load(is);
             GraphService graphService = otpServer.getGraphService();
             graphService.registerGraph(routerId, new MemoryGraphSource(routerId, graph));
             return Response.status(Status.CREATED).entity(graph.toString() + "\n").build();

--- a/src/main/java/org/opentripplanner/graph_builder/GraphStats.java
+++ b/src/main/java/org/opentripplanner/graph_builder/GraphStats.java
@@ -20,6 +20,7 @@ import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.routing.vertextype.StreetVertex;
 import org.opentripplanner.routing.vertextype.TransitStop;
+import org.opentripplanner.serializer.GraphSerializerService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,6 +38,8 @@ import com.vividsolutions.jts.linearref.LocationIndexedLine;
 public class GraphStats {
 
     private static final Logger LOG = LoggerFactory.getLogger(GraphStats.class);
+
+    private final GraphSerializerService graphSerializerService = new GraphSerializerService();
 
     @Parameter(names = { "-v", "--verbose" }, description = "Verbose output")
     private boolean verbose = false;
@@ -95,7 +98,7 @@ public class GraphStats {
         /* open input graph (same for all commands) */
         File graphFile = new File(graphPath);
         try {
-            graph = Graph.load(graphFile, Graph.LoadLevel.FULL);
+            graph = graphSerializerService.load(graphFile);
         } catch (Exception e) {
             LOG.error("Exception while loading graph from " + graphFile);
             return;

--- a/src/main/java/org/opentripplanner/routing/graph/Graph.java
+++ b/src/main/java/org/opentripplanner/routing/graph/Graph.java
@@ -34,7 +34,6 @@ import org.opentripplanner.routing.core.TraverseMode;
 import org.opentripplanner.routing.edgetype.EdgeWithCleanup;
 import org.opentripplanner.routing.edgetype.StreetEdge;
 import org.opentripplanner.routing.edgetype.TripPattern;
-import org.opentripplanner.routing.impl.DefaultStreetVertexIndexFactory;
 import org.opentripplanner.routing.services.StreetVertexIndexFactory;
 import org.opentripplanner.routing.services.StreetVertexIndexService;
 import org.opentripplanner.routing.services.notes.StreetNotesService;
@@ -85,11 +84,9 @@ public class Graph implements Serializable {
     private GraphBundle bundle;
 
     /* vertex index by name is reconstructed from edges */
-    private transient Map<String, Vertex> vertices;
+    public transient Map<String, Vertex> vertices;
 
     private transient CalendarService calendarService;
-
-    private boolean debugData = true;
 
     // TODO this would be more efficient if it was just an array.
     private transient Map<Integer, Vertex> vertexById;
@@ -653,48 +650,11 @@ public class Graph implements Serializable {
 
     /* (de) serialization */
 
-    public enum LoadLevel {
-        BASIC, FULL, DEBUG;
-    }
-
-    public static Graph load(File file, LoadLevel level) throws IOException, ClassNotFoundException {
-        LOG.info("Reading graph " + file.getAbsolutePath() + " ...");
-        // cannot use getClassLoader() in static context
-        ObjectInputStream in = new ObjectInputStream(new FileInputStream(file));
-        return load(in, level);
-    }
-
-    public static Graph load(ClassLoader classLoader, File file, LoadLevel level)
-            throws IOException, ClassNotFoundException {
-        LOG.info("Reading graph " + file.getAbsolutePath() + " with alternate classloader ...");
-        ObjectInputStream in = new GraphObjectInputStream(new BufferedInputStream(
-                new FileInputStream(file)), classLoader);
-        return load(in, level);
-    }
-
-    public static Graph load(InputStream is, LoadLevel level) throws ClassNotFoundException,
-            IOException {
-        return load(new ObjectInputStream(is), level);
-    }
-
     /**
-     * Default load. Uses DefaultStreetVertexIndexFactory.
-     * @param in
-     * @param level
-     * @return
-     * @throws IOException
-     * @throws ClassNotFoundException
-     */
-    public static Graph load(ObjectInputStream in, LoadLevel level) throws IOException,
-            ClassNotFoundException {
-        return load(in, level, new DefaultStreetVertexIndexFactory());
-    }
-    
-    /** 
      * Perform indexing on vertices, edges, and timetables, and create transient data structures.
      * This used to be done in readObject methods upon deserialization, but stand-alone mode now
      * allows passing graphs from graphbuilder to server in memory, without a round trip through
-     * serialization. 
+     * serialization.
      * TODO: do we really need a factory for different street vertex indexes?
      */
     public void index(StreetVertexIndexFactory indexFactory) {
@@ -712,65 +672,15 @@ public class Graph implements Serializable {
         // TODO: Move this ^ stuff into the graph index
         this.index = new GraphIndex(this);
     }
-    
-    /**
-     * Loading which allows you to specify StreetVertexIndexFactory and inject other implementation.
-     * @param in
-     * @param level
-     * @param indexFactory
-     * @return
-     * @throws IOException
-     * @throws ClassNotFoundException
-     */
-    @SuppressWarnings("unchecked")
-    public static Graph load(ObjectInputStream in, LoadLevel level,
-            StreetVertexIndexFactory indexFactory) throws IOException, ClassNotFoundException {
-        try {
-            Graph graph = (Graph) in.readObject();
-            LOG.debug("Basic graph info read.");
-            if (graph.graphVersionMismatch())
-                throw new RuntimeException("Graph version mismatch detected.");
-            if (level == LoadLevel.BASIC)
-                return graph;
-            // vertex edge lists are transient to avoid excessive recursion depth
-            // vertex list is transient because it can be reconstructed from edges
-            LOG.debug("Loading edges...");
-            List<Edge> edges = (ArrayList<Edge>) in.readObject();
-            graph.vertices = new HashMap<String, Vertex>();
-            
-            for (Edge e : edges) {
-                graph.vertices.put(e.getFromVertex().getLabel(), e.getFromVertex());
-                graph.vertices.put(e.getToVertex().getLabel(), e.getToVertex());
-            }
-
-            LOG.info("Main graph read. |V|={} |E|={}", graph.countVertices(), graph.countEdges());
-            graph.index(indexFactory);
-
-            if (level == LoadLevel.FULL) {
-                return graph;
-            }
-            
-            if (graph.debugData) {
-                graph.graphBuilderAnnotations = (List<GraphBuilderAnnotation>) in.readObject();
-                LOG.debug("Debug info read.");
-            } else {
-                LOG.warn("Graph file does not contain debug data.");
-            }
-            return graph;
-        } catch (InvalidClassException ex) {
-            LOG.error("Stored graph is incompatible with this version of OTP, please rebuild it.");
-            throw new IllegalStateException("Stored Graph version error", ex);
-        }
-    }
 
     /**
      * Compares the OTP version number stored in the graph with that of the currently running instance. Logs warnings explaining that mismatched
      * versions can cause problems.
-     * 
+     *
      * @return false if Maven versions match (even if commit ids do not match), true if Maven version of graph does not match this version of OTP or
      *         graphs are otherwise obviously incompatible.
      */
-    private boolean graphVersionMismatch() {
+    public boolean graphVersionMismatch() {
         MavenVersion v = MavenVersion.VERSION;
         MavenVersion gv = this.mavenVersion;
         LOG.info("Graph version: {}", gv);
@@ -794,49 +704,6 @@ public class Graph implements Serializable {
             LOG.info("This graph was built with the currently running version and commit of OTP.");
             return false;
         }
-    }
-
-    public void save(File file) throws IOException {
-        LOG.info("Main graph size: |V|={} |E|={}", this.countVertices(), this.countEdges());
-        LOG.info("Writing graph " + file.getAbsolutePath() + " ...");
-        ObjectOutputStream out = new ObjectOutputStream(new BufferedOutputStream(
-                new FileOutputStream(file)));
-        try {
-            save(out);
-            out.close();
-        } catch (RuntimeException e) {
-            out.close();
-            file.delete(); // remove half-written file
-            throw e;
-        }
-    }
-
-    public void save(ObjectOutputStream out) throws IOException {
-        LOG.debug("Consolidating edges...");
-        // this is not space efficient
-        List<Edge> edges = new ArrayList<Edge>(this.countEdges());
-        for (Vertex v : getVertices()) {
-            // there are assumed to be no edges in an incoming list that are not
-            // in an outgoing list
-            edges.addAll(v.getOutgoing());
-            if (v.getDegreeOut() + v.getDegreeIn() == 0)
-                LOG.debug("vertex {} has no edges, it will not survive serialization.", v);
-        }
-        LOG.debug("Assigning vertex/edge ID numbers...");
-        this.rebuildVertexAndEdgeIndices();
-        LOG.debug("Writing edges...");
-        out.writeObject(this);
-        out.writeObject(edges);
-        if (debugData) {
-            // should we make debug info generation conditional?
-            LOG.debug("Writing debug data...");
-            out.writeObject(this.graphBuilderAnnotations);
-            out.writeObject(this.vertexById);
-            out.writeObject(this.edgeById);
-        } else {
-            LOG.debug("Skipping debug data.");
-        }
-        LOG.info("Graph written.");
     }
 
     /* deserialization for org.opentripplanner.customize */
@@ -1074,4 +941,20 @@ public class Graph implements Serializable {
     public long getTransitServiceEnds() {
         return transitServiceEnds;
     }
+
+    public List<GraphBuilderAnnotation> getGraphBuilderAnnotations() {
+        return graphBuilderAnnotations;
+    }
+
+    /**
+     * Exposed for JavaGraphSerializer
+     */
+    public Map<Integer, Vertex> getVertexById() {
+        return this.vertexById;
+    }
+
+    public Map<Integer, Edge> getEdgeById() {
+        return edgeById;
+    }
+
 }

--- a/src/main/java/org/opentripplanner/routing/impl/GraphScanner.java
+++ b/src/main/java/org/opentripplanner/routing/impl/GraphScanner.java
@@ -11,7 +11,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import org.opentripplanner.routing.error.GraphNotFoundException;
-import org.opentripplanner.routing.graph.Graph.LoadLevel;
 import org.opentripplanner.routing.services.GraphService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,9 +33,6 @@ public class GraphScanner {
 
     /** The default router, none by default */
     public String defaultRouterId = null;
-
-    /** Load level */
-    public LoadLevel loadLevel = LoadLevel.FULL;
 
     /** The GraphService where register graphs to */
     private GraphService graphService;
@@ -69,7 +65,7 @@ public class GraphScanner {
             LOG.info("Graph files will be sought in paths relative to {}", basePath);
             for (String routerId : routerIds) {
                 InputStreamGraphSource graphSource = InputStreamGraphSource.newFileGraphSource(
-                        routerId, getBasePath(routerId), loadLevel);
+                        routerId, getBasePath(routerId));
                 graphService.registerGraph(routerId, graphSource);
             }
         } else {
@@ -119,7 +115,7 @@ public class GraphScanner {
                     Arrays.toString(graphToRegister.toArray()));
             for (String routerId : graphToRegister) {
                 InputStreamGraphSource graphSource = InputStreamGraphSource.newFileGraphSource(
-                        routerId, getBasePath(routerId), loadLevel);
+                        routerId, getBasePath(routerId));
                 // Can be null here if the file has been removed in the meantime.
                 graphService.registerGraph(routerId, graphSource);
             }

--- a/src/main/java/org/opentripplanner/routing/impl/InputStreamGraphSource.java
+++ b/src/main/java/org/opentripplanner/routing/impl/InputStreamGraphSource.java
@@ -6,9 +6,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.MissingNode;
 import com.google.common.io.ByteStreams;
 import org.opentripplanner.routing.graph.Graph;
-import org.opentripplanner.routing.graph.Graph.LoadLevel;
 import org.opentripplanner.routing.services.GraphSource;
-import org.opentripplanner.routing.services.StreetVertexIndexFactory;
+import org.opentripplanner.serializer.GraphSerializerService;
 import org.opentripplanner.standalone.Router;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,13 +32,13 @@ public class InputStreamGraphSource implements GraphSource {
      * */
     private static final long LOAD_DELAY_SEC = 10;
 
+    private final GraphSerializerService graphSerializerService = new GraphSerializerService();
+
     private Router router;
 
     private String routerId;
 
     private long graphLastModified = 0L;
-
-    private LoadLevel loadLevel;
 
     private Object preEvictMutex = new Boolean(false);
 
@@ -48,36 +47,27 @@ public class InputStreamGraphSource implements GraphSource {
      */
     private Streams streams;
 
-    // TODO Why do we need a factory? There is a single one implementation.
-    private StreetVertexIndexFactory streetVertexIndexFactory = new DefaultStreetVertexIndexFactory();
-
     /**
      * @param routerId
      * @param path
-     * @param loadLevel
      * @return A GraphSource loading graph from the file system under a base path.
      */
-    public static InputStreamGraphSource newFileGraphSource(String routerId, File path,
-            LoadLevel loadLevel) {
-        return new InputStreamGraphSource(routerId, loadLevel, new FileStreams(path));
+    public static InputStreamGraphSource newFileGraphSource(String routerId, File path) {
+        return new InputStreamGraphSource(routerId, new FileStreams(path));
     }
 
     /**
      * @param routerId
      * @param path
-     * @param loadLevel
      * @return A GraphSource loading graph from an embedded classpath resources (a graph bundled
      *         inside a pre-packaged WAR for example).
      */
-    public static InputStreamGraphSource newClasspathGraphSource(String routerId, File path,
-            LoadLevel loadLevel) {
-        return new InputStreamGraphSource(routerId, loadLevel, new ClasspathStreams(path));
+    public static InputStreamGraphSource newClasspathGraphSource(String routerId, File path) {
+        return new InputStreamGraphSource(routerId, new ClasspathStreams(path));
     }
 
-    private InputStreamGraphSource(String routerId, LoadLevel loadLevel,
-            Streams streams) {
+    private InputStreamGraphSource(String routerId, Streams streams) {
         this.routerId = routerId;
-        this.loadLevel = loadLevel;
         this.streams = streams;
     }
 
@@ -193,8 +183,7 @@ public class InputStreamGraphSource implements GraphSource {
         try (InputStream is = streams.getGraphInputStream()) {
             LOG.info("Loading graph...");
             try {
-                newGraph = Graph.load(new ObjectInputStream(is), loadLevel,
-                        streetVertexIndexFactory);
+                newGraph = graphSerializerService.load(is);
             } catch (Exception ex) {
                 LOG.error("Exception while loading graph '{}'.", routerId, ex);
                 return null;
@@ -319,16 +308,13 @@ public class InputStreamGraphSource implements GraphSource {
 
         public File basePath;
 
-        public LoadLevel loadLevel = LoadLevel.FULL;
-
         public FileFactory(File basePath) {
             this.basePath = basePath;
         }
 
         @Override
         public GraphSource createGraphSource(String routerId) {
-            return InputStreamGraphSource.newFileGraphSource(routerId, getBasePath(routerId),
-                    loadLevel);
+            return InputStreamGraphSource.newFileGraphSource(routerId, getBasePath(routerId));
         }
 
         @Override

--- a/src/main/java/org/opentripplanner/serializer/GraphSerializationException.java
+++ b/src/main/java/org/opentripplanner/serializer/GraphSerializationException.java
@@ -1,0 +1,12 @@
+package org.opentripplanner.serializer;
+
+public class GraphSerializationException extends RuntimeException {
+
+    public GraphSerializationException(String message, Exception e) {
+        super(message,e);
+    }
+
+    public GraphSerializationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/opentripplanner/serializer/GraphSerializer.java
+++ b/src/main/java/org/opentripplanner/serializer/GraphSerializer.java
@@ -1,0 +1,11 @@
+package org.opentripplanner.serializer;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public interface GraphSerializer {
+
+    GraphWrapper deserialize(InputStream inputStream);
+
+    void serialize(GraphWrapper graphWrapper, OutputStream outputStream);
+}

--- a/src/main/java/org/opentripplanner/serializer/GraphSerializerService.java
+++ b/src/main/java/org/opentripplanner/serializer/GraphSerializerService.java
@@ -1,0 +1,217 @@
+package org.opentripplanner.serializer;
+
+import org.opentripplanner.routing.graph.Edge;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.routing.graph.Vertex;
+import org.opentripplanner.routing.impl.DefaultStreetVertexIndexFactory;
+import org.opentripplanner.routing.services.StreetVertexIndexFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.opentripplanner.serializer.GraphSerializerService.SerializationMethod.JAVA;
+
+/**
+ * Service for serializing and deserializing Graph objects.
+ * Load and save methods are extracted from the {@link Graph}.
+ * This implementation allows to switch implementation of GraphSerializer.
+ * Having multiple implementations makes it easier to compare speed and size of different implementations.
+ */
+public class GraphSerializerService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(GraphSerializerService.class);
+    public static final String SERIALIZATION_METHOD_PROP = "serialization-method";
+
+
+    public enum SerializationMethod {KRYO, JAVA, PROTOSTUFF}
+
+    public static final SerializationMethod DEFAULT_SERIALIZATION_METHOD = SerializationMethod.JAVA;
+
+    /**
+     * Instantiated here. Seems like there is only one implementation.
+     * This class could get the index factory implementation as constructor parameter, if one wanted to override.
+     */
+    private final StreetVertexIndexFactory streetVertexIndexFactory = new DefaultStreetVertexIndexFactory();
+
+    private final GraphSerializer graphSerializer;
+
+
+    public GraphSerializerService() {
+        SerializationMethod serializationMethod;
+        String serializationMethodString = System.getProperty(SERIALIZATION_METHOD_PROP);
+        if (serializationMethodString == null) {
+            LOG.info("Choosing the the default serialization method: " + DEFAULT_SERIALIZATION_METHOD);
+            serializationMethod = DEFAULT_SERIALIZATION_METHOD;
+        } else {
+            serializationMethod = SerializationMethod.valueOf(serializationMethodString);
+        }
+        this.graphSerializer = getGraphSerializer(serializationMethod);
+    }
+
+    public GraphSerializerService(SerializationMethod serializationMethod) {
+        this.graphSerializer = getGraphSerializer(serializationMethod);
+    }
+
+    public GraphSerializerService(GraphSerializer graphSerializer) {
+        this.graphSerializer = graphSerializer;
+    }
+
+    public Graph load(File file) {
+        GraphWrapper graphWrapper = deserialize(file);
+        return prepareGraphAfterDeserialization(graphWrapper);
+    }
+
+    public Graph load(InputStream inputStream) {
+        GraphWrapper graphWrapper = deserialize(inputStream);
+        return prepareGraphAfterDeserialization(graphWrapper);
+    }
+
+    public void save(Graph graph, OutputStream outputStream) {
+        serialize(graph, outputStream);
+    }
+
+    public void save(Graph graph, File file) {
+        serialize(graph, file);
+    }
+
+    private void serialize(Graph graph, File file) {
+        try {
+            LOG.info("Writing graph to file {} using {}", file.getName(), graphSerializer.getClass().getName());
+            serialize(graph, new FileOutputStream(file));
+        } catch (FileNotFoundException e) {
+            throw new GraphSerializationException("Cannot read file " + file.getName(), e);
+        }
+    }
+
+    private void serialize(Graph graph, OutputStream outputStream) {
+        GraphWrapper graphWrapper = prepareAndWrap(graph);
+        LOG.info("Serializing graph. Main graph size: |V|={} |E|={}", graphWrapper.graph.countVertices(), graphWrapper.graph.countEdges());
+        long started = System.currentTimeMillis();
+        graphSerializer.serialize(graphWrapper, outputStream);
+        long spent = System.currentTimeMillis() - started;
+        LOG.info("Graph serialized in {} ms", spent);
+    }
+
+    /***
+     * Beacuse of legacy reasons the graph object and edges were serialized separately these will be wrapped.
+     *
+     * Methods for rebuilding vertex/edge/ID numbers and consolidating edges has been moved to this class,
+     * so that all implementations of {@link GraphSerializer} can benefit from it.
+     *
+     * @param graph the graph to wrap before serialization
+     * @return the wrapped graph with edges separated
+     */
+    private GraphWrapper prepareAndWrap(Graph graph) {
+
+        LOG.debug("Preparing graph for serialization");
+
+        GraphWrapper graphWrapper = new GraphWrapper();
+
+        LOG.debug("Assigning vertex/edge ID numbers...");
+        graph.rebuildVertexAndEdgeIndices();
+
+        graphWrapper.graph = graph;
+        graphWrapper.edges = consolidateEdges(graph);
+
+        return graphWrapper;
+    }
+
+    private List<Edge> consolidateEdges(Graph graph) {
+        LOG.debug("Consolidating edges...");
+        // this is not space efficient
+        List<Edge> edges = new ArrayList<Edge>(graph.countEdges());
+        for (Vertex v : graph.getVertices()) {
+            // there are assumed to be no edges in an incoming list that are not
+            // in an outgoing list
+            edges.addAll(v.getOutgoing());
+            if (v.getDegreeOut() + v.getDegreeIn() == 0)
+                LOG.debug("vertex {} has no edges, it will not survive serialization.", v);
+        }
+        return edges;
+    }
+
+    /**
+     * Prepare the graph after deserialization.
+     * This method should be called regardless of implementaiton of {@link GraphSerializer}.
+     *
+     * The method reads from the already deserialized wrapper object,
+     * it checks the version of the deserialized graph and rebuilds vertices from edges.
+     * At last, this method calls the index method.
+     *
+     * @param graphWrapper the deserializaed wrapper object
+     * @return the prepared graph object, indexed and ready for use.
+     */
+    private Graph prepareGraphAfterDeserialization(GraphWrapper graphWrapper) {
+
+        // Because some fields are marked as transient
+        Graph deserializedGraph = graphWrapper.graph;
+        List<Edge> edges = graphWrapper.edges;
+
+        LOG.debug("Basic graph info read.");
+        if (deserializedGraph.graphVersionMismatch())
+            throw new RuntimeException("Graph version mismatch detected.");
+
+        // vertex edge lists are transient to avoid excessive recursion depth
+        // vertex list is transient because it can be reconstructed from edges
+        deserializedGraph.vertices = new HashMap<>();
+
+        for (Edge e : edges) {
+            deserializedGraph.vertices.put(e.getFromVertex().getLabel(), e.getFromVertex());
+            deserializedGraph.vertices.put(e.getToVertex().getLabel(), e.getToVertex());
+        }
+
+        LOG.info("Main graph read. |V|={} |E|={}", deserializedGraph.countVertices(), deserializedGraph.countEdges());
+        deserializedGraph.index(streetVertexIndexFactory);
+
+        return deserializedGraph;
+
+    }
+
+    private GraphWrapper deserialize(File file) {
+        try {
+            LOG.info("Reading graph from file: " + file.getAbsolutePath() + " ...");
+            return deserialize(new FileInputStream(file));
+        } catch (FileNotFoundException e) {
+            throw new GraphSerializationException("Cannot read file " + file.getName(), e);
+        }
+    }
+
+    private GraphWrapper deserialize(InputStream is) {
+        long started = System.currentTimeMillis();
+        GraphWrapper graphWrapper = graphSerializer.deserialize(is);
+        long spent = System.currentTimeMillis() - started;
+
+        LOG.info("Deserialized graph using: {} in {} ms", graphSerializer.getClass().getSimpleName(), spent);
+
+        return graphWrapper;
+    }
+
+    public GraphSerializer getGraphSerializer() {
+        return graphSerializer;
+    }
+
+    /**
+     * Instantiating the correct graph serializer based on serialization method.
+     *
+     * @param serializationMethod if null or empty,
+     * @return
+     */
+    private static GraphSerializer getGraphSerializer(SerializationMethod serializationMethod) {
+
+        GraphSerializer graphSerializer;
+
+        if (JAVA.equals(serializationMethod)) {
+            graphSerializer = new JavaGraphSerializer();
+        } else {
+            throw new GraphSerializationException("Cannot find implementation for serializer with name: " + serializationMethod);
+        }
+
+        LOG.info("Using the following serializer implementaiton for graph loading/saving: {}", graphSerializer.getClass().getSimpleName());
+        return graphSerializer;
+    }
+
+}

--- a/src/main/java/org/opentripplanner/serializer/GraphWrapper.java
+++ b/src/main/java/org/opentripplanner/serializer/GraphWrapper.java
@@ -1,0 +1,16 @@
+package org.opentripplanner.serializer;
+
+import org.opentripplanner.graph_builder.annotation.GraphBuilderAnnotation;
+import org.opentripplanner.routing.graph.Edge;
+import org.opentripplanner.routing.graph.Graph;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Implemented because of edges transient in graph object and is serialized/deserialized separately.
+ */
+public class GraphWrapper {
+    public List<Edge> edges;
+    public Graph graph;
+}

--- a/src/main/java/org/opentripplanner/serializer/JavaGraphSerializer.java
+++ b/src/main/java/org/opentripplanner/serializer/JavaGraphSerializer.java
@@ -1,0 +1,57 @@
+package org.opentripplanner.serializer;
+
+import org.opentripplanner.routing.graph.Edge;
+import org.opentripplanner.routing.graph.Graph;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.util.ArrayList;
+
+public class JavaGraphSerializer implements GraphSerializer {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JavaGraphSerializer.class);
+
+    @Override
+    public GraphWrapper deserialize(InputStream inputStream) {
+        try {
+            ObjectInputStream objectInputStream = new ObjectInputStream(inputStream);
+
+            GraphWrapper graphWrapper = new GraphWrapper();
+
+            LOG.debug("Loading graph...");
+            graphWrapper.graph = (Graph) objectInputStream.readObject();
+
+            LOG.debug("Loading edges...");
+            graphWrapper.edges = (ArrayList<Edge>) objectInputStream.readObject();
+
+            return graphWrapper;
+
+        } catch (IOException e) {
+            throw new GraphSerializationException("Cannot deserialize incoming date", e);
+        } catch (ClassNotFoundException ex) {
+            LOG.error("Stored graph is incompatible with this version of OTP, please rebuild it.");
+            throw new GraphSerializationException("Stored Graph version error", ex);
+        }
+    }
+
+    @Override
+    public void serialize(GraphWrapper graphWrapper, OutputStream outputStream) throws GraphSerializationException {
+
+        try {
+            ObjectOutputStream objectOutputStream = new ObjectOutputStream(outputStream);
+
+            LOG.debug("Writing graph...");
+            objectOutputStream.writeObject(graphWrapper.graph);
+
+            LOG.debug("Writing edges...");
+            objectOutputStream.writeObject(graphWrapper.edges);
+
+            outputStream.close();
+            LOG.info("Graph written.");
+        } catch (IOException e) {
+            throw new GraphSerializationException("Could not write graph", e);
+        }
+
+    }
+}

--- a/src/test/java/org/opentripplanner/routing/impl/GraphServiceTest.java
+++ b/src/test/java/org/opentripplanner/routing/impl/GraphServiceTest.java
@@ -14,11 +14,14 @@ import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.services.GraphService;
 import org.opentripplanner.routing.vertextype.IntersectionVertex;
 import org.opentripplanner.routing.vertextype.StreetVertex;
+import org.opentripplanner.serializer.GraphSerializerService;
 
 import java.io.*;
 
 
 public class GraphServiceTest extends TestCase {
+
+    private GraphSerializerService graphSerializerService = new GraphSerializerService();
 
     File basePath;
 
@@ -40,7 +43,7 @@ public class GraphServiceTest extends TestCase {
         // Create an empty graph and it's serialized form
         emptyGraph = new Graph();
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        emptyGraph.save(new ObjectOutputStream(baos));
+        graphSerializerService.save(emptyGraph, baos);
         emptyGraphData = baos.toByteArray();
 
         // Create a small graph with 2 vertices and one edge and it's serialized form
@@ -49,7 +52,7 @@ public class GraphServiceTest extends TestCase {
         StreetVertex v2 = new IntersectionVertex(smallGraph, "v2", 0, 0.1);
         new StreetEdge(v1, v2, null, "v1v2", 11000, StreetTraversalPermission.PEDESTRIAN, false);
         baos = new ByteArrayOutputStream();
-        smallGraph.save(new ObjectOutputStream(baos));
+        graphSerializerService.save(smallGraph, baos);
         smallGraphData = baos.toByteArray();
     }
 

--- a/src/test/java/org/opentripplanner/serializer/GraphSerializerServiceTest.java
+++ b/src/test/java/org/opentripplanner/serializer/GraphSerializerServiceTest.java
@@ -1,0 +1,64 @@
+package org.opentripplanner.serializer;
+
+import org.junit.Test;
+import org.opentripplanner.routing.edgetype.StreetEdge;
+import org.opentripplanner.routing.edgetype.StreetTraversalPermission;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.routing.vertextype.IntersectionVertex;
+import org.opentripplanner.routing.vertextype.StreetVertex;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Tests for the GraphSerializerService.
+ * For testing a specific implementation of {@link GraphSerializer} thoroughly, this is not the right place.
+ */
+public class GraphSerializerServiceTest {
+
+    /**
+     * Simple verification that the java serializer implementation is returned when asking for it.
+     */
+    @Test
+    public void getJavaImplementation() {
+        GraphSerializerService graphSerializerService = new GraphSerializerService(GraphSerializerService.SerializationMethod.JAVA);
+        assertEquals(JavaGraphSerializer.class, graphSerializerService.getGraphSerializer().getClass());
+    }
+
+    /**
+     * Save and load a simple graph and do some basic checks.
+     */
+    @Test
+    public void saveAndLoadGraphUsingTheDefaultSerializer() {
+
+        GraphSerializerService graphSerializerService = new GraphSerializerService();
+
+        Graph graph = createSimpleGraph();
+
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        graphSerializerService.save(graph, byteArrayOutputStream);
+
+        byte[] bytes = byteArrayOutputStream.toByteArray();
+
+        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes);
+
+        Graph actual = graphSerializerService.load(byteArrayInputStream);
+
+        assertNotNull(actual);
+        assertEquals(graph.getEdges().size(), actual.getEdges().size());
+        assertEquals(graph.getVertices().size(), actual.getVertices().size());
+    }
+
+    private Graph createSimpleGraph() {
+        // Create a small graph with 2 vertices and one edge and it's serialized form
+        Graph smallGraph = new Graph();
+        StreetVertex v1 = new IntersectionVertex(smallGraph, "v1", 0, 0);
+        StreetVertex v2 = new IntersectionVertex(smallGraph, "v2", 0, 0.1);
+        new StreetEdge(v1, v2, null, "v1v2", 11000, StreetTraversalPermission.PEDESTRIAN, false);
+
+        return smallGraph;
+    }
+}


### PR DESCRIPTION
Separate graph serialization from the Graph class. Should make it easier to provide other serialization methods, like Kryo. (#2643)
This PR also removes LoadLevel and debuginfo.

To be completed by pull request submitter:

- [x] **issue**: Link to or create an [issue](https://github.com/opentripplanner/OpenTripPlanner/issues) that describes the relevant feature or bug. 
- [ ] **roadmap**: Check the [roadmap](https://github.com/orgs/opentripplanner/projects/1) for this feature or bug. If it is not already on the roadmap, PLC will discuss as part of the review process.
- [x] **tests**: Have you added relevant test coverage? Are all the tests passing on [the continuous integration service (Travis CI)](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#continuous-integration)?
- [ ] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#code-style)? 

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **before merging**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)