### PR TITLE
Update to Kryo 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -607,7 +607,7 @@
         <dependency>
             <groupId>com.conveyal</groupId>
             <artifactId>kryo-tools</artifactId>
-            <version>1.3.0</version>
+            <version>1.5.0</version>
         </dependency>
         <!-- Jersey annontation-driven REST web services (JAX-RS implementation) -->
         <dependency>

--- a/src/main/java/org/opentripplanner/kryo/BuildConfigSerializer.java
+++ b/src/main/java/org/opentripplanner/kryo/BuildConfigSerializer.java
@@ -29,7 +29,7 @@ public class BuildConfigSerializer extends Serializer<BuildConfig> {
     }
 
     @Override
-    public BuildConfig read(Kryo kryo, Input input, Class<BuildConfig> type) {
+    public BuildConfig read(Kryo kryo, Input input, Class<? extends BuildConfig> type) {
         return new BuildConfig(
                 ConfigLoader.nodeFromString(input.readString(), SOURCE),
                 SOURCE,

--- a/src/main/java/org/opentripplanner/kryo/RouterConfigSerializer.java
+++ b/src/main/java/org/opentripplanner/kryo/RouterConfigSerializer.java
@@ -26,7 +26,7 @@ public class RouterConfigSerializer extends Serializer<RouterConfig> {
         output.writeString(object.toJson());
     }
     @Override
-    public RouterConfig read(Kryo kryo, Input input, Class<RouterConfig> type) {
+    public RouterConfig read(Kryo kryo, Input input, Class<? extends RouterConfig> type) {
         return new RouterConfig(
                 ConfigLoader.nodeFromString(input.readString(), SOURCE),
                 SOURCE,

--- a/src/main/java/org/opentripplanner/routing/graph/SerializedGraphObject.java
+++ b/src/main/java/org/opentripplanner/routing/graph/SerializedGraphObject.java
@@ -8,6 +8,7 @@ import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 import com.esotericsoftware.kryo.serializers.ExternalizableSerializer;
 import com.esotericsoftware.kryo.serializers.JavaSerializer;
+import com.esotericsoftware.kryo.util.DefaultInstantiatorStrategy;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.HashBiMap;
 import com.google.common.collect.HashMultimap;
@@ -192,7 +193,7 @@ public class SerializedGraphObject implements Serializable {
         // The default strategy requires every class you serialize, even in your dependencies, to have a zero-arg
         // constructor (which can be private). The setInstantiatorStrategy method completely replaces that default
         // strategy. The nesting below specifies the Java approach as a fallback strategy to the default strategy.
-        kryo.setInstantiatorStrategy(new Kryo.DefaultInstantiatorStrategy(new SerializingInstantiatorStrategy()));
+        kryo.setInstantiatorStrategy(new DefaultInstantiatorStrategy(new SerializingInstantiatorStrategy()));
         return kryo;
     }
 


### PR DESCRIPTION
In light of the discussion [here](https://github.com/opentripplanner/OpenTripPlanner/issues/3128#issuecomment-708421256) this PR attempts to update OTP2 to run on Kryo 5 after patching `kryo-tools` as follows:

```
diff --git a/pom.xml b/pom.xml
index cdaf1d2..2cbff0e 100644
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@

     <groupId>com.conveyal</groupId>
     <artifactId>kryo-tools</artifactId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.5.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <licenses>
         <license>
@@ -164,7 +164,7 @@
         <dependency>
             <groupId>com.esotericsoftware</groupId>
             <artifactId>kryo</artifactId>
-            <version>4.0.2</version>
+            <version>5.0.0</version>
         </dependency>
         <!-- Extra serializers for Kryo -->
         <dependency>
```

Unfortunately, the `GraphSerializationTest` roundtrip test fails:

```
10:41:19.709 INFO (SerializedGraphObject.java:232) Writing graph graph15102868215876250797pdx ...
10:41:19.709 INFO (SerializedGraphObject.java:251) Save graph progress tracking started.
10:41:20.031 INFO (SerializedGraphObject.java:251) Save graph progress tracking complete. 6.8 MB done in 0s (21.0 MB pr second).
10:41:20.032 INFO (SerializedGraphObject.java:238) Graph written: graph15102868215876250797pdx
10:41:20.032 INFO (SerializedGraphObject.java:206) Reading graph from '/tmp/graph15102868215876250797pdx'
10:41:20.113 WARN (SerializedGraphObject.java:224) Exception while loading graph: /tmp/graph15102868215876250797pdx
java.lang.NullPointerException
Serialization trace:
interlinedTrips (org.opentripplanner.routing.graph.Graph)
graph (org.opentripplanner.routing.graph.SerializedGraphObject)
Tests run: 4, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 21.263 sec <<< FAILURE! - in org.opentripplanner.routing.graph.GraphSerializationTest
testRoundTripSerializationForGTFSGraph(org.opentripplanner.routing.graph.GraphSerializationTest)  Time elapsed: 0.42 sec  <<< ERROR!
org.opentripplanner.util.OtpAppException: Unable to load graph. The deserialization failed. Is the loaded graph build with the same OTP version as you are using to load it? Graph: /tmp/graph15102868215876250797pdx
        at org.opentripplanner.routing.graph.GraphSerializationTest.testRoundTrip(GraphSerializationTest.java:127)
        at org.opentripplanner.routing.graph.GraphSerializationTest.testRoundTripSerializationForGTFSGraph(GraphSerializationTest.java:45)
```

Any help here would be much appreciated.