### PR TITLE
bugfix: No trip metadata returned when path exist outside search-window

### DIFF
--- a/src/main/java/org/opentripplanner/transit/raptor/service/RangRaptorDynamicSearch.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/service/RangRaptorDynamicSearch.java
@@ -71,7 +71,7 @@ public class RangRaptorDynamicSearch<T extends RaptorTripSchedule> {
            runHeuristics();
 
             RaptorRequest<T> mcRequest = originalRequest;
-            mcRequest = mcRequestWithDynamicSearchParams(mcRequest);
+            mcRequest = requestWithDynamicSearchParams(mcRequest);
 
             return createAndRunWorker(mcRequest);
         }
@@ -79,7 +79,10 @@ public class RangRaptorDynamicSearch<T extends RaptorTripSchedule> {
             return new RaptorResponse<>(
                     Collections.emptyList(),
                     originalRequest,
-                    originalRequest
+                    // If a trip exist(forward heuristics succeed), but is outside the calculated
+                    // search-window, then set the search-window params as if the request was
+                    // performed. This enable the client to page to the next window
+                    requestWithDynamicSearchParams(originalRequest)
             );
         }
     }
@@ -182,7 +185,9 @@ public class RangRaptorDynamicSearch<T extends RaptorTripSchedule> {
         task.withRequest(originalRequest).run();
         calculateDynamicSearchParametersFromHeuristics(task.result());
 
-        if(tasks.size() == 1) { return; }
+        if(tasks.size() == 1) {
+            return;
+        }
 
         // Run the second heuristic search
         task = tasks.get(1);
@@ -230,7 +235,7 @@ public class RangRaptorDynamicSearch<T extends RaptorTripSchedule> {
                 .build();
     }
 
-    private RaptorRequest<T> mcRequestWithDynamicSearchParams(RaptorRequest<T> request) {
+    private RaptorRequest<T> requestWithDynamicSearchParams(RaptorRequest<T> request) {
 
         SearchParamsBuilder<T> builder = request.mutate().searchParams();
 


### PR DESCRIPTION
A travel search sometimes return without any metadata even if there is a path outside the search window. This happens with a McRaptor search if the first heuristics search succeed, but not the last. The meta-data can be set from the first heuristic search, enabling the client to search again with a new search-window (next/previous).

To be completed by pull request submitter:

- [ ] **issue**: closes #3271
- [ ] **roadmap**: No.
- [ ] **tests**: No
- [ ] **formatting**: Yes
- [ ] **documentation**: No
- [ ] **changelog**: No.

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)