### PR TITLE
Parameters for specifing Access egress distance parameter

### DIFF
--- a/src/main/java/org/opentripplanner/api/common/RoutingResource.java
+++ b/src/main/java/org/opentripplanner/api/common/RoutingResource.java
@@ -79,9 +79,29 @@ public abstract class RoutingResource {
     @QueryParam("wheelchair")
     protected Boolean wheelchair;
 
-    /** The maximum distance (in meters) the user is willing to walk. Defaults to unlimited. */
+    /**
+     * The maximum distance (in meters) the user is willing to walk. Defaults to unlimited.
+     * In OTP 2.0 the behaviour of this parameter is modified, this parameter is used to
+     * set-up maxWalkDistanceAccess and maxWalkDistanceEgress when no parameter for this
+     * variables is specified.
+     *
+     * In case maxWalkDistanceAccess or maxWalkDistanceEgress is not used set the value is overriden
+     * based on this field.
+     * */
     @QueryParam("maxWalkDistance")
     protected Double maxWalkDistance;
+
+    @QueryParam("maxWalkDistanceAccess")
+    protected Integer maxWalkDistanceAccess;
+
+    @QueryParam("desiredMaxWalkDistanceAccess")
+    protected Integer desiredMaxWalkDistanceAccess;
+
+    @QueryParam("maxWalkDistanceEgress")
+    protected Integer maxWalkDistanceEgress;
+
+    @QueryParam("desiredMaxWalkDistanceEgress")
+    protected Integer desiredMaxWalkDistanceEgress;
 
     /**
      * The maximum time (in seconds) of pre-transit travel when using drive-to-transit (park and
@@ -458,9 +478,33 @@ public abstract class RoutingResource {
         if (numItineraries != null)
             request.setNumItineraries(numItineraries);
 
+        if (maxWalkDistanceAccess != null) {
+            request.maxWalkDistanceAccess = maxWalkDistanceAccess;
+        }
+
+        if (desiredMaxWalkDistanceAccess != null) {
+            request.desiredMaxWalkDistanceAccess = desiredMaxWalkDistanceAccess;
+        }
+
+        if (maxWalkDistanceEgress != null) {
+            request.maxWalkDistanceEgress = maxWalkDistanceEgress;
+        }
+
+        if (desiredMaxWalkDistanceEgress != null) {
+            request.desiredMaxWalkDistanceEgress = desiredMaxWalkDistanceEgress;
+        }
+
         if (maxWalkDistance != null) {
             request.setMaxWalkDistance(maxWalkDistance);
             request.maxTransferWalkDistance = maxWalkDistance;
+            // When maxWalkDistanceAccess or maxWalkDistanceEgress is not set, maxWalkDistance is used.
+            if (maxWalkDistanceAccess == null) {
+                request.maxWalkDistanceAccess = maxWalkDistance.intValue();
+            }
+            if (maxWalkDistanceEgress == null) {
+                request.maxWalkDistanceEgress = maxWalkDistance.intValue();
+            }
+
         }
 
         if (maxPreTransitTime != null)

--- a/src/main/java/org/opentripplanner/graph_builder/annotation/ParentStationNotFoundAnnotation.java
+++ b/src/main/java/org/opentripplanner/graph_builder/annotation/ParentStationNotFoundAnnotation.java
@@ -1,0 +1,25 @@
+package org.opentripplanner.graph_builder.annotation;
+
+import org.opentripplanner.model.Stop;
+
+public class ParentStationNotFoundAnnotation extends GraphBuilderAnnotation {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final String FMT = "Parent station %s not found. Stop %s will not be linked to a "
+            + "parent station.";
+
+    final String parentStop;
+
+    final Stop stop;
+
+    public ParentStationNotFoundAnnotation(Stop stop, String parentStop){
+    	this.stop = stop;
+    	this.parentStop = parentStop;
+    }
+    
+    @Override
+    public String getMessage() {
+        return String.format(FMT, parentStop, stop);
+    }
+}

--- a/src/main/java/org/opentripplanner/graph_builder/module/GtfsModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/GtfsModule.java
@@ -104,7 +104,10 @@ public class GtfsModule implements GraphBuilderModule {
                     gtfsBundle.useCached = useCached;
                 }
 
-                OtpTransitServiceBuilder builder =  mapGtfsDaoToInternalTransitServiceBuilder(loadBundle(gtfsBundle));
+                OtpTransitServiceBuilder builder =  mapGtfsDaoToInternalTransitServiceBuilder(
+                        loadBundle(gtfsBundle),
+                        graph
+                );
 
                 calendarServiceData.add(builder.buildCalendarServiceData());
 

--- a/src/main/java/org/opentripplanner/gtfs/MockGtfs.java
+++ b/src/main/java/org/opentripplanner/gtfs/MockGtfs.java
@@ -42,11 +42,17 @@ public class MockGtfs {
     }
 
     public OtpTransitServiceBuilder read() throws IOException {
-        return GTFSToOtpTransitServiceMapper.mapGtfsDaoToInternalTransitServiceBuilder(gtfsDelegate.read());
+        return GTFSToOtpTransitServiceMapper.mapGtfsDaoToInternalTransitServiceBuilder(
+                gtfsDelegate.read(),
+                annotation -> null
+        );
     }
 
     public OtpTransitServiceBuilder read(org.onebusaway.gtfs.serialization.GtfsReader reader) throws IOException {
-        return GTFSToOtpTransitServiceMapper.mapGtfsDaoToInternalTransitServiceBuilder(gtfsDelegate.read(reader));
+        return GTFSToOtpTransitServiceMapper.mapGtfsDaoToInternalTransitServiceBuilder(
+                gtfsDelegate.read(reader),
+                annotation -> null
+        );
     }
 
     public void putMinimal() {

--- a/src/main/java/org/opentripplanner/gtfs/mapping/GTFSToOtpTransitServiceMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/GTFSToOtpTransitServiceMapper.java
@@ -3,6 +3,7 @@ package org.opentripplanner.gtfs.mapping;
 import org.onebusaway.gtfs.model.Stop;
 import org.onebusaway.gtfs.services.GtfsRelationalDao;
 import org.opentripplanner.model.impl.OtpTransitServiceBuilder;
+import org.opentripplanner.routing.graph.AddBuilderAnnotation;
 
 /**
  * This class is responsible for mapping between GTFS DAO objects and into OTP Transit model.
@@ -44,14 +45,20 @@ public class GTFSToOtpTransitServiceMapper {
             routeMapper, fareAttributeMapper
     );
 
+    private final AddBuilderAnnotation addBuilderAnnotation;
+
+    GTFSToOtpTransitServiceMapper(AddBuilderAnnotation addBuilderAnnotation) {
+        this.addBuilderAnnotation = addBuilderAnnotation;
+    }
 
     /**
      * Map from GTFS data to the internal OTP model
      */
     public static OtpTransitServiceBuilder mapGtfsDaoToInternalTransitServiceBuilder(
-            GtfsRelationalDao data
+            GtfsRelationalDao data,
+            AddBuilderAnnotation addBuilderAnnotation
     ) {
-        return new GTFSToOtpTransitServiceMapper().map(data);
+        return new GTFSToOtpTransitServiceMapper(addBuilderAnnotation).map(data);
     }
 
     private OtpTransitServiceBuilder map(GtfsRelationalDao data) {
@@ -86,6 +93,10 @@ public class GTFSToOtpTransitServiceMapper {
                 builder.getStations().add(stationMapper.map(it));
             }
         }
-        new LinkStopsAndParentStationsTogether(builder.getStations(), builder.getStops()).link(data.getAllStops());
+        new LinkStopsAndParentStationsTogether(
+                builder.getStations(),
+                builder.getStops(),
+                addBuilderAnnotation)
+            .link(data.getAllStops());
     }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/router/RaptorRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/router/RaptorRouter.java
