### PR TITLE
Add Direction enum to OTP model and add Netex mapping

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLPatternImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLPatternImpl.java
@@ -39,7 +39,7 @@ public class LegacyGraphQLPatternImpl implements LegacyGraphQLDataFetchers.Legac
 
   @Override
   public DataFetcher<Integer> directionId() {
-    return environment -> getSource(environment).directionId;
+    return environment -> getSource(environment).direction.gtfsCode;
   }
 
   @Override

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLPatternImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLPatternImpl.java
@@ -39,7 +39,7 @@ public class LegacyGraphQLPatternImpl implements LegacyGraphQLDataFetchers.Legac
 
   @Override
   public DataFetcher<Integer> directionId() {
-    return environment -> getSource(environment).direction.gtfsCode;
+    return environment -> getSource(environment).getDirection().gtfsCode;
   }
 
   @Override
@@ -54,7 +54,7 @@ public class LegacyGraphQLPatternImpl implements LegacyGraphQLDataFetchers.Legac
 
   @Override
   public DataFetcher<String> headsign() {
-    return environment -> getSource(environment).getDirection();
+    return environment -> getSource(environment).getTripHeadsign();
   }
 
   @Override

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLTripImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLTripImpl.java
@@ -79,7 +79,7 @@ public class LegacyGraphQLTripImpl implements LegacyGraphQLDataFetchers.LegacyGr
 
   @Override
   public DataFetcher<String> directionId() {
-    return environment -> getSource(environment).getDirectionIdAsString(null);
+    return environment -> getSource(environment).getGtfsDirectionIdAsString(null);
   }
 
   @Override

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTripPatternIdGenerator.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTripPatternIdGenerator.java
@@ -26,7 +26,7 @@ class SiriTripPatternIdGenerator {
   FeedScopedId generateUniqueTripPatternId(Trip trip) {
     Route route = trip.getRoute();
     FeedScopedId routeId = route.getId();
-    String directionId = trip.getDirectionIdAsString("");
+    String directionId = trip.getGtfsDirectionIdAsString("");
 
     // OBA library uses underscore as separator, we're moving toward colon.
     String id = String.format("%s:%s:%03d:RT", routeId.getId(), directionId, counter.incrementAndGet());

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/EnumTypes.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/EnumTypes.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.ext.transmodelapi.model;
 
 import graphql.schema.GraphQLEnumType;
+import org.opentripplanner.model.Direction;
 import org.opentripplanner.model.TransitMode;
 import org.opentripplanner.model.plan.AbsoluteDirection;
 import org.opentripplanner.model.plan.RelativeDirection;
@@ -238,11 +239,11 @@ public class EnumTypes {
 
     public static GraphQLEnumType DIRECTION_TYPE = GraphQLEnumType.newEnum()
             .name("DirectionType")
-            .value("unknown",-1)
-            .value("outbound", 0)
-            .value("inbound", 1)
-            .value("clockwise", 2)
-            .value("anticlockwise", 3)
+            .value("unknown", Direction.UNKNOWN)
+            .value("outbound", Direction.OUTBOUND)
+            .value("inbound", Direction.INBOUND)
+            .value("clockwise", Direction.CLOCKWISE)
+            .value("anticlockwise", Direction.ANTICLOCKWISE)
             .build();
 
     public static Object enumToString(GraphQLEnumType type, Enum<?> value) {

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/network/JourneyPatternType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/network/JourneyPatternType.java
@@ -42,7 +42,7 @@ public class JourneyPatternType {
         .field(GraphQLFieldDefinition.newFieldDefinition()
             .name("directionType")
             .type(EnumTypes.DIRECTION_TYPE)
-            .dataFetcher(environment -> ((TripPattern) environment.getSource()).directionId)
+            .dataFetcher(environment -> ((TripPattern) environment.getSource()).direction)
             .build())
         .field(GraphQLFieldDefinition.newFieldDefinition()
             .name("name")

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/network/JourneyPatternType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/network/JourneyPatternType.java
@@ -42,7 +42,7 @@ public class JourneyPatternType {
         .field(GraphQLFieldDefinition.newFieldDefinition()
             .name("directionType")
             .type(EnumTypes.DIRECTION_TYPE)
-            .dataFetcher(environment -> ((TripPattern) environment.getSource()).direction)
+            .dataFetcher(environment -> ((TripPattern) environment.getSource()).getDirection())
             .build())
         .field(GraphQLFieldDefinition.newFieldDefinition()
             .name("name")

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/ServiceJourneyType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/ServiceJourneyType.java
@@ -95,7 +95,7 @@ public class ServiceJourneyType {
             .field(GraphQLFieldDefinition.newFieldDefinition()
                     .name("directionType")
                     .type(EnumTypes.DIRECTION_TYPE)
-                    .dataFetcher(environment -> directionIdToInt(trip(environment).getDirectionId()))
+                    .dataFetcher(environment -> trip(environment).getDirection())
                     .build())
             .field(GraphQLFieldDefinition.newFieldDefinition()
                     .name("wheelchairAccessible")
@@ -210,9 +210,5 @@ public class ServiceJourneyType {
 
   private static Trip trip(DataFetchingEnvironment environment) {
     return environment.getSource();
-  }
-
-  private static int directionIdToInt(Integer directionId) {
-    return directionId == null ? -1 : directionId;
   }
 }

--- a/src/main/java/org/opentripplanner/api/mapping/TripMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/TripMapper.java
@@ -42,7 +42,7 @@ public class TripMapper {
 
         // TODO OTP2 - All ids should be fully qualified including feed scope id.
         api.shapeId = shape == null ? null : shape.getId();
-        api.direction = domain.getDirectionId();
+        api.direction = domain.getDirection().gtfsCode;
 
         return api;
     }

--- a/src/main/java/org/opentripplanner/api/mapping/TripMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/TripMapper.java
@@ -20,7 +20,7 @@ public class TripMapper {
         api.tripShortName = obj.getTripShortName();
         api.tripHeadsign = obj.getTripHeadsign();
         api.routeShortName = obj.getRouteShortName();
-        api.directionId = obj.getDirectionIdAsString(null);
+        api.directionId = obj.getGtfsDirectionIdAsString(null);
         api.blockId = obj.getBlockId();
         api.shapeId = FeedScopedIdMapper.mapToApi(obj.getShapeId());
         api.wheelchairAccessible = obj.getWheelchairAccessible();

--- a/src/main/java/org/opentripplanner/gtfs/GenerateTripPatternsOperation.java
+++ b/src/main/java/org/opentripplanner/gtfs/GenerateTripPatternsOperation.java
@@ -7,6 +7,7 @@ import org.opentripplanner.graph_builder.DataImportIssueStore;
 import org.opentripplanner.graph_builder.issues.GTFSModeNotSupported;
 import org.opentripplanner.graph_builder.issues.TripDegenerate;
 import org.opentripplanner.graph_builder.issues.TripUndefinedService;
+import org.opentripplanner.model.Direction;
 import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.model.Frequency;
 import org.opentripplanner.model.Route;
@@ -122,9 +123,9 @@ public class GenerateTripPatternsOperation {
         // Get the existing TripPattern for this filtered StopPattern, or create one.
         StopPattern stopPattern = new StopPattern(stopTimes);
 
-        Integer directionId = trip.getDirectionId();
+        Direction direction = trip.getDirection();
         TripPattern tripPattern = findOrCreateTripPattern(
-            stopPattern, trip.getRoute(), directionId == null ? -1 : directionId
+            stopPattern, trip.getRoute(), direction
         );
 
         // Create a TripTimes object for this list of stoptimes, which form one trip.
@@ -147,15 +148,15 @@ public class GenerateTripPatternsOperation {
         }
     }
 
-    private TripPattern findOrCreateTripPattern(StopPattern stopPattern, Route route, int directionId) {
+    private TripPattern findOrCreateTripPattern(StopPattern stopPattern, Route route, Direction direction) {
         for(TripPattern tripPattern : tripPatterns.get(stopPattern)) {
-            if(tripPattern.route.equals(route) && tripPattern.directionId == directionId) {
+            if(tripPattern.route.equals(route) && tripPattern.direction.equals(direction)) {
                 return tripPattern;
             }
         }
-        FeedScopedId patternId = generateUniqueIdForTripPattern(route, directionId);
+        FeedScopedId patternId = generateUniqueIdForTripPattern(route, direction.gtfsCode);
         TripPattern tripPattern = new TripPattern(patternId, route, stopPattern);
-        tripPattern.directionId = directionId;
+        tripPattern.direction = direction;
         tripPatterns.put(stopPattern, tripPattern);
         return tripPattern;
     }

--- a/src/main/java/org/opentripplanner/gtfs/GenerateTripPatternsOperation.java
+++ b/src/main/java/org/opentripplanner/gtfs/GenerateTripPatternsOperation.java
@@ -150,13 +150,12 @@ public class GenerateTripPatternsOperation {
 
     private TripPattern findOrCreateTripPattern(StopPattern stopPattern, Route route, Direction direction) {
         for(TripPattern tripPattern : tripPatterns.get(stopPattern)) {
-            if(tripPattern.route.equals(route) && tripPattern.direction.equals(direction)) {
+            if(tripPattern.route.equals(route) && tripPattern.getDirection().equals(direction)) {
                 return tripPattern;
             }
         }
         FeedScopedId patternId = generateUniqueIdForTripPattern(route, direction.gtfsCode);
         TripPattern tripPattern = new TripPattern(patternId, route, stopPattern);
-        tripPattern.direction = direction;
         tripPatterns.put(stopPattern, tripPattern);
         return tripPattern;
     }

--- a/src/main/java/org/opentripplanner/gtfs/mapping/TripMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/TripMapper.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.gtfs.mapping;
 
+import org.opentripplanner.model.Direction;
 import org.opentripplanner.model.Trip;
 import org.opentripplanner.util.MapUtils;
 import org.slf4j.Logger;
@@ -39,7 +40,7 @@ class TripMapper {
         lhs.setTripShortName(rhs.getTripShortName());
         lhs.setTripHeadsign(rhs.getTripHeadsign());
         lhs.setRouteShortName(rhs.getRouteShortName());
-        lhs.setDirectionId(mapDirectionId(rhs));
+        lhs.setDirection(Direction.valueOfGtfsCode(mapDirectionId(rhs)));
         lhs.setBlockId(rhs.getBlockId());
         lhs.setShapeId(AgencyAndIdMapper.mapAgencyAndId(rhs.getShapeId()));
         lhs.setWheelchairAccessible(rhs.getWheelchairAccessible());
@@ -51,16 +52,16 @@ class TripMapper {
     }
 
     @Nullable
-    private static Integer mapDirectionId(org.onebusaway.gtfs.model.Trip trip) {
+    private static int mapDirectionId(org.onebusaway.gtfs.model.Trip trip) {
         try {
             String directionId = trip.getDirectionId();
             if(directionId == null || directionId.isBlank()) {
-                return null;
+                return -1;
             }
             return Integer.parseInt(directionId);
         } catch (NumberFormatException e) {
             LOG.debug("Trip {} does not have direction id, defaults to -1", trip);
         }
-        return null;
+        return -1;
     }
 }

--- a/src/main/java/org/opentripplanner/model/Direction.java
+++ b/src/main/java/org/opentripplanner/model/Direction.java
@@ -1,7 +1,10 @@
 package org.opentripplanner.model;
 
 /**
- * The direction of travel for a TripPattern.
+ * The direction of travel for a TripPattern. This is mapped 1-to-1 in NeTEx, while in GTFS
+ * only values 0 and 1 are available, so they are mapped to OUTBOUND and INBOUND. When mapping
+ * from the model to the REST API, CLOCKWISE and ANTICLOCKWISE are also mapped to 0 and 1 (as they
+ * would also fit the description in the GTFS specification).
  */
 public enum Direction {
   UNKNOWN(-1),

--- a/src/main/java/org/opentripplanner/model/Direction.java
+++ b/src/main/java/org/opentripplanner/model/Direction.java
@@ -1,0 +1,26 @@
+package org.opentripplanner.model;
+
+public enum Direction {
+  UNKNOWN(-1),
+  OUTBOUND(0),
+  INBOUND(1),
+  CLOCKWISE(0),
+  ANTICLOCKWISE(1);
+
+  Direction(int gtfsCode) {
+    this.gtfsCode = gtfsCode;
+  }
+
+  public final int gtfsCode;
+
+  public static Direction valueOfGtfsCode(int gtfsCode) {
+    // Because the enum constant share gtfsCode values, this mapping will depend on the order
+    // they are declared.
+    for (Direction value : values()) {
+      if (value.gtfsCode == gtfsCode) {
+        return value;
+      }
+    }
+    throw new IllegalArgumentException("Unknown GTFS direction type: " + gtfsCode);
+  }
+}

--- a/src/main/java/org/opentripplanner/model/Direction.java
+++ b/src/main/java/org/opentripplanner/model/Direction.java
@@ -1,5 +1,8 @@
 package org.opentripplanner.model;
 
+/**
+ * The direction of travel for a TripPattern.
+ */
 public enum Direction {
   UNKNOWN(-1),
   OUTBOUND(0),
@@ -14,13 +17,13 @@ public enum Direction {
   public final int gtfsCode;
 
   public static Direction valueOfGtfsCode(int gtfsCode) {
-    // Because the enum constant share gtfsCode values, this mapping will depend on the order
-    // they are declared.
-    for (Direction value : values()) {
-      if (value.gtfsCode == gtfsCode) {
-        return value;
-      }
+    switch (gtfsCode) {
+      case 0:
+        return Direction.OUTBOUND;
+      case 1:
+        return Direction.INBOUND;
+      default:
+        return Direction.UNKNOWN;
     }
-    throw new IllegalArgumentException("Unknown GTFS direction type: " + gtfsCode);
   }
 }

--- a/src/main/java/org/opentripplanner/model/Trip.java
+++ b/src/main/java/org/opentripplanner/model/Trip.java
@@ -157,7 +157,7 @@ public final class Trip extends TransitEntity {
         return direction;
     }
 
-    public String getDirectionIdAsString(String unknownValue) {
+    public String getGtfsDirectionIdAsString(String unknownValue) {
         return direction.equals(Direction.UNKNOWN)
             ? unknownValue
             : Integer.toString(direction.gtfsCode);

--- a/src/main/java/org/opentripplanner/model/Trip.java
+++ b/src/main/java/org/opentripplanner/model/Trip.java
@@ -1,6 +1,8 @@
 /* This file is based on code copied from project OneBusAway, see the LICENSE file for further information. */
 package org.opentripplanner.model;
 
+import javax.validation.constraints.NotNull;
+
 public final class Trip extends TransitEntity {
 
     private static final long serialVersionUID = 1L;
@@ -19,7 +21,8 @@ public final class Trip extends TransitEntity {
 
     private String routeShortName;
 
-    private Direction direction;
+    @NotNull
+    private Direction direction = Direction.UNKNOWN;
 
     private String blockId;
 
@@ -145,6 +148,10 @@ public final class Trip extends TransitEntity {
         this.routeShortName = routeShortName;
     }
 
+    // TODO Consider moving this to the TripPattern class once we have refactored the transit model
+    /**
+     * The direction for this Trip (and all other Trips in this TripPattern).
+     */
     public Direction getDirection() {
         return direction;
     }

--- a/src/main/java/org/opentripplanner/model/Trip.java
+++ b/src/main/java/org/opentripplanner/model/Trip.java
@@ -158,7 +158,9 @@ public final class Trip extends TransitEntity {
     }
 
     public String getDirectionIdAsString(String unknownValue) {
-        return direction == null ? unknownValue : Integer.toString(direction.gtfsCode);
+        return direction.equals(Direction.UNKNOWN)
+            ? unknownValue
+            : Integer.toString(direction.gtfsCode);
     }
 
     public void setDirection(Direction direction) {

--- a/src/main/java/org/opentripplanner/model/Trip.java
+++ b/src/main/java/org/opentripplanner/model/Trip.java
@@ -152,6 +152,7 @@ public final class Trip extends TransitEntity {
     /**
      * The direction for this Trip (and all other Trips in this TripPattern).
      */
+    @NotNull
     public Direction getDirection() {
         return direction;
     }
@@ -161,7 +162,8 @@ public final class Trip extends TransitEntity {
     }
 
     public void setDirection(Direction direction) {
-        this.direction = direction;
+        // Enforce non-null
+        this.direction = direction != null ? direction : Direction.UNKNOWN;
     }
 
     public String getBlockId() {

--- a/src/main/java/org/opentripplanner/model/Trip.java
+++ b/src/main/java/org/opentripplanner/model/Trip.java
@@ -19,7 +19,7 @@ public final class Trip extends TransitEntity {
 
     private String routeShortName;
 
-    private Integer directionId;
+    private Direction direction;
 
     private String blockId;
 
@@ -49,7 +49,7 @@ public final class Trip extends TransitEntity {
         this.tripShortName = obj.tripShortName;
         this.tripHeadsign = obj.tripHeadsign;
         this.routeShortName = obj.routeShortName;
-        this.directionId = obj.directionId;
+        this.direction = obj.direction;
         this.blockId = obj.blockId;
         this.shapeId = obj.shapeId;
         this.wheelchairAccessible = obj.wheelchairAccessible;
@@ -145,16 +145,16 @@ public final class Trip extends TransitEntity {
         this.routeShortName = routeShortName;
     }
 
-    public Integer getDirectionId() {
-        return directionId;
+    public Direction getDirection() {
+        return direction;
     }
 
     public String getDirectionIdAsString(String unknownValue) {
-        return directionId == null ? unknownValue : Integer.toString(directionId);
+        return direction == null ? unknownValue : Integer.toString(direction.gtfsCode);
     }
 
-    public void setDirectionId(Integer directionId) {
-        this.directionId = directionId;
+    public void setDirection(Direction direction) {
+        this.direction = direction;
     }
 
     public String getBlockId() {

--- a/src/main/java/org/opentripplanner/model/TripPattern.java
+++ b/src/main/java/org/opentripplanner/model/TripPattern.java
@@ -71,7 +71,7 @@ public class TripPattern extends TransitEntity implements Cloneable, Serializabl
      * The direction id for all trips in this pattern.
      * Use -1 for default direction id
      */
-    public int directionId = -1;
+    public Direction direction = Direction.UNKNOWN;
 
     /**
      * All trips in this pattern call at this sequence of stops. This includes information about GTFS

--- a/src/main/java/org/opentripplanner/model/TripPattern.java
+++ b/src/main/java/org/opentripplanner/model/TripPattern.java
@@ -68,12 +68,6 @@ public class TripPattern extends TransitEntity implements Cloneable, Serializabl
     public final Route route;
 
     /**
-     * The direction id for all trips in this pattern.
-     * Use -1 for default direction id
-     */
-    public Direction direction = Direction.UNKNOWN;
-
-    /**
      * All trips in this pattern call at this sequence of stops. This includes information about GTFS
      * pick-up and drop-off types.
      */
@@ -352,6 +346,13 @@ public class TripPattern extends TransitEntity implements Cloneable, Serializabl
         this.originalTripPattern = originalTripPattern;
     }
 
+    /**
+     * The direction for all the trips in this pattern.
+     */
+    public Direction getDirection() {
+        return trips.get(0).getDirection();
+    }
+
     boolean isCreatedByRealtimeUpdater() {
         return createdByRealtimeUpdater;
     }
@@ -555,7 +556,7 @@ public class TripPattern extends TransitEntity implements Cloneable, Serializabl
         this.services = services;
     }
 
-    public String getDirection() {
+    public String getTripHeadsign() {
         return trips.get(0).getTripHeadsign();
     }
 

--- a/src/main/java/org/opentripplanner/netex/DirectionMapper.java
+++ b/src/main/java/org/opentripplanner/netex/DirectionMapper.java
@@ -1,0 +1,22 @@
+package org.opentripplanner.netex;
+
+import org.opentripplanner.model.Direction;
+import org.rutebanken.netex.model.DirectionTypeEnumeration;
+
+public class DirectionMapper {
+  public static Direction map(DirectionTypeEnumeration direction) {
+    if (direction == null) { return Direction.UNKNOWN; }
+    switch (direction) {
+      case INBOUND:
+        return Direction.INBOUND;
+      case OUTBOUND:
+        return Direction.OUTBOUND;
+      case CLOCKWISE:
+        return Direction.CLOCKWISE;
+      case ANTICLOCKWISE:
+        return Direction.ANTICLOCKWISE;
+      default:
+        return Direction.UNKNOWN;
+    }
+  }
+}

--- a/src/main/java/org/opentripplanner/netex/mapping/TripMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/TripMapper.java
@@ -104,9 +104,7 @@ class TripMapper {
 
     private DirectionTypeEnumeration resolveDirectionType(ServiceJourney serviceJourney) {
         Route netexRoute = lookUpNetexRoute(serviceJourney);
-        if (serviceJourney.getDirectionType() != null) {
-            return serviceJourney.getDirectionType();
-        } else if (netexRoute != null && netexRoute.getDirectionType() != null) {
+        if (netexRoute != null && netexRoute.getDirectionType() != null) {
             return netexRoute.getDirectionType();
         } else {
             return null;

--- a/src/main/java/org/opentripplanner/netex/mapping/TripMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/TripMapper.java
@@ -4,9 +4,10 @@ import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.model.Operator;
 import org.opentripplanner.model.Trip;
 import org.opentripplanner.model.impl.EntityById;
+import org.opentripplanner.netex.DirectionMapper;
 import org.opentripplanner.netex.index.api.ReadOnlyHierarchicalMap;
 import org.opentripplanner.netex.mapping.support.FeedScopedIdFactory;
-import org.opentripplanner.netex.mapping.support.ServiceAlterationFilter;
+import org.rutebanken.netex.model.DirectionTypeEnumeration;
 import org.rutebanken.netex.model.JourneyPattern;
 import org.rutebanken.netex.model.LineRefStructure;
 import org.rutebanken.netex.model.Route;
@@ -96,7 +97,20 @@ class TripMapper {
         trip.setTripShortName(serviceJourney.getPublicCode());
         trip.setTripOperator(findOperator(serviceJourney));
 
+        trip.setDirection(DirectionMapper.map(resolveDirectionType(serviceJourney)));
+
         return trip;
+    }
+
+    private DirectionTypeEnumeration resolveDirectionType(ServiceJourney serviceJourney) {
+        Route netexRoute = lookUpNetexRoute(serviceJourney);
+        if (serviceJourney.getDirectionType() != null) {
+            return serviceJourney.getDirectionType();
+        } else if (netexRoute != null && netexRoute.getDirectionType() != null) {
+            return netexRoute.getDirectionType();
+        } else {
+            return null;
+        }
     }
 
     @Nullable
@@ -109,6 +123,20 @@ class TripMapper {
             : null;
 
     return shapePointIds.contains(serviceLinkId) ? serviceLinkId : null;
+    }
+
+    private Route lookUpNetexRoute(ServiceJourney serviceJourney) {
+        if(serviceJourney.getJourneyPatternRef() != null) {
+            JourneyPattern journeyPattern = journeyPatternsById.lookup(serviceJourney
+                .getJourneyPatternRef()
+                .getValue()
+                .getRef());
+            if (journeyPattern != null && journeyPattern.getRouteRef() != null) {
+                String routeRef = journeyPattern.getRouteRef().getRef();
+                return routeById.lookup(routeRef);
+            }
+        }
+        return null;
     }
 
     private org.opentripplanner.model.Route resolveRoute(ServiceJourney serviceJourney) {

--- a/src/main/java/org/opentripplanner/updater/GtfsRealtimeFuzzyTripMatcher.java
+++ b/src/main/java/org/opentripplanner/updater/GtfsRealtimeFuzzyTripMatcher.java
@@ -80,7 +80,7 @@ public class GtfsRealtimeFuzzyTripMatcher {
             this.servicesRunningForDate = routingService.getServicesRunningForDate(date);
         }
         for (TripPattern pattern : routingService.getPatternsForRoute().get(route)) {
-            if (pattern.direction.gtfsCode != direction) continue;
+            if (pattern.getDirection().gtfsCode != direction) continue;
             for (TripTimes times : pattern.scheduledTimetable.tripTimes) {
                 if (times.getScheduledDepartureTime(0) == startTime &&
                         servicesRunningForDate.get(times.serviceCode)) {

--- a/src/main/java/org/opentripplanner/updater/GtfsRealtimeFuzzyTripMatcher.java
+++ b/src/main/java/org/opentripplanner/updater/GtfsRealtimeFuzzyTripMatcher.java
@@ -80,7 +80,7 @@ public class GtfsRealtimeFuzzyTripMatcher {
             this.servicesRunningForDate = routingService.getServicesRunningForDate(date);
         }
         for (TripPattern pattern : routingService.getPatternsForRoute().get(route)) {
-            if (pattern.directionId != direction) continue;
+            if (pattern.direction.gtfsCode != direction) continue;
             for (TripTimes times : pattern.scheduledTimetable.tripTimes) {
                 if (times.getScheduledDepartureTime(0) == startTime &&
                         servicesRunningForDate.get(times.serviceCode)) {

--- a/src/main/java/org/opentripplanner/updater/stoptime/TripPatternCache.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/TripPatternCache.java
@@ -79,7 +79,7 @@ public class TripPatternCache {
      */
     private FeedScopedId generateUniqueTripPatternCode(Trip trip) {
         FeedScopedId routeId = trip.getRoute().getId();
-        String directionId = trip.getDirectionIdAsString("");
+        String directionId = trip.getGtfsDirectionIdAsString("");
         if (counter == Integer.MAX_VALUE) {
             counter = 0;
         } else {

--- a/src/test/java/org/opentripplanner/gtfs/mapping/TripMapperTest.java
+++ b/src/test/java/org/opentripplanner/gtfs/mapping/TripMapperTest.java
@@ -22,7 +22,7 @@ public class TripMapperTest {
 
     private static final String BLOCK_ID = "Block Id";
 
-    private static final Integer DIRECTION_ID = 1;
+    private static final int DIRECTION_ID = 1;
 
     private static final String FARE_ID = "Fare Id";
 
@@ -74,7 +74,7 @@ public class TripMapperTest {
         assertEquals("A:1", result.getId().toString());
         assertEquals(BIKES_ALLOWED, result.getBikesAllowed());
         assertEquals(BLOCK_ID, result.getBlockId());
-        assertEquals(DIRECTION_ID, result.getDirectionId());
+        assertEquals(DIRECTION_ID, result.getDirection().gtfsCode);
         assertEquals(FARE_ID, result.getFareId());
         assertNotNull(result.getRoute());
         assertEquals(ROUTE_SHORT_NAME, result.getRouteShortName());
@@ -96,7 +96,6 @@ public class TripMapperTest {
         assertNotNull(result.getId());
         assertEquals(0, result.getBikesAllowed());
         assertNull(result.getBlockId());
-        assertNull(result.getDirectionId());
         assertNull(result.getFareId());
         assertNull(result.getRoute());
         assertNull(result.getRouteShortName());
@@ -104,6 +103,7 @@ public class TripMapperTest {
         assertNull(result.getShapeId());
         assertNull(result.getTripHeadsign());
         assertNull(result.getTripShortName());
+        assertEquals(-1, result.getDirection().gtfsCode);
         assertEquals(0, result.getWheelchairAccessible());
         assertEquals(0, result.getTripBikesAllowed());
     }

--- a/src/test/java/org/opentripplanner/model/impl/OtpTransitServiceBuilderLimitPeriodTest.java
+++ b/src/test/java/org/opentripplanner/model/impl/OtpTransitServiceBuilderLimitPeriodTest.java
@@ -2,6 +2,7 @@ package org.opentripplanner.model.impl;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.opentripplanner.model.Direction;
 import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.model.Route;
 import org.opentripplanner.model.Stop;
@@ -188,7 +189,7 @@ public class OtpTransitServiceBuilderLimitPeriodTest {
     private Trip createTrip(String id, FeedScopedId serviceId) {
         Trip trip = new Trip(new FeedScopedId(FEED_ID, id));
         trip.setServiceId(serviceId);
-        trip.setDirectionId(1);
+        trip.setDirection(Direction.valueOfGtfsCode(1));
         trip.setRoute(route);
         return trip;
     }

--- a/src/test/java/org/opentripplanner/netex/NetexBundleSmokeTest.java
+++ b/src/test/java/org/opentripplanner/netex/NetexBundleSmokeTest.java
@@ -136,7 +136,7 @@ public class NetexBundleSmokeTest {
     private void assertTripPatterns(Collection<TripPattern> patterns) {
         Map<FeedScopedId, TripPattern> map = patterns.stream().collect(Collectors.toMap(TripPattern::getId, s -> s));
         TripPattern p = map.get(fId("RUT:JourneyPattern:12-1"));
-        assertEquals("Jernbanetorget", p.getDirection());
+        assertEquals("Jernbanetorget", p.getTripHeadsign());
         assertEquals("RB", p.getFeedId());
         assertEquals("[<Stop RB:NSR:Quay:7203>, <Stop RB:NSR:Quay:8027>]", p.getStops().toString());
         assertEquals("[<Trip RB:RUT:ServiceJourney:12-101375-1000>]", p.getTrips().toString());


### PR DESCRIPTION
To be completed by pull request submitter:

- [ ] **issue**: Link to or create an [issue](https://github.com/opentripplanner/OpenTripPlanner/issues) that describes the relevant feature or bug. Add [GitHub keywords](https://help.github.com/articles/closing-issues-using-keywords/) to this PR's description (e.g., `closes #45`).
- [ ] **roadmap**: Check the [roadmap](https://github.com/orgs/opentripplanner/projects/1) for this feature or bug. If it is not already on the roadmap, PLC will discuss as part of the review process.
- [ ] **tests**: Have you added relevant test coverage? Are all the tests passing on [the continuous integration service (Travis CI)](https://github.com/opentripplanner/OpenTripPlanner/blob/2.0-rc/docs/Developers-Guide.md#continuous-integration)?
- [ ] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/2.0-rc/docs/Developers-Guide.md#code-style)? 
- [ ] **documentation**: If you are adding a new configuration option, have you added an explanation to the [configuration documentation](https://github.com/opentripplanner/OpenTripPlanner/blob/2.0-rc/docs/Configuration.md) tables and sections?
- [ ] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/2.0-rc/docs/Changelog.md) with description and link to the linked issue

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)

This changed the `directionId` field in the `Trip` class to a new `Direction` enum.

>   UNKNOWN(-1),
>   OUTBOUND(0),
>   INBOUND(1),
>   CLOCKWISE(0),
>   ANTICLOCKWISE(1);

GTFS fields 0 and 1 are mapped to OUTBOUND and INBOUND. In addition CLOCKWISE and ANTICLOCKWISE are mapped to 0 and 1. This follows from the GTFS specification.

> 0 - Travel in one direction (e.g. outbound travel).
> 1 - Travel in the opposite direction (e.g. inbound travel).