### PR TITLE
Retry edge traversal if turn restriction encountered while using bike

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.5 (in progress)
+
+- Fix edge case of generating walk steps from SimpleTransfer that encountered a turn restriction while not walking (#2802)
+
 ## 1.4 (2019-07-30)
 
 - Remove Open Traffic prototype code (#2698)

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
@@ -415,8 +415,32 @@ public class StreetEdge extends Edge implements Cloneable {
 
             // Apply turn restrictions
             if (options.arriveBy && !canTurnOnto(backPSE, s0, backMode)) {
-                return null;
+                // A turn restriction exists that forbids this turn with the current traverseMode.
+                // If using a bike, try again while walking
+                if (traverseMode == TraverseMode.BICYCLE) {
+                    return doTraverse(s0, options.bikeWalkingOptions, TraverseMode.WALK);
+                }
+                // After trying again with switching to walking, the backMode will not have changed. Therefore, this
+                // conditional makes an assumption that a transition from non-walking to walking occurs at the very end
+                // of the last state. In this case it might be possible to make said turn if an immediate transition to
+                // walking is assumed at the very end of the previous state.
+                else if (
+                    traverseMode == TraverseMode.WALK &&
+                        backMode != TraverseMode.WALK &&
+                        canTurnOnto(backPSE, s0, TraverseMode.WALK)
+                ) {
+                    // the turn is now possible with the assumption that a transition to walking occurred at the very
+                    // end of the last StreetEdge of the back state.
+                    // Do nothing here in order to continue the traversal and avoid returning null.
+                } else {
+                    return null;
+                }
             } else if (!options.arriveBy && !backPSE.canTurnOnto(this, s0, traverseMode)) {
+                // A turn restriction exists that forbids this turn with the current traverseMode.
+                // If using a bike, try again while walking
+                if (traverseMode == TraverseMode.BICYCLE) {
+                    return doTraverse(s0, options.bikeWalkingOptions, TraverseMode.WALK);
+                }
                 return null;
             }
 


### PR DESCRIPTION
- [x] **issue**: Fixes #2802
- [x] **roadmap**: Is bug fix.
- [ ] **tests**: Haven't added any specific tests related to this issue. I wanted to, but needed to move on to other stuff. :(
- [x] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#code-style)? 
- [x] **documentation**: Added lots of comments
- [x] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)

This PR seeks to resolve the specific edge case reported in opentripplanner#2802. The solution proposed here is if a bicycle mode is being used and a turn restriction is encountered, the StreetEdge traversal is retried, but after a transition to walking the bicycle has occurred. This way, walk steps that are calculated while expanding the pre-calculated edges in a SimpleTransfer instance can properly occur when walking is required.