### PR TITLE
Provide a fake JavaDoc jar with readme

### DIFF
--- a/docs/javadoc/README.md
+++ b/docs/javadoc/README.md
@@ -1,0 +1,19 @@
+# OTP JavaDoc
+
+
+With OTP2, we are not targeting use of OTP as a library, so HTML Javadoc is
+not as relevant. Use the source artifact, github or an IDE to explore the
+code instead.
+
+Maven Central Repository require javadoc to be present, but it is ok to
+provide a fake one:
+
+> If, for some reason (for example, license issue or it's a Scala project), you can not provide
+> -sources.jar or -javadoc.jar , please make fake -sources.jar or -javadoc.jar with simple README
+> inside to pass the checking. We do not want to disable the rules because some people tend to skip
+> it if they have an option and we want to keep the quality of the user experience as high as
+> possible.
+
+See: [Maven Central Repository - Requirements](https://central.sonatype.org/pages/requirements.html)
+
+There is no JavaDoc provided for OTP, use the source artifact, github or an ide to explore the code.

--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
                 </configuration>
                 <executions>
                     <execution>
-                        <!-- OTP include face javadoc. See docs/javadoc/README.md -->
+                        <!-- OTP includes an empty javadoc.jar file. See docs/javadoc/README.md -->
                         <id>package-javadoc</id>
                         <phase>package</phase>
                         <goals><goal>jar</goal></goals>
@@ -231,7 +231,7 @@
                 </configuration>
             </plugin>
             <plugin>
-                <!-- OTP include face javadoc. See docs/javadoc/README.md -->
+                <!-- OTP includes an empty javadoc.jar file. See docs/javadoc/README.md -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.2.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.1.2</version>
+                <version>3.2.0</version>
                 <configuration>
                     <archive>
                         <manifestEntries>
@@ -188,6 +188,18 @@
                         </manifestEntries>
                     </archive>
                 </configuration>
+                <executions>
+                    <execution>
+                        <!-- OTP include face javadoc. See docs/javadoc/README.md -->
+                        <id>package-javadoc</id>
+                        <phase>package</phase>
+                        <goals><goal>jar</goal></goals>
+                        <configuration>
+                            <classesDirectory>${basedir}/docs/javadoc</classesDirectory>
+                            <classifier>javadoc</classifier>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <!-- Recommended way to deploy to OSSRH , which allows deferred manual release to Central. -->
@@ -219,26 +231,11 @@
                 </configuration>
             </plugin>
             <plugin>
+                <!-- OTP include face javadoc. See docs/javadoc/README.md -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.2.0</version>
-                <configuration>
-                    <!-- Turn off strict Javadoc checking -->
-                    <doclint>none</doclint>
-                    <!-- We get tons of errors about classes not existing, maybe due to multiple source roots.
-                         For now we're excluding almost everything just to create dummy Javadoc JARs. -->
-                    <excludePackageNames>org.opentripplanner.*</excludePackageNames>
-                </configuration>
-                <executions>
-                    <!-- Compress Javadoc into JAR and include that JAR when deploying.
-                         Required for deployments to Maven Central. -->
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
+                <configuration><skip>true</skip></configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
I got the JavaDoc plugin to work locally by setting the JAVA_HOME env variable. But it do not work on the CI build. So instead of spending more time to get this to work, the next option was to disable it. I followed the guideline from Maven Central and made the a fake javadoc jar with a README.md file witch explain why we do not provide any java doc. The [README](https://github.com/opentripplanner/OpenTripPlanner/blob/3360a0b92a2d3154c1b59675aaec3f3ccaac911f/docs/javadoc/README.md) is part of this PR.

To be completed by pull request submitter:

- [ ] **issue**: Related to #2694, fixes #3213
- [ ] **roadmap**: No
- [ ] **tests**: No
- [ ] **formatting**: Yes
- [ ] **documentation**: No
- [ ] **changelog**: No - This work in OTP1.


To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)