### PR TITLE
Add support for GTFS-rt TripUpdate delay field. Closes #2733.

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -11,6 +11,7 @@
 - Add support for GTFS-flex services: flag stops, deviated-route service, and call-and-ride (#2603)
 - Fix reverse optimization bug (#2653, #2411)
 - Remove CarFreeAtoZ from list of deployments
+- Add support for GTFS-rt TripUpdate feeds which use TripUpdate.delay field (#2733)
 
 ## 1.3 (2018-08-03)
 

--- a/src/main/java/org/opentripplanner/routing/edgetype/Timetable.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/Timetable.java
@@ -504,6 +504,16 @@ public class Timetable implements Serializable {
         if (tripDescriptor.hasScheduleRelationship() && tripDescriptor.getScheduleRelationship()
                 == TripDescriptor.ScheduleRelationship.CANCELED) {
             newTimes.cancel();
+        } else if (tripUpdate.getStopTimeUpdateList().isEmpty() && tripUpdate.hasDelay()) {
+            int numStops = newTimes.getNumStops();
+
+            int delay = tripUpdate.getDelay();
+
+            for (int i = 0; i < numStops; i++) {
+                newTimes.updateArrivalDelay(i, delay);
+                newTimes.updateDepartureDelay(i, delay);
+            }
+
         } else {
             // The GTFS-RT reference specifies that StopTimeUpdates are sorted by stop_sequence.
             Iterator<StopTimeUpdate> updates = tripUpdate.getStopTimeUpdateList().iterator();

--- a/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
@@ -319,8 +319,8 @@ public class TimetableSnapshotSource {
             return false;
         }
 
-        if (tripUpdate.getStopTimeUpdateCount() < 1) {
-            LOG.warn("TripUpdate contains no updates, skipping.");
+        if (tripUpdate.getStopTimeUpdateCount() < 1 && !tripUpdate.hasDelay()) {
+            LOG.warn("TripUpdate contains no updates and delay is not set, skipping.");
             return false;
         }
 


### PR DESCRIPTION
To be completed by pull request submitter:

- [x] **issue**: Closes #2733.
- [x] **roadmap**: Not on roadmap.
- [x] **tests**: New test `TimetableSnapshotSourceTest.testHandleDelayedTripWithDelay` added.
- [x] **formatting**
- [x] **documentation**: No new configuration options added; no new documentation required.
- [x] **changelog**: Changelog entry added.

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)