### PR TITLE
Fix TripPattern geometry response to contain full data up to last stop

### DIFF
--- a/src/main/java/org/opentripplanner/model/TripPattern.java
+++ b/src/main/java/org/opentripplanner/model/TripPattern.java
@@ -209,7 +209,7 @@ public class TripPattern extends TransitEntity implements Cloneable, Serializabl
         if(hopGeometries == null || hopGeometries.length==0) { return null; }
 
         List<LineString> lineStrings = new ArrayList<>();
-        for (int i = 0; i < hopGeometries.length - 1; i++) {
+        for (int i = 0; i < hopGeometries.length; i++) {
             lineStrings.add(getHopGeometry(i));
         }
         return GeometryUtils.concatenateLineStrings(lineStrings);


### PR DESCRIPTION
Fix geometry response to contain full data up to last stop

`TripPattern`'s `getGeometry` was missing the hop geometry to the last stop because loop offset bug.

To be completed by pull request submitter:

- [ ] **issue**: Link to or create an [issue](https://github.com/opentripplanner/OpenTripPlanner/issues) that describes the relevant feature or bug. Add [GitHub keywords](https://help.github.com/articles/closing-issues-using-keywords/) to this PR's description (e.g., `closes #45`).
- [ ] **roadmap**: Check the [roadmap](https://github.com/orgs/opentripplanner/projects/1) for this feature or bug. If it is not already on the roadmap, PLC will discuss as part of the review process.
- [ ] **tests**: Have you added relevant test coverage? Are all the tests passing on [the continuous integration service (Travis CI)](https://github.com/opentripplanner/OpenTripPlanner/blob/2.0-rc/docs/Developers-Guide.md#continuous-integration)?
- [X] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/2.0-rc/docs/Developers-Guide.md#code-style)? 
- [ ] **documentation**: If you are adding a new configuration option, have you added an explanation to the [configuration documentation](https://github.com/opentripplanner/OpenTripPlanner/blob/2.0-rc/docs/Configuration.md) tables and sections?
- [ ] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/2.0-rc/docs/Changelog.md) with description and link to the linked issue

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)