### PR TITLE
Do not create transfers to stops in patterns that don't allow boardings

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -7,6 +7,7 @@
 - Fixes surefire test failure during build (#2816)
 - Improve documentation for `mode` routing parameter (#2809)
 - Disable linking from already linked stops (#2372)
+- Do not create transfers to stops in patterns that don't allow boarding at that stop (#3026)
 
 ## 1.4 (2019-07-30)
 

--- a/src/main/java/org/opentripplanner/graph_builder/module/NearbyStopFinder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/NearbyStopFinder.java
@@ -104,11 +104,12 @@ public class NearbyStopFinder {
                 // pattern if at least one of the stop times associated with the pattern allows boarding at this stop.
                 // Otherwise, there will be issues with certain GTFS feeds where some trips end at an alight-only stop
                 // and then other trips begin at the alight-only stop, but do not allow boarding there.
-                // See this issue for further info: https://github.com/opentripplanner/OpenTripPlanner/issues/3026
                 //
-                // FIXME: this below check will only work for feeds where all trips associated with a certain pattern
-                //  don't allow pickups. If some trips do allow pickups while others don't, this might not create a
-                //  proper transfer for the trips that do not allow pickups at certain stops.
+                // TripPatterns are created based off of StopPatterns which differentiate between stop sequences with
+                // the same stops, but different boarding and alighting values. Therefore, this check applies to all
+                // possible stop pattern combinations.
+                //
+                // See this issue for further info: https://github.com/opentripplanner/OpenTripPlanner/issues/3026
                 if (pattern.canBoard(pattern.getStops().indexOf(ts1.getStop()))) {
                     closestStopForPattern.putMin(pattern, stopAtDistance);
                 }

--- a/src/main/java/org/opentripplanner/graph_builder/module/NearbyStopFinder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/NearbyStopFinder.java
@@ -106,9 +106,9 @@ public class NearbyStopFinder {
                 // and then other trips begin at the alight-only stop, but do not allow boarding there.
                 // See this issue for further info: https://github.com/opentripplanner/OpenTripPlanner/issues/3026
                 //
-                // FIXME: this below check will only work for feeds that where all trips associated with a certain
-                //  pattern don't allow pickups. If some trips do allow pickups while others don't, this might not
-                //  create a proper transfer for the trips that do not allow pickups at certain stops.
+                // FIXME: this below check will only work for feeds where all trips associated with a certain pattern
+                //  don't allow pickups. If some trips do allow pickups while others don't, this might not create a
+                //  proper transfer for the trips that do not allow pickups at certain stops.
                 if (pattern.canBoard(pattern.getStops().indexOf(ts1.getStop()))) {
                     closestStopForPattern.putMin(pattern, stopAtDistance);
                 }

--- a/src/main/java/org/opentripplanner/graph_builder/module/NearbyStopFinder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/NearbyStopFinder.java
@@ -99,7 +99,19 @@ public class NearbyStopFinder {
             if (!ts1.isStreetLinkable()) continue;
             /* Consider this destination stop as a candidate for every trip pattern passing through it. */
             for (TripPattern pattern : graph.index.patternsForStop.get(ts1.getStop())) {
-                closestStopForPattern.putMin(pattern, stopAtDistance);
+                // In certain GTFS feeds, there can be stops where all stop times do not allow boardings and therefore
+                // should not be considered as candidates for creating transfer edges. Therefore, only add a stop for a
+                // pattern if at least one of the stop times associated with the pattern allows boarding at this stop.
+                // Otherwise, there will be issues with certain GTFS feeds where some trips end at an alight-only stop
+                // and then other trips begin at the alight-only stop, but do not allow boarding there.
+                // See this issue for further info: https://github.com/opentripplanner/OpenTripPlanner/issues/3026
+                //
+                // FIXME: this below check will only work for feeds that where all trips associated with a certain
+                //  pattern don't allow pickups. If some trips do allow pickups while others don't, this might not
+                //  create a proper transfer for the trips that do not allow pickups at certain stops.
+                if (pattern.canBoard(pattern.getStops().indexOf(ts1.getStop()))) {
+                    closestStopForPattern.putMin(pattern, stopAtDistance);
+                }
             }
         }
 


### PR DESCRIPTION
To be completed by pull request submitter:

- [x] **issue**: Fixes #3026.
- [ ] **roadmap**: Not on roadmap. :(
- [ ] **tests**: no, sorry
- [x] **formatting**: Yep
- [x] **documentation**: Lots of comments added in code
- [x] **changelog**: Yep

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)

This adds a some code that will not create transfers to a stop on a stop pattern if all of the stop times associated with that stop don't allow boardings.