### PR TITLE
add links to google groups in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ TODO OTP2: Write a short sentence about the OTP2 work: Raptor, Ruter/Entur, NeTE
 
 ## Mailing Lists
 
-The main forums through which the OpenTripPlanner community organizes development and provides mutual assistance are our two Google discussion groups. Changes and extensions to OTP are debated on the developers' list (opentripplanner-dev). More general questions and announcements of interest to non-developer OTP users should be directed to the opentripplanner-users list.
+The main forums through which the OpenTripPlanner community organizes development and provides mutual assistance are our two Google discussion groups. Changes and extensions to OTP are debated on the developers' list - [opentripplanner-dev](https://groups.google.com/forum/#!forum/opentripplanner-dev). More general questions and announcements of interest to non-developer OTP users should be directed to the [opentripplanner-users](https://groups.google.com/forum/#!forum/opentripplanner-users) list.


### PR DESCRIPTION
Add links in the README documentation to the google user groups. No changes to code.

This is a port of a PR merged into dev-1.x (#2915)


- [ ] **issue**: No issue for this .
- [ ] **roadmap**: No.
- [ ] **tests**: Not relevant.
- [x] **formatting**: README.md formatting unchanged. 
- [x] **documentation**: Doc update.
- [ ] **changelog**: No - not a feature or bugfix, to minor to be added to the change list.

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)