### PR TITLE
Support OSM highway=razed tag

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/OSMFilter.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/OSMFilter.java
@@ -26,23 +26,30 @@ public class OSMFilter {
      * (as well as ways where all access is specifically forbidden to the public).
      * http://wiki.openstreetmap.org/wiki/Tag:highway%3Dproposed
      */
-    public static boolean isWayRoutable(OSMWithTags way) {
-        if (!isOsmEntityRoutable(way))
+    static boolean isWayRoutable(OSMWithTags way) {
+        if (!isOsmEntityRoutable(way)) {
             return false;
+        }
 
         String highway = way.getTag("highway");
-        if (highway != null
-                && (highway.equals("conveyer") || highway.equals("proposed")
-                        || highway.equals("construction") || highway.equals("raceway") || highway
-                            .equals("unbuilt")))
-            return false;
+        if (highway != null) {
+            if(
+                    highway.equals("conveyer") ||
+                    highway.equals("proposed") ||
+                    highway.equals("construction") ||
+                    highway.equals("razed") ||
+                    highway.equals("raceway") ||
+                    highway.equals("unbuilt")
+            ) {
+                return false;
+            }
+        }
 
         if (way.isGeneralAccessDenied()) {
             // There are exceptions.
             return (way.isMotorcarExplicitlyAllowed() || way.isBicycleExplicitlyAllowed() || way
                     .isPedestrianExplicitlyAllowed() || way.isMotorVehicleExplicitlyAllowed());
         }
-
         return true;
     }
 


### PR DESCRIPTION
- [x] **issue**: Closes #2659
- [x] **roadmap**: Bugfix not on roadmap.
- [ ] **tests**: No tests added - sorry. There is a test `TestUnroutable` test the `highway=construction` tag(equivalent tag in the same list). See more on this below below.
- [x] **formatting**: Tried to make the code more readable.

### Testing OSM filtering rules
The tag filtering logic happens in many places witch for me is very hard to understand. It needs refactoring, and a natural start to this, is to create a unit test with the contract/rules. But this is  a big task. When I tried to fix this issue, I first added one line to the `DefaultWayPropertySetSource`: (`props.setProperties("highway=razed", StreetTraversalPermission.NONE);`). This did not have the expected result. I debugged this until I understood that there is no clear precedence between the rules - at least for me to grasp in a few hours. The `OSMFilter#getPermissionsForEntity` method might return *not* `NONE` even if the input parameter `StreetTraversalPermission def` is `NONE`. This is just a small pice of the puzzle, so I went on and fixed it another way (see code).

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **before merging**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)