### PR TITLE
Optimize copying of states to the next round

### DIFF
--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/Stops.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/Stops.java
@@ -13,7 +13,6 @@ import org.opentripplanner.transit.raptor.util.BitSetIterator;
 
 import java.util.BitSet;
 import java.util.Collection;
-import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
 
@@ -79,7 +78,7 @@ public final class Stops<T extends RaptorTripSchedule> {
         if(it==null) {
             return emptyList();
         }
-        return it.streamAfterMarker().collect(Collectors.toList());
+        return it.tailAfterMarker();
     }
 
     void clearTouchedStopsAndSetStopMarkers() {

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/Stops.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/Stops.java
@@ -78,7 +78,7 @@ public final class Stops<T extends RaptorTripSchedule> {
         if(it==null) {
             return emptyList();
         }
-        return it.tailAfterMarker();
+        return it.elementsAfterMarker();
     }
 
     void clearTouchedStopsAndSetStopMarkers() {

--- a/src/main/java/org/opentripplanner/transit/raptor/util/paretoset/ParetoSet.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/util/paretoset/ParetoSet.java
@@ -70,6 +70,10 @@ public class ParetoSet<T> extends AbstractCollection<T> {
         return Arrays.stream(elements, startInclusive, size);
     }
 
+    final T[] copyArray(int startInclusive) {
+        return Arrays.copyOfRange(elements, startInclusive, size);
+    }
+
     @Override
     public boolean add(T  newValue) {
         if (size == 0) {

--- a/src/main/java/org/opentripplanner/transit/raptor/util/paretoset/ParetoSet.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/util/paretoset/ParetoSet.java
@@ -4,7 +4,6 @@ import java.util.AbstractCollection;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 
 /**
@@ -61,17 +60,33 @@ public class ParetoSet<T> extends AbstractCollection<T> {
     }
 
 
+    /**
+     * Return an iterator over the contained collection.
+     * <p>
+     * This is NOT thread-safe and the behavior is undefined if the collection is modified during
+     * the iteration.
+     */
     @Override
     public final Iterator<T> iterator() {
-        return stream(0).iterator();
+        return tailIterator(0);
     }
 
-    final Stream<T> stream(int startInclusive) {
-        return Arrays.stream(elements, startInclusive, size);
-    }
-
-    final T[] copyArray(int startInclusive) {
-        return Arrays.copyOfRange(elements, startInclusive, size);
+    /**
+     * Return an iterable instance. This is made to be as FAST AS POSSIBLE, sacrificing
+     * thread-safety and modifiable protection.
+     * <p>
+     * The iterator created by this iterable is NOT thread-safe.
+     * <p>
+     * Do not modify the collection between the iterator is created, until the iterator complete.
+     * <p>
+     * It is safe to create as many iterators as you like. The iterator created will reflect the
+     * current set of elements in this set at the time of creation.
+     *
+     * @param startIndexInclusive the first element to include in the iterator, unlike the elements
+     *                            in  this set the index is cashed until an iterator is created.
+     */
+    final Iterable<T> tail(final int startIndexInclusive) {
+        return () -> tailIterator(startIndexInclusive);
     }
 
     @Override
@@ -189,6 +204,19 @@ public class ParetoSet<T> extends AbstractCollection<T> {
      */
     protected void notifyElementMoved(int fromIndex, int toIndex) {
         // Noop
+    }
+
+    /**
+     * This tail iterator is made to be FAST, it is NOT thread-safe and it the
+     * underlying collection is changed the returned values of the iterator also
+     * changes. Do not update on this collection while using this iterator.
+     */
+    private Iterator<T> tailIterator(final int startInclusive) {
+        return new Iterator<>() {
+            int i = startInclusive;
+            @Override public boolean hasNext() { return i < size; }
+            @Override public T next() { return elements[i++]; }
+        };
     }
 
     /**

--- a/src/main/java/org/opentripplanner/transit/raptor/util/paretoset/ParetoSetWithMarker.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/util/paretoset/ParetoSetWithMarker.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.transit.raptor.util.paretoset;
 
+import java.util.Iterator;
 import java.util.stream.Stream;
 
 
@@ -34,6 +35,10 @@ public class ParetoSetWithMarker<T> extends ParetoSet<T> {
         return stream(marker);
     }
 
+    public Iterable<T> tailAfterMarker() {
+        return iterableArray(copyArray(marker));
+    }
+
     /**
      * Move the marker after the last element in the set.
      */
@@ -46,5 +51,23 @@ public class ParetoSetWithMarker<T> extends ParetoSet<T> {
         if(fromIndex == marker) {
             marker = toIndex;
         }
+    }
+
+    public static<T> Iterable<T> iterableArray(T[] array) {
+        return () -> new Iterator<>() {
+            private int pos=0;
+
+            public boolean hasNext() {
+                return array.length>pos;
+            }
+
+            public T next() {
+                return array[pos++];
+            }
+
+            public void remove() {
+                throw new UnsupportedOperationException("Cannot remove an element of an array.");
+            }
+        };
     }
 }

--- a/src/main/java/org/opentripplanner/transit/raptor/util/paretoset/ParetoSetWithMarker.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/util/paretoset/ParetoSetWithMarker.java
@@ -1,9 +1,5 @@
 package org.opentripplanner.transit.raptor.util.paretoset;
 
-import java.util.Iterator;
-import java.util.stream.Stream;
-
-
 /**
  * {@link ParetoSet} with the possibility to set a index marker, which
  * can be used to list all elements added after the marker is set.
@@ -29,14 +25,10 @@ public class ParetoSetWithMarker<T> extends ParetoSet<T> {
     }
 
     /**
-     * Create a stream for all elements added after the marker.
+     * List all elements added after the marker.
      */
-    public Stream<T> streamAfterMarker() {
-        return stream(marker);
-    }
-
-    public Iterable<T> tailAfterMarker() {
-        return iterableArray(copyArray(marker));
+    public Iterable<T> elementsAfterMarker() {
+        return tail(marker);
     }
 
     /**
@@ -51,23 +43,5 @@ public class ParetoSetWithMarker<T> extends ParetoSet<T> {
         if(fromIndex == marker) {
             marker = toIndex;
         }
-    }
-
-    public static<T> Iterable<T> iterableArray(T[] array) {
-        return () -> new Iterator<>() {
-            private int pos=0;
-
-            public boolean hasNext() {
-                return array.length>pos;
-            }
-
-            public T next() {
-                return array[pos++];
-            }
-
-            public void remove() {
-                throw new UnsupportedOperationException("Cannot remove an element of an array.");
-            }
-        };
     }
 }

--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTest.java
@@ -175,7 +175,6 @@ public class SpeedTest {
         RaptorRequest<?> rReqUsed = null;
         int nPathsFound = 0;
         try {
-
             final SpeedTestRequest request = new SpeedTestRequest(testCase, opts, getTimeZoneId());
 
             if (opts.compareHeuristics()) {
@@ -241,7 +240,6 @@ public class SpeedTest {
             TIMER_COLLECT_RESULTS.start();
 
             if (response.paths().isEmpty()) {
-                numOfPathsFound.add(0);
                 throw new NoResultFound();
             }
 
@@ -354,7 +352,7 @@ public class SpeedTest {
     }
 
     private void forceGCToAvoidGCLater() {
-        WeakReference ref = new WeakReference<>(new Object());
+        WeakReference<?> ref = new WeakReference<>(new Object());
         while (ref.get() != null) {
             System.gc();
         }

--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTestRequest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTestRequest.java
@@ -99,7 +99,7 @@ public class SpeedTestRequest {
         builder.searchParams()
                 .boardSlackInSeconds(120)
                 .timetableEnabled(true)
-                .allowWaitingBetweenAccessAndTransit(false)
+                .allowWaitingBetweenAccessAndTransit(true)
                 .numberOfAdditionalTransfers(numOfExtraTransfers);
 
         if(testCase.departureTime != TestCase.NOT_SET) {


### PR DESCRIPTION
To be completed by pull request submitter:

- [X] **issue**: #2958
- [x] **roadmap**: Check the [roadmap](https://github.com/orgs/opentripplanner/projects/1) for this feature or bug. If it is not already on the roadmap, PLC will discuss as part of the review process.
- [x] **tests**: Have you added relevant test coverage? Are all the tests passing on [the continuous integration service (Travis CI)](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#continuous-integration)?
- [x] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#code-style)? 
- [x] **documentation**: If you are adding a new configuration option, have you added an explanation to the [configuration documentation](docs/Configuration.md) tables and sections?
- [x] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)

This is a change to the Stops.listArrivalsAfterMarker method. Instead of creating an ArrayList of StopArrivals after the marker, it instead uses Arrays.copyOfRange. This method is called over 8 million times in a long-distance search on the Norwegian graph over a long time range. For my test search the total time spent in this method decreases from 1.31 s to 0.44 s. This should not affect functionality at all.