### PR TITLE
Rename variable to be say egress instead of access

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/RoutingWorker.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/RoutingWorker.java
@@ -182,14 +182,13 @@ public class RoutingWorker {
         }
         // Regular egress routing
         else {
-            // Prepare access/egress transfers
-            Collection<NearbyStop> accessStops = AccessEgressRouter.streetSearch(
+            Collection<NearbyStop> egressStops = AccessEgressRouter.streetSearch(
                 request,
                 request.modes.egressMode,
                 true,
                 2000
             );
-            egressList = accessEgressMapper.mapNearbyStops(accessStops, true);
+            egressList = accessEgressMapper.mapNearbyStops(egressStops, true);
         }
 
         verifyEgressAccess(accessList, egressList);


### PR DESCRIPTION
### Summary

This PR renames a variable that really seems like it ought to be called `egressStops` instead of `accessStops`. It also removes a comment that is not present for the `accessStops` calculation so that these two places of code are consistent.

### Issue

N/A

### Unit tests

No changes to tests.

### Code style

Yep

### Documentation

No extra documentation need for correcting spelling/grammar.

### Changelog

Entry to changelog probably not needed.