### PR TITLE
Otp2 Tag Itinerary with SystemNotieces 

### DIFF
--- a/src/client/i18n/messages.pot
+++ b/src/client/i18n/messages.pot
@@ -1133,6 +1133,12 @@ msgstr ""
 msgid "Wheelchair accesible trip:"
 msgstr ""
 
+
+#. label for checkbox
+#: src/client/js/otp/widgets/tripoptions/TripOptionsWidget.js:466
+msgid "Debug Itinerary Filters:"
+msgstr ""
+
 #. Label for dropdown Travel by: [mode of transport]
 #: src/client/js/otp/widgets/tripoptions/TripOptionsWidget.js:474
 msgid "Travel by"

--- a/src/client/js/otp/modules/multimodal/MultimodalPlannerModule.js
+++ b/src/client/js/otp/modules/multimodal/MultimodalPlannerModule.js
@@ -76,6 +76,7 @@ otp.modules.multimodal.MultimodalPlannerModule =
         if(otp.config.showWheelchairOption === undefined || otp.config.showWheelchairOption === true) {
           modeSelector.addModeControl(new otp.widgets.tripoptions.WheelChairSelector(this.optionsWidget));
         }
+        modeSelector.addModeControl(new otp.widgets.tripoptions.DebugItineraryFiltersSelector(this.optionsWidget));
         modeSelector.refreshModeControls();
 
         this.optionsWidget.addSeparator();

--- a/src/client/js/otp/modules/planner/ItinerariesWidget.js
+++ b/src/client/js/otp/modules/planner/ItinerariesWidget.js
@@ -112,7 +112,6 @@ otp.widgets.ItinerariesWidget =
             $('<div class="otp-itinsWidget-searchLink">[<a href="'+link+'">'+_tr("Link to search")+'</a>]</div>').appendTo(this.footer);
         }
 
