### PR TITLE
Add isPartOfStation() and isPartOfSameStation(..) to StationElement a… …

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/siri/SiriFuzzyTripMatcher.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriFuzzyTripMatcher.java
@@ -156,7 +156,7 @@ public class SiriFuzzyTripMatcher {
             //SIRI-data may report other platform, but still on the same Parent-stop
             String agencyId = routingService.getFeedIds().iterator().next();
             Stop stop = routingService.getStopForId(new FeedScopedId(agencyId, lastStopPoint));
-            if (stop != null && stop.getParentStation() != null) {
+            if (stop != null && stop.isPartOfStation()) {
                 // TODO OTP2 resolve stop-station split
                 Collection<Stop> allQuays = stop.getParentStation().getChildStops();
                 for (Stop quay : allQuays) {

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
@@ -1022,19 +1022,18 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
                 boolean firstStopIsMatch = firstStop.getId().getId().equals(siriOriginRef);
                 boolean lastStopIsMatch = lastStop.getId().getId().equals(siriDestinationRef);
 
-                if (!firstStopIsMatch && firstStop.getParentStation() != null) {
+                if (!firstStopIsMatch && firstStop.isPartOfStation()) {
                     Stop otherFirstStop = routingService.getStopForId(
                             new FeedScopedId(firstStop.getId().getFeedId(), siriOriginRef)
                     );
-                    firstStopIsMatch = (otherFirstStop != null && otherFirstStop.getParentStation() != null && otherFirstStop.getParentStation().equals(firstStop.getParentStation()));
+                    firstStopIsMatch = firstStop.isPartOfSameStationAs(otherFirstStop);
                 }
 
-                if (!lastStopIsMatch && lastStop.getParentStation() != null) {
-                    Stop otherLastStop = routingService
-                        .getStopForId(
-                                new FeedScopedId(lastStop.getId().getFeedId(), siriDestinationRef)
-                        );
-                    lastStopIsMatch = (otherLastStop != null && otherLastStop.getParentStation() != null && otherLastStop.getParentStation().equals(lastStop.getParentStation()));
+                if (!lastStopIsMatch && lastStop.isPartOfStation()) {
+                    Stop otherLastStop = routingService.getStopForId(
+                            new FeedScopedId(lastStop.getId().getFeedId(), siriDestinationRef)
+                    );
+                    lastStopIsMatch = lastStop.isPartOfSameStationAs(otherLastStop);
                 }
 
                 if (firstStopIsMatch & lastStopIsMatch) {
@@ -1113,20 +1112,20 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
                 boolean firstStopIsMatch = firstStop.getId().getId().equals(journeyFirstStopId);
                 boolean lastStopIsMatch = lastStop.getId().getId().equals(journeyLastStopId);
 
-                if (!firstStopIsMatch && firstStop.getParentStation() != null) {
+                if (!firstStopIsMatch && firstStop.isPartOfStation()) {
                     Stop otherFirstStop = routingService
                         .getStopForId(
                                 new FeedScopedId(firstStop.getId().getFeedId(), journeyFirstStopId)
                         );
-                    firstStopIsMatch = (otherFirstStop != null && otherFirstStop.getParentStation() != null && otherFirstStop.getParentStation().equals(firstStop.getParentStation()));
+                    firstStopIsMatch = firstStop.isPartOfSameStationAs(otherFirstStop);
                 }
 
-                if (!lastStopIsMatch && lastStop.getParentStation() != null) {
+                if (!lastStopIsMatch && lastStop.isPartOfStation()) {
                     Stop otherLastStop = routingService
                         .getStopForId(
                                 new FeedScopedId(lastStop.getId().getFeedId(), journeyLastStopId)
                         );
-                    lastStopIsMatch = (otherLastStop != null && otherLastStop.getParentStation() != null && otherLastStop.getParentStation().equals(lastStop.getParentStation()));
+                    lastStopIsMatch = lastStop.isPartOfSameStationAs(otherLastStop);
                 }
 
                 if (firstStopIsMatch & lastStopIsMatch) {
@@ -1244,11 +1243,10 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
                        firstReportedStopIsFound = true;
                     } else {
                         String agencyId = stop.getId().getFeedId();
-                        if (stop.getParentStation() != null) {
+                        if (stop.isPartOfStation()) {
                             Stop alternativeStop = routingService
                                 .getStopForId(new FeedScopedId(agencyId, firstStopId));
-                            if (alternativeStop != null &&
-                                    stop.getParentStation().equals(alternativeStop.getParentStation())) {
+                            if (stop.isPartOfSameStationAs(alternativeStop)) {
                                 firstReportedStopIsFound = true;
                             }
                         }

--- a/src/ext/java/org/opentripplanner/ext/siri/TimetableHelper.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/TimetableHelper.java
@@ -123,11 +123,11 @@ public class TimetableHelper {
                 //Current stop is being updated
                 foundMatch = stop.getId().getId().equals(recordedCall.getStopPointRef().getValue());
 
-                if (!foundMatch && stop.getParentStation() != null) {
+                if (!foundMatch && stop.isPartOfStation()) {
                     Stop alternativeStop = graph.index.getStopForId(
                             new FeedScopedId(stop.getId().getFeedId(), recordedCall.getStopPointRef().getValue())
                     );
-                    if (alternativeStop != null && stop.getParentStation().equals(alternativeStop.getParentStation())) {
+                    if (alternativeStop != null && stop.isPartOfSameStationAs(alternativeStop)) {
                         foundMatch = true;
                         stopPatternChanged = true;
                     }
@@ -201,12 +201,12 @@ public class TimetableHelper {
                     //Current stop is being updated
                     foundMatch = stop.getId().getId().equals(estimatedCall.getStopPointRef().getValue());
 
-                    if (!foundMatch && stop.getParentStation() != null) {
+                    if (!foundMatch && stop.isPartOfStation()) {
                         Stop alternativeStop = graph.index
                             .getStopForId(
                                     new FeedScopedId(stop.getId().getFeedId(), estimatedCall.getStopPointRef().getValue())
                             );
-                        if (alternativeStop != null && stop.getParentStation().equals(alternativeStop.getParentStation())) {
+                        if (alternativeStop != null && stop.isPartOfSameStationAs(alternativeStop)) {
                             foundMatch = true;
                             stopPatternChanged = true;
                         }
@@ -380,10 +380,10 @@ public class TimetableHelper {
                     //Current stop is being updated
                     boolean stopsMatchById = stop.getId().getId().equals(recordedCall.getStopPointRef().getValue());
 
-                    if (!stopsMatchById && stop.getParentStation() != null) {
+                    if (!stopsMatchById && stop.isPartOfStation()) {
                         Stop alternativeStop = routingService
                             .getStopForId(new FeedScopedId(stop.getId().getFeedId(), recordedCall.getStopPointRef().getValue()));
-                        if (alternativeStop != null && stop.getParentStation().equals(alternativeStop.getParentStation())) {
+                        if (alternativeStop != null && stop.isPartOfSameStationAs(alternativeStop)) {
                             stopsMatchById = true;
                             stop = alternativeStop;
                         }
@@ -401,10 +401,10 @@ public class TimetableHelper {
                     //Current stop is being updated
                     boolean stopsMatchById = stop.getId().getId().equals(estimatedCall.getStopPointRef().getValue());
 
-                    if (!stopsMatchById && stop.getParentStation() != null) {
+                    if (!stopsMatchById && stop.isPartOfStation()) {
                         Stop alternativeStop = routingService
                             .getStopForId(new FeedScopedId(stop.getId().getFeedId(), estimatedCall.getStopPointRef().getValue()));
-                        if (alternativeStop != null && stop.getParentStation().equals(alternativeStop.getParentStation())) {
+                        if (alternativeStop != null && stop.isPartOfSameStationAs(alternativeStop)) {
                             stopsMatchById = true;
                             stop = alternativeStop;
                         }
@@ -488,10 +488,10 @@ public class TimetableHelper {
                     //Current stop is being updated
                     boolean stopsMatchById = stop.getId().getId().equals(estimatedCall.getStopPointRef().getValue());
 
-                    if (!stopsMatchById && stop.getParentStation() != null) {
+                    if (!stopsMatchById && stop.isPartOfStation()) {
                         Stop alternativeStop = routingService
                             .getStopForId(new FeedScopedId(stop.getId().getFeedId(), estimatedCall.getStopPointRef().getValue()));
-                        if (alternativeStop != null && stop.getParentStation().equals(alternativeStop.getParentStation())) {
+                        if (alternativeStop != null && stop.isPartOfSameStationAs(alternativeStop)) {
                             stopsMatchById = true;
                             stopTime.setStop(alternativeStop);
                         }
@@ -623,11 +623,11 @@ public class TimetableHelper {
 
                         matchFound = stop.getId().getId().equals(monitoredCall.getStopPointRef().getValue());
 
-                        if (!matchFound && stop.getParentStation() != null) {
+                        if (!matchFound && stop.isPartOfStation()) {
                             FeedScopedId alternativeId = new FeedScopedId(stop.getId().getFeedId(), monitoredCall.getStopPointRef().getValue());
                             Stop alternativeStop = graph.index.getStopForId(alternativeId);
-                            if (alternativeStop != null && alternativeStop.getParentStation() != null) {
-                                matchFound = stop.getParentStation().equals(alternativeStop.getParentStation());
+                            if (alternativeStop != null && alternativeStop.isPartOfStation()) {
+                                matchFound = stop.isPartOfSameStationAs(alternativeStop);
                             }
                         }
 

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/TripTimeShortHelper.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/TripTimeShortHelper.java
@@ -137,7 +137,7 @@ public class TripTimeShortHelper {
         if (!foundMatch) {
             //Check parentStops
             Stop stop = routingService.getStopForId(quayId);
-            if (stop != null && stop.getParentStation() != null) {
+            if (stop != null && stop.isPartOfStation()) {
                 Station parentStation = stop.getParentStation();
                 for (Stop childStop : parentStation.getChildStops()) {
                     if (childStop.getId().equals(candidate)) {

--- a/src/main/java/org/opentripplanner/api/mapping/StopMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/StopMapper.java
@@ -2,6 +2,7 @@ package org.opentripplanner.api.mapping;
 
 import org.opentripplanner.api.model.ApiStop;
 import org.opentripplanner.api.model.ApiStopShort;
+import org.opentripplanner.model.StationElement;
 import org.opentripplanner.model.Stop;
 
 import java.util.Collection;
@@ -34,7 +35,7 @@ public class StopMapper {
             api.url = domain.getUrl();
             api.locationType = 0;
             api.stationId = FeedScopedIdMapper.mapIdToApi(domain.getParentStation());
-            api.parentStation = domain.getParentStation().getId().getId();
+            api.parentStation = mapToParentStationOldId(domain);
             //api.stopTimezone = stop.getTimezone();
             api.wheelchairBoarding = WheelchairBoardingMapper.mapToApi(
                     domain.getWheelchairBoarding()
@@ -57,8 +58,7 @@ public class StopMapper {
         api.stationId = FeedScopedIdMapper.mapIdToApi(domain.getParentStation());
         // parentStation may be missing on the stop returning null.
         // TODO harmonize these names, maybe use "station" everywhere
-        api.cluster = domain.getParentStation() == null
-                ? null : domain.getParentStation().getId().getId();
+        api.cluster = mapToParentStationOldId(domain);
 
         return api;
     }
@@ -78,4 +78,11 @@ public class StopMapper {
         return domain.stream().map(StopMapper::mapToApiShort).collect(Collectors.toList());
     }
 
+    /**
+     * Get the parent station id (without feed-scope) for the given station element,
+     * this method should only be used to fetch old ids for beeing backward compatible.
+     */
+    private static String mapToParentStationOldId(StationElement stop) {
+        return stop.isPartOfStation() ? stop.getParentStation().getId().getId() : null;
+    }
 }

--- a/src/main/java/org/opentripplanner/model/StationElement.java
+++ b/src/main/java/org/opentripplanner/model/StationElement.java
@@ -120,6 +120,19 @@ public abstract class StationElement extends TransitEntity<FeedScopedId>  {
     return parentStation;
   }
 
+  /** Return {@code true} if this stop (element) is part of a station, have a parent station. */
+  public boolean isPartOfStation() {
+    return parentStation != null;
+  }
+
+  /**
+   * Return {@code true} if this stop (element) has the same parent station as the other stop
+   * (element).
+   */
+  public boolean isPartOfSameStationAs(StationElement other) {
+    return isPartOfStation() && parentStation.equals(other.parentStation);
+  }
+
   public void setParentStation(Station parentStation) {
     this.parentStation = parentStation;
   }

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/AlertToLegMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/AlertToLegMapper.java
@@ -124,7 +124,7 @@ public class AlertToLegMapper {
             if (alertsForStopAndRoute == null) {
                 alertsForStopAndRoute = new HashSet<>();
             }
-            if (stop.getParentStation() != null) {
+            if (stop.isPartOfStation()) {
                 //Also check parent
                 Collection<AlertPatch> alerts = graph.getSiriAlertPatchService().getStopAndRoutePatches(stop.getParentStation().getId(), routeId);
                 if (alerts != null) {
@@ -162,7 +162,7 @@ public class AlertToLegMapper {
             if (alertsForStopAndTrip == null) {
                 alertsForStopAndTrip = new HashSet<>();
             }
-            if  (stop.getParentStation() != null) {
+            if  (stop.isPartOfStation()) {
                 // Also check parent
                 Collection<AlertPatch> alerts = graph.getSiriAlertPatchService().getStopAndTripPatches(stop.getParentStation().getId(), tripId);
                 if (alerts != null) {
@@ -198,7 +198,7 @@ public class AlertToLegMapper {
                 alertsForStop = new HashSet<>();
             }
 
-            if  (stop.getParentStation() != null) {
+            if  (stop.isPartOfStation()) {
                 // Also check parent
                 Collection<AlertPatch> parentStopAlerts = graph.getSiriAlertPatchService().getStopPatches(stop.getParentStation().getId());
                 if (parentStopAlerts != null) {

--- a/src/main/java/org/opentripplanner/routing/impl/AlertPatchServiceImpl.java
+++ b/src/main/java/org/opentripplanner/routing/impl/AlertPatchServiceImpl.java
@@ -63,7 +63,7 @@ public class AlertPatchServiceImpl implements AlertPatchService {
                     
                     // TODO - SIRI: Add alerts from parent- and multimodal-stops
                     /*
-                    if ( quay.getParentStation() != null) {
+                    if ( quay.isPartOfStation()) {
                         // Add alerts for parent-station
                         result.addAll(patchesByStop.getOrDefault(quay.getParentStationFeedScopedId(), Collections.emptySet()));
                     }


### PR DESCRIPTION
- Add isPartOfStation() and isPartOfSameStation(..) to StationElement and invoke where appropriate. This improve the flow of the code reading. (This change was done using pure  refactoring techniques without manual edits).
- Add safe mapping function for the old parentStationRef in REST API. The new mapping contain a small bug-fix.

**Description of the bug fixed**
If a _detailed_ Stop is requested and it did not have a parent station set the previous version of OTP2 would throw a NPE, and return 500 on the API.

To be completed by pull request submitter:

- [ ] **issue**: This is a pure refactor with a small bug fix.
- [ ] **roadmap**: NO
- [ ] **tests**: NO
- [x] **formatting**: Yes
- [ ] **documentation**: NO
- [ ] **changelog**: No

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)