### PR TITLE
Do not overwrite TripPattern ids

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -44,6 +44,7 @@ See the [OTP2 Migration Guide](OTP2-MigrationGuide.md) on changes to the REST AP
 - Remove AlertPatcher (#3134)
 - Update DebugOutput to match new routing phases of OTP2 (#3109)
 - Filter transit itineraries with relative high cost (#3157).
+- Fix issue with colliding TripPattern ids after modifications form real-time updaters. (#3202)
 
 
 ## Ported over from the 1.x

--- a/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
@@ -922,9 +922,11 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
 
     private boolean purgeExpiredData() {
         final ServiceDate today = new ServiceDate();
+        // TODO: Base this on numberOfDaysOfLongestTrip for tripPatterns
         final ServiceDate previously = today.previous().previous(); // Just to be safe...
 
-        if(lastPurgeDate != null && lastPurgeDate.compareTo(previously) > 0) {
+        // Purge data only if we have changed date
+        if(lastPurgeDate != null && lastPurgeDate.compareTo(previously) >= 0) {
             return false;
         }
 

--- a/src/main/java/org/opentripplanner/updater/stoptime/TripPatternCache.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/TripPatternCache.java
@@ -59,7 +59,6 @@ public class TripPatternCache {
 
             // Copy information from the TripPattern this is replacing
             if (originalTripPattern != null) {
-                tripPattern.setId(originalTripPattern.getId());
                 tripPattern.setHopGeometriesFromPattern(originalTripPattern);
             }
             


### PR DESCRIPTION
Do not overwrite id on TripPattern, but rather leave the generated id as is. This will fix the issue below, as there are no longer collisions in fetching Timetables for TripPatterns, as the hash and equals are based on the id.

Also fix a bug in date comparison when removing old data.

To be completed by pull request submitter:

- [x] **issue**: #3110 
- [ ] **roadmap**: Check the [roadmap](https://github.com/orgs/opentripplanner/projects/1) for this feature or bug. If it is not already on the roadmap, PLC will discuss as part of the review process.
- [ ] **tests**: Have you added relevant test coverage? Are all the tests passing on [the continuous integration service (Travis CI)](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#continuous-integration)?
- [ ] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#code-style)? 
- [ ] **documentation**: If you are adding a new configuration option, have you added an explanation to the [configuration documentation](docs/Configuration.md) tables and sections?
- [ ] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)