### PR TITLE
Returning 'null' when endTime is not set

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/siri/SiriAlertsUpdateHandlerTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/siri/SiriAlertsUpdateHandlerTest.java
@@ -916,11 +916,25 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
 
     final String situationNumber = "TST:SituationNumber:1234";
     final String stopId0 = "stop0";
+
     PtSituationElement ptSituation = createPtSituationElement(situationNumber,
-        ZonedDateTime.parse("2014-01-01T00:00:00+01:00"),
+        null,
         null,
         createAffectsStop(new ArrayList<>(), stopId0)
     );
+
+    // Add period with start- and endtime
+    HalfOpenTimestampOutputRangeStructure period_1 = new HalfOpenTimestampOutputRangeStructure();
+    period_1.setStartTime(ZonedDateTime.parse("2020-01-01T10:00:00+01:00"));
+    period_1.setEndTime(ZonedDateTime.parse("2020-02-01T11:00:00+01:00"));
+    ptSituation.getValidityPeriods().add(period_1);
+
+
+    // Add period with start-, but NO endtime - i.e. open-ended
+    HalfOpenTimestampOutputRangeStructure period_2 = new HalfOpenTimestampOutputRangeStructure();
+    period_2.setStartTime(ZonedDateTime.parse("2020-02-02T10:00:00+01:00"));
+    period_2.setEndTime(null);
+    ptSituation.getValidityPeriods().add(period_2);
 
     final ServiceDelivery serviceDelivery = createServiceDelivery(ptSituation);
     alertsUpdateHandler.update(serviceDelivery);
@@ -937,6 +951,9 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
     assertEquals(situationNumber, transitAlert.getId());
 
     assertNotNull(transitAlert.getEffectiveStartDate());
+
+    assertEquals(period_1.getStartTime().toEpochSecond(), (transitAlert.getEffectiveStartDate().getTime()/1000));
+
     assertNull(transitAlert.getEffectiveEndDate());
   }
 

--- a/src/ext-test/java/org/opentripplanner/ext/siri/SiriAlertsUpdateHandlerTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/siri/SiriAlertsUpdateHandlerTest.java
@@ -15,6 +15,7 @@ import uk.org.siri.siri20.*;
 
 import java.math.BigInteger;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -903,6 +904,40 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
     assertFalse(transitAlertService.getAllAlerts().isEmpty());
 
     assertSeparateLineAndStopAlerts(situationNumber, routeId, stopId0, stopId1);
