### PR TITLE
Code cleanup - Number of placeholders does not match number logging args

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
@@ -295,7 +295,7 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
                                     }
                                 } catch (Throwable t) {
                                     // Since this is work in progress - catch everything to continue processing updates
-                                    LOG.warn("Adding ExtraJourney with id='{}' failed with '{}'.", journey.getEstimatedVehicleJourneyCode(), t.getMessage());
+                                    LOG.warn("Adding ExtraJourney with id='{}' failed, caused by '{}'.", journey.getEstimatedVehicleJourneyCode(), t.getMessage());
                                     skippedCounter++;
                                 }
                             } else {

--- a/src/main/java/org/opentripplanner/graph_builder/DataImportIssuesToHTML.java
+++ b/src/main/java/org/opentripplanner/graph_builder/DataImportIssuesToHTML.java
@@ -132,7 +132,7 @@ public class DataImportIssuesToHTML implements GraphBuilderModule {
             HTMLWriter indexFileWriter = new HTMLWriter("index", (Multimap<String, String>)null);
             indexFileWriter.writeFile(issueTypeOccurrences, true);
         } catch (FileNotFoundException e) {
-            LOG.error("Index file coudn't be created:{}", e);
+            LOG.error("Index file coudn't be created: {}", e.getMessage(), e);
         }
 
         LOG.info("Data import issue logs are in {}", outPath);
@@ -172,7 +172,7 @@ public class DataImportIssuesToHTML implements GraphBuilderModule {
                 writers.add(file_writer);
             }
         } catch (FileNotFoundException ex) {
-            LOG.error("Output folder not found:{} {}", outPath, ex);
+            LOG.error("Output folder not found: {}", outPath, ex);
         }
     }
 

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/OSMDatabase.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/OSMDatabase.java
@@ -438,9 +438,11 @@ public class OSMDatabase {
                          * This should never happen (intersection between two lines should be a
                          * point or a multi-point).
                          */
-                        LOG.error("Alien intersection type between {} ({}--{}) and {} ({}--{}): ",
+                        LOG.error(
+                                "Alien intersection type between {} ({}--{}) and {} ({}--{}): {}",
                                 way, nA, nB, ringSegment.area.parent, ringSegment.nA,
-                                ringSegment.nB, intersection);
+                                ringSegment.nB, intersection
+                        );
                         continue;
                     }
                     
@@ -463,7 +465,7 @@ public class OSMDatabase {
                         	// we would only add it the first time.
                         	continue;
                         
-                        if (checkDistance(ringSegment.nA, nA, epsilon) || checkDistance(ringSegment.nB, nA, epsilon))
+                        if (checkDistanceWithin(ringSegment.nA, nA, epsilon) || checkDistanceWithin(ringSegment.nB, nA, epsilon))
                                 LOG.info("Node {} in way {} is coincident but disconnected with area {}",
                                     	nA.getId(), way.getId(), ringSegment.area.parent.getId());
                     }
@@ -474,7 +476,7 @@ public class OSMDatabase {
                         if (ringSegment.ring.nodes.contains(splitNode))
                         	continue;
                         
-                        if (checkDistance(ringSegment.nA, nB, epsilon) || checkDistance(ringSegment.nB, nB, epsilon))
+                        if (checkDistanceWithin(ringSegment.nA, nB, epsilon) || checkDistanceWithin(ringSegment.nB, nB, epsilon))
                             LOG.info("Node {} in way {} is coincident but disconnected with area {}",
                                 	nB.getId(), way.getId(), ringSegment.area.parent.getId());
                     }
