### PR TITLE
Do not map trips with ServiceAlteration CANCELLATION or REPLACED

### DIFF
--- a/src/main/java/org/opentripplanner/netex/mapping/TripMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/TripMapper.java
@@ -6,12 +6,15 @@ import org.opentripplanner.model.Trip;
 import org.opentripplanner.model.impl.EntityById;
 import org.opentripplanner.netex.index.api.ReadOnlyHierarchicalMap;
 import org.opentripplanner.netex.mapping.support.FeedScopedIdFactory;
+import org.opentripplanner.netex.mapping.support.ServiceAlterationFilter;
 import org.rutebanken.netex.model.JourneyPattern;
 import org.rutebanken.netex.model.LineRefStructure;
 import org.rutebanken.netex.model.Route;
 import org.rutebanken.netex.model.ServiceJourney;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.opentripplanner.netex.mapping.support.ServiceAlterationFilter.*;
 
 import javax.annotation.Nullable;
 import javax.xml.bind.JAXBElement;
@@ -70,6 +73,13 @@ class TripMapper {
 
         if(route == null) {
             LOG.warn("Unable to map ServiceJourney, missing serviceId. SJ id: {}", serviceJourney.getId());
+            return null;
+        }
+
+        // TODO This currently skips mapping of any trips containing ServiceAlteration CANCELLATION
+        //      or REPLACED. In the future we will want to import these and allow them to be routed
+        //      on if a parameter is set. Also done in DateServiceJourneyMapper.
+        if (!isRunning(serviceJourney.getServiceAlteration())) {
             return null;
         }
 

--- a/src/main/java/org/opentripplanner/netex/mapping/calendar/DatedServiceJourneyMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/calendar/DatedServiceJourneyMapper.java
@@ -2,9 +2,12 @@ package org.opentripplanner.netex.mapping.calendar;
 
 import org.opentripplanner.model.calendar.ServiceDate;
 import org.opentripplanner.netex.index.api.ReadOnlyHierarchicalMapById;
+import org.opentripplanner.netex.mapping.support.ServiceAlterationFilter;
 import org.rutebanken.netex.model.DatedServiceJourney;
 import org.rutebanken.netex.model.OperatingDay;
 import org.rutebanken.netex.model.OperatingDayRefStructure;
+
+import static org.opentripplanner.netex.mapping.support.ServiceAlterationFilter.*;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -42,6 +45,12 @@ public class DatedServiceJourneyMapper {
   ) {
     List<ServiceDate> result = new ArrayList<>();
     for (DatedServiceJourney dsj : dsjs) {
+
+      // TODO This currently skips mapping of any trips containing ServiceAlteration CANCELLATION
+      //      or REPLACED. In the future we will want to import these and allow them to be routed
+      //      on if a parameter is set. Also done in TripMapper.
+      if (!isRunning(dsj.getServiceAlteration())) continue;
+
       OperatingDay opDay = operatingDay(dsj, operatingDayById);
       if(opDay != null) {
         result.add(OperatingDayMapper.map(opDay));

--- a/src/main/java/org/opentripplanner/netex/mapping/support/ServiceAlterationFilter.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/support/ServiceAlterationFilter.java
@@ -1,0 +1,16 @@
+package org.opentripplanner.netex.mapping.support;
+
+import org.rutebanken.netex.model.ServiceAlterationEnumeration;
+
+public class ServiceAlterationFilter {
+
+  public static boolean isRunning(
+      ServiceAlterationEnumeration serviceAlteration
+  ) {
+    return serviceAlteration == null || (
+        !serviceAlteration.equals(ServiceAlterationEnumeration.CANCELLATION)
+            && !serviceAlteration.equals(ServiceAlterationEnumeration.REPLACED)
+    );
+  }
+
+}

--- a/src/test/java/org/opentripplanner/netex/mapping/calendar/DatedServiceJourneyMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/calendar/DatedServiceJourneyMapperTest.java
@@ -71,7 +71,7 @@ public class DatedServiceJourneyMapperTest {
 
     dsjList.add(createDatedServiceJourney("ID-A", OP_DAY_1, SJ_1));
 
-    // ServiceAlteration is ignored, date is added
+    // Date is filtered by ServiceAlteration
     dsjList.add(
         createDatedServiceJourney("ID-C", OP_DAY_3, SJ_1)
             .withServiceAlteration(ServiceAlterationEnumeration.CANCELLATION)
@@ -90,9 +90,8 @@ public class DatedServiceJourneyMapperTest {
     Collection<ServiceDate> result = DatedServiceJourneyMapper.mapToServiceDates(dsjList, opDaysById);
 
     // Then
-    assertEquals(List.of(SD1, SD2, SD3), sort(result));
+    assertEquals(List.of(SD1, SD2), sort(result));
   }
-
 
   private static String listIdsSortedAsStr(List<DatedServiceJourney> list) {
     return list.stream()


### PR DESCRIPTION
To be completed by pull request submitter:

- [ ] **issue**: #3312
- [ ] **roadmap**: Check the [roadmap](https://github.com/orgs/opentripplanner/projects/1) for this feature or bug. If it is not already on the roadmap, PLC will discuss as part of the review process.
- [ ] **tests**: Have you added relevant test coverage? Are all the tests passing on [the continuous integration service (Travis CI)](https://github.com/opentripplanner/OpenTripPlanner/blob/2.0-rc/docs/Developers-Guide.md#continuous-integration)?
- [ ] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/2.0-rc/docs/Developers-Guide.md#code-style)? 
- [ ] **documentation**: If you are adding a new configuration option, have you added an explanation to the [configuration documentation](https://github.com/opentripplanner/OpenTripPlanner/blob/2.0-rc/docs/Configuration.md) tables and sections?
- [ ] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/2.0-rc/docs/Changelog.md) with description and link to the linked issue

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)

This prevents `ServiceJourneys` with `ServiceAlteration` `CANCELLATION` or `REPLACED` from being imported. Also, even though we do not have full `DatedServiceJourneySupport`, I have also added a check that prevents DSJs with `ServiceAlteration` `CANCELLATION` or `REPLACED` from being imported.