### PR TITLE
Extend 2.x itinerary decoration to better match 1.x

### DIFF
--- a/src/main/java/org/opentripplanner/api/resource/PlannerResource.java
+++ b/src/main/java/org/opentripplanner/api/resource/PlannerResource.java
@@ -95,6 +95,12 @@ public class PlannerResource extends RoutingResource {
 
             TripPlan tripPlan = createTripPlan(request, itineraries);
             response.setPlan(tripPlan);
+
+            /* Populate up the elevation metadata */
+            response.elevationMetadata = new ElevationMetadata();
+            response.elevationMetadata.ellipsoidToGeoidDifference = router.graph.ellipsoidToGeoidDifference;
+            response.elevationMetadata.geoidElevation = request.geoidElevation;
+
         } catch (Exception e) {
             PlannerError error = new PlannerError(e);
             if(!PlannerError.isPlanningError(e.getClass()))
@@ -108,11 +114,6 @@ public class PlannerResource extends RoutingResource {
                 request.cleanup(); // TODO verify that this cleanup step is being done on Analyst web services
             }
         }
-
-        /* Populate up the elevation metadata */
-        response.elevationMetadata = new ElevationMetadata();
-        response.elevationMetadata.ellipsoidToGeoidDifference = router.graph.ellipsoidToGeoidDifference;
-        response.elevationMetadata.geoidElevation = request.geoidElevation;
 
         /* Log this request if such logging is enabled. */
         if (request != null && router != null && router.requestLogger != null) {
@@ -145,6 +146,7 @@ public class PlannerResource extends RoutingResource {
             }
             router.requestLogger.info(sb.toString());
         }
+
         return response;
     }
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/itinerary/ItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/itinerary/ItineraryMapper.java
@@ -203,6 +203,7 @@ public class ItineraryMapper {
         leg.agencyId = route.getAgency().getId();
         leg.routeShortName = route.getShortName();
         leg.routeLongName = route.getLongName();
+        leg.headsign = extractTripHeadsignDirection(pathLeg);
         leg.walkSteps = new ArrayList<>();
         return leg;
     }
@@ -280,6 +281,19 @@ public class ItineraryMapper {
         Calendar c = Calendar.getInstance(TimeZone.getTimeZone(zdt.getZone()));
         c.setTimeInMillis(zdt.toInstant().toEpochMilli());
         return c;
+    }
+
+    private String extractTripHeadsignDirection(TransitPathLeg<TripSchedule> pathLeg) {
+        TripPattern tripPattern = pathLeg.trip().getOriginalTripPattern();
+        TripSchedule tripSchedule = pathLeg.trip();
+        for (int j = 0; j < tripPattern.stopPattern.stops.length; j++) {
+            if (tripSchedule.departure(j) == pathLeg.fromTime()) {
+                return tripPattern.scheduledTimetable.getTripTimes(tripSchedule.getOriginalTrip())
+                        .getHeadsign(j);
+            }
+        }
+
+        throw new IllegalStateException("Missing stop for departure at " + pathLeg.fromTime() + " for " + tripSchedule);
     }
 
     private List<Place> extractIntermediateStops(TransitPathLeg<TripSchedule> pathLeg) {

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/itinerary/ItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/itinerary/ItineraryMapper.java
@@ -137,6 +137,7 @@ public class ItineraryMapper {
         itinerary.endTime = createCalendar(egressPathLeg.toTime());
         itinerary.duration = (long) egressPathLeg.toTime() - path.accessLeg().fromTime();
         itinerary.waitingTime = itinerary.duration - itinerary.walkTime - itinerary.transitTime;
+        itinerary.walkLimitExceeded = itinerary.walkDistance > request.maxWalkDistance;
 
         return itinerary;
     }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/router/street/AccessEgressRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/router/street/AccessEgressRouter.java
@@ -42,7 +42,8 @@ public class AccessEgressRouter {
                     new Transfer(-1,
                             (int)stopAtDistance.edges.stream().map(Edge::getDistance)
                                     .collect(Collectors.summarizingDouble(Double::doubleValue)).getSum(),
-                            Arrays.asList(stopAtDistance.geom.getCoordinates())));
+                            Arrays.asList(stopAtDistance.geom.getCoordinates()),
+                            stopAtDistance.edges));
         }
 
         LOG.info("Found {} {} stops", result.size(), fromTarget ? "egress" : "access");

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/Transfer.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/Transfer.java
@@ -1,7 +1,9 @@
 package org.opentripplanner.routing.algorithm.raptor.transit;
 
 import org.locationtech.jts.geom.Coordinate;
