### PR TITLE
RAPTOR: add tests for time restricted access

### DIFF
--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/McTransitWorker.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/McTransitWorker.java
@@ -1,5 +1,7 @@
 package org.opentripplanner.transit.raptor.rangeraptor.multicriteria;
 
+import static org.opentripplanner.transit.raptor.rangeraptor.multicriteria.PatternRide.paretoComparatorRelativeCost;
+
 import org.opentripplanner.transit.raptor.api.transit.CostCalculator;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripPattern;
@@ -11,8 +13,6 @@ import org.opentripplanner.transit.raptor.rangeraptor.multicriteria.arrivals.Abs
 import org.opentripplanner.transit.raptor.rangeraptor.transit.TransitCalculator;
 import org.opentripplanner.transit.raptor.rangeraptor.transit.TripScheduleSearch;
 import org.opentripplanner.transit.raptor.util.paretoset.ParetoSet;
-
-import static org.opentripplanner.transit.raptor.rangeraptor.multicriteria.PatternRide.paretoComparatorRelativeCost;
 
 
 /**
@@ -101,15 +101,11 @@ public final class McTransitWorker<T extends RaptorTripSchedule> implements Rout
                 final T trip = tripSearch.getCandidateTrip();
                 final int boardTime = trip.departure(stopPos);
 
-                if(prevArrival.arrivedByAccess()) {
+                if (prevArrival.arrivedByAccess()) {
                     prevArrival = prevArrival.timeShiftNewArrivalTime(boardTime - slackProvider.boardSlack());
                 }
 
-
-                final int boardWaitTimeForCostCalculation = timeShiftingAllowed(prevArrival)
-                        ? slackProvider.boardSlack()
-                        : boardTime - prevArrival.arrivalTime();
-
+                final int boardWaitTimeForCostCalculation = boardTime - prevArrival.arrivalTime();
                 final int relativeBoardCost = calculateOnTripRelativeCost(
                     prevArrival,
                     boardTime,
@@ -150,15 +146,5 @@ public final class McTransitWorker<T extends RaptorTripSchedule> implements Rout
         int boardWaitTime
     ) {
         return costCalculator.onTripRidingCost(prevArrival, boardWaitTime, boardTime);
-    }
-
-    /**
-     * Some access paths can be time-shifted towards the board time. This has to be taken into
-     * account when calculating the the correct wait-time. This can not be done in the calculator
-     * as done earlier. If we don´t do that the alight slack of the first transit is not added to
-     * the cost, giving the first transit path a lower cost than other transit paths.
-     */
-    private static boolean timeShiftingAllowed(AbstractStopArrival<?> arrival) {
-        return arrival.arrivedByAccess() && !arrival.accessPath().access().hasRides();
     }
 }

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/path/ForwardPathMapper.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/path/ForwardPathMapper.java
@@ -104,8 +104,9 @@ public final class ForwardPathMapper<T extends RaptorTripSchedule> implements Pa
 
         if(access.hasRides()) {
             targetToTime -= slackProvider.transferSlack();
-            targetToTime = access.latestArrivalTime(targetToTime);
         }
+
+        targetToTime = access.latestArrivalTime(targetToTime);
 
         int targetFromTime = targetToTime - access.durationInSeconds();
 

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/path/ReversePathMapper.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/path/ReversePathMapper.java
@@ -148,8 +148,9 @@ public final class ReversePathMapper<T extends RaptorTripSchedule> implements Pa
 
         if(egress.hasRides()) {
             targetFromTime += slackProvider.transferSlack();
-            targetFromTime = egress.earliestDepartureTime(targetFromTime);
         }
+
+        targetFromTime = egress.earliestDepartureTime(targetFromTime);
 
         int targetToTime = targetFromTime + egress.durationInSeconds();
 

