### PR TITLE
Fix issue #3195 - Build and load GTFS files for San Francisco Bay Area.

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -46,6 +46,8 @@ See the [OTP2 Migration Guide](OTP2-MigrationGuide.md) on changes to the REST AP
 - Filter transit itineraries with relative high cost [#3157](https://github.com/opentripplanner/OpenTripPlanner/issues/3157)
 - Fix issue with colliding TripPattern ids after modifications form real-time updaters [#3202](https://github.com/opentripplanner/OpenTripPlanner/issues/3202)
 - Fix: The updater config type is unknown: gtfs-http [#3195](https://github.com/opentripplanner/OpenTripPlanner/issues/3195)
+- Fix: Problem building and loading the GTFS file in San Fransisco Bay Area [#3195](https://github.com/opentripplanner/OpenTripPlanner/issues/3195)
+
 
 ## Ported over from the 1.x
 

--- a/src/main/java/org/opentripplanner/model/StopLevel.java
+++ b/src/main/java/org/opentripplanner/model/StopLevel.java
@@ -1,12 +1,16 @@
 package org.opentripplanner.model;
 
+import java.io.Serializable;
 import java.util.Objects;
 
 /**
  * Immutable value object for stop level. This is currently only supported by
  * the GTFS import.
  */
-public class StopLevel {
+public class StopLevel implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
     private final String name;
     private final double index;
 

--- a/src/main/java/org/opentripplanner/model/TripPattern.java
+++ b/src/main/java/org/opentripplanner/model/TripPattern.java
@@ -185,6 +185,8 @@ public class TripPattern extends TransitEntity<FeedScopedId> implements Cloneabl
     }
 
     public LineString getGeometry() {
+        if(hopGeometries == null || hopGeometries.length==0) { return null; }
+
         List<LineString> lineStrings = new ArrayList<>();
         for (int i = 0; i < hopGeometries.length - 1; i++) {
             lineStrings.add(getHopGeometry(i));


### PR DESCRIPTION
 - Make `StopLevel` Serializable.
 - The `TripPattern#getGeometry()` should return null, not fail with a NPE when there is no geometry - no matter the cause.

To be completed by pull request submitter:

- [ ] **issue**:  closes #3195
- [ ] **roadmap**: Bugfix, not on rodemap.
- [ ] **tests**: No tests added.
- [ ] **formatting**: Yes 
- [ ] **documentation**: No
- [ ] **changelog**: Yes.

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)