### PR TITLE
Refactor StreetTransitLink and TransitEntranceLink to share common code

### DIFF
--- a/src/main/java/org/opentripplanner/common/StreetUtils.java
+++ b/src/main/java/org/opentripplanner/common/StreetUtils.java
@@ -12,9 +12,9 @@ import org.opentripplanner.routing.core.TraverseModeSet;
 import org.opentripplanner.routing.edgetype.ElevatorEdge;
 import org.opentripplanner.routing.edgetype.FreeEdge;
 import org.opentripplanner.routing.edgetype.StreetEdge;
-import org.opentripplanner.routing.edgetype.StreetTransitLink;
+import org.opentripplanner.routing.edgetype.StreetTransitStopLink;
 import org.opentripplanner.routing.edgetype.StreetTraversalPermission;
-import org.opentripplanner.routing.edgetype.TransitEntranceLink;
+import org.opentripplanner.routing.edgetype.StreetTransitEntranceLink;
 import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
@@ -64,8 +64,8 @@ public class StreetUtils {
             State s0 = new State(gv, options);
             for (Edge e : gv.getOutgoing()) {
                 Vertex in = gv;
-                if (!(e instanceof StreetEdge || e instanceof StreetTransitLink ||
-                    e instanceof TransitEntranceLink || e instanceof ElevatorEdge ||
+                if (!(e instanceof StreetEdge || e instanceof StreetTransitStopLink ||
+                    e instanceof StreetTransitEntranceLink || e instanceof ElevatorEdge ||
                     e instanceof FreeEdge)
                 ) {
                     continue;
@@ -176,7 +176,7 @@ public class StreetUtils {
             Collection<Edge> edges = new ArrayList<Edge>(v.getOutgoing());
             edges.addAll(v.getIncoming());
             for (Edge e : edges) {
-                if (e instanceof StreetTransitLink || e instanceof TransitEntranceLink) {
+                if (e instanceof StreetTransitStopLink || e instanceof StreetTransitEntranceLink) {
                     graph.removeEdge(e);
                 }
             }

--- a/src/main/java/org/opentripplanner/graph_builder/module/StreetLinkerModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/StreetLinkerModule.java
@@ -6,8 +6,8 @@ import org.opentripplanner.graph_builder.services.GraphBuilderModule;
 import org.opentripplanner.routing.core.TraverseMode;
 import org.opentripplanner.routing.edgetype.StreetBikeParkLink;
 import org.opentripplanner.routing.edgetype.StreetBikeRentalLink;
-import org.opentripplanner.routing.edgetype.StreetTransitLink;
-import org.opentripplanner.routing.edgetype.TransitEntranceLink;
+import org.opentripplanner.routing.edgetype.StreetTransitStopLink;
+import org.opentripplanner.routing.edgetype.StreetTransitEntranceLink;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.vertextype.BikeParkVertex;
 import org.opentripplanner.routing.vertextype.BikeRentalStationVertex;
@@ -76,8 +76,8 @@ public class StreetLinkerModule implements GraphBuilderModule {
           TraverseMode.WALK,
           LinkingDirection.BOTH_WAYS,
           (vertex, streetVertex) -> List.of(
-              new StreetTransitLink((TransitStopVertex) vertex, streetVertex),
-              new StreetTransitLink(streetVertex, (TransitStopVertex) vertex)
+              new StreetTransitStopLink((TransitStopVertex) vertex, streetVertex),
+              new StreetTransitStopLink(streetVertex, (TransitStopVertex) vertex)
           )
       );
     }
@@ -91,8 +91,8 @@ public class StreetLinkerModule implements GraphBuilderModule {
           TraverseMode.WALK,
           LinkingDirection.BOTH_WAYS,
           (vertex, streetVertex) -> List.of(
-              new TransitEntranceLink((TransitEntranceVertex) vertex, streetVertex),
-              new TransitEntranceLink(streetVertex, (TransitEntranceVertex) vertex)
+              new StreetTransitEntranceLink((TransitEntranceVertex) vertex, streetVertex),
+              new StreetTransitEntranceLink(streetVertex, (TransitEntranceVertex) vertex)
           )
       );
     }

--- a/src/main/java/org/opentripplanner/graph_builder/module/TransitToTaggedStopsModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/TransitToTaggedStopsModule.java
@@ -4,7 +4,7 @@ import org.locationtech.jts.geom.Envelope;
 import org.opentripplanner.common.geometry.SphericalDistanceLibrary;
 import org.opentripplanner.graph_builder.DataImportIssueStore;
 import org.opentripplanner.graph_builder.services.GraphBuilderModule;
-import org.opentripplanner.routing.edgetype.StreetTransitLink;
+import org.opentripplanner.routing.edgetype.StreetTransitStopLink;
 import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
@@ -66,7 +66,7 @@ public class TransitToTaggedStopsModule implements GraphBuilderModule {
             // could happened if using the prune isolated island
             boolean alreadyLinked = false;
             for(Edge e:ts.getOutgoing()){
-                if(e instanceof StreetTransitLink) {
+                if(e instanceof StreetTransitStopLink) {
                     alreadyLinked = true;
                     break;
                 }
@@ -103,8 +103,8 @@ public class TransitToTaggedStopsModule implements GraphBuilderModule {
 
             // Only use stop codes for linking TODO: find better method to connect stops without stop code
             if (tsv.stopCode != null && tsv.stopCode.equals(stopCode)) {
-                new StreetTransitLink(ts, tsv);
-                new StreetTransitLink(tsv, ts);
+                new StreetTransitStopLink(ts, tsv);
+                new StreetTransitStopLink(tsv, ts);
                 LOG.debug("Connected " + ts.toString() + " to " + tsv.getLabel());
                 return true;
             }

--- a/src/main/java/org/opentripplanner/graph_builder/module/stopsAlerts/UnconnectedStop.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/stopsAlerts/UnconnectedStop.java
@@ -1,7 +1,7 @@
 package org.opentripplanner.graph_builder.module.stopsAlerts;
 
 import org.opentripplanner.routing.edgetype.PathwayEdge;
-import org.opentripplanner.routing.edgetype.StreetTransitLink;
+import org.opentripplanner.routing.edgetype.StreetTransitStopLink;
 import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.vertextype.TransitStopVertex;
@@ -19,7 +19,7 @@ public class UnconnectedStop extends AbstractStopTester {
         List<Edge> outgoingStreets = ts.getOutgoingStreetEdges();
         boolean hasStreetLink = false;
         for(Edge e:ts.getIncoming()){
-            if(e instanceof StreetTransitLink || e instanceof PathwayEdge){
+            if(e instanceof StreetTransitStopLink || e instanceof PathwayEdge){
                 hasStreetLink = true;
                 break;
             }
@@ -27,7 +27,7 @@ public class UnconnectedStop extends AbstractStopTester {
         if(!hasStreetLink){
             //TODO: see what if there is incoming and not outgoing
             for(Edge e:ts.getOutgoing()){
-                if(e instanceof StreetTransitLink){
+                if(e instanceof StreetTransitStopLink){
                     hasStreetLink = true;
                     break;
                 }

--- a/src/main/java/org/opentripplanner/inspector/TraversalPermissionsEdgeRenderer.java
+++ b/src/main/java/org/opentripplanner/inspector/TraversalPermissionsEdgeRenderer.java
@@ -46,7 +46,7 @@ public class TraversalPermissionsEdgeRenderer implements EdgeVertexRenderer {
                 attrs.color = getColor(pse.getPermission());
                 attrs.label = getLabel(pse.getPermission());
             }
-        } else if (e instanceof StreetTransitLink) {
+        } else if (e instanceof StreetTransitStopLink) {
             attrs.color = LINK_COLOR_EDGE;
             attrs.label = "link";
         } else if (e instanceof StreetBikeRentalLink) {

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetTransitEntityLink.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetTransitEntityLink.java
@@ -1,0 +1,156 @@
+package org.opentripplanner.routing.edgetype;
+
+import java.util.Locale;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.LineString;
+import org.opentripplanner.common.geometry.GeometryUtils;
+import org.opentripplanner.model.Trip;
+import org.opentripplanner.routing.api.request.RoutingRequest;
+import org.opentripplanner.routing.core.CarPickupState;
+import org.opentripplanner.routing.core.State;
+import org.opentripplanner.routing.core.StateEditor;
+import org.opentripplanner.routing.core.TraverseMode;
+import org.opentripplanner.routing.graph.Edge;
+import org.opentripplanner.routing.graph.Vertex;
+import org.opentripplanner.routing.vertextype.StreetVertex;
+
+/**
+ * This represents the connection between a street vertex and a transit vertex.
+ */
+public abstract class StreetTransitEntityLink<T extends Vertex> extends Edge {
+
+    private static final long serialVersionUID = -3311099256178798981L;
+    static final int STEL_TRAVERSE_COST = 1;
+
+    private final T transitEntityVertex;
+
+    private final boolean wheelchairAccessible;
+
+    public StreetTransitEntityLink(StreetVertex fromv, T tov, boolean wheelchairAccessible) {
+    	super(fromv, tov);
+    	this.transitEntityVertex = tov;
+        this.wheelchairAccessible = wheelchairAccessible;
+    }
+
+    public StreetTransitEntityLink(T fromv, StreetVertex tov, boolean wheelchairAccessible) {
+        super(fromv, tov);
+        this.transitEntityVertex = fromv;
+        this.wheelchairAccessible = wheelchairAccessible;
+    }
+
+    protected abstract int getStreetToStopTime();
+
+    protected T getTransitEntityVertex() {
+        return transitEntityVertex;
+    }
+
+    public String getDirection() {
+        return null;
+    }
+
+    public double getDistanceMeters() {
+        return 0;
+    }
+
+    public LineString getGeometry() {
+        Coordinate[] coordinates = new Coordinate[] { fromv.getCoordinate(), tov.getCoordinate()};
+        return GeometryUtils.getGeometryFactory().createLineString(coordinates);
+    }
+
+    public String getName() {
+        return this.transitEntityVertex.getName();
+    }
+
+    public String getName(Locale locale) {
+        //TODO: localize
+        return getName();
+    }
+
+    public State traverse(State s0) {
+
+        // Forbid taking shortcuts composed of two street-transit links associated with the same stop in a row. Also
+        // avoids spurious leg transitions. As noted in https://github.com/opentripplanner/OpenTripPlanner/issues/2815,
+        // it is possible that two stops can have the same GPS coordinate thus creating a possibility for a
+        // legitimate StreetTransitLink > StreetTransitLink sequence, so only forbid two StreetTransitLinks to be taken
+        // if they are for the same stop.
+        if (
+            s0.backEdge instanceof StreetTransitEntityLink &&
+                ((StreetTransitEntityLink<?>) s0.backEdge).transitEntityVertex
+                    == this.transitEntityVertex
+        ) {
+            return null;
+        }
+
+        RoutingRequest req = s0.getOptions();
+        if (s0.getOptions().wheelchairAccessible && !wheelchairAccessible) {
+            return null;
+        }
+
+        if (s0.getOptions().bikeParkAndRide && !s0.isBikeParked()) {
+            // Forbid taking your own bike in the station if bike P+R activated.
+            return null;
+        }
+        if (s0.isBikeRenting()) {
+            // Forbid taking a rented bike on any transit.
+            // TODO Check this condition, does this always make sense?
+            return null;
+        }
+
+        // Do not check here whether any transit modes are selected. A check for the presence of
+        // transit modes will instead be done in the following PreBoard edge.
+        // This allows searching for nearby transit stops using walk-only options.
+        StateEditor s1 = s0.edit(this);
+
+        /* Only enter stations in CAR mode if parking is not required (kiss and ride) */
+        /* Note that in arriveBy searches this is double-traversing link edges to fork the state into both WALK and CAR mode. This is an insane hack. */
+        if (s0.getNonTransitMode() == TraverseMode.CAR) {
+            if (req.carPickup && s0.getCarPickupState() == CarPickupState.IN_CAR) {
+                s1.setTaxiState(s0.getOptions().arriveBy ? CarPickupState.WALK_TO_PICKUP : CarPickupState.WALK_FROM_DROP_OFF);
+            } else {
+                return null;
+            }
+        }
+
+        // We do not increase the time here, so that searching from the stop coordinates instead of
+        // the stop id catch transit departing at that exact search time.
+        int streetToStopTime = getStreetToStopTime();
+        s1.incrementTimeInSeconds(streetToStopTime);
+        s1.incrementWeight(STEL_TRAVERSE_COST + streetToStopTime);
+        return s1.makeState();
+    }
+
+    public State optimisticTraverse(State s0) {
+        StateEditor s1 = s0.edit(this);
+        s1.incrementWeight(STEL_TRAVERSE_COST);
+        return s1.makeState();
+    }
+    
+    // anecdotally, the lower bound search is about 2x faster when you don't reach stops
+    // and therefore don't even consider boarding
+    @Override
+    public double weightLowerBound(RoutingRequest options) {
+        return options.transitAllowed() ? 0 : Double.POSITIVE_INFINITY;
+    }
+
+    public Vertex getFromVertex() {
+        return fromv;
+    }
+
+    public Vertex getToVertex() {
+        return tov;
+    }
+
+    public Trip getTrip() {
+        return null;
+    }
+
+    public boolean isRoundabout() {
+        return false;
+    }
+
+    public String toString() {
+        return "StreetTransitLink(" + fromv + " -> " + tov + ")";
+    }
+
+
+}

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetTransitEntranceLink.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetTransitEntranceLink.java
@@ -7,13 +7,13 @@ import org.opentripplanner.routing.vertextype.TransitEntranceVertex;
  * This represents the connection between a street vertex and a transit vertex belonging the street
  * network.
  */
-public class TransitEntranceLink extends StreetTransitEntityLink<TransitEntranceVertex> {
+public class StreetTransitEntranceLink extends StreetTransitEntityLink<TransitEntranceVertex> {
 
-    public TransitEntranceLink(StreetVertex fromv, TransitEntranceVertex tov) {
+    public StreetTransitEntranceLink(StreetVertex fromv, TransitEntranceVertex tov) {
         super(fromv, tov, tov.isWheelchairEntrance());
     }
 
-    public TransitEntranceLink(TransitEntranceVertex fromv, StreetVertex tov) {
+    public StreetTransitEntranceLink(TransitEntranceVertex fromv, StreetVertex tov) {
         super(fromv, tov, fromv.isWheelchairEntrance());
     }
 
@@ -22,6 +22,6 @@ public class TransitEntranceLink extends StreetTransitEntityLink<TransitEntrance
     }
 
     public String toString() {
-        return "TransitEntranceLink(" + fromv + " -> " + tov + ")";
+        return "StreetTransitEntranceLink(" + fromv + " -> " + tov + ")";
     }
 }

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetTransitLink.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetTransitLink.java
@@ -1,152 +1,28 @@
 package org.opentripplanner.routing.edgetype;
 
-import org.opentripplanner.model.Trip;
-import org.opentripplanner.common.geometry.GeometryUtils;
-import org.opentripplanner.routing.core.State;
-import org.opentripplanner.routing.core.StateEditor;
-import org.opentripplanner.routing.core.TraverseMode;
-import org.opentripplanner.routing.api.request.RoutingRequest;
-import org.opentripplanner.routing.graph.Edge;
-import org.opentripplanner.routing.graph.Vertex;
-import org.opentripplanner.routing.vertextype.TransitStopVertex;
 import org.opentripplanner.routing.vertextype.StreetVertex;
-
-import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.LineString;
-import java.util.Locale;
+import org.opentripplanner.routing.vertextype.TransitStopVertex;
 
 /** 
  * This represents the connection between a street vertex and a transit vertex
  * where going from the street to the vehicle is immediate -- such as at a 
  * curbside bus stop.
  */
-public class StreetTransitLink extends Edge {
-
-    private static final long serialVersionUID = -3311099256178798981L;
-    static final int STL_TRAVERSE_COST = 1;
-
-    private final boolean wheelchairAccessible;
-
-    private final TransitStopVertex stopVertex;
+public class StreetTransitLink extends StreetTransitEntityLink<TransitStopVertex> {
 
     public StreetTransitLink(StreetVertex fromv, TransitStopVertex tov) {
-    	super(fromv, tov);
-    	stopVertex = tov;
-        this.wheelchairAccessible = tov.hasWheelchairEntrance();
+    	super(fromv, tov, tov.hasWheelchairEntrance());
     }
 
     public StreetTransitLink(TransitStopVertex fromv, StreetVertex tov) {
-        super(fromv, tov);
-        stopVertex = fromv;
-        this.wheelchairAccessible = fromv.hasWheelchairEntrance();
+        super(fromv, tov, fromv.hasWheelchairEntrance());
     }
 
-    public String getDirection() {
-        return null;
-    }
-
-    public double getDistanceMeters() {
-        return 0;
-    }
-
-    public LineString getGeometry() {
-        Coordinate[] coordinates = new Coordinate[] { fromv.getCoordinate(), tov.getCoordinate()};
-        return GeometryUtils.getGeometryFactory().createLineString(coordinates);
-    }
-
-    public String getName() {
-        return this.stopVertex.getStop().getName();
-    }
-
-    @Override
-    public String getName(Locale locale) {
-        //TODO: localize
-        return this.getName();
-    }
-
-    public State traverse(State s0) {
-
-        // Forbid taking shortcuts composed of two street-transit links associated with the same stop in a row. Also
-        // avoids spurious leg transitions. As noted in https://github.com/opentripplanner/OpenTripPlanner/issues/2815,
-        // it is possible that two stops can have the same GPS coordinate thus creating a possibility for a
-        // legitimate StreetTransitLink > StreetTransitLink sequence, so only forbid two StreetTransitLinks to be taken
-        // if they are for the same stop.
-        if (
-            s0.backEdge instanceof StreetTransitLink &&
-                ((StreetTransitLink) s0.backEdge).stopVertex == this.stopVertex
-        ) {
-            return null;
-        }
-
-        RoutingRequest req = s0.getOptions();
-        if (s0.getOptions().wheelchairAccessible && !wheelchairAccessible) {
-            return null;
-        }
-        if (s0.getOptions().bikeParkAndRide && !s0.isBikeParked()) {
-            // Forbid taking your own bike in the station if bike P+R activated.
-            return null;
-        }
-        if (s0.isBikeRenting()) {
-            // Forbid taking a rented bike on any transit.
-            // TODO Check this condition, does this always make sense?
-            return null;
-        }
-
-        // Do not check here whether any transit modes are selected. A check for the presence of
-        // transit modes will instead be done in the following PreBoard edge.
-        // This allows searching for nearby transit stops using walk-only options.
-        StateEditor s1 = s0.edit(this);
-
-        /* Only enter stations in CAR mode if parking is not required (kiss and ride) */
-        /* Note that in arriveBy searches this is double-traversing link edges to fork the state into both WALK and CAR mode. This is an insane hack. */
-        if (s0.getNonTransitMode() == TraverseMode.CAR) {
-            if (req.carPickup && !s0.isCarParked()) {
-                s1.setCarParked(true);
-            } else {
-                return null;
-            }
-        }
-
-        int streetToStopTime = stopVertex.hasPathways() ? 0 : stopVertex.getStreetToStopTime();
-        // We do not increase the time here, so that searching from the stop coordinates instead of
-        // the stop id catch transit departing at that exact search time.
-        s1.incrementTimeInSeconds(streetToStopTime);
-        s1.incrementWeight(STL_TRAVERSE_COST + streetToStopTime);
-        return s1.makeState();
-    }
-
-    public State optimisticTraverse(State s0) {
-        StateEditor s1 = s0.edit(this);
-        s1.incrementWeight(STL_TRAVERSE_COST);
-        return s1.makeState();
-    }
-    
-    // anecdotally, the lower bound search is about 2x faster when you don't reach stops
-    // and therefore don't even consider boarding
-    @Override
-    public double weightLowerBound(RoutingRequest options) {
-        return options.transitAllowed() ? 0 : Double.POSITIVE_INFINITY;
-    }
-
-    public Vertex getFromVertex() {
-        return fromv;
-    }
-
-    public Vertex getToVertex() {
-        return tov;
-    }
-
-    public Trip getTrip() {
-        return null;
-    }
-
-    public boolean isRoundabout() {
-        return false;
+    protected int getStreetToStopTime() {
+        return getTransitEntityVertex().hasPathways() ? 0 : getTransitEntityVertex().getStreetToStopTime();
     }
 
     public String toString() {
         return "StreetTransitLink(" + fromv + " -> " + tov + ")";
     }
-
-
 }

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetTransitStopLink.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetTransitStopLink.java
@@ -8,13 +8,13 @@ import org.opentripplanner.routing.vertextype.TransitStopVertex;
  * where going from the street to the vehicle is immediate -- such as at a 
  * curbside bus stop.
  */
-public class StreetTransitLink extends StreetTransitEntityLink<TransitStopVertex> {
+public class StreetTransitStopLink extends StreetTransitEntityLink<TransitStopVertex> {
 
-    public StreetTransitLink(StreetVertex fromv, TransitStopVertex tov) {
+    public StreetTransitStopLink(StreetVertex fromv, TransitStopVertex tov) {
     	super(fromv, tov, tov.hasWheelchairEntrance());
     }
 
-    public StreetTransitLink(TransitStopVertex fromv, StreetVertex tov) {
+    public StreetTransitStopLink(TransitStopVertex fromv, StreetVertex tov) {
         super(fromv, tov, fromv.hasWheelchairEntrance());
     }
 
@@ -23,6 +23,6 @@ public class StreetTransitLink extends StreetTransitEntityLink<TransitStopVertex
     }
 
     public String toString() {
-        return "StreetTransitLink(" + fromv + " -> " + tov + ")";
+        return "StreetTransitStopLink(" + fromv + " -> " + tov + ")";
     }
 }

--- a/src/main/java/org/opentripplanner/routing/edgetype/TransitEntranceLink.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/TransitEntranceLink.java
@@ -1,136 +1,27 @@
 package org.opentripplanner.routing.edgetype;
 
-import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.LineString;
-import org.opentripplanner.common.geometry.GeometryUtils;
-import org.opentripplanner.routing.api.request.RoutingRequest;
-import org.opentripplanner.routing.core.CarPickupState;
-import org.opentripplanner.routing.core.State;
-import org.opentripplanner.routing.core.StateEditor;
-import org.opentripplanner.routing.core.TraverseMode;
-import org.opentripplanner.routing.graph.Edge;
-import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.routing.vertextype.StreetVertex;
 import org.opentripplanner.routing.vertextype.TransitEntranceVertex;
-
-import java.util.Locale;
 
 /** 
  * This represents the connection between a street vertex and a transit vertex belonging the street
  * network.
  */
-public class TransitEntranceLink extends Edge {
-
-    private static final long serialVersionUID = -3311099256178798981L;
-    static final int TEL_TRAVERSE_COST = 1;
-
-    private final boolean wheelchairAccessible;
-
-    private final TransitEntranceVertex entranceVertex;
+public class TransitEntranceLink extends StreetTransitEntityLink<TransitEntranceVertex> {
 
     public TransitEntranceLink(StreetVertex fromv, TransitEntranceVertex tov) {
-        super(fromv, tov);
-        entranceVertex = tov;
-        this.wheelchairAccessible = tov.isWheelchairEntrance();
+        super(fromv, tov, tov.isWheelchairEntrance());
     }
 
     public TransitEntranceLink(TransitEntranceVertex fromv, StreetVertex tov) {
-        super(fromv, tov);
-        entranceVertex = fromv;
-        this.wheelchairAccessible = fromv.isWheelchairEntrance();
+        super(fromv, tov, fromv.isWheelchairEntrance());
     }
 
-    public LineString getGeometry() {
-        Coordinate[] coordinates = new Coordinate[] { fromv.getCoordinate(), tov.getCoordinate()};
-        return GeometryUtils.getGeometryFactory().createLineString(coordinates);
-    }
-
-    public String getName() {
-        return entranceVertex.getName();
-    }
-
-    @Override
-    public String getName(Locale locale) {
-        //TODO: localize
-        return entranceVertex.getName();
-    }
-
-    public State traverse(State s0) {
-        // Forbid taking shortcuts composed of two street-transit links associated with the same entrance in a row.
-        // As noted in https://github.com/opentripplanner/OpenTripPlanner/issues/2815, it is
-        // possible that two stops can have the same GPS coordinate thus creating a possibility for
-        // a legitimate TransitEntranceLink > TransitEntranceLink sequence, so only forbid two
-        // TransitEntranceLinks to be taken if they are for the same entrance.
-        if (
-            s0.backEdge instanceof TransitEntranceLink &&
-                ((TransitEntranceLink) s0.backEdge).entranceVertex == this.entranceVertex
-        ) {
-            return null;
-        }
-
-        RoutingRequest req = s0.getOptions();
-        if (s0.getOptions().wheelchairAccessible && !wheelchairAccessible) {
-            return null;
-        }
-
-        if (s0.getOptions().bikeParkAndRide && !s0.isBikeParked()) {
-            // Forbid taking your own bike in the station if bike P+R activated.
-            return null;
-        }
-        if (s0.isBikeRenting()) {
-            // Forbid taking a rented bike on any transit.
-            // TODO Check this condition, does this always make sense?
-            return null;
-        }
-
-        // Do not check here whether any transit modes are selected. A check for the presence of
-        // transit modes will instead be done in the following PreBoard edge.
-        // This allows searching for nearby transit stops using walk-only options.
-        StateEditor s1 = s0.edit(this);
-
-        /* Only enter stations in CAR mode if parking is not required (kiss and ride) */
-        /* Note that in arriveBy searches this is double-traversing link edges to fork the state into both WALK and CAR mode. This is an insane hack. */
-        if (s0.getNonTransitMode() == TraverseMode.CAR) {
-            if (req.carPickup && s0.getCarPickupState().equals(CarPickupState.IN_CAR)) {
-                s1.setTaxiState(CarPickupState.WALK_FROM_DROP_OFF);
-            } else {
-                return null;
-            }
-        }
-
-        s1.incrementTimeInSeconds(TEL_TRAVERSE_COST);
-        s1.incrementWeight(TEL_TRAVERSE_COST);
-        return s1.makeState();
-    }
-
-    public State optimisticTraverse(State s0) {
-        StateEditor s1 = s0.edit(this);
-        s1.incrementWeight(TEL_TRAVERSE_COST);
-        return s1.makeState();
-    }
-    
-    // anecdotally, the lower bound search is about 2x faster when you don't reach stops
-    // and therefore don't even consider boarding
-    @Override
-    public double weightLowerBound(RoutingRequest options) {
-        return options.transitAllowed() ? 0 : Double.POSITIVE_INFINITY;
-    }
-
-    public Vertex getFromVertex() {
-        return fromv;
-    }
-
-    public Vertex getToVertex() {
-        return tov;
-    }
-
-    public boolean isRoundabout() {
-        return false;
+    protected int getStreetToStopTime() {
+        return 0;
     }
 
     public String toString() {
         return "TransitEntranceLink(" + fromv + " -> " + tov + ")";
     }
-
-
 }

--- a/src/main/java/org/opentripplanner/visualizer/ShowGraph.java
+++ b/src/main/java/org/opentripplanner/visualizer/ShowGraph.java
@@ -8,7 +8,7 @@ import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.core.TraverseMode;
 import org.opentripplanner.routing.edgetype.PathwayEdge;
 import org.opentripplanner.routing.edgetype.StreetEdge;
-import org.opentripplanner.routing.edgetype.StreetTransitLink;
+import org.opentripplanner.routing.edgetype.StreetTransitStopLink;
 import org.opentripplanner.routing.edgetype.StreetTraversalPermission;
 import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Graph;
@@ -468,7 +468,7 @@ public class ShowGraph extends PApplet implements MouseWheelListener {
             for (Edge e : v.getOutgoing()) {
                 if (e.getGeometry() == null)
                     continue;
-                if (e instanceof StreetTransitLink
+                if (e instanceof StreetTransitStopLink
                         || e instanceof StreetEdge || e instanceof PathwayEdge) {
                     env = e.getGeometry().getEnvelopeInternal();
                     edgeIndex.insert(env, e);
@@ -486,7 +486,7 @@ public class ShowGraph extends PApplet implements MouseWheelListener {
         visibleLinkEdges.clear();
         visibleTransitEdges.clear();
         for (Edge de : (Iterable<Edge>) edgeIndex.query(modelBounds)) {
-            if (de instanceof PathwayEdge || de instanceof StreetTransitLink) {
+            if (de instanceof PathwayEdge || de instanceof StreetTransitStopLink) {
                 visibleLinkEdges.add(de);
             }
             else if (de instanceof StreetEdge) {

--- a/src/test/java/org/opentripplanner/graph_builder/linking/LinkStopToPlatformTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/linking/LinkStopToPlatformTest.java
@@ -14,7 +14,7 @@ import org.opentripplanner.openstreetmap.model.OSMWithTags;
 import org.opentripplanner.routing.core.TraverseMode;
 import org.opentripplanner.routing.edgetype.AreaEdge;
 import org.opentripplanner.routing.edgetype.AreaEdgeList;
-import org.opentripplanner.routing.edgetype.StreetTransitLink;
+import org.opentripplanner.routing.edgetype.StreetTransitStopLink;
 import org.opentripplanner.routing.edgetype.StreetTraversalPermission;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.vertextype.IntersectionVertex;
@@ -82,8 +82,8 @@ public class LinkStopToPlatformTest {
                 TraverseMode.WALK,
                 LinkingDirection.BOTH_WAYS,
                 (vertex, streetVertex) -> List.of(
-                    new StreetTransitLink((TransitStopVertex) vertex, streetVertex),
-                    new StreetTransitLink(streetVertex, (TransitStopVertex) vertex)
+                    new StreetTransitStopLink((TransitStopVertex) vertex, streetVertex),
+                    new StreetTransitStopLink(streetVertex, (TransitStopVertex) vertex)
                 )
             );
         }

--- a/src/test/java/org/opentripplanner/graph_builder/module/FakeGraph.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/FakeGraph.java
@@ -9,7 +9,7 @@ import org.opentripplanner.model.Stop;
 import org.opentripplanner.model.calendar.ServiceDateInterval;
 import org.opentripplanner.openstreetmap.BinaryOpenStreetMapProvider;
 import org.opentripplanner.routing.core.TraverseMode;
-import org.opentripplanner.routing.edgetype.StreetTransitLink;
+import org.opentripplanner.routing.edgetype.StreetTransitStopLink;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.vertextype.TransitStopVertex;
 
@@ -115,8 +115,8 @@ public class FakeGraph {
                 TraverseMode.WALK,
                 LinkingDirection.BOTH_WAYS,
                 (vertex, streetVertex) -> List.of(
-                    new StreetTransitLink((TransitStopVertex) vertex, streetVertex),
-                    new StreetTransitLink(streetVertex, (TransitStopVertex) vertex)
+                    new StreetTransitStopLink((TransitStopVertex) vertex, streetVertex),
+                    new StreetTransitStopLink(streetVertex, (TransitStopVertex) vertex)
                 )
             );
         }

--- a/src/test/java/org/opentripplanner/graph_builder/module/linking/LinkingTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/linking/LinkingTest.java
@@ -9,7 +9,7 @@ import org.opentripplanner.common.geometry.GeometryUtils;
 import org.opentripplanner.common.geometry.SphericalDistanceLibrary;
 import org.opentripplanner.common.model.P2;
 import org.opentripplanner.routing.edgetype.StreetEdge;
-import org.opentripplanner.routing.edgetype.StreetTransitLink;
+import org.opentripplanner.routing.edgetype.StreetTransitStopLink;
 import org.opentripplanner.routing.edgetype.StreetTraversalPermission;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
@@ -89,11 +89,11 @@ public class LinkingTest {
 
         // compare the linkages
         for (TransitStopVertex ts : Iterables.filter(g1.getVertices(), TransitStopVertex.class)) {
-            List<StreetTransitLink> stls1 = outgoingStls(ts);
+            List<StreetTransitStopLink> stls1 = outgoingStls(ts);
             assertTrue(stls1.size() >= 1);
 
             TransitStopVertex other = (TransitStopVertex) g2.getVertex(ts.getLabel());
-            List<StreetTransitLink> stls2 = outgoingStls(other);
+            List<StreetTransitStopLink> stls2 = outgoingStls(other);
 
             assertEquals("Unequal number of links from stop " + ts, stls1.size(), stls2.size());
 
@@ -107,10 +107,10 @@ public class LinkingTest {
         }
     }
 
-    private static List<StreetTransitLink> outgoingStls (final TransitStopVertex tsv) {
-        List<StreetTransitLink> stls = tsv.getOutgoing().stream()
-                .filter(StreetTransitLink.class::isInstance)
-                .map(StreetTransitLink.class::cast)
+    private static List<StreetTransitStopLink> outgoingStls (final TransitStopVertex tsv) {
+        List<StreetTransitStopLink> stls = tsv.getOutgoing().stream()
+                .filter(StreetTransitStopLink.class::isInstance)
+                .map(StreetTransitStopLink.class::cast)
                 .collect(Collectors.toList());
         stls.sort(Comparator.comparing(e -> e.getGeometry().getLength()));
         return stls;

--- a/src/test/java/org/opentripplanner/routing/edgetype/loader/TestGeometryAndBlockProcessor.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/loader/TestGeometryAndBlockProcessor.java
@@ -20,7 +20,7 @@ import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.core.TraverseModeSet;
 import org.opentripplanner.routing.edgetype.StreetEdge;
-import org.opentripplanner.routing.edgetype.StreetTransitLink;
+import org.opentripplanner.routing.edgetype.StreetTransitStopLink;
 import org.opentripplanner.routing.edgetype.StreetTraversalPermission;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
@@ -310,7 +310,7 @@ public class TestGeometryAndBlockProcessor extends TestCase {
 
         Vertex stop_d = graph.getVertex(feedId + ":D");
         Vertex split_d = null;
-        for (StreetTransitLink e : Iterables.filter(stop_d.getOutgoing(), StreetTransitLink.class)) {
+        for (StreetTransitStopLink e : Iterables.filter(stop_d.getOutgoing(), StreetTransitStopLink.class)) {
             split_d = e.getToVertex();
         }
         


### PR DESCRIPTION
### Summary

`StreetTransitLink` and `TransitEntranceLink` share a significant amount of code, so the common part is extracted into a base class (`StreetTransitEntityLink`).

The classes are also renamed:
 * `StreetTransitLink` -> `StreetTransitStopLink`
 * `TransitEntranceLink` -> `StreetTransitEntranceLink`

### Issue

closes #3388

### Unit tests

No changes.

### Code style

:ballot_box_with_check: 

### Documentation

No changes.

### Changelog

No changes.