### PR TITLE
Make the local file resolver configurable and update various documentation

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -38,6 +38,7 @@ See the [OTP2 Migration Guide](OTP2-MigrationGuide.md) on changes to the REST AP
 - Add MQTT transport for the GTFS-RT trip update updater (#3094)
 - Add FinlandWayPropertySetSource (#3096)
 - Map NeTEx publicCode to OTP tripShortName and NeTEx private code to OTP internalPlanningCode (#3088)
+- Reading and writing files(CONFIG, GRAPH, DEM, OSM, GTFS, NETEX, DATA_IMPORT_ISSUES) is changed. All files, except configuration files, are read from a data source. We support Google Cloud Storage and the local file system data sources for now, but plan to add at least support for AWS S3 (#2891)
 
 ## Ported over from the 1.x
 - Add application/x-protobuf to accepted protobuf content-types (#2839)

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -88,42 +88,93 @@ This table lists the possible settings that can be defined in a `build-config.js
 
 config key | description | value type | value default | notes
 ---------- | ----------- | ---------- | ------------- | -----
-`dataImportReport` |  Generate nice HTML report of Graph errors/warnings | boolean | false |
-`transit` | Include all transit input files (GTFS) from scanned directory | boolean | true |
-`useTransfersTxt` | Create direct transfer edges from transfers.txt in GTFS, instead of based on distance | boolean | false |
-`parentStopLinking` | Link GTFS stops to their parent stops | boolean | false |
-`stationTransfers` | Create direct transfers between the constituent stops of each parent station | boolean | false |
-`stopClusterMode` | Stop clusters can be built in one of two ways, either by geographical proximity and name, or according to a parent/child station topology, if it exists | enum | `proximity` | options: `proximity`, `parentStation`
-`subwayAccessTime` | Minutes necessary to reach stops served by trips on routes of `route_type=1` (subway) from the street | double | 2.0 | units: minutes
-`streets` | Include street input files (OSM/PBF) | boolean | true | 
-`embedRouterConfig` | Embed the Router config in the graph, which allows it to be sent to a server fully configured over the wire | boolean | true |
+`` |  TODO | boolean | false |
 `areaVisibility` | Perform visibility calculations. If this is `true` OTP attempts to calculate a path straight through an OSM area using the shortest way rather than around the edge of it. (These calculations can be time consuming). | boolean | false |
-`platformEntriesLinking` | Link unconnected entries to public transport platforms | boolean | false |
-`matchBusRoutesToStreets` | Based on GTFS shape data, guess which OSM streets each bus runs on to improve stop linking | boolean | false |
-`fetchElevationUS` | Download US NED elevation data and apply it to the graph | boolean | false |
-`elevationBucket` | If specified, download NED elevation tiles from the given AWS S3 bucket | object | null | provide an object with `accessKey`, `secretKey`, and `bucketName` for AWS S3
-`elevationUnitMultiplier` | Specify a multiplier to convert elevation units from source to meters | double | 1.0 | see [Elevation unit conversion](#elevation-unit-conversion)
-`readCachedElevations` | If true, reads in pre-calculated elevation data. | boolean | true | see [Elevation Data Calculation Optimizations](#elevation-data-calculation-optimizations)
-`writeCachedElevations` | If true, writes the calculated elevation data. | boolean | false | see [Elevation Data Calculation Optimizations](#elevation-data-calculation-optimizations)
-`multiThreadElevationCalculations` | If true, the elevation module will use multi-threading during elevation calculations. | boolean | false | see [Elevation Data Calculation Optimizations](#elevation-data-calculation-optimizations)
-`fares` | A specific fares service to use | object | null | see [fares configuration](#fares-configuration)
-`osmNaming` | A custom OSM namer to use | object | null | see [custom naming](#custom-naming)
-`osmWayPropertySet` | Custom OSM way properties | string | `default` | options: `default`, `norway`, `uk`
-`staticBikeRental` | Whether bike rental stations should be loaded from OSM, rather than periodically dynamically pulled from APIs | boolean | false | 
-`staticParkAndRide` | Whether we should create car P+R stations from OSM data | boolean | true | 
-`staticBikeParkAndRide` | Whether we should create bike P+R stations from OSM data | boolean | false | 
-`maxDataImportIssuesPerFile` | If number of data import issues is larger then specified maximum number of issues the report will be split in multiple files | int | 1,000 | 
-`maxInterlineDistance` | Maximal distance between stops in meters that will connect consecutive trips that are made with same vehicle | int | 200 | units: meters
-`islandWithoutStopsMaxSize` | Pruning threshold for islands without stops. Any such island under this size will be pruned | int | 40 | 
-`islandWithStopsMaxSize` | Pruning threshold for islands with stops. Any such island under this size will be pruned | int | 5 | 
 `banDiscouragedWalking` | should walking should be allowed on OSM ways tagged with `foot=discouraged"` | boolean | false | 
 `banDiscouragedBiking` | should walking should be allowed on OSM ways tagged with `bicycle=discouraged"` | boolean | false | 
-`maxTransferDistance` | Transfers up to this length in meters will be pre-calculated and included in the Graph | double | 2,000 | units: meters
+`dataImportReport` |  Generate nice HTML report of Graph errors/warnings | boolean | false |
+`distanceBetweenElevationSamples` | TODO OTP2 | double | 10 |
+`elevationBucket` | If specified, download NED elevation tiles from the given AWS S3 bucket | object | null | provide an object with `accessKey`, `secretKey`, and `bucketName` for AWS S3
+`elevationUnitMultiplier` | Specify a multiplier to convert elevation units from source to meters | double | 1.0 | see [Elevation unit conversion](#elevation-unit-conversion)
+`embedRouterConfig` | Embed the Router config in the graph, which allows it to be sent to a server fully configured over the wire | boolean | true |
 `extraEdgesStopPlatformLink` | add extra edges when linking a stop to a platform, to prevent detours along the platform edge | boolean | false | 
+`fares` | A specific fares service to use | object | null | see [fares configuration](#fares-configuration)
+`fetchElevationUS` | Download US NED elevation data and apply it to the graph | boolean | false |
+`islandWithStopsMaxSize` | Pruning threshold for islands with stops. Any such island under this size will be pruned | int | 5 | 
+`islandWithoutStopsMaxSize` | Pruning threshold for islands without stops. Any such island under this size will be pruned | int | 40 | 
+`matchBusRoutesToStreets` | Based on GTFS shape data, guess which OSM streets each bus runs on to improve stop linking | boolean | false |
+`maxDataImportIssuesPerFile` | If number of data import issues is larger then specified maximum number of issues the report will be split in multiple files | int | 1,000 | 
+`maxInterlineDistance` | Maximal distance between stops in meters that will connect consecutive trips that are made with same vehicle | int | 200 | units: meters
+`maxTransferDistance` | Transfers up to this length in meters will be pre-calculated and included in the Graph | double | 2,000 | units: meters
+`multiThreadElevationCalculations` | If true, the elevation module will use multi-threading during elevation calculations. | boolean | false | see [Elevation Data Calculation Optimizations](#elevation-data-calculation-optimizations)
+`osmNaming` | A custom OSM namer to use | object | null | see [custom naming](#custom-naming)
+`osmWayPropertySet` | Custom OSM way properties | string | `default` | options: `default`, `finland`, `norway`, `uk`
+`parentStopLinking` | Link GTFS stops to their parent stops | boolean | false |
+`platformEntriesLinking` | Link unconnected entries to public transport platforms | boolean | false |
+`readCachedElevations` | If true, reads in pre-calculated elevation data. | boolean | true | see [Elevation Data Calculation Optimizations](#elevation-data-calculation-optimizations)
+`staticBikeParkAndRide` | Whether we should create bike P+R stations from OSM data | boolean | false | 
+`staticBikeRental` | Whether bike rental stations should be loaded from OSM, rather than periodically dynamically pulled from APIs | boolean | false | 
+`staticParkAndRide` | Whether we should create car P+R stations from OSM data | boolean | true | 
+`stationTransfers` | Create direct transfers between the constituent stops of each parent station | boolean | false |
+`streets` | Include street input files (OSM/PBF) | boolean | true | 
+`storage` | Configure access to data sources like GRAPH/OSM/DEM/GTFS/NETEX/ISSUE-REPORT. | object | null | 
+`subwayAccessTime` | Minutes necessary to reach stops served by trips on routes of `route_type=1` (subway) from the street | double | 2.0 | units: minutes
+`transit` | Include all transit input files (GTFS) from scanned directory | boolean | true |
 `transitServiceStart` | Limit the import of transit services to the given *start* date. *Inclusive*. Use an absolute date or a period relative to the day the graph is build. To specify a week before the build date use a negative period like `-P1W`. | Date or Period (ISO 8601) | `-P1Y` | `2020-01-01`, `-P1M3D`, `-P3W`
 `transitServiceEnd` | Limit the import of transit services to the given *end* date. *Inclusive*. Use an absolute date or a period relative to the day the graph is build. | Date or Period (ISO 8601) | `P3Y` | `2022-12-31`, `P1Y6M10D`, `P12W`
+`useTransfersTxt` | Create direct transfer edges from transfers.txt in GTFS, instead of based on distance | boolean | false |
+`writeCachedElevations` | If true, writes the calculated elevation data. | boolean | false | see [Elevation Data Calculation Optimizations](#elevation-data-calculation-optimizations)
 
-This list of parameters in defined in the [code](https://github.com/opentripplanner/OpenTripPlanner/blob/master/src/main/java/org/opentripplanner/standalone/config/GraphBuildParameters.java#L186-L215) for `GraphBuildParameters`.
+This list of parameters in defined in the [BuildConfig.java](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/src/main/java/org/opentripplanner/standalone/config/BuildConfig.java).
+
+
+## Storage
+Nested inside `storage {...}` in `build-config.json`.
+
+Using other data-sources than the local file system is new in OTP2. This allow for access to cloud 
+based storage as well as using local disk. If you run OTP in the cloud you might get faster start-up 
+and build times if you use the cloud storage instead of copying the files, it also simplefy the 
+deplyment. Nested `storage` build-config. 
+
+See (StorageConfig.java)[https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/src/main/java/org/opentripplanner/standalone/config/StorageConfig.java] 
+for up-to-date detailed description of each config parameter. Here is an overview:
+
+config key | description | value type | value default
+---------- | ----------- | ---------- | -------------
+`gsCredentials` | Use an environment variable to point to the Google Cloud credentials: `"${MY_GOC_SERVICE}"`. | string | `null`
+`graph` | Absolute path to the graph file. | URI | `null`
+`streetGraph` | Absolute path to the street-graph file. | URI | `null`
+`osm` | List of absolute paths of Open Street Map files to build. | URI array | `null`
+`dem` | List of absolute paths of Elevation DEM files to build. | URI array | `null`
+`gtfs` | List of GTFS transit data files to build. | URI array | `null`
+`netex` | List of NeTEx transit data files to build. | URI array | `null`
+`buildReportDir` | Path to directory for the build issue report generated by OTP. | URI | `null`
+`localFileNamePatterns` | Patterns to use for auto resolving local filenames to input data types. | object | `null`
+
+### Local Filename Patterns
+Nested inside `storage : { localFileNamePatterns : { ... } }` in `build-config.json`.
+
+config key | description | value type | value default
+---------- | ----------- | ---------- | -------------
+`osm` | Pattern used to match Open Street Map files on local disk | Regexp Pattern | `(?i)(\.pbf|\.osm|\.osm\.xml)$` 
+`dem` | Pattern used to match Elevation DEM files on local disk | Regexp Pattern | `(?i)\.tiff?$` 
+`gtfs` | Pattern used to match GTFS files on local disk | Regexp Pattern | `(?i)gtfs` 
+`netex` | Pattern used to match NeTEx files on local disk | Regexp Pattern | `(?i)netex` 
+
+### Storage example:
+```
+storage : {
+  // Use the GCS_SERVICE_CREDENTIALS environment variable to locate GCS credentials
+  gsCredentials: "${GCS_SERVICE_CREDENTIALS}",
+  streetGraph: "file:///Users/kelvin/otp/streetGraph.obj",
+  osm: ["gs://bucket-name/shared-osm-file.pbf"]
+  localFileNamePatterns: {
+    // All filenames that start with "g-" and end with ".zip" is imported as a GTFS file.
+    gtfs : "^g-.*\.zip$", 
+  }
+}
+```
+
 
 ## Limit the transit service period
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -722,8 +722,6 @@ config key | description | value type | value default
 `minWinTimeMinutes` | The constant minimum number of minutes for a raptor search window. Use a value between 20-180 minutes in a normal deployment. | int | `40`
 `maxWinTimeMinutes` | Set an upper limit to the calculation of the dynamic search window to prevent exceptionable cases to cause very long search windows. Long search windows consumes a lot of resources and may take a long time. Use this parameter to tune the desired maximum search time. | int | `180` (3 hours)
 `stepMinutes` | The search window is rounded of to the closest multiplication of N minutes. If N=10 minutes, the search-window can be 10, 20, 30 ... minutes. It the computed search-window is 5 minutes and 17 seconds it will be rounded up to 10 minutes. | int | `10`
-`` |  | int | ``
-
 
 
 ### Tuning transit routing - Stop transfer cost

--- a/docs/OTP2-MigrationGuide.md
+++ b/docs/OTP2-MigrationGuide.md
@@ -1,5 +1,28 @@
 # How to migrate OTP version 1.x to 2.x
 
+## Command line
+The command line parameters are changed. Use the `--help` option to get the current documentation,
+and look at the [Basic Tutorial, Start up OPT](Basic-Tutorial.md#start-up-otp) for examples. The 
+possibility to build the graph in 2 steps is new in OTP2. OTP2 does not support multiple routers.
+
+
+## File loading
+OTP1 access all files using the local file system, no other _data-source_ is supported. In OTP2 we 
+support accessing cloud storage. So far Google Cloud Storage is added and we plan to add support 
+for AWS S3 as well. Config files(_otp-config.json, build-config.json, router-config.json_) are read 
+from the local file system, while other files can be read/written from the local file-system or the
+cloud. OTP2 support mixing any data sources that is supported. 
+
+OTP1 loads input data files(_DEM, OSM, GTFS, NeTEx_) based on the suffix(file extension). But for 
+GTFS files OTP1 also open the zip-file and look for _stops.txt_. OTP2 identify GTFS files by the 
+name only. OTP2 will read any zip-file or directory that contains "gtfs" as part of the name. All 
+files-types in OTP2 is resolved by matching the name with a regexp pattern. You can configure the 
+patterns in the _build-config.json_ if the defaults does not suites you. 
+
+OTP2 do not support for multiple routers, but you can load as many GTFS and/or NeTEx feeds as 
+you want into a single instance of OTP2.
+
+
 ## Build config
 
 These properties changed names from:
@@ -8,15 +31,16 @@ These properties changed names from:
  - `boardTimes` to `routingDefaults.boardSlackByMode`
  - `alightTimes` to `routingDefaults.alightSlackByMode`
  
+These parameters is no longer supported:
+ - `stopClusterMode` - TODO OTP2 Why? Old options: `proximity`, `parentStation`
+
+ 
+ 
  ## Router config
  
  - All updaters that require data sources now require you to specify a `sourceType`, even if that
  particular updater only has one possible data source.
  
-## Command line
- The command line parameters are changed. Use the `--help` option to get the current documentation,
-  and look at the [Basic Tutorial, Start up OPT](Basic-Tutorial.md#start-up-otp) for examples. The 
-  possibility to build the graph in 2 steps is new in OTP2.  
    
 ## REST API
   

--- a/src/main/java/org/opentripplanner/datastore/OtpDataStoreConfig.java
+++ b/src/main/java/org/opentripplanner/datastore/OtpDataStoreConfig.java
@@ -4,6 +4,7 @@ import javax.validation.constraints.NotNull;
 import java.io.File;
 import java.net.URI;
 import java.util.List;
+import java.util.regex.Pattern;
 
 
 /**
@@ -11,6 +12,31 @@ import java.util.List;
  * OTP application.
  */
 public interface OtpDataStoreConfig {
+
+    /**
+     * Match all filenames that contains "gtfs".
+     * The pattern is NOT Case sensitive.
+     */
+    String DEFAULT_GTFS_PATTERN = "(?i)gtfs";
+
+    /**
+     * Match all filenames that contain "netex".
+     * The pattern is NOT Case sensitive.
+     */
+    String DEFAULT_NETEX_PATTERN = "(?i)netex";
+
+    /**
+     * Match all filenames that ends with suffix {@code .pbf}, {@code .osm} or {@code .osm.xml}.
+     * The pattern is NOT Case sensitive.
+     */
+    String DEFAULT_OSM_PATTERN = "(?i)(\\.pbf|\\.osm|\\.osm\\.xml)$";
+
+    /**
+     * Default: {@code (?i).tiff?$} - Match all filenames that ends with suffix
+     * {@code .tif} or {@code .tiff}.
+     * The pattern is NOT Case sensitive.
+     */
+    String DEFAULT_DEM_PATTERN = "(?i)\\.tiff?$";
 
     /**
      * The base directory on the local file-system. Used to lookup config files and all input
@@ -76,4 +102,36 @@ public interface OtpDataStoreConfig {
      * The URI to the street graph object file to load and/or save.
      */
     URI streetGraph();
+
+    /**
+     * Patterns for matching GTFS zip-files or directories. If the filename contains the
+     * given pattern it is considered a match. Any legal Java Regular expression is allowed.
+     * <p>
+     * @see #DEFAULT_GTFS_PATTERN for default value.
+     */
+    Pattern gtfsLocalFilePattern();
+
+    /**
+     * Patterns for matching NeTEx zip files or directories. If the filename contains the
+     * given pattern it is considered a match. Any legal Java Regular expression is allowed.
+     * <p>
+     * @see #DEFAULT_NETEX_PATTERN for default value.
+     */
+    Pattern netexLocalFilePattern();
+
+    /**
+     * Pattern for matching Open Street Map input files. If the filename contains the
+     * given pattern it is considered a match. Any legal Java Regular expression is allowed.
+     * <p>
+     * @see #DEFAULT_OSM_PATTERN for default value.
+     */
+    Pattern osmLocalFilePattern();
+
+    /**
+     * Pattern for matching elevation DEM files. If the filename contains the
+     * given pattern it is considered a match. Any legal Java Regular expression is allowed.
+     * <p>
+     * @see #DEFAULT_DEM_PATTERN for default value.
+     */
+    Pattern demLocalFilePattern();
 }

--- a/src/main/java/org/opentripplanner/datastore/configure/DataStoreFactory.java
+++ b/src/main/java/org/opentripplanner/datastore/configure/DataStoreFactory.java
@@ -67,7 +67,15 @@ public class DataStoreFactory {
         // The file data storage repository should be last, to allow
         // other repositories to "override" and grab files analyzing the
         // datasource uri passed in
-        repositories.add(new FileDataSourceRepository(config.baseDirectory()));
+        repositories.add(
+            new FileDataSourceRepository(
+                config.baseDirectory(),
+                config.gtfsLocalFilePattern(),
+                config.netexLocalFilePattern(),
+                config.osmLocalFilePattern(),
+                config.demLocalFilePattern()
+            )
+        );
 
         OtpDataStore store = new OtpDataStore(config, repositories);
 

--- a/src/main/java/org/opentripplanner/datastore/file/FileDataSourceRepository.java
+++ b/src/main/java/org/opentripplanner/datastore/file/FileDataSourceRepository.java
@@ -13,6 +13,7 @@ import java.io.File;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import static org.opentripplanner.datastore.FileType.CONFIG;
 import static org.opentripplanner.datastore.FileType.DEM;
@@ -35,9 +36,24 @@ public class FileDataSourceRepository implements LocalDataSourceRepository {
     private static final Logger LOG = LoggerFactory.getLogger(FileDataSourceRepository.class);
 
     private final File baseDir;
+    private final Pattern gtfsLocalFilePattern;
+    private final Pattern netexLocalFilePattern;
+    private final Pattern osmLocalFilePattern;
+    private final Pattern demLocalFilePattern;
 
-    public FileDataSourceRepository(File baseDir) {
+
+    public FileDataSourceRepository(
+        File baseDir,
+        Pattern gtfsLocalFilePattern,
+        Pattern netexLocalFilePattern,
+        Pattern osmLocalFilePattern,
+        Pattern demLocalFilePattern
+    ) {
         this.baseDir = baseDir;
+        this.gtfsLocalFilePattern = gtfsLocalFilePattern;
+        this.netexLocalFilePattern = netexLocalFilePattern;
+        this.osmLocalFilePattern = osmLocalFilePattern;
+        this.demLocalFilePattern = demLocalFilePattern;
     }
 
     /**
@@ -132,15 +148,13 @@ public class FileDataSourceRepository implements LocalDataSourceRepository {
 
 
 
-    private static FileType resolveFileType(File file) {
+    private FileType resolveFileType(File file) {
         String name = file.getName();
-        if (isTransitFile(file, "gtfs")) { return GTFS; }
-        if (isTransitFile(file, "netex")) { return NETEX; }
-        if (name.endsWith(".pbf")) { return OSM; }
-        if (name.endsWith(".osm")) { return OSM; }
-        if (name.endsWith(".osm.xml")) { return OSM; }
+        if (isTransitFile(file, gtfsLocalFilePattern)) { return GTFS; }
+        if (isTransitFile(file, netexLocalFilePattern)) { return NETEX; }
+        if (osmLocalFilePattern.matcher(name).find()) { return OSM; }
         // Digital elevation model (elevation raster)
-        if (name.endsWith(".tif") || name.endsWith(".tiff")) { return DEM; }
+        if (demLocalFilePattern.matcher(name).find()) { return DEM; }
         if (name.matches("(streetG|g)raph.obj")) { return GRAPH; }
         if (name.matches("otp-status.(inProgress|ok|failed)")) { return OTP_STATUS; }
         if (name.equals(BUILD_REPORT_DIR)) { return REPORT; }
@@ -148,8 +162,8 @@ public class FileDataSourceRepository implements LocalDataSourceRepository {
         return UNKNOWN;
     }
 
-    private static boolean isTransitFile(File file, String subName) {
-        return file.getName().toLowerCase().contains(subName)
+    private static boolean isTransitFile(File file, Pattern pattern) {
+        return pattern.matcher(file.getName()).find()
                 && (file.isDirectory() || file.getName().endsWith(".zip"));
     }
 }

--- a/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
@@ -119,7 +119,7 @@ public class GraphBuilder implements Runnable {
             streetEdgeFactory.useElevationData = hasDem;
             osmModule.edgeFactory = streetEdgeFactory;
             osmModule.customNamer = config.customNamer;
-            osmModule.setDefaultWayPropertySetSource(config.wayPropertySet);
+            osmModule.setDefaultWayPropertySetSource(config.osmWayPropertySet);
             osmModule.skipVisibility = !config.areaVisibility;
             osmModule.platformEntriesLinking = config.platformEntriesLinking;
             osmModule.staticBikeRental = config.staticBikeRental;

--- a/src/main/java/org/opentripplanner/standalone/config/BuildConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/BuildConfig.java
@@ -134,7 +134,7 @@ public class BuildConfig {
     /**
      * Custom OSM way properties
      */
-    public final WayPropertySetSource wayPropertySet;
+    public final WayPropertySetSource osmWayPropertySet;
 
     /**
      * When loading OSM data, the input is streamed 3 times - one phase for processing RELATIONS,
@@ -299,45 +299,48 @@ public class BuildConfig {
     public BuildConfig(JsonNode node, String source, boolean logUnusedParams) {
         NodeAdapter c = new NodeAdapter(node, source);
         rawJson = node;
-        dataImportReport = c.asBoolean("dataImportReport", false);
-        transit = c.asBoolean("transit", true);
-        useTransfersTxt = c.asBoolean("useTransfersTxt", false);
-        parentStopLinking = c.asBoolean("parentStopLinking", false);
-        stationTransfers = c.asBoolean("stationTransfers", false);
-        subwayAccessTime = c.asDouble("subwayAccessTime", DEFAULT_SUBWAY_ACCESS_TIME_MINUTES);
-        streets = c.asBoolean("streets", true);
-        embedRouterConfig = c.asBoolean("embedRouterConfig", true);
+
+        // Keep this list of BASIC parameters sorted alphabetically on config PARAMETER name
         areaVisibility = c.asBoolean("areaVisibility", false);
-        platformEntriesLinking = c.asBoolean("platformEntriesLinking", false);
-        matchBusRoutesToStreets = c.asBoolean("matchBusRoutesToStreets", false);
-        fetchElevationUS = c.asBoolean("fetchElevationUS", false);
-        elevationBucket = S3BucketConfig.fromConfig(c.path("elevationBucket"));
-        elevationUnitMultiplier = c.asDouble("elevationUnitMultiplier", 1);
-        fareServiceFactory = DefaultFareServiceFactory.fromConfig(c.asRawNode("fares"));
-        customNamer = CustomNamer.CustomNamerFactory.fromConfig(c.asRawNode("osmNaming"));
-        wayPropertySet = WayPropertySetSource.fromConfig(c.asText("osmWayPropertySet", "default"));
-        osmCacheDataInMem = c.asBoolean("osmCacheDataInMem", false);
-        staticBikeRental = c.asBoolean("staticBikeRental", false);
-        staticParkAndRide = c.asBoolean("staticParkAndRide", true);
-        staticBikeParkAndRide = c.asBoolean("staticBikeParkAndRide", false);
-        maxDataImportIssuesPerFile = c.asInt("maxDataImportIssuesPerFile", 1000);
-        maxInterlineDistance = c.asInt("maxInterlineDistance", 200);
-        pruningThresholdIslandWithoutStops = c.asInt("islandWithoutStopsMaxSize", 40);
-        pruningThresholdIslandWithStops = c.asInt("islandWithStopsMaxSize", 5);
         banDiscouragedWalking = c.asBoolean("banDiscouragedWalking", false);
         banDiscouragedBiking = c.asBoolean("banDiscouragedBiking", false);
-        maxTransferDistance = c.asDouble("maxTransferDistance", 2000d);
-        extraEdgesStopPlatformLink = c.asBoolean("extraEdgesStopPlatformLink", false);
+        dataImportReport = c.asBoolean("dataImportReport", false);
         distanceBetweenElevationSamples = c.asDouble("distanceBetweenElevationSamples",
-                CompactElevationProfile.DEFAULT_DISTANCE_BETWEEN_SAMPLES_METERS
+            CompactElevationProfile.DEFAULT_DISTANCE_BETWEEN_SAMPLES_METERS
         );
-        readCachedElevations = c.asBoolean("readCachedElevations", true);
-        writeCachedElevations = c.asBoolean("writeCachedElevations", false);
+        elevationBucket = S3BucketConfig.fromConfig(c.path("elevationBucket"));
+        elevationUnitMultiplier = c.asDouble("elevationUnitMultiplier", 1);
+        embedRouterConfig = c.asBoolean("embedRouterConfig", true);
+        extraEdgesStopPlatformLink = c.asBoolean("extraEdgesStopPlatformLink", false);
+        fetchElevationUS = c.asBoolean("fetchElevationUS", false);
         includeEllipsoidToGeoidDifference = c.asBoolean("includeEllipsoidToGeoidDifference", false);
+        pruningThresholdIslandWithStops = c.asInt("islandWithStopsMaxSize", 5);
+        pruningThresholdIslandWithoutStops = c.asInt("islandWithoutStopsMaxSize", 40);
+        matchBusRoutesToStreets = c.asBoolean("matchBusRoutesToStreets", false);
+        maxDataImportIssuesPerFile = c.asInt("maxDataImportIssuesPerFile", 1000);
+        maxInterlineDistance = c.asInt("maxInterlineDistance", 200);
+        maxTransferDistance = c.asDouble("maxTransferDistance", 2000d);
         multiThreadElevationCalculations = c.asBoolean("multiThreadElevationCalculations", false);
+        osmCacheDataInMem = c.asBoolean("osmCacheDataInMem", false);
+        osmWayPropertySet = WayPropertySetSource.fromConfig(c.asText("osmWayPropertySet", "default"));
+        parentStopLinking = c.asBoolean("parentStopLinking", false);
+        platformEntriesLinking = c.asBoolean("platformEntriesLinking", false);
+        readCachedElevations = c.asBoolean("readCachedElevations", true);
+        staticBikeParkAndRide = c.asBoolean("staticBikeParkAndRide", false);
+        staticBikeRental = c.asBoolean("staticBikeRental", false);
+        staticParkAndRide = c.asBoolean("staticParkAndRide", true);
+        stationTransfers = c.asBoolean("stationTransfers", false);
+        streets = c.asBoolean("streets", true);
+        subwayAccessTime = c.asDouble("subwayAccessTime", DEFAULT_SUBWAY_ACCESS_TIME_MINUTES);
+        transit = c.asBoolean("transit", true);
         transitServiceStart = c.asDateOrRelativePeriod("transitServiceStart", "-P1Y");
         transitServiceEnd = c.asDateOrRelativePeriod( "transitServiceEnd", "P3Y");
+        useTransfersTxt = c.asBoolean("useTransfersTxt", false);
+        writeCachedElevations = c.asBoolean("writeCachedElevations", false);
 
+        // List of complex parameters
+        fareServiceFactory = DefaultFareServiceFactory.fromConfig(c.asRawNode("fares"));
+        customNamer = CustomNamer.CustomNamerFactory.fromConfig(c.asRawNode("osmNaming"));
         netex = new NetexConfig(c.path("netex"));
         storage = new StorageConfig(c.path("storage"));
 

--- a/src/main/java/org/opentripplanner/standalone/config/StorageConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/StorageConfig.java
@@ -1,12 +1,15 @@
 package org.opentripplanner.standalone.config;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import javax.validation.constraints.NotNull;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
+
+import static org.opentripplanner.datastore.OtpDataStoreConfig.DEFAULT_DEM_PATTERN;
+import static org.opentripplanner.datastore.OtpDataStoreConfig.DEFAULT_GTFS_PATTERN;
+import static org.opentripplanner.datastore.OtpDataStoreConfig.DEFAULT_NETEX_PATTERN;
+import static org.opentripplanner.datastore.OtpDataStoreConfig.DEFAULT_OSM_PATTERN;
 
 /**
  * Configure paths to each individual file resource. Use URIs to specify paths. If a parameter is
@@ -126,15 +129,82 @@ public class StorageConfig {
      */
     public final URI buildReportDir;
 
+    /**
+     * Configure patterns for auto-detection of input files in the local base directory. Resolving
+     * input files is only provided for files in the base directory not for any external
+     * resources.
+     */
+    public final LocalFilenamePatterns localFileNamePatterns;
+
 
     StorageConfig(NodeAdapter config) {
-        this.gsCredentials = config.asText("gsCredentials",null);
-        this.graph = config.asUri("graph", null);
-        this.streetGraph = config.asUri("streetGraph", null);
-        this.osm.addAll(config.asUris("osm"));
-        this.dem.addAll(config.asUris("dem"));
-        this.gtfs.addAll(config.asUris("gtfs"));
-        this.netex.addAll(config.asUris("netex"));
-        this.buildReportDir = config.asUri("buildReportDir", null);
+       this.gsCredentials = config.asText("gsCredentials",null);
+       this.graph = config.asUri("graph", null);
+       this.streetGraph = config.asUri("streetGraph", null);
+       this.osm.addAll(config.asUris("osm"));
+       this.dem.addAll(config.asUris("dem"));
+       this.gtfs.addAll(config.asUris("gtfs"));
+       this.netex.addAll(config.asUris("netex"));
+       this.buildReportDir = config.asUri("buildReportDir", null);
+       this.localFileNamePatterns = new LocalFilenamePatterns(config.path("localFileNamePatterns"));
+    }
+
+    /**
+     * Configure patterns for auto-detection of input files in the local base directory. Resolving
+     * input files is only provided for files in the base directory not for any external
+     * resources.
+     */
+    public static class LocalFilenamePatterns {
+        /**
+         * Patterns for matching GTFS zip-files or directories. If the filename contains the
+         * given pattern it is considered a match. Any legal Java Regular expression is allowed.
+         * <p>
+         * This parameter is optional.
+         * <p>
+         * Default: {@code (?i)gtfs} - Match all filenames that contain "gtfs". The default pattern
+         * is NOT case sensitive.
+         */
+        public final Pattern gtfs;
+
+        /**
+         * Patterns for matching NeTEx zip files or directories. If the filename contains the
+         * given pattern it is considered a match. Any legal Java Regular expression is allowed.
+         * <p>
+         * This parameter is optional.
+         * <p>
+         * Default: {@code (?i)netex} - Match all filenames that contain "netex". The default
+         * pattern is NOT case sensitive.
+         */
+        public final Pattern netex;
+
+        /**
+         * Pattern for matching Open Street Map input files. If the filename contains the
+         * given pattern it is considered a match. Any legal Java Regular expression is allowed.
+         * <p>
+         * This parameter is optional.
+         * <p>
+         * Default: {@code (?i)(.pbf|.osm|.osm.xml)$} - Match all filenames that ends with suffix
+         * {@code .pbf}, {@code .osm} or {@code .osm.xml}. The default pattern is NOT case
+         * sensitive.
+         */
+        public final Pattern osm;
+
+        /**
+         * Pattern for matching elevation DEM files. If the filename contains the
+         * given pattern it is considered a match. Any legal Java Regular expression is allowed.
+         * <p>
+         * This parameter is optional.
+         * <p>
+         * Default: {@code (?i).tiff?$} - Match all filenames that ends with suffix
+         * {@code .tif} or {@code .tiff}. The default pattern is NOT case sensitive.
+         */
+        public final Pattern dem;
+
+        public LocalFilenamePatterns(NodeAdapter c) {
+            this.gtfs = c.asPattern("gtfs", DEFAULT_GTFS_PATTERN);
+            this.netex = c.asPattern("netex", DEFAULT_NETEX_PATTERN);
+            this.osm = c.asPattern("osm", DEFAULT_OSM_PATTERN);
+            this.dem = c.asPattern("dem", DEFAULT_DEM_PATTERN);
+        }
     }
 }

--- a/src/main/java/org/opentripplanner/standalone/configure/OtpDataStoreConfigAdapter.java
+++ b/src/main/java/org/opentripplanner/standalone/configure/OtpDataStoreConfigAdapter.java
@@ -6,6 +6,7 @@ import org.opentripplanner.standalone.config.StorageConfig;
 import java.io.File;
 import java.net.URI;
 import java.util.List;
+import java.util.regex.Pattern;
 
 /**
  * This class is a thin wrapper around the OTP configuration to provide a
@@ -70,5 +71,25 @@ class OtpDataStoreConfigAdapter implements OtpDataStoreConfig {
     @Override
     public URI streetGraph() {
         return config.streetGraph;
+    }
+
+    @Override
+    public Pattern gtfsLocalFilePattern() {
+        return config.localFileNamePatterns.gtfs;
+    }
+
+    @Override
+    public Pattern netexLocalFilePattern() {
+        return config.localFileNamePatterns.netex;
+    }
+
+    @Override
+    public Pattern osmLocalFilePattern() {
+        return config.localFileNamePatterns.osm;
+    }
+
+    @Override
+    public Pattern demLocalFilePattern() {
+        return config.localFileNamePatterns.dem;
     }
 }

--- a/src/main/java/org/opentripplanner/transit/raptor/api/request/DynamicSearchWindowCoefficients.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/request/DynamicSearchWindowCoefficients.java
@@ -36,7 +36,7 @@ public interface DynamicSearchWindowCoefficients {
      * {@code 0.0} to {@code 3.0}. Using {@code 0.0} will give you a raptor-search-window ≈
      * {@link #minWinTimeMinutes()}.
      */
-    default double minTripTimeCoefficient() { return 0.3f; }
+    default double minTripTimeCoefficient() { return 0.75f; }
 
     /**
      * {@code C} - The constant minimum number of minutes for a raptor search window. Use a value


### PR DESCRIPTION
This PR contain a few minor updates to configuration and to the documentation.
 - Make the local file type resolver configurable with pattern for matching OSM, DEM, GTFS and NETEX files.
- Extensive configuration updates.
- Added missing changelog item for #2891.


To be completed by pull request submitter:

- [ ] **issue**: Added change log for #2891, and updated the docs for several others.
- [ ] **roadmap**: No
- [ ] **tests**: No.
- [ ] **formatting**: Yes 
- [ ] **documentation**: The `Configuration.md` and `OTP2-MigrationGuide.md` is updated.
- [ ] **changelog**: yes.

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)