### PR TITLE
Remove Conveyal Slack Travis build notification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,10 +35,6 @@ cache:
   directories:
     - $HOME/.m2/repository
 
-# Notify us of the build status on the Slack channel
-notifications:
-  slack: conveyal:RQuTZBfE7FBjVtYkKwdnNRjY
-
 # Decrypt and import the artifact signing certificate before running the build
 before_install:
   - if [[ "$TRAVIS_PULL_REQUEST" = "false" ]]; then openssl aes-256-cbc -K $encrypted_9918733fe303_key -iv $encrypted_9918733fe303_iv -in maven-artifact-signing-key.asc.enc -out maven-artifact-signing-key.asc -d && gpg --import --batch maven-artifact-signing-key.asc; fi


### PR DESCRIPTION
The Travis CI configuration contains a notification section that sends messages to a Conveyal Slack channel. This causes us to be notified of every build of every fork and branch of OpenTripPlanner. This includes a lot of private repos, and can get noisy. This PR removes this Slack integration.