### PR TITLE
Update ItineraryFilterChainBuilder.java

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/filterchain/ItineraryFilterChainBuilder.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/filterchain/ItineraryFilterChainBuilder.java
@@ -171,19 +171,6 @@ public class ItineraryFilterChainBuilder {
             filters.add(new TransitGeneralizedCostFilter(transitGeneralizedCostLimit));
         }
 
-        // Remove itineraries if max limit is set
-        if (maxNumberOfItineraries > 0) {
-            // Sort first to make sure we keep the most relevant itineraries
-            filters.add(new OtpDefaultSortOrder(arriveBy));
-            filters.add(
-                new MaxLimitFilter(
-                    "number-of-itineraries-filter",
-                    maxNumberOfItineraries,
-                    maxLimitReachedSubscriber
-                )
-            );
-        }
-
         // Apply all absolute filters AFTER the groupBy filters. Absolute filters are filters that
         // remove elements/ based on the given itinerary properties - not considering other
         // itineraries. This may remove itineraries in the "groupBy" filters that are considered
@@ -206,6 +193,17 @@ public class ItineraryFilterChainBuilder {
         // Do the final itineraries sort
         filters.add(new OtpDefaultSortOrder(arriveBy));
 
+        // Remove itineraries if max limit is set
+        if (maxNumberOfItineraries > 0) {
+            filters.add(
+                new MaxLimitFilter(
+                    "number-of-itineraries-filter",
+                    maxNumberOfItineraries,
+                    maxLimitReachedSubscriber
+                )
+            );
+        }
+        
         if(debug) {
             filters = addDebugWrappers(filters);
         }

--- a/src/main/java/org/opentripplanner/routing/algorithm/filterchain/ItineraryFilterChainBuilder.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/filterchain/ItineraryFilterChainBuilder.java
@@ -190,11 +190,9 @@ public class ItineraryFilterChainBuilder {
             }
         }
 
-        // Do the final itineraries sort
-        filters.add(new OtpDefaultSortOrder(arriveBy));
-
         // Remove itineraries if max limit is set
         if (maxNumberOfItineraries > 0) {
+            filters.add(new OtpDefaultSortOrder(arriveBy));
             filters.add(
                 new MaxLimitFilter(
                     "number-of-itineraries-filter",
@@ -203,6 +201,9 @@ public class ItineraryFilterChainBuilder {
                 )
             );
         }
+
+        // Do the final itineraries sort
+        filters.add(new OtpDefaultSortOrder(arriveBy));
         
         if(debug) {
             filters = addDebugWrappers(filters);


### PR DESCRIPTION
Filter by maxNumberOfItineraries after final filter (street-vs-transit or latest-departure-time).
Sort results only once

close #3301

To be completed by pull request submitter:

- [x] **issue**: Link to or create an [issue](https://github.com/opentripplanner/OpenTripPlanner/issues) that describes the relevant feature or bug. Add [GitHub keywords](https://help.github.com/articles/closing-issues-using-keywords/) to this PR's description (e.g., `closes #45`).
- [ ] **roadmap**: Check the [roadmap](https://github.com/orgs/opentripplanner/projects/1) for this feature or bug. If it is not already on the roadmap, PLC will discuss as part of the review process.
- [ ] **tests**: Have you added relevant test coverage? Are all the tests passing on [the continuous integration service (Travis CI)](https://github.com/opentripplanner/OpenTripPlanner/blob/2.0-rc/docs/Developers-Guide.md#continuous-integration)?
- [ ] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/2.0-rc/docs/Developers-Guide.md#code-style)? 
- [ ] **documentation**: If you are adding a new configuration option, have you added an explanation to the [configuration documentation](https://github.com/opentripplanner/OpenTripPlanner/blob/2.0-rc/docs/Configuration.md) tables and sections?
- [ ] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/2.0-rc/docs/Changelog.md) with description and link to the linked issue

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)