### PR TITLE
Fix IO test failure on windows (#2950)

### DIFF
--- a/src/test/java/org/opentripplanner/datastore/file/DirectoryDataSourceTest.java
+++ b/src/test/java/org/opentripplanner/datastore/file/DirectoryDataSourceTest.java
@@ -73,8 +73,9 @@ public class DirectoryDataSourceTest {
         assertEquals("[]", toString(subject.content()));
 
         // Write something to a file in the directory
-        IOUtils.write("Go, go, go!", subject.entry(child.getName()).asOutputStream(), UTF_8);
-
+        try (var outputStream = subject.entry(child.getName()).asOutputStream()) {
+            IOUtils.write("Go, go, go!", outputStream, UTF_8);
+        }
 
         // Verify the subject directory is created and still is writable
         assertTrue(subject.exists());


### PR DESCRIPTION
Correctly close files during `DirectoryDataSourceTest.testIO` so that the file may be deleted afterwards.

To be completed by pull request submitter:

- [ ] **issue**: Closes #2950
- [ ] **roadmap**: Check the [roadmap](https://github.com/orgs/opentripplanner/projects/1) for this feature or bug. If it is not already on the roadmap, PLC will discuss as part of the review process.
- [ ] **tests**: Have you added relevant test coverage? Are all the tests passing on [the continuous integration service (Travis CI)](https://github.com/opentripplanner/OpenTripPlanner/blob/2.0-rc/docs/Developers-Guide.md#continuous-integration)?
- [ ] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/2.0-rc/docs/Developers-Guide.md#code-style)? 
- [ ] **documentation**: If you are adding a new configuration option, have you added an explanation to the [configuration documentation](https://github.com/opentripplanner/OpenTripPlanner/blob/2.0-rc/docs/Configuration.md) tables and sections?
- [ ] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/2.0-rc/docs/Changelog.md) with description and link to the linked issue

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)