### PR TITLE
Fix "transit, no airplane" mode in built-in client

### DIFF
--- a/src/client/js/otp/config.js
+++ b/src/client/js/otp/config.js
@@ -301,7 +301,7 @@ otp.config.modes = {
     //TRANSLATORS: Travel by: mode of transport (Used in selection in Travel Options widgets)
     "AIRPLANE,WALK"       : _tr("Airplane Only"),
     //TRANSLATORS: Travel by: mode of transport (Used in selection in Travel Options widgets)
-    "BUS,TRAM,RAIL,FERRY,FLEXIBLE,SUBWAY,FUNICULAR,GONDOLA,WALK" : _tr("Transit, No Airplane"),
+    "BUS,TRAM,RAIL,FERRY,SUBWAY,FUNICULAR,GONDOLA,WALK" : _tr("Transit, No Airplane"),
     //TRANSLATORS: Travel by: mode of transport (Used in selection in Travel Options widgets)
     "BICYCLE"             : _tr('Bicycle Only'),
     //TRANSLATORS: Travel by: mode of transport (Used in selection in Travel Options widgets)


### PR DESCRIPTION
This PR removes FLEXIBLE from the "transit, no airplane" mode in the built-in client. This name is currently not used in the API.

If we want flexible trips to be part of this mode, we would have to specify FLEX_ACCESS, FLEX_EGRESS or FLEX_DIRECT.