### PR TITLE
Also check Trip cancellation for EstimatedCallType

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLStoptimeImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLStoptimeImpl.java
@@ -93,7 +93,7 @@ public class LegacyGraphQLStoptimeImpl implements LegacyGraphQLDataFetchers.Lega
 
   @Override
   public DataFetcher<Trip> trip() {
-    return environment -> getRoutingService(environment).getTripForId().get(getSource(environment).getTripId());
+    return environment -> getSource(environment).getTrip();
   }
 
   @Override

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/JourneyWhiteListed.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/JourneyWhiteListed.java
@@ -50,8 +50,7 @@ public class JourneyWhiteListed {
     public static Stream<TripTimeShort> whiteListAuthoritiesAndOrLines(
         Stream<TripTimeShort> stream,
         Collection<FeedScopedId> authorityIds,
-        Collection<FeedScopedId> lineIds,
-        RoutingService routingService
+        Collection<FeedScopedId> lineIds
     ) {
         if (CollectionUtils.isEmpty(authorityIds) && CollectionUtils.isEmpty(lineIds)) {
             return stream;
@@ -59,18 +58,16 @@ public class JourneyWhiteListed {
         return stream.filter(it -> isTripTimeShortAcceptable(
             it,
             authorityIds,
-            lineIds,
-            routingService
+            lineIds
         ));
     }
 
     private static boolean isTripTimeShortAcceptable(
         TripTimeShort tts,
         Collection<FeedScopedId> authorityIds,
-        Collection<FeedScopedId> lineIds,
-        RoutingService routingService
+        Collection<FeedScopedId> lineIds
     ) {
-        Trip trip = routingService.getTripForId().get(tts.getTripId());
+        Trip trip = tts.getTrip();
 
         if (trip == null || trip.getRoute() == null) {
             return true;

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/et/EstimatedCallType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/et/EstimatedCallType.java
@@ -156,9 +156,7 @@ public class EstimatedCallType {
                         return ((TripTimeShort) environment.getSource()).getPickupType() != PICKDROP_NONE;
                     }
                   return GqlUtil.getRoutingService(environment).getPatternForTrip()
-                        .get(GqlUtil.getRoutingService(environment).getTripForId().get((
-                            (TripTimeShort) environment.getSource()
-                        ).getTripId()))
+                        .get(((TripTimeShort) environment.getSource()).getTrip())
                         .getBoardType(((TripTimeShort) environment.getSource()).getStopIndex()) != PICKDROP_NONE;
                 })
                 .build())
@@ -171,39 +169,27 @@ public class EstimatedCallType {
                         //Realtime-updated
                         return ((TripTimeShort) environment.getSource()).getDropoffType() != PICKDROP_NONE;
                     }
-                  return GqlUtil.getRoutingService(environment).getPatternForTrip()
-                        .get(GqlUtil.getRoutingService(environment).getTripForId().get((
-                            (TripTimeShort) environment.getSource()
-                        ).getTripId()))
-                        .getAlightType(((TripTimeShort) environment.getSource()).getStopIndex()) != PICKDROP_NONE;
-
+                    return GqlUtil.getRoutingService(environment).getPatternForTrip()
+                            .get(((TripTimeShort) environment.getSource()).getTrip())
+                            .getAlightType(((TripTimeShort) environment.getSource()).getStopIndex()) != PICKDROP_NONE;
                 })
                 .build())
             .field(GraphQLFieldDefinition.newFieldDefinition()
                     .name("requestStop")
                     .type(Scalars.GraphQLBoolean)
                     .description("Whether vehicle will only stop on request.")
-                    .dataFetcher(environment -> {
-                      return GqlUtil.getRoutingService(environment).getPatternForTrip()
-                              .get(GqlUtil.getRoutingService(environment).getTripForId().get((
-                                  (TripTimeShort) environment.getSource()
-                              ).getTripId()))
-                              .getAlightType(((TripTimeShort) environment.getSource()).getStopIndex()) == PICKDROP_COORDINATE_WITH_DRIVER;
-                    })
+                    .dataFetcher(environment ->
+                        GqlUtil.getRoutingService(environment).getPatternForTrip()
+                            .get(((TripTimeShort) environment.getSource()).getTrip())
+                            .getAlightType(((TripTimeShort) environment.getSource()).getStopIndex()) == PICKDROP_COORDINATE_WITH_DRIVER)
                     .build())
 
