### PR TITLE
Make agency id feed scoped

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -32,6 +32,7 @@ See the [OTP2 Migration Guide](OTP2-MigrationGuide.md) on changes to the REST AP
 - Update pathways support to official GTFS specification (#2923)
 - Support for XML (de-)serialization is REMOVED from the REST API (#3031)
 - Refactor how to specify access/egress/direct/transit modes in the internal model and the Transmodel API (#3011)
+- Make agency id feed scoped (#3035)
 
 ## Ported over from the 1.x
 - Add application/x-protobuf to accepted protobuf content-types (#2839)

--- a/docs/OTP2-MigrationGuide.md
+++ b/docs/OTP2-MigrationGuide.md
@@ -38,12 +38,15 @@ A lot of the query parameters in the REST API are ignored/deprecated, see the [R
  - `boardSlackByMode` How much time boarding a vehicle takes for each given mode.
  - `alightSlackByMode` How much time alighting a vehicle takes for each given mode.
  - `modes` The REST API is unchanged, but is mapped into a new structure in the RoutingRequest. This means not all combinations of non-transit modes that was available in OTP1 is available in OTP2.
+ - `preferredAgencies`, `unpreferredAgencies`, `bannedAgencies` and `whiteListedAgencies` use feed-
+ scoped ids. If you are using the ids directly from the Index API, no changes are needed.
   
 #### Response changes
 - `metadata` is added to `TripPlan`. The `TripSearchMetadata` has three fields:
   - `searchWindowUsed`
   - `nextDateTime`
   - `prevDateTime`
+- `agencyId` in the `leg` is now feed-scoped and similarly to other ids, is prefixed with `<FEED_ID>:`
 
 ### Changes to the Index API
 - Error handling is improved, this is now consistently applied and uses build in framework support. 
@@ -70,3 +73,5 @@ A lot of the query parameters in the REST API are ignored/deprecated, see the [R
 - `StopShort`
   - The new `stationId` is a feed-scoped-id to the parent station. It should be used instead of the
     deprecated ~~cluster~~.
+- `Agency`
+  - The `id` is now feed-scoped and similarly to other ids, is prefixed with `<FEED_ID>:`

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriAlertsUpdateHandler.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriAlertsUpdateHandler.java
@@ -36,6 +36,12 @@ public class SiriAlertsUpdateHandler {
 
     private SiriFuzzyTripMatcher siriFuzzyTripMatcher;
 
+    private String feedId;
+
+    public SiriAlertsUpdateHandler(String feedId) {
+        this.feedId = feedId;
+    }
+
     public void update(ServiceDelivery delivery) {
         for (SituationExchangeDeliveryStructure sxDelivery : delivery.getSituationExchangeDeliveries()) {
             SituationExchangeDeliveryStructure.Situations situations = sxDelivery.getSituations();
@@ -142,7 +148,7 @@ public class SiriAlertsUpdateHandler {
                         idsToExpire.add(id);
                     } else {
                         AlertPatch alertPatch = new AlertPatch();
-                        alertPatch.setAgencyId(agencyId);
+                        alertPatch.setAgency(new FeedScopedId(feedId, agencyId));
                         alertPatch.setTimePeriods(periods);
                         alertPatch.setAlert(alert);
                         alertPatch.setId(id);

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriFuzzyTripMatcher.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriFuzzyTripMatcher.java
@@ -154,8 +154,8 @@ public class SiriFuzzyTripMatcher {
 
         if (trips == null || trips.isEmpty()) {
             //SIRI-data may report other platform, but still on the same Parent-stop
-            String agencyId = routingService.getFeedIds().iterator().next();
-            Stop stop = routingService.getStopForId(new FeedScopedId(agencyId, lastStopPoint));
+            String feedId = routingService.getFeedIds().iterator().next();
+            Stop stop = routingService.getStopForId(new FeedScopedId(feedId, lastStopPoint));
             if (stop != null && stop.getParentStation() != null) {
                 // TODO OTP2 resolve stop-station split
                 Collection<Stop> allQuays = stop.getParentStation().getChildStops();

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
@@ -114,8 +114,6 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
 
     private final RoutingService routingService;
 
-    private final Agency dummyAgency;
-
     public SiriFuzzyTripMatcher siriFuzzyTripMatcher;
 
     private TransitLayer realtimeTransitLayer;
@@ -127,12 +125,6 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
         routingService = new RoutingService(graph);
         realtimeTransitLayer = graph.getRealtimeTransitLayer();
         transitLayerUpdater = graph.transitLayerUpdater;
-
-        // Create dummy agency for added trips
-        Agency dummy = new Agency();
-        dummy.setId("");
-        dummy.setName("");
-        dummyAgency = dummy;
 
         siriFuzzyTripMatcher = new SiriFuzzyTripMatcher(routingService);
     }

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriSXUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriSXUpdater.java
@@ -56,7 +56,7 @@ public class SiriSXUpdater extends PollingGraphUpdater {
     @Override
     public void setup(Graph graph) throws Exception {
         if (updateHandler == null) {
-            updateHandler = new SiriAlertsUpdateHandler();
+            updateHandler = new SiriAlertsUpdateHandler(feedId);
         }
         updateHandler.setEarlyStart(earlyStart);
         updateHandler.setAlertPatchService(alertPatchService);

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelIndexGraphQLSchema.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelIndexGraphQLSchema.java
@@ -229,8 +229,8 @@ public class TransmodelIndexGraphQLSchema {
             }
             ).build();
 
-    private Agency getAgency(String agencyId, RoutingService routingService) {
-        return routingService.getAgencyWithoutFeedId(agencyId);
+    private Agency getAgency(FeedScopedId agencyId, RoutingService routingService) {
+        return routingService.getAgencyForId(agencyId);
     }
 
     @SuppressWarnings("unchecked")
@@ -1243,7 +1243,7 @@ public class TransmodelIndexGraphQLSchema {
                         .type(authorityType)
                         .description("Authority that reported this situation")
                         .deprecate("Not yet officially supported. May be removed or renamed.")
-                        .dataFetcher(environment -> getAgency(((AlertPatch) environment.getSource()).getFeedId(), getRoutingService(environment)))
+                        .dataFetcher(environment -> getAgency(((AlertPatch) environment.getSource()).getAgency(), getRoutingService(environment)))
                         .build())
                 .build();
 
@@ -3040,13 +3040,15 @@ public class TransmodelIndexGraphQLSchema {
                                 .type(new GraphQLNonNull(Scalars.GraphQLString))
                                 .build())
                         .dataFetcher(environment ->
-                                getRoutingService(environment).getAgencyWithoutFeedId(environment.getArgument("id")))
+                            getRoutingService(environment).getAgencyForId(
+                                mappingUtil.fromIdString(environment.getArgument("id"))
+                            ))
                         .build())
                 .field(GraphQLFieldDefinition.newFieldDefinition()
                         .name("authorities")
                         .description("Get all authorities")
                         .type(new GraphQLNonNull(new GraphQLList(authorityType)))
-                        .dataFetcher(environment -> new ArrayList<>(getRoutingService(environment).getAllAgencies()))
+                        .dataFetcher(environment -> new ArrayList<>(getRoutingService(environment).getAgencies()))
                         .build())
                 .field(GraphQLFieldDefinition.newFieldDefinition()
                         .name("operator")
@@ -3076,13 +3078,15 @@ public class TransmodelIndexGraphQLSchema {
                                 .type(new GraphQLNonNull(Scalars.GraphQLString))
                                 .build())
                         .dataFetcher(environment ->
-                                getRoutingService(environment).getAgencyWithoutFeedId(environment.getArgument("id")))
+                                getRoutingService(environment).getAgencyForId(
+                                        mappingUtil.fromIdString(environment.getArgument("id"))
+                                ))
                         .build())
                 .field(GraphQLFieldDefinition.newFieldDefinition()
                         .name("organisations")
                         .deprecate("Use 'authorities' instead.")
                         .type(new GraphQLNonNull(new GraphQLList(organisationType)))
-                        .dataFetcher(environment -> new ArrayList<>(getRoutingService(environment).getAllAgencies()))
+                        .dataFetcher(environment -> new ArrayList<>(getRoutingService(environment).getAgencies()))
                         .build())
                 .field(GraphQLFieldDefinition.newFieldDefinition()
                         .name("line")

--- a/src/main/java/org/opentripplanner/api/common/LocationStringParser.java
+++ b/src/main/java/org/opentripplanner/api/common/LocationStringParser.java
@@ -71,7 +71,7 @@ public class LocationStringParser {
                 lat = Double.parseDouble(matcher.group(1));
                 lon = Double.parseDouble(matcher.group(4));
             } else if (FeedScopedId.isValidString(place)) {
-                placeId = FeedScopedId.convertFromString(place);
+                placeId = FeedScopedId.parseId(place);
             }
             return new GenericLocation(label, placeId, lat, lon);
         }

--- a/src/main/java/org/opentripplanner/api/common/RoutingResource.java
+++ b/src/main/java/org/opentripplanner/api/common/RoutingResource.java
@@ -782,10 +782,10 @@ public abstract class RoutingResource {
         request.useBikeRentalAvailabilityInformation = tripPlannedForNow; // TODO the same thing for GTFS-RT
 
         if (startTransitStopId != null && !startTransitStopId.isEmpty())
-            request.startingTransitStopId = FeedScopedId.convertFromString(startTransitStopId);
+            request.startingTransitStopId = FeedScopedId.parseId(startTransitStopId);
 
         if (startTransitTripId != null && !startTransitTripId.isEmpty())
-            request.startingTransitTripId = FeedScopedId.convertFromString(startTransitTripId);
+            request.startingTransitTripId = FeedScopedId.parseId(startTransitTripId);
 
         if (ignoreRealtimeUpdates != null)
             request.ignoreRealtimeUpdates = ignoreRealtimeUpdates;

--- a/src/main/java/org/opentripplanner/api/mapping/AgencyMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/AgencyMapper.java
@@ -23,7 +23,7 @@ public class AgencyMapper {
         }
         ApiAgency api = new ApiAgency();
 
-        api.id = domain.getId();
+        api.id = FeedScopedIdMapper.mapToApi(domain.getId());
         api.name = domain.getName();
         api.url = domain.getUrl();
         api.timezone = domain.getTimezone();

--- a/src/main/java/org/opentripplanner/api/mapping/LegMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/LegMapper.java
@@ -60,14 +60,14 @@ public class LegMapper {
         api.agencyTimeZoneOffset = domain.agencyTimeZoneOffset;
         api.routeColor = domain.routeColor;
         api.routeType = domain.routeType;
-        api.routeId = domain.routeId;
+        api.routeId = FeedScopedIdMapper.mapToApi(domain.routeId);
         api.routeTextColor = domain.routeTextColor;
         api.interlineWithPreviousLeg = domain.interlineWithPreviousLeg;
         api.tripShortName = domain.tripShortName;
         api.tripBlockId = domain.tripBlockId;
         api.headsign = domain.headsign;
-        api.agencyId = domain.agencyId;
-        api.tripId = domain.tripId;
+        api.agencyId = FeedScopedIdMapper.mapToApi(domain.agencyId);
+        api.tripId = FeedScopedIdMapper.mapToApi(domain.tripId);
         api.serviceDate = domain.serviceDate;
         api.routeBrandingUrl = domain.routeBrandingUrl;
         api.intermediateStops = PlaceMapper.mapStopArrivals(domain.intermediateStops);

--- a/src/main/java/org/opentripplanner/api/mapping/PlaceMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/PlaceMapper.java
@@ -27,7 +27,7 @@ public class PlaceMapper {
         ApiPlace api = new ApiPlace();
 
         api.name = domain.name;
-        api.stopId = domain.stopId;
+        api.stopId = FeedScopedIdMapper.mapToApi(domain.stopId);
         api.stopCode = domain.stopCode;
         api.platformCode = domain.platformCode;
         if(domain.coordinate != null) {

--- a/src/main/java/org/opentripplanner/api/model/ApiLeg.java
+++ b/src/main/java/org/opentripplanner/api/model/ApiLeg.java
@@ -134,7 +134,7 @@ public class ApiLeg {
      * For transit legs, the ID of the transit agency that operates the service used for this leg.
      * For non-transit legs, null.
      */
-    public String agencyId = null;
+    public FeedScopedId agencyId = null;
 
     /**
      * For transit legs, the ID of the trip.

--- a/src/main/java/org/opentripplanner/api/model/ApiLeg.java
+++ b/src/main/java/org/opentripplanner/api/model/ApiLeg.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.api.model;
 
 import org.opentripplanner.api.model.alertpatch.ApiAlert;
-import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.util.model.EncodedPolylineBean;
 
 import java.util.Calendar;
@@ -102,7 +101,7 @@ public class ApiLeg {
      * For transit legs, the ID of the route.
      * For non-transit legs, null.
      */
-    public FeedScopedId routeId = null;
+    public String routeId = null;
 
     /**
      * For transit leg, the route's text color (if one exists). For non-transit legs, null.
@@ -134,13 +133,13 @@ public class ApiLeg {
      * For transit legs, the ID of the transit agency that operates the service used for this leg.
      * For non-transit legs, null.
      */
-    public FeedScopedId agencyId = null;
+    public String agencyId = null;
 
     /**
      * For transit legs, the ID of the trip.
      * For non-transit legs, null.
      */
-    public FeedScopedId tripId = null;
+    public String tripId = null;
 
     /**
      * For transit legs, the service date of the trip.

--- a/src/main/java/org/opentripplanner/api/model/ApiPlace.java
+++ b/src/main/java/org/opentripplanner/api/model/ApiPlace.java
@@ -1,11 +1,7 @@
 package org.opentripplanner.api.model;
 
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.util.Constants;
 
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
 import java.util.Calendar;
 
 /** 
@@ -21,7 +17,7 @@ public class ApiPlace {
     /** 
      * The ID of the stop. This is often something that users don't care about.
      */
-    public FeedScopedId stopId = null;
+    public String stopId = null;
 
     /** 
      * The "code" of the stop. Depending on the transit agency, this is often

--- a/src/main/java/org/opentripplanner/graph_builder/module/GtfsModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/GtfsModule.java
@@ -126,6 +126,7 @@ public class GtfsModule implements GraphBuilderModule {
 
                 OtpTransitServiceBuilder builder =  mapGtfsDaoToInternalTransitServiceBuilder(
                         loadBundle(gtfsBundle),
+                        gtfsBundle.getFeedId().getId(),
                         issueStore
                 );
 

--- a/src/main/java/org/opentripplanner/gtfs/MockGtfs.java
+++ b/src/main/java/org/opentripplanner/gtfs/MockGtfs.java
@@ -45,6 +45,7 @@ public class MockGtfs {
     public OtpTransitServiceBuilder read() throws IOException {
         return GTFSToOtpTransitServiceMapper.mapGtfsDaoToInternalTransitServiceBuilder(
                 gtfsDelegate.read(),
+                "a0",
                 new DataImportIssueStore(false)
         );
     }
@@ -52,6 +53,7 @@ public class MockGtfs {
     public OtpTransitServiceBuilder read(org.onebusaway.gtfs.serialization.GtfsReader reader) throws IOException {
         return GTFSToOtpTransitServiceMapper.mapGtfsDaoToInternalTransitServiceBuilder(
                 gtfsDelegate.read(reader),
+                "a0",
                 new DataImportIssueStore(false)
         );
     }

--- a/src/main/java/org/opentripplanner/gtfs/mapping/AgencyMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/AgencyMapper.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.gtfs.mapping;
 
 import org.opentripplanner.model.Agency;
+import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.util.MapUtils;
 
 import java.util.Collection;
@@ -11,6 +12,12 @@ import java.util.Map;
 class AgencyMapper {
 
     private final Map<org.onebusaway.gtfs.model.Agency, Agency> mappedAgencies = new HashMap<>();
+
+    private String feedId;
+
+    public AgencyMapper(String feedId) {
+        this.feedId = feedId;
+    }
 
     Collection<Agency> map(Collection<org.onebusaway.gtfs.model.Agency> agencies) {
         return MapUtils.mapToList(agencies, this::map);
@@ -24,7 +31,7 @@ class AgencyMapper {
     private Agency doMap(org.onebusaway.gtfs.model.Agency rhs) {
         Agency lhs = new Agency();
 
-        lhs.setId(rhs.getId());
+        lhs.setId(new FeedScopedId(feedId, rhs.getId()));
         lhs.setName(rhs.getName());
         lhs.setUrl(rhs.getUrl());
         lhs.setTimezone(rhs.getTimezone());

--- a/src/main/java/org/opentripplanner/gtfs/mapping/GTFSToOtpTransitServiceMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/GTFSToOtpTransitServiceMapper.java
@@ -16,7 +16,7 @@ import org.opentripplanner.model.impl.OtpTransitServiceBuilder;
  * reusable for other import modules.
  */
 public class GTFSToOtpTransitServiceMapper {
-    private final AgencyMapper agencyMapper = new AgencyMapper();
+    private final AgencyMapper agencyMapper;
 
     private final StationMapper stationMapper = new StationMapper();
 
@@ -45,36 +45,42 @@ public class GTFSToOtpTransitServiceMapper {
         boardingAreaMapper
     );
 
-    private final RouteMapper routeMapper = new RouteMapper(agencyMapper);
+    private final RouteMapper routeMapper;
 
-    private final TripMapper tripMapper = new TripMapper(routeMapper);
+    private final TripMapper tripMapper;
 
-    private final StopTimeMapper stopTimeMapper = new StopTimeMapper(stopMapper, tripMapper);
+    private final StopTimeMapper stopTimeMapper;
 
-    private final FrequencyMapper frequencyMapper = new FrequencyMapper(tripMapper);
+    private final FrequencyMapper frequencyMapper;
 
-    private final TransferMapper transferMapper = new TransferMapper(
-            routeMapper, stationMapper, stopMapper, tripMapper
-    );
+    private final TransferMapper transferMapper;
 
-    private final FareRuleMapper fareRuleMapper = new FareRuleMapper(
-            routeMapper, fareAttributeMapper
-    );
+    private final FareRuleMapper fareRuleMapper;
 
     private final DataImportIssueStore issueStore;
 
-    GTFSToOtpTransitServiceMapper(DataImportIssueStore issueStore) {
+    GTFSToOtpTransitServiceMapper(DataImportIssueStore issueStore, String feedId) {
         this.issueStore = issueStore;
+        agencyMapper = new AgencyMapper(feedId);
+        routeMapper = new RouteMapper(agencyMapper);
+        tripMapper = new TripMapper(routeMapper);
+        stopTimeMapper = new StopTimeMapper(stopMapper, tripMapper);
+        frequencyMapper = new FrequencyMapper(tripMapper);
+        transferMapper = new TransferMapper(
+            routeMapper, stationMapper, stopMapper, tripMapper
+        );
+        fareRuleMapper = new FareRuleMapper(
+            routeMapper, fareAttributeMapper
+        );
     }
 
     /**
      * Map from GTFS data to the internal OTP model
      */
     public static OtpTransitServiceBuilder mapGtfsDaoToInternalTransitServiceBuilder(
-            GtfsRelationalDao data,
-            DataImportIssueStore issueStore
+        GtfsRelationalDao data, String feedId, DataImportIssueStore issueStore
     ) {
-        return new GTFSToOtpTransitServiceMapper(issueStore).map(data);
+        return new GTFSToOtpTransitServiceMapper(issueStore, feedId).map(data);
     }
 
     private OtpTransitServiceBuilder map(GtfsRelationalDao data) {

--- a/src/main/java/org/opentripplanner/index/IndexAPI.java
+++ b/src/main/java/org/opentripplanner/index/IndexAPI.java
@@ -105,7 +105,11 @@ public class IndexAPI {
     @GET
     @Path("/agencies/{feedId}")
     public Collection<ApiAgency> getAgencies(@PathParam("feedId") String feedId) {
-        Collection<Agency> agencies = createRoutingService().getAgencies(feedId);
+        Collection<Agency> agencies = createRoutingService()
+            .getAgencies()
+            .stream()
+            .filter(agency -> agency.getId().getFeedId().equals(feedId))
+            .collect(Collectors.toList());
         validateExist("Agency", agencies, "feedId", feedId);
         return AgencyMapper.mapToApi(agencies);
     }
@@ -525,7 +529,7 @@ public class IndexAPI {
     }
 
     private static Agency getAgency(RoutingService routingService, String feedId, String agencyId) {
-        Agency agency = routingService.getAgency(feedId, agencyId);
+        Agency agency = routingService.getAgencyForId(new FeedScopedId(feedId, agencyId));
         if(agency == null) {
             throw notFoundException("Agency", "feedId: " + feedId + ", agencyId: " + agencyId);
         }

--- a/src/main/java/org/opentripplanner/model/Agency.java
+++ b/src/main/java/org/opentripplanner/model/Agency.java
@@ -5,11 +5,11 @@ package org.opentripplanner.model;
 /**
  * This class is tha same as a GTFS Agency and Netex Authority.
  */
-public final class Agency extends TransitEntity<String> {
+public final class Agency extends TransitEntity<FeedScopedId> {
 
     private static final long serialVersionUID = 1L;
 
-    private String id;
+    private FeedScopedId id;
 
     private String name;
 
@@ -39,11 +39,11 @@ public final class Agency extends TransitEntity<String> {
     }
 
     @Override
-    public String getId() {
+    public FeedScopedId getId() {
         return id;
     }
 
-    public void setId(String id) {
+    public void setId(FeedScopedId id) {
         this.id = id;
     }
 

--- a/src/main/java/org/opentripplanner/model/FeedScopedId.java
+++ b/src/main/java/org/opentripplanner/model/FeedScopedId.java
@@ -3,6 +3,9 @@ package org.opentripplanner.model;
 
 import javax.validation.constraints.NotNull;
 import java.io.Serializable;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.stream.Collectors;
 
 public final class FeedScopedId implements Serializable, Comparable<FeedScopedId> {
 
@@ -104,5 +107,15 @@ public final class FeedScopedId implements Serializable, Comparable<FeedScopedId
      */
     public static String concatenateId(String feedId, String id) {
         return feedId + ID_SEPARATOR + id;
+    }
+
+    /**
+     * Converts a string consisting of concatenated FeedScopedIds to a Set
+     */
+    public static HashSet<FeedScopedId> convertFromConcatenatedString(String s) {
+        return Arrays
+            .stream(s.split(","))
+            .map(FeedScopedId::convertFromString)
+            .collect(Collectors.toCollection(HashSet::new));
     }
 }

--- a/src/main/java/org/opentripplanner/model/FeedScopedId.java
+++ b/src/main/java/org/opentripplanner/model/FeedScopedId.java
@@ -66,10 +66,10 @@ public final class FeedScopedId implements Serializable, Comparable<FeedScopedId
     }
 
     /**
-     * Given an id of the form "agencyId_entityId", parses into a
+     * Given an id of the form "feedId:entityId", parses into a
      * {@link FeedScopedId} id object.
      *
-     * @param value id of the form "agencyId_entityId"
+     * @param value id of the form "feedId:entityId"
      * @return an id object
      * @throws IllegalArgumentException if the id cannot be parsed
      */
@@ -78,7 +78,7 @@ public final class FeedScopedId implements Serializable, Comparable<FeedScopedId
             return null;
         int index = value.indexOf(ID_SEPARATOR);
         if (index == -1) {
-            throw new IllegalArgumentException("invalid agency-and-id: " + value);
+            throw new IllegalArgumentException("invalid feed-scoped-id: " + value);
         } else {
             return new FeedScopedId(value.substring(0, index), value.substring(index + 1));
         }
@@ -89,7 +89,7 @@ public final class FeedScopedId implements Serializable, Comparable<FeedScopedId
     }
 
     /**
-     * Concatenate agencyId and id into a string.
+     * Concatenate feedId and id into a string.
      */
     public static String concatenateId(String feedId, String id) {
         return feedId + ID_SEPARATOR + id;

--- a/src/main/java/org/opentripplanner/model/FeedScopedId.java
+++ b/src/main/java/org/opentripplanner/model/FeedScopedId.java
@@ -73,7 +73,7 @@ public final class FeedScopedId implements Serializable, Comparable<FeedScopedId
      * @return an id object
      * @throws IllegalArgumentException if the id cannot be parsed
      */
-    public static FeedScopedId convertFromString(String value) throws IllegalArgumentException {
+    public static FeedScopedId parseId(String value) throws IllegalArgumentException {
         if (value == null || value.isEmpty())
             return null;
         int index = value.indexOf(ID_SEPARATOR);
@@ -89,20 +89,6 @@ public final class FeedScopedId implements Serializable, Comparable<FeedScopedId
     }
 
     /**
-     * Given an {@link FeedScopedId} object, creates a string representation of the
-     * form "agencyId_entityId"
-     *
-     * @param aid an id object
-     * @return a string representation of the form "agencyId_entityId"
-     */
-    public static String convertToString(FeedScopedId aid) {
-        if (aid == null) {
-            return null;
-        }
-        return concatenateId(aid.feedId, aid.id);
-    }
-
-    /**
      * Concatenate agencyId and id into a string.
      */
     public static String concatenateId(String feedId, String id) {
@@ -110,12 +96,12 @@ public final class FeedScopedId implements Serializable, Comparable<FeedScopedId
     }
 
     /**
-     * Converts a string consisting of concatenated FeedScopedIds to a Set
+     * Parses a string consisting of concatenated FeedScopedIds to a Set
      */
-    public static HashSet<FeedScopedId> convertFromConcatenatedString(String s) {
+    public static HashSet<FeedScopedId> parseListOfIds(String s) {
         return Arrays
             .stream(s.split(","))
-            .map(FeedScopedId::convertFromString)
+            .map(FeedScopedId::parseId)
             .collect(Collectors.toCollection(HashSet::new));
     }
 }

--- a/src/main/java/org/opentripplanner/model/calendar/CalendarService.java
+++ b/src/main/java/org/opentripplanner/model/calendar/CalendarService.java
@@ -37,5 +37,5 @@ public interface CalendarService {
      * @return the time zone for the specified agency, or null if the agency was
      * not found
      */
-    TimeZone getTimeZoneForAgencyId(String agencyId);
+    TimeZone getTimeZoneForAgencyId(FeedScopedId agencyId);
 }

--- a/src/main/java/org/opentripplanner/model/calendar/CalendarServiceData.java
+++ b/src/main/java/org/opentripplanner/model/calendar/CalendarServiceData.java
@@ -18,7 +18,7 @@ public class CalendarServiceData implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private Map<String, TimeZone> timeZonesByAgencyId = new HashMap<>();
+    private Map<FeedScopedId, TimeZone> timeZonesByAgencyId = new HashMap<>();
 
     private Map<FeedScopedId, List<ServiceDate>> serviceDatesByServiceId = new HashMap<>();
 
@@ -28,15 +28,15 @@ public class CalendarServiceData implements Serializable {
      * @return the time zone for the specified agencyId, or null if the agency was
      *         not found
      */
-    public TimeZone getTimeZoneForAgencyId(String agencyId) {
+    public TimeZone getTimeZoneForAgencyId(FeedScopedId agencyId) {
         return timeZonesByAgencyId.get(agencyId);
     }
 
-    public void putTimeZoneForAgencyId(String agencyId, TimeZone timeZone) {
+    public void putTimeZoneForAgencyId(FeedScopedId agencyId, TimeZone timeZone) {
         timeZonesByAgencyId.put(agencyId, timeZone);
     }
 
-    public Set<String> getAgencyIds() {
+    public Set<FeedScopedId> getAgencyIds() {
         return Collections.unmodifiableSet(timeZonesByAgencyId.keySet());
     }
 
@@ -62,7 +62,7 @@ public class CalendarServiceData implements Serializable {
     }
 
     public void add(CalendarServiceData other) {
-        for (String agencyId : other.getAgencyIds()) {
+        for (FeedScopedId agencyId : other.getAgencyIds()) {
             putTimeZoneForAgencyId(agencyId, other.getTimeZoneForAgencyId(agencyId));
         }
         for (FeedScopedId serviceId : other.serviceDatesByServiceId.keySet()) {

--- a/src/main/java/org/opentripplanner/model/calendar/impl/CalendarServiceDataFactoryImpl.java
+++ b/src/main/java/org/opentripplanner/model/calendar/impl/CalendarServiceDataFactoryImpl.java
@@ -80,7 +80,12 @@ public class CalendarServiceDataFactoryImpl {
 
             LOG.debug("serviceId=" + serviceId + " (" + index + "/" + serviceIds.size() + ")");
 
-            TimeZone serviceIdTimeZone = data.getTimeZoneForAgencyId(serviceId.getFeedId());
+            TimeZone serviceIdTimeZone = data.getTimeZoneForAgencyId(data
+                .getAgencyIds()
+                .stream()
+                .filter(agency -> agency.getFeedId().equals(serviceId.getFeedId()))
+                .findAny()
+                .orElse(null));
             if (serviceIdTimeZone == null) {
                 serviceIdTimeZone = TimeZone.getDefault();
             }

--- a/src/main/java/org/opentripplanner/model/calendar/impl/CalendarServiceImpl.java
+++ b/src/main/java/org/opentripplanner/model/calendar/impl/CalendarServiceImpl.java
@@ -47,7 +47,7 @@ public class CalendarServiceImpl implements CalendarService {
     }
 
     @Override
-    public TimeZone getTimeZoneForAgencyId(String agencyId) {
+    public TimeZone getTimeZoneForAgencyId(FeedScopedId agencyId) {
         return data.getTimeZoneForAgencyId(agencyId);
     }
 }

--- a/src/main/java/org/opentripplanner/model/impl/OtpTransitServiceBuilder.java
+++ b/src/main/java/org/opentripplanner/model/impl/OtpTransitServiceBuilder.java
@@ -51,7 +51,7 @@ import static org.opentripplanner.model.impl.GenerateMissingIds.generateNoneExis
 public class OtpTransitServiceBuilder {
     private static final Logger LOG = LoggerFactory.getLogger(OtpTransitServiceBuilder.class);
 
-    private final EntityById<String, Agency> agenciesById = new EntityById<>();
+    private final EntityById<FeedScopedId, Agency> agenciesById = new EntityById<>();
 
     private final List<ServiceCalendarDate> calendarDates = new ArrayList<>();
 
@@ -104,7 +104,7 @@ public class OtpTransitServiceBuilder {
 
     /* Accessors */
 
-    public EntityById<String, Agency> getAgenciesById() {
+    public EntityById<FeedScopedId, Agency> getAgenciesById() {
         return agenciesById;
     }
 

--- a/src/main/java/org/opentripplanner/model/plan/Leg.java
+++ b/src/main/java/org/opentripplanner/model/plan/Leg.java
@@ -137,7 +137,7 @@ public class Leg {
     * For transit legs, the ID of the transit agency that operates the service used for this leg.
     * For non-transit legs, null.
     */
-   public String agencyId = null;
+   public FeedScopedId agencyId = null;
 
    /**
     * For transit legs, the ID of the trip.
@@ -285,7 +285,7 @@ public class Leg {
                 .addStr("tripShortName", tripShortName)
                 .addStr("tripBlockId", tripBlockId)
                 .addStr("headsign", headsign)
-                .addStr("agencyId", agencyId)
+                .addObj("agencyId", agencyId)
                 .addObj("tripId", tripId)
                 .addStr("serviceDate", serviceDate)
                 .addStr("routeBrandingUrl", routeBrandingUrl)

--- a/src/main/java/org/opentripplanner/netex/loader/mapping/AuthorityToAgencyMapper.java
+++ b/src/main/java/org/opentripplanner/netex/loader/mapping/AuthorityToAgencyMapper.java
@@ -11,6 +11,8 @@ import static org.opentripplanner.netex.support.NetexObjectDecorator.withOptiona
  * authority can be created if input data is missing an authority.
  */
 class AuthorityToAgencyMapper {
+
+    private FeedScopedIdFactory idFactory;
     private final String timeZone;
 
     /**
@@ -20,7 +22,8 @@ class AuthorityToAgencyMapper {
     private final String dummyAgencyId;
 
 
-    AuthorityToAgencyMapper(String timeZone) {
+    AuthorityToAgencyMapper(FeedScopedIdFactory idFactory, String timeZone) {
+        this.idFactory = idFactory;
         this.timeZone = timeZone;
         this.dummyAgencyId = "Dummy-" + timeZone;
     }
@@ -31,7 +34,7 @@ class AuthorityToAgencyMapper {
     Agency mapAuthorityToAgency(Authority source){
         Agency target = new Agency();
 
-        target.setId(source.getId());
+        target.setId(idFactory.createId(source.getId()));
         target.setName(source.getName().getValue());
         target.setTimezone(timeZone);
 
@@ -48,7 +51,7 @@ class AuthorityToAgencyMapper {
      */
     Agency createDummyAgency(){
         Agency agency = new Agency();
-        agency.setId(dummyAgencyId);
+        agency.setId(idFactory.createId(dummyAgencyId));
         agency.setName("N/A");
         agency.setTimezone(timeZone);
         agency.setUrl("N/A");

--- a/src/main/java/org/opentripplanner/netex/loader/mapping/NetexMapper.java
+++ b/src/main/java/org/opentripplanner/netex/loader/mapping/NetexMapper.java
@@ -110,7 +110,7 @@ public class NetexMapper {
     }
 
     private void mapAuthorities(NetexImportDataIndexReadOnlyView netexIndex) {
-        AuthorityToAgencyMapper agencyMapper = new AuthorityToAgencyMapper(netexIndex.getTimeZone());
+        AuthorityToAgencyMapper agencyMapper = new AuthorityToAgencyMapper(idFactory, netexIndex.getTimeZone());
         for (Authority authority : netexIndex.getAuthoritiesById().localValues()) {
             Agency agency = agencyMapper.mapAuthorityToAgency(authority);
             transitBuilder.getAgenciesById().add(agency);

--- a/src/main/java/org/opentripplanner/netex/loader/mapping/RouteMapper.java
+++ b/src/main/java/org/opentripplanner/netex/loader/mapping/RouteMapper.java
@@ -26,14 +26,14 @@ class RouteMapper {
     private final TransportModeMapper transportModeMapper = new TransportModeMapper();
 
     private final FeedScopedIdFactory idFactory;
-    private final EntityById<String, Agency> agenciesById;
+    private final EntityById<FeedScopedId, Agency> agenciesById;
     private final EntityById<FeedScopedId, Operator> operatorsById;
     private final NetexImportDataIndexReadOnlyView netexIndex;
     private final AuthorityToAgencyMapper authorityMapper;
 
     RouteMapper(
             FeedScopedIdFactory idFactory,
-            EntityById<String, Agency> agenciesById,
+            EntityById<FeedScopedId, Agency> agenciesById,
             EntityById<FeedScopedId, Operator> operatorsById,
             NetexImportDataIndexReadOnlyView netexIndex,
             String timeZone
@@ -42,7 +42,7 @@ class RouteMapper {
         this.agenciesById = agenciesById;
         this.operatorsById = operatorsById;
         this.netexIndex = netexIndex;
-        this.authorityMapper = new AuthorityToAgencyMapper(timeZone);
+        this.authorityMapper = new AuthorityToAgencyMapper(idFactory, timeZone);
     }
 
     org.opentripplanner.model.Route mapRoute(Line line){
@@ -85,7 +85,7 @@ class RouteMapper {
 
         if(network != null) {
             String orgRef = network.getTransportOrganisationRef().getValue().getRef();
-            Agency agency = agenciesById.get(orgRef);
+            Agency agency = agenciesById.get(idFactory.createId(orgRef));
             if(agency != null) return agency;
         }
         // No authority found in Network or GroupOfLines.
@@ -96,7 +96,7 @@ class RouteMapper {
     private Agency createOrGetDummyAgency(Line line) {
         LOG.warn("No authority found for " + line.getId());
 
-        Agency agency = agenciesById.get(authorityMapper.dummyAgencyId());
+        Agency agency = agenciesById.get(idFactory.createId(authorityMapper.dummyAgencyId()));
 
         if (agency == null) {
             agency = authorityMapper.createDummyAgency();

--- a/src/main/java/org/opentripplanner/routing/alertpatch/AlertPatch.java
+++ b/src/main/java/org/opentripplanner/routing/alertpatch/AlertPatch.java
@@ -37,7 +37,7 @@ public class AlertPatch implements Serializable {
 
     private List<TimePeriod> timePeriods = new ArrayList<>();
 
-    private String agency;
+    private FeedScopedId agency;
 
     private FeedScopedId operatorId;
 
@@ -100,10 +100,7 @@ public class AlertPatch implements Serializable {
     }
 
     public void apply(Graph graph) {
-        Agency agency = null;
-        if (feedId != null) {
-            agency = graph.index.getAgency(feedId, this.agency);
-        }
+        Agency agency = this.agency != null ? graph.index.getAgencyForId(this.agency) : null;
         Route route = this.route != null ? graph.index.getRouteForId(this.route) : null;
         Stop stop = this.stop != null ? graph.index.getStopForId(this.stop) : null;
         Trip trip = this.trip != null ? graph.index.getTripForId().get(this.trip) : null;
@@ -145,7 +142,7 @@ public class AlertPatch implements Serializable {
     }
 
     public void remove(Graph graph) {
-        Agency agency = graph.index.getAgency(feedId, this.agency);
+        Agency agency = this.agency != null ? graph.index.getAgencyForId(this.agency) : null;
         Route route = this.route != null ? graph.index.getRouteForId(this.route) : null;
         Stop stop = this.stop != null ? graph.index.getStopForId(this.stop) : null;
         Trip trip = this.trip != null ? graph.index.getTripForId().get(this.trip) : null;
@@ -201,7 +198,7 @@ public class AlertPatch implements Serializable {
         timePeriods = periods;
     }
 
-    public String getAgency() {
+    public FeedScopedId getAgency() {
         return agency;
     }
 
@@ -217,7 +214,7 @@ public class AlertPatch implements Serializable {
         return stop;
     }
 
-    public void setAgencyId(String agency) {
+    public void setAgency(FeedScopedId agency) {
         this.agency = agency;
     }
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/AlertToLegMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/AlertToLegMapper.java
@@ -95,8 +95,7 @@ public class AlertToLegMapper {
         }
 
         if (leg.agencyId != null) {
-            String agencId = graph.index.getAgencyWithoutFeedId(leg.agencyId).getId();
-            Collection<AlertPatch> patches = alertPatchService(graph).getAgencyPatches(agencId);
+            Collection<AlertPatch> patches = alertPatchService(graph).getAgencyPatches(leg.agencyId);
             addAlertPatchesToLeg(leg, patches, requestedLocale, legStartTime, legEndTime);
         }
 

--- a/src/main/java/org/opentripplanner/routing/core/FareRuleSet.java
+++ b/src/main/java/org/opentripplanner/routing/core/FareRuleSet.java
@@ -12,7 +12,6 @@ public class FareRuleSet implements Serializable {
 
     private static final long serialVersionUID = 7218355718876553028L;
 
-    private String agency = null;
     private Set<FeedScopedId> routes;
     private Set<P2<String>> originDestinations;
     private Set<String> contains;
@@ -25,15 +24,6 @@ public class FareRuleSet implements Serializable {
         originDestinations= new HashSet<P2<String>>();
         contains = new HashSet<String>();
         trips = new HashSet<FeedScopedId>();
-    }
-
-    public void setAgency(String agency) {
-        // TODO With new GTFS lib, read value from fareAttribute directly?
-        this.agency = agency;
-    }
-    
-    public String getAgency() {
-    	return agency;
     }
 
     public void addOriginDestination(String origin, String destination) {
@@ -60,10 +50,6 @@ public class FareRuleSet implements Serializable {
         return fareAttribute;
     }
 
-    public boolean hasAgencyDefined() {
-        return agency != null;
-    }
-
     public void addTrip(FeedScopedId trip) {
     	trips.add(trip);
     }
@@ -72,14 +58,8 @@ public class FareRuleSet implements Serializable {
     	return trips;
     }
     
-    public boolean matches(Set<String> agencies, String startZone, String endZone, Set<String> zonesVisited,
+    public boolean matches(String startZone, String endZone, Set<String> zonesVisited,
                            Set<FeedScopedId> routesVisited, Set<FeedScopedId> tripsVisited) {
-        //check for matching agency
-        if (agency != null) {
-            if (agencies.size() != 1 || !agencies.contains(agency))
-                return false;
-        }
-
         //check for matching origin/destination, if this ruleset has any origin/destination restrictions
         if (originDestinations.size() > 0) {
             P2<String> od = new P2<String>(startZone, endZone);

--- a/src/main/java/org/opentripplanner/routing/core/ServiceDay.java
+++ b/src/main/java/org/opentripplanner/routing/core/ServiceDay.java
@@ -25,7 +25,7 @@ public class ServiceDay implements Serializable {
     protected ServiceDate serviceDate;
     protected BitSet serviceIdsRunning;
 
-    public ServiceDay(Map<FeedScopedId, Integer> serviceCodes, ServiceDate serviceDate, CalendarService cs, String agencyId) {
+    public ServiceDay(Map<FeedScopedId, Integer> serviceCodes, ServiceDate serviceDate, CalendarService cs, FeedScopedId agencyId) {
         TimeZone timeZone = cs.getTimeZoneForAgencyId(agencyId);
         this.serviceDate = serviceDate;
 

--- a/src/main/java/org/opentripplanner/routing/graph/Graph.java
+++ b/src/main/java/org/opentripplanner/routing/graph/Graph.java
@@ -145,7 +145,7 @@ public class Graph implements Serializable {
 
     private transient TimetableSnapshotProvider timetableSnapshotProvider = null;
 
-    private Map<String, Collection<Agency>> agenciesForFeedId = new HashMap<>();
+    private Collection<Agency> agencies = new ArrayList<>();
 
     private Collection<Operator> operators = new ArrayList<>();
 
@@ -746,9 +746,8 @@ public class Graph implements Serializable {
         return feedIds;
     }
 
-    /** @return the agencies to which the specified feedId is mapped, or null if no mapping exist */
-    public Collection<Agency> getAgencies(String feedId) {
-        return agenciesForFeedId.get(feedId);
+    public Collection<Agency> getAgencies() {
+        return agencies;
     }
 
     public FeedInfo getFeedInfo(String feedId) {
@@ -756,9 +755,7 @@ public class Graph implements Serializable {
     }
 
     public void addAgency(String feedId, Agency agency) {
-        Collection<Agency> agencies = agenciesForFeedId.getOrDefault(feedId, new HashSet<>());
         agencies.add(agency);
-        this.agenciesForFeedId.put(feedId, agencies);
         this.feedIds.add(feedId);
     }
 
@@ -774,10 +771,6 @@ public class Graph implements Serializable {
      */
     public TimeZone getTimeZone() {
         if (timeZone == null) {
-            Collection<Agency> agencies = null;
-            if (agenciesForFeedId.entrySet().size() > 0) {
-                agencies = agenciesForFeedId.entrySet().iterator().next().getValue();
-            }
             if (agencies == null || agencies.size() == 0) {
                 timeZone = TimeZone.getTimeZone("GMT");
                 LOG.warn("graph contains no agencies (yet); API request times will be interpreted as GMT.");

--- a/src/main/java/org/opentripplanner/routing/impl/AlertPatchServiceImpl.java
+++ b/src/main/java/org/opentripplanner/routing/impl/AlertPatchServiceImpl.java
@@ -34,7 +34,7 @@ public class AlertPatchServiceImpl implements AlertPatchService {
     private Map<StopAndRouteOrTripKey, Set<AlertPatch>> patchesByStopAndRoute = new ConcurrentHashMap<>();
     private Map<StopAndRouteOrTripKey, Set<AlertPatch>> patchesByStopAndTrip = new ConcurrentHashMap<>();
     private Map<FeedScopedId, Set<AlertPatch>> patchesByTrip = new ConcurrentHashMap<>();
-    private Map<String, Set<AlertPatch>> patchesByAgency = new ConcurrentHashMap<>();
+    private Map<FeedScopedId, Set<AlertPatch>> patchesByAgency = new ConcurrentHashMap<>();
     private Map<String, Set<AlertPatch>> patchesByTripPattern = new ConcurrentHashMap<>();
 
     public AlertPatchServiceImpl(Graph graph) {
@@ -99,7 +99,7 @@ public class AlertPatchServiceImpl implements AlertPatchService {
 
 
     @Override
-    public Collection<AlertPatch> getAgencyPatches(String agency) {
+    public Collection<AlertPatch> getAgencyPatches(FeedScopedId agency) {
         Set<AlertPatch> result = new HashSet<>();
         if (patchesByAgency.containsKey(agency)) {
             result.addAll(patchesByAgency.get(agency));
@@ -186,9 +186,9 @@ public class AlertPatchServiceImpl implements AlertPatchService {
             }
         }
 
-        String agency = alertPatch.getAgency();
-        if (agency != null && !agency.isEmpty()) {
-            Set<AlertPatch> set = (Set) patchesByAgency.getOrDefault(agency, new HashSet());
+        FeedScopedId agency = alertPatch.getAgency();
+        if (agency != null) {
+            Set<AlertPatch> set = patchesByAgency.getOrDefault(agency, new HashSet());
             set.add(alertPatch);
             patchesByAgency.put(agency, set);
         }
@@ -231,6 +231,7 @@ public class AlertPatchServiceImpl implements AlertPatchService {
         FeedScopedId stop = alertPatch.getStop();
         FeedScopedId route = alertPatch.getRoute();
         FeedScopedId trip = alertPatch.getTrip();
+        FeedScopedId agency = alertPatch.getAgency();
 
         if (stop != null) {
             removeAlertPatch(patchesByStop.get(stop), alertPatch);
@@ -252,7 +253,6 @@ public class AlertPatchServiceImpl implements AlertPatchService {
             removeAlertPatch(patchesByStopAndTrip.get(new StopAndRouteOrTripKey(stop, trip)), alertPatch);
         }
 
-        String agency = alertPatch.getAgency();
         if (agency != null) {
             removeAlertPatch(patchesByAgency.get(agency), alertPatch);
         }

--- a/src/main/java/org/opentripplanner/routing/impl/DefaultFareServiceFactory.java
+++ b/src/main/java/org/opentripplanner/routing/impl/DefaultFareServiceFactory.java
@@ -41,10 +41,10 @@ public class DefaultFareServiceFactory implements FareServiceFactory {
 
     @Override
     public void processGtfs(OtpTransitService transitService) {
-        fillFareRules(null, transitService.getAllFareAttributes(), transitService.getAllFareRules(), regularFareRules);
+        fillFareRules(transitService.getAllFareAttributes(), transitService.getAllFareRules(), regularFareRules);
     }
 
-    protected void fillFareRules(String agencyId, Collection<FareAttribute> fareAttributes,
+    protected void fillFareRules(Collection<FareAttribute> fareAttributes,
             Collection<FareRule> fareRules, Map<FeedScopedId, FareRuleSet> fareRuleSet) {
         /*
          * Create an empty FareRuleSet for each FareAttribute, as some FareAttribute may have no
@@ -56,10 +56,6 @@ public class DefaultFareServiceFactory implements FareServiceFactory {
             if (fareRule == null) {
                 fareRule = new FareRuleSet(fare);
                 fareRuleSet.put(id, fareRule);
-                if (agencyId != null) {
-                    // TODO With the new GTFS lib, use fareAttribute.agency_id directly
-                    fareRule.setAgency(agencyId);
-                }
             }
         }
 

--- a/src/main/java/org/opentripplanner/routing/impl/DefaultFareServiceImpl.java
+++ b/src/main/java/org/opentripplanner/routing/impl/DefaultFareServiceImpl.java
@@ -231,7 +231,6 @@ public class DefaultFareServiceImpl implements FareService {
             Collection<FareRuleSet> fareRules) {
         Set<String> zones = new HashSet<>();
         Set<FeedScopedId> routes = new HashSet<>();
-        Set<String> agencies = new HashSet<>();
         Set<FeedScopedId> trips = new HashSet<>();
         int transfersUsed = -1;
         
@@ -251,7 +250,6 @@ public class DefaultFareServiceImpl implements FareService {
             lastRideStartTime = ride.startTime;
             lastRideEndTime = ride.endTime;
             endZone = ride.endZone;
-            agencies.add(ride.agency);
             routes.add(ride.route);
             zones.addAll(ride.zones);
             trips.add(ride.trip);
@@ -268,10 +266,10 @@ public class DefaultFareServiceImpl implements FareService {
             FareAttribute attribute = ruleSet.getFareAttribute();
             // fares also don't really have an agency id, they will have the per-feed default id
             // check only if the fare is not mapped to an agency
-            if (!ruleSet.hasAgencyDefined() && !attribute.getId().getFeedId().equals(feedId))
+            if (!attribute.getId().getFeedId().equals(feedId))
                 continue;
             
-            if (ruleSet.matches(agencies, startZone, endZone, zones, routes, trips)) {
+            if (ruleSet.matches(startZone, endZone, zones, routes, trips)) {
                 // TODO Maybe move the code below in FareRuleSet::matches() ?
                 if (attribute.isTransfersSet() && attribute.getTransfers() < transfersUsed) {
                     continue;

--- a/src/main/java/org/opentripplanner/routing/impl/DutchFareServiceImpl.java
+++ b/src/main/java/org/opentripplanner/routing/impl/DutchFareServiceImpl.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.routing.impl;
 
 import org.opentripplanner.common.model.P2;
+import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.routing.algorithm.raptor.transit.TransitLayer;
 import org.opentripplanner.routing.algorithm.raptor.transit.TripSchedule;
 import org.opentripplanner.routing.core.Fare;
@@ -97,12 +98,12 @@ public class DutchFareServiceImpl extends DefaultFareServiceImpl {
         }
     }
 
-    private UnitsFareZone getUnitsByZones(String agencyId, String startZone, String endZone, Collection<FareRuleSet> fareRules) {
+    private UnitsFareZone getUnitsByZones(FeedScopedId agencyId, String startZone, String endZone, Collection<FareRuleSet> fareRules) {
         P2<String> od = new P2<String>(startZone, endZone);
 
         LOG.trace("Search " + startZone + " and " + endZone);
 
-        String fareIdStartsWith = agencyId + "::";
+        String fareIdStartsWith = agencyId.getId() + "::";
 
         for (FareRuleSet ruleSet : fareRules) {
             if (ruleSet.getFareAttribute().getId().getId().startsWith(fareIdStartsWith) &&
@@ -216,7 +217,7 @@ public class DutchFareServiceImpl extends DefaultFareServiceImpl {
         boolean mustHaveCheckedOut = false;
         String startTariefEenheden = null;
         String endTariefEenheden = null;
-        String lastAgencyId = null;
+        FeedScopedId lastAgencyId = null;
         String lastFareZone = null;
 
         long alightedEasyTrip = 0;
@@ -225,7 +226,7 @@ public class DutchFareServiceImpl extends DefaultFareServiceImpl {
         for (Ride ride : rides) {
             LOG.trace(String.format("%s %s %s %s %s %s", ride.startZone, ride.endZone, ride.firstStop, ride.lastStop, ride.route, ride.agency));
 
-            if (ride.agency.startsWith("IFF:")) {
+            if (ride.agency.getFeedId().equals("IFF")) {
                 LOG.trace("1. Trains");
 		        /* In Reizen op Saldo we will try to fares as long as possible. */
 

--- a/src/main/java/org/opentripplanner/routing/impl/Ride.java
+++ b/src/main/java/org/opentripplanner/routing/impl/Ride.java
@@ -11,7 +11,7 @@ import java.util.Set;
  */
 public class Ride {
 
-    String agency; // route agency
+    FeedScopedId agency; // route agency
 
     FeedScopedId route;
 

--- a/src/main/java/org/opentripplanner/routing/impl/SeattleFareServiceFactory.java
+++ b/src/main/java/org/opentripplanner/routing/impl/SeattleFareServiceFactory.java
@@ -43,7 +43,7 @@ public class SeattleFareServiceFactory extends DefaultFareServiceFactory {
     	// may not match fare attribute agency IDs (which are feed IDs).
     	
     	Map<FeedScopedId, FareRuleSet> feedFareRules = new HashMap<>();
-    	fillFareRules(null, transitService.getAllFareAttributes(),
+    	fillFareRules(transitService.getAllFareAttributes(),
                 transitService.getAllFareRules(), feedFareRules);
     	
     	regularFareRules.putAll(feedFareRules);

--- a/src/main/java/org/opentripplanner/routing/impl/SeattleFareServiceImpl.java
+++ b/src/main/java/org/opentripplanner/routing/impl/SeattleFareServiceImpl.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.routing.impl;
 
 import com.google.common.collect.Iterables;
+import org.opentripplanner.model.FeedScopedId;
 
 import java.util.List;
 
@@ -13,8 +14,8 @@ public class SeattleFareServiceImpl extends DefaultFareServiceImpl {
     @Override
     protected float addFares(List<Ride> ride0, List<Ride> ride1, float cost0, float cost1) {
         String feedId = ride0.get(0).firstStop.getId().getFeedId();
-        String agencyId = ride0.get(0).agency;
-        if (KCM_FEED_ID.equals(feedId) && KCM_AGENCY_ID.equals(agencyId)) {
+        FeedScopedId agencyId = ride0.get(0).agency;
+        if (KCM_FEED_ID.equals(feedId) && KCM_AGENCY_ID.equals(agencyId.getId())) {
             for (Ride r : Iterables.concat(ride0, ride1)) {
                 if (!isCorrectAgency(r, feedId, agencyId)) {
                     return cost0 + cost1;
@@ -25,9 +26,9 @@ public class SeattleFareServiceImpl extends DefaultFareServiceImpl {
         return cost0 + cost1;
     }
 
-    private static boolean isCorrectAgency(Ride r, String feedId, String agencyId) {
+    private static boolean isCorrectAgency(Ride r, String feedId, FeedScopedId agencyId) {
         String rideFeedId = r.firstStop.getId().getFeedId();
-        String rideAgencyId = r.agency;
+        FeedScopedId rideAgencyId = r.agency;
         return feedId.equals(rideFeedId) && agencyId.equals(rideAgencyId);
     }
 

--- a/src/main/java/org/opentripplanner/routing/request/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/request/RoutingRequest.java
@@ -819,7 +819,7 @@ public class RoutingRequest implements Cloneable, Serializable {
 
     public void setPreferredAgencies(String s) {
         if (!s.isEmpty()) {
-            preferredAgencies = FeedScopedId.convertFromConcatenatedString(s);
+            preferredAgencies = FeedScopedId.parseListOfIds(s);
         }
     }
 
@@ -839,7 +839,7 @@ public class RoutingRequest implements Cloneable, Serializable {
 
     public void setUnpreferredAgencies(String s) {
         if (!s.isEmpty()) {
-            unpreferredAgencies = FeedScopedId.convertFromConcatenatedString(s);
+            unpreferredAgencies = FeedScopedId.parseListOfIds(s);
         }
     }
 
@@ -872,13 +872,13 @@ public class RoutingRequest implements Cloneable, Serializable {
 
     public void setBannedAgencies(String s) {
         if (!s.isEmpty()) {
-            bannedAgencies = FeedScopedId.convertFromConcatenatedString(s);
+            bannedAgencies = FeedScopedId.parseListOfIds(s);
         }
     }
 
     public void setWhiteListedAgencies(String s) {
         if (!s.isEmpty()) {
-            whiteListedAgencies = FeedScopedId.convertFromConcatenatedString(s);
+            whiteListedAgencies = FeedScopedId.parseListOfIds(s);
         }
     }
 

--- a/src/main/java/org/opentripplanner/routing/request/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/request/RoutingRequest.java
@@ -819,13 +819,7 @@ public class RoutingRequest implements Cloneable, Serializable {
 
     public void setPreferredAgencies(String s) {
         if (!s.isEmpty()) {
-            preferredAgencies = new HashSet<>();
-            Collections.addAll(
-                preferredAgencies,
-                Arrays.stream(s.split(","))
-                    .map(FeedScopedId::convertFromString)
-                    .toArray(FeedScopedId[]::new)
-            );
+            preferredAgencies = FeedScopedId.convertFromConcatenatedString(s);
         }
     }
 
@@ -845,13 +839,7 @@ public class RoutingRequest implements Cloneable, Serializable {
 
     public void setUnpreferredAgencies(String s) {
         if (!s.isEmpty()) {
-            unpreferredAgencies = new HashSet<>();
-            Collections.addAll(
-                unpreferredAgencies,
-                Arrays.stream(s.split(","))
-                    .map(FeedScopedId::convertFromString)
-                    .toArray(FeedScopedId[]::new)
-            );
+            unpreferredAgencies = FeedScopedId.convertFromConcatenatedString(s);
         }
     }
 
@@ -884,22 +872,13 @@ public class RoutingRequest implements Cloneable, Serializable {
 
     public void setBannedAgencies(String s) {
         if (!s.isEmpty()) {
-            bannedAgencies = new HashSet<>();
-            Collections.addAll(
-                bannedAgencies,
-                Arrays.stream(s.split(","))
-                    .map(FeedScopedId::convertFromString)
-                    .toArray(FeedScopedId[]::new));
+            bannedAgencies = FeedScopedId.convertFromConcatenatedString(s);
         }
     }
 
     public void setWhiteListedAgencies(String s) {
         if (!s.isEmpty()) {
-            whiteListedAgencies = new HashSet<>();
-            Collections.addAll(whiteListedAgencies,
-                Arrays.stream(s.split(","))
-                    .map(FeedScopedId::convertFromString)
-                    .toArray(FeedScopedId[]::new));
+            whiteListedAgencies = FeedScopedId.convertFromConcatenatedString(s);
         }
     }
 

--- a/src/main/java/org/opentripplanner/routing/request/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/request/RoutingRequest.java
@@ -399,12 +399,12 @@ public class RoutingRequest implements Cloneable, Serializable {
     /**
      * Do not use certain named agencies
      */
-    public HashSet<String> bannedAgencies = new HashSet<String>();
+    public HashSet<FeedScopedId> bannedAgencies = new HashSet<>();
 
     /**
      * Only use certain named agencies
      */
-    public HashSet<String> whiteListedAgencies = new HashSet<String>();
+    public HashSet<FeedScopedId> whiteListedAgencies = new HashSet<>();
 
 
     /**
@@ -413,13 +413,13 @@ public class RoutingRequest implements Cloneable, Serializable {
      * @deprecated TODO OTP2: Needs to be implemented
      */
     @Deprecated
-    public HashSet<String> preferredAgencies = new HashSet<String>();
+    public HashSet<FeedScopedId> preferredAgencies = new HashSet<>();
 
     /**
      * Set of unpreferred agencies for given user.
      */
     @Deprecated
-    public HashSet<String> unpreferredAgencies = new HashSet<String>();
+    public HashSet<FeedScopedId> unpreferredAgencies = new HashSet<>();
 
     /**
      * Do not use certain named routes.
@@ -820,7 +820,12 @@ public class RoutingRequest implements Cloneable, Serializable {
     public void setPreferredAgencies(String s) {
         if (!s.isEmpty()) {
             preferredAgencies = new HashSet<>();
-            Collections.addAll(preferredAgencies, s.split(","));
+            Collections.addAll(
+                preferredAgencies,
+                Arrays.stream(s.split(","))
+                    .map(FeedScopedId::convertFromString)
+                    .toArray(FeedScopedId[]::new)
+            );
         }
     }
 
@@ -841,7 +846,12 @@ public class RoutingRequest implements Cloneable, Serializable {
     public void setUnpreferredAgencies(String s) {
         if (!s.isEmpty()) {
             unpreferredAgencies = new HashSet<>();
-            Collections.addAll(unpreferredAgencies, s.split(","));
+            Collections.addAll(
+                unpreferredAgencies,
+                Arrays.stream(s.split(","))
+                    .map(FeedScopedId::convertFromString)
+                    .toArray(FeedScopedId[]::new)
+            );
         }
     }
 
@@ -875,14 +885,21 @@ public class RoutingRequest implements Cloneable, Serializable {
     public void setBannedAgencies(String s) {
         if (!s.isEmpty()) {
             bannedAgencies = new HashSet<>();
-            Collections.addAll(bannedAgencies, s.split(","));
+            Collections.addAll(
+                bannedAgencies,
+                Arrays.stream(s.split(","))
+                    .map(FeedScopedId::convertFromString)
+                    .toArray(FeedScopedId[]::new));
         }
     }
 
     public void setWhiteListedAgencies(String s) {
         if (!s.isEmpty()) {
             whiteListedAgencies = new HashSet<>();
-            Collections.addAll(whiteListedAgencies, s.split(","));
+            Collections.addAll(whiteListedAgencies,
+                Arrays.stream(s.split(","))
+                    .map(FeedScopedId::convertFromString)
+                    .toArray(FeedScopedId[]::new));
         }
     }
 
@@ -1057,9 +1074,9 @@ public class RoutingRequest implements Cloneable, Serializable {
             clone.streetSubRequestModes = streetSubRequestModes.clone();
             clone.bannedRoutes = bannedRoutes.clone();
             clone.bannedTrips = (HashMap<FeedScopedId, BannedStopSet>) bannedTrips.clone();
-            clone.whiteListedAgencies = (HashSet<String>) whiteListedAgencies.clone();
+            clone.whiteListedAgencies = (HashSet<FeedScopedId>) whiteListedAgencies.clone();
             clone.whiteListedRoutes = whiteListedRoutes.clone();
-            clone.preferredAgencies = (HashSet<String>) preferredAgencies.clone();
+            clone.preferredAgencies = (HashSet<FeedScopedId>) preferredAgencies.clone();
             clone.preferredRoutes = preferredRoutes.clone();
             if (this.bikeWalkingOptions != this)
                 clone.bikeWalkingOptions = this.bikeWalkingOptions.clone();
@@ -1275,7 +1292,7 @@ public class RoutingRequest implements Cloneable, Serializable {
     /** Check if route is preferred according to this request. */
     public long preferencesPenaltyForRoute(Route route) {
         long preferences_penalty = 0;
-        String agencyID = route.getAgency().getId();
+        FeedScopedId agencyID = route.getAgency().getId();
         if ((preferredRoutes != null && !preferredRoutes.equals(RouteMatcher.emptyMatcher())) ||
                 (preferredAgencies != null && !preferredAgencies.isEmpty())) {
             boolean isPreferedRoute = preferredRoutes != null && preferredRoutes.matches(route);

--- a/src/main/java/org/opentripplanner/routing/services/AlertPatchService.java
+++ b/src/main/java/org/opentripplanner/routing/services/AlertPatchService.java
@@ -18,7 +18,7 @@ public interface AlertPatchService {
 
     Collection<AlertPatch> getTripPatches(FeedScopedId trip);
 
-    Collection<AlertPatch> getAgencyPatches(String agency);
+    Collection<AlertPatch> getAgencyPatches(FeedScopedId agency);
 
     Collection<AlertPatch> getStopAndRoutePatches(FeedScopedId stop, FeedScopedId route);
 

--- a/src/main/java/org/opentripplanner/standalone/config/NodeAdapter.java
+++ b/src/main/java/org/opentripplanner/standalone/config/NodeAdapter.java
@@ -243,7 +243,7 @@ public class NodeAdapter {
 
     public FeedScopedId asFeedScopedId(String paramName, FeedScopedId defaultValue) {
         if(!exist(paramName)) { return defaultValue; }
-        return FeedScopedId.convertFromString(asText(paramName));
+        return FeedScopedId.parseId(asText(paramName));
     }
 
     public Locale asLocale(String paramName, Locale defaultValue) {

--- a/src/main/java/org/opentripplanner/updater/alerts/AlertsUpdateHandler.java
+++ b/src/main/java/org/opentripplanner/updater/alerts/AlertsUpdateHandler.java
@@ -135,7 +135,7 @@ public class AlertsUpdateHandler {
                 patch.setStop(new FeedScopedId(feedId, stopId));
             }
             if (agencyId != null && routeId == null && tripId == null && stopId == null) {
-                patch.setAgencyId(agencyId);
+                patch.setAgency(new FeedScopedId(feedId, agencyId));
             }
             patch.setTimePeriods(periods);
             patch.setAlert(alertText);

--- a/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
@@ -101,8 +101,6 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
 
     private final RoutingService routingService;
 
-    private final Agency dummyAgency;
-
     public GtfsRealtimeFuzzyTripMatcher fuzzyTripMatcher;
 
     private TransitLayer realtimeTransitLayer;
@@ -114,11 +112,6 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
         routingService = new RoutingService(graph);
         realtimeTransitLayer = graph.getRealtimeTransitLayer();
         transitLayerUpdater = graph.transitLayerUpdater;
-
-        // Create dummy agency for added trips
-        dummyAgency = new Agency();
-        dummyAgency.setId("");
-        dummyAgency.setName("");
     }
 
     /**
@@ -578,6 +571,10 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
             } else {
                 route.setId(new FeedScopedId(feedId, tripId));
             }
+            // Create dummy agency for added trips
+            Agency dummyAgency = new Agency();
+            dummyAgency.setId(new FeedScopedId(feedId, ""));
+            dummyAgency.setName("");
             route.setAgency(dummyAgency);
             // Guess the route type as it doesn't exist yet in the specifications
             // Bus. Used for short- and long-distance bus routes.

--- a/src/test/java/org/opentripplanner/GtfsTest.java
+++ b/src/test/java/org/opentripplanner/GtfsTest.java
@@ -69,7 +69,7 @@ public abstract class GtfsTest extends TestCase {
         gtfsBundle.setTransfersTxtDefinesStationPaths(true);
         gtfsGraphBuilderImpl.buildGraph(graph, null);
         // Set the agency ID to be used for tests to the first one in the feed.
-        agencyId = graph.getAgencies(feedId.getId()).iterator().next().getId();
+        agencyId = graph.getAgencies().iterator().next().getId().getId();
         System.out.printf("Set the agency ID for this test to %s\n", agencyId);
         graph.index();
         timetableSnapshotSource = new TimetableSnapshotSource(graph);

--- a/src/test/java/org/opentripplanner/gtfs/GtfsContextBuilder.java
+++ b/src/test/java/org/opentripplanner/gtfs/GtfsContextBuilder.java
@@ -43,8 +43,7 @@ public class GtfsContextBuilder {
         GtfsImport gtfsImport = gtfsImport(defaultFeedId, path);
         GtfsFeedId feedId = gtfsImport.getFeedId();
         OtpTransitServiceBuilder transitBuilder = mapGtfsDaoToInternalTransitServiceBuilder(
-                gtfsImport.getDao(),
-                new DataImportIssueStore(false)
+                gtfsImport.getDao(), feedId.getId(), new DataImportIssueStore(false)
         );
         return new GtfsContextBuilder(
                 feedId,

--- a/src/test/java/org/opentripplanner/gtfs/mapping/AgencyMapperTest.java
+++ b/src/test/java/org/opentripplanner/gtfs/mapping/AgencyMapperTest.java
@@ -13,6 +13,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class AgencyMapperTest {
+    private static final String FEED_ID = "FEED";
+
     private static final Agency AGENCY = new Agency();
 
     private static final String ID = "ID";
@@ -42,7 +44,7 @@ public class AgencyMapperTest {
         AGENCY.setBrandingUrl(BRANDING_URL);
     }
 
-    private AgencyMapper subject = new AgencyMapper();
+    private AgencyMapper subject = new AgencyMapper(FEED_ID);
 
     @Test
     public void testMapCollection() throws Exception {
@@ -55,7 +57,7 @@ public class AgencyMapperTest {
     public void testMap() throws Exception {
         org.opentripplanner.model.Agency result = subject.map(AGENCY);
 
-        assertEquals(ID, result.getId());
+        assertEquals("FEED:ID", result.getId().toString());
         assertEquals(NAME, result.getName());
         assertEquals(LANG, result.getLang());
         assertEquals(PHONE, result.getPhone());

--- a/src/test/java/org/opentripplanner/gtfs/mapping/FareRuleMapperTest.java
+++ b/src/test/java/org/opentripplanner/gtfs/mapping/FareRuleMapperTest.java
@@ -15,6 +15,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class FareRuleMapperTest {
+    private static final String FEED_ID = "FEED";
+
     private static final org.onebusaway.gtfs.model.FareRule FARE_RULE = new org.onebusaway.gtfs.model.FareRule();
 
     private static final AgencyAndId AGENCY_AND_ID = new AgencyAndId("A", "1");
@@ -43,7 +45,7 @@ public class FareRuleMapperTest {
         FARE_RULE.setRoute(ROUTE);
     }
 
-    private FareRuleMapper subject = new FareRuleMapper(new RouteMapper(new AgencyMapper()),
+    private FareRuleMapper subject = new FareRuleMapper(new RouteMapper(new AgencyMapper(FEED_ID)),
             new FareAttributeMapper());
 
     @Test

--- a/src/test/java/org/opentripplanner/gtfs/mapping/FrequencyMapperTest.java
+++ b/src/test/java/org/opentripplanner/gtfs/mapping/FrequencyMapperTest.java
@@ -14,6 +14,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class FrequencyMapperTest {
+    private static final String FEED_ID = "FEED";
+
     private static final AgencyAndId AGENCY_AND_ID = new AgencyAndId("A", "1");
 
     private static final Integer ID = 45;
@@ -45,7 +47,7 @@ public class FrequencyMapperTest {
     }
 
     private FrequencyMapper subject = new FrequencyMapper(
-            new TripMapper(new RouteMapper(new AgencyMapper())));
+            new TripMapper(new RouteMapper(new AgencyMapper(FEED_ID))));
 
     @Test
     public void testMapCollection() throws Exception {

--- a/src/test/java/org/opentripplanner/gtfs/mapping/RouteMapperTest.java
+++ b/src/test/java/org/opentripplanner/gtfs/mapping/RouteMapperTest.java
@@ -16,6 +16,8 @@ import static org.junit.Assert.assertTrue;
 
 public class RouteMapperTest {
 
+    private static final String FEED_ID = "FEED";
+
     private static final AgencyAndId AGENCY_AND_ID = new AgencyAndId("A", "1");
 
     private static final String SHORT_NAME = "Short Name";
@@ -62,7 +64,7 @@ public class RouteMapperTest {
         ROUTE.setRouteBikesAllowed(ROUTE_BIKES_ALLOWED);
     }
 
-    private RouteMapper subject = new RouteMapper(new AgencyMapper());
+    private RouteMapper subject = new RouteMapper(new AgencyMapper(FEED_ID));
 
     @Test
     public void testMapCollection() throws Exception {

--- a/src/test/java/org/opentripplanner/gtfs/mapping/StopTimesMapperTest.java
+++ b/src/test/java/org/opentripplanner/gtfs/mapping/StopTimesMapperTest.java
@@ -16,6 +16,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class StopTimesMapperTest {
+    private static final String FEED_ID = "FEED";
+
     private static final AgencyAndId AGENCY_AND_ID = new AgencyAndId("A", "1");
 
     private static final Integer ID = 45;
@@ -66,7 +68,7 @@ public class StopTimesMapperTest {
     }
 
     private StopTimeMapper subject = new StopTimeMapper(
-            new StopMapper(), new TripMapper(new RouteMapper(new AgencyMapper()))
+            new StopMapper(), new TripMapper(new RouteMapper(new AgencyMapper(FEED_ID)))
     );
 
     @Test

--- a/src/test/java/org/opentripplanner/gtfs/mapping/TransferMapperTest.java
+++ b/src/test/java/org/opentripplanner/gtfs/mapping/TransferMapperTest.java
@@ -16,7 +16,9 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class TransferMapperTest {
-    private static final RouteMapper ROUTE_MAPPER = new RouteMapper(new AgencyMapper());
+    private static final String FEED_ID = "FEED";
+
+    private static final RouteMapper ROUTE_MAPPER = new RouteMapper(new AgencyMapper(FEED_ID));
 
     private static final TripMapper TRIP_MAPPER = new TripMapper(ROUTE_MAPPER);
 

--- a/src/test/java/org/opentripplanner/gtfs/mapping/TripMapperTest.java
+++ b/src/test/java/org/opentripplanner/gtfs/mapping/TripMapperTest.java
@@ -14,6 +14,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class TripMapperTest {
+    private static final String FEED_ID = "FEED";
 
     private static final AgencyAndId AGENCY_AND_ID = new AgencyAndId("A", "1");
 
@@ -57,7 +58,7 @@ public class TripMapperTest {
         TRIP.setTripBikesAllowed(TRIP_BIKES_ALLOWED);
     }
 
-    private TripMapper subject = new TripMapper(new RouteMapper(new AgencyMapper()));
+    private TripMapper subject = new TripMapper(new RouteMapper(new AgencyMapper(FEED_ID)));
 
     @Test
     public void testMapCollection() throws Exception {

--- a/src/test/java/org/opentripplanner/model/calendar/impl/CalendarServiceDataFactoryImplTest.java
+++ b/src/test/java/org/opentripplanner/model/calendar/impl/CalendarServiceDataFactoryImplTest.java
@@ -91,7 +91,7 @@ public class CalendarServiceDataFactoryImplTest {
 
     @Test
     public void testDataGetTimeZoneForAgencyId() throws IOException {
-        assertEquals("America/New_York", data.getTimeZoneForAgencyId(AGENCY).getID());
+        assertEquals("America/New_York", data.getTimeZoneForAgencyId(new FeedScopedId(FEED_ID, AGENCY)).getID());
     }
 
     @Test
@@ -115,7 +115,7 @@ public class CalendarServiceDataFactoryImplTest {
 
     @Test
     public void testServiceGetTimeZoneForAgencyId() throws IOException {
-        TimeZone result = calendarService.getTimeZoneForAgencyId(AGENCY);
+        TimeZone result = calendarService.getTimeZoneForAgencyId(new FeedScopedId(FEED_ID, AGENCY));
         assertEquals("America/New_York", result.getID());
     }
 
@@ -156,7 +156,7 @@ public class CalendarServiceDataFactoryImplTest {
 
     private static FareAttribute createFareAttribute(Agency agency) {
         FareAttribute fa = new FareAttribute();
-        fa.setId(new FeedScopedId(agency.getId(), "FA"));
+        fa.setId(new FeedScopedId(FEED_ID, "FA"));
         return fa;
     }
 

--- a/src/test/java/org/opentripplanner/model/impl/OtpTransitServiceBuilderTest.java
+++ b/src/test/java/org/opentripplanner/model/impl/OtpTransitServiceBuilderTest.java
@@ -103,7 +103,7 @@ public class OtpTransitServiceBuilderTest {
 
     private static FareAttribute createFareAttribute(Agency agency) {
         FareAttribute fa = new FareAttribute();
-        fa.setId(new FeedScopedId(agency.getId(), "FA"));
+        fa.setId(new FeedScopedId(FEED_ID, "FA"));
         return fa;
     }
 

--- a/src/test/java/org/opentripplanner/model/impl/OtpTransitServiceImplTest.java
+++ b/src/test/java/org/opentripplanner/model/impl/OtpTransitServiceImplTest.java
@@ -60,7 +60,7 @@ public class OtpTransitServiceImplTest {
         Agency agency = first(agencies);
 
         assertEquals(1, agencies.size());
-        assertEquals("agency", agency.getId());
+        assertEquals("agency", agency.getId().getId());
         assertEquals("Fake Agency", agency.getName());
     }
 
@@ -69,7 +69,7 @@ public class OtpTransitServiceImplTest {
         Collection<FareAttribute> fareAttributes = subject.getAllFareAttributes();
 
         assertEquals(1, fareAttributes.size());
-        assertEquals("<FareAttribute agency:FA>", first(fareAttributes).toString());
+        assertEquals("<FareAttribute Z:FA>", first(fareAttributes).toString());
     }
 
     @Test
@@ -179,7 +179,7 @@ public class OtpTransitServiceImplTest {
 
     private static FareRule createFareRule() {
         FareAttribute fa = new FareAttribute();
-        fa.setId(new FeedScopedId(agency.getId(), "FA"));
+        fa.setId(new FeedScopedId(FEED_ID, "FA"));
         FareRule rule = new FareRule();
         rule.setOriginId("Zone A");
         rule.setContainsId("Zone B");

--- a/src/test/java/org/opentripplanner/netex/NetexLoaderSmokeTest.java
+++ b/src/test/java/org/opentripplanner/netex/NetexLoaderSmokeTest.java
@@ -82,7 +82,7 @@ public class NetexLoaderSmokeTest {
     private void assertAgencies(Collection<Agency> agencies) {
         assertEquals(1, agencies.size());
         Agency a = list(agencies).get(0);
-        assertEquals("RUT:Authority:RUT", a.getId());
+        assertEquals("RUT:Authority:RUT", a.getId().getId());
         assertEquals("RUT", a.getName());
         assertNull( a.getUrl());
         assertEquals("Europe/Oslo", a.getTimezone());
@@ -191,8 +191,8 @@ public class NetexLoaderSmokeTest {
     }
 
     private void assetServiceCalendar(CalendarServiceData cal) {
-        assertEquals("[RUT:Authority:RUT]", cal.getAgencyIds().toString());
-        assertEquals("Europe/Oslo", cal.getTimeZoneForAgencyId("RUT:Authority:RUT").toZoneId().toString());
+        assertEquals("[RB:RUT:Authority:RUT]", cal.getAgencyIds().toString());
+        assertEquals("Europe/Oslo", cal.getTimeZoneForAgencyId(new FeedScopedId("RB", "RUT:Authority:RUT")).toZoneId().toString());
         assertEquals(
                 "[RUT:DayType:0-105025+RUT:DayType:0-105026+RUT:DayType:6-101468, RUT:DayType:6-101468]",
                 cal.getServiceIds().stream().map(FeedScopedId::getId).sorted().collect(Collectors.toList()).toString()

--- a/src/test/java/org/opentripplanner/netex/loader/mapping/AuthorityToAgencyMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/loader/mapping/AuthorityToAgencyMapperTest.java
@@ -8,6 +8,7 @@ import org.rutebanken.netex.model.MultilingualString;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.opentripplanner.netex.loader.mapping.MappingSupport.ID_FACTORY;
 
 public class AuthorityToAgencyMapperTest {
     private static final String ID = "ID";
@@ -17,7 +18,7 @@ public class AuthorityToAgencyMapperTest {
     private static final String TIME_ZONE = "CEST";
     private static final String N_A = "N/A";
 
-    private AuthorityToAgencyMapper mapper = new AuthorityToAgencyMapper(TIME_ZONE);
+    private AuthorityToAgencyMapper mapper = new AuthorityToAgencyMapper(ID_FACTORY, TIME_ZONE);
 
     @Test public void mapAgency() {
         // Given
@@ -27,7 +28,7 @@ public class AuthorityToAgencyMapperTest {
         Agency a = mapper.mapAuthorityToAgency(authority);
 
         // Then expect
-        assertEquals(ID, a.getId());
+        assertEquals(ID, a.getId().getId());
         assertEquals(NAME, a.getName());
         assertEquals(TIME_ZONE, a.getTimezone());
         assertEquals(URL, a.getUrl());
@@ -51,7 +52,7 @@ public class AuthorityToAgencyMapperTest {
         Agency a = mapper.createDummyAgency();
 
         // Then expect
-        assertEquals("Dummy-" + a.getTimezone(), a.getId());
+        assertEquals("Dummy-" + a.getTimezone(), a.getId().getId());
         assertEquals(N_A, a.getName());
         assertEquals(TIME_ZONE, a.getTimezone());
         assertEquals(N_A, a.getUrl());

--- a/src/test/java/org/opentripplanner/netex/loader/mapping/RouteMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/loader/mapping/RouteMapperTest.java
@@ -76,7 +76,7 @@ public class RouteMapperTest {
 
         Route route = routeMapper.mapRoute(line);
 
-        assertEquals(AUTHORITY_ID, route.getAgency().getId());
+        assertEquals(AUTHORITY_ID, route.getAgency().getId().getId());
     }
 
     @Test
@@ -116,7 +116,7 @@ public class RouteMapperTest {
 
     private Agency createAgency() {
         Agency agency = new Agency();
-        agency.setId(AUTHORITY_ID);
+        agency.setId(MappingSupport.ID_FACTORY.createId(AUTHORITY_ID));
         agency.setTimezone(TIME_ZONE);
         agency.setName("Ruter");
         return agency;

--- a/src/test/java/org/opentripplanner/routing/algorithm/TestBanning.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/TestBanning.java
@@ -23,7 +23,7 @@ public class TestBanning {
         RoutingRequest routingRequest = new RoutingRequest();
 
         routingRequest.setBannedRoutes("RB__RUT:Route:1");
-        routingRequest.setBannedAgencies("RUT:Agency:2");
+        routingRequest.setBannedAgencies("RB:RUT:Agency:2");
 
         Collection<FeedScopedId> bannedRoutes =
             routingRequest.getBannedRoutes(routes);
@@ -40,7 +40,7 @@ public class TestBanning {
         RoutingRequest routingRequest = new RoutingRequest();
 
         routingRequest.setWhiteListedRoutes("RB__RUT:Route:1");
-        routingRequest.setWhiteListedAgencies("RUT:Agency:2");
+        routingRequest.setWhiteListedAgencies("RB:RUT:Agency:2");
 
         Collection<FeedScopedId> bannedRoutes =
             routingRequest.getBannedRoutes(routes);
@@ -61,9 +61,9 @@ public class TestBanning {
         route3.setLongName("");
 
         Agency agency1 = new Agency();
-        agency1.setId("RUT:Agency:1");
+        agency1.setId(new FeedScopedId("RB", "RUT:Agency:1"));
         Agency agency2 = new Agency();
-        agency2.setId("RUT:Agency:2");
+        agency2.setId(new FeedScopedId("RB", "RUT:Agency:2"));
 
         route1.setAgency(agency1);
         route2.setAgency(agency1);

--- a/src/test/java/org/opentripplanner/routing/graph/RoutingServiceTest.java
+++ b/src/test/java/org/opentripplanner/routing/graph/RoutingServiceTest.java
@@ -41,10 +41,10 @@ public class RoutingServiceTest extends GtfsTest {
         /* Agencies */
         String feedId = graph.getFeedIds().iterator().next();
         Agency agency;
-        agency = graph.index.getAgency(feedId, "azerty");
+        agency = graph.index.getAgencyForId(new FeedScopedId(feedId, "azerty"));
         assertNull(agency);
-        agency = graph.index.getAgency(feedId, "agency");
-        assertEquals(agency.getId(), "agency");
+        agency = graph.index.getAgencyForId(new FeedScopedId(feedId, "agency"));
+        assertEquals(agency.getId().toString(), feedId + ":" + "agency");
         assertEquals(agency.getName(), "Fake Agency");
 
         /* Stops */

--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/api/model/Leg.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/api/model/Leg.java
@@ -73,7 +73,7 @@ public class Leg {
     * For transit legs, the ID of the transit agency that operates the service used for this leg.
     * For non-transit legs, null.
     */
-   public String agencyId = null;
+   public FeedScopedId agencyId = null;
 
    /**
     * For transit legs, the ID of the trip.

--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/transit/SpeedTestItinerary.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/transit/SpeedTestItinerary.java
@@ -41,7 +41,7 @@ public class SpeedTestItinerary extends Itinerary {
             if (leg.isTransitLeg()) {
                 if (leg.distance > distanceLimit) {
                     //modes.add(leg.mode);
-                    agencies.add(leg.agencyId);
+                    agencies.add(leg.agencyId.getId());
                 }
             }
         }


### PR DESCRIPTION
This pull request aims to make the agency id feed scoped, similar to how all the other transit entities are. The reason for the previous behaviour is due to the OBA GTFS models, which were previously used as the internal model for all transit entities in OTP, and for which the agency id was only a string. As we have copied over the models to internal models, we have the freedom to change them. 

A [comment](https://github.com/opentripplanner/OpenTripPlanner/compare/dev-2.x...kyyticom:agency-feed-id?expand=1#diff-987550d6f2ad238a9d873772878e0634L202-L231) in the code suggest that this is a temporary hack, and should be fixed. Another reason for fixing this, is that the HSLDevcom GraphQL API has the agencies as feed scoped, and when porting over the api to a sandbox feature, we need to somehow make the agencies feed aware. Another less invasive alternative, would be just writing the feed in a separate field in the agency object.

This is a breaking change, as the api responses for the agency will now include the feed id, as they do with all the other transit entities. Similarly for input parameter for banned and preferred agencies, the feed id is now required in similar format to how it is output.

To be completed by pull request submitter:

- [x] **issue**: This issue is described in the code as a [todo](https://github.com/opentripplanner/OpenTripPlanner/compare/dev-2.x...kyyticom:agency-feed-id?expand=1#diff-987550d6f2ad238a9d873772878e0634L202-L231)
- [ ] **roadmap**: Check the [roadmap](https://github.com/orgs/opentripplanner/projects/1) for this feature or bug. If it is not already on the roadmap, PLC will discuss as part of the review process.
- [x] **tests**: Have you added relevant test coverage? Are all the tests passing on [the continuous integration service (Travis CI)](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#continuous-integration)?
- [x] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#code-style)? 
- [x] **documentation**: If you are adding a new configuration option, have you added an explanation to the [configuration documentation](docs/Configuration.md) tables and sections?
- [x] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)