### PR TITLE
Add graph serialization version id as a Maven property and inject thi…

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -73,7 +73,7 @@ deployment.
 {
   storage : {
     gsCredentials: "${GCS_SERVICE_CREDENTIALS}",
-    graph: "file:///var/otp/graph-${maven.version.short}.obj",
+    graph: "file:///var/otp/graph-${otp.serialization.version.id}.obj",
   }
 }
 ```     
@@ -92,7 +92,7 @@ The project information variables available are:
   - `git.commit`
   - `git.commit.timestamp`
   - `graph.file.header`
-  - `graph.file.header.id`
+  - `otp.serialization.version.id`
   
 
 ## Config version 
@@ -114,8 +114,8 @@ OTP has a _OTP Serialization Version Id_ maintained in the pom.xml_ file. OTP st
 serialized _Graph.obj_ file header, allowing OTP the check for compatibility issues when loading
 the graph. The header info is available to configuration substitution:
 
-  - `${graph.file.header}` Will expand to the entire file header: "OpenTripPlannerGraph;0000007;"
-  - `${graph.file.header.id}` Will expand to the serialization version id: "000000A"
+  - `${graph.file.header}` Will expand to: `OpenTripPlannerGraph;0000007;`
+  - `${otp.serialization.version.id}` Will expand to: `7`
  
 The intended usage is to be able to have a graph build pipeline which "knows" witch graph 
 that matches OTP planner instances. For example, you may build new graphs for every OTP 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -91,7 +91,9 @@ The project information variables available are:
   - `git.branch`
   - `git.commit`
   - `git.commit.timestamp`
-
+  - `graph.file.header`
+  - `graph.file.header.id`
+  
 
 ## Config version 
 
@@ -106,6 +108,30 @@ you can do it in your build-pipline, at deployment time or use system environmen
 substituton. 
 
 
+## OTP Serialization version id and _Graph.obj_ file header
+ 
+OTP has a _OTP Serialization Version Id_ maintained in the pom.xml_ file. OTP store the id in the
+serialized _Graph.obj_ file header, allowing OTP the check for compatibility issues when loading
+the graph. The header info is available to configuration substitution:
+
+  - `${graph.file.header}` Will expand to the entire file header: "OpenTripPlannerGraph;0000007;"
+  - `${graph.file.header.id}` Will expand to the serialization version id: "000000A"
+ 
+The intended usage is to be able to have a graph build pipeline which "knows" witch graph 
+that matches OTP planner instances. For example, you may build new graphs for every OTP 
+serialization version id in use by the planning OPT instances you have deploied and plan to deploy.
+This way you can roll forward and backward new OTP instances without worring about building new 
+graphs.
+
+There is various ways to acces this information. To get the `Graph.obj` serialization version id 
+you can run the following bash command:
+ - `head -c 29 Graph.obj  ==>  OpenTripPlannerGraph;0000007;` (file header)
+ - `head -c 28 Graph.obj | tail -c 7  ==>  0000007`  (version id)
+ 
+The Maven _pom.xml_, the _META-INF/MANIFEST.MF_, the OTP command line(`--serVerId`), log start-up
+messages and all OTP APIs can be used to get the OTP Serialization Version Id.  
+              
+ 
 # System-wide Configuration
 
 Using the file `otp-config.json` you can enable or disable different APIs and experimental
@@ -176,6 +202,7 @@ The storage section of `build-config.json` allows you to override the default be
 
 If your OTP instance is running on a cloud compute service, you may get significantly faster start-up and graph build times if you use the cloud storage directly instead of copying the files back and forth to cloud server instances. This also simplifies the deployment process. 
 
+
 ### Specifying Data Sources
 
 Here is a summary of the configuration keys that can be nested inside the`storage` property of the build-config JSON to specify input and output data sources:
@@ -213,6 +240,7 @@ The default behavior of scanning the base directory for inputs is overridden ind
 See the comments in the source code of class [StorageConfig.java](https://github.com/opentripplanner/OpenTripPlanner/blob/v2.0.0/src/main/java/org/opentripplanner/standalone/config/StorageConfig.java) 
 for an up-to-date detailed description of each config parameter.
 
+
 ### Local Filename Patterns
 
 When scanning the base directory for inputs, each file's name is checked against patterns to detect what kind of file it is. These patterns can be overridden in the config, by nesting a `localFileNamePatterns` property inside the `storage` property (see example below). Here are the keys you can place inside `localFileNamePatterns`:
@@ -225,6 +253,7 @@ config key | description | value type | value default
 `netex` | Pattern used to match NeTEx files on local disk | regexp pattern | `(?i)netex` 
 
 OTP1 used to peek inside ZIP files and read the CSV tables to guess if a ZIP was indeed GTFS. Now that we support remote input files (cloud storage or arbitrary URLs) not all data sources allow seeking within files to guess what they are. Therefore, like all other file types GTFS is now detected from a filename pattern. It is not sufficient to look for the `.zip` extension because Netex data is also often supplied in a ZIP file. 
+
 
 ### Storage example
 
@@ -244,11 +273,13 @@ OTP1 used to peek inside ZIP files and read the CSV tables to guess if a ZIP was
 }
 ```
 
+
 ## Limit the transit service period
 
 The properties `transitServiceStart` and `transitServiceEnd` can be used to limit the service dates. This affects both GTFS service calendars and dates. The service calendar is reduced and dates outside the period are dropped. OTP2 will compute a transit schedule for every day for which it can find at least one trip running. On the other hand, OTP will waste resources if a service end date is *unbounded* or very large (`9999-12-31`). To avoid this, limit the OTP service period. Also, if you provide a service with multiple feeds they may have different service end dates. To avoid inconsistent results, the period can be limited, so all feeds have data for the entire period. The default is to use a period of 1 year before, and 3 years after the day the graph is built. Limiting the period will *not* improve the search performance, but OTP will build faster and load faster in most cases.
 
 The `transitServiceStart` and `transitServiceEnd` parameters are set using an absolute date like `2020-12-31` or a period like `P1Y6M5D` relative to the graph build date. Negative periods is used to specify dates in the past. The period is computed using the system time-zone, not the feed time-zone. Also, remember that the service day might be more than 24 hours. So be sure to include enough slack to account for the this. Setting the limits too wide have very little impact and is in general better than trying to be exact. The period and date format follow the ISO 8601 standard.
+
 
 ## Reaching a subway platform
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     </scm>
 
     <properties>
