### PR TITLE
Return OUTSIDE_SERVICE_PERIOD for transit trips outside the data validity

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/RoutingWorker.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/RoutingWorker.java
@@ -106,6 +106,12 @@ public class RoutingWorker {
         request.setRoutingContext(router.graph);
         if (request.modes.transitModes.isEmpty()) { return Collections.emptyList(); }
 
+        if (!router.graph.transitFeedCovers(request.dateTime)) {
+            throw new RoutingValidationException(List.of(
+                    new RoutingError(RoutingErrorCode.OUTSIDE_SERVICE_PERIOD, InputField.DATE_TIME)
+            ));
+        }
+
         TransitLayer transitLayer = request.ignoreRealtimeUpdates
             ? router.graph.getTransitLayer()
             : router.graph.getRealtimeTransitLayer();
@@ -224,7 +230,7 @@ public class RoutingWorker {
     private void checkIfTransitConnectionExists(RaptorResponse<TripSchedule> response) {
         int searchWindowUsed = response.requestUsed().searchParams().searchWindowInSeconds();
         if (searchWindowUsed <= 0 && response.paths().isEmpty()) {
-            throw new RoutingValidationException(Collections.singletonList(
+            throw new RoutingValidationException(List.of(
                 new RoutingError(RoutingErrorCode.NO_TRANSIT_CONNECTION, null)));
         }
     }

--- a/src/main/java/org/opentripplanner/routing/api/response/InputField.java
+++ b/src/main/java/org/opentripplanner/routing/api/response/InputField.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.routing.api.response;
 
 public enum InputField {
+  DATE_TIME,
   FROM_PLACE,
   TO_PLACE,
   INTERMEDIATE_PLACE


### PR DESCRIPTION
The `RoutingErrorCode.OUTSIDE_SERVICE_PERIOD` exists (and existed in OTP1), but is currently not implemented. 

`graph#transitFeedCovers(Date)` is used to verify if the request is covered by the used transit data.

To be completed by pull request submitter:

- [ ] **issue**: Link to or create an [issue](https://github.com/opentripplanner/OpenTripPlanner/issues) that describes the relevant feature or bug. Add [GitHub keywords](https://help.github.com/articles/closing-issues-using-keywords/) to this PR's description (e.g., `closes #45`).
- [ ] **roadmap**: Check the [roadmap](https://github.com/orgs/opentripplanner/projects/1) for this feature or bug. If it is not already on the roadmap, PLC will discuss as part of the review process.
- [ ] **tests**: Have you added relevant test coverage? Are all the tests passing on [the continuous integration service (Travis CI)](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#continuous-integration)?
- [ ] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#code-style)? 
- [ ] **documentation**: If you are adding a new configuration option, have you added an explanation to the [configuration documentation](docs/Configuration.md) tables and sections?
- [ ] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)