### PR TITLE
Parse additionalNetworks in NeTEx import

### DIFF
--- a/src/main/java/org/opentripplanner/netex/loader/parser/ServiceFrameParser.java
+++ b/src/main/java/org/opentripplanner/netex/loader/parser/ServiceFrameParser.java
@@ -11,6 +11,7 @@ import org.rutebanken.netex.model.JourneyPatternsInFrame_RelStructure;
 import org.rutebanken.netex.model.Line;
 import org.rutebanken.netex.model.LinesInFrame_RelStructure;
 import org.rutebanken.netex.model.Network;
+import org.rutebanken.netex.model.NetworksInFrame_RelStructure;
 import org.rutebanken.netex.model.PassengerStopAssignment;
 import org.rutebanken.netex.model.Quay;
 import org.rutebanken.netex.model.Route;
@@ -63,6 +64,7 @@ class ServiceFrameParser extends NetexParser<Service_VersionFrameStructure> {
         parseStopAssignments(frame.getStopAssignments());
         parseRoutes(frame.getRoutes());
         parseNetwork(frame.getNetwork());
+        parseAdditionalNetworks(frame.getAdditionalNetworks());
         noticeParser.parseNotices(frame.getNotices());
         noticeParser.parseNoticeAssignments(frame.getNoticeAssignments());
         parseLines(frame.getLines());
@@ -167,6 +169,14 @@ class ServiceFrameParser extends NetexParser<Service_VersionFrameStructure> {
 
         if (groupsOfLines != null) {
             parseGroupOfLines(groupsOfLines.getGroupOfLines(), network);
+        }
+    }
+
+    private void parseAdditionalNetworks(NetworksInFrame_RelStructure additionalNetworks) {
+        if (additionalNetworks == null) { return; }
+
+        for (Network additionalNetwork : additionalNetworks.getNetwork()) {
+            parseNetwork(additionalNetwork);
         }
     }
 


### PR DESCRIPTION
To be completed by pull request submitter:

- [ ] **issue**: Link to or create an [issue](https://github.com/opentripplanner/OpenTripPlanner/issues) that describes the relevant feature or bug. Add [GitHub keywords](https://help.github.com/articles/closing-issues-using-keywords/) to this PR's description (e.g., `closes #45`).
- [ ] **roadmap**: Check the [roadmap](https://github.com/orgs/opentripplanner/projects/1) for this feature or bug. If it is not already on the roadmap, PLC will discuss as part of the review process.
- [ ] **tests**: Have you added relevant test coverage? Are all the tests passing on [the continuous integration service (Travis CI)](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#continuous-integration)?
- [ ] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#code-style)? 
- [ ] **documentation**: If you are adding a new configuration option, have you added an explanation to the [configuration documentation](docs/Configuration.md) tables and sections?
- [ ] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)

This is a small fix to the NeTEx import, so that additional networks are also imported. Without this, agency information will not be imported for some data providers.

This has been tested on the Norwegian NeTEx data set.