### PR TITLE
Port 1.4 fixes to OTP2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
-# OpenTripPlanner requires Java 8 and Travis doesn't (yet) support OpenJDK 8
+# OpenTripPlanner requires Java 8
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 # Replace Travis's default Maven installation step with a no-op.
 # This avoids redundantly pre-running 'mvn install -DskipTests' every time.

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -15,6 +15,7 @@
 - Fix XML response serialization (#2685)
 - Refactor InterleavedBidirectionalHeuristic (#2671)
 - Fix minor test failure against BANO geocoder (#2798)
+- Add "Accept" headers to GTFS-RT HTTP requests (#2796)
 
 ## 1.3 (2018-08-03)
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -12,6 +12,9 @@
 - Fix reverse optimization bug (#2653, #2411)
 - Remove CarFreeAtoZ from list of deployments
 - increase GTFS-realtime feeds size limit from 64MB to 2G (#2738)
+- Fix XML response serialization (#2685)
+- Refactor InterleavedBidirectionalHeuristic (#2671)
+- Fix minor test failure against BANO geocoder (#2798)
 
 ## 1.3 (2018-08-03)
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -10,6 +10,8 @@
 - Remove the coupling to OneBusAway GTFS within OTP's internal model by creating new classes replacing the external classes (#2494)
 - Allow itineraries in response to be sorted by duration (#2593)
 - Fix reverse optimization bug (#2653, #2411)
+- Remove CarFreeAtoZ from list of deployments
+- increase GTFS-realtime feeds size limit from 64MB to 2G (#2738)
 
 ## 1.3 (2018-08-03)
 
@@ -116,7 +118,7 @@
 - Ignore exceptions caused by errors in OSM linear rings.
 - Updated to version 2.18 of Jersey to fix hanging threads in Grizzly.
 - Removed confusing "Busish" and "Trainish" pseudo-modes.
-- FareService for Seattle: allow specifying fares in GTFS instead of hard-coding them in Java. Senior/youth fare prices are given in an extra column in fare attributes. Per-trip fares are taken into consideration when calculating fares in this region. 
+- FareService for Seattle: allow specifying fares in GTFS instead of hard-coding them in Java. Senior/youth fare prices are given in an extra column in fare attributes. Per-trip fares are taken into consideration when calculating fares in this region.
 - Update new linker to link to transitStops if no streets are found.
 - Show the name supplied in the request for the origin/destination points in the response.
 - Throw a trivialPath exception if start/end point are on the same edge.
@@ -287,7 +289,7 @@
 - full internationalization of the map-based web client
 - basic Lucene-based built-in geocoder
 
-## 0.11.0 (2014-03-24) 
+## 0.11.0 (2014-03-24)
 - Built-in HTTP server layer, making it possible to distribute OTP as a standalone JAR
 - "Long-distance" mode for large graphs, including bidirectional goal direction heuristic.
 - Simplified Maven project structure with less submodules
@@ -310,7 +312,7 @@ This release was made to consolidate all the development that had occurred with 
 - more lenient parsing of times
 - new directions icon set with SVG sources (thanks Laurent G)
 
-## 0.5.4 (2012-04-06) 
+## 0.5.4 (2012-04-06)
 - catch 0 divisors in NED builder, preventing NaN propagation to edge lengths
 - avoid repeated insertion of edges into edge lists, which are now threadsafe edge sets
 - identity equality for edges
@@ -348,7 +350,7 @@ This release was made to consolidate all the development that had occurred with 
 - more transit index features
 - default agencyIDs now determined on a per-feed basis
 - fixed fare overflow problem
-- fixed bug in loop road turn conversion 
+- fixed bug in loop road turn conversion
 - additional graphbuilder warnings and annotations
 - fixed a batch of bugs found by fixbugs  
 
@@ -356,7 +358,7 @@ This release was made to consolidate all the development that had occurred with 
 - stop codes, zones, and agency names in planner responses
 - encapsulation of edge list modifications
 - expanded edge and vertex type hierarchy
-- use mapquest OSM server by default 
+- use mapquest OSM server by default
 - Turkish locale (thanks Hasan Tayyar Beşik)
 - German and Italian locales (thanks Gerardo Carrieri)
 - bookmarkable trip URLs (thanks Matt Conway)

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -10,7 +10,6 @@
 - Remove the coupling to OneBusAway GTFS within OTP's internal model by creating new classes replacing the external classes (#2494)
 - Allow itineraries in response to be sorted by duration (#2593)
 - Fix reverse optimization bug (#2653, #2411)
-- Remove CarFreeAtoZ from list of deployments
 - increase GTFS-realtime feeds size limit from 64MB to 2G (#2738)
 - Fix XML response serialization (#2685)
 - Refactor InterleavedBidirectionalHeuristic (#2671)

--- a/src/main/java/com/google/transit/realtime/GtfsRealtime.java
+++ b/src/main/java/com/google/transit/realtime/GtfsRealtime.java
@@ -17,11 +17,13 @@ package com.google.transit.realtime;
  * </p>
  * <ul>
  * <li>Enum value TripDescriptor.ScheduleRelationship.MODIFIED = 5</li>
+ * <li>FeedMessage PARSER input.setSizeLimit(Integer.MAX_VALUE)</li>
  * </ul>
  * <p>
  * Version 2.5.0 of protoc.exe has been used to generate this file.
  * </p>
  */
+
 public final class GtfsRealtime {
   private GtfsRealtime() {}
   public static void registerAllExtensions(
@@ -221,6 +223,10 @@ public final class GtfsRealtime {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
+        // Increase input stream size limit to 2G (instead of the 64M default).
+        // Mimics a change that was supposed to be released in protobuf 2.7.0,
+        // see https://git.io/fjfg5.
+        input.setSizeLimit(Integer.MAX_VALUE);
         return new FeedMessage(input, extensionRegistry);
       }
     };

--- a/src/main/java/com/google/transit/realtime/GtfsRealtime.java
+++ b/src/main/java/com/google/transit/realtime/GtfsRealtime.java
@@ -23,7 +23,6 @@ package com.google.transit.realtime;
  * Version 2.5.0 of protoc.exe has been used to generate this file.
  * </p>
  */
-
 public final class GtfsRealtime {
   private GtfsRealtime() {}
   public static void registerAllExtensions(

--- a/src/main/java/org/opentripplanner/routing/trippattern/FrequencyEntry.java
+++ b/src/main/java/org/opentripplanner/routing/trippattern/FrequencyEntry.java
@@ -56,11 +56,11 @@ public class FrequencyEntry implements Serializable {
     }
 
     public int nextDepartureTime (int stop, int time) {
-        if (time > endTime) return -1;
         // Start time and end time are for the first stop in the trip. Find the time offset for this stop.
         int stopOffset = tripTimes.getDepartureTime(stop) - tripTimes.getDepartureTime(0);
         int beg = startTime + stopOffset; // First time a vehicle passes by this stop.
         int end = endTime + stopOffset; // Latest a vehicle can pass by this stop.
+        if (time > end) return -1;
         if (exactTimes) {
             for (int dep = beg; dep < end; dep += headway) {
                 if (dep >= time) return dep;
@@ -76,14 +76,18 @@ public class FrequencyEntry implements Serializable {
     }
 
     public int prevArrivalTime (int stop, int t) {
-        if (t < startTime) return -1;
         int stopOffset = tripTimes.getArrivalTime(stop) - tripTimes.getDepartureTime(0);
         int beg = startTime + stopOffset; // First time a vehicle passes by this stop.
         int end = endTime + stopOffset; // Latest a vehicle can pass by this stop.
+        if(t < beg) return -1;
         if (exactTimes) {
-            for (int dep = end; dep > beg; dep -= headway) {
-                if (dep <= t) return dep;
+            // we can't start from end in case end - beg is not a multiple of headway
+            int arr;
+            for (arr = beg + headway; arr < end; arr += headway) {
+                if (arr > t) return arr - headway;
             }
+            // if t > end, return last valid arrival time
+            return arr - headway;
         } else {
             int dep = t - headway;
             if (dep > end) return end; // not quite right

--- a/src/main/java/org/opentripplanner/updater/alerts/GtfsRealtimeAlertsUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/alerts/GtfsRealtimeAlertsUpdater.java
@@ -85,7 +85,7 @@ public class GtfsRealtimeAlertsUpdater extends PollingGraphUpdater {
     @Override
     protected void runPolling() {
         try {
-            InputStream data = HttpUtils.getData(url);
+            InputStream data = HttpUtils.getData(url, "Accept", "application/x-google-protobuf; application/octet-stream; */*");
             if (data == null) {
                 throw new RuntimeException("Failed to get data from url " + url);
             }

--- a/src/main/java/org/opentripplanner/updater/stoptime/GtfsRealtimeHttpTripUpdateSource.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/GtfsRealtimeHttpTripUpdateSource.java
@@ -51,7 +51,7 @@ public class GtfsRealtimeHttpTripUpdateSource implements TripUpdateSource, JsonC
         List<TripUpdate> updates = null;
         fullDataset = true;
         try {
-            InputStream is = HttpUtils.getData(url);
+            InputStream is = HttpUtils.getData(url, "Accept", "application/x-google-protobuf; application/octet-stream; */*");
             if (is != null) {
                 // Decode message
                 feedMessage = FeedMessage.PARSER.parseFrom(is);

--- a/src/test/java/org/opentripplanner/geocoder/bano/BanoGeocoderTest.java
+++ b/src/test/java/org/opentripplanner/geocoder/bano/BanoGeocoderTest.java
@@ -27,7 +27,7 @@ public class BanoGeocoderTest {
 
         boolean found = false;
         for (GeocoderResult result : results.getResults()) {
-            if ("55 Rue du Faubourg Saint-Honoré 75008 Paris".equals(result.getDescription())) {
+            if (result.getDescription().contains("55 Rue du Faubourg")) {
                 double dist = SphericalDistanceLibrary.distance(result.getLat(),
                         result.getLng(), 48.870637, 2.316939);
                 assert (dist < 100);

--- a/src/test/java/org/opentripplanner/routing/trippattern/FrequencyEntryTest.java
+++ b/src/test/java/org/opentripplanner/routing/trippattern/FrequencyEntryTest.java
@@ -22,11 +22,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Test;
-import org.onebusaway.gtfs.model.AgencyAndId;
-import org.onebusaway.gtfs.model.Frequency;
-import org.onebusaway.gtfs.model.Stop;
-import org.onebusaway.gtfs.model.StopTime;
-import org.onebusaway.gtfs.model.Trip;
+import org.opentripplanner.model.FeedScopedId;
+import org.opentripplanner.model.Frequency;
+import org.opentripplanner.model.Stop;
+import org.opentripplanner.model.StopTime;
+import org.opentripplanner.model.Trip;
 
 public class FrequencyEntryTest {
 
@@ -35,13 +35,13 @@ public class FrequencyEntryTest {
 
     static {
         Trip trip = new Trip();
-        trip.setId(new AgencyAndId("agency", "testtrip"));
+        trip.setId(new FeedScopedId("agency", "testtrip"));
 
         List<StopTime> stopTimes = new ArrayList<StopTime>();
 
         int time = 0;
         for(int i = 0; i < STOP_NUM; ++i) {
-            AgencyAndId id = new AgencyAndId("agency", i+"");
+            FeedScopedId id = new FeedScopedId("agency", i+"");
 
             Stop stop= new Stop();
             stop.setId(id);

--- a/src/test/java/org/opentripplanner/routing/trippattern/FrequencyEntryTest.java
+++ b/src/test/java/org/opentripplanner/routing/trippattern/FrequencyEntryTest.java
@@ -1,0 +1,124 @@
+/* This program is free software: you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public License
+ as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+package org.opentripplanner.routing.trippattern;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+import org.onebusaway.gtfs.model.AgencyAndId;
+import org.onebusaway.gtfs.model.Frequency;
+import org.onebusaway.gtfs.model.Stop;
+import org.onebusaway.gtfs.model.StopTime;
+import org.onebusaway.gtfs.model.Trip;
+
+public class FrequencyEntryTest {
+
+    private static final int STOP_NUM = 8;
+    private static final TripTimes tripTimes;
+
+    static {
+        Trip trip = new Trip();
+        trip.setId(new AgencyAndId("agency", "testtrip"));
+
+        List<StopTime> stopTimes = new ArrayList<StopTime>();
+
+        int time = 0;
+        for(int i = 0; i < STOP_NUM; ++i) {
+            AgencyAndId id = new AgencyAndId("agency", i+"");
+
+            Stop stop= new Stop();
+            stop.setId(id);
+
+            StopTime stopTime = new StopTime();
+            stopTime.setStop(stop);
+            stopTime.setArrivalTime(time);
+            if(i != 0 && i != STOP_NUM - 1) {
+                time += 10;
+            }
+            stopTime.setDepartureTime(time);
+            time += 90;
+            stopTime.setStopSequence(i);
+            stopTimes.add(stopTime);
+        }
+
+        tripTimes = new TripTimes(trip, stopTimes, new Deduplicator());
+    }
+
+    private static FrequencyEntry make(int startTime, int endTime, int headwaySecs, boolean exact) {
+        Frequency f = new Frequency();
+        f.setStartTime(startTime);
+        f.setEndTime(endTime);
+        f.setHeadwaySecs(headwaySecs);
+        f.setExactTimes(exact ? 1 : 0);
+
+        return new FrequencyEntry(f, tripTimes);
+    }
+
+    @Test
+    public void testExactFrequencyProperEnd() {
+        FrequencyEntry fe = make(100000, 150000, 100, true);
+        assertEquals(149900, fe.nextDepartureTime(0, 149900));
+        assertEquals(-1,     fe.nextDepartureTime(0, 150000));
+    }
+
+    @Test
+    public void testExactFrequencyStopOffset() {
+        FrequencyEntry fe = make(100000, 150001, 100, true);
+
+        // testing first trip departure
+        assertEquals(100000, fe.nextDepartureTime(0, 100000)); // first stop, on begin
+        assertEquals(100500, fe.nextDepartureTime(5, 100000)); // 6th stop, before begin
+
+        // testing last trip departure
+        assertEquals(150000, fe.nextDepartureTime(0, 150000)); // 1st stop, on end
+        assertEquals(-1,     fe.nextDepartureTime(0, 150100)); // 1st stop, after end
+        assertEquals(150100, fe.nextDepartureTime(1, 150100)); // 2nd stop, on end
+        assertEquals(150500, fe.nextDepartureTime(5, 150500)); // 6th stop, on end
+        assertEquals(-1,     fe.nextDepartureTime(5, 150600)); // 6th stop, after end
+
+        // testing first trip arrival
+        assertEquals(-1,     fe.prevArrivalTime(4, 100300)); // 5th stop, before begin
+        assertEquals(100390, fe.prevArrivalTime(4, 100400)); // 5th stop, after begin
+        assertEquals(-1,     fe.prevArrivalTime(7, 100600)); // 8th stop, before begin
+        assertEquals(100690, fe.prevArrivalTime(7, 100700)); // 8th stop, after begin
+
+        // testing last trip arrival
+        assertEquals(150390, fe.prevArrivalTime(4, 150700)); // 5th stop
+        assertEquals(150690, fe.prevArrivalTime(7, 150700)); // 8th stop, on end
+        assertEquals(150690, fe.prevArrivalTime(7, 150750)); // 8th stop, after end
+    }
+
+    @Test
+    public void testInexactFrequencyStopOffset() {
+        FrequencyEntry fe = make(100000, 150000, 100, false);
+
+        // testing last trip departure
+        assertEquals(149900, fe.nextDepartureTime(0, 149800)); // 1st stop, before end
+        assertEquals(-1,     fe.nextDepartureTime(0, 150100)); // 1st stop, after end
+        assertEquals(150400, fe.nextDepartureTime(5, 150300)); // 6th stop, before end
+        assertEquals(-1,     fe.nextDepartureTime(5, 150600)); // 6th stop, after end
+
+        // testing first trip arrival
+        assertEquals(-1,     fe.prevArrivalTime(4, 100300)); // 5th stop, before begin
+        assertEquals(100400, fe.prevArrivalTime(4, 100500)); // 5th stop, after begin
+        assertEquals(-1,     fe.prevArrivalTime(7, 100600)); // 8th stop, before begin
+        assertEquals(100700, fe.prevArrivalTime(7, 100800)); // 8th stop, after begin
+    }
+}


### PR DESCRIPTION
This PR simply cherry-picks all commits from #2540, #2739, #2799, and #2797 (which were included in the OTP v1.4 release) over onto OTP2.