### PR TITLE
Fix JTS coordinate order for Polygons/Polylines

### DIFF
--- a/src/main/java/org/opentripplanner/common/geometry/GeometryUtils.java
+++ b/src/main/java/org/opentripplanner/common/geometry/GeometryUtils.java
@@ -179,7 +179,7 @@ public class GeometryUtils {
         Coordinate[] coords = new Coordinate[path.size()];
         int i = 0;
         for (LngLatAlt p : path) {
-            coords[i++] = new Coordinate(p.getLatitude(), p.getLongitude());
+            coords[i++] = new Coordinate(p.getLongitude(), p.getLatitude());
         }
         return coords;
     }

--- a/src/test/java/org/opentripplanner/common/geometry/GeometryUtilsTest.java
+++ b/src/test/java/org/opentripplanner/common/geometry/GeometryUtilsTest.java
@@ -1,14 +1,16 @@
 package org.opentripplanner.common.geometry;
 
-import org.locationtech.jts.geom.Geometry;
-import org.locationtech.jts.geom.Polygon;
 import org.junit.Test;
 import org.opentripplanner.common.model.P2;
+import org.opentripplanner.analyst.UnsupportedGeometryException;
 
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.CoordinateSequence;
 import org.locationtech.jts.geom.CoordinateSequenceFactory;
 import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.Polygon;
 import org.locationtech.jts.geom.LineString;
 
 import static org.junit.Assert.assertEquals;
@@ -17,6 +19,35 @@ import static org.junit.Assert.assertTrue;
 public class GeometryUtilsTest {
 
     private static final double tolerance = 0.000001;
+
+    @Test
+    public final void testConvertGeoJsonToJtsGeometry()
+            throws UnsupportedGeometryException {
+
+         { // Should convert Point correctly
+            double lng1 = -77.1111;
+            double lat1 = 38.1111;
+            org.geojson.Point p1 = new org.geojson.Point(lng1, lat1);
+            Point geometry = (Point) GeometryUtils.convertGeoJsonToJtsGeometry(p1);
+            assertEquals(lng1, geometry.getX(), tolerance);
+            assertEquals(lat1, geometry.getY(), tolerance);
+        }
+
+         { // Should convert LineString correctly
+            double lng1 = -77.1111;
+            double lat1 = 38.1111;
+            double lng2 = -77.2222;
+            double lat2 = 38.2222;
+            org.geojson.LngLatAlt a1 = new org.geojson.LngLatAlt(lng1, lat1);
+            org.geojson.LngLatAlt a2 = new org.geojson.LngLatAlt(lng2, lat2);
+            org.geojson.LineString lineString = new org.geojson.LineString(a1, a2);
+            LineString geometry = (LineString) GeometryUtils.convertGeoJsonToJtsGeometry(lineString);
+            assertEquals(lng1, geometry.getCoordinateN(0).x, tolerance);
+            assertEquals(lat1, geometry.getCoordinateN(0).y, tolerance);
+            assertEquals(lng2, geometry.getCoordinateN(1).x, tolerance);
+            assertEquals(lat2, geometry.getCoordinateN(1).y, tolerance);
+        }
+    }
 
     @Test
     public final void testSplitGeometryAtFraction() {


### PR DESCRIPTION
This PR breaks out the small bug fix to `GeometryUtils.java` made in Coord's PR (#2596).

This line in `convertPath`:
`coords[i++] = new Coordinate(p.getLatitude(), p.getLongitude());`

had the wrong coordinate order. The definition of the Coordinate constructor is:

`public Coordinate(double x, double y)`

The `convertPath` function is used only in GeoJSON -> JTS conversion for Polygons and LineStrings, and this PR will correct those conversions.
