### PR TITLE
RAPTOR: keep track of used RaptorTransfers during traversal

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
@@ -15,6 +15,7 @@ import org.opentripplanner.routing.algorithm.raptor.transit.AccessEgress;
 import org.opentripplanner.routing.algorithm.raptor.transit.Transfer;
 import org.opentripplanner.routing.algorithm.raptor.transit.TransitLayer;
 import org.opentripplanner.routing.algorithm.raptor.transit.TripSchedule;
+import org.opentripplanner.routing.algorithm.raptor.transit.request.TransferWithDuration;
 import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.core.StateEditor;
@@ -201,7 +202,7 @@ public class RaptorPathToItineraryMapper {
     private List<Leg> mapTransferLeg(TransferPathLeg<TripSchedule> pathLeg) {
         Stop transferFromStop = transitLayer.getStopByIndex(pathLeg.fromStop());
         Stop transferToStop = transitLayer.getStopByIndex(pathLeg.toStop());
-        Transfer transfer = transitLayer.getTransferByStopIndex().get(pathLeg.fromStop()).stream().filter(t -> t.getToStop() == pathLeg.toStop()).findFirst().get();
+        Transfer transfer = ((TransferWithDuration) pathLeg.transfer()).transfer();
 
         Place from = mapStopToPlace(transferFromStop, null);
         Place to = mapStopToPlace(transferToStop, null);

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/request/TransferWithDuration.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/request/TransferWithDuration.java
@@ -14,6 +14,10 @@ public class TransferWithDuration implements RaptorTransfer {
         this.durationSeconds = (int) Math.round(transfer.getEffectiveWalkDistanceMeters() / walkSpeed);
     }
 
+    public Transfer transfer() {
+        return transfer;
+    }
+
     @Override
     public int stop() {
         return transfer.getToStop();

--- a/src/main/java/org/opentripplanner/transit/raptor/api/path/TransferPathLeg.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/path/TransferPathLeg.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.transit.raptor.api.path;
 
+import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
 
 import java.util.Objects;
@@ -13,10 +14,16 @@ public final class TransferPathLeg<T extends RaptorTripSchedule> extends Interme
 
     private final PathLeg<T> next;
 
+    private final RaptorTransfer transfer;
 
-    public TransferPathLeg(int fromStop, int fromTime, int toStop, int toTime, int cost, PathLeg<T> next) {
+    public TransferPathLeg(int fromStop, int fromTime, int toStop, int toTime, int cost, RaptorTransfer transfer, PathLeg<T> next) {
         super(fromStop, fromTime, toStop, toTime, cost);
+        this.transfer = transfer;
         this.next = next;
+    }
+
+    public final RaptorTransfer transfer() {
+        return transfer;
     }
 
     @Override

--- a/src/main/java/org/opentripplanner/transit/raptor/api/view/TransferPathView.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/view/TransferPathView.java
@@ -1,10 +1,16 @@
 package org.opentripplanner.transit.raptor.api.view;
 
+import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
+
 /**
  * Provide transfer path information to debugger and path mapping.
  */
 public interface TransferPathView {
 
+  RaptorTransfer transfer();
+
   /** The transfer duration in seconds */
-  int durationInSeconds();
+  default int durationInSeconds() {
+    return transfer().durationInSeconds();
+  }
 }

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/arrivals/TransferStopArrival.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/arrivals/TransferStopArrival.java
@@ -10,6 +10,8 @@ import org.opentripplanner.transit.raptor.api.view.TransferPathView;
  */
 public final class TransferStopArrival<T extends RaptorTripSchedule> extends AbstractStopArrival<T> {
 
+    private final RaptorTransfer transfer;
+
     public TransferStopArrival(
         AbstractStopArrival<T> previousState,
         RaptorTransfer transferPath,
@@ -22,6 +24,7 @@ public final class TransferStopArrival<T extends RaptorTripSchedule> extends Abs
                 arrivalTime,
                 additionalCost
         );
+        this.transfer = transferPath;
     }
 
     @Override
@@ -31,12 +34,6 @@ public final class TransferStopArrival<T extends RaptorTripSchedule> extends Abs
 
     @Override
     public TransferPathView transferPath() {
-        return this::durationInSeconds;
-    }
-
-    private int durationInSeconds() {
-        // We do not keep the reference to the TransitLayer transfer(RaptorTransfer),
-        // so we compute the duration.
-        return arrivalTime() - previous().arrivalTime();
+        return () -> transfer;
     }
 }

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/path/ForwardPathMapper.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/path/ForwardPathMapper.java
@@ -92,6 +92,7 @@ public final class ForwardPathMapper<T extends RaptorTripSchedule> implements Pa
                 arrival.stop(),
                 arrival.arrivalTime(),
                 domainCost(arrival),
+                arrival.transferPath().transfer(),
                 nextLeg
         );
     }

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/path/ReversePathMapper.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/path/ReversePathMapper.java
@@ -129,6 +129,7 @@ public final class ReversePathMapper<T extends RaptorTripSchedule> implements Pa
                 toStopArrival.stop(),
                 targetArrivalTime,
                 domainCost(fromStopArrival),
+                fromStopArrival.transferPath().transfer(),
                 mapToTransit(toStopArrival)
         );
     }

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/stoparrivals/AccessStopArrivalState.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/stoparrivals/AccessStopArrivalState.java
@@ -6,26 +6,18 @@ import org.opentripplanner.util.time.TimeUtils;
 
 public class AccessStopArrivalState<T extends RaptorTripSchedule> extends StopArrivalState<T> {
 
-  private final RaptorTransfer accessPath;
-
   public AccessStopArrivalState(int time, RaptorTransfer accessPath) {
-    this.accessPath = accessPath;
-    setAccessTime(time, accessPath.durationInSeconds());
+    setAccessTime(time, accessPath);
   }
 
   public AccessStopArrivalState(int time, RaptorTransfer accessPath, StopArrivalState<T> other) {
     super(other);
-    this.accessPath = accessPath;
-    setAccessTime(time, accessPath.durationInSeconds());
+    setAccessTime(time, accessPath);
   }
 
   @Override
   public final boolean arrivedByAccess() {
     return true;
-  }
-
-  public RaptorTransfer accessPath() {
-    return accessPath;
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/stoparrivals/StopArrivalState.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/stoparrivals/StopArrivalState.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.transit.raptor.rangeraptor.standard.stoparrivals;
 
+import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
 import org.opentripplanner.util.time.DurationUtils;
 import org.opentripplanner.transit.raptor.util.IntUtils;
@@ -40,7 +41,7 @@ public class StopArrivalState<T extends RaptorTripSchedule> {
 
     // Transfer (and access)
     private int transferFromStop = NOT_SET;
-    private int accessOrTransferDuration = NOT_SET;
+    private RaptorTransfer accessOrTransferPath = null;
 
     StopArrivalState(StopArrivalState<T> other) {
         this.bestArrivalTime = other.bestArrivalTime;
@@ -49,7 +50,7 @@ public class StopArrivalState<T extends RaptorTripSchedule> {
         this.boardTime = other.boardTime;
         this.boardStop = other.boardStop;
         this.transferFromStop = other.transferFromStop;
-        this.accessOrTransferDuration = other.accessOrTransferDuration;
+        this.accessOrTransferPath = other.accessOrTransferPath;
     }
 
     public StopArrivalState() { }
@@ -58,8 +59,12 @@ public class StopArrivalState<T extends RaptorTripSchedule> {
         return bestArrivalTime;
     }
 
+    public RaptorTransfer accessPath() {
+        return accessOrTransferPath;
+    }
+
     public final int accessDuration() {
-        return accessOrTransferDuration;
+        return accessOrTransferPath.durationInSeconds();
     }
 
     public final int transitTime() {
@@ -83,7 +88,7 @@ public class StopArrivalState<T extends RaptorTripSchedule> {
     }
 
     public final int transferDuration() {
-        return accessOrTransferDuration;
+        return accessOrTransferPath.durationInSeconds();
     }
 
     public boolean arrivedByAccess() {
@@ -98,9 +103,13 @@ public class StopArrivalState<T extends RaptorTripSchedule> {
         return transferFromStop != NOT_SET;
     }
 
-    void setAccessTime(int time, int accessDuration) {
+    public final RaptorTransfer transferPath() {
+        return accessOrTransferPath;
+    }
+
+    void setAccessTime(int time, RaptorTransfer accessPath) {
         this.bestArrivalTime = time;
-        this.accessOrTransferDuration = accessDuration;
+        this.accessOrTransferPath = accessPath;
     }
 
     final boolean reached() {
@@ -123,10 +132,10 @@ public class StopArrivalState<T extends RaptorTripSchedule> {
     /**
      * Set the time at a transit index iff it is optimal. This sets both the best time and the transfer time
      */
-    public final void transferToStop(int fromStop, int arrivalTime, int transferTime) {
+    public final void transferToStop(int fromStop, int arrivalTime, RaptorTransfer transferPath) {
         this.bestArrivalTime = arrivalTime;
         this.transferFromStop = fromStop;
-        this.accessOrTransferDuration = transferTime;
+        this.accessOrTransferPath = transferPath;
     }
 
     public AccessStopArrivalState<T> asAccessStopArrivalState() {
@@ -142,7 +151,7 @@ public class StopArrivalState<T extends RaptorTripSchedule> {
                 TimeUtils.timeToStrCompact(transitArrivalTime, NOT_SET),
                 trip == null ? "" : trip.pattern().debugInfo(),
                 IntUtils.intToString(transferFromStop, NOT_SET),
-          DurationUtils.durationToStr(accessOrTransferDuration, NOT_SET)
+          accessOrTransferPath != null ? DurationUtils.durationToStr(accessOrTransferPath.durationInSeconds(), NOT_SET) : ""
         );
     }
 }

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/stoparrivals/Stops.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/stoparrivals/Stops.java
@@ -93,7 +93,7 @@ public final class Stops<T extends RaptorTripSchedule> implements BestNumberOfTr
         int stop = transfer.stop();
         StopArrivalState<T> state = findOrCreateStopIndex(round(), stop);
 
-        state.transferToStop(fromStop, arrivalTime, transfer.durationInSeconds());
+        state.transferToStop(fromStop, arrivalTime, transfer);
     }
 
     void transitToStop(int stop, int time, int boardStop, int boardTime, T trip, boolean bestTime) {

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/stoparrivals/view/StopsCursor.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/stoparrivals/view/StopsCursor.java
@@ -52,7 +52,7 @@ public class StopsCursor<T extends RaptorTripSchedule> {
      */
     public Transfer<T> rejectedTransfer(int round, int fromStop, RaptorTransfer transfer, int toStop, int arrivalTime) {
         StopArrivalState<T> arrival = new StopArrivalState<>();
-        arrival.transferToStop(fromStop, arrivalTime, transfer.durationInSeconds());
+        arrival.transferToStop(fromStop, arrivalTime, transfer);
         return new Transfer<>(round, toStop, arrival, this);
     }
 

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/stoparrivals/view/Transfer.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/stoparrivals/view/Transfer.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.transit.raptor.rangeraptor.standard.stoparrivals.view;
 
+import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
 import org.opentripplanner.transit.raptor.api.view.ArrivalView;
 import org.opentripplanner.transit.raptor.api.view.TransferPathView;
@@ -36,6 +37,11 @@ final class Transfer<T extends RaptorTripSchedule>
     @Override
     public int durationInSeconds() {
         return arrival.transferDuration();
+    }
+
+    @Override
+    public RaptorTransfer transfer() {
+        return arrival.transferPath();
     }
 
     @Override

--- a/src/test/java/org/opentripplanner/transit/raptor/_data/stoparrival/StopArrivalsTestData.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/_data/stoparrival/StopArrivalsTestData.java
@@ -137,6 +137,16 @@ public class StopArrivalsTestData implements RaptorTestConstants {
      * here returned as a path.
      */
     public static Path<TestTripSchedule> basicTripAsPath() {
+        var transfer = new RaptorTransfer() {
+            @Override public int stop() {
+                return STOP_3;
+            }
+
+            @Override public int durationInSeconds() {
+                return W1_END - W1_START;
+            }
+        };
+
         PathLeg<TestTripSchedule> leg6 = new EgressPathLeg<>(
                 EGRESS, STOP_5, E_START, E_END, 1_000
         );
@@ -147,7 +157,7 @@ public class StopArrivalsTestData implements RaptorTestConstants {
             STOP_3, T2_START, STOP_4, T2_END, 1_000, TRIP_2, leg5
         );
         PathLeg<TestTripSchedule> leg3 = new TransferPathLeg<>(
-            STOP_2, W1_START, STOP_3, W1_END, 1_000, leg4.asTransitLeg()
+            STOP_2, W1_START, STOP_3, W1_END, 1_000, transfer, leg4.asTransitLeg()
         );
         TransitPathLeg<TestTripSchedule> leg2 = new TransitPathLeg<>(
             STOP_1, T1_START, STOP_2, T1_END, 1_000, TRIP_1, leg3

--- a/src/test/java/org/opentripplanner/transit/raptor/_data/stoparrival/Walk.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/_data/stoparrival/Walk.java
@@ -1,11 +1,12 @@
 package org.opentripplanner.transit.raptor._data.stoparrival;
 
 import org.opentripplanner.transit.raptor._data.transit.TestTripSchedule;
+import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
 import org.opentripplanner.transit.raptor.api.view.ArrivalView;
 import org.opentripplanner.transit.raptor.api.view.TransferPathView;
 
 class Walk extends AbstractStopArrival {
-    private final int durationInSeconds;
+    private final RaptorTransfer transfer;
 
     Walk(
         int round,
@@ -16,7 +17,15 @@ class Walk extends AbstractStopArrival {
     ) {
         super(round, stop, arrivalTime, 1000, previous);
         // In a reverse search we the arrival is before the departure
-        this.durationInSeconds = Math.abs(arrivalTime - departureTime);
+        this.transfer = new RaptorTransfer() {
+            @Override public int stop() {
+                return stop;
+            }
+
+            @Override public int durationInSeconds() {
+                return Math.abs(arrivalTime - departureTime);
+            }
+        };
     }
 
     @Override public boolean arrivedByTransfer() {
@@ -24,6 +33,6 @@ class Walk extends AbstractStopArrival {
     }
 
     @Override public TransferPathView transferPath() {
-        return () -> durationInSeconds;
+        return () -> transfer;
     }
 }


### PR DESCRIPTION
Currently RAPTOR paths don't contain the `RaptorTransfer` actually used, so `TransferPathLeg` leg is modified to contain a reference to the `RaptorTransfer` which was used to construct it.

This allows the itinerary generation from the paths to be cleaner since there is an explicit transfer object to use (`RaptorPathToItineraryMapper#mapTransferLeg`).

To be completed by pull request submitter:

- [ ] **issue**: #3324
- [ ] **roadmap**: Check the [roadmap](https://github.com/orgs/opentripplanner/projects/1) for this feature or bug. If it is not already on the roadmap, PLC will discuss as part of the review process.
- [ ] **tests**: Have you added relevant test coverage? Are all the tests passing on [the continuous integration service (Travis CI)](https://github.com/opentripplanner/OpenTripPlanner/blob/2.0-rc/docs/Developers-Guide.md#continuous-integration)?
- [ ] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/2.0-rc/docs/Developers-Guide.md#code-style)? 
- [ ] **documentation**: If you are adding a new configuration option, have you added an explanation to the [configuration documentation](https://github.com/opentripplanner/OpenTripPlanner/blob/2.0-rc/docs/Configuration.md) tables and sections?
- [ ] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/2.0-rc/docs/Changelog.md) with description and link to the linked issue

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)