### PR TITLE
Use input streams instead of byte[] when parsing NeTEx files

### DIFF
--- a/src/main/java/org/opentripplanner/netex/loader/NetexBundle.java
+++ b/src/main/java/org/opentripplanner/netex/loader/NetexBundle.java
@@ -153,7 +153,7 @@ public class NetexBundle implements Closeable {
         try {
             LOG.info("reading entity {}: {}", fileDescription, entry.name());
 
-            PublicationDeliveryStructure doc = xmlParser.parseXmlDoc(entry.asBytes());
+            PublicationDeliveryStructure doc = xmlParser.parseXmlDoc(entry.asInputStream());
             NetexDocumentParser.parseAndPopulateIndex(index(), doc);
 
         } catch (JAXBException e) {

--- a/src/main/java/org/opentripplanner/netex/loader/NetexXmlParser.java
+++ b/src/main/java/org/opentripplanner/netex/loader/NetexXmlParser.java
@@ -6,7 +6,7 @@ import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBElement;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
-import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 
 /** Simple wrapper to perform typesafe xml parsing and simple error handling. */
 class NetexXmlParser {
@@ -18,11 +18,11 @@ class NetexXmlParser {
     }
 
     /**
-     * Parse a byte array and return the root document type for the given xml file(bytes).
+     * Parse an input stream and return the root document type for the given xml file (stream).
      */
-    PublicationDeliveryStructure parseXmlDoc(byte[] bytesArray) throws JAXBException {
+    PublicationDeliveryStructure parseXmlDoc(InputStream stream) throws JAXBException {
         JAXBElement<PublicationDeliveryStructure> root;
-        ByteArrayInputStream stream = new ByteArrayInputStream(bytesArray);
+
         //noinspection unchecked
         root = (JAXBElement<PublicationDeliveryStructure>) unmarshaller.unmarshal(stream);
 


### PR DESCRIPTION
Use `DataSource#asInputSteam()` for parsing NeTEx documents to avoid
loading the whole document into memory with `asBytes()`.

To be completed by pull request submitter:

- [ ] **issue**: Link to or create an [issue](https://github.com/opentripplanner/OpenTripPlanner/issues) that describes the relevant feature or bug. Add [GitHub keywords](https://help.github.com/articles/closing-issues-using-keywords/) to this PR's description (e.g., `closes #45`).
- [ ] **roadmap**: Check the [roadmap](https://github.com/orgs/opentripplanner/projects/1) for this feature or bug. If it is not already on the roadmap, PLC will discuss as part of the review process.
- [ ] **tests**: Have you added relevant test coverage? Are all the tests passing on [the continuous integration service (Travis CI)](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#continuous-integration)?
- [ ] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#code-style)? 
- [ ] **documentation**: If you are adding a new configuration option, have you added an explanation to the [configuration documentation](docs/Configuration.md) tables and sections?
- [ ] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)