### PR TITLE
Add searchWindow query parameter to legacy GraphQL API

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
@@ -589,7 +589,7 @@ public class LegacyGraphQLQueryTypeImpl
 
       callWith.argument("wheelchair", request::setWheelchairAccessible);
       callWith.argument("numItineraries", request::setNumItineraries);
-      callWith.argument("searchWindow", (Integer m) -> request.searchWindow = Duration.ofSeconds(m));
+      callWith.argument("searchWindow", (Long m) -> request.searchWindow = Duration.ofSeconds(m));
       callWith.argument("maxWalkDistance", request::setMaxWalkDistance);
       // callWith.argument("maxSlope", request::setMaxSlope);
       callWith.argument("maxPreTransitTime", request::setMaxPreTransitTime);

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
@@ -45,6 +45,7 @@ import org.opentripplanner.routing.vertextype.TransitStopVertex;
 import org.opentripplanner.updater.GtfsRealtimeFuzzyTripMatcher;
 import org.opentripplanner.util.ResourceBundleSingleton;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -588,6 +589,7 @@ public class LegacyGraphQLQueryTypeImpl
 
       callWith.argument("wheelchair", request::setWheelchairAccessible);
       callWith.argument("numItineraries", request::setNumItineraries);
+      callWith.argument("searchWindow", (Integer m) -> request.searchWindow = Duration.ofSeconds(m));
       callWith.argument("maxWalkDistance", request::setMaxWalkDistance);
       // callWith.argument("maxSlope", request::setMaxSlope);
       callWith.argument("maxPreTransitTime", request::setMaxPreTransitTime);

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/LegacyGraphQLTypes.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/LegacyGraphQLTypes.java
@@ -896,6 +896,7 @@ public class LegacyGraphQLTypes {
     private String _toPlace;
     private Boolean _wheelchair;
     private Integer _numItineraries;
+    private Integer _searchWindow;
     private Double _maxWalkDistance;
     private Integer _maxPreTransitTime;
     private Double _carParkCarLegWeight;
@@ -950,6 +951,7 @@ public class LegacyGraphQLTypes {
         this._toPlace = (String) args.get("toPlace");
         this._wheelchair = (Boolean) args.get("wheelchair");
         this._numItineraries = (Integer) args.get("numItineraries");
+        this._searchWindow = (Integer) args.get("searchWindow");
         this._maxWalkDistance = (Double) args.get("maxWalkDistance");
         this._maxPreTransitTime = (Integer) args.get("maxPreTransitTime");
         this._carParkCarLegWeight = (Double) args.get("carParkCarLegWeight");
@@ -1012,6 +1014,7 @@ public class LegacyGraphQLTypes {
     public String getLegacyGraphQLToPlace() { return this._toPlace; }
     public Boolean getLegacyGraphQLWheelchair() { return this._wheelchair; }
     public Integer getLegacyGraphQLNumItineraries() { return this._numItineraries; }
+    public Integer getLegacyGraphQLSearchWindow() { return this._searchWindow; }
     public Double getLegacyGraphQLMaxWalkDistance() { return this._maxWalkDistance; }
     public Integer getLegacyGraphQLMaxPreTransitTime() { return this._maxPreTransitTime; }
     public Double getLegacyGraphQLCarParkCarLegWeight() { return this._carParkCarLegWeight; }

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/LegacyGraphQLTypes.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/LegacyGraphQLTypes.java
@@ -896,7 +896,7 @@ public class LegacyGraphQLTypes {
     private String _toPlace;
     private Boolean _wheelchair;
     private Integer _numItineraries;
-    private Integer _searchWindow;
+    private Long _searchWindow;
     private Double _maxWalkDistance;
     private Integer _maxPreTransitTime;
     private Double _carParkCarLegWeight;
@@ -951,7 +951,7 @@ public class LegacyGraphQLTypes {
         this._toPlace = (String) args.get("toPlace");
         this._wheelchair = (Boolean) args.get("wheelchair");
         this._numItineraries = (Integer) args.get("numItineraries");
-        this._searchWindow = (Integer) args.get("searchWindow");
+        this._searchWindow = (Long) args.get("searchWindow");
         this._maxWalkDistance = (Double) args.get("maxWalkDistance");
         this._maxPreTransitTime = (Integer) args.get("maxPreTransitTime");
         this._carParkCarLegWeight = (Double) args.get("carParkCarLegWeight");
@@ -1014,7 +1014,7 @@ public class LegacyGraphQLTypes {
     public String getLegacyGraphQLToPlace() { return this._toPlace; }
     public Boolean getLegacyGraphQLWheelchair() { return this._wheelchair; }
     public Integer getLegacyGraphQLNumItineraries() { return this._numItineraries; }
-    public Integer getLegacyGraphQLSearchWindow() { return this._searchWindow; }
+    public Long getLegacyGraphQLSearchWindow() { return this._searchWindow; }
     public Double getLegacyGraphQLMaxWalkDistance() { return this._maxWalkDistance; }
     public Integer getLegacyGraphQLMaxPreTransitTime() { return this._maxPreTransitTime; }
     public Double getLegacyGraphQLCarParkCarLegWeight() { return this._carParkCarLegWeight; }

--- a/src/ext/resources/legacygraphqlapi/schema.graphqls
+++ b/src/ext/resources/legacygraphqlapi/schema.graphqls
@@ -1510,6 +1510,17 @@ type QueryType {
         numItineraries: Int = 3
 
         """
+        The length of the search-window in seconds. This is normally dynamically
+        calculated by the server, but you may override this by setting it. The
+        search-window used in a request is returned in the response metadata.
+        To get the \"next page\" of trips use the metadata(searchWindowUsed and
+        nextWindowDateTime) to create a new request. If not provided the value
+        is resolved depending on the other input parameters, available transit
+        options and realtime changes.
+        """
+        searchWindow: Int,
+
+        """
         The maximum distance (in meters) the user is willing to walk per walking
         section. If the only transport mode allowed is `WALK`, then the value of
         this argument is ignored.

--- a/src/ext/resources/legacygraphqlapi/schema.graphqls
+++ b/src/ext/resources/legacygraphqlapi/schema.graphqls
@@ -1518,7 +1518,7 @@ type QueryType {
         is resolved depending on the other input parameters, available transit
         options and realtime changes.
         """
-        searchWindow: Int,
+        searchWindow: Long,
 
         """
         The maximum distance (in meters) the user is willing to walk per walking


### PR DESCRIPTION
Add `searchWindow` query parameter to legacy GraphQL API. This is same as Transmodel query parameter, but unit is seconds, because legacy GraphQL API's response `searchWindowUsed` is also in seconds.

- [ ] **issue**: Link to or create an [issue](https://github.com/opentripplanner/OpenTripPlanner/issues) that describes the relevant feature or bug. Add [GitHub keywords](https://help.github.com/articles/closing-issues-using-keywords/) to this PR's description (e.g., `closes #45`).
- [ ] **roadmap**: Check the [roadmap](https://github.com/orgs/opentripplanner/projects/1) for this feature or bug. If it is not already on the roadmap, PLC will discuss as part of the review process.
- [ ] **tests**: Have you added relevant test coverage? Are all the tests passing on [the continuous integration service (Travis CI)](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#continuous-integration)?
- [ ] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#code-style)? 
- [ ] **documentation**: If you are adding a new configuration option, have you added an explanation to the [configuration documentation](docs/Configuration.md) tables and sections?
- [ ] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)