### PR TITLE
Bugfix on dynamic search-window

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/filterchain/filters/DebugFilterChain.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/filterchain/filters/DebugFilterChain.java
@@ -58,6 +58,7 @@ public class DebugFilterChain implements ItineraryFilter {
                 "This itinerary is marked as deleted by " + filterName + " filter. "
         );
         alert.alertDescriptionText = alert.alertDetailText;
+        alert.alertType = "incident";
 
         AlertPatch patch = new AlertPatch();
         patch.setAlert(alert);

--- a/src/main/java/org/opentripplanner/transit/raptor/api/request/RaptorRequest.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/request/RaptorRequest.java
@@ -11,7 +11,7 @@ import java.util.Set;
 
 
 /**
- * All input parameters to RangeRaptor that is spesific to a routing request.
+ * All input parameters to RangeRaptor that is specific to a routing request.
  * See {@link TransitDataProvider} for transit data.
  *
  * @param <T> The TripSchedule type defined by the user of the raptor API.
@@ -19,7 +19,7 @@ import java.util.Set;
 public class RaptorRequest<T extends RaptorTripSchedule> {
     private final SearchParams searchParams;
     private final RaptorProfile profile;
-    private final boolean searchForward;
+    private final SearchDirection searchDirection;
     private final Set<Optimization> optimizations;
     private final McCostParams mcCostParams;
     private final DebugRequest<T> debug;
@@ -32,7 +32,7 @@ public class RaptorRequest<T extends RaptorTripSchedule> {
     private RaptorRequest() {
         searchParams = SearchParams.defaults();
         profile = RaptorProfile.MULTI_CRITERIA;
-        searchForward = true;
+        searchDirection = SearchDirection.FORWARD;
         optimizations = Collections.emptySet();
         mcCostParams = McCostParams.DEFAULTS;
         debug = DebugRequest.defaults();
@@ -41,7 +41,7 @@ public class RaptorRequest<T extends RaptorTripSchedule> {
     RaptorRequest(RaptorRequestBuilder<T> builder) {
         this.searchParams = builder.searchParams().buildSearchParam();
         this.profile = builder.profile();
-        this.searchForward = builder.searchForward();
+        this.searchDirection = builder.searchDirection();
         this.optimizations = Set.copyOf(builder.optimizations());
         this.mcCostParams = new McCostParams(builder.mcCostFactors());
         this.debug = builder.debug().build();
@@ -90,29 +90,8 @@ public class RaptorRequest<T extends RaptorTripSchedule> {
         return profile;
     }
 
-    /**
-     * Set search direction to REVERSE to performed a search  from the destination
-     * to the origin. Thie traverse the transit graph backwards in time.
-     * This parameter is used internally to produce heuristics, and is normally not
-     * something you would like to do unless you are testing or analyzing.
-     * <p/>
-     *
-     * @return  NOT {@link #searchForward()}
-     */
-    public boolean searchInReverse() {
-        return !searchForward;
-    }
-
-    /**
-     * When TRUE the search is performed from the origin to the destination in a
-     * normal way.
-     * <p/>
-     * Optional. Default value is 'true'.
-     *
-     * @return true is search is forward.
-     */
-    public boolean searchForward() {
-        return searchForward;
+    public SearchDirection searchDirection() {
+        return searchDirection;
     }
 
     /**
@@ -162,7 +141,7 @@ public class RaptorRequest<T extends RaptorTripSchedule> {
         return "RangeRaptorRequest{" +
                 "searchParams=" + searchParams +
                 ", profile=" + profile +
-                ", searchForward=" + searchForward +
+                ", searchForward=" + searchDirection +
                 ", optimizations=" + optimizations +
                 ", mcCostParams=" + mcCostParams +
                 ", debug=" + debug +

--- a/src/main/java/org/opentripplanner/transit/raptor/api/request/RaptorRequestBuilder.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/request/RaptorRequestBuilder.java
@@ -21,7 +21,7 @@ import java.util.Set;
 public class RaptorRequestBuilder<T extends RaptorTripSchedule> {
     // Search
     private final SearchParamsBuilder<T> searchParams;
-    private boolean searchForward;
+    private SearchDirection searchDirection;
 
     // Algorithm
     private RaptorProfile profile;
@@ -38,7 +38,7 @@ public class RaptorRequestBuilder<T extends RaptorTripSchedule> {
 
     RaptorRequestBuilder(RaptorRequest<T> defaults) {
         this.searchParams = new SearchParamsBuilder<>(this, defaults.searchParams());
-        this.searchForward = defaults.searchForward();
+        this.searchDirection = defaults.searchDirection();
 
         // Algorithm
         this.profile = defaults.profile();
@@ -62,12 +62,12 @@ public class RaptorRequestBuilder<T extends RaptorTripSchedule> {
         return this;
     }
 
-    public boolean searchForward() {
-        return searchForward;
+    public SearchDirection searchDirection() {
+        return searchDirection;
     }
 
-    public RaptorRequestBuilder<T> searchDirection(boolean searchForward) {
-        this.searchForward = searchForward;
+    public RaptorRequestBuilder<T> searchDirection(SearchDirection searchDirection) {
+        this.searchDirection = searchDirection;
         return this;
     }
 

--- a/src/main/java/org/opentripplanner/transit/raptor/api/request/SearchDirection.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/request/SearchDirection.java
@@ -1,0 +1,38 @@
+package org.opentripplanner.transit.raptor.api.request;
+
+/**
+ * This enum describe the direction witch a search is performed.
+ * <p>
+ * The normal way is to search {@link #FORWARD} from the origin to the destination.
+ * <p>
+ * Set search direction to {@link #REVERSE} to performed a search from the destination to the origin.
+ * This will traverse the transit graph backwards in time. This is used in Raptor to produce
+ * heuristics, and is normally not something you would like to do unless you are testing or
+ * analyzing. This should not be confused with <em>Range Raptor iterations</em>> witch
+ * step-backward-in-time (start with the last minute of the search window), but
+ * searches {@link #FORWARD}. {@link #REVERSE} search is supported by the current implementation
+ * of RangeRaptor.
+ * <p>
+ * In the Raptor code we will refer to the origin and and destination assuming the search direction
+ * is {@link #FORWARD}.
+ */
+public enum SearchDirection {
+
+    /**
+     * Search from origin to destination, forward in time.
+     */
+    FORWARD,
+
+    /**
+     * Search from destination to origin, backward in time.
+      */
+    REVERSE;
+
+    public boolean isForward() {
+        return this == FORWARD;
+    }
+
+    public boolean isInReverse() {
+        return this == REVERSE;
+    }
+}

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/configure/RaptorConfig.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/configure/RaptorConfig.java
@@ -12,7 +12,7 @@ import org.opentripplanner.transit.raptor.rangeraptor.WorkerState;
 import org.opentripplanner.transit.raptor.rangeraptor.multicriteria.configure.McRangeRaptorConfig;
 import org.opentripplanner.transit.raptor.rangeraptor.standard.configure.StdRangeRaptorConfig;
 import org.opentripplanner.transit.raptor.rangeraptor.standard.heuristics.HeuristicSearch;
-import org.opentripplanner.transit.raptor.rangeraptor.transit.RaptorSearchWindowCalculator;
+import org.opentripplanner.transit.raptor.service.RaptorSearchWindowCalculator;
 import org.opentripplanner.transit.raptor.rangeraptor.transit.SearchContext;
 import org.opentripplanner.transit.raptor.service.WorkerPerformanceTimersCache;
 

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/transit/SearchContext.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/transit/SearchContext.java
@@ -66,11 +66,15 @@ public class SearchContext<T extends RaptorTripSchedule> {
     }
 
     public Collection<TransferLeg> accessLegs() {
-        return request.searchForward() ? request.searchParams().accessLegs() : request.searchParams().egressLegs();
+        return request.searchDirection().isForward()
+                ? request.searchParams().accessLegs()
+                : request.searchParams().egressLegs();
     }
 
     public Collection<TransferLeg> egressLegs() {
-        return request.searchForward() ? request.searchParams().egressLegs() : request.searchParams().accessLegs();
+        return request.searchDirection().isForward()
+                ? request.searchParams().egressLegs()
+                : request.searchParams().accessLegs();
     }
 
     public int[] egressStops() {
@@ -143,11 +147,15 @@ public class SearchContext<T extends RaptorTripSchedule> {
      */
     private static TransitCalculator createCalculator(RaptorRequest<?> r, RaptorTuningParameters t) {
         SearchParams s = r.searchParams();
-        return r.searchForward() ? new ForwardSearchTransitCalculator(s, t) : new ReverseSearchTransitCalculator(s, t);
+        return r.searchDirection().isForward()
+                ? new ForwardSearchTransitCalculator(s, t)
+                : new ReverseSearchTransitCalculator(s, t);
     }
 
     private DebugRequest<T> debugRequest(RaptorRequest<T> request) {
-        return request.searchForward() ? request.debug() : request.mutate().debug().reverseDebugRequest().build();
+        return request.searchDirection().isForward()
+                ? request.debug()
+                : request.mutate().debug().reverseDebugRequest().build();
     }
 
     public RoundProvider roundProvider() {

--- a/src/main/java/org/opentripplanner/transit/raptor/service/DebugHeuristics.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/service/DebugHeuristics.java
@@ -3,6 +3,7 @@ package org.opentripplanner.transit.raptor.service;
 import org.opentripplanner.transit.raptor.api.debug.DebugLogger;
 import org.opentripplanner.transit.raptor.api.request.DebugRequest;
 import org.opentripplanner.transit.raptor.api.request.RaptorRequest;
+import org.opentripplanner.transit.raptor.api.request.SearchDirection;
 import org.opentripplanner.transit.raptor.api.view.Heuristics;
 import org.opentripplanner.transit.raptor.util.CompareIntArrays;
 import org.opentripplanner.transit.raptor.util.IntUtils;
@@ -38,7 +39,7 @@ public class DebugHeuristics {
     ) {
         DebugRequest<?> debug = request.debug();
         if (debug.logger().isEnabled(HEURISTICS)) {
-            new DebugHeuristics(aName, bName, debug).debug(h1, h2, request.searchForward());
+            new DebugHeuristics(aName, bName, debug).debug(h1, h2, request.searchDirection());
         }
     }
 
@@ -46,7 +47,7 @@ public class DebugHeuristics {
         logger.debug(HEURISTICS, message);
     }
 
-    private void debug(Heuristics fwdHeur, Heuristics revHeur, boolean forward) {
+    private void debug(Heuristics fwdHeur, Heuristics revHeur, SearchDirection direction) {
         log(CompareIntArrays.compare(
                 "NUMBER OF TRANSFERS",
                 aName, fwdHeur.bestNumOfTransfersToIntArray(UNREACHED),
@@ -61,7 +62,7 @@ public class DebugHeuristics {
                 bName, revHeur.bestTravelDurationToIntArray(UNREACHED),
                 UNREACHED,
                 stops,
-                forward ? comparingInt(i -> i) : (l, r) -> r - l
+                direction.isForward() ? comparingInt(i -> i) : (l, r) -> r - l
         ));
     }
 }

--- a/src/main/java/org/opentripplanner/transit/raptor/service/HeuristicSearchTask.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/service/HeuristicSearchTask.java
@@ -2,6 +2,7 @@ package org.opentripplanner.transit.raptor.service;
 
 import org.opentripplanner.transit.raptor.api.request.RaptorRequest;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
+import org.opentripplanner.transit.raptor.api.request.SearchDirection;
 import org.opentripplanner.transit.raptor.api.transit.TransitDataProvider;
 import org.opentripplanner.transit.raptor.api.view.Heuristics;
 import org.opentripplanner.transit.raptor.rangeraptor.configure.RaptorConfig;
@@ -23,7 +24,7 @@ import static org.opentripplanner.transit.raptor.api.request.RaptorProfile.NO_WA
 public class HeuristicSearchTask<T extends RaptorTripSchedule> {
     private static final Logger LOG = LoggerFactory.getLogger(HeuristicSearchTask.class);
 
-    private final boolean direction;
+    private final SearchDirection direction;
     private final String name;
     private final RaptorConfig<T> config;
     private final TransitDataProvider<T> transitData;
@@ -38,7 +39,7 @@ public class HeuristicSearchTask<T extends RaptorTripSchedule> {
             TransitDataProvider<T> transitData
     ) {
         this(
-                request.searchForward(),
+                request.searchDirection(),
                 RequestAlias.alias(request, config.isMultiThreaded()),
                 config,
                 transitData
@@ -47,7 +48,7 @@ public class HeuristicSearchTask<T extends RaptorTripSchedule> {
     }
 
     public HeuristicSearchTask(
-            boolean direction,
+            SearchDirection direction,
             String name,
             RaptorConfig<T> config,
             TransitDataProvider<T> transitData
@@ -68,6 +69,10 @@ public class HeuristicSearchTask<T extends RaptorTripSchedule> {
 
     public boolean isEnabled() {
         return run;
+    }
+
+    public SearchDirection getDirection() {
+        return direction;
     }
 
     public HeuristicSearch<T> search() {

--- a/src/main/java/org/opentripplanner/transit/raptor/service/RangRaptorDynamicSearch.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/service/RangRaptorDynamicSearch.java
@@ -22,6 +22,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
 import static org.opentripplanner.transit.raptor.api.request.RaptorProfile.MULTI_CRITERIA;
+import static org.opentripplanner.transit.raptor.api.request.SearchDirection.FORWARD;
+import static org.opentripplanner.transit.raptor.api.request.SearchDirection.REVERSE;
 import static org.opentripplanner.transit.raptor.service.HeuristicToRunResolver.resolveHeuristicToRunBasedOnOptimizationsAndSearchParameters;
 
 
@@ -36,11 +38,7 @@ import static org.opentripplanner.transit.raptor.service.HeuristicToRunResolver.
  * to configure the "main" multi-iteration RangeRaptor search.
  */
 public class RangRaptorDynamicSearch<T extends RaptorTripSchedule> {
-
     private static final Logger LOG = LoggerFactory.getLogger(RangRaptorDynamicSearch.class);
-
-    private static final boolean FORWARD = true;
-    private static final boolean REVERSE = false;
 
     private final RaptorConfig<T> config;
     private final TransitDataProvider<T> transitData;

--- a/src/main/java/org/opentripplanner/transit/raptor/service/RangRaptorDynamicSearch.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/service/RangRaptorDynamicSearch.java
@@ -10,7 +10,6 @@ import org.opentripplanner.transit.raptor.api.transit.TransitDataProvider;
 import org.opentripplanner.transit.raptor.api.view.Heuristics;
 import org.opentripplanner.transit.raptor.api.view.Worker;
 import org.opentripplanner.transit.raptor.rangeraptor.configure.RaptorConfig;
-import org.opentripplanner.transit.raptor.rangeraptor.transit.RaptorSearchWindowCalculator;
 import org.opentripplanner.util.OtpAppException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/org/opentripplanner/transit/raptor/service/RangRaptorDynamicSearch.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/service/RangRaptorDynamicSearch.java
@@ -17,8 +17,10 @@ import org.slf4j.LoggerFactory;
 import java.util.BitSet;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.stream.Collectors;
 
 import static org.opentripplanner.transit.raptor.api.request.RaptorProfile.MULTI_CRITERIA;
 import static org.opentripplanner.transit.raptor.api.request.SearchDirection.FORWARD;
@@ -172,24 +174,44 @@ public class RangRaptorDynamicSearch<T extends RaptorTripSchedule> {
      * @throws DestinationNotReachedException if destination is not reached
      */
     private void runHeuristicsSequentially() {
-        if (originalRequest.searchParams().isEarliestDepartureTimeSet()) {
-            fwdHeuristics.withRequest(originalRequest).run();
-            calculateDynamicParametersFromHeuristics(fwdHeuristics.result());
+        List<HeuristicSearchTask<T>> tasks = listTasksInOrder();
 
-            // The request need to be injected here to allow the reverse heuristics
-            // to use a calculated LAT
-            RaptorRequest<T> request = requestForReverseHeurSearchWithDynamicSearchParams();
-            revHeuristics.withRequest(request).run();
-        }
-        else {
-            revHeuristics.withRequest(originalRequest).run();
-            calculateDynamicParametersFromHeuristics(fwdHeuristics.result());
+        if(tasks.isEmpty()) { return; }
 
-            // The request need to be injected here to allow the forward heuristics
-            // to use EDT calculated above
-            RaptorRequest<T> request = requestForForwardHeurSearchWithDynamicSearchParams();
-            fwdHeuristics.withRequest(request).run();
-        }
+        // Run the first heuristic search
+        HeuristicSearchTask<T> task;
+        task = tasks.get(0);
+        task.withRequest(originalRequest).run();
+        calculateDynamicSearchParametersFromHeuristics(task.result());
+
+        if(tasks.size() == 1) { return; }
+
+        // Run the second heuristic search
+        task = tasks.get(1);
+        RaptorRequest<T> request = task.getDirection().isForward()
+                ? requestForForwardHeurSearchWithDynamicSearchParams()
+                : requestForReverseHeurSearchWithDynamicSearchParams();
+
+        task.withRequest(request).run();
+    }
+
+    /**
+     * If the earliest-departure-time(EDT) is set, the task order should be:
+     * <ol>
+     *     <li>{@code FORWARD}</li>
+     *     <li>{@code REVERSE}</li>
+     * </ol>
+     * If not EDT is set, the latest-arrival-time is set, and the order should be the opposite,
+     * with {@code REVERSE} first
+     */
+    private List<HeuristicSearchTask<T>> listTasksInOrder() {
+        boolean performForwardFirst = originalRequest.searchParams().isEarliestDepartureTimeSet();
+
+        List<HeuristicSearchTask<T>> list = performForwardFirst
+                ? List.of(fwdHeuristics, revHeuristics)
+                : List.of(revHeuristics, fwdHeuristics);
+
+        return list.stream().filter(HeuristicSearchTask::isEnabled).collect(Collectors.toList());
     }
 
     private RaptorRequest<T> requestForForwardHeurSearchWithDynamicSearchParams() {
@@ -245,7 +267,7 @@ public class RangRaptorDynamicSearch<T extends RaptorTripSchedule> {
         return request.mutate().searchParams().stopFilter(stopFilter).build();
     }
 
-    private void calculateDynamicParametersFromHeuristics(Heuristics heuristics) {
+    private void calculateDynamicSearchParametersFromHeuristics(Heuristics heuristics) {
         if(heuristics != null) {
             dynamicSearchParamsCalculator
                     .withMinTripTime(heuristics.bestOverallJourneyTravelDuration())

--- a/src/main/java/org/opentripplanner/transit/raptor/service/RaptorSearchWindowCalculator.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/service/RaptorSearchWindowCalculator.java
@@ -108,6 +108,13 @@ public class RaptorSearchWindowCalculator {
      * by the time between the EDT and LAT. The unit is seconds.
      */
     private int calculateSearchWindow() {
+        // If both EDT and LAT is set the search window is the time between these, minus the
+        // min-travel-time.
+        if(params.isEarliestDepartureTimeSet() && params.isLatestArrivalTimeSet()) {
+            int travelWindow = params.latestArrivalTime() - params.earliestDepartureTime();
+            return roundStep(travelWindow - minTravelTime);
+        }
+        // Set the search window using the min-travel-time.
         return roundStep(c + t * minTravelTime);
     }
 

--- a/src/main/java/org/opentripplanner/transit/raptor/service/RaptorSearchWindowCalculator.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/service/RaptorSearchWindowCalculator.java
@@ -1,4 +1,4 @@
-package org.opentripplanner.transit.raptor.rangeraptor.transit;
+package org.opentripplanner.transit.raptor.service;
 
 import org.opentripplanner.transit.raptor.api.request.DynamicSearchWindowCoefficients;
 import org.opentripplanner.transit.raptor.api.request.SearchParams;

--- a/src/main/java/org/opentripplanner/transit/raptor/service/RequestAlias.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/service/RequestAlias.java
@@ -7,7 +7,7 @@ public class RequestAlias {
         boolean multithreaded = serviceMultithreaded && request.runInParallel();
         String alias = request.profile().abbreviation();
 
-        if (request.searchInReverse()) {
+        if (request.searchDirection().isInReverse()) {
             alias += "-Rev";
         }
         if (multithreaded) {

--- a/src/test/java/org/opentripplanner/transit/raptor/service/RaptorSearchWindowCalculatorTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/service/RaptorSearchWindowCalculatorTest.java
@@ -1,4 +1,4 @@
-package org.opentripplanner.transit.raptor.rangeraptor.transit;
+package org.opentripplanner.transit.raptor.service;
 
 import org.junit.Test;
 import org.opentripplanner.transit.raptor.api.TestRaptorTripSchedule;

--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTestProfile.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTestProfile.java
@@ -2,6 +2,7 @@ package org.opentripplanner.transit.raptor.speed_test;
 
 import org.opentripplanner.transit.raptor.api.request.Optimization;
 import org.opentripplanner.transit.raptor.api.request.RaptorProfile;
+import org.opentripplanner.transit.raptor.api.request.SearchDirection;
 
 import java.util.Arrays;
 import java.util.List;
@@ -13,75 +14,75 @@ public enum SpeedTestProfile {
             "rr",
             "Standard Range Raptor, super fast [ transfers, arrival time, travel time ].",
             RaptorProfile.STANDARD,
-            true
+            SearchDirection.FORWARD
     ),
     std_range_raptor_reverse(
             "rrr",
             "Reverse Standard Range Raptor",
             RaptorProfile.STANDARD,
-            false
+            SearchDirection.REVERSE
     ),
     std_best_time(
             "bt",
             "Best Time Range Raptor, super fast. Arrival time only, no path.",
             RaptorProfile.BEST_TIME,
-            true
+            SearchDirection.FORWARD
     ),
     std_best_time_reverse(
             "btr",
             "Reverse Best Time Range Raptor",
             RaptorProfile.BEST_TIME,
-            false
+            SearchDirection.REVERSE
     ),
     no_wait_std(
             "ws",
             "Standard Range Raptor without waiting time.",
             RaptorProfile.NO_WAIT_STD,
-            true
+            SearchDirection.FORWARD
     ),
     no_wait_std_reverse(
             "wsr",
             "Reverse Standard Range Raptor without waiting time.",
             RaptorProfile.NO_WAIT_STD,
-            false
+            SearchDirection.REVERSE
     ),
     no_wait_best_time(
             "wt",
             "Best Time Range Raptor without waiting time.",
             RaptorProfile.NO_WAIT_BEST_TIME,
-            true
+            SearchDirection.FORWARD
     ),
     no_wait_best_time_reverse(
             "wtr",
             "Reverse Best Time Range Raptor without waiting time.",
             RaptorProfile.NO_WAIT_BEST_TIME,
-            false
+            SearchDirection.REVERSE
     ),
     mc_range_raptor(
             "mc",
             "Multi-Criteria Range Raptor [ transfers, arrival time, travel time, cost ].",
             RaptorProfile.MULTI_CRITERIA,
-            true
+            SearchDirection.FORWARD
     ),
     mc_destination(
             "md",
             "Multi-Criteria Range Raptor with check on destination arrival.",
             RaptorProfile.MULTI_CRITERIA,
-            true,
+            SearchDirection.FORWARD,
             Optimization.PARETO_CHECK_AGAINST_DESTINATION
     ),
     mc_filter_stops(
             "ms",
             "Multi-Criteria Range Raptor with check on stop filter.",
             RaptorProfile.MULTI_CRITERIA,
-            true,
+            SearchDirection.FORWARD,
             Optimization.TRANSFERS_STOP_FILTER
     ),
     mc_stop_destination(
             "mds",
             "Multi-Criteria Range Raptor with check on stop filter and destination arrival.",
             RaptorProfile.MULTI_CRITERIA,
-            true,
+            SearchDirection.FORWARD,
             Optimization.PARETO_CHECK_AGAINST_DESTINATION,
             Optimization.TRANSFERS_STOP_FILTER
     ),
@@ -90,14 +91,14 @@ public enum SpeedTestProfile {
     final String shortName;
     final String description;
     final RaptorProfile raptorProfile;
-    final boolean forward;
+    final SearchDirection direction;
     final List<Optimization> optimizations;
 
-    SpeedTestProfile(String shortName, String description, RaptorProfile profile, boolean forward, Optimization... optimizations) {
+    SpeedTestProfile(String shortName, String description, RaptorProfile profile, SearchDirection direction, Optimization... optimizations) {
         this.shortName = shortName;
         this.description = description;
         this.raptorProfile = profile;
-        this.forward = forward;
+        this.direction = direction;
         this.optimizations = Arrays.asList(optimizations);
     }
 
@@ -132,21 +133,21 @@ public enum SpeedTestProfile {
     }
 
     private String description() {
-        String text = description;
+        StringBuilder text;
 
         if (name().equals(shortName)) {
-            text = String.format("%s : %s", name(), text);
+            text = new StringBuilder(String.format("%s : %s", name(), description));
         } else {
-            text = String.format("%s, %s : %s", shortName, name(), text);
+            text = new StringBuilder(String.format("%s, %s : %s", shortName, name(), description));
         }
 
         if (raptorProfile != null) {
-            text += String.format("\n·%22s%s", "", raptorProfile);
-            text += forward ? ", FORWARD" : ", REVERSE";
+            text.append(String.format("\n·%22s%s", "", raptorProfile));
+            text.append(", ").append(direction.name());
             for (Optimization it : optimizations) {
-                text += ", " + it.name();
+                text.append(", ").append(it.name());
             }
         }
-        return text;
+        return text.toString();
     }
 }

--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTestRequest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTestRequest.java
@@ -130,7 +130,7 @@ public class SpeedTestRequest {
             builder.searchParams().searchOneIterationOnly();
         }
 
-        builder.searchDirection(profile.forward);
+        builder.searchDirection(profile.direction);
 
         addAccessEgressStopArrivals(streetRouter.getAccessTimesInSecondsByStopIndex(), builder.searchParams()::addAccessStop);
         addAccessEgressStopArrivals(streetRouter.getEgressTimesInSecondsByStopIndex(), builder.searchParams()::addEgressStop);


### PR DESCRIPTION
This PR fixes 2 bugs to the Dynamic Search Window calculation:
- Calculate the search window correct if both earliest-departure-time(EDT) and latest-arrival-time(LAT) is set. The searchWindow should be: LAT - EDT - minTravelTime.
- Fix the RangRaptorDynamicSearch so that if both earliest-departure-time and latest-arrival-time is set only the reverse search is performed and the search-window is calculated correctly. 



To be completed by pull request submitter:

- [x] **issue**: Fixes 2 bugs related to #2931
- [ ] **roadmap**: No.
- [x] **tests**: One unit test added.
- [x] **formatting**: Yes
- [x] **documentation**: JavaDoc updated
- [ ] **changelog**: No.

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)