### PR TITLE
Add ability to define custom walk comfort rules

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -12,6 +12,7 @@
 - Fix reverse optimization bug (#2653, #2411)
 - Remove CarFreeAtoZ from list of deployments
 - Fix XML response serialization (#2685)
+- Add ability to define custom walk comfort rules
 
 ## 1.3 (2018-08-03)
 

--- a/docs/Pedestrian-Routing.md
+++ b/docs/Pedestrian-Routing.md
@@ -1,0 +1,66 @@
+# Pedestrian Routing
+
+OpenTripPlanner 1.X introduces extended functionality for weighed pedestrian routing based on OpenStreetMap tags. This functionality can be used to favor or disfavor specific street edges in walk routing based on properties of the corresponding OSM ways, such as roadway type, the presence of sidewalks, etc.
+
+## Walk Comfort Configuration
+
+At the heart of the pedestrian routing functionality is the "walk comfort" configuration, which defines a set of "rules" that map specific key/value pairs in a street way's OSM property set to "walk comfort" factors which are then applied to the routing weight of any derived street edges in the street network graph.
+
+A single rule specifies a "test" that consists of an OSM tag key/value pair, as well as a numeric factor that is applied to any ways that satisfy the key/value test. The factor is a multiplier that is applied to the default edge weight (which itself is a combination of edge length and elevation-derived steepness, if applicable); factors *greater* than 1.0 adjust the weight upward (i.e. making the edge *less* attractive to routing) while factors *less* than 1.0 adjust the weight downward (making it *more* attractive).
+
+The walk configuration file is an optional JSON file called `walk-config.json` that must reside in graph's home directory (alongside `build-config.json` and `router-config.json`, if provided). Following is an example of a simple two-rule walk comfort configuration:
+
+```JSON
+// build-config.json
+{
+  "rules": [
+    {
+      "key": "highway",
+      "value": "primary",
+      "factor": 1.5
+    },
+    {
+      "key": "sidewalk",
+      "value": "both",
+      "factor": 0.9
+    }
+  ]
+}
+```
+
+In the above example, two rules are created; one applies a factor of 1.5 (i.e. a 50 percent "penalty") to ways that are designated `primary` highways, and one that applies a factor of 0.9 (i.e. a 10 percent "bonus") to ways that are coded as having sidewalks on both sides of the street.
+
+If multiple rules are satisfied for a given way, the final walk comfort factor will be the product of all associated rule-level factors; in the above example, a way that is both a primary highway and that also has sidewalks would have a final walk comfort factor of 1.5 * 0.9 = __1.35__.
+
+The is no limit on the number of rules that may be specified, and the order of the rules in the configuration file has no affect on how they are applied.
+
+## Dynamic Configuration Reloading
+
+In most production environments, the walk configuration file will be provided at graph build time, with the walk comfort factors computed as part of the graph build process and stored with the street edges in the `Graph.obj` file.
+
+For development and testing of walk comfort rules, however, the ability to make updates to the walk rules and see their impact without rebuilding the graph is helpful. To that end, OTP also includes a mechanism for updating and reloading the walk configuration for running servers "on the fly".
+
+To enable this feature, a special flag, `includeOsmTags`, must be set to `true` in the graph builder's `build-config.json` file, as shown in the following example. This will cause the full set of OSM property tags to be embedded in the graph for all street edges.
+
+```JSON
+// build-config.json
+{
+  "includeOsmTags": true
+}
+```
+
+Enabling this flag will increase the size of the graph, typically by 10 to 20 percent depending on how extensively tagged the OSM data is. Therefore, its use should be limited to testing and development contexts.
+
+Once a graph that was built with the `includeOsmTags` flag enabled is deployed to an OTP server, the `walk-config.json` file can be dynamically reloaded by invoking a special `/walk_comfort` OTP server endpoint; for the default router on a locally-deployed server on port 8001, the endpoint URL would be `http://localhost:8001/otp/routers/default/walk_comfort`
+
+Invoking this endpoint will reload the `walk-config.json` file (which must be located in the current graph's home directory) and will use the freshly loaded rules to recalculate the walk comfort factors for all street edges in the graph. A query to this endpoint will return a simple JSON response indicating whether the query was successful, the number of street edges updated, and the time in milliseconds taken by the query; following is an example of such a response:
+
+```JSON
+{
+  "success": true,
+  "edgesUpdated": 37667,
+  "time": 38
+}
+```
+
+Any subsequent routing requests will be performed on the updated graph, but note that the `Graph.obj` file is *not* rewritten on disk; to incorporate any updated walk rules into the graph file it must be rebuilt using the graph builder.

--- a/docs/Pedestrian-Routing.md
+++ b/docs/Pedestrian-Routing.md
@@ -4,22 +4,24 @@ OpenTripPlanner 1.X introduces extended functionality for weighed pedestrian rou
 
 ## Walk Comfort Configuration
 
-At the heart of the pedestrian routing functionality is the "walk comfort" configuration, which defines a set of "rules" that map specific key/value pairs in a street way's OSM property set to "walk comfort" factors which are then applied to the routing weight of any derived street edges in the street network graph.
+At the heart of the pedestrian routing functionality is the "walk comfort" configuration, which defines a set of "rules" that map specific conditions based on a way's OSM property set to "walk comfort" factors which are then applied to the routing weight of any derived street edges in the street network graph.
 
-A single rule specifies a "test" that consists of an OSM tag key/value pair, as well as a numeric factor that is applied to any ways that satisfy the key/value test. The factor is a multiplier that is applied to the default edge weight (which itself is a combination of edge length and elevation-derived steepness, if applicable); factors *greater* than 1.0 adjust the weight upward (i.e. making the edge *less* attractive to routing) while factors *less* than 1.0 adjust the weight downward (making it *more* attractive).
+A single rule specifies one or more "tests" that must be satisfied in order for the rule's weighting factor to be applied to a given way. The factor is a multiplier that is applied to the default edge weight (which itself is a combination of edge length and elevation-derived steepness, if applicable). Factors *greater* than 1.0 adjust the weight upward (i.e. making the edge *less* attractive to routing) while factors *less* than 1.0 adjust the weight downward (making it *more* attractive).
 
-The walk configuration file is an optional JSON file called `walk-config.json` that must reside in graph's home directory (alongside `build-config.json` and `router-config.json`, if provided). Following is an example of a simple two-rule walk comfort configuration:
+The walk configuration file is an optional JSON file called `walk-config.json` that must reside in graph's home directory (alongside `build-config.json` and `router-config.json`, if provided). Following is an example walk comfort configuration consisting of two simple tag value comparison rules:
 
 ```JSON
-// build-config.json
+// walk-config.json
 {
   "rules": [
     {
+      "type": "equal",
       "key": "highway",
       "value": "primary",
       "factor": 1.5
     },
     {
+      "type": "equal",
       "key": "sidewalk",
       "value": "both",
       "factor": 0.9
@@ -28,11 +30,91 @@ The walk configuration file is an optional JSON file called `walk-config.json` t
 }
 ```
 
-In the above example, two rules are created; one applies a factor of 1.5 (i.e. a 50 percent "penalty") to ways that are designated `primary` highways, and one that applies a factor of 0.9 (i.e. a 10 percent "bonus") to ways that are coded as having sidewalks on both sides of the street.
+In the above example, the first rule applies a factor of 1.5 (i.e. a 50 percent "penalty") to ways that are designated `primary` highways, while the second rule applies a factor of 0.9 (i.e. a 10 percent "bonus") to ways that are coded as having sidewalks on both sides of the street.
 
-If multiple rules are satisfied for a given way, the final walk comfort factor will be the product of all associated rule-level factors; in the above example, a way that is both a primary highway and that also has sidewalks would have a final walk comfort factor of 1.5 * 0.9 = __1.35__.
+If multiple rules are satisfied for a given way, the final walk comfort factor will be the product of all associated rule-specified factors; in the above example, a way that is both a primary highway and that also has sidewalks would have a final walk comfort factor of 1.5 * 0.9 = __1.35__.
 
 The is no limit on the number of rules that may be specified, and the order of the rules in the configuration file has no affect on how they are applied.
+
+## Test types
+
+Several different test types are supported, which are specified by the test's `type` property. Some test types (e.g. `and` and `or`) contain multiple sub-tests, allowing for rules consisting of nested tests (see example below). Following are the different test types and associated additional properties:
+
+### `equal`
+A basic text-based tag value comparison as illustrated in the above example.
+  * `key` - the OSM tag key to be matched (e.g. `"highway"`)
+  * `value` - the specific reference value(s) to be matched. May either be a single string (e.g. `"primary"`) or an array of strings (e.g. `["primary", "secondary"]`)
+
+*Note: if the `type` field is omitted for a test, an `equal` test is assumed.*
+
+### `absent`
+A test of whether a tag is absent from a way's property set. The test only passes if a specified tag is *not* present for a given way.
+* `key` - the OSM tag key that must not be present (e.g. `"cycleway"`)
+
+### `numeric-equal`
+An equality test where both the reference value and all tested tag values are assumed to be numeric (e.g. `2` will equal `2.0`). If either the reference value or the test value is non-numeric, the test will fail.
+* `key` - the OSM tag key to be matched (e.g. `"lanes"`)
+* `value` - a single numeric reference value to be matched (e.g. `2`)
+
+### `greater`
+A numeric test where the tag value must be greater than a specified reference value. If either the reference value or the test value is non-numeric, the test will fail.
+* `key` - the OSM tag key to be matched (e.g. `"lanes"`)
+* `value` - a single numeric reference value (e.g. `2`)
+
+### `less`
+A numeric test where the tag value must be less than a specified reference value. If either the reference value or the test value is non-numeric, the test will fail.
+* `key` - the OSM tag key to be matched (e.g. `"lanes"`)
+* `value` - a single numeric reference value (e.g. `2`)
+
+### `greater-equal`
+A variation on `greater` where the test also allows for the tag value and reference value to be equal.
+
+### `less-equal`
+A variation on `less` where the test also allows for the tag value and reference value to be equal.
+
+### `and`
+A test that performs an "and" comparison of multiple sub-tests. The test passes only if *all* of the specified sub-tests pass.
+* `tests` - An array of sub-tests (which may be of any type)
+
+### `or`
+A test that performs an "or" comparison of multiple sub-tests. The test passes if *any* of the specified sub-tests pass.
+* `tests` - An array of sub-tests (which may be of any type)
+
+## Example
+
+Following is an example of a more advanced rule involving a combination of `and`, `or`, `equal`, and `greater` tests. This rule tests whether a street segment is either a `primary` street *or* a `secondary`/`tertiary` street with more than two lanes, and applies a factor of 1.5 if so.
+
+```JSON
+// walk-config.json
+{"rules": [
+  {
+    "type": "or",
+    "tests": [
+      {
+        "type": "equal",
+        "key": "highway",
+        "value": "primary"
+      },
+      {
+        "type": "and",
+        "tests": [
+          {
+            "type": "equal",
+            "key": "highway",
+            "value": ["secondary", "tertiary"]
+          },
+          {
+            "type": "greater",
+            "key": "lanes",
+            "value": 2
+          }
+        ]
+      }
+    ],
+    "factor": 1.5
+  }
+]}
+```
 
 ## Dynamic Configuration Reloading
 
@@ -53,13 +135,19 @@ Enabling this flag will increase the size of the graph, typically by 10 to 20 pe
 
 Once a graph that was built with the `includeOsmTags` flag enabled is deployed to an OTP server, the `walk-config.json` file can be dynamically reloaded by invoking a special `/walk_comfort` OTP server endpoint; for the default router on a locally-deployed server on port 8001, the endpoint URL would be `http://localhost:8001/otp/routers/default/walk_comfort`
 
-Invoking this endpoint will reload the `walk-config.json` file (which must be located in the current graph's home directory) and will use the freshly loaded rules to recalculate the walk comfort factors for all street edges in the graph. A query to this endpoint will return a simple JSON response indicating whether the query was successful, the number of street edges updated, and the time in milliseconds taken by the query; following is an example of such a response:
+Invoking this endpoint will reload the `walk-config.json` file (which must be located in the current graph's home directory) and will use the freshly loaded rules to recalculate the walk comfort factors for all street edges in the graph. A query to this endpoint will return a simple JSON response indicating whether the query was successful, the time in milliseconds taken by the query, and the number of edges updated and rules loaded for each router active on the OTP server. Following is an example of such a response:
 
 ```JSON
 {
   "success": true,
-  "edgesUpdated": 37667,
-  "time": 38
+  "time": 6,
+  "routers": [
+    {
+      "routerId": "pdx",
+      "edgesUpdated": 3956,
+      "rulesLoaded": 1
+    }
+  ]
 }
 ```
 

--- a/src/main/java/org/opentripplanner/api/resource/WalkComfort.java
+++ b/src/main/java/org/opentripplanner/api/resource/WalkComfort.java
@@ -1,0 +1,56 @@
+package org.opentripplanner.api.resource;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.json.simple.JSONObject;
+import org.opentripplanner.common.walk.WalkComfortCalculator;
+import org.opentripplanner.routing.edgetype.StreetEdge;
+import org.opentripplanner.routing.graph.Edge;
+import org.opentripplanner.standalone.CommandLineParameters;
+import org.opentripplanner.standalone.OTPMain;
+import org.opentripplanner.standalone.OTPServer;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.*;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import java.io.File;
+
+/**
+ * Created by demory on 11/21/17.
+ */
+
+
+@Path("/routers/{routerId}/walk_comfort")
+@XmlRootElement
+public class WalkComfort {
+
+    @Context
+    OTPServer otpServer;
+
+    @GET
+    @Produces({ MediaType.APPLICATION_JSON })
+    public JSONObject recalculateWalkComfort() {
+
+        long startTime = System.currentTimeMillis();
+
+        JsonNode walkConfig = OTPMain.loadJson(new File(otpServer.params.build, WalkComfortCalculator.WALK_CONFIG_FILENAME));
+        WalkComfortCalculator gen = new WalkComfortCalculator(walkConfig);
+
+        int edgeCount = 0;
+        for (Edge edge : otpServer.getGraphService().getRouter().graph.getEdges()) {
+            if(!(edge instanceof StreetEdge)) continue;
+            StreetEdge streetEdge = (StreetEdge) edge;
+            if(streetEdge.getOsmTags() == null) continue;
+
+            streetEdge.setWalkComfortScore(gen.computeScore(streetEdge.getOsmTags()));
+            edgeCount++;
+        }
+        JSONObject response = new JSONObject();
+        response.put("success", true);
+        response.put("edgesUpdated", edgeCount);
+        response.put("time", System.currentTimeMillis() - startTime);
+        return response;
+    }
+}

--- a/src/main/java/org/opentripplanner/common/walk/WalkComfortCalculator.java
+++ b/src/main/java/org/opentripplanner/common/walk/WalkComfortCalculator.java
@@ -18,14 +18,11 @@ public class WalkComfortCalculator {
     private static Logger LOG = LoggerFactory.getLogger(WalkComfortCalculator.class);
 
     public static final String WALK_CONFIG_FILENAME = "walk-config.json";
-
-    private JsonNode walkConfig;
-
     private List<WalkComfortRule> rules = new ArrayList<>();
 
     public WalkComfortCalculator(JsonNode walkConfig) {
 
-        if (!walkConfig.has("rules") || !walkConfig.get("rules").isArray()) {
+        if (walkConfig == null || !walkConfig.has("rules") || !walkConfig.get("rules").isArray()) {
             LOG.info("No rules found in walk config");
             return;
         }

--- a/src/main/java/org/opentripplanner/common/walk/WalkComfortCalculator.java
+++ b/src/main/java/org/opentripplanner/common/walk/WalkComfortCalculator.java
@@ -30,11 +30,7 @@ public class WalkComfortCalculator {
         Iterator<JsonNode> ruleIter = walkConfig.get("rules").elements();
         while(ruleIter.hasNext()) {
             JsonNode ruleNode = ruleIter.next();
-            String key = ruleNode.get("key").asText();
-            String value = ruleNode.get("value").asText();
-            float factor = ruleNode.get("factor").floatValue();
-            WalkComfortRule rule = new WalkComfortRule(key, value, factor);
-            rules.add(rule);
+            rules.add(new WalkComfortRule(ruleNode));
         }
     }
 
@@ -45,11 +41,13 @@ public class WalkComfortCalculator {
     public float computeScore(Map<String, String> tags) {
         float factor = 1.0f;
         for(WalkComfortRule rule : rules) {
-            String val = tags.get(rule.getTagKey());
-            if(val == null) continue;
-            float f = rule.computeFactor(val);
+            float f = rule.computeFactor(tags);
             factor = factor * f;
         }
         return factor;
+    }
+
+    public int getRuleCount() {
+        return rules.size();
     }
 }

--- a/src/main/java/org/opentripplanner/common/walk/WalkComfortCalculator.java
+++ b/src/main/java/org/opentripplanner/common/walk/WalkComfortCalculator.java
@@ -1,0 +1,58 @@
+package org.opentripplanner.common.walk;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.opentripplanner.openstreetmap.model.OSMWithTags;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Created by demory on 11/20/17.
+ */
+
+public class WalkComfortCalculator {
+    private static Logger LOG = LoggerFactory.getLogger(WalkComfortCalculator.class);
+
+    public static final String WALK_CONFIG_FILENAME = "walk-config.json";
+
+    private JsonNode walkConfig;
+
+    private List<WalkComfortRule> rules = new ArrayList<>();
+
+    public WalkComfortCalculator(JsonNode walkConfig) {
+
+        if (!walkConfig.has("rules") || !walkConfig.get("rules").isArray()) {
+            LOG.info("No rules found in walk config");
+            return;
+        }
+
+        Iterator<JsonNode> ruleIter = walkConfig.get("rules").elements();
+        while(ruleIter.hasNext()) {
+            JsonNode ruleNode = ruleIter.next();
+            String key = ruleNode.get("key").asText();
+            String value = ruleNode.get("value").asText();
+            float factor = ruleNode.get("factor").floatValue();
+            WalkComfortRule rule = new WalkComfortRule(key, value, factor);
+            rules.add(rule);
+        }
+    }
+
+    public float computeScore(OSMWithTags way) {
+        return computeScore(way.getTags());
+    }
+
+    public float computeScore(Map<String, String> tags) {
+        float factor = 1.0f;
+        for(WalkComfortRule rule : rules) {
+            String val = tags.get(rule.getTagKey());
+            if(val == null) continue;
+            float f = rule.computeFactor(val);
+            factor = factor * f;
+        }
+        return factor;
+    }
+}

--- a/src/main/java/org/opentripplanner/common/walk/WalkComfortRule.java
+++ b/src/main/java/org/opentripplanner/common/walk/WalkComfortRule.java
@@ -1,0 +1,48 @@
+package org.opentripplanner.common.walk;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * A single rule for use in calculating walk comfort scores. Maps an osm tag
+ * key/value combination to a factor (relative to 1.0) that is used in computing
+ * the score.
+ *
+ * Created by demory on 11/20/17.
+ */
+
+public class WalkComfortRule {
+
+    /** the name (key) of an OSM tag to match **/
+    private String tagKey;
+
+    /** a set of one or more values to match **/
+    private Set<String> values;
+
+    /** the factor to apply to the composite comfort score if this rule matches a given key/value pair */
+    private float factor;
+
+    public WalkComfortRule(String osmKey, String value, float factor) {
+        this.tagKey = osmKey;
+        this.values = new HashSet<>();
+        this.values.add(value);
+        this.factor = factor;
+    }
+
+
+    public String getTagKey () { return this.tagKey; }
+
+    public float getFactor () {
+        return this.factor;
+    }
+
+    /** apply rule to given value; returns true if value matches **/
+    public boolean apply (String val) {
+        return values.contains(val);
+    }
+
+    /** computes factor for given value; returns this rule's factor if matches, or 1.0 if not */
+    public float computeFactor (String val) {
+        return this.apply(val) ? factor : 1.0f;
+    }
+}

--- a/src/main/java/org/opentripplanner/common/walk/WalkComfortRule.java
+++ b/src/main/java/org/opentripplanner/common/walk/WalkComfortRule.java
@@ -47,7 +47,7 @@ public class WalkComfortRule {
     }
 
     private WalkComfortTest createTestFromNode(JsonNode node) {
-        String type = null;
+        String type = "equal"; // Assume basic equality test if no type specified
         if (node.has("type")) type = node.get("type").asText();
         else if (node.has("key") && node.has("referenceValue")) type = "equal";
 

--- a/src/main/java/org/opentripplanner/common/walk/WalkComfortRule.java
+++ b/src/main/java/org/opentripplanner/common/walk/WalkComfortRule.java
@@ -1,48 +1,280 @@
 package org.opentripplanner.common.walk;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
 import java.util.Set;
 
 /**
- * A single rule for use in calculating walk comfort scores. Maps an osm tag
- * key/value combination to a factor (relative to 1.0) that is used in computing
- * the score.
+ * A single rule for use in calculating walk comfort scores. Maps an WalkComfortTest
+ * to a factor (relative to 1.0) that is used in computing the score.
  *
  * Created by demory on 11/20/17.
  */
 
 public class WalkComfortRule {
 
-    /** the name (key) of an OSM tag to match **/
-    private String tagKey;
+    private static final Logger LOG = LoggerFactory.getLogger(WalkComfortRule.class);
 
-    /** a set of one or more values to match **/
-    private Set<String> values;
+    /**
+     * the "root" test for this rule
+     */
+    private WalkComfortTest test;
 
-    /** the factor to apply to the composite comfort score if this rule matches a given key/value pair */
+    /**
+     * the factor to apply to the composite comfort score if this rule's test is satisfied
+     */
     private float factor;
 
-    public WalkComfortRule(String osmKey, String value, float factor) {
-        this.tagKey = osmKey;
-        this.values = new HashSet<>();
-        this.values.add(value);
-        this.factor = factor;
+    public WalkComfortRule(JsonNode ruleNode) { //String osmKey, String referenceValue, float factor) {
+        this.factor = ruleNode.get("factor").floatValue();
+        this.test = createTestFromNode(ruleNode);
     }
 
-
-    public String getTagKey () { return this.tagKey; }
-
-    public float getFactor () {
+    public float getFactor() {
         return this.factor;
     }
 
-    /** apply rule to given value; returns true if value matches **/
-    public boolean apply (String val) {
-        return values.contains(val);
+    /**
+     * returns this rule's factor if test passes, or 1.0 if not
+     */
+    public float computeFactor(Map<String, String> tags) {
+        return test.apply(tags) ? factor : 1.0f;
     }
 
-    /** computes factor for given value; returns this rule's factor if matches, or 1.0 if not */
-    public float computeFactor (String val) {
-        return this.apply(val) ? factor : 1.0f;
+    private WalkComfortTest createTestFromNode(JsonNode node) {
+        String type = null;
+        if (node.has("type")) type = node.get("type").asText();
+        else if (node.has("key") && node.has("referenceValue")) type = "equal";
+
+        switch (type) {
+            case "equal": return new EqualTest(node);
+            case "numeric-equal": return new NumericEqualTest(node);
+            case "greater": return new GreaterTest(node);
+            case "greater-equal": return new GreaterEqualTest(node);
+            case "less": return new LessTest(node);
+            case "less-equal": return new LessEqualTest(node);
+            case "absent": return new AbsentTagTest(node);
+            case "and": return new AndTest(node);
+            case "or": return new OrTest(node);
+        }
+
+        return null;
+    }
+
+
+    /**
+     * WalkComfortTest interface, defines a single method to apply test to an OSM way's tag/value set
+     */
+    private interface WalkComfortTest {
+        boolean apply(Map<String, String> tags);
+    }
+
+    /**
+     * A test to check if a specified tag matches one or more specified values
+     */
+    private class EqualTest implements WalkComfortTest {
+
+        /**
+         * the name (key) of an OSM tag to match
+         **/
+        private String tagKey;
+
+        /**
+         * a set of one or more values to match
+         **/
+        private Set<String> values;
+
+        EqualTest(JsonNode node) {
+            // Read the key from the node, which is always a single referenceValue
+            this.tagKey = node.get("key").asText();
+
+            // Read the values which might be a single referenceValue or an array
+            values = new HashSet<>();
+            if (node.get("value").isArray()) {
+                Iterator<JsonNode> arrIter = node.get("value").elements();
+                while (arrIter.hasNext()) {
+                    JsonNode arrNode = arrIter.next();
+                    values.add(arrNode.textValue());
+                }
+            } else {
+                values.add(node.get("value").asText());
+            }
+        }
+
+        @Override
+        public boolean apply(Map<String, String> tags) {
+            if (tags.containsKey(tagKey)) {
+                String value = tags.get(tagKey);
+                if (values.contains(value)) return true;
+            }
+            return false;
+        }
+    }
+
+    /**
+     * An abstract test to check a numeric tag value against a defined reference value
+     */
+    private abstract class NumericTest implements WalkComfortTest {
+
+        // the name (key) of an OSM tag to match
+        String tagKey;
+
+        // a numeric referenceValue that the test referenceValue must be greater than
+        Double referenceValue;
+
+        NumericTest(JsonNode node) {
+            // Read the key from the node
+            this.tagKey = node.get("key").asText();
+
+            // Read the referenceValue and attempt to process as number
+            String valStr = node.get("value").asText();
+            try {
+                referenceValue = Double.valueOf(valStr);
+            } catch (NumberFormatException e) {
+                referenceValue = null;
+                LOG.warn("Numeric WalkComfortTest defined with non-numeric referenceValue: " + valStr);
+            }
+        }
+
+        @Override
+        public boolean apply(Map<String, String> tags) {
+            if (referenceValue == null || !tags.containsKey(tagKey)) return false;
+            try {
+                Double tagValue = Double.valueOf(tags.get(tagKey));
+                if (applyNumeric(tagValue)) return true;
+            } catch (NumberFormatException e) {
+                LOG.warn("Numeric test encountered non-numeric tag value: " + tags.get(tagKey));
+            }
+            return false;
+        }
+
+        abstract boolean applyNumeric (double tagValue);
+    }
+
+    /**
+     * A test to check if a numeric tag value is equal to a defined reference value
+     */
+    private class NumericEqualTest extends NumericTest {
+        NumericEqualTest (JsonNode node) { super(node); }
+
+        boolean applyNumeric (double tagValue) {
+            return tagValue == referenceValue;
+        }
+    }
+
+    /**
+     * A test to check if a numeric tag value is greater than a defined reference value
+     */
+    private class GreaterTest extends NumericTest {
+        GreaterTest (JsonNode node) { super(node); }
+
+        boolean applyNumeric (double tagValue) {
+            return tagValue > referenceValue;
+        }
+    }
+
+    /**
+     * A test to check if a numeric tag value is greater than or equal to a defined reference value
+     */
+    private class GreaterEqualTest extends NumericTest {
+        GreaterEqualTest (JsonNode node) { super(node); }
+
+        boolean applyNumeric (double tagValue) {
+            return tagValue >= referenceValue;
+        }
+    }
+
+    /**
+     * A test to check if a numeric tag value is less than a defined reference value
+     */
+    private class LessTest extends NumericTest {
+        LessTest (JsonNode node) { super(node); }
+
+        boolean applyNumeric (double tagValue) {
+            return tagValue < referenceValue;
+        }
+    }
+
+    /**
+     * A test to check if a numeric tag value is less than or equal to a defined reference value
+     */
+    private class LessEqualTest extends NumericTest {
+        LessEqualTest (JsonNode node) { super(node); }
+
+        boolean applyNumeric (double tagValue) {
+            return tagValue <= referenceValue;
+        }
+    }
+
+    /**
+     *  A test that passes only if a specified tag is NOT specified
+     */
+    private class AbsentTagTest implements WalkComfortTest {
+
+        /**
+         * the name (key) of an OSM tag that must be absent
+         **/
+        private String tagKey;
+
+        AbsentTagTest(JsonNode node) {
+            // Read the key from the node
+            this.tagKey = node.get("key").asText();
+        }
+
+        @Override
+        public boolean apply(Map<String, String> tags) {
+            return !tags.containsKey(tagKey);
+        }
+    }
+
+    /**
+     *  A test consisting of a set of sub-tests, where ALL sub-tests must pass for the overall test to pass
+     */
+    private class AndTest implements WalkComfortTest {
+        private Set<WalkComfortTest> tests = new HashSet<>();
+
+        AndTest(JsonNode node) {
+            Iterator<JsonNode> testIter = node.get("tests").elements();
+            while (testIter.hasNext()) {
+                tests.add(createTestFromNode(testIter.next()));
+            }
+        }
+
+        @Override
+        public boolean apply(Map<String, String> tags) {
+            int passedTests = 0;
+            for (WalkComfortTest test : tests) {
+                if (test.apply(tags)) passedTests++;
+            }
+            return passedTests == tests.size();
+        }
+    }
+
+    /**
+     * A test consisting of a set of sub-tests, where at least ONE sub-test must pass for the overall test to pass
+     */
+    private class OrTest implements WalkComfortTest {
+        private Set<WalkComfortTest> tests = new HashSet<>();
+
+        OrTest(JsonNode node) {
+            Iterator<JsonNode> testIter = node.get("tests").elements();
+            while (testIter.hasNext()) {
+                tests.add(createTestFromNode(testIter.next()));
+            }
+        }
+
+        @Override
+        public boolean apply(Map<String, String> tags) {
+            int passedTests = 0;
+            for (WalkComfortTest test : tests) {
+                if (test.apply(tags)) passedTests++;
+            }
+            return passedTests > 0;
+        }
     }
 }

--- a/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
@@ -2,6 +2,7 @@ package org.opentripplanner.graph_builder;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Lists;
+import org.opentripplanner.common.walk.WalkComfortCalculator;
 import org.opentripplanner.graph_builder.model.GtfsBundle;
 import org.opentripplanner.graph_builder.module.DirectTransferGenerator;
 import org.opentripplanner.graph_builder.module.EmbedConfig;
@@ -230,6 +231,8 @@ public class GraphBuilder implements Runnable {
             osmModule.staticParkAndRide = builderParams.staticParkAndRide;
             osmModule.banDiscouragedWalking = builderParams.banDiscouragedWalking;
             osmModule.banDiscouragedBiking = builderParams.banDiscouragedBiking;
+            osmModule.walkConfig = OTPMain.loadJson(new File(dir, WalkComfortCalculator.WALK_CONFIG_FILENAME));
+            osmModule.includeOsmTags = builderParams.includeOsmTags;
             graphBuilder.addModule(osmModule);
             PruneFloatingIslands pruneFloatingIslands = new PruneFloatingIslands();
             pruneFloatingIslands.setPruningThresholdIslandWithoutStops(builderParams.pruningThresholdIslandWithoutStops);

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModule.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.graph_builder.module.osm;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Iterables;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Envelope;
@@ -10,6 +11,7 @@ import org.opentripplanner.common.geometry.GeometryUtils;
 import org.opentripplanner.common.geometry.SphericalDistanceLibrary;
 import org.opentripplanner.common.model.P2;
 import org.opentripplanner.common.model.T2;
+import org.opentripplanner.common.walk.WalkComfortCalculator;
 import org.opentripplanner.graph_builder.annotation.*;
 import org.opentripplanner.graph_builder.module.extra_elevation_data.ElevationPoint;
 import org.opentripplanner.graph_builder.services.DefaultStreetEdgeFactory;
@@ -55,6 +57,8 @@ public class OpenStreetMapModule implements GraphBuilderModule {
     private Set<Object> _uniques = new HashSet<Object>();
 
     private HashMap<Vertex, Double> elevationData = new HashMap<Vertex, Double>();
+
+    private WalkComfortCalculator walkLTSGenerator;
 
     public boolean skipVisibility = false;
 
@@ -104,6 +108,11 @@ public class OpenStreetMapModule implements GraphBuilderModule {
      * Whether we should create bike P+R stations from OSM data. (default false)
      */
     public boolean staticBikeParkAndRide;
+
+    public JsonNode walkConfig;
+
+    public boolean includeOsmTags = false;
+
 
     public List<String> provides() {
         return Arrays.asList("streets", "turns");
@@ -155,6 +164,7 @@ public class OpenStreetMapModule implements GraphBuilderModule {
 
     @Override
     public void buildGraph(Graph graph, HashMap<Class<?>, Object> extra) {
+        walkLTSGenerator = new WalkComfortCalculator(walkConfig);
         OSMDatabase osmdb = new OSMDatabase();
         Handler handler = new Handler(graph, osmdb);
         for (OpenStreetMapProvider provider : _providers) {
@@ -675,11 +685,13 @@ public class OpenStreetMapModule implements GraphBuilderModule {
                                         WayProperties wayData, OSMWithTags way) {
 
             Set<T2<Alert, NoteMatcher>> notes = wayPropertySet.getNoteForWay(way);
+            float walkSafetyFactor = walkLTSGenerator.computeScore(way);
             boolean noThruTraffic = way.isThroughTrafficExplicitlyDisallowed();
             // if (noThruTraffic) LOG.info("Way {} does not allow through traffic.", way.getId());
             if (street != null) {
                 double safety = wayData.getSafetyFeatures().first;
                 street.setBicycleSafetyFactor((float)safety);
+                street.setWalkComfortScore(walkSafetyFactor);
                 if (safety < bestBikeSafety) {
                     bestBikeSafety = (float)safety;
                 }
@@ -688,6 +700,9 @@ public class OpenStreetMapModule implements GraphBuilderModule {
                         graph.streetNotesService.addStaticNote(street, note.first, note.second);
                 }
                 street.setNoThruTraffic(noThruTraffic);
+
+                // store the ways w/ the graph
+                if (includeOsmTags) street.setOsmTags(way.getTags());
             }
 
             if (backStreet != null) {
@@ -696,12 +711,19 @@ public class OpenStreetMapModule implements GraphBuilderModule {
                     bestBikeSafety = (float)safety;
                 }
                 backStreet.setBicycleSafetyFactor((float)safety);
+                backStreet.setWalkComfortScore(walkSafetyFactor);
+
                 if (notes != null) {
                     for (T2<Alert, NoteMatcher> note : notes)
                         graph.streetNotesService.addStaticNote(backStreet, note.first, note.second);
                 }
                 backStreet.setNoThruTraffic(noThruTraffic);
+
+                // store the ways w/ the graph
+                if (includeOsmTags) backStreet.setOsmTags(way.getTags());
             }
+
+
         }
 
         private void setWayName(OSMWithTags way) {

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
@@ -28,6 +28,7 @@ import java.io.ObjectOutputStream;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 /**
  * This represents a street segment.
@@ -108,6 +109,15 @@ public class StreetEdge extends Edge implements Cloneable {
     /** The angle at the start of the edge geometry. Internal representation like that of inAngle. */
     private byte outAngle;
 
+    /** The walk comfort score. Applied as multiplier to edge weight; 1.0 is baseline */
+    protected float walkComfortScore;
+
+    /**
+     *  Map of OSM tags for this way. Only stored when 'includeOsmWays' builder param is true;
+     *  enables on-the-fly recalculation of walk comfort scores for testing/calibration purposes.
+     */
+    private Map<String, String> osmTags;
+
     public StreetEdge(StreetVertex v1, StreetVertex v2, LineString geometry,
                       I18NString name, double length,
                       StreetTraversalPermission permission, boolean back) {
@@ -116,6 +126,7 @@ public class StreetEdge extends Edge implements Cloneable {
         this.setGeometry(geometry);
         this.length_mm = (int) (length * 1000); // CONVERT FROM FLOAT METERS TO FIXED MILLIMETERS
         this.bicycleSafetyFactor = 1.0f;
+        this.walkComfortScore = 1.0f;
         this.name = name;
         this.setPermission(permission);
         this.setCarSpeed(DEFAULT_CAR_SPEED);
@@ -359,6 +370,7 @@ public class StreetEdge extends Edge implements Cloneable {
                 // FIXME: this causes steep stairs to be avoided. see #1297.
                 double distance = getSlopeWalkSpeedEffectiveLength();
                 weight = distance / speed;
+                weight = weight * walkComfortScore;
                 time = weight; //treat cost as time, as in the current model it actually is the same (this can be checked for maxSlope == 0)
                 /*
                 // debug code
@@ -578,6 +590,14 @@ public class StreetEdge extends Edge implements Cloneable {
 
     public float getBicycleSafetyFactor() {
         return bicycleSafetyFactor;
+    }
+
+    public void setWalkComfortScore(float walkComfortScore) {
+        this.walkComfortScore = walkComfortScore;
+    }
+
+    public float getWalkComfortScore() {
+        return walkComfortScore;
     }
 
     private void writeObject(ObjectOutputStream out) throws IOException {
@@ -831,6 +851,7 @@ public class StreetEdge extends Edge implements Cloneable {
 
             for (StreetEdge e : new StreetEdge[] { e1, e2 }) {
                 e.setBicycleSafetyFactor(getBicycleSafetyFactor());
+                e.setWalkComfortScore(getWalkComfortScore());
                 e.setHasBogusName(hasBogusName());
                 e.setStairs(isStairs());
                 e.setWheelchairAccessible(isWheelchairAccessible());
@@ -878,5 +899,13 @@ public class StreetEdge extends Edge implements Cloneable {
             return ((SplitterVertex) tov).nextNodeId;
         else
             return -1;
+    }
+
+    public Map<String, String> getOsmTags() {
+        return osmTags;
+    }
+
+    public void setOsmTags(Map<String, String> osmTags) {
+        this.osmTags = osmTags;
     }
 }

--- a/src/main/java/org/opentripplanner/standalone/GraphBuilderParameters.java
+++ b/src/main/java/org/opentripplanner/standalone/GraphBuilderParameters.java
@@ -179,6 +179,8 @@ public class GraphBuilderParameters {
      */
     public final double maxTransferDistance;
 
+    public final boolean includeOsmTags;
+
     /**
      * This will add extra edges when linking a stop to a platform, to prevent detours along the platform edge.
      */
@@ -220,6 +222,7 @@ public class GraphBuilderParameters {
         banDiscouragedBiking = config.path("banDiscouragedBiking").asBoolean(false);
         maxTransferDistance = config.path("maxTransferDistance").asDouble(2000);
         extraEdgesStopPlatformLink = config.path("extraEdgesStopPlatformLink").asBoolean(false);
+        includeOsmTags = config.path("includeOsmTags").asBoolean(false);
     }
 
 

--- a/src/main/java/org/opentripplanner/standalone/OTPApplication.java
+++ b/src/main/java/org/opentripplanner/standalone/OTPApplication.java
@@ -96,7 +96,8 @@ public class OTPApplication extends Application {
             RepeatedRaptorTestResource.class,
             /* Features and Filters: extend Jersey, manipulate requests and responses. */
             CorsFilter.class,
-            MultiPartFeature.class
+            MultiPartFeature.class,
+            WalkComfort.class
         ));
         
         if (this.secure) {


### PR DESCRIPTION
This PR adds the ability to make custom configurations to the weighting of certain edges depending on custom-defined rules. See [added documentation](https://github.com/opentripplanner/OpenTripPlanner/blob/walk-comfort/docs/Pedestrian-Routing.md). This feature was authored primarily by @demory and I am merely making a PR request to isolate this feature out of the work done in #2664.

- [ ] **issue**: Link to or create an [issue](https://github.com/opentripplanner/OpenTripPlanner/issues) that describes the relevant feature or bug. Add [GitHub keywords](https://help.github.com/articles/closing-issues-using-keywords/) to this PR's description (e.g., `closes #45`).
- [ ] **roadmap**: Check the [roadmap](https://github.com/orgs/opentripplanner/projects/1) for this feature or bug. If it is not already on the roadmap, PLC will discuss as part of the review process.
- [x] **tests**: Have you added relevant test coverage? Are all the tests passing on [the continuous integration service (Travis CI)](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#continuous-integration)?
- [x] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#code-style)? 
- [x] **documentation**: If you are adding a new configuration option, have you added an explanation to the [configuration documentation](docs/Configuration.md) tables and sections?
- [x] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)