### PR TITLE
Filter out ways with "planned" tag

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/OSMFilter.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/OSMFilter.java
@@ -36,6 +36,7 @@ public class OSMFilter {
             if(
                     highway.equals("conveyer") ||
                     highway.equals("proposed") ||
+                    highway.equals("planned") ||
                     highway.equals("construction") ||
                     highway.equals("razed") ||
                     highway.equals("raceway") ||


### PR DESCRIPTION
To be completed by pull request submitter:

- [ ] **issue**: no issue
- [ ] **roadmap**: not on roadmap
- [ ] **tests**: no tests made or improved
- [x] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#code-style)? 
- [ n/a ] **documentation**: If you are adding a new configuration option, have you added an explanation to the [configuration documentation](docs/Configuration.md) tables and sections?
- [ ] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)

This PR adds the tag of `"highway"="planned"` to the list of filters that will result in a OSM way not being included as a routeable way. There are significantly fewer of these than the `"highway"="proposed"`, but they do exist.