### PR TITLE
Otp2 fix add cost for first alight slack

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -9,6 +9,7 @@
 - Remove poor transit results for short trips, when walking is better [#3331](https://github.com/opentripplanner/OpenTripPlanner/issues/3331)
 - A pathway's `traversal_time` is used when calculating the duration of transfers [#3357](https://github.com/opentripplanner/OpenTripPlanner/issues/3357).
 - GTFS Trips will by default not allow bikes if no explicit value is set [#3359](https://github.com/opentripplanner/OpenTripPlanner/issues/3359).
+- Improve the dynamic search window calculation. The configuration parameters `minTransitTimeCoefficient` and `minWaitTimeCoefficient` replace the old `minTripTimeCoefficient` parameter. [#3366](https://github.com/opentripplanner/OpenTripPlanner/issues/3366)   
 
 ## 2.0.0 (2020-11-27)
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -795,7 +795,7 @@ Nested inside `transit : { dynamicSearchWindow : { ... } }` in `router-config.js
 
 config key | description | value type | value default
 ---------- | ----------- | ---------- | -------------
-`minTransitTimeCoefficient` | The coefficient to multiply with minimum travel time found using a heuristic search. This value is added to the `minWinTimeMinutes`. A value between `0.0` to `3.0` is expected to give ok results. | double | `0.5`
+`minTransitTimeCoefficient` | The coefficient to multiply with minimum transit time found using a heuristic search. This scaled value is added to the `minWinTimeMinutes`. A value between `0.0` to `3.0` is expected to give ok results. | double | `0.5`
 `minWaitTimeCoefficient` | The coefficient to multiply with a minimum wait time estimated based on the heuristic search. This will increase the search-window in low transit frequency areas. This value is added to the `minWinTimeMinutes`. A value between `0.0` to `1.0` is expected to give ok results. | double | `0.5`
 `minWinTimeMinutes` | The constant minimum number of minutes for a raptor search window. Use a value between 20-180 minutes in a normal deployment. | int | `40`
 `maxWinTimeMinutes` | Set an upper limit to the calculation of the dynamic search window to prevent exceptionable cases to cause very long search windows. Long search windows consumes a lot of resources and may take a long time. Use this parameter to tune the desired maximum search time. | int | `180` (3 hours)

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -795,7 +795,8 @@ Nested inside `transit : { dynamicSearchWindow : { ... } }` in `router-config.js
 
 config key | description | value type | value default
 ---------- | ----------- | ---------- | -------------
-`minTripTimeCoefficient` | The coefficient to multiply with minimum travel time found using a heuristic search. This value is added to the `minWinTimeMinutes`. A value between `0.0` to `3.0` is expected to give ok results. | double | `0.75`
+`minTransitTimeCoefficient` | The coefficient to multiply with minimum travel time found using a heuristic search. This value is added to the `minWinTimeMinutes`. A value between `0.0` to `3.0` is expected to give ok results. | double | `0.5`
+`minWaitTimeCoefficient` | The coefficient to multiply with a minimum wait time estimated based on the heuristic search. This will increase the search-window in low transit frequency areas. This value is added to the `minWinTimeMinutes`. A value between `0.0` to `1.0` is expected to give ok results. | double | `0.5`
 `minWinTimeMinutes` | The constant minimum number of minutes for a raptor search window. Use a value between 20-180 minutes in a normal deployment. | int | `40`
 `maxWinTimeMinutes` | Set an upper limit to the calculation of the dynamic search window to prevent exceptionable cases to cause very long search windows. Long search windows consumes a lot of resources and may take a long time. Use this parameter to tune the desired maximum search time. | int | `180` (3 hours)
 `stepMinutes` | The search window is rounded of to the closest multiplication of N minutes. If N=10 minutes, the search-window can be 10, 20, 30 ... minutes. It the computed search-window is 5 minutes and 17 seconds it will be rounded up to 10 minutes. | int | `10`

--- a/src/main/java/org/opentripplanner/standalone/config/TransitRoutingConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/TransitRoutingConfig.java
@@ -91,20 +91,23 @@ public final class TransitRoutingConfig
     private static class DynamicSearchWindowConfig
             implements DynamicSearchWindowCoefficients
     {
-        private final double minTripTimeCoefficient;
+        private final double minTransitTimeCoefficient;
+        private final double minWaitTimeCoefficient;
         private final int minWinTimeMinutes;
         private final int maxWinTimeMinutes;
         private final int stepMinutes;
 
         public DynamicSearchWindowConfig(NodeAdapter dsWin) {
             DynamicSearchWindowCoefficients dsWinDft = new DynamicSearchWindowCoefficients() {};
-            this.minTripTimeCoefficient = dsWin.asDouble("minTripTimeCoefficient", dsWinDft.minTripTimeCoefficient());
+            this.minTransitTimeCoefficient = dsWin.asDouble("minTransitTimeCoefficient", dsWinDft.minTransitTimeCoefficient());
+            this.minWaitTimeCoefficient = dsWin.asDouble("minWaitTimeCoefficient", dsWinDft.minWaitTimeCoefficient());
             this.minWinTimeMinutes = dsWin.asInt("minWinTimeMinutes",  dsWinDft.minWinTimeMinutes());
             this.maxWinTimeMinutes = dsWin.asInt("maxWinTimeMinutes",  dsWinDft.maxWinTimeMinutes());
             this.stepMinutes = dsWin.asInt("stepMinutes",  dsWinDft.stepMinutes());
         }
 
-        @Override public double minTripTimeCoefficient() { return minTripTimeCoefficient; }
+        @Override public double minTransitTimeCoefficient() { return minTransitTimeCoefficient; }
+        @Override public double minWaitTimeCoefficient() { return minWaitTimeCoefficient; }
         @Override public int minWinTimeMinutes() { return minWinTimeMinutes; }
         @Override public int maxWinTimeMinutes() { return maxWinTimeMinutes; }
         @Override public int stepMinutes() { return stepMinutes; }

--- a/src/main/java/org/opentripplanner/transit/raptor/api/request/DynamicSearchWindowCoefficients.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/request/DynamicSearchWindowCoefficients.java
@@ -5,8 +5,8 @@ package org.opentripplanner.transit.raptor.api.request;
  * The dynamic search window coefficients is used to calculate EDT(earliest-departure-time),
  * LAT(latest-arrival-time) and SW(raptor-search-window) request parameters using heuristics.
  * The heuristics perform a Raptor search (one-iteration) to find a trip witch we use to find a
- * lower bound for the travel duration time - the "minTripTime". The heuristic search is used for
- * other purposes too, and is very fast.
+ * lower bound for the travel duration time - the "minTransitTime". The heuristic search is used
+ * for other purposes too, and is very fast.
  * <p>
  * At least the EDT or the LAT must be passed into Raptor to perform a Range Raptor search. If
  * unknown/missing the parameters(EDT, LAT, DW) is dynamically calculated. The dynamic coefficients
@@ -14,16 +14,17 @@ package org.opentripplanner.transit.raptor.api.request;
  * <p>
  * The request parameters are calculated like this:
  * <pre>
- *     DW  = round_N(C + T * minTripTime)
- *     LAT = EDT + DW + minTripTime
- *     EDT = LAT - (DW + minTripTime)
+ *     DW  = round_N(C + T * minTransitTime + W * minWaitTime)
+ *     LAT = EDT + DW + minTransitTime
+ *     EDT = LAT - (DW + minTransitTime)
  * </pre>
  * The {@code round_N(...)} method is will round the input to the closest multiplication of N.
  * <p>
  * The 3 coefficients above are:
  * <ol>
  *     <li>{@code C} - {@link #minWinTimeMinutes()}</li>
- *     <li>{@code T} - {@link #minTripTimeCoefficient()}</li>
+ *     <li>{@code T} - {@link #minTransitTimeCoefficient()}</li>
+ *     <li>{@code W} - {@link #minWaitTimeCoefficient()}</li>
  *     <li>{@code N} - {@link #stepMinutes()}</li>
  * </ol>
  * In addition the this an upper bound on the calculation of the search window:
@@ -32,11 +33,18 @@ package org.opentripplanner.transit.raptor.api.request;
 public interface DynamicSearchWindowCoefficients {
 
     /**
-     * {@code T} - The coefficient to multiply with {@code minTripTime}. Use a value between
-     * {@code 0.0} to {@code 3.0}. Using {@code 0.0} will give you a raptor-search-window ≈
-     * {@link #minWinTimeMinutes()}.
+     * {@code T} - The coefficient to multiply with {@code minTransitTime}. Use a value between
+     * {@code 0.0} to {@code 3.0}. Using {@code 0.0} will eliminate the {@code minTransitTime}
+     * from the dynamic raptor-search-window calculation.
      */
-    default double minTripTimeCoefficient() { return 0.75f; }
+    default double minTransitTimeCoefficient() { return 0.5f; }
+
+    /**
+     * {@code T} - The coefficient to multiply with {@code minWaitTime}. Use a value between
+     * {@code 0.0} to {@code 1.0}. Using {@code 0.0} will eliminate the {@code minWaitTime}
+     * from the dynamic raptor-search-window calculation.
+     */
+    default double minWaitTimeCoefficient() { return 0.5f; }
 
     /**
      * {@code C} - The constant minimum number of minutes for a raptor search window. Use a value

--- a/src/main/java/org/opentripplanner/transit/raptor/api/view/Heuristics.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/view/Heuristics.java
@@ -50,6 +50,19 @@ public interface Heuristics {
     int bestOverallJourneyNumOfTransfers();
 
     /**
+     * Return an estimate for the shortest possible wait-time needed across all journeys
+     * reaching the destination given the iteration-start-time. Note! This can NOT be
+     * used for destination pruning, because there most likely exist journeys with a
+     * lower wait-time. The access is NOT time-shift before computing this value.
+     *
+     * <p>This would be suitable for calculating a search-time-window, because it give an
+     * estimate for the expected wait-time. In a low frequency transit area the wait-time
+     * might be much larger then the {@link #bestOverallJourneyTravelDuration()}, and in these
+     * cases this gives a better starting point for the search-time-window calculation.
+     */
+    int minWaitTimeForJourneysReachingDestination();
+
+    /**
      * Return true if the destination is reached.
      */
     boolean destinationReached();

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/McRangeRaptorWorkerState.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/McRangeRaptorWorkerState.java
@@ -132,8 +132,8 @@ final public class McRangeRaptorWorkerState<T extends RaptorTripSchedule> implem
 
         if (exceedsTimeLimit(stopArrivalTime)) { return; }
 
-        // Calculate wait time before and after the transit path
-        final int waitTime = ride.boardWaitTime + alightSlack;
+        // Calculate wait time before and after the transit
+        final int waitTime = ride.boardWaitTimeForCostCalculation + alightSlack;
 
         final int costTransit = costCalculator.transitArrivalCost(
             ride.prevArrival,

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/PatternRide.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/PatternRide.java
@@ -56,7 +56,12 @@ public final class PatternRide<T extends RaptorTripSchedule> {
     public final int boardStopIndex;
     public final int boardPos;
     public final int boardTime;
-    public final int boardWaitTime;
+    /**
+     * This is the wait-time before the boarding witch should be accounted for in the cost
+     * calculation. If the access-leg can be time-shifted the actual wait time might be larger
+     * because the time-shifting is done after the raptor search is done.
+     */
+    public final int boardWaitTimeForCostCalculation;
     public final T trip;
 
     // Pareto vector
@@ -77,7 +82,7 @@ public final class PatternRide<T extends RaptorTripSchedule> {
         this.boardStopIndex = boardStopIndex;
         this.boardPos = boardPos;
         this.boardTime = boardTime;
-        this.boardWaitTime = boardWaitTime;
+        this.boardWaitTimeForCostCalculation = boardWaitTime;
         this.tripId = tripId;
         this.trip = trip;
         this.relativeCost = relativeCost;
@@ -120,7 +125,7 @@ public final class PatternRide<T extends RaptorTripSchedule> {
             .addNum("boardStop", boardStopIndex)
             .addNum("boardPos", boardPos)
             .addServiceTime("boardTime", boardTime , -1)
-            .addDurationSec("boardWaitTime", boardWaitTime)
+            .addDurationSec("boardWaitTime", boardWaitTimeForCostCalculation)
             .addObj("trip", trip)
             .addNum("relativeCost", relativeCost)
             .addNum("tripId", tripId)

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/heuristics/HeuristicsAdapter.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/heuristics/HeuristicsAdapter.java
@@ -29,6 +29,7 @@ public class HeuristicsAdapter implements Heuristics {
 
     private int minJourneyTravelDuration = NOT_SET;
     private int minJourneyNumOfTransfers = NOT_SET;
+    private int earliestArrivalTime = NOT_SET;
 
     public HeuristicsAdapter(
             BestTimes times,
@@ -100,6 +101,12 @@ public class HeuristicsAdapter implements Heuristics {
     }
 
     @Override
+    public int minWaitTimeForJourneysReachingDestination() {
+        calculateAggregatedResults();
+        return Math.abs(earliestArrivalTime - originDepartureTime) - minJourneyTravelDuration;
+    }
+
+    @Override
     public boolean destinationReached() {
         calculateAggregatedResults();
         return minJourneyNumOfTransfers != NOT_SET;
@@ -118,6 +125,9 @@ public class HeuristicsAdapter implements Heuristics {
 
                 int n = bestNumOfTransfers(it.stop());
                 minJourneyNumOfTransfers = Math.min(minJourneyNumOfTransfers, n);
+
+                int eat = times.time(it.stop()) + it.durationInSeconds();
+                earliestArrivalTime = Math.min(earliestArrivalTime, eat);
             }
         }
         aggregatedResultsCalculated = true;

--- a/src/main/java/org/opentripplanner/transit/raptor/service/RangRaptorDynamicSearch.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/service/RangRaptorDynamicSearch.java
@@ -254,7 +254,10 @@ public class RangRaptorDynamicSearch<T extends RaptorTripSchedule> {
     private void calculateDynamicSearchParametersFromHeuristics(Heuristics heuristics) {
         if(heuristics != null) {
             dynamicSearchParamsCalculator
-                    .withMinTripTime(heuristics.bestOverallJourneyTravelDuration())
+                    .withHeuristics(
+                        heuristics.bestOverallJourneyTravelDuration(),
+                        heuristics.minWaitTimeForJourneysReachingDestination()
+                    )
                     .calculate();
         }
     }

--- a/src/main/java/org/opentripplanner/transit/raptor/service/RaptorSearchWindowCalculator.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/service/RaptorSearchWindowCalculator.java
@@ -18,7 +18,10 @@ public class RaptorSearchWindowCalculator {
 
 
     /** Min trip time coefficient */
-    private final double minTripTimeCoefficient;
+    private final double minTransitTimeCoefficient;
+
+    /** Min trip time coefficient */
+    private final double minWaitTimeCoefficient;
 
     /** Min search window in seconds */
     private final int minSearchWinSeconds;
@@ -26,14 +29,16 @@ public class RaptorSearchWindowCalculator {
     private final int maxSearchWinSeconds;
     private final int stepSeconds;
 
-    private int minTravelTime = NOT_SET;
+    private int heuristicMinTransitTime = NOT_SET;
+    private int heuristicMinWaitTime = NOT_SET;
     private int earliestDepartureTime = NOT_SET;
     private int latestArrivalTime = NOT_SET;
     private int searchWindowSeconds = NOT_SET;
     private SearchParams params;
 
     public RaptorSearchWindowCalculator(DynamicSearchWindowCoefficients c) {
-        this.minTripTimeCoefficient = c.minTripTimeCoefficient();
+        this.minTransitTimeCoefficient = c.minTransitTimeCoefficient();
+        this.minWaitTimeCoefficient = c.minWaitTimeCoefficient();
         this.minSearchWinSeconds = c.minWinTimeMinutes() * 60;
         this.maxSearchWinSeconds = c.maxWinTimeMinutes() * 60;
         this.stepSeconds = c.stepMinutes() * 60;
@@ -54,8 +59,9 @@ public class RaptorSearchWindowCalculator {
         return searchWindowSeconds;
     }
 
-    public RaptorSearchWindowCalculator withMinTripTime(int minTravelTime) {
-        this.minTravelTime = minTravelTime;
+    public RaptorSearchWindowCalculator withHeuristics(int minTransitTime, int minWaitTime) {
+        this.heuristicMinTransitTime = minTransitTime;
+        this.heuristicMinWaitTime = minWaitTime;
         return this;
     }
 
@@ -68,7 +74,7 @@ public class RaptorSearchWindowCalculator {
     }
 
     public RaptorSearchWindowCalculator calculate() {
-        if(minTravelTime == NOT_SET) {
+        if(heuristicMinTransitTime == NOT_SET) {
             throw new IllegalArgumentException("The minTravelTime is not set.");
         }
 
@@ -77,7 +83,7 @@ public class RaptorSearchWindowCalculator {
         }
 
         // TravelWindow is the time from the earliest-departure-time to the latest-arrival-time
-        int travelWindow = searchWindowSeconds + roundUpToNearestMinute(minTravelTime);
+        int travelWindow = searchWindowSeconds + roundUpToNearestMinute(heuristicMinTransitTime);
 
         if (!params.isLatestArrivalTimeSet()) {
             latestArrivalTime = earliestDepartureTime + travelWindow;
@@ -109,11 +115,14 @@ public class RaptorSearchWindowCalculator {
         if(params.isEarliestDepartureTimeSet() && params.isLatestArrivalTimeSet()) {
             int travelWindow = params.latestArrivalTime() - params.earliestDepartureTime();
             // There is no upper limit the the search window when both EDT and LAT is set.
-            return roundStep(travelWindow - minTravelTime);
+            return roundStep(travelWindow - heuristicMinTransitTime);
         }
         else {
             // Set the search window using the min-travel-time.
-            int v = roundStep(minSearchWinSeconds + minTripTimeCoefficient * minTravelTime);
+            int v = roundStep(minSearchWinSeconds
+                + minTransitTimeCoefficient * heuristicMinTransitTime
+                + minWaitTimeCoefficient * heuristicMinWaitTime
+            );
 
             // Set an upper bound to the search window
             return Math.min(maxSearchWinSeconds, v);

--- a/src/test/java/org/opentripplanner/transit/raptor/service/RaptorSearchWindowCalculatorTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/service/RaptorSearchWindowCalculatorTest.java
@@ -11,13 +11,14 @@ import static org.junit.Assert.assertEquals;
 public class RaptorSearchWindowCalculatorTest {
 
     private static final DynamicSearchWindowCoefficients C = new DynamicSearchWindowCoefficients() {
-            @Override public double minTripTimeCoefficient() { return 0.5; }
-            /** 15 minutes */
-            @Override public int minWinTimeMinutes() { return 15; }
-            /** Round search-window to nearest 5 minutes (300 seconds) */
-            @Override public int stepMinutes() { return 5; }
-            /** Set the max search-window length to 5 hours (300 minutes) */
-            @Override public int maxWinTimeMinutes() { return 5 * 60; }
+            @Override public double minTransitTimeCoefficient() { return 0.6; }
+            @Override public double minWaitTimeCoefficient() { return 0.4; }
+            /** 10 minutes = 600s */
+            @Override public int minWinTimeMinutes() { return 10; }
+            /** Round search-window to nearest 1 minute (60 seconds) */
+            @Override public int stepMinutes() { return 1; }
+            /** Set the max search-window length to 30 minutes (1_800 seconds) */
+            @Override public int maxWinTimeMinutes() { return 30; }
     };
 
     private final RaptorSearchWindowCalculator subject = new RaptorSearchWindowCalculator(C);
@@ -26,106 +27,126 @@ public class RaptorSearchWindowCalculatorTest {
     public void calcEarliestDeparture() {
         SearchParams searchParams = new RaptorRequestBuilder<TestTripSchedule>()
                 .searchParams()
-                // 35 minutes = 2100 seconds
-                .latestArrivalTime(10_200)
+                .latestArrivalTime(3_000)
                 .buildSearchParam();
 
-        int minTripTime = 500;
+        int minTransitTime = 500;
+        int minWaitTime = 200;
 
-        subject.withMinTripTime(minTripTime)
+        subject.withHeuristics(minTransitTime, minWaitTime)
                 .withSearchParams(searchParams)
                 .calculate();
 
         /*
-           search-window = round_300(C + T * minTripTime)
-           search-window = round_300(900s  + 0.5 * 500s) = round_300(1150s) = 1200s
+           search-window: round_N(C + T * minTransitTime + W * minWaitTime)
+               = round_60(600 + 0.6 * 500 + 0.4 * 200)
+               = round_60(980) = 960
 
            EDT = LAT - (search-window + minTripTime)
-           EDT = 10200s - (1200s + roundUp_60(500))
-           EDT = 10200s - (1200s + 540s)
-           EDT = 8460
+           EDT = 3000 - (960s + roundUp_60(500))
+           EDT = 3000 - (960s + 540s)
+           EDT = 1500
          */
-        assertEquals(1200, subject.getSearchWindowSeconds());
-        assertEquals(8460, subject.getEarliestDepartureTime());
+        assertEquals(960, subject.getSearchWindowSeconds());
+        assertEquals(1_500, subject.getEarliestDepartureTime());
         // Given - verify not changed
-        assertEquals(10200, subject.getLatestArrivalTime());
-    }
-
-    @Test
-    public void calcSearchWindow() {
-        SearchParams searchParams = new RaptorRequestBuilder<TestTripSchedule>()
-                .searchParams()
-                .earliestDepartureTime(10_200)
-                .buildSearchParam();
-
-        int minTripTime = 300;
-
-        subject.withMinTripTime(minTripTime)
-                .withSearchParams(searchParams)
-                .calculate();
-
-        /*
-           EDT = 10_200
-           search-window = round_300(0.5 * 300 + 900) = round_300(1_050) = 1200
-           LAT = 10_200 + (1200 + roundUp_60(300)) = 11_700
-         */
-        assertEquals(1200, subject.getSearchWindowSeconds());
-        assertEquals(11_700, subject.getLatestArrivalTime());
-        // Given - verify not changed
-        assertEquals(10200, subject.getEarliestDepartureTime());
-    }
-
-    @Test
-    public void calcSearchWindowLimitByMaxLength() {
-        SearchParams searchParams = new RaptorRequestBuilder<TestTripSchedule>()
-                .searchParams()
-                .earliestDepartureTime(10_000)
-                .buildSearchParam();
-
-        int minTripTime = 34_500;
-
-        subject.withMinTripTime(minTripTime)
-                .withSearchParams(searchParams)
-                .calculate();
-
-        /*
-           EDT = 10_000
-           sw = round_300(0.5 * 34_500 + 900) = round_300(18_150) = 18_300
-           search-window = min(18_300, 18_000) = 18_000
-           LAT = 10_000 + (18_000 + roundUp_60(34_500)) = 62_500
-         */
-        assertEquals(18_000, subject.getSearchWindowSeconds());
-        assertEquals(62_500, subject.getLatestArrivalTime());
-        // Given - verify not changed
-        assertEquals(10_000, subject.getEarliestDepartureTime());
+        assertEquals(3_000, subject.getLatestArrivalTime());
     }
 
     @Test
     public void calcLatestArrivalTime() {
         SearchParams searchParams = new RaptorRequestBuilder<TestTripSchedule>()
                 .searchParams()
-                // 35 minutes = 2100 seconds
-                .searchWindowInSeconds(35 * 60)
                 .earliestDepartureTime(10_200)
                 .buildSearchParam();
 
-        int minTripTime = 300;
+        int minTransitTime = 300;
+        int minWaitTime = 100;
 
-        subject.withMinTripTime(minTripTime)
+        subject.withHeuristics(minTransitTime, minWaitTime)
                 .withSearchParams(searchParams)
                 .calculate();
 
         /*
-           search-window = 2100
-           LAT = EAT + (search-window + roundUp_60(minTripTime))
-           LAT = 10200s + (2100s + roundUp60(300s))
-           EDT = 10200s + (2100s + 300s)
-           EDT = 12600s
+           search-window: round_N(C + T * minTransitTime + W * minWaitTime)
+               = round_60(600 + 0.6 * 300 + 0.4 * 100)
+               = round_60(820) = 840
+
+           EDT = 10_200
+           LAT = 10_200 + (840 + roundUp_60(300)) = 11_340
          */
-        assertEquals(2100, subject.getSearchWindowSeconds());
-        assertEquals(12600, subject.getLatestArrivalTime());
+        assertEquals(840, subject.getSearchWindowSeconds());
+        assertEquals(11_340, subject.getLatestArrivalTime());
         // Given - verify not changed
-        assertEquals(10200, subject.getEarliestDepartureTime());
+        assertEquals(10_200, subject.getEarliestDepartureTime());
+    }
+
+    @Test
+    public void calcSearchWindowLimitByMaxLength() {
+        SearchParams searchParams = new RaptorRequestBuilder<TestTripSchedule>()
+                .searchParams()
+                .earliestDepartureTime(12_000)
+                .buildSearchParam();
+
+        int minTransitTime = 1_500;
+        int minWaitTime = 1_200;
+
+        subject.withHeuristics(minTransitTime, minWaitTime)
+                .withSearchParams(searchParams)
+                .calculate();
+
+        /*
+           search-window: round_N(C + T * minTransitTime + W * minWaitTime)
+               = round_60(600 + 0.6 * 1_500 + 0.4 * 1_200) = 1_980
+
+           EDT = 12_000
+           search-window = min(1_980, 1_800) = 1_800
+           LAT = 12_000 + (1_500 + roundUp_60(1_800)) = 15_300
+         */
+        assertEquals(1_800, subject.getSearchWindowSeconds());
+        assertEquals(15_300, subject.getLatestArrivalTime());
+        // Given - verify not changed
+        assertEquals(12_000, subject.getEarliestDepartureTime());
+    }
+
+    @Test
+    public void calcSearchWindowMin() {
+        SearchParams searchParams = new RaptorRequestBuilder<TestTripSchedule>()
+            .searchParams()
+            .earliestDepartureTime(12_000)
+            .buildSearchParam();
+
+        int minTransitTime = 49;
+        int minWaitTime = 0;
+
+        subject.withHeuristics(minTransitTime, minWaitTime)
+            .withSearchParams(searchParams)
+            .calculate();
+
+        assertEquals(600, subject.getSearchWindowSeconds());
+    }
+
+    @Test
+    public void calcSearchWindowFromLATAndEDT() {
+        SearchParams searchParams = new RaptorRequestBuilder<TestTripSchedule>()
+            .searchParams()
+            .earliestDepartureTime(12_000)
+            .latestArrivalTime(18_000)
+            .buildSearchParam();
+
+        int minTransitTime = 3_000;
+        int minWaitTime = 6_000;
+
+        subject.withHeuristics(minTransitTime, minWaitTime)
+            .withSearchParams(searchParams)
+            .calculate();
+
+        /*
+           search-window: round_60(LAT - EDT - minTransitTime)
+               = round_60(18 000 - 12 000 - 3 000)
+               = 3 000
+         */
+        assertEquals(3_000, subject.getSearchWindowSeconds());
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -148,11 +169,11 @@ public class RaptorSearchWindowCalculatorTest {
 
     @Test
     public void roundStep() {
-        assertEquals(-300, subject.roundStep(-151f));
-        assertEquals(0, subject.roundStep(-150f));
+        assertEquals(-60, subject.roundStep(-31f));
+        assertEquals(0, subject.roundStep(-30f));
         assertEquals(0, subject.roundStep(0f));
-        assertEquals(300, subject.roundStep(300f));
-        assertEquals(300, subject.roundStep(449f));
-        assertEquals(600, subject.roundStep(450f));
+        assertEquals(0, subject.roundStep(29f));
+        assertEquals(60, subject.roundStep(30f));
+        assertEquals(480, subject.roundStep(450f));
     }
 }


### PR DESCRIPTION
### Summary
This PR contain:
- Fix: The cost calculation did not calculate board and wait cost correctly for the first transit boarding. This would only be a problem if FLEX access and normal transit would compete by cost.
- Improvement: Improve dynamic search window calculation #3366

### Issue
closes #3366 

### Unit tests
Unit tests updated and SpeedTest run to verity the performance unchanged.

### Documentation
- JavaDoc, Changelog.md and Configuration.md updated
