### PR TITLE
Authority id fix

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelIndexGraphQLSchema.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelIndexGraphQLSchema.java
@@ -2405,7 +2405,7 @@ public class TransmodelIndexGraphQLSchema {
                         .name("id")
                         .description("Authority id")
                         .type(new GraphQLNonNull(Scalars.GraphQLID))
-                        .dataFetcher(environment -> ((Agency) environment.getSource()).getId())
+                        .dataFetcher(environment -> ((Agency) environment.getSource()).getId().getId())
                         .build())
                 .field(GraphQLFieldDefinition.newFieldDefinition()
                         .name("name")


### PR DESCRIPTION
This is a small fix to the transmodel sandbox API that was made necessary by #3035. The API expects the Id part of the FeedScopeId.