### PR TITLE
Handle pathways with only traversal_time set

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -7,6 +7,7 @@
 - Prioritize "direct" routes over transfers in group-filters [#3309](https://github.com/opentripplanner/OpenTripPlanner/issues/3309)
 - The itinerary filter configuration is moved from the `RoutingRequest` into its own JSON node `itineraryFilters`.  
 - Remove poor transit results for short trips, when walking is better [#3331](https://github.com/opentripplanner/OpenTripPlanner/issues/3331)
+- A pathway's `traversal_time` is used when calculating the duration of transfers [#3357](https://github.com/opentripplanner/OpenTripPlanner/issues/3357).
 
 ## 2.0.0 (2020-11-27)
 

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
@@ -120,7 +120,7 @@ public class LegacyGraphQLQueryTypeImpl
           Stop stop = routingService.getStopForId(FeedScopedId.parseId(parts[1]));
 
           // TODO: Add geometry
-          return new NearbyStop(stop, Integer.parseInt(parts[0]), null, null, null);
+          return new NearbyStop(stop, Integer.parseInt(parts[0]), 0, null, null, null);
         }
         case "TicketType":
           return null; //TODO

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLStopImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLStopImpl.java
@@ -235,6 +235,7 @@ public class LegacyGraphQLStopImpl implements LegacyGraphQLDataFetchers.LegacyGr
               .map(transfer -> new NearbyStop(
                   transfer.to,
                   transfer.getDistanceMeters(),
+                  0,
                   transfer.getEdges(),
                   GeometryUtils.concatenateLineStrings(transfer
                         .getEdges()

--- a/src/main/java/org/opentripplanner/graph_builder/module/DirectTransferGenerator.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/DirectTransferGenerator.java
@@ -85,7 +85,7 @@ public class DirectTransferGenerator implements GraphBuilderModule {
                 if (sd.stop == stop) { continue; }
                 graph.transfersByStop.put(
                     stop,
-                    new SimpleTransfer(stop, sd.stop, sd.distance, sd.edges)
+                    new SimpleTransfer(stop, sd.stop, sd.distance, sd.distanceIndependentTime, sd.edges)
                 );
                 n += 1;
             }
@@ -97,7 +97,7 @@ public class DirectTransferGenerator implements GraphBuilderModule {
                     if (sd.stop == ts0.getStop()) { continue; }
                     if (sd.stop instanceof Stop) { continue; }
                     graph.transfersByStop.put(sd.stop,
-                        new SimpleTransfer(sd.stop, ts0.getStop(), sd.distance, sd.edges)
+                        new SimpleTransfer(sd.stop, ts0.getStop(), sd.distance, sd.distanceIndependentTime, sd.edges)
                     );
                     n += 1;
                 }

--- a/src/main/java/org/opentripplanner/model/SimpleTransfer.java
+++ b/src/main/java/org/opentripplanner/model/SimpleTransfer.java
@@ -17,14 +17,16 @@ public class SimpleTransfer implements Serializable {
     public final StopLocation from;
     public final StopLocation to;
 
-    private double effectiveWalkDistance;
-    
-    private List<Edge> edges;
+    private final double effectiveWalkDistance;
+    private final int distanceIndependentTime;
 
-    public SimpleTransfer(StopLocation from, StopLocation to, double effectiveWalkDistance, List<Edge> edges) {
+    private final List<Edge> edges;
+
+    public SimpleTransfer(StopLocation from, StopLocation to, double effectiveWalkDistance, int distanceIndependentTime, List<Edge> edges) {
         this.from = from;
         this.to = to;
         this.effectiveWalkDistance = effectiveWalkDistance;
+        this.distanceIndependentTime = distanceIndependentTime;
         this.edges = edges;
     }
 
@@ -36,8 +38,29 @@ public class SimpleTransfer implements Serializable {
         return edges.stream().mapToDouble(Edge::getDistanceMeters).sum();
     }
 
+    /**
+     * The distance to walk adjusted for elevation and obstacles. This is used together
+     * with the walking speed to find the actual walking transfer time. This plus
+     * {@link #getDistanceIndependentTime()} is used to calculate the actual-transfer-time
+     * given a walking speed.
+     * <p>
+     * Unit: meters. Default: 0.
+     * @see Edge#getEffectiveWalkDistance()
+     */
     public double getEffectiveWalkDistance(){
     	return this.effectiveWalkDistance;
+    }
+
+    /**
+     * This is the transfer time(duration) spent NOT moving like time in in elevators, escalators
+     * and waiting on read light when crossing a street. This is used together with
+     * {@link #getEffectiveWalkDistance()} to calculate the actual-transfer-time.
+     * <p>
+     * Unit: seconds. Default: 0.
+     * @see Edge#getDistanceIndependentTime()
+     */
+    public int getDistanceIndependentTime() {
+        return distanceIndependentTime;
     }
 
     public List<Edge> getEdges() { return this.edges; }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/Transfer.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/Transfer.java
@@ -11,12 +11,16 @@ public class Transfer {
     private int toStop;
 
     private final int effectiveWalkDistanceMeters;
+    private final int distanceIndependentTime;
 
     private final List<Edge> edges;
 
-    public Transfer(int toStop, int effectiveWalkDistanceMeters, List<Edge> edges) {
+    public Transfer(
+        int toStop, int effectiveWalkDistanceMeters, int distanceIndependentTime, List<Edge> edges
+    ) {
         this.toStop = toStop;
         this.effectiveWalkDistanceMeters = effectiveWalkDistanceMeters;
+        this.distanceIndependentTime = distanceIndependentTime;
         this.edges = edges;
     }
 
@@ -43,6 +47,10 @@ public class Transfer {
      */
     public int getEffectiveWalkDistanceMeters() {
         return effectiveWalkDistanceMeters;
+    }
+
+    public int getDistanceIndependentTime() {
+        return distanceIndependentTime;
     }
 
     public int getDistanceMeters() {

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/mappers/TransfersMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/mappers/TransfersMapper.java
@@ -31,8 +31,12 @@ class TransfersMapper {
                 double effectiveDistance = simpleTransfer.getEffectiveWalkDistance();
                 if (simpleTransfer.to instanceof Stop) {
                     int toStopIndex = stopIndex.indexByStop.get(simpleTransfer.to);
-                    Transfer transfer = new Transfer(toStopIndex, (int) effectiveDistance,
-                        simpleTransfer.getEdges());
+                    Transfer transfer = new Transfer(
+                        toStopIndex,
+                        (int) effectiveDistance,
+                        simpleTransfer.getDistanceIndependentTime(),
+                        simpleTransfer.getEdges()
+                    );
 
                     list.add(transfer);
                 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/request/TransferWithDuration.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/request/TransferWithDuration.java
@@ -11,7 +11,8 @@ public class TransferWithDuration implements RaptorTransfer {
 
     public TransferWithDuration(Transfer transfer, double walkSpeed) {
         this.transfer = transfer;
-        this.durationSeconds = (int) Math.round(transfer.getEffectiveWalkDistanceMeters() / walkSpeed);
+        this.durationSeconds = (int) Math.round(transfer.getEffectiveWalkDistanceMeters() / walkSpeed)
+            + transfer.getDistanceIndependentTime();
     }
 
     public Transfer transfer() {

--- a/src/main/java/org/opentripplanner/routing/edgetype/PathwayEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/PathwayEdge.java
@@ -62,6 +62,20 @@ public class PathwayEdge extends Edge {
         return this.distance;
     }
 
+    @Override
+    public double getEffectiveWalkDistance() {
+        if (traversalTime > 0) {
+            return 0;
+        } else {
+            return distance;
+        }
+    }
+
+    @Override
+    public int getDistanceIndependentTime() {
+        return traversalTime;
+    }
+
     public TraverseMode getMode() {
        return TraverseMode.WALK;
     }

--- a/src/main/java/org/opentripplanner/routing/graph/Edge.java
+++ b/src/main/java/org/opentripplanner/routing/graph/Edge.java
@@ -179,10 +179,25 @@ public abstract class Edge implements Serializable {
     }
 
     /**
-     * This gets the effective length for walking, taking slopes into account. This can be divided
-     * by the speed on a flat surface to get the duration.
+     * The distance to walk adjusted for elevation and obstacles. This is used together
+     * with the walking speed to find the actual walking transfer time. This plus
+     * {@link #getDistanceIndependentTime()} is used to calculate the actual-transfer-time
+     * given a walking speed.
+     * <p>
+     * Unit: meters. Default: 0.
      */
-    public double getEffectiveWalkDistance() {
+    public double getEffectiveWalkDistance(){
+        return 0;
+    }
+
+    /**
+     * This is the transfer time(duration) spent NOT moving like time in in elevators, escalators
+     * and waiting on read light when crossing a street. This is used together with
+     * {@link #getEffectiveWalkDistance()} to calculate the actual-transfer-time.
+     * <p>
+     * Unit: seconds. Default: 0.
+     */
+    public int getDistanceIndependentTime() {
         return 0;
     }
 


### PR DESCRIPTION
### Summary

Pathway edges may have a length of zero with an explicit `traversalTime`, which is incorrectly handled as having a duration and length of `0`.

With this PR when constructing RAPTOR transfers the "time-only" aspect of the transfer is summed in addition to the "distance / speed-dependent" aspect. For this a `distanceIndependentTime` is added to `SimpleTransfer` / `Transfer`.

### Issue

closes #3357

### Unit tests

No new tests are added. The changes were manually tested.

### Code style

:ballot_box_with_check: 

### Documentation

No changes are made to the documentation.

### Changelog

> A pathway's `traversal_time` is used when calculating the duration of transfers [#3357](https://github.com/opentripplanner/OpenTripPlanner/issues/3357).
