### PR TITLE
Return BUS for taxi extended route types, fixes #2280

### DIFF
--- a/src/main/java/org/opentripplanner/gtfs/GtfsLibrary.java
+++ b/src/main/java/org/opentripplanner/gtfs/GtfsLibrary.java
@@ -7,6 +7,8 @@ import org.opentripplanner.model.CalendarService;
 import org.opentripplanner.model.OtpTransitService;
 import org.opentripplanner.model.Route;
 import org.opentripplanner.routing.core.TraverseMode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -14,6 +16,8 @@ import java.io.IOException;
 import static org.opentripplanner.calendar.impl.CalendarServiceDataFactoryImpl.createCalendarService;
 
 public class GtfsLibrary {
+
+    private static final Logger LOG = LoggerFactory.getLogger(GtfsLibrary.class);
 
     public static final char ID_SEPARATOR = ':'; // note this is different than what OBA GTFS uses to match our 1.0 API
 
@@ -88,7 +92,9 @@ public class GtfsLibrary {
         } else if (routeType >= 1400 && routeType < 1500) { //Funicalar Service
             return TraverseMode.FUNICULAR;
         } else if (routeType >= 1500 && routeType < 1600) { //Taxi Service
-            throw new IllegalArgumentException("Taxi service not supported" + routeType);
+            LOG.warn("Treating taxi route {} (extended route type {}) as a bus.",
+                route.getId(), routeType);
+            return TraverseMode.BUS;
         } else if (routeType >= 1600 && routeType < 1700) { //Self drive
             return TraverseMode.CAR;
         }


### PR DESCRIPTION
This is a minimal solution for #2280. It does not add a special taxi mode, it just treats them as buses so the GTFS import won't crash when the data contains a route with a taxi extended mode.

A more complete solution to this exists in #2373, but development seems to have stalled at a point where it was awaiting a few changes. Also, I'm not sure if there will be implications to adding new modes

I plan to port this over to OTP2. Considering OTP2 is used in Nordic countries, who are likely to import the Swedish data that has the taxi routes, I would defer to users there including @t2gran and others at Entur on whether we should finish up the other PR #2373. OTP2 will be able to import Netex data though so probably won't even use these GTFS extended route codes.
