### PR TITLE
Add API endpoint for Park and Rides

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -12,6 +12,7 @@
 - Fix reverse optimization bug (#2653, #2411)
 - Remove CarFreeAtoZ from list of deployments
 - Fix XML response serialization (#2685)
+- Add API endpoint for fetching Park and Rides (#1412)
 
 ## 1.3 (2018-08-03)
 

--- a/src/main/java/org/opentripplanner/api/resource/ParkAndRide.java
+++ b/src/main/java/org/opentripplanner/api/resource/ParkAndRide.java
@@ -1,0 +1,92 @@
+/* This program is free software: you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public License
+ as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+package org.opentripplanner.api.resource;
+
+import com.vividsolutions.jts.geom.Envelope;
+import org.opentripplanner.routing.graph.Vertex;
+import org.opentripplanner.routing.vertextype.ParkAndRideVertex;
+import org.opentripplanner.standalone.OTPServer;
+import org.opentripplanner.standalone.Router;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by demory on 7/26/18.
+ */
+
+@Path("/routers/{routerId}/park_and_ride")
+public class ParkAndRide {
+
+    @Context
+    OTPServer otpServer;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getParkAndRide(
+            @QueryParam("lowerLeft") String lowerLeft,
+            @QueryParam("upperRight") String upperRight,
+            @PathParam("routerId") String routerId) {
+
+        Router router = otpServer.getRouter(routerId);
+        if (router == null) return null;
+
+        Envelope envelope;
+        if (lowerLeft != null) {
+            envelope = getEnvelope(lowerLeft, upperRight);
+        } else {
+            envelope = new Envelope(-180,180,-90,90);
+        }
+
+        List<ParkAndRideInfo> prs = new ArrayList<>();
+        for (Vertex v : router.graph.getVertices()) {
+            if (v instanceof ParkAndRideVertex && envelope.contains(v.getX(), v.getY())) {
+                prs.add(new ParkAndRideInfo((ParkAndRideVertex) v));
+            }
+        }
+
+        return Response.status(Status.OK).entity(prs).build();
+    }
+
+    /** Envelopes are in latitude, longitude format */
+    public static Envelope getEnvelope(String lowerLeft, String upperRight) {
+        String[] lowerLeftParts = lowerLeft.split(",");
+        String[] upperRightParts = upperRight.split(",");
+
+        Envelope envelope = new Envelope(Double.parseDouble(lowerLeftParts[1]),
+                Double.parseDouble(upperRightParts[1]), Double.parseDouble(lowerLeftParts[0]),
+                Double.parseDouble(upperRightParts[0]));
+        return envelope;
+    }
+
+    public class ParkAndRideInfo {
+        private static final long serialVersionUID = 1L;
+
+        public String name;
+
+        public Double x, y;
+
+        public ParkAndRideInfo(ParkAndRideVertex vertex) {
+            this.name = vertex.getName();
+            this.x = vertex.getX();
+            this.y = vertex.getY();
+        }
+    }
+
+}

--- a/src/main/java/org/opentripplanner/api/resource/ParkAndRide.java
+++ b/src/main/java/org/opentripplanner/api/resource/ParkAndRide.java
@@ -13,15 +13,19 @@
 
 package org.opentripplanner.api.resource;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.Envelope;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Envelope;
 import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.routing.vertextype.ParkAndRideVertex;
 import org.opentripplanner.routing.vertextype.TransitStop;
 import org.opentripplanner.standalone.OTPServer;
 import org.opentripplanner.standalone.Router;
 
-import javax.ws.rs.*;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -68,7 +72,7 @@ public class ParkAndRide {
             // Check if vertex is within maxTransitDistance of a stop (if specified)
             if (maxTransitDistance != null) {
                 List<TransitStop> stops = router.graph.streetIndex.getNearbyTransitStops(
-                        new Coordinate(v.getX(), v.getY()), maxTransitDistance);
+                    new Coordinate(v.getX(), v.getY()), maxTransitDistance);
                 if (stops.isEmpty()) continue;
             }
 

--- a/src/main/java/org/opentripplanner/standalone/OTPApplication.java
+++ b/src/main/java/org/opentripplanner/standalone/OTPApplication.java
@@ -96,7 +96,8 @@ public class OTPApplication extends Application {
             RepeatedRaptorTestResource.class,
             /* Features and Filters: extend Jersey, manipulate requests and responses. */
             CorsFilter.class,
-            MultiPartFeature.class
+            MultiPartFeature.class,
+            ParkAndRide.class
         ));
         
         if (this.secure) {


### PR DESCRIPTION
This PR adds a new API endpoint which is able to fetch a list of Park and Rides present in a graph. This fixes #1412 

- [x] **issue**: Link to or create an [issue](https://github.com/opentripplanner/OpenTripPlanner/issues) that describes the relevant feature or bug. Add [GitHub keywords](https://help.github.com/articles/closing-issues-using-keywords/) to this PR's description (e.g., `closes #45`).
- [ ] **roadmap**: Check the [roadmap](https://github.com/orgs/opentripplanner/projects/1) for this feature or bug. If it is not already on the roadmap, PLC will discuss as part of the review process.
- [x] **tests**: Have you added relevant test coverage? Are all the tests passing on [the continuous integration service (Travis CI)](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#continuous-integration)?
- [x] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#code-style)? 
- [x] **documentation**: If you are adding a new configuration option, have you added an explanation to the [configuration documentation](docs/Configuration.md) tables and sections?
- [x] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)