+import org.opentripplanner.routing.graph.Edge;
 
+import java.util.Collections;
 import java.util.List;
 
 public class Transfer {
@@ -11,20 +13,33 @@ public class Transfer {
 
     private final List<Coordinate> coordinates;
 
+    private final List<Edge> edges;
+
     public Transfer(int toStop, int distanceMeters, List<Coordinate> coordinates) {
         this.toStop = toStop;
         this.distanceMeters = distanceMeters;
         this.coordinates = coordinates;
+        this.edges = Collections.emptyList();
+    }
+
+    public Transfer(int toStop, int distanceMeters, List<Coordinate> coordinates, List<Edge> edges) {
+        this.toStop = toStop;
+        this.distanceMeters = distanceMeters;
+        this.coordinates = coordinates;
+        this.edges = edges;
     }
 
     public List<Coordinate> getCoordinates() {
         return coordinates;
     }
 
-    //TODO getToStop
-    public int stop() { return toStop; }
+    public int getToStop() { return toStop; }
 
     public int getDistanceMeters() {
         return distanceMeters;
+    }
+
+    public List<Edge> getEdges() {
+        return edges;
     }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/TransitLayer.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/TransitLayer.java
@@ -4,6 +4,7 @@ import org.opentripplanner.model.Stop;
 
 import java.time.LocalDate;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -55,7 +56,7 @@ public class TransitLayer {
     }
 
     public Collection<TripPatternForDate> getTripPatternsForDate(LocalDate date) {
-        return tripPatternsForDate.get(date);
+        return tripPatternsForDate.getOrDefault(date, Collections.emptyList());
     }
 
     public List<List<Transfer>> getTransferByStopIndex() {

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/mappers/TransfersMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/mappers/TransfersMapper.java
@@ -35,7 +35,8 @@ class TransfersMapper {
 
                     int toStopIndex = indexByStop.get(((TransitStop) edge.getToVertex()).getStop());
                     Transfer transfer = new Transfer(toStopIndex, (int) distance,
-                            Arrays.asList(edge.getGeometry().getCoordinates()));
+                            Arrays.asList(edge.getGeometry().getCoordinates()),
+                            ((SimpleTransfer) edge).getEdges());
 
                     list.add(transfer);
                 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/request/TransferWithDuration.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/request/TransferWithDuration.java
@@ -16,7 +16,7 @@ public class TransferWithDuration implements TransferLeg {
 
     @Override
     public int stop() {
-        return transfer.stop();
+        return transfer.getToStop();
     }
 
     @Override


### PR DESCRIPTION
Similarly to #2776 this updates the RAPTOR itinerary/leg decoration to more closely match 1.x.

The first four commits are simple refactors / bug fixes, but the last two are bit more complex.

 * In the commit for filling in the trip headsign (87a1e58) the original `TripTime` needs to be used, which doesn't seems as straightforward as it could be. Is there a reason `TripSchedules` don't reuse the existing `TripTimes`? Would it be possible to store the boarding/alighting pattern stopIndex on the `TransitPathLeg`s?
 * For accurately recreating non-transit legs (7213851) the edges stored on the `SimpleTransfer` are used in combination with the existing `GraphPathToTripPlanConverter`. With this the walk steps, leg segmentation and calculations match 1.x and the non-transit itineraries.

To be completed by pull request submitter:

- [ ] **issue**: This is needed to keep existing functionality in #2626
- [x] **roadmap**: This is on the [roadmap](https://github.com/orgs/opentripplanner/projects/1).
- [ ] **tests**: No new tests are added, nor do existing tests need to be updated.
- [x] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#code-style)? 
- [ ] **documentation**: No documentation is changed or added, it is still to early to do this.
- [ ] **changelog**: The change log is not updated.

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)