### PR TITLE
Bump dependency versions in response to security alerts, closes #2892

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
     <properties>
         <geotools.version>20.1</geotools.version>
         <geotools.wfs.version>16.5</geotools.wfs.version>
-        <jackson.version>2.9.7</jackson.version>
+        <jackson.version>2.10.1</jackson.version>
         <jersey.version>2.18</jersey.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
@@ -672,7 +672,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.18</version>
+            <version>1.19</version>
         </dependency>
         <dependency>
             <groupId>commons-discovery</groupId>


### PR DESCRIPTION
This resolves the Github security alerts. Explanation of changes and why the alerts were dismissed in the associated issue #2892.  
