### PR TITLE
Use enunciate-openapi to generate an openapi.yml for dev-2.x (closes #2998)

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## 2.0 (in progress)
+
+- Add openapi generation (#2998)
 - Sandbox for experimental features (#2745)
 - Bugfix for Missing platforms for stops in GTFS import causes a NPE (#2804)
 - Remove extra Djikstra implementations

--- a/enunciate.xml
+++ b/enunciate.xml
@@ -1,28 +1,24 @@
 <enunciate xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xsi:noNamespaceSchemaLocation="http://enunciate.webcohesion.com/schemas/enunciate-2.4.0.xsd">
+           xsi:noNamespaceSchemaLocation="http://enunciate.webcohesion.com/schemas/enunciate-2.10.1.xsd">
 
   <!--
-  We only use Enunciate to generate documentation for the trip planner API.
-  This is a barebones config file that moslty just turns off modules we don't need.
-  See https://github.com/stoicflame/enunciate/wiki/User-Guide#configuration
+  We use Enunciate to generate HTML API documentation and a YAML OpenAPI v3 schema
+  for the trip planner API. See https://github.com/stoicflame/enunciate/wiki/User-Guide#configuration
   -->
 
-  <modules>
-    <c-xml-client disabled="true"/>
-    <csharp-xml-client disabled="true"/>
-    <java-xml-client disabled="true"/>
-    <java-json-client disabled="true"/>
-    <gwt-json-overlay disabled="true"/>
-    <obj-c-xml-client disabled="true"/>
-    <php-xml-client disabled="true"/>
-    <php-json-client disabled="true"/>
-    <ruby-json-client disabled="true"/>
-    <idl disabled="true"/>
-    <swagger disabled="true"/>
-    <docs disableRestMountpoint="true"  includeApplicationPath="true"/>
-    <jaxrs>
+  <modules disabledByDefault="true">
+    <openapi disabled="false" removeObjectPrefix="true" />
+    <docs disabled="false" />
+    <jaxrs disabled="false">
        <application path="/otp/" />
     </jaxrs>
+		<jackson disabled ="false" />
+		<jaxb disabled="false" />
+		<jaxrs disabled="false" />
   </modules>
+  <api-classes>
+    <!-- enuciate-openapi 1.4.0 throws an error on ScriptResource's particular use of FormData -->
+    <exclude pattern="org.opentripplanner.api.resource.ScriptResource"/>
+  </api-classes>
 
 </enunciate>

--- a/pom.xml
+++ b/pom.xml
@@ -229,6 +229,15 @@
                 <configuration>
                     <docsDir>${project.build.directory}/site/enunciate</docsDir>
                 </configuration>
+                <dependencies>
+                    <!-- Provides OpenAPI 3 generation -->
+                    <dependency>
+                        <groupId>dk.jyskebank.tooling.enunciate</groupId>
+                        <artifactId>enunciate-openapi</artifactId>
+                        <version>1.1.2</version>
+                    </dependency>
+                </dependencies>
+
             </plugin>
             <plugin>
                 <!-- This plugin must be configured both here (for attach-javadoc during release)


### PR DESCRIPTION
- [X] **issue**: Issue #2998 describes the feature I'm proposing, generating an openapi.yml.
- [ ] **roadmap**: The [roadmap](https://github.com/orgs/opentripplanner/projects/1) does not yet contain this feature. I'm excited for the PLC to discuss this as part of the review process!
- [X] **tests**: Travis CI passes. For development, my test was checking that the openapi.yml built and generally looked right:
```sh
clear; rm -rf ./target &&
  mvn clean -X enunciate:docs &&
  find . -name '*.y*ml'
```
- [X] **formatting**: To the best of my knowledge, I've followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#code-style).  Let me know if I've made a mistake.
- [X] **documentation**: I haven't added a new configuration option.
- [X] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue.

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)
---

Here's the relevant result of running `mvn enunciate:docs`: [`./target/site/enunciate/openapi.yml`](https://gist.github.com/SKalt/ba5006b0d6ff4d28650de2f6bd150ef0). 

Caveat: you've got to `mvn clean package` before you `mvn enunciate:docs`, else enunciate will be unable to find imports from the sandbox (src/ext).

<details><summary>In case you're particularly interested, here's the stack trace from <code>mvn enunciate:docs</code> without a prior <code>mvn package</code>.</summary>

```
# ...
[DEBUG] [ENUNCIATE] Writing /path/to/OpenTripPlanner/target/site/enunciate/apidocs/xml_ns0_translatedString.html...
[DEBUG] [ENUNCIATE] Writing /path/to/OpenTripPlanner/target/site/enunciate/apidocs/xml_ns0_encodedPolylineBean.html...
[DEBUG] [ENUNCIATE] Writing /path/to/OpenTripPlanner/target/site/enunciate/apidocs/data.html...
[DEBUG] [ENUNCIATE] Writing /path/to/OpenTripPlanner/target/site/enunciate/apidocs/resources.html...
[DEBUG] [ENUNCIATE] Freemarker processing output:

[WARNING] [ENUNCIATE] [javac] [ERROR] com.webcohesion.enunciate.Enunciate$URLFileObject[file:/path/to/OpenTripPlanner/src/main/java/org/opentripplanner/routing/graph/Graph.java]:26:44 /path/to/OpenTripPlanner/src/main/java/org/opentripplanner/routing/graph/Graph.java:26: error: package org.opentripplanner.ext.siri.updater does not exist
[WARNING] [ENUNCIATE] [javac] /path/to/OpenTripPlanner/src/main/java/org/opentripplanner/routing/graph/Graph.java:26: error: package org.opentripplanner.ext.siri.updater does not exist
[WARNING] [ENUNCIATE] [javac] import org.opentripplanner.ext.siri.updater.SiriSXUpdater;
[WARNING] [ENUNCIATE] [javac]                                            ^
[WARNING] [ENUNCIATE] [javac] [ERROR] com.webcohesion.enunciate.Enunciate$URLFileObject[file:/path/to/OpenTripPlanner/src/main/java/org/opentripplanner/api/configuration/APIEndpoints.java]:10:64 /path/to/OpenTripPlanner/src/main/java/org/opentripplanner/api/configuration/APIEndpoints.java:10: error: package org.opentripplanner.ext.examples.statistics.api.resource does not exist
[WARNING] [ENUNCIATE] [javac] /path/to/OpenTripPlanner/src/main/java/org/opentripplanner/api/configuration/APIEndpoints.java:10: error: package org.opentripplanner.ext.examples.statistics.api.resource does not exist
[WARNING] [ENUNCIATE] [javac] import org.opentripplanner.ext.examples.statistics.api.resource.GraphStatisticsResource;
[WARNING] [ENUNCIATE] [javac]                                                                ^
[WARNING] [ENUNCIATE] [javac] [ERROR] com.webcohesion.enunciate.Enunciate$URLFileObject[file:/path/to/OpenTripPlanner/src/main/java/org/opentripplanner/api/configuration/APIEndpoints.java]:11:50 /path/to/OpenTripPlanner/src/main/java/org/opentripplanner/api/configuration/APIEndpoints.java:11: error: package org.opentripplanner.ext.readiness_endpoint does not exist
[WARNING] [ENUNCIATE] [javac] /path/to/OpenTripPlanner/src/main/java/org/opentripplanner/api/configuration/APIEndpoints.java:11: error: package org.opentripplanner.ext.readiness_endpoint does not exist
[WARNING] [ENUNCIATE] [javac] import org.opentripplanner.ext.readiness_endpoint.ActuatorAPI;
[WARNING] [ENUNCIATE] [javac]                                                  ^
[WARNING] [ENUNCIATE] [javac] [ERROR] com.webcohesion.enunciate.Enunciate$URLFileObject[file:/path/to/OpenTripPlanner/src/main/java/org/opentripplanner/api/configuration/APIEndpoints.java]:13:45 /path/to/OpenTripPlanner/src/main/java/org/opentripplanner/api/configuration/APIEndpoints.java:13: error: package org.opentripplanner.ext.transmodelapi does not exist
[WARNING] [ENUNCIATE] [javac] /path/to/OpenTripPlanner/src/main/java/org/opentripplanner/api/configuration/APIEndpoints.java:13: error: package org.opentripplanner.ext.transmodelapi does not exist
[WARNING] [ENUNCIATE] [javac] import org.opentripplanner.ext.transmodelapi.TransmodelIndexAPI;
[WARNING] [ENUNCIATE] [javac]                                             ^
[WARNING] [ENUNCIATE] [javac] [ERROR] com.webcohesion.enunciate.Enunciate$URLFileObject[file:/path/to/OpenTripPlanner/src/main/java/org/opentripplanner/datastore/configure/DataStoreFactory.java]:9:44 /path/to/OpenTripPlanner/src/main/java/org/opentripplanner/datastore/configure/DataStoreFactory.java:9: error: package org.opentripplanner.ext.datastore.gs does not exist
[WARNING] [ENUNCIATE] [javac] /path/to/OpenTripPlanner/src/main/java/org/opentripplanner/datastore/configure/DataStoreFactory.java:9: error: package org.opentripplanner.ext.datastore.gs does not exist
[WARNING] [ENUNCIATE] [javac] import org.opentripplanner.ext.datastore.gs.GsDataSourceRepository;
[WARNING] [ENUNCIATE] [javac]                                            ^
[WARNING] [ENUNCIATE] [javac] [ERROR] com.webcohesion.enunciate.Enunciate$URLFileObject[file:/path/to/OpenTripPlanner/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java]:6:48 /path/to/OpenTripPlanner/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java:6: error: package org.opentripplanner.ext.transferanalyzer does not exist
[WARNING] [ENUNCIATE] [javac] /path/to/OpenTripPlanner/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java:6: error: package org.opentripplanner.ext.transferanalyzer does not exist
[WARNING] [ENUNCIATE] [javac] import org.opentripplanner.ext.transferanalyzer.DirectTransferAnalyzer;
[WARNING] [ENUNCIATE] [javac]                                                ^
[WARNING] [ENUNCIATE] [javac] [ERROR] com.webcohesion.enunciate.Enunciate$URLFileObject[file:/path/to/OpenTripPlanner/src/main/java/org/opentripplanner/updater/GraphUpdaterConfigurator.java]:4:48 /path/to/OpenTripPlanner/src/main/java/org/opentripplanner/updater/GraphUpdaterConfigurator.java:4: error: package org.opentripplanner.ext.examples.updater does not exist
[WARNING] [ENUNCIATE] [javac] /path/to/OpenTripPlanner/src/main/java/org/opentripplanner/updater/GraphUpdaterConfigurator.java:4: error: package org.opentripplanner.ext.examples.updater does not exist
[WARNING] [ENUNCIATE] [javac] import org.opentripplanner.ext.examples.updater.ExampleGraphUpdater;
[WARNING] [ENUNCIATE] [javac]                                                ^
[WARNING] [ENUNCIATE] [javac] [ERROR] com.webcohesion.enunciate.Enunciate$URLFileObject[file:/path/to/OpenTripPlanner/src/main/java/org/opentripplanner/updater/GraphUpdaterConfigurator.java]:5:48 /path/to/OpenTripPlanner/src/main/java/org/opentripplanner/updater/GraphUpdaterConfigurator.java:5: error: package org.opentripplanner.ext.examples.updater does not exist
[WARNING] [ENUNCIATE] [javac] /path/to/OpenTripPlanner/src/main/java/org/opentripplanner/updater/GraphUpdaterConfigurator.java:5: error: package org.opentripplanner.ext.examples.updater does not exist
[WARNING] [ENUNCIATE] [javac] import org.opentripplanner.ext.examples.updater.ExamplePollingGraphUpdater;
[WARNING] [ENUNCIATE] [javac]                                                ^
[WARNING] [ENUNCIATE] [javac] [ERROR] com.webcohesion.enunciate.Enunciate$URLFileObject[file:/path/to/OpenTripPlanner/src/main/java/org/opentripplanner/updater/GraphUpdaterConfigurator.java]:6:44 /path/to/OpenTripPlanner/src/main/java/org/opentripplanner/updater/GraphUpdaterConfigurator.java:6: error: package org.opentripplanner.ext.siri.updater does not exist
[WARNING] [ENUNCIATE] [javac] /path/to/OpenTripPlanner/src/main/java/org/opentripplanner/updater/GraphUpdaterConfigurator.java:6: error: package org.opentripplanner.ext.siri.updater does not exist
[WARNING] [ENUNCIATE] [javac] import org.opentripplanner.ext.siri.updater.SiriETUpdater;
[WARNING] [ENUNCIATE] [javac]                                            ^
[WARNING] [ENUNCIATE] [javac] [ERROR] com.webcohesion.enunciate.Enunciate$URLFileObject[file:/path/to/OpenTripPlanner/src/main/java/org/opentripplanner/updater/GraphUpdaterConfigurator.java]:7:44 /path/to/OpenTripPlanner/src/main/java/org/opentripplanner/updater/GraphUpdaterConfigurator.java:7: error: package org.opentripplanner.ext.siri.updater does not exist
[WARNING] [ENUNCIATE] [javac] /path/to/OpenTripPlanner/src/main/java/org/opentripplanner/updater/GraphUpdaterConfigurator.java:7: error: package org.opentripplanner.ext.siri.updater does not exist
[WARNING] [ENUNCIATE] [javac] import org.opentripplanner.ext.siri.updater.SiriSXUpdater;
[WARNING] [ENUNCIATE] [javac]                                            ^
[WARNING] [ENUNCIATE] [javac] [ERROR] com.webcohesion.enunciate.Enunciate$URLFileObject[file:/path/to/OpenTripPlanner/src/main/java/org/opentripplanner/updater/GraphUpdaterConfigurator.java]:8:44 /path/to/OpenTripPlanner/src/main/java/org/opentripplanner/updater/GraphUpdaterConfigurator.java:8: error: package org.opentripplanner.ext.siri.updater does not exist
[WARNING] [ENUNCIATE] [javac] /path/to/OpenTripPlanner/src/main/java/org/opentripplanner/updater/GraphUpdaterConfigurator.java:8: error: package org.opentripplanner.ext.siri.updater does not exist
[WARNING] [ENUNCIATE] [javac] import org.opentripplanner.ext.siri.updater.SiriVMUpdater;
[WARNING] [ENUNCIATE] [javac]                                            ^
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  33.130 s
[INFO] Finished at: 2020-03-07T11:27:58-05:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal com.webcohesion.enunciate:enunciate-maven-plugin:2.12.0:docs (default-cli) on project otp: Enunciate compile failed. -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal com.webcohesion.enunciate:enunciate-maven-plugin:2.12.0:docs (default-cli) on project otp: Enunciate compile failed.
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:215)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:956)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:288)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:192)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
Caused by: org.apache.maven.plugin.MojoExecutionException: Enunciate compile failed.
    at com.webcohesion.enunciate.mojo.ConfigMojo.execute (ConfigMojo.java:441)
    at com.webcohesion.enunciate.mojo.DocsBaseMojo.execute (DocsBaseMojo.java:99)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:210)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:956)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:288)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:192)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
Caused by: com.webcohesion.enunciate.EnunciateException: Enunciate compile failed.
    at com.webcohesion.enunciate.Enunciate.run (Enunciate.java:717)
    at com.webcohesion.enunciate.mojo.ConfigMojo.execute (ConfigMojo.java:436)
    at com.webcohesion.enunciate.mojo.DocsBaseMojo.execute (DocsBaseMojo.java:99)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:210)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:956)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:288)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:192)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
[ERROR] 
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```
</details>
