### PR TITLE
Improve documentation for LegacyGraphQLApi

### DIFF
--- a/docs/Getting-OTP.md
+++ b/docs/Getting-OTP.md
@@ -4,7 +4,7 @@
 
 OpenTripPlanner is distributed as a single stand-alone runnable JAR file. These JARs are deployed to the Sonatype OSSRH Maven repository, and release versions are synced to the Maven Central repository. Most people will want to go to [the OTP directory at Maven Central](https://repo1.maven.org/maven2/org/opentripplanner/otp/), navigate to the directory for the highest version number, and download the file whose name ends with `shaded.jar`.
 
-We use the [Travis continuous integration system](https://travis-ci.com/opentripplanner/OpenTripPlanner) to build OTP every time a change is made. You can find the JARs resulting from those builds in the [OSSRH staging repository](https://oss.sonatype.org/#nexus-search;gav~org.opentripplanner~otp~~~~kw,versionexpand). A folder named `x.y.z-SNAPSHOT` contains JARs for builds leading up to (preceding) the `x.y.z` release. 
+We use the [Github Actions CI system](https://github.com/opentripplanner/OpenTripPlanner/actions) to build OTP every time a change is made. You can find the JARs resulting from those builds in the [Github Packages repositor](https://github.com/opentripplanner/OpenTripPlanner/packages/562174).
 
 ## Building from Source
 

--- a/docs/sandbox/LegacyGraphQLApi.md
+++ b/docs/sandbox/LegacyGraphQLApi.md
@@ -12,6 +12,23 @@
 This is a copy of HSL's GraphQL API used by the Digitransit project. The API is used to run OTP2
  together with the [digitransit-ui](https://github.com/HSLdevcom/digitransit-ui).
  
+
+The GraphQL endpoint is available at
+
+```
+http://localhost:8080/otp/routers/default/index/graphql
+```
+
+A complete example that fetches the list of all stops from OTP is:
+
+```
+curl --request POST \
+  --url http://localhost:8080/otp/routers/default/index/graphql \
+  --header 'Content-Type: application/json' \
+  --header 'OTPTimeout: 180000' \
+  --data '{"query":"query stops {\n  stops {\n    gtfsId\n    name\n  }\n}\n","operationName":"stops"}'
+```
+
 ### OTP2 Official GraphQL API (Not available) 
 We **plan** to make a new offical OTP2 API, replacing the REST API. The plan is to base the new API
 on this API and the [Legacy GraphQL Api](LegacyGraphQLApi.md). The new API will most likely have 2 
@@ -20,3 +37,11 @@ on this API and the [Legacy GraphQL Api](LegacyGraphQLApi.md). The new API will 
 ### Configuration
 To enable this you need to add the feature `SandboxAPILegacyGraphQLApi`.
  
+```
+// otp-config.json
+{
+  "otpFeatures" : {
+    "SandboxAPILegacyGraphQLApi": true
+  }
+}
+```

--- a/docs/sandbox/LegacyGraphQLApi.md
+++ b/docs/sandbox/LegacyGraphQLApi.md
@@ -13,11 +13,10 @@ This is a copy of HSL's GraphQL API used by the Digitransit project. The API is 
  together with the [digitransit-ui](https://github.com/HSLdevcom/digitransit-ui).
  
 
-The GraphQL endpoint is available at
+The GraphQL endpoints are available at:
 
-```
-http://localhost:8080/otp/routers/default/index/graphql
-```
+- single query: `http://localhost:8080/otp/routers/default/index/graphql`
+- batch query: `http://localhost:8080/otp/routers/default/index/graphql/batch`
 
 A complete example that fetches the list of all stops from OTP is:
 

--- a/docs/sandbox/MapboxVectorTilesApi.md
+++ b/docs/sandbox/MapboxVectorTilesApi.md
@@ -13,7 +13,7 @@
 
 This API produces [Mapbox vector tiles](https://docs.mapbox.com/vector-tiles/reference/), which are used by eg. [Digitransit-ui](https://github.com/HSLdevcom/digitransit-ui) to show information about public transit entities on the map.
 
-The tiles can be fetched from `/otp/routers/{routerId}/vectorTiles/{layers}/{z}/{x}/{y}.pbf`, where `layers is a comma separated list of layer names from the configuration.
+The tiles can be fetched from `/otp/routers/{routerId}/vectorTiles/{layers}/{z}/{x}/{y}.pbf`, where `layers` is a comma separated list of layer names from the configuration.
 
 ### Configuration
 To enable this you need to add the feature `SandboxAPIMapboxVectorTilesApi` in `otp-config.json`.


### PR DESCRIPTION
(I hope you can forgive me for not following the usual PR form, but this PR is tiny.)

Today I tried out the Legacy GraphQL API and it works really well. Well done for that.

The documentation was a little thin on the ground so I took upon myself to flesh it out.

I also noticed that the instructions to download snapshots are outdated as the code is built and deployed to Github now. However, if you follow the link to the packages page it's not actually possible to download the very newest snapshots. It seems that Github simply cannot display more than a few assets.

I also fixed a few typos.