### PR TITLE
Add links to master, 1.x and 2.x documentation on the front page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,12 @@ _This documentation is targeted primarily at the OTP development community and m
 
 If you want to get started right away running your own OTP instance, the best place to start is the [Basic Tutorial](Basic-Tutorial) page.
 
+## Versions of this documentation
+ - (OTP Master)[http://docs.opentripplanner.org/en/latest] - Latest release
+ - (OTP dev-1.x)[http://docs.opentripplanner.org/en/dev-1.x] - OTP 1 development branch 
+ - (OTP dev-2.x)[http://docs.opentripplanner.org/en/dev-2.x] - OTP 2 development branch
+
+
 ## External Technical Documentation
 
 Some technical documentation is generated automatically from the OTP source code and available from other locations.

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,9 +8,9 @@ _This documentation is targeted primarily at the OTP development community and m
 If you want to get started right away running your own OTP instance, the best place to start is the [Basic Tutorial](Basic-Tutorial) page.
 
 ## Versions of this documentation
- - (OTP Master)[http://docs.opentripplanner.org/en/latest] - Latest release
- - (OTP dev-1.x)[http://docs.opentripplanner.org/en/dev-1.x] - OTP 1 development branch 
- - (OTP dev-2.x)[http://docs.opentripplanner.org/en/dev-2.x] - OTP 2 development branch
+ - [OTP Master](http://docs.opentripplanner.org/en/latest) - Latest release
+ - [OTP dev-1.x](http://docs.opentripplanner.org/en/dev-1.x) - OTP 1 development branch 
+ - [OTP dev-2.x[(http://docs.opentripplanner.org/en/dev-2.x) - OTP 2 development branch
 
 
 ## External Technical Documentation


### PR DESCRIPTION
We have started to get questions on were to find the OTP2 documentation and the version button on the documentation page is a bit difficult to see, so I though it would be useful to at least have some links to the different versions on the front page.

- [ ] **issue**: No.
- [ ] **roadmap**: No
- [ ] **tests**: No
- [x] **formatting**: Yes
- [x] **documentation**: Yes
- [ ] **changelog**: No.

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)