### PR TITLE
Use Raptor calculation of leg start/end times

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
@@ -291,7 +291,9 @@ public class RaptorPathToItineraryMapper {
                 // TODO OTP2 We use the duration initially calculated for use during routing
                 //      because they do not always match up and we risk getting negative wait times
                 //      (#2955)
-                subItinerary.nonTransitTimeSeconds = pathLeg.duration();
+                assert(subItinerary.legs.size() == 1);
+                subItinerary.legs.get(0).startTime = createCalendar(pathLeg.fromTime());
+                subItinerary.legs.get(0).endTime = createCalendar(pathLeg.toTime());
 
                 if (!onlyIfNonZeroDistance || subItinerary.nonTransitDistanceMeters > 0) {
                     legs.addAll(subItinerary.legs);

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
@@ -291,7 +291,9 @@ public class RaptorPathToItineraryMapper {
                 // TODO OTP2 We use the duration initially calculated for use during routing
                 //      because they do not always match up and we risk getting negative wait times
                 //      (#2955)
-                assert(subItinerary.legs.size() == 1);
+                if (subItinerary.legs.size() != 1) {
+                    throw new IllegalArgumentException("Sub itineraries should only contain one leg.");
+                }
                 subItinerary.legs.get(0).startTime = createCalendar(pathLeg.fromTime());
                 subItinerary.legs.get(0).endTime = createCalendar(pathLeg.toTime());
 


### PR DESCRIPTION
To be completed by pull request submitter:

- [x] **issue**: #2955
- [x] **roadmap**: Check the [roadmap](https://github.com/orgs/opentripplanner/projects/1) for this feature or bug. If it is not already on the roadmap, PLC will discuss as part of the review process.
- [x] **tests**: Have you added relevant test coverage? Are all the tests passing on [the continuous integration service (Travis CI)](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#continuous-integration)?
- [x] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#code-style)? 
- [x] **documentation**: If you are adding a new configuration option, have you added an explanation to the [configuration documentation](docs/Configuration.md) tables and sections?
- [x] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)

The RaptorPathToItineraryMapper calculates walk legs by iterating over the legs the way it is done in AStar. This can differ from the times originally used in the Raptor routing. This pull request causes the mapper to ignore the start and end times from iterating over the legs and instead use the Raptor times.