### PR TITLE
GitHub Action to build container image with Jib

### DIFF
--- a/.github/workflows/maven-jib.yml
+++ b/.github/workflows/maven-jib.yml
@@ -1,0 +1,44 @@
+name: Test and build
+
+on:
+  push:
+  pull_request:
+    branches: [ $default-branch ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Maven cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+
+    - name: Test
+      run: mvn -B -V clean verify --settings maven-settings.xml -Dgpg.skip
+
+    - name: Build container image
+      run: |
+        BRANCH=${GITHUB_REF#refs/heads/}
+        if [ $BRANCH = dev-2.x -o $BRANCH = ci-github-action-container-image ];
+        then
+          JIB_ACTION=build
+        else
+          JIB_ACTION=buildTar
+        fi
+        # lowercase to match image name rules (DNS without underscores)
+        CONTAINER_IMAGE=ghcr.io/$(echo $GITHUB_REPOSITORY | tr A-Z a-z | tr -d _)
+        mvn compile com.google.cloud.tools:jib-maven-plugin:2.7.0:${JIB_ACTION} \
+          -Dimage=${CONTAINER_IMAGE}:${GITHUB_SHA} \
+          -Djib.container.mainClass=org.opentripplanner.standalone.OTPMain \
+          -Djib.container.labels=org.opencontainers.image.source=https://github.com/${GITHUB_REPOSITORY}
+

--- a/.github/workflows/maven-jib.yml
+++ b/.github/workflows/maven-jib.yml
@@ -27,18 +27,30 @@ jobs:
       run: mvn -B -V clean verify --settings maven-settings.xml -Dgpg.skip
 
     - name: Build container image
+      env:
+        GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}
+        GHCR_PASSWORD: ${{ secrets.GHCR_PASSWORD }}
       run: |
         BRANCH=${GITHUB_REF#refs/heads/}
+        # lowercase to match image name rules (DNS without underscores)
+        CONTAINER_IMAGE=ghcr.io/$(echo "${GITHUB_REPOSITORY}" | tr A-Z a-z | tr -d _)
+        JIB_ARGS="-Dimage=${CONTAINER_IMAGE}:${GITHUB_SHA} -Djib.container.mainClass=org.opentripplanner.standalone.OTPMain -Djib.container.labels=org.opencontainers.image.source=https://github.com/${GITHUB_REPOSITORY}"
+
         if [ $BRANCH = dev-2.x -o $BRANCH = ci-github-action-container-image ];
         then
           JIB_ACTION=build
+          JIB_ARGS="${JIB_ARGS} -Djib.to.tags=latest"
         else
           JIB_ACTION=buildTar
         fi
-        # lowercase to match image name rules (DNS without underscores)
-        CONTAINER_IMAGE=ghcr.io/$(echo $GITHUB_REPOSITORY | tr A-Z a-z | tr -d _)
-        mvn compile com.google.cloud.tools:jib-maven-plugin:2.7.0:${JIB_ACTION} \
-          -Dimage=${CONTAINER_IMAGE}:${GITHUB_SHA} \
-          -Djib.container.mainClass=org.opentripplanner.standalone.OTPMain \
-          -Djib.container.labels=org.opencontainers.image.source=https://github.com/${GITHUB_REPOSITORY}
-
+        if [ -n "${GHCR_USERNAME-}" ]; then
+          JIB_ARGS="${JIB_ARGS} -Djib.to.auth.username=${GHCR_USERNAME}"
+        else
+          JIB_ACTION=buildTar
+        fi
+        if [ -n "${GHCR_PASSWORD-}" ]; then
+          JIB_ARGS="${JIB_ARGS} -Djib.to.auth.password=${GHCR_PASSWORD}"
+        else
+          JIB_ACTION=buildTar
+        fi
+        mvn -B compile com.google.cloud.tools:jib-maven-plugin:2.7.0:${JIB_ACTION} ${JIB_ARGS}


### PR DESCRIPTION
This is a draft pull request, which might need total rewrite.

This is based on discussions about how to build and publish container (Docker) images in GitHub's Container Registry.

Currently GitHub Action automatically gets `GITHUB_TOKEN` but this token is not enough to publish into Container Registry, but looks like it is on their roadmap.

Artifacts created this way are under our testing. Read build container artifacts are publicly available from https://github.com/orgs/kyyticom/packages/container/package/opentripplanner

TODO:
- Decide which branches or tags should build a container image revision to be published
- Integrate into `pom.xml` or keep as separate `mvn` command in GH Action yaml?



To be completed by pull request submitter:

- [ ] **issue**: Link to or create an [issue](https://github.com/opentripplanner/OpenTripPlanner/issues) that describes the relevant feature or bug. Add [GitHub keywords](https://help.github.com/articles/closing-issues-using-keywords/) to this PR's description (e.g., `closes #45`).
- [ ] **roadmap**: Check the [roadmap](https://github.com/orgs/opentripplanner/projects/1) for this feature or bug. If it is not already on the roadmap, PLC will discuss as part of the review process.
- [ ] **tests**: Have you added relevant test coverage? Are all the tests passing on [the continuous integration service (Travis CI)](https://github.com/opentripplanner/OpenTripPlanner/blob/2.0-rc/docs/Developers-Guide.md#continuous-integration)?
- [ ] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/2.0-rc/docs/Developers-Guide.md#code-style)? 
- [ ] **documentation**: If you are adding a new configuration option, have you added an explanation to the [configuration documentation](https://github.com/opentripplanner/OpenTripPlanner/blob/2.0-rc/docs/Configuration.md) tables and sections?
- [ ] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/2.0-rc/docs/Changelog.md) with description and link to the linked issue

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)