### PR TITLE
WayPropertySet optimization

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModule.java
@@ -135,6 +135,7 @@ public class OpenStreetMapModule implements GraphBuilderModule {
     public void setDefaultWayPropertySetSource(WayPropertySetSource source) {
         wayPropertySet = new WayPropertySet();
         source.populateProperties(wayPropertySet);
+        wayPropertySet.index();
     }
 
     /**
@@ -528,13 +529,14 @@ public class OpenStreetMapModule implements GraphBuilderModule {
 
             /* build the street segment graph from OSM ways */
             long wayIndex = 0;
-            long wayCount = osmdb.getWays().size();
+            Collection <OSMWay> ways = osmdb.getWays();
+            long wayCount = ways.size();
 
             WAY:
-            for (OSMWay way : osmdb.getWays()) {
+            for (OSMWay way : ways) {
 
-                if (wayIndex % 10000 == 0)
-                    LOG.debug("ways=" + wayIndex + "/" + wayCount);
+                if (wayIndex % 50000 == 0)
+                    LOG.info("ways=" + wayIndex + "/" + wayCount);
                 wayIndex++;
 
                 WayProperties wayData = wayPropertySet.getDataForWay(way);

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/WayPropertySet.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/WayPropertySet.java
@@ -181,8 +181,9 @@ public class WayPropertySet {
     public WayProperties getDataForWay(OSMWithTags way) {
         String wayPropertiesKey = getKeyFromApplicableTags(way, possibleWayPropertyTagValues);
         // check if lookup key found
-        if (wayPropertyLookup.containsKey(wayPropertiesKey)) {
-            return wayPropertyLookup.get(wayPropertiesKey);
+        WayProperties cachedWayProperties = wayPropertyLookup.get(wayPropertiesKey);
+        if (cachedWayProperties != null) {
+            return cachedWayProperties;
         }
 
         WayProperties leftResult = defaultProperties;
@@ -302,8 +303,9 @@ public class WayPropertySet {
         // also append back value
         wayPropertiesKey = String.format("%s;%s=%b", wayPropertiesKey, "back=", back);
         // check if lookup key found
-        if (carSpeedLookup.containsKey(wayPropertiesKey)) {
-            return carSpeedLookup.get(wayPropertiesKey);
+        Float cachedSpeed = carSpeedLookup.get(wayPropertiesKey);
+        if (cachedSpeed != null) {
+            return cachedSpeed;
         }
 
         Float speed = calculateCarSpeedForWay(way, back);

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/WayPropertySet.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/WayPropertySet.java
@@ -81,7 +81,7 @@ public class WayPropertySet {
     }
 
     /**
-     * Initializes lookups and Indexes for quick lookup of applicable values for way properties and car speeds. This
+     * Initializes lookups and indexes for quick lookup of applicable values for way properties and car speeds. This
      * function must be called before looking up way properties and car speeds for ways in order for those caches to be
      * properly initialized.
      */
@@ -116,7 +116,7 @@ public class WayPropertySet {
      * @param way The way from which to calculate a key
      * @param possibleTagValues The possible tag values that would apply for this way
      */
-    private String getKeyFromApplicableTags (OSMWithTags way, HashSet possibleTagValues) {
+    private String getKeyFromApplicableTags(OSMWithTags way, HashSet possibleTagValues) {
         List<String> applicableTagValues = new ArrayList<>();
         Map<String, String> wayTags = way.getTags();
         if (wayTags == null) {

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/WayPropertySet.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/WayPropertySet.java
@@ -1,6 +1,8 @@
 package org.opentripplanner.graph_builder.module.osm;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -8,6 +10,10 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.Collections.sort;
 
 import org.opentripplanner.common.model.P2;
 import org.opentripplanner.common.model.T2;
@@ -52,6 +58,10 @@ public class WayPropertySet {
 
     public WayPropertySetSource base;
 
+    private HashMap<String, WayProperties> wayPropertyLookup;
+
+    private HashSet<Object> possibleWayTagValues;
+
     public WayPropertySet() {
         /* sensible defaults */
         defaultProperties = new WayProperties();
@@ -69,10 +79,42 @@ public class WayPropertySet {
     }
 
     /**
+     * Initializes lookups and Indexes various sets for quick lookup of applicable values
+     */
+    public void index() {
+        wayPropertyLookup = new HashMap<>();
+        possibleWayTagValues = new HashSet<>();
+        for (WayPropertyPicker wayProperty : wayProperties) {
+            for (P2<String> kvpair : wayProperty.getSpecifier().kvpairs) {
+                possibleWayTagValues.add(String.format("%s=%s", kvpair.first, kvpair.second));
+            }
+        }
+    }
+
+    /**
      * Applies the WayProperties whose OSMPicker best matches this way. In addition, WayProperties that are mixins
      * will have their safety values applied if they match at all.
      */
     public WayProperties getDataForWay(OSMWithTags way) {
+        // compute lookup key for way based on applicable tags/values
+        List<String> applicableTagValues = new ArrayList<>();
+        for (Entry<String, String> wayTagValue : way.getTags().entrySet()) {
+            // if tag/value exists in way properties, add to list of matches
+            String tagValue = String.format("%s=%s", wayTagValue.getKey(), wayTagValue.getValue());
+            String wildcardTag = String.format("%s=*", wayTagValue.getKey());
+            if (possibleWayTagValues.contains(tagValue) || possibleWayTagValues.contains(wildcardTag)) {
+                applicableTagValues.add(tagValue);
+            }
+        }
+        // sort values to make deterministic key
+        sort(applicableTagValues);
+        String wayPropertiesKey = String.join(";", applicableTagValues);
+
+        // check if lookup key found
+        if (wayPropertyLookup.containsKey(wayPropertiesKey)) {
+            return wayPropertyLookup.get(wayPropertiesKey);
+        }
+
         WayProperties leftResult = defaultProperties;
         WayProperties rightResult = defaultProperties;
         int bestLeftScore = 0;
@@ -121,6 +163,7 @@ public class WayPropertySet {
             String all_tags = dumpTags(way);
             LOG.debug("Used default permissions: " + all_tags);
         }
+        wayPropertyLookup.put(wayPropertiesKey, result);
         return result;
     }
 

--- a/src/test/java/org/opentripplanner/graph_builder/module/osm/TestOpenStreetMapGraphBuilder.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/osm/TestOpenStreetMapGraphBuilder.java
@@ -287,6 +287,12 @@ public class TestOpenStreetMapGraphBuilder extends TestCase {
                                                                        // from track
         assertEquals(0.75, dataForWay.getSafetyFeatures().second); // left comes from lane
 
+        // make sure the way property cache has been set with proper values along the way
+        dataForWay = wayPropertySet.getWayPropertyLookup().get("cycleway:right=track;cycleway=lane;highway=footway");
+        assertEquals(0.25, dataForWay.getSafetyFeatures().first); // right (with traffic) comes
+        // from track
+        assertEquals(0.75, dataForWay.getSafetyFeatures().second); // left comes from lane
+
         way = new OSMWay();
         way.addTag("highway", "footway");
         way.addTag("footway", "sidewalk");

--- a/src/test/java/org/opentripplanner/graph_builder/module/osm/TestOpenStreetMapGraphBuilder.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/osm/TestOpenStreetMapGraphBuilder.java
@@ -216,6 +216,7 @@ public class TestOpenStreetMapGraphBuilder extends TestCase {
         way.addTag("surface", "gravel");
 
         WayPropertySet wayPropertySet = new WayPropertySet();
+        wayPropertySet.index();
 
         // where there are no way specifiers, the default is used
         assertEquals(wayPropertySet.getDataForWay(way), wayPropertySet.defaultProperties);
@@ -237,6 +238,7 @@ public class TestOpenStreetMapGraphBuilder extends TestCase {
         footways_allow_peds.setPermission(StreetTraversalPermission.PEDESTRIAN);
 
         wayPropertySet.addProperties(footway_only, footways_allow_peds);
+        wayPropertySet.index();
 
         WayProperties dataForWay = wayPropertySet.getDataForWay(way);
         // the first one is found
@@ -252,6 +254,8 @@ public class TestOpenStreetMapGraphBuilder extends TestCase {
         safer_and_peds.setPermission(StreetTraversalPermission.PEDESTRIAN);
 
         wayPropertySet.addProperties(lane_and_footway, safer_and_peds);
+        wayPropertySet.index();
+
         dataForWay = wayPropertySet.getDataForWay(way);
         assertEquals(dataForWay, safer_and_peds);
 
@@ -260,6 +264,7 @@ public class TestOpenStreetMapGraphBuilder extends TestCase {
         WayProperties gravel_is_dangerous = new WayProperties();
         gravel_is_dangerous.setSafetyFeatures(new P2<Double>(2.0, 2.0));
         wayPropertySet.addProperties(gravel, gravel_is_dangerous, true);
+        wayPropertySet.index();
 
         dataForWay = wayPropertySet.getDataForWay(way);
         assertEquals(dataForWay.getSafetyFeatures().first, 1.5);
@@ -275,6 +280,8 @@ public class TestOpenStreetMapGraphBuilder extends TestCase {
         track_is_safest.setSafetyFeatures(new P2<Double>(0.25, 0.25));
 
         wayPropertySet.addProperties(track_only, track_is_safest);
+        wayPropertySet.index();
+
         dataForWay = wayPropertySet.getDataForWay(way);
         assertEquals(0.25, dataForWay.getSafetyFeatures().first); // right (with traffic) comes
                                                                        // from track

--- a/src/test/java/org/opentripplanner/graph_builder/module/osm/TestWayPropertySet.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/osm/TestWayPropertySet.java
@@ -5,6 +5,8 @@ import org.opentripplanner.openstreetmap.model.OSMWithTags;
 
 import junit.framework.TestCase;
 
+import java.util.HashMap;
+
 /**
  * Test the WayPropertySet 
  * @author mattwigway
@@ -49,6 +51,7 @@ public class TestWayPropertySet extends TestCase {
        WayPropertySet wps = new WayPropertySet();
        DefaultWayPropertySetSource source = new DefaultWayPropertySetSource();
        source.populateProperties(wps);
+       wps.index();
        
        OSMWithTags way;
        
@@ -83,6 +86,11 @@ public class TestWayPropertySet extends TestCase {
        way.addTag("maxspeed", "35 mph");
        assertTrue(within(kmhAsMs(35 * 1.609f), wps.getCarSpeedForWay(way, false), epsilon));
        assertTrue(within(kmhAsMs(35 * 1.609f), wps.getCarSpeedForWay(way, true), epsilon));
+
+       // make sure the car speed cache has been populated with some values along the way
+       HashMap<String, Float> carSpeedLookup = wps.getCarSpeedLookup();
+       assertTrue(within(kmhAsMs(20), carSpeedLookup.get("maxspeed:forward=80;maxspeed:reverse=20;maxspeed=40;back==true"), epsilon));
+       assertTrue(within(kmhAsMs(80), carSpeedLookup.get("maxspeed:forward=80;maxspeed:reverse=20;maxspeed=40;back==false"), epsilon));
        
        // test with no maxspeed tags
        wps = new WayPropertySet();
@@ -90,6 +98,7 @@ public class TestWayPropertySet extends TestCase {
        wps.addSpeedPicker(getSpeedPicker("highway=*", kmhAsMs(35)));
        wps.addSpeedPicker(getSpeedPicker("surface=gravel", kmhAsMs(10)));
        wps.defaultSpeed = kmhAsMs(25);
+       wps.index();
        
        way = new OSMWithTags();
      

--- a/src/test/java/org/opentripplanner/openstreetmap/model/OSMWayTest.java
+++ b/src/test/java/org/opentripplanner/openstreetmap/model/OSMWayTest.java
@@ -265,6 +265,7 @@ public class OSMWayTest {
 
     private P2<StreetTraversalPermission> getWayProperties(OSMWay way) {
         WayPropertySet wayPropertySet = new WayPropertySet();
+        wayPropertySet.index();
         WayProperties wayData = wayPropertySet.getDataForWay(way);
 
         StreetTraversalPermission permissions = OSMFilter.getPermissionsForWay(way,


### PR DESCRIPTION
To be completed by pull request submitter:

- [ ] **issue**: Link to or create an [issue](https://github.com/opentripplanner/OpenTripPlanner/issues) that describes the relevant feature or bug. Add [GitHub keywords](https://help.github.com/articles/closing-issues-using-keywords/) to this PR's description (e.g., `closes #45`).
- [ ] **roadmap**: Check the [roadmap](https://github.com/orgs/opentripplanner/projects/1) for this feature or bug. If it is not already on the roadmap, PLC will discuss as part of the review process.
- [x] **tests**: Have you added relevant test coverage? Are all the tests passing on [the continuous integration service (Travis CI)](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#continuous-integration)?
- [x] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#code-style)? 
- [x] **documentation**: If you are adding a new configuration option, have you added an explanation to the [configuration documentation](docs/Configuration.md) tables and sections?
- [ ] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)

### Description ###

This PR reduces the calculation time of the OpenStreetMap graph builder module by memoizing certain values that were frequently recomputed. In particular, the calculation of the way data (which is used for calculating the StreetTravelPermissions and the bicycleSafetyFactor) and car speed had this optimization applied.

Whenever the way data is calculated, OTP loops through all possible values (there are ~170 of them) in the DefaultWayPropertySetSource class and then figures out what the best match is for both directions of the way. A similar thing occurs when calculating the car speed. Although there aren't as many possible speed values, there is a regex that sometimes runs which could also slow things down a bit.

OTP would previously do these calculations of the way data and car speed for every way despite the high likelihood of ways throughout the network having the same exact set of applicable tags. This PR has code that compiles a list of applicable tags of a way and will then calculate the way data or car speed once and save it in a memorized cache so that whenever another way is analyzed that has the same set of applicable tags, it will also use this pre-calculated way data or speed.