### PR TITLE
Update TransmodelAPI sandbox feature as code owner (2)

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelIndexGraphQLSchema.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelIndexGraphQLSchema.java
@@ -2066,7 +2066,7 @@ public class TransmodelIndexGraphQLSchema {
                         .name("publicCode")
                         .type(Scalars.GraphQLString)
                         .description("Publicly announced code for service journey, differentiating it from other service journeys for the same line. NOT IMPLEMENTED")
-                        .dataFetcher(environment -> null)
+                        .dataFetcher(environment -> "")
                         .build())
                 /*
                 .field(GraphQLFieldDefinition.newFieldDefinition()
@@ -2322,7 +2322,7 @@ public class TransmodelIndexGraphQLSchema {
                         .name("publicCode")
                         .type(Scalars.GraphQLString)
                         .description("Publicly announced code for line, differentiating it from other lines for the same operator.")
-                        .dataFetcher(environment -> (((Route) environment.getSource()).getShortName()))
+                        .dataFetcher(environment -> "")
                         .build())
                 .field(GraphQLFieldDefinition.newFieldDefinition()
                         .name("name")
@@ -3310,10 +3310,10 @@ public class TransmodelIndexGraphQLSchema {
                                 .findFirst()
                                 .orElse(null))
                         .build())
-                /*
+
                 .field(GraphQLFieldDefinition.newFieldDefinition()
                         .name("bikeRentalStationsByBbox")
-                        .description("Get all bike rental stations within the specified bounding box.")
+                        .description("Get all bike rental stations within the specified bounding box. NOT IMPLEMENTED")
                         .type(new GraphQLNonNull(new GraphQLList(bikeRentalStationType)))
                         .argument(GraphQLArgument.newArgument()
                                 .name("minimumLatitude")
@@ -3331,18 +3331,8 @@ public class TransmodelIndexGraphQLSchema {
                                 .name("maximumLongitude")
                                 .type(Scalars.GraphQLFloat)
                                 .build())
-                        .dataFetcher(environment -> index.graph.streetIndex
-                                .getBikeRentalStationForEnvelope(new Envelope(
-                                        new Coordinate(environment.getArgument("minimumLongitude"),
-                                                environment.getArgument("minimumLatitude")),
-                                        new Coordinate(environment.getArgument("maximumLongitude"),
-                                                environment.getArgument("maximumLatitude")))).stream()
-                                        .map(b -> b.getStation())
-                                        .sorted((s1, s2) -> s1.getName().toString().compareTo(s2.getName().toString()))
-                                        .collect(Collectors.toList())
-                                )
+                        .dataFetcher(environment -> Collections.emptyList())
                         .build())
-                 */
                 .field(GraphQLFieldDefinition.newFieldDefinition()
                         .name("bikePark")
                         .description("Get a single bike park based on its id")


### PR DESCRIPTION
This updates the Transmodel GraphQL schema to conform to the Entur clients. This change is needed so that we can test deployments of OTP2 at Entur.

This only changes sandbox code, and should therefore only require approval from the same organization.

Continuation of [#2890 ](https://github.com/opentripplanner/OpenTripPlanner/pull/2890)