### PR TITLE
Upgrade org.entur:netex-java-model to 1.0.11 (from 1.0.8)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -600,7 +600,7 @@
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
-            <version>2.3.1</version>
+            <version>2.3.2</version>
         </dependency>
 
         <!-- TESTING -->

--- a/pom.xml
+++ b/pom.xml
@@ -223,6 +223,7 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.2.0</version>
                 <configuration>
+                    <skip>true</skip>
                     <!-- Turn off strict Javadoc checking -->
                     <doclint>none</doclint>
                     <!-- We get tons of errors about classes not existing, maybe due to multiple source roots.

--- a/pom.xml
+++ b/pom.xml
@@ -561,7 +561,7 @@
         <dependency>
             <groupId>org.entur</groupId>
             <artifactId>netex-java-model</artifactId>
-            <version>1.0.8</version>
+            <version>1.0.11</version>
         </dependency>
 
         <!-- SIRI -->

--- a/src/main/java/org/opentripplanner/netex/loader/mapping/TripPatternMapper.java
+++ b/src/main/java/org/opentripplanner/netex/loader/mapping/TripPatternMapper.java
@@ -84,7 +84,7 @@ class TripPatternMapper {
         if (serviceJourneys == null || serviceJourneys.isEmpty()) {
             LOG.warn("ServiceJourneyPattern " + journeyPattern.getId()
                     + " does not contain any serviceJourneys.");
-            return null;
+            return result;
         }
 
         List<Trip> trips = new ArrayList<>();

--- a/src/main/java/org/opentripplanner/netex/loader/parser/ServiceCalendarFrameParser.java
+++ b/src/main/java/org/opentripplanner/netex/loader/parser/ServiceCalendarFrameParser.java
@@ -38,7 +38,7 @@ class ServiceCalendarFrameParser extends NetexParser<ServiceCalendarFrame_Versio
         parseServiceCalendar(frame.getServiceCalendar());
         parseDayTypes(frame.getDayTypes());
         parseOperatingPeriods(frame.getOperatingPeriods());
-        parseRequiredDayTypeAssignments(frame.getDayTypeAssignments());
+        parseDayTypeAssignments(frame.getDayTypeAssignments());
 
         // Keep list sorted alphabetically
 
@@ -61,7 +61,7 @@ class ServiceCalendarFrameParser extends NetexParser<ServiceCalendarFrame_Versio
 
         parseDayTypes(serviceCalendar.getDayTypes());
         // TODO OTP2 - What about OperatingPeriods here?
-        parseRequiredDayTypeAssignments(serviceCalendar.getDayTypeAssignments());
+        parseDayTypeAssignments(serviceCalendar.getDayTypeAssignments());
     }
 
     //List<JAXBElement<? extends DataManagedObjectStructure>>
@@ -92,15 +92,17 @@ class ServiceCalendarFrameParser extends NetexParser<ServiceCalendarFrame_Versio
         }
     }
 
