### PR TITLE
Remove trips added by realtime messages #2810

### DIFF
--- a/src/main/java/org/opentripplanner/routing/edgetype/TimetableSnapshot.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/TimetableSnapshot.java
@@ -99,6 +99,7 @@ public class TimetableSnapshot {
      * <p>
      * This is a HashMap and not a Map so the clone function is available.
      * </p>
+     * TODO clarify what it means to say "last" added trip pattern. There can be more than one? What happens to the older ones?
      */
     private HashMap<TripIdAndServiceDate, TripPattern> lastAddedTripPattern = new HashMap<>();
     
@@ -143,6 +144,7 @@ public class TimetableSnapshot {
      * Get the last <b>added</b> trip pattern given a trip id (without agency) and a service date as
      * a result of a call to {@link #update(String feedId, TripPattern, TripTimes, ServiceDate)} with trip times of
      * a trip that didn't exist yet in the trip pattern.
+     * TODO clarify what it means to say "last" added trip pattern. There can be more than one? What happens to the older ones?
      *
      * @param feedId feed id the trip id belongs to
      * @param tripId trip id (without agency)

--- a/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
@@ -324,6 +324,10 @@ public class TimetableSnapshotSource {
             return false;
         }
 
+        // If this trip_id has been used for previously ADDED/MODIFIED trip message (e.g. when the sequence of stops has
+        // changed, and is now changing back to the originally scheduled one) cancel that previously created trip.
+        cancelPreviouslyAddedTrip(feedId, tripId, serviceDate);
+
         // Apply update on the *scheduled* time table and set the updated trip times in the buffer
         final TripTimes updatedTripTimes = pattern.scheduledTimetable.createUpdatedTripTimes(tripUpdate,
                 timeZone, serviceDate);
@@ -747,7 +751,10 @@ public class TimetableSnapshotSource {
 
     /**
      * Cancel previously added trip from buffer if there is a previously added trip with given trip
-     * id (without agency id) on service date
+     * id (without agency id) on service date. This does not remove the modified/added trip from the buffer, it just
+     * marks it as canceled. This also does not remove the corresponding vertices and edges from the Graph. Any
+     * TripPattern that was created for the added/modified trip continues to exist, and will be reused if a similar
+     * added/modified trip message is received with the same route and stop sequence.
      *
      * @param feedId feed id the trip id belongs to
      * @param tripId trip id without agency id
@@ -923,7 +930,7 @@ public class TimetableSnapshotSource {
     }
 
     /**
-     * Retrieve a trip pattern given a feed id and trid id.
+     * Retrieve a trip pattern given a feed id and trip id.
      *
      * @param feedId feed id for the trip id
      * @param tripId trip id without agency


### PR DESCRIPTION
This PR addresses issue #2810. It is a one-line bugfix (with some comments added along the way). 

Note, I have been able to verify that realtime updates continue to work after this change, but I have not been able to verify that this actually fixes the original problem. This is because I have no data that reproduces the situation where we transition from a modified (rerouted) trip back to the originally scheduled trip with realtime delay information. But based on the way these methods are used for other realtime message types, this looks like the correct approach.

Hopefully @lassetyr or I can empirically verify correctness of this approach once we have SIRI support moved over to the main OTP repo (in 2.x).