### PR TITLE
Add elevationUnitMultiplier builder parameter

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -180,6 +180,18 @@ order as the above-mentioned SRTM data, which is also the default for the popula
 DEM files(USGS DEM) is not supported by OTP, but can be converted to GeoTIFF with tools like [GDAL](http://www.gdal.org/). 
 Use `gdal_merge.py -o merged.tiff *.dem` to merge a set of `dem` files into one `tif` file.
 
+### Elevation unit conversion
+
+By default, OTP expects the elevation data to use metres. However, by setting `elevationUnitMultiplier` in `build-config.json`,
+it is possible to define a multiplier that converts the elevation values from some other unit to metres.
+
+```JSON
+// build-config.json
+{
+  // Correct conversation multiplier when source data uses decimetres instead of metres
+  "elevationUnitMultiplier": 0.1
+}
+```
 
 ## Fares configuration
 

--- a/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
@@ -278,18 +278,18 @@ public class GraphBuilder implements Runnable {
             awsTileSource.awsBucketName = bucketConfig.bucketName;
             NEDGridCoverageFactoryImpl gcf = new NEDGridCoverageFactoryImpl(cacheDirectory);
             gcf.tileSource = awsTileSource;
-            GraphBuilderModule elevationBuilder = new ElevationModule(gcf);
+            GraphBuilderModule elevationBuilder = new ElevationModule(gcf, builderParams.elevationUnitMultiplier);
             graphBuilder.addModule(elevationBuilder);
         } else if (builderParams.fetchElevationUS) {
             // Download the elevation tiles from the official web service
             File cacheDirectory = new File(params.cacheDirectory, "ned");
             ElevationGridCoverageFactory gcf = new NEDGridCoverageFactoryImpl(cacheDirectory);
-            GraphBuilderModule elevationBuilder = new ElevationModule(gcf);
+            GraphBuilderModule elevationBuilder = new ElevationModule(gcf, builderParams.elevationUnitMultiplier);
             graphBuilder.addModule(elevationBuilder);
         } else if (demFile != null) {
             // Load the elevation from a file in the graph inputs directory
             ElevationGridCoverageFactory gcf = new GeotiffGridCoverageFactoryImpl(demFile);
-            GraphBuilderModule elevationBuilder = new ElevationModule(gcf);
+            GraphBuilderModule elevationBuilder = new ElevationModule(gcf, builderParams.elevationUnitMultiplier);
             graphBuilder.addModule(elevationBuilder);
         }
         if ( hasGTFS ) {

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -58,10 +58,19 @@ public class ElevationModule implements GraphBuilderModule {
      */
     private double distanceBetweenSamplesM = 10;
 
+
+    /**
+     * Unit conversion multiplier for elevation values. No conversion needed if the elevation values
+     * are defined in meters in the source data. If, for example, decimetres are used in the source data,
+     * this should be set to 0.1 in build-config.json.
+     */
+    private double elevationUnitMultiplier = 1;
+
     public ElevationModule() { /* This makes me a "bean" */ };
     
-    public ElevationModule(ElevationGridCoverageFactory factory) {
+    public ElevationModule(ElevationGridCoverageFactory factory, double elevationUnitMultiplier) {
         this.setGridCoverageFactory(factory);
+        this.elevationUnitMultiplier = elevationUnitMultiplier;
     }
 
     public List<String> provides() {
@@ -441,7 +450,7 @@ public class ElevationModule implements GraphBuilderModule {
             nPointsOutsideDEM += 1;
         }
         nPointsEvaluated += 1;
-        return values[0];
+        return values[0] * elevationUnitMultiplier;
     }
 
     @Override

--- a/src/main/java/org/opentripplanner/standalone/GraphBuilderParameters.java
+++ b/src/main/java/org/opentripplanner/standalone/GraphBuilderParameters.java
@@ -109,6 +109,13 @@ public class GraphBuilderParameters {
     public final S3BucketConfig elevationBucket;
 
     /**
+     * Unit conversion multiplier for elevation values. No conversion needed if the elevation values
+     * are defined in meters in the source data. If, for example, decimetres are used in the source data,
+     * this should be set to 0.1.
+    */
+    public final double elevationUnitMultiplier;
+
+    /**
      * A specific fares service to use.
      */
     public final FareServiceFactory fareServiceFactory;
@@ -198,6 +205,7 @@ public class GraphBuilderParameters {
         matchBusRoutesToStreets = config.path("matchBusRoutesToStreets").asBoolean(false);
         fetchElevationUS = config.path("fetchElevationUS").asBoolean(false);
         elevationBucket = S3BucketConfig.fromConfig(config.path("elevationBucket"));
+        elevationUnitMultiplier = config.path("elevationUnitMultiplier").asDouble(1);
         fareServiceFactory = DefaultFareServiceFactory.fromConfig(config.path("fares"));
         customNamer = CustomNamer.CustomNamerFactory.fromConfig(config.path("osmNaming"));
         wayPropertySet = WayPropertySetSource.fromConfig(config.path("osmWayPropertySet").asText("default"));


### PR DESCRIPTION
Allows using other units than meters in source elevation data by adding elevationUnitMultiplier build parameter. This is related to issue #2651 

- [x] **issue**: Link to or create an [issue](https://github.com/opentripplanner/OpenTripPlanner/issues) that describes the relevant feature or bug. Add [GitHub keywords](https://help.github.com/articles/closing-issues-using-keywords/) to this PR's description (e.g., `closes #45`).
- [ ] **roadmap**: Check the [roadmap](https://github.com/orgs/opentripplanner/projects/1) for this feature or bug. If it is not already on the roadmap, PLC will discuss as part of the review process.
- [ ] **tests**: Have you added relevant test coverage? Are all the tests passing on [the continuous integration service (Travis CI)](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#continuous-integration)?
- [x] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#code-style)? 

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **before merging**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)