### PR TITLE
Fix a few spelling and grammar errors

### DIFF
--- a/src/main/java/org/opentripplanner/transit/raptor/RaptorService.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/RaptorService.java
@@ -7,7 +7,7 @@ import org.opentripplanner.transit.raptor.api.transit.RaptorTransitDataProvider;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
 import org.opentripplanner.transit.raptor.rangeraptor.configure.RaptorConfig;
 import org.opentripplanner.transit.raptor.service.HeuristicSearchTask;
-import org.opentripplanner.transit.raptor.service.RangRaptorDynamicSearch;
+import org.opentripplanner.transit.raptor.service.RangeRaptorDynamicSearch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,7 +31,7 @@ public class RaptorService<T extends RaptorTripSchedule> {
     public RaptorResponse<T> route(RaptorRequest<T> request, RaptorTransitDataProvider<T> transitData) {
         LOG.debug("Original request: {}", request);
         if(request.isDynamicSearch()) {
-            return new RangRaptorDynamicSearch<>(config, transitData, request).route();
+            return new RangeRaptorDynamicSearch<>(config, transitData, request).route();
         }
         return routeUsingStdWorker(transitData, request);
     }

--- a/src/main/java/org/opentripplanner/transit/raptor/service/HeuristicSearchTask.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/service/HeuristicSearchTask.java
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Thin wrapper around a {@link HeuristicSearch} to allow for some small additional features. This
- * is mostly to extracted some "glue" out of the {@link RangRaptorDynamicSearch} to make that
+ * is mostly to extracted some "glue" out of the {@link RangeRaptorDynamicSearch} to make that
  * simpler and let it focus on the main bossiness logic.
  * <p>
  * This class is not meant for reuse, create one task for each potential heuristic search. The task

--- a/src/main/java/org/opentripplanner/transit/raptor/service/RangeRaptorDynamicSearch.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/service/RangeRaptorDynamicSearch.java
@@ -28,17 +28,17 @@ import org.slf4j.LoggerFactory;
 
 
 /**
- * This search help the {@link org.opentripplanner.transit.raptor.RaptorService} to configure
+ * This search helps the {@link org.opentripplanner.transit.raptor.RaptorService} to configure
  * heuristics and set dynamic search parameters like EDT, LAT and raptor-search-window.
  * <p>
- * If possible the forward and revers heuristics will be run in parallel.
+ * If possible the forward and reverse heuristics will be run in parallel.
  * <p>
- * Depending on witch optimization is enabled and witch search parameters is set a forward and/or a
- * revers "singel-iteration" raptor search is performed and heuristics is collected. This is used
+ * Depending on which optimization is enabled and which search parameters are set a forward and/or a
+ * reverse "single-iteration" raptor search is performed and heuristics are collected. This is used
  * to configure the "main" multi-iteration RangeRaptor search.
  */
-public class RangRaptorDynamicSearch<T extends RaptorTripSchedule> {
-    private static final Logger LOG = LoggerFactory.getLogger(RangRaptorDynamicSearch.class);
+public class RangeRaptorDynamicSearch<T extends RaptorTripSchedule> {
+    private static final Logger LOG = LoggerFactory.getLogger(RangeRaptorDynamicSearch.class);
 
     private final RaptorConfig<T> config;
     private final RaptorTransitDataProvider<T> transitData;
@@ -48,7 +48,7 @@ public class RangRaptorDynamicSearch<T extends RaptorTripSchedule> {
     private final HeuristicSearchTask<T> fwdHeuristics;
     private final HeuristicSearchTask<T> revHeuristics;
 
-    public RangRaptorDynamicSearch(
+    public RangeRaptorDynamicSearch(
             RaptorConfig<T> config,
             RaptorTransitDataProvider<T> transitData,
             RaptorRequest<T> originalRequest


### PR DESCRIPTION
### Summary

This PR fixes a few spellings. There was a class called `RangRaptorDynamicSearch` that has been renamed to `RangeRaptorDynamicSearch`. Also, a number of misspellings and grammar within the `RangeRaptorDynamicSearch` are also corrected.

### Issue

N/A

### Unit tests

No changes to tests.

### Code style

Yep

### Documentation

No extra documentation need for correcting spelling/grammar.

### Changelog

Entry to changelog probably not needed.