### PR TITLE
Add back the 'otp/routers' REST endpoint to be backward compatible with OTP1.

### DIFF
--- a/src/main/java/org/opentripplanner/api/configuration/APIEndpoints.java
+++ b/src/main/java/org/opentripplanner/api/configuration/APIEndpoints.java
@@ -5,12 +5,13 @@ import org.opentripplanner.api.resource.BikeRental;
 import org.opentripplanner.api.resource.ExternalGeocoderResource;
 import org.opentripplanner.api.resource.GraphInspectorTileResource;
 import org.opentripplanner.api.resource.PlannerResource;
+import org.opentripplanner.api.resource.Routers;
 import org.opentripplanner.api.resource.ServerInfo;
 import org.opentripplanner.api.resource.UpdaterStatusResource;
 import org.opentripplanner.ext.examples.statistics.api.resource.GraphStatisticsResource;
 import org.opentripplanner.ext.readiness_endpoint.ActuatorAPI;
-import org.opentripplanner.index.IndexAPI;
 import org.opentripplanner.ext.transmodelapi.TransmodelIndexAPI;
+import org.opentripplanner.index.IndexAPI;
 import org.opentripplanner.util.OTPFeature;
 
 import java.util.ArrayList;
@@ -24,9 +25,9 @@ import static org.opentripplanner.util.OTPFeature.APIExternalGeocoder;
 import static org.opentripplanner.util.OTPFeature.APIGraphInspectorTile;
 import static org.opentripplanner.util.OTPFeature.APIServerInfo;
 import static org.opentripplanner.util.OTPFeature.APIUpdaterStatus;
+import static org.opentripplanner.util.OTPFeature.ActuatorAPI;
 import static org.opentripplanner.util.OTPFeature.SandboxAPITransmodelApi;
 import static org.opentripplanner.util.OTPFeature.SandboxExampleAPIGraphStatistics;
-import static org.opentripplanner.util.OTPFeature.ActuatorAPI;
 
 /**
  * Configure API resource endpoints.
@@ -37,6 +38,7 @@ public class APIEndpoints {
 
     private APIEndpoints() {
         // Add mandatory APIs
+        add(Routers.class);
         add(PlannerResource.class);
         add(IndexAPI.class);
 

--- a/src/main/java/org/opentripplanner/api/resource/Routers.java
+++ b/src/main/java/org/opentripplanner/api/resource/Routers.java
@@ -24,7 +24,7 @@ import static org.opentripplanner.api.resource.ServerInfo.Q;
  * <p>
  * GET - see the registered routerIds(there is just one: default) with the graph.
  * <p>
- * The HTTP request URLs are of the form /ws/routers/{routerId}. The {routerId} is kept to be
+ * The HTTP request URLs are of the form /otp/routers/{routerId}. The {routerId} is kept to be
  * backward compatible, but the value is ignored. There is only one router, the "default" and
  * that is returned - even if you specify something else.
  */

--- a/src/main/java/org/opentripplanner/api/resource/Routers.java
+++ b/src/main/java/org/opentripplanner/api/resource/Routers.java
@@ -1,0 +1,71 @@
+package org.opentripplanner.api.resource;
+
+import org.opentripplanner.api.model.RouterInfo;
+import org.opentripplanner.api.model.RouterList;
+import org.opentripplanner.routing.error.GraphNotFoundException;
+import org.opentripplanner.standalone.server.OTPServer;
+import org.opentripplanner.standalone.server.Router;
+
+import javax.annotation.security.PermitAll;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+
+import static org.opentripplanner.api.resource.ServerInfo.Q;
+
+/**
+ * This REST API endpoint returns some meta-info about a router. OTP2 does no longer support
+ * remotely loading, reloading, and evicting graphs on a running server (Supported in OTP1).
+ * <p>
+ * The HTTP verbs are used as follows:
+ * <p>
+ * GET - see the registered routerIds(there is just one: default) with the graph.
+ * <p>
+ * The HTTP request URLs are of the form /ws/routers/{routerId}. The {routerId} is kept to be
+ * backward compatible, but the value is ignored. There is only one router, the "default" and
+ * that is returned - even if you specify something else.
+ */
+@Path("/routers")
+@PermitAll // exceptions on methods
+public class Routers {
+
+    @Context
+    protected OTPServer otpServer;
+
+    /**
+     * Return the "default" router information.
+     */
+    @GET
+    @Path("{routerId}")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML + Q, MediaType.TEXT_XML + Q})
+    public RouterInfo getGraphId(@PathParam("routerId") String routerId) {
+        return getRouterInfo();
+    }
+
+    /**
+     * Returns a list of routers and their bounds. A list with one item, the "default" router,
+     * is returned.
+     * @return a representation of the graphs and their geographic bounds, in JSON or XML depending
+     * on the Accept header in the HTTP request.
+     */
+    @GET
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML + Q, MediaType.TEXT_XML + Q})
+    public RouterList getRouterIds() {
+        RouterList routerList = new RouterList();
+        routerList.routerInfo.add(getRouterInfo());
+        return routerList;
+    }
+
+    private RouterInfo getRouterInfo() {
+        try {
+            Router router = otpServer.getRouter(null);
+            return new RouterInfo("default", router.graph);
+        }
+        catch (GraphNotFoundException e) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
The GET RouterInfo enpoint is added to OTP 2. This endpoint provided some meta info about the graph needed by the bundeled OTP client.The full functionallity of the old API is not included, only the GET methods and the it ignore the `{routerId}` and return the info about the `default` router (witch) is the only router available.

To be completed by pull request submitter:

- [ ] **issue**: Regression.
- [ ] **roadmap**: No.
- [ ] **tests**: No
- [ x ] **formatting**:Yes. 
- [ x ] **documentation**: All JavaDoc on old code is updated to explain the regression.
- [ ] **changelog**: No, this is a regression.


To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)