### PR TITLE
Add support for actualArrivalTimes and actualDepartureTimes

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLStopImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLStopImpl.java
@@ -339,7 +339,7 @@ public class LegacyGraphQLStopImpl implements LegacyGraphQLDataFetchers.LegacyGr
       );
 
       return stream.flatMap(stoptimesWithPattern -> stoptimesWithPattern.times.stream())
-          .sorted(Comparator.comparing(t -> t.serviceDay + t.realtimeDeparture))
+          .sorted(Comparator.comparing(t -> t.getServiceDay() + t.getRealtimeDeparture()))
           .limit(args.getLegacyGraphQLNumberOfDepartures())
           .collect(Collectors.toList());
     };

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLStoptimeImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLStoptimeImpl.java
@@ -12,58 +12,58 @@ public class LegacyGraphQLStoptimeImpl implements LegacyGraphQLDataFetchers.Lega
 
   @Override
   public DataFetcher<Object> stop() {
-    return environment -> getRoutingService(environment).getStopForId(getSource(environment).stopId);
+    return environment -> getRoutingService(environment).getStopForId(getSource(environment).getStopId());
   }
 
   @Override
   public DataFetcher<Integer> scheduledArrival() {
-    return environment -> getSource(environment).scheduledArrival;
+    return environment -> getSource(environment).getScheduledArrival();
   }
 
   @Override
   public DataFetcher<Integer> realtimeArrival() {
-    return environment -> getSource(environment).realtimeArrival;
+    return environment -> getSource(environment).getRealtimeArrival();
   }
 
   @Override
   public DataFetcher<Integer> arrivalDelay() {
-    return environment -> getSource(environment).arrivalDelay;
+    return environment -> getSource(environment).getArrivalDelay();
   }
 
   @Override
   public DataFetcher<Integer> scheduledDeparture() {
-    return environment -> getSource(environment).scheduledDeparture;
+    return environment -> getSource(environment).getScheduledDeparture();
   }
 
   @Override
   public DataFetcher<Integer> realtimeDeparture() {
-    return environment -> getSource(environment).realtimeDeparture;
+    return environment -> getSource(environment).getRealtimeDeparture();
   }
 
   @Override
   public DataFetcher<Integer> departureDelay() {
-    return environment -> getSource(environment).departureDelay;
+    return environment -> getSource(environment).getDepartureDelay();
   }
 
   @Override
   public DataFetcher<Boolean> timepoint() {
-    return environment -> getSource(environment).timepoint;
+    return environment -> getSource(environment).isTimepoint();
   }
 
   @Override
   public DataFetcher<Boolean> realtime() {
-    return environment -> getSource(environment).realtime;
+    return environment -> getSource(environment).isRealtime();
   }
 
   @Override
   public DataFetcher<String> realtimeState() {
-    return environment -> getSource(environment).realtimeState.name();
+    return environment -> getSource(environment).getRealtimeState().name();
   }
 
   @Override
   public DataFetcher<String> pickupType() {
     return environment -> {
-      switch (getSource(environment).pickupType) {
+      switch (getSource(environment).getPickupType()) {
         case 0: return "SCHEDULED";
         case 1: return "NONE";
         case 2: return "CALL_AGENCY";
@@ -76,7 +76,7 @@ public class LegacyGraphQLStoptimeImpl implements LegacyGraphQLDataFetchers.Lega
   @Override
   public DataFetcher<String> dropoffType() {
     return environment -> {
-      switch (getSource(environment).dropoffType) {
+      switch (getSource(environment).getDropoffType()) {
         case 0: return "SCHEDULED";
         case 1: return "NONE";
         case 2: return "CALL_AGENCY";
@@ -88,17 +88,17 @@ public class LegacyGraphQLStoptimeImpl implements LegacyGraphQLDataFetchers.Lega
 
   @Override
   public DataFetcher<Long> serviceDay() {
-    return environment -> getSource(environment).serviceDay;
+    return environment -> getSource(environment).getServiceDay();
   }
 
   @Override
   public DataFetcher<Trip> trip() {
-    return environment -> getRoutingService(environment).getTripForId().get(getSource(environment).tripId);
+    return environment -> getRoutingService(environment).getTripForId().get(getSource(environment).getTripId());
   }
 
   @Override
   public DataFetcher<String> headsign() {
-    return environment -> getSource(environment).headsign;
+    return environment -> getSource(environment).getHeadsign();
   }
 
   private RoutingService getRoutingService(DataFetchingEnvironment environment) {

--- a/src/ext/java/org/opentripplanner/ext/siri/TimetableHelper.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/TimetableHelper.java
@@ -153,7 +153,7 @@ public class TimetableHelper {
                     }
 
                     //Flag as recorded
-                    newTimes.setRecorded(callCounter, true);
+                    newTimes.setRecorded(callCounter, true); // TODO only set if actual arrival time is not null
 
                     if (recordedCall.isCancellation() != null) {
                         newTimes.setCancelledStop(callCounter, recordedCall.isCancellation());

--- a/src/ext/java/org/opentripplanner/ext/siri/TimetableHelper.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/TimetableHelper.java
@@ -152,9 +152,6 @@ public class TimetableHelper {
                         }
                     }
 
-                    //Flag as recorded
-                    newTimes.setRecorded(callCounter, true); // TODO only set if actual arrival time is not null
-
                     if (recordedCall.isCancellation() != null) {
                         newTimes.setCancelledStop(callCounter, recordedCall.isCancellation());
                     }
@@ -166,6 +163,8 @@ public class TimetableHelper {
                     int realtimeArrivalTime = arrivalTime;
                     if (recordedCall.getActualArrivalTime() != null) {
                         realtimeArrivalTime = DateMapper.secondsSinceStartOfService(departureDate, recordedCall.getActualArrivalTime(), zoneId);
+                        //Flag as recorded
+                        newTimes.setRecorded(callCounter, true);
                     } else if (recordedCall.getExpectedArrivalTime() != null) {
                         realtimeArrivalTime = DateMapper.secondsSinceStartOfService(departureDate, recordedCall.getExpectedArrivalTime(), zoneId);
                     } else if (recordedCall.getAimedArrivalTime() != null) {
@@ -179,6 +178,8 @@ public class TimetableHelper {
                     int realtimeDepartureTime = departureTime;
                     if (recordedCall.getActualDepartureTime() != null) {
                         realtimeDepartureTime = DateMapper.secondsSinceStartOfService(departureDate, recordedCall.getActualDepartureTime(), zoneId);
+                        //Flag as recorded
+                        newTimes.setRecorded(callCounter, true);
                     } else if (recordedCall.getExpectedDepartureTime() != null) {
                         realtimeDepartureTime = DateMapper.secondsSinceStartOfService(departureDate, recordedCall.getExpectedDepartureTime(), zoneId);
                     } else if (recordedCall.getAimedDepartureTime() != null) {

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
@@ -121,7 +121,7 @@ public class TransmodelGraphQLSchema {
   private GraphQLSchema create() {
     /*
     multilingualStringType, validityPeriodType, infoLinkType, bookingArrangementType, systemNoticeType,
-    linkGeometryType, serverInfoType, authorityType, operatorType, noticeType
+    linkGeometryType, serverInfoType, authorityType, operatorType, noticeTypea
 
 
 

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
@@ -121,7 +121,7 @@ public class TransmodelGraphQLSchema {
   private GraphQLSchema create() {
     /*
     multilingualStringType, validityPeriodType, infoLinkType, bookingArrangementType, systemNoticeType,
-    linkGeometryType, serverInfoType, authorityType, operatorType, noticeTypea
+    linkGeometryType, serverInfoType, authorityType, operatorType, noticeType
 
 
 

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/TripTimeShortHelper.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/TripTimeShortHelper.java
@@ -41,9 +41,11 @@ public class TripTimeShortHelper {
          */
 
         if (leg.realTime) {
-            return tripTimes.stream().filter(tripTime -> tripTime.realtimeDeparture == startTimeSeconds && matchesQuayOrSiblingQuay(leg.from.stopId, tripTime.stopId, routingService)).findFirst().orElse(null);
+            return tripTimes.stream().filter(tripTime -> tripTime.getRealtimeDeparture() == startTimeSeconds && matchesQuayOrSiblingQuay(leg.from.stopId,
+                tripTime.getStopId(), routingService)).findFirst().orElse(null);
         }
-        return tripTimes.stream().filter(tripTime -> tripTime.scheduledDeparture == startTimeSeconds && matchesQuayOrSiblingQuay(leg.from.stopId, tripTime.stopId, routingService)).findFirst().orElse(null);
+        return tripTimes.stream().filter(tripTime -> tripTime.getScheduledDeparture() == startTimeSeconds && matchesQuayOrSiblingQuay(leg.from.stopId,
+            tripTime.getStopId(), routingService)).findFirst().orElse(null);
     }
 
     /**
@@ -70,9 +72,11 @@ public class TripTimeShortHelper {
         */
 
         if (leg.realTime) {
-            return tripTimes.stream().filter(tripTime -> tripTime.realtimeArrival == endTimeSeconds && matchesQuayOrSiblingQuay(leg.to.stopId, tripTime.stopId, routingService)).findFirst().orElse(null);
+            return tripTimes.stream().filter(tripTime -> tripTime.getRealtimeArrival() == endTimeSeconds && matchesQuayOrSiblingQuay(leg.to.stopId,
+                tripTime.getStopId(), routingService)).findFirst().orElse(null);
         }
-        return tripTimes.stream().filter(tripTime -> tripTime.scheduledArrival == endTimeSeconds && matchesQuayOrSiblingQuay(leg.to.stopId, tripTime.stopId, routingService)).findFirst().orElse(null);
+        return tripTimes.stream().filter(tripTime -> tripTime.getScheduledArrival() == endTimeSeconds && matchesQuayOrSiblingQuay(leg.to.stopId,
+            tripTime.getStopId(), routingService)).findFirst().orElse(null);
     }
 
 
@@ -104,16 +108,20 @@ public class TripTimeShortHelper {
         boolean boardingStopFound = false;
         for (TripTimeShort tripTime : tripTimes) {
 
-            long boardingTime = leg.realTime ? tripTime.realtimeDeparture : tripTime.scheduledDeparture;
+            long boardingTime = leg.realTime ? tripTime.getRealtimeDeparture()
+                : tripTime.getScheduledDeparture();
 
             if (!boardingStopFound) {
                 boardingStopFound = boardingTime == startTimeSeconds
-                    && matchesQuayOrSiblingQuay(leg.from.stopId, tripTime.stopId, routingService);
+                    && matchesQuayOrSiblingQuay(leg.from.stopId,
+                    tripTime.getStopId(), routingService);
                 continue;
             }
 
-            long arrivalTime = leg.realTime ? tripTime.realtimeArrival : tripTime.scheduledArrival;
-            if (arrivalTime == endTimeSeconds && matchesQuayOrSiblingQuay(leg.to.stopId, tripTime.stopId, routingService)) {
+            long arrivalTime = leg.realTime ? tripTime.getRealtimeArrival()
+                : tripTime.getScheduledArrival();
+            if (arrivalTime == endTimeSeconds && matchesQuayOrSiblingQuay(leg.to.stopId,
+                tripTime.getStopId(), routingService)) {
                 break;
             }
 

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/JourneyWhiteListed.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/JourneyWhiteListed.java
@@ -70,7 +70,7 @@ public class JourneyWhiteListed {
         Collection<FeedScopedId> lineIds,
         RoutingService routingService
     ) {
-        Trip trip = routingService.getTripForId().get(tts.tripId);
+        Trip trip = routingService.getTripForId().get(tts.getTripId());
 
         if (trip == null || trip.getRoute() == null) {
             return true;

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/et/EstimatedCallType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/et/EstimatedCallType.java
@@ -81,7 +81,12 @@ public class EstimatedCallType {
                            .type(gqlUtil.dateTimeScalar)
                            .description("Actual time of arrival at quay. Updated from real time information if available. NOT IMPLEMENTED")
                            .dataFetcher(
-                                   environment -> null)
+                                environment -> {
+                                  TripTimeShort tripTimeShort = environment.getSource();
+                                  if (tripTimeShort.getActualArrival() == -1) { return null; }
+                                  return 1000 * (tripTimeShort.getServiceDay() +
+                                    tripTimeShort.getActualArrival());
+                              })
                            .build())
             .field(GraphQLFieldDefinition.newFieldDefinition()
                            .name("aimedDepartureTime")
@@ -111,7 +116,12 @@ public class EstimatedCallType {
                            .type(gqlUtil.dateTimeScalar)
                            .description("Actual time of departure from quay. Updated with real time information if available. NOT IMPLEMENTED")
                            .dataFetcher(
-                                   environment -> null)
+                                environment -> {
+                                    TripTimeShort tripTimeShort = environment.getSource();
+                                    if (tripTimeShort.getActualDeparture() == -1) { return null; }
+                                    return 1000 * (tripTimeShort.getServiceDay() +
+                                        tripTimeShort.getActualDeparture());
+                              })
                            .build())
             .field(GraphQLFieldDefinition.newFieldDefinition()
                     .name("timingPoint")

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/et/EstimatedCallType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/et/EstimatedCallType.java
@@ -48,8 +48,9 @@ public class EstimatedCallType {
                     .name("quay")
                     .type(quayType)
                     .dataFetcher(environment -> {
-                      return GqlUtil.getRoutingService(environment).getStopForId(
-                                  ((TripTimeShort) environment.getSource()).stopId);
+                      return GqlUtil.getRoutingService(environment).getStopForId((
+                          (TripTimeShort) environment.getSource()
+                      ).getStopId());
                         }
                     ).build())
             .field(GraphQLFieldDefinition.newFieldDefinition()
@@ -57,8 +58,10 @@ public class EstimatedCallType {
                            .description("Scheduled time of arrival at quay. Not affected by read time updated")
                            .type(gqlUtil.dateTimeScalar)
                            .dataFetcher(
-                                   environment -> 1000 * (((TripTimeShort) environment.getSource()).serviceDay +
-                                                                  ((TripTimeShort) environment.getSource()).scheduledArrival))
+                                   environment -> 1000 * (
+                                       ((TripTimeShort) environment.getSource()).getServiceDay()
+                                           + ((TripTimeShort) environment.getSource()).getScheduledArrival()
+                                   ))
                            .build())
             .field(GraphQLFieldDefinition.newFieldDefinition()
                            .name("expectedArrivalTime")
@@ -67,8 +70,10 @@ public class EstimatedCallType {
                            .dataFetcher(
                                    environment -> {
                                        TripTimeShort tripTimeShort = environment.getSource();
-                                       return 1000 * (tripTimeShort.serviceDay +
-                                                              tripTimeShort.realtimeArrival);
+                                       return 1000 * (
+                                           tripTimeShort.getServiceDay()
+                                               + tripTimeShort.getRealtimeArrival()
+                                       );
                                    })
                            .build())
             .field(GraphQLFieldDefinition.newFieldDefinition()
@@ -83,8 +88,10 @@ public class EstimatedCallType {
                            .description("Scheduled time of departure from quay. Not affected by read time updated")
                            .type(gqlUtil.dateTimeScalar)
                            .dataFetcher(
-                                   environment -> 1000 * (((TripTimeShort) environment.getSource()).serviceDay +
-                                                                  ((TripTimeShort) environment.getSource()).scheduledDeparture))
+                                   environment -> 1000 * (
+                                       ((TripTimeShort) environment.getSource()).getServiceDay()
+                                           + ((TripTimeShort) environment.getSource()).getScheduledDeparture()
+                                   ))
                            .build())
             .field(GraphQLFieldDefinition.newFieldDefinition()
                            .name("expectedDepartureTime")
@@ -93,8 +100,10 @@ public class EstimatedCallType {
                            .dataFetcher(
                                    environment -> {
                                        TripTimeShort tripTimeShort = environment.getSource();
-                                       return 1000 * (tripTimeShort.serviceDay +
-                                                              tripTimeShort.realtimeDeparture);
+                                       return 1000 * (
+                                           tripTimeShort.getServiceDay()
+                                               + tripTimeShort.getRealtimeDeparture()
+                                       );
                                    })
                            .build())
             .field(GraphQLFieldDefinition.newFieldDefinition()
@@ -108,13 +117,13 @@ public class EstimatedCallType {
                     .name("timingPoint")
                     .type(Scalars.GraphQLBoolean)
                     .description("Whether this is a timing point or not. Boarding and alighting is not allowed at timing points.")
-                    .dataFetcher(environment -> ((TripTimeShort) environment.getSource()).timepoint)
+                    .dataFetcher(environment -> ((TripTimeShort) environment.getSource()).isTimepoint())
                     .build())
             .field(GraphQLFieldDefinition.newFieldDefinition()
                     .name("realtime")
                     .type(Scalars.GraphQLBoolean)
                     .description("Whether this call has been updated with real time information.")
-                    .dataFetcher(environment -> ((TripTimeShort) environment.getSource()).realtime)
+                    .dataFetcher(environment -> ((TripTimeShort) environment.getSource()).isRealtime())
                     .build())
             .field(GraphQLFieldDefinition.newFieldDefinition()
                     .name("predictionInaccurate")
@@ -125,20 +134,22 @@ public class EstimatedCallType {
             .field(GraphQLFieldDefinition.newFieldDefinition()
                     .name("realtimeState")
                     .type(EnumTypes.REALTIME_STATE)
-                    .dataFetcher(environment -> ((TripTimeShort) environment.getSource()).realtimeState)
+                    .dataFetcher(environment -> ((TripTimeShort) environment.getSource()).getRealtimeState())
                     .build())
             .field(GraphQLFieldDefinition.newFieldDefinition()
                 .name("forBoarding")
                 .type(Scalars.GraphQLBoolean)
                 .description("Whether vehicle may be boarded at quay.")
                 .dataFetcher(environment -> {
-                    if (((TripTimeShort) environment.getSource()).pickupType >= 0) {
+                    if (((TripTimeShort) environment.getSource()).getPickupType() >= 0) {
                         //Realtime-updated
-                        return ((TripTimeShort) environment.getSource()).pickupType != PICKDROP_NONE;
+                        return ((TripTimeShort) environment.getSource()).getPickupType() != PICKDROP_NONE;
                     }
                   return GqlUtil.getRoutingService(environment).getPatternForTrip()
-                        .get(GqlUtil.getRoutingService(environment).getTripForId().get(((TripTimeShort) environment.getSource()).tripId))
-                        .getBoardType(((TripTimeShort) environment.getSource()).stopIndex) != PICKDROP_NONE;
+                        .get(GqlUtil.getRoutingService(environment).getTripForId().get((
+                            (TripTimeShort) environment.getSource()
+                        ).getTripId()))
+                        .getBoardType(((TripTimeShort) environment.getSource()).getStopIndex()) != PICKDROP_NONE;
                 })
                 .build())
             .field(GraphQLFieldDefinition.newFieldDefinition()
@@ -146,13 +157,15 @@ public class EstimatedCallType {
                 .type(Scalars.GraphQLBoolean)
                 .description("Whether vehicle may be alighted at quay.")
                 .dataFetcher(environment -> {
-                    if (((TripTimeShort) environment.getSource()).dropoffType >= 0) {
+                    if (((TripTimeShort) environment.getSource()).getDropoffType() >= 0) {
                         //Realtime-updated
-                        return ((TripTimeShort) environment.getSource()).dropoffType != PICKDROP_NONE;
+                        return ((TripTimeShort) environment.getSource()).getDropoffType() != PICKDROP_NONE;
                     }
                   return GqlUtil.getRoutingService(environment).getPatternForTrip()
-                        .get(GqlUtil.getRoutingService(environment).getTripForId().get(((TripTimeShort) environment.getSource()).tripId))
-                        .getAlightType(((TripTimeShort) environment.getSource()).stopIndex) != PICKDROP_NONE;
+                        .get(GqlUtil.getRoutingService(environment).getTripForId().get((
+                            (TripTimeShort) environment.getSource()
+                        ).getTripId()))
+                        .getAlightType(((TripTimeShort) environment.getSource()).getStopIndex()) != PICKDROP_NONE;
 
                 })
                 .build())
@@ -162,34 +175,36 @@ public class EstimatedCallType {
                     .description("Whether vehicle will only stop on request.")
                     .dataFetcher(environment -> {
                       return GqlUtil.getRoutingService(environment).getPatternForTrip()
-                              .get(GqlUtil.getRoutingService(environment).getTripForId().get(((TripTimeShort) environment.getSource()).tripId))
-                              .getAlightType(((TripTimeShort) environment.getSource()).stopIndex) == PICKDROP_COORDINATE_WITH_DRIVER;
+                              .get(GqlUtil.getRoutingService(environment).getTripForId().get((
+                                  (TripTimeShort) environment.getSource()
+                              ).getTripId()))
+                              .getAlightType(((TripTimeShort) environment.getSource()).getStopIndex()) == PICKDROP_COORDINATE_WITH_DRIVER;
                     })
                     .build())
             .field(GraphQLFieldDefinition.newFieldDefinition()
                     .name("cancellation")
                     .type(Scalars.GraphQLBoolean)
                     .description("Whether stop is cancelled.")
-                    .dataFetcher(environment -> ((TripTimeShort) environment.getSource()).isCancelledStop)
+                    .dataFetcher(environment -> ((TripTimeShort) environment.getSource()).isCancelledStop())
                     .build())
             .field(GraphQLFieldDefinition.newFieldDefinition()
                     .name("date")
                     .type(gqlUtil.dateScalar)
                     .description("The date the estimated call is valid for.")
-                    .dataFetcher(environment -> ((TripTimeShort) environment.getSource()).serviceDay)
+                    .dataFetcher(environment -> ((TripTimeShort) environment.getSource()).getServiceDay())
                     .build())
             .field(GraphQLFieldDefinition.newFieldDefinition()
                     .name("serviceJourney")
                     .type(serviceJourneyType)
                     .dataFetcher(environment -> {
                       return GqlUtil.getRoutingService(environment).getTripForId()
-                              .get(((TripTimeShort) environment.getSource()).tripId);
+                              .get(((TripTimeShort) environment.getSource()).getTripId());
                     })
                     .build())
             .field(GraphQLFieldDefinition.newFieldDefinition()
                     .name("destinationDisplay")
                     .type(destinationDisplayType)
-                    .dataFetcher(environment -> ((TripTimeShort) environment.getSource()).headsign)
+                    .dataFetcher(environment -> ((TripTimeShort) environment.getSource()).getHeadsign())
                     .build())
             .field(GraphQLFieldDefinition.newFieldDefinition()
                     .name("notices")
@@ -234,11 +249,11 @@ public class EstimatedCallType {
       TripTimeShort tripTimeShort,
       RoutingService routingService
   ) {
-    FeedScopedId tripId = tripTimeShort.tripId;
+    FeedScopedId tripId = tripTimeShort.getTripId();
     Trip trip = routingService.getTripForId().get(tripId);
     FeedScopedId routeId = trip.getRoute().getId();
 
-    FeedScopedId stopId = tripTimeShort.stopId;
+    FeedScopedId stopId = tripTimeShort.getStopId();
 
     Stop stop = routingService.getStopForId(stopId);
     FeedScopedId parentStopId = stop.getParentStation().getId();
@@ -265,9 +280,9 @@ public class EstimatedCallType {
     // TripPattern
     allAlerts.addAll(alertPatchService.getTripPatternAlerts(routingService.getPatternForTrip().get(trip).getId()));
 
-    long serviceDayMillis = 1000 * tripTimeShort.serviceDay;
-    long arrivalMillis = 1000 * tripTimeShort.realtimeArrival;
-    long departureMillis = 1000 * tripTimeShort.realtimeDeparture;
+    long serviceDayMillis = 1000 * tripTimeShort.getServiceDay();
+    long arrivalMillis = 1000 * tripTimeShort.getRealtimeArrival();
+    long departureMillis = 1000 * tripTimeShort.getRealtimeDeparture();
 
     filterSituationsByDateAndStopConditions(allAlerts,
         new Date(serviceDayMillis + arrivalMillis),

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/StopPlaceType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/StopPlaceType.java
@@ -387,7 +387,7 @@ public class StopPlaceType {
   }
 
   private static String destinationDisplayPerLine(TripTimeShort t, RoutingService routingService) {
-    Trip trip = routingService.getTripForId().get(t.tripId);
-    return trip == null ? t.headsign : trip.getRoute().getId() + "|" + t.headsign;
+    Trip trip = routingService.getTripForId().get(t.getTripId());
+    return trip == null ? t.getHeadsign() : trip.getRoute().getId() + "|" + t.getHeadsign();
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/TimetabledPassingTimeType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/TimetabledPassingTimeType.java
@@ -36,7 +36,7 @@ public class TimetabledPassingTimeType {
             .dataFetcher(environment -> {
               return GqlUtil.getRoutingService(environment).getStopForId((
                   (TripTimeShort) environment.getSource()
-              ).stopId);
+              ).getStopId());
             })
             .build())
         .field(GraphQLFieldDefinition
@@ -44,14 +44,14 @@ public class TimetabledPassingTimeType {
             .name("arrival")
             .type(gqlUtil.timeScalar)
             .description("Scheduled time of arrival at quay")
-            .dataFetcher(environment -> ((TripTimeShort) environment.getSource()).scheduledArrival)
+            .dataFetcher(environment -> ((TripTimeShort) environment.getSource()).getScheduledArrival())
             .build())
         .field(GraphQLFieldDefinition
             .newFieldDefinition()
             .name("departure")
             .type(gqlUtil.timeScalar)
             .description("Scheduled time of departure from quay")
-            .dataFetcher(environment -> ((TripTimeShort) environment.getSource()).scheduledDeparture)
+            .dataFetcher(environment -> ((TripTimeShort) environment.getSource()).getScheduledDeparture())
             .build())
         .field(GraphQLFieldDefinition
             .newFieldDefinition()
@@ -59,7 +59,7 @@ public class TimetabledPassingTimeType {
             .type(Scalars.GraphQLBoolean)
             .description(
                 "Whether this is a timing point or not. Boarding and alighting is not allowed at timing points.")
-            .dataFetcher(environment -> ((TripTimeShort) environment.getSource()).timepoint)
+            .dataFetcher(environment -> ((TripTimeShort) environment.getSource()).isTimepoint())
             .build())
         .field(GraphQLFieldDefinition
             .newFieldDefinition()
@@ -71,8 +71,8 @@ public class TimetabledPassingTimeType {
                   .getPatternForTrip()
                   .get(GqlUtil.getRoutingService(environment)
                       .getTripForId()
-                      .get(((TripTimeShort) environment.getSource()).tripId))
-                  .getBoardType(((TripTimeShort) environment.getSource()).stopIndex) != PICKDROP_NONE;
+                      .get(((TripTimeShort) environment.getSource()).getTripId()))
+                  .getBoardType(((TripTimeShort) environment.getSource()).getStopIndex()) != PICKDROP_NONE;
             })
             .build())
         .field(GraphQLFieldDefinition
@@ -85,8 +85,8 @@ public class TimetabledPassingTimeType {
                   .getPatternForTrip()
                   .get(GqlUtil.getRoutingService(environment)
                       .getTripForId()
-                      .get(((TripTimeShort) environment.getSource()).tripId))
-                  .getAlightType(((TripTimeShort) environment.getSource()).stopIndex)
+                      .get(((TripTimeShort) environment.getSource()).getTripId()))
+                  .getAlightType(((TripTimeShort) environment.getSource()).getStopIndex())
                   != PICKDROP_NONE;
             })
             .build())
@@ -100,8 +100,8 @@ public class TimetabledPassingTimeType {
                   .getPatternForTrip()
                   .get(GqlUtil.getRoutingService(environment)
                       .getTripForId()
-                      .get(((TripTimeShort) environment.getSource()).tripId))
-                  .getAlightType(((TripTimeShort) environment.getSource()).stopIndex)
+                      .get(((TripTimeShort) environment.getSource()).getTripId()))
+                  .getAlightType(((TripTimeShort) environment.getSource()).getStopIndex())
                   == PICKDROP_COORDINATE_WITH_DRIVER;
             })
             .build())
@@ -112,14 +112,14 @@ public class TimetabledPassingTimeType {
             .dataFetcher(environment -> {
               return GqlUtil.getRoutingService(environment)
                   .getTripForId()
-                  .get(((TripTimeShort) environment.getSource()).tripId);
+                  .get(((TripTimeShort) environment.getSource()).getTripId());
             })
             .build())
         .field(GraphQLFieldDefinition
             .newFieldDefinition()
             .name("destinationDisplay")
             .type(destinationDisplayType)
-            .dataFetcher(environment -> ((TripTimeShort) environment.getSource()).headsign)
+            .dataFetcher(environment -> ((TripTimeShort) environment.getSource()).getHeadsign())
             .build())
         .field(GraphQLFieldDefinition
             .newFieldDefinition()

--- a/src/main/java/org/opentripplanner/api/mapping/TripTimeMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/TripTimeMapper.java
@@ -21,20 +21,20 @@ public class TripTimeMapper {
 
         ApiTripTimeShort api = new ApiTripTimeShort();
 
-        api.stopId             = FeedScopedIdMapper.mapToApi(domain.stopId);
-        api.stopIndex          = domain.stopIndex;
-        api.stopCount          = domain.stopCount;
-        api.scheduledArrival   = domain.scheduledArrival;
-        api.scheduledDeparture = domain.scheduledDeparture;
-        api.realtimeArrival    = domain.realtimeArrival;
-        api.realtimeDeparture  = domain.realtimeDeparture;
-        api.arrivalDelay       = domain.arrivalDelay;
-        api.departureDelay     = domain.departureDelay;
-        api.timepoint          = domain.timepoint;
-        api.realtime           = domain.realtime;
-        api.realtimeState      = ApiRealTimeState.RealTimeState(domain.realtimeState);
-        api.blockId            = domain.blockId;
-        api.headsign           = domain.headsign;
+        api.stopId             = FeedScopedIdMapper.mapToApi(domain.getStopId());
+        api.stopIndex          = domain.getStopIndex();
+        api.stopCount          = domain.getStopCount();
+        api.scheduledArrival   = domain.getScheduledArrival();
+        api.scheduledDeparture = domain.getScheduledDeparture();
+        api.realtimeArrival    = domain.getRealtimeArrival();
+        api.realtimeDeparture  = domain.getRealtimeDeparture();
+        api.arrivalDelay       = domain.getArrivalDelay();
+        api.departureDelay     = domain.getDepartureDelay();
+        api.timepoint          = domain.isTimepoint();
+        api.realtime           = domain.isRealtime();
+        api.realtimeState      = ApiRealTimeState.RealTimeState(domain.getRealtimeState());
+        api.blockId            = domain.getBlockId();
+        api.headsign           = domain.getHeadsign();
 
         return api;
     }

--- a/src/main/java/org/opentripplanner/model/TripTimeShort.java
+++ b/src/main/java/org/opentripplanner/model/TripTimeShort.java
@@ -21,12 +21,12 @@ public class TripTimeShort {
     private final int scheduledDeparture;
     private final int realtimeArrival;
     private final int realtimeDeparture;
-    private final boolean isRecordedStop;
+    private final boolean recordedStop;
     private final int arrivalDelay;
     private final int departureDelay;
     private final boolean timepoint;
     private final boolean realtime;
-    private final boolean isCancelledStop;
+    private final boolean cancelledStop;
     private final RealTimeState realtimeState;
     private final long serviceDay;
     private final FeedScopedId tripId;
@@ -48,16 +48,16 @@ public class TripTimeShort {
         scheduledDeparture = tt.getScheduledDepartureTime(i);
         timepoint          = tt.isTimepoint(i);
         realtime           = !tt.isScheduled();
-        isCancelledStop    = tt.isCancelledStop(i);
-        isRecordedStop     = tt.isRecordedStop(i);
+        cancelledStop = tt.isCancelledStop(i);
+        recordedStop = tt.isRecordedStop(i);
 
         if (isRealtime() && isCancelledStop()) {
             /*
              Trips/stops cancelled in realtime should not present "23:59:59, yesterday" as arrival-/departureTime
              Setting realtime arrival and departure to planned times
              */
-            realtimeArrival = getScheduledArrival();
-            realtimeDeparture = getScheduledDeparture();
+            realtimeArrival = tt.getScheduledArrivalTime(i);
+            realtimeDeparture = tt.getScheduledDepartureTime(i);
             arrivalDelay = 0;
             departureDelay = 0;
         } else {
@@ -138,14 +138,14 @@ public class TripTimeShort {
      * Returns the actual arrival time if available. Otherwise -1 is returned.
      */
     public int getActualArrival() {
-        return isRecordedStop ? realtimeArrival : UNDEFINED;
+        return recordedStop ? realtimeArrival : UNDEFINED;
     }
 
     /**
      * Returns the actual departure time if available. Otherwise -1 is returned.
      */
     public int getActualDeparture() {
-        return isRecordedStop ? realtimeDeparture : UNDEFINED;
+        return recordedStop ? realtimeDeparture : UNDEFINED;
     }
 
     public int getArrivalDelay() {
@@ -165,7 +165,7 @@ public class TripTimeShort {
     }
 
     public boolean isCancelledStop() {
-        return isCancelledStop;
+        return cancelledStop;
     }
 
     public RealTimeState getRealtimeState() {

--- a/src/main/java/org/opentripplanner/model/TripTimeShort.java
+++ b/src/main/java/org/opentripplanner/model/TripTimeShort.java
@@ -13,50 +13,49 @@ import java.util.List;
 public class TripTimeShort {
 
     public static final int UNDEFINED = -1;
-    public FeedScopedId stopId;
-    public int stopIndex;
-    public int stopCount;
-    public int scheduledArrival = UNDEFINED ;
-    public int scheduledDeparture = UNDEFINED ;
-    public int realtimeArrival = UNDEFINED ;
-    public int realtimeDeparture = UNDEFINED ;
-    public int arrivalDelay = UNDEFINED ;
-    public int departureDelay = UNDEFINED ;
-    public boolean timepoint = false;
-    public boolean realtime = false;
-    public boolean isCancelledStop;
-    public RealTimeState realtimeState = RealTimeState.SCHEDULED ;
-    public long serviceDay;
-    public FeedScopedId tripId;
-    public String blockId;
-    public String headsign;
-    public int pickupType;
-    public int dropoffType;
+
+    private final FeedScopedId stopId;
+    private final int stopIndex;
+    private final int stopCount;
+    private final int scheduledArrival;
+    private final int scheduledDeparture;
+    private final int realtimeArrival;
+    private final int realtimeDeparture;
+    private final int arrivalDelay;
+    private final int departureDelay;
+    private final boolean timepoint;
+    private final boolean realtime;
+    private final boolean isCancelledStop;
+    private final RealTimeState realtimeState;
+    private final long serviceDay;
+    private final FeedScopedId tripId;
+    private final String blockId;
+    private final String headsign;
+    private final int pickupType;
+    private final int dropoffType;
 
     /**
      * This is stop-specific, so the index i is a stop index, not a hop index.
      */
-    public TripTimeShort(TripTimes tt, int i, Stop stop) {
+    public TripTimeShort(TripTimes tt, int i, Stop stop, ServiceDay sd) {
+        serviceDay         = sd != null ? sd.time(0) : UNDEFINED;
+        tripId             = tt.trip.getId();
         stopId             = stop.getId();
         stopIndex          = i;
         stopCount          = tt.getNumStops();
         scheduledArrival   = tt.getScheduledArrivalTime(i);
-        realtimeArrival    = tt.getArrivalTime(i);
-        arrivalDelay       = tt.getArrivalDelay(i);
         scheduledDeparture = tt.getScheduledDepartureTime(i);
-        realtimeDeparture  = tt.getDepartureTime(i);
-        departureDelay     = tt.getDepartureDelay(i);
         timepoint          = tt.isTimepoint(i);
         realtime           = !tt.isScheduled();
         isCancelledStop    = tt.isCancelledStop(i);
 
-        if (realtime && isCancelledStop) {
+        if (isRealtime() && isCancelledStop()) {
             /*
              Trips/stops cancelled in realtime should not present "23:59:59, yesterday" as arrival-/departureTime
              Setting realtime arrival and departure to planned times
              */
-            realtimeArrival = scheduledArrival;
-            realtimeDeparture = scheduledDeparture;
+            realtimeArrival = getScheduledArrival();
+            realtimeDeparture = getScheduledDeparture();
             arrivalDelay = 0;
             departureDelay = 0;
         } else {
@@ -73,12 +72,6 @@ public class TripTimeShort {
         dropoffType        = tt.getDropoffType(i);
     }
 
-    public TripTimeShort(TripTimes tt, int i, Stop stop, ServiceDay sd) {
-        this(tt, i, stop);
-        tripId = tt.trip.getId();
-        serviceDay = sd.time(0);
-    }
-
     /**
      * must pass in both table and trip, because tripTimes do not have stops.
      */
@@ -87,7 +80,7 @@ public class TripTimeShort {
         List<TripTimeShort> out = new ArrayList<>();
         // one per stop, not one per hop, thus the <= operator
         for (int i = 0; i < times.getNumStops(); ++i) {
-            out.add(new TripTimeShort(times, i, table.pattern.getStop(i)));
+            out.add(new TripTimeShort(times, i, table.pattern.getStop(i), null));
         }
         return out;
     }
@@ -108,6 +101,82 @@ public class TripTimeShort {
     }
 
     public static Comparator<TripTimeShort> compareByDeparture() {
-        return Comparator.comparing(t -> t.serviceDay + t.realtimeDeparture);
+        return Comparator.comparing(t -> t.getServiceDay() + t.getRealtimeDeparture());
+    }
+
+    public FeedScopedId getStopId() {
+        return stopId;
+    }
+
+    public int getStopIndex() {
+        return stopIndex;
+    }
+
+    public int getStopCount() {
+        return stopCount;
+    }
+
+    public int getScheduledArrival() {
+        return scheduledArrival;
+    }
+
+    public int getScheduledDeparture() {
+        return scheduledDeparture;
+    }
+
+    public int getRealtimeArrival() {
+        return realtimeArrival;
+    }
+
+    public int getRealtimeDeparture() {
+        return realtimeDeparture;
+    }
+
+    public int getArrivalDelay() {
+        return arrivalDelay;
+    }
+
+    public int getDepartureDelay() {
+        return departureDelay;
+    }
+
+    public boolean isTimepoint() {
+        return timepoint;
+    }
+
+    public boolean isRealtime() {
+        return realtime;
+    }
+
+    public boolean isCancelledStop() {
+        return isCancelledStop;
+    }
+
+    public RealTimeState getRealtimeState() {
+        return realtimeState;
+    }
+
+    public long getServiceDay() {
+        return serviceDay;
+    }
+
+    public FeedScopedId getTripId() {
+        return tripId;
+    }
+
+    public String getBlockId() {
+        return blockId;
+    }
+
+    public String getHeadsign() {
+        return headsign;
+    }
+
+    public int getPickupType() {
+        return pickupType;
+    }
+
+    public int getDropoffType() {
+        return dropoffType;
     }
 }

--- a/src/main/java/org/opentripplanner/model/TripTimeShort.java
+++ b/src/main/java/org/opentripplanner/model/TripTimeShort.java
@@ -21,6 +21,7 @@ public class TripTimeShort {
     private final int scheduledDeparture;
     private final int realtimeArrival;
     private final int realtimeDeparture;
+    private final boolean isRecordedStop;
     private final int arrivalDelay;
     private final int departureDelay;
     private final boolean timepoint;
@@ -48,6 +49,7 @@ public class TripTimeShort {
         timepoint          = tt.isTimepoint(i);
         realtime           = !tt.isScheduled();
         isCancelledStop    = tt.isCancelledStop(i);
+        isRecordedStop     = tt.isRecordedStop(i);
 
         if (isRealtime() && isCancelledStop()) {
             /*
@@ -130,6 +132,20 @@ public class TripTimeShort {
 
     public int getRealtimeDeparture() {
         return realtimeDeparture;
+    }
+
+    /**
+     * Returns the actual arrival time if available. Otherwise -1 is returned.
+     */
+    public int getActualArrival() {
+        return isRecordedStop ? realtimeArrival : UNDEFINED;
+    }
+
+    /**
+     * Returns the actual departure time if available. Otherwise -1 is returned.
+     */
+    public int getActualDeparture() {
+        return isRecordedStop ? realtimeDeparture : UNDEFINED;
     }
 
     public int getArrivalDelay() {

--- a/src/main/java/org/opentripplanner/routing/StopTimesHelper.java
+++ b/src/main/java/org/opentripplanner/routing/StopTimesHelper.java
@@ -195,7 +195,8 @@ public class StopTimesHelper {
     //
     // The {@link MinMaxPriorityQueue} is marked beta, but we do not have a god alternative.
     MinMaxPriorityQueue<TripTimeShort> pq = MinMaxPriorityQueue
-            .orderedBy(Comparator.comparing((TripTimeShort tts) -> tts.serviceDay + tts.realtimeDeparture))
+            .orderedBy(Comparator.comparing((TripTimeShort tts) -> tts.getServiceDay()
+                + tts.getRealtimeDeparture()))
             .maximumSize(numberOfDepartures)
             .create();
 

--- a/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
+++ b/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
@@ -92,21 +92,21 @@ public class TripTimes implements Serializable, Comparable<TripTimes>, Cloneable
      *
      * Non-final to allow updates.
      */
-    boolean[] isRecordedStop;
+    boolean[] recordedStops;
 
     /**
      * TODO OTP2 - This needs redesign and a bit more analyzes
      *
      * Flag tho indicate cancellations on each stop. Non-final to allow updates.
      */
-    boolean[] isCancelledStop;
+    boolean[] cancelledStops;
 
     /**
      * TODO OTP2 - This needs redesign and a bit more analyzes
      *
      * Flag tho indicate inaccurate predictions on each stop. Non-final to allow updates, transient for backwards graph-compatibility.
      */
-    boolean[] isPredictionInaccurate;
+    boolean[] predictionInaccurateOnStops;
 
     /**
      * TODO OTP2 - This needs redesign and a bit more analyzes
@@ -178,7 +178,7 @@ public class TripTimes implements Serializable, Comparable<TripTimes>, Cloneable
         // We cannot point to the scheduled times because they are shifted, and updated times are not.
         this.arrivalTimes = null;
         this.departureTimes = null;
-        this.isRecordedStop = null;
+        this.recordedStops = null;
         this.timepoints = deduplicator.deduplicateBitSet(timepoints);
         LOG.trace("trip {} has timepoint at indexes {}", trip, timepoints);
     }
@@ -294,43 +294,43 @@ public class TripTimes implements Serializable, Comparable<TripTimes>, Cloneable
 
     public void setRecorded(int stop, boolean recorded) {
         checkCreateTimesArrays();
-        isRecordedStop[stop] = recorded;
+        recordedStops[stop] = recorded;
     }
 
     // TODO OTP2 - Unused, but will be used by Transmodel API
     public boolean isRecordedStop(int stop) {
-        if (isRecordedStop == null) {
+        if (recordedStops == null) {
             return false;
         }
-        return isRecordedStop[stop];
+        return recordedStops[stop];
     }
 
     //Is single stop cancelled
     public void setCancelledStop(int stop, boolean isCancelled) {
         checkCreateTimesArrays();
-        isCancelledStop[stop] = isCancelled;
+        cancelledStops[stop] = isCancelled;
     }
 
     // TODO OTP2 - Unused, but will be used by Transmodel API
     public boolean isCancelledStop(int stop) {
-        if (isCancelledStop == null) {
+        if (cancelledStops == null) {
             return false;
         }
-        return isCancelledStop[stop];
+        return cancelledStops[stop];
     }
 
     //Is prediction for single stop inaccurate
     public void setPredictionInaccurate(int stop, boolean predictionInaccurate) {
         checkCreateTimesArrays();
-        isPredictionInaccurate[stop] = predictionInaccurate;
+        predictionInaccurateOnStops[stop] = predictionInaccurate;
     }
 
     // TODO OTP2 - Unused, but will be used by Transmodel API
     public boolean isPredictionInaccurate(int stop) {
-        if (isPredictionInaccurate == null) {
+        if (predictionInaccurateOnStops == null) {
             return false;
         }
-        return isPredictionInaccurate[stop];
+        return predictionInaccurateOnStops[stop];
     }
 
     public void setPickupType(int stop, int pickupType) {
@@ -463,8 +463,8 @@ public class TripTimes implements Serializable, Comparable<TripTimes>, Cloneable
 
     public void cancelAllStops() {
         // Flag all stops as cancelled
-        isCancelledStop = new boolean[getNumStops()];
-        Arrays.fill(isCancelledStop, true);
+        cancelledStops = new boolean[getNumStops()];
+        Arrays.fill(cancelledStops, true);
     }
 
     public void updateDepartureTime(final int stop, final int time) {
@@ -495,15 +495,15 @@ public class TripTimes implements Serializable, Comparable<TripTimes>, Cloneable
         if (arrivalTimes == null) {
             arrivalTimes = Arrays.copyOf(scheduledArrivalTimes, scheduledArrivalTimes.length);
             departureTimes = Arrays.copyOf(scheduledDepartureTimes, scheduledDepartureTimes.length);
-            isRecordedStop = new boolean[arrivalTimes.length];
-            isCancelledStop = new boolean[arrivalTimes.length];
-            isPredictionInaccurate = new boolean[arrivalTimes.length];
+            recordedStops = new boolean[arrivalTimes.length];
+            cancelledStops = new boolean[arrivalTimes.length];
+            predictionInaccurateOnStops = new boolean[arrivalTimes.length];
             for (int i = 0; i < arrivalTimes.length; i++) {
                 arrivalTimes[i] += timeShift;
                 departureTimes[i] += timeShift;
-                isRecordedStop[i] = false;
-                isCancelledStop[i] = false;
-                isPredictionInaccurate[i] = false;
+                recordedStops[i] = false;
+                cancelledStops[i] = false;
+                predictionInaccurateOnStops[i] = false;
             }
 
             // Update the real-time state


### PR DESCRIPTION
To be completed by pull request submitter:

- [ ] **issue**: Closes #3333
- [ ] **roadmap**: Check the [roadmap](https://github.com/orgs/opentripplanner/projects/1) for this feature or bug. If it is not already on the roadmap, PLC will discuss as part of the review process.
- [ ] **tests**: Have you added relevant test coverage? Are all the tests passing on [the continuous integration service (Travis CI)](https://github.com/opentripplanner/OpenTripPlanner/blob/2.0-rc/docs/Developers-Guide.md#continuous-integration)?
- [ ] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/2.0-rc/docs/Developers-Guide.md#code-style)? 
- [ ] **documentation**: If you are adding a new configuration option, have you added an explanation to the [configuration documentation](https://github.com/opentripplanner/OpenTripPlanner/blob/2.0-rc/docs/Configuration.md) tables and sections?
- [ ] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/2.0-rc/docs/Changelog.md) with description and link to the linked issue

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)

This PR does the following:
- Make all fields in TripTimeShort private final
- Add the isRecordedStop field from TripTimes. This marks whether the realtime fields represent expected or actual times.
- Implement getters for actualDepartureTime and actualArrivalTime
- Use these getters in the transmodel api