-            // TODO This checks both whether the Trip or the Stop is cancelled. Change after implementing DSJ
             .field(GraphQLFieldDefinition
                     .newFieldDefinition()
                     .name("cancellation")
                     .type(Scalars.GraphQLBoolean)
                     .description("Whether stop is cancelled.")
-                    .dataFetcher(environment -> ((TripTimeShort) environment.getSource()).isCancelledStop()
-                        || GqlUtil.getRoutingService(environment)
-                            .getTripForId()
-                            .get(((TripTimeShort) environment.getSource()).getTripId())
-                            .getTripAlteration()
-                            .isCanceledOrReplaced())
+                    .dataFetcher(environment -> ((TripTimeShort) environment.getSource()).isCanceledEffectively())
             .build())
             .field(GraphQLFieldDefinition.newFieldDefinition()
                     .name("date")
@@ -214,10 +200,7 @@ public class EstimatedCallType {
             .field(GraphQLFieldDefinition.newFieldDefinition()
                     .name("serviceJourney")
                     .type(serviceJourneyType)
-                    .dataFetcher(environment -> {
-                      return GqlUtil.getRoutingService(environment).getTripForId()
-                              .get(((TripTimeShort) environment.getSource()).getTripId());
-                    })
+                    .dataFetcher(environment -> ((TripTimeShort) environment.getSource()).getTrip())
                     .build())
             .field(GraphQLFieldDefinition.newFieldDefinition()
                     .name("destinationDisplay")
@@ -267,8 +250,8 @@ public class EstimatedCallType {
       TripTimeShort tripTimeShort,
       RoutingService routingService
   ) {
-    FeedScopedId tripId = tripTimeShort.getTripId();
-    Trip trip = routingService.getTripForId().get(tripId);
+    Trip trip = tripTimeShort.getTrip();
+    FeedScopedId tripId = trip.getId();
     FeedScopedId routeId = trip.getRoute().getId();
 
     FeedScopedId stopId = tripTimeShort.getStopId();

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/et/EstimatedCallType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/et/EstimatedCallType.java
@@ -191,12 +191,20 @@ public class EstimatedCallType {
                               .getAlightType(((TripTimeShort) environment.getSource()).getStopIndex()) == PICKDROP_COORDINATE_WITH_DRIVER;
                     })
                     .build())
-            .field(GraphQLFieldDefinition.newFieldDefinition()
+
+            // TODO This checks both whether the Trip or the Stop is cancelled. Change after implementing DSJ
+            .field(GraphQLFieldDefinition
+                    .newFieldDefinition()
                     .name("cancellation")
                     .type(Scalars.GraphQLBoolean)
                     .description("Whether stop is cancelled.")
-                    .dataFetcher(environment -> ((TripTimeShort) environment.getSource()).isCancelledStop())
-                    .build())
+                    .dataFetcher(environment -> ((TripTimeShort) environment.getSource()).isCancelledStop()
+                        || GqlUtil.getRoutingService(environment)
+                            .getTripForId()
+                            .get(((TripTimeShort) environment.getSource()).getTripId())
+                            .getTripAlteration()
+                            .isCanceledOrReplaced())
+            .build())
             .field(GraphQLFieldDefinition.newFieldDefinition()
                     .name("date")
                     .type(gqlUtil.dateScalar)

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/StopPlaceType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/StopPlaceType.java
@@ -276,8 +276,7 @@ public class StopPlaceType {
     tripTimesStream = JourneyWhiteListed.whiteListAuthoritiesAndOrLines(
         tripTimesStream,
         authorityIdsWhiteListed,
-        lineIdsWhiteListed,
-        routingService
+        lineIdsWhiteListed
     );
 
     if (!limitOnDestinationDisplay) {
@@ -286,8 +285,7 @@ public class StopPlaceType {
     // Group by line and destination display, limit departures per group and merge
     return tripTimesStream
         .collect(Collectors.groupingBy(t -> destinationDisplayPerLine(
-            ((TripTimeShort) t),
-            routingService
+            ((TripTimeShort) t)
         )))
         .values()
         .stream()
@@ -386,8 +384,8 @@ public class StopPlaceType {
     return false;
   }
 
-  private static String destinationDisplayPerLine(TripTimeShort t, RoutingService routingService) {
-    Trip trip = routingService.getTripForId().get(t.getTripId());
+  private static String destinationDisplayPerLine(TripTimeShort t) {
+    Trip trip = t.getTrip();
     return trip == null ? t.getHeadsign() : trip.getRoute().getId() + "|" + t.getHeadsign();
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/TimetabledPassingTimeType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/TimetabledPassingTimeType.java
@@ -69,9 +69,7 @@ public class TimetabledPassingTimeType {
             .dataFetcher(environment -> {
               return GqlUtil.getRoutingService(environment)
                   .getPatternForTrip()
-                  .get(GqlUtil.getRoutingService(environment)
-                      .getTripForId()
-                      .get(((TripTimeShort) environment.getSource()).getTripId()))
+                  .get(((TripTimeShort) environment.getSource()).getTrip())
                   .getBoardType(((TripTimeShort) environment.getSource()).getStopIndex()) != PICKDROP_NONE;
             })
             .build())
@@ -83,9 +81,7 @@ public class TimetabledPassingTimeType {
             .dataFetcher(environment -> {
               return GqlUtil.getRoutingService(environment)
                   .getPatternForTrip()
-                  .get(GqlUtil.getRoutingService(environment)
-                      .getTripForId()
-                      .get(((TripTimeShort) environment.getSource()).getTripId()))
+                  .get(((TripTimeShort) environment.getSource()).getTrip())
                   .getAlightType(((TripTimeShort) environment.getSource()).getStopIndex())
                   != PICKDROP_NONE;
             })
@@ -98,9 +94,7 @@ public class TimetabledPassingTimeType {
             .dataFetcher(environment -> {
               return GqlUtil.getRoutingService(environment)
                   .getPatternForTrip()
-                  .get(GqlUtil.getRoutingService(environment)
-                      .getTripForId()
-                      .get(((TripTimeShort) environment.getSource()).getTripId()))
+                  .get(((TripTimeShort) environment.getSource()).getTrip())
                   .getAlightType(((TripTimeShort) environment.getSource()).getStopIndex())
                   == PICKDROP_COORDINATE_WITH_DRIVER;
             })
@@ -109,11 +103,7 @@ public class TimetabledPassingTimeType {
             .newFieldDefinition()
             .name("serviceJourney")
             .type(serviceJourneyType)
-            .dataFetcher(environment -> {
-              return GqlUtil.getRoutingService(environment)
-                  .getTripForId()
-                  .get(((TripTimeShort) environment.getSource()).getTripId());
-            })
+            .dataFetcher(environment -> ((TripTimeShort) environment.getSource()).getTrip())
             .build())
         .field(GraphQLFieldDefinition
             .newFieldDefinition()

--- a/src/main/java/org/opentripplanner/model/TripTimeShort.java
+++ b/src/main/java/org/opentripplanner/model/TripTimeShort.java
@@ -29,7 +29,7 @@ public class TripTimeShort {
     private final boolean cancelledStop;
     private final RealTimeState realtimeState;
     private final long serviceDay;
-    private final FeedScopedId tripId;
+    private final Trip trip;
     private final String blockId;
     private final String headsign;
     private final int pickupType;
@@ -40,7 +40,7 @@ public class TripTimeShort {
      */
     public TripTimeShort(TripTimes tt, int i, Stop stop, ServiceDay sd) {
         serviceDay         = sd != null ? sd.time(0) : UNDEFINED;
-        tripId             = tt.trip.getId();
+        trip               = tt.trip;
         stopId             = stop.getId();
         stopIndex          = i;
         stopCount          = tt.getNumStops();
@@ -168,6 +168,11 @@ public class TripTimeShort {
         return cancelledStop;
     }
 
+    /** Return {code true} if stop is cancelled, or trip is canceled/replaced */
+    public boolean isCanceledEffectively() {
+        return cancelledStop || trip.getTripAlteration().isCanceledOrReplaced();
+    }
+
     public RealTimeState getRealtimeState() {
         return realtimeState;
     }
@@ -176,8 +181,8 @@ public class TripTimeShort {
         return serviceDay;
     }
 
-    public FeedScopedId getTripId() {
-        return tripId;
+    public Trip getTrip() {
+        return trip;
     }
 
     public String getBlockId() {


### PR DESCRIPTION
### Summary
This only changed the Transmodel sandbox API. If a Trip had a planned cancellation, it would not show up on the EstimatedCallType. This adds an additional check in the API to account for this.

### Issue
This is a bug fix for #3340