### PR TITLE
Otp2 speed test add options

### DIFF
--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTest.java
@@ -11,7 +11,7 @@ import org.opentripplanner.transit.raptor.api.request.RaptorRequest;
 import org.opentripplanner.transit.raptor.api.response.RaptorResponse;
 import org.opentripplanner.transit.raptor.api.transit.TransitDataProvider;
 import org.opentripplanner.transit.raptor.speed_test.api.model.TripPlan;
-import org.opentripplanner.transit.raptor.speed_test.cli.SpeedTestCmdLineOpts;
+import org.opentripplanner.transit.raptor.speed_test.options.SpeedTestCmdLineOpts;
 import org.opentripplanner.transit.raptor.speed_test.testcase.CsvFileIO;
 import org.opentripplanner.transit.raptor.speed_test.testcase.NoResultFound;
 import org.opentripplanner.transit.raptor.speed_test.testcase.TestCase;

--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTest.java
@@ -12,6 +12,7 @@ import org.opentripplanner.transit.raptor.api.response.RaptorResponse;
 import org.opentripplanner.transit.raptor.api.transit.TransitDataProvider;
 import org.opentripplanner.transit.raptor.speed_test.api.model.TripPlan;
 import org.opentripplanner.transit.raptor.speed_test.options.SpeedTestCmdLineOpts;
+import org.opentripplanner.transit.raptor.speed_test.options.SpeedTestConfig;
 import org.opentripplanner.transit.raptor.speed_test.testcase.CsvFileIO;
 import org.opentripplanner.transit.raptor.speed_test.testcase.NoResultFound;
 import org.opentripplanner.transit.raptor.speed_test.testcase.TestCase;
