### PR TITLE
Transportation network company routing (closes #2642)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -580,13 +580,20 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <version>1.10.19</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- wiremock is used to mock http requests -->
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+            <version>2.14.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/client/js/otp/config.js
+++ b/src/client/js/otp/config.js
@@ -334,5 +334,10 @@ otp.config.modes = {
     'WALK,BICYCLE_RENT'        : _tr('Rented Bicycle'),
     //TRANSLATORS: Travel by: mode of transport (Used in selection in Travel
     //Options widgets)
-    'TRANSIT,WALK,BICYCLE_RENT': _tr('Transit & Rented Bicycle')
+    //    'TRANSIT,WALK,BICYCLE_RENT': _tr('Transit & Rented Bicycle')
+    //uncomment only if transportation network companies exists in a map
+    //TRANSLATORS: Travel by: mode of transport (Used in selection in Travel
+    //Options widgets)
+    "CAR_HAIL,WALK,TRANSIT"     : _tr('TNC &amp; Transit'),
+    "CAR_HAIL,WALK,TRAM,RAIL,SUBWAY,FUNICULAR,GONDOLA"     : _tr('TNC &amp; Rail')
     };

--- a/src/main/java/org/opentripplanner/api/common/Message.java
+++ b/src/main/java/org/opentripplanner/api/common/Message.java
@@ -1,8 +1,8 @@
 package org.opentripplanner.api.common;
 
-import java.util.Locale;
-
 import org.opentripplanner.util.Properties;
+
+import java.util.Locale;
 
 /**
  * The purpose of Messages is to read supply Message.properties to underlying calling code...
@@ -16,6 +16,7 @@ public enum Message {
 
     OUTSIDE_BOUNDS(400),
     PATH_NOT_FOUND(404),
+    NO_PATHS_AFTER_FILTERING(405),
     NO_TRANSIT_TIMES(406),
     REQUEST_TIMEOUT(408),
     BOGUS_PARAMETER(413),
@@ -24,6 +25,9 @@ public enum Message {
     GEOCODE_FROM_TO_NOT_FOUND(460),
     TOO_CLOSE(409),
     LOCATION_NOT_ACCESSIBLE(470),
+    TRANSPORTATION_NETWORK_COMPANY_UNAVAILABLE(480),
+    TRANSPORTATION_NETWORK_COMPANY_REQUEST_INVALID(481),
+    TRANSPORTATION_NETWORK_COMPANY_CONFIG_INVALID(482),
 
     GEOCODE_FROM_AMBIGUOUS(340),
     GEOCODE_TO_AMBIGUOUS(350),

--- a/src/main/java/org/opentripplanner/api/model/Leg.java
+++ b/src/main/java/org/opentripplanner/api/model/Leg.java
@@ -1,23 +1,21 @@
 package org.opentripplanner.api.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.opentripplanner.api.model.alertpatch.LocalizedAlert;
+import org.opentripplanner.model.FeedScopedId;
+import org.opentripplanner.routing.alertpatch.Alert;
+import org.opentripplanner.routing.core.TraverseMode;
+import org.opentripplanner.util.model.EncodedPolylineBean;
+
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
 import java.util.Locale;
 import java.util.TimeZone;
-
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
-
-import org.opentripplanner.model.FeedScopedId;
-import org.opentripplanner.api.model.alertpatch.LocalizedAlert;
-import org.opentripplanner.routing.alertpatch.Alert;
-import org.opentripplanner.routing.core.TraverseMode;
-import org.opentripplanner.util.model.EncodedPolylineBean;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
  /**
  * One leg of a trip -- that is, a temporally continuous piece of the journey that takes place on a
@@ -246,6 +244,14 @@ public class Leg {
     @XmlAttribute
     @JsonSerialize
     public Boolean rentedBike;
+
+    @XmlAttribute
+    @JsonSerialize
+    public Boolean hailedCar;
+
+    @XmlAttribute
+    @JsonSerialize
+    public TransportationNetworkCompanySummary tncData;
 
     /**
      * Whether this leg is a transit leg or not.

--- a/src/main/java/org/opentripplanner/api/model/TransportationNetworkCompanyResponse.java
+++ b/src/main/java/org/opentripplanner/api/model/TransportationNetworkCompanyResponse.java
@@ -1,0 +1,57 @@
+/* This program is free software: you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public License
+ as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+package org.opentripplanner.api.model;
+
+import org.opentripplanner.routing.transportation_network_company.ArrivalTime;
+import org.opentripplanner.routing.transportation_network_company.RideEstimate;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.util.List;
+
+@XmlRootElement
+public class TransportationNetworkCompanyResponse {
+
+    private String error;
+    private List<ArrivalTime> estimates;
+    private RideEstimate rideEstimate;
+
+    @XmlElement(required=false)
+    public List<ArrivalTime> getEstimates() {
+        return estimates;
+    }
+
+    public void setEtaEstimates(List<ArrivalTime> estimates) {
+        this.estimates = estimates;
+    }
+
+    @XmlElement(required=false)
+    public RideEstimate getRideEstimate() {
+        return rideEstimate;
+    }
+
+    public void setRideEstimate(RideEstimate rideEstimate) {
+        this.rideEstimate = rideEstimate;
+    }
+
+    /** The error (if any) that this response raised. */
+    @XmlElement(required=false)
+    public String getError() {
+        return error;
+    }
+
+    public void setError(Exception error) {
+        this.error = error.getClass().getSimpleName() + ": " + error.getMessage();
+    }
+}

--- a/src/main/java/org/opentripplanner/api/model/TransportationNetworkCompanySummary.java
+++ b/src/main/java/org/opentripplanner/api/model/TransportationNetworkCompanySummary.java
@@ -1,0 +1,34 @@
+package org.opentripplanner.api.model;
+
+import org.opentripplanner.routing.transportation_network_company.ArrivalTime;
+import org.opentripplanner.routing.transportation_network_company.RideEstimate;
+import org.opentripplanner.routing.transportation_network_company.TransportationNetworkCompany;
+
+/**
+ * Simplified TNC summary included with itinerary {@link Leg}.
+ */
+public class TransportationNetworkCompanySummary {
+    public TransportationNetworkCompany company;
+    public String currency;
+    public int travelDuration;  // in seconds
+    public double maxCost;
+    public double minCost;
+    public String productId;
+    public String displayName;
+    public int estimatedArrival;
+
+    public TransportationNetworkCompanySummary (RideEstimate estimate, ArrivalTime time) {
+        if (estimate != null) {
+            this.company = estimate.company;
+            this.currency = estimate.currency;
+            this.travelDuration = estimate.duration;
+            this.maxCost = estimate.maxCost;
+            this.minCost = estimate.minCost;
+        }
+        if (time != null) {
+            this.productId = time.productId;
+            this.displayName = time.displayName;
+            this.estimatedArrival = time.estimatedSeconds;
+        }
+    }
+}

--- a/src/main/java/org/opentripplanner/api/model/error/PlannerError.java
+++ b/src/main/java/org/opentripplanner/api/model/error/PlannerError.java
@@ -1,18 +1,19 @@
 package org.opentripplanner.api.model.error;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import org.opentripplanner.api.common.Message;
 import org.opentripplanner.api.common.LocationNotAccessible;
+import org.opentripplanner.api.common.Message;
 import org.opentripplanner.routing.error.GraphNotFoundException;
 import org.opentripplanner.routing.error.PathNotFoundException;
 import org.opentripplanner.routing.error.TransitTimesException;