--- a/src/test/java/org/opentripplanner/transit/raptor/_data/RaptorTestConstants.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/_data/RaptorTestConstants.java
@@ -24,6 +24,7 @@ public interface RaptorTestConstants {
   int T00_04 = hm2time(0, 4);
   int T00_10 = hm2time(0, 10);
   int T00_30 = hm2time(0, 30);
+  int T01_00 = hm2time(1, 0);
 
   // Stop indexes - Note! There is no stop defined for index 0(zero)! You must
   // account for that in the test if you uses a stop index.

--- a/src/test/java/org/opentripplanner/transit/raptor/_data/transit/TestTransfer.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/_data/transit/TestTransfer.java
@@ -12,6 +12,7 @@ import java.util.List;
  */
 public class TestTransfer implements RaptorTransfer {
 
+    public static final int SECONDS_IN_DAY = 24 * 3600;
     public static final int DEFAULT_NUMBER_OF_LEGS = 0;
     public static final boolean STOP_REACHED_ON_BOARD = true;
     public static final boolean STOP_REACHED_ON_FOOT = false;
@@ -19,6 +20,8 @@ public class TestTransfer implements RaptorTransfer {
     private final int durationInSeconds;
     private final int numberOfRides;
     private final boolean stopReachedOnBoard;
+    private final Integer opening;
+    private final Integer closing;
 
     private TestTransfer(
         int stop,
@@ -26,10 +29,23 @@ public class TestTransfer implements RaptorTransfer {
         int numberOfRides,
         boolean stopReachedOnBoard
     ) {
+        this(stop, durationInSeconds, numberOfRides, stopReachedOnBoard, null, null);
+    }
+
+    private TestTransfer(
+            int stop,
+            int durationInSeconds,
+            int numberOfRides,
+            boolean stopReachedOnBoard,
+            Integer opening,
+            Integer closing
+    ) {
         this.stop = stop;
         this.durationInSeconds = durationInSeconds;
         this.numberOfRides = numberOfRides;
         this.stopReachedOnBoard = stopReachedOnBoard;
+        this.opening = opening;
+        this.closing = closing;
     }
 
     /** Only use this to override this class, use factory methods to create instances. */
@@ -38,7 +54,17 @@ public class TestTransfer implements RaptorTransfer {
     }
 
     public static TestTransfer walk(int stop, int durationInSeconds) {
-        return new TestTransfer(stop, durationInSeconds, DEFAULT_NUMBER_OF_LEGS, STOP_REACHED_ON_FOOT);
+        return new TestTransfer(stop, durationInSeconds, DEFAULT_NUMBER_OF_LEGS, STOP_REACHED_ON_FOOT, null, null);
+    }
+
+    /**
+     * Creates a walk transfer with time restrictions. opening and closing may be specified as seconds
+     * since the start of "RAPTOR time" to limit the time periods that the access is traversable, which
+     * is repeatead every 24 hours. This allows the access to only be traversable between for example
+     * 08:00 and 16:00 every day.
+     */
+    public static TestTransfer walk(int stop, int durationInSeconds, int opening, int closing) {
+        return new TestTransfer(stop, durationInSeconds, DEFAULT_NUMBER_OF_LEGS, STOP_REACHED_ON_FOOT, opening, closing);
     }
 
     /** Create a new flex access and arrive stop onBoard with 1 ride/extra transfer. */
@@ -89,6 +115,47 @@ public class TestTransfer implements RaptorTransfer {
     @Override
     public boolean stopReachedOnBoard() {
         return stopReachedOnBoard;
+    }
+
+    @Override
+    public int earliestDepartureTime(int requestedDepartureTime) {
+        if (opening == null || closing == null) {
+            return requestedDepartureTime;
+        }
+
+        int days = Math.floorDiv(requestedDepartureTime, SECONDS_IN_DAY);
+        int specificOpening = days * SECONDS_IN_DAY + opening;
+        int specificClosing = days * SECONDS_IN_DAY + closing;
+        if (requestedDepartureTime < specificOpening) {
+            return specificOpening;
+        } else if (requestedDepartureTime > specificClosing) {
+            // return the opening time for the next day
+            return specificOpening + SECONDS_IN_DAY;
+        }
+        return requestedDepartureTime;
+    }
+
+    @Override
+    public int latestArrivalTime(int requestedArrivalTime) {
+        if (opening == null || closing == null) {
+            return requestedArrivalTime;
+        }
+
+        // opening & closing is relative to the departure
+        int requestedDepartureTime = requestedArrivalTime - durationInSeconds();
+        int days = Math.floorDiv(requestedDepartureTime, SECONDS_IN_DAY);
+        int specificOpening = days * SECONDS_IN_DAY + opening;
+        int specificClosing = days * SECONDS_IN_DAY + closing;
+        int closeAtArrival = specificClosing + durationInSeconds();
+
+        if (requestedDepartureTime < specificOpening) {
+            // return the closing for the previous day, offset with durationInSeconds()
+            return closeAtArrival - SECONDS_IN_DAY;
+        }
+        else if (requestedArrivalTime > closeAtArrival) {
+            return closeAtArrival;
+        }
+        return requestedArrivalTime;
     }
 
     @Override

--- a/src/test/java/org/opentripplanner/transit/raptor/moduletests/D01_TimeDependentAccessTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/moduletests/D01_TimeDependentAccessTest.java
@@ -145,7 +145,7 @@ public class D01_TimeDependentAccessTest implements RaptorTestConstants {
                 ""
                         + "Walk 2m ~ 2 ~ BUS R1 0:15 0:30 ~ 5 ~ Walk 1m [00:13:00 00:31:00 18m, cost: 2220]\n"
                         + "Walk 2m ~ 2 ~ BUS R2 0:20 0:35 ~ 5 ~ Walk 1m [00:18:00 00:36:00 18m, cost: 2220]\n"
-                        + "Walk 2m ~ 2 ~ BUS R3 0:25 0:40 ~ 5 ~ Walk 1m [00:20:00 00:41:00 21m, cost: 2220]",
+                        + "Walk 2m ~ 2 ~ BUS R3 0:25 0:40 ~ 5 ~ Walk 1m [00:20:00 00:41:00 21m, cost: 2400]",
                 pathsToString(response)
         );
     }
@@ -171,7 +171,7 @@ public class D01_TimeDependentAccessTest implements RaptorTestConstants {
         assertEquals(
                 ""
                         + "Walk 2m ~ 2 ~ BUS R2 0:20 0:35 ~ 5 ~ Walk 1m [00:18:00 00:36:00 18m, cost: 2220]\n"
-                        + "Walk 2m ~ 2 ~ BUS R3 0:25 0:40 ~ 5 ~ Walk 1m [00:20:00 00:41:00 21m, cost: 2220]",
+                        + "Walk 2m ~ 2 ~ BUS R3 0:25 0:40 ~ 5 ~ Walk 1m [00:20:00 00:41:00 21m, cost: 2400]",
                 pathsToString(response)
         );
     }

--- a/src/test/java/org/opentripplanner/transit/raptor/moduletests/D01_TimeDependentAccessTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/moduletests/D01_TimeDependentAccessTest.java
@@ -1,0 +1,223 @@
+package org.opentripplanner.transit.raptor.moduletests;
+
+import static org.junit.Assert.assertEquals;
+import static org.opentripplanner.transit.raptor._data.api.PathUtils.pathsToString;
+import static org.opentripplanner.transit.raptor._data.transit.TestRoute.route;
+import static org.opentripplanner.transit.raptor._data.transit.TestTransfer.walk;
+import static org.opentripplanner.transit.raptor._data.transit.TestTripSchedule.schedule;
+import static org.opentripplanner.transit.raptor.api.transit.RaptorSlackProvider.defaultSlackProvider;
+import static org.opentripplanner.util.time.TimeUtils.hm2time;
+
+import java.time.Duration;
+import org.junit.Before;
+import org.junit.Test;
+import org.opentripplanner.routing.algorithm.raptor.transit.AccessEgress;
+import org.opentripplanner.routing.core.State;
+import org.opentripplanner.transit.raptor.RaptorService;
+import org.opentripplanner.transit.raptor._data.RaptorTestConstants;
+import org.opentripplanner.transit.raptor._data.transit.TestTransitData;
+import org.opentripplanner.transit.raptor._data.transit.TestTripSchedule;
+import org.opentripplanner.transit.raptor.api.request.RaptorProfile;
+import org.opentripplanner.transit.raptor.api.request.RaptorRequestBuilder;
+import org.opentripplanner.transit.raptor.rangeraptor.configure.RaptorConfig;
+
+/*
+ * FEATURE UNDER TEST
+ *
+ * Raptor should take into account time restrictions on access. If the time restrictions require it,
+ * there should be a wait before boarding the trip so that the access is traversed while "open".
+ */
+public class D01_TimeDependentAccessTest implements RaptorTestConstants {
+
+    private final TestTransitData data = new TestTransitData();
+    private final RaptorRequestBuilder<TestTripSchedule> requestBuilder =
+            new RaptorRequestBuilder<>();
+    private final RaptorService<TestTripSchedule> raptorService = new RaptorService<>(
+            RaptorConfig.defaultConfigForTest()
+    );
+
+    @Before
+    public void setup() {
+        data.add(
+                route("R1", STOP_A, STOP_B, STOP_C, STOP_D, STOP_E)
+                        .withTimetable(
+                                schedule("0:10 0:15 0:20 0:25 0:30")
+                        )
+        );
+        data.add(
+                route("R2", STOP_A, STOP_B, STOP_C, STOP_D, STOP_E)
+                        .withTimetable(
+                                schedule("0:15 0:20 0:25 0:30 0:35")
+                        )
+        );
+        data.add(
+                route("R3", STOP_A, STOP_B, STOP_C, STOP_D, STOP_E)
+                        .withTimetable(
+                                schedule("0:20 0:25 0:30 0:35 0:40")
+                        )
+        );
+        data.add(
+                route("R4", STOP_A, STOP_B, STOP_C, STOP_D, STOP_E)
+                        .withTimetable(
+                                schedule("0:25 0:30 0:35 0:40 0:45")
+                        )
+        );
+        requestBuilder.searchParams()
+                .addEgressPaths(walk(STOP_E, D1m));
+
+        requestBuilder.searchParams()
+                .earliestDepartureTime(T00_10)
+                .searchWindow(Duration.ofMinutes(30))
+                .timetableEnabled(true);
+
+        // We will test board- and alight-slack in a separate test
+        requestBuilder.slackProvider(
+                defaultSlackProvider(60, 0, 0)
+        );
+
+        // Enable Raptor debugging by configuring the requestBuilder
+        // data.debugToStdErr(requestBuilder);
+    }
+
+    /*
+     * There is no time restriction, all routes are found.
+     */
+    @Test
+    public void openInWholeSearchIntervalTest() {
+        requestBuilder.profile(RaptorProfile.MULTI_CRITERIA)
+                .searchParams()
+                .addAccessPaths(
+                        new TimeDependentAccessEgress(STOP_B, D2m, null, T00_00, T01_00)
+                );
+
+        var response = raptorService.route(requestBuilder.build(), data);
+
+        assertEquals(
+                ""
+                        + "Walk 2m ~ 2 ~ BUS R1 0:15 0:30 ~ 5 ~ Walk 1m [00:13:00 00:31:00 18m, cost: 2220]\n"
+                        + "Walk 2m ~ 2 ~ BUS R2 0:20 0:35 ~ 5 ~ Walk 1m [00:18:00 00:36:00 18m, cost: 2220]\n"
+                        + "Walk 2m ~ 2 ~ BUS R3 0:25 0:40 ~ 5 ~ Walk 1m [00:23:00 00:41:00 18m, cost: 2220]\n"
+                        + "Walk 2m ~ 2 ~ BUS R4 0:30 0:45 ~ 5 ~ Walk 1m [00:28:00 00:46:00 18m, cost: 2220]",
+                pathsToString(response)
+        );
+    }
+
+    /*
+     * The access is only open after 00:18, which means that we may arrive at the stop at 00:20 at
+     * the earliest. Due to this:
+     *   - boarding R1 is not possible
+     */
+    @Test
+    public void openInSecondHalfIntervalTest() {
+        requestBuilder.profile(RaptorProfile.MULTI_CRITERIA)
+                .searchParams()
+                .addAccessPaths(
+                        new TimeDependentAccessEgress(STOP_B, D2m, null, hm2time(0, 18), T01_00)
+                );
+
+        var response = raptorService.route(requestBuilder.build(), data);
+
+        assertEquals(
+                ""
+                        + "Walk 2m ~ 2 ~ BUS R2 0:20 0:35 ~ 5 ~ Walk 1m [00:18:00 00:36:00 18m, cost: 2220]\n"
+                        + "Walk 2m ~ 2 ~ BUS R3 0:25 0:40 ~ 5 ~ Walk 1m [00:23:00 00:41:00 18m, cost: 2220]\n"
+                        + "Walk 2m ~ 2 ~ BUS R4 0:30 0:45 ~ 5 ~ Walk 1m [00:28:00 00:46:00 18m, cost: 2220]",
+                pathsToString(response)
+        );
+    }
+
+    /*
+     * The access is only open before 00:20, which means that we arrive at the stop by 00:22. Due to this:
+     *   - there needs to be a wait of 3 minutes for R3
+     *   - R4 is discarded since it is not better than taking R3
+     */
+    @Test
+    public void openInFirstHalfIntervalTest() {
+        requestBuilder.profile(RaptorProfile.MULTI_CRITERIA)
+                .searchParams()
+                .addAccessPaths(
+                        new TimeDependentAccessEgress(STOP_B, D2m, null, T00_00, hm2time(0, 20))
+                );
+
+        var response = raptorService.route(requestBuilder.build(), data);
+
+        assertEquals(
+                ""
+                        + "Walk 2m ~ 2 ~ BUS R1 0:15 0:30 ~ 5 ~ Walk 1m [00:13:00 00:31:00 18m, cost: 2220]\n"
+                        + "Walk 2m ~ 2 ~ BUS R2 0:20 0:35 ~ 5 ~ Walk 1m [00:18:00 00:36:00 18m, cost: 2220]\n"
+                        + "Walk 2m ~ 2 ~ BUS R3 0:25 0:40 ~ 5 ~ Walk 1m [00:20:00 00:41:00 21m, cost: 2220]",
+                pathsToString(response)
+        );
+    }
+
+    /*
+     * The access is only open after 00:18 and before 00:20. This means that we arrive at the stop at
+     * 00:20 at the earliest and 00:22 at the latest. Due to this:
+     *   - boarding R1 is not possible
+     *   - there needs to be a wait of 3 minutes for R3
+     *   - R4 is discarded since it is not better than taking R3
+     */
+    @Test
+    public void partiallyOpenIntervalTest() {
+        requestBuilder.profile(RaptorProfile.MULTI_CRITERIA)
+                .searchParams()
+                .addAccessPaths(
+                        new TimeDependentAccessEgress(
+                                STOP_B, D2m, null, hm2time(0, 18), hm2time(0, 20))
+                );
+
+        var response = raptorService.route(requestBuilder.build(), data);
+
+        assertEquals(
+                ""
+                        + "Walk 2m ~ 2 ~ BUS R2 0:20 0:35 ~ 5 ~ Walk 1m [00:18:00 00:36:00 18m, cost: 2220]\n"
+                        + "Walk 2m ~ 2 ~ BUS R3 0:25 0:40 ~ 5 ~ Walk 1m [00:20:00 00:41:00 21m, cost: 2220]",
+                pathsToString(response)
+        );
+    }
+
+    private static class TimeDependentAccessEgress extends AccessEgress {
+
+        private final int opening;
+        private final int closing;
+
+        public TimeDependentAccessEgress(
+                int toFromStop,
+                int durationInSeconds,
+                State lastState,
+                int opening,
+                int closing
+        ) {
+            super(toFromStop, durationInSeconds, lastState);
+            this.opening = opening;
+            this.closing = closing;
+        }
+
+        @Override
+        public int earliestDepartureTime(int requestedDepartureTime) {
+            if (requestedDepartureTime < opening) {
+                return opening;
+            } else if (requestedDepartureTime > closing) {
+                // return the opening time for the next day
+                return opening + 24 * 3600;
+            }
+            return requestedDepartureTime;
+        }
+
+        @Override
+        public int latestArrivalTime(int requestedArrivalTime) {
+            // opening & closing is relative to the departure
+            int requestedDepartureTime = requestedArrivalTime - durationInSeconds();
+            int closeAtArrival = closing + durationInSeconds();
+
+            if (requestedDepartureTime < opening) {
+                // return the closing hours for the previous day, offset with durationInSeconds()
+                return closeAtArrival - 24 * 3600;
+            }
+            else if (requestedArrivalTime > closeAtArrival) {
+                return closeAtArrival;
+            }
+            return requestedArrivalTime;
+        }
+    }
+}

--- a/src/test/java/org/opentripplanner/transit/raptor/moduletests/D01_TimeDependentAccessTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/moduletests/D01_TimeDependentAccessTest.java
@@ -3,16 +3,14 @@ package org.opentripplanner.transit.raptor.moduletests;
 import static org.junit.Assert.assertEquals;
 import static org.opentripplanner.transit.raptor._data.api.PathUtils.pathsToString;
 import static org.opentripplanner.transit.raptor._data.transit.TestRoute.route;
+import static org.opentripplanner.transit.raptor._data.transit.TestTransfer.SECONDS_IN_DAY;
 import static org.opentripplanner.transit.raptor._data.transit.TestTransfer.walk;
 import static org.opentripplanner.transit.raptor._data.transit.TestTripSchedule.schedule;
-import static org.opentripplanner.transit.raptor.api.transit.RaptorSlackProvider.defaultSlackProvider;
 import static org.opentripplanner.util.time.TimeUtils.hm2time;
 
 import java.time.Duration;
 import org.junit.Before;
 import org.junit.Test;
-import org.opentripplanner.routing.algorithm.raptor.transit.AccessEgress;
-import org.opentripplanner.routing.core.State;
 import org.opentripplanner.transit.raptor.RaptorService;
 import org.opentripplanner.transit.raptor._data.RaptorTestConstants;
 import org.opentripplanner.transit.raptor._data.transit.TestTransitData;
@@ -41,25 +39,14 @@ public class D01_TimeDependentAccessTest implements RaptorTestConstants {
         data.add(
                 route("R1", STOP_A, STOP_B, STOP_C, STOP_D, STOP_E)
                         .withTimetable(
-                                schedule("0:10 0:15 0:20 0:25 0:30")
-                        )
-        );
-        data.add(
-                route("R2", STOP_A, STOP_B, STOP_C, STOP_D, STOP_E)
-                        .withTimetable(
-                                schedule("0:15 0:20 0:25 0:30 0:35")
-                        )
-        );
-        data.add(
-                route("R3", STOP_A, STOP_B, STOP_C, STOP_D, STOP_E)
-                        .withTimetable(
-                                schedule("0:20 0:25 0:30 0:35 0:40")
-                        )
-        );
-        data.add(
-                route("R4", STOP_A, STOP_B, STOP_C, STOP_D, STOP_E)
-                        .withTimetable(
-                                schedule("0:25 0:30 0:35 0:40 0:45")
+                                schedule("00:10 00:15 00:20 00:25 00:30"),
+                                schedule("00:15 00:20 00:25 00:30 00:35"),
+                                schedule("00:20 00:25 00:30 00:35 00:40"),
+                                schedule("00:25 00:30 00:35 00:40 00:45"),
+                                schedule("24:10 24:15 24:20 24:25 24:30"),
+                                schedule("24:15 24:20 24:25 24:30 24:35"),
+                                schedule("24:20 24:25 24:30 24:35 24:40"),
+                                schedule("24:25 24:30 24:35 24:40 24:45")
                         )
         );
         requestBuilder.searchParams()
@@ -69,14 +56,6 @@ public class D01_TimeDependentAccessTest implements RaptorTestConstants {
                 .earliestDepartureTime(T00_10)
                 .searchWindow(Duration.ofMinutes(30))
                 .timetableEnabled(true);
-
-        // We will test board- and alight-slack in a separate test
-        requestBuilder.slackProvider(
-                defaultSlackProvider(60, 0, 0)
-        );
-
-        // Enable Raptor debugging by configuring the requestBuilder
-        // data.debugToStdErr(requestBuilder);
     }
 
     /*
@@ -87,7 +66,7 @@ public class D01_TimeDependentAccessTest implements RaptorTestConstants {
         requestBuilder.profile(RaptorProfile.MULTI_CRITERIA)
                 .searchParams()
                 .addAccessPaths(
-                        new TimeDependentAccessEgress(STOP_B, D2m, null, T00_00, T01_00)
+                        walk(STOP_B, D2m)
                 );
 
         var response = raptorService.route(requestBuilder.build(), data);
@@ -95,48 +74,139 @@ public class D01_TimeDependentAccessTest implements RaptorTestConstants {
         assertEquals(
                 ""
                         + "Walk 2m ~ 2 ~ BUS R1 0:15 0:30 ~ 5 ~ Walk 1m [00:13:00 00:31:00 18m, cost: 2220]\n"
-                        + "Walk 2m ~ 2 ~ BUS R2 0:20 0:35 ~ 5 ~ Walk 1m [00:18:00 00:36:00 18m, cost: 2220]\n"
-                        + "Walk 2m ~ 2 ~ BUS R3 0:25 0:40 ~ 5 ~ Walk 1m [00:23:00 00:41:00 18m, cost: 2220]\n"
-                        + "Walk 2m ~ 2 ~ BUS R4 0:30 0:45 ~ 5 ~ Walk 1m [00:28:00 00:46:00 18m, cost: 2220]",
+                        + "Walk 2m ~ 2 ~ BUS R1 0:20 0:35 ~ 5 ~ Walk 1m [00:18:00 00:36:00 18m, cost: 2220]\n"
+                        + "Walk 2m ~ 2 ~ BUS R1 0:25 0:40 ~ 5 ~ Walk 1m [00:23:00 00:41:00 18m, cost: 2220]\n"
+                        + "Walk 2m ~ 2 ~ BUS R1 0:30 0:45 ~ 5 ~ Walk 1m [00:28:00 00:46:00 18m, cost: 2220]\n"
+                        + "Walk 2m ~ 2 ~ BUS R1 0:15+1d 0:30+1d ~ 5 ~ Walk 1m [00:13:00+1d 00:31:00+1d 18m, cost: 2220]",
+                pathsToString(response)
+        );
+    }
+
+    @Test
+    public void openInWholeSearchIntervalTestFullDay() {
+        requestBuilder.profile(RaptorProfile.MULTI_CRITERIA)
+                .searchParams()
+                .searchWindow(Duration.ofDays(2))
+                .addAccessPaths(
+                        walk(STOP_B, D2m, T00_00, T01_00)
+                );
+
+        var response = raptorService.route(requestBuilder.build(), data);
+
+        assertEquals(
+                ""
+                        + "Walk 2m ~ 2 ~ BUS R1 0:15 0:30 ~ 5 ~ Walk 1m [00:13:00 00:31:00 18m, cost: 2220]\n"
+                        + "Walk 2m ~ 2 ~ BUS R1 0:20 0:35 ~ 5 ~ Walk 1m [00:18:00 00:36:00 18m, cost: 2220]\n"
+                        + "Walk 2m ~ 2 ~ BUS R1 0:25 0:40 ~ 5 ~ Walk 1m [00:23:00 00:41:00 18m, cost: 2220]\n"
+                        + "Walk 2m ~ 2 ~ BUS R1 0:30 0:45 ~ 5 ~ Walk 1m [00:28:00 00:46:00 18m, cost: 2220]\n"
+                        + "Walk 2m ~ 2 ~ BUS R1 0:15+1d 0:30+1d ~ 5 ~ Walk 1m [00:13:00+1d 00:31:00+1d 18m, cost: 2220]\n"
+                        + "Walk 2m ~ 2 ~ BUS R1 0:20+1d 0:35+1d ~ 5 ~ Walk 1m [00:18:00+1d 00:36:00+1d 18m, cost: 2220]\n"
+                        + "Walk 2m ~ 2 ~ BUS R1 0:25+1d 0:40+1d ~ 5 ~ Walk 1m [00:23:00+1d 00:41:00+1d 18m, cost: 2220]\n"
+                        + "Walk 2m ~ 2 ~ BUS R1 0:30+1d 0:45+1d ~ 5 ~ Walk 1m [00:28:00+1d 00:46:00+1d 18m, cost: 2220]",
+                pathsToString(response)
+        );
+    }
+
+    @Test
+    public void openInWholeSearchIntervalTestNextDay() {
+        requestBuilder.profile(RaptorProfile.MULTI_CRITERIA)
+                .searchParams()
+                .earliestDepartureTime(SECONDS_IN_DAY + T00_10)
+                .addAccessPaths(
+                        walk(STOP_B, D2m, T00_00, T01_00)
+                );
+
+        var response = raptorService.route(requestBuilder.build(), data);
+
+        assertEquals(
+                ""
+                        + "Walk 2m ~ 2 ~ BUS R1 0:15+1d 0:30+1d ~ 5 ~ Walk 1m [00:13:00+1d 00:31:00+1d 18m, cost: 2220]\n"
+                        + "Walk 2m ~ 2 ~ BUS R1 0:20+1d 0:35+1d ~ 5 ~ Walk 1m [00:18:00+1d 00:36:00+1d 18m, cost: 2220]\n"
+                        + "Walk 2m ~ 2 ~ BUS R1 0:25+1d 0:40+1d ~ 5 ~ Walk 1m [00:23:00+1d 00:41:00+1d 18m, cost: 2220]\n"
+                        + "Walk 2m ~ 2 ~ BUS R1 0:30+1d 0:45+1d ~ 5 ~ Walk 1m [00:28:00+1d 00:46:00+1d 18m, cost: 2220]",
                 pathsToString(response)
         );
     }
 
     /*
      * The access is only open after 00:18, which means that we may arrive at the stop at 00:20 at
-     * the earliest. Due to this:
-     *   - boarding R1 is not possible
+     * the earliest.
      */
     @Test
     public void openInSecondHalfIntervalTest() {
         requestBuilder.profile(RaptorProfile.MULTI_CRITERIA)
                 .searchParams()
                 .addAccessPaths(
-                        new TimeDependentAccessEgress(STOP_B, D2m, null, hm2time(0, 18), T01_00)
+                        walk(STOP_B, D2m, hm2time(0, 18), T01_00)
                 );
 
         var response = raptorService.route(requestBuilder.build(), data);
 
         assertEquals(
                 ""
-                        + "Walk 2m ~ 2 ~ BUS R2 0:20 0:35 ~ 5 ~ Walk 1m [00:18:00 00:36:00 18m, cost: 2220]\n"
-                        + "Walk 2m ~ 2 ~ BUS R3 0:25 0:40 ~ 5 ~ Walk 1m [00:23:00 00:41:00 18m, cost: 2220]\n"
-                        + "Walk 2m ~ 2 ~ BUS R4 0:30 0:45 ~ 5 ~ Walk 1m [00:28:00 00:46:00 18m, cost: 2220]",
+                        + "Walk 2m ~ 2 ~ BUS R1 0:20 0:35 ~ 5 ~ Walk 1m [00:18:00 00:36:00 18m, cost: 2220]\n"
+                        + "Walk 2m ~ 2 ~ BUS R1 0:25 0:40 ~ 5 ~ Walk 1m [00:23:00 00:41:00 18m, cost: 2220]\n"
+                        + "Walk 2m ~ 2 ~ BUS R1 0:30 0:45 ~ 5 ~ Walk 1m [00:28:00 00:46:00 18m, cost: 2220]\n"
+                        // This bus may only be reached by waiting at the stop between 01:00 and 24:15:00,
+                        // since the access only opens at 0:18, which is too late to catch the bus.
+                        + "Walk 2m ~ 2 ~ BUS R1 0:15+1d 0:30+1d ~ 5 ~ Walk 1m [01:00:00 00:31:00+1d 23h31m, cost: 85800]",
+                pathsToString(response)
+        );
+    }
+
+    @Test
+    public void openInSecondHalfIntervalTestFullDay() {
+        requestBuilder.profile(RaptorProfile.MULTI_CRITERIA)
+                .searchParams()
+                .searchWindow(Duration.ofDays(2))
+                .addAccessPaths(
+                        walk(STOP_B, D2m, hm2time(0, 18), T01_00)
+                );
+
+        var response = raptorService.route(requestBuilder.build(), data);
+
+        assertEquals(
+                ""
+                        + "Walk 2m ~ 2 ~ BUS R1 0:20 0:35 ~ 5 ~ Walk 1m [00:18:00 00:36:00 18m, cost: 2220]\n"
+                        + "Walk 2m ~ 2 ~ BUS R1 0:25 0:40 ~ 5 ~ Walk 1m [00:23:00 00:41:00 18m, cost: 2220]\n"
+                        + "Walk 2m ~ 2 ~ BUS R1 0:30 0:45 ~ 5 ~ Walk 1m [00:28:00 00:46:00 18m, cost: 2220]\n"
+                        + "Walk 2m ~ 2 ~ BUS R1 0:15+1d 0:30+1d ~ 5 ~ Walk 1m [01:00:00 00:31:00+1d 23h31m, cost: 85800]\n"
+                        + "Walk 2m ~ 2 ~ BUS R1 0:20+1d 0:35+1d ~ 5 ~ Walk 1m [00:18:00+1d 00:36:00+1d 18m, cost: 2220]\n"
+                        + "Walk 2m ~ 2 ~ BUS R1 0:25+1d 0:40+1d ~ 5 ~ Walk 1m [00:23:00+1d 00:41:00+1d 18m, cost: 2220]\n"
+                        + "Walk 2m ~ 2 ~ BUS R1 0:30+1d 0:45+1d ~ 5 ~ Walk 1m [00:28:00+1d 00:46:00+1d 18m, cost: 2220]",
+                pathsToString(response)
+        );
+    }
+
+    @Test
+    public void openInSecondHalfIntervalTestNextDay() {
+        requestBuilder.profile(RaptorProfile.MULTI_CRITERIA)
+                .searchParams()
+                .earliestDepartureTime(SECONDS_IN_DAY + T00_10)
+                .addAccessPaths(
+                        walk(STOP_B, D2m, hm2time(0, 18), T01_00)
+                );
+
+        var response = raptorService.route(requestBuilder.build(), data);
+
+        assertEquals(
+                ""
+                        + "Walk 2m ~ 2 ~ BUS R1 0:20+1d 0:35+1d ~ 5 ~ Walk 1m [00:18:00+1d 00:36:00+1d 18m, cost: 2220]\n"
+                        + "Walk 2m ~ 2 ~ BUS R1 0:25+1d 0:40+1d ~ 5 ~ Walk 1m [00:23:00+1d 00:41:00+1d 18m, cost: 2220]\n"
+                        + "Walk 2m ~ 2 ~ BUS R1 0:30+1d 0:45+1d ~ 5 ~ Walk 1m [00:28:00+1d 00:46:00+1d 18m, cost: 2220]",
                 pathsToString(response)
         );
     }
 
     /*
-     * The access is only open before 00:20, which means that we arrive at the stop by 00:22. Due to this:
-     *   - there needs to be a wait of 3 minutes for R3
-     *   - R4 is discarded since it is not better than taking R3
+     * The access is only open before 00:20, which means that we arrive at the stop by 00:22 at the latest.
      */
     @Test
     public void openInFirstHalfIntervalTest() {
         requestBuilder.profile(RaptorProfile.MULTI_CRITERIA)
                 .searchParams()
                 .addAccessPaths(
-                        new TimeDependentAccessEgress(STOP_B, D2m, null, T00_00, hm2time(0, 20))
+                        walk(STOP_B, D2m, T00_00, hm2time(0, 20))
                 );
 
         var response = raptorService.route(requestBuilder.build(), data);
@@ -144,80 +214,114 @@ public class D01_TimeDependentAccessTest implements RaptorTestConstants {
         assertEquals(
                 ""
                         + "Walk 2m ~ 2 ~ BUS R1 0:15 0:30 ~ 5 ~ Walk 1m [00:13:00 00:31:00 18m, cost: 2220]\n"
-                        + "Walk 2m ~ 2 ~ BUS R2 0:20 0:35 ~ 5 ~ Walk 1m [00:18:00 00:36:00 18m, cost: 2220]\n"
-                        + "Walk 2m ~ 2 ~ BUS R3 0:25 0:40 ~ 5 ~ Walk 1m [00:20:00 00:41:00 21m, cost: 2400]",
+                        + "Walk 2m ~ 2 ~ BUS R1 0:20 0:35 ~ 5 ~ Walk 1m [00:18:00 00:36:00 18m, cost: 2220]\n"
+                        + "Walk 2m ~ 2 ~ BUS R1 0:25 0:40 ~ 5 ~ Walk 1m [00:20:00 00:41:00 21m, cost: 2400]\n"
+                        + "Walk 2m ~ 2 ~ BUS R1 0:15+1d 0:30+1d ~ 5 ~ Walk 1m [00:13:00+1d 00:31:00+1d 18m, cost: 2220]",
+                pathsToString(response)
+        );
+    }
+
+    @Test
+    public void openInFirstHalfIntervalTestFullDay() {
+        requestBuilder.profile(RaptorProfile.MULTI_CRITERIA)
+                .searchParams()
+                .searchWindow(Duration.ofDays(2))
+                .addAccessPaths(
+                        walk(STOP_B, D2m, T00_00, hm2time(0, 20))
+                );
+
+        var response = raptorService.route(requestBuilder.build(), data);
+
+        assertEquals( ""
+                        + "Walk 2m ~ 2 ~ BUS R1 0:15 0:30 ~ 5 ~ Walk 1m [00:13:00 00:31:00 18m, cost: 2220]\n"
+                        + "Walk 2m ~ 2 ~ BUS R1 0:20 0:35 ~ 5 ~ Walk 1m [00:18:00 00:36:00 18m, cost: 2220]\n"
+                        + "Walk 2m ~ 2 ~ BUS R1 0:25 0:40 ~ 5 ~ Walk 1m [00:20:00 00:41:00 21m, cost: 2400]\n"
+                        + "Walk 2m ~ 2 ~ BUS R1 0:15+1d 0:30+1d ~ 5 ~ Walk 1m [00:13:00+1d 00:31:00+1d 18m, cost: 2220]\n"
+                        + "Walk 2m ~ 2 ~ BUS R1 0:20+1d 0:35+1d ~ 5 ~ Walk 1m [00:18:00+1d 00:36:00+1d 18m, cost: 2220]\n"
+                        + "Walk 2m ~ 2 ~ BUS R1 0:25+1d 0:40+1d ~ 5 ~ Walk 1m [00:20:00+1d 00:41:00+1d 21m, cost: 2400]",
+                pathsToString(response)
+        );
+    }
+
+    @Test
+    public void openInFirstHalfIntervalTestNextDay() {
+        requestBuilder.profile(RaptorProfile.MULTI_CRITERIA)
+                .searchParams()
+                .earliestDepartureTime(SECONDS_IN_DAY + T00_10)
+                .addAccessPaths(
+                        walk(STOP_B, D2m, T00_00, hm2time(0, 20))
+                );
+
+        var response = raptorService.route(requestBuilder.build(), data);
+
+        assertEquals( ""
+                        + "Walk 2m ~ 2 ~ BUS R1 0:15+1d 0:30+1d ~ 5 ~ Walk 1m [00:13:00+1d 00:31:00+1d 18m, cost: 2220]\n"
+                        + "Walk 2m ~ 2 ~ BUS R1 0:20+1d 0:35+1d ~ 5 ~ Walk 1m [00:18:00+1d 00:36:00+1d 18m, cost: 2220]\n"
+                        + "Walk 2m ~ 2 ~ BUS R1 0:25+1d 0:40+1d ~ 5 ~ Walk 1m [00:20:00+1d 00:41:00+1d 21m, cost: 2400]",
                 pathsToString(response)
         );
     }
 
     /*
      * The access is only open after 00:18 and before 00:20. This means that we arrive at the stop at
-     * 00:20 at the earliest and 00:22 at the latest. Due to this:
-     *   - boarding R1 is not possible
-     *   - there needs to be a wait of 3 minutes for R3
-     *   - R4 is discarded since it is not better than taking R3
+     * 00:20 at the earliest and 00:22 at the latest.
      */
     @Test
     public void partiallyOpenIntervalTest() {
         requestBuilder.profile(RaptorProfile.MULTI_CRITERIA)
                 .searchParams()
                 .addAccessPaths(
-                        new TimeDependentAccessEgress(
-                                STOP_B, D2m, null, hm2time(0, 18), hm2time(0, 20))
+                        walk(STOP_B, D2m, hm2time(0, 18), hm2time(0, 20))
                 );
 
         var response = raptorService.route(requestBuilder.build(), data);
 
         assertEquals(
                 ""
-                        + "Walk 2m ~ 2 ~ BUS R2 0:20 0:35 ~ 5 ~ Walk 1m [00:18:00 00:36:00 18m, cost: 2220]\n"
-                        + "Walk 2m ~ 2 ~ BUS R3 0:25 0:40 ~ 5 ~ Walk 1m [00:20:00 00:41:00 21m, cost: 2400]",
+                        + "Walk 2m ~ 2 ~ BUS R1 0:20 0:35 ~ 5 ~ Walk 1m [00:18:00 00:36:00 18m, cost: 2220]\n"
+                        + "Walk 2m ~ 2 ~ BUS R1 0:25 0:40 ~ 5 ~ Walk 1m [00:20:00 00:41:00 21m, cost: 2400]\n"
+                        + "Walk 2m ~ 2 ~ BUS R1 0:20+1d 0:35+1d ~ 5 ~ Walk 1m [00:18:00+1d 00:36:00+1d 18m, cost: 2220]",
                 pathsToString(response)
         );
     }
 
-    private static class TimeDependentAccessEgress extends AccessEgress {
+    @Test
+    public void partiallyOpenIntervalTestFullDay() {
+        requestBuilder.profile(RaptorProfile.MULTI_CRITERIA)
+                .searchParams()
+                .searchWindow(Duration.ofDays(2))
+                .addAccessPaths(
+                        walk(STOP_B, D2m, hm2time(0, 18), hm2time(0, 20))
+                );
 
-        private final int opening;
-        private final int closing;
+        var response = raptorService.route(requestBuilder.build(), data);
 
-        public TimeDependentAccessEgress(
-                int toFromStop,
-                int durationInSeconds,
-                State lastState,
-                int opening,
-                int closing
-        ) {
-            super(toFromStop, durationInSeconds, lastState);
-            this.opening = opening;
-            this.closing = closing;
-        }
+        assertEquals(
+                ""
+                        + "Walk 2m ~ 2 ~ BUS R1 0:20 0:35 ~ 5 ~ Walk 1m [00:18:00 00:36:00 18m, cost: 2220]\n"
+                        + "Walk 2m ~ 2 ~ BUS R1 0:25 0:40 ~ 5 ~ Walk 1m [00:20:00 00:41:00 21m, cost: 2400]\n"
+                        + "Walk 2m ~ 2 ~ BUS R1 0:20+1d 0:35+1d ~ 5 ~ Walk 1m [00:18:00+1d 00:36:00+1d 18m, cost: 2220]\n"
+                        + "Walk 2m ~ 2 ~ BUS R1 0:25+1d 0:40+1d ~ 5 ~ Walk 1m [00:20:00+1d 00:41:00+1d 21m, cost: 2400]",
+                pathsToString(response)
+        );
+    }
 
-        @Override
-        public int earliestDepartureTime(int requestedDepartureTime) {
-            if (requestedDepartureTime < opening) {
-                return opening;
-            } else if (requestedDepartureTime > closing) {
-                // return the opening time for the next day
-                return opening + 24 * 3600;
-            }
-            return requestedDepartureTime;
-        }
+    @Test
+    public void partiallyOpenIntervalTestNextDay() {
+        requestBuilder.profile(RaptorProfile.MULTI_CRITERIA)
+                .searchParams()
+                .earliestDepartureTime(SECONDS_IN_DAY + T00_10)
+                .addAccessPaths(
+                        walk(STOP_B, D2m, hm2time(0, 18), hm2time(0, 20))
+                );
 
-        @Override
-        public int latestArrivalTime(int requestedArrivalTime) {
-            // opening & closing is relative to the departure
-            int requestedDepartureTime = requestedArrivalTime - durationInSeconds();
-            int closeAtArrival = closing + durationInSeconds();
+        var response = raptorService.route(requestBuilder.build(), data);
 
-            if (requestedDepartureTime < opening) {
-                // return the closing hours for the previous day, offset with durationInSeconds()
-                return closeAtArrival - 24 * 3600;
-            }
-            else if (requestedArrivalTime > closeAtArrival) {
-                return closeAtArrival;
-            }
-            return requestedArrivalTime;
-        }
+        assertEquals(
+                ""
+                        + "Walk 2m ~ 2 ~ BUS R1 0:20+1d 0:35+1d ~ 5 ~ Walk 1m [00:18:00+1d 00:36:00+1d 18m, cost: 2220]\n"
+                        + "Walk 2m ~ 2 ~ BUS R1 0:25+1d 0:40+1d ~ 5 ~ Walk 1m [00:20:00+1d 00:41:00+1d 21m, cost: 2400]",
+                pathsToString(response)
+        );
     }
 }


### PR DESCRIPTION
### Summary

Adds tests for time restricted access in RAPTOR, with an example implementation in `TestTransfer`.

Three cases are covered:
 * [x] the access may only be used in the second "half" of the search window, so some trips may not be boarded due to arriving too late.
 * [x] the access may only be used in the first "half" of the search window, so trips in the second half may be boarded, but with a wait due to the access being used earlier.
 * [x] the access may be used only the middle "third" of the search window (a combination of the previous two).

It would seem that ([documentation](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/src/main/java/org/opentripplanner/transit/raptor/api/transit/RaptorTransfer.java#L36)):
 * `RaptorTransfer#earliestDepartureTime(requestedDepartureTime)` needs to return a value `>= requestedDepartureTime`
 * `RaptorTransfer#latestArrivalTime(requestedArrivalTime)` needs to return a value `<= requestedArrivalTime`

### Issue

closes #3385

### Unit tests

:ballot_box_with_check: 

### Code style

:ballot_box_with_check: 

### Documentation

No changes required.

### Changelog

None.