### PR TITLE
Do not throw NPEs when routing without OSM data

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
@@ -231,7 +231,7 @@ public class RaptorPathToItineraryMapper {
 
     private void mapNonTransitLeg(List<Leg> legs, PathLeg<TripSchedule> pathLeg, Transfer transfer, Place from, Place to, boolean onlyIfNonZeroDistance) {
         List<Edge> edges = transfer.getEdges();
-        if (edges.isEmpty()) {
+        if (edges == null || edges.isEmpty()) {
             Leg leg = new Leg(TraverseMode.WALK);
             leg.from = from;
             leg.to = to;

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/Transfer.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/Transfer.java
@@ -46,7 +46,9 @@ public class Transfer {
     }
 
     public int getDistanceMeters() {
-        return edges != null ? (int)edges.stream().mapToDouble(Edge::getDistanceMeters).sum() : 0;
+        return edges != null
+            ? (int) edges.stream().mapToDouble(Edge::getDistanceMeters).sum()
+            : effectiveWalkDistanceMeters;
     }
 
     public List<Edge> getEdges() {

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/Transfer.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/Transfer.java
@@ -22,6 +22,7 @@ public class Transfer {
 
     public List<Coordinate> getCoordinates() {
         List<Coordinate> coordinates = new ArrayList<>();
+        if (edges == null) return coordinates;
         for (Edge edge : edges) {
             if (edge.getGeometry() != null) {
                 coordinates.addAll((Arrays.asList(edge.getGeometry().getCoordinates())));
@@ -45,7 +46,7 @@ public class Transfer {
     }
 
     public int getDistanceMeters() {
-        return (int)edges.stream().mapToDouble(Edge::getDistanceMeters).sum();
+        return edges != null ? (int)edges.stream().mapToDouble(Edge::getDistanceMeters).sum() : 0;
     }
 
     public List<Edge> getEdges() {


### PR DESCRIPTION
To be completed by pull request submitter:

- [ ] **issue**: #3204 - This PR do not fix the issue, but prevent the server from craching.
- [ ] **roadmap**: No

- [ ] **tests**: No
- [ ] **formatting**: Yes 
- [ ] **documentation**: No
- [ ] **changelog**: No


To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)

This is the minimal amount of changes to make transit routing work on graphs that were built without OSM data. The `AccessEgressRouter` will currently only snap to the nearest stop (with no walk time). This can result in not finding any routes, if it snaps to the wrong stop.

A more complete fix will involve refactoring the NearbyStopFinder, so that the `AccessEgressRouter` does not call the `findNearbyStopsViaStreets` method directly. This will also involve making the `findNearbyStops` method work with multiple start vertices.

We can discuss in the meeting tomorrow whether this should be merged or not.