### PR TITLE
Support relative file URIs for accessing local files

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -24,7 +24,10 @@ graph.obj
 
 You could have more than one of these directories if you are building separate graphs for separate regions. Each one should contain one or more GTFS feeds, a PBF OpenStreetMap file, some JSON configuration files, and any output files such as `graph.obj`. For convenience, especially if you work with only one graph at a time, you may want to place your OTP2 JAR file in this same directory. Note that file types are detected through a case-insensitive combination of file extension and words within the file name. GTFS file names must end in `.zip` and contain the letters `gtfs`, and OSM files must end in `.pbf`.
 
-It is also possible to provide a list of input files in the configuration, which will override this default behavior of scanning the base directory for input files. Scanning is overridden independently for each file type, and can point to remote cloud storage with arbitrary URIs. See [the storage section](Configuration.md#Storage) for further details. 
+It is also possible to provide a list of input files in the configuration, which will override the
+default behavior of scanning the base directory for input files. Scanning is overridden 
+independently for each file type, and can point to remote cloud storage with arbitrary URIs. 
+See [the storage section](Configuration.md#Storage) for further details. 
 
 ## Three Scopes of Configuration
 
@@ -56,7 +59,7 @@ locale | _`Language[\_country[\_variant]]`_. A Locale object represents a specif
 date | Local date. The format is _YYYY-MM-DD_ (ISO-8601). | `2020-09-21`
 date or period | A _local date_, or a _period_ relative to today. The local date has the format `YYYY-MM-DD` and the period has the format `PnYnMnD` or `-PnYnMnD` where `n` is a integer number. | `P1Y` is one year from now, `-P3M2D` means 3 months and 2 days ago, and `P1D` means tomorrow.
 regexp pattern | A regular expression pattern used to match a sting. | `"$^"` matches an empty string. `"gtfs"` matches `"A-*gtfs*-file.zip"`. `"$\w{3})-.*\.xml^"` matches a filename with 3 alpha-numeric characters in the beginning of the filename and _.xml_ as file extension.   
-uri | An URI path to a resource like a file or a URL. | `"gs://bucket/path/a.obj"` `"http://foo.bar/"` `"file:///Users/x/local/file"
+uri | An URI path to a resource like a file or a URL. Relative URIs are resolved relative to the OTP base path. | `"gs://bucket/path/a.obj"` `"http://foo.bar/"` `"file:///Users/x/local/file"` `"myGraph.obj"` `"../street/streetGraph-${otp.serialization.version.id}.obj"`
 linear function | A linear function with one input parameter(x) used to calculate a value. Usually used to calculate a limit. For example to calculate a limit in seconds to be 1 hour plus 2 times the value(x) use: `3600 + 2.0 x`, to set an absolute value(3000) use: `3000 + 0x` | `"600 + 2.0 x"`
 
 
@@ -231,11 +234,18 @@ For example, this configuration could be used to load GTFS and OSM inputs from G
 }
 ```
 
-The Google Storage system will inherit the permissions of the server it's running on within Google Cloud. It is also possible to supply credentials in this configuration file (see example below).
+The Google Storage system will inherit the permissions of the server it's running on within Google 
+Cloud. It is also possible to supply credentials in this configuration file (see example below).
 
-Note that when files are specified with URIs in this configuration, the file types do not need to be inferred from the file names so these GTFS files can have any names - there is no requirement that they have the letters "gtfs" in them.
+Note that when files are specified with URIs in this configuration, the file types do not need to 
+be inferred from the file names, so these GTFS files can have any names - there is no requirement
+that they have the letters "gtfs" in them.
 
-The default behavior of scanning the base directory for inputs is overridden independently for each file type. So in the above configuration, GTFS and OSM will be loaded from Google Cloud Storage, but OTP2 will still scan the base directory for all other types such as DEM files. Supplying an empty array for a particular file type will ensure that no inputs of that type are loaded, including by local directory scanning.
+The default behavior of scanning the base directory for inputs is overridden independently for each
+file type. So in the above configuration, GTFS and OSM will be loaded from Google Cloud Storage, but
+OTP2 will still scan the base directory for all other types such as DEM files. Supplying an empty
+array for a particular file type will ensure that no inputs of that type are loaded, including by
+local directory scanning.
 
 See the comments in the source code of class [StorageConfig.java](https://github.com/opentripplanner/OpenTripPlanner/blob/v2.0.0/src/main/java/org/opentripplanner/standalone/config/StorageConfig.java) 
 for an up-to-date detailed description of each config parameter.
@@ -243,7 +253,10 @@ for an up-to-date detailed description of each config parameter.
 
 ### Local Filename Patterns
 
-When scanning the base directory for inputs, each file's name is checked against patterns to detect what kind of file it is. These patterns can be overridden in the config, by nesting a `localFileNamePatterns` property inside the `storage` property (see example below). Here are the keys you can place inside `localFileNamePatterns`:
+When scanning the base directory for inputs, each file's name is checked against patterns to detect
+what kind of file it is. These patterns can be overridden in the config, by nesting a
+`localFileNamePatterns` property inside the `storage` property (see example below). Here are the
+keys you can place inside `localFileNamePatterns`:
 
 config key | description | value type | value default
 ---------- | ----------- | ---------- | -------------
@@ -252,7 +265,11 @@ config key | description | value type | value default
 `gtfs` | Pattern used to match GTFS files on local disk | regexp pattern | `(?i)gtfs` 
 `netex` | Pattern used to match NeTEx files on local disk | regexp pattern | `(?i)netex` 
 
-OTP1 used to peek inside ZIP files and read the CSV tables to guess if a ZIP was indeed GTFS. Now that we support remote input files (cloud storage or arbitrary URLs) not all data sources allow seeking within files to guess what they are. Therefore, like all other file types GTFS is now detected from a filename pattern. It is not sufficient to look for the `.zip` extension because Netex data is also often supplied in a ZIP file. 
+OTP1 used to peek inside ZIP files and read the CSV tables to guess if a ZIP was indeed GTFS. Now
+that we support remote input files (cloud storage or arbitrary URLs) not all data sources allow
+seeking within files to guess what they are. Therefore, like all other file types GTFS is now
+detected from a filename pattern. It is not sufficient to look for the `.zip` extension because
+Netex data is also often supplied in a ZIP file. 
 
 
 ### Storage example

--- a/src/main/java/org/opentripplanner/datastore/DataSource.java
+++ b/src/main/java/org/opentripplanner/datastore/DataSource.java
@@ -120,8 +120,7 @@ public interface DataSource {
      * {@code [icon] [filename]  [path]  [date time]  [file size]}
      */
     default String detailedInfo() {
-        String dir = path().substring(0, path().length() - name().length() - 1);
-        String info = String.format("%s %s  %s", type().icon(), name(), dir);
+        String info = String.format("%s %s  %s", type().icon(), name(), directory());
         if (lastModified() > 0) {
             SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
             info += "  " + sdf.format(lastModified());
@@ -130,5 +129,10 @@ public interface DataSource {
             info += "  " + LoggingUtil.fileSizeToString(size());
         }
         return info;
+    }
+
+    private String directory() {
+        int endIndex = path().length() - (name().length() + 1);
+        return endIndex <= 0 ? "" :  path().substring(0, endIndex);
     }
 }

--- a/src/main/java/org/opentripplanner/datastore/FileType.java
+++ b/src/main/java/org/opentripplanner/datastore/FileType.java
@@ -16,7 +16,6 @@ public enum FileType {
   NETEX("🚌", "NeTEx data"),
   GRAPH("🌐", "OTP Graph file"),
   REPORT("📈", "Issue report"),
-  OTP_STATUS("⏳", "OTP build status"),
   UNKNOWN("❓", "Unknown file");
 
   private final String icon;
@@ -40,7 +39,8 @@ public enum FileType {
 
   /**
    * Return {@code true} if the the file is an INPUT data file. This is GTFS, Netex, OpenStreetMap,
-   * and elevation data files. Config files and graphs are not considered input data files.
+   * and elevation data files. Config files is not data sources and graphs are not considered input
+   * data files.
    * <p>
    * At least one input data file must be present to build a graph.
    */
@@ -49,11 +49,11 @@ public enum FileType {
   }
 
   /**
-   * Return {@code true} if the the file is an OUTPUT data file/directory. This is the graph files,
-   * build-report and the otp-status file. Config files are not considered output data files.
+   * Return {@code true} if the the file is an OUTPUT data file/directory. This is the graph files
+   * and the build-report file.
    */
   public boolean isOutputDataSource() {
-    return EnumSet.of(GRAPH, REPORT, OTP_STATUS).contains(this);
+    return EnumSet.of(GRAPH, REPORT).contains(this);
   }
 
   /**

--- a/src/main/java/org/opentripplanner/graph_builder/GraphBuilderDataSources.java
+++ b/src/main/java/org/opentripplanner/graph_builder/GraphBuilderDataSources.java
@@ -6,8 +6,8 @@ import org.opentripplanner.datastore.CompositeDataSource;
 import org.opentripplanner.datastore.DataSource;
 import org.opentripplanner.datastore.FileType;
 import org.opentripplanner.datastore.OtpDataStore;
-import org.opentripplanner.standalone.config.CommandLineParameters;
 import org.opentripplanner.standalone.config.BuildConfig;
+import org.opentripplanner.standalone.config.CommandLineParameters;
 import org.opentripplanner.util.OtpAppException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -128,15 +128,10 @@ public class GraphBuilderDataSources {
         );
 
         // Sort data input files by type
-        LOG.info("Files expected to be read or written:");
+        LOG.info("Existing files expected to be read or written:");
         for (FileType type : FileType.values()) {
             for (DataSource source : inputData.get(type)) {
-                if (type == FileType.CONFIG) {
-                    LOG.info(BULLET_POINT + source.detailedInfo());
-                }
-                else {
-                    LOG.info(BULLET_POINT + source.detailedInfo());
-                }
+                LOG.info(BULLET_POINT + source.detailedInfo());
             }
         }
 

--- a/src/main/java/org/opentripplanner/standalone/config/StorageConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/StorageConfig.java
@@ -17,7 +17,9 @@ import static org.opentripplanner.datastore.OtpDataStoreConfig.DEFAULT_OSM_PATTE
  * <p>
  * Local file access is supported. Use the following URI format:
  * <pre>
- *     file:/a/b/c/filename.ext
+ *     file:/a/b/c/filename.ext                    -- Absolute URI
+ *     ../street/streetGraph.obj                   -- Relative URI (to OTP base path)
+ *     graph-${otp.serialization.version.id}.obj   -- Relative path with property substitution
  * </pre>
  * Google Cloud Storage(GCS) access is supported. Use the following URI format:
  * <pre>
@@ -40,8 +42,8 @@ import static org.opentripplanner.datastore.OtpDataStoreConfig.DEFAULT_OSM_PATTE
  * In the example above, the Google cloud service credentials file resolved using an environment
  * variable. The OSM and GTFS data is streamed from Google Cloud Storage, the elevation data is
  * fetched from the local file system and the build report is stored in the cloud. All other
- * artifacts like the loaded graph, saved graph and NeTEx files are loaded and written from/to the local
- * base directory - it they exist.
+ * artifacts like the loaded graph, saved graph and NeTEx files are loaded and written from/to the
+ * local base directory - it they exist.
  */
 public class StorageConfig {
 

--- a/src/test/java/org/opentripplanner/datastore/OtpDataStoreTest.java
+++ b/src/test/java/org/opentripplanner/datastore/OtpDataStoreTest.java
@@ -30,7 +30,6 @@ import static org.opentripplanner.datastore.FileType.GRAPH;
 import static org.opentripplanner.datastore.FileType.GTFS;
 import static org.opentripplanner.datastore.FileType.NETEX;
 import static org.opentripplanner.datastore.FileType.OSM;
-import static org.opentripplanner.datastore.FileType.OTP_STATUS;
 import static org.opentripplanner.datastore.FileType.REPORT;
 import static org.opentripplanner.datastore.FileType.UNKNOWN;
 import static org.opentripplanner.standalone.config.CommandLineParameters.createCliForTest;
@@ -80,7 +79,6 @@ public class OtpDataStoreTest {
         assertEquals("[]", store.listExistingSourcesFor(GRAPH).toString());
         assertEquals("[]", store.listExistingSourcesFor(REPORT).toString());
         assertEquals("[]", store.listExistingSourcesFor(UNKNOWN).toString());
-        assertEquals("[]", store.listExistingSourcesFor(OTP_STATUS).toString());
     }
 
     @Test


### PR DESCRIPTION
This PR improve the file loading (storage) by:
 - Support for relative file names in the configuration. Resolved relative to the OTP base path.
 - Fix NullPointerException if a is relative(could happen before also).
 - Removed unused OTP_STATUS file type + small cleanups.


To be completed by pull request submitter:

- [ ] **issue**: No.
- [ ] **roadmap**: No.
- [ ] **tests**: Existing unit tests only.
- [ ] **formatting**: Yes
- [ ] **documentation**: Doc is updated and more examples added.
- [ ] **changelog**: No

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)