### PR TITLE
Remove redundant LineStrings in order to save memory

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2,6 +2,7 @@
 
 ## 2.0 (in progress)
 - Sandbox for experimental features (#2745)
+- Remove redundant LineStrings in order to save memory (#2795)
 
 ## Ported over from the 1.x
 - Remove Open Traffic prototype code (#2698)

--- a/src/main/java/org/opentripplanner/common/geometry/CompactElevationProfile.java
+++ b/src/main/java/org/opentripplanner/common/geometry/CompactElevationProfile.java
@@ -29,8 +29,14 @@ public final class CompactElevationProfile implements Serializable {
     private static final double FIXED_FLOAT_MULT = 1.0e2;
 
     /**
+     * The distance between samples in meters. Defaults to 10m, the approximate resolution of 1/3
+     * arc-second NED data.
+     */
+    private static double distanceBetweenSamplesM = 10;
+
+    /**
      * Compact an elevation profile onto a var-len int packed form (Dlugosz coding).
-     * 
+     *
      * @param profile The elevation profile to compact
      * @return The compacted format
      */
@@ -60,9 +66,9 @@ public final class CompactElevationProfile implements Serializable {
 
     /**
      * Uncompact an ElevationProfile from a var-len int packed form (Dlugosz coding).
-     * 
+     *
      * TODO relax the returned type to CoordinateSequence
-     * 
+     *
      * @param packedCoords Compacted coordinates
      * @return The elevation profile
      */
@@ -82,5 +88,66 @@ public final class CompactElevationProfile implements Serializable {
             oiy = iy;
         }
         return new PackedCoordinateSequence.Double(c, 2);
+    }
+
+    /**
+     * Compact an elevation profile onto a var-len int packed form (Dlugosz coding). This method
+     * supposes that only the y-values are to be compacted and the x-values can be reconstructed
+     * at regular intervals according to the distanceBetweenSamplesM field. The last x-value is given
+     * by the length of the geometry.
+     * 
+     * @param profile The elevation profile to compact
+     * @return The compacted format
+     */
+    public static byte[] compactElevationProfileWithRegularSamples(CoordinateSequence elevation) {
+        if (elevation == null)
+            return null;
+        int oiy = 0;
+        int[] coords = new int[elevation.size()];
+        for (int i = 0; i < elevation.size(); i++) {
+            /*
+             * Note: We should do the rounding *before* the delta to prevent rounding errors from
+             * accumulating on long line strings.
+             */
+            Coordinate c = elevation.getCoordinate(i);
+            int iy = (int) Math.round(c.y * FIXED_FLOAT_MULT);
+            int diy = iy - oiy;
+            coords[i] = diy;
+            oiy = iy;
+        }
+        return DlugoszVarLenIntPacker.pack(coords);
+    }
+
+    /**
+     * Uncompact an ElevationProfile from a var-len int packed form (Dlugosz coding). This method
+     * supposes that only the y-values have been compacted and x-values will be reconstructed at
+     * regular interval according to the distanceBetweenSamplesM field. The last x-value is given
+     * by the length of the geometry.
+     *
+     * @param packedCoords Compacted coordinates
+     * @param lengthM The length of the edge in meters. This is used as the x-value of the final
+     *                height sample
+     * @return The elevation profile
+     */
+    public static PackedCoordinateSequence uncompactElevationProfileWithRegularSamples(byte[] packedCoords, double lengthM) {
+        if (packedCoords == null)
+            return null;
+        int[] coords = DlugoszVarLenIntPacker.unpack(packedCoords);
+        int size = coords.length;
+        Coordinate[] c = new Coordinate[size];
+        int oiy = 0;
+        for (int i = 0; i < c.length; i++) {
+            int iy = oiy + coords[i];
+            c[i] = new Coordinate(
+                    i == c.length - 1 ?
+                            lengthM :
+                            i * distanceBetweenSamplesM, iy / FIXED_FLOAT_MULT);
+            oiy = iy;
+        }
+        return new PackedCoordinateSequence.Double(c, 2);
+    }
+
+    public static double getDistanceBetweenSamplesM() {
+        return distanceBetweenSamplesM;
     }
 }

--- a/src/main/java/org/opentripplanner/common/geometry/CompactElevationProfile.java
+++ b/src/main/java/org/opentripplanner/common/geometry/CompactElevationProfile.java
@@ -22,6 +22,8 @@ public final class CompactElevationProfile implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
+    public static final double DEFAULT_DISTANCE_BETWEEN_SAMPLES_METERS = 10;
+
     /**
      * Multipler for fixed-float representation. In meters, the precision is 1 cm (elevation and arc
      * length).
@@ -32,7 +34,7 @@ public final class CompactElevationProfile implements Serializable {
      * The distance between samples in meters. Defaults to 10m, the approximate resolution of 1/3
      * arc-second NED data.
      */
-    private static double distanceBetweenSamplesM;
+    private static double distanceBetweenSamplesM = DEFAULT_DISTANCE_BETWEEN_SAMPLES_METERS;
 
     /**
      * Compact an elevation profile onto a var-len int packed form (Dlugosz coding). This method

--- a/src/main/java/org/opentripplanner/common/geometry/CompactElevationProfile.java
+++ b/src/main/java/org/opentripplanner/common/geometry/CompactElevationProfile.java
@@ -32,63 +32,7 @@ public final class CompactElevationProfile implements Serializable {
      * The distance between samples in meters. Defaults to 10m, the approximate resolution of 1/3
      * arc-second NED data.
      */
-    private static double distanceBetweenSamplesM = 10;
-
-    /**
-     * Compact an elevation profile onto a var-len int packed form (Dlugosz coding).
-     *
-     * @param profile The elevation profile to compact
-     * @return The compacted format
-     */
-    public static byte[] compactElevationProfile(CoordinateSequence elevation) {
-        if (elevation == null)
-            return null;
-        int oix = 0;
-        int oiy = 0;
-        int[] coords = new int[elevation.size() * 2];
-        for (int i = 0; i < elevation.size(); i++) {
-            /*
-             * Note: We should do the rounding *before* the delta to prevent rounding errors from
-             * accumulating on long line strings.
-             */
-            Coordinate c = elevation.getCoordinate(i);
-            int ix = (int) Math.round(c.x * FIXED_FLOAT_MULT);
-            int iy = (int) Math.round(c.y * FIXED_FLOAT_MULT);
-            int dix = ix - oix;
-            int diy = iy - oiy;
-            coords[i * 2] = dix;
-            coords[i * 2 + 1] = diy;
-            oix = ix;
-            oiy = iy;
-        }
-        return DlugoszVarLenIntPacker.pack(coords);
-    }
-
-    /**
-     * Uncompact an ElevationProfile from a var-len int packed form (Dlugosz coding).
-     *
-     * TODO relax the returned type to CoordinateSequence
-     *
-     * @param packedCoords Compacted coordinates
-     * @return The elevation profile
-     */
-    public static PackedCoordinateSequence uncompactElevationProfile(byte[] packedCoords) {
-        if (packedCoords == null)
-            return null;
-        int[] coords = DlugoszVarLenIntPacker.unpack(packedCoords);
-        int size = coords.length / 2;
-        Coordinate[] c = new Coordinate[size];
-        int oix = 0;
-        int oiy = 0;
-        for (int i = 0; i < c.length; i++) {
-            int ix = oix + coords[i * 2];
-            int iy = oiy + coords[i * 2 + 1];
-            c[i] = new Coordinate(ix / FIXED_FLOAT_MULT, iy / FIXED_FLOAT_MULT);
-            oix = ix;
-            oiy = iy;
-        }
-        return new PackedCoordinateSequence.Double(c, 2);
-    }
+    private static double distanceBetweenSamplesM;
 
     /**
      * Compact an elevation profile onto a var-len int packed form (Dlugosz coding). This method
@@ -147,7 +91,8 @@ public final class CompactElevationProfile implements Serializable {
         return new PackedCoordinateSequence.Double(c, 2);
     }
 
-    public static double getDistanceBetweenSamplesM() {
-        return distanceBetweenSamplesM;
+    public static void setDistanceBetweenSamplesM(double distance) {
+        distanceBetweenSamplesM = distance;
     }
+
 }

--- a/src/main/java/org/opentripplanner/common/geometry/CompactLineString.java
+++ b/src/main/java/org/opentripplanner/common/geometry/CompactLineString.java
@@ -1,7 +1,5 @@
 package org.opentripplanner.common.geometry;
 
-import java.io.Serializable;
-
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.LineString;
@@ -24,9 +22,7 @@ import org.locationtech.jts.geom.LineString;
  * 
  * @author laurent
  */
-public final class CompactLineString implements Serializable {
-
-    private static final long serialVersionUID = 1L;
+public final class CompactLineString {
 
     /**
      * Multiplier for fixed-float representation. For lat/lon CRS, 1e6 leads to a precision of 0.11
@@ -44,9 +40,9 @@ public final class CompactLineString implements Serializable {
     /**
      * Singleton representation of a straight-line (where nothing has to be stored), to be re-used.
      */
-    protected static final int[] STRAIGHT_LINE = new int[0];
+    public static final int[] STRAIGHT_LINE = new int[0];
 
-    protected static final byte[] STRAIGHT_LINE_PACKED = new byte[0];
+    public static final byte[] STRAIGHT_LINE_PACKED = new byte[0];
 
     /**
      * Geometry factory. TODO - Do we need to make this parametrable?
@@ -124,6 +120,18 @@ public final class CompactLineString implements Serializable {
     }
 
     /**
+     * Wrapper for the above method in the case where there are no start/end coordinates provided.
+     * 0-coordinates are added in order for the delta encoding to work correctly.
+     */
+    public static byte[] compackLineString(LineString lineString, boolean reverse) {
+        lineString = GeometryUtils.addStartEndCoordinatesToLineString(
+                new Coordinate(0.0, 0.0),
+                lineString,
+                new Coordinate(0.0, 0.0));
+        return compackLineString(0.0, 0.0, 0.0, 0.0, lineString, reverse);
+    }
+
+    /**
      * Construct a LineString based on external end-points and compacted int version.
      * 
      * @param xa
@@ -174,5 +182,14 @@ public final class CompactLineString implements Serializable {
     public static LineString uncompackLineString(double x0, double y0, double x1, double y1,
             byte[] packedCoords, boolean reverse) {
         return uncompactLineString(x0, y0, x1, y1, DlugoszVarLenIntPacker.unpack(packedCoords), reverse);
+    }
+
+    /**
+     * Wrapper for the above method in the case where there are no start/end coordinates provided.
+     * 0-coordinates are added and then removed in order for the delta encoding to work correctly.
+     */
+    public static LineString uncompackLineString(byte[] packedCoords, boolean reverse) {
+        LineString lineString = uncompackLineString(0.0, 0.0, 0.0, 0.0, packedCoords, reverse);
+        return GeometryUtils.removeStartEndCoordinatesFromLineString(lineString);
     }
 }

--- a/src/main/java/org/opentripplanner/common/geometry/GeometryUtils.java
+++ b/src/main/java/org/opentripplanner/common/geometry/GeometryUtils.java
@@ -63,6 +63,14 @@ public class GeometryUtils {
         return makeLineString(coordinates);
     }
 
+    public static LineString removeStartEndCoordinatesFromLineString(LineString lineString) {
+        Coordinate[] coordinates = new Coordinate[lineString.getCoordinates().length - 2];
+        for (int j = 1; j < lineString.getCoordinates().length - 1; j++) {
+            coordinates[j - 1] = lineString.getCoordinates()[j];
+        }
+        return makeLineString(coordinates);
+    }
+
     public static GeometryFactory getGeometryFactory() {
         return gf;
     }

--- a/src/main/java/org/opentripplanner/common/geometry/GeometryUtils.java
+++ b/src/main/java/org/opentripplanner/common/geometry/GeometryUtils.java
@@ -11,6 +11,7 @@ import org.opentripplanner.common.model.P2;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Arrays;
 import java.util.List;
 
 public class GeometryUtils {
@@ -37,6 +38,29 @@ public class GeometryUtils {
             coordinates[i / 2] = new Coordinate(coords[i], coords[i+1]);
         }
         return factory.createLineString(coordinates);
+    }
+
+    public static LineString makeLineString(Coordinate[] coordinates) {
+        GeometryFactory factory = getGeometryFactory();
+        return factory.createLineString(coordinates);
+    }
+
+    public static LineString concatenateLineStrings(List<LineString> lineStrings) {
+        GeometryFactory factory = getGeometryFactory();
+        return factory.createLineString(
+                lineStrings.stream()
+                        .flatMap(t -> Arrays.stream(t.getCoordinates()))
+                        .toArray(Coordinate[]::new));
+    }
+
+    public static LineString addStartEndCoordinatesToLineString(Coordinate startCoord, LineString lineString, Coordinate endCoord) {
+        Coordinate[] coordinates = new Coordinate[lineString.getCoordinates().length + 2];
+        coordinates[0] = startCoord;
+        for (int j = 0; j < lineString.getCoordinates().length; j++) {
+            coordinates[j + 1] = lineString.getCoordinates()[j];
+        }
+        coordinates[lineString.getCoordinates().length + 1] = endCoord;
+        return makeLineString(coordinates);
     }
 
     public static GeometryFactory getGeometryFactory() {

--- a/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
@@ -236,18 +236,30 @@ public class GraphBuilder implements Runnable {
             awsTileSource.awsBucketName = bucketConfig.bucketName;
             NEDGridCoverageFactoryImpl gcf = new NEDGridCoverageFactoryImpl(cacheDirectory);
             gcf.tileSource = awsTileSource;
-            GraphBuilderModule elevationBuilder = new ElevationModule(gcf, builderParams.elevationUnitMultiplier);
+            GraphBuilderModule elevationBuilder = new ElevationModule(
+                    gcf,
+                    builderParams.elevationUnitMultiplier,
+                    builderParams.distanceBetweenElevationSamples
+            );
             graphBuilder.addModule(elevationBuilder);
         } else if (builderParams.fetchElevationUS) {
             // Download the elevation tiles from the official web service
             File cacheDirectory = new File(params.cacheDirectory, "ned");
             ElevationGridCoverageFactory gcf = new NEDGridCoverageFactoryImpl(cacheDirectory);
-            GraphBuilderModule elevationBuilder = new ElevationModule(gcf, builderParams.elevationUnitMultiplier);
+            GraphBuilderModule elevationBuilder = new ElevationModule(
+                    gcf,
+                    builderParams.elevationUnitMultiplier,
+                    builderParams.distanceBetweenElevationSamples
+            );
             graphBuilder.addModule(elevationBuilder);
         } else if (demFile != null) {
             // Load the elevation from a file in the graph inputs directory
             ElevationGridCoverageFactory gcf = new GeotiffGridCoverageFactoryImpl(demFile);
-            GraphBuilderModule elevationBuilder = new ElevationModule(gcf, builderParams.elevationUnitMultiplier);
+            GraphBuilderModule elevationBuilder = new ElevationModule(
+                    gcf,
+                    builderParams.elevationUnitMultiplier,
+                    builderParams.distanceBetweenElevationSamples
+            );
             graphBuilder.addModule(elevationBuilder);
         }
         if ( hasGTFS ) {

--- a/src/main/java/org/opentripplanner/graph_builder/module/map/BusRouteStreetMatcher.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/map/BusRouteStreetMatcher.java
@@ -62,10 +62,10 @@ public class BusRouteStreetMatcher implements GraphBuilderModule {
                     //If there are no shapes in GTFS pattern geometry is generated
                     //generated geometry is useless for street matching
                     //that is why pattern.geometry is null in that case
-                    if (pattern.geometry == null) {
+                    if (pattern.getGeometry() == null) {
                         continue;
                     }
-                    List<Edge> edges = matcher.match(pattern.geometry);
+                    List<Edge> edges = matcher.match(pattern.getGeometry());
                     if (edges == null || edges.isEmpty()) {
                         log.warn("Could not match to street network: {}", pattern);
                         continue;
@@ -78,7 +78,9 @@ public class BusRouteStreetMatcher implements GraphBuilderModule {
                     Coordinate[] coordinateArray = new Coordinate[coordinates.size()];
                     LineString ls = GeometryUtils.getGeometryFactory().createLineString(coordinates.toArray(coordinateArray));
                     // Replace the pattern's geometry from GTFS with that of the equivalent OSM edges.
-                    pattern.geometry = ls;
+                    // TODO: It is not possible to replace the geometry of a TripPattern anymore,
+                    // TODO: as it is constructed from the hopGeometries
+                    //pattern.getGeometry() = ls;
                 }
             }
         }

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -6,6 +6,7 @@ import org.geotools.coverage.grid.GridCoverage2D;
 import org.geotools.coverage.grid.Interpolator2D;
 import org.geotools.geometry.DirectPosition2D;
 import org.opengis.coverage.Coverage;
+import org.opentripplanner.common.geometry.CompactElevationProfile;
 import org.opentripplanner.common.geometry.GeometryUtils;
 import org.opentripplanner.common.geometry.PackedCoordinateSequence;
 import org.opentripplanner.common.geometry.SphericalDistanceLibrary;
@@ -53,13 +54,6 @@ public class ElevationModule implements GraphBuilderModule {
     private int nPointsOutsideDEM = 0;
 
     /**
-     * The distance between samples in meters. Defaults to 10m, the approximate resolution of 1/3
-     * arc-second NED data.
-     */
-    private double distanceBetweenSamplesM = 10;
-
-
-    /**
      * Unit conversion multiplier for elevation values. No conversion needed if the elevation values
      * are defined in meters in the source data. If, for example, decimetres are used in the source data,
      * this should be set to 0.1 in build-config.json.
@@ -83,10 +77,6 @@ public class ElevationModule implements GraphBuilderModule {
     
     public void setGridCoverageFactory(ElevationGridCoverageFactory factory) {
         gridCoverageFactory = factory;
-    }
-
-    public void setDistanceBetweenSamplesM(double distance) {
-        distanceBetweenSamplesM = distance;
     }
 
     @Override
@@ -350,6 +340,8 @@ public class ElevationModule implements GraphBuilderModule {
 
         // initial sample (x = 0)
         coordList.add(new Coordinate(0, getElevation(coords[0])));
+
+        double distanceBetweenSamplesM = CompactElevationProfile.getDistanceBetweenSamplesM();
 
         // loop for edge-internal samples
         for (double x = distanceBetweenSamplesM; x < edgeLenM; x += distanceBetweenSamplesM) {

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -53,6 +53,8 @@ public class ElevationModule implements GraphBuilderModule {
     private int nPointsEvaluated = 0;
     private int nPointsOutsideDEM = 0;
 
+    private final double distanceBetweenSamplesM;
+
     /**
      * Unit conversion multiplier for elevation values. No conversion needed if the elevation values
      * are defined in meters in the source data. If, for example, decimetres are used in the source data,
@@ -60,11 +62,13 @@ public class ElevationModule implements GraphBuilderModule {
      */
     private double elevationUnitMultiplier = 1;
 
-    public ElevationModule() { /* This makes me a "bean" */ };
-    
-    public ElevationModule(ElevationGridCoverageFactory factory, double elevationUnitMultiplier) {
+    public ElevationModule(ElevationGridCoverageFactory factory,
+            double elevationUnitMultiplier,
+            double distanceBetweenSamples
+    ) {
         this.setGridCoverageFactory(factory);
         this.elevationUnitMultiplier = elevationUnitMultiplier;
+        this.distanceBetweenSamplesM = distanceBetweenSamples;
     }
 
     public List<String> provides() {
@@ -81,6 +85,7 @@ public class ElevationModule implements GraphBuilderModule {
 
     @Override
     public void buildGraph(Graph graph, HashMap<Class<?>, Object> extra) {
+        graph.setDistanceBetweenElevationSamples(this.distanceBetweenSamplesM);
         gridCoverageFactory.setGraph(graph);
         Coverage gridCov = gridCoverageFactory.getGridCoverage();
 
@@ -340,8 +345,6 @@ public class ElevationModule implements GraphBuilderModule {
 
         // initial sample (x = 0)
         coordList.add(new Coordinate(0, getElevation(coords[0])));
-
-        double distanceBetweenSamplesM = CompactElevationProfile.getDistanceBetweenSamplesM();
 
         // loop for edge-internal samples
         for (double x = distanceBetweenSamplesM; x < edgeLenM; x += distanceBetweenSamplesM) {

--- a/src/main/java/org/opentripplanner/index/IndexAPI.java
+++ b/src/main/java/org/opentripplanner/index/IndexAPI.java
@@ -530,7 +530,7 @@ public class IndexAPI {
     public Response getGeometryForPattern (@PathParam("patternId") String patternIdString) {
         TripPattern pattern = index.graph.tripPatternForId.get(patternIdString);
         if (pattern != null) {
-            EncodedPolylineBean geometry = PolylineEncoder.createEncodings(pattern.geometry);
+            EncodedPolylineBean geometry = PolylineEncoder.createEncodings(pattern.getGeometry());
             return Response.status(Status.OK).entity(geometry).build();
         } else {
             return Response.status(Status.NOT_FOUND).entity(MSG_404).build();

--- a/src/main/java/org/opentripplanner/index/IndexGraphQLSchema.java
+++ b/src/main/java/org/opentripplanner/index/IndexGraphQLSchema.java
@@ -537,7 +537,7 @@ public class IndexGraphQLSchema {
                 .name("geometry")
                 .type(Scalars.GraphQLString) //TODO: Should be geometry
                 .dataFetcher(environment -> index.patternForTrip
-                    .get((Trip) environment.getSource()).geometry.getCoordinateSequence())
+                    .get((Trip) environment.getSource()).getGeometry())
                 .build())
             .build();
 
@@ -603,7 +603,7 @@ public class IndexGraphQLSchema {
                 .name("geometry")
                 .type(new GraphQLList(coordinateType))
                 .dataFetcher(environment -> {
-                    LineString geometry = ((TripPattern) environment.getSource()).geometry;
+                    LineString geometry = ((TripPattern) environment.getSource()).getGeometry();
                     if (geometry == null) {
                         return null;
                     } else {

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/router/street/AccessEgressRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/router/street/AccessEgressRouter.java
@@ -42,7 +42,6 @@ public class AccessEgressRouter {
                     new Transfer(-1,
                             (int)stopAtDistance.edges.stream().map(Edge::getDistance)
                                     .collect(Collectors.summarizingDouble(Double::doubleValue)).getSum(),
-                            Arrays.asList(stopAtDistance.geom.getCoordinates()),
                             stopAtDistance.edges));
         }
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/router/street/TransferToAccessEgressLegMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/router/street/TransferToAccessEgressLegMapper.java
@@ -24,7 +24,7 @@ public class TransferToAccessEgressLegMapper {
             Stop stop = entry.getKey();
             Transfer transfer = entry.getValue();
             int stopIndex = transitLayer.getIndexByStop(stop);
-            Transfer newTransfer = new Transfer(stopIndex, transfer.getDistanceMeters(), transfer.getCoordinates());
+            Transfer newTransfer = new Transfer(stopIndex, transfer.getDistanceMeters());
             result.add(new TransferWithDuration(newTransfer, walkSpeed));
         }
         return result;

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/Transfer.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/Transfer.java
@@ -3,6 +3,8 @@ package org.opentripplanner.routing.algorithm.raptor.transit;
 import org.locationtech.jts.geom.Coordinate;
 import org.opentripplanner.routing.graph.Edge;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -11,25 +13,27 @@ public class Transfer {
 
     private final int distanceMeters; // TODO Add units in the name of the field
 
-    private final List<Coordinate> coordinates;
-
     private final List<Edge> edges;
 
-    public Transfer(int toStop, int distanceMeters, List<Coordinate> coordinates) {
+    public Transfer(int toStop, int distanceMeters) {
         this.toStop = toStop;
         this.distanceMeters = distanceMeters;
-        this.coordinates = coordinates;
         this.edges = Collections.emptyList();
     }
 
-    public Transfer(int toStop, int distanceMeters, List<Coordinate> coordinates, List<Edge> edges) {
+    public Transfer(int toStop, int distanceMeters, List<Edge> edges) {
         this.toStop = toStop;
         this.distanceMeters = distanceMeters;
-        this.coordinates = coordinates;
         this.edges = edges;
     }
 
     public List<Coordinate> getCoordinates() {
+        List<Coordinate> coordinates = new ArrayList<>();
+        for (Edge edge : edges) {
+            if (edge.getGeometry() != null) {
+                coordinates.addAll((Arrays.asList(edge.getGeometry().getCoordinates())));
+            }
+        }
         return coordinates;
     }
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/mappers/TransfersMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/mappers/TransfersMapper.java
@@ -34,7 +34,6 @@ class TransfersMapper {
 
                     int toStopIndex = stopIndex.indexByStop.get(((TransitStop) edge.getToVertex()).getStop());
                     Transfer transfer = new Transfer(toStopIndex, (int) distance,
-                            Arrays.asList(edge.getGeometry().getCoordinates()),
                             ((SimpleTransfer) edge).getEdges());
 
                     list.add(transfer);

--- a/src/main/java/org/opentripplanner/routing/edgetype/SimpleTransfer.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/SimpleTransfer.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.routing.edgetype;
 
+import org.opentripplanner.common.geometry.GeometryUtils;
 import org.opentripplanner.routing.core.RoutingRequest;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.core.StateEditor;
@@ -11,6 +12,7 @@ import org.locationtech.jts.geom.LineString;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.stream.Collectors;
 
 /**
  * Represents a transfer between stops that does not take the street network into account.
@@ -22,13 +24,11 @@ public class SimpleTransfer extends Edge {
 
     private double distance;
     
-    private LineString geometry;
     private List<Edge> edges;
 
     public SimpleTransfer(TransitStop from, TransitStop to, double distance, LineString geometry, List<Edge> edges) {
         super(from, to);
         this.distance = distance;
-        this.geometry = geometry;
         this.edges = edges;
     }
 
@@ -81,11 +81,14 @@ public class SimpleTransfer extends Edge {
     public double getDistance(){
     	return this.distance;
     }
-    
-    
+
     @Override
     public LineString getGeometry(){
-	   return this.geometry;
+        return GeometryUtils.concatenateLineStrings(
+                edges.stream()
+                        .filter(t -> t.getGeometry() != null)
+                        .map(Edge::getGeometry)
+                        .collect(Collectors.toList()));
    }
 
     public List<Edge> getEdges() { return this.edges; }

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
@@ -82,7 +82,7 @@ public class StreetEdge extends Edge implements Cloneable {
      */
     protected float bicycleSafetyFactor;
 
-    private int[] compactGeometry;
+    private byte[] compactGeometry;
     
     private I18NString name;
 
@@ -643,11 +643,11 @@ public class StreetEdge extends Edge implements Cloneable {
 	}
 
 	public LineString getGeometry() {
-		return CompactLineString.uncompactLineString(fromv.getLon(), fromv.getLat(), tov.getLon(), tov.getLat(), compactGeometry, isBack());
+		return CompactLineString.uncompackLineString(fromv.getLon(), fromv.getLat(), tov.getLon(), tov.getLat(), compactGeometry, isBack());
 	}
 
 	private void setGeometry(LineString geometry) {
-		this.compactGeometry = CompactLineString.compactLineString(fromv.getLon(), fromv.getLat(), tov.getLon(), tov.getLat(), isBack() ? (LineString)geometry.reverse() : geometry, isBack());
+		this.compactGeometry = CompactLineString.compackLineString(fromv.getLon(), fromv.getLat(), tov.getLon(), tov.getLat(), isBack() ? (LineString)geometry.reverse() : geometry, isBack());
 	}
 
 	public void shareData(StreetEdge reversedEdge) {

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
@@ -643,11 +643,11 @@ public class StreetEdge extends Edge implements Cloneable {
 	}
 
 	public LineString getGeometry() {
-		return CompactLineString.uncompackLineString(fromv.getLon(), fromv.getLat(), tov.getLon(), tov.getLat(), compactGeometry, isBack());
+		return CompactLineString.uncompactLineString(fromv.getLon(), fromv.getLat(), tov.getLon(), tov.getLat(), compactGeometry, isBack());
 	}
 
 	private void setGeometry(LineString geometry) {
-		this.compactGeometry = CompactLineString.compackLineString(fromv.getLon(), fromv.getLat(), tov.getLon(), tov.getLat(), isBack() ? (LineString)geometry.reverse() : geometry, isBack());
+		this.compactGeometry = CompactLineString.compactLineString(fromv.getLon(), fromv.getLat(), tov.getLon(), tov.getLat(), isBack() ? (LineString)geometry.reverse() : geometry, isBack());
 	}
 
 	public void shareData(StreetEdge reversedEdge) {

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetWithElevationEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetWithElevationEdge.java
@@ -2,7 +2,6 @@ package org.opentripplanner.routing.edgetype;
 
 import org.opentripplanner.common.geometry.CompactElevationProfile;
 import org.opentripplanner.common.geometry.PackedCoordinateSequence;
-import org.opentripplanner.common.geometry.SphericalDistanceLibrary;
 import org.opentripplanner.routing.util.ElevationUtils;
 import org.opentripplanner.routing.util.SlopeCosts;
 import org.opentripplanner.routing.vertextype.StreetVertex;
@@ -61,7 +60,7 @@ public class StreetWithElevationEdge extends StreetEdge {
         boolean slopeLimit = getPermission().allows(StreetTraversalPermission.CAR);
         SlopeCosts costs = ElevationUtils.getSlopeCosts(elev, slopeLimit);
 
-        packedElevationProfile = CompactElevationProfile.compactElevationProfile(elev);
+        packedElevationProfile = CompactElevationProfile.compactElevationProfileWithRegularSamples(elev);
         slopeSpeedFactor = (float)costs.slopeSpeedFactor;
         slopeWorkFactor = (float)costs.slopeWorkFactor;
         maxSlope = (float)costs.maxSlope;
@@ -75,7 +74,10 @@ public class StreetWithElevationEdge extends StreetEdge {
 
     @Override
     public PackedCoordinateSequence getElevationProfile() {
-        return CompactElevationProfile.uncompactElevationProfile(packedElevationProfile);
+        return CompactElevationProfile.uncompactElevationProfileWithRegularSamples(
+                packedElevationProfile,
+                getDistance()
+        );
     }
 
     @Override

--- a/src/main/java/org/opentripplanner/routing/edgetype/TripPattern.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/TripPattern.java
@@ -10,16 +10,15 @@ import com.google.common.hash.Hashing;
 import com.google.common.io.BaseEncoding;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.LineString;
-import org.opentripplanner.api.resource.CoordinateArrayListSequence;
-import org.opentripplanner.common.MavenVersion;
-import org.opentripplanner.common.geometry.GeometryUtils;
-import org.opentripplanner.common.geometry.PackedCoordinateSequence;
-import org.opentripplanner.gtfs.GtfsLibrary;
+import org.opentripplanner.common.geometry.CompactLineString;
 import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.model.Route;
 import org.opentripplanner.model.Stop;
 import org.opentripplanner.model.StopPattern;
 import org.opentripplanner.model.Trip;
+import org.opentripplanner.common.MavenVersion;
+import org.opentripplanner.common.geometry.GeometryUtils;
+import org.opentripplanner.gtfs.GtfsLibrary;
 import org.opentripplanner.routing.core.RoutingRequest;
 import org.opentripplanner.routing.core.ServiceDay;
 import org.opentripplanner.routing.core.State;
@@ -130,15 +129,74 @@ public class TripPattern implements Cloneable, Serializable {
      */
     final ArrayList<Trip> trips = new ArrayList<Trip>();
 
-    /** Used by the MapBuilder (and should be exposed by the Index API). */
-    public LineString geometry = null;
-
     /**
-     * Geometries of each inter-stop segment of the tripPattern. This is redundant information but should just reuse
-     * references to the same coordinates referenced by the single geometry field. These probably could be raw coordinate
-     * arrays (or some kind of packed coordinate sequences) since we just use the coordinate arrays out of them.
+     * Geometries of each inter-stop segment of the tripPattern.
      */
-    public LineString[] hopGeometries = null;
+    private int[][] hopGeometries = null;
+
+
+    public LineString getHopGeometry(int stopIndex) {
+        TransitStop transitStopStart = stopVertices[stopIndex];
+        TransitStop transitStopEnd = stopVertices[stopIndex + 1];
+
+        if (hopGeometries != null) {
+            return CompactLineString.uncompactLineString(
+                    transitStopStart.getX(),
+                    transitStopStart.getY(),
+                    transitStopEnd.getX(),
+                    transitStopEnd.getY(),
+                    hopGeometries[stopIndex],
+                    false
+            );
+        } else {
+            return GeometryUtils.getGeometryFactory()
+                    .createLineString(
+                            new Coordinate[] {
+                                    transitStopStart.getCoordinate(),
+                                    transitStopEnd.getCoordinate() });
+        }
+    }
+
+    public void setHopGeometries(LineString[] hopGeometries) {
+        this.hopGeometries = new int[hopGeometries.length][];
+
+        for (int i = 0; i < hopGeometries.length; i++) {
+            setHopGeometry(i, hopGeometries[i]);
+        }
+    }
+
+    public void setHopGeometry(int i, LineString hopGeometry) {
+        TransitStop transitStopStart = stopVertices[i];
+        TransitStop transitStopEnd = stopVertices[i + 1];
+
+        LineString lineString = GeometryUtils.addStartEndCoordinatesToLineString(
+                transitStopStart.getCoordinate(),
+                hopGeometry,
+                transitStopEnd.getCoordinate());
+
+        int[] compactCoordinates = CompactLineString.compactLineString(
+                transitStopStart.getX(),
+                transitStopStart.getY(),
+                transitStopEnd.getX(),
+                transitStopEnd.getY(),
+                lineString,
+                false
+        );
+
+        this.hopGeometries[i] = compactCoordinates;
+    }
+
+    public LineString getGeometry() {
+        List<LineString> lineStrings = new ArrayList<>();
+        for (int i = 0; i < hopGeometries.length - 1; i++) {
+            lineStrings.add(getHopGeometry(i));
+        }
+        return GeometryUtils.concatenateLineStrings(lineStrings);
+    }
+
+    public int numHopGeometries() {
+        return hopGeometries.length;
+    }
 
     /** Holds stop-specific information such as wheelchair accessibility and pickup/dropoff roles. */
     // TODO: is this necessary? Can we just look at the Stop and StopPattern objects directly?
@@ -513,33 +571,6 @@ public class TripPattern implements Cloneable, Serializable {
         return String.format("<TripPattern %s>", this.code);
     }
 
-    /**
-     * Generates a geometry for the full pattern.
-     * This is done by concatenating the shapes of all the constituent hops.
-     * It could probably just come from the full shapes.txt entry for the trips in the route, but given all the details
-     * in how the individual hop geometries are constructed we just recombine them here.
-     */
-    public void makeGeometry(LineString[] hopGeoms) {
-        CoordinateArrayListSequence coordinates = new CoordinateArrayListSequence();
-        for (int i = 0; i < hopGeoms.length; i++) {
-            LineString geometry = hopGeoms[i];
-            if (geometry != null) {
-                if (coordinates.size() == 0) {
-                    coordinates.extend(geometry.getCoordinates());
-                } else {
-                    coordinates.extend(geometry.getCoordinates(), 1); // Avoid duplicate coords at stops
-                }
-            }
-        }
-        // The CoordinateArrayListSequence is easy to append to, but is not serializable.
-        // It might be possible to just mark it serializable, but it is not particularly compact either.
-        // So we convert it to a packed coordinate sequence, since that is serializable and smaller.
-        // FIXME It seems like we could simply accumulate the coordinates into an array instead of using the CoordinateArrayListSequence.
-        PackedCoordinateSequence packedCoords = new PackedCoordinateSequence.Double(coordinates.toCoordinateArray(), 2);
-        this.geometry = GeometryUtils.getGeometryFactory().createLineString(packedCoords);
-    }
-
-
 	public Trip getExemplar() {
 		if(this.trips.isEmpty()){
 			return null;
@@ -612,17 +643,4 @@ public class TripPattern implements Cloneable, Serializable {
         return route.getId().getAgencyId();
     }
 
-    // TODO OTP2 - This should probably be precalculated in the PatternHopFactory
-    public LineString getHopGeometry(int stopIndex) {
-        if (hopGeometries != null) {
-            return hopGeometries[stopIndex];
-        } else {
-            Stop s1 = stopPattern.stops[stopIndex];
-            Stop s2 = stopPattern.stops[stopIndex + 1];
-            Coordinate c1 = new Coordinate(s1.getLon(), s1.getLat());
-            Coordinate c2 = new Coordinate(s2.getLon(), s2.getLat());
-
-            return GeometryUtils.getGeometryFactory().createLineString(new Coordinate[] { c1, c2 });
-        }
-    }
 }

--- a/src/main/java/org/opentripplanner/routing/edgetype/TripPattern.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/TripPattern.java
@@ -132,7 +132,7 @@ public class TripPattern implements Cloneable, Serializable {
     /**
      * Geometries of each inter-stop segment of the tripPattern.
      */
-    private int[][] hopGeometries = null;
+    private byte[][] hopGeometries = null;
 
 
     public LineString getHopGeometry(int stopIndex) {
@@ -140,7 +140,7 @@ public class TripPattern implements Cloneable, Serializable {
         TransitStop transitStopEnd = stopVertices[stopIndex + 1];
 
         if (hopGeometries != null) {
-            return CompactLineString.uncompactLineString(
+            return CompactLineString.uncompackLineString(
                     transitStopStart.getX(),
                     transitStopStart.getY(),
                     transitStopEnd.getX(),
@@ -158,7 +158,7 @@ public class TripPattern implements Cloneable, Serializable {
     }
 
     public void setHopGeometries(LineString[] hopGeometries) {
-        this.hopGeometries = new int[hopGeometries.length][];
+        this.hopGeometries = new byte[hopGeometries.length][];
 
         for (int i = 0; i < hopGeometries.length; i++) {
             setHopGeometry(i, hopGeometries[i]);
@@ -174,7 +174,7 @@ public class TripPattern implements Cloneable, Serializable {
                 hopGeometry,
                 transitStopEnd.getCoordinate());
 
-        int[] compactCoordinates = CompactLineString.compactLineString(
+        byte[] compactCoordinates = CompactLineString.compackLineString(
                 transitStopStart.getX(),
                 transitStopStart.getY(),
                 transitStopEnd.getX(),

--- a/src/main/java/org/opentripplanner/routing/edgetype/TripPattern.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/TripPattern.java
@@ -140,7 +140,7 @@ public class TripPattern implements Cloneable, Serializable {
         TransitStop transitStopEnd = stopVertices[stopIndex + 1];
 
         if (hopGeometries != null) {
-            return CompactLineString.uncompackLineString(
+            return CompactLineString.uncompactLineString(
                     hopGeometries[stopIndex],
                     false
             );
@@ -162,7 +162,7 @@ public class TripPattern implements Cloneable, Serializable {
     }
 
     public void setHopGeometry(int i, LineString hopGeometry) {
-        this.hopGeometries[i] = CompactLineString.compackLineString(hopGeometry,false);
+        this.hopGeometries[i] = CompactLineString.compactLineString(hopGeometry,false);
     }
 
     public LineString getGeometry() {

--- a/src/main/java/org/opentripplanner/routing/edgetype/TripPattern.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/TripPattern.java
@@ -141,10 +141,6 @@ public class TripPattern implements Cloneable, Serializable {
 
         if (hopGeometries != null) {
             return CompactLineString.uncompackLineString(
-                    transitStopStart.getX(),
-                    transitStopStart.getY(),
-                    transitStopEnd.getX(),
-                    transitStopEnd.getY(),
                     hopGeometries[stopIndex],
                     false
             );
@@ -166,24 +162,7 @@ public class TripPattern implements Cloneable, Serializable {
     }
 
     public void setHopGeometry(int i, LineString hopGeometry) {
-        TransitStop transitStopStart = stopVertices[i];
-        TransitStop transitStopEnd = stopVertices[i + 1];
-
-        LineString lineString = GeometryUtils.addStartEndCoordinatesToLineString(
-                transitStopStart.getCoordinate(),
-                hopGeometry,
-                transitStopEnd.getCoordinate());
-
-        byte[] compactCoordinates = CompactLineString.compackLineString(
-                transitStopStart.getX(),
-                transitStopStart.getY(),
-                transitStopEnd.getX(),
-                transitStopEnd.getY(),
-                lineString,
-                false
-        );
-
-        this.hopGeometries[i] = compactCoordinates;
+        this.hopGeometries[i] = CompactLineString.compackLineString(hopGeometry,false);
     }
 
     public LineString getGeometry() {

--- a/src/main/java/org/opentripplanner/routing/edgetype/factory/PatternHopFactory.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/factory/PatternHopFactory.java
@@ -191,8 +191,7 @@ public class PatternHopFactory {
             LineString[] hopGeometries = geometriesByTripPattern.get(tripPattern);
             if (hopGeometries != null) {
                 // Make a single unified geometry, and also store the per-hop split geometries.
-                tripPattern.makeGeometry(hopGeometries);
-                tripPattern.hopGeometries = hopGeometries;
+                tripPattern.setHopGeometries(hopGeometries);
             }
             tripPattern.setServiceCodes(graph.serviceCodes); // TODO this could be more elegant
 

--- a/src/main/java/org/opentripplanner/routing/graph/Graph.java
+++ b/src/main/java/org/opentripplanner/routing/graph/Graph.java
@@ -21,6 +21,7 @@ import org.locationtech.jts.geom.Geometry;
 import org.opentripplanner.calendar.impl.CalendarServiceImpl;
 import org.opentripplanner.common.MavenVersion;
 import org.opentripplanner.common.TurnRestriction;
+import org.opentripplanner.common.geometry.CompactElevationProfile;
 import org.opentripplanner.common.geometry.GraphUtils;
 import org.opentripplanner.graph_builder.annotation.GraphBuilderAnnotation;
 import org.opentripplanner.graph_builder.annotation.NoFutureDates;
@@ -222,6 +223,9 @@ public class Graph implements Serializable, AddBuilderAnnotation {
 
     /** Interlining relationships between trips. */
     public final BiMap<Trip,Trip> interlinedTrips = HashBiMap.create();
+
+    /** The distance between elevation samples used in CompactElevationProfile. */
+    private double distanceBetweenElevationSamples;
 
     /** Data model for Raptor routing, with realtime updates applied (if any). */
     public transient TransitLayer transitLayer;
@@ -909,5 +913,14 @@ public class Graph implements Serializable, AddBuilderAnnotation {
 
     public long getTransitServiceEnds() {
         return transitServiceEnds;
+    }
+
+    public double getDistanceBetweenElevationSamples() {
+        return distanceBetweenElevationSamples;
+    }
+
+    public void setDistanceBetweenElevationSamples(double distanceBetweenElevationSamples) {
+        this.distanceBetweenElevationSamples = distanceBetweenElevationSamples;
+        CompactElevationProfile.setDistanceBetweenSamplesM(distanceBetweenElevationSamples);
     }
 }

--- a/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
+++ b/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
@@ -11,6 +11,7 @@ import graphql.execution.ExecutorServiceExecutionStrategy;
 import org.apache.lucene.util.PriorityQueue;
 import org.joda.time.LocalDate;
 import org.locationtech.jts.geom.Envelope;
+import org.opentripplanner.common.geometry.CompactElevationProfile;
 import org.opentripplanner.common.geometry.HashGridSpatialIndex;
 import org.opentripplanner.common.model.GenericLocation;
 import org.opentripplanner.index.IndexGraphQLSchema;
@@ -92,6 +93,8 @@ public class GraphIndex {
 
     public GraphIndex (Graph graph) {
         LOG.info("Indexing graph...");
+
+        CompactElevationProfile.setDistanceBetweenSamplesM(graph.getDistanceBetweenElevationSamples());
 
         for (String feedId : graph.getFeedIds()) {
             for (Agency agency : graph.getAgencies(feedId)) {

--- a/src/main/java/org/opentripplanner/standalone/GraphBuilderParameters.java
+++ b/src/main/java/org/opentripplanner/standalone/GraphBuilderParameters.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.standalone;
 
+import org.opentripplanner.common.geometry.CompactElevationProfile;
 import org.opentripplanner.graph_builder.module.osm.WayPropertySetSource;
 import org.opentripplanner.graph_builder.services.osm.CustomNamer;
 import org.opentripplanner.routing.impl.DefaultFareServiceFactory;
@@ -174,7 +175,7 @@ public class GraphBuilderParameters {
 
     /**
      * The distance between elevation samples in meters. Defaults to 10m, the approximate resolution of 1/3
-     * arc-second NED data. This should not be smaller than the resolution of the height data used.
+     * arc-second NED data. This should not be smaller than the horizontal resolution of the height data used.
      */
     public double distanceBetweenElevationSamples;
 
@@ -213,7 +214,8 @@ public class GraphBuilderParameters {
         banDiscouragedBiking = config.path("banDiscouragedBiking").asBoolean(false);
         maxTransferDistance = config.path("maxTransferDistance").asDouble(2000);
         extraEdgesStopPlatformLink = config.path("extraEdgesStopPlatformLink").asBoolean(false);
-        distanceBetweenElevationSamples = config.path("distanceBetweenElevationSamples").asDouble(25);
+        distanceBetweenElevationSamples = config.path("distanceBetweenElevationSamples").asDouble(
+                CompactElevationProfile.DEFAULT_DISTANCE_BETWEEN_SAMPLES_METERS);
     }
 
 

--- a/src/main/java/org/opentripplanner/standalone/GraphBuilderParameters.java
+++ b/src/main/java/org/opentripplanner/standalone/GraphBuilderParameters.java
@@ -173,6 +173,12 @@ public class GraphBuilderParameters {
     public final Boolean extraEdgesStopPlatformLink;
 
     /**
+     * The distance between elevation samples in meters. Defaults to 10m, the approximate resolution of 1/3
+     * arc-second NED data. This should not be smaller than the resolution of the height data used.
+     */
+    public double distanceBetweenElevationSamples;
+
+    /**
      * Set all parameters from the given Jackson JSON tree, applying defaults.
      * Supplying MissingNode.getInstance() will cause all the defaults to be applied.
      * This could be done automatically with the "reflective query scraper" but it's less type safe and less clear.
@@ -207,6 +213,7 @@ public class GraphBuilderParameters {
         banDiscouragedBiking = config.path("banDiscouragedBiking").asBoolean(false);
         maxTransferDistance = config.path("maxTransferDistance").asDouble(2000);
         extraEdgesStopPlatformLink = config.path("extraEdgesStopPlatformLink").asBoolean(false);
+        distanceBetweenElevationSamples = config.path("distanceBetweenElevationSamples").asDouble(25);
     }
 
 

--- a/src/test/java/org/opentripplanner/common/geometry/CompactElevationProfileTest.java
+++ b/src/test/java/org/opentripplanner/common/geometry/CompactElevationProfileTest.java
@@ -6,7 +6,7 @@ import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.CoordinateSequence;
 
 public class CompactElevationProfileTest extends TestCase {
-
+/*
     public final void testEncodingDecoding() {
 
         runOneTest(null);
@@ -41,4 +41,6 @@ public class CompactElevationProfileTest extends TestCase {
             assertTrue("Too large elevation delta", dy <= 1e-2);
         }
     }
+
+ */
 }

--- a/src/test/java/org/opentripplanner/common/geometry/CompactElevationProfileTest.java
+++ b/src/test/java/org/opentripplanner/common/geometry/CompactElevationProfileTest.java
@@ -7,11 +7,9 @@ import org.locationtech.jts.geom.CoordinateSequence;
 
 public class CompactElevationProfileTest extends TestCase {
 
-    private final static double DISTANCE_BETWEEN_SAMPLES = 10;
-
     public final void testEncodingDecoding() {
-
-        CompactElevationProfile.setDistanceBetweenSamplesM(DISTANCE_BETWEEN_SAMPLES);
+        CompactElevationProfile.setDistanceBetweenSamplesM(
+                CompactElevationProfile.DEFAULT_DISTANCE_BETWEEN_SAMPLES_METERS);
 
         runOneTest(new Coordinate[] {
                 new Coordinate(0.0, 0.0),

--- a/src/test/java/org/opentripplanner/common/geometry/CompactElevationProfileTest.java
+++ b/src/test/java/org/opentripplanner/common/geometry/CompactElevationProfileTest.java
@@ -6,26 +6,32 @@ import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.CoordinateSequence;
 
 public class CompactElevationProfileTest extends TestCase {
-/*
+
+    private final static double DISTANCE_BETWEEN_SAMPLES = 10;
+
     public final void testEncodingDecoding() {
 
-        runOneTest(null);
-        runOneTest(new Coordinate[] { new Coordinate(0.0, 0.0) });
-        runOneTest(new Coordinate[] { new Coordinate(0.0, 1.0) });
-        runOneTest(new Coordinate[] { new Coordinate(0.0, 10000.0) }); // More than Mt Everest
-                                                                       // elevation
-        runOneTest(new Coordinate[] { new Coordinate(100000.0, 0.0) }); // A long street segment
-                                                                        // length
-        runOneTest(new Coordinate[] { new Coordinate(0.0, 10.0), new Coordinate(8.0, -10.0),
-                new Coordinate(120.0, 20.0), new Coordinate(150.0, 0.0) });
-        runOneTest(new Coordinate[] { new Coordinate(0.0, 0.12345678), new Coordinate(1.1111111111, -0.987654321),
-                new Coordinate(2.222222222222, 0.0000123), new Coordinate(3.33333333333, 6789.987654321) });
+        CompactElevationProfile.setDistanceBetweenSamplesM(DISTANCE_BETWEEN_SAMPLES);
+
+        runOneTest(new Coordinate[] {
+                new Coordinate(0.0, 0.0),
+                new Coordinate(3.0, 0.0),
+        },
+        3);
+
+        runOneTest(new Coordinate[] {
+                new Coordinate(0.0, 0.0),
+                new Coordinate(10.0, 0.0),
+                new Coordinate(19.0, 0.0)
+        },
+        19);
     }
 
-    private void runOneTest(Coordinate[] c) {
+    private void runOneTest(Coordinate[] c, double length) {
         CoordinateSequence elev1 = c == null ? null : new PackedCoordinateSequence.Double(c);
-        byte[] packed = CompactElevationProfile.compactElevationProfile(elev1);
-        CoordinateSequence elev2 = CompactElevationProfile.uncompactElevationProfile(packed);
+        byte[] packed = CompactElevationProfile.compactElevationProfileWithRegularSamples(elev1);
+        CoordinateSequence elev2 = CompactElevationProfile
+                .uncompactElevationProfileWithRegularSamples(packed, length);
         if (elev1 == null) {
             // This is rather simple
             assertNull(elev2);
@@ -41,6 +47,4 @@ public class CompactElevationProfileTest extends TestCase {
             assertTrue("Too large elevation delta", dy <= 1e-2);
         }
     }
-
- */
 }

--- a/src/test/java/org/opentripplanner/common/geometry/CompactLineStringTest.java
+++ b/src/test/java/org/opentripplanner/common/geometry/CompactLineStringTest.java
@@ -27,13 +27,13 @@ public class CompactLineStringTest extends TestCase {
         c.add(new Coordinate(x0, y0));
         c.add(new Coordinate(x1, y1));
         LineString ls = gf.createLineString(c.toArray(new Coordinate[0]));
-        int[] coords = CompactLineString.compactLineString(x0, y0, x1, y1, ls, false);
-        assertTrue(coords == CompactLineString.STRAIGHT_LINE); // ==, not equals
+        byte[] coords = CompactLineString.compactLineString(x0, y0, x1, y1, ls, false);
+        assertTrue(coords == CompactLineString.STRAIGHT_LINE_PACKED); // ==, not equals
         LineString ls2 = CompactLineString.uncompactLineString(x0, y0, x1, y1, coords, false);
         assertTrue(ls.equalsExact(ls2, 0.00000015));
-        byte[] packedCoords = CompactLineString.compackLineString(x0, y0, x1, y1, ls, false);
+        byte[] packedCoords = CompactLineString.compactLineString(x0, y0, x1, y1, ls, false);
         assertTrue(packedCoords == CompactLineString.STRAIGHT_LINE_PACKED); // ==, not equals
-        ls2 = CompactLineString.uncompackLineString(x0, y0, x1, y1, packedCoords, false);
+        ls2 = CompactLineString.uncompactLineString(x0, y0, x1, y1, packedCoords, false);
         assertTrue(ls.equalsExact(ls2, 0.00000015));
 
         c.clear();
@@ -43,18 +43,18 @@ public class CompactLineStringTest extends TestCase {
         c.add(new Coordinate(x1, y1));
         ls = gf.createLineString(c.toArray(new Coordinate[0]));
         coords = CompactLineString.compactLineString(x0, y0, x1, y1, ls, false);
-        assertTrue(coords != CompactLineString.STRAIGHT_LINE);
+        assertTrue(coords != CompactLineString.STRAIGHT_LINE_PACKED);
         ls2 = CompactLineString.uncompactLineString(x0, y0, x1, y1, coords, false);
         assertTrue(ls.equalsExact(ls2, 0.00000015));
-        packedCoords = CompactLineString.compackLineString(x0, y0, x1, y1, ls, false);
+        packedCoords = CompactLineString.compactLineString(x0, y0, x1, y1, ls, false);
         assertTrue(packedCoords != CompactLineString.STRAIGHT_LINE_PACKED);
-        ls2 = CompactLineString.uncompackLineString(x0, y0, x1, y1, packedCoords, false);
+        ls2 = CompactLineString.uncompactLineString(x0, y0, x1, y1, packedCoords, false);
         assertTrue(ls.equalsExact(ls2, 0.00000015));
 
         // Test reverse mode
         LineString lsi = (LineString) ls.reverse(); // The expected output
-        int[] coords2 = CompactLineString.compactLineString(x1, y1, x0, y0, ls, true);
-        assertTrue(coords2 != CompactLineString.STRAIGHT_LINE);
+        byte[] coords2 = CompactLineString.compactLineString(x1, y1, x0, y0, ls, true);
+        assertTrue(coords2 != CompactLineString.STRAIGHT_LINE_PACKED);
         assertEquals(coords.length, coords2.length);
         for (int i = 0; i < coords.length; i++)
             assertEquals(coords[i], coords2[i]);
@@ -62,14 +62,14 @@ public class CompactLineStringTest extends TestCase {
         assertTrue(lsi.equalsExact(ls2, 0.00000015));
         LineString ls3 = CompactLineString.uncompactLineString(x1, y1, x0, y0, coords, true);
         assertTrue(lsi.equalsExact(ls3, 0.00000015));
-        byte[] packedCoords2 = CompactLineString.compackLineString(x1, y1, x0, y0, ls, true);
+        byte[] packedCoords2 = CompactLineString.compactLineString(x1, y1, x0, y0, ls, true);
         assertTrue(packedCoords2 != CompactLineString.STRAIGHT_LINE_PACKED);
         assertEquals(packedCoords.length, packedCoords2.length);
         for (int i = 0; i < packedCoords.length; i++)
             assertEquals(packedCoords[i], packedCoords2[i]);
-        ls2 = CompactLineString.uncompackLineString(x1, y1, x0, y0, packedCoords2, true);
+        ls2 = CompactLineString.uncompactLineString(x1, y1, x0, y0, packedCoords2, true);
         assertTrue(lsi.equalsExact(ls2, 0.00000015));
-        ls3 = CompactLineString.uncompackLineString(x1, y1, x0, y0, packedCoords, true);
+        ls3 = CompactLineString.uncompactLineString(x1, y1, x0, y0, packedCoords, true);
         assertTrue(lsi.equalsExact(ls2, 0.00000015));
     }
 


### PR DESCRIPTION
After doing some memory profiling of OTP, we found that a lot of space is taken up by LineStrings. This affects both graph size and the memory requirement to run OTP. It is especially important for very large graphs, since you may run into a limit to the file size supported by the Kryo serializer.

Note that this is based on [#2794 ](https://github.com/opentripplanner/OpenTripPlanner/pull/2794), so only the last commit is relevant for this particular pull request.

The following changes have been made:

The geometries in SimpleTransfer and Raptor Transfer objects have been removed. In the first case they were saved as LineStrings, and in the second as Coordinate arrays. Since we already have a list of edges, it is possible to just combine these whenever we need the complete geometry. This is typically when building the itineraries, so performance is not so critical. The geometries of StreetEdges are delta compressed using CompactLineString, so they do not take up much space.

The geometries in TripPatterns have been removed. This information is duplicated in the hop geometries, and are not needed before creating the itineraries. In addition, the geometries in hop edges now use the CompactLineString, like with StreetEdges.

In total this cuts the size of the serialized graph in half when testing with the Oslo GTFS and Oslo OSM files. I have tested with maxTransferDistance of 2000, which means there were relatively many SimpleTransfers, which took up a lot of space.

This does break the BusRouteStreetMatcher, as it tries to replace the whole TripPattern geometry, so that needs to be looked into before merging.