### PR TITLE
Update tutorial links to documentation, to use version 1.4.0 instead of 1.0.0

### DIFF
--- a/docs/Basic-Tutorial.md
+++ b/docs/Basic-Tutorial.md
@@ -80,4 +80,4 @@ There are a number of different resources available through the HTTP API. Beside
 
 - Return all unique sequences of stops on the TriMet Green rail line: [http://localhost:8080/otp/routers/default/index/routes/TriMet:4/patterns](http://localhost:8080/otp/routers/default/index/routes/TriMet:4/patterns)
 
-We refer to this as the Index API. It is also documented [in the OTP HTTP API docs](http://dev.opentripplanner.org/apidoc/1.0.0/resource_IndexAPI.html).
+We refer to this as the Index API. It is also documented [in the OTP HTTP API docs](http://dev.opentripplanner.org/apidoc/1.4.0/resource_IndexAPI.html).

--- a/docs/Intermediate-Tutorial.md
+++ b/docs/Intermediate-Tutorial.md
@@ -7,7 +7,7 @@ One of the most important ways that OpenTripPlanner is used is, of course, the p
 
 [`http://localhost:8080/otp/routers/default/plan?fromPlace=43.637,-79.434&toPlace=43.646,-79.388&time=1:02pm&date=11-14-2017&mode=TRANSIT,WALK&maxWalkDistance=500&arriveBy=false`](http://localhost:8080/otp/routers/default/plan?fromPlace=43.637,-79.434&toPlace=43.646,-79.388&time=1:02pm&date=11-14-2017&mode=TRANSIT,WALK&maxWalkDistance=500&arriveBy=false)
 
-The above query makes a request to the locally running server `http://localhost:8080/`, requesting the [planner resource](http://dev.opentripplanner.org/apidoc/1.0.0/resource_PlannerResource.html) `...otp/routers/default/plan`, and passes the following parameters:
+The above query makes a request to the locally running server `http://localhost:8080/`, requesting the [planner resource](http://dev.opentripplanner.org/apidoc/1.4.0/resource_PlannerResource.html) `...otp/routers/default/plan`, and passes the following parameters:
 
 - **fromPlace=43.637,-79.434**, the origin of the trip, in latitude, longitude
 - **toPlace=43.646,-79.388**, the destination of the trip
@@ -17,7 +17,7 @@ The above query makes a request to the locally running server `http://localhost:
 - **mode=TRANSIT,WALK**, transport modes to consider, in this case a combination of walking and transit
 - **maxWalkDistance=500**, the maximum distance in meters that you are willing to walk
 
-If you run this query as is you will very likely get a response saying that a trip has not been found. Try changing the fromPlace, toPlace, time and date parameters to match the location and time period of the data you loaded when you initially built the graph. More (optional) parameters for the planner resource are documented [here](http://dev.opentripplanner.org/apidoc/1.0.0/resource_PlannerResource.html). 
+If you run this query as is you will very likely get a response saying that a trip has not been found. Try changing the fromPlace, toPlace, time and date parameters to match the location and time period of the data you loaded when you initially built the graph. More (optional) parameters for the planner resource are documented [here](http://dev.opentripplanner.org/apidoc/1.4.0/resource_PlannerResource.html). 
 
 
 ## Calculating travel time isochrones
@@ -27,7 +27,7 @@ OpenTripPlanner can also be used to calculate the area which is accessible from 
 
 (_Image courtesy of [marcusyoung](https://github.com/marcusyoung)_)
 
-Here we'll use of the [LIsochrone resource](http://dev.opentripplanner.org/apidoc/1.0.0/resource_LIsochrone.html) in the following query:
+Here we'll use of the [LIsochrone resource](http://dev.opentripplanner.org/apidoc/1.4.0/resource_LIsochrone.html) in the following query:
 
 [`http://localhost:8080/otp/routers/ttc/isochrone?fromPlace=43.637,-79.434&mode=WALK,TRANSIT&date=11-14-2017&time=8:00am&maxWalkDistance=500&cutoffSec=1800&cutoffSec=3600`](http://localhost:8080/otp/routers/ttc/isochrone?fromPlace=43.637,-79.434&mode=WALK,TRANSIT&date=11-14-2017&time=8:00am&maxWalkDistance=500&cutoffSec=1800&cutoffSec=3600)
 
@@ -38,11 +38,11 @@ Many of the parameters in this GET request should be familiar from the last exam
 - **cutoffSec=3600** the second (optional) specification of this parameter means that we'll get a second result, this time one hour (3600 seconds) from the origin
 - **cutoffSec=...** this argument can be passed any number of times with diferent values. 
 
-The result of the above query, if all goes well, is a geoJSON file with two multipolygons showing the area accessible within both one and one-half hour. Take a look at the [LIsochrone resource](http://dev.opentripplanner.org/apidoc/1.0.0/resource_LIsochrone.html) page for additional options. 
+The result of the above query, if all goes well, is a geoJSON file with two multipolygons showing the area accessible within both one and one-half hour. Take a look at the [LIsochrone resource](http://dev.opentripplanner.org/apidoc/1.4.0/resource_LIsochrone.html) page for additional options. 
 
 ## Additional resources and documentation
 See the [configuration](Configuration.md) page for configuration settings which effect either the router instance or the graph building process (e.g. fare settings, elevation models, request logging, transfer settings, etc.). 
 
 It may also be helpful to try running the OTP .jar file with the `--help` option for a full list of command line parameters. 
 
-Full documentation for the API is available [here](http://dev.opentripplanner.org/apidoc/1.0.0/index.html#resources).
+Full documentation for the API is available [here](http://dev.opentripplanner.org/apidoc/1.4.0/index.html#resources).


### PR DESCRIPTION
OTP.org's tutorial pages point to HTTP API documentation (from OTP version 1.0.0) that is slightly out-of-date and (more importantly) is missing request-response examples present in later doc versions (that do the heft of illustrating the usefulness of each endpoint). It was confusing to me as a new-to-OTP developer reading the 1.0.0 documentation that was linked, until I found that version 1.4.0 was the most recent released Git tag and tried to update the URL path in my browser. (Unfortunately, [it doesn't seem like `apidoc` is serving](http://dev.opentripplanner.org/apidoc/) a `latest` alias that could be used instead of hardcoding to `1.4.0`.)

I also couldn't quite grok whether such a `./doc`-only PR should be made to `dev-1.x`, `master`, or both `dev-1.x` and `dev-2.x` branches, so let me know if I've made a PR against the wrong one.