### PR TITLE
Update OTP version to 2.0.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>org.opentripplanner</groupId>
     <artifactId>otp</artifactId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <licenses>


### PR DESCRIPTION
I think we forgot to update the OTP version number in `pom.xml`.

OTP version changed from 1.4.0-SNAPSHOT to 2.0.0-SNAPSHOT.

