### PR TITLE
Correctly add GroupOfLines

### DIFF
--- a/src/main/java/org/opentripplanner/netex/loader/parser/ServiceFrameParser.java
+++ b/src/main/java/org/opentripplanner/netex/loader/parser/ServiceFrameParser.java
@@ -172,7 +172,8 @@ class ServiceFrameParser extends NetexParser<Service_VersionFrameStructure> {
 
     private void parseGroupOfLines(Collection<GroupOfLines> groupOfLines, Network network) {
         for (GroupOfLines group : groupOfLines) {
-            networkIdByGroupOfLineId.put(network.getId(), group.getId());
+            networkIdByGroupOfLineId.put(group.getId(), network.getId());
+            this.groupOfLines.add(group);
         }
     }
 


### PR DESCRIPTION
To be completed by pull request submitter:

- [x] **issue**: Small bug fix, so no issue
- [x] **roadmap**: Check the [roadmap](https://github.com/orgs/opentripplanner/projects/1) for this feature or bug. If it is not already on the roadmap, PLC will discuss as part of the review process.
- [x] **tests**: Have you added relevant test coverage? Are all the tests passing on [the continuous integration service (Travis CI)](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#continuous-integration)?
- [x] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#code-style)? 
- [x] **documentation**: If you are adding a new configuration option, have you added an explanation to the [configuration documentation](docs/Configuration.md) tables and sections?
- [x] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)

This two bugs in the NeTEx import. The first was that the NeTEx parser never added the GroupOfLine entities to the NetexIndex. The other was that the networkIdByGroupOfLineId added networkId and groupId in the reverse order.

The result of this was that Lines that connected to Authority through GroupOfLines instead of via Network directly got set to the default Authority (name N/A). This can be seen in the NetexImportDataIndex.lookUpNetworkForLine method.

I have tested this by importing the Norwegian NeTEx file and doing API calls from the Entur client.