### PR TITLE
Sort GTFS files alphabetically before processing

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -7,6 +7,7 @@
 - Fixes surefire test failure during build (#2816)
 - Improve documentation for `mode` routing parameter (#2809)
 - Disable linking from already linked stops (#2372)
+- Process GTFS files in deterministic order (#3022)
 
 ## 1.4 (2019-07-30)
 

--- a/src/main/java/org/opentripplanner/graph_builder/model/GtfsBundle.java
+++ b/src/main/java/org/opentripplanner/graph_builder/model/GtfsBundle.java
@@ -21,6 +21,7 @@ public class GtfsBundle {
 
     private static final Logger LOG = LoggerFactory.getLogger(GtfsBundle.class);
 
+
     private File path;
 
     private URL url;
@@ -63,6 +64,8 @@ public class GtfsBundle {
     public GtfsBundle(File gtfsFile) {
         this.setPath(gtfsFile);
     }
+
+    public File getPath() { return path; }
 
     public void setPath(File path) {
         this.path = path;

--- a/src/main/java/org/opentripplanner/graph_builder/module/GtfsModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/GtfsModule.java
@@ -4,13 +4,8 @@ import java.awt.Color;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
+import java.util.stream.Collectors;
 
 import org.onebusaway.csv_entities.EntityHandler;
 import org.onebusaway.gtfs.impl.GtfsRelationalDaoImpl;
@@ -64,9 +59,21 @@ public class GtfsModule implements GraphBuilderModule {
 
     int nextAgencyId = 1; // used for generating agency IDs to resolve ID conflicts
 
-    public List<GtfsBundle> gtfsBundles;
 
-    public GtfsModule(List<GtfsBundle> bundles) { this.gtfsBundles = bundles; }
+
+    private List<GtfsBundle> gtfsBundles;
+
+    public Boolean getUseCached() {
+        return useCached;
+    }
+
+    private Comparator<GtfsBundle> compareByFileName = Comparator.comparing(bundle -> bundle.getPath().getName());
+
+    public GtfsModule(List<GtfsBundle> bundles) {
+        List<GtfsBundle> defensiveCopy = new ArrayList<>(bundles);
+        defensiveCopy.sort(compareByFileName);
+        this.gtfsBundles = defensiveCopy;
+    }
 
     public List<String> provides() {
         List<String> result = new ArrayList<String>();
@@ -95,6 +102,8 @@ public class GtfsModule implements GraphBuilderModule {
         GtfsStopContext stopContext = new GtfsStopContext();
 
         try {
+            String fileNames = gtfsBundles.stream().map(b -> b.getPath().getName()).collect(Collectors.joining(", "));
+            LOG.info("Processing GTFS files in the following order: {}", fileNames);
             for (GtfsBundle gtfsBundle : gtfsBundles) {
                 // apply global defaults to individual GTFSBundles (if globals have been set)
                 if (cacheDirectory != null && gtfsBundle.cacheDirectory == null) {
@@ -392,4 +401,7 @@ public class GtfsModule implements GraphBuilderModule {
         }
     }
 
+    public List<GtfsBundle> getGtfsBundles() {
+        return Collections.unmodifiableList(gtfsBundles);
+    }
 }

--- a/src/test/java/org/opentripplanner/graph_builder/module/GtfsModuleTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/GtfsModuleTest.java
@@ -1,0 +1,29 @@
+package org.opentripplanner.graph_builder.module;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+import org.opentripplanner.graph_builder.model.GtfsBundle;
+
+import java.io.File;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class GtfsModuleTest {
+
+    @Test
+    public void shouldSortByFileNameAlphabetically() {
+        List<GtfsBundle> bundles = ImmutableList.of("C.gtfs", "c.gtfs", "/tmp/z.gtfs", "/x-files/001-a.gtfs", "/some/other/folder/b.gtfs")
+                .stream()
+                .map(name -> new GtfsBundle(new File(name))).collect(Collectors.toList());
+
+        GtfsModule module = new GtfsModule(bundles);
+
+        List<String> names = module.getGtfsBundles().stream().map(m -> m.getPath().getName()).collect(Collectors.toList());
+
+        assertThat(names, is(ImmutableList.of("001-a.gtfs", "C.gtfs", "b.gtfs", "c.gtfs", "z.gtfs")));
+
+    }
+}


### PR DESCRIPTION
This PR makes the order deterministic in which GTFS files are processed leading to more predictable graph builds.

The Java file API doesn't guarantee any order (and presumably relies on the OS's one) when listing files in a directory.

Why is a random order bad?

- Numeric feed ids can change and that makes it hard to refer to a specific GTFS feed in config files (i.e. GTFS-RT)
- The time zone of a graph can also change depending in which order files are processed.

An alternative approach would be the following: https://github.com/ibi-group/OpenTripPlanner/commit/718b23e8fe44730269dc8e484284a7bb6d21b04c

I've chosen to do the sorting inside `GtfsModule` as it's easier to test.

- [x] **issue**: partially solves https://github.com/opentripplanner/OpenTripPlanner/pull/3022/
- [ ] **roadmap**: Check the [roadmap](https://github.com/orgs/opentripplanner/projects/1) for this feature or bug. If it is not already on the roadmap, PLC will discuss as part of the review process.
- [x] **tests**
- [x] **formatting**
- [ ] **documentation**: If you are adding a new configuration option, have you added an explanation to the [configuration documentation](docs/Configuration.md) tables and sections?
- [x] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)