### PR TITLE
Insert project info in configuration files

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -47,6 +47,7 @@ See the [OTP2 Migration Guide](OTP2-MigrationGuide.md) on changes to the REST AP
 - Fix issue with colliding TripPattern ids after modifications form real-time updaters [#3202](https://github.com/opentripplanner/OpenTripPlanner/issues/3202)
 - Fix: The updater config type is unknown: gtfs-http [#3195](https://github.com/opentripplanner/OpenTripPlanner/issues/3195)
 - Fix: Problem building and loading the GTFS file in San Fransisco Bay Area [#3195](https://github.com/opentripplanner/OpenTripPlanner/issues/3195)
+- Improvement: Insert project information like Maven version number into configuration files. [#3254](https://github.com/opentripplanner/OpenTripPlanner/pull/3254)   
 
 
 ## Ported over from the 1.x

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -54,6 +54,39 @@ uri | An URI path to a resource like a file or a URL. | `"gs://bucket/path/a.obj
 linear function | A linear function with one input parameter(x) used to calculate a value. Usually used to calculate a limit. For example to calculate a limit in seconds to be 1 hour plus 2 times the value(x) use: `3600 + 2.0 x`, to set an absolute value(3000) use: `3000 + 0x` | `"600 + 2.0 x"`
 
 
+## System environment and project information substitution
+
+OTP support injecting system environment variables and project information parameters into the 
+configuration. A pattern like `${VAR_NAME}` in a configuration file is substituted with an
+environment variable with name `VAR_NAME`. The substitution is done BEFORE the JSON is parsed, so
+both json keys and values is subject to substitution. This is useful if you want OTPs version 
+number to be part of the _graph-file-name_, or you want to inject credentials in a cloud based 
+deployment.
+
+```JSON
+{
+  storage : {
+    gsCredentials: "${GCS_SERVICE_CREDENTIALS}",
+    graph: "file:///var/otp/graph-${maven.version.short}.obj",
+  }
+}
+```     
+In the example above the environment variable `GCS_SERVICE_CREDENTIALS` on the local machine where
+OTP is deployed is injected into the config. Also, the Maven version number `x.y.z` is injected.
+
+The project information variables available are:
+
+  - `maven.version`
+  - `maven.version.short`
+  - `maven.version.major`
+  - `maven.version.minor`
+  - `maven.version.patch`
+  - `maven.version.qualifier`
+  - `git.branch`
+  - `git.commit`
+  - `git.commit.timestamp`
+
+
 # System-wide Configuration
 
 Using the file `otp-config.json` you can enable or disable different APIs and experimental

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
@@ -18,7 +18,7 @@ import graphql.schema.GraphQLOutputType;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLType;
 import org.apache.commons.collections.CollectionUtils;
-import org.opentripplanner.common.MavenVersion;
+import org.opentripplanner.common.ProjectInfo;
 import org.opentripplanner.ext.transmodelapi.mapping.PlaceMapper;
 import org.opentripplanner.ext.transmodelapi.mapping.TransitIdMapper;
 import org.opentripplanner.ext.transmodelapi.model.DefaultRoutingRequestType;
@@ -1077,7 +1077,7 @@ public class TransmodelGraphQLSchema {
             .name("serverInfo")
             .description("Get OTP server information")
             .type(new GraphQLNonNull(serverInfoType))
-            .dataFetcher(e -> MavenVersion.VERSION)
+            .dataFetcher(e -> ProjectInfo.INSTANCE)
             .build())
         .build();
 

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/framework/ServerInfoType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/framework/ServerInfoType.java
@@ -4,7 +4,7 @@ import graphql.Scalars;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLOutputType;
-import org.opentripplanner.common.MavenVersion;
+import org.opentripplanner.common.ProjectInfo;
 
 public class ServerInfoType {
   public static GraphQLOutputType create() {
@@ -16,35 +16,35 @@ public class ServerInfoType {
             .name("version")
             .description("Maven version")
             .type(Scalars.GraphQLString)
-            .dataFetcher(e -> MavenVersion.VERSION.version)
+            .dataFetcher(e -> ProjectInfo.INSTANCE.version)
             .build())
         .field(GraphQLFieldDefinition
             .newFieldDefinition()
             .name("buildTime")
             .description("OTP Build timestamp")
             .type(Scalars.GraphQLString)
-            .dataFetcher(e -> MavenVersion.VERSION.buildTime)
+            .dataFetcher(e -> ProjectInfo.INSTANCE.buildTime)
             .build())
         .field(GraphQLFieldDefinition
             .newFieldDefinition()
             .name("gitBranch")
             .description("")
             .type(Scalars.GraphQLString)
-            .dataFetcher(e -> MavenVersion.VERSION.branch)
+            .dataFetcher(e -> ProjectInfo.INSTANCE.branch)
             .build())
         .field(GraphQLFieldDefinition
             .newFieldDefinition()
             .name("gitCommit")
             .description("")
             .type(Scalars.GraphQLString)
-            .dataFetcher(e -> MavenVersion.VERSION.commit)
+            .dataFetcher(e -> ProjectInfo.INSTANCE.commit)
             .build())
         .field(GraphQLFieldDefinition
             .newFieldDefinition()
             .name("gitCommitTime")
             .description("")
             .type(Scalars.GraphQLString)
-            .dataFetcher(e -> MavenVersion.VERSION.commitTime)
+            .dataFetcher(e -> ProjectInfo.INSTANCE.commitTime)
             .build())
         .build();
   }

--- a/src/main/java/org/opentripplanner/api/resource/ServerInfo.java
+++ b/src/main/java/org/opentripplanner/api/resource/ServerInfo.java
@@ -1,6 +1,6 @@
 package org.opentripplanner.api.resource;
 
-import org.opentripplanner.common.MavenVersion;
+import org.opentripplanner.common.ProjectInfo;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -25,7 +25,7 @@ public class ServerInfo {
     
     // Fields must be public or have a public getter to be auto-serialized to JSON
 
-    public MavenVersion serverVersion = MavenVersion.VERSION;
+    public ProjectInfo serverInfo = ProjectInfo.INSTANCE;
     public String cpuName = "unknown";
     public int nCores = 0;
 

--- a/src/main/java/org/opentripplanner/common/ProjectInfo.java
+++ b/src/main/java/org/opentripplanner/common/ProjectInfo.java
@@ -7,18 +7,18 @@ import java.io.InputStream;
 import java.io.Serializable;
 import java.util.Properties;
 
-public class MavenVersion implements Serializable {
+public class ProjectInfo implements Serializable {
 
-    private static final Logger LOG = LoggerFactory.getLogger(MavenVersion.class);
-    public static final MavenVersion VERSION = fromProperties();
-    private static final long serialVersionUID = VERSION.getUID();
+    private static final Logger LOG = LoggerFactory.getLogger(ProjectInfo.class);
+    public static final ProjectInfo INSTANCE = fromProperties();
+    private static final long serialVersionUID = INSTANCE.getUID();
     private static final String UNKNOWN = "UNKNOWN";
 
     /* Info derived from version string */
     public final String version; 
     public final int major;
     public final int minor;
-    public final int incremental;
+    public final int patch;
     public final String qualifier;
     
     /* Other info from git-commit-id-plugin via maven-version.properties */
@@ -29,13 +29,13 @@ public class MavenVersion implements Serializable {
     public final String buildTime;
     public final boolean dirty;
 
-    private static MavenVersion fromProperties() {
+    private static ProjectInfo fromProperties() {
         final String FILE = "maven-version.properties";
         try {
             Properties props = new java.util.Properties();
-            InputStream in = MavenVersion.class.getClassLoader().getResourceAsStream(FILE);
+            InputStream in = ProjectInfo.class.getClassLoader().getResourceAsStream(FILE);
             props.load(in);
-            MavenVersion version = new MavenVersion(
+            ProjectInfo version = new ProjectInfo(
                     props.getProperty("project.version"),
                     props.getProperty("git.commit.id"),
                     props.getProperty("git.commit.id.describe"),
@@ -48,11 +48,11 @@ public class MavenVersion implements Serializable {
             return version;
         } catch (Exception e) {
             LOG.error("Error reading version from properties file: {}", e.getMessage());
-            return new MavenVersion();
+            return new ProjectInfo();
         }
     }
     
-    private MavenVersion () {
+    private ProjectInfo() {
         // JAXB Marshalling requires classes to have a 0-arg constructor and mutable fields.
         // otherwise it throws a com.sun.xml.bind.v2.runtime.IllegalAnnotationsException.
         // It is protecting you against yourself, since you might someday want to
@@ -66,7 +66,7 @@ public class MavenVersion implements Serializable {
         this("0.0.0-ParseFailure", UNKNOWN, UNKNOWN, UNKNOWN, UNKNOWN, UNKNOWN, UNKNOWN);
     }
     
-    public MavenVersion (
+    public ProjectInfo(
             String version,
             String commit,
             String describe,
@@ -91,9 +91,9 @@ public class MavenVersion implements Serializable {
         else
             minor = 0;
         if (fields.length > 2)
-            incremental = Integer.parseInt(fields[2]);
+            patch = Integer.parseInt(fields[2]);
         else
-            incremental = 0;
+            patch = 0;
         this.commit = normalize(commit);
         this.describe = normalize(describe);
         this.commitTime = normalize(commitTime);
@@ -103,12 +103,12 @@ public class MavenVersion implements Serializable {
     }
 
     public long getUID() {
-        return (long) hashCode();
+        return hashCode();
     }
 
     public String toString() {
         return String.format("MavenVersion(%d, %d, %d, %s, %s)", 
-               major, minor, incremental, qualifier, commit);
+               major, minor, patch, qualifier, commit);
     }
 
     public String toStringVerbose() {
@@ -121,21 +121,26 @@ public class MavenVersion implements Serializable {
 
     public String getLongVersionString() {
         String format = "version: %s\nmajor: %s\nminor: %s\npatch: %s\nqualifier: %s\ncommit: %s\n";
-        return String.format(format, version, major, minor, incremental, qualifier, commit);
+        return String.format(format, version, major, minor, patch, qualifier, commit);
+    }
+
+    /** @return "major.minor.patch". The SNAPSHOT `qualifier` is removed. */
+    public String unqualifiedVersion() {
+        return String.format("%d.%d.%d", major, minor, patch);
     }
 
     public int hashCode () {
         return (qualifier.equals("SNAPSHOT") ? -1 : +1) *
-                (1000000 * major + 1000 * minor + incremental);
+                (1000000 * major + 1000 * minor + patch);
     }
 
     public boolean equals (Object other) {
-        if ( ! (other instanceof MavenVersion))
+        if ( ! (other instanceof ProjectInfo))
             return false;
-        MavenVersion that = (MavenVersion) other;
+        ProjectInfo that = (ProjectInfo) other;
         return this.major == that.major &&
                this.minor == that.minor &&
-               this.incremental == that.incremental &&
+               this.patch == that.patch &&
                this.qualifier.equals(that.qualifier);
     }
 

--- a/src/main/java/org/opentripplanner/model/Timetable.java
+++ b/src/main/java/org/opentripplanner/model/Timetable.java
@@ -5,9 +5,7 @@ import com.google.transit.realtime.GtfsRealtime.TripDescriptor;
 import com.google.transit.realtime.GtfsRealtime.TripUpdate;
 import com.google.transit.realtime.GtfsRealtime.TripUpdate.StopTimeEvent;
 import com.google.transit.realtime.GtfsRealtime.TripUpdate.StopTimeUpdate;
-import org.opentripplanner.common.MavenVersion;
 import org.opentripplanner.model.calendar.ServiceDate;
-import org.opentripplanner.routing.algorithm.raptor.transit.mappers.DateMapper;
 import org.opentripplanner.routing.core.ServiceDay;
 import org.opentripplanner.routing.trippattern.FrequencyEntry;
 import org.opentripplanner.routing.trippattern.TripTimes;
@@ -35,7 +33,7 @@ import java.util.TimeZone;
 public class Timetable implements Serializable {
 
     private static final Logger LOG = LoggerFactory.getLogger(Timetable.class);
-    private static final long serialVersionUID = MavenVersion.VERSION.getUID();
+    private static final long serialVersionUID = 1L;
 
     /**
      * A circular reference between TripPatterns and their scheduled (non-updated) timetables.

--- a/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
@@ -3,7 +3,6 @@ package org.opentripplanner.routing.api.request;
 import org.opentripplanner.api.common.LocationStringParser;
 import org.opentripplanner.api.common.Message;
 import org.opentripplanner.api.common.ParameterException;
-import org.opentripplanner.common.MavenVersion;
 import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.model.GenericLocation;
 import org.opentripplanner.model.Route;
@@ -64,7 +63,7 @@ import java.util.function.DoubleFunction;
  */
 public class RoutingRequest implements Cloneable, Serializable {
 
-    private static final long serialVersionUID = MavenVersion.VERSION.getUID();
+    private static final long serialVersionUID = 1L;
 
     private static final Logger LOG = LoggerFactory.getLogger(RoutingRequest.class);
 

--- a/src/main/java/org/opentripplanner/routing/edgetype/ParkAndRideEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/ParkAndRideEdge.java
@@ -1,6 +1,6 @@
 package org.opentripplanner.routing.edgetype;
 
-import org.opentripplanner.common.MavenVersion;
+import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.core.StateEditor;
@@ -8,7 +8,6 @@ import org.opentripplanner.routing.core.TraverseMode;
 import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.vertextype.ParkAndRideVertex;
 
-import org.locationtech.jts.geom.LineString;
 import java.util.Locale;
 
 /**
@@ -24,7 +23,7 @@ import java.util.Locale;
  */
 public class ParkAndRideEdge extends Edge {
 
-    private static final long serialVersionUID = MavenVersion.VERSION.getUID();
+    private static final long serialVersionUID = 1L;
 
     public ParkAndRideEdge(ParkAndRideVertex parkAndRide) {
         super(parkAndRide, parkAndRide);

--- a/src/main/java/org/opentripplanner/routing/edgetype/ParkAndRideLinkEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/ParkAndRideLinkEdge.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.routing.edgetype;
 
-import org.opentripplanner.common.MavenVersion;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.common.geometry.GeometryUtils;
 import org.opentripplanner.common.geometry.SphericalDistanceLibrary;
 import org.opentripplanner.routing.api.request.RoutingRequest;
@@ -11,8 +12,6 @@ import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.routing.vertextype.ParkAndRideVertex;
 
-import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.LineString;
 import java.util.Locale;
 
 /**
@@ -22,7 +21,7 @@ import java.util.Locale;
  */
 public class ParkAndRideLinkEdge extends Edge {
 
-    private static final long serialVersionUID = MavenVersion.VERSION.getUID();
+    private static final long serialVersionUID = 1L;
 
     /*
      * By how much we have to really walk compared to straight line distance. This is a magic factor

--- a/src/main/java/org/opentripplanner/routing/graph/Edge.java
+++ b/src/main/java/org/opentripplanner/routing/graph/Edge.java
@@ -2,7 +2,6 @@ package org.opentripplanner.routing.graph;
 
 import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.model.Trip;
-import org.opentripplanner.common.MavenVersion;
 import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.core.State;
 
@@ -18,7 +17,7 @@ import java.util.Locale;
  */
 public abstract class Edge implements Serializable {
 
-    private static final long serialVersionUID = MavenVersion.VERSION.getUID();
+    private static final long serialVersionUID = 1L;
 
     protected Vertex fromv;
 

--- a/src/main/java/org/opentripplanner/routing/graph/Graph.java
+++ b/src/main/java/org/opentripplanner/routing/graph/Graph.java
@@ -15,7 +15,7 @@ import org.apache.commons.math3.stat.descriptive.rank.Median;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
-import org.opentripplanner.common.MavenVersion;
+import org.opentripplanner.common.ProjectInfo;
 import org.opentripplanner.common.TurnRestriction;
 import org.opentripplanner.common.geometry.CompactElevationProfile;
 import org.opentripplanner.common.geometry.GraphUtils;
@@ -97,9 +97,9 @@ public class Graph implements Serializable {
 
     private static final Logger LOG = LoggerFactory.getLogger(Graph.class);
 
-    private static final long serialVersionUID = MavenVersion.VERSION.getUID();
+    private static final long serialVersionUID = 1L;
 
-    private final MavenVersion mavenVersion = MavenVersion.VERSION;
+    private final ProjectInfo projectInfo = ProjectInfo.INSTANCE;
 
     // TODO Remove this field, use Router.routerId ?
     public String routerId;
@@ -630,8 +630,8 @@ public class Graph implements Serializable {
      *         graphs are otherwise obviously incompatible.
      */
     boolean graphVersionMismatch() {
-        MavenVersion v = MavenVersion.VERSION;
-        MavenVersion gv = this.mavenVersion;
+        ProjectInfo v = ProjectInfo.INSTANCE;
+        ProjectInfo gv = this.projectInfo;
         LOG.info("Graph version: {}", gv);
         LOG.info("OTP version:   {}", v);
         if (!v.equals(gv)) {

--- a/src/main/java/org/opentripplanner/routing/graph/Vertex.java
+++ b/src/main/java/org/opentripplanner/routing/graph/Vertex.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.routing.graph;
 
 import org.locationtech.jts.geom.Coordinate;
-import org.opentripplanner.common.MavenVersion;
 import org.opentripplanner.common.geometry.DirectionUtils;
 import org.opentripplanner.model.StationElement;
 import org.opentripplanner.routing.edgetype.StreetEdge;
@@ -26,7 +25,7 @@ import java.util.Locale;
  */
 public abstract class Vertex implements Serializable, Cloneable {
 
-    private static final long serialVersionUID = MavenVersion.VERSION.getUID();
+    private static final long serialVersionUID = 1L;
 
     private static final Logger LOG = LoggerFactory.getLogger(Vertex.class);
 

--- a/src/main/java/org/opentripplanner/routing/trippattern/FrequencyEntry.java
+++ b/src/main/java/org/opentripplanner/routing/trippattern/FrequencyEntry.java
@@ -1,13 +1,10 @@
 package org.opentripplanner.routing.trippattern;
 
-import static org.opentripplanner.routing.trippattern.TripTimes.formatSeconds;
-
 import org.opentripplanner.model.Frequency;
-import org.opentripplanner.common.MavenVersion;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
+
+import static org.opentripplanner.routing.trippattern.TripTimes.formatSeconds;
 
 /**
  * Uses a TripTimes to represent multiple trips following the same template at regular intervals.
@@ -15,8 +12,7 @@ import java.io.Serializable;
  */
 public class FrequencyEntry implements Serializable {
 
-    private static final Logger LOG = LoggerFactory.getLogger(FrequencyEntry.class);
-    private static final long serialVersionUID = MavenVersion.VERSION.getUID();
+    private static final long serialVersionUID = 1L;
 
     public final int startTime; // sec after midnight
     public final int endTime;   // sec after midnight

--- a/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
+++ b/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
@@ -3,14 +3,13 @@ package org.opentripplanner.routing.trippattern;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hasher;
-import org.opentripplanner.common.MavenVersion;
 import org.opentripplanner.model.BikeAccess;
 import org.opentripplanner.model.StopTime;
 import org.opentripplanner.model.Trip;
+import org.opentripplanner.routing.api.request.BannedStopSet;
 import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.core.TraverseMode;
-import org.opentripplanner.routing.api.request.BannedStopSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,7 +27,7 @@ import static org.opentripplanner.model.StopPattern.PICKDROP_NONE;
  */
 public class TripTimes implements Serializable, Comparable<TripTimes>, Cloneable {
 
-    private static final long serialVersionUID = MavenVersion.VERSION.getUID();
+    private static final long serialVersionUID = 1L;
     private static final Logger LOG = LoggerFactory.getLogger(TripTimes.class);
 
     /**

--- a/src/main/java/org/opentripplanner/routing/vertextype/BikeParkVertex.java
+++ b/src/main/java/org/opentripplanner/routing/vertextype/BikeParkVertex.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.routing.vertextype;
 
-import org.opentripplanner.common.MavenVersion;
 import org.opentripplanner.routing.bike_park.BikePark;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
@@ -21,7 +20,7 @@ import org.opentripplanner.util.NonLocalizedString;
  */
 public class BikeParkVertex extends Vertex {
 
-    private static final long serialVersionUID = MavenVersion.VERSION.getUID();
+    private static final long serialVersionUID = 1L;
 
     private int spacesAvailable;
 

--- a/src/main/java/org/opentripplanner/routing/vertextype/BikeRentalStationVertex.java
+++ b/src/main/java/org/opentripplanner/routing/vertextype/BikeRentalStationVertex.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.routing.vertextype;
 
-import org.opentripplanner.common.MavenVersion;
 import org.opentripplanner.routing.bike_rental.BikeRentalStation;
 import org.opentripplanner.routing.core.TraverseMode;
 import org.opentripplanner.routing.graph.Graph;
@@ -17,7 +16,7 @@ import org.opentripplanner.routing.graph.Vertex;
  */
 public class BikeRentalStationVertex extends Vertex {
 
-    private static final long serialVersionUID = MavenVersion.VERSION.getUID();
+    private static final long serialVersionUID = 1L;
 
     private int bikesAvailable;
 

--- a/src/main/java/org/opentripplanner/routing/vertextype/ParkAndRideVertex.java
+++ b/src/main/java/org/opentripplanner/routing/vertextype/ParkAndRideVertex.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.routing.vertextype;
 
-import org.opentripplanner.common.MavenVersion;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.util.I18NString;
@@ -15,7 +14,7 @@ import org.opentripplanner.util.I18NString;
  */
 public class ParkAndRideVertex extends Vertex {
 
-    private static final long serialVersionUID = MavenVersion.VERSION.getUID();
+    private static final long serialVersionUID = 1L;
 
     private String id;
 

--- a/src/main/java/org/opentripplanner/standalone/OTPMain.java
+++ b/src/main/java/org/opentripplanner/standalone/OTPMain.java
@@ -2,7 +2,7 @@ package org.opentripplanner.standalone;
 
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterException;
-import org.opentripplanner.common.MavenVersion;
+import org.opentripplanner.common.ProjectInfo;
 import org.opentripplanner.datastore.DataSource;
 import org.opentripplanner.graph_builder.GraphBuilder;
 import org.opentripplanner.routing.graph.Graph;
@@ -71,18 +71,18 @@ public class OTPMain {
             // parsed commands, since there will be three separate objects.
             JCommander jc = JCommander.newBuilder().addObject(params).args(args).build();
             if (params.version) {
-                System.out.println(MavenVersion.VERSION.getLongVersionString());
+                System.out.println(ProjectInfo.INSTANCE.getLongVersionString());
                 System.exit(0);
             }
             if (params.help) {
-                System.out.println(MavenVersion.VERSION.getShortVersionString());
+                System.out.println(ProjectInfo.INSTANCE.getShortVersionString());
                 jc.setProgramName("java -Xmx4G -jar otp.jar");
                 jc.usage();
                 System.exit(0);
             }
             params.inferAndValidate();
         } catch (ParameterException pex) {
-            System.out.println(MavenVersion.VERSION.getShortVersionString());
+            System.out.println(ProjectInfo.INSTANCE.getShortVersionString());
             LOG.error("Parameter error: {}", pex.getMessage());
             System.exit(1);
         }

--- a/src/main/java/org/opentripplanner/standalone/OtpStartupInfo.java
+++ b/src/main/java/org/opentripplanner/standalone/OtpStartupInfo.java
@@ -1,6 +1,6 @@
 package org.opentripplanner.standalone;
 
-import org.opentripplanner.common.MavenVersion;
+import org.opentripplanner.common.ProjectInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,15 +24,15 @@ public class OtpStartupInfo {
     static {
         INFO = ""
                 + HEADER.stream().map(OtpStartupInfo::line).collect(Collectors.joining())
-                + line("Version:  " + MavenVersion.VERSION.version)
-                + line("Commit:   " + MavenVersion.VERSION.commit)
-                + line("Branch:   " + MavenVersion.VERSION.branch)
-                + line("Build:    " + MavenVersion.VERSION.buildTime)
+                + line("Version:  " + ProjectInfo.INSTANCE.version)
+                + line("Commit:   " + ProjectInfo.INSTANCE.commit)
+                + line("Branch:   " + ProjectInfo.INSTANCE.branch)
+                + line("Build:    " + ProjectInfo.INSTANCE.buildTime)
                 + dirtyLineIfDirty();
     }
 
     private static String dirtyLineIfDirty() {
-        return MavenVersion.VERSION.dirty
+        return ProjectInfo.INSTANCE.dirty
         ? line("Dirty:    Local modification exist!")
         : "";
     }

--- a/src/main/java/org/opentripplanner/standalone/config/ConfigLoader.java
+++ b/src/main/java/org/opentripplanner/standalone/config/ConfigLoader.java
@@ -16,7 +16,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
-import static org.opentripplanner.util.EnvironmentVariableReplacer.insertEnvironmentVariables;
+import static org.opentripplanner.standalone.config.EnvironmentVariableReplacer.insertEnvironmentVariables;
 
 /**
  * Generic config file loader. This is used to load all configuration files.

--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTest.java
@@ -1,6 +1,6 @@
 package org.opentripplanner.transit.raptor.speed_test;
 
-import org.opentripplanner.common.MavenVersion;
+import org.opentripplanner.common.ProjectInfo;
 import org.opentripplanner.datastore.OtpDataStore;
 import org.opentripplanner.routing.algorithm.raptor.transit.TransitLayer;
 import org.opentripplanner.routing.algorithm.raptor.transit.TripSchedule;
@@ -123,7 +123,7 @@ public class SpeedTest {
         printProfileStatistics();
 
         service.shutdown();
-        System.err.println("\nSpeedTest done! " + MavenVersion.VERSION.getShortVersionString());
+        System.err.println("\nSpeedTest done! " + ProjectInfo.INSTANCE.getShortVersionString());
     }
 
     private void runSingleTest(int sample, int nSamples) throws Exception {


### PR DESCRIPTION
There is not issue for this PR. The PR provide:
 -  a cleanup of the MavenInfo class in OTP
 - Cleanup: The `serialVersionUID` in a class should change when the class change, not depend on the Maven version
    number. The serialized graph on the other hand can have a check on the Maven version number to see if two graphs
    are complient.
 - MavenInfo is renamed ProjectInfo - it holds info avout the Maven project version as well as som Git info.
 - Documentation on the environment substitution. This is just mentioned in the Configuration.md, but not clearly 
    described, now it is.
 - Include ProjectInfo in the configuration substitution as well as the environmental variables substitution.  
 - I have changed the 3 version number from `incremental` to `patch`, using the [terminology on wikipedia](https://en.wikipedia.org/wiki/Software_versioning). `incremental` is used by Maven, but not as the 3rd version number.

To be completed by pull request submitter:

- [ ] **issue**: No
- [ ] **roadmap**: No
- [ ] **tests**: Yes, Unit tests on all new features are added.
- [ ] **formatting**: Yes 
- [ ] **documentation**: Yes
- [ ] **changelog**: Yes.

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)