### PR TITLE
Otp2 include planned cancellations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     </scm>
 
     <properties>
-        <otp.serialization.version.id>1</otp.serialization.version.id>
+        <otp.serialization.version.id>2</otp.serialization.version.id>
         <!-- Lib versions - keep list sorted on property name -->
         <geotools.version>21.2</geotools.version>
         <geotools.wfs.version>16.5</geotools.wfs.version>

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLPlanner.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLPlanner.java
@@ -235,7 +235,7 @@ public class TransmodelGraphQLPlanner {
         callWith.argument("maximumTransfers", (Integer v) -> request.maxTransfers = v);
         callWith.argument("useBikeRentalAvailabilityInformation", (Boolean v) -> request.useBikeRentalAvailabilityInformation = v);
         callWith.argument("ignoreRealtimeUpdates", (Boolean v) -> request.ignoreRealtimeUpdates = v);
-        //callWith.argument("includePlannedCancellations", (Boolean v) -> request.includePlannedCancellations = v);
+        callWith.argument("includePlannedCancellations", (Boolean v) -> request.includePlannedCancellations = v);
         //callWith.argument("ignoreInterchanges", (Boolean v) -> request.ignoreInterchanges = v);
 
         return request;

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/DefaultRoutingRequestType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/DefaultRoutingRequestType.java
@@ -319,14 +319,12 @@ public class DefaultRoutingRequestType {
                         .type(Scalars.GraphQLBoolean)
                         .dataFetcher(env -> request.ignoreRealtimeUpdates)
                         .build())
-                /*
                 .field(GraphQLFieldDefinition.newFieldDefinition()
                         .name("includedPlannedCancellations")
                         .description("When true, service journeys cancelled in scheduled route data will be included during this search.")
                         .type(Scalars.GraphQLBoolean)
-                        .dataFetcher(env -> defaults.includePlannedCancellations)
+                        .dataFetcher(env -> request.includePlannedCancellations)
                         .build())
-                 */
                 .field(GraphQLFieldDefinition
                         .newFieldDefinition()
                         .name("disableRemainingWeightHeuristic")

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/TripQuery.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/TripQuery.java
@@ -89,6 +89,13 @@ public class TripQuery {
             .build()
         )
         .argument(GraphQLArgument.newArgument()
+            .name("includePlannedCancellations")
+            .description("When true, service journeys cancelled in scheduled route data will be included during this search.")
+            .type(Scalars.GraphQLBoolean)
+            .defaultValue(routing.request.includePlannedCancellations)
+            .build()
+        )
+        .argument(GraphQLArgument.newArgument()
             .name("locale")
             .description(
                 "The preferable language to use for text targeted the end user. Note! The data "

--- a/src/main/java/org/opentripplanner/model/Trip.java
+++ b/src/main/java/org/opentripplanner/model/Trip.java
@@ -45,7 +45,7 @@ public final class Trip extends TransitEntity {
      *
      * This is planned, by default (e.g. GTFS and if not set explicit).
      */
-    private TripAlteration alteration = TripAlteration.planned;
+    private TripAlteration alteration = TripAlteration.PLANNED;
 
     public Trip(FeedScopedId id) {
         super(id);

--- a/src/main/java/org/opentripplanner/model/Trip.java
+++ b/src/main/java/org/opentripplanner/model/Trip.java
@@ -40,6 +40,13 @@ public final class Trip extends TransitEntity {
     /** Custom extension for KCM to specify a fare per-trip */
     private String fareId;
 
+    /**
+     * Default alteration for a trip. // TODO Implement alterations for DSJ
+     *
+     * This is planned, by default (e.g. GTFS and if not set explicit).
+     */
+    private TripAlteration alteration = TripAlteration.planned;
+
     public Trip(FeedScopedId id) {
         super(id);
     }
@@ -226,6 +233,16 @@ public final class Trip extends TransitEntity {
 
     public void setFareId(String fareId) {
         this.fareId = fareId;
+    }
+
+    public TripAlteration getTripAlteration() {
+        return alteration;
+    }
+
+    public void setAlteration(TripAlteration tripAlteration) {
+        if (tripAlteration != null) {
+            this.alteration = tripAlteration;
+        }
     }
 
     private boolean hasValue(String text) {

--- a/src/main/java/org/opentripplanner/model/TripAlteration.java
+++ b/src/main/java/org/opentripplanner/model/TripAlteration.java
@@ -1,12 +1,16 @@
 package org.opentripplanner.model;
 
+/**
+ * Alterations specified on a Trip in the planned data. This is in some ways equivalent with GTFS-RT
+ * scheduled relationship.
+ */
 public enum TripAlteration {
-  cancellation,
-  planned,
-  extraJourney,
-  replaced;
+  CANCELLATION,
+  PLANNED,
+  EXTRA_JOURNEY,
+  REPLACED;
 
   public boolean isCanceledOrReplaced() {
-    return this == cancellation || this == replaced;
+    return this == CANCELLATION || this == REPLACED;
   }
 }

--- a/src/main/java/org/opentripplanner/model/TripAlteration.java
+++ b/src/main/java/org/opentripplanner/model/TripAlteration.java
@@ -1,0 +1,12 @@
+package org.opentripplanner.model;
+
+public enum TripAlteration {
+  cancellation,
+  planned,
+  extraJourney,
+  replaced;
+
+  public boolean isCanceledOrReplaced() {
+    return this == cancellation || this == replaced;
+  }
+}

--- a/src/main/java/org/opentripplanner/netex/mapping/TripMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/TripMapper.java
@@ -77,13 +77,6 @@ class TripMapper {
             return null;
         }
 
-        // TODO This currently skips mapping of any trips containing ServiceAlteration CANCELLATION
-        //      or REPLACED. In the future we will want to import these and allow them to be routed
-        //      on if a parameter is set. Also done in DateServiceJourneyMapper.
-        if (!isRunning(serviceJourney.getServiceAlteration())) {
-            return null;
-        }
-
         Trip trip = new Trip(idFactory.createId(serviceJourney.getId()));
 
         trip.setRoute(route);
@@ -98,6 +91,9 @@ class TripMapper {
         trip.setTripOperator(findOperator(serviceJourney));
 
         trip.setDirection(DirectionMapper.map(resolveDirectionType(serviceJourney)));
+
+        trip.setAlteration(
+            TripServiceAlterationMapper.mapAlteration(serviceJourney.getServiceAlteration()));
 
         return trip;
     }

--- a/src/main/java/org/opentripplanner/netex/mapping/TripMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/TripMapper.java
@@ -93,7 +93,8 @@ class TripMapper {
         trip.setDirection(DirectionMapper.map(resolveDirectionType(serviceJourney)));
 
         trip.setAlteration(
-            TripServiceAlterationMapper.mapAlteration(serviceJourney.getServiceAlteration()));
+            TripServiceAlterationMapper.mapAlteration(serviceJourney.getServiceAlteration())
+        );
 
         return trip;
     }

--- a/src/main/java/org/opentripplanner/netex/mapping/TripServiceAlterationMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/TripServiceAlterationMapper.java
@@ -7,10 +7,10 @@ public class TripServiceAlterationMapper {
   public static TripAlteration mapAlteration(ServiceAlterationEnumeration netexValue) {
     if (netexValue == null) { return null; }
     switch (netexValue) {
-      case PLANNED: return TripAlteration.planned;
-      case CANCELLATION: return TripAlteration.cancellation;
-      case REPLACED: return TripAlteration.replaced;
-      case EXTRA_JOURNEY: return TripAlteration.extraJourney;
+      case PLANNED: return TripAlteration.PLANNED;
+      case CANCELLATION: return TripAlteration.CANCELLATION;
+      case REPLACED: return TripAlteration.REPLACED;
+      case EXTRA_JOURNEY: return TripAlteration.EXTRA_JOURNEY;
     }
     throw new IllegalArgumentException("Unmapped alternation: " + netexValue);
   }

--- a/src/main/java/org/opentripplanner/netex/mapping/TripServiceAlterationMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/TripServiceAlterationMapper.java
@@ -1,0 +1,17 @@
+package org.opentripplanner.netex.mapping;
+
+import org.opentripplanner.model.TripAlteration;
+import org.rutebanken.netex.model.ServiceAlterationEnumeration;
+
+public class TripServiceAlterationMapper {
+  public static TripAlteration mapAlteration(ServiceAlterationEnumeration netexValue) {
+    if (netexValue == null) { return null; }
+    switch (netexValue) {
+      case PLANNED: return TripAlteration.planned;
+      case CANCELLATION: return TripAlteration.cancellation;
+      case REPLACED: return TripAlteration.replaced;
+      case EXTRA_JOURNEY: return TripAlteration.extraJourney;
+    }
+    throw new IllegalArgumentException("Unmapped alternation: " + netexValue);
+  }
+}

--- a/src/main/java/org/opentripplanner/netex/mapping/calendar/DatedServiceJourneyMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/calendar/DatedServiceJourneyMapper.java
@@ -2,7 +2,6 @@ package org.opentripplanner.netex.mapping.calendar;
 
 import org.opentripplanner.model.calendar.ServiceDate;
 import org.opentripplanner.netex.index.api.ReadOnlyHierarchicalMapById;
-import org.opentripplanner.netex.mapping.support.ServiceAlterationFilter;
 import org.rutebanken.netex.model.DatedServiceJourney;
 import org.rutebanken.netex.model.OperatingDay;
 import org.rutebanken.netex.model.OperatingDayRefStructure;
@@ -48,7 +47,7 @@ public class DatedServiceJourneyMapper {
 
       // TODO This currently skips mapping of any trips containing ServiceAlteration CANCELLATION
       //      or REPLACED. In the future we will want to import these and allow them to be routed
-      //      on if a parameter is set. Also done in TripMapper.
+      //      on if a parameter is set.
       if (!isRunning(dsj.getServiceAlteration())) continue;
 
       OperatingDay opDay = operatingDay(dsj, operatingDayById);

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/TripPatternForDate.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/TripPatternForDate.java
@@ -115,6 +115,10 @@ public class TripPatternForDate {
             .filter(filter)
             .collect(Collectors.toList());
 
+        if (filteredTripTimes.isEmpty()) {
+            return null;
+        }
+
         if (tripTimes.length == filteredTripTimes.size()) {
             return this;
         }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/request/RaptorRoutingRequestTransitDataCreator.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/request/RaptorRoutingRequestTransitDataCreator.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -155,6 +156,7 @@ class RaptorRoutingRequestTransitDataCreator {
         .filter(filter::tripPatternPredicate)
         .filter(p -> firstDay || p.getStartOfRunningPeriod().toLocalDate().equals(date))
         .map(p -> p.newWithFilteredTripTimes(filter::tripTimesPredicate))
+        .filter(Objects::nonNull)
         .collect(Collectors.toList());
   }
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/request/RoutingRequestTransitDataProviderFilter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/request/RoutingRequestTransitDataProviderFilter.java
@@ -17,6 +17,8 @@ public class RoutingRequestTransitDataProviderFilter implements TransitDataProvi
 
   private final boolean requireWheelchairAccessible;
 
+  private final boolean includePlannedCancellations;
+
   private final Set<TransitMode> transitModes;
 
   private final Set<FeedScopedId> bannedRoutes;
@@ -24,11 +26,13 @@ public class RoutingRequestTransitDataProviderFilter implements TransitDataProvi
   public RoutingRequestTransitDataProviderFilter(
       boolean requireBikesAllowed,
       boolean requireWheelchairAccessible,
+      boolean includePlannedCancellations,
       Set<TransitMode> transitModes,
       Set<FeedScopedId> bannedRoutes
   ) {
     this.requireBikesAllowed = requireBikesAllowed;
     this.requireWheelchairAccessible = requireWheelchairAccessible;
+    this.includePlannedCancellations = includePlannedCancellations;
     this.transitModes = transitModes.isEmpty()
         ? EnumSet.noneOf(TransitMode.class)
         : EnumSet.copyOf(transitModes);
@@ -39,6 +43,7 @@ public class RoutingRequestTransitDataProviderFilter implements TransitDataProvi
     this(
         request.modes.directMode == StreetMode.BIKE,
         request.wheelchairAccessible,
+        request.includePlannedCancellations,
         request.modes.transitModes,
         request.rctx.bannedRoutes
     );
@@ -57,6 +62,10 @@ public class RoutingRequestTransitDataProviderFilter implements TransitDataProvi
 
     if (requireWheelchairAccessible) {
       return tripTimes.trip.getWheelchairAccessible() == 1;
+    }
+
+    if (!includePlannedCancellations) {
+      return !tripTimes.trip.getTripAlteration().isCanceledOrReplaced();
     }
 
     return true;

--- a/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
@@ -579,6 +579,11 @@ public class RoutingRequest implements Cloneable, Serializable {
     public boolean ignoreRealtimeUpdates = false;
 
     /**
+     * When true, trips cancelled in scheduled data are included in this search.
+     */
+    public boolean includePlannedCancellations = false;
+
+    /**
      * If true, the remaining weight heuristic is disabled. Currently only implemented for the long
      * distance path service.
      *

--- a/src/test/java/org/opentripplanner/netex/mapping/TripMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/TripMapperTest.java
@@ -99,58 +99,6 @@ public class TripMapperTest {
         assertEquals(trip.getId(), ID_FACTORY.createId("RUT:ServiceJourney:1"));
     }
 
-    @Test
-    public void skipMappingOfCancelledOrReplacedTrips() {
-        OtpTransitServiceBuilder transitBuilder = new OtpTransitServiceBuilder();
-        Route route = new Route(ID_FACTORY.createId(ROUTE_ID));
-        transitBuilder.getRoutes().add(route);
-
-        TripMapper tripMapper = new TripMapper(
-            ID_FACTORY,
-            transitBuilder.getOperatorsById(),
-            transitBuilder.getRoutes(),
-            new HierarchicalMapById<>(),
-            new HierarchicalMap<>(),
-            Map.of(SERVICE_JOURNEY_ID, SERVICE_ID),
-            Collections.emptySet()
-        );
-
-        ServiceJourney serviceJourney1 = createExampleServiceJourney();
-        serviceJourney1.setServiceAlteration(ServiceAlterationEnumeration.CANCELLATION);
-        serviceJourney1.setLineRef(LINE_REF);
-
-        // Should NOT be mapped
-        assertNull(tripMapper.mapServiceJourney(serviceJourney1));
-
-        ServiceJourney serviceJourney2 = createExampleServiceJourney();
-        serviceJourney2.setServiceAlteration(ServiceAlterationEnumeration.REPLACED);
-        serviceJourney2.setLineRef(LINE_REF);
-
-        // Should NOT be mapped
-        assertNull(tripMapper.mapServiceJourney(serviceJourney2));
-
-        ServiceJourney serviceJourney3 = createExampleServiceJourney();
-        serviceJourney3.setServiceAlteration(ServiceAlterationEnumeration.PLANNED);
-        serviceJourney3.setLineRef(LINE_REF);
-
-        // Should be mapped
-        assertNotNull(tripMapper.mapServiceJourney(serviceJourney3));
-
-        ServiceJourney serviceJourney4 = createExampleServiceJourney();
-        serviceJourney4.setServiceAlteration(ServiceAlterationEnumeration.EXTRA_JOURNEY);
-        serviceJourney4.setLineRef(LINE_REF);
-
-        // Should be mapped
-        assertNotNull(tripMapper.mapServiceJourney(serviceJourney4));
-
-        // ServiceAlteration is null
-        ServiceJourney serviceJourney5 = createExampleServiceJourney();
-        serviceJourney5.setLineRef(LINE_REF);
-
-        // Should be mapped
-        assertNotNull(tripMapper.mapServiceJourney(serviceJourney5));
-    }
-
     private ServiceJourney createExampleServiceJourney() {
         ServiceJourney serviceJourney = new ServiceJourney();
         serviceJourney.setId("RUT:ServiceJourney:1");

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptor/transit/request/RoutingRequestTransitDataProviderFilterTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptor/transit/request/RoutingRequestTransitDataProviderFilterTest.java
@@ -156,10 +156,10 @@ public class RoutingRequestTransitDataProviderFilterTest {
   }
   @Test
   public void includePlannedCancellationsTest() {
-    TripTimes tripTimes1 = createTestTripTimes();
-    TripTimes tripTimes2 = createTestTripTimes();
-    tripTimes1.trip.setAlteration(TripAlteration.CANCELLATION);
-    tripTimes2.trip.setAlteration(TripAlteration.REPLACED);
+    TripTimes tripTimesWithCancellation = createTestTripTimes();
+    TripTimes tripTimesWithReplaced = createTestTripTimes();
+    tripTimesWithCancellation.trip.setAlteration(TripAlteration.CANCELLATION);
+    tripTimesWithReplaced.trip.setAlteration(TripAlteration.REPLACED);
 
     // Given
     var filter1 = new RoutingRequestTransitDataProviderFilter(
@@ -171,12 +171,12 @@ public class RoutingRequestTransitDataProviderFilterTest {
     );
 
     // When
-    boolean valid1 = filter1.tripTimesPredicate(tripTimes1);
+    boolean valid1 = filter1.tripTimesPredicate(tripTimesWithCancellation);
     // Then
     assertTrue(valid1);
 
     // When
-    boolean valid2 = filter1.tripTimesPredicate(tripTimes2);
+    boolean valid2 = filter1.tripTimesPredicate(tripTimesWithReplaced);
     // Then
     assertTrue(valid2);
 
@@ -190,12 +190,12 @@ public class RoutingRequestTransitDataProviderFilterTest {
     );
 
     // When
-    boolean valid3 = filter2.tripTimesPredicate(tripTimes1);
+    boolean valid3 = filter2.tripTimesPredicate(tripTimesWithCancellation);
     // Then
     assertFalse(valid3);
 
     // When
-    boolean valid4 = filter2.tripTimesPredicate(tripTimes2);
+    boolean valid4 = filter2.tripTimesPredicate(tripTimesWithReplaced);
     // Then
     assertFalse(valid4);
   }

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptor/transit/request/RoutingRequestTransitDataProviderFilterTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptor/transit/request/RoutingRequestTransitDataProviderFilterTest.java
@@ -14,6 +14,7 @@ import java.util.Set;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class RoutingRequestTransitDataProviderFilterTest {
 
@@ -26,6 +27,7 @@ public class RoutingRequestTransitDataProviderFilterTest {
     TripPatternForDate tripPatternForDate = createTestTripPatternForDate();
 
     var filter = new RoutingRequestTransitDataProviderFilter(
+        false,
         false,
         false,
         Set.of(TransitMode.BUS),
@@ -44,6 +46,7 @@ public class RoutingRequestTransitDataProviderFilterTest {
     var filter = new RoutingRequestTransitDataProviderFilter(
         false,
         false,
+        false,
         Set.of(TransitMode.BUS),
         Set.of(TEST_ROUTE_ID)
     );
@@ -58,6 +61,7 @@ public class RoutingRequestTransitDataProviderFilterTest {
     TripPatternForDate tripPatternForDate = createTestTripPatternForDate();
 
     var filter = new RoutingRequestTransitDataProviderFilter(
+        false,
         false,
         false,
         Set.of(),
@@ -76,6 +80,7 @@ public class RoutingRequestTransitDataProviderFilterTest {
     var filter = new RoutingRequestTransitDataProviderFilter(
         false,
         false,
+        false,
         Set.of(),
         Set.of()
     );
@@ -91,6 +96,7 @@ public class RoutingRequestTransitDataProviderFilterTest {
 
     var filter = new RoutingRequestTransitDataProviderFilter(
         true,
+        false,
         false,
         Set.of(),
         Set.of()
@@ -108,6 +114,7 @@ public class RoutingRequestTransitDataProviderFilterTest {
     var filter = new RoutingRequestTransitDataProviderFilter(
         false,
         true,
+        false,
         Set.of(),
         Set.of()
     );
@@ -146,5 +153,41 @@ public class RoutingRequestTransitDataProviderFilterTest {
     stopTime.setStopSequence(0);
 
     return new TripTimes(trip, List.of(stopTime), new Deduplicator());
+  }
+  @Test
+  public void includePlannedCancellationsTest() {
+    TripTimes tripTimes1 = createTestTripTimes();
+    TripTimes tripTimes2 = createTestTripTimes();
+    tripTimes1.trip.setAlteration(TripAlteration.cancellation);
+    tripTimes2.trip.setAlteration(TripAlteration.replaced);
+
+    var filter1 = new RoutingRequestTransitDataProviderFilter(
+        false,
+        false,
+        true,
+        Set.of(),
+        Set.of()
+    );
+
+    boolean valid1 = filter1.tripTimesPredicate(tripTimes1);
+    boolean valid2 = filter1.tripTimesPredicate(tripTimes2);
+
+    assertTrue(valid1);
+    assertTrue(valid2);
+
+
+    var filter2 = new RoutingRequestTransitDataProviderFilter(
+        false,
+        false,
+        false,
+        Set.of(),
+        Set.of()
+    );
+
+    boolean valid3 = filter2.tripTimesPredicate(tripTimes1);
+    boolean valid4 = filter2.tripTimesPredicate(tripTimes2);
+
+    assertFalse(valid3);
+    assertFalse(valid4);
   }
 }

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptor/transit/request/RoutingRequestTransitDataProviderFilterTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptor/transit/request/RoutingRequestTransitDataProviderFilterTest.java
@@ -158,9 +158,10 @@ public class RoutingRequestTransitDataProviderFilterTest {
   public void includePlannedCancellationsTest() {
     TripTimes tripTimes1 = createTestTripTimes();
     TripTimes tripTimes2 = createTestTripTimes();
-    tripTimes1.trip.setAlteration(TripAlteration.cancellation);
-    tripTimes2.trip.setAlteration(TripAlteration.replaced);
+    tripTimes1.trip.setAlteration(TripAlteration.CANCELLATION);
+    tripTimes2.trip.setAlteration(TripAlteration.REPLACED);
 
+    // Given
     var filter1 = new RoutingRequestTransitDataProviderFilter(
         false,
         false,
@@ -169,13 +170,17 @@ public class RoutingRequestTransitDataProviderFilterTest {
         Set.of()
     );
 
+    // When
     boolean valid1 = filter1.tripTimesPredicate(tripTimes1);
-    boolean valid2 = filter1.tripTimesPredicate(tripTimes2);
-
+    // Then
     assertTrue(valid1);
+
+    // When
+    boolean valid2 = filter1.tripTimesPredicate(tripTimes2);
+    // Then
     assertTrue(valid2);
 
-
+    // Given
     var filter2 = new RoutingRequestTransitDataProviderFilter(
         false,
         false,
@@ -184,10 +189,14 @@ public class RoutingRequestTransitDataProviderFilterTest {
         Set.of()
     );
 
+    // When
     boolean valid3 = filter2.tripTimesPredicate(tripTimes1);
-    boolean valid4 = filter2.tripTimesPredicate(tripTimes2);
-
+    // Then
     assertFalse(valid3);
+
+    // When
+    boolean valid4 = filter2.tripTimesPredicate(tripTimes2);
+    // Then
     assertFalse(valid4);
   }
 }

--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTest.java
@@ -365,6 +365,7 @@ public class SpeedTest {
         TransitDataProviderFilter transitDataProviderFilter = new RoutingRequestTransitDataProviderFilter(
                 false,
                 false,
+                false,
                 request.getTransitModes(),
                 Set.of()
         );


### PR DESCRIPTION
To be completed by pull request submitter:

- [ ] **issue**: Closes #3339
- [ ] **roadmap**: Check the [roadmap](https://github.com/orgs/opentripplanner/projects/1) for this feature or bug. If it is not already on the roadmap, PLC will discuss as part of the review process.
- [ ] **tests**: Have you added relevant test coverage? Are all the tests passing on [the continuous integration service (Travis CI)](https://github.com/opentripplanner/OpenTripPlanner/blob/2.0-rc/docs/Developers-Guide.md#continuous-integration)?
- [ ] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/2.0-rc/docs/Developers-Guide.md#code-style)? 
- [ ] **documentation**: If you are adding a new configuration option, have you added an explanation to the [configuration documentation](https://github.com/opentripplanner/OpenTripPlanner/blob/2.0-rc/docs/Configuration.md) tables and sections?
- [ ] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/2.0-rc/docs/Changelog.md) with description and link to the linked issue

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)

This PR builds on #3332

- Imports ServiceAlterations on ServiceJourney and saves them in a new field on Trip.
- Adds a new filter on TripTimes, using the functionality added in #3332, which allows cancelled trips to be filtered out.
- Adds includePlannedCancellations parameter in the transmodel api
- Removes an obsolete test and adds a new test
- Have the newWithFilteredTripTimes return null if all TripTimes are filtered out
- Have the filterActiveTripPatterns stream filter out all TripPatternForDate objects that are null