### PR TITLE
Fix accept header

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2,6 +2,7 @@
 
 ## 1.5.0 (in progress)
 
+- Add application/x-protobuf to accepted protobuf content-types (#2839)
 - Add Way Property Set for the UK (#2818)
 - Fixes surefire test failure during build (#2816)
 - Improve documentation for `mode` routing parameter (#2809)

--- a/src/main/java/org/opentripplanner/updater/alerts/GtfsRealtimeAlertsUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/alerts/GtfsRealtimeAlertsUpdater.java
@@ -88,7 +88,7 @@ public class GtfsRealtimeAlertsUpdater extends PollingGraphUpdater {
             InputStream data = HttpUtils.getData(
                     url,
                     "Accept",
-                    "application/x-google-protobuf; application/x-protobuf; application/protobuf; application/octet-stream; */*");
+                    "application/x-google-protobuf, application/x-protobuf, application/protobuf, application/octet-stream, */*");
             if (data == null) {
                 throw new RuntimeException("Failed to get data from url " + url);
             }

--- a/src/main/java/org/opentripplanner/updater/alerts/GtfsRealtimeAlertsUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/alerts/GtfsRealtimeAlertsUpdater.java
@@ -85,7 +85,10 @@ public class GtfsRealtimeAlertsUpdater extends PollingGraphUpdater {
     @Override
     protected void runPolling() {
         try {
-            InputStream data = HttpUtils.getData(url, "Accept", "application/x-google-protobuf; application/octet-stream; */*");
+            InputStream data = HttpUtils.getData(
+                    url,
+                    "Accept",
+                    "application/x-google-protobuf; application/x-protobuf; application/protobuf; application/octet-stream; */*");
             if (data == null) {
                 throw new RuntimeException("Failed to get data from url " + url);
             }

--- a/src/main/java/org/opentripplanner/updater/stoptime/GtfsRealtimeHttpTripUpdateSource.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/GtfsRealtimeHttpTripUpdateSource.java
@@ -51,7 +51,10 @@ public class GtfsRealtimeHttpTripUpdateSource implements TripUpdateSource, JsonC
         List<TripUpdate> updates = null;
         fullDataset = true;
         try {
-            InputStream is = HttpUtils.getData(url, "Accept", "application/x-google-protobuf; application/octet-stream; */*");
+            InputStream is = HttpUtils.getData(
+                    url,
+                    "Accept",
+                    "application/x-google-protobuf; application/x-protobuf; application/protobuf; application/octet-stream; */*");
             if (is != null) {
                 // Decode message
                 feedMessage = FeedMessage.PARSER.parseFrom(is);

--- a/src/main/java/org/opentripplanner/updater/stoptime/GtfsRealtimeHttpTripUpdateSource.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/GtfsRealtimeHttpTripUpdateSource.java
@@ -54,7 +54,7 @@ public class GtfsRealtimeHttpTripUpdateSource implements TripUpdateSource, JsonC
             InputStream is = HttpUtils.getData(
                     url,
                     "Accept",
-                    "application/x-google-protobuf; application/x-protobuf; application/protobuf; application/octet-stream; */*");
+                    "application/x-google-protobuf, application/x-protobuf, application/protobuf, application/octet-stream, */*");
             if (is != null) {
                 // Decode message
                 feedMessage = FeedMessage.PARSER.parseFrom(is);


### PR DESCRIPTION
Seems like application/x-google-protobuf and application/octet-stream are not the only types that feed publishers use. I added couple of other popular ones. Also more crucially, fixed the separator between different options that prevented wildcard (`*/*`) matcher from working in certain servers. 

Fixes https://github.com/opentripplanner/OpenTripPlanner/issues/2839.

To be completed by pull request submitter:

- [x] **issue**: Link to or create an [issue](https://github.com/opentripplanner/OpenTripPlanner/issues) that describes the relevant feature or bug. Add [GitHub keywords](https://help.github.com/articles/closing-issues-using-keywords/) to this PR's description (e.g., `closes #45`).
- [ ] **roadmap**: Check the [roadmap](https://github.com/orgs/opentripplanner/projects/1) for this feature or bug. If it is not already on the roadmap, PLC will discuss as part of the review process.
- [ ] **tests**: Have you added relevant test coverage? Are all the tests passing on [the continuous integration service (Travis CI)](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#continuous-integration)?
- [ ] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#code-style)? 
- [ ] **documentation**: If you are adding a new configuration option, have you added an explanation to the [configuration documentation](docs/Configuration.md) tables and sections?
- [x] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)