### PR TITLE
 Do not throw error when a transit subItinerary has no legs

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
@@ -280,6 +280,10 @@ public class RaptorPathToItineraryMapper {
             Itinerary subItinerary = GraphPathToItineraryMapper
                     .generateItinerary(graphPath, request.locale);
 
+            if (subItinerary.legs.isEmpty()) {
+                return;
+            }
+
             // TODO OTP2 We use the duration initially calculated for use during routing
             //      because they do not always match up and we risk getting negative wait times
             //      (#2955)


### PR DESCRIPTION
In #3144 we removed the trivial path exception, and made it possible for (sub)itineraries in a RAPTOR search to have no legs. Unfortunately there is a check, which makes sure subItineraries in transfers always has exactly one leg. 

When there are two stops in separate feeds so that they link to the same vertex, no leg is generated for a transfer between them, and an error is thrown. This adds a separate check for empty itineraries, which bypasses the check and fixup of that leg.

To be completed by pull request submitter:

- [ ] **issue**: Link to or create an [issue](https://github.com/opentripplanner/OpenTripPlanner/issues) that describes the relevant feature or bug. Add [GitHub keywords](https://help.github.com/articles/closing-issues-using-keywords/) to this PR's description (e.g., `closes #45`).
- [ ] **roadmap**: Check the [roadmap](https://github.com/orgs/opentripplanner/projects/1) for this feature or bug. If it is not already on the roadmap, PLC will discuss as part of the review process.
- [ ] **tests**: Have you added relevant test coverage? Are all the tests passing on [the continuous integration service (Travis CI)](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#continuous-integration)?
- [ ] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#code-style)? 
- [ ] **documentation**: If you are adding a new configuration option, have you added an explanation to the [configuration documentation](docs/Configuration.md) tables and sections?
- [ ] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)