### PR TITLE
Remove link "a quick introduction" in readme (which currently is 404)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ OpenTripPlanner (OTP) is an open source multi-modal trip planner. It depends on 
 
 The main Java server code is in `src/main/`. OTP also includes a Javascript client based on the Leaflet mapping library in `src/client/`. The Maven build produces a JAR file at `target/otp-VERSION.jar` containing all necessary code and dependencies to run OpenTripPlanner.
 
-Additional information and instructions are available in the [main documentation](http://opentripplanner.readthedocs.org/en/latest/), including a 
-[quick introduction](http://opentripplanner.readthedocs.org/en/latest/Basic-Usage/).
+Additional information and instructions are available in the [main documentation](http://opentripplanner.readthedocs.org/en/latest/).
 
 [![Build Status](https://travis-ci.org/opentripplanner/OpenTripPlanner.svg?branch=master)](https://travis-ci.org/opentripplanner/OpenTripPlanner)
 


### PR DESCRIPTION
Perhaps "a quick introduction" was meant to link to what is now "Basic Tutorial", but I think the home page of the docs lays out the options better, and this reduces maintenance needed at the readme, lets you focus on the docs.

I did not create an issue for this; the URL that is 404 is visible here in the change.

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)