@@ -50,6 +51,7 @@ public class SpeedTest {
     private final AvgTimer TIMER_COLLECT_RESULTS = AvgTimer.timerMilliSec("SpeedTest: Collect Results");
 
     private final SpeedTestCmdLineOpts opts;
+    private final SpeedTestConfig config;
     private int nAdditionalTransfers;
     private SpeedTestProfile routeProfile;
     private SpeedTestProfile heuristicProfile;
@@ -66,6 +68,7 @@ public class SpeedTest {
 
     private SpeedTest(SpeedTestCmdLineOpts opts) {
         this.opts = opts;
+        this.config = SpeedTestConfig.config(opts.rootDir());
         this.graph = loadGraph(opts.rootDir());
         this.transitLayer = TransitLayerMapper.map(graph);
         this.streetRouter = new EgressAccessRouter(graph, transitLayer);
@@ -175,11 +178,11 @@ public class SpeedTest {
         RaptorRequest<?> rReqUsed = null;
         int nPathsFound = 0;
         try {
-            final SpeedTestRequest request = new SpeedTestRequest(testCase, opts, getTimeZoneId());
+            final SpeedTestRequest request = new SpeedTestRequest(testCase, opts, config, getTimeZoneId());
 
             if (opts.compareHeuristics()) {
                 TOT_TIMER.start();
-                SpeedTestRequest heurReq = new SpeedTestRequest(testCase, opts, getTimeZoneId());
+                SpeedTestRequest heurReq = new SpeedTestRequest(testCase, opts, config, getTimeZoneId());
                 compareHeuristics(heurReq, request);
                 TOT_TIMER.stop();
             } else {

--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTestRequest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTestRequest.java
@@ -10,7 +10,7 @@ import org.opentripplanner.transit.raptor.api.request.RaptorProfile;
 import org.opentripplanner.transit.raptor.api.request.RaptorRequest;
 import org.opentripplanner.transit.raptor.api.request.RaptorRequestBuilder;
 import org.opentripplanner.transit.raptor.api.request.RaptorTuningParameters;
-import org.opentripplanner.transit.raptor.speed_test.cli.SpeedTestCmdLineOpts;
+import org.opentripplanner.transit.raptor.speed_test.options.SpeedTestCmdLineOpts;
 import org.opentripplanner.transit.raptor.speed_test.testcase.TestCase;
 import org.opentripplanner.transit.raptor.speed_test.transit.AccessEgressLeg;
 import org.opentripplanner.transit.raptor.speed_test.transit.EgressAccessRouter;

--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTestRequest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTestRequest.java
@@ -11,6 +11,7 @@ import org.opentripplanner.transit.raptor.api.request.RaptorRequest;
 import org.opentripplanner.transit.raptor.api.request.RaptorRequestBuilder;
 import org.opentripplanner.transit.raptor.api.request.RaptorTuningParameters;
 import org.opentripplanner.transit.raptor.speed_test.options.SpeedTestCmdLineOpts;
+import org.opentripplanner.transit.raptor.speed_test.options.SpeedTestConfig;
 import org.opentripplanner.transit.raptor.speed_test.testcase.TestCase;
 import org.opentripplanner.transit.raptor.speed_test.transit.AccessEgressLeg;
 import org.opentripplanner.transit.raptor.speed_test.transit.EgressAccessRouter;
@@ -48,11 +49,12 @@ public class SpeedTestRequest {
     private final TestCase testCase;
     private final SpeedTestCmdLineOpts opts;
     private final ZoneId inputZoneId;
-    private final LocalDate date = LocalDate.of(2019, 11, 12);
+    private final LocalDate date;
 
-    SpeedTestRequest(TestCase testCase, SpeedTestCmdLineOpts opts, ZoneId inputZoneId) {
+    SpeedTestRequest(TestCase testCase, SpeedTestCmdLineOpts opts, SpeedTestConfig config, ZoneId inputZoneId) {
         this.testCase = testCase;
         this.opts = opts;
+        this.date = config.getTestDate();
         this.inputZoneId = inputZoneId;
     }
 

--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/options/SpeedTestCmdLineOpts.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/options/SpeedTestCmdLineOpts.java
@@ -1,4 +1,4 @@
-package org.opentripplanner.transit.raptor.speed_test.cli;
+package org.opentripplanner.transit.raptor.speed_test.options;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;

--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/options/SpeedTestCmdLineOpts.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/options/SpeedTestCmdLineOpts.java
@@ -95,35 +95,7 @@ public class SpeedTestCmdLineOpts {
         return 0;
     }
 
-    private Options options() {
-        Options options = new Options();
-
-        // General options
-        options.addOption(HELP, "help", false, "Print all command line options, then exit. (Optional)");
-        options.addOption(VERBOSE, "verbose", false, "Verbose output, print itineraries.");
-        options.addOption(ROOT_DIR, "dir", true, "The directory where network and input files are located. (Optional)");
-
-        // Search options
-        options.addOption(PROFILES, "profiles", true, "A coma separated list of configuration profiles:\n" + String.join("\n", SpeedTestProfile.options()));
-        options.addOption(TEST_CASES, "testCases", true, "A coma separated list of test case ids to run.");
-        options.addOption(SAMPLE_TEST_N_TIMES, "sampleTestNTimes", true, "Repeat the test N times. Profiles are altered in a round robin fashion.");
-        options.addOption(NUM_OF_ADD_TRANSFERS, "nExtraTransfers", true, "The maximum number of extra transfers allowed relative to the path with the fewest transfers.");
-
-        // Result options
-        options.addOption(NUM_OF_ITINERARIES, "numOfItineraries", true, "Number of itineraries to return.");
-        options.addOption(COMPARE_HEURISTICS, "compare", false, "Compare heuristics for the listed profiles. The 1st profile is compared with 2..n listed profiles.");
-
-        // Debug options
-        options.addOption(DEBUG, "debug", false, "Enable debug info.");
-        options.addOption(DEBUG_STOPS, "debugStops", true, "A coma separated list of stops to debug.");
-        options.addOption(DEBUG_PATH, "debugPath", true, "A coma separated list of stops representing a trip/path to debug. " +
-                "Use a '*' to indicate where to start debugging. For example '1,*2,3' will print event at stop 2 and 3, " +
-                "but not stop 1 for all trips starting with the given stop sequence.");
-        options.addOption(DEBUG_REQUEST, "debugRequest", false, "Debug request.");
-        return options;
-    }
-
-   public boolean verbose() {
+    public boolean verbose() {
         return cmd.hasOption(VERBOSE);
     }
 
@@ -152,6 +124,34 @@ public class SpeedTestCmdLineOpts {
     public List<String> testCaseIds() {
         return parseCSVList(TEST_CASES);
     }
+
+    private Options options() {
+        Options options = new Options();
+
+        // General options
+        options.addOption(HELP, "help", false, "Print all command line options, then exit. (Optional)");
+        options.addOption(VERBOSE, "verbose", false, "Verbose output, print itineraries.");
+        options.addOption(ROOT_DIR, "dir", true, "The directory where network and input files are located. (Optional)");
+
+        // Search options
+        options.addOption(PROFILES, "profiles", true, "A coma separated list of configuration profiles:\n" + String.join("\n", SpeedTestProfile.options()));
+        options.addOption(TEST_CASES, "testCases", true, "A coma separated list of test case ids to run.");
+        options.addOption(SAMPLE_TEST_N_TIMES, "sampleTestNTimes", true, "Repeat the test N times. Profiles are altered in a round robin fashion.");
+        options.addOption(NUM_OF_ADD_TRANSFERS, "nExtraTransfers", true, "The maximum number of extra transfers allowed relative to the path with the fewest transfers.");
+
+        // Result options
+        options.addOption(NUM_OF_ITINERARIES, "numOfItineraries", true, "Number of itineraries to return.");
+        options.addOption(COMPARE_HEURISTICS, "compare", false, "Compare heuristics for the listed profiles. The 1st profile is compared with 2..n listed profiles.");
+
+        // Debug options
+        options.addOption(DEBUG, "debug", false, "Enable debug info.");
+        options.addOption(DEBUG_STOPS, "debugStops", true, "A coma separated list of stops to debug.");
+        options.addOption(DEBUG_PATH, "debugPath", true, "A coma separated list of stops representing a trip/path to debug. " +
+                "Use a '*' to indicate where to start debugging. For example '1,*2,3' will print event at stop 2 and 3, " +
+                "but not stop 1 for all trips starting with the given stop sequence.");
+        options.addOption(DEBUG_REQUEST, "debugRequest", false, "Debug request.");
+        return options;
+   }
 
     List<String> parseCSVList(String opt) {
         return cmd.hasOption(opt)

--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/options/SpeedTestConfig.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/options/SpeedTestConfig.java
@@ -1,0 +1,52 @@
+package org.opentripplanner.transit.raptor.speed_test.options;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.LocalDate;
+
+public class SpeedTestConfig {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SpeedTestConfig.class);
+    public static final String FILE_NAME = "speed-test-config.json";
+
+    private LocalDate testDate = LocalDate.now();
+
+    public void setTestDate(String testDate) {
+        this.testDate = LocalDate.parse(testDate);
+    }
+
+    /**
+     * The test date is the date used for all test cases. The default value is today.
+     */
+    public LocalDate getTestDate() {
+        return testDate;
+    }
+
+    public static SpeedTestConfig config(File dir) {
+        try {
+            File configFile = new File(dir, FILE_NAME);
+
+            if(!configFile.exists()) {
+                LOG.warn(
+                        "SpeedTest config file not found. Default " +
+                        "config is used. Missing file: {}",
+                        configFile.getAbsolutePath()
+                );
+                return new SpeedTestConfig();
+            }
+
+            ObjectMapper mapper = new ObjectMapper();
+            mapper.configure(JsonParser.Feature.ALLOW_COMMENTS, true);
+            mapper.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true);
+            return mapper.readValue(configFile, SpeedTestConfig.class);
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+}

--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/testcase/Place.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/testcase/Place.java
@@ -15,7 +15,7 @@ public class Place {
         this.lat = lat;
         this.lon = lon;
         this.description = description;
-        this.stopId = stopId == null ? null : new FeedScopedId(feedId, stopId);
+        this.stopId = isBlank(stopId) ? null : new FeedScopedId(feedId, stopId);
     }
 
     public double getLat() {
@@ -32,6 +32,10 @@ public class Place {
 
     public FeedScopedId getStopId() {
         return stopId;
+    }
+
+    public Coordinate getCoordinate() {
+        return new Coordinate(lon, lat);
     }
 
     public String coordinateAsString() {
@@ -58,7 +62,7 @@ public class Place {
         return Objects.hash(lat, lon, stopId);
     }
 
-    public Coordinate getCoordinate() {
-        return new Coordinate(lon, lat);
+    private static boolean isBlank(String value) {
+        return value == null || value.isBlank();
     }
 }

--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/transit/StreetSearch.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/transit/StreetSearch.java
@@ -68,7 +68,7 @@ class StreetSearch {
         );
 
         if(stopAtDistanceList.isEmpty()) {
-            throw new RuntimeException("Point not near a road: " + place);
+            throw new RuntimeException("No stops found nearby: " + place);
         }
 
         for (NearbyStopFinder.StopAtDistance stopAtDistance : stopAtDistanceList) {

--- a/src/test/resources/raptor/speedtest/norway/README.md
+++ b/src/test/resources/raptor/speedtest/norway/README.md
@@ -1,8 +1,12 @@
 
-Download GTFS data:
+#### Download GTFS data:
 
  - https://storage.googleapis.com/marduk-production/outbound/gtfs/rb_norway-aggregated-gtfs.zip
 
 If the link above do not work you should be able to find it on the ENTUR web:
  
  - https://www.entur.org/
+
+#### Configure the test
+ - Set the testDate in the speed-test-config.json
+ 

--- a/src/test/resources/raptor/speedtest/norway/speed-test-config.json
+++ b/src/test/resources/raptor/speedtest/norway/speed-test-config.json
@@ -1,0 +1,4 @@
+{
+  // Run all test-cases on the given date
+  testDate: "2020-01-15"
+}


### PR DESCRIPTION
**This PR only modify the SpeedTest.**

This PR add the possibility to configure the SpeedTest using a config file _speed-test-config.json_. The only configurable property added is the `testDate`. The `testDate` is used to set witch date all test cases travel requests are made. This was previously hardcoded in the code. We want this to be configurable and follow the test input. It is important to run the test for a given date to get consistent results (regression testing). This also allow for creating multiple set setups with different cases and data. 

An alternative was to make the date part each test case _travelSearch.csv_, but this would be harder to maintain when the graph is updated and you want to run the test for a different day. If needed we could add date the the  _travelSearch.csv_ later and used the config value as a default.

- [ ] **issue**: No - SpeedTest update only.
- [ ] **roadmap**: The SpeedTest is essencial to regression test the Raptor implementaion.
- [x] **tests**: This is the test.
- [x] **formatting**: yes. 
- [x] **documentation**: The example README.md is updated.
- [ ] **changelog**: No, the SpeedTest is added as part of the new Raptor implementation, witch has a changelog entry already.

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)