### PR TITLE
Override getDistanceMeters for SimpleTransfer

### DIFF
--- a/src/main/java/org/opentripplanner/routing/edgetype/SimpleTransfer.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/SimpleTransfer.java
@@ -71,7 +71,12 @@ public class SimpleTransfer extends Edge {
         int time = (int) (effectiveWalkDistance / rr.walkSpeed);
         return (time * rr.walkReluctance);
     }
-    
+
+    @Override
+    public double getDistanceMeters() {
+        return edges.stream().mapToDouble(Edge::getDistanceMeters).sum();
+    }
+
     @Override
     public double getEffectiveWalkDistance(){
     	return this.effectiveWalkDistance;


### PR DESCRIPTION
To be completed by pull request submitter:

- [x] **issue**: #3001
- [x] **roadmap**: Check the [roadmap](https://github.com/orgs/opentripplanner/projects/1) for this feature or bug. If it is not already on the roadmap, PLC will discuss as part of the review process.
- [x] **tests**: Have you added relevant test coverage? Are all the tests passing on [the continuous integration service (Travis CI)](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#continuous-integration)?
- [x] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#code-style)? 
- [x] **documentation**: If you are adding a new configuration option, have you added an explanation to the [configuration documentation](docs/Configuration.md) tables and sections?
- [x] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)

This fixes an error in the SimpleTransfer, where the getDistanceMeters() method was not overridden, resulting in 0 being returned from Edge. This in turn sometimes caused access/egress legs to not be mapped before there is a check on the distance being larger than 0. This has been tested in the Entur deployment of OTP2.