### PR TITLE
Add unit tests for org.opentripplanner.common.geometry.Subgraph (Fixes #2723)

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -9,6 +9,7 @@
 - Allow itineraries in response to be sorted by duration (#2593)
 - Add support for GTFS-flex services: flag stops, deviated-route service, and call-and-ride (#2603)
 - Fix reverse optimization bug (#2653, #2411)
+- Add unit tests for org.opentripplanner.common.geometry.Subgraph (#2723)
 
 ## 1.3 (2018-08-03)
 

--- a/src/test/java/org/opentripplanner/common/geometry/SubgraphTest.java
+++ b/src/test/java/org/opentripplanner/common/geometry/SubgraphTest.java
@@ -1,0 +1,54 @@
+package org.opentripplanner.common.geometry;
+
+import org.junit.Test;
+import org.opentripplanner.common.geometry.Subgraph;
+import org.opentripplanner.model.Stop;
+import org.opentripplanner.routing.bike_park.BikePark;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.routing.graph.Vertex;
+import org.opentripplanner.routing.vertextype.BikeParkVertex;
+import org.opentripplanner.routing.vertextype.TransitVertex;
+import org.opentripplanner.routing.vertextype.PatternStopVertex;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+
+public class SubgraphTest {
+
+  @Test
+  public void testVertex() {
+    // Arrange
+    final Subgraph subgraph = new Subgraph();
+    final BikeParkVertex vertex = new BikeParkVertex(new Graph(),  new BikePark());
+
+    // Act
+    subgraph.addVertex(vertex);
+
+    // Assert result
+    assertTrue(subgraph.containsStreet(vertex));
+    assertEquals(subgraph.streetSize(), 1);
+    assertEquals(subgraph.streetIterator().next().toString(), vertex.toString());
+    assertEquals(subgraph.getRepresentativeVertex().toString(), vertex.toString());
+    assertNull(subgraph.getConvexHull());
+  }
+
+  @Test
+  public void testTransitVertex() {
+    // Arrange
+    final Subgraph subgraph = new Subgraph();
+    final PatternStopVertex vertex = new PatternStopVertex(new Graph(), "Test", null, new Stop());
+
+    // Act
+    subgraph.addVertex(vertex);
+
+    // Assert result
+    assertTrue(subgraph.contains(vertex));
+    assertEquals(subgraph.stopSize(), 1);
+    assertEquals(subgraph.stopIterator().next().toString(), vertex.toString());
+    assertNull(subgraph.getConvexHull());
+  }
+}


### PR DESCRIPTION
Hi,

I've analysed your code base and noticed some gaps in the coverage of `org.opentripplanner.common.geometry.Subgraph`.

I've written some tests for the functions in this class with the help of [Diffblue](https://www.diffblue.com/) [Cover](https://www.diffblue.com/products). This PR Fixes #2723.

In addition, it appears that the `getConvexHull` method in this class will always return `null`, is this the desired behaviour? It seems to me that `mp` should be assigned to `convexHullAsGeom` before that is returned?

Hopefully these tests should help you detect any regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be more than happy to look at a particular class and you help achieve a higher coverage figure.

To be completed by pull request submitter:

- [x] **issue**: Link to or create an [issue](https://github.com/opentripplanner/OpenTripPlanner/issues) that describes the relevant feature or bug. Add [GitHub keywords](https://help.github.com/articles/closing-issues-using-keywords/) to this PR's description (e.g., `closes #45`).
- [ ] **roadmap**: Check the [roadmap](https://github.com/orgs/opentripplanner/projects/1) for this feature or bug. If it is not already on the roadmap, PLC will discuss as part of the review process.
- [x] **tests**: Have you added relevant test coverage? Are all the tests passing on [the continuous integration service (Travis CI)](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#continuous-integration)?
- [x] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#code-style)? 
- [ ] **documentation**: If you are adding a new configuration option, have you added an explanation to the [configuration documentation](docs/Configuration.md) tables and sections?
- [x] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)