### PR TITLE
Support multiple modes for on-street transfers

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -7,7 +7,6 @@
 - Prioritize "direct" routes over transfers in group-filters [#3309](https://github.com/opentripplanner/OpenTripPlanner/issues/3309)
 - The itinerary filter configuration is moved from the `RoutingRequest` into its own JSON node `itineraryFilters`.  
 - Remove poor transit results for short trips, when walking is better [#3331](https://github.com/opentripplanner/OpenTripPlanner/issues/3331)
-- A pathway's `traversal_time` is used when calculating the duration of transfers [#3357](https://github.com/opentripplanner/OpenTripPlanner/issues/3357).
 - GTFS Trips will by default not allow bikes if no explicit value is set [#3359](https://github.com/opentripplanner/OpenTripPlanner/issues/3359).
 - Improve the dynamic search window calculation. The configuration parameters `minTransitTimeCoefficient` and `minWaitTimeCoefficient` replace the old `minTripTimeCoefficient` parameter. [#3366](https://github.com/opentripplanner/OpenTripPlanner/issues/3366)   
 - Allow loops caused by turn restriction in street routes [#3399](https://github.com/opentripplanner/OpenTripPlanner/pull/3399)
@@ -51,6 +50,7 @@
 - Remove null default values for Transmodel API [#3613](https://github.com/opentripplanner/OpenTripPlanner/pull/3613)
 - Extract GBFS loading logic [#3608](https://github.com/opentripplanner/OpenTripPlanner/pull/3608)
 - Route not found in some conditions with boarding/alighting restrictions [#3621](https://github.com/opentripplanner/OpenTripPlanner/pull/3621)
+- Allow transfers to use customizable request options [#3324](https://github.com/opentripplanner/OpenTripPlanner/issues/3324).
 
 
 ## 2.0.0 (2020-11-27)

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -211,6 +211,7 @@ config key | description | value type | value default | notes
 `streets` | Include street input files (OSM/PBF) | boolean | true | 
 `storage` | Configure access to data sources like GRAPH/OSM/DEM/GTFS/NETEX/ISSUE-REPORT. | object | null | 
 `subwayAccessTime` | Minutes necessary to reach stops served by trips on routes of `route_type=1` (subway) from the street | double | 2.0 | units: minutes
+`transferRequests` | Routing requests to use for pre-calculating stop-to-stop transfers. | object | `[ { mode: WALK } ]` |
 `transit` | Include all transit input files (GTFS) from scanned directory | boolean | true |
 `transitServiceStart` | Limit the import of transit services to the given *start* date. *Inclusive*. Use an absolute date or a period relative to the day the graph is build. To specify a week before the build date use a negative period like `-P1W`. | date or period | &minus;P1Y | _2020&#8209;01&#8209;01, &minus;P1M3D, &minus;P3W_
 `transitServiceEnd` | Limit the import of transit services to the given *end* date. *Inclusive*. Use an absolute date or a period relative to the day the graph is build. | date or period | P3Y | _2022&#8209;12&#8209;31, P1Y6M10D, P12W_

--- a/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
@@ -216,7 +216,7 @@ public class GraphBuilder implements Runnable {
             // The stops can be linked to each other once they are already linked to the street network.
             if ( ! config.useTransfersTxt) {
                 // This module will use streets or straight line distance depending on whether OSM data is found in the graph.
-                graphBuilder.addModule(new DirectTransferGenerator(config.maxTransferDurationSeconds));
+                graphBuilder.addModule(new DirectTransferGenerator(config.maxTransferDurationSeconds, config.transferRequests));
             }
             // Analyze routing between stops to generate report
             if (OTPFeature.TransferAnalyzer.isOn()) {

--- a/src/main/java/org/opentripplanner/graph_builder/module/DirectTransferGenerator.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/DirectTransferGenerator.java
@@ -1,13 +1,20 @@
 package org.opentripplanner.graph_builder.module;
 
-import com.google.common.collect.Iterables;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.opentripplanner.graph_builder.DataImportIssueStore;
 import org.opentripplanner.graph_builder.issues.StopNotLinkedForTransfers;
 import org.opentripplanner.graph_builder.services.GraphBuilderModule;
 import org.opentripplanner.model.SimpleTransfer;
 import org.opentripplanner.model.Stop;
+import org.opentripplanner.model.StopLocation;
 import org.opentripplanner.routing.algorithm.raptor.transit.Transfer;
 import org.opentripplanner.routing.api.request.RoutingRequest;
+import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.GraphIndex;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
@@ -17,24 +24,20 @@ import org.opentripplanner.util.ProgressTracker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-
 /**
  * {@link org.opentripplanner.graph_builder.services.GraphBuilderModule} module that links up the stops of a transit
  * network among themselves. This is necessary for routing in long-distance mode.
  *
  * It will use the street network if OSM data has already been loaded into the graph.
  * Otherwise it will use straight-line distance between stops.
- *
- * TODO make tests for this that are sensitive to the presence of trip patterns
  */
 public class DirectTransferGenerator implements GraphBuilderModule {
 
     private static final Logger LOG = LoggerFactory.getLogger(DirectTransferGenerator.class);
 
     final double radiusByDurationInSeconds;
+
+    private final List<RoutingRequest> transferRequests;
 
     public List<String> provides() {
         return Arrays.asList("linking");
@@ -44,8 +47,9 @@ public class DirectTransferGenerator implements GraphBuilderModule {
         return Arrays.asList("street to transit");
     }
 
-    public DirectTransferGenerator (double radiusByDurationInSeconds) {
+    public DirectTransferGenerator (double radiusByDurationInSeconds, List<RoutingRequest> transferRequests) {
         this.radiusByDurationInSeconds = radiusByDurationInSeconds;
+        this.transferRequests = transferRequests;
     }
 
     @Override
@@ -67,59 +71,67 @@ public class DirectTransferGenerator implements GraphBuilderModule {
             LOG.info("Creating direct transfer edges between stops using straight line distance (not streets)...");
         }
 
-        Iterable<TransitStopVertex> stops = graph.getVerticesOfType(TransitStopVertex.class);
+        List<TransitStopVertex> stops = graph.getVerticesOfType(TransitStopVertex.class);
 
         ProgressTracker progress = ProgressTracker.track(
-                "Create transfer edges", 1000, Iterables.size(stops)
+            "Create transfer edges for stops",
+            1000,
+            stops.size()
         );
-        int nTransfersTotal = 0;
-        int nLinkableStops = 0;
 
-        RoutingRequest streetRequest = Transfer.prepareTransferRoutingRequest(new RoutingRequest());
+        AtomicInteger nTransfersTotal = new AtomicInteger();
+        AtomicInteger nLinkedStops = new AtomicInteger();
 
-        // This could be multi-threaded, in which case we'd need to be careful about the lifecycle of NearbyStopFinder instances.
-        for (TransitStopVertex ts0 : stops) {
+        stops.stream().parallel().forEach(ts0 -> {
+            /* Make transfers to each nearby stop that has lowest weight on some trip pattern.
+             * Use map based on the list of edges, so that only distinct transfers are stored. */
+            Map<TransferKey, SimpleTransfer> distinctTransfers = new HashMap<>();
             Stop stop = ts0.getStop();
             LOG.debug("Linking stop '{}' {}", stop, ts0);
 
-            /* Make transfers to each nearby stop that is the closest stop on some trip pattern. */
-            int n = 0;
-            for (NearbyStop sd : nearbyStopFinder.findNearbyStopsConsideringPatterns(ts0, streetRequest, false)) {
-                // Skip the origin stop, loop transfers are not needed.
-                if (sd.stop == stop) { continue; }
-                graph.transfersByStop.put(
-                    stop,
-                    new SimpleTransfer(ts0.getStop(), sd.stop, sd.distance, sd.edges)
-                );
-                n += 1;
-            }
-            if (OTPFeature.FlexRouting.isOn()) {
-                // This code is for finding transfers from FlexStopLocations to Stops, transfers
-                // from Stops to FlexStopLocations and between Stops are already covered above.
-                for (NearbyStop sd : nearbyStopFinder.findNearbyStopsConsideringPatterns(ts0,  streetRequest, true)) {
+            for (RoutingRequest transferProfile : transferRequests) {
+                RoutingRequest streetRequest = Transfer.prepareTransferRoutingRequest(transferProfile);
+
+                for (NearbyStop sd : nearbyStopFinder.findNearbyStopsConsideringPatterns(ts0, streetRequest, false)) {
                     // Skip the origin stop, loop transfers are not needed.
-                    if (sd.stop == ts0.getStop()) { continue; }
-                    if (sd.stop instanceof Stop) { continue; }
-                    graph.transfersByStop.put(sd.stop,
-                        new SimpleTransfer(sd.stop, ts0.getStop(), sd.distance, sd.edges)
+                    if (sd.stop == stop) { continue; }
+                    distinctTransfers.put(
+                        new TransferKey(sd.stop, sd.edges),
+                        new SimpleTransfer(ts0.getStop(), sd.stop, sd.distance, sd.edges)
                     );
-                    n += 1;
+                }
+                if (OTPFeature.FlexRouting.isOn()) {
+                    // This code is for finding transfers from FlexStopLocations to Stops, transfers
+                    // from Stops to FlexStopLocations and between Stops are already covered above.
+                    for (NearbyStop sd : nearbyStopFinder.findNearbyStopsConsideringPatterns(ts0, streetRequest,  true)) {
+                        // Skip the origin stop, loop transfers are not needed.
+                        if (sd.stop == ts0.getStop()) { continue; }
+                        if (sd.stop instanceof Stop) { continue; }
+                        distinctTransfers.put(
+                            new TransferKey(sd.stop, sd.edges),
+                            new SimpleTransfer(sd.stop, ts0.getStop(), sd.distance, sd.edges)
+                        );
+                    }
                 }
             }
-            LOG.debug("Linked stop {} to {} nearby stops on other patterns.", stop, n);
-            if (n == 0) {
+
+            LOG.debug("Linked stop {} with {} transfers to stops with different patterns.", stop, distinctTransfers.size());
+            if (distinctTransfers.isEmpty()) {
                 issueStore.add(new StopNotLinkedForTransfers(ts0));
+            } else {
+                distinctTransfers.values()
+                        .forEach(transfer -> graph.transfersByStop.put(transfer.from, transfer));
+                nLinkedStops.incrementAndGet();
+                nTransfersTotal.addAndGet(distinctTransfers.size());
             }
-            else {
-                nLinkableStops++;
-            }
+
             //Keep lambda! A method-ref would causes incorrect class and line number to be logged
             //noinspection Convert2MethodRef
             progress.step(m -> LOG.info(m));
-            nTransfersTotal += n;
-        }
+        });
+
         LOG.info(progress.completeMessage());
-        LOG.info("Done connecting stops to one another. Created a total of {} transfers from {} stops.", nTransfersTotal, nLinkableStops);
+        LOG.info("Done connecting stops to one another. Created a total of {} transfers from {} stops.", nTransfersTotal, nLinkedStops);
         graph.hasDirectTransfers = true;
     }
 
@@ -128,5 +140,26 @@ public class DirectTransferGenerator implements GraphBuilderModule {
         // No inputs
     }
 
+    private static class TransferKey {
+        private final StopLocation target;
+        private final List<Edge> edges;
 
+        private TransferKey(StopLocation target, List<Edge> edges) {
+            this.target = target;
+            this.edges = edges;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) { return true; }
+            if (o == null || getClass() != o.getClass()) { return false; }
+            final TransferKey that = (TransferKey) o;
+            return target.equals(that.target) && Objects.equals(edges, that.edges);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(target, edges);
+        }
+    }
 }

--- a/src/main/java/org/opentripplanner/graph_builder/module/DirectTransferGenerator.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/DirectTransferGenerator.java
@@ -101,8 +101,8 @@ public class DirectTransferGenerator implements GraphBuilderModule {
                     // Skip the origin stop, loop transfers are not needed.
                     if (sd.stop == stop) { continue; }
                     distinctTransfers.put(
-                        new TransferKey(ts0.getStop(), sd.stop, sd.edges),
-                        new SimpleTransfer(ts0.getStop(), sd.stop, sd.distance, sd.edges)
+                        new TransferKey(stop, sd.stop, sd.edges),
+                        new SimpleTransfer(stop, sd.stop, sd.distance, sd.edges)
                     );
                 }
                 if (OTPFeature.FlexRouting.isOn()) {
@@ -110,11 +110,11 @@ public class DirectTransferGenerator implements GraphBuilderModule {
                     // from Stops to FlexStopLocations and between Stops are already covered above.
                     for (NearbyStop sd : nearbyStopFinder.findNearbyStopsConsideringPatterns(ts0, streetRequest,  true)) {
                         // Skip the origin stop, loop transfers are not needed.
-                        if (sd.stop == ts0.getStop()) { continue; }
+                        if (sd.stop == stop) { continue; }
                         if (sd.stop instanceof Stop) { continue; }
                         distinctTransfers.put(
-                            new TransferKey(sd.stop, ts0.getStop(), sd.edges),
-                            new SimpleTransfer(sd.stop, ts0.getStop(), sd.distance, sd.edges)
+                            new TransferKey(sd.stop, stop, sd.edges),
+                            new SimpleTransfer(sd.stop, stop, sd.distance, sd.edges)
                         );
                     }
                 }

--- a/src/main/java/org/opentripplanner/graph_builder/module/DirectTransferGenerator.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/DirectTransferGenerator.java
@@ -101,7 +101,7 @@ public class DirectTransferGenerator implements GraphBuilderModule {
                     // Skip the origin stop, loop transfers are not needed.
                     if (sd.stop == stop) { continue; }
                     distinctTransfers.put(
-                        new TransferKey(sd.stop, sd.edges),
+                        new TransferKey(ts0.getStop(), sd.stop, sd.edges),
                         new SimpleTransfer(ts0.getStop(), sd.stop, sd.distance, sd.edges)
                     );
                 }
@@ -113,7 +113,7 @@ public class DirectTransferGenerator implements GraphBuilderModule {
                         if (sd.stop == ts0.getStop()) { continue; }
                         if (sd.stop instanceof Stop) { continue; }
                         distinctTransfers.put(
-                            new TransferKey(sd.stop, sd.edges),
+                            new TransferKey(sd.stop, ts0.getStop(), sd.edges),
                             new SimpleTransfer(sd.stop, ts0.getStop(), sd.distance, sd.edges)
                         );
                     }
@@ -148,10 +148,12 @@ public class DirectTransferGenerator implements GraphBuilderModule {
     }
 
     private static class TransferKey {
+        private final StopLocation source;
         private final StopLocation target;
         private final List<Edge> edges;
 
-        private TransferKey(StopLocation target, List<Edge> edges) {
+        private TransferKey(StopLocation source, StopLocation target, List<Edge> edges) {
+            this.source = source;
             this.target = target;
             this.edges = edges;
         }
@@ -161,12 +163,12 @@ public class DirectTransferGenerator implements GraphBuilderModule {
             if (this == o) { return true; }
             if (o == null || getClass() != o.getClass()) { return false; }
             final TransferKey that = (TransferKey) o;
-            return target.equals(that.target) && Objects.equals(edges, that.edges);
+            return source.equals(that.source) && target.equals(that.target) && Objects.equals(edges, that.edges);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(target, edges);
+            return Objects.hash(source, target, edges);
         }
     }
 }

--- a/src/main/java/org/opentripplanner/graph_builder/module/NearbyStopFinder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/NearbyStopFinder.java
@@ -4,6 +4,7 @@ import com.beust.jcommander.internal.Lists;
 import com.beust.jcommander.internal.Sets;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
+import java.util.Comparator;
 import org.locationtech.jts.geom.Coordinate;
 import org.opentripplanner.common.MinMap;
 import org.opentripplanner.ext.flex.trip.FlexTrip;
@@ -223,9 +224,7 @@ public class NearbyStopFinder {
                 Collection<State> states = locationStates.getValue();
                 // Select the vertex from all vertices that are reachable per FlexStopLocation by taking
                 // the minimum walking distance
-                State min = Collections.min(states,
-                    (s1, s2) -> (int) (s1.walkDistance - s2.walkDistance)
-                );
+                State min = Collections.min(states, Comparator.comparing(State::getWeight));
 
                 // If the best state for this FlexStopLocation is a SplitterVertex, we want to get the
                 // TemporaryStreetLocation instead. This allows us to reach SplitterVertices in both

--- a/src/main/java/org/opentripplanner/graph_builder/module/NearbyStopFinder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/NearbyStopFinder.java
@@ -55,9 +55,6 @@ public class NearbyStopFinder {
     private final Graph graph;
     private final double durationLimitInSeconds;
 
-    /* Fields used when finding stops via the street network. */
-    private AStar astar;
-
     private DirectGraphFinder directGraphFinder;
 
     /**
@@ -76,12 +73,11 @@ public class NearbyStopFinder {
         this.graph = graph;
         this.useStreets = useStreets;
         this.durationLimitInSeconds = durationLimitInSeconds;
-        if (useStreets) {
-            astar = new AStar();
+
+        if (!useStreets) {
             // We need to accommodate straight line distance (in meters) but when streets are present we use an
             // earliest arrival search, which optimizes on time. Ideally we'd specify in meters,
             // but we don't have much of a choice here. Use the default walking speed to convert.
-        } else {
             this.directGraphFinder = new DirectGraphFinder(graph);
         }
     }
@@ -190,6 +186,8 @@ public class NearbyStopFinder {
         routingRequest.disableRemainingWeightHeuristic = true;
         routingRequest.rctx.remainingWeightHeuristic = new TrivialRemainingWeightHeuristic();
         routingRequest.dominanceFunction = new DominanceFunction.MinimumWeight();
+
+        var astar = new AStar();
         astar.setSkipEdgeStrategy(new DurationSkipEdgeStrategy(durationLimitInSeconds));
         ShortestPathTree spt = astar.getShortestPathTree(routingRequest);
 

--- a/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
@@ -734,6 +734,11 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
         this.setStreetSubRequestModes(modeSet);
     }
 
+    public RoutingRequest(RequestModes modes) {
+        this();
+        this.modes = modes;
+    }
+
     /* ACCESSOR/SETTER METHODS */
 
     public boolean transitAllowed() {

--- a/src/main/java/org/opentripplanner/routing/api/request/StreetMode.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/StreetMode.java
@@ -12,9 +12,6 @@ public enum StreetMode {
   WALK(true, true, true, true, false, false),
   /**
    * Bike only
-   *
-   * This can be used as access/egress, but transfers will still be walk only.
-   * // TODO OTP2 Implement bicycle transfers
    */
   BIKE(true, true, true, true, true, false),
   /**

--- a/src/main/java/org/opentripplanner/routing/graph/Graph.java
+++ b/src/main/java/org/opentripplanner/routing/graph/Graph.java
@@ -10,6 +10,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
 import gnu.trove.list.TDoubleList;
 import gnu.trove.list.linked.TDoubleLinkedList;
 import gnu.trove.set.hash.TIntHashSet;
@@ -249,7 +250,7 @@ public class Graph implements Serializable {
     public final BiMap<Trip,Trip> interlinedTrips = HashBiMap.create();
 
     /** Pre-generated transfers between all stops. */
-    public final Multimap<StopLocation, SimpleTransfer> transfersByStop = HashMultimap.create();
+    public final Multimap<StopLocation, SimpleTransfer> transfersByStop = Multimaps.synchronizedMultimap(HashMultimap.create());
 
     public Map<FeedScopedId, FlexStopLocation> locationsById = new HashMap<>();
 

--- a/src/main/java/org/opentripplanner/routing/graph/Graph.java
+++ b/src/main/java/org/opentripplanner/routing/graph/Graph.java
@@ -10,7 +10,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
-import com.google.common.collect.Multimaps;
 import gnu.trove.list.TDoubleList;
 import gnu.trove.list.linked.TDoubleLinkedList;
 import gnu.trove.set.hash.TIntHashSet;
@@ -250,7 +249,7 @@ public class Graph implements Serializable {
     public final BiMap<Trip,Trip> interlinedTrips = HashBiMap.create();
 
     /** Pre-generated transfers between all stops. */
-    public final Multimap<StopLocation, SimpleTransfer> transfersByStop = Multimaps.synchronizedMultimap(HashMultimap.create());
+    public final Multimap<StopLocation, SimpleTransfer> transfersByStop = HashMultimap.create();
 
     public Map<FeedScopedId, FlexStopLocation> locationsById = new HashMap<>();
 

--- a/src/main/java/org/opentripplanner/routing/graphfinder/NearbyStop.java
+++ b/src/main/java/org/opentripplanner/routing/graphfinder/NearbyStop.java
@@ -42,6 +42,9 @@ public class NearbyStop implements Comparable<NearbyStop> {
 
   @Override
   public int compareTo(NearbyStop that) {
+    if (state != null && that.state != null) {
+      return (int) (this.state.getWeight()) - (int) (that.state.getWeight());
+    }
     return (int) (this.distance) - (int) (that.distance);
   }
 

--- a/src/main/java/org/opentripplanner/routing/graphfinder/NearbyStop.java
+++ b/src/main/java/org/opentripplanner/routing/graphfinder/NearbyStop.java
@@ -42,7 +42,11 @@ public class NearbyStop implements Comparable<NearbyStop> {
 
   @Override
   public int compareTo(NearbyStop that) {
-    if (state != null && that.state != null) {
+    if ((this.state == null) != (that.state == null)) {
+      throw new IllegalStateException("Only NearbyStops which both contain or lack a state may be compared.");
+    }
+
+    if (this.state != null) {
       return (int) (this.state.getWeight()) - (int) (that.state.getWeight());
     }
     return (int) (this.distance) - (int) (that.distance);

--- a/src/main/java/org/opentripplanner/standalone/config/BuildConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/BuildConfig.java
@@ -8,6 +8,7 @@ import org.opentripplanner.graph_builder.module.osm.WayPropertySetSource;
 import org.opentripplanner.graph_builder.services.osm.CustomNamer;
 import org.opentripplanner.model.calendar.ServiceDate;
 import org.opentripplanner.model.calendar.ServiceDateInterval;
+import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.impl.DefaultFareServiceFactory;
 import org.opentripplanner.routing.services.FareServiceFactory;
 import org.slf4j.Logger;
@@ -16,6 +17,8 @@ import org.slf4j.LoggerFactory;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.Period;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * This class is an object representation of the 'build-config.json'.
@@ -297,6 +300,8 @@ public class BuildConfig {
      */
     public final StorageConfig storage;
 
+    public final List<RoutingRequest> transferRequests;
+
     /**
      * Visibility calculations for an area will not be done if there are more nodes than this limit.
      */
@@ -355,6 +360,17 @@ public class BuildConfig {
         customNamer = CustomNamer.CustomNamerFactory.fromConfig(c.asRawNode("osmNaming"));
         netex = new NetexConfig(c.path("netex"));
         storage = new StorageConfig(c.path("storage"));
+
+        if (c.path("transferRequests") != null && !c.path("transferRequests").asList().isEmpty()) {
+            transferRequests = c
+                .path("transferRequests")
+                .asList()
+                .stream()
+                .map(RoutingRequestMapper::mapRoutingRequest)
+                .collect(Collectors.toUnmodifiableList());
+        } else {
+            transferRequests = List.of(new RoutingRequest());
+        }
 
         if(logUnusedParams) {
             c.logAllUnusedParameters(LOG);

--- a/src/main/java/org/opentripplanner/standalone/config/NodeAdapter.java
+++ b/src/main/java/org/opentripplanner/standalone/config/NodeAdapter.java
@@ -1,13 +1,6 @@
 package org.opentripplanner.standalone.config;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import java.util.stream.Collectors;
-import org.opentripplanner.model.FeedScopedId;
-import org.opentripplanner.routing.api.request.RequestFunctions;
-import org.opentripplanner.util.OtpAppException;
-import org.slf4j.Logger;
-
-import javax.validation.constraints.NotNull;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.LocalDate;
@@ -26,6 +19,14 @@ import java.util.function.BiFunction;
 import java.util.function.DoubleFunction;
 import java.util.function.Function;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import javax.validation.constraints.NotNull;
+import org.opentripplanner.api.parameter.QualifiedModeSet;
+import org.opentripplanner.model.FeedScopedId;
+import org.opentripplanner.routing.api.request.RequestFunctions;
+import org.opentripplanner.routing.api.request.RequestModes;
+import org.opentripplanner.util.OtpAppException;
+import org.slf4j.Logger;
 
 
 /**
@@ -172,6 +173,11 @@ public class NodeAdapter {
     public Set<String> asTextSet(String paramName, Set<String> defaultValue) {
         if(!exist(paramName)) return defaultValue;
         return arrayAsList(paramName, JsonNode::asText).stream().collect(Collectors.toSet());
+    }
+
+    public RequestModes asRequestModes(String paramName, RequestModes defaultValue) {
+        var node = param(paramName);
+        return node == null || node.asText().isBlank() ? defaultValue : new QualifiedModeSet(node.asText()).getRequestModes();
     }
 
     /**

--- a/src/main/java/org/opentripplanner/standalone/config/RoutingRequestMapper.java
+++ b/src/main/java/org/opentripplanner/standalone/config/RoutingRequestMapper.java
@@ -70,7 +70,7 @@ public class RoutingRequestMapper {
         // 'maxTransfers' is configured in the Raptor tuning parameters, not here
         request.maxDirectStreetDurationSeconds = c.asDouble("maxDirectStreetDurationSeconds", dft.maxDirectStreetDurationSeconds);
         request.maxWheelchairSlope = c.asDouble("maxWheelchairSlope", dft.maxWheelchairSlope); // ADA max wheelchair ramp slope is a good default.
-        request.modes = RequestModes.defaultRequestModes; // TODO Map default modes from config
+        request.modes = c.asRequestModes("modes", RequestModes.defaultRequestModes);
         request.nonpreferredTransferCost = c.asInt("nonpreferredTransferPenalty", dft.nonpreferredTransferCost);
         request.numItineraries = c.asInt("numItineraries", dft.numItineraries);
         request.onlyTransitTrips = c.asBoolean("onlyTransitTrips", dft.onlyTransitTrips);

--- a/src/main/java/org/opentripplanner/transit/raptor/api/transit/RaptorTransfer.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/transit/RaptorTransfer.java
@@ -133,6 +133,6 @@ public interface RaptorTransfer {
       String duration = DurationUtils.durationToStr(durationInSeconds());
         return hasRides()
             ? String.format("Flex %s %dx ~ %d", duration, numberOfRides(), stop())
-            : String.format("Walk %s ~ %d", duration, stop());
+            : String.format("On-Street %s ~ %d", duration, stop());
     }
 }

--- a/src/test/java/org/opentripplanner/graph_builder/module/DirectTransferGeneratorTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/DirectTransferGeneratorTest.java
@@ -1,0 +1,360 @@
+package org.opentripplanner.graph_builder.module;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.google.common.collect.Multimap;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.opentripplanner.model.FeedScopedId;
+import org.opentripplanner.model.SimpleTransfer;
+import org.opentripplanner.model.StopLocation;
+import org.opentripplanner.model.StopPattern;
+import org.opentripplanner.model.TransitMode;
+import org.opentripplanner.model.TripPattern;
+import org.opentripplanner.model.base.ToStringBuilder;
+import org.opentripplanner.routing.algorithm.GraphRoutingTest;
+import org.opentripplanner.routing.api.request.RequestModes;
+import org.opentripplanner.routing.api.request.RoutingRequest;
+import org.opentripplanner.routing.api.request.StreetMode;
+import org.opentripplanner.routing.edgetype.StreetTraversalPermission;
+import org.opentripplanner.routing.graph.Edge;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.routing.vertextype.StreetVertex;
+import org.opentripplanner.routing.vertextype.TransitStopVertex;
+
+/**
+ * This creates a graph with trip patterns S0 - V0 | S11 - V11 --------> V21 - S21 |     \ S12 - V12
+ * ----> V22 - V22
+ */
+class DirectTransferGeneratorTest extends GraphRoutingTest {
+
+    private static final double MAX_TRANSFER_DURATION = 3600;
+    private TransitStopVertex S0, S11, S12, S21, S22;
+    private StreetVertex V0, V11, V12, V21, V22;
+
+    private Graph graph(boolean addPatterns) {
+        return graphOf(new Builder() {
+            @Override
+            public void build() {
+                S0 = stop("S0", 47.495, 19.001);
+                S11 = stop("S11", 47.500, 19.001);
+                S12 = stop("S12", 47.520, 19.001);
+                S21 = stop("S21", 47.500, 19.011);
+                S22 = stop("S22", 47.520, 19.011);
+
+                V0 = intersection("V0", 47.495, 19.000);
+                V11 = intersection("V11", 47.500, 19.000);
+                V12 = intersection("V12", 47.510, 19.000);
+                V21 = intersection("V21", 47.500, 19.010);
+                V22 = intersection("V22", 47.510, 19.010);
+
+                biLink(V0, S0);
+                biLink(V11, S11);
+                biLink(V12, S12);
+                biLink(V21, S21);
+                biLink(V22, S22);
+
+                street(V0, V11, 100, StreetTraversalPermission.ALL);
+                street(V0, V12, 200, StreetTraversalPermission.ALL);
+                street(V0, V21, 100, StreetTraversalPermission.ALL);
+                street(V0, V22, 200, StreetTraversalPermission.ALL);
+
+                street(V11, V12, 100, StreetTraversalPermission.PEDESTRIAN);
+                street(V21, V22, 100, StreetTraversalPermission.PEDESTRIAN);
+                street(V11, V21, 100, StreetTraversalPermission.PEDESTRIAN);
+                street(V11, V22, 110, StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE);
+
+                if (addPatterns) {
+                    var agency = agency("Agency");
+
+                    tripPattern(new TripPattern(
+                            new FeedScopedId("Test", "TP1"),
+                            route("R1", TransitMode.BUS, agency),
+                            new StopPattern(List.of(st(S11), st(S12)))
+                    ));
+
+                    tripPattern(new TripPattern(
+                            new FeedScopedId("Test", "TP2"),
+                            route("R2", TransitMode.BUS, agency),
+                            new StopPattern(List.of(st(S21), st(S22)))
+                    ));
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testDirectTransfersWithoutPatterns() {
+        var generator = new DirectTransferGenerator(
+                MAX_TRANSFER_DURATION,
+                List.of(
+                        new RoutingRequest(
+                                new RequestModes(null, StreetMode.WALK, null, null, null)
+                        )
+                )
+        );
+
+        var graph = graph(false);
+        graph.index();
+        graph.hasStreets = false;
+
+        generator.buildGraph(graph, null);
+
+        assertTransfers(
+                graph.transfersByStop
+        );
+    }
+
+    @Test
+    public void testDirectTransfersWithPatterns() {
+        var generator = new DirectTransferGenerator(
+                MAX_TRANSFER_DURATION,
+                List.of(
+                        new RoutingRequest(
+                                new RequestModes(null, StreetMode.WALK, null, null, null)
+                        )
+                )
+        );
+
+        var graph = graph(true);
+        graph.hasStreets = false;
+
+        generator.buildGraph(graph, null);
+
+        assertTransfers(
+                graph.transfersByStop,
+                tr(S0, 556, S11),
+                tr(S0, 935, S21),
+                tr(S11, 751, S21),
+                tr(S12, 751, S22),
+                tr(S21, 751, S11),
+                tr(S22, 751, S12)
+        );
+    }
+
+    @Test
+    public void testSingleRequestWithoutPatterns() {
+        var generator = new DirectTransferGenerator(
+                MAX_TRANSFER_DURATION,
+                List.of(
+                        new RoutingRequest(
+                                new RequestModes(null, StreetMode.WALK, null, null, null)
+                        )
+                )
+        );
+
+        var graph = graph(false);
+        graph.hasStreets = true;
+
+        generator.buildGraph(graph, null);
+
+        assertTransfers(
+                graph.transfersByStop
+        );
+    }
+
+    @Test
+    public void testSingleRequestWithPatterns() {
+        var generator = new DirectTransferGenerator(
+                MAX_TRANSFER_DURATION,
+                List.of(
+                        new RoutingRequest(
+                                new RequestModes(null, StreetMode.WALK, null, null, null)
+                        )
+                )
+        );
+
+        var graph = graph(true);
+        graph.hasStreets = true;
+
+        generator.buildGraph(graph, null);
+
+        assertTransfers(
+                graph.transfersByStop,
+                tr(S0, 100, List.of(V0, V11), S11),
+                tr(S0, 100, List.of(V0, V21), S21),
+                tr(S11, 100, List.of(V11, V21), S21)
+        );
+    }
+
+    @Test
+    public void testMultipleRequestsWithoutPatterns() {
+        var generator = new DirectTransferGenerator(
+                MAX_TRANSFER_DURATION,
+                List.of(
+                        new RoutingRequest(
+                                new RequestModes(null, StreetMode.WALK, null, null, null)
+                        ),
+                        new RoutingRequest(
+                                new RequestModes(null, StreetMode.BIKE, null, null, null)
+                        )
+                )
+        );
+
+        var graph = graph(false);
+        graph.hasStreets = true;
+
+        generator.buildGraph(graph, null);
+
+        assertTransfers(
+                graph.transfersByStop
+        );
+    }
+
+    @Test
+    public void testMultipleRequestsWithPatterns() {
+        var generator = new DirectTransferGenerator(
+                MAX_TRANSFER_DURATION,
+                List.of(
+                        new RoutingRequest(
+                                new RequestModes(null, StreetMode.WALK, null, null, null)
+                        ),
+                        new RoutingRequest(
+                                new RequestModes(null, StreetMode.BIKE, null, null, null)
+                        )
+                )
+        );
+
+        var graph = graph(true);
+        graph.hasStreets = true;
+
+        generator.buildGraph(graph, null);
+
+        assertTransfers(
+                graph.transfersByStop,
+                tr(S0, 100, List.of(V0, V11), S11),
+                tr(S0, 100, List.of(V0, V21), S21),
+                tr(S11, 100, List.of(V11, V21), S21),
+                tr(S11, 110, List.of(V11, V22), S22)
+        );
+    }
+
+    private void assertTransfers(
+            Multimap<StopLocation, SimpleTransfer> transfersByStop,
+            TransferDescriptor... transfers
+    ) {
+        var matchedTransfers = new HashSet<SimpleTransfer>();
+        var assertions = Stream.concat(
+                Arrays.stream(transfers).map(td -> td.matcher(transfersByStop, matchedTransfers)),
+                Stream.of(allTransfersMatched(transfersByStop, matchedTransfers))
+        );
+
+        assertAll(assertions);
+    }
+
+    private Executable allTransfersMatched(
+            Multimap<StopLocation, SimpleTransfer> transfersByStop,
+            Set<SimpleTransfer> matchedTransfers
+    ) {
+        return () -> {
+            var missingTransfers = new HashSet<>(transfersByStop.values());
+            missingTransfers.removeAll(matchedTransfers);
+
+            assertEquals(Set.of(), missingTransfers, "All transfers matched");
+        };
+    }
+
+    private TransferDescriptor tr(TransitStopVertex from, double distance, TransitStopVertex to) {
+        return new TransferDescriptor(from, distance, to);
+    }
+
+    private TransferDescriptor tr(
+            TransitStopVertex from,
+            double distance,
+            List<StreetVertex> vertices,
+            TransitStopVertex to
+    ) {
+        return new TransferDescriptor(from, distance, vertices, to);
+    }
+
+    private static class TransferDescriptor {
+
+        private final StopLocation from;
+        private final StopLocation to;
+        private final Double distanceMeters;
+        private final List<StreetVertex> vertices;
+
+        public TransferDescriptor(
+                TransitStopVertex from,
+                Double distanceMeters,
+                TransitStopVertex to
+        ) {
+            this.from = from.getStop();
+            this.distanceMeters = distanceMeters;
+            this.vertices = null;
+            this.to = to.getStop();
+        }
+
+        public TransferDescriptor(
+                TransitStopVertex from,
+                Double distanceMeters,
+                List<StreetVertex> vertices,
+                TransitStopVertex to
+        ) {
+            this.from = from.getStop();
+            this.distanceMeters = distanceMeters;
+            this.vertices = vertices;
+            this.to = to.getStop();
+        }
+
+        boolean matches(SimpleTransfer transfer) {
+            if (!Objects.equals(from, transfer.from) || !Objects.equals(to, transfer.to)) {
+                return false;
+            }
+
+            if (vertices == null) {
+                return distanceMeters == transfer.getDistanceMeters()
+                        && transfer.getEdges() == null;
+            }
+            else {
+                var transferVertices = transfer.getEdges().stream()
+                        .map(Edge::getToVertex)
+                        .filter(StreetVertex.class::isInstance)
+                        .collect(Collectors.toList());
+
+                return distanceMeters == transfer.getDistanceMeters() && Objects.equals(
+                        vertices, transferVertices);
+            }
+        }
+
+        @Override
+        public String toString() {
+            return ToStringBuilder.of(getClass())
+                    .addObj("from", from)
+                    .addObj("to", to)
+                    .addNum("distanceMeters", distanceMeters)
+                    .addCol("vertices", vertices)
+                    .toString();
+        }
+
+        private Executable matcher(
+                Multimap<StopLocation, SimpleTransfer> transfersByStop,
+                Set<SimpleTransfer> matchedTransfers
+        ) {
+            return () -> {
+                var matched = transfersByStop.values()
+                        .stream()
+                        .filter(this::matches)
+                        .findFirst();
+
+                if (matched.isPresent()) {
+                    assertTrue(true, "Found transfer for " + this);
+                    matchedTransfers.add(matched.get());
+                }
+                else {
+                    fail("Missing transfer for " + this);
+                }
+            };
+        }
+    }
+}

--- a/src/test/java/org/opentripplanner/routing/algorithm/GraphRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/GraphRoutingTest.java
@@ -7,9 +7,13 @@ import org.locationtech.jts.geom.Coordinate;
 import org.opentripplanner.common.TurnRestriction;
 import org.opentripplanner.common.TurnRestrictionType;
 import org.opentripplanner.common.geometry.GeometryUtils;
+import org.opentripplanner.model.Agency;
 import org.opentripplanner.model.Entrance;
 import org.opentripplanner.model.FeedScopedId;
+import org.opentripplanner.model.Route;
 import org.opentripplanner.model.Stop;
+import org.opentripplanner.model.StopTime;
+import org.opentripplanner.model.TransitMode;
 import org.opentripplanner.model.TripPattern;
 import org.opentripplanner.model.WgsCoordinate;
 import org.opentripplanner.model.WheelChairBoarding;
@@ -389,9 +393,26 @@ public abstract class GraphRoutingTest {
             return List.of(link(from, to), link(to, from));
         }
 
+        public Agency agency(String name) {
+            return new Agency(new FeedScopedId("Test", name), name, null);
+        }
+
+        public Route route(String id, TransitMode mode, Agency agency) {
+            var route = new Route(new FeedScopedId("Test", id));
+            route.setAgency(agency);
+            route.setMode(mode);
+            return route;
+        }
+
         // Transit
         public void tripPattern(TripPattern tripPattern) {
             graph.tripPatternForId.put(tripPattern.getId(), tripPattern);
+        }
+
+        public StopTime st(TransitStopVertex s1) {
+            var st = new StopTime();
+            st.setStop(s1.getStop());
+            return st;
         }
     }
 }

--- a/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/services/TransferGeneratorTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/services/TransferGeneratorTest.java
@@ -135,7 +135,7 @@ class TransferGeneratorTest implements RaptorTestConstants {
                 "[["
                         + "TripToTripTransfer{from: [2 10:20:00 BUS L1], to: [2 10:20:00 BUS L2]}"
                         + "], ["
-                        + "TripToTripTransfer{from: [3 10:30:00 BUS L2], to: [4 10:31:00 BUS L3], transfer: Walk 1m ~ 4}"
+                        + "TripToTripTransfer{from: [3 10:30:00 BUS L2], to: [4 10:31:00 BUS L3], transfer: On-Street 1m ~ 4}"
                         + "]]",
                 result.toString()
         );
@@ -161,9 +161,9 @@ class TransferGeneratorTest implements RaptorTestConstants {
         var result = subject.findAllPossibleTransfers(transitLegs);
         assertEquals(
                 "[["
-                        + "TripToTripTransfer{from: [2 10:10:00 BUS L1], to: [5 10:12:00 BUS L2], transfer: Walk 1m ~ 5}, "
+                        + "TripToTripTransfer{from: [2 10:10:00 BUS L1], to: [5 10:12:00 BUS L2], transfer: On-Street 1m ~ 5}, "
                         + "TripToTripTransfer{from: [3 10:20:00 BUS L1], to: [3 10:22:00 BUS L2]}, "
-                        + "TripToTripTransfer{from: [4 10:30:00 BUS L1], to: [6 10:32:00 BUS L2], transfer: Walk 20s ~ 6}"
+                        + "TripToTripTransfer{from: [4 10:30:00 BUS L1], to: [6 10:32:00 BUS L2], transfer: On-Street 20s ~ 6}"
                         + "]]",
                 result.toString()
         );
@@ -200,9 +200,9 @@ class TransferGeneratorTest implements RaptorTestConstants {
         assertEquals(
                 "[["
                         + "TripToTripTransfer{from: [2 10:10:00 BUS L1], to: [2 10:12:00 BUS L2]}, "
-                        + "TripToTripTransfer{from: [3 10:20:00 BUS L1], to: [4 10:22:00 BUS L2], transfer: Walk 30s ~ 4}"
+                        + "TripToTripTransfer{from: [3 10:20:00 BUS L1], to: [4 10:22:00 BUS L2], transfer: On-Street 30s ~ 4}"
                         + "], ["
-                        + "TripToTripTransfer{from: [4 10:22:00 BUS L2], to: [6 10:24:00 BUS L3], transfer: Walk 20s ~ 6}, "
+                        + "TripToTripTransfer{from: [4 10:22:00 BUS L2], to: [6 10:24:00 BUS L3], transfer: On-Street 20s ~ 6}, "
                         + "TripToTripTransfer{from: [5 10:32:00 BUS L2], to: [5 10:34:00 BUS L3]}"
                         + "]]",
                 result.toString()

--- a/src/test/java/org/opentripplanner/routing/graphfinder/StreetGraphFinderTest.java
+++ b/src/test/java/org/opentripplanner/routing/graphfinder/StreetGraphFinderTest.java
@@ -7,11 +7,9 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.opentripplanner.model.Agency;
 import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.model.Route;
 import org.opentripplanner.model.StopPattern;
-import org.opentripplanner.model.StopTime;
 import org.opentripplanner.model.TransitMode;
 import org.opentripplanner.model.TripPattern;
 import org.opentripplanner.routing.RoutingService;
@@ -38,19 +36,14 @@ class StreetGraphFinderTest extends GraphRoutingTest {
 
     @BeforeEach
     protected void setUp() throws Exception {
-        var a = new Agency(new FeedScopedId("F", "Agency"), "Agency", null);
-
-        R1 = new Route(new FeedScopedId("F", "R1"));
-        R1.setAgency(a);
-        R1.setMode(TransitMode.BUS);
-
-        R2 = new Route(new FeedScopedId("F", "R2"));
-        R2.setAgency(a);
-        R2.setMode(TransitMode.TRAM);
-
         var graph = graphOf(new Builder() {
             @Override
             public void build() {
+                var a = agency("Agency");
+
+                R1 = route("R1", TransitMode.BUS, a);
+                R2 = route("R2", TransitMode.TRAM, a);
+
                 S1 = stop("S1", 47.500, 19.001);
                 S2 = stop("S2", 47.510, 19.001);
                 S3 = stop("S3", 47.520, 19.001);
@@ -297,11 +290,5 @@ class StreetGraphFinderTest extends GraphRoutingTest {
                 )
         )
                 .collect(Collectors.toList());
-    }
-
-    private StopTime st(TransitStopVertex s1) {
-        var st = new StopTime();
-        st.setStop(s1.getStop());
-        return st;
     }
 }


### PR DESCRIPTION
### Summary

Extend the handling of pre-calculated on-street transfers to support additional modes, options besides the default `WALK`. 

The `RoutingRequest`s can be specified in `build-config.json` which will be used to collect the possible transfers:
```
"transferRequests": [
  { "modes": "WALK"    },
  { "modes": "WALK",   "wheelchairAccessible": true },
  { "modes": "BICYCLE" }
]
```

The length of the transfers are restricted by `maxTransferDurationSeconds` -- if set to 30 minutes, than the transfers will included 30 minutes of walking or 30 minutes of bicycling.

### Issue

closes #3324

### Unit tests

`DirectTransferGeneratorTest` is added with tests which account for `TripPattern`s along with street-network and straight line transfers. 

### Code style

:ballot_box_with_check: 

### Documentation

`Configuration.md` contains the new property.

### Changelog

>  Allow transfers to use customizable request options [#3324](https://github.com/opentripplanner/OpenTripPlanner/issues/3324).