@@ -488,10 +490,17 @@ public class OSMDatabase {
                     	
                     	way.addNodeRef(ringSegment.nA.getId(), i + 1);
                     	
-                        if (checkDistance(ringSegment.nA, nA, epsilon) || checkDistance(ringSegment.nA, nB, epsilon))
-                            LOG.info("Node {} in area {} is coincident but disconnected with way {}",
-                                	ringSegment.nA.getId(), way.getId(), ringSegment.area.parent.getId(), way.getId());
-                    	
+                        if (
+                                checkDistanceWithin(ringSegment.nA, nA, epsilon) ||
+                                checkDistanceWithin(ringSegment.nA, nB, epsilon)
+                        ) {
+                            LOG.info(
+                                    "Node {} in area {} is coincident but disconnected with way {}",
+                                    ringSegment.nA.getId(),
+                                    ringSegment.area.parent.getId(),
+                                    way.getId()
+                            );
+                        }
                     	// restart loop over way segments as we may have more intersections
                         // as we haven't modified the ring, there is no need to modify the spatial index, so breaking here is fine 
                     	i--;
@@ -505,10 +514,16 @@ public class OSMDatabase {
                     	
                     	way.addNodeRef(ringSegment.nB.getId(), i + 1);
                     	
-                        if (checkDistance(ringSegment.nB, nA, epsilon) || checkDistance(ringSegment.nB, nB, epsilon))
+                        if (
+                                checkDistanceWithin(ringSegment.nB, nA, epsilon) ||
+                                checkDistanceWithin(ringSegment.nB, nB, epsilon)
+                        ) {
                             LOG.info("Node {} in area {} is coincident but disconnected with way {}",
-                                	ringSegment.nB.getId(), way.getId(), ringSegment.area.parent.getId(), way.getId());
-                    	
+                                    ringSegment.nB.getId(),
+                                    ringSegment.area.parent.getId(),
+                                    way.getId()
+                            );
+                        }
                     	i--;
                     	break;
                     }
@@ -958,7 +973,7 @@ public class OSMDatabase {
     /**
      * Check if two nodes are within an epsilon.
      */
-    private static boolean checkDistance(OSMNode a, OSMNode b, double epsilon) {
+    private static boolean checkDistanceWithin(OSMNode a, OSMNode b, double epsilon) {
     	return Math.abs(a.lat - b.lat) < epsilon && Math.abs(a.lon - b.lon) < epsilon;
 	}
 }

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModule.java
@@ -537,7 +537,7 @@ public class OpenStreetMapModule implements GraphBuilderModule {
                 return false;
             }
             if (!walkAccessibleIn || !carAccessibleOut) {
-                LOG.warn("P+R '{}' ({}) is not walk-accessible");
+                LOG.warn("P+R '{}' ({}) is not walk-accessible", creativeName, osmId);
                 // This does not prevent routing as we only use P+R for car dropoff,
                 // but this is an issue with OSM data.
             }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/router/RaptorRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/router/RaptorRouter.java
@@ -159,14 +159,11 @@ public class RaptorRouter {
       itineraries.add(itinerary);
   }
 
-    LOG.info(
-        "Creating itineraries took {} ms",
-        itineraries.size(),
-        System.currentTimeMillis() - startItineraries
+  LOG.info(
+            "Creating {} itineraries took {} ms",
+            itineraries.size(),
+          System.currentTimeMillis() - startItineraries
     );
-
-    LOG.info("Creating itineraries took {} ms", itineraries.size(),
-        System.currentTimeMillis() - startItineraries);
 
     return itineraries;
   }

--- a/src/main/java/org/opentripplanner/standalone/config/ConfigFile.java
+++ b/src/main/java/org/opentripplanner/standalone/config/ConfigFile.java
@@ -112,8 +112,7 @@ class ConfigFile {
         try {
             return mapper.readTree(jsonString);
         } catch (IOException e) {
-            LOG.error("Can't read embedded config.");
-            LOG.error(e.getMessage());
+            LOG.error("Can't read embedded config: {}", e.getLocalizedMessage());
             throw new RuntimeException(e.getLocalizedMessage(), e);
         }
     }

--- a/src/main/java/org/opentripplanner/updater/stoptime/WebsocketGtfsRealtimeUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/WebsocketGtfsRealtimeUpdater.java
@@ -109,7 +109,7 @@ public class WebsocketGtfsRealtimeUpdater implements GraphUpdater {
                 LOG.error("Could not connect to {}: {}", url, e.getCause().getMessage());
                 connectionSuccessful = false;
             } catch (Exception e) {
-                LOG.error("Unknown exception when trying to connect to {}:", url, e);
+                LOG.error("Unknown exception when trying to connect to {}.", url, e);
                 connectionSuccessful = false;
             }
 


### PR DESCRIPTION
Number of placeholders does not match number of args in logging call inspections (IntelliJ code inspection used to fix this).

- [ ] **issue**: No issue, code cleanup - discussed at developer meeting 6. jan 2020.
- [ ] **roadmap**: No - to small.
- [ ] **tests**: No.
- [x] **formatting**: Done for code lines changed.
- [ ] **documentation**: No.
- [ ] **changelog**: No - to small

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)