### PR TITLE
Use Kryo library for cached elevation serialization/deserialization

### DIFF
--- a/src/main/java/org/opentripplanner/common/geometry/PackedCoordinateSequence.java
+++ b/src/main/java/org/opentripplanner/common/geometry/PackedCoordinateSequence.java
@@ -200,6 +200,11 @@ public abstract class PackedCoordinateSequence implements CoordinateSequence, Se
         double[] coords;
 
         /**
+         * For use with Kryo library only. Kryo needs an no-arg constructor in order to deserialize data.
+         */
+        public Double() {}
+
+        /**
          * Builds a new packed coordinate sequence
          * 
          * @param coords


### PR DESCRIPTION
To be completed by pull request submitter:

- [ ] **issue**: No issue. :(
- [ ] **roadmap**: Not on roadmap. :(
- [ ] **tests**: No new tests.
- [x] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#code-style)? 
- [ ] **documentation**: n/a
- [ ] **changelog**: There's already a changelog entry for optimizing elevation calculations.

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)

I tried to see if it'd be any better to use the Kryo library for the cached elevations file since it's used for the Graph.obj file. Looks like this will save a little bit of processing time and file size.