### PR TITLE
No longer require externalLineRef on added trips - SIRI Updaters

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
@@ -440,7 +440,12 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
 //        String groupOfLines = estimatedVehicleJourney.getGroupOfLinesRef().getValue();
 
 //        Preconditions.checkNotNull(estimatedVehicleJourney.getExternalLineRef(), "ExternalLineRef is required");
-        String externalLineRef = estimatedVehicleJourney.getExternalLineRef().getValue();
+        String externalLineRef;
+        if (estimatedVehicleJourney.getExternalLineRef() != null) {
+            externalLineRef = estimatedVehicleJourney.getExternalLineRef().getValue();
+        } else {
+            externalLineRef = lineRef;
+        }
 
         // TODO - SIRI: Where is the Operator?
 //        Operator operator = graphIndex.operatorForId.get(new FeedScopedId(feedId, operatorRef));


### PR DESCRIPTION
When trips are added in SIRI Realtime, the field `ExternalLineRef` is no longer required - will fall back to `LineRef`.