### PR TITLE
Subgraph fix

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -11,6 +11,7 @@
 - Add support for GTFS-flex services: flag stops, deviated-route service, and call-and-ride (#2603)
 - Fix reverse optimization bug (#2653, #2411)
 - Add unit tests for org.opentripplanner.common.geometry.Subgraph (#2723)
+- Fix a bug in org.opentripplanner.common.geometry.Subgraph.getConvexHull (#2727)
 
 ## 1.3 (2018-08-03)
 

--- a/src/main/java/org/opentripplanner/common/geometry/Subgraph.java
+++ b/src/main/java/org/opentripplanner/common/geometry/Subgraph.java
@@ -1,17 +1,16 @@
 package org.opentripplanner.common.geometry;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Set;
-
-import org.opentripplanner.routing.graph.Vertex;
-import org.opentripplanner.routing.vertextype.TransitVertex;
-
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.MultiPoint;
+import org.opentripplanner.routing.graph.Vertex;
+import org.opentripplanner.routing.vertextype.TransitVertex;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
 
 
 public class Subgraph {
@@ -70,9 +69,9 @@ public class Subgraph {
     private static GeometryFactory gf = new GeometryFactory();
     public Geometry getConvexHull() {
         if (newVertexAdded) {
-            MultiPoint mp = gf.createMultiPoint(vertexCoords.toArray(new Coordinate[0]));
+            MultiPoint mp = gf.createMultiPointFromCoords(vertexCoords.toArray(new Coordinate[0]));
             newVertexAdded = false;
-            mp.convexHull();
+            convexHullAsGeom = mp.convexHull();
         }
         return convexHullAsGeom;
     }

--- a/src/test/java/org/opentripplanner/common/geometry/SubgraphTest.java
+++ b/src/test/java/org/opentripplanner/common/geometry/SubgraphTest.java
@@ -1,21 +1,14 @@
 package org.opentripplanner.common.geometry;
 
 import org.junit.Test;
-import org.opentripplanner.common.geometry.Subgraph;
 import org.opentripplanner.model.Stop;
 import org.opentripplanner.routing.bike_park.BikePark;
 import org.opentripplanner.routing.graph.Graph;
-import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.routing.vertextype.BikeParkVertex;
-import org.opentripplanner.routing.vertextype.TransitVertex;
 import org.opentripplanner.routing.vertextype.PatternStopVertex;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-
-import java.lang.reflect.Method;
-import java.util.ArrayList;
 
 public class SubgraphTest {
 
@@ -33,7 +26,7 @@ public class SubgraphTest {
     assertEquals(subgraph.streetSize(), 1);
     assertEquals(subgraph.streetIterator().next().toString(), vertex.toString());
     assertEquals(subgraph.getRepresentativeVertex().toString(), vertex.toString());
-    assertNull(subgraph.getConvexHull());
+    assertEquals(subgraph.getConvexHull().getCoordinates().length, 1);
   }
 
   @Test
@@ -49,6 +42,6 @@ public class SubgraphTest {
     assertTrue(subgraph.contains(vertex));
     assertEquals(subgraph.stopSize(), 1);
     assertEquals(subgraph.stopIterator().next().toString(), vertex.toString());
-    assertNull(subgraph.getConvexHull());
+    assertEquals(subgraph.getConvexHull().getCoordinates().length, 1);
   }
 }


### PR DESCRIPTION
To be completed by pull request submitter:

- [x] **issue**: Link to or create an [issue](https://github.com/opentripplanner/OpenTripPlanner/issues) that describes the relevant feature or bug. Add [GitHub keywords](https://help.github.com/articles/closing-issues-using-keywords/) to this PR's description (e.g., `closes #45`).
- [ ] **roadmap**: Check the [roadmap](https://github.com/orgs/opentripplanner/projects/1) for this feature or bug. If it is not already on the roadmap, PLC will discuss as part of the review process.
- [x] **tests**: Have you added relevant test coverage? Are all the tests passing on [the continuous integration service (Travis CI)](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#continuous-integration)?
- [x] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#code-style)? 
- [x] **documentation**: If you are adding a new configuration option, have you added an explanation to the [configuration documentation](docs/Configuration.md) tables and sections?
- [x] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)

Description:

The changes here fix #2727. Before this, the getConvexHull method was always returning null. Also, the deprecated GeometryFactory call of `createMultiPoint` was replaced in favor of `createMultiPointFromCoords`.

Thanks for pointing out this bug, @JohnBergqvist!