### PR TITLE
Add openapi generation to dev-1.x (closes #2998)

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2,6 +2,7 @@
 
 ## 1.5.0 (in progress)
 
+- Add an openapi.yml specification of the APIs (#2998)
 - Add application/x-protobuf to accepted protobuf content-types (#2839)
 - Add Way Property Set for the UK (#2818)
 - Fixes surefire test failure during build (#2816)

--- a/enunciate.xml
+++ b/enunciate.xml
@@ -12,9 +12,13 @@
     <jaxrs disabled="false">
        <application path="/otp/" />
     </jaxrs>
-		<jackson disabled="false" />
+		<jackson disabled ="false" />
 		<jaxb disabled="false" />
 		<jaxrs disabled="false" />
   </modules>
+  <api-classes>
+    <!-- enuciate-openapi 1.4.0 throws an error on ScriptResource's particular use of FormData -->
+    <exclude pattern="org.opentripplanner.api.resource.ScriptResource"/>
+  </api-classes>
 
 </enunciate>

--- a/enunciate.xml
+++ b/enunciate.xml
@@ -1,28 +1,20 @@
 <enunciate xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xsi:noNamespaceSchemaLocation="http://enunciate.webcohesion.com/schemas/enunciate-2.4.0.xsd">
+           xsi:noNamespaceSchemaLocation="http://enunciate.webcohesion.com/schemas/enunciate-2.10.1.xsd">
 
   <!--
-  We only use Enunciate to generate documentation for the trip planner API.
-  This is a barebones config file that moslty just turns off modules we don't need.
-  See https://github.com/stoicflame/enunciate/wiki/User-Guide#configuration
+  We use Enunciate to generate HTML API documentation and a YAML OpenAPI v3 schema
+  for the trip planner API. See https://github.com/stoicflame/enunciate/wiki/User-Guide#configuration
   -->
 
-  <modules>
-    <c-xml-client disabled="true"/>
-    <csharp-xml-client disabled="true"/>
-    <java-xml-client disabled="true"/>
-    <java-json-client disabled="true"/>
-    <gwt-json-overlay disabled="true"/>
-    <obj-c-xml-client disabled="true"/>
-    <php-xml-client disabled="true"/>
-    <php-json-client disabled="true"/>
-    <ruby-json-client disabled="true"/>
-    <idl disabled="true"/>
-    <swagger disabled="true"/>
-    <docs disableRestMountpoint="true"  includeApplicationPath="true"/>
-    <jaxrs>
+  <modules disabledByDefault="true">
+    <openapi disabled="false" removeObjectPrefix="true" />
+    <docs disabled="false" />
+    <jaxrs disabled="false">
        <application path="/otp/" />
     </jaxrs>
+		<jackson disabled="false" />
+		<jaxb disabled="false" />
+		<jaxrs disabled="false" />
   </modules>
 
 </enunciate>

--- a/pom.xml
+++ b/pom.xml
@@ -194,7 +194,7 @@
             <plugin>
                 <groupId>com.webcohesion.enunciate</groupId>
                 <artifactId>enunciate-maven-plugin</artifactId>
-                <version>2.11.1</version>
+                <version>2.12.1</version>
                 <executions>
                     <execution>
                         <!-- override default binding to process-sources phase (enunciate generates web services). -->
@@ -206,7 +206,16 @@
                 </executions>
                 <configuration>
                     <docsDir>${project.build.directory}/site/enunciate</docsDir>
+                    <encoding>UTF-8</encoding>
                 </configuration>
+                <dependencies>
+                    <!-- Provides OpenAPI 3 generation -->
+                    <dependency>
+                        <groupId>dk.jyskebank.tooling.enunciate</groupId>
+                        <artifactId>enunciate-openapi</artifactId>
+                        <version>1.1.2</version>
+                    </dependency>
+                </dependencies>
             </plugin>
             <plugin>
                 <!-- This plugin must be configured both here (for attach-javadoc during release)


### PR DESCRIPTION

- [X] **issue**: #2998.
- [ ] **roadmap**: the [roadmap](https://github.com/orgs/opentripplanner/projects/1) does not yet contain this feature.
- [X] **tests**: Travis CI should pass. All my work was configuring `enunciate`, so I wrote no new tests.       For development, my test was checking that the openapi.yml built and generally looked right:
```sh
clear; rm -rf ./target &&
  mvn clean -X enunciate:docs &&
  find . -name '*.y*ml'
```
- [X] **formatting**:I've followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#code-style) to the best of my ability. 
- [X] **documentation**: I haven't added a configuration option, and so I haven't added any explanations to the [configuration documentation](docs/Configuration.md) tables and sections.
- [X] **changelog**: I added a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue.

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)
---
[Here's](https://gist.github.com/SKalt/23c7c2729d7f57a54eeeae252e649b59) an example of the resulting openapi.yml built from the dev-1.x branch.   