### PR TITLE
Correctly calculate elevation profile for partial street edges

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -12,6 +12,7 @@
 - Fix reverse optimization bug (#2653, #2411)
 - Remove CarFreeAtoZ from list of deployments
 - Fix XML response serialization (#2685)
+- Correctly calculation elevation profile for partial street edges
 
 ## 1.3 (2018-08-03)
 

--- a/src/main/java/org/opentripplanner/routing/edgetype/TemporaryPartialStreetEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/TemporaryPartialStreetEdge.java
@@ -135,7 +135,7 @@ final public class TemporaryPartialStreetEdge extends StreetWithElevationEdge im
         }
 
         Coordinate coords[] = partialElevCoords.toArray(new Coordinate[partialElevCoords.size()]);
-        return new PackedCoordinateSequence.Double(coords);
+        return new PackedCoordinateSequence.Double(coords, 2);
     }
 
     /**

--- a/src/main/java/org/opentripplanner/routing/edgetype/TemporaryPartialStreetEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/TemporaryPartialStreetEdge.java
@@ -76,7 +76,7 @@ final public class TemporaryPartialStreetEdge extends StreetWithElevationEdge im
      */
     @Override
     public PackedCoordinateSequence getElevationProfile() {
-        PackedCoordinateSequence parentElev = parentEdge.getElevationProfile();
+        PackedCoordinateSequence parentElev = super.getElevationProfile();
         if (parentElev == null) return null;
 
         // Compute the linear-reference bounds of the partial edge as fractions of the parent edge


### PR DESCRIPTION
This PR correctly calculates the way elevation profiles are calculated for partial street edges. This feature was authored primarily by @demory and I am merely making a PR request to isolate this feature out of the work done in #2664. This feature was initially implemented in the PartialStreetEdge class which has since been deleted in dev-1.x, so I don't even know for sure if this is actually needed anymore.

- [ ] **issue**: Link to or create an [issue](https://github.com/opentripplanner/OpenTripPlanner/issues) that describes the relevant feature or bug. Add [GitHub keywords](https://help.github.com/articles/closing-issues-using-keywords/) to this PR's description (e.g., `closes #45`).
- [ ] **roadmap**: Check the [roadmap](https://github.com/orgs/opentripplanner/projects/1) for this feature or bug. If it is not already on the roadmap, PLC will discuss as part of the review process.
- [x] **tests**: Have you added relevant test coverage? Are all the tests passing on [the continuous integration service (Travis CI)](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#continuous-integration)?
- [x] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#code-style)? 
- [x] **documentation**: If you are adding a new configuration option, have you added an explanation to the [configuration documentation](docs/Configuration.md) tables and sections?
- [x] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)