+  }
+
+
+
+  @Test
+  public void testSiriSxWithOpenEndedValidity() {
+    init();
+
+    assertTrue(transitAlertService.getAllAlerts().isEmpty());
+
+    final String situationNumber = "TST:SituationNumber:1234";
+    final String stopId0 = "stop0";
+    PtSituationElement ptSituation = createPtSituationElement(situationNumber,
+        ZonedDateTime.parse("2014-01-01T00:00:00+01:00"),
+        null,
+        createAffectsStop(new ArrayList<>(), stopId0)
+    );
+
+    final ServiceDelivery serviceDelivery = createServiceDelivery(ptSituation);
+    alertsUpdateHandler.update(serviceDelivery);
+
+    assertFalse(transitAlertService.getAllAlerts().isEmpty());
+
+    final FeedScopedId stopId = new FeedScopedId("FEED", stopId0);
+
+    Collection<TransitAlert> tripPatches = transitAlertService.getStopAlerts(stopId);
+
+    assertNotNull(tripPatches);
+    assertEquals(1, tripPatches.size());
+    TransitAlert transitAlert = tripPatches.iterator().next();
+    assertEquals(situationNumber, transitAlert.getId());
+
+    assertNotNull(transitAlert.getEffectiveStartDate());
+    assertNull(transitAlert.getEffectiveEndDate());
   }
 
   private AffectsScopeStructure createAffectsLineWithExternallyDefinedStopPoints(

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriAlertsUpdateHandler.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriAlertsUpdateHandler.java
@@ -135,13 +135,14 @@ public class SiriAlertsUpdateHandler {
                 final long realStart = activePeriod.getStartTime() != null ? getEpochSecond(activePeriod.getStartTime()) : 0;
                 final long start = activePeriod.getStartTime() != null? realStart - earlyStart : 0;
 
-                final long realEnd = activePeriod.getEndTime() != null ? getEpochSecond(activePeriod.getEndTime()) : 0;
-                final long end = activePeriod.getEndTime() != null? realEnd  : 0;
+                final long realEnd = activePeriod.getEndTime() != null ? getEpochSecond(activePeriod.getEndTime()) : TimePeriod.OPEN_ENDED;
+                final long end = activePeriod.getEndTime() != null? realEnd  : TimePeriod.OPEN_ENDED;
+
                 periods.add(new TimePeriod(start, end));
             }
         } else {
             // Per the GTFS-rt spec, if an alert has no TimeRanges, than it should always be shown.
-            periods.add(new TimePeriod(0, Long.MAX_VALUE));
+            periods.add(new TimePeriod(0, TimePeriod.OPEN_ENDED));
         }
 
         alert.setTimePeriods(periods);

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/framework/ValidityPeriodType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/framework/ValidityPeriodType.java
@@ -22,7 +22,7 @@ public class ValidityPeriodType {
           .field(GraphQLFieldDefinition.newFieldDefinition()
                   .name("endTime")
                   .type(qglUtil.dateTimeScalar)
-                  .description("End of validity period")
+                  .description("End of validity period. Will return 'null' if validity is open-ended.")
                   .dataFetcher(environment -> {
                       Pair<Long, Long> period = environment.getSource();
                       return period != null ? period.getRight() : null;

--- a/src/main/java/org/opentripplanner/routing/alertpatch/TimePeriod.java
+++ b/src/main/java/org/opentripplanner/routing/alertpatch/TimePeriod.java
@@ -12,6 +12,8 @@ public class TimePeriod {
     //           - a external API version should be created to decouple the internal model
     //           - from any API usage.
 
+    public static final long OPEN_ENDED = Long.MAX_VALUE;
+
     public TimePeriod(long start, long end) {
         this.startTime = start;
         this.endTime = end;

--- a/src/main/java/org/opentripplanner/routing/alertpatch/TransitAlert.java
+++ b/src/main/java/org/opentripplanner/routing/alertpatch/TransitAlert.java
@@ -112,9 +112,10 @@ public class TransitAlert implements Serializable {
     public Date getEffectiveEndDate() {
         return timePeriods
             .stream()
+            .filter(timePeriod -> timePeriod.endTime > 0)
             .map(timePeriod -> timePeriod.endTime)
             .max(Comparator.naturalOrder())
-            .map(startTime -> new Date(startTime * 1000))
+            .map(endTime -> new Date(endTime * 1000))
             .orElse(null);
     }
 

--- a/src/main/java/org/opentripplanner/routing/alertpatch/TransitAlert.java
+++ b/src/main/java/org/opentripplanner/routing/alertpatch/TransitAlert.java
@@ -100,6 +100,11 @@ public class TransitAlert implements Serializable {
         this.feedId = feedId;
     }
 
+    /**
+     * Finds the first validity startTime from all timePeriods for this alert.
+     *
+     * @return First endDate for this Alert
+     */
     public Date getEffectiveStartDate() {
         return timePeriods
             .stream()
@@ -109,12 +114,18 @@ public class TransitAlert implements Serializable {
             .orElse(null);
     }
 
+    /**
+     * Finds the last validity endTime from all timePeriods for this alert.
+     * Returns <code>null</code> if the validity is open-ended
+     *
+     * @return Last endDate for this Alert, <code>null</code> if open-ended
+     */
     public Date getEffectiveEndDate() {
         return timePeriods
             .stream()
-            .filter(timePeriod -> timePeriod.endTime > 0)
             .map(timePeriod -> timePeriod.endTime)
             .max(Comparator.naturalOrder())
+            .filter(timePeriod -> timePeriod < TimePeriod.OPEN_ENDED) //If open-ended, null should be returned
             .map(endTime -> new Date(endTime * 1000))
             .orElse(null);
     }

--- a/src/main/java/org/opentripplanner/routing/alertpatch/TransitAlert.java
+++ b/src/main/java/org/opentripplanner/routing/alertpatch/TransitAlert.java
@@ -125,7 +125,7 @@ public class TransitAlert implements Serializable {
             .stream()
             .map(timePeriod -> timePeriod.endTime)
             .max(Comparator.naturalOrder())
-            .filter(timePeriod -> timePeriod < TimePeriod.OPEN_ENDED) //If open-ended, null should be returned
+            .filter(endTime -> endTime < TimePeriod.OPEN_ENDED) //If open-ended, null should be returned
             .map(endTime -> new Date(endTime * 1000))
             .orElse(null);
     }

--- a/src/main/java/org/opentripplanner/updater/alerts/AlertsUpdateHandler.java
+++ b/src/main/java/org/opentripplanner/updater/alerts/AlertsUpdateHandler.java
@@ -63,12 +63,12 @@ public class AlertsUpdateHandler {
             for (TimeRange activePeriod : alert.getActivePeriodList()) {
                 final long realStart = activePeriod.hasStart() ? activePeriod.getStart() : 0;
                 final long start = activePeriod.hasStart() ? realStart - earlyStart : 0;
-                final long end = activePeriod.hasEnd() ? activePeriod.getEnd() : Long.MAX_VALUE;
+                final long end = activePeriod.hasEnd() ? activePeriod.getEnd() : TimePeriod.OPEN_ENDED;
                 periods.add(new TimePeriod(start, end));
             }
         } else {
             // Per the GTFS-rt spec, if an alert has no TimeRanges, than it should always be shown.
-            periods.add(new TimePeriod(0, Long.MAX_VALUE));
+            periods.add(new TimePeriod(0, TimePeriod.OPEN_ENDED));
         }
         alertText.setTimePeriods(periods);
         alertText.setFeedId(feedId);


### PR DESCRIPTION
Open ended alerts/situations should return _null_, not _epoch 0_ as endTime.