### PR TITLE
Use the station name for pathway levels if no value is provided

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/module/AddTransitModelEntitiesToGraph.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/AddTransitModelEntitiesToGraph.java
@@ -248,13 +248,13 @@ public class AddTransitModelEntitiesToGraph {
         Vertex toVertex
     ) {
         StationElement fromStation = fromVertex.getStationElement();
-        String fromVertexLevelName = fromStation == null
+        String fromVertexLevelName = fromStation == null || fromStation.getLevelName() == null
             ? fromVertex.getName()
             : fromStation.getLevelName();
         Double fromVertexLevelIndex = fromStation == null ? null : fromStation.getLevelIndex();
 
         StationElement toStation = toVertex.getStationElement();
-        String toVertexLevelName = toStation == null
+        String toVertexLevelName = toStation == null || toStation.getLevelName() == null
             ? toVertex.getName()
             : toStation.getLevelName();
         Double toVertexLevelIndex = toStation == null ? null : toStation.getLevelIndex();


### PR DESCRIPTION
### Summary

If levels are not defined for GTFS pathway elevators (`pathway_mode=5`), then WalkStep generation will fail with an NPE.

This avoids that by not only checking if there is a `StationElement`, but also if it has a `levelName` defined when determining the level name for onboard/offboard vertices.

### Issues

closes #3362 

### Unit tests

No test were modified.

### Code style

:ballot_box_with_check: 

### Documentation

No documentation was updated.

### Changelog

No item is added to the changelog.