+import org.opentripplanner.routing.error.TransportationNetworkCompanyAvailabilityException;
 import org.opentripplanner.routing.error.TrivialPathException;
 import org.opentripplanner.routing.error.VertexNotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /** This API response element represents an error in trip planning. */
 public class PlannerError {
@@ -28,6 +29,7 @@ public class PlannerError {
         messages.put(TrivialPathException.class,     Message.TOO_CLOSE);
         messages.put(GraphNotFoundException.class,   Message.GRAPH_UNAVAILABLE);
         messages.put(IllegalArgumentException.class, Message.BOGUS_PARAMETER);
+        messages.put(TransportationNetworkCompanyAvailabilityException.class, Message.TRANSPORTATION_NETWORK_COMPANY_UNAVAILABLE);
     }
     
     public int    id;

--- a/src/main/java/org/opentripplanner/api/parameter/QualifiedMode.java
+++ b/src/main/java/org/opentripplanner/api/parameter/QualifiedMode.java
@@ -54,6 +54,10 @@ public class QualifiedMode implements Serializable {
         if (usingTransit && this.mode == TraverseMode.CAR) {
             if (this.qualifiers.contains(Qualifier.PARK)) {
                 req.parkAndRide = true;
+            } else if (this.qualifiers.contains(Qualifier.HAIL)) {
+                req.useTransportationNetworkCompany = true;
+                req.driveTimeReluctance = 1.75;
+                req.driveDistanceReluctance = 0.2;
             } else {
                 req.kissAndRide = true;
             }
@@ -78,5 +82,5 @@ public class QualifiedMode implements Serializable {
 }
 
 enum Qualifier {
-    RENT, HAVE, PARK, KEEP
+    RENT, HAVE, PARK, HAIL, KEEP
 }

--- a/src/main/java/org/opentripplanner/api/resource/TransportationNetworkCompanyResource.java
+++ b/src/main/java/org/opentripplanner/api/resource/TransportationNetworkCompanyResource.java
@@ -1,0 +1,135 @@
+/* This program is free software: you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public License
+ as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+package org.opentripplanner.api.resource;
+
+import org.opentripplanner.api.model.Place;
+import org.opentripplanner.api.model.TransportationNetworkCompanyResponse;
+import org.opentripplanner.routing.transportation_network_company.TransportationNetworkCompanyService;
+import org.opentripplanner.standalone.OTPServer;
+import org.opentripplanner.standalone.Router;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+
+import static org.opentripplanner.api.param.QueryParameter.checkRangeInclusive;
+import static org.opentripplanner.api.resource.ServerInfo.Q;
+
+@Path("/routers/{routerId}/transportation_network_company")
+public class TransportationNetworkCompanyResource {
+    public static final String[] ACCEPTED_RIDE_TYPES = {
+        "lyft", // standard lyft pickup
+        "a6eef2e1-c99a-436f-bde9-fefb9181c0b0" // uberX
+    };
+    private static final Logger LOG = LoggerFactory.getLogger(TransportationNetworkCompanyResource.class);
+
+    @Context
+    OTPServer otpServer;
+
+    @GET
+    @Path("/eta_estimate")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML + Q, MediaType.TEXT_XML + Q})
+    public TransportationNetworkCompanyResponse getEtaEstimates(
+        @QueryParam("from") String from,
+        @QueryParam("companies") String companies,
+        @PathParam("routerId") String routerId
+    ) {
+        LOG.info("Received eta_estimate request");
+
+        TransportationNetworkCompanyResponse response = new TransportationNetworkCompanyResponse();
+
+        try {
+            requireParameter(companies, "companies");
+            Place fromPlace = getPlace(from, "from");
+            TransportationNetworkCompanyService service = getService(routerId);
+            response.setEtaEstimates(service.getArrivalTimes(fromPlace, companies));
+        } catch (Exception e) {
+            response.setError(e);
+        }
+
+        return response;
+    }
+
+    @GET
+    @Path("/ride_estimate")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML + Q, MediaType.TEXT_XML + Q})
+    public TransportationNetworkCompanyResponse getRideEstimate(
+        @QueryParam("from") String from,
+        @QueryParam("to") String to,
+        @QueryParam("company") String company,
+        @QueryParam("rideType") String rideType,
+        @PathParam("routerId") String routerId
+    ) {
+        LOG.info("Received ride_estimate request");
+
+        TransportationNetworkCompanyResponse response = new TransportationNetworkCompanyResponse();
+
+        try {
+            requireParameter(company, "company");
+            requireParameter(rideType, "rideType");
+            Place fromPlace = getPlace(from, "from");
+            Place toPlace = getPlace(to, "to");
+            TransportationNetworkCompanyService service = getService(routerId);
+            response.setRideEstimate(service.getRideEstimate(company, rideType, fromPlace, toPlace));
+        } catch (Exception e) {
+            response.setError(e);
+        }
+
+        return response;
+    }
+
+    private Place getPlace(String positionString, String paramName) throws Exception {
+        requireParameter(positionString, paramName);
+
+        String[] fields = positionString.split(",");
+        double latitude, longitude;
+        try {
+            latitude = Double.parseDouble(fields[0]);
+            longitude = Double.parseDouble(fields[1]);
+        } catch (Exception e) {
+            throw new Exception("Invalid format of " + paramName + " parameter.  Should be `lat,lon`.");
+        }
+
+        checkRangeInclusive(latitude, -90, 90);
+        checkRangeInclusive(longitude, -180, 180);
+
+        Place place = new Place();
+        place.lat = latitude;
+        place.lon = longitude;
+
+        return place;
+    }
+
+    private TransportationNetworkCompanyService getService(String routerId) {
+        Router router = otpServer.getRouter(routerId);
+        if (router == null) {
+            throw new UnsupportedOperationException("Unable to find router with id: " + routerId);
+        }
+
+        TransportationNetworkCompanyService service = router.graph.getService(TransportationNetworkCompanyService.class);
+        if (service == null) {
+            throw new UnsupportedOperationException("Unconfigured Transportaiton Network Company service for router with id: " + routerId);
+        }
+
+        return service;
+    }
+
+    private void requireParameter(String param, String paramName) {
+        if (param == null) {
+            throw new UnsupportedOperationException(paramName + " paramater is required");
+        }
+    }
+}

--- a/src/main/java/org/opentripplanner/common/geometry/GeometryUtils.java
+++ b/src/main/java/org/opentripplanner/common/geometry/GeometryUtils.java
@@ -177,7 +177,7 @@ public class GeometryUtils {
         Coordinate[] coords = new Coordinate[path.size()];
         int i = 0;
         for (LngLatAlt p : path) {
-            coords[i++] = new Coordinate(p.getLatitude(), p.getLongitude());
+            coords[i++] = new Coordinate(p.getLongitude(), p.getLatitude());
         }
         return coords;
     }

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModule.java
@@ -1076,6 +1076,7 @@ public class OpenStreetMapModule implements GraphBuilderModule {
             StreetEdge street = edgeFactory.createEdge(startEndpoint, endEndpoint, geometry, name, length,
                     permissions, back);
             street.setCarSpeed(carSpeed);
+            street.setTNCStopSuitability(wayPropertySet.isSuitableForTNCStop(way));
 
             String highway = way.getTag("highway");
             int cls;

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/WayPropertySet.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/WayPropertySet.java
@@ -1,6 +1,18 @@
 package org.opentripplanner.graph_builder.module.osm;
 
+import org.opentripplanner.common.model.P2;
+import org.opentripplanner.common.model.T2;
+import org.opentripplanner.openstreetmap.model.OSMWay;
+import org.opentripplanner.openstreetmap.model.OSMWithTags;
+import org.opentripplanner.routing.alertpatch.Alert;
+import org.opentripplanner.routing.edgetype.StreetTraversalPermission;
+import org.opentripplanner.routing.services.notes.NoteMatcher;
+import org.opentripplanner.util.I18NString;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -8,16 +20,6 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import org.opentripplanner.common.model.P2;
-import org.opentripplanner.common.model.T2;
-import org.opentripplanner.openstreetmap.model.OSMWithTags;
-import org.opentripplanner.routing.alertpatch.Alert;
-import org.opentripplanner.routing.edgetype.StreetTraversalPermission;
-import org.opentripplanner.routing.services.notes.NoteMatcher;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.opentripplanner.util.I18NString;
 
 /**
  * Information given to the GraphBuilder about how to assign permissions, safety values, names, etc. to edges based on OSM tags.
@@ -380,5 +382,26 @@ public class WayPropertySet {
 		picker.speed = speed;
 		addSpeedPicker(picker);
 	}
+
+    private String getFirstParkingLaneProperty(OSMWay way) {
+        List<String> parkingTags = Arrays
+                .asList("parking:lane:both", "parking:lane:right", "parking:lane:left");
+        for (String parkingTag : parkingTags) {
+            String value = way.getTag(parkingTag);
+            if (value != null) {
+                return value;
+            }
+        }
+        return null;
+    }
+    // Determining whether this edge is suitable for TNC stops
+    public boolean isSuitableForTNCStop(OSMWay way) {
+        String parkingLaneProperty = getFirstParkingLaneProperty(way);
+        // assume this is a suitable place if no property exists
+        if (parkingLaneProperty == null)
+            return true;
+        // return false if this way is marked as no stopping or a fire lane
+        return !parkingLaneProperty.equals("no_stopping") && !parkingLaneProperty.equals("fire_lane");
+    }
 
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/strategies/InterleavedBidirectionalHeuristic.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/strategies/InterleavedBidirectionalHeuristic.java
@@ -12,6 +12,7 @@ import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.routing.location.StreetLocation;
 import org.opentripplanner.routing.spt.DominanceFunction;
 import org.opentripplanner.routing.spt.ShortestPathTree;
+import org.opentripplanner.routing.vertextype.BikeRentalStationVertex;
 import org.opentripplanner.routing.vertextype.StreetVertex;
 import org.opentripplanner.routing.vertextype.TransitStop;
 import org.slf4j.Logger;
@@ -106,21 +107,33 @@ public class InterleavedBidirectionalHeuristic implements RemainingWeightHeurist
         this.routingRequest = request;
         request.softWalkLimiting = false;
         request.softPreTransitLimiting = false;
+        // change the defaults in bikeWalkingOptions because traversals of one-way streets or
+        // otherwise non-traversable streets may occur while walking a bicycle that extend the
+        // pretransit search further than is needed
+        request.bikeWalkingOptions.softWalkLimiting = false;
+        request.bikeWalkingOptions.softPreTransitLimiting = false;
         transitQueue = new BinHeap<>();
-        // Forward street search first, mark street vertices around the origin so H evaluates to 0
-        TObjectDoubleMap<Vertex> forwardStreetSearchResults = streetSearch(request, false, abortTime);
+        // Forward street search first, mark street vertices around the origin so H evaluates to 0.
+        // If the car mode is allowed, avoid creating pretransit vertices because the entire graph
+        // could get explored due to car travel not counting towards the maxWalkDistance.
+        TObjectDoubleMap<Vertex> forwardStreetSearchResults = request.modes.getCar()
+                ? new TObjectDoubleHashMap<>()
+                : streetSearch(request, false, abortTime);
         if (forwardStreetSearchResults == null) {
             return; // Search timed out
         }
         preTransitVertices = forwardStreetSearchResults.keySet();
         LOG.debug("end forward street search {} ms", System.currentTimeMillis() - start);
+        // When the car mode is allowed the postBoardingWeights are the result of searching the
+        // graph until the origin is reached, but doing so makes the overall search considerably
+        // faster when transit is also present.
         postBoardingWeights = streetSearch(request, true, abortTime);
         if (postBoardingWeights == null) {
             return; // Search timed out
         }
         LOG.debug("end backward street search {} ms", System.currentTimeMillis() - start);
         // once street searches are done, raise the limits to max
-        // because hard walk limiting is incorrect and is observed to cause problems 
+        // because hard walk limiting is incorrect and is observed to cause problems
         // for trips near the cutoff
         request.setMaxWalkDistance(Double.POSITIVE_INFINITY);
         request.setMaxPreTransitTime(Integer.MAX_VALUE);
@@ -143,15 +156,16 @@ public class InterleavedBidirectionalHeuristic implements RemainingWeightHeurist
             // Zero is always an underestimate.
             return 0;
         }
-        if (v instanceof StreetVertex) {
-            // The main search is on the streets, not on transit.
+        if (v instanceof StreetVertex || v instanceof BikeRentalStationVertex) {
+            // The main search is not on transit.
             if (s.isEverBoarded()) {
                 // If we have already ridden transit we must be near the destination. If not the map returns INF.
                 return postBoardingWeights.get(v);
             } else {
                 // We have not boarded transit yet. We have no idea what the weight to the target is so return zero.
                 // We could also use a Euclidean heuristic here.
-                if (preTransitVertices.contains(v)) {
+                // If the car mode is allowed, the preTransitVertices will be empty, so always return 0.
+                if (s.getOptions().modes.getCar() || preTransitVertices.contains(v)) {
                     return 0;
                 } else {
                     return Double.POSITIVE_INFINITY;
@@ -291,15 +305,19 @@ public class InterleavedBidirectionalHeuristic implements RemainingWeightHeurist
             if (!vertices.containsKey(v)) {
                 vertices.put(v, (int) s.getWeight()); // FIXME time or weight? is RR using right mode?
             }
+            // if searching from the target and traveling via car and the origin has been reached,
+            // exit this loop and immediately return the vertices so that the entire graph isn't
+            // searched.
+            if (fromTarget && rr.modes.getCar() && v == rr.rctx.origin) break;
             for (Edge e : rr.arriveBy ? v.getIncoming() : v.getOutgoing()) {
                 // arriveBy has been set to match actual directional behavior in this subsearch.
                 // Walk cutoff will happen in the street edge traversal method.
-                State s1 = e.traverse(s);
-                if (s1 == null) {
-                    continue;
-                }
-                if (spt.add(s1)) {
-                    pq.insert(s1,  s1.getWeight());
+                // In here we must iterate through all state results to consider the forkStates
+                // produced when possibly transitioning to car or walk on a StreetEdge.
+                for (State s1 = e.traverse(s); s1 != null; s1 = s1.getNextResult()) {
+                    if (spt.add(s1)) {
+                        pq.insert(s1,  s1.getWeight());
+                    }
                 }
             }
         }
@@ -307,5 +325,4 @@ public class InterleavedBidirectionalHeuristic implements RemainingWeightHeurist
         LOG.debug("Heuristric street search hit {} transit stops.", transitQueue.size());
         return vertices;
     }
- 
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/strategies/InterleavedBidirectionalHeuristic.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/strategies/InterleavedBidirectionalHeuristic.java
@@ -12,6 +12,7 @@ import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.routing.location.StreetLocation;
 import org.opentripplanner.routing.spt.DominanceFunction;
 import org.opentripplanner.routing.spt.ShortestPathTree;
+import org.opentripplanner.routing.vertextype.BikeParkVertex;
 import org.opentripplanner.routing.vertextype.BikeRentalStationVertex;
 import org.opentripplanner.routing.vertextype.StreetVertex;
 import org.opentripplanner.routing.vertextype.TransitStop;
@@ -156,7 +157,11 @@ public class InterleavedBidirectionalHeuristic implements RemainingWeightHeurist
             // Zero is always an underestimate.
             return 0;
         }
-        if (v instanceof StreetVertex || v instanceof BikeRentalStationVertex) {
+        if (
+            v instanceof StreetVertex ||
+                v instanceof BikeRentalStationVertex ||
+                v instanceof BikeParkVertex
+        ) {
             // The main search is not on transit.
             if (s.isEverBoarded()) {
                 // If we have already ridden transit we must be near the destination. If not the map returns INF.

--- a/src/main/java/org/opentripplanner/routing/core/State.java
+++ b/src/main/java/org/opentripplanner/routing/core/State.java
@@ -1,19 +1,24 @@
 package org.opentripplanner.routing.core;
 
-import java.util.Date;
-import java.util.Set;
-
 import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.model.Stop;
 import org.opentripplanner.model.Trip;
 import org.opentripplanner.routing.algorithm.NegativeWeightException;
-import org.opentripplanner.routing.edgetype.*;
+import org.opentripplanner.routing.edgetype.OnboardEdge;
+import org.opentripplanner.routing.edgetype.PatternInterlineDwell;
+import org.opentripplanner.routing.edgetype.StreetEdge;
+import org.opentripplanner.routing.edgetype.TablePatternEdge;
+import org.opentripplanner.routing.edgetype.TransitBoardAlight;
+import org.opentripplanner.routing.edgetype.TripPattern;
 import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.routing.trippattern.TripTimes;
 import org.opentripplanner.routing.vertextype.BikeRentalStationVertex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Date;
+import java.util.Set;
 
 public class State implements Cloneable {
     /* Data which is likely to change at most traversals */
@@ -48,6 +53,9 @@ public class State implements Cloneable {
 
     // track the states of all path parsers -- probably changes frequently
     protected int[] pathParserStates;
+
+    // The current distance traveled in a transportation network company vehicle
+    public double transportationNetworkCompanyDriveDistance;
     
     private static final Logger LOG = LoggerFactory.getLogger(State.class);
 
@@ -113,8 +121,13 @@ public class State implements Cloneable {
             this.stateData.nonTransitMode = this.stateData.bikeParked ? TraverseMode.WALK
                     : TraverseMode.BICYCLE;
         }
+        // if allowed to hail a car, initialize state with CAR mode if we're already in a hailed car
+        else if (options.useTransportationNetworkCompany) {
+            this.stateData.nonTransitMode = this.stateData.usingHailedCar ? TraverseMode.CAR : TraverseMode.WALK;
+        }
         this.walkDistance = 0;
         this.preTransitTime = 0;
+        this.transportationNetworkCompanyDriveDistance = 0;
         this.time = timeSeconds * 1000;
         stateData.routeSequence = new FeedScopedId[0];
     }
@@ -249,6 +262,8 @@ public class State implements Cloneable {
     public boolean isBikeRenting() {
         return stateData.usingRentedBike;
     }
+
+    public boolean isUsingHailedCar() { return stateData.usingHailedCar; }
     
     public boolean isCarParked() {
         return stateData.carParked;
@@ -268,6 +283,10 @@ public class State implements Cloneable {
         boolean bikeRentingOk = false;
         boolean bikeParkAndRideOk = false;
         boolean carParkAndRideOk = false;
+        boolean tncOK = !stateData.opt.useTransportationNetworkCompany || (
+                isEverBoarded() &&
+                        (!isUsingHailedCar() || isTNCStopAllowed())
+        );
         if (stateData.opt.arriveBy) {
             bikeRentingOk = !isBikeRenting();
             bikeParkAndRideOk = !bikeParkAndRide || !isBikeParked();
@@ -277,7 +296,7 @@ public class State implements Cloneable {
             bikeParkAndRideOk = !bikeParkAndRide || isBikeParked();
             carParkAndRideOk = !parkAndRide || isCarParked();
         }
-        return bikeRentingOk && bikeParkAndRideOk && carParkAndRideOk;
+        return bikeRentingOk && bikeParkAndRideOk && carParkAndRideOk && tncOK;
     }
 
     public Stop getPreviousStop() {
@@ -332,6 +351,13 @@ public class State implements Cloneable {
 
     public double getWeightDelta() {
         return this.weight - backState.weight;
+    }
+
+    public double getTransportationNetworkCompanyDistanceDelta() {
+        if (backState != null)
+            return Math.abs(this.transportationNetworkCompanyDriveDistance - backState.transportationNetworkCompanyDriveDistance);
+        else
+            return 0;
     }
 
     public void checkNegativeWeight() {
@@ -469,6 +495,7 @@ public class State implements Cloneable {
         newState.stateData.usingRentedBike = stateData.usingRentedBike;
         newState.stateData.carParked = stateData.carParked;
         newState.stateData.bikeParked = stateData.bikeParked;
+        newState.stateData.usingHailedCar = stateData.usingHailedCar;
         return newState;
     }
 
@@ -702,19 +729,23 @@ public class State implements Cloneable {
                 editor.incrementWeight(orig.getWeightDelta());
                 editor.incrementWalkDistance(orig.getWalkDistanceDelta());
                 editor.incrementPreTransitTime(orig.getPreTransitTimeDelta());
+                editor.incrementTransportationNetworkCompanyDistance(orig.getTransportationNetworkCompanyDistanceDelta());
                 
                 // propagate the modes through to the reversed edge
                 editor.setBackMode(orig.getBackMode());
+                State origBackState = orig.getBackState();
 
-                if (orig.isBikeRenting() && !orig.getBackState().isBikeRenting()) {
+                if (orig.isBikeRenting() && !origBackState.isBikeRenting()) {
                     editor.doneVehicleRenting();
-                } else if (!orig.isBikeRenting() && orig.getBackState().isBikeRenting()) {
+                } else if (!orig.isBikeRenting() && origBackState.isBikeRenting()) {
                     editor.beginVehicleRenting(((BikeRentalStationVertex)orig.vertex).getVehicleMode());
                 }
-                if (orig.isCarParked() != orig.getBackState().isCarParked())
+                if (orig.isCarParked() != origBackState.isCarParked())
                     editor.setCarParked(!orig.isCarParked());
-                if (orig.isBikeParked() != orig.getBackState().isBikeParked())
+                if (orig.isBikeParked() != origBackState.isBikeParked())
                     editor.setBikeParked(!orig.isBikeParked());
+                if (orig.isUsingHailedCar() != origBackState.isUsingHailedCar())
+                    editor.setUsingHailedCar(!orig.isUsingHailedCar());
 
                 editor.setNumBoardings(getNumBoardings() - orig.getNumBoardings());
 
@@ -827,4 +858,34 @@ public class State implements Cloneable {
         return stateData.enteredNoThroughTrafficArea;
     }
 
+    /**
+     * Checks if a TNC stop (alighting or boarding) should be allowed given the current state and
+     * characteristics of the last seen street edge.
+     */
+    public boolean isTNCStopAllowed() {
+        // Make sure travel distance in car is greater than minimum distance
+        if (this.transportationNetworkCompanyDriveDistance <
+                this.stateData.opt.minimumTransportationNetworkCompanyDistance) {
+            return false;
+        }
+        // see if street edge forbids parking
+        StreetEdge theEdge = getLastSeenStreetEdge(this);
+        if (!theEdge.getTNCStopSuitability())
+            return false;
+        return true;
+    }
+
+    /**
+     * Returns the last street edge traversed by scanning the backEdge of the state chain backward.
+     * @param state a State
+     */
+    private StreetEdge getLastSeenStreetEdge(State state) {
+        if (state == null) {
+            return null;
+        }
+        if (state.backEdge instanceof StreetEdge) {
+            return (StreetEdge) state.backEdge;
+        }
+        return getLastSeenStreetEdge(state.backState);
+    }
 }

--- a/src/main/java/org/opentripplanner/routing/core/StateData.java
+++ b/src/main/java/org/opentripplanner/routing/core/StateData.java
@@ -1,13 +1,13 @@
 package org.opentripplanner.routing.core;
 
-import java.util.HashMap;
-import java.util.Set;
-
 import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.model.Stop;
 import org.opentripplanner.model.Trip;
 import org.opentripplanner.routing.edgetype.TripPattern;
 import org.opentripplanner.routing.trippattern.TripTimes;
+
+import java.util.HashMap;
+import java.util.Set;
 
 /**
  * StateData contains the components of search state that are unlikely to be changed as often as
@@ -37,6 +37,11 @@ public class StateData implements Cloneable {
     protected boolean everBoarded;
 
     protected boolean usingRentedBike;
+
+    protected boolean usingHailedCar;
+
+    protected boolean hasHailedCarPostTransit = false;
+    protected boolean hasHailedCarPreTransit = false;
 
     protected boolean carParked;
 
@@ -107,5 +112,9 @@ public class StateData implements Cloneable {
     public int getNumBooardings(){
         return numBoardings;
     }
+
+    public boolean hasHailedCarPostTransit() { return hasHailedCarPostTransit; }
+
+    public boolean hasHailedCarPreTransit() { return hasHailedCarPreTransit; }
 
 }

--- a/src/main/java/org/opentripplanner/routing/core/StateEditor.java
+++ b/src/main/java/org/opentripplanner/routing/core/StateEditor.java
@@ -1,9 +1,5 @@
 package org.opentripplanner.routing.core;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Set;
-
 import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.model.Stop;
 import org.opentripplanner.model.Trip;
@@ -13,6 +9,10 @@ import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.routing.trippattern.TripTimes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Set;
 
 /**
  * This class is a wrapper around a new State that provides it with setter and increment methods,
@@ -231,6 +231,11 @@ public class StateEditor {
         cloneStateDataAsNeeded();
         child.stateData.numBoardings++;
         setEverBoarded(true);
+    }
+
+    public void incrementTransportationNetworkCompanyDistance(double distance) {
+        cloneStateDataAsNeeded();
+        child.transportationNetworkCompanyDriveDistance += distance;
     }
 
     /* Basic Setters */
@@ -519,6 +524,71 @@ public class StateEditor {
 
     public boolean hasEnteredNoThroughTrafficArea() {
         return child.hasEnteredNoThruTrafficArea();
+    }
+
+    public void alightHailedCar() {
+        cloneStateDataAsNeeded();
+        child.stateData.usingHailedCar = false;
+        child.stateData.nonTransitMode = TraverseMode.WALK;
+    }
+
+    /**
+     * Board a hailed car (provided by a transportation network company).
+     *
+     * If boarding a hailed car before boarding transit in "depart at" mode, we assume that the ETA estimate is
+     * applicable and it is added to the duration of the TNC trip.  In all other cases, the assumption is being made
+     * that this is not necessarily trip plan for "right now".  Furthermore, it is assumed that in "right now" trips
+     * once a user has boarded transit they are able to minimize their wait time at their final transit deboarding
+     * location by somehow getting a TNC vehicle to be available to board immediately at the next possible street edge.
+     *
+     * This method is called from the traverse method of the StreetEdge class.  The edge will be traversed in CAR mode,
+     * but since the determination to board a hailed car happens after that, the initial distance traveled in the car
+     * must be added here to the transportationNetworkCompanyDriveDistance variable.
+     */
+    public void boardHailedCar(double initialEdgeDistance) {
+        cloneStateDataAsNeeded();
+        child.stateData.usingHailedCar = true;
+        child.stateData.nonTransitMode = TraverseMode.CAR;
+        if (child.isEverBoarded()) {
+            child.stateData.hasHailedCarPostTransit = true;
+        } else {
+            child.stateData.hasHailedCarPreTransit = true;
+            RoutingRequest options = child.getContext().opt;
+            // add the earliest ETA of a TNC vehicle if using "departing at" mode and if before transit.
+            // This uses the ETA of a TNC vehicle at the origin, so this code is making the assumption that the ETA
+            // estimate obtained for the origin is applicable at other places and times so long as transit has not been
+            // boarded yet.  The way to obtain ETA estimates for every possible street and vertex would involve making
+            // potentially hundreds of thousands of http requests to existing TNC API endpoints.  It sure would be nice
+            // if there were a way to download network-wide ETA estimates in a single request, but that option currently
+            // does not exist.
+            //
+            // FIXME: If a non-transit mode travels a significant distance from the origin prior to boarding a TNC, the
+            // ETA will still be added when it probably shouldn't be.
+            if (
+                    !options.arriveBy &&
+                            options.transportationNetworkCompanyEtaAtOrigin > -1 &&
+                            !child.stateData.everBoarded
+            ) {
+                // increment the time by the ETA at the origin.
+                incrementTimeInMilliseconds(options.transportationNetworkCompanyEtaAtOrigin * 1000);
+            }
+        }
+        // Add the initial TNC distance as the first StreetEdge traversed is done so while the usingHailedCar flag is
+        // still set to false
+        child.transportationNetworkCompanyDriveDistance = initialEdgeDistance;
+    }
+
+    /**
+     * Used only in State.optimizeOrReverse
+     */
+    public void setUsingHailedCar(boolean usingHailedCar) {
+        cloneStateDataAsNeeded();
+        child.stateData.usingHailedCar = usingHailedCar;
+        if (usingHailedCar) {
+            child.stateData.nonTransitMode = TraverseMode.CAR;
+        } else {
+            child.stateData.nonTransitMode = TraverseMode.WALK;
+        }
     }
 
 }

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetTransitLink.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetTransitLink.java
@@ -99,11 +99,18 @@ public class StreetTransitLink extends Edge {
         // This allows searching for nearby transit stops using walk-only options.
         StateEditor s1 = s0.edit(this);
 
-        /* Only enter stations in CAR mode if parking is not required (kiss and ride) */
+        /* Determine if transit should be boarded if currently traveling in a car */
         /* Note that in arriveBy searches this is double-traversing link edges to fork the state into both WALK and CAR mode. This is an insane hack. */
         if (s0.getNonTransitMode() == TraverseMode.CAR) {
             if (req.kissAndRide && !s0.isCarParked()) {
                 s1.setCarParked(true);
+            } else if (req.useTransportationNetworkCompany && s0.isUsingHailedCar()) {
+                // check to see if the last state has conditions that allow alighting a hailed car
+                if (s0.isTNCStopAllowed()) {
+                    s1.alightHailedCar();
+                } else {
+                    return null;
+                }
             } else {
                 return null;
             }

--- a/src/main/java/org/opentripplanner/routing/error/TransportationNetworkCompanyAvailabilityException.java
+++ b/src/main/java/org/opentripplanner/routing/error/TransportationNetworkCompanyAvailabilityException.java
@@ -1,0 +1,16 @@
+/* This program is free software: you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public License
+ as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+package org.opentripplanner.routing.error;
+
+public class TransportationNetworkCompanyAvailabilityException extends RuntimeException { }

--- a/src/main/java/org/opentripplanner/routing/impl/GraphPathFinder.java
+++ b/src/main/java/org/opentripplanner/routing/impl/GraphPathFinder.java
@@ -77,6 +77,7 @@ public class GraphPathFinder {
         // Reuse one instance of AStar for all N requests, which are carried out sequentially
         AStar aStar = new AStar();
         if (options.rctx == null) {
+            // This call will also set the start and end vertices
             options.setRoutingContext(router.graph);
             // The special long-distance heuristic should be sufficient to constrain the search to the right area.
         }
@@ -141,7 +142,9 @@ public class GraphPathFinder {
             if (timeoutIndex >= router.timeouts.length) {
                 timeoutIndex = router.timeouts.length - 1;
             }
-            double timeout = searchBeginTime + (router.timeouts[timeoutIndex] * 1000);
+            double timeout = searchBeginTime + (
+                options.searchTimeout < 0 ? router.timeouts[timeoutIndex] * 1000 : options.searchTimeout
+            );
             timeout -= System.currentTimeMillis(); // Convert from absolute to relative time
             timeout /= 1000; // Convert milliseconds to seconds
             if (timeout <= 0) {

--- a/src/main/java/org/opentripplanner/routing/spt/DominanceFunction.java
+++ b/src/main/java/org/opentripplanner/routing/spt/DominanceFunction.java
@@ -81,6 +81,19 @@ public abstract class DominanceFunction implements Serializable {
             return false;
         }
 
+        // Does one state represent using a hailed car and the other using another mode?
+        if (a.isUsingHailedCar() != b.isUsingHailedCar()) {
+            return false;
+        }
+        // Does one state represent using a hailed car before transit and the other using a hailed car after?
+        if (a.stateData.hasHailedCarPreTransit() != b.stateData.hasHailedCarPreTransit()) {
+            return false;
+        }
+        // Does one state represent using a hailed car before transit and the other using a hailed car after?
+        if (a.stateData.hasHailedCarPostTransit() != b.stateData.hasHailedCarPostTransit()) {
+            return false;
+        }
+
         // Are the two states arriving at a vertex from two different directions where turn restrictions apply?
         if (a.backEdge != b.getBackEdge() && (a.backEdge instanceof StreetEdge)) {
             if (! a.getOptions().getRoutingContext().graph.getTurnRestrictions(a.backEdge).isEmpty()) {

--- a/src/main/java/org/opentripplanner/routing/transportation_network_company/ArrivalTime.java
+++ b/src/main/java/org/opentripplanner/routing/transportation_network_company/ArrivalTime.java
@@ -1,0 +1,29 @@
+/* This program is free software: you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public License
+ as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+package org.opentripplanner.routing.transportation_network_company;
+
+// A class to model estimated arrival times of service from a transportaiton network company
+public class ArrivalTime {
+    public TransportationNetworkCompany company;
+    public String productId;
+    public String displayName;
+    public int estimatedSeconds;
+
+    public ArrivalTime(TransportationNetworkCompany company, String productId, String displayName, int estimatedSeconds) {
+        this.company = company;
+        this.productId = productId;
+        this.displayName = displayName;
+        this.estimatedSeconds = estimatedSeconds;
+    }
+}

--- a/src/main/java/org/opentripplanner/routing/transportation_network_company/RideEstimate.java
+++ b/src/main/java/org/opentripplanner/routing/transportation_network_company/RideEstimate.java
@@ -1,0 +1,34 @@
+/* This program is free software: you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public License
+ as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+package org.opentripplanner.routing.transportation_network_company;
+
+// A class to model the estimated ride time while using service from a transportation network company
+public class RideEstimate {
+
+    public TransportationNetworkCompany company;
+    public String currency;
+    public int duration;  // in seconds
+    public double maxCost;
+    public double minCost;
+    public String rideType;
+
+    public RideEstimate(TransportationNetworkCompany company, String currency, int duration, double maxCost, double minCost, String rideType) {
+        this.company = company;
+        this.currency = currency;
+        this.duration = duration;
+        this.maxCost = maxCost;
+        this.minCost = minCost;
+        this.rideType = rideType;
+    }
+}

--- a/src/main/java/org/opentripplanner/routing/transportation_network_company/TransportationNetworkCompany.java
+++ b/src/main/java/org/opentripplanner/routing/transportation_network_company/TransportationNetworkCompany.java
@@ -1,0 +1,18 @@
+/* This program is free software: you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public License
+ as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+package org.opentripplanner.routing.transportation_network_company;
+
+public enum TransportationNetworkCompany {
+    LYFT, UBER
+}

--- a/src/main/java/org/opentripplanner/routing/transportation_network_company/TransportationNetworkCompanyService.java
+++ b/src/main/java/org/opentripplanner/routing/transportation_network_company/TransportationNetworkCompanyService.java
@@ -1,0 +1,112 @@
+/* This program is free software: you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public License
+ as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+package org.opentripplanner.routing.transportation_network_company;
+
+import org.opentripplanner.api.model.Place;
+import org.opentripplanner.updater.transportation_network_company.TransportationNetworkCompanyDataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.*;
+
+public class TransportationNetworkCompanyService implements Serializable {
+
+    private static Logger LOG = LoggerFactory.getLogger(TransportationNetworkCompanyService.class);
+
+    private Map<TransportationNetworkCompany, TransportationNetworkCompanyDataSource> sources =
+        new HashMap<>();
+
+    public void addSource(TransportationNetworkCompanyDataSource source) {
+        sources.put(source.getType(), source);
+    }
+
+    public List<ArrivalTime> getArrivalTimes(
+        Place place,
+        String companies
+    ) throws ExecutionException, InterruptedException {
+
+        List<ArrivalTime> arrivalTimes = new ArrayList<>();
+
+        List<TransportationNetworkCompanyDataSource> companiesToRequestFrom
+            = new ArrayList<>();
+
+        // parse list of tnc companies
+        for (String company : companies.split(",")) {
+            companiesToRequestFrom.add(getTransportationNetworkCompanyDataSource(company));
+        }
+
+        if (companiesToRequestFrom.size() == 0) {
+            return arrivalTimes;
+        }
+
+        LOG.debug("Finding TNC arrival times for {} companies", companiesToRequestFrom.size());
+
+        // add a request for all matching companies
+        ExecutorService pool = Executors.newFixedThreadPool(10);
+        List<Callable<List<ArrivalTime>>> tasks = new ArrayList<>();
+
+        for (TransportationNetworkCompanyDataSource transportationNetworkCompany : companiesToRequestFrom) {
+            tasks.add(() -> {
+                LOG.debug("Finding TNC arrival times for {} ({},{})", transportationNetworkCompany.getType(), place.lat, place.lon);
+                return transportationNetworkCompany.getArrivalTimes(place.lat, place.lon);
+            });
+        }
+
+        List<Future<List<ArrivalTime>>> results = pool.invokeAll(tasks);
+
+        LOG.debug("Collecting results");
+
+        for (Future<List<ArrivalTime>> future : results) {
+            arrivalTimes.addAll(future.get());
+        }
+        pool.shutdown();
+
+        return arrivalTimes;
+    }
+
+    public RideEstimate getRideEstimate(
+        String company,
+        String rideType,
+        Place fromPlace,
+        Place toPlace
+    ) throws IOException, ExecutionException {
+        TransportationNetworkCompanyDataSource source = getTransportationNetworkCompanyDataSource(company);
+        return source.getRideEstimate(rideType, fromPlace.lat, fromPlace.lon, toPlace.lat, toPlace.lon);
+    }
+
+    private TransportationNetworkCompanyDataSource getTransportationNetworkCompanyDataSource(String company) {
+        TransportationNetworkCompany co = TransportationNetworkCompany.valueOf(company);
+        if (co == null) {
+            throw new UnsupportedOperationException("Transportation Network Company value " +
+                company +
+                " is not a valid type"
+            );
+        }
+
+        if (!sources.containsKey(co)) {
+            throw new UnsupportedOperationException("Transportation Network Company value " +
+                company +
+                " is not configured in this router"
+            );
+        }
+
+        return sources.get(co);
+    }
+}

--- a/src/main/java/org/opentripplanner/standalone/OTPApplication.java
+++ b/src/main/java/org/opentripplanner/standalone/OTPApplication.java
@@ -94,6 +94,7 @@ public class OTPApplication extends Application {
             UpdaterStatusResource.class,
             ScenarioResource.class,
             RepeatedRaptorTestResource.class,
+            TransportationNetworkCompanyResource.class,
             /* Features and Filters: extend Jersey, manipulate requests and responses. */
             CorsFilter.class,
             MultiPartFeature.class

--- a/src/main/java/org/opentripplanner/updater/GraphUpdaterConfigurator.java
+++ b/src/main/java/org/opentripplanner/updater/GraphUpdaterConfigurator.java
@@ -11,6 +11,7 @@ import org.opentripplanner.updater.stoptime.PollingStoptimeUpdater;
 import org.opentripplanner.updater.stoptime.WebsocketGtfsRealtimeUpdater;
 import org.opentripplanner.updater.street_notes.WinkkiPollingGraphUpdater;
 import org.opentripplanner.updater.traffic.OpenTrafficUpdater;
+import org.opentripplanner.updater.transportation_network_company.TransportationNetworkCompanyUpdater;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -94,6 +95,9 @@ public abstract class GraphUpdaterConfigurator {
                 }
                 else if (type.equals("opentraffic-updater")) {
                     updater = new OpenTrafficUpdater();
+                }
+                else if (type.equals("transportation-network-company-updater")) {
+                    updater = new TransportationNetworkCompanyUpdater();
                 }
             }
 

--- a/src/main/java/org/opentripplanner/updater/transportation_network_company/Position.java
+++ b/src/main/java/org/opentripplanner/updater/transportation_network_company/Position.java
@@ -1,0 +1,61 @@
+/* This program is free software: you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public License
+as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+package org.opentripplanner.updater.transportation_network_company;
+
+import java.util.Objects;
+
+/**
+ * This class is used for approximating a position.
+ * It is used so that numerous TNC requests with very similar coordinates can be assumed to be the same.
+ */
+public class Position {
+    public double latitude;
+    public double longitude;
+
+    private int intLat;
+    private int intLon;
+
+    public Position(double latitude, double longitude) {
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.intLat = intVal(latitude);
+        this.intLon = intVal(longitude);
+    }
+
+    public int getIntLat() {
+        return intLat;
+    }
+
+    public int getIntLon() {
+        return intLon;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Position position = (Position) o;
+        return intLat == position.getIntLat() &&
+            intLon == position.getIntLon();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(intLat, intLon);
+    }
+
+    public int intVal (double d) {
+        return (int) (d * 10000);
+    }
+}

--- a/src/main/java/org/opentripplanner/updater/transportation_network_company/RideEstimateRequest.java
+++ b/src/main/java/org/opentripplanner/updater/transportation_network_company/RideEstimateRequest.java
@@ -1,0 +1,46 @@
+/* This program is free software: you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public License
+as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+package org.opentripplanner.updater.transportation_network_company;
+
+import java.util.Objects;
+
+public class RideEstimateRequest {
+
+    public Position startPosition;
+    public Position endPosition;
+
+    public RideEstimateRequest(double startLatitude, double startLongitude, double endLatitude, double endLongitude) {
+        this.startPosition = new Position(startLatitude, startLongitude);
+        this.endPosition = new Position(endLatitude, endLongitude);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RideEstimateRequest request = (RideEstimateRequest) o;
+        return startPosition.equals(request.startPosition) &&
+            endPosition.equals(request.endPosition);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+            startPosition.getIntLat(),
+            startPosition.getIntLon(),
+            endPosition.getIntLat(),
+            endPosition.getIntLon()
+        );
+    }
+}

--- a/src/main/java/org/opentripplanner/updater/transportation_network_company/TransportationNetworkCompanyDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/transportation_network_company/TransportationNetworkCompanyDataSource.java
@@ -1,0 +1,86 @@
+/* This program is free software: you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public License
+as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+package org.opentripplanner.updater.transportation_network_company;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import org.opentripplanner.routing.transportation_network_company.ArrivalTime;
+import org.opentripplanner.routing.transportation_network_company.RideEstimate;
+import org.opentripplanner.routing.transportation_network_company.TransportationNetworkCompany;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+public abstract class TransportationNetworkCompanyDataSource {
+    // This value should be no longer than 30 minutes (according to Uber API docs) TODO check Lyft time limit
+    private static final int cacheTimeSeconds = 120;
+
+    private Cache<Position, List<ArrivalTime>> arrivalTimeCache =
+        CacheBuilder.newBuilder().expireAfterWrite(cacheTimeSeconds, TimeUnit.SECONDS).build();
+    private Cache<RideEstimateRequest, List<RideEstimate>> rideEstimateCache =
+        CacheBuilder.newBuilder().expireAfterWrite(cacheTimeSeconds, TimeUnit.SECONDS).build();
+
+    public abstract TransportationNetworkCompany getType();
+
+    // get the next arrivals for a specific location
+    public List<ArrivalTime> getArrivalTimes(double latitude, double longitude) throws ExecutionException {
+        Position position = new Position(truncateValue(latitude), truncateValue(longitude));
+        return arrivalTimeCache.get(position, () -> queryArrivalTimes(position));
+    }
+
+    protected abstract List<ArrivalTime> queryArrivalTimes(Position position) throws IOException;
+
+    // get the estimated trip time
+    public RideEstimate getRideEstimate(
+        String rideType,
+        double startLatitude,
+        double startLongitude,
+        double endLatitude,
+        double endLongitude
+    ) throws ExecutionException {
+        // Truncate lat/lon values in order to reduce the number of API requests made.
+        double roundedStartLat = truncateValue(startLatitude);
+        double roundedStartLon = truncateValue(startLongitude);
+        double roundedEndLat = truncateValue(endLatitude);
+        double roundedEndLon = truncateValue(endLongitude);
+        RideEstimateRequest request = new RideEstimateRequest(roundedStartLat, roundedStartLon, roundedEndLat, roundedEndLon);
+        List<RideEstimate> rideEstimates = rideEstimateCache.get(request, () -> queryRideEstimates(request));
+
+
+        for (RideEstimate rideEstimate : rideEstimates) {
+            if (rideEstimate.rideType.equals(rideType)) {
+                return rideEstimate;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Truncate double values by the specified precision factor.
+     */
+    private static double truncateValue(double value) {
+        double precisionFactor = 10000.0;
+        return Math.round(value * precisionFactor) / precisionFactor;
+    }
+
+    protected abstract List<RideEstimate> queryRideEstimates(
+        RideEstimateRequest request
+    ) throws IOException;
+}

--- a/src/main/java/org/opentripplanner/updater/transportation_network_company/TransportationNetworkCompanyUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/transportation_network_company/TransportationNetworkCompanyUpdater.java
@@ -1,0 +1,74 @@
+/* This program is free software: you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public License
+as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+package org.opentripplanner.updater.transportation_network_company;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.routing.transportation_network_company.TransportationNetworkCompanyService;
+import org.opentripplanner.updater.GraphUpdater;
+import org.opentripplanner.updater.GraphUpdaterManager;
+import org.opentripplanner.updater.transportation_network_company.lyft.LyftTransportationNetworkCompanyDataSource;
+import org.opentripplanner.updater.transportation_network_company.uber.UberTransportationNetworkCompanyDataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TransportationNetworkCompanyUpdater implements GraphUpdater {
+
+    private static Logger LOG = LoggerFactory.getLogger(TransportationNetworkCompanyUpdater.class);
+
+    private GraphUpdaterManager updaterManager;
+    private TransportationNetworkCompanyDataSource source;
+    private TransportationNetworkCompanyService service;
+
+    @Override
+    public void setGraphUpdaterManager(GraphUpdaterManager updaterManager) {
+        this.updaterManager = updaterManager;
+    }
+
+    @Override
+    public void setup(Graph graph) {
+        service = graph.getService(TransportationNetworkCompanyService.class, true);
+    }
+
+    @Override
+    public void run() throws Exception {
+        // Adds the source upon startup
+        service.addSource(source);
+    }
+
+    @Override
+    public void teardown() { }
+
+    @Override
+    public void configure(Graph graph, JsonNode config) throws Exception {
+        // Set data source type from config JSON
+        String sourceType = config.path("sourceType").asText();
+        if (sourceType != null) {
+            if (sourceType.equals("uber")) {
+                source = new UberTransportationNetworkCompanyDataSource(config.path("serverToken").asText());
+            } else if (sourceType.equals("lyft")) {
+                source = new LyftTransportationNetworkCompanyDataSource(
+                    config.path("clientId").asText(),
+                    config.path("clientSecret").asText()
+                );
+            }
+        }
+
+        if (source == null) {
+            throw new IllegalArgumentException("Unknown transportation netowrk company source type: " + sourceType);
+        }
+
+        LOG.info("Setup a transportation netowrk company updater for type: " + sourceType);
+    }
+}

--- a/src/main/java/org/opentripplanner/updater/transportation_network_company/lyft/LyftArrivalEstimate.java
+++ b/src/main/java/org/opentripplanner/updater/transportation_network_company/lyft/LyftArrivalEstimate.java
@@ -1,0 +1,20 @@
+/* This program is free software: you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public License
+as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+package org.opentripplanner.updater.transportation_network_company.lyft;
+
+public class LyftArrivalEstimate {
+    public int eta_seconds;
+    public String display_name;
+    public String ride_type;
+}

--- a/src/main/java/org/opentripplanner/updater/transportation_network_company/lyft/LyftArrivalEstimateResponse.java
+++ b/src/main/java/org/opentripplanner/updater/transportation_network_company/lyft/LyftArrivalEstimateResponse.java
@@ -1,0 +1,20 @@
+/* This program is free software: you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public License
+as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+package org.opentripplanner.updater.transportation_network_company.lyft;
+
+import java.util.List;
+
+public class LyftArrivalEstimateResponse {
+    public List<LyftArrivalEstimate> eta_estimates;
+}

--- a/src/main/java/org/opentripplanner/updater/transportation_network_company/lyft/LyftAuthenticationRequestBody.java
+++ b/src/main/java/org/opentripplanner/updater/transportation_network_company/lyft/LyftAuthenticationRequestBody.java
@@ -1,0 +1,25 @@
+/* This program is free software: you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public License
+as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+package org.opentripplanner.updater.transportation_network_company.lyft;
+
+public class LyftAuthenticationRequestBody {
+
+    public String grant_type;
+    public String scope;
+
+    public LyftAuthenticationRequestBody(String grant_type, String scope) {
+        this.grant_type = grant_type;
+        this.scope = scope;
+    }
+}

--- a/src/main/java/org/opentripplanner/updater/transportation_network_company/lyft/LyftAuthenticationResponse.java
+++ b/src/main/java/org/opentripplanner/updater/transportation_network_company/lyft/LyftAuthenticationResponse.java
@@ -1,0 +1,21 @@
+/* This program is free software: you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public License
+as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+package org.opentripplanner.updater.transportation_network_company.lyft;
+
+public class LyftAuthenticationResponse {
+    public String access_token;
+    public int expires_in;
+    public String scope;
+    public String token_type;
+}

--- a/src/main/java/org/opentripplanner/updater/transportation_network_company/lyft/LyftError.java
+++ b/src/main/java/org/opentripplanner/updater/transportation_network_company/lyft/LyftError.java
@@ -1,0 +1,27 @@
+/* This program is free software: you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public License
+as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+package org.opentripplanner.updater.transportation_network_company.lyft;
+
+public class LyftError {
+    public String error;
+    public String error_description;
+
+    @Override
+    public String toString() {
+        return "LyftError{" +
+            "error='" + error + '\'' +
+            ", error_description='" + error_description + '\'' +
+            '}';
+    }
+}

--- a/src/main/java/org/opentripplanner/updater/transportation_network_company/lyft/LyftRideEstimate.java
+++ b/src/main/java/org/opentripplanner/updater/transportation_network_company/lyft/LyftRideEstimate.java
@@ -1,0 +1,22 @@
+/* This program is free software: you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public License
+as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+package org.opentripplanner.updater.transportation_network_company.lyft;
+
+public class LyftRideEstimate {
+    public String currency;
+    public int estimated_cost_cents_max;
+    public int estimated_cost_cents_min;
+    public int estimated_duration_seconds;
+    public String ride_type;
+}

--- a/src/main/java/org/opentripplanner/updater/transportation_network_company/lyft/LyftRideEstimateResponse.java
+++ b/src/main/java/org/opentripplanner/updater/transportation_network_company/lyft/LyftRideEstimateResponse.java
@@ -1,0 +1,20 @@
+/* This program is free software: you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public License
+as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+package org.opentripplanner.updater.transportation_network_company.lyft;
+
+import java.util.List;
+
+public class LyftRideEstimateResponse {
+    public List<LyftRideEstimate> cost_estimates;
+}

--- a/src/main/java/org/opentripplanner/updater/transportation_network_company/lyft/LyftTransportationNetworkCompanyDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/transportation_network_company/lyft/LyftTransportationNetworkCompanyDataSource.java
@@ -1,0 +1,215 @@
+/* This program is free software: you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public License
+as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+package org.opentripplanner.updater.transportation_network_company.lyft;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.opentripplanner.routing.transportation_network_company.ArrivalTime;
+import org.opentripplanner.routing.transportation_network_company.RideEstimate;
+import org.opentripplanner.routing.transportation_network_company.TransportationNetworkCompany;
+import org.opentripplanner.updater.transportation_network_company.Position;
+import org.opentripplanner.updater.transportation_network_company.RideEstimateRequest;
+import org.opentripplanner.updater.transportation_network_company.TransportationNetworkCompanyDataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.core.UriBuilder;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+public class LyftTransportationNetworkCompanyDataSource extends TransportationNetworkCompanyDataSource {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LyftTransportationNetworkCompanyDataSource.class);
+
+    private static final String LYFT_API_URL = "https://api.lyft.com/";
+
+    private String accessToken;
+    private String baseUrl;  // for testing purposes
+    private String clientId;
+    private String clientSecret;
+    private Date tokenExpirationTime;
+
+    public LyftTransportationNetworkCompanyDataSource(String clientId, String clientSecret) {
+        this.baseUrl = LYFT_API_URL;
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+    }
+
+    // intended for use during testing
+    public LyftTransportationNetworkCompanyDataSource(String baseUrl, String clientId, String clientSecret) {
+        this.baseUrl = baseUrl;
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+    }
+
+    private String getAccessToken() throws IOException {
+        // check if token needs to be obtained
+        Date now = new Date();
+        if (tokenExpirationTime == null || now.after(tokenExpirationTime)) {
+            // token needs to be obtained
+            LOG.info("Requesting new lyft access token");
+
+            ObjectMapper mapper = new ObjectMapper();
+            mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+            // prepare request to get token
+            UriBuilder uriBuilder = UriBuilder.fromUri(baseUrl + "oauth/token");
+            URL url = new URL(uriBuilder.toString());
+            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+            String userpass = clientId + ":" + clientSecret;
+            String basicAuth = "Basic " + javax.xml.bind.DatatypeConverter.printBase64Binary(userpass.getBytes());
+            connection.setRequestProperty("Authorization", basicAuth);
+            connection.setRequestProperty("Content-Type", "application/json;charset=UTF-8");
+
+            // set request body
+            LyftAuthenticationRequestBody authRequest = new LyftAuthenticationRequestBody(
+                "client_credentials",
+                "public"
+            );
+            connection.setDoOutput(true);
+            mapper.writeValue(connection.getOutputStream(), authRequest);
+
+            // send request and parse repsonse
+            InputStream responseStream = connection.getInputStream();
+            LyftAuthenticationResponse response = mapper.readValue(responseStream, LyftAuthenticationResponse.class);
+            accessToken = response.access_token;
+            tokenExpirationTime = new Date();
+            tokenExpirationTime.setTime(tokenExpirationTime.getTime() + (response.expires_in - 60) * 1000);
+
+            LOG.info("Received new lyft access token");
+        }
+
+        return accessToken;
+    }
+
+    @Override
+    public TransportationNetworkCompany getType() {
+        return TransportationNetworkCompany.LYFT;
+    }
+
+    @Override
+    public List<ArrivalTime> queryArrivalTimes(Position request) throws IOException {
+        // prepare request
+        UriBuilder uriBuilder = UriBuilder.fromUri(baseUrl + "v1/eta");
+        uriBuilder.queryParam("lat", request.latitude);
+        uriBuilder.queryParam("lng", request.longitude);
+        String requestUrl = uriBuilder.toString();
+        URL url = new URL(requestUrl);
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        connection.setRequestProperty("Authorization", "Bearer " + getAccessToken());
+        connection.setRequestProperty("Content-Type", "application/json;charset=UTF-8");
+
+        LOG.info("Made request to lyft API at following URL: " + requestUrl);
+
+        // make request, parse repsonse
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        if (connection.getResponseCode() < HttpURLConnection.HTTP_BAD_REQUEST) {
+            LyftArrivalEstimateResponse response = mapper.readValue(
+                connection.getInputStream(),
+                LyftArrivalEstimateResponse.class
+            );
+
+            // serialize into Arrival Time objects
+            ArrayList<ArrivalTime> arrivalTimes = new ArrayList<ArrivalTime>();
+
+            LOG.info("Received " + response.eta_estimates.size() + " lyft arrival time estimates");
+
+            for (final LyftArrivalEstimate time: response.eta_estimates) {
+                arrivalTimes.add(
+                    new ArrivalTime(
+                        TransportationNetworkCompany.LYFT,
+                        time.ride_type,
+                        time.display_name,
+                        time.eta_seconds
+                    )
+                );
+            }
+
+            return arrivalTimes;
+        } else {
+            LyftError error = mapper.readValue(connection.getErrorStream(), LyftError.class);
+            if (error.error.equals("no_service_in_area") || error.error.equals("ridetype_unavailable_in_region")) {
+                return Collections.emptyList();
+            }
+            LOG.error(error.toString());
+            throw new IOException("received an error from the Lyft API");
+        }
+    }
+
+    @Override
+    public List<RideEstimate> queryRideEstimates(
+        RideEstimateRequest request
+    ) throws IOException {
+        // prepare request
+        UriBuilder uriBuilder = UriBuilder.fromUri(baseUrl + "v1/cost");
+        uriBuilder.queryParam("start_lat", request.startPosition.latitude);
+        uriBuilder.queryParam("start_lng", request.startPosition.longitude);
+        uriBuilder.queryParam("end_lat", request.endPosition.latitude);
+        uriBuilder.queryParam("end_lng", request.endPosition.longitude);
+        String requestUrl = uriBuilder.toString();
+        URL url = new URL(requestUrl);
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        connection.setRequestProperty("Authorization", "Bearer " + getAccessToken());
+        connection.setRequestProperty("Content-Type", "application/json;charset=UTF-8");
+
+        LOG.info("Made request to lyft API at following URL: " + requestUrl);
+
+        // make request, parse repsonse
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+        if (connection.getResponseCode() < HttpURLConnection.HTTP_BAD_REQUEST) {
+            InputStream responseStream = connection.getInputStream();
+            LyftRideEstimateResponse response = mapper.readValue(responseStream, LyftRideEstimateResponse.class);
+
+            if (response.cost_estimates == null) {
+                throw new IOException("Unrecocginzed response format");
+            }
+
+            LOG.info("Recieved " + response.cost_estimates.size() + " lyft price/time estimates");
+
+            List<RideEstimate> estimates = new ArrayList<RideEstimate>();
+
+            for (final LyftRideEstimate estimate: response.cost_estimates) {
+                estimates.add(new RideEstimate(
+                    TransportationNetworkCompany.LYFT,
+                    estimate.currency,
+                    estimate.estimated_duration_seconds,
+                    // Lyft's esimated cost is in the "minor" unit, so the following
+                    // may not work in countries that don't have 100 minor units per major unit
+                    // see https://en.wikipedia.org/wiki/ISO_4217#Treatment_of_minor_currency_units_(the_"exponent")
+                    estimate.estimated_cost_cents_max / 100,
+                    estimate.estimated_cost_cents_min / 100,
+                    estimate.ride_type
+                ));
+            }
+
+            return estimates;
+        } else {
+            LyftError error = mapper.readValue(connection.getErrorStream(), LyftError.class);
+            LOG.error(error.toString());
+            if (error.error_description != null) {
+                throw new IOException(error.error_description);
+            }
+            throw new IOException("received an error from the Lyft API");
+        }
+    }
+}

--- a/src/main/java/org/opentripplanner/updater/transportation_network_company/uber/UberArrivalEstimate.java
+++ b/src/main/java/org/opentripplanner/updater/transportation_network_company/uber/UberArrivalEstimate.java
@@ -1,0 +1,21 @@
+/* This program is free software: you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public License
+as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+package org.opentripplanner.updater.transportation_network_company.uber;
+
+public class UberArrivalEstimate {
+    public String display_name;
+    public int estimate;
+    public String localized_display_name;
+    public String product_id;
+}

--- a/src/main/java/org/opentripplanner/updater/transportation_network_company/uber/UberArrivalEstimateResponse.java
+++ b/src/main/java/org/opentripplanner/updater/transportation_network_company/uber/UberArrivalEstimateResponse.java
@@ -1,0 +1,20 @@
+/* This program is free software: you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public License
+as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+package org.opentripplanner.updater.transportation_network_company.uber;
+
+import java.util.List;
+
+public class UberArrivalEstimateResponse {
+    public List<UberArrivalEstimate> times;
+}

--- a/src/main/java/org/opentripplanner/updater/transportation_network_company/uber/UberTransportationNetworkCompanyDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/transportation_network_company/uber/UberTransportationNetworkCompanyDataSource.java
@@ -1,0 +1,145 @@
+/* This program is free software: you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public License
+as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+package org.opentripplanner.updater.transportation_network_company.uber;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.opentripplanner.routing.transportation_network_company.ArrivalTime;
+import org.opentripplanner.routing.transportation_network_company.RideEstimate;
+import org.opentripplanner.routing.transportation_network_company.TransportationNetworkCompany;
+import org.opentripplanner.updater.transportation_network_company.Position;
+import org.opentripplanner.updater.transportation_network_company.RideEstimateRequest;
+import org.opentripplanner.updater.transportation_network_company.TransportationNetworkCompanyDataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.core.UriBuilder;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+public class UberTransportationNetworkCompanyDataSource extends TransportationNetworkCompanyDataSource {
+
+    private static final Logger LOG = LoggerFactory.getLogger(UberTransportationNetworkCompanyDataSource.class);
+
+    private static final String UBER_API_URL = "https://api.uber.com/v1.2/";
+
+    private String serverToken;
+    private String baseUrl;
+
+    public UberTransportationNetworkCompanyDataSource (String serverToken) {
+        this.serverToken = serverToken;
+        this.baseUrl = UBER_API_URL;
+    }
+
+    public UberTransportationNetworkCompanyDataSource (String serverToken, String baseUrl) {
+        this.serverToken = serverToken;
+        this.baseUrl = baseUrl;
+    }
+
+    @Override
+    public TransportationNetworkCompany getType() {
+        return TransportationNetworkCompany.UBER;
+    }
+
+    @Override
+    public List<ArrivalTime> queryArrivalTimes(Position position) throws IOException {
+        // prepare request
+        UriBuilder uriBuilder = UriBuilder.fromUri(baseUrl + "estimates/time");
+        uriBuilder.queryParam("start_latitude", position.latitude);
+        uriBuilder.queryParam("start_longitude", position.longitude);
+        String requestUrl = uriBuilder.toString();
+        URL uberUrl = new URL(requestUrl);
+        HttpURLConnection connection = (HttpURLConnection) uberUrl.openConnection();
+        connection.setRequestProperty("Authorization", "Token " + serverToken);
+        connection.setRequestProperty("Accept-Language", "en_US");
+        connection.setRequestProperty("Content-Type", "application/json");
+
+        LOG.info("Made arrival time request to Uber API at following URL: {}", requestUrl);
+
+        // Make request, parse response
+        InputStream responseStream = connection.getInputStream();
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        UberArrivalEstimateResponse response = mapper.readValue(responseStream, UberArrivalEstimateResponse.class);
+
+        // serialize into Arrival Time objects
+        List<ArrivalTime> arrivalTimes = new ArrayList<>();
+
+        LOG.debug("Received {} Uber arrival time estimates", response.times.size());
+
+        for (final UberArrivalEstimate time: response.times) {
+            arrivalTimes.add(
+                new ArrivalTime(
+                    TransportationNetworkCompany.UBER,
+                    time.product_id,
+                    time.localized_display_name,
+                    time.estimate
+                )
+            );
+        }
+
+        return arrivalTimes;
+    }
+
+    @Override
+    public List<RideEstimate> queryRideEstimates(
+        RideEstimateRequest request
+    ) throws IOException {
+        // prepare request
+        UriBuilder uriBuilder = UriBuilder.fromUri(baseUrl + "estimates/price");
+        uriBuilder.queryParam("start_latitude", request.startPosition.latitude);
+        uriBuilder.queryParam("start_longitude", request.startPosition.longitude);
+        uriBuilder.queryParam("end_latitude", request.endPosition.latitude);
+        uriBuilder.queryParam("end_longitude", request.endPosition.longitude);
+        String requestUrl = uriBuilder.toString();
+        URL uberUrl = new URL(requestUrl);
+        HttpURLConnection connection = (HttpURLConnection) uberUrl.openConnection();
+        connection.setRequestProperty("Authorization", "Token " + serverToken);
+        connection.setRequestProperty("Accept-Language", "en_US");
+        connection.setRequestProperty("Content-Type", "application/json");
+
+        LOG.info("Made price estimate request to Uber API at following URL: " + requestUrl);
+
+        // Make request, parse response
+        InputStream responseStream = connection.getInputStream();
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        UberTripTimeEstimateResponse response = mapper.readValue(responseStream, UberTripTimeEstimateResponse.class);
+
+        if (response.prices == null) {
+            throw new IOException("Unexpected response format");
+        }
+
+        LOG.debug("Received {} Uber price estimates", response.prices.size());
+
+        List<RideEstimate> estimates = new ArrayList<>();
+
+        for (final UberTripTimeEstimate price: response.prices) {
+            estimates.add(new RideEstimate(
+                TransportationNetworkCompany.UBER,
+                price.currency_code,
+                price.duration,
+                price.high_estimate,
+                price.low_estimate,
+                price.product_id
+            ));
+        }
+
+        return estimates;
+    }
+}

--- a/src/main/java/org/opentripplanner/updater/transportation_network_company/uber/UberTripTimeEstimate.java
+++ b/src/main/java/org/opentripplanner/updater/transportation_network_company/uber/UberTripTimeEstimate.java
@@ -1,0 +1,22 @@
+/* This program is free software: you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public License
+as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+package org.opentripplanner.updater.transportation_network_company.uber;
+
+public class UberTripTimeEstimate {
+    public String currency_code;
+    public int duration;
+    public int high_estimate;
+    public int low_estimate;
+    public String product_id;
+}

--- a/src/main/java/org/opentripplanner/updater/transportation_network_company/uber/UberTripTimeEstimateResponse.java
+++ b/src/main/java/org/opentripplanner/updater/transportation_network_company/uber/UberTripTimeEstimateResponse.java
@@ -1,0 +1,20 @@
+/* This program is free software: you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public License
+as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+package org.opentripplanner.updater.transportation_network_company.uber;
+
+import java.util.List;
+
+public class UberTripTimeEstimateResponse {
+    public List<UberTripTimeEstimate> prices;
+}

--- a/src/main/resources/Message.properties
+++ b/src/main/resources/Message.properties
@@ -11,11 +11,15 @@ OUTSIDE_BOUNDS            = Trip is not possible.  You might be trying to plan a
 REQUEST_TIMEOUT           = The trip planner is taking way too long to process your request. Please try again later.
 BOGUS_PARAMETER           = The request has errors that the server is not willing or able to process.
 PATH_NOT_FOUND            = No trip found. There may be no transit service within the maximum specified distance or at the specified time, or your start or end point might not be safely accessible.
+NO_PATHS_AFTER_FILTERING  = No trips found that satisfy the defined trip plan filters.
 NO_TRANSIT_TIMES          = No transit times available. The date may be past or too far in the future or there may not be transit service for your trip at the time you chose.
 GEOCODE_FROM_NOT_FOUND    = Origin is unknown. Can you be a bit more descriptive?
 GEOCODE_TO_NOT_FOUND      = Destination is unknown.  Can you be a bit more descriptive?
 GEOCODE_FROM_TO_NOT_FOUND = Both origin and destination are unknown. Can you be a bit more descriptive?
 TOO_CLOSE                 = Origin is within a trivial distance of the destination.
+TRANSPORTATION_NETWORK_COMPANY_UNAVAILABLE = No available Transportation Network Company service at from location
+TRANSPORTATION_NETWORK_COMPANY_REQUEST_INVALID = Missing companies parameter in plan request
+TRANSPORTATION_NETWORK_COMPANY_CONFIG_INVALID = Invalid Transportation Network Company config
 
 GEOCODE_FROM_AMBIGUOUS    = The trip planner is unsure of the location you want to start from. Please select from the following options, or be more specific.
 GEOCODE_TO_AMBIGUOUS      = The trip planner is unsure of the destination you want to go to. Please select from the following options, or be more specific.

--- a/src/test/java/org/opentripplanner/updater/transportation_network_company/LyftTransportationNetworkCompanyDataSourceTest.java
+++ b/src/test/java/org/opentripplanner/updater/transportation_network_company/LyftTransportationNetworkCompanyDataSourceTest.java
@@ -1,0 +1,114 @@
+/* This program is free software: you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public License
+as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+package org.opentripplanner.updater.transportation_network_company;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.opentripplanner.routing.transportation_network_company.ArrivalTime;
+import org.opentripplanner.routing.transportation_network_company.RideEstimate;
+import org.opentripplanner.updater.transportation_network_company.lyft.LyftAuthenticationRequestBody;
+import org.opentripplanner.updater.transportation_network_company.lyft.LyftTransportationNetworkCompanyDataSource;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.junit.Assert.assertEquals;
+
+public class LyftTransportationNetworkCompanyDataSourceTest {
+
+    private static LyftTransportationNetworkCompanyDataSource source = new LyftTransportationNetworkCompanyDataSource(
+        "http://localhost:8089/",
+        "testClientId",
+        "testClientSecret"
+    );
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(
+        options()
+            .port(8089)
+            .usingFilesUnderDirectory("src/test/resources/updater/")
+    );
+
+    @Before
+    public void setUp() throws Exception {
+        // setup mock server to respond to ride estimate request
+        ObjectMapper mapper = new ObjectMapper();
+        stubFor(
+            post(urlPathEqualTo("/oauth/token"))
+                .withBasicAuth("testClientId", "testClientSecret")
+                .withRequestBody(equalToJson(mapper.writeValueAsString(new LyftAuthenticationRequestBody(
+                    "client_credentials",
+                    "public"
+                ))))
+                .willReturn(
+                    aResponse()
+                        .withBodyFile("lyft_authentication.json")
+                )
+        );
+    }
+
+    @Test
+    public void testGetArrivalTimes () throws IOException, ExecutionException {
+        // setup mock server to respond to ride estimate request
+        stubFor(
+            get(urlPathEqualTo("/v1/eta"))
+                .withQueryParam("lat", equalTo("1.2"))
+                .withQueryParam("lng", equalTo("3.4"))
+                .willReturn(
+                    aResponse()
+                        .withBodyFile("lyft_eta_estimates.json")
+                )
+        );
+
+        List<ArrivalTime> arrivalTimes = source.getArrivalTimes(1.2, 3.4);
+
+        assertEquals(arrivalTimes.size(),  3);
+        ArrivalTime arrival = arrivalTimes.get(0);
+        assertEquals(arrival.displayName, "Lyft Line");
+        assertEquals(arrival.productId, "lyft_line");
+        assertEquals(arrival.estimatedSeconds, 120);
+    }
+
+    @Test
+    public void testGetEstimatedRideTime () throws IOException, ExecutionException {
+        // setup mock server to respond to estimated ride time request
+        stubFor(
+            get(urlPathEqualTo("/v1/cost"))
+                .withQueryParam("start_lat", equalTo("1.2"))
+                .withQueryParam("start_lng", equalTo("3.4"))
+                .withQueryParam("end_lat", equalTo("1.201"))
+                .withQueryParam("end_lng", equalTo("3.401"))
+                .willReturn(
+                    aResponse()
+                        .withBodyFile("lyft_trip_estimates.json")
+                )
+        );
+
+        RideEstimate rideTime = source.getRideEstimate(
+            "lyft",
+            1.2,
+            3.4,
+            1.201,
+            3.401
+        );
+
+        assertEquals(rideTime.duration, 913);
+    }
+}

--- a/src/test/java/org/opentripplanner/updater/transportation_network_company/UberTransportationNetworkCompanyDataSourceTest.java
+++ b/src/test/java/org/opentripplanner/updater/transportation_network_company/UberTransportationNetworkCompanyDataSourceTest.java
@@ -1,0 +1,92 @@
+/* This program is free software: you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public License
+as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+package org.opentripplanner.updater.transportation_network_company;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.opentripplanner.routing.transportation_network_company.ArrivalTime;
+import org.opentripplanner.routing.transportation_network_company.RideEstimate;
+import org.opentripplanner.updater.transportation_network_company.uber.UberTransportationNetworkCompanyDataSource;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.junit.Assert.assertEquals;
+
+public class UberTransportationNetworkCompanyDataSourceTest {
+
+    private static UberTransportationNetworkCompanyDataSource source = new UberTransportationNetworkCompanyDataSource(
+        "test",
+        "http://localhost:8089/"
+    );
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(
+        options()
+            .port(8089)
+            .usingFilesUnderDirectory("src/test/resources/updater/")
+    );
+
+    @Test
+    public void testGetArrivalTimes () throws IOException, ExecutionException {
+        // setup mock server to respond to ride estimate request
+        stubFor(
+            get(urlPathEqualTo("/estimates/time"))
+                .withQueryParam("start_latitude", equalTo("1.2"))
+                .withQueryParam("start_longitude", equalTo("3.4"))
+                .willReturn(
+                    aResponse()
+                        .withBodyFile("uber_arrival_estimates.json")
+                )
+        );
+
+        List<ArrivalTime> arrivalTimes = source.getArrivalTimes(1.2, 3.4);
+
+        assertEquals(arrivalTimes.size(),  8);
+        ArrivalTime arrival = arrivalTimes.get(0);
+        assertEquals(arrival.displayName, "POOL");
+        assertEquals(arrival.productId, "26546650-e557-4a7b-86e7-6a3942445247");
+        assertEquals(arrival.estimatedSeconds, 60);
+    }
+
+    @Test
+    public void testGetEstimatedRideTime () throws IOException, ExecutionException {
+        // setup mock server to respond to estimated ride time request
+        stubFor(
+            get(urlPathEqualTo("/estimates/price"))
+                .withQueryParam("start_latitude", equalTo("1.2"))
+                .withQueryParam("start_longitude", equalTo("3.4"))
+                .withQueryParam("end_latitude", equalTo("1.201"))
+                .withQueryParam("end_longitude", equalTo("3.401"))
+                .willReturn(
+                    aResponse()
+                        .withBodyFile("uber_trip_estimates.json")
+                )
+        );
+
+        RideEstimate rideTime = source.getRideEstimate(
+            "26546650-e557-4a7b-86e7-6a3942445247",
+            1.2,
+            3.4,
+            1.201,
+            3.401
+        );
+
+        assertEquals(rideTime.duration, 1080);
+    }
+}

--- a/src/test/resources/updater/__files/lyft_authentication.json
+++ b/src/test/resources/updater/__files/lyft_authentication.json
@@ -1,0 +1,6 @@
+{
+  "token_type": "Bearer",
+  "access_token": "test_token",
+  "expires_in": 86400,
+  "scope": "public"
+}

--- a/src/test/resources/updater/__files/lyft_eta_estimates.json
+++ b/src/test/resources/updater/__files/lyft_eta_estimates.json
@@ -1,0 +1,22 @@
+{
+  "eta_estimates": [
+    {
+      "display_name": "Lyft Line",
+      "ride_type": "lyft_line",
+      "eta_seconds": 120,
+      "is_valid_estimate": true
+    },
+    {
+      "display_name": "Lyft",
+      "ride_type": "lyft",
+      "eta_seconds": 120,
+      "is_valid_estimate": true
+    },
+    {
+      "display_name": "Lyft Plus",
+      "ride_type": "lyft_plus",
+      "eta_seconds": 660,
+      "is_valid_estimate": true
+    }
+  ]
+}

--- a/src/test/resources/updater/__files/lyft_trip_estimates.json
+++ b/src/test/resources/updater/__files/lyft_trip_estimates.json
@@ -1,0 +1,43 @@
+{
+  "cost_estimates": [
+    {
+      "ride_type": "lyft_plus",
+      "estimated_duration_seconds": 913,
+      "estimated_distance_miles": 3.29,
+      "estimated_cost_cents_max": 2355,
+      "primetime_percentage": "25%",
+      "currency": "USD",
+      "estimated_cost_cents_min": 1561,
+      "display_name": "Lyft Plus",
+      "primetime_confirmation_token": null,
+      "cost_token": null,
+      "is_valid_estimate": true
+    },
+    {
+      "ride_type": "lyft_line",
+      "estimated_duration_seconds": 913,
+      "estimated_distance_miles": 3.29,
+      "estimated_cost_cents_max": 475,
+      "primetime_percentage": "0%",
+      "currency": "USD",
+      "estimated_cost_cents_min": 475,
+      "display_name": "Lyft Line",
+      "primetime_confirmation_token": null,
+      "cost_token": null,
+      "is_valid_estimate": true
+    },
+    {
+      "ride_type": "lyft",
+      "estimated_duration_seconds": 913,
+      "estimated_distance_miles": 3.29,
+      "estimated_cost_cents_max": 1755,
+      "primetime_percentage": "25%",
+      "currency": "USD",
+      "estimated_cost_cents_min": 1052,
+      "display_name": "Lyft",
+      "primetime_confirmation_token": null,
+      "cost_token": null,
+      "is_valid_estimate": true
+    }
+  ]
+}

--- a/src/test/resources/updater/__files/uber_arrival_estimates.json
+++ b/src/test/resources/updater/__files/uber_arrival_estimates.json
@@ -1,0 +1,52 @@
+{
+  "times": [
+    {
+      "localized_display_name": "POOL",
+      "estimate": 60,
+      "display_name": "POOL",
+      "product_id": "26546650-e557-4a7b-86e7-6a3942445247"
+    },
+    {
+      "localized_display_name": "uberX",
+      "estimate": 60,
+      "display_name": "uberX",
+      "product_id": "a1111c8c-c720-46c3-8534-2fcdd730040d"
+    },
+    {
+      "localized_display_name": "uberXL",
+      "estimate": 240,
+      "display_name": "uberXL",
+      "product_id": "821415d8-3bd5-4e27-9604-194e4359a449"
+    },
+    {
+      "localized_display_name": "SELECT",
+      "estimate": 240,
+      "display_name": "SELECT",
+      "product_id": "57c0ff4e-1493-4ef9-a4df-6b961525cf92"
+    },
+    {
+      "localized_display_name": "BLACK",
+      "estimate": 240,
+      "display_name": "BLACK",
+      "product_id": "d4abaae7-f4d6-4152-91cc-77523e8165a4"
+    },
+    {
+      "localized_display_name": "SUV",
+      "estimate": 240,
+      "display_name": "SUV",
+      "product_id": "8920cb5e-51a4-4fa4-acdf-dd86c5e18ae0"
+    },
+    {
+      "localized_display_name": "ASSIST",
+      "estimate": 300,
+      "display_name": "ASSIST",
+      "product_id": "ff5ed8fe-6585-4803-be13-3ca541235de3"
+    },
+    {
+      "localized_display_name": "TAXI",
+      "estimate": 480,
+      "display_name": "TAXI",
+      "product_id": "3ab64887-4842-4c8e-9780-ccecd3a0391d"
+    }
+  ]
+}

--- a/src/test/resources/updater/__files/uber_trip_estimates.json
+++ b/src/test/resources/updater/__files/uber_trip_estimates.json
@@ -1,0 +1,103 @@
+{
+  "prices": [
+    {
+      "localized_display_name": "POOL",
+      "distance": 6.17,
+      "display_name": "POOL",
+      "product_id": "26546650-e557-4a7b-86e7-6a3942445247",
+      "high_estimate": 15,
+      "low_estimate": 13,
+      "duration": 1080,
+      "estimate": "$13-14",
+      "currency_code": "USD"
+    },
+    {
+      "localized_display_name": "uberX",
+      "distance": 6.17,
+      "display_name": "uberX",
+      "product_id": "a1111c8c-c720-46c3-8534-2fcdd730040d",
+      "high_estimate": 17,
+      "low_estimate": 13,
+      "duration": 1080,
+      "estimate": "$13-17",
+      "currency_code": "USD"
+    },
+    {
+      "localized_display_name": "uberXL",
+      "distance": 6.17,
+      "display_name": "uberXL",
+      "product_id": "821415d8-3bd5-4e27-9604-194e4359a449",
+      "high_estimate": 26,
+      "low_estimate": 20,
+      "duration": 1080,
+      "estimate": "$20-26",
+      "currency_code": "USD"
+    },
+    {
+      "localized_display_name": "SELECT",
+      "distance": 6.17,
+      "display_name": "SELECT",
+      "product_id": "57c0ff4e-1493-4ef9-a4df-6b961525cf92",
+      "high_estimate": 38,
+      "low_estimate": 30,
+      "duration": 1080,
+      "estimate": "$30-38",
+      "currency_code": "USD"
+    },
+    {
+      "localized_display_name": "BLACK",
+      "distance": 6.17,
+      "display_name": "BLACK",
+      "product_id": "d4abaae7-f4d6-4152-91cc-77523e8165a4",
+      "high_estimate": 43,
+      "low_estimate": 43,
+      "duration": 1080,
+      "estimate": "$43.10",
+      "currency_code": "USD"
+    },
+    {
+      "localized_display_name": "SUV",
+      "distance": 6.17,
+      "display_name": "SUV",
+      "product_id": "8920cb5e-51a4-4fa4-acdf-dd86c5e18ae0",
+      "high_estimate": 63,
+      "low_estimate": 50,
+      "duration": 1080,
+      "estimate": "$50-63",
+      "currency_code": "USD"
+    },
+    {
+      "localized_display_name": "ASSIST",
+      "distance": 6.17,
+      "display_name": "ASSIST",
+      "product_id": "ff5ed8fe-6585-4803-be13-3ca541235de3",
+      "high_estimate": 17,
+      "low_estimate": 13,
+      "duration": 1080,
+      "estimate": "$13-17",
+      "currency_code": "USD"
+    },
+    {
+      "localized_display_name": "WAV",
+      "distance": 6.17,
+      "display_name": "WAV",
+      "product_id": "2832a1f5-cfc0-48bb-ab76-7ea7a62060e7",
+      "high_estimate": 33,
+      "low_estimate": 25,
+      "duration": 1080,
+      "estimate": "$25-33",
+      "currency_code": "USD"
+    },
+    {
+      "localized_display_name": "TAXI",
+      "distance": 6.17,
+      "display_name": "TAXI",
+      "product_id": "3ab64887-4842-4c8e-9780-ccecd3a0391d",
+      "high_estimate": null,
+      "low_estimate": null,
+      "duration": 1080,
+      "estimate": "Metered",
+      "currency_code": null
+    }
+  ]
+}


### PR DESCRIPTION
This PR seeks to isolate the changes in PR #2664 required to allow for Transportation Network Company routing.  This PR is built off of the work done in PR #2677.

- [x] **issue**: #2642.

Transportation Network Company (TNC) routing has been added from inspiration of how the current Park and Ride and Kiss and Ride routing works. TNC routing is currently implemented to work with either Uber or Lyft. In a shortest path search, it is possible to hail a TNC vehicle while on a StreetEdge. The TNC must be used a minimum amount of distance before deboarding and is alighted whenever a StreetEdge that forbids driving is encountered or when a StreetTransitLink is encountered or the destination is reached. While traversing streets, the weight is increased by multiplying the weight with a drive time reluctance factor and a drive distance reluctance factor which are configurable. A postprocessing check will occur that will remove certain itineraries that do not have a certain percent of the distance of the overall journey using transit.

Part of the TNC routing includes an updater that doesn't actually update the graph, but does allow for querying the TNC APIs for arrival, trip duration and price estimates. The arrival estimates are used to determine if a TNC is avaible to pickup at a certain location and will result in no results being found if no service is reported to exist. Each response with a TNC leg is returned with arrival, duration and price estimates.

This code also attempts to read OSM way tags to determine if a particular way is suitable for a TNC pickup/dropoff. Currently, the first parking:lane tag is read and if the value is either no_stopping or fire_lane then TNC pickups/dropoffs are not allowed. This has limitations of data quality since there are only 597 ways with a parking:lane:* tag in the Portland Metro area at the time of the creation of this PR.

- [x] **roadmap**: Included in 1.4
- [x] **tests**:  Some tests added for the Transportation Network Company updaters.
- [x] **formatting** 

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **before merging**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)