-        <otp.graph.serialization.id>1</otp.graph.serialization.id>
+        <otp.serialization.version.id>1</otp.serialization.version.id>
         <!-- Lib versions - keep list sorted on property name -->
         <geotools.version>21.2</geotools.version>
         <geotools.wfs.version>16.5</geotools.wfs.version>
@@ -144,6 +144,7 @@
                             <!-- For Java 11 Modules, specify a module name. Do not create module-info.java until all
                                  our dependencies specify a module name. -->
                             <Automatic-Module-Name>org.opentripplanner.otp</Automatic-Module-Name>
+                            <OTP-Serialization-Version-Id>${otp.serialization.version.id}</OTP-Serialization-Version-Id>
                         </manifestEntries>
                     </archive>
                 </configuration>
@@ -256,14 +257,12 @@
                     <verbose>false</verbose>
                     <includeOnlyProperties>
                         <!-- Including each property used reduce the plugin execution time. -->
-                        <includeOnlyProperty>project.version</includeOnlyProperty>
                         <includeOnlyProperty>git.commit.id</includeOnlyProperty>
                         <includeOnlyProperty>git.commit.id.describe</includeOnlyProperty>
                         <includeOnlyProperty>git.commit.time</includeOnlyProperty>
                         <includeOnlyProperty>git.build.time</includeOnlyProperty>
                         <includeOnlyProperty>git.branch</includeOnlyProperty>
                         <includeOnlyProperty>git.dirty</includeOnlyProperty>
-                        <includeOnlyProperty>otp.graph.serialization.id</includeOnlyProperty>
                     </includeOnlyProperties>
                 </configuration>
             </plugin>
@@ -334,7 +333,6 @@
                                         <Implementation-Version>1.1</Implementation-Version>
                                         <Implementation-Vendor>Sun Microsystems, Inc.</Implementation-Vendor>
                                         <Extension-Name>com.sun.media.imageio</Extension-Name>
-                                        <OTP-Graph-Serialization-Id>${otp.graph.serialization.id}</OTP-Graph-Serialization-Id>
                                     </manifestEntries>
                                 </transformer>
                             </transformers>

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
     </scm>
 
     <properties>
+        <otp.graph.serialization.id>1</otp.graph.serialization.id>
         <!-- Lib versions - keep list sorted on property name -->
         <geotools.version>21.2</geotools.version>
         <geotools.wfs.version>16.5</geotools.wfs.version>
@@ -262,6 +263,7 @@
                         <includeOnlyProperty>git.build.time</includeOnlyProperty>
                         <includeOnlyProperty>git.branch</includeOnlyProperty>
                         <includeOnlyProperty>git.dirty</includeOnlyProperty>
+                        <includeOnlyProperty>otp.graph.serialization.id</includeOnlyProperty>
                     </includeOnlyProperties>
                 </configuration>
             </plugin>
@@ -332,6 +334,7 @@
                                         <Implementation-Version>1.1</Implementation-Version>
                                         <Implementation-Vendor>Sun Microsystems, Inc.</Implementation-Vendor>
                                         <Extension-Name>com.sun.media.imageio</Extension-Name>
+                                        <OTP-Graph-Serialization-Id>${otp.graph.serialization.id}</OTP-Graph-Serialization-Id>
                                     </manifestEntries>
                                 </transformer>
                             </transformers>

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/framework/ServerInfoType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/framework/ServerInfoType.java
@@ -68,6 +68,13 @@ public class ServerInfoType {
             .type(Scalars.GraphQLString)
             .dataFetcher(e -> projectInfo().routerConfigVersion)
             .build())
+        .field(GraphQLFieldDefinition
+            .newFieldDefinition()
+            .name("graphSerializationId")
+            .description("The 'serializationId' in the pom.xml and graph header.")
+            .type(Scalars.GraphQLString)
+            .dataFetcher(e -> projectInfo().graphFileHeaderInfo.serializationId())
+            .build())
         .build();
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/framework/ServerInfoType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/framework/ServerInfoType.java
@@ -70,10 +70,10 @@ public class ServerInfoType {
             .build())
         .field(GraphQLFieldDefinition
             .newFieldDefinition()
-            .name("graphSerializationId")
-            .description("The 'serializationId' in the pom.xml and graph header.")
+            .name("otpSerializationVersionId")
+            .description("The otp-serialization-version-id used to check graphs for compatibility with current version of OTP.")
             .type(Scalars.GraphQLString)
-            .dataFetcher(e -> projectInfo().graphFileHeaderInfo.serializationId())
+            .dataFetcher(e -> projectInfo().getOtpSerializationVersionId())
             .build())
         .build();
   }

