### PR TITLE
Do not throw NPE if linestring is null in CompactLineString

### DIFF
--- a/src/main/java/org/opentripplanner/common/geometry/CompactLineString.java
+++ b/src/main/java/org/opentripplanner/common/geometry/CompactLineString.java
@@ -104,6 +104,7 @@ public final class CompactLineString {
      * 0-coordinates are added in order for the delta encoding to work correctly.
      */
     public static byte[] compactLineString(LineString lineString, boolean reverse) {
+        if (lineString == null) return null;
         lineString = GeometryUtils.addStartEndCoordinatesToLineString(
                 new Coordinate(0.0, 0.0),
                 lineString,

--- a/src/main/java/org/opentripplanner/graph_builder/module/geometry/GeometryAndBlockProcessor.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/geometry/GeometryAndBlockProcessor.java
@@ -263,9 +263,9 @@ public class GeometryAndBlockProcessor {
         // One less geometry than stoptime as array indexes represetn hops not stops (fencepost problem).
         LineString[] geoms = new LineString[stopTimes.size() - 1];
 
-        // Detect presence or absence of shape_dist_traveled on a per-trip basis
+        // Detect presence or absence of shape_dist_traveled on a per-trip basis both for stop_times and shape itself
         StopTime st0 = stopTimes.get(0);
-        boolean hasShapeDist = st0.isShapeDistTraveledSet();
+        boolean hasShapeDist = st0.isShapeDistTraveledSet() && getDistanceForShapeId(shapeId) != null;
         if (hasShapeDist) {
             // this trip has shape_dist in stop_times
             for (int i = 0; i < stopTimes.size() - 1; ++i) {


### PR DESCRIPTION
Closes #2962 

Also adds check if shape_dist_traveled does not exit for shapes, and progresses to interpolate the shapes based on closest points for each stop, similar to how the shapes are calculated, if no shape_dist_traveled exists in stop_times.

To be completed by pull request submitter:

- [x] **issue**: Link to or create an [issue](https://github.com/opentripplanner/OpenTripPlanner/issues) that describes the relevant feature or bug. Add [GitHub keywords](https://help.github.com/articles/closing-issues-using-keywords/) to this PR's description (e.g., `closes #45`).
- [ ] **roadmap**: Check the [roadmap](https://github.com/orgs/opentripplanner/projects/1) for this feature or bug. If it is not already on the roadmap, PLC will discuss as part of the review process.
- [x] **tests**: Have you added relevant test coverage? Are all the tests passing on [the continuous integration service (Travis CI)](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#continuous-integration)?
- [x] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#code-style)? 
- [x] **documentation**: If you are adding a new configuration option, have you added an explanation to the [configuration documentation](docs/Configuration.md) tables and sections?
- [ ] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)