### PR TITLE
Add documentation for PlannerResource#mode

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -4,6 +4,7 @@
 
 - Add Way Property Set for the UK (#2818)
 - Fixes surefire test failure during build (#2816)
+- Improve documentation for `mode` routing parameter (#2809)
 
 ## 1.4 (2019-07-30)
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -79,7 +79,7 @@ config key | description | value type | value default | notes
 `subwayAccessTime` | Minutes necessary to reach stops served by trips on routes of `route_type=1` (subway) from the street | double | 2.0 | units: minutes
 `streets` | Include street input files (OSM/PBF) | boolean | true | 
 `embedRouterConfig` | Embed the Router config in the graph, which allows it to be sent to a server fully configured over the wire | boolean | true |
-`areaVisibility` | Perform visibility calculations on OSM areas (these calculations can be time consuming) | boolean | true |
+`areaVisibility` | Perform visibility calculations. If this is `true` OTP attempts to calculate a path straight through an OSM area using the shortest way rather than around the edge of it. (These calculations can be time consuming). | boolean | false |
 `platformEntriesLinking` | Link unconnected entries to public transport platforms | boolean | false |
 `matchBusRoutesToStreets` | Based on GTFS shape data, guess which OSM streets each bus runs on to improve stop linking | boolean | false |
 `fetchElevationUS` | Download US NED elevation data and apply it to the graph | boolean | false |

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -349,7 +349,7 @@ internally that are not exposed via the API. You may want to change the default 
 i.e. the value which will be applied unless it is overridden in a web API request.
 
 A full list of them can be found in the RoutingRequest class
-[in the Javadoc](http://dev.opentripplanner.org/javadoc/1.3.0/org/opentripplanner/routing/core/RoutingRequest.html).
+[in the Javadoc](http://dev.opentripplanner.org/javadoc/1.4.0/org/opentripplanner/routing/core/RoutingRequest.html).
 Any public field or setter method in this class can be given a default value using the routingDefaults section of
 `router-config.json` as follows:
 
@@ -362,6 +362,78 @@ Any public field or setter method in this class can be given a default value usi
     }
 }
 ```
+
+## Routing modes
+
+The routing request parameter `mode` determines which transport modalities should be considered when calculating the list
+of routes.
+
+Some modes (mostly bicycle and car) also have optional qualifiers `RENT` and `PARK` to specify if vehicles are to be parked at a station or rented. In theory
+this can also apply to other modes but makes sense only in select cases which are listed below.
+
+Whether a transport mode is available highly depends on the input feeds (GTFS, OSM, bike sharing feeds) and the graph building options supplied to OTP.
+
+The complete list of modes are:
+
+- `WALK`: Walking some or all of the route.
+
+- `TRANSIT`: General catch-all for all public transport modes.
+
+- `BICYCLE`: Cycling for the entirety of the route or taking a bicycle onto the public transport and cycling from the arrival station to the destination.
+
+- `BICYCLE_RENT`: Taking a rented, shared-mobility bike for part or the entirety of the route.  
+
+    _Prerequisite:_ Vehicle positions need to be added to OTP either as static stations or dynamic data feeds. 
+
+    For dynamic bike positions configure an input feed. See [Configuring real-time updaters](Configuration.md#configuring-real-time-updaters).
+
+    For static stations check the graph building documentation for the property `staticBikeRental`.
+
+- `BICYCLE_PARK`: Leaving the bicycle at the departure station and walking from the arrival station to the destination.
+
+    This mode needs to be combined with at least one transit mode (or `TRANSIT`) otherwise it behaves like an ordinary bicycle journey.
+
+    _Prerequisite:_ Bicycle parking stations present in the OSM file and visible to OTP by enabling the property `staticBikeParkAndRide` during graph build.
+
+- `CAR`: Driving your own car the entirety of the route. 
+
+    If this is combined with `TRANSIT` it will return routes with a 
+    [Kiss & Ride](https://en.wikipedia.org/wiki/Park_and_ride#Kiss_and_ride_/_kiss_and_fly) component. This means that the car is not parked in a permanent
+    parking area but rather the passenger is dropped off (for example, at an airport) and the driver continues driving the car away from the drop off
+    location.
+
+- `CAR_PARK`: Driving a car to the park-and-ride facilities near a station and taking public transport.
+
+    This mode needs to be combined with at least one transit mode (or `TRANSIT`) otherwise it behaves like an ordinary car journey.
+
+    _Prerequisite:_ Park-and-ride areas near the station need to be present in the OSM input file.
+
+
+The following modes are 1-to-1 mappings from the [GTFS `route_type`](https://developers.google.com/transit/gtfs/reference/#routestxt):
+
+- `TRAM`: Tram, streetcar, or light rail. Used for any light rail or street-level system within a metropolitan area.
+
+- `SUBWAY`: Subway or metro. Used for any underground rail system within a metropolitan area.
+
+- `RAIL`: Used for intercity or long-distance travel.
+
+- `BUS`: Used for short- and long-distance bus routes.
+
+- `FERRY`: Ferry. Used for short- and long-distance boat service.
+
+- `CABLE_CAR`: Cable car. Used for street-level cable cars where the cable runs beneath the car.
+
+- `GONDOLA`: Gondola or suspended cable car. Typically used for aerial cable cars where the car is suspended from the cable.
+
+- `FUNICULAR`: Funicular. Used for any rail system that moves on steep inclines with a cable traction system.
+
+Lastly, this mode is part of the [Extended GTFS route types](https://developers.google.com/transit/gtfs/reference/extended-route-types):
+
+- `AIRPLANE`: Taking an airplane.
+
+Note that there are conceptual overlaps between `TRAM`, `SUBWAY` and `RAIL` and some transport providers categorize their routes differently to others.
+In other words, what is considered a `SUBWAY` in one city might be of type `RAIL` in another. Study your input GTFS feed carefully to 
+find out the appropriate mapping in your region.
 
 ### Drive-to-transit routing defaults
 
@@ -621,4 +693,4 @@ url: the URL of the GBFS feed (do not include the gbfs.json at the end) *
 
 # Configure using command-line arguments
 
-Certain settings can be provided on the command line, when starting OpenTripPlanner. See the `CommandLineParameters` class for [a full list of arguments](http://dev.opentripplanner.org/javadoc/1.3.0/org/opentripplanner/standalone/CommandLineParameters.html).
+Certain settings can be provided on the command line, when starting OpenTripPlanner. See the `CommandLineParameters` class for [a full list of arguments](http://dev.opentripplanner.org/javadoc/1.4.0/org/opentripplanner/standalone/CommandLineParameters.html).

--- a/src/main/java/org/opentripplanner/api/common/RoutingResource.java
+++ b/src/main/java/org/opentripplanner/api/common/RoutingResource.java
@@ -151,7 +151,40 @@ public abstract class RoutingResource {
     @QueryParam("optimize")
     protected OptimizeType optimize;
     
-    /** The set of modes that a user is willing to use, with qualifiers stating whether vehicles should be parked, rented, etc. */
+    /**
+     * <p>The set of modes that a user is willing to use, with qualifiers stating whether vehicles should be parked, rented, etc.</p>
+     * <p>The possible values of the comma-separated list are:</p>
+     *
+     * <ul>
+     *  <li>WALK</li>
+     *  <li>TRANSIT: General catch-all for all public transport modes.</li>
+     *  <li>BICYCLE: Taking a bicycle onto the public transport and cycling from the arrival station to the destination.</li>
+     *  <li>BICYCLE_RENT: Taking a rented, shared-mobility bike for part or the entirety of the route.
+     *      <br>
+     *      <em>Prerequisite:</em> Vehicle positions need to be added to OTP either as static stations or dynamic data feeds.
+     *      For static stations check the graph building documentation for the property <code>staticBikeRental</code>.
+     *  </li>
+     *  <li>BICYCLE_PARK: Leaving the bicycle at the departure station and walking from the arrival station to the destination.
+     *      <br>
+     *      <em>Prerequisite:</em> Bicycle parking stations near the station and visible to OTP by enabling the property <code>staticBikeParkAndRide</code>
+     *      during graph build.
+     *   </li>
+     *  <li>CAR</li>
+     *  <li>CAR_PARK: Driving a car to the park-and-ride facilities near a station and taking public transport.
+     *      <br>
+     *      <em>Prerequisite:</em> Park-and-ride areas near the station and visible to OTP by enabling the property <code>staticParkAndRide</code>
+     *      during graph build.
+     *  </li>
+     *  <li>TRAM</li>
+     *  <li>SUBWAY</li>
+     *  <li>RAIL</li>
+     *  <li>BUS</li>
+     *  <li>FERRY</li>
+     *  <li>CABLE_CAR</li>
+     *  <li>GONDOLA</li>
+     *  <li>AIRPLANE</li>
+     * </ul>
+     */
     @QueryParam("mode")
     protected QualifiedModeSet modes;
 

--- a/src/main/java/org/opentripplanner/api/common/RoutingResource.java
+++ b/src/main/java/org/opentripplanner/api/common/RoutingResource.java
@@ -157,33 +157,26 @@ public abstract class RoutingResource {
      *
      * <ul>
      *  <li>WALK</li>
-     *  <li>TRANSIT: General catch-all for all public transport modes.</li>
-     *  <li>BICYCLE: Taking a bicycle onto the public transport and cycling from the arrival station to the destination.</li>
-     *  <li>BICYCLE_RENT: Taking a rented, shared-mobility bike for part or the entirety of the route.
-     *      <br>
-     *      <em>Prerequisite:</em> Vehicle positions need to be added to OTP either as static stations or dynamic data feeds.
-     *      For static stations check the graph building documentation for the property <code>staticBikeRental</code>.
-     *  </li>
-     *  <li>BICYCLE_PARK: Leaving the bicycle at the departure station and walking from the arrival station to the destination.
-     *      <br>
-     *      <em>Prerequisite:</em> Bicycle parking stations near the station and visible to OTP by enabling the property <code>staticBikeParkAndRide</code>
-     *      during graph build.
-     *   </li>
+     *  <li>TRANSIT</li>
+     *  <li>BICYCLE</li>
+     *  <li>BICYCLE_RENT</li>
+     *  <li>BICYCLE_PARK</li>
      *  <li>CAR</li>
-     *  <li>CAR_PARK: Driving a car to the park-and-ride facilities near a station and taking public transport.
-     *      <br>
-     *      <em>Prerequisite:</em> Park-and-ride areas near the station and visible to OTP by enabling the property <code>staticParkAndRide</code>
-     *      during graph build.
-     *  </li>
+     *  <li>CAR_PARK</li>
      *  <li>TRAM</li>
      *  <li>SUBWAY</li>
      *  <li>RAIL</li>
      *  <li>BUS</li>
-     *  <li>FERRY</li>
      *  <li>CABLE_CAR</li>
+     *  <li>FERRY</li>
      *  <li>GONDOLA</li>
+     *  <li>FUNICULAR</li>
      *  <li>AIRPLANE</li>
      * </ul>
+     *
+     * <p>
+     *   For a more complete discussion of this parameter see <a href="http://docs.opentripplanner.org/en/latest/Configuration/#routing-modes">Routing modes</a>.
+     * </p>
      */
     @QueryParam("mode")
     protected QualifiedModeSet modes;


### PR DESCRIPTION
Since this is purely about documentation I took the liberty to remove the PR checklist. I hope this is acceptable.

I was confused about the mode parameter, and especially about the qualifiers like BICYCLE_PARK and BICYCLE_RENT so I experimented and dug through the code.

The documentation contained in the PR are the result of my findings.

I'm very happy to discuss the format and content.

Thanks for OTP - it's a great piece of software!