### PR TITLE
Otp2 speed test imprive graph loding

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/EnumTypes.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/EnumTypes.java
@@ -3,13 +3,14 @@ package org.opentripplanner.ext.transmodelapi.model;
 import graphql.schema.GraphQLEnumType;
 import org.opentripplanner.model.Direction;
 import org.opentripplanner.model.TransitMode;
+import org.opentripplanner.model.TripAlteration;
 import org.opentripplanner.model.plan.AbsoluteDirection;
 import org.opentripplanner.model.plan.RelativeDirection;
 import org.opentripplanner.model.plan.VertexType;
-import org.opentripplanner.routing.core.BicycleOptimizeType;
 import org.opentripplanner.routing.alertpatch.StopCondition;
-import org.opentripplanner.routing.core.TraverseMode;
 import org.opentripplanner.routing.api.request.StreetMode;
+import org.opentripplanner.routing.core.BicycleOptimizeType;
+import org.opentripplanner.routing.core.TraverseMode;
 import org.opentripplanner.routing.trippattern.RealTimeState;
 
 import java.util.Arrays;
@@ -245,6 +246,15 @@ public class EnumTypes {
             .value("clockwise", Direction.CLOCKWISE)
             .value("anticlockwise", Direction.ANTICLOCKWISE)
             .build();
+
+
+    public static GraphQLEnumType SERVICE_ALTERATION_TYPE = GraphQLEnumType.newEnum()
+        .name("ServiceAlteration")
+        .value("cancellation", TripAlteration.CANCELLATION)
+        .value("replaced", TripAlteration.REPLACED)
+        .value("extraJourney", TripAlteration.EXTRA_JOURNEY)
+        .value("planned", TripAlteration.PLANNED)
+        .build();
 
     public static Object enumToString(GraphQLEnumType type, Enum<?> value) {
         return type.getCoercing().serialize(value);

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/network/LineType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/network/LineType.java
@@ -15,6 +15,7 @@ import org.opentripplanner.ext.transmodelapi.support.GqlUtil;
 import org.opentripplanner.model.Route;
 import org.opentripplanner.model.Trip;
 import org.opentripplanner.model.TripPattern;
+import org.opentripplanner.util.OTPFeature;
 
 import java.util.Collection;
 import java.util.List;
@@ -130,13 +131,14 @@ public class LineType {
                           .distinct()
                           .collect(Collectors.toList());
 
-                      // Workaround since flex trips are not part of patterns yet
-                      result.addAll(GqlUtil.getRoutingService(environment).getFlexIndex().tripById
-                          .values()
-                          .stream()
-                          .filter(t -> t.getRoute().equals((Route) environment.getSource()))
-                          .collect(Collectors.toList()));
-
+                      if(OTPFeature.FlexRouting.isOn()) {
+                        // Workaround since flex trips are not part of patterns yet
+                        result.addAll(GqlUtil.getRoutingService(environment).getFlexIndex().tripById
+                            .values()
+                            .stream()
+                            .filter(t -> t.getRoute().equals((Route) environment.getSource()))
+                            .collect(Collectors.toList()));
+                      }
                       return result;
                     })
                     .build())

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/ServiceJourneyType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/ServiceJourneyType.java
@@ -98,6 +98,16 @@ public class ServiceJourneyType {
                     .dataFetcher(environment -> trip(environment).getDirection())
                     .build())
             .field(GraphQLFieldDefinition.newFieldDefinition()
+                .name("serviceAlteration")
+                .deprecate(
+                    "The service journey alteration will be moved out of SJ and grouped "
+                    + "together with the SJ and date. In Netex this new type is called "
+                    + "DatedServiceJourney. We will create artificial DSJs for the old SJs."
+                )
+                .type(EnumTypes.SERVICE_ALTERATION_TYPE)
+                .dataFetcher(environment -> trip(environment).getTripAlteration())
+                .build())
+            .field(GraphQLFieldDefinition.newFieldDefinition()
                     .name("wheelchairAccessible")
                     .type(EnumTypes.WHEELCHAIR_BOARDING)
                     .description("Whether service journey is accessible with wheelchair.")

--- a/src/main/java/org/opentripplanner/netex/issues/DayTypeScheduleIsEmpty.java
+++ b/src/main/java/org/opentripplanner/netex/issues/DayTypeScheduleIsEmpty.java
@@ -1,0 +1,16 @@
+package org.opentripplanner.netex.issues;
+
+import org.opentripplanner.graph_builder.DataImportIssue;
+
+public class DayTypeScheduleIsEmpty implements DataImportIssue {
+  private final String dayTypeId;
+
+  public DayTypeScheduleIsEmpty(String dayTypeId) {
+    this.dayTypeId = dayTypeId;
+  }
+
+  @Override
+  public String getMessage() {
+    return String.format("DayType calendar(set of operating days) is empty. DayType=%s.", dayTypeId);
+  }
+}

--- a/src/main/java/org/opentripplanner/netex/issues/ObjectNotFound.java
+++ b/src/main/java/org/opentripplanner/netex/issues/ObjectNotFound.java
@@ -2,14 +2,14 @@ package org.opentripplanner.netex.issues;
 
 import org.opentripplanner.graph_builder.DataImportIssue;
 
-public class ObjecctNotFound implements DataImportIssue {
+public class ObjectNotFound implements DataImportIssue {
 
   private final String sourceType;
   private final String sourceId;
   private final String targetFieldName;
   private final String missingTargetId;
 
-  public ObjecctNotFound(
+  public ObjectNotFound(
       String sourceType,
       String sourceId,
       String targetFieldName,

--- a/src/main/java/org/opentripplanner/netex/mapping/TripCalendarBuilder.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/TripCalendarBuilder.java
@@ -6,7 +6,7 @@ import org.opentripplanner.model.calendar.ServiceDate;
 import org.opentripplanner.netex.index.api.ReadOnlyHierarchicalMap;
 import org.opentripplanner.netex.index.api.ReadOnlyHierarchicalMapById;
 import org.opentripplanner.netex.index.hierarchy.HierarchicalMap;
-import org.opentripplanner.netex.issues.ObjecctNotFound;
+import org.opentripplanner.netex.issues.ObjectNotFound;
 import org.opentripplanner.netex.mapping.calendar.CalendarServiceBuilder;
 import org.opentripplanner.netex.mapping.calendar.DatedServiceJourneyMapper;
 import org.opentripplanner.netex.mapping.calendar.DayTypeAssignmentMapper;
@@ -67,7 +67,8 @@ public class TripCalendarBuilder {
             dayTypeById,
             dayTypeAssignmentByDayTypeId,
             operatingDays,
-            operatingPeriodById
+            operatingPeriodById,
+            issueStore
         )
     );
   }
@@ -139,7 +140,7 @@ public class TripCalendarBuilder {
 
   private void reportSJDayTypeNotFound(ServiceJourney sj, String dayTypeRef) {
     issueStore.add(
-        new ObjecctNotFound(
+        new ObjectNotFound(
             "ServiceJourney", sj.getId(),
             "DayTypes", dayTypeRef
         )

--- a/src/main/java/org/opentripplanner/netex/mapping/calendar/DatedServiceJourneyMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/calendar/DatedServiceJourneyMapper.java
@@ -6,14 +6,14 @@ import org.rutebanken.netex.model.DatedServiceJourney;
 import org.rutebanken.netex.model.OperatingDay;
 import org.rutebanken.netex.model.OperatingDayRefStructure;
 
-import static org.opentripplanner.netex.mapping.support.ServiceAlterationFilter.*;
-
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import static org.opentripplanner.netex.mapping.support.ServiceAlterationFilter.isRunning;
 
 
 /**
@@ -48,7 +48,7 @@ public class DatedServiceJourneyMapper {
       // TODO This currently skips mapping of any trips containing ServiceAlteration CANCELLATION
       //      or REPLACED. In the future we will want to import these and allow them to be routed
       //      on if a parameter is set.
-      if (!isRunning(dsj.getServiceAlteration())) continue;
+      if (!isRunning(dsj.getServiceAlteration())) { continue; }
 
       OperatingDay opDay = operatingDay(dsj, operatingDayById);
       if(opDay != null) {

--- a/src/main/java/org/opentripplanner/netex/validation/DSJOperatingDayNotFound.java
+++ b/src/main/java/org/opentripplanner/netex/validation/DSJOperatingDayNotFound.java
@@ -1,7 +1,7 @@
 package org.opentripplanner.netex.validation;
 
 import org.opentripplanner.graph_builder.DataImportIssue;
-import org.opentripplanner.netex.issues.ObjecctNotFound;
+import org.opentripplanner.netex.issues.ObjectNotFound;
 import org.rutebanken.netex.model.DatedServiceJourney;
 import org.rutebanken.netex.model.OperatingDayRefStructure;
 
@@ -21,7 +21,7 @@ class DSJOperatingDayNotFound extends AbstractHMapValidationRule<String, DatedSe
   public DataImportIssue logMessage(String dsjId, DatedServiceJourney dsj) {
     String ref = getOperatingDayRef(dsj);
 
-    return new ObjecctNotFound(
+    return new ObjectNotFound(
         "DatedServiceJourney",
         dsj.getId(),
         "OperatingDayRef",

--- a/src/main/java/org/opentripplanner/netex/validation/DSJServiceJourneyNotFound.java
+++ b/src/main/java/org/opentripplanner/netex/validation/DSJServiceJourneyNotFound.java
@@ -1,7 +1,7 @@
 package org.opentripplanner.netex.validation;
 
 import org.opentripplanner.graph_builder.DataImportIssue;
-import org.opentripplanner.netex.issues.ObjecctNotFound;
+import org.opentripplanner.netex.issues.ObjectNotFound;
 import org.rutebanken.netex.model.DatedServiceJourney;
 import org.rutebanken.netex.model.JourneyRefStructure;
 
@@ -22,7 +22,7 @@ class DSJServiceJourneyNotFound extends AbstractHMapValidationRule<String, Dated
   public DataImportIssue logMessage(String dsjId, DatedServiceJourney dsj) {
     String ref = getServiceJourneyRef(dsj);
 
-    return new ObjecctNotFound(
+    return new ObjectNotFound(
         "DatedServiceJourney",
         dsj.getId(),
         "ServiceJourneyRef",

--- a/src/main/java/org/opentripplanner/netex/validation/JourneyPatternNotFoundInSJ.java
+++ b/src/main/java/org/opentripplanner/netex/validation/JourneyPatternNotFoundInSJ.java
@@ -1,7 +1,7 @@
 package org.opentripplanner.netex.validation;
 
 import org.opentripplanner.graph_builder.DataImportIssue;
-import org.opentripplanner.netex.issues.ObjecctNotFound;
+import org.opentripplanner.netex.issues.ObjectNotFound;
 import org.rutebanken.netex.model.ServiceJourney;
 
 class JourneyPatternNotFoundInSJ extends AbstractHMapValidationRule<String, ServiceJourney> {
@@ -15,7 +15,7 @@ class JourneyPatternNotFoundInSJ extends AbstractHMapValidationRule<String, Serv
 
   @Override
   public DataImportIssue logMessage(String key, ServiceJourney sj) {
-    return new ObjecctNotFound("ServiceJourney", sj.getId(), "JourneyPattern", getPatternId(sj));
+    return new ObjectNotFound("ServiceJourney", sj.getId(), "JourneyPattern", getPatternId(sj));
   }
 
   private String getPatternId(ServiceJourney sj) {

--- a/src/main/java/org/opentripplanner/netex/validation/PassengerStopAssignmentQuayNotFound.java
+++ b/src/main/java/org/opentripplanner/netex/validation/PassengerStopAssignmentQuayNotFound.java
@@ -2,7 +2,7 @@ package org.opentripplanner.netex.validation;
 
 import org.opentripplanner.graph_builder.DataImportIssue;
 import org.opentripplanner.netex.index.api.HMapValidationRule;
-import org.opentripplanner.netex.issues.ObjecctNotFound;
+import org.opentripplanner.netex.issues.ObjectNotFound;
 
 
 /**
@@ -17,6 +17,6 @@ class PassengerStopAssignmentQuayNotFound extends AbstractHMapValidationRule<Str
 
     @Override
     public DataImportIssue logMessage(String stopPointRef, String quayRef) {
-        return new ObjecctNotFound("PassengerStopAssignment", stopPointRef, "quay", quayRef);
+        return new ObjectNotFound("PassengerStopAssignment", stopPointRef, "quay", quayRef);
     }
 }

--- a/src/main/java/org/opentripplanner/standalone/config/ConfigLoader.java
+++ b/src/main/java/org/opentripplanner/standalone/config/ConfigLoader.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.MissingNode;
 import com.fasterxml.jackson.databind.node.TextNode;
-import com.google.common.collect.ImmutableSet;
 import org.apache.commons.io.IOUtils;
 import org.opentripplanner.util.OtpAppException;
 import org.slf4j.Logger;
@@ -141,9 +140,11 @@ public class ConfigLoader {
      * Load the router configuration file as a JsonNode three. An empty node is
      * returned if the given {@code configDir}  is {@code null} or config file is NOT found.
      * <p>
+     * This is public to allow loading configuration files from tests like the SpeedTest.
+     *
      * @see #loadJsonFile for more details.
      */
-    private JsonNode loadJsonByFilename(String filename) {
+    public JsonNode loadJsonByFilename(String filename) {
         // Use default parameters if no configDir is available.
         if (configDir == null) {
             if(jsonFallback != null) {

--- a/src/test/java/org/opentripplanner/netex/mapping/calendar/DayTypeAssignmentMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/calendar/DayTypeAssignmentMapperTest.java
@@ -72,7 +72,8 @@ public class DayTypeAssignmentMapperTest {
         dayTypes,
         assignments,
         EMPTY_OPERATING_DAYS,
-        EMPTY_PERIODS
+        EMPTY_PERIODS,
+        null
     );
 
     // THEN - verify
@@ -104,7 +105,8 @@ public class DayTypeAssignmentMapperTest {
         dayTypes,
         assignments,
         EMPTY_OPERATING_DAYS,
-        EMPTY_PERIODS
+        EMPTY_PERIODS,
+        null
     );
 
     // THEN - verify
@@ -129,7 +131,8 @@ public class DayTypeAssignmentMapperTest {
         dayTypes,
         assignments,
         operatingDays,
-        EMPTY_PERIODS
+        EMPTY_PERIODS,
+        null
     );
 
     // THEN - verify
@@ -159,7 +162,8 @@ public class DayTypeAssignmentMapperTest {
         dayTypes,
         assignments,
         EMPTY_OPERATING_DAYS,
-        periods
+        periods,
+        null
     );
 
     // THEN - verify
@@ -192,7 +196,8 @@ public class DayTypeAssignmentMapperTest {
         dayTypes,
         assignments,
         operatingDays,
-        periods
+        periods,
+        null
     );
 
     // THEN - verify

--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTest.java
@@ -1,12 +1,12 @@
 package org.opentripplanner.transit.raptor.speed_test;
 
 import org.opentripplanner.datastore.OtpDataStore;
-import org.opentripplanner.routing.algorithm.raptor.transit.request.RoutingRequestTransitDataProviderFilter;
-import org.opentripplanner.routing.algorithm.raptor.transit.request.TransitDataProviderFilter;
 import org.opentripplanner.routing.algorithm.raptor.transit.TransitLayer;
 import org.opentripplanner.routing.algorithm.raptor.transit.TripSchedule;
 import org.opentripplanner.routing.algorithm.raptor.transit.mappers.TransitLayerMapper;
 import org.opentripplanner.routing.algorithm.raptor.transit.request.RaptorRoutingRequestTransitData;
+import org.opentripplanner.routing.algorithm.raptor.transit.request.RoutingRequestTransitDataProviderFilter;
+import org.opentripplanner.routing.algorithm.raptor.transit.request.TransitDataProviderFilter;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.SerializedGraphObject;
 import org.opentripplanner.standalone.OtpStartupInfo;
@@ -29,6 +29,7 @@ import org.opentripplanner.util.OtpAppException;
 
 import java.io.File;
 import java.lang.ref.WeakReference;
+import java.net.URI;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -76,7 +77,7 @@ public class SpeedTest {
     private SpeedTest(SpeedTestCmdLineOpts opts) {
         this.opts = opts;
         this.config = SpeedTestConfig.config(opts.rootDir());
-        this.graph = loadGraph(opts.rootDir());
+        this.graph = loadGraph(opts.rootDir(), config.graph);
         this.transitLayer = TransitLayerMapper.map(config.transitRoutingParams, graph);
         this.streetRouter = new EgressAccessRouter(graph, transitLayer);
         this.nAdditionalTransfers = opts.numOfExtraTransfers();
@@ -105,8 +106,11 @@ public class SpeedTest {
         }
     }
 
-    private static Graph loadGraph(File rootDir) {
-        Graph graph = SerializedGraphObject.load(OtpDataStore.graphFile(rootDir));
+    private static Graph loadGraph(File baseDir, URI path) {
+        File file = path == null
+            ? OtpDataStore.graphFile(baseDir)
+            : path.isAbsolute() ? new File(path) : new File(baseDir, path.getPath());
+        Graph graph = SerializedGraphObject.load(file);
         if(graph == null) { throw new IllegalStateException(); }
         graph.index();
         return graph;


### PR DESCRIPTION
### Summary
Make it possible to configure the graph file in the SpeedTest. This reuses the configuration loader used by OTP. This enables environment variable filtering and absolute and relative file paths. For example, this allows graph filenames to include the serialization version number, so multiple graphs can coexist for different versions or commits of OTP.

There are some minor changes in the Transmodel API and in the Netex import:
- Transmodel GraphQL API - Add ServiceAlteration to SJ.
- Netex - Add import issue for emtpy DayType.
