### PR TITLE
OTP2: Handle that fuzzy-matches may not be found

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/siri/SiriAlertsUpdateHandler.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriAlertsUpdateHandler.java
@@ -374,47 +374,58 @@ public class SiriAlertsUpdateHandler {
 
                         FeedScopedId tripId = siriFuzzyTripMatcher.getTripId(datedVehicleJourneyRef);
 
-                        ServiceDate serviceDate = null;
-                        ZonedDateTime startOfService = null;
-                        if (dataFrameRef != null && dataFrameRef.getValue() != null) {
-                            startOfService = DateMapper.asStartOfService(
-                                LocalDate.parse(dataFrameRef.getValue()), graph.getTimeZone().toZoneId()
+                        if (tripId != null) {
+                            ServiceDate serviceDate = null;
+                            ZonedDateTime startOfService = null;
+                            if (dataFrameRef != null && dataFrameRef.getValue() != null) {
+                                startOfService = DateMapper.asStartOfService(LocalDate.parse(
+                                    dataFrameRef.getValue()), graph.getTimeZone().toZoneId());
+
+                                serviceDate = new ServiceDate(startOfService.getYear(),
+                                    startOfService.getMonthValue(),
+                                    startOfService.getDayOfMonth()
+                                );
+
+                            }
+                            final TimePeriod timePeriod = calculateTimePeriodForTrip(alert,
+                                tripId,
+                                serviceDate,
+                                startOfService,
+                                6 * 3600
                             );
 
-                            serviceDate = new ServiceDate(startOfService.getYear(), startOfService.getMonthValue(), startOfService.getDayOfMonth());
+                            //  A tripId for a given date may be reused for other dates not affected by this alert.
 
-                        }
-                        final TimePeriod timePeriod = calculateTimePeriodForTrip(alert,
-                            tripId,
-                            serviceDate,
-                            startOfService, 6 * 3600
-                        );
+                            // TODO: Make it possible to add time periods for trip selectors
+                            alert.setTimePeriods(Arrays.asList(timePeriod));
 
-                        //  A tripId for a given date may be reused for other dates not affected by this alert.
+                            if (!affectedStops.isEmpty()) {
+                                for (AffectedStopPointStructure affectedStop : affectedStops) {
+                                    FeedScopedId stop = siriFuzzyTripMatcher.getStop(affectedStop
+                                        .getStopPointRef()
+                                        .getValue());
+                                    if (stop == null) {
+                                        stop = new FeedScopedId(feedId,
+                                            affectedStop.getStopPointRef().getValue()
+                                        );
+                                    }
 
-                        // TODO: Make it possible to add time periods for trip selectors
-                        alert.setTimePeriods(Arrays.asList(timePeriod));
-
-                        if (!affectedStops.isEmpty()) {
-                            for (AffectedStopPointStructure affectedStop : affectedStops) {
-                                FeedScopedId stop = siriFuzzyTripMatcher.getStop(affectedStop.getStopPointRef().getValue());
-                                if (stop == null) {
-                                    stop = new FeedScopedId(feedId, affectedStop.getStopPointRef().getValue());
+                                    alert.addEntity(new EntitySelector.StopAndTrip(stop, tripId));
                                 }
-
-                                alert.addEntity(new EntitySelector.StopAndTrip(stop, tripId));
                             }
-                        } else {
-                            alert.addEntity(new EntitySelector.Trip(tripId));
+                            else {
+                                alert.addEntity(new EntitySelector.Trip(tripId));
+                            }
                         }
-
                     }
 
                     if (lineRef != null) {
 
                         Set<Route> affectedRoutes = siriFuzzyTripMatcher.getRoutes(lineRef);
-                        for (Route route : affectedRoutes) {
-                            alert.addEntity(new EntitySelector.Route(route.getId()));
+                        if (affectedRoutes != null) {
+                            for (Route route : affectedRoutes) {
+                                alert.addEntity(new EntitySelector.Route(route.getId()));
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Sandbox-changes only

When the fuzzy-matcher fails to find a result for a provided id for an Alert, `null` is returned. When this is not handled, a NullPointerException occurs that causes the rest of the alerts in the same update to be ignored.

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)