### PR TITLE
Allow multiple time-constrained accesses and egresses for each stop

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/RoutingWorker.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/RoutingWorker.java
@@ -146,9 +146,7 @@ public class RoutingWorker {
         RaptorPathToItineraryMapper itineraryMapper = new RaptorPathToItineraryMapper(
                 transitLayer,
                 requestTransitDataProvider.getStartOfTime(),
-                request,
-                accessTransfers,
-                egressTransfers
+                request
         );
         FareService fareService = request.getRoutingContext().graph.getService(FareService.class);
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/AccessEgress.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/AccessEgress.java
@@ -29,6 +29,16 @@ public class AccessEgress implements RaptorTransfer {
   }
 
   @Override
+  public int earliestDepartureTime(int requestedDepartureTime) {
+    return requestedDepartureTime;
+  }
+
+  @Override
+  public int latestArrivalTime(int requestedArrivalTime) {
+    return requestedArrivalTime;
+  }
+
+  @Override
   public int durationInSeconds() {
     return durationInSeconds;
   }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/request/TransferWithDuration.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/request/TransferWithDuration.java
@@ -20,6 +20,16 @@ public class TransferWithDuration implements RaptorTransfer {
     }
 
     @Override
+    public int earliestDepartureTime(int requestedDepartureTime) {
+        return requestedDepartureTime;
+    }
+
+    @Override
+    public int latestArrivalTime(int requestedArrivalTime) {
+        return requestedArrivalTime;
+    }
+
+    @Override
     public int durationInSeconds() {
         return this.durationSeconds;
     }

--- a/src/main/java/org/opentripplanner/transit/raptor/README.md
+++ b/src/main/java/org/opentripplanner/transit/raptor/README.md
@@ -119,11 +119,11 @@ stops/routes that can be used as a filter for the _McRR_. _RR_ is super fast, mo
 than McRR with 4 criteria.
 
 ## Understanding the search (range-raptor algorithm implementation)
-The `RangeRaptorWorker` and the `TransitRoutingStrategy` together implement the _range-raptor_ 
-algorithm. There are 3 `TransitRoutingStrategy` implementations:
+The `RangeRaptorWorker` and the `RoutingStrategy` together implement the _range-raptor_ 
+algorithm. There are 3 `RoutingStrategy` implementations:
 1. The `StdTransitWorker` is the standard Range Raptor implementation. Support both _forward_ and 
 _reverse_ search.
-1. The `NoWaitTransitWorker` is the same as the standard, but it eliminate _wait-time_. It support 
+1. The `NoWaitTransitWorker` is the same as the standard, but it eliminates _wait-time_. It support 
 both _forward_ and _reverse_ search. It is very fast, and can be used to compute various 
 heuristics, like _minimum-number-of-transfers_, _minimum-travel-time_ and 
 _earliest-possible-arrival-time_.

--- a/src/main/java/org/opentripplanner/transit/raptor/api/path/AccessPathLeg.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/path/AccessPathLeg.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.transit.raptor.api.path;
 
+import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
 
 import java.util.Objects;
@@ -11,13 +12,15 @@ import java.util.Objects;
  * @param <T> The TripSchedule type defined by the user of the raptor API.
  */
 public final class AccessPathLeg<T extends RaptorTripSchedule> implements PathLeg<T> {
+    private final RaptorTransfer access;
     private final int fromTime;
     private final int toStop;
     private final int toTime;
     private final TransitPathLeg<T> next;
 
 
-    public AccessPathLeg(int toStop, int fromTime, int toTime, TransitPathLeg<T> next) {
+    public AccessPathLeg(RaptorTransfer access, int toStop, int fromTime, int toTime, TransitPathLeg<T> next) {
+        this.access = access;
         this.fromTime = fromTime;
         this.toStop = toStop;
         this.toTime = toTime;
@@ -39,6 +42,10 @@ public final class AccessPathLeg<T extends RaptorTripSchedule> implements PathLe
     @Override
     public int toTime() {
         return toTime;
+    }
+
+    public RaptorTransfer access() {
+        return access;
     }
 
     @Override

--- a/src/main/java/org/opentripplanner/transit/raptor/api/path/EgressPathLeg.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/path/EgressPathLeg.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.transit.raptor.api.path;
 
+import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
 
 import java.util.Objects;
@@ -11,11 +12,13 @@ import java.util.Objects;
  * @param <T> The TripSchedule type defined by the user of the raptor API.
  */
 public final class EgressPathLeg<T extends RaptorTripSchedule> implements PathLeg<T> {
+    private final RaptorTransfer egress;
     private final int fromStop;
     private final int fromTime;
     private final int toTime;
 
-    public EgressPathLeg(int fromStop, int fromTime, int toTime) {
+    public EgressPathLeg(RaptorTransfer egress, int fromStop, int fromTime, int toTime) {
+        this.egress = egress;
         this.fromStop = fromStop;
         this.fromTime = fromTime;
         this.toTime = toTime;
@@ -36,6 +39,10 @@ public final class EgressPathLeg<T extends RaptorTripSchedule> implements PathLe
     @Override
     public final int toTime() {
         return toTime;
+    }
+
+    public RaptorTransfer egress() {
+        return egress;
     }
 
     /**

--- a/src/main/java/org/opentripplanner/transit/raptor/api/transit/CostCalculator.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/transit/CostCalculator.java
@@ -18,6 +18,11 @@ public interface CostCalculator {
     int walkCost(int walkTimeInSeconds);
 
     /**
+     * Calculate the value, when waiting between the last transit and egress legs
+     */
+    int waitCost(int waitTimeInSeconds);
+
+    /**
      * Used for estimating the remaining value for a criteria at a given stop arrival. The
      * calculated value should be a an optimistic estimate for the heuristics to work properly. So,
      * to calculate the generalized cost for given the {@code minTravelTime} and {@code

--- a/src/main/java/org/opentripplanner/transit/raptor/api/transit/RaptorTransfer.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/transit/RaptorTransfer.java
@@ -20,6 +20,23 @@ public interface RaptorTransfer {
     int stop();
 
     /**
+     * Returns the earliest possible departure time for the leg. Used Eg. in flex routing and TNC
+     * when the access leg can't start immediately, but have to wait for a vehicle arriving. Also
+     * DRT systems or bike shares can have operation time limitations.
+     *
+     * Returns -1 if transfer is not possible after the requested departure time
+     */
+    int earliestDepartureTime(int requestedDepartureTime);
+
+    /**
+     * Returns the latest possible arrival time for the leg. Used in DRT systems or bike shares
+     * where they can have operation time limitations.
+     *
+     * Returns -1 if transfer is not possible before the requested arrival time
+     */
+    int latestArrivalTime(int requestedArrivalTime);
+
+    /**
      * The time duration to walk or travel the leg in seconds. This is not the entire duration from the journey origin,
      * but just:
      * <ul>

--- a/src/main/java/org/opentripplanner/transit/raptor/api/view/ArrivalView.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/view/ArrivalView.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.transit.raptor.api.view;
 
 
+import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
 import org.opentripplanner.transit.raptor.util.TimeUtils;
 
@@ -39,6 +40,13 @@ public interface ArrivalView<T extends RaptorTripSchedule> {
      * @throws UnsupportedOperationException if arrived at destination.
      */
     int stop();
+
+    /**
+     * The access or egress connecting this leg to the start or end location of the search.
+     *
+     * @throws UnsupportedOperationException if did not arrive via street network.
+     */
+    RaptorTransfer accessEgress();
 
     /**
      * The Range Raptor ROUND this stop is reached. Note! the destination

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/RangeRaptorWorker.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/RangeRaptorWorker.java
@@ -51,7 +51,7 @@ import java.util.Iterator;
 public final class RangeRaptorWorker<T extends RaptorTripSchedule, S extends WorkerState<T>> implements Worker<T> {
 
 
-    private final TransitRoutingStrategy<T> transitWorker;
+    private final RoutingStrategy<T> transitWorker;
 
     /**
      * The RangeRaptor state - we delegate keeping track of state to the state object,
@@ -90,7 +90,7 @@ public final class RangeRaptorWorker<T extends RaptorTripSchedule, S extends Wor
 
     public RangeRaptorWorker(
             S state,
-            TransitRoutingStrategy<T> transitWorker,
+            RoutingStrategy<T> transitWorker,
             RaptorTransitDataProvider<T> transitData,
             Collection<RaptorTransfer> accessLegs,
             RoundProvider roundProvider,
@@ -177,7 +177,7 @@ public final class RangeRaptorWorker<T extends RaptorTripSchedule, S extends Wor
      */
     private void doTransfersForAccessLegs(int iterationDepartureTime) {
         for (RaptorTransfer it : accessLegs) {
-            state.setInitialTimeForIteration(it, iterationDepartureTime);
+            transitWorker.setInitialTimeForIteration(it, iterationDepartureTime);
         }
     }
 

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/RoutingStrategy.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/RoutingStrategy.java
@@ -1,20 +1,20 @@
 package org.opentripplanner.transit.raptor.rangeraptor;
 
+import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripPattern;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
 import org.opentripplanner.transit.raptor.rangeraptor.transit.TripScheduleSearch;
 
 
 /**
- * Provides alternative implementations of some transit-specific logic within the {@link
- * RangeRaptorWorker}.
+ * Provides alternative implementations of some logic within the {@link RangeRaptorWorker}.
  *
  * @param <T> The TripSchedule type defined by the user of the raptor API.
  */
-public interface TransitRoutingStrategy<T extends RaptorTripSchedule> {
+public interface RoutingStrategy<T extends RaptorTripSchedule> {
 
     /**
-     * Prepare the {@link TransitRoutingStrategy} to route using the given pattern and tripSearch.
+     * Prepare the {@link RoutingStrategy} to route using the given pattern and tripSearch.
      */
     void prepareForTransitWith(RaptorTripPattern pattern, TripScheduleSearch<T> tripSearch);
 
@@ -29,4 +29,10 @@ public interface TransitRoutingStrategy<T extends RaptorTripSchedule> {
      *                              #prepareForTransitWith(RaptorTripPattern, TripScheduleSearch)}
      */
     void routeTransitAtStop(final int stopPositionInPattern);
+
+    /**
+     * Sets the access times for the departure stops. This method is called for each possible access
+     * leg.
+     */
+    void setInitialTimeForIteration(RaptorTransfer it, int iterationDepartureTime);
 }

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/configure/RaptorConfig.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/configure/RaptorConfig.java
@@ -7,7 +7,7 @@ import org.opentripplanner.transit.raptor.api.transit.RaptorTransitDataProvider;
 import org.opentripplanner.transit.raptor.api.view.Heuristics;
 import org.opentripplanner.transit.raptor.api.view.Worker;
 import org.opentripplanner.transit.raptor.rangeraptor.RangeRaptorWorker;
-import org.opentripplanner.transit.raptor.rangeraptor.TransitRoutingStrategy;
+import org.opentripplanner.transit.raptor.rangeraptor.RoutingStrategy;
 import org.opentripplanner.transit.raptor.rangeraptor.WorkerState;
 import org.opentripplanner.transit.raptor.rangeraptor.multicriteria.configure.McRangeRaptorConfig;
 import org.opentripplanner.transit.raptor.rangeraptor.standard.configure.StdRangeRaptorConfig;
@@ -87,11 +87,11 @@ public class RaptorConfig<T extends RaptorTripSchedule> {
     private Worker<T> createWorker(
             SearchContext<T> ctx,
             WorkerState<T> workerState,
-            TransitRoutingStrategy<T> transitRoutingStrategy
+            RoutingStrategy<T> routingStrategy
     ) {
         return new RangeRaptorWorker<>(
                 workerState,
-                transitRoutingStrategy,
+                routingStrategy,
                 ctx.transit(),
                 ctx.accessLegs(),
                 ctx.roundProvider(),

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/CalculateTransferToDestination.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/CalculateTransferToDestination.java
@@ -8,6 +8,8 @@ import org.opentripplanner.transit.raptor.rangeraptor.path.DestinationArrivalPat
 import org.opentripplanner.transit.raptor.api.transit.CostCalculator;
 import org.opentripplanner.transit.raptor.util.paretoset.ParetoSetEventListener;
 
+import java.util.List;
+
 /**
  * This class listen to pareto set egress stop arrivals and on accepted
  * transit arrivals make the transfer to the destination.
@@ -17,16 +19,16 @@ import org.opentripplanner.transit.raptor.util.paretoset.ParetoSetEventListener;
 public class CalculateTransferToDestination<T extends RaptorTripSchedule>
         implements ParetoSetEventListener<ArrivalView<T>> {
 
-    private final RaptorTransfer egressLeg;
+    private final List<RaptorTransfer> egressLegs;
     private final DestinationArrivalPaths<T> destinationArrivals;
     private final CostCalculator costCalculator;
 
     CalculateTransferToDestination(
-            RaptorTransfer egressLeg,
+            List<RaptorTransfer> egressLegs,
             DestinationArrivalPaths<T> destinationArrivals,
             CostCalculator costCalculator
     ) {
-        this.egressLeg = egressLeg;
+        this.egressLegs = egressLegs;
         this.destinationArrivals = destinationArrivals;
         this.costCalculator = costCalculator;
     }
@@ -42,11 +44,13 @@ public class CalculateTransferToDestination<T extends RaptorTripSchedule>
     public void notifyElementAccepted(ArrivalView<T> newElement) {
         if(newElement instanceof TransitStopArrival) {
             TransitStopArrival<T> transitStopArrival = (TransitStopArrival<T>) newElement;
-            destinationArrivals.add(
+            for (RaptorTransfer egressLeg : egressLegs) {
+                destinationArrivals.add(
                     transitStopArrival,
                     egressLeg,
                     costCalculator.walkCost(egressLeg.durationInSeconds())
-            );
+                );
+            }
         }
     }
 }

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/McRangeRaptorWorkerState.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/McRangeRaptorWorkerState.java
@@ -75,13 +75,7 @@ final public class McRangeRaptorWorkerState<T extends RaptorTripSchedule> implem
     }
 
     @Override
-    public void setInitialTimeForIteration(RaptorTransfer accessLeg, int iterationDepartureTime) {
-        // Earliest possible departure time from the origin using this Access.
-        int departureTime = accessLeg.earliestDepartureTime(iterationDepartureTime);
-
-        // This access is not available after the iteration departure time
-        if (departureTime == -1) return;
-
+    public void setInitialTimeForIteration(RaptorTransfer accessLeg, int departureTime) {
         addStopArrival(
                 new AccessStopArrival<>(
                         accessLeg,

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/McRangeRaptorWorkerState.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/McRangeRaptorWorkerState.java
@@ -78,6 +78,7 @@ final public class McRangeRaptorWorkerState<T extends RaptorTripSchedule> implem
     public void setInitialTimeForIteration(RaptorTransfer accessLeg, int iterationDepartureTime) {
         addStopArrival(
                 new AccessStopArrival<>(
+                        accessLeg,
                         accessLeg.stop(),
                         iterationDepartureTime,
                         accessLeg.durationInSeconds(),

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/McRangeRaptorWorkerState.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/McRangeRaptorWorkerState.java
@@ -76,11 +76,17 @@ final public class McRangeRaptorWorkerState<T extends RaptorTripSchedule> implem
 
     @Override
     public void setInitialTimeForIteration(RaptorTransfer accessLeg, int iterationDepartureTime) {
+        // Earliest possible departure time from the origin using this Access.
+        int departureTime = accessLeg.earliestDepartureTime(iterationDepartureTime);
+
+        // This access is not available after the iteration departure time
+        if (departureTime == -1) return;
+
         addStopArrival(
                 new AccessStopArrival<>(
                         accessLeg,
                         accessLeg.stop(),
-                        iterationDepartureTime,
+                        departureTime,
                         accessLeg.durationInSeconds(),
                         costCalculator.walkCost(accessLeg.durationInSeconds()),
                         transitCalculator

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/McTransitWorker.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/McTransitWorker.java
@@ -1,10 +1,11 @@
 package org.opentripplanner.transit.raptor.rangeraptor.multicriteria;
 
 import org.opentripplanner.transit.raptor.api.transit.IntIterator;
+import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
 import org.opentripplanner.transit.raptor.rangeraptor.SlackProvider;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripPattern;
-import org.opentripplanner.transit.raptor.rangeraptor.TransitRoutingStrategy;
+import org.opentripplanner.transit.raptor.rangeraptor.RoutingStrategy;
 import org.opentripplanner.transit.raptor.rangeraptor.multicriteria.arrivals.AbstractStopArrival;
 import org.opentripplanner.transit.raptor.rangeraptor.transit.TransitCalculator;
 import org.opentripplanner.transit.raptor.rangeraptor.transit.TripScheduleSearch;
@@ -16,7 +17,7 @@ import org.opentripplanner.transit.raptor.rangeraptor.transit.TripScheduleSearch
  *
  * @param <T> The TripSchedule type defined by the user of the raptor API.
  */
-public final class McTransitWorker<T extends RaptorTripSchedule> implements TransitRoutingStrategy<T> {
+public final class McTransitWorker<T extends RaptorTripSchedule> implements RoutingStrategy<T> {
 
     private final McRangeRaptorWorkerState<T> state;
     private final TransitCalculator calculator;
@@ -83,5 +84,17 @@ public final class McTransitWorker<T extends RaptorTripSchedule> implements Tran
                 }
             }
         }
+    }
+
+    @Override
+    public void setInitialTimeForIteration(RaptorTransfer it, int iterationDepartureTime) {
+        // Earliest possible departure time from the origin, or latest possible arrival time at the
+        // destination if searching backwards, using this AccessEgress.
+        int departureTime = calculator.departureTime(it, iterationDepartureTime);
+
+        // This access is not available after the iteration departure time
+        if (departureTime == -1) return;
+
+        state.setInitialTimeForIteration(it, departureTime);
     }
 }

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/StopArrivalParetoSet.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/StopArrivalParetoSet.java
@@ -11,6 +11,9 @@ import org.opentripplanner.transit.raptor.util.paretoset.ParetoSetEventListener;
 import org.opentripplanner.transit.raptor.util.paretoset.ParetoSetEventListenerComposite;
 import org.opentripplanner.transit.raptor.util.paretoset.ParetoSetWithMarker;
 
+import java.util.List;
+import java.util.Map;
+
 /**
  * A pareto optimal set of stop arrivals for a given stop.
  *
@@ -41,7 +44,7 @@ class StopArrivalParetoSet<T extends RaptorTripSchedule> extends ParetoSetWithMa
      * new destination arrivals for each accepted egress stop arrival.
      */
     static <T extends RaptorTripSchedule> StopArrivalParetoSet<T> createEgressStopArrivalSet(
-            RaptorTransfer egressLeg,
+            Map.Entry<Integer, List<RaptorTransfer>> egressLegs,
             CostCalculator costCalculator,
             DestinationArrivalPaths<T> destinationArrivals,
             DebugHandlerFactory<T> debugHandlerFactory
@@ -49,8 +52,8 @@ class StopArrivalParetoSet<T extends RaptorTripSchedule> extends ParetoSetWithMa
         ParetoSetEventListener<ArrivalView<T>> listener;
         ParetoSetEventListener<ArrivalView<T>> debugListener;
 
-        listener = new CalculateTransferToDestination<>(egressLeg, destinationArrivals, costCalculator);
-        debugListener = debugHandlerFactory.paretoSetStopArrivalListener(egressLeg.stop());
+        listener = new CalculateTransferToDestination<>(egressLegs.getValue(), destinationArrivals, costCalculator);
+        debugListener = debugHandlerFactory.paretoSetStopArrivalListener(egressLegs.getKey());
 
         if(debugListener != null) {
             listener = new ParetoSetEventListenerComposite<>(debugListener, listener);

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/arrivals/AccessStopArrival.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/arrivals/AccessStopArrival.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.transit.raptor.rangeraptor.multicriteria.arrivals;
 
 
+import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
 import org.opentripplanner.transit.raptor.rangeraptor.transit.TransitCalculator;
 
@@ -13,8 +14,16 @@ import org.opentripplanner.transit.raptor.rangeraptor.transit.TransitCalculator;
 public final class AccessStopArrival<T extends RaptorTripSchedule> extends AbstractStopArrival<T> {
     private final int accessDurationInSeconds;
     private final TransitCalculator calculator;
+    private final RaptorTransfer access;
 
-    public AccessStopArrival(int stop, int departureTime, int accessDurationInSeconds, int cost, TransitCalculator calculator) {
+    public AccessStopArrival(
+        RaptorTransfer access,
+        int stop,
+        int departureTime,
+        int accessDurationInSeconds,
+        int cost,
+        TransitCalculator calculator
+    ) {
         super(
                 stop,
                 departureTime,
@@ -22,8 +31,14 @@ public final class AccessStopArrival<T extends RaptorTripSchedule> extends Abstr
                 accessDurationInSeconds,
                 cost
         );
+        this.access = access;
         this.calculator = calculator;
         this.accessDurationInSeconds = accessDurationInSeconds;
+    }
+
+    @Override
+    public RaptorTransfer accessEgress() {
+        return access;
     }
 
     public boolean arrivedByAccessLeg() {

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/arrivals/TransferStopArrival.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/arrivals/TransferStopArrival.java
@@ -26,6 +26,11 @@ public final class TransferStopArrival<T extends RaptorTripSchedule> extends Abs
     }
 
     @Override
+    public RaptorTransfer accessEgress() {
+        throw new UnsupportedOperationException("No accessEgress for transfer stop arrival");
+    }
+
+    @Override
     public boolean arrivedByTransfer() {
         return true;
     }

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/arrivals/TransitStopArrival.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/arrivals/TransitStopArrival.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.transit.raptor.rangeraptor.multicriteria.arrivals;
 
 
+import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
 
 /**
@@ -20,6 +21,11 @@ public final class TransitStopArrival<T extends RaptorTripSchedule> extends Abst
                 additionalCost
         );
         this.trip = trip;
+    }
+
+    @Override
+    public RaptorTransfer accessEgress() {
+        throw new UnsupportedOperationException("No accessEgress for transit stop arrival");
     }
 
     @Override

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/configure/McRangeRaptorConfig.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/configure/McRangeRaptorConfig.java
@@ -3,7 +3,7 @@ package org.opentripplanner.transit.raptor.rangeraptor.multicriteria.configure;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
 import org.opentripplanner.transit.raptor.api.view.Heuristics;
 import org.opentripplanner.transit.raptor.api.view.Worker;
-import org.opentripplanner.transit.raptor.rangeraptor.TransitRoutingStrategy;
+import org.opentripplanner.transit.raptor.rangeraptor.RoutingStrategy;
 import org.opentripplanner.transit.raptor.rangeraptor.WorkerState;
 import org.opentripplanner.transit.raptor.rangeraptor.multicriteria.McRangeRaptorWorkerState;
 import org.opentripplanner.transit.raptor.rangeraptor.multicriteria.McTransitWorker;
@@ -37,7 +37,7 @@ public class McRangeRaptorConfig<T extends RaptorTripSchedule> {
      */
     public Worker<T> createWorker(
             Heuristics heuristics,
-            BiFunction<WorkerState<T>, TransitRoutingStrategy<T>, Worker<T>> createWorker
+            BiFunction<WorkerState<T>, RoutingStrategy<T>, Worker<T>> createWorker
     ) {
         McRangeRaptorWorkerState<T> state = createState(heuristics);
         return createWorker.apply(state, createTransitWorkerStrategy(state));
@@ -46,7 +46,7 @@ public class McRangeRaptorConfig<T extends RaptorTripSchedule> {
 
     /* private factory methods */
 
-    private TransitRoutingStrategy<T> createTransitWorkerStrategy(McRangeRaptorWorkerState<T> state) {
+    private RoutingStrategy<T> createTransitWorkerStrategy(McRangeRaptorWorkerState<T> state) {
         return new McTransitWorker<>(
                 state,
                 context.slackProvider(),

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/path/DestinationArrival.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/path/DestinationArrival.java
@@ -35,10 +35,10 @@ class DestinationArrival<T extends RaptorTripSchedule> implements ArrivalView<T>
     private final int cost;
 
 
-    DestinationArrival(RaptorTransfer egress, ArrivalView<T> previous, int arrivalTime, int additionalCost) {
+    DestinationArrival(RaptorTransfer egress, ArrivalView<T> previous, int departureTime, int arrivalTime, int additionalCost) {
         this.previous = previous;
         this.egress = egress;
-        this.departureTime = previous.arrivalTime();
+        this.departureTime = departureTime;
         this.arrivalTime = arrivalTime;
         this.numberOfTransfers = previous.round() - 1;
         this.cost = previous.cost() + additionalCost;

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/path/DestinationArrival.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/path/DestinationArrival.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.transit.raptor.rangeraptor.path;
 
+import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
 import org.opentripplanner.transit.raptor.api.view.ArrivalView;
 
@@ -27,14 +28,16 @@ import org.opentripplanner.transit.raptor.api.view.ArrivalView;
 class DestinationArrival<T extends RaptorTripSchedule> implements ArrivalView<T> {
 
     private final ArrivalView<T> previous;
+    private final RaptorTransfer egress;
     private final int departureTime;
     private final int arrivalTime;
     private final int numberOfTransfers;
     private final int cost;
 
 
-    DestinationArrival(ArrivalView<T> previous, int arrivalTime, int additionalCost) {
+    DestinationArrival(RaptorTransfer egress, ArrivalView<T> previous, int arrivalTime, int additionalCost) {
         this.previous = previous;
+        this.egress = egress;
         this.departureTime = previous.arrivalTime();
         this.arrivalTime = arrivalTime;
         this.numberOfTransfers = previous.round() - 1;
@@ -48,6 +51,11 @@ class DestinationArrival<T extends RaptorTripSchedule> implements ArrivalView<T>
     @Override
     public int stop() {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RaptorTransfer accessEgress() {
+        return egress;
     }
 
     @Override

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/path/DestinationArrivalPaths.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/path/DestinationArrivalPaths.java
@@ -52,7 +52,7 @@ public class DestinationArrivalPaths<T extends RaptorTripSchedule> {
 
         int arrivalTime = calculator.plusDuration(egressStopArrival.arrivalTime(), egressLeg.durationInSeconds());
 
-        DestinationArrival<T> destArrival = new DestinationArrival<>(egressStopArrival, arrivalTime, additionalCost);
+        DestinationArrival<T> destArrival = new DestinationArrival<>(egressLeg, egressStopArrival, arrivalTime, additionalCost);
 
         if (calculator.exceedsTimeLimit(arrivalTime)) {
             debugRejectByTimeLimitOptimization(destArrival);

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/path/DestinationArrivalPaths.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/path/DestinationArrivalPaths.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.transit.raptor.rangeraptor.path;
 
 import org.opentripplanner.transit.raptor.api.path.Path;
+import org.opentripplanner.transit.raptor.api.transit.CostCalculator;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
 import org.opentripplanner.transit.raptor.api.view.ArrivalView;
@@ -29,32 +30,46 @@ import java.util.Collection;
  */
 public class DestinationArrivalPaths<T extends RaptorTripSchedule> {
     private final ParetoSet<Path<T>> paths;
-    private final TransitCalculator calculator;
+    private final TransitCalculator transitCalculator;
+    private final CostCalculator costCalculator;
     private final PathMapper<T> pathMapper;
     private final DebugHandler<ArrivalView<T>> debugHandler;
     private boolean reachedCurrentRound = false;
 
     public DestinationArrivalPaths(
             ParetoComparator<Path<T>> paretoComparator,
-            TransitCalculator calculator,
+            TransitCalculator transitCalculator,
+            CostCalculator costCalculator,
             PathMapper<T> pathMapper,
             DebugHandlerFactory<T> debugHandlerFactory,
             WorkerLifeCycle lifeCycle
     ) {
+        this.costCalculator = costCalculator;
         this.paths = new ParetoSet<>(paretoComparator, debugHandlerFactory.paretoSetDebugPathListener());
         this.debugHandler = debugHandlerFactory.debugStopArrival();
-        this.calculator = calculator;
+        this.transitCalculator = transitCalculator;
         this.pathMapper = pathMapper;
         lifeCycle.onPrepareForNextRound(round -> clearReachedCurrentRoundFlag());
     }
 
     public void add(ArrivalView<T> egressStopArrival, RaptorTransfer egressLeg, int additionalCost) {
+        int departureTime = transitCalculator.departureTime(egressLeg, egressStopArrival.arrivalTime());
 
-        int arrivalTime = calculator.plusDuration(egressStopArrival.arrivalTime(), egressLeg.durationInSeconds());
+        if (departureTime == -1) { return; }
 
-        DestinationArrival<T> destArrival = new DestinationArrival<>(egressLeg, egressStopArrival, arrivalTime, additionalCost);
+        int arrivalTime = transitCalculator.plusDuration(departureTime, egressLeg.durationInSeconds());
 
-        if (calculator.exceedsTimeLimit(arrivalTime)) {
+        int waitTimeInSeconds = Math.abs(departureTime - egressStopArrival.arrivalTime());
+
+        DestinationArrival<T> destArrival = new DestinationArrival<>(
+            egressLeg,
+            egressStopArrival,
+            departureTime, // TODO: What about NoWaitTransitWorker
+            arrivalTime,
+            additionalCost + costCalculator.waitCost(waitTimeInSeconds)
+        );
+
+        if (transitCalculator.exceedsTimeLimit(arrivalTime)) {
             debugRejectByTimeLimitOptimization(destArrival);
         } else {
             Path<T> path = pathMapper.mapToPath(destArrival);
@@ -98,7 +113,7 @@ public class DestinationArrivalPaths<T extends RaptorTripSchedule> {
 
     private void debugRejectByTimeLimitOptimization(DestinationArrival<T> destArrival) {
         if (debugHandler != null) {
-            debugHandler.reject(destArrival.previous(), null, calculator.exceedsTimeLimitReason());
+            debugHandler.reject(destArrival.previous(), null, transitCalculator.exceedsTimeLimitReason());
         }
     }
 }

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/path/ForwardPathMapper.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/path/ForwardPathMapper.java
@@ -39,6 +39,7 @@ public final class ForwardPathMapper<T extends RaptorTripSchedule> implements Pa
 
         from = destinationArrival.previous();
         lastLeg = new EgressPathLeg<>(
+                destinationArrival.accessEgress(),
                 from.stop(),
                 destinationArrival.departureTime(),
                 destinationArrival.arrivalTime()
@@ -92,6 +93,6 @@ public final class ForwardPathMapper<T extends RaptorTripSchedule> implements Pa
         int timeShift = arrivalTime - from.arrivalTime();
         int departureTime = from.departureTime() + timeShift;
 
-        return new AccessPathLeg<>(from.stop(), departureTime, arrivalTime, nextLeg);
+        return new AccessPathLeg<>(from.accessEgress(), from.stop(), departureTime, arrivalTime, nextLeg);
     }
 }

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/path/ReversePathMapper.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/path/ReversePathMapper.java
@@ -58,6 +58,7 @@ public final class ReversePathMapper<T extends RaptorTripSchedule> implements Pa
             ArrivalView<T> lastStopArrival
     ) {
         return new AccessPathLeg<>(
+                destinationArrival.accessEgress(),
                 lastStopArrival.stop(),
                 destinationArrival.arrivalTime(),
                 destinationArrival.departureTime(),
@@ -127,6 +128,6 @@ public final class ReversePathMapper<T extends RaptorTripSchedule> implements Pa
         int boardSlack = transitLayerSlackProvider.alightSlack(tripSchedule.pattern());
         int fromTime = transitAlightTime + boardSlack;
         int toTime = fromTime + (stopArrival.departureTime() - stopArrival.arrivalTime());
-        return new EgressPathLeg<>(stopArrival.stop(), fromTime, toTime);
+        return new EgressPathLeg<>(stopArrival.accessEgress(), stopArrival.stop(), fromTime, toTime);
     }
 }

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/path/configure/PathConfig.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/path/configure/PathConfig.java
@@ -39,6 +39,7 @@ public class PathConfig<T extends RaptorTripSchedule> {
         return new DestinationArrivalPaths<>(
                 paretoComparator(includeCost),
                 ctx.calculator(),
+                ctx.costCalculator(),
                 ctx.pathMapper(),
                 ctx.debugFactory(),
                 ctx.lifeCycle()

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/NoWaitTransitWorker.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/NoWaitTransitWorker.java
@@ -1,9 +1,10 @@
 package org.opentripplanner.transit.raptor.rangeraptor.standard;
 
+import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
 import org.opentripplanner.transit.raptor.rangeraptor.SlackProvider;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripPattern;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
-import org.opentripplanner.transit.raptor.rangeraptor.TransitRoutingStrategy;
+import org.opentripplanner.transit.raptor.rangeraptor.RoutingStrategy;
 import org.opentripplanner.transit.raptor.rangeraptor.transit.TransitCalculator;
 import org.opentripplanner.transit.raptor.rangeraptor.transit.TripScheduleSearch;
 
@@ -14,7 +15,7 @@ import org.opentripplanner.transit.raptor.rangeraptor.transit.TripScheduleSearch
  * <p/>
  * @param <T> The TripSchedule type defined by the user of the raptor API.
  */
-public final class NoWaitTransitWorker<T extends RaptorTripSchedule> implements TransitRoutingStrategy<T> {
+public final class NoWaitTransitWorker<T extends RaptorTripSchedule> implements RoutingStrategy<T> {
 
     private static final int NOT_SET = -1;
 
@@ -107,5 +108,18 @@ public final class NoWaitTransitWorker<T extends RaptorTripSchedule> implements 
         // calculator because of the way we compute the time-shift. It is positive in the case of a
         // forward-search and negative int he case of a reverse-search.
         return stopArrivalTime - onTripTimeShift;
+    }
+
+    @Override
+    public void setInitialTimeForIteration(RaptorTransfer it, int iterationDepartureTime) {
+        // Earliest possible departure time from the origin, or latest possible arrival time at the
+        // destination if searching backwards, using this AccessEgress.
+        int departureTime = calculator.departureTime(it, iterationDepartureTime);
+
+        // This access is not available after the iteration departure time
+        if (departureTime == -1) return;
+
+        // Pass in the original departure time, as wait time should not be included
+        state.setInitialTimeForIteration(it, iterationDepartureTime);
     }
 }

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/StdRangeRaptorWorkerState.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/StdRangeRaptorWorkerState.java
@@ -74,9 +74,18 @@ public final class StdRangeRaptorWorkerState<T
     public final void setInitialTimeForIteration(RaptorTransfer accessEgressLeg, int iterationDepartureTime) {
         int durationInSeconds = accessEgressLeg.durationInSeconds();
         int stop = accessEgressLeg.stop();
+
+        // Earliest possible departure time from the origin, or latest possible arrival time at the
+        // destination if searching backwards, using this AccessEgress.
+        // TODO: Should this be done only in McRangeRaptor?
+        int departureTime = calculator.departureTime(accessEgressLeg, iterationDepartureTime);
+
+        // This access is not available after the iteration departure time
+        if (departureTime == -1) return;
+
         // The time of arrival at the given stop for the current iteration
         // (or departure time at the last stop if we search backwards).
-        int arrivalTime = calculator.plusDuration(iterationDepartureTime, durationInSeconds);
+        int arrivalTime = calculator.plusDuration(departureTime, durationInSeconds);
 
         bestTimes.setAccessStopTime(stop, arrivalTime);
         stopArrivalsState.setInitialTime(stop, arrivalTime, durationInSeconds);

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/StdRangeRaptorWorkerState.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/StdRangeRaptorWorkerState.java
@@ -80,7 +80,7 @@ public final class StdRangeRaptorWorkerState<T
         int arrivalTime = calculator.plusDuration(departureTime, durationInSeconds);
 
         bestTimes.setAccessStopTime(stop, arrivalTime);
-        stopArrivalsState.setInitialTime(stop, arrivalTime, durationInSeconds);
+        stopArrivalsState.setAccess(stop, arrivalTime, accessEgressLeg);
     }
 
     @Override

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/StdRangeRaptorWorkerState.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/StdRangeRaptorWorkerState.java
@@ -71,17 +71,9 @@ public final class StdRangeRaptorWorkerState<T
     }
 
     @Override
-    public final void setInitialTimeForIteration(RaptorTransfer accessEgressLeg, int iterationDepartureTime) {
+    public final void setInitialTimeForIteration(RaptorTransfer accessEgressLeg, int departureTime) {
         int durationInSeconds = accessEgressLeg.durationInSeconds();
         int stop = accessEgressLeg.stop();
-
-        // Earliest possible departure time from the origin, or latest possible arrival time at the
-        // destination if searching backwards, using this AccessEgress.
-        // TODO: Should this be done only in McRangeRaptor?
-        int departureTime = calculator.departureTime(accessEgressLeg, iterationDepartureTime);
-
-        // This access is not available after the iteration departure time
-        if (departureTime == -1) return;
 
         // The time of arrival at the given stop for the current iteration
         // (or departure time at the last stop if we search backwards).

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/StdTransitWorker.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/StdTransitWorker.java
@@ -1,9 +1,10 @@
 package org.opentripplanner.transit.raptor.rangeraptor.standard;
 
+import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripPattern;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
 import org.opentripplanner.transit.raptor.rangeraptor.SlackProvider;
-import org.opentripplanner.transit.raptor.rangeraptor.TransitRoutingStrategy;
+import org.opentripplanner.transit.raptor.rangeraptor.RoutingStrategy;
 import org.opentripplanner.transit.raptor.rangeraptor.transit.TransitCalculator;
 import org.opentripplanner.transit.raptor.rangeraptor.transit.TripScheduleSearch;
 
@@ -13,7 +14,7 @@ import org.opentripplanner.transit.raptor.rangeraptor.transit.TripScheduleSearch
  *
  * @param <T> The TripSchedule type defined by the user of the raptor API.
  */
-public final class StdTransitWorker<T extends RaptorTripSchedule> implements TransitRoutingStrategy<T> {
+public final class StdTransitWorker<T extends RaptorTripSchedule> implements RoutingStrategy<T> {
 
     private static final int NOT_SET = -1;
 
@@ -98,5 +99,17 @@ public final class StdTransitWorker<T extends RaptorTripSchedule> implements Tra
                 }
             }
         }
+    }
+
+    @Override
+    public void setInitialTimeForIteration(RaptorTransfer it, int iterationDepartureTime) {
+        // Earliest possible departure time from the origin, or latest possible arrival time at the
+        // destination if searching backwards, using this AccessEgress.
+        int departureTime = calculator.departureTime(it, iterationDepartureTime);
+
+        // This access is not available after the iteration departure time
+        if (departureTime == -1) return;
+
+        state.setInitialTimeForIteration(it, departureTime);
     }
 }

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/StopArrivalsState.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/StopArrivalsState.java
@@ -23,7 +23,7 @@ import java.util.Collection;
 */
 public interface StopArrivalsState<T extends RaptorTripSchedule> {
 
-    void setInitialTime(final int stop, final int arrivalTime, int durationInSeconds);
+    void setAccess(final int stop, final int arrivalTime, RaptorTransfer access);
 
     Collection<Path<T>> extractPaths();
 

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/besttimes/BestTimesOnlyStopArrivalsState.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/besttimes/BestTimesOnlyStopArrivalsState.java
@@ -34,7 +34,7 @@ public class BestTimesOnlyStopArrivalsState<T extends RaptorTripSchedule> implem
     }
 
     @Override
-    public void setInitialTime(int stop, int arrivalTime, int durationInSeconds) {
+    public void setAccess(int stop, int arrivalTime, RaptorTransfer access) {
         bestNumberOfTransfers.arriveAtStop(stop);
     }
 

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/configure/StdRangeRaptorConfig.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/configure/StdRangeRaptorConfig.java
@@ -3,7 +3,7 @@ package org.opentripplanner.transit.raptor.rangeraptor.standard.configure;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
 import org.opentripplanner.transit.raptor.api.view.Heuristics;
 import org.opentripplanner.transit.raptor.api.view.Worker;
-import org.opentripplanner.transit.raptor.rangeraptor.TransitRoutingStrategy;
+import org.opentripplanner.transit.raptor.rangeraptor.RoutingStrategy;
 import org.opentripplanner.transit.raptor.rangeraptor.WorkerState;
 import org.opentripplanner.transit.raptor.rangeraptor.path.DestinationArrivalPaths;
 import org.opentripplanner.transit.raptor.rangeraptor.path.configure.PathConfig;
@@ -60,7 +60,7 @@ public class StdRangeRaptorConfig<T extends RaptorTripSchedule> {
      * worker, if not the heuristic can not be added to the worker lifecycle and fails.
      */
     public HeuristicSearch<T> createHeuristicSearch(
-            BiFunction<WorkerState<T>, TransitRoutingStrategy<T>, Worker<T>> createWorker
+            BiFunction<WorkerState<T>, RoutingStrategy<T>, Worker<T>> createWorker
     ) {
         StdRangeRaptorWorkerState<T> state = createState();
         Heuristics heuristics = createHeuristicsAdapter();
@@ -68,7 +68,7 @@ public class StdRangeRaptorConfig<T extends RaptorTripSchedule> {
     }
 
     public Worker<T> createSearch(
-            BiFunction<WorkerState<T>, TransitRoutingStrategy<T>, Worker<T>> createWorker
+            BiFunction<WorkerState<T>, RoutingStrategy<T>, Worker<T>> createWorker
     ) {
         StdRangeRaptorWorkerState<T> state = createState();
         return createWorker.apply(state, createWorkerStrategy(state));
@@ -90,7 +90,7 @@ public class StdRangeRaptorConfig<T extends RaptorTripSchedule> {
         throw new IllegalArgumentException(ctx.profile().toString());
     }
 
-    private TransitRoutingStrategy<T> createWorkerStrategy(StdWorkerState<T> state) {
+    private RoutingStrategy<T> createWorkerStrategy(StdWorkerState<T> state) {
         switch (ctx.profile()) {
             case STANDARD:
             case BEST_TIME:

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/debug/DebugStopArrivalsState.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/debug/DebugStopArrivalsState.java
@@ -37,8 +37,8 @@ public final class DebugStopArrivalsState<T extends RaptorTripSchedule> implemen
     }
 
     @Override
-    public final void setInitialTime(final int stop, final int arrivalTime, int durationInSeconds) {
-        delegate.setInitialTime(stop, arrivalTime, durationInSeconds);
+    public final void setAccess(final int stop, final int arrivalTime, RaptorTransfer access) {
+        delegate.setAccess(stop, arrivalTime, access);
         debug.acceptAccess(stop);
     }
 

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/stoparrivals/AccessStopArrivalState.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/stoparrivals/AccessStopArrivalState.java
@@ -1,0 +1,28 @@
+package org.opentripplanner.transit.raptor.rangeraptor.standard.stoparrivals;
+
+import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
+import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
+import org.opentripplanner.transit.raptor.util.TimeUtils;
+
+public class AccessStopArrivalState<T extends RaptorTripSchedule> extends StopArrivalState<T> {
+
+  private RaptorTransfer access;
+
+  public RaptorTransfer access() {
+    return access;
+  }
+
+  void setAccess(int time, RaptorTransfer access) {
+    super.setAccessTime(time, access.durationInSeconds());
+    this.access = access;
+  }
+
+  @Override
+  public String toString() {
+    return String.format(
+        "Access Arrival { time: %s, duration: %s }",
+        TimeUtils.timeToStrLong(time()),
+        TimeUtils.timeToStrCompact(accessDuration())
+    );
+  }
+}

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/stoparrivals/StdStopArrivalsState.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/stoparrivals/StdStopArrivalsState.java
@@ -31,8 +31,8 @@ public final class StdStopArrivalsState<T extends RaptorTripSchedule> implements
     }
 
     @Override
-    public final void setInitialTime(final int stop, final int arrivalTime, int durationInSeconds) {
-        stops.setInitialTime(stop, arrivalTime, durationInSeconds);
+    public final void setAccess(final int stop, final int arrivalTime, RaptorTransfer access) {
+        stops.setAccess(stop, arrivalTime, access);
     }
 
     @Override

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/stoparrivals/StopArrivalState.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/stoparrivals/StopArrivalState.java
@@ -73,10 +73,6 @@ public class StopArrivalState<T extends RaptorTripSchedule> {
         return accessOrTransferDuration;
     }
 
-    final boolean arrivedByAccess() {
-        return !arrivedByTransfer() && accessOrTransferDuration != NOT_SET;
-    }
-
     public final boolean arrivedByTransit() {
         return transitArrivalTime != NOT_SET;
     }
@@ -85,7 +81,7 @@ public class StopArrivalState<T extends RaptorTripSchedule> {
         return transferFromStop != NOT_SET;
     }
 
-    final void setAccessTime(int time, int accessDuration) {
+    void setAccessTime(int time, int accessDuration) {
         this.bestArrivalTime = time;
         this.accessOrTransferDuration = accessDuration;
     }
@@ -116,14 +112,12 @@ public class StopArrivalState<T extends RaptorTripSchedule> {
         this.accessOrTransferDuration = transferTime;
     }
 
+    public AccessStopArrivalState<T> asAccessStopArrivalState() {
+        return (AccessStopArrivalState<T>) this;
+    }
+
     @Override
     public String toString() {
-        if(arrivedByAccess()) {
-            return String.format("Access Arrival { time: %s, duration: %s }",
-                    TimeUtils.timeToStrLong(bestArrivalTime),
-                    TimeUtils.timeToStrCompact(accessOrTransferDuration)
-            );
-        }
         return String.format("Arrival { time: %s, Transit: %s %s-%s, trip: %s, Transfer from: %s %s }",
                 TimeUtils.timeToStrLong(bestArrivalTime, NOT_SET),
                 IntUtils.intToString(boardStop, NOT_SET),

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/stoparrivals/Stops.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/stoparrivals/Stops.java
@@ -65,8 +65,8 @@ public final class Stops<T extends RaptorTripSchedule> implements BestNumberOfTr
         return unreachedMinNumberOfTransfers();
     }
 
-    void setInitialTime(int stop, int time, int duration) {
-        findOrCreateStopIndex(round(), stop).setAccessTime(time, duration);
+    void setAccess(int stop, int time, RaptorTransfer access) {
+        findOrCreateStopIndex(round(), stop).asAccessStopArrivalState().setAccess(time, access);
     }
 
     void transitToStop(int stop, int time, int boardStop, int boardTime, T trip, boolean bestTime) {
@@ -98,7 +98,7 @@ public final class Stops<T extends RaptorTripSchedule> implements BestNumberOfTr
 
     private StopArrivalState<T> findOrCreateStopIndex(final int round, final int stop) {
         if (stops[round][stop] == null) {
-            stops[round][stop] = new StopArrivalState<>();
+            stops[round][stop] = round == 0 ? new AccessStopArrivalState<>() : new StopArrivalState<>();
         }
         return get(round, stop);
     }

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/stoparrivals/path/EgressArrivalToPathAdapter.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/stoparrivals/path/EgressArrivalToPathAdapter.java
@@ -53,6 +53,7 @@ public class EgressArrivalToPathAdapter<T extends RaptorTripSchedule> implements
     }
 
     public void add(EgressStopArrivalState<T> egressStopArrival) {
+        // TODO: Check earliestDepartureTime?
         int time = destinationArrivalTime(egressStopArrival);
         if (calculator.isBest(time, bestDestinationTime)) {
             newElementSet = true;

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/stoparrivals/view/StopArrivalViewAdapter.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/stoparrivals/view/StopArrivalViewAdapter.java
@@ -26,11 +26,6 @@ abstract class StopArrivalViewAdapter<T extends RaptorTripSchedule> implements A
     }
 
     @Override
-    public RaptorTransfer accessEgress() {
-        return null; //TODO throw?
-    }
-
-    @Override
     public int round() {
         return round;
     }
@@ -39,11 +34,13 @@ abstract class StopArrivalViewAdapter<T extends RaptorTripSchedule> implements A
     static final class Access<T extends RaptorTripSchedule> extends StopArrivalViewAdapter<T> {
         private final int departureTime;
         private final int arrivalTime;
+        private final RaptorTransfer access;
 
-        Access(int stop, int departureTime, int arrivalTime) {
+        Access(int stop, int departureTime, int arrivalTime, RaptorTransfer access) {
             super(0, stop);
             this.departureTime = departureTime;
             this.arrivalTime = arrivalTime;
+            this.access = access;
         }
 
         @Override
@@ -54,6 +51,11 @@ abstract class StopArrivalViewAdapter<T extends RaptorTripSchedule> implements A
         @Override
         public int departureTime() {
             return departureTime;
+        }
+
+        @Override
+        public RaptorTransfer accessEgress() {
+            return access;
         }
 
         @Override
@@ -98,6 +100,11 @@ abstract class StopArrivalViewAdapter<T extends RaptorTripSchedule> implements A
         }
 
         @Override
+        public RaptorTransfer accessEgress() {
+            throw new UnsupportedOperationException("No accessEgress for transit stop arrival");
+        }
+
+        @Override
         public boolean arrivedByTransit() {
             return true;
         }
@@ -133,6 +140,11 @@ abstract class StopArrivalViewAdapter<T extends RaptorTripSchedule> implements A
         @Override
         public int departureTime() {
             return cursor.departureTime(arrivalTime(), arrival.transferDuration());
+        }
+
+        @Override
+        public RaptorTransfer accessEgress() {
+            throw new UnsupportedOperationException("No accessEgress for transfer stop arrival");
         }
 
         @Override

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/stoparrivals/view/StopArrivalViewAdapter.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/stoparrivals/view/StopArrivalViewAdapter.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.transit.raptor.rangeraptor.standard.stoparrivals.view;
 
+import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
 import org.opentripplanner.transit.raptor.api.view.ArrivalView;
 import org.opentripplanner.transit.raptor.rangeraptor.standard.stoparrivals.StopArrivalState;
@@ -22,6 +23,11 @@ abstract class StopArrivalViewAdapter<T extends RaptorTripSchedule> implements A
     @Override
     public int stop() {
         return stop;
+    }
+
+    @Override
+    public RaptorTransfer accessEgress() {
+        return null; //TODO throw?
     }
 
     @Override

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/stoparrivals/view/StopsCursor.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/stoparrivals/view/StopsCursor.java
@@ -4,6 +4,7 @@ import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripPattern;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
 import org.opentripplanner.transit.raptor.api.view.ArrivalView;
+import org.opentripplanner.transit.raptor.rangeraptor.standard.stoparrivals.AccessStopArrivalState;
 import org.opentripplanner.transit.raptor.rangeraptor.standard.stoparrivals.StopArrivalState;
 import org.opentripplanner.transit.raptor.rangeraptor.standard.stoparrivals.Stops;
 import org.opentripplanner.transit.raptor.rangeraptor.transit.TransitCalculator;
@@ -89,19 +90,19 @@ public class StopsCursor<T extends RaptorTripSchedule> {
      * Access without known transit, uses the iteration departure time without time shift
      */
     private ArrivalView<T> newAccessView(int stop) {
-        StopArrivalState<T> arrival = stops.get(0, stop);
+        AccessStopArrivalState<T> arrival = stops.get(0, stop).asAccessStopArrivalState();
         int departureTime = transitCalculator.minusDuration(arrival.time(), arrival.accessDuration());
-        return new StopArrivalViewAdapter.Access<>(stop, departureTime, arrival.time());
+        return new StopArrivalViewAdapter.Access<>(stop, departureTime, arrival.time(), arrival.access());
     }
 
     /**
      * A access stop arrival, time-shifted according to the first transit boarding/departure time.
      */
     private ArrivalView<T> newAccessView(int stop, int transitDepartureTime, int boardSlack) {
-        StopArrivalState<T> state = stops.get(0, stop);
+        AccessStopArrivalState<T> state = stops.get(0, stop).asAccessStopArrivalState();
         int departureTime = transitCalculator.minusDuration(transitDepartureTime, state.accessDuration() + boardSlack);
         int arrivalTime = transitCalculator.plusDuration(departureTime, state.accessDuration());
-        return new StopArrivalViewAdapter.Access<>(stop, departureTime, arrivalTime);
+        return new StopArrivalViewAdapter.Access<>(stop, departureTime, arrivalTime, state.access());
     }
 
     private ArrivalView<T> newTransitOrTransferView(int round, int stop) {

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/transit/DefaultCostCalculator.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/transit/DefaultCostCalculator.java
@@ -55,6 +55,11 @@ public class DefaultCostCalculator implements CostCalculator {
     }
 
     @Override
+    public int waitCost(int waitTimeInSeconds) {
+        return waitFactor * waitTimeInSeconds;
+    }
+
+    @Override
     public int calculateMinCost(int minTravelTime, int minNumTransfers) {
         return  boardCost * (minNumTransfers + 1) + transitFactor * minTravelTime;
     }

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/transit/ForwardTransitCalculator.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/transit/ForwardTransitCalculator.java
@@ -4,6 +4,7 @@ import org.opentripplanner.transit.raptor.api.request.RaptorTuningParameters;
 import org.opentripplanner.transit.raptor.api.request.SearchParams;
 import org.opentripplanner.transit.raptor.api.transit.IntIterator;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTimeTable;
+import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
 import org.opentripplanner.transit.raptor.util.IntIterators;
 import org.opentripplanner.transit.raptor.util.TimeUtils;
@@ -84,6 +85,11 @@ final class ForwardTransitCalculator implements TransitCalculator {
     @Override
     public final int unreachedTime() {
         return Integer.MAX_VALUE;
+    }
+
+    @Override
+    public int departureTime(RaptorTransfer transfer, int departureTime) {
+        return transfer.earliestDepartureTime(departureTime);
     }
 
     @Override

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/transit/ReverseTransitCalculator.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/transit/ReverseTransitCalculator.java
@@ -4,6 +4,7 @@ import org.opentripplanner.transit.raptor.api.request.RaptorTuningParameters;
 import org.opentripplanner.transit.raptor.api.request.SearchParams;
 import org.opentripplanner.transit.raptor.api.transit.IntIterator;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTimeTable;
+import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
 import org.opentripplanner.transit.raptor.util.IntIterators;
 import org.opentripplanner.transit.raptor.util.TimeUtils;
@@ -100,6 +101,11 @@ final class ReverseTransitCalculator implements TransitCalculator {
     @Override
     public final int unreachedTime() {
         return Integer.MIN_VALUE;
+    }
+
+    @Override
+    public int departureTime(RaptorTransfer transfer, int departureTime) {
+        return transfer.latestArrivalTime(departureTime);
     }
 
     @Override

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/transit/TransitCalculator.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/transit/TransitCalculator.java
@@ -4,6 +4,7 @@ package org.opentripplanner.transit.raptor.rangeraptor.transit;
 import org.opentripplanner.transit.raptor.api.request.SearchParams;
 import org.opentripplanner.transit.raptor.api.transit.IntIterator;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTimeTable;
+import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
 
 import static org.opentripplanner.transit.raptor.util.TimeUtils.hm2time;
@@ -88,6 +89,13 @@ public interface TransitCalculator {
      * search this should be Integer.MIN_VALUE.
      */
     int unreachedTime();
+
+    /**
+     * Selects the earliest or latest possible departure time depending on the direction.
+     * For forward search it will be the earliest possible departure time, while for reverse search
+     * it uses the latest arrival time.
+     */
+    int departureTime(RaptorTransfer transfer, int departureTime);
 
     /**
      * Return an iterator, iterating over the minutes in the RangeRaptor algorithm.

--- a/src/test/java/org/opentripplanner/transit/raptor/_shared/AbstractStopArrival.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/_shared/AbstractStopArrival.java
@@ -2,6 +2,7 @@ package org.opentripplanner.transit.raptor._shared;
 
 
 
+import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
 import org.opentripplanner.transit.raptor.api.view.ArrivalView;
 
 abstract class AbstractStopArrival implements ArrivalView<TestRaptorTripSchedule> {
@@ -26,6 +27,11 @@ abstract class AbstractStopArrival implements ArrivalView<TestRaptorTripSchedule
         this.arrivalTime = arrivalTime;
         this.cost = (previous==null ? 0 : previous.cost()) + extraCost;
         this.previous = previous;
+    }
+
+    @Override
+    public RaptorTransfer accessEgress() {
+        return null;
     }
 
     @Override public int stop() { return stop; }

--- a/src/test/java/org/opentripplanner/transit/raptor/_shared/StopArrivalsTestData.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/_shared/StopArrivalsTestData.java
@@ -149,7 +149,7 @@ public class StopArrivalsTestData {
      * here returned as a path.
      */
     public static Path<TestRaptorTripSchedule> basicTripAsPath() {
-        PathLeg<TestRaptorTripSchedule> leg6 = new EgressPathLeg<>(STOP_5, E_START, E_END);
+        PathLeg<TestRaptorTripSchedule> leg6 = new EgressPathLeg<>(null, STOP_5, E_START, E_END);
         TransitPathLeg<TestRaptorTripSchedule> leg5 = new TransitPathLeg<>(
                 STOP_4, T3_START, STOP_5, T3_END, TRIP_3, leg6
         );
@@ -163,7 +163,7 @@ public class StopArrivalsTestData {
                 STOP_1, T1_START, STOP_2, T1_END, TRIP_1, leg3
         );
         AccessPathLeg<TestRaptorTripSchedule> leg1 = new AccessPathLeg<>(
-                STOP_1, A_START, A_END, leg2.asTransitLeg()
+                null, STOP_1, A_START, A_END, leg2.asTransitLeg()
         );
 
         return new Path<>(leg1, RaptorCostConverter.toOtpDomainCost(6_000));

--- a/src/test/java/org/opentripplanner/transit/raptor/_shared/TestLeg.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/_shared/TestLeg.java
@@ -18,6 +18,17 @@ public class TestLeg implements RaptorTransfer {
     }
 
     @Override
+    public int earliestDepartureTime(int requestedDepartureTime) {
+        return requestedDepartureTime;
+    }
+
+    @Override
+    public int latestArrivalTime(int requestedArrivalTime) {
+        return requestedArrivalTime;
+    }
+
+
+    @Override
     public int durationInSeconds() {
         return durationInSeconds;
     }

--- a/src/test/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/StopArrivalStateParetoSetTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/StopArrivalStateParetoSetTest.java
@@ -113,7 +113,7 @@ public class StopArrivalStateParetoSetTest {
     }
 
     private static AccessStopArrival<RaptorTripSchedule> newAccessStopState(int stop, int accessDurationInSeconds) {
-        return new AccessStopArrival<>(stop, A_TIME, accessDurationInSeconds, ANY, CALCULATOR);
+        return new AccessStopArrival<>(null, stop, A_TIME, accessDurationInSeconds, ANY, CALCULATOR);
     }
 
     private static TransitStopArrival<RaptorTripSchedule> newMcTransitStopState(int round, int stop, int arrivalTime) {

--- a/src/test/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/arrivals/AccessStopArrivalTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/arrivals/AccessStopArrivalTest.java
@@ -18,7 +18,7 @@ public class AccessStopArrivalTest {
     private static final int COST = 500;
 
     private static final TransitCalculator TRANSIT_CALCULATOR = TransitCalculator.testDummyCalculator(true);
-    private AccessStopArrival<RaptorTripSchedule> subject = new AccessStopArrival<>(ALIGHT_STOP, DEPATURE_TIME, LEG_DURATION, COST, TRANSIT_CALCULATOR);
+    private AccessStopArrival<RaptorTripSchedule> subject = new AccessStopArrival<>(null, ALIGHT_STOP, DEPATURE_TIME, LEG_DURATION, COST, TRANSIT_CALCULATOR);
 
 
 

--- a/src/test/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/arrivals/TransferStopArrivalTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/arrivals/TransferStopArrivalTest.java
@@ -37,6 +37,7 @@ public class TransferStopArrivalTest {
 
     private static final TransitCalculator TRANSIT_CALCULATOR = TransitCalculator.testDummyCalculator(true);
     private static final AccessStopArrival<RaptorTripSchedule> ACCESS_ARRIVAL = new AccessStopArrival<>(
+            null,
             ACCESS_TO_STOP,
             ACCESS_DEPARTURE_TIME,
             ACCESS_DURATION,

--- a/src/test/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/arrivals/TransitStopArrivalTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/arrivals/TransitStopArrivalTest.java
@@ -36,6 +36,7 @@ public class TransitStopArrivalTest {
     private static final TransitCalculator TRANSIT_CALCULATOR = testDummyCalculator(true);
 
     private static final AccessStopArrival<RaptorTripSchedule> ACCESS_ARRIVAL = new AccessStopArrival<>(
+            null,
             ACCESS_TO_STOP,
             ACCESS_DEPARTURE_TIME,
             ACCESS_DURATION,

--- a/src/test/java/org/opentripplanner/transit/raptor/rangeraptor/path/DestinationArrivalTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/rangeraptor/path/DestinationArrivalTest.java
@@ -35,6 +35,7 @@ public class DestinationArrivalTest {
      * Setup a simple journey with an access leg, one transit and a egress leg.
      */
     private static final AccessStopArrival<RaptorTripSchedule> ACCESS_ARRIVAL = new AccessStopArrival<>(
+            null,
             ACCESS_STOP,
             ACCESS_DEPARTURE_TIME,
             ACCESS_DURATION_TIME,
@@ -53,6 +54,7 @@ public class DestinationArrivalTest {
     );
 
     private DestinationArrival<RaptorTripSchedule> subject = new DestinationArrival<>(
+            null,
             TRANSIT_ARRIVAL,
             TRANSIT_ALIGHT_TIME + DESTINATION_DURATION_TIME,
             DESTINATION_COST

--- a/src/test/java/org/opentripplanner/transit/raptor/rangeraptor/path/DestinationArrivalTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/rangeraptor/path/DestinationArrivalTest.java
@@ -56,6 +56,7 @@ public class DestinationArrivalTest {
     private DestinationArrival<RaptorTripSchedule> subject = new DestinationArrival<>(
             null,
             TRANSIT_ARRIVAL,
+            TRANSIT_ALIGHT_TIME,
             TRANSIT_ALIGHT_TIME + DESTINATION_DURATION_TIME,
             DESTINATION_COST
     );

--- a/src/test/java/org/opentripplanner/transit/raptor/rangeraptor/path/ForwardPathMapperTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/rangeraptor/path/ForwardPathMapperTest.java
@@ -17,6 +17,7 @@ public class ForwardPathMapperTest {
     public void mapToPathForwardSearch() {
         Egress egress = StopArrivalsTestData.basicTripByForwardSearch();
         DestinationArrival<TestRaptorTripSchedule> destArrival = new DestinationArrival<>(
+                null,
                 egress.previous(),
                 egress.arrivalTime(),
                 egress.additionalCost()

--- a/src/test/java/org/opentripplanner/transit/raptor/rangeraptor/path/ForwardPathMapperTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/rangeraptor/path/ForwardPathMapperTest.java
@@ -19,6 +19,7 @@ public class ForwardPathMapperTest {
         DestinationArrival<TestRaptorTripSchedule> destArrival = new DestinationArrival<>(
                 null,
                 egress.previous(),
+                egress.previous().arrivalTime(),
                 egress.arrivalTime(),
                 egress.additionalCost()
         );

--- a/src/test/java/org/opentripplanner/transit/raptor/rangeraptor/path/ReversePathMapperTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/rangeraptor/path/ReversePathMapperTest.java
@@ -17,6 +17,7 @@ public class ReversePathMapperTest {
         // Given:
         Egress egress = basicTripByReverseSearch();
         DestinationArrival<TestRaptorTripSchedule> destArrival = new DestinationArrival<>(
+                null,
                 egress.previous(),
                 egress.arrivalTime(),
                 egress.additionalCost()

--- a/src/test/java/org/opentripplanner/transit/raptor/rangeraptor/path/ReversePathMapperTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/rangeraptor/path/ReversePathMapperTest.java
@@ -19,6 +19,7 @@ public class ReversePathMapperTest {
         DestinationArrival<TestRaptorTripSchedule> destArrival = new DestinationArrival<>(
                 null,
                 egress.previous(),
+                egress.previous().arrivalTime(),
                 egress.arrivalTime(),
                 egress.additionalCost()
         );

--- a/src/test/java/org/opentripplanner/transit/raptor/service/HeuristicToRunResolverTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/service/HeuristicToRunResolverTest.java
@@ -122,6 +122,8 @@ public class HeuristicToRunResolverTest {
     private RaptorTransfer dummyLeg() {
         return new RaptorTransfer() {
             @Override public int stop() { return 1; }
+            @Override public int earliestDepartureTime(int requestedDepartureTime) { return requestedDepartureTime; }
+            @Override public int latestArrivalTime(int requestedArrivalTime) { return requestedArrivalTime; }
             @Override public int durationInSeconds() { return 10; }
         };
     }

--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/transit/AccessEgressLeg.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/transit/AccessEgressLeg.java
@@ -17,6 +17,16 @@ public class AccessEgressLeg implements RaptorTransfer {
     }
 
     @Override
+    public int earliestDepartureTime(int requestedDepartureTime) {
+        return requestedDepartureTime;
+    }
+
+    @Override
+    public int latestArrivalTime(int requestedArrivalTime) {
+        return requestedArrivalTime;
+    }
+
+    @Override
     public int durationInSeconds() {
         return durationInSeconds;
     }


### PR DESCRIPTION
Currently the RAPTOR to itinerary mapper is limited to using only one access and egress per stop. Also the algorithm itself uses only one egress per stop. This pull request adds the functionality to add multiple time-constrained accesses and egresses. It is useful eg. when using a bike share scheme or flexible transit, with limited operating hours as the first and/or last mile.

It adds two methods, `earliestDepartureTime` and `latestArrivalTime` to `RaptorTransfer `. These are used depending on the search direction to set the either the departure or arrival times of the first and last leg. Current implementations return the given time, as there are no restrictions.

To be completed by pull request submitter:

- [ ] **issue**: Link to or create an [issue](https://github.com/opentripplanner/OpenTripPlanner/issues) that describes the relevant feature or bug. Add [GitHub keywords](https://help.github.com/articles/closing-issues-using-keywords/) to this PR's description (e.g., `closes #45`).
- [ ] **roadmap**: Check the [roadmap](https://github.com/orgs/opentripplanner/projects/1) for this feature or bug. If it is not already on the roadmap, PLC will discuss as part of the review process.
- [ ] **tests**: Have you added relevant test coverage? Are all the tests passing on [the continuous integration service (Travis CI)](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#continuous-integration)?
- [ ] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#code-style)? 
- [ ] **documentation**: If you are adding a new configuration option, have you added an explanation to the [configuration documentation](docs/Configuration.md) tables and sections?
- [ ] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)