--- a/src/main/java/org/opentripplanner/api/model/serverinfo/ApiServerInfo.java
+++ b/src/main/java/org/opentripplanner/api/model/serverinfo/ApiServerInfo.java
@@ -8,6 +8,7 @@ public class ApiServerInfo {
   public final ApiProjectVersion version;
   public final ApiVersionControlInfo versionControl;
   public final ApiConfigInfo config;
+  public final String otpSerializationVersionId;
 
   public ApiServerInfo(String cpuName, int nCores, OtpProjectInfo projectInfo) {
     this.cpuName = cpuName;
@@ -15,6 +16,7 @@ public class ApiServerInfo {
     this.version = new ApiProjectVersion(projectInfo.version);
     this.versionControl = new ApiVersionControlInfo(projectInfo.versionControl);
     this.config = new ApiConfigInfo(projectInfo);
+    this.otpSerializationVersionId = projectInfo.getOtpSerializationVersionId();
   }
 
 }

--- a/src/main/java/org/opentripplanner/model/projectinfo/GraphFileHeader.java
+++ b/src/main/java/org/opentripplanner/model/projectinfo/GraphFileHeader.java
@@ -1,5 +1,7 @@
 package org.opentripplanner.model.projectinfo;
 
+import org.opentripplanner.util.OtpAppException;
+
 import java.io.Serializable;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -51,7 +53,7 @@ public class GraphFileHeader implements Serializable {
 
   public static GraphFileHeader parse(byte[] buf) {
     if(buf.length < HEADER_LENGTH) {
-      throw new IllegalArgumentException(
+      throw new OtpAppException(
           "Input file header is not large enough. At least " + HEADER_LENGTH + " bytes is needed. "
               + "Input: " + prettyBytesToString(buf)
       );
@@ -60,9 +62,9 @@ public class GraphFileHeader implements Serializable {
 
     Matcher m = HEADER_PATTERN.matcher(header);
     if(!m.matches()) {
-      throw new IllegalArgumentException(
+      throw new OtpAppException(
           "The file is no recognized as an OTP Graph file. The header do not match \""
-              + HEADER_PATTERN.pattern() + "\". Input: " + prettyBytesToString(buf)
+              + HEADER_PATTERN.pattern() + "\".\n\tInput: " + prettyBytesToString(buf)
       );
     }
     return new GraphFileHeader(m.group(1));

--- a/src/main/java/org/opentripplanner/model/projectinfo/GraphFileHeader.java
+++ b/src/main/java/org/opentripplanner/model/projectinfo/GraphFileHeader.java
@@ -1,0 +1,127 @@
+package org.opentripplanner.model.projectinfo;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+
+/**
+ * The Graph.obj file start with file header. The header have two things:
+ * <ol>
+ *   <li>Magic number: {@code "OpenTripPlannerGraph-01"}</li>
+ *   <li>The graph file serialization compatibility id</li>
+ * </ol>
+ *
+ * This class represent the header and contain logic to parse and validate it.
+ */
+public class GraphFileHeader {
+
+  private static final String MAGIC_NUMBER = "OpenTripPlannerGraph-01";
+  private static final char ID_PREFIX = '0';
+  private static final char DELIMITER = ';';
+  private static final int SER_ID_LENGTH = 6;
+  private static final int HEADER_LENGTH = MAGIC_NUMBER.length() + SER_ID_LENGTH + 2;
+
+  private static final Pattern HEADER_PATTERN = Pattern.compile(
+      MAGIC_NUMBER + DELIMITER + "([-\\w/+:]{6})" + DELIMITER
+  );
+  public static final Charset CHARSET = StandardCharsets.ISO_8859_1;
+  public static final String UNKNOWN_ID = "------";
+
+  private final String serializationId;
+  private final byte[] bytes;
+
+  GraphFileHeader() {
+    this(UNKNOWN_ID);
+  }
+
+  public GraphFileHeader(String serializationId) {
+    this.serializationId = padId(serializationId);
+    this.bytes = toString().getBytes(CHARSET);
+  }
+
+  public static int headerLength() {
+    return HEADER_LENGTH;
+  }
+
+  public static GraphFileHeader parse(byte[] buf) {
+    if(buf.length < HEADER_LENGTH) {
+      throw new IllegalArgumentException(
+          "Input file header is not large enough. At least " + HEADER_LENGTH + " bytes is needed. "
+              + "Input: " + prettyBytesToString(buf)
+      );
+    }
+    String header = new String(buf, 0, HEADER_LENGTH, CHARSET);
+
+    Matcher m = HEADER_PATTERN.matcher(header);
+    if(!m.matches()) {
+      throw new IllegalArgumentException(
+          "The file is no recognized as an OTP Graph file. The header do not match \""
+              + HEADER_PATTERN.pattern() + "\". Input: " + prettyBytesToString(buf)
+      );
+    }
+    return new GraphFileHeader(m.group(1));
+  }
+
+  public byte[] header() {
+    return bytes;
+  }
+
+  public String magicNumber() {
+    return MAGIC_NUMBER;
+  }
+
+  /**
+   * The graph file serialization compatibility id. If OTP and a Graph.obj file have the same
+   * version, then OTP is compatible with the graph and should be able to deserialize it.
+   */
+  public String serializationId() {
+    return serializationId;
+  }
+
+  public String asString() {
+    return MAGIC_NUMBER + DELIMITER + serializationId + DELIMITER;
+  }
+
+  public boolean isUnknown() {
+    return UNKNOWN_ID.equals(serializationId);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) { return true; }
+    if (o == null || getClass() != o.getClass()) { return false; }
+    GraphFileHeader that = (GraphFileHeader) o;
+    return serializationId.equals(that.serializationId);
+  }
+
+  @Override
+  public int hashCode() {
+    return serializationId.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return asString();
+  }
+
+  static String padId(String text) {
+    StringBuilder buf = new StringBuilder();
+    while (buf.length() + text.length() < SER_ID_LENGTH) { buf.append(ID_PREFIX); }
+    buf.append(text);
+    return buf.toString();
+  }
+
+  /** Example: 41 6C 66 61 2D 31  "Alfa-1" */
+  static String prettyBytesToString(byte[] text) {
+    if(text == null || text.length == 0) {
+      return "<empty>";
+    }
+    StringBuilder buf = new StringBuilder();
+    for (int v : text) {
+      buf.append(" ").append(String.format("%02X", v));
+    }
+    return buf.substring(1) + "  \"" + new String(text, CHARSET) + "\"";
+  }
+}

--- a/src/main/java/org/opentripplanner/model/projectinfo/GraphFileHeader.java
+++ b/src/main/java/org/opentripplanner/model/projectinfo/GraphFileHeader.java
@@ -12,7 +12,7 @@ import java.util.regex.Pattern;
 /**
  * The Graph.obj file start with file header. The header have two things:
  * <ol>
- *   <li>Magic number: {@code "OpenTripPlannerGraph-01"}</li>
+ *   <li>Magic number: {@code "OpenTripPlannerGraph"}</li>
  *   <li>The graph file serialization compatibility id</li>
  * </ol>
  *

--- a/src/main/java/org/opentripplanner/model/projectinfo/OtpProjectInfo.java
+++ b/src/main/java/org/opentripplanner/model/projectinfo/OtpProjectInfo.java
@@ -12,13 +12,17 @@ public class OtpProjectInfo implements Serializable {
 
     private static final OtpProjectInfo INSTANCE = OtpProjectInfoParser.loadFromProperties();
 
-
     static final String UNKNOWN = "UNKNOWN";
 
-    /* Info derived from version string */
+    /** Info derived from version string */
     public final MavenProjectVersion version;
 
-    /* Other info from git-commit-id-plugin via otp-project-info.properties */
+    /**
+     * The graph file header expected for this instance of OTP.
+     */
+    public final GraphFileHeader graphFileHeaderInfo;
+
+    /** Other info from git-commit-id-plugin via otp-project-info.properties */
     public final VersionControlInfo versionControl;
 
 
@@ -44,26 +48,34 @@ public class OtpProjectInfo implements Serializable {
     OtpProjectInfo() {
         this(
             "0.0.0-ParseFailure",
-            new VersionControlInfo(
-                UNKNOWN,
-                UNKNOWN,
-                UNKNOWN,
-                UNKNOWN,
-                true
-            )
+            new GraphFileHeader(),
+            new VersionControlInfo()
         );
     }
     
     public OtpProjectInfo(
             String version,
+            GraphFileHeader graphFileHeaderInfo,
             VersionControlInfo versionControl
     ) {
         this.version = MavenProjectVersion.parse(version);
+        this.graphFileHeaderInfo = graphFileHeaderInfo;
         this.versionControl = versionControl;
     }
 
     public long getUID() {
         return hashCode();
+    }
+
+    /**
+     * Return {@code true} if the graph file and the running instance of OTP is the
+     * same instance. If the running instance of OTP or the Graph.obj serialization id
+     * is unknown, then {@code true} is returned.
+     */
+    public boolean matchesRunningOTPInstance(GraphFileHeader graphFileHeader) {
+        if(graphFileHeader.isUnknown()) { return true; }
+        if(this.graphFileHeaderInfo.isUnknown()) { return true; }
+        return this.graphFileHeaderInfo.equals(graphFileHeader);
     }
 
     public String toString() {
@@ -72,11 +84,17 @@ public class OtpProjectInfo implements Serializable {
 
     /**
      * Return a version string:
-     * {@code version: 2.1.0, commit: 2121212.., branch: dev-2.x}
+     * {@code version: 2.1.0, graph-id: 00001, commit: 2121212.., branch: dev-2.x}
      */
     public String getVersionString() {
-        String format = "version: %s, commit: %s, branch: %s";
-        return String.format(format, version.version, versionControl.commit, versionControl.branch);
+        String format = "version: %s, graph-id: %s, commit: %s, branch: %s";
+        return String.format(
+            format,
+            version.version,
+            getExpectedGraphVersion(),
+            versionControl.commit,
+            versionControl.branch
+        );
     }
 
     /**
@@ -85,5 +103,11 @@ public class OtpProjectInfo implements Serializable {
      */
     public boolean sameVersion(OtpProjectInfo other) {
         return this.version.sameVersion(other.version);
+    }
+
+    public String getExpectedGraphVersion() {
+        return graphFileHeaderInfo.isUnknown()
+            ? UNKNOWN
+            : graphFileHeaderInfo.serializationId();
     }
 }

--- a/src/main/java/org/opentripplanner/model/projectinfo/OtpProjectInfo.java
+++ b/src/main/java/org/opentripplanner/model/projectinfo/OtpProjectInfo.java
@@ -84,14 +84,14 @@ public class OtpProjectInfo implements Serializable {
 
     /**
      * Return a version string:
-     * {@code version: 2.1.0, graph-id: 00001, commit: 2121212.., branch: dev-2.x}
+     * {@code version: 2.1.0, ser.ver.id: 7, commit: 2121212.., branch: dev-2.x}
      */
     public String getVersionString() {
-        String format = "version: %s, graph-id: %s, commit: %s, branch: %s";
+        String format = "version: %s, ser.ver.id: %s, commit: %s, branch: %s";
         return String.format(
             format,
             version.version,
-            getExpectedGraphVersion(),
+            getOtpSerializationVersionId(),
             versionControl.commit,
             versionControl.branch
         );
@@ -105,9 +105,12 @@ public class OtpProjectInfo implements Serializable {
         return this.version.sameVersion(other.version);
     }
 
-    public String getExpectedGraphVersion() {
-        return graphFileHeaderInfo.isUnknown()
-            ? UNKNOWN
-            : graphFileHeaderInfo.serializationId();
+    /**
+     * The OTP Serialization version id is used to determine if OTP and a serialized blob(Graph.obj)
+     * of the otp internal model are compatible. This filed is writen into the Graph.obj file header
+     * and checked when loading the graph later.
+     */
+    public String getOtpSerializationVersionId() {
+        return graphFileHeaderInfo.otpSerializationVersionId();
     }
 }

--- a/src/main/java/org/opentripplanner/model/projectinfo/OtpProjectInfoParser.java
+++ b/src/main/java/org/opentripplanner/model/projectinfo/OtpProjectInfoParser.java
@@ -15,14 +15,18 @@ class OtpProjectInfoParser {
       InputStream in = OtpProjectInfo.class.getClassLoader().getResourceAsStream(FILENAME);
       Properties props = new java.util.Properties();
       props.load(in);
+
+      String gId = get(props, "otp.graph.serialization.id");
+
       OtpProjectInfo version = new OtpProjectInfo(
           normalize(props.getProperty("project.version")),
+          isUnknown(gId) ? new GraphFileHeader() : new GraphFileHeader(gId),
           new VersionControlInfo(
-              normalize(props.getProperty("git.commit.id")),
-              normalize(props.getProperty("git.branch")),
-              normalize(props.getProperty("git.commit.time")),
-              normalize(props.getProperty("git.build.time")),
-              "true".equalsIgnoreCase(props.getProperty("git.dirty", "true"))
+              get(props, "git.commit.id"),
+              get(props,"git.branch"),
+              get(props,"git.commit.time"),
+              get(props,"git.build.time"),
+              getBool(props, "git.dirty")
           )
       );
       LOG.debug("Parsed Maven artifact version: {}", version.toString());
@@ -31,6 +35,18 @@ class OtpProjectInfoParser {
       LOG.error("Error reading version from properties file: {}", e.getMessage());
       return new OtpProjectInfo();
     }
+  }
+
+  private static String get(Properties props, String key) {
+    return normalize(props.getProperty(key));
+  }
+
+  private static boolean getBool(Properties props, String key) {
+    return "true".equalsIgnoreCase(props.getProperty(key, "true"));
+  }
+
+  private static boolean isUnknown(String text) {
+    return OtpProjectInfo.UNKNOWN.equals(text);
   }
 
   private static String normalize(String text) {

--- a/src/main/java/org/opentripplanner/model/projectinfo/OtpProjectInfoParser.java
+++ b/src/main/java/org/opentripplanner/model/projectinfo/OtpProjectInfoParser.java
@@ -16,11 +16,9 @@ class OtpProjectInfoParser {
       Properties props = new java.util.Properties();
       props.load(in);
 
-      String gId = get(props, "otp.graph.serialization.id");
-
       OtpProjectInfo version = new OtpProjectInfo(
           normalize(props.getProperty("project.version")),
-          isUnknown(gId) ? new GraphFileHeader() : new GraphFileHeader(gId),
+          new GraphFileHeader(get(props, "otp.serialization.version.id")),
           new VersionControlInfo(
               get(props, "git.commit.id"),
               get(props,"git.branch"),
@@ -43,10 +41,6 @@ class OtpProjectInfoParser {
 
   private static boolean getBool(Properties props, String key) {
     return "true".equalsIgnoreCase(props.getProperty(key, "true"));
-  }
-
-  private static boolean isUnknown(String text) {
-    return OtpProjectInfo.UNKNOWN.equals(text);
   }
 
   private static String normalize(String text) {

--- a/src/main/java/org/opentripplanner/model/projectinfo/VersionControlInfo.java
+++ b/src/main/java/org/opentripplanner/model/projectinfo/VersionControlInfo.java
@@ -4,6 +4,8 @@ import org.opentripplanner.model.base.ToStringBuilder;
 
 import java.io.Serializable;
 
+import static org.opentripplanner.model.projectinfo.OtpProjectInfo.UNKNOWN;
+
 public class VersionControlInfo implements Serializable {
   private static final long serialVersionUID = 1L;
 
@@ -13,6 +15,9 @@ public class VersionControlInfo implements Serializable {
   public final String buildTime;
   public final boolean dirty;
 
+  public VersionControlInfo() {
+    this(UNKNOWN, UNKNOWN, UNKNOWN, UNKNOWN, true);
+  }
 
   public VersionControlInfo(
       String commit,

--- a/src/main/java/org/opentripplanner/routing/graph/Graph.java
+++ b/src/main/java/org/opentripplanner/routing/graph/Graph.java
@@ -15,8 +15,6 @@ import org.apache.commons.math3.stat.descriptive.rank.Median;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
-import org.opentripplanner.model.projectinfo.GraphFileHeader;
-import org.opentripplanner.model.projectinfo.OtpProjectInfo;
 import org.opentripplanner.common.TurnRestriction;
 import org.opentripplanner.common.geometry.CompactElevationProfile;
 import org.opentripplanner.common.geometry.GraphUtils;
@@ -28,10 +26,10 @@ import org.opentripplanner.graph_builder.issues.NoFutureDates;
 import org.opentripplanner.model.Agency;
 import org.opentripplanner.model.FeedInfo;
 import org.opentripplanner.model.FeedScopedId;
+import org.opentripplanner.model.FlexLocationGroup;
+import org.opentripplanner.model.FlexStopLocation;
 import org.opentripplanner.model.GraphBundle;
 import org.opentripplanner.model.GroupOfStations;
-import org.opentripplanner.model.FlexStopLocation;
-import org.opentripplanner.model.FlexLocationGroup;
 import org.opentripplanner.model.MultiModalStation;
 import org.opentripplanner.model.Notice;
 import org.opentripplanner.model.Operator;
@@ -50,6 +48,7 @@ import org.opentripplanner.model.calendar.CalendarService;
 import org.opentripplanner.model.calendar.CalendarServiceData;
 import org.opentripplanner.model.calendar.ServiceDate;
 import org.opentripplanner.model.calendar.impl.CalendarServiceImpl;
+import org.opentripplanner.model.projectinfo.OtpProjectInfo;
 import org.opentripplanner.routing.algorithm.raptor.transit.TransitLayer;
 import org.opentripplanner.routing.algorithm.raptor.transit.mappers.TransitLayerUpdater;
 import org.opentripplanner.routing.bike_rental.BikeRentalStationService;
@@ -625,25 +624,6 @@ public class Graph implements Serializable {
         LOG.info("Index graph complete.");
     }
     
-    /**
-     * Checks if the graph file is compatible with the current version of OTP.
-     */
-    boolean graphVersionMismatch() {
-        GraphFileHeader graphFileHeader = this.projectInfo.graphFileHeaderInfo;
-        GraphFileHeader expectedGraphFileHeader = projectInfo().graphFileHeaderInfo;
-        LOG.info("Graph file serialization version: {}",
-            graphFileHeader.serializationId());
-        LOG.info("OTP expected graph serialization version: {}",
-            expectedGraphFileHeader.serializationId());
-        if (!graphFileHeader.equals(expectedGraphFileHeader)) {
-            LOG.error("The graph file is incompatible with this version of OTP.");
-            return true; // do not allow graph use
-        } else {
-            LOG.info("The graph file is compatible with this version of OTP.");
-            return false;
-        }
-    }
-
     public CalendarService getCalendarService() {
         if (calendarService == null) {
             CalendarServiceData data = this.getService(CalendarServiceData.class);

--- a/src/main/java/org/opentripplanner/routing/graph/SerializedGraphObject.java
+++ b/src/main/java/org/opentripplanner/routing/graph/SerializedGraphObject.java
@@ -264,8 +264,6 @@ public class SerializedGraphObject implements Serializable {
         var graphFileHeader = GraphFileHeader.parse(header);
 
         if(!expFileHeader.equals(graphFileHeader)) {
-            LOG.info("Graph file serialization version id: {}", graphFileHeader.otpSerializationVersionId());
-            LOG.info("OTP expected graph serialization version id: {}", expFileHeader.otpSerializationVersionId());
             if (!expFileHeader.equals(graphFileHeader)) {
                 throw new OtpAppException(
                     "The graph file is incompatible with this version of OTP. "

--- a/src/main/java/org/opentripplanner/routing/graph/SerializedGraphObject.java
+++ b/src/main/java/org/opentripplanner/routing/graph/SerializedGraphObject.java
@@ -22,6 +22,8 @@ import org.opentripplanner.datastore.DataSource;
 import org.opentripplanner.kryo.BuildConfigSerializer;
 import org.opentripplanner.kryo.HashBiMapSerializer;
 import org.opentripplanner.kryo.RouterConfigSerializer;
+import org.opentripplanner.model.projectinfo.GraphFileHeader;
+import org.opentripplanner.model.projectinfo.OtpProjectInfo;
 import org.opentripplanner.standalone.config.BuildConfig;
 import org.opentripplanner.standalone.config.RouterConfig;
 import org.opentripplanner.util.OtpAppException;
@@ -204,6 +206,7 @@ public class SerializedGraphObject implements Serializable {
         try(inputStream) {
             LOG.info("Reading graph from '{}'", sourceDescription);
             Input input = new Input(inputStream);
+            input.skip(GraphFileHeader.headerLength());
             Kryo kryo = makeKryo();
             SerializedGraphObject serObj = (SerializedGraphObject) kryo.readClassAndObject(input);
             Graph graph = serObj.graph;
@@ -232,6 +235,7 @@ public class SerializedGraphObject implements Serializable {
         outputStream = wrapOutputStreamWithProgressTracker(outputStream, size);
         Kryo kryo = makeKryo();
         Output output = new Output(outputStream);
+        output.write(OtpProjectInfo.projectInfo().graphFileHeaderInfo.header());
         kryo.writeClassAndObject(output, this);
         output.close();
         LOG.info("Graph written: {}", graphName);

--- a/src/main/java/org/opentripplanner/standalone/OTPMain.java
+++ b/src/main/java/org/opentripplanner/standalone/OTPMain.java
@@ -76,6 +76,10 @@ public class OTPMain {
                 System.out.println("OpenTripPlanner " + projectInfo().getVersionString());
                 System.exit(0);
             }
+            if (params.serializationVersionId) {
+                System.out.println(projectInfo().getOtpSerializationVersionId());
+                System.exit(0);
+            }
             if (params.help) {
                 System.out.println("OpenTripPlanner " + projectInfo().getVersionString());
                 jc.setProgramName("java -Xmx4G -jar otp.jar");

--- a/src/main/java/org/opentripplanner/standalone/OtpStartupInfo.java
+++ b/src/main/java/org/opentripplanner/standalone/OtpStartupInfo.java
@@ -25,11 +25,11 @@ public class OtpStartupInfo {
     static {
         INFO = ""
             + HEADER.stream().map(OtpStartupInfo::line).collect(Collectors.joining())
-            + line("Version:   " + projectInfo().version.version)
-            + line("Graph id:  " + projectInfo().getExpectedGraphVersion())
-            + line("Commit:    " + projectInfo().versionControl.commit)
-            + line("Branch:    " + projectInfo().versionControl.branch)
-            + line("Build:     " + projectInfo().versionControl.buildTime)
+            + line("Version:    " + projectInfo().version.version)
+            + line("Ser.ver.id: " + projectInfo().getOtpSerializationVersionId())
+            + line("Commit:     " + projectInfo().versionControl.commit)
+            + line("Branch:     " + projectInfo().versionControl.branch)
+            + line("Build:      " + projectInfo().versionControl.buildTime)
             + dirtyLineIfDirty();
     }
 

--- a/src/main/java/org/opentripplanner/standalone/OtpStartupInfo.java
+++ b/src/main/java/org/opentripplanner/standalone/OtpStartupInfo.java
@@ -24,12 +24,13 @@ public class OtpStartupInfo {
 
     static {
         INFO = ""
-                + HEADER.stream().map(OtpStartupInfo::line).collect(Collectors.joining())
-                + line("Version:  " + projectInfo().version.version)
-                + line("Commit:   " + projectInfo().versionControl.commit)
-                + line("Branch:   " + projectInfo().versionControl.branch)
-                + line("Build:    " + projectInfo().versionControl.buildTime)
-                + dirtyLineIfDirty();
+            + HEADER.stream().map(OtpStartupInfo::line).collect(Collectors.joining())
+            + line("Version:   " + projectInfo().version.version)
+            + line("Graph id:  " + projectInfo().getExpectedGraphVersion())
+            + line("Commit:    " + projectInfo().versionControl.commit)
+            + line("Branch:    " + projectInfo().versionControl.branch)
+            + line("Build:     " + projectInfo().versionControl.buildTime)
+            + dirtyLineIfDirty();
     }
 
     private static String dirtyLineIfDirty() {

--- a/src/main/java/org/opentripplanner/standalone/OtpStartupInfo.java
+++ b/src/main/java/org/opentripplanner/standalone/OtpStartupInfo.java
@@ -57,4 +57,6 @@ public class OtpStartupInfo {
     public static void main(String[] args) {
         System.out.println(INFO);
     }
+
+
 }

--- a/src/main/java/org/opentripplanner/standalone/config/CommandLineParameters.java
+++ b/src/main/java/org/opentripplanner/standalone/config/CommandLineParameters.java
@@ -41,6 +41,12 @@ public class CommandLineParameters implements Cloneable {
     @Parameter(names = {"--version"}, description = "Print the version, and then exit.")
     public boolean version = false;
 
+    @Parameter(
+        names = {"--serializationVersionId"},
+        description = "Print the OTP serialization-version-id, and then exit."
+    )
+    public boolean serializationVersionId = false;
+
     /* Options for graph building and loading. */
 
     @Parameter(

--- a/src/main/java/org/opentripplanner/standalone/config/EnvironmentVariableReplacer.java
+++ b/src/main/java/org/opentripplanner/standalone/config/EnvironmentVariableReplacer.java
@@ -38,6 +38,7 @@ class EnvironmentVariableReplacer {
 
     private static final Map<String, String> PROJECT_INFO = Map.of(
         "maven.version" , projectInfo().version.version,
+        "otp.graph.serialization.id", projectInfo().graphFileHeaderInfo.serializationId(),
         "maven.version.short" , projectInfo().version.unqualifiedVersion(),
         "maven.version.major" , Integer.toString(projectInfo().version.major),
         "maven.version.minor" , Integer.toString(projectInfo().version.minor),

--- a/src/main/java/org/opentripplanner/standalone/config/EnvironmentVariableReplacer.java
+++ b/src/main/java/org/opentripplanner/standalone/config/EnvironmentVariableReplacer.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static java.util.Map.entry;
 import static org.opentripplanner.model.projectinfo.OtpProjectInfo.projectInfo;
 
 /**
@@ -36,19 +37,19 @@ class EnvironmentVariableReplacer {
      */
     private final static Pattern PATTERN = Pattern.compile("\\$\\{([.\\w]+)}");
 
-    private static final Map<String, String> PROJECT_INFO = Map.of(
-        "maven.version" , projectInfo().version.version,
-        "otp.graph.serialization.id", projectInfo().graphFileHeaderInfo.serializationId(),
-        "maven.version.short" , projectInfo().version.unqualifiedVersion(),
-        "maven.version.major" , Integer.toString(projectInfo().version.major),
-        "maven.version.minor" , Integer.toString(projectInfo().version.minor),
-        "maven.version.patch" , Integer.toString(projectInfo().version.patch),
-        "maven.version.qualifier" , projectInfo().version.qualifier,
-        "git.branch" , projectInfo().versionControl.branch,
-        "git.commit" , projectInfo().versionControl.commit,
-        "git.commit.timestamp" , projectInfo().versionControl.commitTime
+    private static final Map<String, String> PROJECT_INFO = Map.ofEntries(
+        entry("maven.version" , projectInfo().version.version),
+        entry("maven.version.short" , projectInfo().version.unqualifiedVersion()),
+        entry("maven.version.major" , Integer.toString(projectInfo().version.major)),
+        entry("maven.version.minor" , Integer.toString(projectInfo().version.minor)),
+        entry("maven.version.patch" , Integer.toString(projectInfo().version.patch)),
+        entry("maven.version.qualifier" , projectInfo().version.qualifier),
+        entry("graph.file.header", projectInfo().graphFileHeaderInfo.asString()),
+        entry("graph.file.header.id", projectInfo().graphFileHeaderInfo.otpSerializationVersionIdPadded()),
+        entry("git.branch" , projectInfo().versionControl.branch),
+        entry("git.commit" , projectInfo().versionControl.commit),
+        entry("git.commit.timestamp" , projectInfo().versionControl.commitTime)
     );
-
 
     /**
      * Search for {@link #PATTERN}s and replace each placeholder with the value of the

--- a/src/main/java/org/opentripplanner/standalone/config/EnvironmentVariableReplacer.java
+++ b/src/main/java/org/opentripplanner/standalone/config/EnvironmentVariableReplacer.java
@@ -45,7 +45,7 @@ class EnvironmentVariableReplacer {
         entry("maven.version.patch" , Integer.toString(projectInfo().version.patch)),
         entry("maven.version.qualifier" , projectInfo().version.qualifier),
         entry("graph.file.header", projectInfo().graphFileHeaderInfo.asString()),
-        entry("graph.file.header.id", projectInfo().graphFileHeaderInfo.otpSerializationVersionIdPadded()),
+        entry("otp.serialization.version.id", projectInfo().graphFileHeaderInfo.otpSerializationVersionId()),
         entry("git.branch" , projectInfo().versionControl.branch),
         entry("git.commit" , projectInfo().versionControl.commit),
         entry("git.commit.timestamp" , projectInfo().versionControl.commitTime)

--- a/src/main/resources/otp-project-info.properties
+++ b/src/main/resources/otp-project-info.properties
@@ -2,7 +2,7 @@
 # git.x variables are defined by the git-commit-id-plugin.
 # more info at https://github.com/ktoso/maven-git-commit-id-plugin/
 project.version = ${project.version}
-otp.graph.serialization.id=${otp.graph.serialization.id}
+otp.serialization.version.id=${otp.serialization.version.id}
 git.commit.id = ${git.commit.id}
 git.commit.id.describe=${git.commit.id.describe}
 git.commit.time=${git.commit.time}

--- a/src/main/resources/otp-project-info.properties
+++ b/src/main/resources/otp-project-info.properties
@@ -2,6 +2,7 @@
 # git.x variables are defined by the git-commit-id-plugin.
 # more info at https://github.com/ktoso/maven-git-commit-id-plugin/
 project.version = ${project.version}
+otp.graph.serialization.id=${otp.graph.serialization.id}
 git.commit.id = ${git.commit.id}
 git.commit.id.describe=${git.commit.id.describe}
 git.commit.time=${git.commit.time}

--- a/src/test/java/org/opentripplanner/model/projectinfo/GraphFileHeaderTest.java
+++ b/src/test/java/org/opentripplanner/model/projectinfo/GraphFileHeaderTest.java
@@ -1,0 +1,74 @@
+package org.opentripplanner.model.projectinfo;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class GraphFileHeaderTest {
+  private static final String HEADER = "OpenTripPlannerGraph-01;00000A;";
+  private static final byte[] HEADER_BYTES = HEADER.getBytes(GraphFileHeader.CHARSET);
+  private static final GraphFileHeader SUBJECT = new GraphFileHeader("A");
+
+  @Test
+  public void headerLength() {
+    assertEquals(31, GraphFileHeader.headerLength());
+  }
+
+  @Test
+  public void parse() {
+    assertEquals(SUBJECT, GraphFileHeader.parse(HEADER_BYTES));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void parseToShort() {
+    GraphFileHeader.parse(new byte[10]);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void parseIllegalId() {
+    GraphFileHeader.parse("OpenTripPlannerGraph-01;#$%&/(;".getBytes(GraphFileHeader.CHARSET));
+  }
+
+  @Test
+  public void header() {
+    assertArrayEquals(HEADER_BYTES, SUBJECT.header());
+  }
+
+  @Test
+  public void magicNumber() {
+    assertEquals("OpenTripPlannerGraph-01", SUBJECT.magicNumber());
+  }
+
+  @Test
+  public void serializationId() {
+    assertEquals("00000A", SUBJECT.serializationId());
+  }
+
+  @Test
+  public void asString() {
+    assertEquals("OpenTripPlannerGraph-01;00000A;", SUBJECT.asString());
+  }
+
+  @Test
+  public void testToString() {
+    assertEquals(
+        "OpenTripPlannerGraph-01;00000A;",
+        SUBJECT.toString()
+    );
+  }
+
+  @Test
+  public void padId() {
+    assertEquals("00000A", GraphFileHeader.padId("A"));
+  }
+
+  @Test
+  public void dump() {
+    assertEquals("<empty>", GraphFileHeader.prettyBytesToString(null));
+    assertEquals("<empty>", GraphFileHeader.prettyBytesToString(new byte[0]));
+    assertEquals(
+        "41 6C 66 61 2D 31  \"Alfa-1\"",
+        GraphFileHeader.prettyBytesToString(new byte[]{'A', 'l', 'f', 'a', '-', '1'})
+    );
+  }
+}

--- a/src/test/java/org/opentripplanner/model/projectinfo/GraphFileHeaderTest.java
+++ b/src/test/java/org/opentripplanner/model/projectinfo/GraphFileHeaderTest.java
@@ -1,8 +1,10 @@
 package org.opentripplanner.model.projectinfo;
 
 import org.junit.Test;
+import org.opentripplanner.util.OtpAppException;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
 public class GraphFileHeaderTest {
   private static final String HEADER = "OpenTripPlannerGraph;000000A;";
@@ -19,12 +21,12 @@ public class GraphFileHeaderTest {
     assertEquals(SUBJECT, GraphFileHeader.parse(HEADER_BYTES));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test(expected = OtpAppException.class)
   public void parseToShort() {
     GraphFileHeader.parse(new byte[10]);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test(expected = OtpAppException.class)
   public void parseIllegalId() {
     GraphFileHeader.parse("OpenTripPlannerGraph-01;#$%&/(;".getBytes(GraphFileHeader.CHARSET));
   }

--- a/src/test/java/org/opentripplanner/model/projectinfo/GraphFileHeaderTest.java
+++ b/src/test/java/org/opentripplanner/model/projectinfo/GraphFileHeaderTest.java
@@ -5,13 +5,13 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 
 public class GraphFileHeaderTest {
-  private static final String HEADER = "OpenTripPlannerGraph-01;00000A;";
+  private static final String HEADER = "OpenTripPlannerGraph;000000A;";
   private static final byte[] HEADER_BYTES = HEADER.getBytes(GraphFileHeader.CHARSET);
   private static final GraphFileHeader SUBJECT = new GraphFileHeader("A");
 
   @Test
   public void headerLength() {
-    assertEquals(31, GraphFileHeader.headerLength());
+    assertEquals(29, GraphFileHeader.headerLength());
   }
 
   @Test
@@ -36,30 +36,41 @@ public class GraphFileHeaderTest {
 
   @Test
   public void magicNumber() {
-    assertEquals("OpenTripPlannerGraph-01", SUBJECT.magicNumber());
+    assertEquals("OpenTripPlannerGraph", SUBJECT.magicNumber());
   }
 
   @Test
-  public void serializationId() {
-    assertEquals("00000A", SUBJECT.serializationId());
+  public void otpSerializationVersionId() {
+    assertEquals("A", SUBJECT.otpSerializationVersionId());
   }
+
+  @Test
+  public void otpSerializationVersionIdPadded() {
+    assertEquals("000000A", SUBJECT.otpSerializationVersionIdPadded());
+  }
+
 
   @Test
   public void asString() {
-    assertEquals("OpenTripPlannerGraph-01;00000A;", SUBJECT.asString());
+    assertEquals("OpenTripPlannerGraph;000000A;", SUBJECT.asString());
   }
 
   @Test
   public void testToString() {
     assertEquals(
-        "OpenTripPlannerGraph-01;00000A;",
+        "OpenTripPlannerGraph;000000A;",
         SUBJECT.toString()
     );
   }
 
   @Test
   public void padId() {
-    assertEquals("00000A", GraphFileHeader.padId("A"));
+    assertEquals("000000A", GraphFileHeader.padId("A"));
+  }
+
+  @Test
+  public void stripId() {
+    assertEquals("A", GraphFileHeader.stripId("000000A"));
   }
 
   @Test

--- a/src/test/java/org/opentripplanner/model/projectinfo/GraphFileHeaderTest.java
+++ b/src/test/java/org/opentripplanner/model/projectinfo/GraphFileHeaderTest.java
@@ -5,10 +5,11 @@ import org.opentripplanner.util.OtpAppException;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.opentripplanner.model.projectinfo.GraphFileHeader.CHARSET;
 
 public class GraphFileHeaderTest {
   private static final String HEADER = "OpenTripPlannerGraph;000000A;";
-  private static final byte[] HEADER_BYTES = HEADER.getBytes(GraphFileHeader.CHARSET);
+  private static final byte[] HEADER_BYTES = HEADER.getBytes(CHARSET);
   private static final GraphFileHeader SUBJECT = new GraphFileHeader("A");
 
   @Test
@@ -28,7 +29,9 @@ public class GraphFileHeaderTest {
 
   @Test(expected = OtpAppException.class)
   public void parseIllegalId() {
-    GraphFileHeader.parse("OpenTripPlannerGraph-01;#$%&/(;".getBytes(GraphFileHeader.CHARSET));
+    String illegalVersionId = "€€€€€€";
+    byte[] header = ("OpenTripPlannerGraph;"+ illegalVersionId +";").getBytes(CHARSET);
+    GraphFileHeader.parse(header);
   }
 
   @Test

--- a/src/test/java/org/opentripplanner/model/projectinfo/OtpProjectInfoTest.java
+++ b/src/test/java/org/opentripplanner/model/projectinfo/OtpProjectInfoTest.java
@@ -30,11 +30,11 @@ public class OtpProjectInfoTest {
       assertNotNull(p.versionControl.commitTime);
     }
     else {
-      assertEquals("------", p.graphFileHeaderInfo.serializationId());
-      assertEquals(p.versionControl.commit, "UNKNOWN");
-      assertEquals(p.versionControl.branch, "UNKNOWN");
-      assertEquals(p.versionControl.buildTime, "UNKNOWN");
-      assertEquals(p.versionControl.commitTime, "UNKNOWN");
+      assertEquals("UNKNOWN", p.graphFileHeaderInfo.otpSerializationVersionIdPadded());
+      assertEquals("UNKNOWN", p.versionControl.commit);
+      assertEquals("UNKNOWN", p.versionControl.branch);
+      assertEquals("UNKNOWN", p.versionControl.buildTime);
+      assertEquals("UNKNOWN", p.versionControl.commitTime);
     }
   }
 

--- a/src/test/java/org/opentripplanner/model/projectinfo/OtpProjectInfoTest.java
+++ b/src/test/java/org/opentripplanner/model/projectinfo/OtpProjectInfoTest.java
@@ -3,6 +3,7 @@ package org.opentripplanner.model.projectinfo;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -29,10 +30,34 @@ public class OtpProjectInfoTest {
       assertNotNull(p.versionControl.commitTime);
     }
     else {
+      assertEquals("------", p.graphFileHeaderInfo.serializationId());
       assertEquals(p.versionControl.commit, "UNKNOWN");
       assertEquals(p.versionControl.branch, "UNKNOWN");
       assertEquals(p.versionControl.buildTime, "UNKNOWN");
       assertEquals(p.versionControl.commitTime, "UNKNOWN");
     }
+  }
+
+  @Test
+  public void matchesRunningOTPInstance() {
+    VersionControlInfo vci = new VersionControlInfo();
+    GraphFileHeader unknown = new GraphFileHeader();
+    GraphFileHeader ver1 = new GraphFileHeader("1");
+    GraphFileHeader verX = new GraphFileHeader("X");
+
+    // Given: project info with known version: 1
+    OtpProjectInfo p = new OtpProjectInfo("1.1.1", ver1, vci);
+
+    // Match same version and unknown
+    assertTrue(p.matchesRunningOTPInstance(ver1));
+    assertTrue(p.matchesRunningOTPInstance(unknown));
+    // Fail to match other version
+    assertFalse(p.matchesRunningOTPInstance(verX));
+
+    // Given: project info with unknown version
+    p = new OtpProjectInfo("1.1.1", unknown, vci);
+    // Match any version
+    assertTrue(p.matchesRunningOTPInstance(verX));
+    assertTrue(p.matchesRunningOTPInstance(unknown));
   }
 }


### PR DESCRIPTION
…s into OTP. Log it during startup and make it available to config filtering.

To be completed by pull request submitter:

- [ ] **issue**: closes #3283
- [ ] **roadmap**: No
- [ ] **tests**: Unit tests
- [ ] **formatting**: Yes
- [ ] **documentation**: Todo
- [ ] **changelog**: Todo

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)