@@ -18,6 +18,7 @@ import org.opentripplanner.routing.algorithm.raptor.transit.TripSchedule;
 import org.opentripplanner.routing.algorithm.raptor.transit.mappers.DateMapper;
 import org.opentripplanner.routing.algorithm.raptor.transit.request.RaptorRoutingRequestTransitData;
 import org.opentripplanner.routing.core.RoutingRequest;
+import org.opentripplanner.routing.error.PathNotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,6 +70,18 @@ public class RaptorRouter {
             AccessEgressRouter.streetSearch(request, false);
         Map<Stop, Transfer> egressTransfers =
             AccessEgressRouter.streetSearch(request, true);
+
+        if (accessTransfers.size() == 0 ) {
+            // TODO Would be nice a specification about why not path was found can be added.
+            // In this case base at the egress side no route can be found within the maxWalkDistanceAccess
+            throw new PathNotFoundException();
+        }
+        if (egressTransfers.size() == 0 ) {
+            // TODO Would be nice a specification about why not path was found can be added.
+            // In this case base at the egress side no route can be found within the maxWalkDistanceEgress
+            throw new PathNotFoundException();
+        }
+
 
         TransferToAccessEgressLegMapper accessEgressLegMapper = new TransferToAccessEgressLegMapper(transitLayer);
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/router/RaptorRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/router/RaptorRouter.java
@@ -66,9 +66,9 @@ public class RaptorRouter {
         double startTimeAccessEgress = System.currentTimeMillis();
 
         Map<Stop, Transfer> accessTransfers =
-            AccessEgressRouter.streetSearch(request, false, 2000);
+            AccessEgressRouter.streetSearch(request, false);
         Map<Stop, Transfer> egressTransfers =
-            AccessEgressRouter.streetSearch(request, true, 2000);
+            AccessEgressRouter.streetSearch(request, true);
 
         TransferToAccessEgressLegMapper accessEgressLegMapper = new TransferToAccessEgressLegMapper(transitLayer);
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/router/street/AccessEgressRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/router/street/AccessEgressRouter.java
@@ -27,6 +27,40 @@ public class AccessEgressRouter {
      * @param rr the current routing request
      * @param fromTarget whether to route from or towards the point provided in the routing request
      *                   (access or egress)
+     * @return Transfer objects by access/egress stop
+     */
+    public static Map<Stop, Transfer> streetSearch (RoutingRequest rr, boolean fromTarget) {
+        int desiredDistance = fromTarget ? rr.desiredMaxWalkDistanceAccess : rr.desiredMaxWalkDistanceEgress;
+        int maxDistance = fromTarget ? rr.maxWalkDistanceAccess : rr.maxWalkDistanceEgress;
+
+
+        // Make sure that always one try is made.
+        if (desiredDistance > maxDistance) {
+            desiredDistance = maxDistance;
+        }
+
+        Map<Stop, Transfer> result = null;
+        while (desiredDistance < maxDistance) {
+            result = streetSearch(rr, fromTarget, desiredDistance);
+            if (result.size() > 0) {
+                return result;
+            }
+            desiredDistance += 1000;
+
+            if (desiredDistance >= maxDistance) {
+                result = streetSearch(rr, fromTarget, maxDistance);
+                return result;
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     *
+     * @param rr the current routing request
+     * @param fromTarget whether to route from or towards the point provided in the routing request
+     *                   (access or egress)
      * @param distanceMeters the maximum street distance to search for access/egress stops
      * @return Transfer objects by access/egress stop
      */

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/router/street/AccessEgressRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/router/street/AccessEgressRouter.java
@@ -30,8 +30,8 @@ public class AccessEgressRouter {
      * @return Transfer objects by access/egress stop
      */
     public static Map<Stop, Transfer> streetSearch (RoutingRequest rr, boolean fromTarget) {
-        int desiredDistance = fromTarget ? rr.desiredMaxWalkDistanceAccess : rr.desiredMaxWalkDistanceEgress;
-        int maxDistance = fromTarget ? rr.maxWalkDistanceAccess : rr.maxWalkDistanceEgress;
+        int desiredDistance = fromTarget ? rr.desiredMaxWalkDistanceEgress : rr.desiredMaxWalkDistanceAccess;
+        int maxDistance = fromTarget ?  rr.maxWalkDistanceEgress : rr.maxWalkDistanceAccess ;
 
 
         // Make sure that always one try is made.

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/router/street/AccessEgressRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/router/street/AccessEgressRouter.java
@@ -40,7 +40,7 @@ public class AccessEgressRouter {
         }
 
         Map<Stop, Transfer> result = null;
-        while (desiredDistance < maxDistance) {
+        while (desiredDistance <= maxDistance) {
             result = streetSearch(rr, fromTarget, desiredDistance);
             if (result.size() > 0) {
                 return result;

--- a/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
@@ -81,6 +81,34 @@ public class RoutingRequest implements Cloneable, Serializable {
      */
     public double maxWalkDistance = Double.MAX_VALUE;
 
+
+    /**
+     *  new maxWalkdistance parameters for RAPTOR (OTP 2.0) algorithm
+     */
+
+    /**
+     * The absolute maximum that can be walked in access to public transport.
+     */
+    public int maxWalkDistanceAccess = 10 * 1000;
+
+    /**
+     * The desired maximum walk distance in access to public transport.
+     * When no stop can be found within this range, the range will be increased until the maxWalkDistanceAccess is
+     * reached.
+     */
+    public int desiredMaxWalkDistanceAccess = 2 * 1000;
+
+    /**
+     *
+     */
+    public int maxWalkDistanceEgress = 10 * 1000;
+
+    /**
+     *
+     */
+    public int desiredMaxWalkDistanceEgress = 2 * 1000;
+
+
     /**
      * The maximum distance (in meters) the user is willing to walk for transfer legs.
      * Defaults to unlimited. Currently set to be the same value as maxWalkDistance.

--- a/src/test/java/org/opentripplanner/gtfs/GtfsContextBuilder.java
+++ b/src/test/java/org/opentripplanner/gtfs/GtfsContextBuilder.java
@@ -53,7 +53,10 @@ public class GtfsContextBuilder {
     public static GtfsContextBuilder contextBuilder(String defaultFeedId, String path) throws IOException {
         GtfsImport gtfsImport = gtfsImport(defaultFeedId, path);
         GtfsFeedId feedId = gtfsImport.getFeedId();
-        OtpTransitServiceBuilder transitBuilder = mapGtfsDaoToInternalTransitServiceBuilder(gtfsImport.getDao());
+        OtpTransitServiceBuilder transitBuilder = mapGtfsDaoToInternalTransitServiceBuilder(
+                gtfsImport.getDao(),
+                annotation -> null
+        );
         return new GtfsContextBuilder(feedId, transitBuilder);
     }
 


### PR DESCRIPTION
This pull requests introduces four new parameters in the OTP `/routers/{routerId}/plan` endpoint. These parameters are needed to make the access and egress walk distance more flexible.

The introduced parameters are:
- maxWalkDistanceAccess (The absolute maximum walking distance to transit)
- desiredMaxWalkDistanceAccess (The desired maximum walking distance to transit, first this distance is tried and then every time no stop is found 1000m is added until the maxWalkDistanceAccess is reached)
- maxWalkDistanceEgress (The absolute maximum walking distance in egress from transit)
- desiredMaxWalkDistanceEgress (The desired maximum walking distance in egress from transit, first this distance is tried and then every time no stop is found 1000m is added until the  maxWalkDistanceEgress is reached)

The existing maxWalkDistance parameter is used to setup maxWalkDistanceAccess and maxWalkDistanceEgress when one of the parameters is not specified. 

To be completed by pull request submitter:

- [x] **issue**: Part of #2622 
- [ ] **roadmap**: 
- [ ] **tests**: Have you added relevant test coverage? Are all the tests passing on [the continuous integration service (Travis CI)](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#continuous-integration)?
- [x] **formatting**: I think so (in the existing code there are already many warnings). 
- [ ] **documentation**: Will update the documentation when we agree about parameter naming.
- [ ] **changelog**: 

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)