### PR TITLE
Improve configuration docs

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2,6 +2,7 @@
 
 ## 1.4 (in progress)
 
+- Docs: improve configuration documentation
 - Update onebusaway-gtfs to latest version from OBA project (#2636)
 - Remove the coupling to OneBusAway GTFS within OTP's internal model by creating new classes replacing the external classes (#2494)
 - Allow itineraries in response to be sorted by duration (#2593)

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -99,7 +99,7 @@ config key | description | value type | value default | notes
 `maxTransferDistance` | Transfers up to this length in meters will be pre-calculated and included in the Graph | double | 2,000 | units: meters
 `extraEdgesStopPlatformLink` | add extra edges when linking a stop to a platform, to prevent detours along the platform edge | boolean | false | 
 
-This list of parameters in defined in the code for `GraphBuilderParameters` at https://github.com/opentripplanner/OpenTripPlanner/blob/master/src/main/java/org/opentripplanner/standalone/GraphBuilderParameters.java#L186-L215
+This list of parameters in defined in the [code](https://github.com/opentripplanner/OpenTripPlanner/blob/master/src/main/java/org/opentripplanner/standalone/GraphBuilderParameters.java#L186-L215) for `GraphBuilderParameters`.
 
 ## Reaching a subway platform
 
@@ -319,7 +319,7 @@ These options can be applied by the OTP server without rebuilding the graph.
 
 config key | description | value type | value default | notes
 ---------- | ----------- | ---------- | ------------- | -----
-`routingDefaults` | Default routing parameters, which will be applied to every request | object | TODO | see [routing defaults](#routing-defaults)
+`routingDefaults` | Default routing parameters, which will be applied to every request | object |  | see [routing defaults](#routing-defaults)
 `timeout` | maximum time limit for route queries | double | null | units: seconds; see [timeouts](#timeouts)
 `timeouts` | when returning multiple itineraries, set different maximum time limits for the 1st, 2nd, etc. itinerary | array of doubles | `[5, 4, 2]` | units: seconds; see [timeouts](#timeouts)
 `requestLogFile` | Path to a plain-text file where requests will be logged | string | null | see [logging incoming requests](#logging-incoming-requests)

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -66,6 +66,41 @@ are found in `router-config.json`.
 
 # Graph build configuration
 
+This table lists the possible settings that can be defined in a `build-config.json` file. Sections follow that describe particular settings in more depth.
+
+config key | description | value type | value default | notes
+---------- | ----------- | ---------- | ------------- | -----
+`htmlAnnotations` |  Generate nice HTML report of Graph errors/warnings (annotations) | boolean | false |
+`transit` | Include all transit input files (GTFS) from scanned directory | boolean | false |
+`useTransfersTxt` | Create direct transfer edges from transfers.txt in GTFS, instead of based on distance | boolean | false |
+`parentStopLinking` | Link GTFS stops to their parent stops | boolean | false |
+`stationTransfers` | Create direct transfers between the constituent stops of each parent station | boolean | false |
+`stopClusterMode` | Stop clusters can be built in one of two ways, either by geographical proximity and name, or according to a parent/child station topology, if it exists | enum | `proximity` | options: `proximity`, `parentStation`
+`subwayAccessTime` | Minutes necessary to reach stops served by trips on routes of `route_type=1` (subway) from the street | double | 2.0 | units: minutes
+`streets` | Include street input files (OSM/PBF) | boolean | true | 
+`embedRouterConfig` | Embed the Router config in the graph, which allows it to be sent to a server fully configured over the wire | boolean | true |
+`areaVisibility` | Perform visibility calculations on OSM areas (these calculations can be time consuming) | boolean | true |
+`platformEntriesLinking` | Link unconnected entries to public transport platforms | boolean | false |
+`matchBusRoutesToStreets` | Based on GTFS shape data, guess which OSM streets each bus runs on to improve stop linking | boolean | false |
+`fetchElevationUS` | Download US NED elevation data and apply it to the graph | boolean | false |
+`elevationBucket` | If specified, download NED elevation tiles from the given AWS S3 bucket | object | null | provide an object with `accessKey`, `secretKey`, and `bucketName` for AWS S3
+`fares` | A specific fares service to use | object | null | see [fares configuration](#fares-configuration)
+`osmNaming` | A custom OSM namer to use | object | null | see [custom naming](#custom-naming)
+`osmWayPropertySet` | Custom OSM way properties | string | `default` | options: `default`, `norway`
+`staticBikeRental` | Whether bike rental stations should be loaded from OSM, rather than periodically dynamically pulled from APIs | boolean | false | 
+`staticParkAndRide` | Whether we should create car P+R stations from OSM data | boolean | true | 
+`staticBikeParkAndRide` | Whether we should create bike P+R stations from OSM data | boolean | false | 
+`maxHtmlAnnotationsPerFile` | If number of annotations is larger then specified number annotations will be split in multiple files | int | 1,000 | 
+`maxInterlineDistance` | Maximal distance between stops in meters that will connect consecutive trips that are made with same vehicle | int | 200 | units: meters
+`islandWithoutStopsMaxSize` | Pruning threshold for islands without stops. Any such island under this size will be pruned | int | 40 | 
+`islandWithStopsMaxSize` | Pruning threshold for islands with stops. Any such island under this size will be pruned | int | 5 | 
+`banDiscouragedWalking` | should walking should be allowed on OSM ways tagged with `foot=discouraged"` | boolean | false | 
+`banDiscouragedBiking` | should walking should be allowed on OSM ways tagged with `bicycle=discouraged"` | boolean | false | 
+`maxTransferDistance` | Transfers up to this length in meters will be pre-calculated and included in the Graph | double | 2,000 | units: meters
+`extraEdgesStopPlatformLink` | add extra edges when linking a stop to a platform, to prevent detours along the platform edge | boolean | false | 
+
+This list of parameters in defined in the code for `GraphBuilderParameters` at https://github.com/opentripplanner/OpenTripPlanner/blob/master/src/main/java/org/opentripplanner/standalone/GraphBuilderParameters.java#L186-L215
+
 ## Reaching a subway platform
 
 The boarding locations for some modes of transport such as subways and airplanes can be slow to reach from the street.
@@ -282,6 +317,15 @@ There is currently only one custom naming module called `portland` (which has no
 This section covers all options that can be set for each router using the `router-config.json` file.
 These options can be applied by the OTP server without rebuilding the graph.
 
+config key | description | value type | value default | notes
+---------- | ----------- | ---------- | ------------- | -----
+`routingDefaults` | Default routing parameters, which will be applied to every request | object | TODO | see [routing defaults](#routing-defaults)
+`timeout` | maximum time limit for route queries | double | null | units: seconds; see [timeouts](#timeouts)
+`timeouts` | when returning multiple itineraries, set different maximum time limits for the 1st, 2nd, etc. itinerary | array of doubles | `[5, 4, 2]` | units: seconds; see [timeouts](#timeouts)
+`requestLogFile` | Path to a plain-text file where requests will be logged | string | null | see [logging incoming requests](#logging-incoming-requests)
+`boardTimes` | change boarding times by mode | object | null | see [boarding and alighting times](#boarding-and-alighting-times)
+`alightTimes` | change alighting times by mode | object | null | see [boarding and alighting times](#boarding-and-alighting-times)
+`updaters` | configure real-time updaters, such as GTFS-realtime feeds | object | null | see [configuring real-time updaters](#configuring-real-time-updaters)
 
 ## Routing defaults
 
@@ -444,7 +488,7 @@ The generic KML needs to be in format like
 </Document></kml>
 ```
 
-### Configuration
+### Configuring real-time updaters
 
 Real-time data can be provided using either a pull or push system. In a pull configuration, the GTFS-RT consumer polls the
 real-time provider over HTTP. That is to say, OTP fetches a file from a web server every few minutes. In the push
@@ -569,59 +613,6 @@ url: the URL of the GBFS feed (do not include the gbfs.json at the end) *
 ```
 \* For a list of known GBFS feeds see the [list of known GBFS feeds](https://github.com/NABSA/gbfs/blob/master/systems.csv)
 
-------
+# Configure using command-line arguments
 
-## List of allowed settings in build-config.json
-
-config key | description | value type | value default | notes
----------- | ----------- | ---------- | ------------- | -----
-`htmlAnnotations` |  Generate nice HTML report of Graph errors/warnings (annotations) | boolean | false |
-`transit` | Include all transit input files (GTFS) from scanned directory | boolean | false |
-`useTransfersTxt` | Create direct transfer edges from transfers.txt in GTFS, instead of based on distance | boolean | false |
-`parentStopLinking` | Link GTFS stops to their parent stops | boolean | false |
-`stationTransfers` | Create direct transfers between the constituent stops of each parent station | boolean | false |
-`stopClusterMode` | Stop clusters can be built in one of two ways, either by geographical proximity and name, or according to a parent/child station topology, if it exists | enum | `proximity` | options: `proximity`, `parentStation`
-`subwayAccessTime` | Minutes necessary to reach stops served by trips on routes of `route_type=1` (subway) from the street | double | 2.0 | units: minutes
-`streets` | Include street input files (OSM/PBF) | boolean | true | 
-`embedRouterConfig` | Embed the Router config in the graph, which allows it to be sent to a server fully configured over the wire | boolean | true |
-`areaVisibility` | Perform visibility calculations on OSM areas (these calculations can be time consuming) | boolean | true |
-`platformEntriesLinking` | Link unconnected entries to public transport platforms | boolean | false |
-`matchBusRoutesToStreets` | Based on GTFS shape data, guess which OSM streets each bus runs on to improve stop linking | boolean | false |
-`fetchElevationUS` | Download US NED elevation data and apply it to the graph | boolean | false |
-`elevationBucket` | If specified, download NED elevation tiles from the given AWS S3 bucket | object | null | provide an object with `accessKey`, `secretKey`, and `bucketName` for AWS S3
-`fares` | A specific fares service to use | object | null | see [fares configuration](#fares-configuration)
-`osmNaming` | A custom OSM namer to use | object | null | see [custom naming](#custom-naming)
-`osmWayPropertySet` | Custom OSM way properties | string | `default` | options: `default`, `norway`
-`staticBikeRental` | Whether bike rental stations should be loaded from OSM, rather than periodically dynamically pulled from APIs | boolean | false | 
-`staticParkAndRide` | Whether we should create car P+R stations from OSM data | boolean | true | 
-`staticBikeParkAndRide` | Whether we should create bike P+R stations from OSM data | boolean | false | 
-`maxHtmlAnnotationsPerFile` | If number of annotations is larger then specified number annotations will be split in multiple files | int | 1,000 | 
-`maxInterlineDistance` | Maximal distance between stops in meters that will connect consecutive trips that are made with same vehicle | int | 200 | units: meters
-`islandWithoutStopsMaxSize` | Pruning threshold for islands without stops. Any such island under this size will be pruned | int | 40 | 
-`islandWithStopsMaxSize` | Pruning threshold for islands with stops. Any such island under this size will be pruned | int | 5 | 
-`banDiscouragedWalking` | should walking should be allowed on OSM ways tagged with `foot=discouraged"` | boolean | false | 
-`banDiscouragedBiking` | should walking should be allowed on OSM ways tagged with `bicycle=discouraged"` | boolean | false | 
-`maxTransferDistance` | Transfers up to this length in meters will be pre-calculated and included in the Graph | double | 2,000 | units: meters
-`extraEdgesStopPlatformLink` | add extra edges when linking a stop to a platform, to prevent detours along the platform edge | boolean | false | 
-
-See the code for `GraphBuilderParameters` at https://github.com/opentripplanner/OpenTripPlanner/blob/master/src/main/java/org/opentripplanner/standalone/GraphBuilderParameters.java#L186-L215
-
-## List of allowed settings in router-config.json
-
-config key | description | value type | value default | notes
----------- | ----------- | ---------- | ------------- | -----
-`routingDefaults` | Default routing parameters, which will be applied to every request | object | TODO | see [routing defaults](#routing-defaults)
-`timeout` | TODO | double | units: seconds; see [timeouts](#timeouts)
-`timeouts` | TODO| array of doubles | none | units: seconds; see [timeouts](#timeouts)
-`requestLogFile` | Path to a plain-text file where requests will be logged | string | null | see [logging incoming requests](#logging-incoming-requests)
-`boardTimes` | TODO | object | TODO | see [boarding and alighting times](#boarding-and-alighting-times)
-`alightTimes` | TODO | object | TODO | see [boarding and alighting times](#boarding-and-alighting-times)
-
-See https://github.com/opentripplanner/OpenTripPlanner/blob/master/src/main/java/org/opentripplanner/standalone/Router.java
-
-
-## List of allowed command-line parameters
-
-See `CommandLineParameters` class in https://github.com/opentripplanner/OpenTripPlanner/blob/master/src/main/java/org/opentripplanner/standalone/CommandLineParameters.java
-
-and http://dev.opentripplanner.org/javadoc/1.3.0/org/opentripplanner/standalone/CommandLineParameters.html
+Certain settings can be provided on the command line, when starting OpenTripPlanner. See the `CommandLineParameters` class for [a full list of arguments](http://dev.opentripplanner.org/javadoc/1.3.0/org/opentripplanner/standalone/CommandLineParameters.html).

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -71,7 +71,7 @@ This table lists the possible settings that can be defined in a `build-config.js
 config key | description | value type | value default | notes
 ---------- | ----------- | ---------- | ------------- | -----
 `htmlAnnotations` |  Generate nice HTML report of Graph errors/warnings (annotations) | boolean | false |
-`transit` | Include all transit input files (GTFS) from scanned directory | boolean | false |
+`transit` | Include all transit input files (GTFS) from scanned directory | boolean | true |
 `useTransfersTxt` | Create direct transfer edges from transfers.txt in GTFS, instead of based on distance | boolean | false |
 `parentStopLinking` | Link GTFS stops to their parent stops | boolean | false |
 `stationTransfers` | Create direct transfers between the constituent stops of each parent station | boolean | false |

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -334,7 +334,7 @@ internally that are not exposed via the API. You may want to change the default 
 i.e. the value which will be applied unless it is overridden in a web API request.
 
 A full list of them can be found in the RoutingRequest class
-[in the Javadoc](http://dev.opentripplanner.org/javadoc/master/org/opentripplanner/routing/core/RoutingRequest.html).
+[in the Javadoc](http://dev.opentripplanner.org/javadoc/1.3.0/org/opentripplanner/routing/core/RoutingRequest.html).
 Any public field or setter method in this class can be given a default value using the routingDefaults section of
 `router-config.json` as follows:
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -569,3 +569,59 @@ url: the URL of the GBFS feed (do not include the gbfs.json at the end) *
 ```
 \* For a list of known GBFS feeds see the [list of known GBFS feeds](https://github.com/NABSA/gbfs/blob/master/systems.csv)
 
+------
+
+## List of allowed settings in build-config.json
+
+config key | description | value type | value default | notes
+---------- | ----------- | ---------- | ------------- | -----
+`htmlAnnotations` |  Generate nice HTML report of Graph errors/warnings (annotations) | boolean | false |
+`transit` | Include all transit input files (GTFS) from scanned directory | boolean | false |
+`useTransfersTxt` | Create direct transfer edges from transfers.txt in GTFS, instead of based on distance | boolean | false |
+`parentStopLinking` | Link GTFS stops to their parent stops | boolean | false |
+`stationTransfers` | Create direct transfers between the constituent stops of each parent station | boolean | false |
+`stopClusterMode` | Stop clusters can be built in one of two ways, either by geographical proximity and name, or according to a parent/child station topology, if it exists | enum | `proximity` | options: `proximity`, `parentStation`
+`subwayAccessTime` | Minutes necessary to reach stops served by trips on routes of `route_type=1` (subway) from the street | double | 2.0 | units: minutes
+`streets` | Include street input files (OSM/PBF) | boolean | true | 
+`embedRouterConfig` | Embed the Router config in the graph, which allows it to be sent to a server fully configured over the wire | boolean | true |
+`areaVisibility` | Perform visibility calculations on OSM areas (these calculations can be time consuming) | boolean | true |
+`platformEntriesLinking` | Link unconnected entries to public transport platforms | boolean | false |
+`matchBusRoutesToStreets` | Based on GTFS shape data, guess which OSM streets each bus runs on to improve stop linking | boolean | false |
+`fetchElevationUS` | Download US NED elevation data and apply it to the graph | boolean | false |
+`elevationBucket` | If specified, download NED elevation tiles from the given AWS S3 bucket | object | null | provide an object with `accessKey`, `secretKey`, and `bucketName` for AWS S3
+`fares` | A specific fares service to use | object | null | see [fares configuration](#fares-configuration)
+`osmNaming` | A custom OSM namer to use | object | null | see [custom naming](#custom-naming)
+`osmWayPropertySet` | Custom OSM way properties | string | `default` | options: `default`, `norway`
+`staticBikeRental` | Whether bike rental stations should be loaded from OSM, rather than periodically dynamically pulled from APIs | boolean | false | 
+`staticParkAndRide` | Whether we should create car P+R stations from OSM data | boolean | true | 
+`staticBikeParkAndRide` | Whether we should create bike P+R stations from OSM data | boolean | false | 
+`maxHtmlAnnotationsPerFile` | If number of annotations is larger then specified number annotations will be split in multiple files | int | 1,000 | 
+`maxInterlineDistance` | Maximal distance between stops in meters that will connect consecutive trips that are made with same vehicle | int | 200 | units: meters
+`islandWithoutStopsMaxSize` | Pruning threshold for islands without stops. Any such island under this size will be pruned | int | 40 | 
+`islandWithStopsMaxSize` | Pruning threshold for islands with stops. Any such island under this size will be pruned | int | 5 | 
+`banDiscouragedWalking` | should walking should be allowed on OSM ways tagged with `foot=discouraged"` | boolean | false | 
+`banDiscouragedBiking` | should walking should be allowed on OSM ways tagged with `bicycle=discouraged"` | boolean | false | 
+`maxTransferDistance` | Transfers up to this length in meters will be pre-calculated and included in the Graph | double | 2,000 | units: meters
+`extraEdgesStopPlatformLink` | add extra edges when linking a stop to a platform, to prevent detours along the platform edge | boolean | false | 
+
+See the code for `GraphBuilderParameters` at https://github.com/opentripplanner/OpenTripPlanner/blob/master/src/main/java/org/opentripplanner/standalone/GraphBuilderParameters.java#L186-L215
+
+## List of allowed settings in router-config.json
+
+config key | description | value type | value default | notes
+---------- | ----------- | ---------- | ------------- | -----
+`routingDefaults` | Default routing parameters, which will be applied to every request | object | TODO | see [routing defaults](#routing-defaults)
+`timeout` | TODO | double | units: seconds; see [timeouts](#timeouts)
+`timeouts` | TODO| array of doubles | none | units: seconds; see [timeouts](#timeouts)
+`requestLogFile` | Path to a plain-text file where requests will be logged | string | null | see [logging incoming requests](#logging-incoming-requests)
+`boardTimes` | TODO | object | TODO | see [boarding and alighting times](#boarding-and-alighting-times)
+`alightTimes` | TODO | object | TODO | see [boarding and alighting times](#boarding-and-alighting-times)
+
+See https://github.com/opentripplanner/OpenTripPlanner/blob/master/src/main/java/org/opentripplanner/standalone/Router.java
+
+
+## List of allowed command-line parameters
+
+See `CommandLineParameters` class in https://github.com/opentripplanner/OpenTripPlanner/blob/master/src/main/java/org/opentripplanner/standalone/CommandLineParameters.java
+
+and http://dev.opentripplanner.org/javadoc/1.3.0/org/opentripplanner/standalone/CommandLineParameters.html

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -215,6 +215,7 @@ order as the above-mentioned SRTM data, which is also the default for the popula
 DEM files(USGS DEM) is not supported by OTP, but can be converted to GeoTIFF with tools like [GDAL](http://www.gdal.org/). 
 Use `gdal_merge.py -o merged.tiff *.dem` to merge a set of `dem` files into one `tif` file.
 
+See Interline [PlanetUtils](https://github.com/interline-io/planetutils) for a set of scripts to download, merge, and resample [Mapzen/Amazon Terrain Tiles](https://registry.opendata.aws/terrain-tiles/).
 
 ## Fares configuration
 


### PR DESCRIPTION
To be completed by pull request submitter:

- closes #2526

To be completed by @opentripplanner/plc:

- [x] reviews and approvals by 2 members, ideally from different organizations
- [x] **before merging**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue

---

At @interline-io, we've found it a recurring challenge to keep track of possible OTP config options. We put together some tables internally a while back. They're probably useful to others, so this PR adds to them to the public documentation.