### PR TITLE
InteractiveOtpMain save flag not set.

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/interactivelauncher/InteractiveOtpMain.java
+++ b/src/ext/java/org/opentripplanner/ext/interactivelauncher/InteractiveOtpMain.java
@@ -25,7 +25,7 @@ public class InteractiveOtpMain {
   private void run() {
     this.model = Model.load();
     MainView frame = new MainView(this::startOtp, model);
-    frame.start();;
+    frame.start();
   }
 
   private void startOtp() {

--- a/src/ext/java/org/opentripplanner/ext/interactivelauncher/views/OptionsView.java
+++ b/src/ext/java/org/opentripplanner/ext/interactivelauncher/views/OptionsView.java
@@ -58,7 +58,7 @@ class OptionsView {
   public void updateModel(Model model) {
     model.setBuildStreet(buildStreet());
     model.setBuildTransit(buildTransit());
-    model.setServeGraph(saveGraph());
+    model.setSaveGraph(saveGraph());
     model.setServeGraph(startOptServer());
   }
 


### PR DESCRIPTION
This is a small bugfix on the InteractiveOtpMain. The "[ ] save" checkbox was ignored and changing the value had no effect. This PR fixes this by setting the value on the model.  

To be completed by pull request submitter:

- [ ] **issue**: No, Sandbox.
- [ ] **roadmap**: No.
- [ ] **tests**: No
- [ ] **formatting**: Yes 
- [ ] **documentation**: No
- [ ] **changelog**: No

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)