### PR TITLE
Copy geometries from previous TripPattern when doing real-time updates

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -26,6 +26,7 @@
 - Fix mismatch in duration for walk legs, resulting in negative wait times (#2955)
 - NeTEx import now supports ServiceLinks (#2951)
 - Also check TripPatterns added by realtime when showing stoptimes for stop (#2954)
+- Copy geometries from previous TripPattern when realtime updates result in a TripPattern being replaced (#2987)
 
 ## Ported over from the 1.x
 - Add application/x-protobuf to accepted protobuf content-types (#2839)

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTripPatternCache.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTripPatternCache.java
@@ -74,7 +74,7 @@ public class SiriTripPatternCache {
             // Copy information from the TripPattern this is replacing
             if (originalTripPattern != null) {
                 tripPattern.setId(originalTripPattern.getId());
-                tripPattern.setHopGeometriesFromPreviousTripPattern(originalTripPattern);
+                tripPattern.setHopGeometriesFromPattern(originalTripPattern);
             }
             
             // Add pattern to cache

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTripPatternCache.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTripPatternCache.java
@@ -13,6 +13,7 @@ import org.opentripplanner.routing.graph.Graph;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.validation.constraints.NotNull;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -43,8 +44,11 @@ public class SiriTripPatternCache {
      * @param serviceDate
      * @return cached or newly created trip pattern
      */
-    public synchronized TripPattern getOrCreateTripPattern(final StopPattern stopPattern,
-                                                           final Trip trip, final Graph graph, ServiceDate serviceDate) {
+    public synchronized TripPattern getOrCreateTripPattern(
+            @NotNull final StopPattern stopPattern,
+            @NotNull final Trip trip,
+            @NotNull final Graph graph,
+            @NotNull ServiceDate serviceDate) {
         // Check cache for trip pattern
         StopPatternServiceDateKey key = new StopPatternServiceDateKey(stopPattern, serviceDate);
         TripPattern tripPattern = cache.get(key);

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTripPatternCache.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTripPatternCache.java
@@ -68,6 +68,14 @@ public class SiriTripPatternCache {
 //            tripPattern.makePatternVerticesAndEdges(graph, graph.index.stopVertexForStop);
             
             // TODO - SIRI: Add pattern to graph index?
+
+            TripPattern originalTripPattern = graph.index.getPatternForTrip().get(trip);
+
+            // Copy information from the TripPattern this is replacing
+            if (originalTripPattern != null) {
+                tripPattern.setId(originalTripPattern.getId());
+                tripPattern.setHopGeometriesFromPreviousTripPattern(originalTripPattern);
+            }
             
             // Add pattern to cache
             cache.put(key, tripPattern);

--- a/src/main/java/org/opentripplanner/model/TripPattern.java
+++ b/src/main/java/org/opentripplanner/model/TripPattern.java
@@ -162,7 +162,7 @@ public class TripPattern extends TransitEntity<FeedScopedId> implements Cloneabl
      *
      * @param other TripPattern to copy geometry from
      */
-    public void setHopGeometriesFromPreviousTripPattern(TripPattern other) {
+    public void setHopGeometriesFromPattern(TripPattern other) {
         this.hopGeometries = new byte[this.getStops().size() - 1][];
         for (int i = 0; i < other.getStops().size() - 1; i++) {
             if (other.getHopGeometry(i) != null

--- a/src/main/java/org/opentripplanner/model/TripPattern.java
+++ b/src/main/java/org/opentripplanner/model/TripPattern.java
@@ -155,6 +155,35 @@ public class TripPattern extends TransitEntity<FeedScopedId> implements Cloneabl
         this.hopGeometries[i] = CompactLineString.compactLineString(hopGeometry,false);
     }
 
+    /**
+     * This will copy the geometry from another TripPattern to this one. It checks if each hop is
+     * between the same stops before copying that hop geometry. If the stops are different, a
+     * straight-line hop-geometry will be used instead.
+     *
+     * @param other TripPattern to copy geometry from
+     */
+    public void setHopGeometriesFromPreviousTripPattern(TripPattern other) {
+        this.hopGeometries = new byte[this.getStops().size() - 1][];
+        for (int i = 0; i < other.getStops().size() - 1; i++) {
+            if (other.getHopGeometry(i) != null
+                && other.getStop(i).equals(this.getStop(i))
+                && other.getStop(i + 1).equals(this.getStop(i + 1))) {
+                // Copy hop geometry from previous pattern
+                this.setHopGeometry(i, other.getHopGeometry(i));
+            } else {
+                // Create new straight-line geometry for hop
+                this.setHopGeometry(i,
+                    GeometryUtils.getGeometryFactory().createLineString(
+                        new Coordinate[]{
+                            coordinate(stopPattern.stops[i]),
+                            coordinate(stopPattern.stops[i + 1])
+                        }
+                    )
+                );
+            }
+        }
+    }
+
     public LineString getGeometry() {
         List<LineString> lineStrings = new ArrayList<>();
         for (int i = 0; i < hopGeometries.length - 1; i++) {

--- a/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
@@ -694,7 +694,7 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
         final StopPattern stopPattern = new StopPattern(stopTimes);
 
         // Get cached trip pattern or create one if it doesn't exist yet
-        final TripPattern pattern = tripPatternCache.getOrCreateTripPattern(stopPattern, trip.getRoute(), graph);
+        final TripPattern pattern = tripPatternCache.getOrCreateTripPattern(stopPattern, trip, graph);
 
         // Add service code to bitset of pattern if needed (using copy on write)
         final int serviceCode = graph.getServiceCodes().get(trip.getServiceId());

--- a/src/main/java/org/opentripplanner/updater/stoptime/TripPatternCache.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/TripPatternCache.java
@@ -3,6 +3,7 @@ package org.opentripplanner.updater.stoptime;
 import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.model.Route;
 import org.opentripplanner.model.StopPattern;
+import org.opentripplanner.model.Trip;
 import org.opentripplanner.model.TripPattern;
 import org.opentripplanner.routing.graph.Graph;
 
@@ -28,12 +29,13 @@ public class TripPatternCache {
      * and edges for this trip pattern are also created in the graph.
      * 
      * @param stopPattern stop pattern to retrieve/create trip pattern
-     * @param route route of new trip pattern in case a new trip pattern will be created
+     * @param trip the trip the new trip pattern will be created for
      * @param graph graph to add vertices and edges in case a new trip pattern will be created
      * @return cached or newly created trip pattern
      */
     public synchronized TripPattern getOrCreateTripPattern(final StopPattern stopPattern,
-            final Route route, final Graph graph) {
+            final Trip trip, final Graph graph) {
+        Route route = trip.getRoute();
         // Check cache for trip pattern
         TripPattern tripPattern = cache.get(stopPattern);
         
@@ -49,6 +51,14 @@ public class TripPatternCache {
             
             // Finish scheduled time table
             tripPattern.scheduledTimetable.finish();
+
+            TripPattern originalTripPattern = graph.index.getPatternForTrip().get(trip);
+
+            // Copy information from the TripPattern this is replacing
+            if (originalTripPattern != null) {
+                tripPattern.setId(originalTripPattern.getId());
+                tripPattern.setHopGeometriesFromPreviousTripPattern(originalTripPattern);
+            }
             
             // Add pattern to cache
             cache.put(stopPattern, tripPattern);

--- a/src/main/java/org/opentripplanner/updater/stoptime/TripPatternCache.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/TripPatternCache.java
@@ -57,7 +57,7 @@ public class TripPatternCache {
             // Copy information from the TripPattern this is replacing
             if (originalTripPattern != null) {
                 tripPattern.setId(originalTripPattern.getId());
-                tripPattern.setHopGeometriesFromPreviousTripPattern(originalTripPattern);
+                tripPattern.setHopGeometriesFromPattern(originalTripPattern);
             }
             
             // Add pattern to cache

--- a/src/main/java/org/opentripplanner/updater/stoptime/TripPatternCache.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/TripPatternCache.java
@@ -7,6 +7,7 @@ import org.opentripplanner.model.Trip;
 import org.opentripplanner.model.TripPattern;
 import org.opentripplanner.routing.graph.Graph;
 
+import javax.validation.constraints.NotNull;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -33,8 +34,10 @@ public class TripPatternCache {
      * @param graph graph to add vertices and edges in case a new trip pattern will be created
      * @return cached or newly created trip pattern
      */
-    public synchronized TripPattern getOrCreateTripPattern(final StopPattern stopPattern,
-            final Trip trip, final Graph graph) {
+    public synchronized TripPattern getOrCreateTripPattern(
+            @NotNull final StopPattern stopPattern,
+            @NotNull final Trip trip,
+            @NotNull final Graph graph) {
         Route route = trip.getRoute();
         // Check cache for trip pattern
         TripPattern tripPattern = cache.get(stopPattern);


### PR DESCRIPTION
To be completed by pull request submitter:

- [x] **issue**: #2987
- [x] **roadmap**: Check the [roadmap](https://github.com/orgs/opentripplanner/projects/1) for this feature or bug. If it is not already on the roadmap, PLC will discuss as part of the review process.
- [x] **tests**: Have you added relevant test coverage? Are all the tests passing on [the continuous integration service (Travis CI)](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#continuous-integration)?
- [x] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#code-style)? 
- [x] **documentation**: If you are adding a new configuration option, have you added an explanation to the [configuration documentation](docs/Configuration.md) tables and sections?
- [x] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)

This adds a methods to the TripPattern class that will copy the geometry from another TripPattern to the current one. It checks if each hop is between the same stops before copying that hop geometry. If the stops are different, a straight-line hop-geometry will be used instead.

This method is called in the TripPatternCache.getOrCreateTripPattern and SiriTripPatternCache.getOrCreateTripPattern method in order to copy the geometries when a TripPattern is replaced by another.