### PR TITLE
Use correct method to update tripPatternsRunningOnDateMapCache

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/mappers/TransitLayerUpdater.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/mappers/TransitLayerUpdater.java
@@ -118,7 +118,7 @@ public class TransitLayerUpdater {
     // the tripPatternsByRunningPeriodDate accordingly
     for (LocalDate date : datesToBeUpdated) {
       tripPatternsRunningOnDateMapCache.computeIfAbsent(date,
-          p -> new HashSet<>(realtimeTransitLayer.getTripPatternsStartingOnDateCopy(date))
+          p -> new HashSet<>(realtimeTransitLayer.getTripPatternsRunningOnDateCopy(date))
       );
 
       Set<TripPatternForDate> patternsForDate = tripPatternsRunningOnDateMapCache.get(date);


### PR DESCRIPTION
### Summary
This fixes a method call in the TransitLayerUpdater. The `getTripPatternsStartingOnDateCopy` and `getTripPatternsRunningOnDateCopy` were mixed up, and based on the naming of the value being computed called `tripPatternsRunningOnDateMapCache`, it is obvious what the correct method call would be.

This caused trips not to be found in some cases when a trip crossed midnight.