### PR TITLE
Method `getSomeOSMObject()` does not check the emptiness of member collection `areas`

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/AreaGroup.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/AreaGroup.java
@@ -162,6 +162,9 @@ class AreaGroup {
     }
 
     public OSMWithTags getSomeOSMObject() {
+        if (!areas.iterator().hasNext()) {
+            throw new IllegalArgumentException("No OSM object available.");
+        }
         return areas.iterator().next().parent;
     }
 }


### PR DESCRIPTION
Method `getSomeOSMObject()` in `AreaGroup.java` calls `areas.iterator().next().parent` without first checking if `areas` is an empty collection. This can lead to a `NoSuchElementException` without a useful error message.

This pull request adds a hasNext() check and an error message. 