### PR TITLE
Realtime updater optimisations and fixes

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -44,6 +44,7 @@ See the [OTP2 Migration Guide](OTP2-MigrationGuide.md) on changes to the REST AP
 - Remove AlertPatcher (#3134)
 - Update DebugOutput to match new routing phases of OTP2 (#3109)
 - Filter transit itineraries with relative high cost (#3157).
+- Fix issue with colliding TripPattern ids after modifications form real-time updaters. (#3202)
 
 
 ## Ported over from the 1.x

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTripPatternCache.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTripPatternCache.java
@@ -77,7 +77,7 @@ public class SiriTripPatternCache {
 
             // Copy information from the TripPattern this is replacing
             if (originalTripPattern != null) {
-                tripPattern.setId(originalTripPattern.getId());
+                tripPattern.setOriginalTripPattern(originalTripPattern);
                 tripPattern.setHopGeometriesFromPattern(originalTripPattern);
             }
             

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTripPatternCache.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTripPatternCache.java
@@ -75,6 +75,8 @@ public class SiriTripPatternCache {
 
             TripPattern originalTripPattern = graph.index.getPatternForTrip().get(trip);
 
+            tripPattern.setCreatedByRealtimeUpdater();
+
             // Copy information from the TripPattern this is replacing
             if (originalTripPattern != null) {
                 tripPattern.setOriginalTripPattern(originalTripPattern);

--- a/src/main/java/org/opentripplanner/model/FareZone.java
+++ b/src/main/java/org/opentripplanner/model/FareZone.java
@@ -1,7 +1,5 @@
 package org.opentripplanner.model;
 
-import java.util.Objects;
-
 public class FareZone extends TransitEntity<FeedScopedId> {
 
   private final FeedScopedId id;
@@ -24,19 +22,5 @@ public class FareZone extends TransitEntity<FeedScopedId> {
 
   public String getName() {
     return name;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) { return true; }
-    if (o == null || getClass() != o.getClass()) { return false; }
-    if (!super.equals(o)) { return false; }
-    FareZone fareZone = (FareZone) o;
-    return Objects.equals(id, fareZone.id);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(super.hashCode(), id);
   }
 }

--- a/src/main/java/org/opentripplanner/model/StopTimeKey.java
+++ b/src/main/java/org/opentripplanner/model/StopTimeKey.java
@@ -1,14 +1,12 @@
 package org.opentripplanner.model;
 
-import java.util.Objects;
-
 /**
  * This class is used as a reference to a StopTime wrapping the {@link Trip#getId()} and {@code stopSequence}.
  * StopTimes instances do not exist in the graph as entities, they are represented by
  * the {@link org.opentripplanner.routing.trippattern.TripTimes}, but we use this class to map other entities
  * (NoticeAssignment) to StopTimes to be able to decorate itineraries with such data.
  */
-public class StopTimeKey extends TransitEntity<StopTimeKey> {
+public class StopTimeKey extends TransitEntity<String> {
 
     private final FeedScopedId tripId;
     private final int stopSequenceNumber;
@@ -18,26 +16,12 @@ public class StopTimeKey extends TransitEntity<StopTimeKey> {
         this.stopSequenceNumber = stopSequenceNumber;
     }
 
-    @Override
-    public StopTimeKey getId() {
-        return this;
+    public String getId() {
+        return this.stopSequenceNumber + ";" + tripId.toString();
     }
 
     @Override
     public String toString() {
         return "StopTimeKey<" + tripId.toString() + "_" + stopSequenceNumber + ">";
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        StopTimeKey that = (StopTimeKey) o;
-        return stopSequenceNumber == that.stopSequenceNumber && tripId.equals(that.tripId);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(tripId, stopSequenceNumber);
     }
 }

--- a/src/main/java/org/opentripplanner/model/Timetable.java
+++ b/src/main/java/org/opentripplanner/model/Timetable.java
@@ -264,7 +264,7 @@ public class Timetable implements Serializable {
             int numStops = newTimes.getNumStops();
             Integer delay = null;
 
-            long today = updateServiceDate.getAsDate(timeZone).getTime() / 1000;
+            final long today = updateServiceDate.getAsDate(timeZone).getTime() / 1000;
 
             for (int i = 0; i < numStops; i++) {
                 boolean match = false;

--- a/src/main/java/org/opentripplanner/model/Timetable.java
+++ b/src/main/java/org/opentripplanner/model/Timetable.java
@@ -18,7 +18,6 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.TimeZone;
 
 
@@ -265,6 +264,8 @@ public class Timetable implements Serializable {
             int numStops = newTimes.getNumStops();
             Integer delay = null;
 
+            long today = updateServiceDate.getAsDate(timeZone).getTime() / 1000;
+
             for (int i = 0; i < numStops; i++) {
                 boolean match = false;
                 if (update != null) {
@@ -289,8 +290,6 @@ public class Timetable implements Serializable {
                         newTimes.updateDepartureDelay(i, 0);
                         delay = 0;
                     } else {
-                        long today = updateServiceDate.getAsDate(timeZone).getTime() / 1000;
-
                         if (update.hasArrival()) {
                             StopTimeEvent arrival = update.getArrival();
                             if (arrival.hasDelay()) {

--- a/src/main/java/org/opentripplanner/model/TimetableSnapshot.java
+++ b/src/main/java/org/opentripplanner/model/TimetableSnapshot.java
@@ -389,7 +389,7 @@ public class TimetableSnapshot {
      * Add the patterns to the stop index, only if they come from a modified pattern
      */
     private void addPatternToIndex(TripPattern tripPattern) {
-        if (tripPattern.getOriginalTripPattern() != null) {
+        if (tripPattern.isCreatedByRealtimeUpdater()) {
             for (Stop stop: tripPattern.getStops()) {
                 patternsForStop.put(stop, tripPattern);
             }

--- a/src/main/java/org/opentripplanner/model/TimetableSnapshot.java
+++ b/src/main/java/org/opentripplanner/model/TimetableSnapshot.java
@@ -386,9 +386,14 @@ public class TimetableSnapshot {
         return timetables.keySet();
     }
 
+    /**
+     * Add the patterns to the stop index, only if they come from a modified pattern
+     */
     private void addPatternToIndex(TripPattern tripPattern) {
-        for (Stop stop: tripPattern.getStops()) {
-            patternsForStop.put(stop, tripPattern);
+        if (tripPattern.getOriginalTripPattern() != null) {
+            for (Stop stop: tripPattern.getStops()) {
+                patternsForStop.put(stop, tripPattern);
+            }
         }
     }
 

--- a/src/main/java/org/opentripplanner/model/TimetableSnapshot.java
+++ b/src/main/java/org/opentripplanner/model/TimetableSnapshot.java
@@ -120,6 +120,8 @@ public class TimetableSnapshot {
      * stop. This has to be kept in order for them to be included in the stop times api call on a
      * specific stop.
      *
+     * This is a SetMultimap, so that each pattern can only be added once.
+     *
      * TODO Find a generic way to keep all realtime indexes.
      */
     private SetMultimap<Stop, TripPattern> patternsForStop = HashMultimap.create();

--- a/src/main/java/org/opentripplanner/model/TimetableSnapshot.java
+++ b/src/main/java/org/opentripplanner/model/TimetableSnapshot.java
@@ -1,9 +1,8 @@
 package org.opentripplanner.model;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Multimap;
+import com.google.common.collect.SetMultimap;
 import org.opentripplanner.model.calendar.ServiceDate;
 import org.opentripplanner.routing.algorithm.raptor.transit.mappers.TransitLayerUpdater;
 import org.opentripplanner.routing.trippattern.TripTimes;
@@ -123,7 +122,7 @@ public class TimetableSnapshot {
      *
      * TODO Find a generic way to keep all realtime indexes.
      */
-    private Multimap<Stop, TripPattern> patternsForStop = ArrayListMultimap.create();
+    private SetMultimap<Stop, TripPattern> patternsForStop = HashMultimap.create();
     
     /**
      * Boolean value indicating that timetable snapshot is read only if true. Once it is true, it shouldn't
@@ -401,7 +400,7 @@ public class TimetableSnapshot {
         return patternsForStop.get(stop);
     }
 
-    public void setPatternsForStop(Multimap<Stop, TripPattern> patternsForStop) {
+    public void setPatternsForStop(SetMultimap<Stop, TripPattern> patternsForStop) {
         this.patternsForStop = patternsForStop;
     }
 }

--- a/src/main/java/org/opentripplanner/model/TransitEntity.java
+++ b/src/main/java/org/opentripplanner/model/TransitEntity.java
@@ -30,7 +30,7 @@ public abstract class TransitEntity<T extends Serializable> implements Serializa
      * example after reloading a serialized instance.
      */
     @Override
-    public boolean equals(Object obj) {
+    final public boolean equals(Object obj) {
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
@@ -39,7 +39,7 @@ public abstract class TransitEntity<T extends Serializable> implements Serializa
     }
 
     @Override
-    public int hashCode() {
+    final public int hashCode() {
         return getId().hashCode();
     }
 }

--- a/src/main/java/org/opentripplanner/model/TripPattern.java
+++ b/src/main/java/org/opentripplanner/model/TripPattern.java
@@ -28,7 +28,6 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -654,64 +653,4 @@ public class TripPattern extends TransitEntity<FeedScopedId> implements Cloneabl
         return new Coordinate(s.getLon(), s.getLat());
     }
 
-    /**
-     * Need an equals() since trips in a pattern are no longer necessarily running on the same
-     * service ID.
-     * <p>
-     * A TransitEntity SHOULD not implement hashCode/equals. We make an EXCEPTION to this for
-     * TripPattern, because the alternative is worse. Since TripPatterns are cloned and changed by
-     * realtime updates and exist in a "global" space in Sets/Maps, the equals and hash code
-     * need to include all elements that can be changed. We could make a wrapper type and implement
-     * hc/eq for that and use that in all Set/Maps, but that would also ve quite messy. The REAL
-     * fix to this problem is to make TripPattern unique within the context it live. This is a
-     * larger task and should be addressed when implementing the issue:
-     * https://github.com/opentripplanner/OpenTripPlanner/issues/3030
-     * <p>
-     * The TripPattern is used as a <em>key</em> in a Set/Map in quite a few places. Use a reg-exp
-     * search for "(Map|Set)<TripPattern") to find the places where it is used.
-     * <p>
-     * Note! Classes that have mutable fields that are part of eq/hc are vulnerable. If added to a
-     * Set/Map the set/map MUST be re-indexed it the object is mutated. When mutating TripPattens
-     * make sure the object is NOT part of an existing Set/Map.
-     * <p>
-     * {@code hopGeometries}  is NOT part of the equals/hashCode methods to avoid costly
-     * computations. Hence; It is not allowed to ONLY change the hopGeometries, but at least one
-     * other field must be changed.
-     */
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        if (!super.equals(o)) {
-            return false;
-        }
-        TripPattern that = (TripPattern) o;
-        return directionId == that.directionId &&
-                Objects.equals(id, that.id) &&
-                Objects.equals(name, that.name) &&
-                Objects.equals(route, that.route) &&
-                Objects.equals(stopPattern, that.stopPattern) &&
-                Objects.equals(scheduledTimetable, that.scheduledTimetable) &&
-                Objects.equals(trips, that.trips) &&
-                Objects.equals(services, that.services) &&
-                Arrays.equals(perStopFlags, that.perStopFlags);
-    }
-
-    @Override
-    public int hashCode() {
-        return 31 * Objects.hash(
-            id,
-            name,
-            route,
-            directionId,
-            stopPattern,
-            scheduledTimetable,
-            trips,
-            services
-        ) + Arrays.hashCode(perStopFlags);
-    }
 }

--- a/src/main/java/org/opentripplanner/model/TripPattern.java
+++ b/src/main/java/org/opentripplanner/model/TripPattern.java
@@ -108,6 +108,11 @@ public class TripPattern extends TransitEntity<FeedScopedId> implements Cloneabl
     private TripPattern originalTripPattern = null;
 
     /**
+     * Has the TripPattern been created by a real-time update.
+     */
+    private boolean createdByRealtimeUpdater = false;
+
+    /**
      * The unique identifier for this trip pattern. For GTFS feeds this is generally
      * generated in the format FeedId:Agency:RouteId:DirectionId:PatternNumber. For
      * NeTEx the JourneyPattern id is used.
@@ -349,6 +354,14 @@ public class TripPattern extends TransitEntity<FeedScopedId> implements Cloneabl
 
     public void setOriginalTripPattern(TripPattern originalTripPattern) {
         this.originalTripPattern = originalTripPattern;
+    }
+
+    boolean isCreatedByRealtimeUpdater() {
+        return createdByRealtimeUpdater;
+    }
+
+    public void setCreatedByRealtimeUpdater() {
+        createdByRealtimeUpdater = true;
     }
 
     private static String stopNameAndId (Stop stop) {

--- a/src/main/java/org/opentripplanner/model/TripPattern.java
+++ b/src/main/java/org/opentripplanner/model/TripPattern.java
@@ -104,6 +104,11 @@ public class TripPattern extends TransitEntity<FeedScopedId> implements Cloneabl
     private byte[][] hopGeometries = null;
 
     /**
+     * The original TripPattern this replaces at least for one modified trip.
+     */
+    private TripPattern originalTripPattern = null;
+
+    /**
      * The unique identifier for this trip pattern. For GTFS feeds this is generally
      * generated in the format FeedId:Agency:RouteId:DirectionId:PatternNumber. For
      * NeTEx the JourneyPattern id is used.
@@ -337,6 +342,14 @@ public class TripPattern extends TransitEntity<FeedScopedId> implements Cloneabl
         else {
             scheduledTimetable.tripTimes.removeIf(tt -> removeTrip.test(tt.trip));
         }
+    }
+
+    public TripPattern getOriginalTripPattern() {
+        return originalTripPattern;
+    }
+
+    public void setOriginalTripPattern(TripPattern originalTripPattern) {
+        this.originalTripPattern = originalTripPattern;
     }
 
     private static String stopNameAndId (Stop stop) {

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/mappers/TransitLayerUpdater.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/mappers/TransitLayerUpdater.java
@@ -104,6 +104,9 @@ public class TransitLayerUpdater {
         );
         if (tripPatternForDate != null) {
           patternsForDateMap.put(timetable.pattern, tripPatternForDate);
+        } else {
+          // This has been completely cancelled, or otherwise doesn't map cleanly
+          patternsForDateMap.remove(timetable.pattern);
         }
       }
 

--- a/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
@@ -922,9 +922,11 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
 
     private boolean purgeExpiredData() {
         final ServiceDate today = new ServiceDate();
+        // TODO: Base this on numberOfDaysOfLongestTrip for tripPatterns
         final ServiceDate previously = today.previous().previous(); // Just to be safe...
 
-        if(lastPurgeDate != null && lastPurgeDate.compareTo(previously) > 0) {
+        // Purge data only if we have changed date
+        if(lastPurgeDate != null && lastPurgeDate.compareTo(previously) >= 0) {
             return false;
         }
 

--- a/src/main/java/org/opentripplanner/updater/stoptime/TripPatternCache.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/TripPatternCache.java
@@ -59,7 +59,6 @@ public class TripPatternCache {
 
             // Copy information from the TripPattern this is replacing
             if (originalTripPattern != null) {
-                tripPattern.setId(originalTripPattern.getId());
                 tripPattern.setHopGeometriesFromPattern(originalTripPattern);
             }
             

--- a/src/main/java/org/opentripplanner/updater/stoptime/TripPatternCache.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/TripPatternCache.java
@@ -57,6 +57,8 @@ public class TripPatternCache {
 
             TripPattern originalTripPattern = graph.index.getPatternForTrip().get(trip);
 
+            tripPattern.setCreatedByRealtimeUpdater();
+
             // Copy information from the TripPattern this is replacing
             if (originalTripPattern != null) {
                 tripPattern.setOriginalTripPattern(originalTripPattern);

--- a/src/main/java/org/opentripplanner/updater/stoptime/TripPatternCache.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/TripPatternCache.java
@@ -59,6 +59,7 @@ public class TripPatternCache {
 
             // Copy information from the TripPattern this is replacing
             if (originalTripPattern != null) {
+                tripPattern.setOriginalTripPattern(originalTripPattern);
                 tripPattern.setHopGeometriesFromPattern(originalTripPattern);
             }
             

--- a/src/test/java/org/opentripplanner/netex/NetexLoaderSmokeTest.java
+++ b/src/test/java/org/opentripplanner/netex/NetexLoaderSmokeTest.java
@@ -161,9 +161,9 @@ public class NetexLoaderSmokeTest {
 
     private void assertNoticeAssignments(Multimap<TransitEntity<?>, Notice> map) {
         assertNote(map, fId("RUT:ServiceJourney:4-101468-583"),"045", "Notice on ServiceJourney");
-        assertNote(map, stId("RUT:ServiceJourney:4-101468-583", 0), "035", "Notice on TimetabledPassingTime");
+        assertNote(map, stId("RUT:ServiceJourney:4-101468-583", 0).getId(), "035", "Notice on TimetabledPassingTime");
         assertNote(map, fId("RUT:Line:4"), "075", "Notice on Line");
-        assertNote(map, stId("RUT:ServiceJourney:4-101493-1098", 1), "090", "Notice on Journeypattern");
+        assertNote(map, stId("RUT:ServiceJourney:4-101493-1098", 1).getId(), "090", "Notice on Journeypattern");
         assertEquals(4, map.size());
     }
 


### PR DESCRIPTION
This pull request is done based on discussions on the OTP dev meeting last Thursday. It contains the following:

- Do not overwrite `TripPattern` ids
- Make TransitEntity `equals` and `hashCode` final, removing the three implementations extending those.
- Store original trip pattern on trip patterns created from realtime updates
- Cache or move expensive calculations outside loops in realtime updaters
- Fix purging of old data, so it is run only on actual day changes
- Fix TimetableSnapshot by only adding modified patterns to the cache of new patterns and make it explicitly a `SetMultimap `, so the same pattern is not added more than once.


To be completed by pull request submitter:

- [x] **issue**: #3110
- [ ] **roadmap**: Check the [roadmap](https://github.com/orgs/opentripplanner/projects/1) for this feature or bug. If it is not already on the roadmap, PLC will discuss as part of the review process.
- [ ] **tests**: Have you added relevant test coverage? Are all the tests passing on [the continuous integration service (Travis CI)](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#continuous-integration)?
- [ ] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#code-style)? 
- [ ] **documentation**: If you are adding a new configuration option, have you added an explanation to the [configuration documentation](docs/Configuration.md) tables and sections?
- [ ] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)