### PR TITLE
Fill out Leg#serviceDate using the relevant TripSchedule

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLLegImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLLegImpl.java
@@ -2,13 +2,13 @@ package org.opentripplanner.ext.legacygraphqlapi.datafetchers;
 
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
+import org.opentripplanner.api.mapping.ServiceDateMapper;
 import org.opentripplanner.ext.legacygraphqlapi.LegacyGraphQLRequestContext;
 import org.opentripplanner.ext.legacygraphqlapi.generated.LegacyGraphQLDataFetchers;
 import org.opentripplanner.model.Agency;
 import org.opentripplanner.model.Route;
 import org.opentripplanner.model.Trip;
 import org.opentripplanner.model.plan.Leg;
-import org.opentripplanner.model.plan.Place;
 import org.opentripplanner.model.plan.StopArrival;
 import org.opentripplanner.model.plan.WalkStep;
 import org.opentripplanner.routing.RoutingService;
@@ -115,7 +115,7 @@ public class LegacyGraphQLLegImpl implements LegacyGraphQLDataFetchers.LegacyGra
 
   @Override
   public DataFetcher<String> serviceDate() {
-    return environment -> getSource(environment).serviceDate;
+    return environment -> ServiceDateMapper.mapToApi(getSource(environment).serviceDate);
   }
 
   @Override

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/TripTimeShortHelper.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/TripTimeShortHelper.java
@@ -23,7 +23,7 @@ public class TripTimeShortHelper {
         if (trip == null) {
             return null;
         }
-        ServiceDate serviceDate = parseServiceDate(leg.serviceDate);
+        ServiceDate serviceDate = leg.serviceDate;
 
         List<TripTimeShort> tripTimes = routingService.getTripTimesShort(trip, serviceDate);
         long startTimeSeconds = (leg.startTime.toInstant().toEpochMilli() - serviceDate.getAsDate().getTime()) / 1000;
@@ -51,7 +51,7 @@ public class TripTimeShortHelper {
         if (trip == null) {
             return null;
         }
-        ServiceDate serviceDate = parseServiceDate(leg.serviceDate);
+        ServiceDate serviceDate = leg.serviceDate;
 
         List<TripTimeShort> tripTimes = routingService.getTripTimesShort(trip, serviceDate);
         long endTimeSeconds = (leg.endTime.toInstant().toEpochMilli() - serviceDate.getAsDate().getTime()) / 1000;
@@ -80,7 +80,7 @@ public class TripTimeShortHelper {
             return new ArrayList<>();
         }
         Trip trip = routingService.getTripForId().get(leg.tripId);
-        ServiceDate serviceDate = parseServiceDate(leg.serviceDate);
+        ServiceDate serviceDate = leg.serviceDate;
         return routingService.getTripTimesShort(trip, serviceDate);
     }
 
@@ -93,7 +93,7 @@ public class TripTimeShortHelper {
         if (trip == null) {
             return new ArrayList<>();
         }
-        ServiceDate serviceDate = parseServiceDate(leg.serviceDate);
+        ServiceDate serviceDate = leg.serviceDate;
 
         List<TripTimeShort> tripTimes = routingService.getTripTimesShort(trip, serviceDate);
         List<TripTimeShort> filteredTripTimes = new ArrayList<>();
@@ -119,17 +119,6 @@ public class TripTimeShortHelper {
         }
 
         return filteredTripTimes;
-    }
-
-
-    private ServiceDate parseServiceDate(String serviceDateString) {
-        ServiceDate serviceDate;
-        try {
-            serviceDate = ServiceDate.parseString(serviceDateString);
-        } catch (ParseException pe) {
-            throw new RuntimeException("Unparsable service date: " + serviceDateString, pe);
-        }
-        return serviceDate;
     }
 
     private boolean matchesQuayOrSiblingQuay(FeedScopedId quayId, FeedScopedId candidate, RoutingService routingService) {

--- a/src/main/java/org/opentripplanner/api/mapping/LegMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/LegMapper.java
@@ -68,7 +68,7 @@ public class LegMapper {
         api.headsign = domain.headsign;
         api.agencyId = FeedScopedIdMapper.mapToApi(domain.agencyId);
         api.tripId = FeedScopedIdMapper.mapToApi(domain.tripId);
-        api.serviceDate = domain.serviceDate;
+        api.serviceDate = ServiceDateMapper.mapToApi(domain.serviceDate);
         api.routeBrandingUrl = domain.routeBrandingUrl;
         api.intermediateStops = PlaceMapper.mapStopArrivals(domain.intermediateStops);
         api.legGeometry = domain.legGeometry;

--- a/src/main/java/org/opentripplanner/api/model/ApiLeg.java
+++ b/src/main/java/org/opentripplanner/api/model/ApiLeg.java
@@ -144,6 +144,11 @@ public class ApiLeg {
     /**
      * For transit legs, the service date of the trip.
      * For non-transit legs, null.
+     * <p>
+     * The trip service date should be used to identify the correct trip schedule and
+     * can not be trusted to display the date for any departures or arrivals. For example,
+     * the first departure for a given trip may happen at service date March 25th and
+     * service time 25:00, which in local time would be Mach 26th 01:00.
      */
     public String serviceDate = null;
 

--- a/src/main/java/org/opentripplanner/model/plan/Leg.java
+++ b/src/main/java/org/opentripplanner/model/plan/Leg.java
@@ -2,6 +2,7 @@ package org.opentripplanner.model.plan;
 
 import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.model.base.ToStringBuilder;
+import org.opentripplanner.model.calendar.ServiceDate;
 import org.opentripplanner.routing.alertpatch.Alert;
 import org.opentripplanner.routing.alertpatch.AlertPatch;
 import org.opentripplanner.routing.core.TraverseMode;
@@ -148,10 +149,13 @@ public class Leg {
    /**
     * For transit legs, the service date of the trip.
     * For non-transit legs, null.
+    * <p>
+    * The trip service date should be used to identify the correct trip schedule and
+    * can not be trusted to display the date for any departures or arrivals. For example,
+    * the first departure for a given trip may happen at service date March 25th and
+    * service time 25:00, which in local time would be Mach 26th 01:00.
     */
-   // TODO OTP2 - This should not be a String? What is this used for? Is it the actual date or the
-   //           - Service date?
-   public String serviceDate = null;
+   public ServiceDate serviceDate = null;
 
     /**
      * For transit leg, the route's branding URL (if one exists). For non-transit legs, null.
@@ -290,7 +294,7 @@ public class Leg {
                 .addStr("headsign", headsign)
                 .addObj("agencyId", agencyId)
                 .addObj("tripId", tripId)
-                .addStr("serviceDate", serviceDate)
+                .addObj("serviceDate", serviceDate)
                 .addStr("routeBrandingUrl", routeBrandingUrl)
                 .addCol("intermediateStops", intermediateStops)
                 .addObj("legGeometry", legGeometry)

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
@@ -163,7 +163,7 @@ public class RaptorPathToItineraryMapper {
             leg.arrivalDelay = tripTimes.getArrivalDelay(alightStopIndexInPattern);
         }
 
-        leg.serviceDate = new ServiceDate(request.getDateTime()).asCompactString(); // TODO: This has to be changed for multi-day searches
+        leg.serviceDate = new ServiceDate(tripSchedule.getServiceDate());
         leg.intermediateStops = new ArrayList<>();
         leg.startTime = createCalendar(pathLeg.fromTime());
         leg.endTime = createCalendar(pathLeg.toTime());

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/TripSchedule.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/TripSchedule.java
@@ -4,6 +4,8 @@ import org.opentripplanner.model.TripPattern;
 import org.opentripplanner.routing.trippattern.TripTimes;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
 
+import java.time.LocalDate;
+
 /**
  * Extension of RaptorTripSchedule passed through Raptor searches to be able to retrieve the
  * original trip from the path when creating itineraries.
@@ -19,6 +21,8 @@ public interface TripSchedule extends RaptorTripSchedule {
      * TODO OTP2 - Add JavaDoc
      */
     TripPattern getOriginalTripPattern();
+
+    LocalDate getServiceDate();
 
     /**
      * Raptor save memory by NOT storing the board/arrival stop positions in pattern; Hence we need

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/request/TripPatternForDates.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/request/TripPatternForDates.java
@@ -80,7 +80,8 @@ public class TripPatternForDates implements RaptorRoute<TripSchedule>,
             TripPatternForDate tripPatternForDate = tripPatternForDates[i];
 
             if (index < tripPatternForDate.numberOfTripSchedules()) {
-                return new TripScheduleWithOffset(this, tripPatternForDate.getTripTimes(index), offsets[i]);
+                return new TripScheduleWithOffset(this, tripPatternForDate.getLocalDate(),
+                        tripPatternForDate.getTripTimes(index), offsets[i]);
             }
             index -= tripPatternForDate.numberOfTripSchedules();
         }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/request/TripScheduleWithOffset.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/request/TripScheduleWithOffset.java
@@ -5,6 +5,8 @@ import org.opentripplanner.routing.algorithm.raptor.transit.TripSchedule;
 import org.opentripplanner.routing.trippattern.TripTimes;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripPattern;
 
+import java.time.LocalDate;
+
 /**
  * This represents a single trip within a TripPattern, but with a time offset in seconds. This is used to represent
  * a trip on a subsequent service day than the first one in the date range used.
@@ -15,11 +17,13 @@ public class TripScheduleWithOffset implements TripSchedule {
     private final int secondsOffset;
     private final TripPatternForDates pattern;
     private final TripTimes tripTimes;
+    private final LocalDate serviceDate;
 
-    TripScheduleWithOffset(TripPatternForDates pattern, TripTimes tripTimes, int offset) {
+    TripScheduleWithOffset(TripPatternForDates pattern, LocalDate localDate, TripTimes tripTimes, int offset) {
         this.pattern = pattern;
         this.tripTimes = tripTimes;
         this.secondsOffset = offset;
+        this.serviceDate = localDate;
     }
 
     @Override
@@ -45,6 +49,10 @@ public class TripScheduleWithOffset implements TripSchedule {
     @Override
     public TripPattern getOriginalTripPattern() {
         return pattern.getTripPattern().getPattern();
+    }
+
+    @Override public LocalDate getServiceDate() {
+        return serviceDate;
     }
 
     @Override


### PR DESCRIPTION
`LegMapper` is updated to use the service date of the `TripSchedule` to correctly fill out `leg.serviceDate`. For this to be possible, `TripSchedule` is extended with a `getServiceDate()` method which exposes the service date (`LocalDate`) in `TripScheduleWithOffset` throught `TripPatternForDate` / `TripPatternForDates`.

Closes #3126 

To be completed by pull request submitter:

- [ ] **issue**: Link to or create an [issue](https://github.com/opentripplanner/OpenTripPlanner/issues) that describes the relevant feature or bug. Add [GitHub keywords](https://help.github.com/articles/closing-issues-using-keywords/) to this PR's description (e.g., `closes #45`).
- [ ] **roadmap**: Check the [roadmap](https://github.com/orgs/opentripplanner/projects/1) for this feature or bug. If it is not already on the roadmap, PLC will discuss as part of the review process.
- [ ] **tests**: Have you added relevant test coverage? Are all the tests passing on [the continuous integration service (Travis CI)](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#continuous-integration)?
- [ ] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#code-style)? 
- [ ] **documentation**: If you are adding a new configuration option, have you added an explanation to the [configuration documentation](docs/Configuration.md) tables and sections?
- [ ] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)