### PR TITLE
Add support for GBFS auto discovery of endpoints

### DIFF
--- a/docs/OTP2-MigrationGuide.md
+++ b/docs/OTP2-MigrationGuide.md
@@ -234,3 +234,8 @@ The analyst API endpoints have been removed.
 ### Scripting
 
 The scripting API endpoint has been removed.
+
+### Updaters
+
+- Floating bikes have been disabled by default in the GbfsBikeRentalDataSource unless explicitly 
+turned on via OTPFeature.

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/network/LineType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/network/LineType.java
@@ -161,7 +161,7 @@ public class LineType {
                 .name("flexibleLineType")
                 .description("Type of flexible line, or null if line is not flexible.")
                 .type(Scalars.GraphQLString)
-                .dataFetcher(environment -> null)
+                .dataFetcher(environment -> ((Route) environment.getSource()).getFlexibleLineType())
                 .build())
             .field(GraphQLFieldDefinition.newFieldDefinition()
                 .name("bookingArrangements")

--- a/src/main/java/org/opentripplanner/model/Route.java
+++ b/src/main/java/org/opentripplanner/model/Route.java
@@ -38,6 +38,7 @@ public final class Route extends TransitEntity {
 
     private String brandingUrl;
 
+    private String flexibleLineType;
 
     public Route(FeedScopedId id) {
         super(id);
@@ -174,6 +175,17 @@ public final class Route extends TransitEntity {
 
     public void setBrandingUrl(String brandingUrl) {
         this.brandingUrl = brandingUrl;
+    }
+
+    /**
+     * Pass-through information from NeTEx FlexibleLineType. This information is not used by OTP.
+     */
+    public String getFlexibleLineType() {
+        return flexibleLineType;
+    }
+
+    public void setFlexibleLineType(String flexibleLineType) {
+        this.flexibleLineType = flexibleLineType;
     }
 
     /** @return the route's short name, or the long name if the short name is null. */

--- a/src/main/java/org/opentripplanner/netex/mapping/RouteMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/RouteMapper.java
@@ -6,6 +6,7 @@ import org.opentripplanner.model.Operator;
 import org.opentripplanner.model.impl.EntityById;
 import org.opentripplanner.netex.index.api.NetexEntityIndexReadOnlyView;
 import org.opentripplanner.netex.mapping.support.FeedScopedIdFactory;
+import org.rutebanken.netex.model.FlexibleLine_VersionStructure;
 import org.rutebanken.netex.model.Line_VersionStructure;
 import org.rutebanken.netex.model.Network;
 import org.rutebanken.netex.model.OperatorRefStructure;
@@ -60,6 +61,10 @@ class RouteMapper {
         );
         otpRoute.setType(transportType);
         otpRoute.setMode(TransitModeMapper.mapMode(transportType));
+        if (line instanceof FlexibleLine_VersionStructure) {
+            otpRoute.setFlexibleLineType(((FlexibleLine_VersionStructure) line)
+                .getFlexibleLineType().value());
+        }
 
         if (line.getPresentation() != null) {
             PresentationStructure presentation = line.getPresentation();

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/mappers/TransitLayerUpdater.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/mappers/TransitLayerUpdater.java
@@ -123,10 +123,9 @@ public class TransitLayerUpdater {
 
       Set<TripPatternForDate> patternsForDate = tripPatternsRunningOnDateMapCache.get(date);
 
-      for (Map.Entry<TripPattern, TripPatternForDate> entry : newTripPatternsForDate.entrySet()) {
+      for (Map.Entry<TripPattern, TripPatternForDate> entry : oldTripPatternsForDate.entrySet()) {
         TripPattern tripPattern = entry.getKey();
         TripPatternForDate oldTripPatternForDate = oldTripPatternsForDate.get(tripPattern);
-        TripPatternForDate newTripPatternForDate = entry.getValue();
 
         // Remove old TripPatternForDate for this date if it was valid on this date
         if (oldTripPatternForDate != null) {
@@ -134,6 +133,10 @@ public class TransitLayerUpdater {
             patternsForDate.remove(oldTripPatternForDate);
           }
         }
+      }
+
+      for (Map.Entry<TripPattern, TripPatternForDate> entry : newTripPatternsForDate.entrySet()) {
+        TripPatternForDate newTripPatternForDate = entry.getValue();
 
         // Add new TripPatternForDate for this date if it mapped correctly and is valid on this date
         if (newTripPatternForDate != null) {

--- a/src/main/java/org/opentripplanner/updater/bike_rental/datasources/GbfsBikeRentalDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/bike_rental/datasources/GbfsBikeRentalDataSource.java
@@ -1,12 +1,19 @@
 package org.opentripplanner.updater.bike_rental.datasources;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Sets;
 import org.opentripplanner.routing.bike_rental.BikeRentalStation;
 import org.opentripplanner.updater.bike_rental.BikeRentalDataSource;
 import org.opentripplanner.updater.bike_rental.datasources.params.GbfsBikeRentalDataSourceParameters;
+import org.opentripplanner.util.HttpUtils;
 import org.opentripplanner.util.NonLocalizedString;
+import org.opentripplanner.util.OTPFeature;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -15,8 +22,23 @@ import java.util.Set;
 
 /**
  * Created by demory on 2017-03-14.
+ *
+ * Be aware that there are problems with the floating bike support. It therefore has to be
+ * explicitly turned on by using OTPFeature.FloatingBike. Use at your own risk.
+ *
+ * See https://github.com/opentripplanner/OpenTripPlanner/issues/3316
+ *
+ * Leaving OTPFeature.FloatingBike turned off both prevents floating bike updaters added to
+ * router-config.json from being used, but more importantly, floating bikes added by a
+ * BikeRentalServiceDirectoryFetcher endpoint (which may be outside our control) will not be used.
  */
 class GbfsBikeRentalDataSource implements BikeRentalDataSource {
+
+    private static final Logger LOG = LoggerFactory.getLogger(GbfsBikeRentalDataSource.class);
+
+    private static final String AUTO_DISCOVERY_FILENAME = "gbfs";
+
+    private static final String DEFAULT_NETWORK_NAME = "GBFS";
 
     // station_information.json required by GBFS spec
     private final GbfsStationDataSource stationInformationSource;
@@ -32,22 +54,36 @@ class GbfsBikeRentalDataSource implements BikeRentalDataSource {
     /** Some car rental systems and flex transit systems work exactly like bike rental, but with cars. */
     private final boolean routeAsCar;
 
-    public GbfsBikeRentalDataSource (GbfsBikeRentalDataSourceParameters parameters) {
+    public GbfsBikeRentalDataSource(GbfsBikeRentalDataSourceParameters parameters) {
         routeAsCar = parameters.routeAsCar();
         stationInformationSource = new GbfsStationDataSource(parameters);
         stationStatusSource = new GbfsStationStatusDataSource(parameters);
-        floatingBikeSource = new GbfsFloatingBikeDataSource(parameters);
-        setBaseUrl(parameters.getUrl());
-        this.networkName = parameters.getNetwork("GBFS");
+        floatingBikeSource = OTPFeature.FloatingBike.isOn()
+            ? new GbfsFloatingBikeDataSource(parameters)
+            : null;
+
+        configureUrls(parameters.getUrl());
+        this.networkName = parameters.getNetwork(DEFAULT_NETWORK_NAME);
     }
 
-    // TODO This should be updated to fetch the endpoints defined in gbfs.json
-    private void setBaseUrl (String url) {
+    private void configureUrls(String url) {
+        String baseUrl = getBaseUrl(url);
+        GbfsAutoDiscoveryDataSource gbfsAutoDiscoveryDataSource = new GbfsAutoDiscoveryDataSource(baseUrl);
+        stationInformationSource.setUrl(gbfsAutoDiscoveryDataSource.stationInformationUrl);
+        stationStatusSource.setUrl(gbfsAutoDiscoveryDataSource.stationStatusUrl);
+        if (OTPFeature.FloatingBike.isOn()) {
+            floatingBikeSource.setUrl(gbfsAutoDiscoveryDataSource.freeBikeStatusUrl);
+        }
+    }
+
+    private String getBaseUrl(String url) {
         String baseUrl = url;
+        if (baseUrl.endsWith("gbfs.json"))
+            baseUrl = baseUrl.substring(0, url.length() - "gbfs.json".length());
+        if (baseUrl.endsWith("gbfs"))
+            baseUrl = baseUrl.substring(0, url.length() - "gbfs".length());
         if (!baseUrl.endsWith("/")) baseUrl += "/";
-        stationInformationSource.setUrl(baseUrl + "station_information.json");
-        stationStatusSource.setUrl(baseUrl + "station_status.json");
-        floatingBikeSource.setUrl(baseUrl + "free_bike_status.json");
+        return baseUrl;
     }
 
     @Override
@@ -56,7 +92,9 @@ class GbfsBikeRentalDataSource implements BikeRentalDataSource {
         boolean updatesFound = stationInformationSource.update();
         updatesFound |= stationStatusSource.update();
         // This floating-bikes file is optional, and does not appear in all GBFS feeds.
-        updatesFound |= floatingBikeSource.update();
+        if (OTPFeature.FloatingBike.isOn()) {
+            updatesFound |= floatingBikeSource.update();
+        }
         // Return true if ANY of the sub-updaters found any updates.
         return updatesFound;
     }
@@ -80,13 +118,57 @@ class GbfsBikeRentalDataSource implements BikeRentalDataSource {
 
         // Copy the full list of station objects (with status updates) into a List, appending the floating bike stations.
         List<BikeRentalStation> stations = new LinkedList<>(stationInformationSource.getStations());
-        stations.addAll(floatingBikeSource.getStations());
+        if (OTPFeature.FloatingBike.isOn()) {
+            stations.addAll(floatingBikeSource.getStations());
+        }
 
         // Set identical network ID on all stations
         Set<String> networkIdSet = Sets.newHashSet(this.networkName);
         for (BikeRentalStation station : stations) station.networks = networkIdSet;
 
         return stations;
+    }
+
+    private static class GbfsAutoDiscoveryDataSource {
+        private String stationInformationUrl;
+        private String stationStatusUrl;
+        private String freeBikeStatusUrl;
+
+        public GbfsAutoDiscoveryDataSource(String baseUrl) {
+            String autoDiscoveryUrl = baseUrl + AUTO_DISCOVERY_FILENAME;
+
+            try {
+                InputStream is = HttpUtils.getData(autoDiscoveryUrl);
+                JsonNode node = (new ObjectMapper()).readTree(is);
+                JsonNode languages = node.get("data");
+
+                for (JsonNode language : languages) {
+
+                    JsonNode feeds = language.get("feeds");
+
+                    for (JsonNode feed : feeds) {
+                        String url = feed.get("url").asText();
+                        switch (feed.get("name").asText()) {
+                            case "station_information":
+                                stationInformationUrl = url;
+                                break;
+                            case "station_status":
+                                stationStatusUrl = url;
+                                break;
+                            case "free_bike_status":
+                                freeBikeStatusUrl = url;
+                                break;
+                        }
+                    }
+                }
+            } catch (IOException | IllegalArgumentException e) {
+                LOG.warn("Error reading auto discovery file at {}. Using default values.",
+                    autoDiscoveryUrl, e);
+                stationInformationUrl = baseUrl + "station_information.json";
+                stationStatusUrl = baseUrl + "station_status.json";
+                freeBikeStatusUrl = baseUrl + "free_bike_status.json";
+            }
+        }
     }
 
     class GbfsStationDataSource extends GenericJsonBikeRentalDataSource {
@@ -124,6 +206,7 @@ class GbfsBikeRentalDataSource implements BikeRentalDataSource {
         }
     }
 
+    // TODO This is not currently safe to use. See javadoc on GbfsBikeRentalDataSource class.
     class GbfsFloatingBikeDataSource extends GenericJsonBikeRentalDataSource {
 
         public GbfsFloatingBikeDataSource (GbfsBikeRentalDataSourceParameters config) {

--- a/src/main/java/org/opentripplanner/updater/bike_rental/datasources/GenericJsonBikeRentalDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/bike_rental/datasources/GenericJsonBikeRentalDataSource.java
@@ -80,6 +80,8 @@ abstract class GenericJsonBikeRentalDataSource implements BikeRentalDataSource {
 
     @Override
     public boolean update() {
+        if (url == null) { return false; }
+
         try {
             InputStream data;
         	
@@ -140,8 +142,9 @@ abstract class GenericJsonBikeRentalDataSource implements BikeRentalDataSource {
                 continue;
             }
             BikeRentalStation brstation = makeStation(node);
-            if (brstation != null)
+            if (brstation != null) {
                 out.add(brstation);
+            }
         }
         synchronized(this) {
             stations = out;
@@ -159,8 +162,9 @@ abstract class GenericJsonBikeRentalDataSource implements BikeRentalDataSource {
         }
         finally
         {
-           if(scanner!=null)
+           if(scanner!=null) {
                scanner.close();
+           }
         }
         return result;
         

--- a/src/main/java/org/opentripplanner/util/OTPFeature.java
+++ b/src/main/java/org/opentripplanner/util/OTPFeature.java
@@ -28,7 +28,8 @@ public enum OTPFeature {
     SandboxAPIMapboxVectorTilesApi(false),
     SandboxExampleAPIGraphStatistics(false),
     TransferAnalyzer(false),
-    FlexRouting(false);
+    FlexRouting(false),
+    FloatingBike(false);
 
     private static final Logger LOG = LoggerFactory.getLogger(OTPFeature.class);
 


### PR DESCRIPTION
To be completed by pull request submitter:

- [ ] **issue**: #3316
- [ ] **roadmap**: Check the [roadmap](https://github.com/orgs/opentripplanner/projects/1) for this feature or bug. If it is not already on the roadmap, PLC will discuss as part of the review process.
- [ ] **tests**: Have you added relevant test coverage? Are all the tests passing on [the continuous integration service (Travis CI)](https://github.com/opentripplanner/OpenTripPlanner/blob/2.0-rc/docs/Developers-Guide.md#continuous-integration)?
- [ ] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/2.0-rc/docs/Developers-Guide.md#code-style)? 
- [ ] **documentation**: If you are adding a new configuration option, have you added an explanation to the [configuration documentation](https://github.com/opentripplanner/OpenTripPlanner/blob/2.0-rc/docs/Configuration.md) tables and sections?
- [ ] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/2.0-rc/docs/Changelog.md) with description and link to the linked issue

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)

This PR adds support for GBFS auto discovery of endpoints, which brings the updater closer to GBFS 2.1 compatibility. It also turns off floating bike support by default, as it is contains a memory leak and is not safe to use.