### PR TITLE
Refactor StreetWithElevationEdge and use effectiveDistance for transfers

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -7,6 +7,7 @@
 - Remove redundant LineStrings in order to save memory (#2795)
 - NeTEx import support (#2769).
 - Added NeTEx notices (#2824)
+- Make transfers and access/egress use effectiveWalkDistance to take slopes into account (#2857)
 
 ## Ported over from the 1.x
 - Add application/x-protobuf to accepted protobuf content-types (#2839)

--- a/src/main/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverter.java
+++ b/src/main/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverter.java
@@ -341,7 +341,7 @@ public abstract class GraphPathToTripPlanConverter {
         leg.distance = 0.0;
         for (int i = 0; i < edges.length; i++) {
             edges[i] = states[i + 1].getBackEdge();
-            leg.distance += edges[i].getDistance();
+            leg.distance += edges[i].getDistanceMeters();
         }
 
         TimeZone timeZone = leg.startTime.getTimeZone();
@@ -1054,7 +1054,7 @@ public abstract class GraphPathToTripPlanConverter {
                     step.setDirections(previous.angle, thisAngle, false);
                 }
                 // new step, set distance to length of first edge
-                distance = edge.getDistance();
+                distance = edge.getDistanceMeters();
             } else if (((step.streetName != null && !step.streetNameNoParens().equals(streetNameNoParens))
                     && (!step.bogusName || !edge.hasBogusName())) ||
                     edge.isRoundabout() != (roundaboutExit > 0) || // went on to or off of a roundabout
@@ -1086,7 +1086,7 @@ public abstract class GraphPathToTripPlanConverter {
                 double thisAngle = DirectionUtils.getFirstAngle(geom);
                 step.setDirections(lastAngle, thisAngle, edge.isRoundabout());
                 // new step, set distance to length of first edge
-                distance = edge.getDistance();
+                distance = edge.getDistanceMeters();
             } else {
                 /* street name has not changed */
                 double thisAngle = DirectionUtils.getFirstAngle(geom);
@@ -1163,7 +1163,7 @@ public abstract class GraphPathToTripPlanConverter {
                         step.setDirections(lastAngle, thisAngle, false);
                         step.stayOn = true;
                         // new step, set distance to length of first edge
-                        distance = edge.getDistance();
+                        distance = edge.getDistanceMeters();
                     }
                 }
             }
@@ -1248,12 +1248,12 @@ public abstract class GraphPathToTripPlanConverter {
                         step.elevation = s;
                     }
                 }
-                distance += edge.getDistance();
+                distance += edge.getDistanceMeters();
 
             }
 
             // increment the total length for this step
-            step.distance += edge.getDistance();
+            step.distance += edge.getDistanceMeters();
             step.addAlerts(graph.streetNotesService.getNotes(forwardState), requestedLocale);
             lastAngle = DirectionUtils.getLastAngle(geom);
 

--- a/src/main/java/org/opentripplanner/graph_builder/module/DirectTransferGenerator.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/DirectTransferGenerator.java
@@ -89,7 +89,7 @@ public class DirectTransferGenerator implements GraphBuilderModule {
             for (NearbyStopFinder.StopAtDistance sd : nearbyStopFinder.findNearbyStopsConsideringPatterns(ts0)) {
                 /* Skip the origin stop, loop transfers are not needed. */
                 if (sd.tstop == ts0 || pathwayDestinations.contains(sd.tstop)) continue;
-                new SimpleTransfer(ts0, sd.tstop, sd.dist, sd.geom, sd.edges);
+                new SimpleTransfer(ts0, sd.tstop, sd.dist, sd.edges);
                 n += 1;
             }
             LOG.debug("Linked stop {} to {} nearby stops on other patterns.", ts0.getStop(), n);

--- a/src/main/java/org/opentripplanner/graph_builder/module/NearbyStopFinder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/NearbyStopFinder.java
@@ -231,7 +231,7 @@ public class NearbyStopFinder {
      * TODO this should probably be merged with similar classes in Profile routing.
      */
     public static StopAtDistance stopAtDistanceForState (State state) {
-        double distance = 0.0;
+        double effectiveWalkDistance = 0.0;
         GraphPath graphPath = new GraphPath(state, false);
         CoordinateArrayListSequence coordinates = new CoordinateArrayListSequence();
         List<Edge> edges = new ArrayList<>();
@@ -245,7 +245,7 @@ public class NearbyStopFinder {
                         coordinates.extend(geometry.getCoordinates(), 1);
                     }
                 }
-                distance += edge.getDistance();
+                effectiveWalkDistance += edge.getEffectiveWalkDistance();
             }
             edges.add(edge);
         }
@@ -256,7 +256,7 @@ public class NearbyStopFinder {
             coordinateList.add(lastState.getVertex().getCoordinate());
             coordinates = new CoordinateArrayListSequence(coordinateList);
         }
-        StopAtDistance sd = new StopAtDistance((TransitStopVertex) state.getVertex(), distance);
+        StopAtDistance sd = new StopAtDistance((TransitStopVertex) state.getVertex(), effectiveWalkDistance);
         sd.geom = geometryFactory.createLineString(new PackedCoordinateSequence.Double(coordinates.toCoordinateArray()));
         sd.edges = edges;
         return sd;

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -218,7 +218,7 @@ public class ElevationModule implements GraphBuilderModule {
 
                 Double elevation = elevations.get(tov);
                 if (elevation != null) {
-                    double distance = e.getDistance();
+                    double distance = e.getDistanceMeters();
                     if (distance < bestDistance) {
                         bestDistance = distance;
                         bestElevation = elevation;
@@ -226,8 +226,8 @@ public class ElevationModule implements GraphBuilderModule {
                 } else {
                     // continue
                     ElevationRepairState newState = new ElevationRepairState(edge, state, tov,
-                            e.getDistance() + state.distance, state.initialElevation);
-                    pq.insert(newState, e.getDistance() + state.distance);
+                            e.getDistanceMeters() + state.distance, state.initialElevation);
+                    pq.insert(newState, e.getDistanceMeters() + state.distance);
                 }
             } // end loop over outgoing edges
 
@@ -241,7 +241,7 @@ public class ElevationModule implements GraphBuilderModule {
                     continue;
                 Double elevation = elevations.get(fromv);
                 if (elevation != null) {
-                    double distance = e.getDistance();
+                    double distance = e.getDistanceMeters();
                     if (distance < bestDistance) {
                         bestDistance = distance;
                         bestElevation = elevation;
@@ -249,8 +249,8 @@ public class ElevationModule implements GraphBuilderModule {
                 } else {
                     // continue
                     ElevationRepairState newState = new ElevationRepairState(edge, state, fromv,
-                            e.getDistance() + state.distance, state.initialElevation);
-                    pq.insert(newState, e.getDistance() + state.distance);
+                            e.getDistanceMeters() + state.distance, state.initialElevation);
+                    pq.insert(newState, e.getDistanceMeters() + state.distance);
                 }
             } // end loop over incoming edges
 
@@ -278,7 +278,7 @@ public class ElevationModule implements GraphBuilderModule {
                     }
                     if (state.backState == null)
                         break;
-                    bestDistance += state.backEdge.getDistance();
+                    bestDistance += state.backEdge.getDistanceMeters();
                     state = state.backState;
                     if (elevations.containsKey(state.vertex))
                         break;
@@ -308,7 +308,7 @@ public class ElevationModule implements GraphBuilderModule {
 
                     Coordinate[] coords = new Coordinate[2];
                     coords[0] = new Coordinate(0, fromElevation);
-                    coords[1] = new Coordinate(edge.getDistance(), toElevation);
+                    coords[1] = new Coordinate(edge.getDistanceMeters(), toElevation);
 
                     PackedCoordinateSequence profile = new PackedCoordinateSequence.Double(coords);
 

--- a/src/main/java/org/opentripplanner/index/IndexAPI.java
+++ b/src/main/java/org/opentripplanner/index/IndexAPI.java
@@ -591,7 +591,7 @@ public class IndexAPI {
         /** Make a transfer from a simpletransfer edge from the graph. */
         public Transfer(SimpleTransfer e) {
             toStopId = GtfsLibrary.convertIdToString(((TransitStopVertex) e.getToVertex()).getStop().getId());
-            distance = e.getDistance();
+            distance = e.getDistanceMeters();
         }
     }
 }

--- a/src/main/java/org/opentripplanner/index/IndexGraphQLSchema.java
+++ b/src/main/java/org/opentripplanner/index/IndexGraphQLSchema.java
@@ -279,7 +279,7 @@ public class IndexGraphQLSchema {
                     .filter(edge -> edge instanceof SimpleTransfer)
                     .map(edge -> new ImmutableMap.Builder<String, Object>()
                         .put("stop", ((TransitStopVertex) edge.getToVertex()).getStop())
-                        .put("distance", edge.getDistance())
+                        .put("distance", edge.getDistanceMeters())
                         .build())
                     .collect(Collectors.toList()))
                 .build())

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/router/street/AccessEgressRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/router/street/AccessEgressRouter.java
@@ -44,7 +44,7 @@ public class AccessEgressRouter {
             result.put(
                     stopAtDistance.tstop.getStop(),
                     new Transfer(-1,
-                            (int)stopAtDistance.edges.stream().map(Edge::getDistance)
+                            (int)stopAtDistance.edges.stream().map(Edge::getEffectiveWalkDistance)
                                     .collect(Collectors.summarizingDouble(Double::doubleValue)).getSum(),
                             stopAtDistance.edges));
         }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/router/street/TransferToAccessEgressLegMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/router/street/TransferToAccessEgressLegMapper.java
@@ -24,7 +24,11 @@ public class TransferToAccessEgressLegMapper {
             Stop stop = entry.getKey();
             Transfer transfer = entry.getValue();
             int stopIndex = transitLayer.getIndexByStop(stop);
-            Transfer newTransfer = new Transfer(stopIndex, transfer.getDistanceMeters());
+            Transfer newTransfer = new Transfer(
+                    stopIndex,
+                    transfer.getEffectiveWalkDistanceMeters(),
+                    transfer.getEdges()
+            );
             result.add(new TransferWithDuration(newTransfer, walkSpeed));
         }
         return result;

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/Transfer.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/Transfer.java
@@ -10,14 +10,6 @@ import java.util.List;
 public class Transfer {
     private int toStop;
 
-    /**
-     * The effective distance is defined as the value that divided by the speed will give the
-     * correct duration of the transfer. This takes into account slowdowns/speedups related to
-     * slopes. It can also account for other factors that affect the transfer duration, but all
-     * factors are required to be proportional to the speed. The reason we are doing this is so
-     * that we can calculate all transfer durations in a reasonable amount of time for each
-     * incoming request.
-     */
     private final int effectiveWalkDistanceMeters;
 
     private final List<Edge> edges;
@@ -40,6 +32,14 @@ public class Transfer {
 
     public int getToStop() { return toStop; }
 
+    /**
+     * The effective distance is defined as the value that divided by the speed will give the
+     * correct duration of the transfer. This takes into account slowdowns/speedups related to
+     * slopes. It can also account for other factors that affect the transfer duration, but all
+     * factors are required to be proportional to the speed. The reason we are doing this is so
+     * that we can calculate all transfer durations in a reasonable amount of time for each
+     * incoming request.
+     */
     public int getEffectiveWalkDistanceMeters() {
         return effectiveWalkDistanceMeters;
     }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/Transfer.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/Transfer.java
@@ -5,32 +5,26 @@ import org.opentripplanner.routing.graph.Edge;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 public class Transfer {
     private int toStop;
 
-    // TODO OTP2: we only have a distance field here but in other cases have more detail.
-    // Inside Raptor we need distance to apply walking speed on the fly to precomputed transfers;
-    // Outside raptor (in access and egress searches) we can actually have true travel times, because we compute
-    // throw-away request-scoped transfers that are specific to a single set of routing parameters.
-    // Keeping the transfers simplified to only distances which are scaled at search time makes it impossible to
-    // include slowdown due to slope, for example. We could store an "effective distance" which bakes the non-linear
-    // slope (and other) components into the distance, and then the linear speed scaling can be applied fast in routing.
-    private final int distanceMeters;
+    /**
+     * The effective distance is defined as the value that divided by the speed will give the
+     * correct duration of the transfer. This takes into account slowdowns/speedups related to
+     * slopes. It can also account for other factors that affect the transfer duration, but all
+     * factors are required to be proportional to the speed. The reason we are doing this is so
+     * that we can calculate all transfer durations in a reasonable amount of time for each
+     * incoming request.
+     */
+    private final int effectiveWalkDistanceMeters;
 
     private final List<Edge> edges;
 
-    public Transfer(int toStop, int distanceMeters) {
+    public Transfer(int toStop, int effectiveWalkDistanceMeters, List<Edge> edges) {
         this.toStop = toStop;
-        this.distanceMeters = distanceMeters;
-        this.edges = Collections.emptyList();
-    }
-
-    public Transfer(int toStop, int distanceMeters, List<Edge> edges) {
-        this.toStop = toStop;
-        this.distanceMeters = distanceMeters;
+        this.effectiveWalkDistanceMeters = effectiveWalkDistanceMeters;
         this.edges = edges;
     }
 
@@ -46,8 +40,12 @@ public class Transfer {
 
     public int getToStop() { return toStop; }
 
+    public int getEffectiveWalkDistanceMeters() {
+        return effectiveWalkDistanceMeters;
+    }
+
     public int getDistanceMeters() {
-        return distanceMeters;
+        return (int)edges.stream().mapToDouble(Edge::getDistanceMeters).sum();
     }
 
     public List<Edge> getEdges() {

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/mappers/TransfersMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/mappers/TransfersMapper.java
@@ -29,10 +29,10 @@ class TransfersMapper {
 
             for (Edge edge : stopVertexForStop.get(stop).getOutgoing()) {
                 if (edge instanceof SimpleTransfer) {
-                    double distance = edge.getDistance();
+                    double effectiveDistance = edge.getEffectiveWalkDistance();
 
                     int toStopIndex = stopIndex.indexByStop.get(((TransitStopVertex) edge.getToVertex()).getStop());
-                    Transfer transfer = new Transfer(toStopIndex, (int) distance,
+                    Transfer transfer = new Transfer(toStopIndex, (int) effectiveDistance,
                             ((SimpleTransfer) edge).getEdges());
 
                     list.add(transfer);

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/request/TransferWithDuration.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/request/TransferWithDuration.java
@@ -11,7 +11,7 @@ public class TransferWithDuration implements TransferLeg {
 
     public TransferWithDuration(Transfer transfer, double walkSpeed) {
         this.transfer = transfer;
-        this.durationSeconds = (int) Math.round(transfer.getDistanceMeters() / walkSpeed);
+        this.durationSeconds = (int) Math.round(transfer.getEffectiveWalkDistanceMeters() / walkSpeed);
     }
 
     @Override

--- a/src/main/java/org/opentripplanner/routing/core/RoutingContext.java
+++ b/src/main/java/org/opentripplanner/routing/core/RoutingContext.java
@@ -163,7 +163,7 @@ public class RoutingContext implements Cloneable {
                     from.getCoordinate(), to.getCoordinate());
 
             double lengthRatio = partial.getLength() / parent.getLength();
-            double length = streetEdge.getDistance() * lengthRatio;
+            double length = streetEdge.getDistanceMeters() * lengthRatio;
 
             //TODO: localize this
             String name = from.getLabel() + " to " + to.getLabel();

--- a/src/main/java/org/opentripplanner/routing/core/StateEditor.java
+++ b/src/main/java/org/opentripplanner/routing/core/StateEditor.java
@@ -125,16 +125,6 @@ public class StateEditor {
         return child;
     }
 
-    public boolean weHaveWalkedTooFar(RoutingRequest options) {
-        // Only apply limit in transit-only case, unless this is a one-to-many request with hard
-        // walk limiting, in which case we want to cut off the search.
-        if (options.modes.isTransit()) {
-            return child.walkDistance >= options.maxWalkDistance;
-        } else {
-            return false;
-        }
-    }
-
     public boolean isMaxPreTransitTimeExceeded(RoutingRequest options) {
         return child.preTransitTime > options.maxPreTransitTime;
     }

--- a/src/main/java/org/opentripplanner/routing/edgetype/BikeParkEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/BikeParkEdge.java
@@ -85,7 +85,7 @@ public class BikeParkEdge extends Edge {
     }
 
     @Override
-    public double getDistance() {
+    public double getDistanceMeters() {
         return 0;
     }
 

--- a/src/main/java/org/opentripplanner/routing/edgetype/ElevatorAlightEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/ElevatorAlightEdge.java
@@ -58,7 +58,7 @@ public class ElevatorAlightEdge extends Edge implements ElevatorEdge {
     }
 
     @Override
-    public double getDistance() {
+    public double getDistanceMeters() {
         return 0;
     }
 

--- a/src/main/java/org/opentripplanner/routing/edgetype/ElevatorBoardEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/ElevatorBoardEdge.java
@@ -52,7 +52,7 @@ public class ElevatorBoardEdge extends Edge implements ElevatorEdge {
     }
 
     @Override
-    public double getDistance() {
+    public double getDistanceMeters() {
         return 0;
     }
 

--- a/src/main/java/org/opentripplanner/routing/edgetype/ElevatorHopEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/ElevatorHopEdge.java
@@ -61,7 +61,7 @@ public class ElevatorHopEdge extends Edge implements ElevatorEdge {
     }
 
     @Override
-    public double getDistance() {
+    public double getDistanceMeters() {
         return 0;
     }
 

--- a/src/main/java/org/opentripplanner/routing/edgetype/FreeEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/FreeEdge.java
@@ -32,7 +32,7 @@ public class FreeEdge extends Edge {
     }
 
     @Override
-    public double getDistance() {
+    public double getDistanceMeters() {
         return 0;
     }
 

--- a/src/main/java/org/opentripplanner/routing/edgetype/LegSwitchingEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/LegSwitchingEdge.java
@@ -33,7 +33,7 @@ public class LegSwitchingEdge extends Edge {
 	}
 
 	@Override
-	public double getDistance() {
+	public double getDistanceMeters() {
 		return 0;
 	}
 

--- a/src/main/java/org/opentripplanner/routing/edgetype/ParkAndRideEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/ParkAndRideEdge.java
@@ -74,7 +74,7 @@ public class ParkAndRideEdge extends Edge {
     }
 
     @Override
-    public double getDistance() {
+    public double getDistanceMeters() {
         return 0;
     }
 

--- a/src/main/java/org/opentripplanner/routing/edgetype/PathwayEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/PathwayEdge.java
@@ -37,7 +37,7 @@ public class PathwayEdge extends Edge {
         return null;
     }
 
-    public double getDistance() {
+    public double getDistanceMeters() {
         return 0;
     }
     

--- a/src/main/java/org/opentripplanner/routing/edgetype/RentABikeAbstractEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/RentABikeAbstractEdge.java
@@ -82,7 +82,7 @@ public abstract class RentABikeAbstractEdge extends Edge {
     }
 
     @Override
-    public double getDistance() {
+    public double getDistanceMeters() {
         return 0;
     }
 

--- a/src/main/java/org/opentripplanner/routing/edgetype/SimpleTransfer.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/SimpleTransfer.java
@@ -21,18 +21,14 @@ import java.util.stream.Collectors;
 public class SimpleTransfer extends Edge {
     private static final long serialVersionUID = 20140408L;
 
-    private double distance;
+    private double effectiveWalkDistance;
     
     private List<Edge> edges;
 
-    public SimpleTransfer(TransitStopVertex from, TransitStopVertex to, double distance, LineString geometry, List<Edge> edges) {
+    public SimpleTransfer(TransitStopVertex from, TransitStopVertex to, double effectiveWalkDistance, List<Edge> edges) {
         super(from, to);
-        this.distance = distance;
+        this.effectiveWalkDistance = effectiveWalkDistance;
         this.edges = edges;
-    }
-
-    public SimpleTransfer(TransitStopVertex from, TransitStopVertex to, double distance, LineString geometry) {
-        this(from, to, distance, geometry, null);
     }
 
     @Override
@@ -44,7 +40,7 @@ public class SimpleTransfer extends Edge {
         if (s0.backEdge instanceof StreetTransitLink) {
             return null;
         }
-        if(distance > s0.getOptions().maxTransferWalkDistance) {
+        if(effectiveWalkDistance > s0.getOptions().maxTransferWalkDistance) {
             return null;
         }
         // Only transfer right after riding a vehicle.
@@ -52,10 +48,10 @@ public class SimpleTransfer extends Edge {
         double walkspeed = rr.walkSpeed;
         StateEditor se = s0.edit(this);
         se.setBackMode(TraverseMode.WALK);
-        int time = (int) Math.ceil(distance / walkspeed) + 2 * StreetTransitLink.STL_TRAVERSE_COST;
+        int time = (int) Math.ceil(effectiveWalkDistance / walkspeed) + 2 * StreetTransitLink.STL_TRAVERSE_COST;
         se.incrementTimeInSeconds(time);
         se.incrementWeight(time * rr.walkReluctance);
-        se.incrementWalkDistance(distance);
+        se.incrementWalkDistance(effectiveWalkDistance);
         return se.makeState();
     }
 
@@ -72,13 +68,13 @@ public class SimpleTransfer extends Edge {
 
     @Override
     public double weightLowerBound(RoutingRequest rr) {
-        int time = (int) (distance / rr.walkSpeed); 
+        int time = (int) (effectiveWalkDistance / rr.walkSpeed);
         return (time * rr.walkReluctance);
     }
     
     @Override
-    public double getDistance(){
-    	return this.distance;
+    public double getEffectiveWalkDistance(){
+    	return this.effectiveWalkDistance;
     }
 
     @Override

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetBikeParkLink.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetBikeParkLink.java
@@ -43,7 +43,7 @@ public class StreetBikeParkLink extends Edge {
         return null;
     }
 
-    public double getDistance() {
+    public double getDistanceMeters() {
         return 0;
     }
 

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetBikeRentalLink.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetBikeRentalLink.java
@@ -36,7 +36,7 @@ public class StreetBikeRentalLink extends Edge {
         return null;
     }
 
-    public double getDistance() {
+    public double getDistanceMeters() {
         return 0;
     }
 

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetTransitLink.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetTransitLink.java
@@ -45,7 +45,7 @@ public class StreetTransitLink extends Edge {
         return null;
     }
 
-    public double getDistance() {
+    public double getDistanceMeters() {
         return 0;
     }
 

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetWithElevationEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetWithElevationEdge.java
@@ -67,7 +67,7 @@ public class StreetWithElevationEdge extends StreetEdge {
         effectiveWalkDistanceFactor = costs.effectiveWalkFactor;
 
         bicycleSafetyFactor *= costs.lengthMultiplier;
-        bicycleSafetyFactor += costs.slopeSafetyCost / getEffectiveWalkDistance();
+        bicycleSafetyFactor += costs.slopeSafetyCost / getDistanceMeters();
         return costs.flattened;
     }
 
@@ -90,24 +90,24 @@ public class StreetWithElevationEdge extends StreetEdge {
     }
 
     @Override
-    public double getSlopeBikeSpeedEffectiveDistance() {
-        return effectiveBikeDistanceFactor * getEffectiveWalkDistance();
+    public double getEffectiveBikeDistance() {
+        return effectiveBikeDistanceFactor * getDistanceMeters();
     }
 
     @Override
-    public double getSlopeBikeWorkCostEffectiveDistance() {
-        return effectiveBikeWorkFactor * getEffectiveWalkDistance();
+    public double getEffectiveBikeWorkCost() {
+        return effectiveBikeWorkFactor * getDistanceMeters();
     }
 
     @Override
-    public double getSlopeWalkSpeedEffectiveDistance() {
-        return effectiveWalkDistanceFactor * getEffectiveWalkDistance();
+    public double getEffectiveWalkDistance() {
+        return effectiveWalkDistanceFactor * getDistanceMeters();
     }
 
     @Override
     public String toString() {
         return "StreetWithElevationEdge(" + getName() + ", " + fromv + " -> "
-                + tov + " length=" + this.getEffectiveWalkDistance() + " carSpeed=" + this.getCarSpeed()
+                + tov + " length=" + this.getDistanceMeters() + " carSpeed=" + this.getCarSpeed()
                 + " permission=" + this.getPermission() + ")";
     }
 }

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetWithElevationEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetWithElevationEdge.java
@@ -18,17 +18,17 @@ public class StreetWithElevationEdge extends StreetEdge {
 
     private static final long serialVersionUID = 1L;
 
+    private double effectiveWalkDistanceFactor = 1.0;
+
+    private double effectiveBikeDistanceFactor = 1.0;
+
+    private double effectiveBikeWorkFactor = 1.0;
+
     private byte[] packedElevationProfile;
-
-    private float slopeSpeedFactor = 1.0f;
-
-    private float slopeWorkFactor = 1.0f;
 
     private float maxSlope;
 
     private boolean flattened;
-
-    private double effectiveWalkFactor = 1.0;
 
     /**
      * Remember to call the {@link #setElevationProfile(PackedCoordinateSequence, boolean)} to initiate elevation data.
@@ -60,14 +60,14 @@ public class StreetWithElevationEdge extends StreetEdge {
         SlopeCosts costs = ElevationUtils.getSlopeCosts(elev, slopeLimit);
 
         packedElevationProfile = CompactElevationProfile.compactElevationProfileWithRegularSamples(elev);
-        slopeSpeedFactor = (float)costs.slopeSpeedFactor;
-        slopeWorkFactor = (float)costs.slopeWorkFactor;
+        effectiveBikeDistanceFactor = costs.slopeSpeedFactor;
+        effectiveBikeWorkFactor = costs.slopeWorkFactor;
         maxSlope = (float)costs.maxSlope;
         flattened = costs.flattened;
-        effectiveWalkFactor = costs.effectiveWalkFactor;
+        effectiveWalkDistanceFactor = costs.effectiveWalkFactor;
 
         bicycleSafetyFactor *= costs.lengthMultiplier;
-        bicycleSafetyFactor += costs.slopeSafetyCost / getDistance();
+        bicycleSafetyFactor += costs.slopeSafetyCost / getEffectiveWalkDistance();
         return costs.flattened;
     }
 
@@ -75,7 +75,7 @@ public class StreetWithElevationEdge extends StreetEdge {
     public PackedCoordinateSequence getElevationProfile() {
         return CompactElevationProfile.uncompactElevationProfileWithRegularSamples(
                 packedElevationProfile,
-                getDistance()
+                getEffectiveWalkDistance()
         );
     }
 
@@ -90,27 +90,24 @@ public class StreetWithElevationEdge extends StreetEdge {
     }
 
     @Override
-    public double getSlopeSpeedEffectiveLength() {
-        return slopeSpeedFactor * getDistance();
+    public double getSlopeBikeSpeedEffectiveDistance() {
+        return effectiveBikeDistanceFactor * getEffectiveWalkDistance();
     }
 
     @Override
-    public double getSlopeWorkCostEffectiveLength() {
-        return slopeWorkFactor * getDistance();
+    public double getSlopeBikeWorkCostEffectiveDistance() {
+        return effectiveBikeWorkFactor * getEffectiveWalkDistance();
     }
 
-    /**
-     * The effective walk distance is adjusted to take the elevation into account.
-     */
     @Override
-    public double getSlopeWalkSpeedEffectiveLength() {
-        return effectiveWalkFactor * getDistance();
+    public double getSlopeWalkSpeedEffectiveDistance() {
+        return effectiveWalkDistanceFactor * getEffectiveWalkDistance();
     }
 
     @Override
     public String toString() {
         return "StreetWithElevationEdge(" + getName() + ", " + fromv + " -> "
-                + tov + " length=" + this.getDistance() + " carSpeed=" + this.getCarSpeed()
+                + tov + " length=" + this.getEffectiveWalkDistance() + " carSpeed=" + this.getCarSpeed()
                 + " permission=" + this.getPermission() + ")";
     }
 }

--- a/src/main/java/org/opentripplanner/routing/edgetype/TemporaryPartialStreetEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/TemporaryPartialStreetEdge.java
@@ -132,7 +132,7 @@ final public class TemporaryPartialStreetEdge extends StreetWithElevationEdge im
     @Override
     public String toString() {
         return "TemporaryPartialStreetEdge(" + this.getName() + ", " + this.getFromVertex() + " -> "
-                + this.getToVertex() + " length=" + this.getDistance() + " carSpeed="
+                + this.getToVertex() + " length=" + this.getDistanceMeters() + " carSpeed="
                 + this.getCarSpeed() + " parentEdge=" + parentEdge + ")";
     }
 
@@ -155,7 +155,7 @@ final public class TemporaryPartialStreetEdge extends StreetWithElevationEdge im
     private void setElevationProfileUsingParents() {
         setElevationProfile(
                 ElevationUtils.getPartialElevationProfile(
-                        getParentEdge().getElevationProfile(), 0, getDistance()
+                        getParentEdge().getElevationProfile(), 0, getDistanceMeters()
                 ),
                 false
         );

--- a/src/main/java/org/opentripplanner/routing/edgetype/TimedTransferEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/TimedTransferEdge.java
@@ -41,7 +41,7 @@ public class TimedTransferEdge extends Edge {
     }
 
     @Override
-    public double getDistance() {
+    public double getDistanceMeters() {
         return 0;
     }
 

--- a/src/main/java/org/opentripplanner/routing/graph/Edge.java
+++ b/src/main/java/org/opentripplanner/routing/graph/Edge.java
@@ -182,6 +182,10 @@ public abstract class Edge implements Serializable {
         return 0;
     }
 
+    /**
+     * This gets the effective length for walking, taking slopes into account. This can be divided
+     * by the speed on a flat surface to get the duration.
+     */
     public double getEffectiveWalkDistance() {
         return 0;
     }

--- a/src/main/java/org/opentripplanner/routing/graph/Edge.java
+++ b/src/main/java/org/opentripplanner/routing/graph/Edge.java
@@ -178,7 +178,11 @@ public abstract class Edge implements Serializable {
         return getFromVertex().azimuthTo(getToVertex());
     }
 
-    public double getDistance() {
+    public double getDistanceMeters() {
+        return 0;
+    }
+
+    public double getEffectiveWalkDistance() {
         return 0;
     }
 

--- a/src/main/java/org/opentripplanner/routing/impl/StreetVertexIndexServiceImpl.java
+++ b/src/main/java/org/opentripplanner/routing/impl/StreetVertexIndexServiceImpl.java
@@ -150,8 +150,8 @@ public class StreetVertexIndexServiceImpl implements StreetVertexIndexService {
         double totalGeomLength = geometry.getLength();
         double lengthRatioIn = geometries.first.getLength() / totalGeomLength;
 
-        double lengthIn = street.getDistance() * lengthRatioIn;
-        double lengthOut = street.getDistance() * (1 - lengthRatioIn);
+        double lengthIn = street.getDistanceMeters() * lengthRatioIn;
+        double lengthOut = street.getDistanceMeters() * (1 - lengthRatioIn);
 
         if (endVertex) {
             TemporaryPartialStreetEdge temporaryPartialStreetEdge = new TemporaryPartialStreetEdge(

--- a/src/main/java/org/opentripplanner/routing/spt/SPTWalker.java
+++ b/src/main/java/org/opentripplanner/routing/spt/SPTWalker.java
@@ -102,7 +102,7 @@ public class SPTWalker {
                         TraverseMode mode = s0.getNonTransitMode();
                         speedAlongEdge = se.calculateSpeed(spt.getOptions(), mode, s0.getTimeInMillis());
                         if (mode != TraverseMode.CAR)
-                            speedAlongEdge = speedAlongEdge * se.getDistanceMeters() / se.getSlopeBikeSpeedEffectiveDistance();
+                            speedAlongEdge = speedAlongEdge * se.getDistanceMeters() / se.getEffectiveBikeDistance();
                         double avgSpeed = se.getDistanceMeters()
                                 / Math.abs(s0.getTimeInMillis() - s1.getTimeInMillis()) * 1000;
                         if (avgSpeed < 1e-10)

--- a/src/main/java/org/opentripplanner/routing/spt/SPTWalker.java
+++ b/src/main/java/org/opentripplanner/routing/spt/SPTWalker.java
@@ -102,8 +102,8 @@ public class SPTWalker {
                         TraverseMode mode = s0.getNonTransitMode();
                         speedAlongEdge = se.calculateSpeed(spt.getOptions(), mode, s0.getTimeInMillis());
                         if (mode != TraverseMode.CAR)
-                            speedAlongEdge = speedAlongEdge * se.getDistance() / se.getSlopeSpeedEffectiveLength();
-                        double avgSpeed = se.getDistance()
+                            speedAlongEdge = speedAlongEdge * se.getDistanceMeters() / se.getSlopeBikeSpeedEffectiveDistance();
+                        double avgSpeed = se.getDistanceMeters()
                                 / Math.abs(s0.getTimeInMillis() - s1.getTimeInMillis()) * 1000;
                         if (avgSpeed < 1e-10)
                             avgSpeed = 1e-10;

--- a/src/test/java/org/opentripplanner/graph_builder/module/linking/LinkingTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/linking/LinkingTest.java
@@ -58,8 +58,8 @@ public class LinkingTest {
 
             // distances expressed internally in mm so this epsilon is plenty good enough to ensure that they
             // have the same values
-            assertEquals(sp0.first.getDistance(), sp1.second.getDistance(), 0.0000001);
-            assertEquals(sp0.second.getDistance(), sp1.first.getDistance(), 0.0000001);
+            assertEquals(sp0.first.getDistanceMeters(), sp1.second.getDistanceMeters(), 0.0000001);
+            assertEquals(sp0.second.getDistanceMeters(), sp1.first.getDistanceMeters(), 0.0000001);
             assertFalse(sp0.first.isBack());
             assertFalse(sp0.second.isBack());
             assertTrue(sp1.first.isBack());

--- a/src/test/java/org/opentripplanner/graph_builder/module/map/TestStreetMatcher.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/map/TestStreetMatcher.java
@@ -163,7 +163,7 @@ public class TestStreetMatcher {
         
         @Override
         public State traverse(State s0) {
-            double d = getDistance();
+            double d = getDistanceMeters();
             TraverseMode mode = s0.getNonTransitMode();
             int t = (int) (d / s0.getOptions().getSpeed(mode));
             StateEditor s1 = s0.edit(this);
@@ -194,7 +194,7 @@ public class TestStreetMatcher {
         }
 
         @Override
-        public double getDistance() {
+        public double getDistanceMeters() {
             return SphericalDistanceLibrary.distance(getFromVertex().getCoordinate(), getToVertex().getCoordinate());
         }
 

--- a/src/test/java/org/opentripplanner/routing/edgetype/PlainStreetEdgeTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/PlainStreetEdgeTest.java
@@ -78,7 +78,7 @@ public class PlainStreetEdgeTest {
         State s1 = e1.traverse(s0);
         
         // Should use the speed on the edge.
-        double expectedWeight = e1.getDistance() / options.walkSpeed;
+        double expectedWeight = e1.getDistanceMeters() / options.walkSpeed;
         long expectedDuration = (long) Math.ceil(expectedWeight);
         assertEquals(expectedDuration, s1.getElapsedTimeSeconds(), 0.0);
         assertEquals(expectedWeight, s1.getWeight(), 0.0);
@@ -97,7 +97,7 @@ public class PlainStreetEdgeTest {
         State s1 = e1.traverse(s0);
         
         // Should use the speed on the edge.
-        double expectedWeight = e1.getDistance() / e1.getCarSpeed();
+        double expectedWeight = e1.getDistanceMeters() / e1.getCarSpeed();
         long expectedDuration = (long) Math.ceil(expectedWeight);
         assertEquals(expectedDuration, s1.getElapsedTimeSeconds(), 0.0);
         assertEquals(expectedWeight, s1.getWeight(), 0.0);

--- a/src/test/java/org/opentripplanner/routing/edgetype/TemporaryPartialStreetEdgeTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/TemporaryPartialStreetEdgeTest.java
@@ -50,7 +50,7 @@ public class TemporaryPartialStreetEdgeTest {
     @Test
     public void testConstruction() {
         TemporaryPartialStreetEdge pEdge = newTemporaryPartialStreetEdge(e1, v1, v2, e1.getGeometry(),
-                "partial e1", e1.getDistance());
+                "partial e1", e1.getDistanceMeters());
 
         assertTrue(pEdge.isEquivalentTo(e1));
         assertTrue(pEdge.isPartial());
@@ -69,9 +69,9 @@ public class TemporaryPartialStreetEdgeTest {
 
         // Partial edge with same endpoints as the parent.
         TemporaryPartialStreetEdge pEdge1 = newTemporaryPartialStreetEdge(e1, v1, v2, e1.getGeometry(),
-                "partial e1", e1.getDistance());
+                "partial e1", e1.getDistanceMeters());
         TemporaryPartialStreetEdge pEdge2 = newTemporaryPartialStreetEdge(e2, v2, v3, e2.getGeometry(),
-                "partial e2", e2.getDistance());
+                "partial e2", e2.getDistanceMeters());
 
         // Traverse both the partial and parent edges.
         State s0 = new State(options);
@@ -173,9 +173,9 @@ public class TemporaryPartialStreetEdgeTest {
     @Test
     public void testReverseEdge() {
         TemporaryPartialStreetEdge pEdge1 = newTemporaryPartialStreetEdge(e1, v1, v2, e1.getGeometry(),
-                "partial e1", e1.getDistance());
+                "partial e1", e1.getDistanceMeters());
         TemporaryPartialStreetEdge pEdge2 = newTemporaryPartialStreetEdge(e1Reverse, v2, v1, e1Reverse.getGeometry(),
-                "partial e2", e1Reverse.getDistance());
+                "partial e2", e1Reverse.getDistanceMeters());
         
         assertFalse(e1.isReverseOf(pEdge1));
         assertFalse(pEdge1.isReverseOf(e1));

--- a/src/test/java/org/opentripplanner/routing/edgetype/TestTriangle.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/TestTriangle.java
@@ -45,8 +45,8 @@ public class TestTriangle extends TestCase {
 
         SlopeCosts costs = ElevationUtils.getSlopeCosts(elev, true);
         double trueLength = costs.lengthMultiplier * length;
-        double slopeWorkLength = testStreet.getSlopeWorkCostEffectiveLength();
-        double slopeSpeedLength = testStreet.getSlopeSpeedEffectiveLength();
+        double slopeWorkLength = testStreet.getSlopeBikeWorkCostEffectiveDistance();
+        double slopeSpeedLength = testStreet.getSlopeBikeSpeedEffectiveDistance();
 
         RoutingRequest options = new RoutingRequest(TraverseMode.BICYCLE);
         options.optimize = OptimizeType.TRIANGLE;

--- a/src/test/java/org/opentripplanner/routing/edgetype/TestTriangle.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/TestTriangle.java
@@ -45,8 +45,8 @@ public class TestTriangle extends TestCase {
 
         SlopeCosts costs = ElevationUtils.getSlopeCosts(elev, true);
         double trueLength = costs.lengthMultiplier * length;
-        double slopeWorkLength = testStreet.getSlopeBikeWorkCostEffectiveDistance();
-        double slopeSpeedLength = testStreet.getSlopeBikeSpeedEffectiveDistance();
+        double slopeWorkLength = testStreet.getEffectiveBikeWorkCost();
+        double slopeSpeedLength = testStreet.getEffectiveBikeDistance();
 
         RoutingRequest options = new RoutingRequest(TraverseMode.BICYCLE);
         options.optimize = OptimizeType.TRIANGLE;

--- a/src/test/java/org/opentripplanner/routing/graph/SimpleConcreteEdge.java
+++ b/src/test/java/org/opentripplanner/routing/graph/SimpleConcreteEdge.java
@@ -23,7 +23,7 @@ public class SimpleConcreteEdge extends Edge {
 
     @Override
     public State traverse(State s0) {
-        double d = getDistance();
+        double d = getDistanceMeters();
         TraverseMode mode = s0.getNonTransitMode();
         int t = (int) (d / s0.getOptions().getSpeed(mode));
         StateEditor s1 = s0.edit(this);
@@ -48,7 +48,7 @@ public class SimpleConcreteEdge extends Edge {
     }
 
     @Override
-    public double getDistance() {
+    public double getDistanceMeters() {
         return SphericalDistanceLibrary.distance(getFromVertex().getCoordinate(), getToVertex().getCoordinate());
     }
 }

--- a/src/test/java/org/opentripplanner/routing/graph/TemporaryConcreteEdge.java
+++ b/src/test/java/org/opentripplanner/routing/graph/TemporaryConcreteEdge.java
@@ -30,7 +30,7 @@ public class TemporaryConcreteEdge extends Edge implements TemporaryEdge {
 
     @Override
     public State traverse(State s0) {
-        double d = getDistance();
+        double d = getDistanceMeters();
         TraverseMode mode = s0.getNonTransitMode();
         int t = (int) (d / s0.getOptions().getSpeed(mode));
         StateEditor s1 = s0.edit(this);
@@ -55,7 +55,7 @@ public class TemporaryConcreteEdge extends Edge implements TemporaryEdge {
     }
 
     @Override
-    public double getDistance() {
+    public double getDistanceMeters() {
         return SphericalDistanceLibrary.distance(getFromVertex().getCoordinate(), getToVertex().getCoordinate());
     }
 }


### PR DESCRIPTION
To be completed by pull request submitter:

- [x] **issue**: [#2857](https://github.com/opentripplanner/OpenTripPlanner/issues/2857) OTP2 does not take slopes into account
- [x] **roadmap**: [#2626](https://github.com/opentripplanner/OpenTripPlanner/issues/2626)
- [x] **tests**: Existing tests pass
- [x] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#code-style)? 
- [x] **documentation**: No new configuration options, but javadoc added to some existing classes
- [x] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)

This changes Raptor transfers to use effectiveWalkDistance instead of distance, in order to take slopes into account. I have also changed some names and added javadoc to clarify what happens in StreetWithElevationEdge. It should now be clear which factors affect walking and which affect biking.