-        var header;
         for(var i=0; i<this.itineraries.length; i++) {
             var itin = this.itineraries[i];
             //$('<h3><span id='+divId+'-headerContent-'+i+'>'+this.headerContent(itin, i)+'<span></h3>').appendTo(this.itinsAccord).click(function(evt) {
@@ -121,8 +120,8 @@ otp.widgets.ItinerariesWidget =
             var headerDivId = divId+'-headerContent-'+i;
             var itinSyle = "";
 
-            if(itin.itinData.debugMarkedAsDeleted) {
-                itinSyle = "style=\"background: #FFB3DA\"";
+            if(itin.itinData.systemNotices != null) {
+                itinSyle = "class=\"sysNotice\"";
             }
 
             $('<h3 ' + itinSyle + ' ><div id=' + headerDivId + '></div></h3>')
@@ -467,6 +466,13 @@ otp.widgets.ItinerariesWidget =
         // add start and end time rows and the main leg accordion display
         //TRANSLATORS: Start: Time and date (Shown before path itinerary)
         itinDiv.append("<div class='otp-itinStartRow'><b>" + pgettext('template', "Start") + "</b>: "+itin.getStartTimeStr()+"</div>");
+        if(itin.itinData.systemNotices != null) {
+            let systemTags;
+            for(const it of itin.itinData.systemNotices) {
+                systemTags = (!systemTags) ? it.tag : (systemTags + ", " + it.tag);
+            }
+            itinDiv.append("<div class='otp-itinSysNoticeRow'><b>System tags</b>: " + systemTags + "</div>");
+        }
         itinDiv.append(itinAccord);
         //TRANSLATORS: End: Time and date (Shown after path itinerary)
         itinDiv.append("<div class='otp-itinEndRow'><b>" + _tr("End") + "</b>: "+itin.getEndTimeStr()+"</div>");

--- a/src/client/js/otp/modules/planner/PlannerModule.js
+++ b/src/client/js/otp/modules/planner/PlannerModule.js
@@ -32,7 +32,8 @@ otp.modules.planner.defaultQueryParams = {
     triangleTimeFactor              : 0.333,
     triangleSlopeFactor             : 0.333,
     triangleSafetyFactor            : 0.334,
-}
+    debugItineraryFilter            : false,
+};
 
 otp.modules.planner.PlannerModule =
     otp.Class(otp.modules.Module, {
@@ -362,6 +363,7 @@ otp.modules.planner.PlannerModule =
             if(this.numItineraries) queryParams.numItineraries = this.numItineraries;
             if(this.minTransferTime) queryParams.minTransferTime = this.minTransferTime;
             if(this.showIntermediateStops) queryParams.showIntermediateStops = this.showIntermediateStops;
+            if(this.debugItineraryFilter !== null) _.extend(queryParams, { debugItineraryFilter : this.debugItineraryFilter });
 
             if(otp.config.routerId !== undefined) {
                 queryParams.routerId = otp.config.routerId;

--- a/src/client/js/otp/modules/planner/planner-style.css
+++ b/src/client/js/otp/modules/planner/planner-style.css
@@ -123,6 +123,14 @@
 .otp-itinStartRow {
     margin-bottom: .5em;
 }
+h3.sysNotice {
+    background: #FFB3DA;
+}
+.otp-itinSysNoticeRow {
+    background: #FFB3DA;
+    color: #141abb;
+    margin-bottom: .5em;
+}
 
 .otp-itinAlertRow {
     background: #C00000;

--- a/src/client/js/otp/widgets/tripoptions/TripOptionsWidget.js
+++ b/src/client/js/otp/widgets/tripoptions/TripOptionsWidget.js
@@ -457,6 +457,42 @@ otp.widgets.tripoptions.WheelChairSelector =
     }
 });
 
+//** Debug Itineraries Filters **//
+otp.widgets.tripoptions.DebugItineraryFiltersSelector = otp.Class(
+    otp.widgets.tripoptions.TripOptionsWidgetControl,
+    {
+        id: null,
+        //TRANSLATORS: label for checkbox
+        label: _tr("Debug Itinerary Filters:"),
+
+        initialize: function (tripWidget) {
+
+            otp.widgets.tripoptions.TripOptionsWidgetControl.prototype.initialize.apply(this, arguments);
+
+            this.id = tripWidget.id;
+
+            ich['otp-tripOptions-debug-filters']({
+                widgetId: this.id,
+                label: this.label,
+            }).appendTo(this.$());
+
+        },
+        doAfterLayout: function () {
+            var this_ = this;
+
+            $("#" + this.id + "-debug-filters-input").change(function () {
+                this_.tripWidget.module.debugItineraryFilter = this.checked;
+            });
+        },
+        restorePlan: function (data) {
+            if (data.queryParams.debugItineraryFilter) {
+                $("#" + this.id + "-debug-filters-input").prop("checked", data.queryParams.debugItineraryFilter);
+            }
+        },
+        isApplicableForMode : function(mode) { return true; }
+    }
+);
+
 
 //** ModeSelector **//
 

--- a/src/client/js/otp/widgets/tripoptions/tripoptions-templates.html
+++ b/src/client/js/otp/widgets/tripoptions/tripoptions-templates.html
@@ -74,6 +74,15 @@
 
 </script>
 
+<!-- Debug Itineraries Filter -->
+<script id="otp-tripOptions-debug-filters" type="text/html">
+    <div class="notDraggable">
+        {{label}} &nbsp;
+         <input type="checkbox" id="{{widgetId}}-debug-filters-input" />
+    </div>
+</script>
+
+
 <!-- MaxDistanceSelector -->
 
 <script id="otp-tripOptions-maxDistance" type="text/html">

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelIndexGraphQLSchema.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelIndexGraphQLSchema.java
@@ -48,6 +48,7 @@ import org.opentripplanner.model.Route;
 import org.opentripplanner.model.Station;
 import org.opentripplanner.model.Stop;
 import org.opentripplanner.model.StopCollection;
+import org.opentripplanner.model.SystemNotice;
 import org.opentripplanner.model.Transfer;
 import org.opentripplanner.model.Trip;
 import org.opentripplanner.model.TripPattern;
@@ -364,6 +365,8 @@ public class TransmodelIndexGraphQLSchema {
     private GraphQLOutputType bookingArrangementType = new GraphQLTypeReference("BookingArrangement");
 
     private GraphQLOutputType contactType = new GraphQLTypeReference("Contact");
+
+    private GraphQLOutputType systemNoticeType = new GraphQLTypeReference("SystemNotice");
 
     private GraphQLInputObjectType locationType;
 
@@ -708,6 +711,26 @@ public class TransmodelIndexGraphQLSchema {
                         .build())
                 .build();
 
+        systemNoticeType = GraphQLObjectType.newObject()
+                .name("SystemNotice")
+                .description("A system notice is used to tag elements with system information for "
+                        + "debugging or other system related purpose. One use-case is to run a "
+                        + "routing search with 'debugItineraryFilter: true'. This will then tag "
+                        + "itineraries instead of removing them from the result. This make it "
+                        + "possible to inspect the itinerary-filter-chain. A SystemNotice only "
+                        + "have english text, because the primary user are technical staff, like "
+                        + "testers and developers.")
+                .field(GraphQLFieldDefinition.newFieldDefinition()
+                        .name("tag")
+                        .type(Scalars.GraphQLString)
+                        .dataFetcher(env -> ((SystemNotice) env.getSource()).tag)
+                        .build())
+                .field(GraphQLFieldDefinition.newFieldDefinition()
+                        .name("text")
+                        .type(Scalars.GraphQLString)
+                        .dataFetcher(env -> ((SystemNotice) env.getSource()).text)
+                        .build())
+                .build();
 
         createPlanType();
 
@@ -4105,22 +4128,22 @@ public class TransmodelIndexGraphQLSchema {
                         .dataFetcher(environment -> ((Itinerary) environment.getSource()).nonTransitDistanceMeters)
                         .build())
                 .field(GraphQLFieldDefinition.newFieldDefinition()
-                        .name("debugMarkedAsDeleted")
-                        .description("This itinerary is marked as deleted by at least one itinerary filter.")
-                        .type(Scalars.GraphQLBoolean)
-                        .dataFetcher(environment -> ((Itinerary) environment.getSource()).debugMarkedAsDeleted)
-                        .build())
-                .field(GraphQLFieldDefinition.newFieldDefinition()
                         .name("legs")
                         .description("A list of legs. Each leg is either a walking (cycling, car) portion of the trip, or a ride leg on a particular vehicle. So a trip where the use walks to the Q train, transfers to the 6, then walks to their destination, has four legs.")
                         .type(new GraphQLNonNull(new GraphQLList(legType)))
                         .dataFetcher(environment -> ((Itinerary) environment.getSource()).legs)
                         .build())
                 .field(GraphQLFieldDefinition.newFieldDefinition()
+                        .name("systemNotices")
+                        .description("Get all system notices.")
+                        .type(new GraphQLNonNull(new GraphQLList(systemNoticeType)))
+                        .dataFetcher(env -> ((Itinerary) env.getSource()).systemNotices)
+                        .build())
+                .field(GraphQLFieldDefinition.newFieldDefinition()
                         .name("weight")
-                        .description("Weight of the itinerary. Used for debugging. NOT IMPLEMENTED")
+                        .description("Generalized cost or weight of the itinerary. Used for debugging.")
                         .type(Scalars.GraphQLFloat)
-                        .dataFetcher(environment -> 0.0)
+                        .dataFetcher(env -> ((Itinerary) env.getSource()).generalizedCost)
                         .build())
                 .build();
 

--- a/src/main/java/org/opentripplanner/api/mapping/ItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/ItineraryMapper.java
@@ -35,12 +35,10 @@ public class ItineraryMapper {
         api.elevationLost = domain.elevationLost;
         api.elevationGained = domain.elevationGained;
         api.transfers = domain.nTransfers;
+        api.tooSloped = domain.tooSloped;
         api.fare = domain.fare;
         api.legs = legMapper.mapLegs(domain.legs);
-        api.tooSloped = domain.tooSloped;
-
-        // To be backward compatible we set this to {@code null} and not false when not set.
-        api.debugMarkedAsDeleted = domain.debugMarkedAsDeleted ? Boolean.TRUE : null;
+        api.systemNotices = SystemNoticeMapper.mapSystemNotices(domain.systemNotices);
 
         return api;
     }

--- a/src/main/java/org/opentripplanner/api/mapping/SystemNoticeMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/SystemNoticeMapper.java
@@ -1,0 +1,27 @@
+package org.opentripplanner.api.mapping;
+
+import org.opentripplanner.api.model.ApiSystemNotice;
+import org.opentripplanner.model.SystemNotice;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public final class SystemNoticeMapper {
+
+    private SystemNoticeMapper() {}
+
+    public static List<ApiSystemNotice> mapSystemNotices(Collection<SystemNotice> domainList) {
+        // Using {@code null} and not an empty set will minimize the JSON removing the
+        // {@code systemNotices} from the result.
+        if (domainList == null || domainList.isEmpty()) {
+            return null;
+        }
+
+        return domainList.stream().map(SystemNoticeMapper::mapSystemNotice).collect(Collectors.toList());
+    }
+
+    public static ApiSystemNotice mapSystemNotice(SystemNotice domain) {
+        return new ApiSystemNotice(domain.tag, domain.text);
+    }
+}

--- a/src/main/java/org/opentripplanner/api/mapping/TripSearchMetadataMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/TripSearchMetadataMapper.java
@@ -6,6 +6,8 @@ import org.opentripplanner.model.routing.TripSearchMetadata;
 public class TripSearchMetadataMapper {
 
     public static ApiTripSearchMetadata mapTripSearchMetadata(TripSearchMetadata domain) {
+        if(domain == null) { return null; }
+
         ApiTripSearchMetadata api = new ApiTripSearchMetadata();
         api.searchWindowUsed = (int)domain.searchWindowUsed.toSeconds();
         api.nextDateTime = domain.nextDateTime.toEpochMilli();

--- a/src/main/java/org/opentripplanner/api/model/ApiItinerary.java
+++ b/src/main/java/org/opentripplanner/api/model/ApiItinerary.java
@@ -14,14 +14,6 @@ import java.util.List;
 public class ApiItinerary {
 
     /**
-     * The Itinerary filter may mark itineraries as deleted in stead of actually deleting them. This
-     * is very handy, when tuning the system or debugging - looking for missing expected trips.
-     * <p>
-     * Default is {@code null} - flag is not returned unless set to true.
-     */
-    public Boolean debugMarkedAsDeleted = null;
-
-    /**
      * Duration of the trip on this itinerary, in seconds.
      */
     public Long duration = 0L;
@@ -88,6 +80,18 @@ public class ApiItinerary {
     @XmlElementWrapper(name = "legs")
     @XmlElement(name = "leg")
     public List<ApiLeg> legs = new ArrayList<>();
+
+    /**
+     * A itinerary can be tagged with a system notice. System notices should only be added to a
+     * response if explicit asked for in the request.
+     * <p>
+     * For example when tuning or manually testing the itinerary-filter-chain it you can enable
+     * the {@link org.opentripplanner.routing.core.RoutingRequest#debugItineraryFilter} and instead
+     * of removing itineraries from the result the itineraries would be tagged by the filters
+     * instead. This enable investigating, why an expected itinerary is missing from the result
+     * set.
+     */
+    public List<ApiSystemNotice> systemNotices = null;
 
     /**
      * This itinerary has a greater slope than the user requested (but there are no possible 

--- a/src/main/java/org/opentripplanner/api/model/ApiSystemNotice.java
+++ b/src/main/java/org/opentripplanner/api/model/ApiSystemNotice.java
@@ -1,0 +1,35 @@
+package org.opentripplanner.api.model;
+
+
+import org.opentripplanner.model.Notice;
+
+/**
+ * A system notice is used to tag elements with system information.
+ * <p>
+ * One use-case is to run a routing search in debug-filter-mode and instead of removing
+ * itineraries from the result, the itineraries could be tagged instead. These notices
+ * are meant for system testers and developers and should not be used for end user notification
+ * or alerts.
+ *
+ * @see org.opentripplanner.routing.alertpatch.Alert for end user alerts
+ * @see Notice for end user notices
+ */
+public class ApiSystemNotice {
+
+    /**
+     * An id or code identifying the notice. Use a descriptive tag like:
+     * 'transit-walking-filter'.
+     */
+    public final String tag;
+
+    /**
+     * An english text explaining why the element is tagged, and/or what the
+     * tag means.
+     */
+    public final String text;
+
+    public ApiSystemNotice(String tag, String text) {
+        this.tag = tag;
+        this.text = text;
+    }
+}

--- a/src/main/java/org/opentripplanner/model/SystemNotice.java
+++ b/src/main/java/org/opentripplanner/model/SystemNotice.java
@@ -1,0 +1,33 @@
+package org.opentripplanner.model;
+
+
+/**
+ * A system notice is used to tag elements with system information.
+ * <p>
+ * One use-case is to run a routing search in debug-filter-mode and instead of removing
+ * itineraries from the result, the itineraries could be tagged instead. These notices
+ * are meant for system testers and developers and should not be used for end user notification
+ * or alerts.
+ *
+ * @see org.opentripplanner.routing.alertpatch.Alert for end user alerts
+ * @see Notice for end user notices
+ */
+public class SystemNotice {
+
+    /**
+     * An id or code identifying the notice. Use a descriptive tag like:
+     * 'transit-walking-filter'.
+     */
+    public final String tag;
+
+    /**
+     * An english text explaining why the element is tagged, and/or what the
+     * tag means.
+     */
+    public final String text;
+
+    public SystemNotice(String tag, String text) {
+        this.tag = tag;
+        this.text = text;
+    }
+}

--- a/src/main/java/org/opentripplanner/model/plan/Itinerary.java
+++ b/src/main/java/org/opentripplanner/model/plan/Itinerary.java
@@ -1,9 +1,11 @@
 package org.opentripplanner.model.plan;
 
 
+import org.opentripplanner.model.SystemNotice;
 import org.opentripplanner.model.base.ToStringBuilder;
 import org.opentripplanner.routing.core.Fare;
 
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
 import java.util.Optional;
@@ -77,10 +79,14 @@ public class Itinerary {
     public final boolean walkOnly;
 
     /**
-     * The Itinerary filters may mark itineraries as deleted instead of actually deleting them.
-     * This is very handy, when tuning the system or debugging - looking for missing expected trips.
+     * System notices is used to tag itineraries with system information. For example if you run the
+     * itinerary-filter in debug mode, the filters would tag itineraries instead of deleting them
+     * from the result. More than one filter might apply, so there can be more than one notice for
+     * an itinerary. This is very handy, when tuning the system or debugging - looking for missing
+     * expected trips.
      */
-    public boolean debugMarkedAsDeleted;
+    public final List<SystemNotice> systemNotices = new ArrayList<>();
+
 
     /**
      * The cost of this trip
@@ -160,12 +166,21 @@ public class Itinerary {
     }
 
     /**
-     * A itinerary can be marked as deleted instead of actually deleting it. This is very handy
-     * when tuning the system or debugging. This is combined with an alert on the first transit
-     * leg to explain why this itinerary is deleted.
+     * A itinerary can be tagged with a system notice. System notices should only be added to a
+     * response if explicit asked for in the request.
+     * <p>
+     * For example when tuning or manually testing the itinerary-filter-chain it you can enable
+     * the {@link org.opentripplanner.routing.core.RoutingRequest#debugItineraryFilter} and instead
+     * of removing itineraries from the result the itineraries would be tagged by the filters
+     * instead. This enable investigating, why an expected itinerary is missing from the result
+     * set.
      */
-    public void markAsDeleted() {
-        this.debugMarkedAsDeleted = true;
+    public void addSystemNotice(SystemNotice notice) {
+        systemNotices.add(notice);
+    }
+
+    public boolean hasSystemNotices() {
+        return !systemNotices.isEmpty();
     }
 
     /**

--- a/src/main/java/org/opentripplanner/routing/algorithm/filterchain/ItineraryFilterChainBuilder.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/filterchain/ItineraryFilterChainBuilder.java
@@ -72,9 +72,8 @@ public class ItineraryFilterChainBuilder {
     }
 
     /**
-     * This will NOT delete itineraries, but mark them as deleted using the
-     * {@link Itinerary#markAsDeleted()} and add an alert to the first
-     * transit leg.
+     * This will NOT delete itineraries, but tag them as deleted using the
+     * {@link Itinerary#systemNotices}.
      */
     public void debug() {
         this.debug = true;

--- a/src/main/java/org/opentripplanner/routing/algorithm/filterchain/filters/DebugFilterChain.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/filterchain/filters/DebugFilterChain.java
@@ -1,14 +1,10 @@
 package org.opentripplanner.routing.algorithm.filterchain.filters;
 
+import org.opentripplanner.model.SystemNotice;
 import org.opentripplanner.model.plan.Itinerary;
-import org.opentripplanner.model.plan.Leg;
-import org.opentripplanner.routing.alertpatch.Alert;
-import org.opentripplanner.routing.alertpatch.AlertPatch;
 import org.opentripplanner.routing.algorithm.filterchain.ItineraryFilter;
-import org.opentripplanner.util.NonLocalizedString;
 
 import java.util.List;
-import java.util.Optional;
 
 public class DebugFilterChain implements ItineraryFilter {
     private final List<ItineraryFilter> filters;
@@ -46,27 +42,9 @@ public class DebugFilterChain implements ItineraryFilter {
     }
 
     private void markItineraryAsDeleted(String filterName, Itinerary itinerary) {
-        itinerary.markAsDeleted();
-
-        // Add a alert to the first transit leg.
-        Optional<Leg> legOp = itinerary.firstTransitLeg();
-        if(legOp.isEmpty()) { return; }
-
-        Alert alert = new Alert();
-        alert.alertHeaderText = new NonLocalizedString(filterName);
-        alert.alertDetailText = new NonLocalizedString(
-                "This itinerary is marked as deleted by " + filterName + " filter. "
-        );
-        alert.alertDescriptionText = alert.alertDetailText;
-        alert.alertType = "incident";
-
-        AlertPatch patch = new AlertPatch();
-        patch.setAlert(alert);
-        patch.setId(filterName);
-
-        // Add both an alert and a alert-patch to
-        // make sure the user interfce picks it up.
-        legOp.get().addAlert(alert);
-        legOp.get().addAlertPatch(patch);
+        itinerary.addSystemNotice(new SystemNotice(
+                filterName,
+                "This itinerary is marked as deleted by the " + filterName + " filter. "
+        ));
     }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/filterchain/filters/MaxLimitFilter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/filterchain/filters/MaxLimitFilter.java
@@ -34,7 +34,8 @@ public class MaxLimitFilter implements ItineraryFilter {
 
         while (i < itineraries.size() && j < maxLimit) {
             Itinerary it = itineraries.get(i);
-            if(!it.debugMarkedAsDeleted) { ++j; }
+            // Skip itineraries with system-notices; they are already "tagged" for removal.
+            if(!it.hasSystemNotices()) { ++j; }
             ++i;
         }
         return itineraries.stream().limit(i).collect(Collectors.toList());

--- a/src/test/java/org/opentripplanner/routing/algorithm/filterchain/ItineraryFilterChainBuilderTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/filterchain/ItineraryFilterChainBuilderTest.java
@@ -49,13 +49,14 @@ public class ItineraryFilterChainBuilderTest {
 
     @Test
     public void testDebugFilterChain() {
-        // Given a filter-chain with debuging enabled
+        // Given a filter-chain with debugging enabled
         builder.debug();
 
         ItineraryFilter chain = builder.build();
 
         assertEquals(List.of(i1, i2), chain.filter(List.of(i1, i2)));
-        assertFalse(i1.debugMarkedAsDeleted);
-        assertTrue(i2.debugMarkedAsDeleted);
+        assertFalse(i1.hasSystemNotices());
+        assertTrue(i2.hasSystemNotices());
+        assertEquals("transit-walking-filter", i2.systemNotices.get(0).tag);
     }
 }

--- a/src/test/java/org/opentripplanner/routing/algorithm/filterchain/filters/MaxLimitFilterTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/filterchain/filters/MaxLimitFilterTest.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.routing.algorithm.filterchain.filters;
 
 import org.junit.Test;
+import org.opentripplanner.model.SystemNotice;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.routing.core.TraverseMode;
 
@@ -46,7 +47,7 @@ public class MaxLimitFilterTest {
     public void testGetExtraWhenItineraryIsMarkedAlreadyFilter() {
         MaxLimitFilter subject;
 
-        i2.markAsDeleted();
+        i2.addSystemNotice(new SystemNotice("sys-tag-A", "text"));
 
         subject = new MaxLimitFilter("Test", 2);
         assertEquals(toStr(List.of(i1, i2, i3)), toStr(subject.filter(itineraries)));
@@ -54,7 +55,7 @@ public class MaxLimitFilterTest {
         subject = new MaxLimitFilter("Test", 1);
         assertEquals(toStr(List.of(i1)), toStr(subject.filter(itineraries)));
 
-        i1.markAsDeleted();
+        i1.addSystemNotice(new SystemNotice("sys-tag-B", "text"));
 
         subject = new MaxLimitFilter("Test", 2);
         assertEquals(toStr(itineraries), toStr(subject.filter(itineraries)));


### PR DESCRIPTION
This is used for debugging the itinerary-filter-chain. When the request 'debugItineraryFilter' is set, Itineraries are tagged instead of removed from the result set.

- Enable the old 'weight' and 'generalizedCost' in the Transmodel API.

To be completed by pull request submitter:

- [ ] **issue**: This is improving the #2936
- [ ] **roadmap**: No.
- [ ] **tests**: Unit tests updated.
- [ ] **formatting**: Yes. 
- [ ] **documentation**: JavaDoc added.
- [ ] **changelog**: No - this is just a improvement of an earlier OTP2 PR.

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)