### PR TITLE
docs: Add OTP2 REST API docs URL to the Developer Guide

### DIFF
--- a/docs/Developers-Guide.md
+++ b/docs/Developers-Guide.md
@@ -115,9 +115,11 @@ $ mkdocs serve
 ```
 
 The OTP REST API documentation is available online in the format of:
+
 http://dev.opentripplanner.org/apidoc/x.x.x/index.html
 
 For example, for v2.0.0:
+
 http://dev.opentripplanner.org/apidoc/2.0.0/index.html
 
 

--- a/docs/Developers-Guide.md
+++ b/docs/Developers-Guide.md
@@ -114,6 +114,12 @@ $ pip install mkdocs
 $ mkdocs serve
 ```
 
+The OTP REST API documentation is available online in the format of:
+http://dev.opentripplanner.org/apidoc/x.x.x/index.html
+
+For example, for v2.0.0:
+http://dev.opentripplanner.org/apidoc/2.0.0/index.html
+
 
 ### Debug layers
 


### PR DESCRIPTION
### Summary
We were interested in using the OTP2 REST API, but struggled to find the REST API docs in the current OTP2 documentation. Eventually we found the OTP1 REST API docs URL and plugged in the OTP2 version numbers to stumble on it.

We looked at a lot of the documentation, including this Developer Guide file and:
* http://docs.opentripplanner.org/en/dev-2.x/Basic-Tutorial/
* http://docs.opentripplanner.org/en/dev-2.x/OTP2-MigrationGuide/#rest-api
* http://docs.opentripplanner.org/en/dev-2.x/Version-Comparison/

...among others but couldn't find any reference (the links that are there point to the source files on GitHub). 

This PR adds a link to the OTP2 REST API docs in the Developer Guide to make it more visible to developers.

Apologies if there is already a link to this somewhere else and we just overlooked it - alternate suggestions for this text or a better way to surface these docs for other developers is welcome.

### Unit tests
N/A

### Code style

N/A

### Documentation

Yes 😄 

### Changelog

No, but I'm assuming this doesn't need a Changelog entry.
