### PR TITLE
Elevation calculation speed-up

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -5,6 +5,7 @@
 - Add Way Property Set for the UK (#2818)
 - Fixes surefire test failure during build (#2816)
 - Improve documentation for `mode` routing parameter (#2809)
+- Optimize elevation calculations
 
 ## 1.4 (2019-07-30)
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -238,7 +238,7 @@ Calculating elevations on all StreetEdges can take a dramatically long time. In 
 
 If you are using cloud computing for your OTP instances, it is recommended to create prebuilt images that contain the elevation data you need. This will save time because all of the data won't need to be downloaded.
 
-However, the bulk of the time will still spent calculating elevations for all of the street edges. Therefore, a further optimazation can be done to calculate and save the elevation data during a graph build and then save it for future use.
+However, the bulk of the time will still be spent calculating elevations for all of the street edges. Therefore, a further optimization can be done to calculate and save the elevation data during a graph build and then save it for future use.
 
 In order to write out the precalculated elevation data, add this to your `build-config.json` file:
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -281,7 +281,7 @@ After building the graph, a file called `cached_elevations.obj` will be written 
 
 In graph builds, the elevation module will attempt to read the `cached_elevations.obj` file from the cache directory. The cache directory defaults to `/var/otp/cache`, but this can be overriden via the CLI argument `--cache <directory>`. For the same graph build for multiple Northeast US states, the time it took with using this predownloaded and precalculated data became 543.7 seconds (roughly 9 minutes).
 
-The cached data is a lookup table where the coordinate sequences of respective street edges are used as keys for calculated data. Therefore, it is expected that over time various edits to OpenStreetMap will cause this cached data to become stale and not include new OSM ways. Therefore, periodic update of this cached data is recommended.
+The cached data is a lookup table where the coordinate sequences of respective street edges are used as keys for calculated data. It is assumed that all of the other input data except for the OpenStreetMap data remains the same between graph builds. Therefore, if the underlying elevation data is changed, or different configuration values for `elevationUnitMultiplier` or `includeEllipsoidToGeoidDifference` are used, then this data becomes invalid and all elevation data should be recalculated. Over time, various edits to OpenStreetMap will cause this cached data to become stale and not include new OSM ways. Therefore, periodic update of this cached data is recommended.
 
 #### Configuring the number of processors during elevation calculations
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -196,6 +196,29 @@ You can configure it as follows in `build-config.json`:
 }
 ```
 
+### Geoid Difference
+
+With some elevation data, the elevation values are specified as relative to the a geoid (irregular estimate of mean sea level). See [issue #2301](https://github.com/opentripplanner/OpenTripPlanner/issues/2301) for detailed discussion of this. In this cases, it is necessary to also add this geoid value onto the elevation value to get the correct result. OTP can automatically calculate these values in one of two ways. 
+
+The first way is to use the geoid difference value that is calculated once at the center of the graph. This value is returned in each trip plan response in the [ElevationMetadata](http://dev.opentripplanner.org/apidoc/1.4.0/json_ElevationMetadata.html) field. Using a single value can be sufficient for smaller OTP deployments, but might result in incorrect values at the edges of larger OTP deployments. If your OTP instance uses this, it is recommended to set a default request value in the `router-config.json` file as follows:
+
+```JSON
+// router-config.json
+{
+    "routingDefaults": {
+        "geoidElevation ": true   
+    }
+}
+```
+
+The second way is to precompute these geoid difference values at a more granular level and include them when calculating elevations for each sampled point along each street edge. In order to speed up calculations, the geoid difference values are calculated and cached using only 2 significant digits of GPS coordinates. This is more than enough detail for most regions of the world and should result in less than one meter of difference in areas that have large changes in geoid difference values. To enable this, include the following in the `build-config.json` file: 
+
+```JSON
+// build-config.json
+{
+  "includeEllipsoidToGeoidDifference": true
+}
+```
 
 ### Other raster elevation data
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -87,7 +87,7 @@ config key | description | value type | value default | notes
 `elevationUnitMultiplier` | Specify a multiplier to convert elevation units from source to meters | double | 1.0 | see [Elevation unit conversion](#elevation-unit-conversion)
 `readCachedElevations` | If true, reads in pre-calculated elevation data. | boolean | true | see [Elevation Data Calculation Optimizations](#elevation-data-calculation-optimizations)
 `writeCachedElevations` | If true, writes the calculated elevation data. | boolean | false | see [Elevation Data Calculation Optimizations](#elevation-data-calculation-optimizations)
-`elevationModuleParallelism` | Set the number of processors to use during elevation calculations. | int | Current machine's number of processors. | see [Elevation Data Calculation Optimizations](#elevation-data-calculation-optimizations)
+`elevationModuleParallelism` | Set the number of processors to use during elevation calculations. | int | 1 | see [Elevation Data Calculation Optimizations](#elevation-data-calculation-optimizations)
 `fares` | A specific fares service to use | object | null | see [fares configuration](#fares-configuration)
 `osmNaming` | A custom OSM namer to use | object | null | see [custom naming](#custom-naming)
 `osmWayPropertySet` | Custom OSM way properties | string | `default` | options: `default`, `norway`, `uk`

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -87,7 +87,7 @@ config key | description | value type | value default | notes
 `elevationUnitMultiplier` | Specify a multiplier to convert elevation units from source to meters | double | 1.0 | see [Elevation unit conversion](#elevation-unit-conversion)
 `readCachedElevations` | If true, reads in pre-calculated elevation data. | boolean | true | see [Elevation Data Calculation Optimizations](#elevation-data-calculation-optimizations)
 `writeCachedElevations` | If true, writes the calculated elevation data. | boolean | false | see [Elevation Data Calculation Optimizations](#elevation-data-calculation-optimizations)
-`elevationModuleParallelism` | Set the number of processors to use during elevation calculations. | int | 1 | see [Elevation Data Calculation Optimizations](#elevation-data-calculation-optimizations)
+`multiThreadElevationCalculations` | If true, the elevation module will use multi-threading during elevation calculations. | boolean | false | see [Elevation Data Calculation Optimizations](#elevation-data-calculation-optimizations)
 `fares` | A specific fares service to use | object | null | see [fares configuration](#fares-configuration)
 `osmNaming` | A custom OSM namer to use | object | null | see [custom naming](#custom-naming)
 `osmWayPropertySet` | Custom OSM way properties | string | `default` | options: `default`, `norway`, `uk`
@@ -283,16 +283,14 @@ In graph builds, the elevation module will attempt to read the `cached_elevation
 
 The cached data is a lookup table where the coordinate sequences of respective street edges are used as keys for calculated data. It is assumed that all of the other input data except for the OpenStreetMap data remains the same between graph builds. Therefore, if the underlying elevation data is changed, or different configuration values for `elevationUnitMultiplier` or `includeEllipsoidToGeoidDifference` are used, then this data becomes invalid and all elevation data should be recalculated. Over time, various edits to OpenStreetMap will cause this cached data to become stale and not include new OSM ways. Therefore, periodic update of this cached data is recommended.
 
-#### Configuring the number of processors during elevation calculations
+#### Configuring multi-threading during elevation calculations
 
-For unknown reasons that seem to depend on data and machine settings, it might be faster to use a single processor. For this reason, it is possible to define the parallelism or number of processors used during elevation calculations. It may be helpful to run experiments with different values to determine the optimal amount given the elevation data being used.
-
-By default, only 1 processor will be used. The maximum amount of processors is capped according to the maximum number of processors that java detects on the current machine. To set a custom amount of processors, add the following to the `build-config.json` file:
+For unknown reasons that seem to depend on data and machine settings, it might be faster to use a single processor. For this reason, multi-threading of elevation calculations is only done if `multiThreadElevationCalculations` is set to true. To enable multi-threading in the elevation module, add the following to the `build-config.json` file:
                                                                
 ```JSON
 // build-config.json
 {  
-  "elevationModuleParallelism": 2
+  "multiThreadElevationCalculations": true
 }
 ```
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -285,9 +285,9 @@ The cached data is a lookup table where the coordinate sequences of respective s
 
 #### Configuring the number of processors during elevation calculations
 
-For unknown reasons that seem to depend on data and machine settings, it might be faster to not use all processors available. For this reason, it is possible to define the parallelism or number of processors used during elevation calculations. It may be helpful to run experiments with different values to determine the optimal amount given the elevation data being used.
+For unknown reasons that seem to depend on data and machine settings, it might be faster to use a single processor. For this reason, it is possible to define the parallelism or number of processors used during elevation calculations. It may be helpful to run experiments with different values to determine the optimal amount given the elevation data being used.
 
-By default, the maximum amount of available processors will be used. To set a custom amount of processors, add the following to the `build-config.json` file:
+By default, only 1 processor will be used. The maximum amount of processors is capped according to the maximum number of processors that java detects on the current machine. To set a custom amount of processors, add the following to the `build-config.json` file:
                                                                
 ```JSON
 // build-config.json

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -220,6 +220,8 @@ The second way is to precompute these geoid difference values at a more granular
 }
 ```
 
+If the geoid difference values are precomputed, be careful to not set the routing resource value of `geoidElevation` to true in order to avoid having the graph-wide geoid added again to all elevation values in the relevant street edges in responses.
+
 ### Other raster elevation data
 
 For other parts of the world you will need a GeoTIFF file containing the elevation data. These are often available from

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -85,6 +85,8 @@ config key | description | value type | value default | notes
 `fetchElevationUS` | Download US NED elevation data and apply it to the graph | boolean | false |
 `elevationBucket` | If specified, download NED elevation tiles from the given AWS S3 bucket | object | null | provide an object with `accessKey`, `secretKey`, and `bucketName` for AWS S3
 `elevationUnitMultiplier` | Specify a multiplier to convert elevation units from source to meters | double | 1.0 | see [Elevation unit conversion](#elevation-unit-conversion)
+`readCachedElevations` | If true, reads in pre-calculated elevation data. | boolean | true | see [Elevation Data Calculation Optimizations](#elevation-data-calculation-optimizations)
+`writeCachedElevations` | If true, writes the calculated elevation data. | boolean | false | see [Elevation Data Calculation Optimizations](#elevation-data-calculation-optimizations)
 `fares` | A specific fares service to use | object | null | see [fares configuration](#fares-configuration)
 `osmNaming` | A custom OSM namer to use | object | null | see [custom naming](#custom-naming)
 `osmWayPropertySet` | Custom OSM way properties | string | `default` | options: `default`, `norway`
@@ -229,6 +231,29 @@ it is possible to define a multiplier that converts the elevation values from so
   "elevationUnitMultiplier": 0.1
 }
 ```
+
+### Elevation Data Calculation Optimizations
+
+Calculating elevations on all StreetEdges can take a dramatically long time. In a very large graph build for multiple Northeast US states, the time it took to download the elevation data and calculate all of the elevations took 5,509 seconds (roughly 1.5 hours).
+
+If you are using cloud computing for your OTP instances, it is recommended to create prebuilt images that contain the elevation data you need. This will save time because all of the data won't need to be downloaded.
+
+However, the bulk of the time will still spent calculating elevations for all of the street edges. Therefore, a further optimazation can be done to calculate and save the elevation data during a graph build and then save it for future use.
+
+In order to write out the precalculated elevation data, add this to your `build-config.json` file:
+
+```JSON
+// build-config.json
+{  
+  "writeCachedElevations": true
+}
+```
+
+After building the graph, a file called `cached_elevations.obj` will be written to the cache directory. By default, this file is not written during graph builds. There is also a graph build parameter called `readCachedElevations` which is set to `true` by default.
+
+In graph builds, the elevation module will attempt to read the `cached_elevations.obj` file from the cache directory. The cache directory defaults to `/var/otp/cache`, but this can be overriden via the CLI argument `--cache <directory>`. For the same graph build for multiple Northeast US states, the time it took with using this predownloaded and precalculated data became 543.7 seconds (roughly 9 minutes).
+
+The cached data is a lookup table where the coordinate sequences of respective street edges are used as keys for calculated data. Therefore, it is expected that over time various edits to OpenStreetMap will cause this cached data to become stale and not include new OSM ways. Therefore, periodic update of this cached data is recommended.
 
 ## Fares configuration
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -198,7 +198,7 @@ You can configure it as follows in `build-config.json`:
 
 ### Geoid Difference
 
-With some elevation data, the elevation values are specified as relative to the a geoid (irregular estimate of mean sea level). See [issue #2301](https://github.com/opentripplanner/OpenTripPlanner/issues/2301) for detailed discussion of this. In this cases, it is necessary to also add this geoid value onto the elevation value to get the correct result. OTP can automatically calculate these values in one of two ways. 
+With some elevation data, the elevation values are specified as relative to the a geoid (irregular estimate of mean sea level). See [issue #2301](https://github.com/opentripplanner/OpenTripPlanner/issues/2301) for detailed discussion of this. In these cases, it is necessary to also add this geoid value onto the elevation value to get the correct result. OTP can automatically calculate these values in one of two ways. 
 
 The first way is to use the geoid difference value that is calculated once at the center of the graph. This value is returned in each trip plan response in the [ElevationMetadata](http://dev.opentripplanner.org/apidoc/1.4.0/json_ElevationMetadata.html) field. Using a single value can be sufficient for smaller OTP deployments, but might result in incorrect values at the edges of larger OTP deployments. If your OTP instance uses this, it is recommended to set a default request value in the `router-config.json` file as follows:
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -87,6 +87,7 @@ config key | description | value type | value default | notes
 `elevationUnitMultiplier` | Specify a multiplier to convert elevation units from source to meters | double | 1.0 | see [Elevation unit conversion](#elevation-unit-conversion)
 `readCachedElevations` | If true, reads in pre-calculated elevation data. | boolean | true | see [Elevation Data Calculation Optimizations](#elevation-data-calculation-optimizations)
 `writeCachedElevations` | If true, writes the calculated elevation data. | boolean | false | see [Elevation Data Calculation Optimizations](#elevation-data-calculation-optimizations)
+`elevationModuleParallelism` | Set the number of processors to use during elevation calculations. | int | Current machine's number of processors. | see [Elevation Data Calculation Optimizations](#elevation-data-calculation-optimizations)
 `fares` | A specific fares service to use | object | null | see [fares configuration](#fares-configuration)
 `osmNaming` | A custom OSM namer to use | object | null | see [custom naming](#custom-naming)
 `osmWayPropertySet` | Custom OSM way properties | string | `default` | options: `default`, `norway`, `uk`
@@ -265,6 +266,8 @@ If you are using cloud computing for your OTP instances, it is recommended to cr
 
 However, the bulk of the time will still be spent calculating elevations for all of the street edges. Therefore, a further optimization can be done to calculate and save the elevation data during a graph build and then save it for future use.
 
+#### Reusing elevation data from previous builds
+
 In order to write out the precalculated elevation data, add this to your `build-config.json` file:
 
 ```JSON
@@ -279,6 +282,19 @@ After building the graph, a file called `cached_elevations.obj` will be written 
 In graph builds, the elevation module will attempt to read the `cached_elevations.obj` file from the cache directory. The cache directory defaults to `/var/otp/cache`, but this can be overriden via the CLI argument `--cache <directory>`. For the same graph build for multiple Northeast US states, the time it took with using this predownloaded and precalculated data became 543.7 seconds (roughly 9 minutes).
 
 The cached data is a lookup table where the coordinate sequences of respective street edges are used as keys for calculated data. Therefore, it is expected that over time various edits to OpenStreetMap will cause this cached data to become stale and not include new OSM ways. Therefore, periodic update of this cached data is recommended.
+
+#### Configuring the number of processors during elevation calculations
+
+For unknown reasons that seem to depend on data and machine settings, it might be faster to not use all processors available. For this reason, it is possible to define the parallelism or number of processors used during elevation calculations. It may be helpful to run experiments with different values to determine the optimal amount given the elevation data being used.
+
+By default, the maximum amount of available processors will be used. To set a custom amount of processors, add the following to the `build-config.json` file:
+                                                               
+```JSON
+// build-config.json
+{  
+  "elevationModuleParallelism": 2
+}
+```
 
 ## Fares configuration
 

--- a/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
@@ -294,7 +294,7 @@ public class GraphBuilder implements Runnable {
                     builderParams.writeCachedElevations,
                     builderParams.elevationUnitMultiplier,
                     builderParams.includeEllipsoidToGeoidDifference,
-                    builderParams.elevationModuleParallelism
+                    builderParams.multiThreadElevationCalculations
                 )
             );
         }

--- a/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
@@ -274,7 +274,6 @@ public class GraphBuilder implements Runnable {
             S3BucketConfig bucketConfig = builderParams.elevationBucket;
             File cacheDirectory = new File(params.cacheDirectory, "ned");
             DegreeGridNEDTileSource awsTileSource = new DegreeGridNEDTileSource();
-            awsTileSource = new DegreeGridNEDTileSource();
             awsTileSource.awsAccessKey = bucketConfig.accessKey;
             awsTileSource.awsSecretKey = bucketConfig.secretKey;
             awsTileSource.awsBucketName = bucketConfig.bucketName;

--- a/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
@@ -294,7 +294,9 @@ public class GraphBuilder implements Runnable {
                     params.cacheDirectory,
                     builderParams.readCachedElevations,
                     builderParams.writeCachedElevations,
-                    builderParams.elevationUnitMultiplier
+                    builderParams.elevationUnitMultiplier,
+                    builderParams.includeEllipsoidToGeoidDifference,
+                    builderParams.geoidDifferenceSignficantDigits
                 )
             );
         }

--- a/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -173,6 +174,8 @@ public class GraphBuilder implements Runnable {
             LOG.error("'{}' is not a readable directory.", dir);
             return null;
         }
+        File cachedElevationsFile = Paths.get(dir.getAbsolutePath(), "cached_elevations.obj").toFile();
+
         // Find and parse config files first to reveal syntax errors early without waiting for graph build.
         builderConfig = OTPMain.loadJson(new File(dir, BUILDER_CONFIG_FILENAME));
         GraphBuilderParameters builderParams = new GraphBuilderParameters(builderConfig);
@@ -200,6 +203,9 @@ public class GraphBuilder implements Runnable {
                     } else {
                         LOG.info("Skipping DEM file {}", file);
                     }
+                    break;
+                case CACHED_ELEVATIONS:
+                    LOG.info("Found cached elevations file {}", file);
                     break;
                 case OTHER:
                     LOG.warn("Skipping unrecognized file '{}'", file);
@@ -266,6 +272,7 @@ public class GraphBuilder implements Runnable {
         graphBuilder.addModule(streetLinkerModule);
         // Load elevation data and apply it to the streets.
         // We want to do run this module after loading the OSM street network but before finding transfers.
+        ElevationModule elevationBuilder = null;
         if (builderParams.elevationBucket != null) {
             // Download the elevation tiles from an Amazon S3 bucket
             S3BucketConfig bucketConfig = builderParams.elevationBucket;
@@ -277,18 +284,21 @@ public class GraphBuilder implements Runnable {
             awsTileSource.awsBucketName = bucketConfig.bucketName;
             NEDGridCoverageFactoryImpl gcf = new NEDGridCoverageFactoryImpl(cacheDirectory);
             gcf.tileSource = awsTileSource;
-            GraphBuilderModule elevationBuilder = new ElevationModule(gcf, builderParams.elevationUnitMultiplier);
-            graphBuilder.addModule(elevationBuilder);
+            elevationBuilder = new ElevationModule(gcf, builderParams.elevationUnitMultiplier);
         } else if (builderParams.fetchElevationUS) {
             // Download the elevation tiles from the official web service
             File cacheDirectory = new File(params.cacheDirectory, "ned");
             ElevationGridCoverageFactory gcf = new NEDGridCoverageFactoryImpl(cacheDirectory);
-            GraphBuilderModule elevationBuilder = new ElevationModule(gcf, builderParams.elevationUnitMultiplier);
-            graphBuilder.addModule(elevationBuilder);
+            elevationBuilder = new ElevationModule(gcf, builderParams.elevationUnitMultiplier);
         } else if (demFile != null) {
             // Load the elevation from a file in the graph inputs directory
             ElevationGridCoverageFactory gcf = new GeotiffGridCoverageFactoryImpl(demFile);
-            GraphBuilderModule elevationBuilder = new ElevationModule(gcf, builderParams.elevationUnitMultiplier);
+            elevationBuilder = new ElevationModule(gcf, builderParams.elevationUnitMultiplier);
+        }
+        if (elevationBuilder != null) {
+            // add in extra settings that can lookup elevation data from previous graph builds
+            elevationBuilder.setCacheElevations(builderParams.cacheElevations);
+            elevationBuilder.setCachedElevationsFile(cachedElevationsFile);
             graphBuilder.addModule(elevationBuilder);
         }
         if ( hasGTFS ) {
@@ -312,7 +322,7 @@ public class GraphBuilder implements Runnable {
      * types are present. This helps point out when config files have been misnamed (builder-config vs. build-config).
      */
     private static enum InputFileType {
-        GTFS, OSM, DEM, CONFIG, GRAPH, OTHER;
+        GTFS, OSM, DEM, CACHED_ELEVATIONS, CONFIG, GRAPH, OTHER;
         public static InputFileType forFile(File file) {
             String name = file.getName();
             if (name.endsWith(".zip")) {
@@ -328,6 +338,7 @@ public class GraphBuilder implements Runnable {
             if (name.endsWith(".osm.xml")) return OSM;
             if (name.endsWith(".tif") || name.endsWith(".tiff")) return DEM; // Digital elevation model (elevation raster)
             if (name.equals("Graph.obj")) return GRAPH;
+            if (name.equals("cached_elevations.obj")) return CACHED_ELEVATIONS;
             if (name.equals(GraphBuilder.BUILDER_CONFIG_FILENAME) || name.equals(Router.ROUTER_CONFIG_FILENAME)) {
                 return CONFIG;
             }

--- a/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
@@ -295,8 +295,7 @@ public class GraphBuilder implements Runnable {
                     builderParams.readCachedElevations,
                     builderParams.writeCachedElevations,
                     builderParams.elevationUnitMultiplier,
-                    builderParams.includeEllipsoidToGeoidDifference,
-                    builderParams.geoidDifferenceSignficantDigits
+                    builderParams.includeEllipsoidToGeoidDifference
                 )
             );
         }

--- a/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
@@ -174,7 +174,6 @@ public class GraphBuilder implements Runnable {
             LOG.error("'{}' is not a readable directory.", dir);
             return null;
         }
-        File cachedElevationsFile = Paths.get(dir.getAbsolutePath(), "cached_elevations.obj").toFile();
 
         // Find and parse config files first to reveal syntax errors early without waiting for graph build.
         builderConfig = OTPMain.loadJson(new File(dir, BUILDER_CONFIG_FILENAME));
@@ -203,9 +202,6 @@ public class GraphBuilder implements Runnable {
                     } else {
                         LOG.info("Skipping DEM file {}", file);
                     }
-                    break;
-                case CACHED_ELEVATIONS:
-                    LOG.info("Found cached elevations file {}", file);
                     break;
                 case OTHER:
                     LOG.warn("Skipping unrecognized file '{}'", file);
@@ -272,7 +268,7 @@ public class GraphBuilder implements Runnable {
         graphBuilder.addModule(streetLinkerModule);
         // Load elevation data and apply it to the streets.
         // We want to do run this module after loading the OSM street network but before finding transfers.
-        ElevationModule elevationBuilder = null;
+        ElevationGridCoverageFactory gcf = null;
         if (builderParams.elevationBucket != null) {
             // Download the elevation tiles from an Amazon S3 bucket
             S3BucketConfig bucketConfig = builderParams.elevationBucket;
@@ -282,24 +278,25 @@ public class GraphBuilder implements Runnable {
             awsTileSource.awsAccessKey = bucketConfig.accessKey;
             awsTileSource.awsSecretKey = bucketConfig.secretKey;
             awsTileSource.awsBucketName = bucketConfig.bucketName;
-            NEDGridCoverageFactoryImpl gcf = new NEDGridCoverageFactoryImpl(cacheDirectory);
-            gcf.tileSource = awsTileSource;
-            elevationBuilder = new ElevationModule(gcf, builderParams.elevationUnitMultiplier);
+            gcf = new NEDGridCoverageFactoryImpl(cacheDirectory, awsTileSource);
         } else if (builderParams.fetchElevationUS) {
             // Download the elevation tiles from the official web service
             File cacheDirectory = new File(params.cacheDirectory, "ned");
-            ElevationGridCoverageFactory gcf = new NEDGridCoverageFactoryImpl(cacheDirectory);
-            elevationBuilder = new ElevationModule(gcf, builderParams.elevationUnitMultiplier);
+            gcf = new NEDGridCoverageFactoryImpl(cacheDirectory);
         } else if (demFile != null) {
             // Load the elevation from a file in the graph inputs directory
-            ElevationGridCoverageFactory gcf = new GeotiffGridCoverageFactoryImpl(demFile);
-            elevationBuilder = new ElevationModule(gcf, builderParams.elevationUnitMultiplier);
+            gcf = new GeotiffGridCoverageFactoryImpl(demFile);
         }
-        if (elevationBuilder != null) {
-            // add in extra settings that can lookup elevation data from previous graph builds
-            elevationBuilder.setCacheElevations(builderParams.cacheElevations);
-            elevationBuilder.setCachedElevationsFile(cachedElevationsFile);
-            graphBuilder.addModule(elevationBuilder);
+        if (gcf != null) {
+            graphBuilder.addModule(
+                new ElevationModule(
+                    gcf,
+                    params.cacheDirectory,
+                    builderParams.readCachedElevations,
+                    builderParams.writeCachedElevations,
+                    builderParams.elevationUnitMultiplier
+                )
+            );
         }
         if ( hasGTFS ) {
             // The stops can be linked to each other once they are already linked to the street network.
@@ -322,7 +319,7 @@ public class GraphBuilder implements Runnable {
      * types are present. This helps point out when config files have been misnamed (builder-config vs. build-config).
      */
     private static enum InputFileType {
-        GTFS, OSM, DEM, CACHED_ELEVATIONS, CONFIG, GRAPH, OTHER;
+        GTFS, OSM, DEM, CONFIG, GRAPH, OTHER;
         public static InputFileType forFile(File file) {
             String name = file.getName();
             if (name.endsWith(".zip")) {
@@ -338,7 +335,6 @@ public class GraphBuilder implements Runnable {
             if (name.endsWith(".osm.xml")) return OSM;
             if (name.endsWith(".tif") || name.endsWith(".tiff")) return DEM; // Digital elevation model (elevation raster)
             if (name.equals("Graph.obj")) return GRAPH;
-            if (name.equals("cached_elevations.obj")) return CACHED_ELEVATIONS;
             if (name.equals(GraphBuilder.BUILDER_CONFIG_FILENAME) || name.equals(Router.ROUTER_CONFIG_FILENAME)) {
                 return CONFIG;
             }

--- a/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
@@ -33,7 +33,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -294,7 +293,8 @@ public class GraphBuilder implements Runnable {
                     builderParams.readCachedElevations,
                     builderParams.writeCachedElevations,
                     builderParams.elevationUnitMultiplier,
-                    builderParams.includeEllipsoidToGeoidDifference
+                    builderParams.includeEllipsoidToGeoidDifference,
+                    builderParams.elevationModuleParallelism
                 )
             );
         }

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/DegreeGridNEDTileSource.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/DegreeGridNEDTileSource.java
@@ -8,6 +8,7 @@ import org.jets3t.service.impl.rest.httpclient.RestS3Service;
 import org.jets3t.service.model.S3Object;
 import org.jets3t.service.security.AWSCredentials;
 import org.opentripplanner.common.model.P2;
+import org.opentripplanner.graph_builder.annotation.Graphwide;
 import org.opentripplanner.graph_builder.services.ned.NEDTileSource;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
@@ -33,6 +34,8 @@ import java.util.List;
 public class DegreeGridNEDTileSource implements NEDTileSource {
     private static Logger log = LoggerFactory.getLogger(DegreeGridNEDTileSource.class);
 
+    private Graph graph;
+
     private File cacheDirectory;
 
     public String awsAccessKey;
@@ -49,6 +52,7 @@ public class DegreeGridNEDTileSource implements NEDTileSource {
     }
 
     @Override public void fetchData(Graph graph, File cacheDirectory) {
+        this.graph = graph;
         this.cacheDirectory = cacheDirectory;
 
         HashSet<P2<Integer>> tiles = new HashSet<P2<Integer>>();
@@ -120,7 +124,13 @@ public class DegreeGridNEDTileSource implements NEDTileSource {
                 ostream.close();
                 istream.close();
             } catch (ServiceException | IOException e) {
-                log.error("Error downloading tile {}! Error: {}.", key, e.getMessage());
+                log.error(
+                    graph.addBuilderAnnotation(
+                        new Graphwide(
+                            String.format("Error downloading elevation tile %s! Error: %s.", key, e.getMessage())
+                        )
+                    )
+                );
                 path.deleteOnExit();
                 return null;
             }

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/DegreeGridNEDTileSource.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/DegreeGridNEDTileSource.java
@@ -16,7 +16,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -71,6 +70,9 @@ public class DegreeGridNEDTileSource implements NEDTileSource {
                 paths.add(tilePath);
             }
         }
+        if (paths.size() == 0) {
+            throw new RuntimeException("No elevation tiles were able to be downloaded!");
+        }
         nedTiles = paths;
     }
 
@@ -123,16 +125,30 @@ public class DegreeGridNEDTileSource implements NEDTileSource {
                 }
                 ostream.close();
                 istream.close();
-            } catch (ServiceException | IOException e) {
-                log.error(
-                    graph.addBuilderAnnotation(
-                        new Graphwide(
-                            String.format("Error downloading elevation tile %s! Error: %s.", key, e.getMessage())
+            } catch (S3ServiceException e) {
+                // Check if the error code is a NoSuchKey code which indicates that the file was not found in the S3
+                // bucket. If this is the cause, allow execution to continue, but add an annotation about the missing
+                // file.
+                //
+                // Note: The IAM policy for the provided credentials must allow both s3:GetObject and s3:ListBucket for
+                // the target bucket. If just GetObject is provided, the S3ServiceException will instead indicate a
+                // forbidden access error.
+                if (e.getS3ErrorCode().equals("NoSuchKey")) {
+                    log.error(
+                        graph.addBuilderAnnotation(
+                            new Graphwide(
+                                String.format("Elevation tile %s missing from s3bucket. Proceeding without tile!", key)
+                            )
                         )
-                    )
-                );
+                    );
+                    return null;
+                }
+                // Some other error occurred.
                 path.deleteOnExit();
-                return null;
+                throw new RuntimeException(e);
+            } catch (ServiceException | IOException e) {
+                path.deleteOnExit();
+                throw new RuntimeException(e);
             }
             return path;
         }

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/DegreeGridNEDTileSource.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/DegreeGridNEDTileSource.java
@@ -106,10 +106,9 @@ public class DegreeGridNEDTileSource implements NEDTileSource {
             log.info("Downloading NED degree tile " + path);
             // download the file from S3.
             AWSCredentials awsCredentials = new AWSCredentials(awsAccessKey, awsSecretKey);
-            String key = null;
+            String key = formatLatLon(x, y) + ".tiff";
             try {
                 S3Service s3Service = new RestS3Service(awsCredentials);
-                key = formatLatLon(x, y) + ".tiff";
                 S3Object object = s3Service.getObject(awsBucketName, key);
 
                 InputStream istream = object.getDataInputStream();

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/DegreeGridNEDTileSource.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/DegreeGridNEDTileSource.java
@@ -43,19 +43,18 @@ public class DegreeGridNEDTileSource implements NEDTileSource {
 
     public String awsBucketName;
 
-    @Override
-    public void setGraph(Graph graph) {
+    @Override public void fetchData(Graph graph, File cacheDirectory) {
         this.graph = graph;
-    }
-
-    @Override
-    public void setCacheDirectory(File cacheDirectory) {
         this.cacheDirectory = cacheDirectory;
+        getNEDTiles(true);
     }
 
     @Override
     public List<File> getNEDTiles() {
+        return getNEDTiles(false);
+    }
 
+    public List<File> getNEDTiles(boolean downloadIfMissing) {
         HashSet<P2<Integer>> tiles = new HashSet<P2<Integer>>();
 
         for (Vertex v : graph.getVertices()) {
@@ -67,7 +66,7 @@ public class DegreeGridNEDTileSource implements NEDTileSource {
         for (P2<Integer> tile : tiles) {
             int x = tile.first - 1;
             int y = tile.second + 1;
-            File tilePath = getPathToTile(x, y);
+            File tilePath = getPathToTile(x, y, downloadIfMissing);
             if (tilePath != null) {
                 paths.add(tilePath);
             }
@@ -92,10 +91,12 @@ public class DegreeGridNEDTileSource implements NEDTileSource {
         return String.format("%s%d%s%03d", northSouth, y, eastWest, x);
     }
 
-    private File getPathToTile(int x, int y) {
+    private File getPathToTile(int x, int y, boolean downloadIfMissing) {
         File path = new File(cacheDirectory, formatLatLon(x, y) + ".tiff");
         if (path.exists()) {
             return path;
+        } else if (!downloadIfMissing) {
+            return null;
         } else {
             path.getParentFile().mkdirs();
 

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -68,7 +68,6 @@ public class ElevationModule implements GraphBuilderModule {
     private final boolean writeCachedElevations;
     private final File cachedElevationsFile;
     private final boolean includeEllipsoidToGeoidDifference;
-    private final int geoidDifferenceCoordinateValueMultiplier;
 
     /**
      * In regular use of OTP, no transformation is needed, however, in order to make an assertion in a downstream
@@ -118,7 +117,6 @@ public class ElevationModule implements GraphBuilderModule {
         writeCachedElevations = false;
         elevationUnitMultiplier = 1;
         includeEllipsoidToGeoidDifference = true;
-        geoidDifferenceCoordinateValueMultiplier = 10;
         transformCoordinates = true;
     }
 
@@ -128,8 +126,7 @@ public class ElevationModule implements GraphBuilderModule {
         boolean readCachedElevations,
         boolean writeCachedElevations,
         double elevationUnitMultiplier,
-        boolean includeEllipsoidToGeoidDifference,
-        int geoidDifferenceSignficantDigits
+        boolean includeEllipsoidToGeoidDifference
     ) {
         gridCoverageFactory = factory;
         cachedElevationsFile = new File(cacheDirectory, "cached_elevations.obj");
@@ -137,7 +134,6 @@ public class ElevationModule implements GraphBuilderModule {
         this.writeCachedElevations = writeCachedElevations;
         this.elevationUnitMultiplier = elevationUnitMultiplier;
         this.includeEllipsoidToGeoidDifference = includeEllipsoidToGeoidDifference;
-        geoidDifferenceCoordinateValueMultiplier = (int) Math.pow(10, geoidDifferenceSignficantDigits);
         transformCoordinates = false;
     }
 
@@ -645,20 +641,22 @@ public class ElevationModule implements GraphBuilderModule {
         }
         nPointsEvaluated.incrementAndGet();
         return (values[0] * elevationUnitMultiplier) -
-            (includeEllipsoidToGeoidDifference ? getEllipsoidToGeoidDifference(y, x) : 0);
+            (includeEllipsoidToGeoidDifference ? getApproximateEllipsoidToGeoidDifference(y, x) : 0);
     }
 
     /**
      * The Calculation of the EllipsoidToGeoidDifference is a very expensive operation, so the resulting values are
-     * cached based on the coordinate values and the desired amount of significant digits. The number of significant
-     * digits that should be considered will vary depending on what part of the world the graph is being built for.
+     * cached based on the coordinate values up to 2 significant digits. Two signficant digits is often more than enough
+     * for most parts of the world, but is useful for certain areas that have dramatic changes. Since the values are
+     * computer once and cached, it has almost no affect on performance to have this level of detail.
      * See this image for an approximate mapping of these difference values:
      * https://earth-info.nga.mil/GandG/images/ww15mgh2.gif
      *
      * @param y latitue
      * @param x longitue
      */
-    private double getEllipsoidToGeoidDifference(double y, double x) throws TransformException {
+    private double getApproximateEllipsoidToGeoidDifference(double y, double x) throws TransformException {
+        int geoidDifferenceCoordinateValueMultiplier = 100;
         int xVal = (int) Math.round(x * geoidDifferenceCoordinateValueMultiplier);
         int yVal = (int) Math.round(y * geoidDifferenceCoordinateValueMultiplier);
         int hash = yVal * 104729 + xVal;

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -70,9 +70,10 @@ public class ElevationModule implements GraphBuilderModule {
 
     private Coverage coverage;
 
-    // Keep track of the proportion of elevation fetch operations that fail so we can issue warnings.
-    private AtomicInteger nPointsEvaluated = new AtomicInteger(0);
-    private AtomicInteger nPointsOutsideDEM = new AtomicInteger(0);
+    // Keep track of the proportion of elevation fetch operations that fail so we can issue warnings. AtomicInteger is
+    // used to provide thread-safe updating capabilities.
+    private final AtomicInteger nPointsEvaluated = new AtomicInteger(0);
+    private final AtomicInteger nPointsOutsideDEM = new AtomicInteger(0);
 
     /**
      * The distance between samples in meters. Defaults to 10m, the approximate resolution of 1/3

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -235,8 +235,8 @@ public class ElevationModule implements GraphBuilderModule {
         }
 
         @Override public void run() {
-            // first check if the edge already has been calculated or if it exists a pre-calculated cache. Checking in
-            // this method avoids potentially waiting for a lock to be released for calculating the thread-specific
+            // First, check if the edge already has been calculated or if it exists in a pre-calculated cache. Checking
+            // with this method avoids potentially waiting for a lock to be released for calculating the thread-specific
             // coverage.
             boolean edgeNeedsProcessing = true;
             // Store the edge geometry in this block to avoid recalculating it twice if the edge needs a full elevation
@@ -252,8 +252,8 @@ public class ElevationModule implements GraphBuilderModule {
                     PackedCoordinateSequence coordinateSequence = cachedElevations.get(
                         PolylineEncoder.createEncodings(edgeGeometry).getPoints()
                     );
-                    // found a cached value!
                     if (coordinateSequence != null) {
+                        // found a cached value! Set the elevation profile with the pre-calculated data.
                         setEdgeElevationProfile(swee, coordinateSequence, graph);
                         edgeNeedsProcessing = false;
                     }

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -48,6 +48,8 @@ import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.opentripplanner.util.ElevationUtils.computeEllipsoidToGeoidDifference;
+
 /**
  * {@link org.opentripplanner.graph_builder.services.GraphBuilderModule} plugin that applies elevation data to street
  * data that has already been loaded into a (@link Graph}, creating elevation profiles for each Street encountered
@@ -65,6 +67,8 @@ public class ElevationModule implements GraphBuilderModule {
     private final boolean readCachedElevations;
     private final boolean writeCachedElevations;
     private final File cachedElevationsFile;
+    private final boolean includeEllipsoidToGeoidDifference;
+    private final int geoidDifferenceCoordinateValueMultiplier;
 
     /**
      * In regular use of OTP, no transformation is needed, however, in order to make an assertion in a downstream
@@ -104,6 +108,8 @@ public class ElevationModule implements GraphBuilderModule {
     /** the graph being built */
     private Graph graph;
 
+    private final ConcurrentHashMap<Integer, Double> geoidDifferenceCache = new ConcurrentHashMap<>();
+
     // used only for testing purposes
     public ElevationModule(ElevationGridCoverageFactory factory) {
         gridCoverageFactory = factory;
@@ -111,6 +117,8 @@ public class ElevationModule implements GraphBuilderModule {
         readCachedElevations = false;
         writeCachedElevations = false;
         elevationUnitMultiplier = 1;
+        includeEllipsoidToGeoidDifference = true;
+        geoidDifferenceCoordinateValueMultiplier = 10;
         transformCoordinates = true;
     }
 
@@ -119,13 +127,17 @@ public class ElevationModule implements GraphBuilderModule {
         File cacheDirectory,
         boolean readCachedElevations,
         boolean writeCachedElevations,
-        double elevationUnitMultiplier
+        double elevationUnitMultiplier,
+        boolean includeEllipsoidToGeoidDifference,
+        int geoidDifferenceSignficantDigits
     ) {
         gridCoverageFactory = factory;
         cachedElevationsFile = new File(cacheDirectory, "cached_elevations.obj");
         this.readCachedElevations = readCachedElevations;
         this.writeCachedElevations = writeCachedElevations;
         this.elevationUnitMultiplier = elevationUnitMultiplier;
+        this.includeEllipsoidToGeoidDifference = includeEllipsoidToGeoidDifference;
+        geoidDifferenceCoordinateValueMultiplier = (int) Math.pow(10, geoidDifferenceSignficantDigits);
         transformCoordinates = false;
     }
 
@@ -632,7 +644,33 @@ public class ElevationModule implements GraphBuilderModule {
             throw e;
         }
         nPointsEvaluated.incrementAndGet();
-        return values[0] * elevationUnitMultiplier;
+        return (values[0] * elevationUnitMultiplier) -
+            (includeEllipsoidToGeoidDifference ? getEllipsoidToGeoidDifference(y, x) : 0);
+    }
+
+    /**
+     * The Calculation of the EllipsoidToGeoidDifference is a very expensive operation, so the resulting values are
+     * cached based on the coordinate values and the desired amount of significant digits. The number of significant
+     * digits that should be considered will vary depending on what part of the world the graph is being built for.
+     * See this image for an approximate mapping of these difference values:
+     * https://earth-info.nga.mil/GandG/images/ww15mgh2.gif
+     *
+     * @param y latitue
+     * @param x longitue
+     */
+    private double getEllipsoidToGeoidDifference(double y, double x) throws TransformException {
+        int xVal = (int) Math.round(x * geoidDifferenceCoordinateValueMultiplier);
+        int yVal = (int) Math.round(y * geoidDifferenceCoordinateValueMultiplier);
+        int hash = yVal * 104729 + xVal;
+        Double difference = geoidDifferenceCache.get(hash);
+        if (difference == null) {
+            difference = computeEllipsoidToGeoidDifference(
+                yVal / (1.0 * geoidDifferenceCoordinateValueMultiplier),
+                xVal / (1.0 * geoidDifferenceCoordinateValueMultiplier)
+            );
+            geoidDifferenceCache.put(hash, difference);
+        }
+        return difference;
     }
 
     @Override

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -236,6 +236,10 @@ public class ElevationModule implements GraphBuilderModule {
 
         @Override public void run() {
             processEdge(swee, getThreadSpecificCoverageInstance());
+            int curNumProcessed = nEdgesProcessed.addAndGet(1);
+            if (curNumProcessed % 50000 == 0) {
+                log.info("set elevation on {}/{} edges", curNumProcessed, totalElevationEdges);
+            }
         }
 
         /**
@@ -550,10 +554,6 @@ public class ElevationModule implements GraphBuilderModule {
             setEdgeElevationProfile(ee, elevPCS, graph);
         } catch (PointOutsideCoverageException | TransformException e) {
             log.debug("Error processing elevation for edge: {} due to error: {}", ee, e);
-        }
-        int curNumProcessed = nEdgesProcessed.addAndGet(1);
-        if (curNumProcessed % 50000 == 0) {
-            log.info("set elevation on {}/{} edges", curNumProcessed, totalElevationEdges);
         }
     }
 

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -48,7 +48,7 @@ import static org.opentripplanner.util.ElevationUtils.computeEllipsoidToGeoidDif
 
 /**
  * THIS CLASS IS MULTI-THREADED
- * (It uses a ForkJoinPool to distribute elevation calculation tasks for edges.)
+ * (When configured to do so, it uses a ForkJoinPool to distribute elevation calculation tasks for edges.)
  *
  * {@link org.opentripplanner.graph_builder.services.GraphBuilderModule} plugin that applies elevation data to street
  * data that has already been loaded into a (@link Graph}, creating elevation profiles for each Street encountered
@@ -73,7 +73,8 @@ public class ElevationModule implements GraphBuilderModule {
     private final boolean includeEllipsoidToGeoidDifference;
     /*
      * The parallelism to use when processing edges. For unknown reasons that seem to depend on data and machine
-     * settings, it might be faster to not use all processors available.
+     * settings, it might be faster to use a single processor. If the parallelism is set to 1, then this module will not
+     * do any multi-threading and instead do all calculations in the OTP thread.
      */
     private final int parallelism;
 
@@ -145,7 +146,8 @@ public class ElevationModule implements GraphBuilderModule {
 
     /**
      * Gets the desired amount of processors to use for elevation calculations from the build-config setting. It will
-     * return at least 1 processor and no more than the maximum available processors.
+     * return at least 1 processor and no more than the maximum available processors. The default return value is 1
+     * processor.
      */
     public static int fromConfig(JsonNode elevationModuleParallelism) {
         int maxProcessors = Runtime.getRuntime().availableProcessors();
@@ -153,21 +155,13 @@ public class ElevationModule implements GraphBuilderModule {
         return Math.max(minimumProcessors, Math.min(elevationModuleParallelism.asInt(minimumProcessors), maxProcessors));
     }
 
-    public List<String> provides() {
-        return Arrays.asList("elevation");
-    }
-
-    public List<String> getPrerequisites() {
-        return Arrays.asList("streets");
-    }
-
     @Override
     public void buildGraph(Graph graph, HashMap<Class<?>, Object> extra) {
         this.graph = graph;
         gridCoverageFactory.fetchData(graph);
 
-        // try to load in the cached elevation data
         if (readCachedElevations) {
+            // try to load in the cached elevation data
             try {
                 ObjectInputStream in = new ObjectInputStream(new FileInputStream(cachedElevationsFile));
                 cachedElevations = (HashMap<String, PackedCoordinateSequence>) in.readObject();
@@ -307,7 +301,7 @@ public class ElevationModule implements GraphBuilderModule {
         }
 
         /**
-         * Synchronize the creation of the Thread-specific Coverage instances to avoid potential locks that  could arise
+         * Synchronize the creation of the Thread-specific Coverage instances to avoid potential locks that could arise
          * from downstream classes that have synchronized methods.
          */
         private Coverage createThreadSpecificCoverage() {
@@ -537,7 +531,7 @@ public class ElevationModule implements GraphBuilderModule {
     }
 
     /**
-     * Processes a street edge and updates the current progress.
+     * Calculate the elevation for a single street edge. After the calculation is complete, update the current progress.
      */
     private void processEdgeWithProgress(StreetWithElevationEdge ee) {
         processEdge(ee);
@@ -548,7 +542,7 @@ public class ElevationModule implements GraphBuilderModule {
     }
 
     /**
-     * Processes a single street edge, creating and assigning the elevation profile.
+     * Calculate the elevation for a single street edge, creating and assigning the elevation profile.
      *
      * @param ee the street edge
      */
@@ -573,7 +567,7 @@ public class ElevationModule implements GraphBuilderModule {
             }
         }
 
-        // Needs full calculation. Calculate with a thread-specific coverage to avoid waiting for any locks on
+        // Needs full calculation. Calculate with a thread-specific coverage instance to avoid waiting for any locks on
         // coverage instances in other threads.
         Coverage coverage = getThreadSpecificCoverageInstance();
 

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -385,7 +385,9 @@ public class ElevationModule implements GraphBuilderModule {
                 coordList.toArray(coordArr));
 
         if(ee.setElevationProfile(elevPCS, false)) {
-            log.trace(graph.addBuilderAnnotation(new ElevationFlattened(ee)));
+            synchronized (graph) {
+                log.trace(graph.addBuilderAnnotation(new ElevationFlattened(ee)));
+            }
         }
     }
 

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -149,7 +149,8 @@ public class ElevationModule implements GraphBuilderModule {
      */
     public static int fromConfig(JsonNode elevationModuleParallelism) {
         int maxProcessors = Runtime.getRuntime().availableProcessors();
-        return Math.max(1, Math.min(elevationModuleParallelism.asInt(maxProcessors), maxProcessors));
+        int minimumProcessors = 1;
+        return Math.max(minimumProcessors, Math.min(elevationModuleParallelism.asInt(minimumProcessors), maxProcessors));
     }
 
     public List<String> provides() {

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -235,7 +235,36 @@ public class ElevationModule implements GraphBuilderModule {
         }
 
         @Override public void run() {
-            processEdge(swee, getThreadSpecificCoverageInstance());
+            // first check if the edge already has been calculated or if it exists a pre-calculated cache. Checking in
+            // this method avoids potentially waiting for a lock to be released for calculating the thread-specific
+            // coverage.
+            boolean edgeNeedsProcessing = true;
+            // Store the edge geometry in this block to avoid recalculating it twice if the edge needs a full elevation
+            // calculation.
+            Geometry edgeGeometry = null;
+
+            if (swee.hasPackedElevationProfile()) {
+                edgeNeedsProcessing = false; /* already set up */
+            } else {
+                edgeGeometry = swee.getGeometry();
+                // first try to find a cached value if possible
+                if (cachedElevations != null) {
+                    PackedCoordinateSequence coordinateSequence = cachedElevations.get(
+                        PolylineEncoder.createEncodings(edgeGeometry).getPoints()
+                    );
+                    // found a cached value!
+                    if (coordinateSequence != null) {
+                        setEdgeElevationProfile(swee, coordinateSequence, graph);
+                        edgeNeedsProcessing = false;
+                    }
+                }
+            }
+
+            if (edgeNeedsProcessing) {
+                // Needs full calculation. Calculate with a thread-specific coverage to avoid waiting for any locks on
+                // coverage instances in other threads.
+                processEdge(swee, edgeGeometry, getThreadSpecificCoverageInstance());
+            }
             int curNumProcessed = nEdgesProcessed.addAndGet(1);
             if (curNumProcessed % 50000 == 0) {
                 log.info("set elevation on {}/{} edges", curNumProcessed, totalElevationEdges);
@@ -470,31 +499,15 @@ public class ElevationModule implements GraphBuilderModule {
      * Processes a single street edge, creating and assigning the elevation profile.
      *
      * @param ee the street edge
+     * @param edgeGeomerty The geometry of the edge
      * @param coverage the specific Coverage instance to use in order to avoid competition between threads
      */
-    private void processEdge(StreetWithElevationEdge ee, Coverage coverage) {
-        if (ee.hasPackedElevationProfile()) {
-            return; /* already set up */
-        }
-        Geometry g = ee.getGeometry();
-
-        // first try to find a cached value if possible
-        if (cachedElevations != null) {
-            PackedCoordinateSequence coordinateSequence = cachedElevations.get(
-                PolylineEncoder.createEncodings(g).getPoints()
-            );
-            // found a cached value!
-            if (coordinateSequence != null) {
-                setEdgeElevationProfile(ee, coordinateSequence, graph);
-                return;
-            }
-        }
-
+    private void processEdge(StreetWithElevationEdge ee, Geometry edgeGeomerty, Coverage coverage) {
         // did not find a cached value, calculate
         // If any of the coordinates throw an error when trying to lookup their value, immediately bail and do not
         // process the elevation on the edge
         try {
-            Coordinate[] coords = g.getCoordinates();
+            Coordinate[] coords = edgeGeomerty.getCoordinates();
 
             List<Coordinate> coordList = new LinkedList<Coordinate>();
 

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -384,6 +384,24 @@ public class ElevationModule implements GraphBuilderModule {
         else
             elevations = new HashMap<Vertex, Double>();
 
+        // If including the EllipsoidToGeoidDifference, subtract these from the known elevations found in OpenStreetMap
+        // data.
+        if (includeEllipsoidToGeoidDifference) {
+            elevations.forEach((vertex, elevation) -> {
+                try {
+                    elevations.put(
+                        vertex, elevation - getApproximateEllipsoidToGeoidDifference(vertex.getY(), vertex.getX())
+                    );
+                } catch (TransformException e) {
+                    log.error(
+                        "Error processing elevation for known elevation at vertex: {} due to error: {}",
+                        vertex,
+                        e
+                    );
+                }
+            });
+        }
+
         HashSet<Vertex> closed = new HashSet<Vertex>();
 
         // initialize queue with all vertices which already have known elevation

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -5,11 +5,8 @@ import org.locationtech.jts.geom.Geometry;
 import org.geotools.coverage.grid.GridCoverage2D;
 import org.geotools.coverage.grid.Interpolator2D;
 import org.geotools.geometry.DirectPosition2D;
-import org.geotools.referencing.CRS;
 import org.opengis.coverage.Coverage;
 import org.opengis.coverage.PointOutsideCoverageException;
-import org.opengis.referencing.FactoryException;
-import org.opengis.referencing.operation.MathTransform;
 import org.opengis.referencing.operation.TransformException;
 import org.opentripplanner.common.geometry.GeometryUtils;
 import org.opentripplanner.common.geometry.PackedCoordinateSequence;
@@ -63,17 +60,16 @@ public class ElevationModule implements GraphBuilderModule {
 
     private static final Logger log = LoggerFactory.getLogger(ElevationModule.class);
 
+    /** The elevation data to be used in calculating elevations. */
     private final ElevationGridCoverageFactory gridCoverageFactory;
+    /* Whether or not to attempt reading in a file of cached elevations */
     private final boolean readCachedElevations;
+    /* Whether or not to attempt writing out a file of cached elevations */
     private final boolean writeCachedElevations;
+    /* The file of cached elevations */
     private final File cachedElevationsFile;
+    /* Whether or not to include geoid difference values in individual elevation calculations */
     private final boolean includeEllipsoidToGeoidDifference;
-
-    /**
-     * In regular use of OTP, no transformation is needed, however, in order to make an assertion in a downstream
-     * library pass during testing, a transformation must take place.
-     */
-    private final boolean transformCoordinates;
 
     private HashMap<String, PackedCoordinateSequence> cachedElevations;
 
@@ -82,10 +78,7 @@ public class ElevationModule implements GraphBuilderModule {
     private AtomicInteger nEdgesProcessed = new AtomicInteger(0);
     private final AtomicInteger nPointsEvaluated = new AtomicInteger(0);
     private final AtomicInteger nPointsOutsideDEM = new AtomicInteger(0);
-    /**
-     * This initial value probably won't be shown in logs, but is set to an absurdly high value initially to make things
-     * seem better later.
-     */
+    /** keeps track of the total amount of elevation edges for logging purposes */
     private int totalElevationEdges = Integer.MAX_VALUE;
 
     /**
@@ -101,12 +94,10 @@ public class ElevationModule implements GraphBuilderModule {
      */
     private final double elevationUnitMultiplier;
 
-    /** used to transform street coordinates into the projection used by the elevation data */
-    private MathTransform transformer;
-
     /** the graph being built */
     private Graph graph;
 
+    /** A concurrent hashmap used for storing geoid difference values at various coordinates */
     private final ConcurrentHashMap<Integer, Double> geoidDifferenceCache = new ConcurrentHashMap<>();
 
     // used only for testing purposes
@@ -117,7 +108,6 @@ public class ElevationModule implements GraphBuilderModule {
         writeCachedElevations = false;
         elevationUnitMultiplier = 1;
         includeEllipsoidToGeoidDifference = true;
-        transformCoordinates = true;
     }
 
     public ElevationModule(
@@ -134,7 +124,6 @@ public class ElevationModule implements GraphBuilderModule {
         this.writeCachedElevations = writeCachedElevations;
         this.elevationUnitMultiplier = elevationUnitMultiplier;
         this.includeEllipsoidToGeoidDifference = includeEllipsoidToGeoidDifference;
-        transformCoordinates = false;
     }
 
     public List<String> provides() {
@@ -149,15 +138,6 @@ public class ElevationModule implements GraphBuilderModule {
     public void buildGraph(Graph graph, HashMap<Class<?>, Object> extra) {
         this.graph = graph;
         gridCoverageFactory.setGraph(graph);
-        if (transformCoordinates) {
-            try {
-                transformer = CRS
-                    .findMathTransform(GeometryUtils.WGS84_XY, getCoverage().getCoordinateReferenceSystem(), true);
-            } catch (FactoryException e) {
-                log.error("Could not find an appropriate transformer!");
-                throw new RuntimeException(e);
-            }
-        }
 
         // try to load in the cached elevation data
         if (readCachedElevations) {
@@ -181,16 +161,21 @@ public class ElevationModule implements GraphBuilderModule {
         // store these thread-specific Coverage instances.
         ConcurrentHashMap<Long, Coverage> coveragesForThread = new ConcurrentHashMap<>();
 
-        List<StreetWithElevationEdge> streetWithElevationEdges = new LinkedList<>();
+        // At first, set the totalElevationEdges to the total number of edges in the graph.
+        totalElevationEdges = graph.countEdges();
+        List<StreetWithElevationEdge> streetsWithElevationEdges = new LinkedList<>();
         for (Vertex gv : graph.getVertices()) {
             for (Edge ee : gv.getOutgoing()) {
                 if (ee instanceof StreetWithElevationEdge) {
                     forkJoinPool.submit(new ProcessEdgeTask((StreetWithElevationEdge) ee, coveragesForThread));
-                    streetWithElevationEdges.add((StreetWithElevationEdge) ee);
+                    streetsWithElevationEdges.add((StreetWithElevationEdge) ee);
                 }
             }
         }
-        totalElevationEdges = streetWithElevationEdges.size();
+        // update this value to the now-known amount of edges that are StreetWithElevation edges
+        totalElevationEdges = streetsWithElevationEdges.size();
+
+        // shutdown the forkJoinPool and wait until all tasks are finished. If this takes longer than 1 day, give up.
         forkJoinPool.shutdown();
         try {
             forkJoinPool.awaitTermination(1, TimeUnit.DAYS);
@@ -213,7 +198,7 @@ public class ElevationModule implements GraphBuilderModule {
         // iterate again to find edges that had elevation calculated. This is done here instead of in the forkJoinPool
         // to avoid thread locking for writes to a synchronized list
         LinkedList<StreetEdge> edgesWithCalculatedElevations = new LinkedList<>();
-        for (StreetWithElevationEdge edgeWithElevation : streetWithElevationEdges) {
+        for (StreetWithElevationEdge edgeWithElevation : streetsWithElevationEdges) {
             if (edgeWithElevation.hasPackedElevationProfile() && !edgeWithElevation.isElevationFlattened()) {
                 edgesWithCalculatedElevations.add(edgeWithElevation);
             }
@@ -265,10 +250,11 @@ public class ElevationModule implements GraphBuilderModule {
             long currentThreadId = Thread.currentThread().getId();
             Coverage threadSpecificCoverage = coveragesForThread.get(currentThreadId);
             if (threadSpecificCoverage == null) {
-                // Synchronize the creation of the Thread-specific Coverage instances to avoid potential deadlocks that
+                // Synchronize the creation of the Thread-specific Coverage instances to avoid potential locks that
                 // could arise from downstream classes that have synchronized methods.
                 synchronized (coveragesForThread) {
-                    threadSpecificCoverage = getCoverage();
+                    // Get a new Coverage instance from the module's ElevationGridCoverageFactory.
+                    threadSpecificCoverage = gridCoverageFactory.getGridCoverage();
                     // The Coverage instance relies on some synchronized static methods shared across all threads that
                     // can cause deadlocks if not fully initialized. Therefore, make a single request for the first
                     // point on the edge to initialize these other items.
@@ -283,20 +269,6 @@ public class ElevationModule implements GraphBuilderModule {
             }
             return threadSpecificCoverage;
         }
-    }
-
-    /**
-     * Get an uncached Coverage instance from the module's ElevationGridCoverageFactory.
-     */
-    private Coverage getCoverage() {
-        // If gridCov is a GridCoverage2D, apply a bilinear interpolator. Otherwise, just use the
-        // coverage as is (note: UnifiedGridCoverages created by NEDGridCoverageFactoryImpl handle
-        // interpolation internally)
-        Coverage gridCov = gridCoverageFactory instanceof NEDGridCoverageFactoryImpl
-            ? ((NEDGridCoverageFactoryImpl) gridCoverageFactory).getUncachedCoverage()
-            : gridCoverageFactory.getGridCoverage();
-        return (gridCov instanceof GridCoverage2D) ? Interpolator2D.create(
-            (GridCoverage2D) gridCov, new InterpolationBilinear()) : gridCov;
     }
 
     class ElevationRepairState {
@@ -624,18 +596,8 @@ public class ElevationModule implements GraphBuilderModule {
             // GeoTIFFs in various projections. Note that GeoTools defaults to strict EPSG axis ordering of (lat, long)
             // for DefaultGeographicCRS.WGS84, but OTP is using (long, lat) throughout and assumes unprojected DEM
             // rasters to also use (long, lat).
-            DirectPosition2D projectedPosition = new DirectPosition2D(GeometryUtils.WGS84_XY, x, y);
-            DirectPosition2D position2D;
-            // If this is not done during testing, a downstream library will raise an assertion error
-            if (transformCoordinates) {
-                DirectPosition2D transformedPosition = new DirectPosition2D();
-                transformer.transform(projectedPosition, transformedPosition);
-                position2D = transformedPosition;
-            } else {
-                position2D = projectedPosition;
-            }
-            coverage.evaluate(position2D, values);
-        } catch (PointOutsideCoverageException | TransformException e) {
+            coverage.evaluate(new DirectPosition2D(GeometryUtils.WGS84_XY, x, y), values);
+        } catch (PointOutsideCoverageException e) {
             nPointsOutsideDEM.incrementAndGet();
             throw e;
         }
@@ -652,13 +614,16 @@ public class ElevationModule implements GraphBuilderModule {
      * See this image for an approximate mapping of these difference values:
      * https://earth-info.nga.mil/GandG/images/ww15mgh2.gif
      *
-     * @param y latitue
-     * @param x longitue
+     * @param y latitude
+     * @param x longitude
      */
     private double getApproximateEllipsoidToGeoidDifference(double y, double x) throws TransformException {
         int geoidDifferenceCoordinateValueMultiplier = 100;
         int xVal = (int) Math.round(x * geoidDifferenceCoordinateValueMultiplier);
         int yVal = (int) Math.round(y * geoidDifferenceCoordinateValueMultiplier);
+        // create a hash value that can be used to look up the value for the given rounded coordinate. The expected
+        // value of xVal should never be less than -18000 (-180 * 100) or more than 18000 (180 * 100), so multiply the
+        // yVal by a prime number of a magnitude larger so that there won't be any hash collisions.
         int hash = yVal * 104729 + xVal;
         Double difference = geoidDifferenceCache.get(hash);
         if (difference == null) {

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -2,8 +2,6 @@ package org.opentripplanner.graph_builder.module.ned;
 
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
-import org.geotools.coverage.grid.GridCoverage2D;
-import org.geotools.coverage.grid.Interpolator2D;
 import org.geotools.geometry.DirectPosition2D;
 import org.opengis.coverage.Coverage;
 import org.opengis.coverage.PointOutsideCoverageException;
@@ -26,7 +24,6 @@ import org.opentripplanner.util.PolylineEncoder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.media.jai.InterpolationBilinear;
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -50,11 +47,10 @@ import static org.opentripplanner.util.ElevationUtils.computeEllipsoidToGeoidDif
 /**
  * {@link org.opentripplanner.graph_builder.services.GraphBuilderModule} plugin that applies elevation data to street
  * data that has already been loaded into a (@link Graph}, creating elevation profiles for each Street encountered
- * in the Graph. Depending on the {@link ElevationGridCoverageFactory} specified this could be auto-downloaded and
- * cached National Elevation Dataset (NED) raster data or a GeoTIFF file. The elevation profiles are stored as
- * {@link PackedCoordinateSequence} objects, where each (x,y) pair represents one sample, with the x-coord representing
- * the distance along the edge measured from the start, and the y-coord representing the sampled elevation at that
- * point (both in meters).
+ * in the Graph. Data sources that could be used include auto-downloaded and cached National Elevation Dataset (NED)
+ * raster data or a GeoTIFF file. The elevation profiles are stored as {@link PackedCoordinateSequence} objects, where
+ * each (x,y) pair represents one sample, with the x-coord representing the distance along the edge measured from the
+ * start, and the y-coord representing the sampled elevation at that point (both in meters).
  */
 public class ElevationModule implements GraphBuilderModule {
 
@@ -137,7 +133,7 @@ public class ElevationModule implements GraphBuilderModule {
     @Override
     public void buildGraph(Graph graph, HashMap<Class<?>, Object> extra) {
         this.graph = graph;
-        gridCoverageFactory.setGraph(graph);
+        gridCoverageFactory.fetchData(graph);
 
         // try to load in the cached elevation data
         if (readCachedElevations) {

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -24,10 +24,19 @@ import org.opentripplanner.routing.edgetype.StreetWithElevationEdge;
 import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
+import org.opentripplanner.util.PolylineEncoder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.media.jai.InterpolationBilinear;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -52,6 +61,12 @@ public class ElevationModule implements GraphBuilderModule {
     private static final Logger log = LoggerFactory.getLogger(ElevationModule.class);
 
     private ElevationGridCoverageFactory gridCoverageFactory;
+
+    private boolean cacheElevations = false;
+
+    private File cachedElevationsFile;
+
+    private HashMap<String, PackedCoordinateSequence> cachedElevations;
 
     private Coverage coverage;
 
@@ -98,6 +113,12 @@ public class ElevationModule implements GraphBuilderModule {
         distanceBetweenSamplesM = distance;
     }
 
+    public void setCacheElevations(boolean cacheElevations) { this.cacheElevations = cacheElevations; }
+
+    public void setCachedElevationsFile(File cachedElevationsFile) {
+        this.cachedElevationsFile = cachedElevationsFile;
+    }
+
     @Override
     public void buildGraph(Graph graph, HashMap<Class<?>, Object> extra) {
         gridCoverageFactory.setGraph(graph);
@@ -117,6 +138,22 @@ public class ElevationModule implements GraphBuilderModule {
         } catch (FactoryException e) {
             log.error("Could not find an appropriate transformer!");
             throw new RuntimeException(e);
+        }
+
+        // try to load in the cached elevation data
+        try {
+            ObjectInputStream in = new ObjectInputStream(new FileInputStream(cachedElevationsFile));
+            cachedElevations = (HashMap<String, PackedCoordinateSequence>) in.readObject();
+            log.info("Cached elevation data loaded into memory!");
+        } catch (IOException | ClassNotFoundException e) {
+            log.warn(graph.addBuilderAnnotation(
+                new Graphwide(
+                    String.format(
+                        "Cached elevations file could not be read in due to error: %s!",
+                        e.getMessage()
+                    )
+                )
+            ));
         }
         log.info("Setting street elevation profiles from digital elevation model...");
 
@@ -153,6 +190,24 @@ public class ElevationModule implements GraphBuilderModule {
             )));
             log.warn("Elevation is missing at a large number of points. DEM may be for the wrong region. " +
                 "If it is unprojected, perhaps the axes are not in (longitude, latitude) order.");
+        }
+
+        if (cacheElevations) {
+            // write information from edgesWithElevation to a new cache file for subsequent graph builds
+            HashMap<String, PackedCoordinateSequence> newCachedElevations = new HashMap<>();
+            for (StreetEdge streetEdge : edgesWithElevation) {
+                newCachedElevations.put(PolylineEncoder.createEncodings(streetEdge.getGeometry()).getPoints(),
+                    streetEdge.getElevationProfile());
+            }
+            try {
+                ObjectOutputStream out = new ObjectOutputStream(
+                    new BufferedOutputStream(new FileOutputStream(cachedElevationsFile)));
+                out.writeObject(newCachedElevations);
+                out.close();
+            } catch (IOException e) {
+                log.error(e.getMessage());
+                log.error(graph.addBuilderAnnotation(new Graphwide("Failed to write cached elevation file!")));
+            }
         }
 
         @SuppressWarnings("unchecked")
@@ -366,6 +421,21 @@ public class ElevationModule implements GraphBuilderModule {
             return; /* already set up */
         }
         Geometry g = ee.getGeometry();
+
+        // first try to find a cached value if possible
+        if (cachedElevations != null) {
+            PackedCoordinateSequence coordinateSequence = cachedElevations.get(
+                PolylineEncoder.createEncodings(g).getPoints()
+            );
+            // found a cached value!
+            if (coordinateSequence != null) {
+                setEdgeElevationProfile(ee, coordinateSequence, graph);
+                return;
+            }
+        }
+
+        // did not find a cached value, calculate
+
         Coordinate[] coords = g.getCoordinates();
 
         List<Coordinate> coordList = new LinkedList<Coordinate>();
@@ -422,6 +492,10 @@ public class ElevationModule implements GraphBuilderModule {
         PackedCoordinateSequence elevPCS = new PackedCoordinateSequence.Double(
                 coordList.toArray(coordArr));
 
+        setEdgeElevationProfile(ee, elevPCS, graph);
+    }
+
+    private void setEdgeElevationProfile(StreetWithElevationEdge ee, PackedCoordinateSequence elevPCS, Graph graph) {
         if(ee.setElevationProfile(elevPCS, false)) {
             synchronized (graph) {
                 log.trace(graph.addBuilderAnnotation(new ElevationFlattened(ee)));
@@ -468,6 +542,17 @@ public class ElevationModule implements GraphBuilderModule {
     @Override
     public void checkInputs() {
         gridCoverageFactory.checkInputs();
+
+        // check for the existence of cached elevation data.
+        if (cacheElevations) {
+            if (Files.exists(cachedElevationsFile.toPath())) {
+                log.info("Cached elevations file found!");
+            } else {
+                log.warn("No cached elevations file found or read access not allowed! Unable to load in cached elevations. This could take a while...");
+            }
+        } else {
+            log.warn("Not using cached elevations! This could take a while...");
+        }
     }
 
 }

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -46,7 +46,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.opentripplanner.util.ElevationUtils.computeEllipsoidToGeoidDifference;
 
 /**
- * THIS CLASS IS MULTI-THEARED
+ * THIS CLASS IS MULTI-THREADED
  * (It uses a ForkJoinPool to distribute elevation calculation tasks for edges.)
  *
  * {@link org.opentripplanner.graph_builder.services.GraphBuilderModule} plugin that applies elevation data to street
@@ -251,8 +251,8 @@ public class ElevationModule implements GraphBuilderModule {
         /**
          * For unknown reasons, the interpolation of heights at coordinates is a synchronized method in the commonly
          * used Interpolator2D class. Therefore, it is critical to use a dedicated Coverage instance for each thread to
-         * avoid other threads waiting for a lock to be released on the Coverage instance. This concurrent HashMap will
-         * store these thread-specific Coverage instances.
+         * avoid other threads waiting for a lock to be released on the Coverage instance. This method will get/lazy-
+         * create a thread-specific Coverage instance.
          *
          * @param swee An exemplar StreetWithElevationEdge to use to initialize a few calculations in the newly created
          *             coverage instance.

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -141,19 +141,15 @@ public class ElevationModule implements GraphBuilderModule {
         }
 
         // try to load in the cached elevation data
-        try {
-            ObjectInputStream in = new ObjectInputStream(new FileInputStream(cachedElevationsFile));
-            cachedElevations = (HashMap<String, PackedCoordinateSequence>) in.readObject();
-            log.info("Cached elevation data loaded into memory!");
-        } catch (IOException | ClassNotFoundException e) {
-            log.warn(graph.addBuilderAnnotation(
-                new Graphwide(
-                    String.format(
-                        "Cached elevations file could not be read in due to error: %s!",
-                        e.getMessage()
-                    )
-                )
-            ));
+        if (cacheElevations) {
+            try {
+                ObjectInputStream in = new ObjectInputStream(new FileInputStream(cachedElevationsFile));
+                cachedElevations = (HashMap<String, PackedCoordinateSequence>) in.readObject();
+                log.info("Cached elevation data loaded into memory!");
+            } catch (IOException | ClassNotFoundException e) {
+                log.warn(graph.addBuilderAnnotation(new Graphwide(
+                    String.format("Cached elevations file could not be read in due to error: %s!", e.getMessage()))));
+            }
         }
         log.info("Setting street elevation profiles from digital elevation model...");
 

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -70,6 +70,11 @@ public class ElevationModule implements GraphBuilderModule {
     private final File cachedElevationsFile;
     /* Whether or not to include geoid difference values in individual elevation calculations */
     private final boolean includeEllipsoidToGeoidDifference;
+    /*
+     * The parallelism to use when processing edges. For unknown reasons that seem to depend on data and machine
+     * settings, it might be faster to not use all processors available.
+     */
+    private final int parallelism;
 
     private HashMap<String, PackedCoordinateSequence> cachedElevations;
 
@@ -111,7 +116,8 @@ public class ElevationModule implements GraphBuilderModule {
             false,
             false,
             1,
-            true
+            true,
+            1
         );
     }
 
@@ -121,7 +127,8 @@ public class ElevationModule implements GraphBuilderModule {
         boolean readCachedElevations,
         boolean writeCachedElevations,
         double elevationUnitMultiplier,
-        boolean includeEllipsoidToGeoidDifference
+        boolean includeEllipsoidToGeoidDifference,
+        int parallelism
     ) {
         gridCoverageFactory = factory;
         cachedElevationsFile = cacheDirectory != null ? new File(cacheDirectory, "cached_elevations.obj") : null;
@@ -129,6 +136,7 @@ public class ElevationModule implements GraphBuilderModule {
         this.writeCachedElevations = writeCachedElevations;
         this.elevationUnitMultiplier = elevationUnitMultiplier;
         this.includeEllipsoidToGeoidDifference = includeEllipsoidToGeoidDifference;
+        this.parallelism = parallelism;
     }
 
     public List<String> provides() {
@@ -161,7 +169,7 @@ public class ElevationModule implements GraphBuilderModule {
 
         // Multithread elevation calculations
         ForkJoinPool forkJoinPool = new ForkJoinPool(
-            Runtime.getRuntime().availableProcessors(),
+            parallelism,
             forkJoinWorkerThreadFactory,
             null,
             false

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -65,13 +65,15 @@ public class ElevationModule implements GraphBuilderModule {
      */
     private double distanceBetweenSamplesM = 10;
 
-
     /**
      * Unit conversion multiplier for elevation values. No conversion needed if the elevation values
      * are defined in meters in the source data. If, for example, decimetres are used in the source data,
      * this should be set to 0.1 in build-config.json.
      */
     private double elevationUnitMultiplier = 1;
+
+    /** used to transform street coordinates into the projection used by the elevation data */
+    private MathTransform transformer;
 
     public ElevationModule() { /* This makes me a "bean" */ };
     
@@ -106,26 +108,39 @@ public class ElevationModule implements GraphBuilderModule {
         // interpolation internally)
         coverage = (gridCov instanceof GridCoverage2D) ? Interpolator2D.create(
                 (GridCoverage2D) gridCov, new InterpolationBilinear()) : gridCov;
+        try {
+            transformer = CRS.findMathTransform(
+                GeometryUtils.WGS84_XY,
+                coverage.getCoordinateReferenceSystem(),
+                true
+            );
+        } catch (FactoryException e) {
+            log.error("Could not find an appropriate transformer!");
+            throw new RuntimeException(e);
+        }
         log.info("Setting street elevation profiles from digital elevation model...");
 
         List<StreetEdge> edgesWithElevation = Collections.synchronizedList(new ArrayList<>());
         AtomicInteger nProcessed = new AtomicInteger();
-        int nTotal = graph.countEdges();
 
-        graph.getVertices().parallelStream().forEach(gv -> {
-            gv.getOutgoing().parallelStream().forEach(ee -> {
+        List<StreetWithElevationEdge> edgesToCalculate = new ArrayList<>();
+        for (Vertex gv : graph.getVertices()) {
+            for (Edge ee : gv.getOutgoing()) {
                 if (ee instanceof StreetWithElevationEdge) {
-                    StreetWithElevationEdge edgeWithElevation = (StreetWithElevationEdge) ee;
-                    processEdge(graph, edgeWithElevation);
-                    if (edgeWithElevation.getElevationProfile() != null && !edgeWithElevation.isElevationFlattened()) {
-                        edgesWithElevation.add(edgeWithElevation);
-                    }
-                    int curNumProcessed = nProcessed.addAndGet(1);
-                    if (curNumProcessed % 50000 == 0) {
-                        log.info("set elevation on {}/{} edges", curNumProcessed, nTotal);
-                    }
+                    edgesToCalculate.add((StreetWithElevationEdge) ee);
                 }
-            });
+            }
+        }
+
+        edgesToCalculate.parallelStream().forEach(edgeWithElevation -> {
+            processEdge(graph, edgeWithElevation);
+            if (edgeWithElevation.hasPackedElevationProfile() && !edgeWithElevation.isElevationFlattened()) {
+                edgesWithElevation.add(edgeWithElevation);
+            }
+            int curNumProcessed = nProcessed.addAndGet(1);
+            if (curNumProcessed % 50000 == 0) {
+                log.info("set elevation on {}/{} edges", curNumProcessed, edgesToCalculate.size());
+            }
         });
 
         double failurePercentage = nPointsOutsideDEM.get() / nPointsEvaluated.get() * 100;
@@ -347,7 +362,7 @@ public class ElevationModule implements GraphBuilderModule {
      * @param graph the graph (used only for error handling)
      */
     private void processEdge(Graph graph, StreetWithElevationEdge ee) {
-        if (ee.getElevationProfile() != null) {
+        if (ee.hasPackedElevationProfile()) {
             return; /* already set up */
         }
         Geometry g = ee.getGeometry();
@@ -440,15 +455,10 @@ public class ElevationModule implements GraphBuilderModule {
             // for DefaultGeographicCRS.WGS84, but OTP is using (long, lat) throughout and assumes unprojected DEM
             // rasters to also use (long, lat).
             DirectPosition2D projectedPosition = new DirectPosition2D(GeometryUtils.WGS84_XY, x, y);
-            MathTransform transformer = CRS.findMathTransform(
-                GeometryUtils.WGS84_XY,
-                coverage.getCoordinateReferenceSystem(),
-                true
-            );
             DirectPosition2D transformedPosition = new DirectPosition2D();
             transformer.transform(projectedPosition, transformedPosition);
             coverage.evaluate(transformedPosition, values);
-        } catch (org.opengis.coverage.PointOutsideCoverageException | FactoryException | TransformException e) {
+        } catch (org.opengis.coverage.PointOutsideCoverageException | TransformException e) {
             nPointsOutsideDEM.incrementAndGet();
         }
         nPointsEvaluated.incrementAndGet();

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -156,10 +156,9 @@ public class ElevationModule implements GraphBuilderModule {
         }
         log.info("Setting street elevation profiles from digital elevation model...");
 
-        List<StreetEdge> edgesWithElevation = Collections.synchronizedList(new ArrayList<>());
         AtomicInteger nProcessed = new AtomicInteger();
 
-        List<StreetWithElevationEdge> edgesToCalculate = new ArrayList<>();
+        LinkedList<StreetWithElevationEdge> edgesToCalculate = new LinkedList<>();
         for (Vertex gv : graph.getVertices()) {
             for (Edge ee : gv.getOutgoing()) {
                 if (ee instanceof StreetWithElevationEdge) {
@@ -170,14 +169,20 @@ public class ElevationModule implements GraphBuilderModule {
 
         edgesToCalculate.parallelStream().forEach(edgeWithElevation -> {
             processEdge(graph, edgeWithElevation);
-            if (edgeWithElevation.hasPackedElevationProfile() && !edgeWithElevation.isElevationFlattened()) {
-                edgesWithElevation.add(edgeWithElevation);
-            }
             int curNumProcessed = nProcessed.addAndGet(1);
             if (curNumProcessed % 50000 == 0) {
                 log.info("set elevation on {}/{} edges", curNumProcessed, edgesToCalculate.size());
             }
         });
+
+        // iterate again to find edges that had elevation calculated. This is done here instead of in the above loop to
+        // avoid thread locking for writes to a synchronized list
+        LinkedList<StreetEdge> edgesWithElevation = new LinkedList<>();
+        for (StreetWithElevationEdge edgeWithElevation : edgesToCalculate) {
+            if (edgeWithElevation.hasPackedElevationProfile() && !edgeWithElevation.isElevationFlattened()) {
+                edgesWithElevation.add(edgeWithElevation);
+            }
+        }
 
         double failurePercentage = nPointsOutsideDEM.get() / nPointsEvaluated.get() * 100;
         if (failurePercentage > 50) {

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -1,6 +1,8 @@
 package org.opentripplanner.graph_builder.module.ned;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import org.geotools.coverage.grid.GridCoverage2D;
+import org.geotools.coverage.grid.Interpolator2D;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.geotools.geometry.DirectPosition2D;
@@ -25,6 +27,7 @@ import org.opentripplanner.util.PolylineEncoder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.media.jai.InterpolationBilinear;
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -33,7 +36,6 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.nio.file.Files;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -78,6 +80,12 @@ public class ElevationModule implements GraphBuilderModule {
      */
     private final int parallelism;
 
+    /**
+     * A map of PackedCoordinateSequence values identified by Strings of encoded polylines.
+     *
+     * Note: Since this map has a key of only the encoded polylines, it is assumed that all other inputs are the same as
+     * those that occurred in the graph build that produced this data.
+     */
     private HashMap<String, PackedCoordinateSequence> cachedElevations;
 
     // Keep track of the proportion of elevation fetch operations that fail so we can issue warnings. AtomicInteger is
@@ -111,7 +119,7 @@ public class ElevationModule implements GraphBuilderModule {
     private final ConcurrentHashMap<Integer, Double> geoidDifferenceCache = new ConcurrentHashMap<>();
 
     /** Used only when the ElevationModule is requested to be ran with a single thread */
-    private Coverage singleThreadedCoverageInstance;
+    private Coverage singleThreadedCoverageInterpolator;
 
     /** used only for testing purposes */
     public ElevationModule(ElevationGridCoverageFactory factory) {
@@ -271,7 +279,7 @@ public class ElevationModule implements GraphBuilderModule {
      * thread.
      */
     private class ElevationWorkerThread extends ForkJoinWorkerThread {
-        private Coverage threadSpecificCoverage;
+        private Coverage threadSpecificCoverageInterpolator;
 
         /**
          * Creates a ForkJoinWorkerThread operating in the given pool.
@@ -285,29 +293,29 @@ public class ElevationModule implements GraphBuilderModule {
 
         /**
          * For unknown reasons, the interpolation of heights at coordinates is a synchronized method in the commonly
-         * used Interpolator2D class. Therefore, it is critical to use a dedicated Coverage instance for each thread to
-         * avoid other threads waiting for a lock to be released on the Coverage instance. This method will get/lazy-
-         * create a thread-specific Coverage instance.
+         * used Interpolator2D class. Therefore, it is critical to use a dedicated Coverage interpolator instance for
+         * each thread to avoid other threads waiting for a lock to be released on the Coverage interpolator instance.
+         * This method will get/lazy-create a thread-specific Coverage interpolator instance.
          *
-         * @return A thread-specific coverage instance that can be used without being locked from other threads.
+         * @return A thread-specific coverage interpolator instance.
          */
-        public Coverage getThreadSpecificCoverageInstance () {
-            if (threadSpecificCoverage == null) {
+        public Coverage getThreadSpecificCoverageInterpolator() {
+            if (threadSpecificCoverageInterpolator == null) {
                 // Synchronize the creation of the Thread-specific Coverage instances to avoid potential locks that
                 // could arise from downstream classes that have synchronized methods.
-                threadSpecificCoverage = createThreadSpecificCoverage();
+                threadSpecificCoverageInterpolator = createThreadSpecificCoverageInterpolator();
             }
-            return threadSpecificCoverage;
+            return threadSpecificCoverageInterpolator;
         }
 
         /**
          * Synchronize the creation of the Thread-specific Coverage instances to avoid potential locks that could arise
          * from downstream classes that have synchronized methods.
          */
-        private Coverage createThreadSpecificCoverage() {
+        private Coverage createThreadSpecificCoverageInterpolator() {
             Coverage coverage;
             synchronized (gridCoverageFactory) {
-                coverage = gridCoverageFactory.getGridCoverage();
+                coverage = createNewCoverageInterpolator();
                 // The Coverage instance relies on some synchronized static methods shared across all threads that
                 // can cause deadlocks if not fully initialized. Therefore, make a single request for the first
                 // point on the edge to initialize these other items.
@@ -569,7 +577,7 @@ public class ElevationModule implements GraphBuilderModule {
 
         // Needs full calculation. Calculate with a thread-specific coverage instance to avoid waiting for any locks on
         // coverage instances in other threads.
-        Coverage coverage = getThreadSpecificCoverageInstance();
+        Coverage coverage = getThreadSpecificCoverageInterpolator();
 
         // did not find a cached value, calculate
         // If any of the coordinates throw an error when trying to lookup their value, immediately bail and do not
@@ -639,18 +647,33 @@ public class ElevationModule implements GraphBuilderModule {
     }
 
     /**
-     * Gets a coverage instance specific to the current thread. If using multiple threads, get the coverage instance
-     * associated with the ElevationWorkerThread. Otherwise, use a class field.
+     * Gets a coverage interpolator instance specific to the current thread. If using multiple threads, get the coverage
+     * interpolator instance associated with the ElevationWorkerThread. Otherwise, use a class field.
      */
-    private Coverage getThreadSpecificCoverageInstance() {
+    private Coverage getThreadSpecificCoverageInterpolator() {
         if (parallelism == 1) {
-            if (singleThreadedCoverageInstance == null) {
-                singleThreadedCoverageInstance = gridCoverageFactory.getGridCoverage();
+            if (singleThreadedCoverageInterpolator == null) {
+                singleThreadedCoverageInterpolator = gridCoverageFactory.getGridCoverage();
             }
-            return singleThreadedCoverageInstance;
+            return singleThreadedCoverageInterpolator;
         } else {
-            return ((ElevationWorkerThread) Thread.currentThread()).getThreadSpecificCoverageInstance();
+            return ((ElevationWorkerThread) Thread.currentThread()).getThreadSpecificCoverageInterpolator();
         }
+    }
+
+    /**
+     * Create a new coverage interpolator instance.
+     */
+    private Coverage createNewCoverageInterpolator() {
+        // If the grid coverage factory is the NEDGridCoverageFactoryImpl, then get the grid coverage from that factory.
+        // Otherwise, apply a bilinear interpolator.
+        // (note: UnifiedGridCoverages created by NEDGridCoverageFactoryImpl handle interpolation internally)
+        return gridCoverageFactory instanceof NEDGridCoverageFactoryImpl
+            ? gridCoverageFactory.getGridCoverage()
+            : Interpolator2D.create(
+                (GridCoverage2D) gridCoverageFactory.getGridCoverage(),
+                new InterpolationBilinear()
+            );
     }
 
     private void setEdgeElevationProfile(StreetWithElevationEdge ee, PackedCoordinateSequence elevPCS, Graph graph) {

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -608,9 +608,9 @@ public class ElevationModule implements GraphBuilderModule {
 
     /**
      * The Calculation of the EllipsoidToGeoidDifference is a very expensive operation, so the resulting values are
-     * cached based on the coordinate values up to 2 significant digits. Two signficant digits is often more than enough
+     * cached based on the coordinate values up to 2 significant digits. Two significant digits are often more than enough
      * for most parts of the world, but is useful for certain areas that have dramatic changes. Since the values are
-     * computer once and cached, it has almost no affect on performance to have this level of detail.
+     * computed once and cached, it has almost no affect on performance to have this level of detail.
      * See this image for an approximate mapping of these difference values:
      * https://earth-info.nga.mil/GandG/images/ww15mgh2.gif
      *

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -257,7 +257,20 @@ public class ElevationModule implements GraphBuilderModule {
             long currentThreadId = Thread.currentThread().getId();
             Coverage threadSpecificCoverage = coveragesForThread.get(currentThreadId);
             if (threadSpecificCoverage == null) {
-                threadSpecificCoverage = getCoverage();
+                // Synchronize the creation of the Thread-specific Coverage instances to avoid potential deadlocks that
+                // could arise from downstream classes that have synchronized methods.
+                synchronized (coveragesForThread) {
+                    threadSpecificCoverage = getCoverage();
+                    // The Coverage instance relies on some synchronized static methods shared across all threads that
+                    // can cause deadlocks if not fully initialized. Therefore, make a single request for the first
+                    // point on the edge to initialize these other items.
+                    Coordinate firstEdgeCoord =  swee.getGeometry().getCoordinates()[0];
+                    double[] dummy = new double[1];
+                    threadSpecificCoverage.evaluate(
+                        new DirectPosition2D(GeometryUtils.WGS84_XY, firstEdgeCoord.x, firstEdgeCoord.y),
+                        dummy
+                    );
+                }
                 coveragesForThread.put(currentThreadId, threadSpecificCoverage);
             }
             return threadSpecificCoverage;

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.graph_builder.module.ned;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.geotools.geometry.DirectPosition2D;
@@ -108,6 +109,9 @@ public class ElevationModule implements GraphBuilderModule {
     /** A concurrent hashmap used for storing geoid difference values at various coordinates */
     private final ConcurrentHashMap<Integer, Double> geoidDifferenceCache = new ConcurrentHashMap<>();
 
+    /** Used only when the ElevationModule is requested to be ran with a single thread */
+    private Coverage singleThreadedCoverageInstance;
+
     /** used only for testing purposes */
     public ElevationModule(ElevationGridCoverageFactory factory) {
         this(
@@ -139,6 +143,15 @@ public class ElevationModule implements GraphBuilderModule {
         this.parallelism = parallelism;
     }
 
+    /**
+     * Gets the desired amount of processors to use for elevation calculations from the build-config setting. It will
+     * return at least 1 processor and no more than the maximum available processors.
+     */
+    public static int fromConfig(JsonNode elevationModuleParallelism) {
+        int maxProcessors = Runtime.getRuntime().availableProcessors();
+        return Math.max(1, Math.min(elevationModuleParallelism.asInt(maxProcessors), maxProcessors));
+    }
+
     public List<String> provides() {
         return Arrays.asList("elevation");
     }
@@ -165,15 +178,14 @@ public class ElevationModule implements GraphBuilderModule {
         }
         log.info("Setting street elevation profiles from digital elevation model...");
 
-        ForkJoinPool.ForkJoinWorkerThreadFactory forkJoinWorkerThreadFactory = pool -> new ElevationWorkerThread(pool);
+        ForkJoinPool forkJoinPool = null;
+        if (parallelism > 1) {
+            // Create a thread factory for multi-threaded elevation calculations
+            ForkJoinPool.ForkJoinWorkerThreadFactory forkJoinWorkerThreadFactory = pool -> new ElevationWorkerThread(
+                pool);
 
-        // Multithread elevation calculations
-        ForkJoinPool forkJoinPool = new ForkJoinPool(
-            parallelism,
-            forkJoinWorkerThreadFactory,
-            null,
-            false
-        );
+            forkJoinPool = new ForkJoinPool(parallelism, forkJoinWorkerThreadFactory, null, false);
+        }
 
         // At first, set the totalElevationEdges to the total number of edges in the graph.
         totalElevationEdges = graph.countEdges();
@@ -181,7 +193,16 @@ public class ElevationModule implements GraphBuilderModule {
         for (Vertex gv : graph.getVertices()) {
             for (Edge ee : gv.getOutgoing()) {
                 if (ee instanceof StreetWithElevationEdge) {
-                    forkJoinPool.submit(new ProcessEdgeTask((StreetWithElevationEdge) ee));
+                    if (parallelism > 1) {
+                        // Multi-threaded execution requested, check and prepare a few things that are used only during
+                        // multi-threaded runs.
+                        if (examplarCoordinate == null) {
+                            // store the first coordinate of the first StreetEdge for later use in initializing coverage
+                            // instances
+                            examplarCoordinate = ee.getGeometry().getCoordinates()[0];
+                        }
+                        forkJoinPool.submit(new ProcessEdgeTask((StreetWithElevationEdge) ee));
+                    }
                     streetsWithElevationEdges.add((StreetWithElevationEdge) ee);
                 }
             }
@@ -189,17 +210,22 @@ public class ElevationModule implements GraphBuilderModule {
         // update this value to the now-known amount of edges that are StreetWithElevation edges
         totalElevationEdges = streetsWithElevationEdges.size();
 
-        // store the first coordinate of the first StreetEdge for later use ininitializing coverage instances
-        examplarCoordinate = streetsWithElevationEdges.get(0).getGeometry().getCoordinates()[0];
-
-        // shutdown the forkJoinPool and wait until all tasks are finished. If this takes longer than 1 day, give up.
-        forkJoinPool.shutdown();
-        try {
-            forkJoinPool.awaitTermination(1, TimeUnit.DAYS);
-        } catch (InterruptedException ex) {
-            log.error("Multi-threaded elevation calculations timed-out!");
-            Thread.currentThread().interrupt();
-            throw new RuntimeException(ex);
+        if (parallelism == 1) {
+            // If using just a single thread, process each edge inline
+            for (StreetWithElevationEdge ee : streetsWithElevationEdges) {
+                processEdgeWithProgress(ee);
+            }
+        } else {
+            // Multi-threaded execution
+            // shutdown the forkJoinPool and wait until all tasks are finished. If this takes longer than 1 day, give up.
+            forkJoinPool.shutdown();
+            try {
+                forkJoinPool.awaitTermination(1, TimeUnit.DAYS);
+            } catch (InterruptedException ex) {
+                log.error("Multi-threaded elevation calculations timed-out!");
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(ex);
+            }
         }
 
         double failurePercentage = nPointsOutsideDEM.get() / nPointsEvaluated.get() * 100;
@@ -310,11 +336,7 @@ public class ElevationModule implements GraphBuilderModule {
         }
 
         @Override public void run() {
-            processEdge(swee);
-            int curNumProcessed = nEdgesProcessed.addAndGet(1);
-            if (curNumProcessed % 50_000 == 0) {
-                log.info("set elevation on {}/{} edges", curNumProcessed, totalElevationEdges);
-            }
+            processEdgeWithProgress(swee);
         }
     }
 
@@ -514,6 +536,17 @@ public class ElevationModule implements GraphBuilderModule {
     }
 
     /**
+     * Processes a street edge and updates the current progress.
+     */
+    private void processEdgeWithProgress(StreetWithElevationEdge ee) {
+        processEdge(ee);
+        int curNumProcessed = nEdgesProcessed.addAndGet(1);
+        if (curNumProcessed % 50_000 == 0) {
+            log.info("set elevation on {}/{} edges", curNumProcessed, totalElevationEdges);
+        }
+    }
+
+    /**
      * Processes a single street edge, creating and assigning the elevation profile.
      *
      * @param ee the street edge
@@ -541,7 +574,7 @@ public class ElevationModule implements GraphBuilderModule {
 
         // Needs full calculation. Calculate with a thread-specific coverage to avoid waiting for any locks on
         // coverage instances in other threads.
-        Coverage coverage = ((ElevationWorkerThread) Thread.currentThread()).getThreadSpecificCoverageInstance();
+        Coverage coverage = getThreadSpecificCoverageInstance();
 
         // did not find a cached value, calculate
         // If any of the coordinates throw an error when trying to lookup their value, immediately bail and do not
@@ -607,6 +640,21 @@ public class ElevationModule implements GraphBuilderModule {
             setEdgeElevationProfile(ee, elevPCS, graph);
         } catch (PointOutsideCoverageException | TransformException e) {
             log.debug("Error processing elevation for edge: {} due to error: {}", ee, e);
+        }
+    }
+
+    /**
+     * Gets a coverage instance specific to the current thread. If using multiple threads, get the coverage instance
+     * associated with the ElevationWorkerThread. Otherwise, use a class field.
+     */
+    private Coverage getThreadSpecificCoverageInstance() {
+        if (parallelism == 1) {
+            if (singleThreadedCoverageInstance == null) {
+                singleThreadedCoverageInstance = gridCoverageFactory.getGridCoverage();
+            }
+            return singleThreadedCoverageInstance;
+        } else {
+            return ((ElevationWorkerThread) Thread.currentThread()).getThreadSpecificCoverageInstance();
         }
     }
 

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -16,6 +16,7 @@ import org.opentripplanner.common.geometry.SphericalDistanceLibrary;
 import org.opentripplanner.common.pqueue.BinHeap;
 import org.opentripplanner.graph_builder.annotation.ElevationFlattened;
 import org.opentripplanner.graph_builder.module.extra_elevation_data.ElevationPoint;
+import org.opentripplanner.graph_builder.annotation.Graphwide;
 import org.opentripplanner.graph_builder.services.GraphBuilderModule;
 import org.opentripplanner.graph_builder.services.ned.ElevationGridCoverageFactory;
 import org.opentripplanner.routing.edgetype.StreetEdge;
@@ -29,10 +30,12 @@ import org.slf4j.LoggerFactory;
 import javax.media.jai.InterpolationBilinear;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * {@link org.opentripplanner.graph_builder.services.GraphBuilderModule} plugin that applies elevation data to street data that has already
@@ -53,8 +56,8 @@ public class ElevationModule implements GraphBuilderModule {
     private Coverage coverage;
 
     // Keep track of the proportion of elevation fetch operations that fail so we can issue warnings.
-    private int nPointsEvaluated = 0;
-    private int nPointsOutsideDEM = 0;
+    private AtomicInteger nPointsEvaluated = new AtomicInteger(0);
+    private AtomicInteger nPointsOutsideDEM = new AtomicInteger(0);
 
     /**
      * The distance between samples in meters. Defaults to 10m, the approximate resolution of 1/3
@@ -104,30 +107,37 @@ public class ElevationModule implements GraphBuilderModule {
         coverage = (gridCov instanceof GridCoverage2D) ? Interpolator2D.create(
                 (GridCoverage2D) gridCov, new InterpolationBilinear()) : gridCov;
         log.info("Setting street elevation profiles from digital elevation model...");
-        List<StreetEdge> edgesWithElevation = new ArrayList<StreetEdge>();
-        int nProcessed = 0;
+
+        List<StreetEdge> edgesWithElevation = Collections.synchronizedList(new ArrayList<>());
+        AtomicInteger nProcessed = new AtomicInteger();
         int nTotal = graph.countEdges();
-        for (Vertex gv : graph.getVertices()) {
-            for (Edge ee : gv.getOutgoing()) {
+
+        graph.getVertices().parallelStream().forEach(gv -> {
+            gv.getOutgoing().parallelStream().forEach(ee -> {
                 if (ee instanceof StreetWithElevationEdge) {
                     StreetWithElevationEdge edgeWithElevation = (StreetWithElevationEdge) ee;
                     processEdge(graph, edgeWithElevation);
                     if (edgeWithElevation.getElevationProfile() != null && !edgeWithElevation.isElevationFlattened()) {
                         edgesWithElevation.add(edgeWithElevation);
                     }
-                    nProcessed += 1;
-                    if (nProcessed % 50000 == 0) {
-                        log.info("set elevation on {}/{} edges", nProcessed, nTotal);
-                        double failurePercentage = nPointsOutsideDEM / nPointsEvaluated * 100;
-                        if (failurePercentage > 50) {
-                            log.warn("Fetching elevation failed at {}/{} points ({}%)",
-                                    nPointsOutsideDEM, nPointsEvaluated, failurePercentage);
-                            log.warn("Elevation is missing at a large number of points. DEM may be for the wrong region. " +
-                                    "If it is unprojected, perhaps the axes are not in (longitude, latitude) order.");
-                        }
+                    int curNumProcessed = nProcessed.addAndGet(1);
+                    if (curNumProcessed % 50000 == 0) {
+                        log.info("set elevation on {}/{} edges", curNumProcessed, nTotal);
                     }
                 }
-            }
+            });
+        });
+
+        double failurePercentage = nPointsOutsideDEM.get() / nPointsEvaluated.get() * 100;
+        if (failurePercentage > 50) {
+            log.warn(graph.addBuilderAnnotation(new Graphwide(
+                String.format(
+                    "Fetching elevation failed at %d/%d points (%d%%)",
+                    nPointsOutsideDEM, nPointsEvaluated, failurePercentage
+                )
+            )));
+            log.warn("Elevation is missing at a large number of points. DEM may be for the wrong region. " +
+                "If it is unprojected, perhaps the axes are not in (longitude, latitude) order.");
         }
 
         @SuppressWarnings("unchecked")
@@ -459,9 +469,9 @@ public class ElevationModule implements GraphBuilderModule {
             transformer.transform(projectedPosition, transformedPosition);
             coverage.evaluate(transformedPosition, values);
         } catch (org.opengis.coverage.PointOutsideCoverageException | FactoryException | TransformException e) {
-            nPointsOutsideDEM += 1;
+            nPointsOutsideDEM.incrementAndGet();
         }
-        nPointsEvaluated += 1;
+        nPointsEvaluated.incrementAndGet();
         return values[0] * elevationUnitMultiplier;
     }
 

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -81,6 +81,9 @@ public class ElevationModule implements GraphBuilderModule {
     /** keeps track of the total amount of elevation edges for logging purposes */
     private int totalElevationEdges = Integer.MAX_VALUE;
 
+    // the first coordinate in the first StreetWithElevationEdge which is used for initializing coverage instances
+    private Coordinate examplarCoordinate;
+
     /**
      * The distance between samples in meters. Defaults to 10m, the approximate resolution of 1/3
      * arc-second NED data.
@@ -178,6 +181,9 @@ public class ElevationModule implements GraphBuilderModule {
         // update this value to the now-known amount of edges that are StreetWithElevation edges
         totalElevationEdges = streetsWithElevationEdges.size();
 
+        // store the first coordinate of the first StreetEdge for later use ininitializing coverage instances
+        examplarCoordinate = streetsWithElevationEdges.get(0).getGeometry().getCoordinates()[0];
+
         // shutdown the forkJoinPool and wait until all tasks are finished. If this takes longer than 1 day, give up.
         forkJoinPool.shutdown();
         try {
@@ -254,29 +260,34 @@ public class ElevationModule implements GraphBuilderModule {
          * avoid other threads waiting for a lock to be released on the Coverage instance. This method will get/lazy-
          * create a thread-specific Coverage instance.
          *
-         * @param swee An exemplar StreetWithElevationEdge to use to initialize a few calculations in the newly created
-         *             coverage instance.
          * @return A thread-specific coverage instance that can be used without being locked from other threads.
          */
-        public Coverage getThreadSpecificCoverageInstance (StreetWithElevationEdge swee) {
+        public Coverage getThreadSpecificCoverageInstance () {
             if (threadSpecificCoverage == null) {
                 // Synchronize the creation of the Thread-specific Coverage instances to avoid potential locks that
                 // could arise from downstream classes that have synchronized methods.
-                synchronized (gridCoverageFactory) {
-                    // Get a new Coverage instance from the module's ElevationGridCoverageFactory.
-                    threadSpecificCoverage = gridCoverageFactory.getGridCoverage();
-                    // The Coverage instance relies on some synchronized static methods shared across all threads that
-                    // can cause deadlocks if not fully initialized. Therefore, make a single request for the first
-                    // point on the edge to initialize these other items.
-                    Coordinate firstEdgeCoord =  swee.getGeometry().getCoordinates()[0];
-                    double[] dummy = new double[1];
-                    threadSpecificCoverage.evaluate(
-                        new DirectPosition2D(GeometryUtils.WGS84_XY, firstEdgeCoord.x, firstEdgeCoord.y),
-                        dummy
-                    );
-                }
+                threadSpecificCoverage = createThreadSpecificCoverage();
             }
             return threadSpecificCoverage;
+        }
+
+        /**
+         * Synchronize the creation of the Thread-specific Coverage instances to avoid potential locks that  could arise
+         * from downstream classes that have synchronized methods.
+         */
+        private Coverage createThreadSpecificCoverage() {
+            Coverage coverage;
+            synchronized (gridCoverageFactory) {
+                coverage = gridCoverageFactory.getGridCoverage();
+                // The Coverage instance relies on some synchronized static methods shared across all threads that
+                // can cause deadlocks if not fully initialized. Therefore, make a single request for the first
+                // point on the edge to initialize these other items.
+                double[] dummy = new double[1];
+                coverage.evaluate(new DirectPosition2D(GeometryUtils.WGS84_XY, examplarCoordinate.x, examplarCoordinate.y),
+                    dummy
+                );
+            }
+            return coverage;
         }
     }
 
@@ -522,7 +533,7 @@ public class ElevationModule implements GraphBuilderModule {
 
         // Needs full calculation. Calculate with a thread-specific coverage to avoid waiting for any locks on
         // coverage instances in other threads.
-        Coverage coverage = ((ElevationWorkerThread) Thread.currentThread()).getThreadSpecificCoverageInstance(ee);
+        Coverage coverage = ((ElevationWorkerThread) Thread.currentThread()).getThreadSpecificCoverageInstance();
 
         // did not find a cached value, calculate
         // If any of the coordinates throw an error when trying to lookup their value, immediately bail and do not

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -355,25 +355,48 @@ public class ElevationModule implements GraphBuilderModule {
 
         List<Coordinate> coordList = new LinkedList<Coordinate>();
 
-        // calculate the total edge length in meters
-        double edgeLenM = 0;
-        for (int i = 0; i < coords.length - 1; i++) {
-            edgeLenM += SphericalDistanceLibrary.distance(coords[i].y, coords[i].x, coords[i + 1].y,
-                    coords[i + 1].x);
-        }
-
         // initial sample (x = 0)
         coordList.add(new Coordinate(0, getElevation(coords[0])));
 
-        // loop for edge-internal samples
-        for (double x = distanceBetweenSamplesM; x < edgeLenM; x += distanceBetweenSamplesM) {
-            // avoid final-segment samples less than half the distance between samples:
-            if (edgeLenM - x < distanceBetweenSamplesM / 2) {
-                break;
-            }
+        // iterate through coordinates calculating the edge length and creating intermediate elevation coordinates at
+        // the regularly specified interval
+        double edgeLenM = 0;
+        double sampleDistance = distanceBetweenSamplesM;
+        double previousDistance = 0;
+        double x1 = coords[0].x, y1 = coords[0].y, x2, y2;
+        for (int i = 0; i < coords.length - 1; i++) {
+            x2 = coords[i + 1].x;
+            y2 = coords[i + 1].y;
+            double curSegmentDistance = SphericalDistanceLibrary.distance(y1, x1, y2, x2);
+            edgeLenM += curSegmentDistance;
+            while (edgeLenM > sampleDistance) {
+                // if current edge length is longer than the current sample distance, insert new elevation coordinates
+                // as needed until sample distance has caught up
 
-            Coordinate internal = getPointAlongEdge(coords, edgeLenM, x / edgeLenM);
-            coordList.add(new Coordinate(x, getElevation(internal)));
+                // calculate percent of current segment that distance is between
+                double pctAlongSeg = (sampleDistance - previousDistance) / curSegmentDistance;
+                // add an elevation coordinate
+                coordList.add(
+                    new Coordinate(
+                        sampleDistance,
+                        getElevation(
+                            new Coordinate(
+                                x1 + (pctAlongSeg * (x2 - x1)),
+                                y1 + (pctAlongSeg * (y2 - y1))
+                            )
+                        )
+                    )
+                );
+                sampleDistance += distanceBetweenSamplesM;
+            }
+            previousDistance = edgeLenM;
+            x1 = x2;
+            y1 = y2;
+        }
+
+        // remove final-segment sample if it is less than half the distance between samples
+        if (edgeLenM - coordList.get(coordList.size() - 1).x < distanceBetweenSamplesM / 2) {
+            coordList.remove(coordList.size() - 1);
         }
 
         // final sample (x = edge length)
@@ -389,51 +412,6 @@ public class ElevationModule implements GraphBuilderModule {
                 log.trace(graph.addBuilderAnnotation(new ElevationFlattened(ee)));
             }
         }
-    }
-
-    /**
-     * Returns a coordinate along a path located at a specific point indicated by the percentage of
-     * distance covered from start to end.
-     * 
-     * @param coords the list of (x,y) coordinates that form the path
-     * @param length the total length of the path
-     * @param t the percentage (ranges from 0 to 1)
-     * @return the (x,y) coordinate at t
-     */
-    public Coordinate getPointAlongEdge(Coordinate[] coords, double length, double t) {
-
-        double pctThrough = 0; // current percentage of the edge length traversed
-
-        // endpoints of current segment within edge:
-        double x1 = coords[0].x, y1 = coords[0].y, x2, y2;
-
-        for (int i = 1; i < coords.length - 1; i++) { // loop through inner points
-            Coordinate innerPt = coords[i];
-            x2 = innerPt.x;
-            y2 = innerPt.y;
-
-            // percentage of total edge length represented by current segment:
-            double pct = SphericalDistanceLibrary.distance(y1, x1, y2, x2) / length;
-
-            if (pctThrough + pct > t) { // if current segment contains 't,' we're done
-                double pctAlongSeg = (t - pctThrough) / pct;
-                return new Coordinate(x1 + (pctAlongSeg * (x2 - x1)), y1
-                        + (pctAlongSeg * (y2 - y1)));
-            }
-
-            pctThrough += pct;
-            x1 = x2;
-            y1 = y2;
-        }
-
-        // handle the final segment separately
-        x2 = coords[coords.length - 1].x;
-        y2 = coords[coords.length - 1].y;
-
-        double pct = SphericalDistanceLibrary.distance(y1, x1, y2, x2) / length;
-        double pctAlongSeg = (t - pctThrough) / pct;
-
-        return new Coordinate(x1 + (pctAlongSeg * (x2 - x1)), y1 + (pctAlongSeg * (y2 - y1)));
     }
 
     /**

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/GeotiffGridCoverageFactoryImpl.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/GeotiffGridCoverageFactoryImpl.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.graph_builder.module.ned;
 
 import org.geotools.coverage.grid.GridCoverage2D;
+import org.geotools.coverage.grid.Interpolator2D;
 import org.geotools.factory.Hints;
 import org.geotools.gce.geotiff.GeoTiffFormat;
 import org.geotools.gce.geotiff.GeoTiffReader;
@@ -9,6 +10,7 @@ import org.opentripplanner.routing.graph.Graph;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.media.jai.InterpolationBilinear;
 import java.io.File;
 import java.io.IOException;
 
@@ -28,13 +30,20 @@ public class GeotiffGridCoverageFactoryImpl implements ElevationGridCoverageFact
     }
 
     /**
+     * Wraps the underlying grid coverage instance with an interpolator that can be used in a specific thread.
+     */
+    @Override
+    public GridCoverage2D getGridCoverage() {
+        return Interpolator2D.create(getUninterpolatedGridCoverage(), new InterpolationBilinear());
+    }
+
+    /**
      * Lazy-creates a GridCoverage2D instance by loading the specific elevation file into memory. During a refactor in
      * the year 2020, the code at one point was written such that each coverage instance was created and wrapped in the
      * Interpolator2D interpolator for each thread to use. However, benchmarking showed that this caused longer run
      * times which is likely due to too much memory competing for a slot in the processor cache.
      */
-    @Override
-    public GridCoverage2D getGridCoverage() {
+    public GridCoverage2D getUninterpolatedGridCoverage() {
         if (coverage == null) {
             try {
                 // There is a serious standardization failure around the axis order of WGS84. See issue #1930.

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/GeotiffGridCoverageFactoryImpl.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/GeotiffGridCoverageFactoryImpl.java
@@ -37,7 +37,7 @@ public class GeotiffGridCoverageFactoryImpl implements ElevationGridCoverageFact
             GeoTiffFormat format = new GeoTiffFormat();
             GeoTiffReader reader = format.getReader(path, forceLongLat);
             coverage = reader.read(null);
-            LOG.info("Elevation model CRS is: {}", coverage.getCoordinateReferenceSystem2D());
+            LOG.debug("Elevation model CRS is: {}", coverage.getCoordinateReferenceSystem2D());
         } catch (IOException e) {
             throw new RuntimeException("Error getting coverage automatically. ", e);
         }

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/GeotiffGridCoverageFactoryImpl.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/GeotiffGridCoverageFactoryImpl.java
@@ -56,7 +56,7 @@ public class GeotiffGridCoverageFactoryImpl implements ElevationGridCoverageFact
     }
 
     @Override
-    public void setGraph(Graph graph) {
+    public void fetchData(Graph graph) {
         //nothing to do here
     }
 

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/GeotiffGridCoverageFactoryImpl.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/GeotiffGridCoverageFactoryImpl.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.graph_builder.module.ned;
 
 import org.geotools.coverage.grid.GridCoverage2D;
+import org.geotools.coverage.grid.Interpolator2D;
 import org.geotools.factory.Hints;
 import org.geotools.gce.geotiff.GeoTiffFormat;
 import org.geotools.gce.geotiff.GeoTiffReader;
@@ -9,6 +10,7 @@ import org.opentripplanner.routing.graph.Graph;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.media.jai.InterpolationBilinear;
 import java.io.File;
 import java.io.IOException;
 
@@ -20,7 +22,6 @@ public class GeotiffGridCoverageFactoryImpl implements ElevationGridCoverageFact
     private static final Logger LOG = LoggerFactory.getLogger(GeotiffGridCoverageFactoryImpl.class);
 
     private final File path;
-    private GridCoverage2D coverage;
 
     public GeotiffGridCoverageFactoryImpl(File path) {
         this.path = path;
@@ -28,6 +29,7 @@ public class GeotiffGridCoverageFactoryImpl implements ElevationGridCoverageFact
 
     @Override
     public GridCoverage2D getGridCoverage() {
+        GridCoverage2D coverage;
         try {
             // There is a serious standardization failure around the axis order of WGS84. See issue #1930.
             // GeoTools assumes strict EPSG axis order of (latitude, longitude) unless told otherwise.
@@ -38,6 +40,8 @@ public class GeotiffGridCoverageFactoryImpl implements ElevationGridCoverageFact
             GeoTiffReader reader = format.getReader(path, forceLongLat);
             coverage = reader.read(null);
             LOG.debug("Elevation model CRS is: {}", coverage.getCoordinateReferenceSystem2D());
+            // TODO might bicubic interpolation give better results?
+            coverage = Interpolator2D.create(coverage, new InterpolationBilinear());
         } catch (IOException e) {
             throw new RuntimeException("Error getting coverage automatically. ", e);
         }

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/NEDDownloader.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/NEDDownloader.java
@@ -45,6 +45,8 @@ public class NEDDownloader implements NEDTileSource {
 
     private double _lonXStep = 0.16;
 
+    private List<File> nedTiles;
+
     private File getPathToNEDArchive(String key) {
         if (!cacheDirectory.exists()) {
             if (!cacheDirectory.mkdirs()) {
@@ -282,20 +284,17 @@ public class NEDDownloader implements NEDTileSource {
         return lft + "_" + rgt + "_" + top + "_" + bot;
     }
 
+    @Override
+    public List<File> getNEDTiles() {
+        return nedTiles;
+    }
+
     @Override public void fetchData(Graph graph, File cacheDirectory) {
         this.graph = graph;
         this.cacheDirectory = cacheDirectory;
 
         log.info("Downloading NED elevation data (or fetching it from local cache).");
-        getNEDTiles(true);
-    }
-
-    @Override
-    public List<File> getNEDTiles() {
-        return getNEDTiles(false);
-    }
-
-    public List<File> getNEDTiles(boolean downloadIfMissing) {
+        
         List<URL> urls = getDownloadURLsCached();
         List<File> files = new ArrayList<File>();
         int tileCount = 0;
@@ -306,9 +305,6 @@ public class NEDDownloader implements NEDTileSource {
             if (tile.exists()) {
                 files.add(tile);
                 log.debug("{} found in NED cache, not downloading: {}", tileProgress, tile);
-                continue;
-            } else if (!downloadIfMissing) {
-                log.debug("{} not found in NED cache, but skipping download: {}", tileProgress, tile);
                 continue;
             }
             REQUEST: for (int req_attempt = 0; req_attempt < 5; ++req_attempt) {
@@ -340,7 +336,7 @@ public class NEDDownloader implements NEDTileSource {
             }
             log.error("Unable to download a NED tile after 5 requests.");
         }
-        return files;
+        nedTiles = files;
     }
 
     private List<URL> getDownloadURLsCached() {

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/NEDDownloader.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/NEDDownloader.java
@@ -45,16 +45,6 @@ public class NEDDownloader implements NEDTileSource {
 
     private double _lonXStep = 0.16;
 
-    @Override
-    public void setGraph(Graph graph) {
-        this.graph = graph;
-    }
-
-    @Override
-    public void setCacheDirectory(File cacheDirectory) {
-        this.cacheDirectory = cacheDirectory;
-    }
-
     private File getPathToNEDArchive(String key) {
         if (!cacheDirectory.exists()) {
             if (!cacheDirectory.mkdirs()) {
@@ -292,9 +282,20 @@ public class NEDDownloader implements NEDTileSource {
         return lft + "_" + rgt + "_" + top + "_" + bot;
     }
 
+    @Override public void fetchData(Graph graph, File cacheDirectory) {
+        this.graph = graph;
+        this.cacheDirectory = cacheDirectory;
+
+        log.info("Downloading NED elevation data (or fetching it from local cache).");
+        getNEDTiles(true);
+    }
+
     @Override
     public List<File> getNEDTiles() {
-        log.info("Downloading NED elevation data (or fetching it from local cache).");
+        return getNEDTiles(false);
+    }
+
+    public List<File> getNEDTiles(boolean downloadIfMissing) {
         List<URL> urls = getDownloadURLsCached();
         List<File> files = new ArrayList<File>();
         int tileCount = 0;
@@ -305,6 +306,9 @@ public class NEDDownloader implements NEDTileSource {
             if (tile.exists()) {
                 files.add(tile);
                 log.debug("{} found in NED cache, not downloading: {}", tileProgress, tile);
+                continue;
+            } else if (!downloadIfMissing) {
+                log.debug("{} not found in NED cache, but skipping download: {}", tileProgress, tile);
                 continue;
             }
             REQUEST: for (int req_attempt = 0; req_attempt < 5; ++req_attempt) {

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/NEDGridCoverageFactoryImpl.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/NEDGridCoverageFactoryImpl.java
@@ -107,16 +107,8 @@ public class NEDGridCoverageFactoryImpl implements ElevationGridCoverageFactory 
         }
     }
 
-    /** @return a GeoTools grid coverage for the entire area of interest, lazy-creating it on the first call. */
+    /** @return a GeoTools grid coverage for the entire area of interest. */
     public Coverage getGridCoverage() {
-        if (unifiedCoverage == null) {
-            unifiedCoverage = getUncachedCoverage();
-        }
-        return unifiedCoverage;
-    }
-
-    /** @return a GeoTools grid coverage for the entire area of interest */
-    public UnifiedGridCoverage getUncachedCoverage() {
         loadVerticalDatum();
         tileSource.setGraph(graph);
         tileSource.setCacheDirectory(cacheDirectory);
@@ -125,9 +117,7 @@ public class NEDGridCoverageFactoryImpl implements ElevationGridCoverageFactory 
         // Make one grid coverage for each NED tile, adding them all to a single UnifiedGridCoverage.
         for (File path : paths) {
             GeotiffGridCoverageFactoryImpl factory = new GeotiffGridCoverageFactoryImpl(path);
-            // TODO might bicubic interpolation give better results?
-            GridCoverage2D regionCoverage = Interpolator2D.create(factory.getGridCoverage(),
-                new InterpolationBilinear());
+            GridCoverage2D regionCoverage = factory.getGridCoverage();
             if (unifiedCoverage == null) {
                 unifiedCoverage = new UnifiedGridCoverage("unified", regionCoverage, datums);
             } else {

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/NEDGridCoverageFactoryImpl.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/NEDGridCoverageFactoryImpl.java
@@ -34,14 +34,20 @@ public class NEDGridCoverageFactoryImpl implements ElevationGridCoverageFactory 
     /** All tiles for the DEM stitched into a single coverage. */
     UnifiedGridCoverage unifiedCoverage = null;
 
-    private File cacheDirectory;
+    private final File cacheDirectory;
 
-    public NEDTileSource tileSource = new NEDDownloader();
+    public final NEDTileSource tileSource;
 
     private List<VerticalDatum> datums;
 
     public NEDGridCoverageFactoryImpl(File cacheDirectory) {
         this.cacheDirectory = cacheDirectory;
+        this.tileSource = new NEDDownloader();
+    }
+
+    public NEDGridCoverageFactoryImpl(File cacheDirectory, NEDTileSource tileSource) {
+        this.cacheDirectory = cacheDirectory;
+        this.tileSource = tileSource;
     }
 
     private static final String[] DATUM_FILENAMES = {"g2012a00.gtx", "g2012g00.gtx", "g2012h00.gtx", "g2012p00.gtx", "g2012s00.gtx", "g2012u00.gtx"};

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/NEDGridCoverageFactoryImpl.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/NEDGridCoverageFactoryImpl.java
@@ -29,11 +29,6 @@ public class NEDGridCoverageFactoryImpl implements ElevationGridCoverageFactory 
 
     private static final Logger LOG = LoggerFactory.getLogger(NEDGridCoverageFactoryImpl.class);
 
-    private Graph graph;
-
-    /** All tiles for the DEM stitched into a single coverage. */
-    UnifiedGridCoverage unifiedCoverage = null;
-
     private final File cacheDirectory;
 
     public final NEDTileSource tileSource;
@@ -110,8 +105,6 @@ public class NEDGridCoverageFactoryImpl implements ElevationGridCoverageFactory 
     /** @return a GeoTools grid coverage for the entire area of interest. */
     public Coverage getGridCoverage() {
         loadVerticalDatum();
-        tileSource.setGraph(graph);
-        tileSource.setCacheDirectory(cacheDirectory);
         List<File> paths = tileSource.getNEDTiles();
         UnifiedGridCoverage unifiedCoverage = null;
         // Make one grid coverage for each NED tile, adding them all to a single UnifiedGridCoverage.
@@ -184,9 +177,12 @@ public class NEDGridCoverageFactoryImpl implements ElevationGridCoverageFactory 
 
     }
 
-    /** Set the graph that will be used to determine the extent of the NED. */
+    /**
+     * Verify that the needed elevation data exists in the cache and if it does not exist, try to download it. The graph
+     * is used to determine the extent of the NED.
+     */
     @Override
-    public void setGraph(Graph graph) {
-        this.graph = graph;
+    public void fetchData(Graph graph) {
+        tileSource.fetchData(graph, cacheDirectory);
     }
 }

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/UnifiedGridCoverage.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/UnifiedGridCoverage.java
@@ -1,12 +1,12 @@
 package org.opentripplanner.graph_builder.module.ned;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.Envelope;
-import com.vividsolutions.jts.index.SpatialIndex;
-import com.vividsolutions.jts.index.strtree.STRtree;
 import org.geotools.coverage.AbstractCoverage;
 import org.geotools.coverage.grid.GridCoverage2D;
 import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Envelope;
+import org.locationtech.jts.index.SpatialIndex;
+import org.locationtech.jts.index.strtree.STRtree;
 import org.opengis.coverage.CannotEvaluateException;
 import org.opengis.coverage.Coverage;
 import org.opengis.coverage.PointOutsideCoverageException;

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/UnifiedGridCoverage.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/UnifiedGridCoverage.java
@@ -6,7 +6,6 @@ import com.vividsolutions.jts.index.SpatialIndex;
 import com.vividsolutions.jts.index.strtree.STRtree;
 import org.geotools.coverage.AbstractCoverage;
 import org.geotools.coverage.grid.GridCoverage2D;
-import org.geotools.geometry.GeneralEnvelope;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.opengis.coverage.CannotEvaluateException;
 import org.opengis.coverage.Coverage;
@@ -31,6 +30,13 @@ public class UnifiedGridCoverage extends AbstractCoverage {
     private static final long serialVersionUID = -7798801307087575896L;
 
     private static Logger log = LoggerFactory.getLogger(UnifiedGridCoverage.class);
+
+    /**
+     * A spatial index of the intersection of all regions and datums. For smaller-scale deployments, this spatial index
+     * might perform more slowly than manually iterating over each region and datum. However, in larger regions, this
+     * can result in 20+% more calculations being done. In smaller-scale deployments since the overall time is not as
+     * long, we leave this in here for the benefit of larger regions where this will result in much better performance.
+     */
     private final SpatialIndex datumRegionIndex;
     private ArrayList<Coverage> regions;
     private List<VerticalDatum> datums;
@@ -55,6 +61,9 @@ public class UnifiedGridCoverage extends AbstractCoverage {
         return null;
     }
 
+    /**
+     * Calculate the elevation at a given point
+     */
     public double[] evaluate(DirectPosition point, double[] values) throws CannotEvaluateException {
         double x = point.getOrdinate(0);
         double y = point.getOrdinate(1);
@@ -71,12 +80,12 @@ public class UnifiedGridCoverage extends AbstractCoverage {
                 return result;
             } catch (PointOutsideCoverageException e) {
                 /* not found */
-                log.warn("Point not found: " + point);
+                log.debug("Point not found: " + point);
                 return null;
             }
         }
         /* not found */
-        log.warn("Point not found: " + point);
+        log.debug("Point not found: " + point);
         return null;
     }
     

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/UnifiedGridCoverage.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/UnifiedGridCoverage.java
@@ -26,7 +26,9 @@ public class UnifiedGridCoverage extends AbstractCoverage {
     private static final long serialVersionUID = -7798801307087575896L;
 
     private static Logger log = LoggerFactory.getLogger(UnifiedGridCoverage.class);
-    
+
+    private List<GeneralEnvelope> regionEnvelopes;
+
     private ArrayList<Coverage> regions;
 
     private List<VerticalDatum> datums;
@@ -40,6 +42,8 @@ public class UnifiedGridCoverage extends AbstractCoverage {
         super(name, coverage);
         regions = new ArrayList<Coverage>();
         regions.add(coverage);
+        regionEnvelopes = new ArrayList<>();
+        regionEnvelopes.add((GeneralEnvelope) coverage.getEnvelope());
         this.datums = datums;
     }
 
@@ -52,12 +56,13 @@ public class UnifiedGridCoverage extends AbstractCoverage {
     public double[] evaluate(DirectPosition point, double[] values)
             throws PointOutsideCoverageException, CannotEvaluateException {
 
-        for (Coverage region : regions) {
+        for (int i = 0; i < regions.size(); i++) {
             // GeneralEnvelope has a contains method, OpenGIS Envelope does not
-            GeneralEnvelope env = ((GeneralEnvelope)region.getEnvelope());
+            GeneralEnvelope env = regionEnvelopes.get(i);
             // Check envelope to avoid incurring exception construction overhead (PointOutsideCoverageException),
             // especially important when there are many regions.
             if (env.contains(point)) {
+                Coverage region = regions.get(i);
                 double[] result;
                 double x = point.getOrdinate(0);
                 double y = point.getOrdinate(1);
@@ -96,6 +101,7 @@ public class UnifiedGridCoverage extends AbstractCoverage {
 
     public void add(GridCoverage2D regionCoverage) {
         regions.add(regionCoverage);
+        regionEnvelopes.add((GeneralEnvelope) regionCoverage.getEnvelope());
     }
 
 }

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/UnifiedGridCoverage.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/UnifiedGridCoverage.java
@@ -74,19 +74,11 @@ public class UnifiedGridCoverage extends AbstractCoverage {
             // Found a match for coverage/datum.
             DatumRegion datumRegion = coverageCandidates.get(0);
             double[] result;
-            try {
-                result = datumRegion.region.evaluate(point, values);
-                result[0] += datumRegion.datum.interpolatedHeight(x, y);
-                return result;
-            } catch (PointOutsideCoverageException e) {
-                /* not found */
-                log.debug("Point not found: " + point);
-                return null;
-            }
+            result = datumRegion.region.evaluate(point, values);
+            result[0] += datumRegion.datum.interpolatedHeight(x, y);
+            return result;
         }
-        /* not found */
-        log.debug("Point not found: " + point);
-        return null;
+        throw new PointOutsideCoverageException("Point not found: " + point);
     }
     
     @Override

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/UnifiedGridCoverage.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/UnifiedGridCoverage.java
@@ -34,8 +34,9 @@ public class UnifiedGridCoverage extends AbstractCoverage {
     /**
      * A spatial index of the intersection of all regions and datums. For smaller-scale deployments, this spatial index
      * might perform more slowly than manually iterating over each region and datum. However, in larger regions, this
-     * can result in 20+% more calculations being done. In smaller-scale deployments since the overall time is not as
-     * long, we leave this in here for the benefit of larger regions where this will result in much better performance.
+     * can result in 20+% more calculations being done during the same time compared to the brute-force method. In
+     * smaller-scale deployments since the overall time is not as long, we leave this in here for the benefit of larger
+     * regions where this will result in much better performance.
      */
     private final SpatialIndex datumRegionIndex;
     private ArrayList<Coverage> regions;
@@ -73,8 +74,7 @@ public class UnifiedGridCoverage extends AbstractCoverage {
         if (coverageCandidates.size() > 0) {
             // Found a match for coverage/datum.
             DatumRegion datumRegion = coverageCandidates.get(0);
-            double[] result;
-            result = datumRegion.region.evaluate(point, values);
+            double[] result = datumRegion.region.evaluate(point, values);
             result[0] += datumRegion.datum.interpolatedHeight(x, y);
             return result;
         }

--- a/src/main/java/org/opentripplanner/graph_builder/services/ned/ElevationGridCoverageFactory.java
+++ b/src/main/java/org/opentripplanner/graph_builder/services/ned/ElevationGridCoverageFactory.java
@@ -13,9 +13,11 @@ import org.opentripplanner.routing.graph.Graph;
  */
 
 public interface ElevationGridCoverageFactory {
+    /** Creates a new coverage instance from files already fetched */
     public Coverage getGridCoverage();
 
     public void checkInputs();
 
-    public void setGraph(Graph graph);
+    /** Sets the graph of the factory and initiates the fetching of data that is not present in the cache */
+    public void fetchData(Graph graph);
 }

--- a/src/main/java/org/opentripplanner/graph_builder/services/ned/NEDTileSource.java
+++ b/src/main/java/org/opentripplanner/graph_builder/services/ned/NEDTileSource.java
@@ -12,15 +12,12 @@ import java.util.List;
  */
 public interface NEDTileSource {
 
-    public abstract void setGraph(Graph graph);
-
     /**
-     * The cache directory stores NED tiles.  It is crucial that this be somewhere permanent
-     * with plenty of disk space.  Don't use /tmp -- the downloading process takes a long time
+     * Fetches all of the required data and stores it in the specified cache directory. It is crucial that this be
+     * somewhere permanent with plenty of disk space.  Don't use /tmp -- the downloading process takes a long time
      * and you don't want to repeat it if at all possible.
-     * @param cacheDirectory
      */
-    public abstract void setCacheDirectory(File cacheDirectory);
+    public abstract void fetchData(Graph graph, File cacheDirectory);
 
     /**
      * Download all the NED tiles into the cache.

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetWithElevationEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetWithElevationEdge.java
@@ -78,6 +78,8 @@ public class StreetWithElevationEdge extends StreetEdge {
         return CompactElevationProfile.uncompactElevationProfile(packedElevationProfile);
     }
 
+    public boolean hasPackedElevationProfile () { return packedElevationProfile != null; }
+
     @Override
     public boolean isElevationFlattened() {
         return flattened;

--- a/src/main/java/org/opentripplanner/standalone/GraphBuilderParameters.java
+++ b/src/main/java/org/opentripplanner/standalone/GraphBuilderParameters.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.standalone;
 
+import org.opentripplanner.api.common.RoutingResource;
 import org.opentripplanner.graph_builder.module.osm.WayPropertySetSource;
 import org.opentripplanner.graph_builder.services.osm.CustomNamer;
 import org.opentripplanner.profile.StopClusterMode;
@@ -200,6 +201,10 @@ public class GraphBuilderParameters {
     /**
      * When set to true (it is false by default), the elevation module will include the Ellipsoid to Geiod difference in
      * the calculations of every point along every StreetWithElevationEdge in the graph.
+     *
+     * NOTE: if this is set to true for graph building, make sure to not set the value of
+     * {@link RoutingResource#geoidElevation} to true otherwise OTP will add this geoid value again to all of the
+     * elevation values in the street edges.
      */
     public boolean includeEllipsoidToGeoidDifference;
 

--- a/src/main/java/org/opentripplanner/standalone/GraphBuilderParameters.java
+++ b/src/main/java/org/opentripplanner/standalone/GraphBuilderParameters.java
@@ -204,12 +204,6 @@ public class GraphBuilderParameters {
     public boolean includeEllipsoidToGeoidDifference;
 
     /**
-     * The number of significant digits to use when caching Ellipsoid to Geiod difference values. The defualt is 0 and
-     * is capped at 2.
-     */
-    public int geoidDifferenceSignficantDigits;
-
-    /**
      * Set all parameters from the given Jackson JSON tree, applying defaults.
      * Supplying MissingNode.getInstance() will cause all the defaults to be applied.
      * This could be done automatically with the "reflective query scraper" but it's less type safe and less clear.
@@ -248,7 +242,6 @@ public class GraphBuilderParameters {
         readCachedElevations = config.path("readCachedElevations").asBoolean(true);
         writeCachedElevations = config.path("writeCachedElevations").asBoolean(false);
         includeEllipsoidToGeoidDifference = config.path("includeEllipsoidToGeoidDifference").asBoolean(false);
-        geoidDifferenceSignficantDigits = Math.min(2, config.path("geoidDifferenceSignficantDigits").asInt(0));
     }
 
 

--- a/src/main/java/org/opentripplanner/standalone/GraphBuilderParameters.java
+++ b/src/main/java/org/opentripplanner/standalone/GraphBuilderParameters.java
@@ -185,11 +185,17 @@ public class GraphBuilderParameters {
     public final Boolean extraEdgesStopPlatformLink;
 
     /**
-     * When set to true (it is by default), this will create a file after building elevations with information about
-     * all the elevations organized by coordinates. Subsequent graph builds will reuse the data in this file to avoid
-     * recalculating all the elevation data again.
+     * When set to true (it is by default), the elevation module will attempt to read this file in order to reuse
+     * calculations of elevation data for various coordinate sequences instead of recalculating them all over again.
      */
-    public boolean cacheElevations;
+    public boolean readCachedElevations;
+
+    /**
+     * When set to true (it is false by default), the elevation module will create a file of a lookup map of the
+     * LineStrings and the corresponding calculated elevation data for those coordinates. Subsequent graph builds can
+     * reuse the data in this file to avoid recalculating all the elevation data again.
+     */
+    public boolean writeCachedElevations;
 
     /**
      * Set all parameters from the given Jackson JSON tree, applying defaults.
@@ -227,7 +233,8 @@ public class GraphBuilderParameters {
         banDiscouragedBiking = config.path("banDiscouragedBiking").asBoolean(false);
         maxTransferDistance = config.path("maxTransferDistance").asDouble(2000);
         extraEdgesStopPlatformLink = config.path("extraEdgesStopPlatformLink").asBoolean(false);
-        cacheElevations = config.path("cacheElevations").asBoolean(true);
+        readCachedElevations = config.path("readCachedElevations").asBoolean(true);
+        writeCachedElevations = config.path("writeCachedElevations").asBoolean(false);
     }
 
 

--- a/src/main/java/org/opentripplanner/standalone/GraphBuilderParameters.java
+++ b/src/main/java/org/opentripplanner/standalone/GraphBuilderParameters.java
@@ -211,8 +211,9 @@ public class GraphBuilderParameters {
 
     /**
      * A customizable level of parallelism with which to process elevation data for street edges. The default is set to
-     * the maximum available processors. For unknown reasons that seem to depend on data and machine settings, it might
-     * be faster to not use all processors available.
+     * the 1 processor. For unknown reasons that seem to depend on data and machine settings, it might be faster to use
+     * a single processors. The maximum amount of processors is capped according to the maximum number of processors
+     * that java detects on the current machine.
      */
     public int elevationModuleParallelism;
 

--- a/src/main/java/org/opentripplanner/standalone/GraphBuilderParameters.java
+++ b/src/main/java/org/opentripplanner/standalone/GraphBuilderParameters.java
@@ -185,6 +185,13 @@ public class GraphBuilderParameters {
     public final Boolean extraEdgesStopPlatformLink;
 
     /**
+     * When set to true (it is by default), this will create a file after building elevations with information about
+     * all the elevations organized by coordinates. Subsequent graph builds will reuse the data in this file to avoid
+     * recalculating all the elevation data again.
+     */
+    public boolean cacheElevations;
+
+    /**
      * Set all parameters from the given Jackson JSON tree, applying defaults.
      * Supplying MissingNode.getInstance() will cause all the defaults to be applied.
      * This could be done automatically with the "reflective query scraper" but it's less type safe and less clear.
@@ -220,6 +227,7 @@ public class GraphBuilderParameters {
         banDiscouragedBiking = config.path("banDiscouragedBiking").asBoolean(false);
         maxTransferDistance = config.path("maxTransferDistance").asDouble(2000);
         extraEdgesStopPlatformLink = config.path("extraEdgesStopPlatformLink").asBoolean(false);
+        cacheElevations = config.path("cacheElevations").asBoolean(true);
     }
 
 

--- a/src/main/java/org/opentripplanner/standalone/GraphBuilderParameters.java
+++ b/src/main/java/org/opentripplanner/standalone/GraphBuilderParameters.java
@@ -198,6 +198,18 @@ public class GraphBuilderParameters {
     public boolean writeCachedElevations;
 
     /**
+     * When set to true (it is false by default), the elevation module will include the Ellipsoid to Geiod difference in
+     * the calculations of every point along every StreetWithElevationEdge in the graph.
+     */
+    public boolean includeEllipsoidToGeoidDifference;
+
+    /**
+     * The number of significant digits to use when caching Ellipsoid to Geiod difference values. The defualt is 0 and
+     * is capped at 2.
+     */
+    public int geoidDifferenceSignficantDigits;
+
+    /**
      * Set all parameters from the given Jackson JSON tree, applying defaults.
      * Supplying MissingNode.getInstance() will cause all the defaults to be applied.
      * This could be done automatically with the "reflective query scraper" but it's less type safe and less clear.
@@ -235,6 +247,8 @@ public class GraphBuilderParameters {
         extraEdgesStopPlatformLink = config.path("extraEdgesStopPlatformLink").asBoolean(false);
         readCachedElevations = config.path("readCachedElevations").asBoolean(true);
         writeCachedElevations = config.path("writeCachedElevations").asBoolean(false);
+        includeEllipsoidToGeoidDifference = config.path("includeEllipsoidToGeoidDifference").asBoolean(false);
+        geoidDifferenceSignficantDigits = Math.min(2, config.path("geoidDifferenceSignficantDigits").asInt(0));
     }
 
 

--- a/src/main/java/org/opentripplanner/standalone/GraphBuilderParameters.java
+++ b/src/main/java/org/opentripplanner/standalone/GraphBuilderParameters.java
@@ -210,12 +210,11 @@ public class GraphBuilderParameters {
     public boolean includeEllipsoidToGeoidDifference;
 
     /**
-     * A customizable level of parallelism with which to process elevation data for street edges. The default is set to
-     * the 1 processor. For unknown reasons that seem to depend on data and machine settings, it might be faster to use
-     * a single processors. The maximum amount of processors is capped according to the maximum number of processors
-     * that java detects on the current machine.
+     * Whether or not to multi-thread the elevation calculations in the elevation module. The default is set to false.
+     * For unknown reasons that seem to depend on data and machine settings, it might be faster to use a single
+     * processor. If multi-threading is activated, parallel streams will be used to calculate the elevations.
      */
-    public int elevationModuleParallelism;
+    public boolean multiThreadElevationCalculations;
 
     /**
      * Set all parameters from the given Jackson JSON tree, applying defaults.
@@ -256,7 +255,7 @@ public class GraphBuilderParameters {
         readCachedElevations = config.path("readCachedElevations").asBoolean(true);
         writeCachedElevations = config.path("writeCachedElevations").asBoolean(false);
         includeEllipsoidToGeoidDifference = config.path("includeEllipsoidToGeoidDifference").asBoolean(false);
-        elevationModuleParallelism = ElevationModule.fromConfig(config.path("elevationModuleParallelism"));
+        multiThreadElevationCalculations = config.path("multiThreadElevationCalculations").asBoolean(false);
     }
 
 

--- a/src/main/java/org/opentripplanner/standalone/GraphBuilderParameters.java
+++ b/src/main/java/org/opentripplanner/standalone/GraphBuilderParameters.java
@@ -209,6 +209,13 @@ public class GraphBuilderParameters {
     public boolean includeEllipsoidToGeoidDifference;
 
     /**
+     * A customizable level of parallelism with which to process elevation data for street edges. The default is set to
+     * the maximum available processors. For unknown reasons that seem to depend on data and machine settings, it might
+     * be faster to not use all processors available.
+     */
+    public int elevationModuleParallelism;
+
+    /**
      * Set all parameters from the given Jackson JSON tree, applying defaults.
      * Supplying MissingNode.getInstance() will cause all the defaults to be applied.
      * This could be done automatically with the "reflective query scraper" but it's less type safe and less clear.
@@ -247,6 +254,8 @@ public class GraphBuilderParameters {
         readCachedElevations = config.path("readCachedElevations").asBoolean(true);
         writeCachedElevations = config.path("writeCachedElevations").asBoolean(false);
         includeEllipsoidToGeoidDifference = config.path("includeEllipsoidToGeoidDifference").asBoolean(false);
+        int maxProcessors = Runtime.getRuntime().availableProcessors();
+        elevationModuleParallelism = Math.min(config.path("elevationModuleParallelism").asInt(maxProcessors), maxProcessors);
     }
 
 

--- a/src/main/java/org/opentripplanner/standalone/GraphBuilderParameters.java
+++ b/src/main/java/org/opentripplanner/standalone/GraphBuilderParameters.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.standalone;
 
 import org.opentripplanner.api.common.RoutingResource;
+import org.opentripplanner.graph_builder.module.ned.ElevationModule;
 import org.opentripplanner.graph_builder.module.osm.WayPropertySetSource;
 import org.opentripplanner.graph_builder.services.osm.CustomNamer;
 import org.opentripplanner.profile.StopClusterMode;
@@ -254,8 +255,7 @@ public class GraphBuilderParameters {
         readCachedElevations = config.path("readCachedElevations").asBoolean(true);
         writeCachedElevations = config.path("writeCachedElevations").asBoolean(false);
         includeEllipsoidToGeoidDifference = config.path("includeEllipsoidToGeoidDifference").asBoolean(false);
-        int maxProcessors = Runtime.getRuntime().availableProcessors();
-        elevationModuleParallelism = Math.min(config.path("elevationModuleParallelism").asInt(maxProcessors), maxProcessors);
+        elevationModuleParallelism = ElevationModule.fromConfig(config.path("elevationModuleParallelism"));
     }
 
 

--- a/src/main/java/org/opentripplanner/util/ElevationUtils.java
+++ b/src/main/java/org/opentripplanner/util/ElevationUtils.java
@@ -26,7 +26,9 @@ public class ElevationUtils {
     }
 
     /**
-     * Computes the difference between the ellipsoid and geoid at a specified lat/lon using Geotools EarthGravitationalModel
+     * Computes the difference between the ellipsoid and geoid at a specified lat/lon using Geotools
+     * EarthGravitationalModel. For unknown reasons, this method can produce incorrect results if called at the same
+     * time from multiple threads, so the method has been made synchronized.
      *
      * @param lat
      * @param lon
@@ -34,8 +36,7 @@ public class ElevationUtils {
      * @throws FactoryException
      * @throws TransformException
      */
-
-    public static double computeEllipsoidToGeoidDifference(double lat, double lon) throws TransformException {
+    public static synchronized double computeEllipsoidToGeoidDifference(double lat, double lon) throws TransformException {
         // Compute the offset
         DirectPosition3D dest = new DirectPosition3D();
         mt.transform(new DirectPosition3D(lon, lat, 0), dest);

--- a/src/main/java/org/opentripplanner/util/ElevationUtils.java
+++ b/src/main/java/org/opentripplanner/util/ElevationUtils.java
@@ -13,6 +13,18 @@ import org.opengis.referencing.operation.TransformException;
 
 public class ElevationUtils {
 
+    // Set up a MathTransform based on the EarthGravitationalModel
+    private static MathTransform mt;
+    static {
+        try {
+            mt = new DefaultMathTransformFactory().createParameterizedTransform(
+                new EarthGravitationalModel.Provider().getParameters().createValue()
+            );
+        } catch (FactoryException e) {
+            e.printStackTrace();
+        }
+    }
+
     /**
      * Computes the difference between the ellipsoid and geoid at a specified lat/lon using Geotools EarthGravitationalModel
      *
@@ -23,12 +35,7 @@ public class ElevationUtils {
      * @throws TransformException
      */
 
-    public static double computeEllipsoidToGeoidDifference(double lat, double lon) throws FactoryException, TransformException {
-        // Set up a MathTransform based on the EarthGravitationalModel
-        EarthGravitationalModel.Provider provider = new EarthGravitationalModel.Provider();
-        DefaultMathTransformFactory factory = new DefaultMathTransformFactory();
-        MathTransform mt = factory.createParameterizedTransform(provider.getParameters().createValue());
-
+    public static double computeEllipsoidToGeoidDifference(double lat, double lon) throws TransformException {
         // Compute the offset
         DirectPosition3D dest = new DirectPosition3D();
         mt.transform(new DirectPosition3D(lon, lat, 0), dest);

--- a/src/test/java/org/opentripplanner/geocoder/bano/BanoGeocoderTest.java
+++ b/src/test/java/org/opentripplanner/geocoder/bano/BanoGeocoderTest.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.geocoder.bano;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.opentripplanner.common.geometry.SphericalDistanceLibrary;
 import org.opentripplanner.geocoder.GeocoderResult;
@@ -14,6 +15,7 @@ public class BanoGeocoderTest {
      * if a network connection is not active or the server is down.
      */
     @Test
+    @Ignore
     public void testOnLine() throws Exception {
 
         BanoGeocoder banoGeocoder = new BanoGeocoder();

--- a/src/test/java/org/opentripplanner/geocoder/bano/BanoGeocoderTest.java
+++ b/src/test/java/org/opentripplanner/geocoder/bano/BanoGeocoderTest.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.geocoder.bano;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.Ignore;
 import org.opentripplanner.common.geometry.SphericalDistanceLibrary;

--- a/src/test/java/org/opentripplanner/graph_builder/module/ElevationModuleTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/ElevationModuleTest.java
@@ -101,6 +101,6 @@ public class ElevationModuleTest {
 
         // verify that elevation data has been set on the StreetWithElevationEdge
         assertNotNull(edge.getElevationProfile());
-        assertEquals(114.71, edge.getElevationProfile().getY(1), 0.1);
+        assertEquals(133.95, edge.getElevationProfile().getY(1), 0.1);
     }
 }

--- a/src/test/java/org/opentripplanner/graph_builder/module/ElevationModuleTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/ElevationModuleTest.java
@@ -1,0 +1,108 @@
+package org.opentripplanner.graph_builder.module;
+
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.LineString;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.opentripplanner.common.geometry.GeometryUtils;
+import org.opentripplanner.common.geometry.SphericalDistanceLibrary;
+import org.opentripplanner.graph_builder.module.ned.DegreeGridNEDTileSource;
+import org.opentripplanner.graph_builder.module.ned.ElevationModule;
+import org.opentripplanner.graph_builder.module.ned.NEDGridCoverageFactoryImpl;
+import org.opentripplanner.routing.edgetype.StreetTraversalPermission;
+import org.opentripplanner.routing.edgetype.StreetWithElevationEdge;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.routing.vertextype.OsmVertex;
+import org.opentripplanner.routing.vertextype.StreetVertex;
+import org.opentripplanner.standalone.S3BucketConfig;
+
+import java.io.File;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class ElevationModuleTest {
+
+    /**
+     * Tests whether elevation can be properly set using s3 bucket tiles. This test is ignored by default because it
+     * would require checking in a file to this repository that is about 450mb large.
+     *
+     * To setup this test, copy everything in the /var/otp/cache/ned into
+     * .../src/test/resources/org/opentripplanner/graph_builder/module/ned/
+     */
+    @Test
+    @Ignore
+    public void testSetElevationOnEdgesUsingS3BucketTiles() {
+        // create a graph with a StreetWithElevationEdge
+        Graph graph = new Graph();
+        OsmVertex from = new OsmVertex(graph, "from", -122.6932051, 45.5122964, 40513757);
+        OsmVertex to = new OsmVertex(graph, "to", -122.6903532, 45.5115309, 1677595882);
+        LineString geometry = GeometryUtils.makeLineString(
+            -122.6932051,
+            45.5122964,
+            -122.6931118,
+            45.5122687,
+            -122.692677,
+            45.512204,
+            -122.692443,
+            45.512142,
+            -122.6923995,
+            45.5121229,
+            -122.692359,
+            45.512096,
+            -122.692294,
+            45.512024,
+            -122.692219,
+            45.511961,
+            -122.69212,
+            45.511908,
+            -122.6920612,
+            45.5118889,
+            -122.6920047,
+            45.5118749,
+            -122.6919636,
+            45.5118711,
+            -122.6918977,
+            45.5118684,
+            -122.6918211,
+            45.5118662,
+            -122.6917612,
+            45.5118599,
+            -122.6916928,
+            45.5118503,
+            -122.691241,
+            45.511774,
+            -122.6903532,
+            45.5115309
+        );
+        Coordinate[] coordinates = geometry.getCoordinates();
+        double length = 0;
+        for (int i = 1; i < coordinates.length; ++i) {
+            length += SphericalDistanceLibrary.distance(coordinates[i - 1], coordinates[i]);
+        }
+        StreetWithElevationEdge edge = new StreetWithElevationEdge(
+            from,
+            to,
+            geometry,
+            "Southwest College St",
+            length,
+            StreetTraversalPermission.ALL,
+            false
+        );
+
+        // create the elevation module
+        File cacheDirectory = new File(ElevationModuleTest.class.getResource("ned").getFile());
+        DegreeGridNEDTileSource awsTileSource = new DegreeGridNEDTileSource();
+        NEDGridCoverageFactoryImpl gcf = new NEDGridCoverageFactoryImpl(cacheDirectory);
+        gcf.tileSource = awsTileSource;
+        ElevationModule elevationModule = new ElevationModule(gcf);
+
+        // build to graph to execute the elevation module
+        elevationModule.checkInputs();
+        elevationModule.buildGraph(graph, new GraphBuilderModuleSummary(elevationModule));
+
+        // verify that elevation data has been set on the StreetWithElevationEdge
+        assertNotNull(edge.getElevationProfile());
+        assertEquals(114.71, edge.getElevationProfile().getY(1), 0.1);
+    }
+}

--- a/src/test/java/org/opentripplanner/graph_builder/module/ElevationModuleTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/ElevationModuleTest.java
@@ -1,9 +1,9 @@
 package org.opentripplanner.graph_builder.module;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.LineString;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.common.geometry.GeometryUtils;
 import org.opentripplanner.common.geometry.SphericalDistanceLibrary;
 import org.opentripplanner.graph_builder.module.ned.DegreeGridNEDTileSource;
@@ -13,10 +13,9 @@ import org.opentripplanner.routing.edgetype.StreetTraversalPermission;
 import org.opentripplanner.routing.edgetype.StreetWithElevationEdge;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.vertextype.OsmVertex;
-import org.opentripplanner.routing.vertextype.StreetVertex;
-import org.opentripplanner.standalone.S3BucketConfig;
 
 import java.io.File;
+import java.util.HashMap;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -98,7 +97,7 @@ public class ElevationModuleTest {
 
         // build to graph to execute the elevation module
         elevationModule.checkInputs();
-        elevationModule.buildGraph(graph, new GraphBuilderModuleSummary(elevationModule));
+        elevationModule.buildGraph(graph, new HashMap<>());
 
         // verify that elevation data has been set on the StreetWithElevationEdge
         assertNotNull(edge.getElevationProfile());

--- a/src/test/java/org/opentripplanner/graph_builder/module/ElevationModuleTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/ElevationModuleTest.java
@@ -93,8 +93,7 @@ public class ElevationModuleTest {
         // create the elevation module
         File cacheDirectory = new File(ElevationModuleTest.class.getResource("ned").getFile());
         DegreeGridNEDTileSource awsTileSource = new DegreeGridNEDTileSource();
-        NEDGridCoverageFactoryImpl gcf = new NEDGridCoverageFactoryImpl(cacheDirectory);
-        gcf.tileSource = awsTileSource;
+        NEDGridCoverageFactoryImpl gcf = new NEDGridCoverageFactoryImpl(cacheDirectory, awsTileSource);
         ElevationModule elevationModule = new ElevationModule(gcf);
 
         // build to graph to execute the elevation module


### PR DESCRIPTION
To be completed by pull request submitter:

- [x] **issue**: #2583 seems relevant
- [x] **roadmap**: Not on roadmap :(
- [x] **tests**: Test added for elevation module
- [x] **formatting**:
- [x] **documentation**: If you are adding a new configuration option, have you added an explanation to the [configuration documentation](docs/Configuration.md) tables and sections?
- [x] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)

This PR dramatically speeds up the calculations in the ElevationModule of the graph builder modules. It does so by:

- Optimizing as many calculations of elevations for a street edge as possible.
- Adding the ability to read/write cached elevation data
  - After graph building, a file with a lookup of the cached elevation for a coordinate sequence can be written
  - In subsequent graph builds, this file can be loaded and the cached data can be used.
  - custom graph build parameters can be entered to enable or disable reading or writing of this data. The default is to read, but not to write.

In addition to the performance improvements, this PR also has changes that:
- tolerate areas where elevation tiles are unavailable.
- refactor a few elevation classes to simplify constructors
- Add a simple test of the elevation module
- adds documentation of how to optimize elevation calculations