### PR TITLE
allow big GTFS-realtime feeds by increasing protobuf size limit to 2G

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -11,6 +11,7 @@
 - Add support for GTFS-flex services: flag stops, deviated-route service, and call-and-ride (#2603)
 - Fix reverse optimization bug (#2653, #2411)
 - Remove CarFreeAtoZ from list of deployments
+- increase GTFS-realtime feeds size limit from 64MB to 2G (#2738)
 
 ## 1.3 (2018-08-03)
 
@@ -117,7 +118,7 @@
 - Ignore exceptions caused by errors in OSM linear rings.
 - Updated to version 2.18 of Jersey to fix hanging threads in Grizzly.
 - Removed confusing "Busish" and "Trainish" pseudo-modes.
-- FareService for Seattle: allow specifying fares in GTFS instead of hard-coding them in Java. Senior/youth fare prices are given in an extra column in fare attributes. Per-trip fares are taken into consideration when calculating fares in this region. 
+- FareService for Seattle: allow specifying fares in GTFS instead of hard-coding them in Java. Senior/youth fare prices are given in an extra column in fare attributes. Per-trip fares are taken into consideration when calculating fares in this region.
 - Update new linker to link to transitStops if no streets are found.
 - Show the name supplied in the request for the origin/destination points in the response.
 - Throw a trivialPath exception if start/end point are on the same edge.
@@ -288,7 +289,7 @@
 - full internationalization of the map-based web client
 - basic Lucene-based built-in geocoder
 
-## 0.11.0 (2014-03-24) 
+## 0.11.0 (2014-03-24)
 - Built-in HTTP server layer, making it possible to distribute OTP as a standalone JAR
 - "Long-distance" mode for large graphs, including bidirectional goal direction heuristic.
 - Simplified Maven project structure with less submodules
@@ -311,7 +312,7 @@ This release was made to consolidate all the development that had occurred with 
 - more lenient parsing of times
 - new directions icon set with SVG sources (thanks Laurent G)
 
-## 0.5.4 (2012-04-06) 
+## 0.5.4 (2012-04-06)
 - catch 0 divisors in NED builder, preventing NaN propagation to edge lengths
 - avoid repeated insertion of edges into edge lists, which are now threadsafe edge sets
 - identity equality for edges
@@ -349,7 +350,7 @@ This release was made to consolidate all the development that had occurred with 
 - more transit index features
 - default agencyIDs now determined on a per-feed basis
 - fixed fare overflow problem
-- fixed bug in loop road turn conversion 
+- fixed bug in loop road turn conversion
 - additional graphbuilder warnings and annotations
 - fixed a batch of bugs found by fixbugs  
 
@@ -357,7 +358,7 @@ This release was made to consolidate all the development that had occurred with 
 - stop codes, zones, and agency names in planner responses
 - encapsulation of edge list modifications
 - expanded edge and vertex type hierarchy
-- use mapquest OSM server by default 
+- use mapquest OSM server by default
 - Turkish locale (thanks Hasan Tayyar Beşik)
 - German and Italian locales (thanks Gerardo Carrieri)
 - bookmarkable trip URLs (thanks Matt Conway)

--- a/src/main/java/com/google/transit/realtime/GtfsRealtime.java
+++ b/src/main/java/com/google/transit/realtime/GtfsRealtime.java
@@ -17,11 +17,13 @@ package com.google.transit.realtime;
  * </p>
  * <ul>
  * <li>Enum value TripDescriptor.ScheduleRelationship.MODIFIED = 5</li>
+ * <li>FeedMessage PARSER input.setSizeLimit(Integer.MAX_VALUE)</li>
  * </ul>
  * <p>
  * Version 2.5.0 of protoc.exe has been used to generate this file.
  * </p>
  */
+
 public final class GtfsRealtime {
   private GtfsRealtime() {}
   public static void registerAllExtensions(
@@ -221,6 +223,10 @@ public final class GtfsRealtime {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
+        // Increase input stream size limit to 2G (instead of the 64M default).
+        // Mimics a change that was supposed to be released in protobuf 2.7.0,
+        // see https://git.io/fjfg5.
+        input.setSizeLimit(Integer.MAX_VALUE);
         return new FeedMessage(input, extensionRegistry);
       }
     };


### PR DESCRIPTION
To be completed by pull request submitter:
- [x] **issue**: closes opentripplanner/OpenTripPlanner#2738
- [ ] **roadmap**: PLC should discuss as part of the review process.
- [x] **tests**:  all tests pass.
- [ ] **formatting**: should be ok (used formatter.xml in IDEA IntelliJ), please give feedback if necessary.
- [x] **documentation**: no new configuration option.
- [x] **changelog**: done.

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)