### PR TITLE
Otp2 add progress bar to bus route street matcher

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -47,7 +47,7 @@ See the [OTP2 Migration Guide](OTP2-MigrationGuide.md) on changes to the REST AP
 - Fix issue with colliding TripPattern ids after modifications form real-time updaters [#3202](https://github.com/opentripplanner/OpenTripPlanner/issues/3202)
 - Fix: The updater config type is unknown: gtfs-http [#3195](https://github.com/opentripplanner/OpenTripPlanner/issues/3195)
 - Fix: Problem building and loading the GTFS file in San Fransisco Bay Area [#3195](https://github.com/opentripplanner/OpenTripPlanner/issues/3195)
-
+- Fix: The `BusRouteStreetMatcher` and `TransitToTaggedStopsModule` graph builder modules are not run if the graph is build in two steps, and add progress tracker to BusRouteStreetMatcher. [#3195](https://github.com/opentripplanner/OpenTripPlanner/issues/3195)
 
 ## Ported over from the 1.x
 

--- a/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
@@ -107,6 +107,8 @@ public class GraphBuilder implements Runnable {
 
         GraphBuilder graphBuilder = new GraphBuilder(baseGraph);
 
+        boolean hasStreetData = hasOsm || graphBuilder.graph.hasStreets;
+
 
         if ( hasOsm ) {
             List<BinaryOpenStreetMapProvider> osmProviders = Lists.newArrayList();
@@ -164,7 +166,7 @@ public class GraphBuilder implements Runnable {
             graphBuilder.addModule(netexModule(config, dataSources.get(NETEX)));
         }
 
-        if(hasTransitData && hasOsm) {
+        if(hasTransitData && hasStreetData) {
             if (config.matchBusRoutesToStreets) {
                 graphBuilder.addModule(new BusRouteStreetMatcher());
             }

--- a/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
@@ -107,9 +107,6 @@ public class GraphBuilder implements Runnable {
 
         GraphBuilder graphBuilder = new GraphBuilder(baseGraph);
 
-        boolean hasStreetData = hasOsm || graphBuilder.graph.hasStreets;
-
-
         if ( hasOsm ) {
             List<BinaryOpenStreetMapProvider> osmProviders = Lists.newArrayList();
             for (DataSource osmFile : dataSources.get(OSM)) {
@@ -166,7 +163,7 @@ public class GraphBuilder implements Runnable {
             graphBuilder.addModule(netexModule(config, dataSources.get(NETEX)));
         }
 
-        if(hasTransitData && hasStreetData) {
+        if(hasTransitData && (hasOsm || graphBuilder.graph.hasStreets)) {
             if (config.matchBusRoutesToStreets) {
                 graphBuilder.addModule(new BusRouteStreetMatcher());
             }


### PR DESCRIPTION
This PR fixes a small bug in the graph build and add a progress tracker to the BusRouteStreetMatcher:

- Bugfix - The `BusRouteStreetMatcher` and `TransitToTaggedStopsModule` graph builder modules are not run if the graph is build in two steps. So, if you first build a _streetGraph.obj_ file, and the build the _graph.obj_ these modules are not run. The bug is independent of the config `matchBusRoutesToStreets` setting.
- Add progress tracking to BusRouteStreetMatcher.



- [ ] **issue**: Add progress tracking to BusRouteStreetMatcher as mentioned in #3195.
- [ ] **roadmap**: No.
- [ ] **tests**: No
- [ ] **formatting**: Yes
- [ ] **documentation**: No
- [ ] **changelog**: Yes.

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)