### PR TITLE
Slightly relax string match in geocoder test

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -13,6 +13,7 @@
 - Remove CarFreeAtoZ from list of deployments
 - Fix XML response serialization (#2685)
 - Refactor InterleavedBidirectionalHeuristic (#2671)
+- Fix minor test failure against BANO geocoder (#2798)
 
 ## 1.3 (2018-08-03)
 

--- a/src/test/java/org/opentripplanner/geocoder/bano/BanoGeocoderTest.java
+++ b/src/test/java/org/opentripplanner/geocoder/bano/BanoGeocoderTest.java
@@ -27,7 +27,7 @@ public class BanoGeocoderTest {
 
         boolean found = false;
         for (GeocoderResult result : results.getResults()) {
-            if ("55 Rue du Faubourg Saint-Honoré 75008 Paris".equals(result.getDescription())) {
+            if (result.getDescription().contains("55 Rue du Faubourg")) {
                 double dist = SphericalDistanceLibrary.distance(result.getLat(),
                         result.getLng(), 48.870637, 2.316939);
                 assert (dist < 100);


### PR DESCRIPTION
Avoid worrying if the response included "é" or "e".

To be completed by pull request submitter:

- [x] **issue**: #2798
- [x] **roadmap**: Minor test fix
- [x] **tests**: Yes
- [x] **formatting**: Yes
- [x] **documentation**: N/A
- [x] **changelog**: Yes

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)