### PR TITLE
Remove repo, add https for 2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -456,14 +456,9 @@
             <url>https://repo1.maven.org/maven2</url>
         </repository>
         <repository>
-            <id>download.java.net</id>
-            <name>Java.net Repository for Maven</name>
-            <url>http://download.java.net/maven/2/</url>
-        </repository>
-        <repository>
             <id>osgeo</id>
             <name>Open Source Geospatial Foundation Repository</name>
-            <url>http://download.osgeo.org/webdav/geotools/</url>
+            <url>https://download.osgeo.org/webdav/geotools/</url>
         </repository>
         <repository>
             <id>axis</id>


### PR DESCRIPTION
This is the same change as I have pull requested for OTP1. It removed an unused repository and adds https to another.

https://github.com/opentripplanner/OpenTripPlanner/pull/2774