### PR TITLE
Prevent duplicate stop times entries caused by realtime updates

### DIFF
--- a/src/main/java/org/opentripplanner/model/TimetableSnapshot.java
+++ b/src/main/java/org/opentripplanner/model/TimetableSnapshot.java
@@ -117,8 +117,9 @@ public class TimetableSnapshot {
     private HashMap<TripIdAndServiceDate, TripPattern> lastAddedTripPattern = new HashMap<>();
 
     /**
-     * This maps contains all of the new TripPatterns added by realtime data indexed on stop. This
-     * has to be kept in order for them to be included in the stop times api call on a specific stop.
+     * This maps contains all of the new or updated TripPatterns added by realtime data indexed on
+     * stop. This has to be kept in order for them to be included in the stop times api call on a
+     * specific stop.
      *
      * TODO Find a generic way to keep all realtime indexes.
      */

--- a/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
+++ b/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
@@ -27,10 +27,9 @@ import org.opentripplanner.routing.vertextype.TransitStopVertex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -175,13 +174,15 @@ public class GraphIndex {
 
     /**
      * Returns all the patterns for a specific stop. If includeRealtimeUpdates is set, new patterns
-     * added by realtime updates are added to the collection.
+     * added by realtime updates are added to the collection. A set is used here because trip
+     * patterns that were updated by realtime data is both part of the GraphIndex and the
+     * TimetableSnapshot.
      */
     public Collection<TripPattern> getPatternsForStop(
             Stop stop,
             TimetableSnapshot timetableSnapshot
     ) {
-        List<TripPattern> tripPatterns = new ArrayList<>(getPatternsForStop(stop));
+        Set<TripPattern> tripPatterns = new HashSet<>(getPatternsForStop(stop));
 
         if (timetableSnapshot != null) {
             tripPatterns.addAll(timetableSnapshot.getPatternsForStop(stop));


### PR DESCRIPTION
To be completed by pull request submitter:

- [x] **issue**: This is a bug fix
- [x] **roadmap**: Check the [roadmap](https://github.com/orgs/opentripplanner/projects/1) for this feature or bug. If it is not already on the roadmap, PLC will discuss as part of the review process.
- [x] **tests**: Have you added relevant test coverage? Are all the tests passing on [the continuous integration service (Travis CI)](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#continuous-integration)?
- [x] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#code-style)? 
- [x] **documentation**: If you are adding a new configuration option, have you added an explanation to the [configuration documentation](docs/Configuration.md) tables and sections?
- [x] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)

The GraphIndex.getPatternsFroStop method collects patterns from both the GraphIndex itself and from the current TimetableSnapshot. The javadoc for the TimetableSnapshot.patternsForStop incorrectly said that it only contained new trip patterns, when it also contains updated trip patterns. This PR updates the javadoc and changes the GraphIndex.getPatternsFroStop method to use a set instead of a list to avoid duplicate patterns being returned.