### PR TITLE
Fix memory leak in routing context destroy.

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/linking/SimpleStreetSplitter.java
+++ b/src/main/java/org/opentripplanner/graph_builder/linking/SimpleStreetSplitter.java
@@ -393,7 +393,7 @@ public class SimpleStreetSplitter {
         // every edge can be split exactly once, so this is a valid label
         SplitterVertex v;
         if (temporarySplit) {
-            v = new TemporarySplitterVertex(graph, "split from " + edge.getId(), splitPoint.x, splitPoint.y,
+            v = new TemporarySplitterVertex("split from " + edge.getId(), splitPoint.x, splitPoint.y,
                 edge, endVertex);
             if (edge.isWheelchairAccessible()) {
                 ((TemporarySplitterVertex) v).setWheelchairAccessible(true);

--- a/src/main/java/org/opentripplanner/routing/core/RoutingContext.java
+++ b/src/main/java/org/opentripplanner/routing/core/RoutingContext.java
@@ -141,7 +141,7 @@ public class RoutingContext implements Cloneable {
         for (Edge e : Iterables.concat(u.getIncoming(), u.getOutgoing())) {
             uIds.add(e.getId());
         }
-        
+
         // Intesection of edge IDs between u and v.
         uIds.retainAll(vIds);
         Set<Integer> overlappingIds = uIds;
@@ -229,7 +229,6 @@ public class RoutingContext implements Cloneable {
         else
             this.streetSpeedSnapshot = null;
 
-
         Edge fromBackEdge = null;
         Edge toBackEdge = null;
         if (findPlaces) {
@@ -290,7 +289,7 @@ public class RoutingContext implements Cloneable {
                 makePartialEdgeAlong(pse, fromStreetVertex, toStreetVertex);
             }
         }
-        
+
         if (opt.startingTransitStopId != null) {
             Stop stop = graph.index.stopForId.get(opt.startingTransitStopId);
             TransitStop tstop = graph.index.stopVertexForStop.get(stop);
@@ -404,27 +403,7 @@ public class RoutingContext implements Cloneable {
      * for garbage collection.
      */
     public void destroy() {
-        disposeTemporaryStart(fromVertex, null);
-        disposeTemporaryEnd(toVertex, null);
-    }
-
-    private static void disposeTemporaryStart(Vertex v, Edge incoming) {
-        if (v instanceof TemporaryVertex) {
-            for (Edge edge : v.getOutgoing()) {
-                disposeTemporaryStart(edge.getToVertex(), edge);
-            }
-        } else if (incoming != null) {
-            v.removeIncoming(incoming);
-        }
-    }
-
-    private static void disposeTemporaryEnd(Vertex v, Edge outgoing) {
-        if (v instanceof TemporaryVertex) {
-            for (Edge edge : v.getIncoming()) {
-                disposeTemporaryEnd(edge.getFromVertex(), edge);
-            }
-        } else if (outgoing != null) {
-            v.removeOutgoing(outgoing);
-        }
+        TemporaryVertex.dispose(fromVertex);
+        TemporaryVertex.dispose(toVertex);
     }
 }

--- a/src/main/java/org/opentripplanner/routing/core/RoutingContext.java
+++ b/src/main/java/org/opentripplanner/routing/core/RoutingContext.java
@@ -399,10 +399,32 @@ public class RoutingContext implements Cloneable {
     }
 
     /**
-     * Tear down this routing context, removing any temporary edges.
+     * Tear down this routing context, removing any temporary edges from
+     * the "permanent" graph objects. This enables all temporary objects
+     * for garbage collection.
      */
     public void destroy() {
-        if (origin instanceof TemporaryVertex) ((TemporaryVertex) origin).dispose();
-        if (target instanceof TemporaryVertex) ((TemporaryVertex) target).dispose();
+        disposeTemporaryStart(fromVertex, null);
+        disposeTemporaryEnd(toVertex, null);
+    }
+
+    private static void disposeTemporaryStart(Vertex v, Edge incoming) {
+        if (v instanceof TemporaryVertex) {
+            for (Edge edge : v.getOutgoing()) {
+                disposeTemporaryStart(edge.getToVertex(), edge);
+            }
+        } else if (incoming != null) {
+            v.removeIncoming(incoming);
+        }
+    }
+
+    private static void disposeTemporaryEnd(Vertex v, Edge outgoing) {
+        if (v instanceof TemporaryVertex) {
+            for (Edge edge : v.getIncoming()) {
+                disposeTemporaryEnd(edge.getFromVertex(), edge);
+            }
+        } else if (outgoing != null) {
+            v.removeOutgoing(outgoing);
+        }
     }
 }

--- a/src/main/java/org/opentripplanner/routing/edgetype/OnBoardDepartPatternHop.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/OnBoardDepartPatternHop.java
@@ -153,9 +153,4 @@ public class OnBoardDepartPatternHop extends Edge implements OnboardEdge, Tempor
     public String getDirection() {
         return tripTimes.getHeadsign(stopIndex);
     }
-
-    @Override
-    public void dispose() {
-        tov.removeIncoming(this);
-    }
 }

--- a/src/main/java/org/opentripplanner/routing/edgetype/SampleEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/SampleEdge.java
@@ -28,12 +28,6 @@ public class SampleEdge extends Edge implements TemporaryEdge {
     }
 
     @Override
-    public void dispose() {
-        tov.removeIncoming(this);
-        fromv.removeOutgoing(this);
-    }
-
-    @Override
     /** We want to use exactly the same logic here as is used in propagating to samples */
     public State traverse(State s0) {
         StateEditor s1 = s0.edit(this);

--- a/src/main/java/org/opentripplanner/routing/edgetype/TemporaryEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/TemporaryEdge.java
@@ -1,6 +1,4 @@
 package org.opentripplanner.routing.edgetype;
 
 /** Marker interface for temporary edges */
-public interface TemporaryEdge {
-    public void dispose();
-}
+public interface TemporaryEdge { }

--- a/src/main/java/org/opentripplanner/routing/edgetype/TemporaryFreeEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/TemporaryFreeEdge.java
@@ -4,34 +4,20 @@ import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.routing.vertextype.TemporaryVertex;
 
 public class TemporaryFreeEdge extends FreeEdge implements TemporaryEdge {
-    final private boolean endEdge;
 
     public TemporaryFreeEdge(TemporaryVertex from, Vertex to) {
         super((Vertex) from, to);
 
         if (from.isEndVertex()) {
             throw new IllegalStateException("A temporary edge is directed away from an end vertex");
-        } else {
-            endEdge = false;
         }
     }
 
     public TemporaryFreeEdge(Vertex from, TemporaryVertex to) {
         super(from, (Vertex) to);
 
-        if (to.isEndVertex()) {
-            endEdge = true;
-        } else {
+        if (!to.isEndVertex()) {
             throw new IllegalStateException("A temporary edge is directed towards a start vertex");
-        }
-    }
-
-    @Override
-    public void dispose() {
-        if (endEdge) {
-            fromv.removeOutgoing(this);
-        } else {
-            tov.removeIncoming(this);
         }
     }
 

--- a/src/main/java/org/opentripplanner/routing/edgetype/TemporaryPartialStreetEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/TemporaryPartialStreetEdge.java
@@ -4,21 +4,16 @@ import com.vividsolutions.jts.geom.LineString;
 import org.opentripplanner.routing.location.TemporaryStreetLocation;
 import org.opentripplanner.routing.vertextype.StreetVertex;
 import org.opentripplanner.routing.vertextype.TemporarySplitterVertex;
-import org.opentripplanner.routing.vertextype.TemporaryVertex;
 import org.opentripplanner.util.I18NString;
 
 final public class TemporaryPartialStreetEdge extends PartialStreetEdge implements TemporaryEdge {
-    final private Boolean endEdge;  // A null value means that the vertices are temporary themselves
-
     public TemporaryPartialStreetEdge(StreetEdge parentEdge, TemporaryStreetLocation v1,
             TemporaryStreetLocation v2, LineString geometry, I18NString name, double length) {
         super(parentEdge, v1, v2, geometry, name, length);
 
         if (v1.isEndVertex()) {
             throw new IllegalStateException("A temporary edge is directed away from an end vertex");
-        } else if (v2.isEndVertex()) {
-            endEdge = null;
-        } else {
+        } else if (!v2.isEndVertex()) {
             throw new IllegalStateException("A temporary edge is directed towards a start vertex");
         }
     }
@@ -29,8 +24,6 @@ final public class TemporaryPartialStreetEdge extends PartialStreetEdge implemen
 
         if (v1.isEndVertex()) {
             throw new IllegalStateException("A temporary edge is directed away from an end vertex");
-        } else {
-            endEdge = false;
         }
     }
 
@@ -40,8 +33,6 @@ final public class TemporaryPartialStreetEdge extends PartialStreetEdge implemen
 
         if (v1.isEndVertex()) {
             throw new IllegalStateException("A temporary edge is directed away from an end vertex");
-        } else {
-            endEdge = false;
         }
     }
 
@@ -49,9 +40,7 @@ final public class TemporaryPartialStreetEdge extends PartialStreetEdge implemen
             TemporaryStreetLocation v2, LineString geometry, I18NString name, double length) {
         super(parentEdge, v1, v2, geometry, name, length);
 
-        if (v2.isEndVertex()) {
-            endEdge = true;
-        } else {
+        if (!v2.isEndVertex()) {
             throw new IllegalStateException("A temporary edge is directed towards a start vertex");
         }
     }
@@ -60,21 +49,8 @@ final public class TemporaryPartialStreetEdge extends PartialStreetEdge implemen
         TemporarySplitterVertex v2, LineString geometry, I18NString name, double length) {
         super(parentEdge, v1, v2, geometry, name, length);
 
-        if (v2.isEndVertex()) {
-            endEdge = true;
-        } else {
+        if (!v2.isEndVertex()) {
             throw new IllegalStateException("A temporary edge is directed towards a start vertex");
-        }
-    }
-
-    @Override
-    public void dispose() {
-        if (endEdge != null) {
-            if (endEdge) {
-                fromv.removeOutgoing(this);
-            } else {
-                tov.removeIncoming(this);
-            }
         }
     }
 

--- a/src/main/java/org/opentripplanner/routing/impl/StreetVertexIndexServiceImpl.java
+++ b/src/main/java/org/opentripplanner/routing/impl/StreetVertexIndexServiceImpl.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.routing.impl;
 
 
-import com.google.common.collect.Iterables;
 import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.Envelope;
 import com.vividsolutions.jts.geom.LineString;
@@ -16,8 +15,6 @@ import org.opentripplanner.common.model.GenericLocation;
 import org.opentripplanner.common.model.P2;
 import org.opentripplanner.graph_builder.linking.SimpleStreetSplitter;
 import org.opentripplanner.routing.core.RoutingRequest;
-import org.opentripplanner.routing.core.TraversalRequirements;
-import org.opentripplanner.routing.core.TraverseModeSet;
 import org.opentripplanner.routing.edgetype.*;
 import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Graph;
@@ -29,8 +26,6 @@ import org.opentripplanner.routing.vertextype.SampleVertex;
 import org.opentripplanner.routing.vertextype.StreetVertex;
 import org.opentripplanner.routing.vertextype.TransitStop;
 import org.opentripplanner.util.I18NString;
-import org.opentripplanner.util.NonLocalizedString;
-import org.opentripplanner.util.ResourceBundleSingleton;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -121,12 +116,13 @@ public class StreetVertexIndexServiceImpl implements StreetVertexIndexService {
             I18NString name, Iterable<StreetEdge> edges, Coordinate nearestPoint, boolean endVertex) {
         boolean wheelchairAccessible = false;
 
-        TemporaryStreetLocation location = new TemporaryStreetLocation(label, nearestPoint, name,
-                endVertex);
+        TemporaryStreetLocation location = new TemporaryStreetLocation(label, nearestPoint, name, endVertex);
+
         for (StreetEdge street : edges) {
             Vertex fromv = street.getFromVertex();
             Vertex tov = street.getToVertex();
-            wheelchairAccessible |= ((StreetEdge) street).isWheelchairAccessible();
+            wheelchairAccessible |= street.isWheelchairAccessible();
+
             /* forward edges and vertices */
             Vertex edgeLocation;
             if (SphericalDistanceLibrary.distance(nearestPoint, fromv.getCoordinate()) < 1) {

--- a/src/main/java/org/opentripplanner/routing/location/TemporaryStreetLocation.java
+++ b/src/main/java/org/opentripplanner/routing/location/TemporaryStreetLocation.java
@@ -45,11 +45,4 @@ final public class TemporaryStreetLocation extends StreetLocation implements Tem
     public boolean isEndVertex() {
         return endVertex;
     }
-
-    @Override
-    public void dispose() {
-        for (Object temp : endVertex ? getIncoming() : getOutgoing()) {
-            ((TemporaryEdge) temp).dispose();
-        }
-    }
 }

--- a/src/main/java/org/opentripplanner/routing/vertextype/OnboardDepartVertex.java
+++ b/src/main/java/org/opentripplanner/routing/vertextype/OnboardDepartVertex.java
@@ -35,11 +35,4 @@ public class OnboardDepartVertex extends Vertex implements TemporaryVertex {
     public boolean isEndVertex() {
         return false;
     }
-
-    @Override
-    public void dispose() {
-        for (Object temp : getOutgoing()) {
-            ((TemporaryEdge) temp).dispose();
-        }
-    }
 }

--- a/src/main/java/org/opentripplanner/routing/vertextype/SampleVertex.java
+++ b/src/main/java/org/opentripplanner/routing/vertextype/SampleVertex.java
@@ -40,13 +40,6 @@ public class SampleVertex extends StreetVertex implements TemporaryVertex  {
     }
 
     @Override
-    public void dispose() {
-        for (Object temp : getOutgoing()) {
-            ((TemporaryEdge) temp).dispose();
-        }
-    }
-
-    @Override
     public String getLabel () {
         return "sample-" + getIndex();
     }

--- a/src/main/java/org/opentripplanner/routing/vertextype/TemporarySplitterVertex.java
+++ b/src/main/java/org/opentripplanner/routing/vertextype/TemporarySplitterVertex.java
@@ -16,8 +16,7 @@ public class TemporarySplitterVertex extends SplitterVertex implements Temporary
 
     final private boolean endVertex;
 
-    public TemporarySplitterVertex(Graph g, String label, double x, double y, StreetEdge streetEdge,
-        boolean endVertex) {
+    public TemporarySplitterVertex(String label, double x, double y, StreetEdge streetEdge, boolean endVertex) {
         super(null, label, x, y, streetEdge);
         this.endVertex = endVertex;
     }
@@ -26,12 +25,7 @@ public class TemporarySplitterVertex extends SplitterVertex implements Temporary
     public void addIncoming(Edge edge) {
 
         if (edge instanceof TemporaryEdge) {
-            if (endVertex) {
-                super.addIncoming(edge);
-            } else {
-                super.addIncoming(edge);
-                //throw new UnsupportedOperationException("Can't add incoming edge to start vertex");
-            }
+            super.addIncoming(edge);
         } else {
             throw new UnsupportedOperationException("Can't add permanent edge to temporary vertex");
         }
@@ -39,14 +33,8 @@ public class TemporarySplitterVertex extends SplitterVertex implements Temporary
 
     @Override
     public void addOutgoing(Edge edge) {
-
         if (edge instanceof TemporaryEdge) {
-            if (endVertex) {
-                super.addOutgoing(edge);
-                //throw new UnsupportedOperationException("Can't add outgoing edge to end vertex");
-            } else {
-                super.addOutgoing(edge);
-            }
+            super.addOutgoing(edge);
         } else {
             throw new UnsupportedOperationException("Can't add permanent edge to temporary vertex");
         }
@@ -55,13 +43,6 @@ public class TemporarySplitterVertex extends SplitterVertex implements Temporary
     @Override
     public boolean isEndVertex() {
         return endVertex;
-    }
-
-    @Override
-    public void dispose() {
-        for (Object temp : endVertex ? getIncoming() : getOutgoing()) {
-            ((TemporaryEdge) temp).dispose();
-        }
     }
 
     public boolean isWheelchairAccessible() {

--- a/src/main/java/org/opentripplanner/routing/vertextype/TemporaryVertex.java
+++ b/src/main/java/org/opentripplanner/routing/vertextype/TemporaryVertex.java
@@ -1,8 +1,26 @@
 package org.opentripplanner.routing.vertextype;
 
+import org.opentripplanner.routing.graph.Vertex;
+
 /**
- * Marker interface for temporary vertices
+ * Marker interface for temporary vertices.
+ * <p/>
+ * Remember to use the {@link #dispose(Vertex)} to delete the temporary vertex
+ * from the main graph after use.
  */
 public interface TemporaryVertex {
     boolean isEndVertex();
+
+    /**
+     * This method traverse the subgraph of temporary vertices, and cuts that subgraph off from the
+     * main graph at each point it encounters a non-temporary vertexes. OTP then holds no
+     * references to the temporary subgraph and it is garbage collected.
+     * <p/>
+     * Note! If the {@code vertex} is NOT a TemporaryVertex the method returns. No action taken.
+     *
+     * @param vertex Vertex part of the temporary part of the graph.
+     */
+    static void dispose(Vertex vertex) {
+        TemporaryVertexDispose.dispose(vertex);
+    }
 }

--- a/src/main/java/org/opentripplanner/routing/vertextype/TemporaryVertex.java
+++ b/src/main/java/org/opentripplanner/routing/vertextype/TemporaryVertex.java
@@ -1,8 +1,8 @@
 package org.opentripplanner.routing.vertextype;
 
-/** Marker interface for temporary vertices */
+/**
+ * Marker interface for temporary vertices
+ */
 public interface TemporaryVertex {
-    public boolean isEndVertex();
-
-    public void dispose();
+    boolean isEndVertex();
 }

--- a/src/main/java/org/opentripplanner/routing/vertextype/TemporaryVertexDispose.java
+++ b/src/main/java/org/opentripplanner/routing/vertextype/TemporaryVertexDispose.java
@@ -1,0 +1,117 @@
+package org.opentripplanner.routing.vertextype;
+
+import org.opentripplanner.routing.graph.Edge;
+import org.opentripplanner.routing.graph.Vertex;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * This is a utility class used to remove a temporary subgraph from the manin graph.
+ * It traverse the subgraph of temporary vertices, and cuts that subgraph off from the
+ * main graph at each point it encounters a non-temporary vertexes.
+ * <p/>
+ * OTP then holds no references to the temporary subgraph and it is garbage collected.
+ * <p/>
+ * The static {@link #dispose(Vertex)} utility method is the only way to access the logic,
+ * hence preventing this class from reuse. This make the class thread safe, and simplify
+ * the implementation.
+ */
+class TemporaryVertexDispose {
+    /**
+     * A list of all Vertexes not jet processed.
+     */
+    private List<Vertex> todo = new ArrayList<>();
+
+    /**
+     * Processed vertexes. To prevent looping and processing the same vertex twice we
+     * keep all processed vertexes in the 'done' set.
+     */
+    private Set<Vertex> done = new HashSet<>();
+
+    /** Intentionally private constructor to prevent instantiation outside of the class. */
+    private TemporaryVertexDispose(Vertex tempVertex) {
+        todo.add(tempVertex);
+    }
+
+    /**
+     * Create an instance and dispose temporary subgraph.
+     * @param tempVertex any temporary vertex part of the temporary subgrap.
+     */
+    static void dispose(Vertex tempVertex) {
+        if(tempVertex instanceof TemporaryVertex) {
+            new TemporaryVertexDispose(tempVertex).dispose();
+        }
+    }
+
+
+    /* private methods */
+
+    private void dispose() {
+        // Add all connected vertexes to the TODO_list and disconnect all
+        // main graph vertexes. We use a loop and not recursion to avoid
+        // stack overflow in the case of deep temporary graphs.
+        while (!todo.isEmpty()) {
+            Vertex current = next();
+            if(isNotAlreadyProcessed(current)) {
+                for (Edge edge : current.getOutgoing()) {
+                    disposeVertex(edge.getToVertex(), edge, true);
+                }
+                for (Edge edge : current.getIncoming()) {
+                    disposeVertex(edge.getFromVertex(), edge, false);
+                }
+                done.add(current);
+            }
+        }
+    }
+
+    /**
+     * Add the temporary vertex to processing queue OR disconnect edge from vertex if
+     * vertex is part of the main graph.
+     *
+     * @param v the vertex to dispose
+     * @param connectedEdge the connected temporary edge
+     * @param incoming true if the edge is an incoming edge, false if it is an outgoing edge
+     */
+    private void disposeVertex(Vertex v, Edge connectedEdge, boolean incoming) {
+        if(v instanceof TemporaryVertex) {
+            addVertexToProcessTodoList(v);
+        }
+        else {
+            removeEdgeFromMainGraphVertex(v, connectedEdge, incoming);
+        }
+    }
+
+    /**
+     * We have reached a NONE temporary Vertex and need to remove the temporary `connectedEdge`
+     * from the Vertex part of the main graph.
+     *
+     * @param v the vertex part of the main graph
+     * @param connectedEdge the connected temporary edge to be removed
+     * @param incoming true if the edge is an incoming edge, false if it is an outgoing edge
+     */
+    private void removeEdgeFromMainGraphVertex(Vertex v, Edge connectedEdge, boolean incoming) {
+        if(incoming) {
+            v.removeIncoming(connectedEdge);
+        }
+        else {
+            v.removeOutgoing(connectedEdge);
+        }
+    }
+
+    private void addVertexToProcessTodoList(Vertex v) {
+        if(isNotAlreadyProcessed(v)) {
+            todo.add(v);
+        }
+    }
+
+    private boolean isNotAlreadyProcessed(Vertex v) {
+        return !done.contains(v);
+    }
+
+    private Vertex next() {
+        return todo.remove(todo.size()-1);
+    }
+}

--- a/src/main/java/org/opentripplanner/util/DateUtils.java
+++ b/src/main/java/org/opentripplanner/util/DateUtils.java
@@ -125,8 +125,8 @@ public class DateUtils implements DateConstants {
             }
 
             retVal = new int[] {hour, min, sec};
-        } catch (Exception e) {
-            LOG.info(time + " didn't parse", e);
+        } catch (Exception ignore) {
+            LOG.info("Time '{}' didn't parse", time);
             retVal = null;
         }
 

--- a/src/test/java/org/opentripplanner/routing/TestHalfEdges.java
+++ b/src/test/java/org/opentripplanner/routing/TestHalfEdges.java
@@ -383,7 +383,6 @@ public class TestHalfEdges {
 
         req.setWheelchairAccessible(true);
 
-        start.dispose();
         start = StreetVertexIndexServiceImpl.createTemporaryStreetLocation(graph, "start", new NonLocalizedString("start"),
                 filter(turns, StreetEdge.class),
                 new LinearLocation(0, 0.4).getCoordinate(left.getGeometry()), false);
@@ -400,7 +399,6 @@ public class TestHalfEdges {
         assertEquals(wheelchairAlerts, graph.streetNotesService.getNotes(traversedOne));
         assertNotSame(left, traversedOne.getBackEdge().getFromVertex());
         assertNotSame(leftBack, traversedOne.getBackEdge().getFromVertex());
-        start.dispose();
     }
 
     @Test
@@ -414,7 +412,6 @@ public class TestHalfEdges {
         TemporaryStreetLocation some = (TemporaryStreetLocation) finder.getVertexForLocation(
                 new GenericLocation(40.00, -74.00), null, true);
         assertNotNull(some);
-        some.dispose();
 
         // test that the closest vertex finder correctly splits streets
         TemporaryStreetLocation start = (TemporaryStreetLocation) finder.getVertexForLocation(
@@ -424,7 +421,6 @@ public class TestHalfEdges {
                 start.isWheelchairAccessible());
 
         Collection<Edge> edges = start.getOutgoing();
-        start.dispose();
         assertEquals(2, edges.size());
 
         RoutingRequest biking = new RoutingRequest(new TraverseModeSet(TraverseMode.BICYCLE));
@@ -433,7 +429,6 @@ public class TestHalfEdges {
         assertNotNull(end);
 
         edges = end.getIncoming();
-        end.dispose();
         assertEquals(2, edges.size());
 
 

--- a/src/test/java/org/opentripplanner/routing/core/RoutingContextDestroyTest.java
+++ b/src/test/java/org/opentripplanner/routing/core/RoutingContextDestroyTest.java
@@ -28,9 +28,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-public class RoutingContext_Destroy_Test {
+public class RoutingContextDestroyTest {
     private final GeometryFactory gf = GeometryUtils.getGeometryFactory();
-    private RoutingRequest request;
     private RoutingContext subject;
 
     // Given:
@@ -59,9 +58,9 @@ public class RoutingContext_Destroy_Test {
         g.index(new DefaultStreetVertexIndexFactory());
     }
 
-    @Test public void temporary_changes_is_removed_from_graph_on_context_destroy() {
+    @Test public void temporaryChangesRemovedOnContextDestroy() {
         // Given - A request
-        request = new RoutingRequest();
+        RoutingRequest request = new RoutingRequest();
         request.from = from;
         request.to = to;
 
@@ -69,7 +68,7 @@ public class RoutingContext_Destroy_Test {
         subject = new RoutingContext(request, g);
 
         // Then:
-        origin_and_destination_is_inserted_correct_in_the_graph();
+        originAndDestinationInsertedCorrect();
 
         // And When:
         subject.destroy();
@@ -86,7 +85,7 @@ public class RoutingContext_Destroy_Test {
         }
     }
 
-    private void origin_and_destination_is_inserted_correct_in_the_graph() {
+    private void originAndDestinationInsertedCorrect() {
         // Then - the origin and destination is
         assertEquals("Origin", subject.fromVertex.getName());
         assertEquals("Destination", subject.toVertex.getName());

--- a/src/test/java/org/opentripplanner/routing/core/RoutingContext_Destroy_Test.java
+++ b/src/test/java/org/opentripplanner/routing/core/RoutingContext_Destroy_Test.java
@@ -1,0 +1,160 @@
+package org.opentripplanner.routing.core;
+
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.GeometryFactory;
+import com.vividsolutions.jts.geom.LineString;
+import org.junit.Before;
+import org.junit.Test;
+import org.opentripplanner.common.geometry.GeometryUtils;
+import org.opentripplanner.common.geometry.SphericalDistanceLibrary;
+import org.opentripplanner.common.model.GenericLocation;
+import org.opentripplanner.routing.edgetype.StreetEdge;
+import org.opentripplanner.routing.edgetype.StreetTraversalPermission;
+import org.opentripplanner.routing.edgetype.TemporaryEdge;
+import org.opentripplanner.routing.graph.Edge;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.routing.graph.Vertex;
+import org.opentripplanner.routing.impl.DefaultStreetVertexIndexFactory;
+import org.opentripplanner.routing.vertextype.IntersectionVertex;
+import org.opentripplanner.routing.vertextype.StreetVertex;
+import org.opentripplanner.routing.vertextype.TemporaryVertex;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class RoutingContext_Destroy_Test {
+
+    private static final boolean ARRIVE_BY_TRUE = true;
+
+    private static final boolean ARRIVE_BY_FALSE = false;
+
+    private final GeometryFactory gf = GeometryUtils.getGeometryFactory();
+    private RoutingRequest request;
+    private RoutingContext subject;
+
+    // Given:
+    // - a graph with 3 intersections/vertexes
+    private final Graph g = new Graph();
+
+    private final StreetVertex a = new IntersectionVertex(g, "A", 1.0, 1.0);
+
+    private final StreetVertex b = new IntersectionVertex(g, "B", 0.0, 1.0);
+
+    private final StreetVertex c = new IntersectionVertex(g, "C", 1.0, 0.0);
+
+    private final List<Vertex> permanentVertexes = Arrays.asList(a, b, c);
+
+    // - And travel *origin* is 0,4 degrees on the road from B to A
+    private final GenericLocation from = new GenericLocation(1.0, 0.4);
+
+    // - and *destination* is slightly off 0.7 degrees on road from C to A
+    private final GenericLocation to = new GenericLocation(0.701, 1.001);
+
+    // - and some roads
+    @Before public void setup() {
+        createStreetEdge(a, b, "a -> b");
+        createStreetEdge(b, a, "b -> a");
+        createStreetEdge(a, c, "a -> c");
+        g.index(new DefaultStreetVertexIndexFactory());
+    }
+
+    @Test public void temporary_changes_is_removed_from_graph_on_context_destroy() {
+        // try arriveBy set to both true and false
+        temporary_changes_is_removed_from_graph_on_context_destroy(ARRIVE_BY_TRUE);
+        temporary_changes_is_removed_from_graph_on_context_destroy(ARRIVE_BY_FALSE);
+    }
+
+    private void temporary_changes_is_removed_from_graph_on_context_destroy(boolean arriveBy) {
+        // Given - A request
+        request = new RoutingRequest();
+        request.from = from;
+        request.to = to;
+        request.arriveBy = arriveBy;
+
+        // When - the context is created
+        subject = new RoutingContext(request, g);
+
+        // Then:
+        origin_and_destination_is_inserted_correct_in_the_graph();
+
+        // And When:
+        subject.destroy();
+
+        // Then - permanent vertexes
+        for (Vertex v : permanentVertexes) {
+            // - does not reference the any temporary nodes any more
+            for (Edge e : v.getIncoming()) {
+                assertVertexEdgeIsNotReferencingTemporaryElements(v, e, e.getFromVertex());
+            }
+            for (Edge e : v.getOutgoing()) {
+                assertVertexEdgeIsNotReferencingTemporaryElements(v, e, e.getToVertex());
+            }
+        }
+    }
+
+    private void origin_and_destination_is_inserted_correct_in_the_graph() {
+        // Then - the origin and destination is
+        assertEquals("Origin", subject.fromVertex.getName());
+        assertEquals("Destination", subject.toVertex.getName());
+
+        // And - from the origin
+        Collection<String> vertexesReachableFromOrigin = findAllReachableVertexes(
+                subject.fromVertex, true, new ArrayList<>());
+        String msg = "All reachable vertexes from origin: " + vertexesReachableFromOrigin;
+
+        // it is possible to reach the A, B, C and the Destination Vertex
+        assertTrue(msg, vertexesReachableFromOrigin.contains("A"));
+        assertTrue(msg, vertexesReachableFromOrigin.contains("B"));
+        assertTrue(msg, vertexesReachableFromOrigin.contains("C"));
+        assertTrue(msg, vertexesReachableFromOrigin.contains("Destination"));
+
+        // And - from the destination we can backtrack
+        Collection<String> vertexesReachableFromDestination = findAllReachableVertexes(
+                subject.toVertex, false, new ArrayList<>());
+        msg = "All reachable vertexes back from destination: " + vertexesReachableFromDestination;
+
+        // and reach the A, B and the Origin Vertex
+        assertTrue(msg, vertexesReachableFromDestination.contains("A"));
+        assertTrue(msg, vertexesReachableFromDestination.contains("B"));
+        assertTrue(msg, vertexesReachableFromDestination.contains("Origin"));
+
+        // But - not the C Vertex
+        assertFalse(msg, vertexesReachableFromDestination.contains("C"));
+    }
+
+    private void createStreetEdge(StreetVertex v0, StreetVertex v1, String name) {
+        LineString geom = gf
+                .createLineString(new Coordinate[] { v0.getCoordinate(), v1.getCoordinate() });
+        double dist = SphericalDistanceLibrary.distance(v0.getCoordinate(), v1.getCoordinate());
+        new StreetEdge(v0, v1, geom, name, dist, StreetTraversalPermission.ALL, false);
+    }
+
+    private static <T extends Collection<String>> T findAllReachableVertexes(Vertex vertex,
+            boolean forward, T list) {
+        if (list.contains(vertex.getName()))
+            return list;
+
+        list.add(vertex.getName());
+        if (forward) {
+            vertex.getOutgoing()
+                    .forEach(it -> findAllReachableVertexes(it.getToVertex(), forward, list));
+        } else {
+            vertex.getIncoming()
+                    .forEach(it -> findAllReachableVertexes(it.getFromVertex(), forward, list));
+        }
+        return list;
+    }
+
+    private void assertVertexEdgeIsNotReferencingTemporaryElements(Vertex source, Edge e,
+            Vertex v) {
+        String sourceName = source.getName();
+        assertFalse(sourceName + " -> " + e.getName(), e instanceof TemporaryEdge);
+        assertFalse(sourceName + " -> " + v.getName(), v instanceof TemporaryVertex);
+    }
+}

--- a/src/test/java/org/opentripplanner/routing/core/RoutingContext_Destroy_Test.java
+++ b/src/test/java/org/opentripplanner/routing/core/RoutingContext_Destroy_Test.java
@@ -29,11 +29,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class RoutingContext_Destroy_Test {
-
-    private static final boolean ARRIVE_BY_TRUE = true;
-
-    private static final boolean ARRIVE_BY_FALSE = false;
-
     private final GeometryFactory gf = GeometryUtils.getGeometryFactory();
     private RoutingRequest request;
     private RoutingContext subject;
@@ -65,17 +60,10 @@ public class RoutingContext_Destroy_Test {
     }
 
     @Test public void temporary_changes_is_removed_from_graph_on_context_destroy() {
-        // try arriveBy set to both true and false
-        temporary_changes_is_removed_from_graph_on_context_destroy(ARRIVE_BY_TRUE);
-        temporary_changes_is_removed_from_graph_on_context_destroy(ARRIVE_BY_FALSE);
-    }
-
-    private void temporary_changes_is_removed_from_graph_on_context_destroy(boolean arriveBy) {
         // Given - A request
         request = new RoutingRequest();
         request.from = from;
         request.to = to;
-        request.arriveBy = arriveBy;
 
         // When - the context is created
         subject = new RoutingContext(request, g);
@@ -151,9 +139,8 @@ public class RoutingContext_Destroy_Test {
         return list;
     }
 
-    private void assertVertexEdgeIsNotReferencingTemporaryElements(Vertex source, Edge e,
-            Vertex v) {
-        String sourceName = source.getName();
+    private void assertVertexEdgeIsNotReferencingTemporaryElements(Vertex src, Edge e, Vertex v) {
+        String sourceName = src.getName();
         assertFalse(sourceName + " -> " + e.getName(), e instanceof TemporaryEdge);
         assertFalse(sourceName + " -> " + v.getName(), v instanceof TemporaryVertex);
     }

--- a/src/test/java/org/opentripplanner/routing/graph/TemporaryConcreteEdge.java
+++ b/src/test/java/org/opentripplanner/routing/graph/TemporaryConcreteEdge.java
@@ -11,24 +11,19 @@ import org.opentripplanner.routing.edgetype.TemporaryEdge;
 import org.opentripplanner.routing.vertextype.TemporaryVertex;
 
 public class TemporaryConcreteEdge extends Edge implements TemporaryEdge {
-    final private boolean endEdge;
 
     public TemporaryConcreteEdge(TemporaryVertex v1, Vertex v2) {
         super((Vertex) v1, v2);
 
         if (v1.isEndVertex()) {
             throw new IllegalStateException("A temporary edge is directed away from an end vertex");
-        } else {
-            endEdge = false;
         }
     }
 
     public TemporaryConcreteEdge(Vertex v1, TemporaryVertex v2) {
         super(v1, (Vertex) v2);
 
-        if (v2.isEndVertex()) {
-            endEdge = true;
-        } else {
+        if (!v2.isEndVertex()) {
             throw new IllegalStateException("A temporary edge is directed towards a start vertex");
         }
     }
@@ -62,14 +57,5 @@ public class TemporaryConcreteEdge extends Edge implements TemporaryEdge {
     @Override
     public double getDistance() {
         return SphericalDistanceLibrary.distance(getFromVertex().getCoordinate(), getToVertex().getCoordinate());
-    }
-
-    @Override
-    public void dispose() {
-        if (endEdge) {
-            fromv.removeOutgoing(this);
-        } else {
-            tov.removeIncoming(this);
-        }
     }
 }

--- a/src/test/java/org/opentripplanner/routing/vertextype/TemporaryVertexDisposeTest.java
+++ b/src/test/java/org/opentripplanner/routing/vertextype/TemporaryVertexDisposeTest.java
@@ -1,0 +1,227 @@
+package org.opentripplanner.routing.vertextype;
+
+import org.junit.Test;
+import org.opentripplanner.routing.edgetype.FreeEdge;
+import org.opentripplanner.routing.graph.Vertex;
+
+import static org.junit.Assert.assertEquals;
+
+public class TemporaryVertexDisposeTest {
+
+    private static final double ANY_LOC = 1;
+
+    // Given a very simple graph: A -> B
+    private final Vertex a = new V("A");
+    private final Vertex b = new V("B");
+    {
+        edge(a, b);
+        assertOriginalGraphIsIntact();
+    }
+
+    @Test public void disposeNormalCase() {
+        // Given a temporary vertex 'origin' and 'destination' connected to graph
+        Vertex origin = new TempVertex("origin");
+        Vertex destination = new TempVertex("dest");
+        edge(origin, a);
+        edge(b, destination);
+
+        // Then before we dispose temporary vertexes
+        assertEquals("[origin->A]", a.getIncoming().toString());
+        assertEquals("[B->dest]", b.getOutgoing().toString());
+
+        // When
+        TemporaryVertex.dispose(origin);
+        TemporaryVertex.dispose(destination);
+
+        // Then
+        assertOriginalGraphIsIntact();
+    }
+
+    @Test public void disposeShouldNotDeleteOtherIncomingEdges() {
+        // Given a temporary vertex 'origin' connected to B - has other incoming edges
+        Vertex origin = new TempVertex("origin");
+        Vertex otherTemp = new TempVertex("OT");
+        edge(origin, b);
+        edge(otherTemp, b);
+
+        // Then before we dispose temporary vertexes
+        assertEquals("[A->B, origin->B, OT->B]", b.getIncoming().toString());
+        // When
+        TemporaryVertex.dispose(origin);
+
+        // Then B is back to normal
+        assertEquals("[A->B, OT->B]", b.getIncoming().toString());
+    }
+
+    @Test public void disposeShouldNotDeleteOtherOutgoingEdges() {
+        // Given a temporary vertex 'destination' connected from A - with one other outgoing edge
+        Vertex destination = new TempVertex("destination");
+        Vertex otherTemp = new TempVertex("OT");
+        edge(a, destination);
+        edge(a, otherTemp);
+
+        // Then before we dispose temporary vertexes
+        assertEquals("[A->B, A->destination, A->OT]", a.getOutgoing().toString());
+
+        // When
+        TemporaryVertex.dispose(destination);
+
+        // A is back to normal
+        assertEquals("[A->B, A->OT]", a.getOutgoing().toString());
+    }
+
+
+    @Test public void disposeShouldHandleLoopsInTemporaryPath() {
+        Vertex x = new TempVertex("x");
+        Vertex y = new TempVertex("y");
+        Vertex z = new TempVertex("z");
+
+        edge(x, y);
+        edge(y, z);
+        edge(z, x);
+        // Add some random links the the main graph
+        edge(x, a);
+        edge(b, y);
+        edge(z, a);
+
+        // When
+        TemporaryVertex.dispose(x);
+
+        // Then do return without stack overflow and:
+        assertOriginalGraphIsIntact();
+    }
+
+    /**
+     * Verify a complex temporary path is disposed. The temporary graph is connected to the
+     * main graph in both directions (in/out) from many places (temp. vertexes).
+     * <p/>
+     * The temporary part of the graph do NOT contain any loops.
+     */
+    @Test public void disposeTemporaryVertexesWithComplexPaths() {
+
+        TempVertex x = new TempVertex("x");
+        Vertex y = new TempVertex("y");
+        Vertex z = new TempVertex("z");
+        Vertex q = new TempVertex("q");
+
+        // A and B are connected both ways A->B and B->A (A->B is done in the class init)
+        edge(b, a);
+
+        // All temporary vertexes are connected in a chain
+        edge(x, y);
+        edge(y, z);
+        edge(z, q);
+
+        // And they are connected to the graph in many ways - no loops
+        edge(x, a);
+        edge(y, b);
+        edge(z, a);
+        edge(q, a);
+        edge(q, b);
+
+        // Then before we dispose temporary vertexes
+        assertEquals("[B->A, x->A, z->A, q->A]", a.getIncoming().toString());
+        assertEquals("[A->B, y->B, q->B]", b.getIncoming().toString());
+
+        // When
+        TemporaryVertex.dispose(x);
+
+        // Then
+        assertEquals("[B->A]", a.getIncoming().toString());
+        assertEquals("[A->B]", b.getIncoming().toString());
+
+
+        // Destination, connect to A and B outgoing - we can reuse the temp structure
+        edge(a, x);
+        edge(b, y);
+        edge(a, z);
+        edge(a, q);
+        edge(b, q);
+
+        assertEquals("[A->B, A->x, A->z, A->q]", a.getOutgoing().toString());
+        assertEquals("[B->A, B->y, B->q]", b.getOutgoing().toString());
+
+        // When
+        TemporaryVertex.dispose(x);
+
+        // Then
+        assertEquals("[B->A]", a.getIncoming().toString());
+        assertEquals("[A->B]", b.getIncoming().toString());
+    }
+
+    /**
+     * We should be able to delete an alternative path/loop created in the graph like:
+     * <p/>
+     * A -> x -> y -> B
+     * <p/>
+     * Where 'x' and 'y' are temporary vertexes
+     */
+    @Test public void disposeTemporaryAlternativePath() {
+        Vertex x = new TempVertex("x");
+        Vertex y = new TempVertex("y");
+
+        // Make a new loop from 'A' via 'x' and 'y' to 'B'
+        edge(a, x);
+        edge(x, y);
+        edge(y, b);
+
+        // Then before we dispose temporary vertexes
+        assertEquals("[A->B, A->x]", a.getOutgoing().toString());
+        assertEquals("[A->B, y->B]", b.getIncoming().toString());
+
+        // When
+        TemporaryVertex.dispose(x);
+
+        // Then
+        assertOriginalGraphIsIntact();
+    }
+
+    /* private test helper classes */
+
+    private void assertOriginalGraphIsIntact() {
+        assertEquals("[]", a.getIncoming().toString());
+        assertEquals("[A->B]", a.getOutgoing().toString());
+        assertEquals("[A->B]", b.getIncoming().toString());
+        assertEquals("[]", b.getOutgoing().toString());
+    }
+
+
+    static class V extends Vertex {
+        private V(String label) {
+            super(null, label, ANY_LOC, ANY_LOC);
+        }
+
+        @Override public String toString() {
+            return getLabel();
+        }
+    }
+
+    static class TempVertex extends Vertex implements TemporaryVertex {
+        private TempVertex(String label) {
+            super(null, label, ANY_LOC, ANY_LOC);
+        }
+
+        @Override public boolean isEndVertex() {
+            throw new IllegalStateException("The `isEndVertex` is not used by dispose logic.");
+        }
+
+        @Override public String toString() {
+            return getLabel();
+        }
+    }
+
+    // Factory method to create an edge
+    private static void edge(Vertex a, Vertex b) {
+        new E(a, b);
+    }
+
+    static class E extends FreeEdge {
+        private E(Vertex from, Vertex to) {
+            super(from, to);
+        }
+
+        @Override public String toString() {
+            return getFromVertex().toString() + "->" + getToVertex();
+        }
+    }
+}


### PR DESCRIPTION
To be completed by pull request submitter:

- [x] **issue**: Fixes #2461, fixes #2523, fixes #2527 and fixes #2574.
- [x] **roadmap**: This is NOT a feature - just a bug fix; Hence, not on the road map.
- [x] **tests**: I tested the memory leak by running JMeter with more than 1000 routing requests taken from Ruter´s operation. The test-cases contains coordinate to coordinate searches, with lead to the memory leak. I used the JVisualVM to track the memory leek and to debug the objects.  I have in addition added a unit test that verify the destruction of the RoutingContext. 
- [x] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#code-style)? 

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **before merging**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)