### PR TITLE
RAPTOR: migrate TripPatternForDate#tripTimes to a List

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/mappers/TripPatternForDateMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/mappers/TripPatternForDateMapper.java
@@ -99,9 +99,10 @@ public class TripPatternForDateMapper {
             return null;
         }
 
-        return new TripPatternForDate(newTripPatternForOld.get(oldTripPattern),
-                times.toArray(TripTimes[]::new),
-                ServiceCalendarMapper.localDateFromServiceDate(serviceDate)
+        return new TripPatternForDate(
+            newTripPatternForOld.get(oldTripPattern),
+            times,
+            ServiceCalendarMapper.localDateFromServiceDate(serviceDate)
         );
     }
 }

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptor/transit/request/RaptorRoutingRequestTransitDataCreatorTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptor/transit/request/RaptorRoutingRequestTransitDataCreatorTest.java
@@ -33,7 +33,7 @@ public class RaptorRoutingRequestTransitDataCreatorTest {
 
     ZonedDateTime startOfTime = DateMapper.asStartOfService(second, ZoneId.of("Europe/London"));
 
-    TripTimes[] tripTimes = new TripTimes[] {createTripTimesForTest()};
+    List<TripTimes> tripTimes = List.of(createTripTimesForTest());
 
     // Total available trip patterns
     TripPatternWithRaptorStopIndexes tripPattern1 = new TripPatternWithId(TP_ID_1, null, null);

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptor/transit/request/RoutingRequestTransitDataProviderFilterTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptor/transit/request/RoutingRequestTransitDataProviderFilterTest.java
@@ -132,7 +132,7 @@ public class RoutingRequestTransitDataProviderFilterTest {
 
     TripTimes tripTimes = Mockito.mock(TripTimes.class);
 
-    return new TripPatternForDate(tripPattern, new TripTimes[] {tripTimes}, LocalDate.now());
+    return new TripPatternForDate(tripPattern, List.of(tripTimes), LocalDate.now());
   }
 
   private TripTimes createTestTripTimes() {


### PR DESCRIPTION
This updates `TripPatternForDate#tripTimes` to contain a `List<TripTimes>` instead of an array so as to make the code cleaner based on comments in https://github.com/opentripplanner/OpenTripPlanner/pull/3332#discussion_r568939735.

The performance implications of this change have not yet been tested.

To be completed by pull request submitter:

- [ ] **issue**: #3324
- [ ] **roadmap**: Check the [roadmap](https://github.com/orgs/opentripplanner/projects/1) for this feature or bug. If it is not already on the roadmap, PLC will discuss as part of the review process.
- [ ] **tests**: Have you added relevant test coverage? Are all the tests passing on [the continuous integration service (Travis CI)](https://github.com/opentripplanner/OpenTripPlanner/blob/2.0-rc/docs/Developers-Guide.md#continuous-integration)?
- [ ] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/2.0-rc/docs/Developers-Guide.md#code-style)? 
- [ ] **documentation**: If you are adding a new configuration option, have you added an explanation to the [configuration documentation](https://github.com/opentripplanner/OpenTripPlanner/blob/2.0-rc/docs/Configuration.md) tables and sections?
- [ ] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/2.0-rc/docs/Changelog.md) with description and link to the linked issue

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)