-    private void parseRequiredDayTypeAssignments(DayTypeAssignments_RelStructure element) {
-        parseRequiredDayTypeAssignments(element.getDayTypeAssignment());
+    private void parseDayTypeAssignments(DayTypeAssignments_RelStructure element) {
+        if(element == null) { return; }
+        parseDayTypeAssignments(element.getDayTypeAssignment());
     }
 
-    private void parseRequiredDayTypeAssignments(DayTypeAssignmentsInFrame_RelStructure element) {
-        parseRequiredDayTypeAssignments(element.getDayTypeAssignment());
+    private void parseDayTypeAssignments(DayTypeAssignmentsInFrame_RelStructure element) {
+        if(element == null) { return; }
+        parseDayTypeAssignments(element.getDayTypeAssignment());
     }
 
-    private void parseRequiredDayTypeAssignments(List<DayTypeAssignment> elements) {
+    private void parseDayTypeAssignments(List<DayTypeAssignment> elements) {
         for (DayTypeAssignment it : elements) {
             String ref = it.getDayTypeRef().getValue().getRef();
             dayTypeAssignmentByDayTypeId.put(ref, it);

--- a/src/main/java/org/opentripplanner/netex/loader/parser/SiteFrameParser.java
+++ b/src/main/java/org/opentripplanner/netex/loader/parser/SiteFrameParser.java
@@ -7,11 +7,14 @@ import org.rutebanken.netex.model.Quays_RelStructure;
 import org.rutebanken.netex.model.Site_VersionFrameStructure;
 import org.rutebanken.netex.model.StopPlace;
 import org.rutebanken.netex.model.TariffZone;
+import org.rutebanken.netex.model.Zone_VersionStructure;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.xml.bind.JAXBElement;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 class SiteFrameParser extends NetexParser<Site_VersionFrameStructure> {
     private static final Logger LOG = LoggerFactory.getLogger(NetexParser.class);
@@ -82,8 +85,12 @@ class SiteFrameParser extends NetexParser<Site_VersionFrameStructure> {
         }
     }
 
-    private void parseTariffZones(Collection<TariffZone> tariffZoneList) {
-        tariffZones.addAll(tariffZoneList);
+    private void parseTariffZones(List<JAXBElement<? extends Zone_VersionStructure>> tariffZoneList) {
+        for (JAXBElement<? extends Zone_VersionStructure> tariffZone : tariffZoneList) {
+            if(tariffZone.getValue() instanceof TariffZone) {
+                tariffZones.add((TariffZone) tariffZone.getValue());
+            }
+        }
     }
 
     private void parseQuays(Quays_RelStructure quayRefOrQuay) {

--- a/src/main/java/org/opentripplanner/netex/loader/parser/TimeTableFrameParser.java
+++ b/src/main/java/org/opentripplanner/netex/loader/parser/TimeTableFrameParser.java
@@ -86,7 +86,7 @@ class TimeTableFrameParser extends NetexParser<Timetable_VersionFrameStructure> 
 
     private void parseJourneys(JourneysInFrame_RelStructure element) {
 
-        for (Journey_VersionStructure it : element.getDatedServiceJourneyOrDeadRunOrServiceJourney()) {
+        for (Journey_VersionStructure it : element.getVehicleJourneyOrDatedVehicleJourneyOrNormalDatedVehicleJourney()) {
             if (it instanceof ServiceJourney) {
                 parseServiceJourney((ServiceJourney)it);
             }

--- a/src/main/java/org/opentripplanner/netex/support/DayTypeRefsToServiceIdAdapter.java
+++ b/src/main/java/org/opentripplanner/netex/support/DayTypeRefsToServiceIdAdapter.java
@@ -51,10 +51,11 @@ public final class DayTypeRefsToServiceIdAdapter {
     }
 
     private static Set<String> collectDayTypeRefs(DayTypeRefs_RelStructure refs) {
+        if(refs == null) { return Set.of(); }
         Set<String> dayTypeRefs = new HashSet<>();
         for (JAXBElement<? extends DayTypeRefStructure> e : refs.getDayTypeRef()) {
             // Keep the ref, ignore version info. Handling the version info is part of the
-            // Norwegian NeTEx profile, so this should probably be fixed. On the other hand
+            // Nordic NeTEx profile, so this should probably be fixed. On the other hand
             // there is not problems reported on this.
             dayTypeRefs.add(e.getValue().getRef());
         }

--- a/src/test/java/org/opentripplanner/netex/NetexBundleSmokeTest.java
+++ b/src/test/java/org/opentripplanner/netex/NetexBundleSmokeTest.java
@@ -39,7 +39,7 @@ import static org.junit.Assert.fail;
  * and should be excluded from line coverage. The focus of this test is
  * to test that the different parts of the NeTEx works together.
  */
-public class NetexLoaderSmokeTest {
+public class NetexBundleSmokeTest {
     /**
      * This test load a very simple Netex data set and do assertions on it.
      * For each type we assert some of the most important fields for one element


### PR DESCRIPTION
The 1.0.11 support DateServiceJourneys(DSJs), and this update of the library allow us to import netex files with DSJs without crashing. The DSJ offer an alternative way to add calendar data, and Service Journeys with DSJ do not have DayTypeAssignments. In the previous version this was required. Also some of the returned datatypes have changes, so whenever these are used the code had to be updated. 

**NOTE This PR do NOT add support for DSJ, it only allow us to parse Netex files with DSJs without crashing - DSJs are ignored.**

Only the NeTEx import code is touched by this PR - no changes is done to the OTP core.

To be completed by pull request submitter:

- [ ] **issue**: No issue
- [ ] **roadmap**: No
- [ ] **tests**: No
- [ ] **formatting**: Yes 
- [ ] **documentation**: No
- [ ] **changelog**: No.

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)