### PR TITLE
Catch interpolation exceptions

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -7,7 +7,8 @@
 - Fixes surefire test failure during build (#2816)
 - Improve documentation for `mode` routing parameter (#2809)
 - Disable linking from already linked stops (#2372)
-- Optimize elevation calculations
+- Optimize elevation calculations (#2990)
+- Safely catch some elevation interpolation exceptions (#3078)
 
 ## 1.4 (2019-07-30)
 

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -556,6 +556,7 @@ public class ElevationModule implements GraphBuilderModule {
 
             setEdgeElevationProfile(ee, elevPCS, graph);
         } catch (ElevationLookupException e) {
+            // only catch known elevation lookup exceptions
             log.debug("Error processing elevation for edge: {} due to error: {}", ee, e);
         }
     }
@@ -622,10 +623,18 @@ public class ElevationModule implements GraphBuilderModule {
         try {
             return getElevation(coverage, c.x, c.y);
         } catch (ArrayIndexOutOfBoundsException | PointOutsideCoverageException | TransformException e) {
+            // Each of the above exceptions can occur when finding the elevation at a coordinate.
+            // - The ArrayIndexOutOfBoundsException seems to occur at the edges of some elevation tiles that
+            //     might have areas with NoData. See https://github.com/opentripplanner/OpenTripPlanner/issues/2792
+            // - The PointOutsideCoverageException can be thrown for points that are outside of the elevation tile area.
+            // - The TransformException can occur when trying to compute the EllipsoidToGeoidDifference.
             throw new ElevationLookupException(e);
         }
     }
 
+    /**
+     * A custom exception wrapper for all known elevation lookup exceptions
+     */
     class ElevationLookupException extends Exception {
         public ElevationLookupException(Exception e) {
             super(e);

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -555,7 +555,7 @@ public class ElevationModule implements GraphBuilderModule {
                     coordList.toArray(coordArr));
 
             setEdgeElevationProfile(ee, elevPCS, graph);
-        } catch (PointOutsideCoverageException | TransformException e) {
+        } catch (ElevationLookupException e) {
             log.debug("Error processing elevation for edge: {} due to error: {}", ee, e);
         }
     }
@@ -582,11 +582,15 @@ public class ElevationModule implements GraphBuilderModule {
                     // The Coverage instance relies on some synchronized static methods shared across all threads that
                     // can cause deadlocks if not fully initialized. Therefore, make a single request for the first
                     // point on the edge to initialize these other items.
-                    double[] dummy = new double[1];
-                    coverage.evaluate(
-                        new DirectPosition2D(GeometryUtils.WGS84_XY, examplarCoordinate.x, examplarCoordinate.y),
-                        dummy
-                    );
+                    try {
+                        getElevation(coverage, examplarCoordinate);
+                    } catch (ElevationLookupException e) {
+                        log.debug(
+                            "Error processing elevation for coordinate: {} due to error: {}",
+                            examplarCoordinate,
+                            e
+                        );
+                    }
                     coverageInterpolatorThreadLocal.set(coverage);
                 }
             }
@@ -614,8 +618,18 @@ public class ElevationModule implements GraphBuilderModule {
      * @param c the coordinate (NAD83)
      * @return elevation in meters
      */
-    private double getElevation(Coverage coverage, Coordinate c) throws PointOutsideCoverageException, TransformException {
-        return getElevation(coverage, c.x, c.y);
+    private double getElevation(Coverage coverage, Coordinate c) throws ElevationLookupException {
+        try {
+            return getElevation(coverage, c.x, c.y);
+        } catch (ArrayIndexOutOfBoundsException | PointOutsideCoverageException | TransformException e) {
+            throw new ElevationLookupException(e);
+        }
+    }
+
+    class ElevationLookupException extends Exception {
+        public ElevationLookupException(Exception e) {
+            super(e);
+        }
     }
 
     /**


### PR DESCRIPTION
To be completed by pull request submitter:

- [x] **issue**: Fixes #2792 .
- [ ] **roadmap**: Not on roadmap.
- [ ] **tests**: No new tests added.
- [x] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#code-style)? 
- [x] **documentation**: No new configuration, but code comments added.
- [x] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)

This PR "fixes" #2792 by safely catching any ArrayIndexOutOfBoundsExceptions that the Interpolator2D class throws. I put fixes in quotes because this code change merely swallows the error allowing OTP to proceed with graph building. Some street edges will therefore lack proper elevation data assignment. We observed this happening with our New York graph where we don't have elevation tiles for parts of Canada. We got lots of PointOutsideCoverageExceptions, but also saw the Interpolator2D throw the ArrayIndexOutOfBoundsException at the edge of some tiles we did have. I'm not sure why, but all of these errors happen outside of the focus area of our graph (see below screenshot). Therefore, we're ok with swallowing the errors and letting the graph building proceed.

<img width="1210" alt="Screen Shot 2020-05-14 at 11 44 10 AM" src="https://user-images.githubusercontent.com/3112493/81972961-474e2680-95d8-11ea-9f34-4e14ecd9f8d2.png">
