### PR TITLE
Add FlexibleLineType as pass-through field on Route

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/network/LineType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/network/LineType.java
@@ -161,7 +161,7 @@ public class LineType {
                 .name("flexibleLineType")
                 .description("Type of flexible line, or null if line is not flexible.")
                 .type(Scalars.GraphQLString)
-                .dataFetcher(environment -> null)
+                .dataFetcher(environment -> ((Route) environment.getSource()).getFlexibleLineType())
                 .build())
             .field(GraphQLFieldDefinition.newFieldDefinition()
                 .name("bookingArrangements")

--- a/src/main/java/org/opentripplanner/model/Route.java
+++ b/src/main/java/org/opentripplanner/model/Route.java
@@ -38,6 +38,10 @@ public final class Route extends TransitEntity {
 
     private String brandingUrl;
 
+    /**
+     * Pass-through information from NeTEx FlexibleLineType. This information is not used by OTP.
+     */
+    private String flexibleLineType;
 
     public Route(FeedScopedId id) {
         super(id);
@@ -174,6 +178,14 @@ public final class Route extends TransitEntity {
 
     public void setBrandingUrl(String brandingUrl) {
         this.brandingUrl = brandingUrl;
+    }
+
+    public String getFlexibleLineType() {
+        return flexibleLineType;
+    }
+
+    public void setFlexibleLineType(String flexibleLineType) {
+        this.flexibleLineType = flexibleLineType;
     }
 
     /** @return the route's short name, or the long name if the short name is null. */

--- a/src/main/java/org/opentripplanner/netex/mapping/RouteMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/RouteMapper.java
@@ -6,6 +6,7 @@ import org.opentripplanner.model.Operator;
 import org.opentripplanner.model.impl.EntityById;
 import org.opentripplanner.netex.index.api.NetexEntityIndexReadOnlyView;
 import org.opentripplanner.netex.mapping.support.FeedScopedIdFactory;
+import org.rutebanken.netex.model.FlexibleLine_VersionStructure;
 import org.rutebanken.netex.model.Line_VersionStructure;
 import org.rutebanken.netex.model.Network;
 import org.rutebanken.netex.model.OperatorRefStructure;
@@ -60,6 +61,10 @@ class RouteMapper {
         );
         otpRoute.setType(transportType);
         otpRoute.setMode(TransitModeMapper.mapMode(transportType));
+        if (line instanceof FlexibleLine_VersionStructure) {
+            otpRoute.setFlexibleLineType(((FlexibleLine_VersionStructure) line)
+                .getFlexibleLineType().value());
+        }
 
         if (line.getPresentation() != null) {
             PresentationStructure presentation = line.getPresentation();


### PR DESCRIPTION
This adds FlexibleLineType as a pass-through field on Route. We had a discussion about how to handle these types of fields during today's OTP meeting, and @t2gran agreed to write some guidelines regarding this.

This PR adds:
- NeTEx import
- FlexibleLineType field on Route
- Transmodel GraphQL api field