### PR TITLE
Remove XML annotations from response objects 2.x

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -2,7 +2,7 @@
 
 At the core of OpenTripPlanner is a library of Java code that finds efficient paths through multi-modal transportation networks built from [OpenStreetMap](http://wiki.openstreetmap.org/wiki/Main_Page) and [GTFS](https://developers.google.com/transit/gtfs/) data. Several different services are built upon this library:
 
-The **OTP Routing API** is a [RESTful](https://en.wikipedia.org/wiki/Representational_state_transfer) web service that responds to journey planning requests with itineraries in a JSON or XML representation. You can combine this API with OTP's standard Javascript front end to provide users with trip planning functionality in a familiar map interface, or write your own applications that talk directly to the API.
+The **OTP Routing API** is a [RESTful](https://en.wikipedia.org/wiki/Representational_state_transfer) web service that responds to journey planning requests with itineraries in a JSON representation. You can combine this API with OTP's standard Javascript front end to provide users with trip planning functionality in a familiar map interface, or write your own applications that talk directly to the API.
 
 The **OTP Transit Index API** is another [RESTful](https://en.wikipedia.org/wiki/Representational_state_transfer) web service that provides information derived from the input GTFS feed(s). Examples include routes serving a particular stop, upcoming vehicles at a particular stop, upcoming stops on a given trip, etc. More complex transit data requests can be formulated using a GraphQL API.
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -1,7 +1,11 @@
 # Changelog
 
-## 1.4 (in progress)
 
+## 2.0 (in progress)
+- Fix XML response serialization (#2685)
+
+## 1.4 ( not merged into 2.x !!! )
+(TODO: Merge or delete, and move bullet to 2.x list of changes) 
 - Remove Open Traffic prototype code (#2698)
 - Docs: improve configuration documentation
 - Update onebusaway-gtfs to latest version from OBA project (#2636)

--- a/src/main/java/org/opentripplanner/api/model/Itinerary.java
+++ b/src/main/java/org/opentripplanner/api/model/Itinerary.java
@@ -6,9 +6,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.TimeZone;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
-
 import org.opentripplanner.model.calendar.CalendarServiceData;
 import org.opentripplanner.routing.core.Fare;
 
@@ -81,8 +78,6 @@ public class Itinerary {
      * trip on a particular vehicle. So a trip where the use walks to the Q train, transfers to the
      * 6, then walks to their destination, has four legs.
      */
-    @XmlElementWrapper(name = "legs")
-    @XmlElement(name = "leg")
     public List<Leg> legs = new ArrayList<Leg>();
 
     /**

--- a/src/main/java/org/opentripplanner/api/model/Leg.java
+++ b/src/main/java/org/opentripplanner/api/model/Leg.java
@@ -6,10 +6,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.TimeZone;
 
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
-
 import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.api.model.alertpatch.LocalizedAlert;
 import org.opentripplanner.routing.alertpatch.Alert;
@@ -76,7 +72,6 @@ public class Leg {
     /**
      * The mode (e.g., <code>Walk</code>) used when traversing this leg.
      */
-    @XmlAttribute
     @JsonSerialize
     public String mode = TraverseMode.WALK.toString();
 
@@ -84,30 +79,24 @@ public class Leg {
      * For transit legs, the route of the bus or train being used. For non-transit legs, the name of
      * the street being traversed.
      */
-    @XmlAttribute
     @JsonSerialize
     public String route = "";
 
-    @XmlAttribute
     @JsonSerialize
     public String agencyName;
 
-    @XmlAttribute
     @JsonSerialize
     public String agencyUrl;
 
-    @XmlAttribute
     @JsonSerialize
     public String agencyBrandingUrl;
 
-    @XmlAttribute
     @JsonSerialize
     public int agencyTimeZoneOffset;
 
     /**
      * For transit leg, the route's (background) color (if one exists). For non-transit legs, null.
      */
-    @XmlAttribute
     @JsonSerialize
     public String routeColor = null;
 
@@ -117,7 +106,6 @@ public class Leg {
      * When equal or highter than 100, it is coded using the Hierarchical Vehicle Type (HVT) codes from the European TPEG standard
      * Also see http://groups.google.com/group/gtfs-changes/msg/ed917a69cf8c5bef
      */
-    @XmlAttribute
     @JsonSerialize
     public Integer routeType = null;
     
@@ -130,14 +118,12 @@ public class Leg {
     /**
      * For transit leg, the route's text color (if one exists). For non-transit legs, null.
      */
-    @XmlAttribute
     @JsonSerialize
     public String routeTextColor = null;
 
     /**
      * For transit legs, if the rider should stay on the vehicle as it changes route names.
      */
-    @XmlAttribute
     @JsonSerialize
     public Boolean interlineWithPreviousLeg;
 
@@ -145,21 +131,18 @@ public class Leg {
     /**
      * For transit leg, the trip's short name (if one exists). For non-transit legs, null.
      */
-    @XmlAttribute
     @JsonSerialize
     public String tripShortName = null;
 
     /**
      * For transit leg, the trip's block ID (if one exists). For non-transit legs, null.
      */
-    @XmlAttribute
     @JsonSerialize
     public String tripBlockId = null;
     
     /**
      * For transit legs, the headsign of the bus or train being used. For non-transit legs, null.
      */
-    @XmlAttribute
     @JsonSerialize
     public String headsign = null;
 
@@ -167,7 +150,6 @@ public class Leg {
      * For transit legs, the ID of the transit agency that operates the service used for this leg.
      * For non-transit legs, null.
      */
-    @XmlAttribute
     @JsonSerialize
     public String agencyId = null;
     
@@ -181,14 +163,12 @@ public class Leg {
      * For transit legs, the service date of the trip.
      * For non-transit legs, null.
      */
-    @XmlAttribute
     @JsonSerialize
     public String serviceDate = null;
 
      /**
       * For transit leg, the route's branding URL (if one exists). For non-transit legs, null.
       */
-     @XmlAttribute
      @JsonSerialize
      public String routeBrandingUrl = null;
 
@@ -207,7 +187,6 @@ public class Leg {
      * For non-transit legs, null.
      * This field is optional i.e. it is always null unless "showIntermediateStops" parameter is set to "true" in the planner request.
      */
-    @XmlElementWrapper(name = "intermediateStops")
     @JsonProperty(value="intermediateStops")
     public List<Place> stop;
 
@@ -219,31 +198,24 @@ public class Leg {
     /**
      * A series of turn by turn instructions used for walking, biking and driving. 
      */
-    @XmlElementWrapper(name = "steps")
     @JsonProperty(value="steps")
     public List<WalkStep> walkSteps;
 
-    @XmlElement
     @JsonSerialize
     public List<LocalizedAlert> alerts;
 
-    @XmlAttribute
     @JsonSerialize
     public String routeShortName;
 
-    @XmlAttribute
     @JsonSerialize
     public String routeLongName;
 
-    @XmlAttribute
     @JsonSerialize
     public String boardRule;
 
-    @XmlAttribute
     @JsonSerialize
     public String alightRule;
 
-    @XmlAttribute
     @JsonSerialize
     public Boolean rentedBike;
 
@@ -262,7 +234,6 @@ public class Leg {
     /** 
      * The leg's duration in seconds
      */
-    @XmlElement
     @JsonSerialize
     public double getDuration() {
         return endTime.getTimeInMillis()/1000.0 - startTime.getTimeInMillis()/1000.0;

--- a/src/main/java/org/opentripplanner/api/model/Place.java
+++ b/src/main/java/org/opentripplanner/api/model/Place.java
@@ -1,8 +1,6 @@
 package org.opentripplanner.api.model;
 
 import java.util.Calendar;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement; 
 
 import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.util.Constants;
@@ -56,25 +54,21 @@ public class Place {
      */
     public Calendar departure = null;
 
-    @XmlAttribute
     @JsonSerialize
     public String orig;
 
-    @XmlAttribute
     @JsonSerialize
     public String zoneId;
 
     /**
      * For transit trips, the stop index (numbered from zero from the start of the trip
      */
-    @XmlAttribute
     @JsonSerialize
     public Integer stopIndex;
 
     /**
      * For transit trips, the sequence number of the stop. Per GTFS, these numbers are increasing.
      */
-    @XmlAttribute
     @JsonSerialize
     public Integer stopSequence;
 
@@ -82,7 +76,6 @@ public class Place {
      * Type of vertex. (Normal, Bike sharing station, Bike P+R, Transit stop)
      * Mostly used for better localization of bike sharing and P+R station names
      */
-    @XmlAttribute
     @JsonSerialize
     public VertexType vertexType;
 
@@ -95,7 +88,6 @@ public class Place {
      * Returns the geometry in GeoJSON format
      * @return
      */
-    @XmlElement
     String getGeometry() {
         return Constants.GEO_JSON_POINT + lon + "," + lat + Constants.GEO_JSON_TAIL;
     }

--- a/src/main/java/org/opentripplanner/api/model/RouterInfo.java
+++ b/src/main/java/org/opentripplanner/api/model/RouterInfo.java
@@ -9,11 +9,6 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.locationtech.jts.geom.Geometry;
 
-
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
 import org.locationtech.jts.geom.Coordinate;
 import org.opentripplanner.common.geometry.GeometryDeserializer;
 import org.opentripplanner.common.geometry.GeometrySerializer;
@@ -24,26 +19,20 @@ import org.opentripplanner.util.TravelOption;
 import org.opentripplanner.util.TravelOptionsMaker;
 import org.opentripplanner.util.WorldEnvelope;
 
-@XmlRootElement(name = "RouterInfo")
 public class RouterInfo {
 
     private final BikeRentalStationService service;
 
-    @XmlElement
     public String routerId;
     
     @JsonSerialize(using= GeometrySerializer.class)
     @JsonDeserialize(using= GeometryDeserializer.class)
-    @XmlJavaTypeAdapter(value=GeometryAdapter.class,type=Geometry.class)
     public Geometry polygon;
 
-    @XmlElement
     public Date buildTime;
 
-    @XmlElement
     public long transitServiceStarts;
 
-    @XmlElement
     public long transitServiceEnds;
 
     public HashSet<TraverseMode> transitModes;

--- a/src/main/java/org/opentripplanner/api/model/RouterList.java
+++ b/src/main/java/org/opentripplanner/api/model/RouterList.java
@@ -3,13 +3,6 @@ package org.opentripplanner.api.model;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElements;
-import javax.xml.bind.annotation.XmlRootElement;
-
-@XmlRootElement(name = "RouterList")
 public class RouterList {
-    @XmlElements(value = { @XmlElement(name="routerInfo") })
     public List<RouterInfo> routerInfo = new ArrayList<RouterInfo>();
-    
 }

--- a/src/main/java/org/opentripplanner/api/model/TripPlan.java
+++ b/src/main/java/org/opentripplanner/api/model/TripPlan.java
@@ -4,8 +4,6 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlElementWrapper;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -23,7 +21,6 @@ public class TripPlan {
     public Place to = null;
 
     /** A list of possible itineraries */
-    @XmlElementWrapper(name="itineraries") //TODO: why don't we just change the variable name?
     @JsonProperty(value="itineraries")
     public List<Itinerary> itinerary = new ArrayList<Itinerary>();
 

--- a/src/main/java/org/opentripplanner/api/model/WalkStep.java
+++ b/src/main/java/org/opentripplanner/api/model/WalkStep.java
@@ -5,10 +5,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlTransient;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
 import org.opentripplanner.api.model.alertpatch.LocalizedAlert;
 import org.opentripplanner.common.model.P2;
 import org.opentripplanner.model.BikeRentalStationInfo;
@@ -102,10 +98,8 @@ public class WalkStep {
      * The elevation profile as a comma-separated list of x,y values. x is the distance from the start of the step, y is the elevation at this
      * distance.
      */
-    @XmlTransient
     public List<P2<Double>> elevation;
 
-    @XmlElement
     @JsonSerialize
     public List<LocalizedAlert> alerts;
 
@@ -208,7 +202,6 @@ public class WalkStep {
         return streetName.substring(0, idx - 1);
     }
 
-    @XmlJavaTypeAdapter(ElevationAdapter.class)
     @JsonSerialize
     public List<P2<Double>> getElevation() {
         return elevation;

--- a/src/main/java/org/opentripplanner/api/model/alertpatch/AlertPatchCreationResponse.java
+++ b/src/main/java/org/opentripplanner/api/model/alertpatch/AlertPatchCreationResponse.java
@@ -1,10 +1,5 @@
 package org.opentripplanner.api.model.alertpatch;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-
-@XmlRootElement(name = "AlertPatchCreationResponse")
 public class AlertPatchCreationResponse {
-    @XmlElement
     public String status;
 }

--- a/src/main/java/org/opentripplanner/api/model/alertpatch/AlertPatchResponse.java
+++ b/src/main/java/org/opentripplanner/api/model/alertpatch/AlertPatchResponse.java
@@ -3,19 +3,9 @@ package org.opentripplanner.api.model.alertpatch;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
-import javax.xml.bind.annotation.XmlElements;
-import javax.xml.bind.annotation.XmlRootElement;
-
 import org.opentripplanner.routing.alertpatch.AlertPatch;
 
-@XmlRootElement
 public class AlertPatchResponse {
-    @XmlElementWrapper
-    @XmlElements({
-        @XmlElement(name = "AlertPatch", type = AlertPatch.class)
-        })
     public List<AlertPatch> alertPatches;
 
     public void addAlertPatch(AlertPatch alertPatch) {

--- a/src/main/java/org/opentripplanner/api/model/alertpatch/AlertPatchSet.java
+++ b/src/main/java/org/opentripplanner/api/model/alertpatch/AlertPatchSet.java
@@ -2,16 +2,8 @@ package org.opentripplanner.api.model.alertpatch;
 
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElements;
-import javax.xml.bind.annotation.XmlRootElement;
-
 import org.opentripplanner.routing.alertpatch.AlertPatch;
 
-@XmlRootElement(name="AlertPatchSet")
 public class AlertPatchSet {
-    @XmlElements({
-        @XmlElement(name = "AlertPatch", type = AlertPatch.class)
-    })
     public List<AlertPatch> alertPatches;
 }

--- a/src/main/java/org/opentripplanner/api/model/alertpatch/LocalizedAlert.java
+++ b/src/main/java/org/opentripplanner/api/model/alertpatch/LocalizedAlert.java
@@ -4,21 +4,14 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.opentripplanner.routing.alertpatch.Alert;
 
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlTransient;
 import java.util.Date;
 import java.util.Locale;
 
-@XmlRootElement(name = "Alert")
 public class LocalizedAlert {
 
-    @XmlTransient
     @JsonIgnore
     public Alert alert;
 
-    @XmlTransient
     @JsonIgnore
     private Locale locale;
 
@@ -30,7 +23,6 @@ public class LocalizedAlert {
     public LocalizedAlert(){
     }
 
-    @XmlAttribute
     @JsonSerialize
     public String getAlertHeaderText() {
         if (alert.alertHeaderText == null) {
@@ -39,7 +31,6 @@ public class LocalizedAlert {
         return alert.alertHeaderText.toString(locale);
     }
 
-    @XmlAttribute
     @JsonSerialize
     public String getAlertDescriptionText() {
         if (alert.alertDescriptionText == null) {
@@ -48,7 +39,6 @@ public class LocalizedAlert {
         return alert.alertDescriptionText.toString(locale);
     }
 
-    @XmlAttribute
     @JsonSerialize
     public String getAlertUrl() {
         if (alert.alertUrl == null) {
@@ -58,7 +48,6 @@ public class LocalizedAlert {
     }
 
     //null means unknown
-    @XmlElement
     @JsonSerialize
     public Date getEffectiveStartDate() {
         return alert.effectiveStartDate;

--- a/src/main/java/org/opentripplanner/api/model/error/TransitError.java
+++ b/src/main/java/org/opentripplanner/api/model/error/TransitError.java
@@ -1,9 +1,5 @@
 package org.opentripplanner.api.model.error;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-
-@XmlRootElement
 public class TransitError {
     private String message;
     
@@ -17,7 +13,6 @@ public class TransitError {
         this.message = message;
     }
 
-    @XmlElement(name="message")
     public String getMessage() {
         return message;
     }

--- a/src/main/java/org/opentripplanner/api/resource/AlertPatcher.java
+++ b/src/main/java/org/opentripplanner/api/resource/AlertPatcher.java
@@ -31,12 +31,12 @@ public class AlertPatcher {
     /**
      * Return a list of all patches that apply to a given stop
      *
-     * @return Returns either an XML or a JSON document, depending on the HTTP Accept header of the
+     * @return Returns a JSON document, depending on the HTTP Accept header of the
      *         client making the request.
      */
     @GET
     @Path("/stopPatches")
-    @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML + Q, MediaType.TEXT_XML + Q })
+    @Produces({ MediaType.APPLICATION_JSON })
     public AlertPatchResponse getStopPatches(@QueryParam("agency") String agency,
             @QueryParam("id") String id) {
 
@@ -51,12 +51,12 @@ public class AlertPatcher {
     /**
      * Return a list of all patches that apply to a given route
      *
-     * @return Returns either an XML or a JSON document, depending on the HTTP Accept header of the
+     * @return Returns a JSON document, depending on the HTTP Accept header of the
      *         client making the request.
      */
     @GET
     @Path("/routePatches")
-    @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML + Q, MediaType.TEXT_XML + Q })
+    @Produces({ MediaType.APPLICATION_JSON })
     public AlertPatchResponse getRoutePatches(@QueryParam("agency") String agency,
             @QueryParam("id") String id) {
 
@@ -72,8 +72,8 @@ public class AlertPatcher {
     @RolesAllowed("user")
     @POST
     @Path("/patch")
-    @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML + Q, MediaType.TEXT_XML + Q })
-    @Consumes({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.TEXT_XML })
+    @Produces({ MediaType.APPLICATION_JSON })
+    @Consumes({ MediaType.APPLICATION_JSON })
     public AlertPatchCreationResponse createPatches(AlertPatchSet alertPatches) {
         AlertPatchCreationResponse response = new AlertPatchCreationResponse();
         for (AlertPatch alertPatch : alertPatches.alertPatches) {

--- a/src/main/java/org/opentripplanner/api/resource/BikeRental.java
+++ b/src/main/java/org/opentripplanner/api/resource/BikeRental.java
@@ -31,7 +31,7 @@ public class BikeRental {
     OTPServer otpServer;
 
     @GET
-    @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML + Q, MediaType.TEXT_XML + Q })
+    @Produces({ MediaType.APPLICATION_JSON })
     public BikeRentalStationList getBikeRentalStations(
             @QueryParam("lowerLeft") String lowerLeft,
             @QueryParam("upperRight") String upperRight,

--- a/src/main/java/org/opentripplanner/api/resource/BikeRentalStationList.java
+++ b/src/main/java/org/opentripplanner/api/resource/BikeRentalStationList.java
@@ -3,14 +3,8 @@ package org.opentripplanner.api.resource;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElements;
-import javax.xml.bind.annotation.XmlRootElement;
-
 import org.opentripplanner.routing.bike_rental.BikeRentalStation;
 
-@XmlRootElement(name="BikeRentalStationList")
 public class BikeRentalStationList {
-    @XmlElements(value = { @XmlElement(name="station") })
     public List<BikeRentalStation> stations = new ArrayList<BikeRentalStation>();
 }

--- a/src/main/java/org/opentripplanner/api/resource/DebugOutput.java
+++ b/src/main/java/org/opentripplanner/api/resource/DebugOutput.java
@@ -17,7 +17,6 @@ import com.google.common.collect.Lists;
  * finishedCalculating and finishedRendering are all called in PlanGenerator.generate().
  * finishedPrecalculating and foundPaths are called in the SPTService implementations.
  */
-@XmlRootElement
 public class DebugOutput {
 
     private static final Logger LOG = LoggerFactory.getLogger(DebugOutput.class);

--- a/src/main/java/org/opentripplanner/api/resource/GraphInspectorTileResource.java
+++ b/src/main/java/org/opentripplanner/api/resource/GraphInspectorTileResource.java
@@ -99,7 +99,7 @@ public class GraphInspectorTileResource extends RoutingResource {
      * @return 
      */
     @GET @Path("layers")
-    @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML + Q, MediaType.TEXT_XML + Q })
+    @Produces({ MediaType.APPLICATION_JSON })
     public InspectorLayersList getLayers() {
 
         Router router = otpServer.getRouter(routerId);

--- a/src/main/java/org/opentripplanner/api/resource/InspectorLayersList.java
+++ b/src/main/java/org/opentripplanner/api/resource/InspectorLayersList.java
@@ -4,21 +4,15 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElements;
-import javax.xml.bind.annotation.XmlRootElement;
+
 import org.opentripplanner.inspector.TileRenderer;
 
 /**
  *
  * @author mabu
  */
-@XmlRootElement(name="InspectorLayersList")
 public class InspectorLayersList {
     
-    @XmlElements(value = {@XmlElement(name="layer") })
     public List<InspectorLayer> layers;
 
     InspectorLayersList(Map<String, TileRenderer> renderers) {
@@ -32,10 +26,8 @@ public class InspectorLayersList {
 
     private static class InspectorLayer {
         
-        @XmlAttribute
         @JsonSerialize
         String key;
-        @XmlAttribute
         @JsonSerialize
         String name;
 

--- a/src/main/java/org/opentripplanner/api/resource/PlannerResource.java
+++ b/src/main/java/org/opentripplanner/api/resource/PlannerResource.java
@@ -41,7 +41,7 @@ public class PlannerResource extends RoutingResource {
     // parameters in the outgoing response. This is a TriMet requirement.
     // Jersey uses @Context to inject internal types and @InjectParam or @Resource for DI objects.
     @GET
-    @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML + Q, MediaType.TEXT_XML + Q })
+    @Produces({ MediaType.APPLICATION_JSON })
     public Response plan(@Context UriInfo uriInfo, @Context Request grizzlyRequest) {
 
         /*

--- a/src/main/java/org/opentripplanner/api/resource/Response.java
+++ b/src/main/java/org/opentripplanner/api/resource/Response.java
@@ -5,18 +5,14 @@ import java.util.List;
 import java.util.Map.Entry;
 
 import javax.ws.rs.core.UriInfo;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
 
 import org.opentripplanner.api.model.TripPlan;
 import org.opentripplanner.api.model.error.PlannerError;
 
 /** Represents a trip planner response, will be serialized into XML or JSON by Jersey */
-@XmlRootElement
 public class Response {
 
     /** A dictionary of the parameters provided in the request that triggered this response. */
-    @XmlElement
     public HashMap<String, String> requestParameters;
     private TripPlan plan;
     private PlannerError error = null;
@@ -57,7 +53,6 @@ public class Response {
     }
 
     /** The error (if any) that this response raised. */
-    @XmlElement(required=false)
     public PlannerError getError() {
         return error;
     }

--- a/src/main/java/org/opentripplanner/api/resource/Response.java
+++ b/src/main/java/org/opentripplanner/api/resource/Response.java
@@ -9,7 +9,7 @@ import javax.ws.rs.core.UriInfo;
 import org.opentripplanner.api.model.TripPlan;
 import org.opentripplanner.api.model.error.PlannerError;
 
-/** Represents a trip planner response, will be serialized into XML or JSON by Jersey */
+/** Represents a trip planner response, will be serialized into JSON by Jersey */
 public class Response {
 
     /** A dictionary of the parameters provided in the request that triggered this response. */

--- a/src/main/java/org/opentripplanner/api/resource/Routers.java
+++ b/src/main/java/org/opentripplanner/api/resource/Routers.java
@@ -93,11 +93,10 @@ public class Routers {
 
     /** 
      * Returns a list of routers and their bounds. 
-     * @return a representation of the graphs and their geographic bounds, in JSON or XML depending
-     * on the Accept header in the HTTP request.
+     * @return a representation of the graphs and their geographic bounds in JSON.
      */
     @GET
-    @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML + Q, MediaType.TEXT_XML + Q })
+    @Produces({ MediaType.APPLICATION_JSON })
     public RouterList getRouterIds() {
         RouterList routerList = new RouterList();
         for (String id : otpServer.getRouterIds()) {
@@ -115,7 +114,7 @@ public class Routers {
      * @returns status code 200 if the routerId is registered, otherwise a 404.
      */
     @GET @Path("{routerId}")
-    @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML + Q, MediaType.TEXT_XML + Q })
+    @Produces({ MediaType.APPLICATION_JSON })
     public RouterInfo getGraphId(@PathParam("routerId") String routerId) {
         // factor out build one entry
         RouterInfo routerInfo = getRouterInfo(routerId);

--- a/src/main/java/org/opentripplanner/api/resource/ServerInfo.java
+++ b/src/main/java/org/opentripplanner/api/resource/ServerInfo.java
@@ -6,8 +6,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+
 import java.io.BufferedReader;
 import java.io.FileInputStream;
 import java.io.InputStream;
@@ -15,7 +14,6 @@ import java.io.InputStreamReader;
 import java.nio.charset.Charset;
 
 @Path("/")
-@XmlRootElement 
 public class ServerInfo {
 
     /** Quality value prioritizes MIME types */
@@ -29,16 +27,12 @@ public class ServerInfo {
         return SERVER_INFO;
     }    
     
-    // Fields must be public or have a public getter to be auto-serialized to JSON;
-    // they are annotated with @XmlElement to be serialized to XML elements (as opposed to attributes).
+    // Fields must be public or have a public getter to be auto-serialized to JSON
 
-    @XmlElement 
-    public MavenVersion serverVersion = MavenVersion.VERSION; 
+    public MavenVersion serverVersion = MavenVersion.VERSION;
     
-    @XmlElement 
     public String cpuName = "unknown";
     
-    @XmlElement 
     public int nCores = 0;
 
     /* It would make sense to have one object containing maven, git, and hardware subobjects. */

--- a/src/main/java/org/opentripplanner/api/resource/ServerInfo.java
+++ b/src/main/java/org/opentripplanner/api/resource/ServerInfo.java
@@ -22,7 +22,7 @@ public class ServerInfo {
     private static final ServerInfo SERVER_INFO = new ServerInfo();
 
     @GET
-    @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML + Q, MediaType.TEXT_XML + Q })
+    @Produces({ MediaType.APPLICATION_JSON })
     public static ServerInfo getServerInfo() {
         return SERVER_INFO;
     }    

--- a/src/main/java/org/opentripplanner/geocoder/GeocoderResults.java
+++ b/src/main/java/org/opentripplanner/geocoder/GeocoderResults.java
@@ -3,14 +3,9 @@ package org.opentripplanner.geocoder;
 import java.util.ArrayList;
 import java.util.Collection;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
-import javax.xml.bind.annotation.XmlRootElement;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 
-@XmlRootElement
 public class GeocoderResults {
 
     private String error;
@@ -26,7 +21,6 @@ public class GeocoderResults {
         this.results = results;
     }
 
-    @XmlElement(required=false)
     public String getError() {
         return error;
     }
@@ -36,9 +30,6 @@ public class GeocoderResults {
         this.error = error;
     }
 
-    
-    @XmlElementWrapper(name="results")
-    @XmlElement(name="result")
     @JsonProperty(value="results")
     public Collection<GeocoderResult> getResults() {
         return results;
@@ -55,7 +46,6 @@ public class GeocoderResults {
         results.add(result);
     }
 
-    @XmlElement(name="count")
     public int getCount() {
         return results != null ? results.size() : 0;
     }

--- a/src/main/java/org/opentripplanner/geocoder/reverse/MunicoderServer.java
+++ b/src/main/java/org/opentripplanner/geocoder/reverse/MunicoderServer.java
@@ -32,7 +32,7 @@ public class MunicoderServer {
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON}) // APPLICATION_XML + "; charset=UTF-8", MediaType.APPLICATION_JSON + "; charset=UTF-8"})
+    @Produces({MediaType.APPLICATION_JSON})
     public String resolveLocation(
             @QueryParam("location") String location,
             @QueryParam("callback") String callback) {

--- a/src/main/java/org/opentripplanner/routing/alertpatch/Alert.java
+++ b/src/main/java/org/opentripplanner/routing/alertpatch/Alert.java
@@ -7,28 +7,19 @@ import java.io.Serializable;
 import java.util.Date;
 import java.util.HashSet;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlType;
-
-@XmlType
 public class Alert implements Serializable {
     private static final long serialVersionUID = 8305126586053909836L;
 
-    @XmlElement
     public I18NString alertHeaderText;
 
-    @XmlElement
     public I18NString alertDescriptionText;
 
-    @XmlElement
     public I18NString alertUrl;
 
     //null means unknown
-    @XmlElement
     public Date effectiveStartDate;
 
     //null means unknown
-    @XmlElement
     public Date effectiveEndDate;
 
     public static HashSet<Alert> newSimpleAlertSet(String text) {

--- a/src/main/java/org/opentripplanner/routing/alertpatch/AlertPatch.java
+++ b/src/main/java/org/opentripplanner/routing/alertpatch/AlertPatch.java
@@ -5,10 +5,6 @@ import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.util.*;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
 import org.opentripplanner.model.Agency;
 import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.model.Route;
@@ -31,7 +27,6 @@ import org.slf4j.LoggerFactory;
  * @author novalis
  *
  */
-@XmlRootElement(name = "AlertPatch")
 public class AlertPatch implements Serializable {
     private static final Logger LOG = LoggerFactory.getLogger(AlertPatch.class);
 
@@ -66,7 +61,6 @@ public class AlertPatch implements Serializable {
      */
     private int directionId = -1;
 
-    @XmlElement
     public Alert getAlert() {
         return alert;
     }
@@ -82,7 +76,6 @@ public class AlertPatch implements Serializable {
         return false;
     }
 
-    @XmlElement
     public String getId() {
         return id;
     }
@@ -232,17 +225,14 @@ public class AlertPatch implements Serializable {
         return agency;
     }
 
-    @XmlJavaTypeAdapter(AgencyAndIdAdapter.class)
     public FeedScopedId getRoute() {
         return route;
     }
 
-    @XmlJavaTypeAdapter(AgencyAndIdAdapter.class)
     public FeedScopedId getTrip() {
         return trip;
     }
 
-    @XmlJavaTypeAdapter(AgencyAndIdAdapter.class)
     public FeedScopedId getStop() {
         return stop;
     }
@@ -270,12 +260,10 @@ public class AlertPatch implements Serializable {
         this.directionId = direction;
     }
 
-    @XmlElement
     public String getDirection() {
         return direction;
     }
 
-    @XmlElement
     public int getDirectionId() {
         return directionId;
     }

--- a/src/main/java/org/opentripplanner/routing/alertpatch/TimePeriod.java
+++ b/src/main/java/org/opentripplanner/routing/alertpatch/TimePeriod.java
@@ -1,8 +1,5 @@
 package org.opentripplanner.routing.alertpatch;
 
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlType;
-
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 /**
@@ -10,7 +7,6 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
  * @author novalis
  *
  */
-@XmlType
 public class TimePeriod {
     public TimePeriod(long start, long end) {
         this.startTime = start;
@@ -20,11 +16,9 @@ public class TimePeriod {
     public TimePeriod() {
     }
 
-    @XmlAttribute
     @JsonSerialize
     public long startTime;
 
-    @XmlAttribute
     @JsonSerialize
     public long endTime;
 

--- a/src/main/java/org/opentripplanner/routing/bike_park/BikePark.java
+++ b/src/main/java/org/opentripplanner/routing/bike_park/BikePark.java
@@ -3,8 +3,6 @@ package org.opentripplanner.routing.bike_park;
 import java.io.Serializable;
 import java.util.Locale;
 
-import javax.xml.bind.annotation.XmlAttribute;
-
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 public class BikePark implements Serializable {
@@ -14,20 +12,16 @@ public class BikePark implements Serializable {
      * Unique ID of the bike park. Creator should ensure the ID is unique server-wide (prefix by a
      * source ID if there are several sources)
      */
-    @XmlAttribute
     @JsonSerialize
     public String id;
 
-    @XmlAttribute
     @JsonSerialize
     public String name;
 
     /** Note: x = Longitude, y = Latitude */
-    @XmlAttribute
     @JsonSerialize
     public double x, y;
 
-    @XmlAttribute
     @JsonSerialize
     public int spacesAvailable = Integer.MAX_VALUE;
 
@@ -35,7 +29,6 @@ public class BikePark implements Serializable {
      * Whether this station has space available information updated in real-time. If no real-time
      * data, users should take spacesAvailable with a pinch of salt, as they are a crude estimate.
      */
-    @XmlAttribute
     @JsonSerialize
     public boolean realTimeData = true;
 

--- a/src/main/java/org/opentripplanner/routing/bike_rental/BikeRentalStation.java
+++ b/src/main/java/org/opentripplanner/routing/bike_rental/BikeRentalStation.java
@@ -5,9 +5,6 @@ import java.io.Serializable;
 import java.util.Locale;
 import java.util.Set;
 
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlTransient;
-
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.opentripplanner.util.I18NString;
 import org.opentripplanner.util.ResourceBundleSingleton;
@@ -15,36 +12,27 @@ import org.opentripplanner.util.ResourceBundleSingleton;
 public class BikeRentalStation implements Serializable, Cloneable {
     private static final long serialVersionUID = 8311460609708089384L;
 
-    @XmlAttribute
     @JsonSerialize
     public String id;
     //Serialized in TranslatedBikeRentalStation
-    @XmlTransient
     @JsonIgnore
     public I18NString name;
-    @XmlAttribute
     @JsonSerialize
     public double x, y; //longitude, latitude
-    @XmlAttribute
     @JsonSerialize
     public int bikesAvailable = Integer.MAX_VALUE;
-    @XmlAttribute
     @JsonSerialize
     public int spacesAvailable = Integer.MAX_VALUE;
-    @XmlAttribute
     @JsonSerialize
     public boolean allowDropoff = true;
-    @XmlAttribute
     @JsonSerialize
     public boolean isFloatingBike = false;
-    @XmlAttribute
     @JsonSerialize
     public boolean isCarStation = false;
 
     /**
      * List of compatible network names. Null (default) to be compatible with all.
      */
-    @XmlAttribute
     @JsonSerialize
     public Set<String> networks = null;
     
@@ -52,7 +40,6 @@ public class BikeRentalStation implements Serializable, Cloneable {
      * Whether this station is static (usually coming from OSM data) or a real-time source. If no real-time data, users should take
      * bikesAvailable/spacesAvailable with a pinch of salt, as they are always the total capacity divided by two. Only the total is meaningful.
      */
-    @XmlAttribute
     @JsonSerialize
     public boolean realTimeData = true;
 
@@ -69,7 +56,6 @@ public class BikeRentalStation implements Serializable, Cloneable {
      *
      */
     @JsonIgnore
-    @XmlTransient
     public Locale locale = ResourceBundleSingleton.INSTANCE.getLocale(null);
 
     /**
@@ -104,7 +90,6 @@ public class BikeRentalStation implements Serializable, Cloneable {
     /**
      * Gets translated name of bike rental station based on locale
      */
-    @XmlAttribute
     @JsonSerialize
     public String getName() {
         return name.toString(locale);

--- a/src/main/java/org/opentripplanner/routing/edgetype/TripPattern.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/TripPattern.java
@@ -31,8 +31,6 @@ import org.opentripplanner.routing.vertextype.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlTransient;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
@@ -140,7 +138,7 @@ public class TripPattern implements Cloneable, Serializable {
 
     /** Holds stop-specific information such as wheelchair accessibility and pickup/dropoff roles. */
     // TODO: is this necessary? Can we just look at the Stop and StopPattern objects directly?
-    @XmlElement int[] perStopFlags;
+    int[] perStopFlags;
 
     /**
      * A set of serviceIds with at least one trip in this pattern.
@@ -217,7 +215,6 @@ public class TripPattern implements Cloneable, Serializable {
         return trips.get(tripIndex);
     }
 
-    @XmlTransient
     public List<Trip> getTrips() {
         return trips;
     }


### PR DESCRIPTION
This removes XML annotations from response objects, so Jackson reverts to default behavior (before 2.7.4). In particular, generic collections do not use wrapper tags anymore. Jackson uses the typical JSON annotations to name the XML tags.

To be completed by pull request submitter:

- [x] **issue**: #2685, Copy of PR #2741 
- [x] **roadmap**: XML is set to be deprecated, but I think we may as well fix the response types for the current version. In any case, this PR deletes XML-specific annotations, so it will be helpful for the XML deprecation as well
- [x] **tests**: No new tests
- [x] **formatting**: No changes. 
- [x] **documentation**: N/A
- [x] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)