### PR TITLE
CarPickup tests and related fixes

### DIFF
--- a/src/client/js/otp/config.js
+++ b/src/client/js/otp/config.js
@@ -310,6 +310,7 @@ otp.config.modes = {
     "WALK"                : _tr('Walk Only'),
     //TRANSLATORS: Travel by: mode of transport (Used in selection in Travel Options widgets)
     "CAR"                 : _tr('Drive Only'),
+    "CAR_PICKUP,WALK"     : _tr('Taxi'),
     //TRANSLATORS: Travel by: mode of transport (Used in selection in Travel Options widgets)
     "CAR_PARK,WALK,TRANSIT"     : _tr('Park and Ride'),
     //TRANSLATORS: Travel by: mode of transport (Used in selection in Travel Options widgets)

--- a/src/client/js/otp/config.js
+++ b/src/client/js/otp/config.js
@@ -313,7 +313,9 @@ otp.config.modes = {
     //TRANSLATORS: Travel by: mode of transport (Used in selection in Travel Options widgets)
     "CAR_PARK,WALK,TRANSIT"     : _tr('Park and Ride'),
     //TRANSLATORS: Travel by: mode of transport (Used in selection in Travel Options widgets)
-    "CAR,WALK,TRANSIT"          : _tr('Kiss and Ride'),
+    "CAR_PICKUP,WALK,TRANSIT"   : _tr('Ride and Kiss (Car Pickup)'),
+    //TRANSLATORS: Travel by: mode of transport (Used in selection in Travel Options widgets)
+    "CAR_DROPOFF,WALK,TRANSIT"   : _tr('Kiss and Ride (Car Dropoff)'),
     //TRANSLATORS: Travel by: mode of transport (Used in selection in Travel Options widgets)
     "BICYCLE_PARK,WALK,TRANSIT" : _tr('Bike and Ride'),
     //uncomment only if bike rental exists in a map

--- a/src/main/java/org/opentripplanner/api/parameter/QualifiedModeSet.java
+++ b/src/main/java/org/opentripplanner/api/parameter/QualifiedModeSet.java
@@ -117,12 +117,12 @@ public class QualifiedModeSet implements Serializable {
                     else if (qMode.qualifiers.contains(Qualifier.PICKUP)) {
                         accessMode = StreetMode.WALK;
                         egressMode = StreetMode.CAR_PICKUP;
-                        directMode = StreetMode.CAR;
+                        directMode = StreetMode.CAR_PICKUP;
                     }
                     else if (qMode.qualifiers.contains(Qualifier.DROPOFF)) {
                         accessMode = StreetMode.CAR_PICKUP;
                         egressMode = StreetMode.WALK;
-                        directMode = StreetMode.CAR;
+                        directMode = StreetMode.CAR_PICKUP;
                     }
                     else {
                         accessMode = StreetMode.WALK;

--- a/src/main/java/org/opentripplanner/routing/algorithm/astar/AStar.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/astar/AStar.java
@@ -124,7 +124,7 @@ public class AStar {
         runState.targetAcceptedStates = Lists.newArrayList();
         
         if (addToQueue) {
-            for (State initialState : State.getStates(options)) {
+            for (State initialState : State.getInitialStates(options)) {
                 runState.spt.add(initialState);
                 runState.pq.insert(initialState, 0);
             }

--- a/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
@@ -1118,9 +1118,11 @@ public class RoutingRequest implements Cloneable, Serializable {
 
     // TODO OTP2 This is needed in order to find the correct from/to vertices for the mode
     private void resetRoutingContext() {
-        Graph graph = rctx.graph;
-        rctx = null;
-        setRoutingContext(graph);
+        if (rctx != null) {
+            Graph graph = rctx.graph;
+            rctx = null;
+            setRoutingContext(graph);
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/org/opentripplanner/routing/core/State.java
+++ b/src/main/java/org/opentripplanner/routing/core/State.java
@@ -50,6 +50,12 @@ public class State implements Cloneable {
     public static Collection<State> getStates(RoutingRequest request) {
         Collection<State> states = new ArrayList<>();
         for (Vertex vertex : request.rctx.fromVertices) {
+            /* carPickup searches may end in two states (see isFinal()): IN_CAR and WALK_FROM_DROP_OFF/WALK_TO_PICKUP
+               for forward/reverse searches to be symmetric both inital states need to be created. */
+            if (request.carPickup) {
+                states.add(new State(vertex, request.rctx.originBackEdge, request.getSecondsSinceEpoch(), request, true));
+            }
+
             states.add(new State(vertex, request.rctx.originBackEdge, request.getSecondsSinceEpoch(), request));
         }
         return states;
@@ -87,14 +93,22 @@ public class State implements Cloneable {
      * a RoutingContext in TransitIndex, tests, etc.
      */
     public State(Vertex vertex, Edge backEdge, long timeSeconds, RoutingRequest options) {
-        this(vertex, backEdge, timeSeconds, timeSeconds, options);
+        this(vertex, backEdge, timeSeconds, timeSeconds, options, false);
     }
-    
+
+    /**
+     * Create an initial state, forcing vertex, back edge and time to the specified values. Useful for reusing
+     * a RoutingContext in TransitIndex, tests, etc.
+     */
+    public State(Vertex vertex, Edge backEdge, long timeSeconds, RoutingRequest options, boolean carPickupStateInCar) {
+        this(vertex, backEdge, timeSeconds, timeSeconds, options, carPickupStateInCar);
+    }
+
     /**
      * Create an initial state, forcing vertex, back edge, time and start time to the specified values. Useful for starting
      * a multiple initial state search, for example when propagating profile results to the street network in RoundBasedProfileRouter.
      */
-    public State(Vertex vertex, Edge backEdge, long timeSeconds, long startTime, RoutingRequest options) {
+    public State(Vertex vertex, Edge backEdge, long timeSeconds, long startTime, RoutingRequest options, boolean carPickupStateInCar) {
         this.weight = 0;
         this.vertex = vertex;
         this.backEdge = backEdge;
@@ -105,14 +119,20 @@ public class State implements Cloneable {
         this.stateData.opt = options;
         this.stateData.startTime = startTime;
         this.stateData.usingRentedBike = false;
+        if (options.carPickup) {
+            /* For carPickup two initial states are created in getStates(request):
+                 1. WALK / WALK_FROM_DROP_OFF or WALK_TO_PICKUP for cases with an initial walk
+                 2. CAR / IN_CAR where pickup happens directly at the bus stop */
+            if (carPickupStateInCar) {
+                this.stateData.carPickupState = CarPickupState.IN_CAR;
+                this.stateData.nonTransitMode = TraverseMode.CAR;
+            } else {
+                this.stateData.carPickupState = options.arriveBy ? CarPickupState.WALK_FROM_DROP_OFF : CarPickupState.WALK_TO_PICKUP;
+                this.stateData.nonTransitMode = TraverseMode.WALK;
+            }
+        }
         /* If the itinerary is to begin with a car that is left for transit, the initial state of arriveBy searches is
            with the car already "parked" and in WALK mode. Otherwise, we are in CAR mode and "unparked". */
-        if (options.carPickup) {
-            this.stateData.carPickupState = options.arriveBy
-                ? CarPickupState.WALK_FROM_DROP_OFF
-                : CarPickupState.WALK_TO_PICKUP;
-            this.stateData.nonTransitMode = TraverseMode.WALK;
-        }
         if (options.parkAndRide) {
             this.stateData.carParked = options.arriveBy;
             this.stateData.nonTransitMode = this.stateData.carParked ? TraverseMode.WALK : TraverseMode.CAR;
@@ -463,6 +483,9 @@ public class State implements Cloneable {
             }
             if (orig.isBikeParked() != orig.getBackState().isBikeParked()) {
                 editor.setBikeParked(!orig.isBikeParked());
+            }
+            if (orig.getCarPickupState() != null) {
+                editor.setCarPickupState(orig.getCarPickupState());
             }
 
             ret = editor.makeState();

--- a/src/main/java/org/opentripplanner/routing/core/State.java
+++ b/src/main/java/org/opentripplanner/routing/core/State.java
@@ -47,7 +47,7 @@ public class State implements Cloneable {
      * Initial "parent-less" states can only be created at the beginning of a trip. elsewhere, all
      * states must be created from a parent and associated with an edge.
      */
-    public static Collection<State> getStates(RoutingRequest request) {
+    public static Collection<State> getInitialStates(RoutingRequest request) {
         Collection<State> states = new ArrayList<>();
         for (Vertex vertex : request.rctx.fromVertices) {
             /* carPickup searches may end in two states (see isFinal()): IN_CAR and WALK_FROM_DROP_OFF/WALK_TO_PICKUP

--- a/src/main/java/org/opentripplanner/routing/core/StateEditor.java
+++ b/src/main/java/org/opentripplanner/routing/core/StateEditor.java
@@ -276,7 +276,8 @@ public class StateEditor {
         child.stateData.usingRentedBike = state.isBikeRenting();
     }
 
-    public void setTaxiState(CarPickupState carPickupState) {
+    public void setCarPickupState(CarPickupState carPickupState) {
+        cloneStateDataAsNeeded();
         child.stateData.carPickupState = carPickupState;
         switch (carPickupState) {
             case WALK_TO_PICKUP:

--- a/src/main/java/org/opentripplanner/routing/edgetype/CarPickupableEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/CarPickupableEdge.java
@@ -1,0 +1,32 @@
+package org.opentripplanner.routing.edgetype;
+
+import org.opentripplanner.routing.core.CarPickupState;
+import org.opentripplanner.routing.core.State;
+import org.opentripplanner.routing.core.StateEditor;
+
+public interface CarPickupableEdge {
+
+    default boolean canPickupAndDrive(State state) {
+        return state.getOptions().carPickup
+                && state.getCarPickupState() == (
+                state.getOptions().arriveBy
+                        ? CarPickupState.WALK_FROM_DROP_OFF
+                        : CarPickupState.WALK_TO_PICKUP
+        );
+    }
+
+    default boolean canDropOffAfterDriving(State state) {
+        return state.getOptions().carPickup
+                && state.getCarPickupState() == CarPickupState.IN_CAR;
+    }
+
+    default void dropOffAfterDriving(State state, StateEditor editor) {
+        editor.setCarPickupState(state.getOptions().arriveBy
+                ? CarPickupState.WALK_TO_PICKUP
+                : CarPickupState.WALK_FROM_DROP_OFF);
+    }
+
+    default void driveAfterPickup(State state, StateEditor editor) {
+        editor.setCarPickupState(CarPickupState.IN_CAR);
+    }
+}

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
@@ -19,7 +19,6 @@ import org.opentripplanner.common.model.P2;
 import org.opentripplanner.graph_builder.linking.DisposableEdgeCollection;
 import org.opentripplanner.graph_builder.linking.LinkingDirection;
 import org.opentripplanner.routing.api.request.RoutingRequest;
-import org.opentripplanner.routing.core.CarPickupState;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.core.StateEditor;
 import org.opentripplanner.routing.core.TraverseMode;
@@ -43,7 +42,7 @@ import org.slf4j.LoggerFactory;
  * @author novalis
  * 
  */
-public class StreetEdge extends Edge implements Cloneable {
+public class StreetEdge extends Edge implements Cloneable, CarPickupableEdge {
 
     private static Logger LOG = LoggerFactory.getLogger(StreetEdge.class);
 
@@ -250,70 +249,31 @@ public class StreetEdge extends Edge implements Cloneable {
     @Override
     public State traverse(State s0) {
         final RoutingRequest options = s0.getOptions();
-        final TraverseMode currMode = s0.getNonTransitMode();
         StateEditor editor = doTraverse(s0, options, s0.getNonTransitMode());
         State state = (editor == null) ? null : editor.makeState();
-        /* Kiss and ride support. Mode transitions occur without the explicit loop edges used in park-and-ride. */
-        // TODO Replace with a more general state machine implementation
-        if (options.carPickup) {
-            if (options.arriveBy) {
-                // Check if we can enter the taxi and continue by car
-                // Final WALK check needed to prevent infinite recursion.
-                if (s0.getCarPickupState().equals(CarPickupState.WALK_FROM_DROP_OFF)
-                        && currMode == TraverseMode.WALK) {
-                    editor = doTraverse(s0, options, TraverseMode.CAR);
-                    if (editor != null) {
-                        editor.setTaxiState(CarPickupState.IN_CAR);
-                        State forkState = editor.makeState();
-                        if (forkState != null) {
-                            forkState.addToExistingResultChain(state);
-                            return forkState; // return both taxi and walk states
-                        }
-                    }
-                }
 
-                // Check if we can exit the taxi and continue by walking
-                // Final CAR check needed to prevent infinite recursion.
-                if ( s0.getCarPickupState().equals(CarPickupState.IN_CAR) &&
-                        !getPermission().allows(TraverseMode.CAR)
-                        && currMode == TraverseMode.CAR) {
-                    // Check if it is possible to continue by walking
-                    editor = doTraverse(s0, options, TraverseMode.WALK);
-                    if (editor != null) {
-                        editor.setTaxiState(CarPickupState.WALK_TO_PICKUP);
-                        return editor.makeState(); // return only the walk state
-                    }
-                }
-            } else { /* departAfter */
-                // Check if we can enter the taxi and continue by car
-                // Final WALK check needed to prevent infinite recursion.
-                if (s0.getCarPickupState().equals(CarPickupState.WALK_TO_PICKUP)
-                    && currMode == TraverseMode.WALK) {
-                    editor = doTraverse(s0, options, TraverseMode.CAR);
-                    if (editor != null) {
-                        editor.setTaxiState(CarPickupState.IN_CAR);
-                        State forkState = editor.makeState();
-                        if (forkState != null) {
-                            forkState.addToExistingResultChain(state);
-                            return forkState; // return both the car and the walk state
-                        }
-                    }
-                }
-
-                // Check if we can exit the taxi and continue by walking
-                // Final CAR check needed to prevent infinite recursion.
-                if ( s0.getCarPickupState().equals(CarPickupState.IN_CAR) &&
-                    !getPermission().allows(TraverseMode.CAR)
-                    && currMode == TraverseMode.CAR) {
-                    // Check if it is possible to continue by walking
-                    editor = doTraverse(s0, options, TraverseMode.WALK);
-                    if (editor != null) {
-                        editor.setTaxiState(CarPickupState.WALK_FROM_DROP_OFF);
-                        return editor.makeState(); // return only the walk state
-                    }
+        if (canPickupAndDrive(s0)) {
+            StateEditor inCar = doTraverse(s0, options, TraverseMode.CAR);
+            if (inCar != null) {
+                driveAfterPickup(s0, inCar);
+                State forkState = inCar.makeState();
+                if (forkState != null) {
+                    // Return both the original WALK state, along with the new IN_CAR state
+                    forkState.addToExistingResultChain(state);
+                    return forkState;
                 }
             }
         }
+
+        if (canDropOffAfterDriving(s0) && !getPermission().allows(TraverseMode.CAR)) {
+            editor = doTraverse(s0, options, TraverseMode.WALK);
+            if (editor != null) {
+                dropOffAfterDriving(s0, editor);
+                // Only the walk state is returned, since traversing by car was not possible
+                return editor.makeState();
+            }
+        }
+
         return state;
     }
 

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetTransitEntityLink.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetTransitEntityLink.java
@@ -6,7 +6,6 @@ import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.common.geometry.GeometryUtils;
 import org.opentripplanner.model.Trip;
 import org.opentripplanner.routing.api.request.RoutingRequest;
-import org.opentripplanner.routing.core.CarPickupState;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.core.StateEditor;
 import org.opentripplanner.routing.core.TraverseMode;
@@ -17,7 +16,7 @@ import org.opentripplanner.routing.vertextype.StreetVertex;
 /**
  * This represents the connection between a street vertex and a transit vertex.
  */
-public abstract class StreetTransitEntityLink<T extends Vertex> extends Edge {
+public abstract class StreetTransitEntityLink<T extends Vertex> extends Edge implements CarPickupableEdge {
 
     private static final long serialVersionUID = -3311099256178798981L;
     static final int STEL_TRAVERSE_COST = 1;
@@ -101,15 +100,19 @@ public abstract class StreetTransitEntityLink<T extends Vertex> extends Edge {
         // This allows searching for nearby transit stops using walk-only options.
         StateEditor s1 = s0.edit(this);
 
-        /* Only enter stations in CAR mode if parking is not required (kiss and ride) */
-        /* Note that in arriveBy searches this is double-traversing link edges to fork the state into both WALK and CAR mode. This is an insane hack. */
+        TraverseMode mode = s0.getBackMode() == null ? s0.getNonTransitMode() : s0.getBackMode();
+
         if (s0.getNonTransitMode() == TraverseMode.CAR) {
-            if (req.carPickup && s0.getCarPickupState() == CarPickupState.IN_CAR) {
-                s1.setTaxiState(s0.getOptions().arriveBy ? CarPickupState.WALK_TO_PICKUP : CarPickupState.WALK_FROM_DROP_OFF);
+            // For Kiss & Ride allow dropping of the passenger before entering the station
+            if (canDropOffAfterDriving(s0) && isLeavingStreetNetwork(req)) {
+                dropOffAfterDriving(s0, s1);
+                mode = TraverseMode.WALK;
             } else {
                 return null;
             }
         }
+
+        s1.setBackMode(mode);
 
         // We do not increase the time here, so that searching from the stop coordinates instead of
         // the stop id catch transit departing at that exact search time.
@@ -119,12 +122,16 @@ public abstract class StreetTransitEntityLink<T extends Vertex> extends Edge {
         return s1.makeState();
     }
 
+    boolean isLeavingStreetNetwork(RoutingRequest req) {
+        return (req.arriveBy ? fromv : tov) == getTransitEntityVertex();
+    }
+
     public State optimisticTraverse(State s0) {
         StateEditor s1 = s0.edit(this);
         s1.incrementWeight(STEL_TRAVERSE_COST);
         return s1.makeState();
     }
-    
+
     // anecdotally, the lower bound search is about 2x faster when you don't reach stops
     // and therefore don't even consider boarding
     @Override

--- a/src/main/java/org/opentripplanner/routing/spt/DominanceFunction.java
+++ b/src/main/java/org/opentripplanner/routing/spt/DominanceFunction.java
@@ -60,6 +60,10 @@ public abstract class DominanceFunction implements Serializable {
             return false;
         }
 
+        if (a.getCarPickupState() != b.getCarPickupState()) {
+            return false;
+        }
+
         // Does one state represent riding a bike and the other represent walking after the bike was parked?
         if (a.isBikeParked() != b.isBikeParked()) {
             return false;

--- a/src/test/java/org/opentripplanner/routing/algorithm/GraphRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/GraphRoutingTest.java
@@ -1,0 +1,316 @@
+package org.opentripplanner.routing.algorithm;
+
+import java.util.List;
+import java.util.Set;
+import junit.framework.TestCase;
+import org.opentripplanner.common.TurnRestriction;
+import org.opentripplanner.common.TurnRestrictionType;
+import org.opentripplanner.common.geometry.GeometryUtils;
+import org.opentripplanner.model.Entrance;
+import org.opentripplanner.model.FeedScopedId;
+import org.opentripplanner.model.Stop;
+import org.opentripplanner.model.WgsCoordinate;
+import org.opentripplanner.model.WheelChairBoarding;
+import org.opentripplanner.routing.bike_park.BikePark;
+import org.opentripplanner.routing.bike_rental.BikeRentalStation;
+import org.opentripplanner.routing.core.TraverseMode;
+import org.opentripplanner.routing.core.TraverseModeSet;
+import org.opentripplanner.routing.edgetype.BikeParkEdge;
+import org.opentripplanner.routing.edgetype.ParkAndRideEdge;
+import org.opentripplanner.routing.edgetype.ParkAndRideLinkEdge;
+import org.opentripplanner.routing.edgetype.PathwayEdge;
+import org.opentripplanner.routing.edgetype.RentABikeOffEdge;
+import org.opentripplanner.routing.edgetype.RentABikeOnEdge;
+import org.opentripplanner.routing.edgetype.StreetBikeParkLink;
+import org.opentripplanner.routing.edgetype.StreetBikeRentalLink;
+import org.opentripplanner.routing.edgetype.StreetEdge;
+import org.opentripplanner.routing.edgetype.StreetTransitEntranceLink;
+import org.opentripplanner.routing.edgetype.StreetTransitStopLink;
+import org.opentripplanner.routing.edgetype.StreetTraversalPermission;
+import org.opentripplanner.routing.graph.Edge;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.routing.graph.Vertex;
+import org.opentripplanner.routing.vertextype.BikeParkVertex;
+import org.opentripplanner.routing.vertextype.BikeRentalStationVertex;
+import org.opentripplanner.routing.vertextype.IntersectionVertex;
+import org.opentripplanner.routing.vertextype.ParkAndRideVertex;
+import org.opentripplanner.routing.vertextype.StreetVertex;
+import org.opentripplanner.routing.vertextype.TransitEntranceVertex;
+import org.opentripplanner.routing.vertextype.TransitStopVertex;
+
+public abstract class GraphRoutingTest extends TestCase {
+
+    public static final String TEST_FEED_ID = "testFeed";
+    public static final String TEST_BIKE_RENTAL_NETWORK = "test network";
+
+    protected Graph graphOf(Builder builder) {
+        return builder.graph();
+    }
+
+    public abstract static class Builder {
+
+        private final Graph graph = new Graph();
+
+        abstract void build();
+
+        public Graph graph() {
+            build();
+            return graph;
+        }
+
+
+        public <T> T v(String label) {
+            return vertex(label);
+        }
+
+        public <T> T vertex(String label) {
+            return (T) graph.getVertex(label);
+        }
+
+        // -- Street network
+        public IntersectionVertex intersection(String label, double latitude, double longitude) {
+            return new IntersectionVertex(graph, label, latitude, longitude);
+        }
+
+        public StreetEdge street(
+                StreetVertex from,
+                StreetVertex to,
+                int length,
+                StreetTraversalPermission permissions
+        ) {
+            return new StreetEdge(from, to,
+                    GeometryUtils.makeLineString(
+                            from.getLat(), from.getLon(), to.getLat(), to.getLon()),
+                    String.format("%s%s street", from.getName(), to.getName()),
+                    length,
+                    permissions,
+                    false
+            );
+        }
+
+        public List<StreetEdge> street(
+                StreetVertex from,
+                StreetVertex to,
+                int length,
+                StreetTraversalPermission forwardPermissions,
+                StreetTraversalPermission reversePermissions
+        ) {
+            return List.of(
+                    new StreetEdge(from, to,
+                            GeometryUtils.makeLineString(
+                                    from.getLat(), from.getLon(), to.getLat(), to.getLon()),
+                            String.format("%s%s street", from.getName(), to.getName()),
+                            length,
+                            forwardPermissions,
+                            false
+                    ),
+                    new StreetEdge(to, from,
+                            GeometryUtils.makeLineString(
+                                    to.getLat(), to.getLon(), from.getLat(), from.getLon()),
+                            String.format("%s%s street", from.getName(), to.getName()),
+                            length,
+                            reversePermissions,
+                            true
+                    )
+            );
+        }
+
+        public TurnRestriction turnRestriction(
+                Edge from,
+                Edge to,
+                TurnRestrictionType type,
+                TraverseModeSet modes
+        ) {
+            var turnRestriction = new TurnRestriction(from, to, type, modes);
+            graph.addTurnRestriction(from, turnRestriction);
+            return turnRestriction;
+        }
+
+        public TurnRestriction turnRestriction(Edge from, Edge to, TurnRestrictionType type) {
+            return turnRestriction(
+                    from, to, type, new TraverseModeSet(TraverseMode.BICYCLE, TraverseMode.CAR));
+        }
+
+        public TurnRestriction bicycleTurnRestriction(
+                Edge from,
+                Edge to,
+                TurnRestrictionType type
+        ) {
+            return turnRestriction(from, to, type, new TraverseModeSet(TraverseMode.BICYCLE));
+        }
+
+        public TurnRestriction carTurnRestriction(Edge from, Edge to, TurnRestrictionType type) {
+            return turnRestriction(from, to, type, new TraverseModeSet(TraverseMode.CAR));
+        }
+
+        // -- Transit network (pathways, linking)
+        public Entrance entranceEntity(String id, double latitude, double longitude) {
+            return new Entrance(
+                    new FeedScopedId(TEST_FEED_ID, id),
+                    id,
+                    id,
+                    null,
+                    WgsCoordinate.creatOptionalCoordinate(latitude, longitude),
+                    WheelChairBoarding.NO_INFORMATION,
+                    null
+            );
+        }
+
+        public Stop stopEntity(String id, double latitude, double longitude) {
+            return new Stop(
+                    new FeedScopedId(TEST_FEED_ID, id),
+                    id,
+                    id,
+                    null,
+                    WgsCoordinate.creatOptionalCoordinate(latitude, longitude),
+                    WheelChairBoarding.NO_INFORMATION,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+            );
+        }
+
+        public TransitStopVertex stop(String id, double latitude, double longitude) {
+            return new TransitStopVertex(
+                    graph, stopEntity(id, latitude, longitude), null);
+        }
+
+        public TransitEntranceVertex entrance(String id, double latitude, double longitude) {
+            return new TransitEntranceVertex(
+                    graph, entranceEntity(id, latitude, longitude));
+        }
+
+        public StreetTransitEntranceLink link(StreetVertex from, TransitEntranceVertex to) {
+            return new StreetTransitEntranceLink(from, to);
+        }
+
+        public StreetTransitEntranceLink link(TransitEntranceVertex from, StreetVertex to) {
+            return new StreetTransitEntranceLink(from, to);
+        }
+
+        public List<StreetTransitEntranceLink> biLink(
+                StreetVertex from,
+                TransitEntranceVertex to
+        ) {
+            return List.of(link(from, to), link(to, from));
+        }
+
+        public StreetTransitStopLink link(StreetVertex from, TransitStopVertex to) {
+            return new StreetTransitStopLink(from, to);
+        }
+
+        public StreetTransitStopLink link(TransitStopVertex from, StreetVertex to) {
+            return new StreetTransitStopLink(from, to);
+        }
+
+        public List<StreetTransitStopLink> biLink(StreetVertex from, TransitStopVertex to) {
+            return List.of(link(from, to), link(to, from));
+        }
+
+        public PathwayEdge pathway(Vertex from, Vertex to) {
+            return new PathwayEdge(
+                    from, to, String.format("%s%s pathway", from.getName(), to.getName()));
+        }
+
+        // -- Bike rental
+        public BikeRentalStation bikeRentalStationEntity(
+                String id,
+                double latitude,
+                double longitude
+        ) {
+            var bikeRentalStation = new BikeRentalStation();
+            bikeRentalStation.id = id;
+            bikeRentalStation.x = latitude;
+            bikeRentalStation.y = longitude;
+            return bikeRentalStation;
+        }
+
+        public BikeRentalStationVertex bikeRentalStation(
+                String id,
+                double latitude,
+                double longitude,
+                Set<String> networks
+        ) {
+            var vertex = new BikeRentalStationVertex(
+                    graph,
+                    bikeRentalStationEntity(id, latitude, longitude)
+            );
+            new RentABikeOnEdge(vertex, vertex, networks);
+            new RentABikeOffEdge(vertex, vertex, networks);
+            return vertex;
+        }
+
+        public BikeRentalStationVertex bikeRentalStation(
+                String id,
+                double latitude,
+                double longitude
+        ) {
+            return bikeRentalStation(id, latitude, longitude, Set.of(TEST_BIKE_RENTAL_NETWORK));
+        }
+
+        public StreetBikeRentalLink link(StreetVertex from, BikeRentalStationVertex to) {
+            return new StreetBikeRentalLink(from, to);
+        }
+
+        public StreetBikeRentalLink link(BikeRentalStationVertex from, StreetVertex to) {
+            return new StreetBikeRentalLink(from, to);
+        }
+
+        public List<StreetBikeRentalLink> biLink(StreetVertex from, BikeRentalStationVertex to) {
+            return List.of(link(from, to), link(to, from));
+        }
+
+        // -- Bike P+R
+        public BikePark bikeParkEntity(String id, double latitude, double longitude) {
+            var bikePark = new BikePark();
+            bikePark.id = id;
+            bikePark.x = latitude;
+            bikePark.y = longitude;
+            return bikePark;
+        }
+
+        public BikeParkVertex bikePark(String id, double latitude, double longitude) {
+            var vertex = new BikeParkVertex(
+                    graph,
+                    bikeParkEntity(id, latitude, longitude)
+            );
+            new BikeParkEdge(vertex);
+            return vertex;
+        }
+
+        public StreetBikeParkLink link(StreetVertex from, BikeParkVertex to) {
+            return new StreetBikeParkLink(from, to);
+        }
+
+        public StreetBikeParkLink link(BikeParkVertex from, StreetVertex to) {
+            return new StreetBikeParkLink(from, to);
+        }
+
+        public List<StreetBikeParkLink> biLink(StreetVertex from, BikeParkVertex to) {
+            return List.of(link(from, to), link(to, from));
+        }
+
+        // -- Car P+R
+        public ParkAndRideVertex carPark(String id, double latitude, double longitude) {
+            var vertex =
+                    new ParkAndRideVertex(graph, id, id, latitude, longitude, null);
+            new ParkAndRideEdge(vertex);
+            return vertex;
+        }
+
+        public ParkAndRideLinkEdge link(StreetVertex from, ParkAndRideVertex to) {
+            return new ParkAndRideLinkEdge(from, to);
+        }
+
+        public ParkAndRideLinkEdge link(ParkAndRideVertex from, StreetVertex to) {
+            return new ParkAndRideLinkEdge(from, to);
+        }
+
+        public List<ParkAndRideLinkEdge> biLink(StreetVertex from, ParkAndRideVertex to) {
+            return List.of(link(from, to), link(to, from));
+        }
+    }
+}

--- a/src/test/java/org/opentripplanner/routing/algorithm/TestCarPickup.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/TestCarPickup.java
@@ -1,0 +1,182 @@
+package org.opentripplanner.routing.algorithm;
+
+import java.util.stream.Collectors;
+import org.opentripplanner.routing.algorithm.astar.AStar;
+import org.opentripplanner.routing.api.request.RoutingRequest;
+import org.opentripplanner.routing.api.request.StreetMode;
+import org.opentripplanner.routing.edgetype.StreetTraversalPermission;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.routing.graph.Vertex;
+import org.opentripplanner.routing.vertextype.StreetVertex;
+import org.opentripplanner.routing.vertextype.TransitEntranceVertex;
+import org.opentripplanner.routing.vertextype.TransitStopVertex;
+
+/**
+ * Test CarPickup:
+ * - it may start with (WALK - WALK_TO_PICKUP, CAR - IN_CAR)
+ * - it may end with (WALK - WALK_FROM_DROP_OFF, CAR - IN_CAR)
+ * - StreetTransitEntityLink require mode changes to WALK
+ * - StreetEdges may contain mode changes between CAR / WALK
+ *
+ * arriveBy and departAt paths should be symmetric.
+ */
+public class TestCarPickup extends GraphRoutingTest {
+
+    private Graph graph;
+    private TransitStopVertex S1;
+    private TransitEntranceVertex E1;
+    private StreetVertex A, B, C, D, E;
+
+    @Override
+    protected void setUp() throws Exception {
+        // Generate a very simple graph
+        //
+        //   A <-> B <-> C <-> D <-> E
+        //   TS1 <-^           ^-> TE1
+
+        graph = graphOf(new Builder() {
+            @Override
+            public void build() {
+                S1 = stop("S1", 0, 45);
+                E1 = entrance("E1", 0.004, 45);
+                A = intersection("A", 0.001, 45);
+                B = intersection("B", 0.002, 45);
+                C = intersection("C", 0.003, 45);
+                D = intersection("D", 0.004, 45);
+                E = intersection("E", 0.005, 45);
+
+                biLink(B, S1);
+                biLink(C, E1);
+
+                street(A, B, 87, StreetTraversalPermission.PEDESTRIAN);
+                street(B, C, 87, StreetTraversalPermission.CAR);
+                street(C, D, 87, StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE);
+                street(D, E, 87, StreetTraversalPermission.PEDESTRIAN);
+            }
+        });
+    }
+
+    public void testCarPickupCarOnly() {
+        assertPath(B, C, "null - IN_CAR - null, CAR - IN_CAR - BC street");
+    }
+
+    public void testCarPickupCarThenWalk() {
+        assertPath(
+                A, C,
+                "null - WALK_TO_PICKUP - null, WALK - WALK_TO_PICKUP - AB street, CAR - IN_CAR - BC street"
+        );
+    }
+
+    public void testCarPickupFromEntranceThenCar() {
+        assertPath(
+                S1, C,
+                "null - WALK_TO_PICKUP - null, WALK - WALK_TO_PICKUP - S1, CAR - IN_CAR - BC street"
+        );
+    }
+
+    public void testCarPickupWalkFromEntranceThenCarThenWalk() {
+        assertPath(
+                S1, D,
+                "null - WALK_TO_PICKUP - null, WALK - WALK_TO_PICKUP - S1, CAR - IN_CAR - BC street, WALK - WALK_FROM_DROP_OFF - CD street"
+        );
+    }
+
+    public void testCarPickupCarThenWalkToStop() {
+        assertPath(
+                B, E1,
+                "null - IN_CAR - null, CAR - IN_CAR - BC street, WALK - WALK_FROM_DROP_OFF - E1"
+        );
+    }
+
+    public void testCarPickupWalkFromEntranceThenCarThenWalkToStop() {
+        assertPath(
+                S1, E1,
+                "null - WALK_TO_PICKUP - null, WALK - WALK_TO_PICKUP - S1, CAR - IN_CAR - BC street, WALK - WALK_FROM_DROP_OFF - E1"
+        );
+    }
+
+    public void testCarPickupWalkThenCarThenWalk() {
+        assertPath(
+                A, D,
+                "null - WALK_TO_PICKUP - null, WALK - WALK_TO_PICKUP - AB street, CAR - IN_CAR - BC street, WALK - WALK_FROM_DROP_OFF - CD street"
+        );
+    }
+
+    public void testWalkOnlyCarPickup() {
+        // This is a special case where the reverse states differ, due to both starting in the IN_CAR
+        // state and switching to walking when encountering the first edge. This is the only valid
+        // path since a CarPickup must be in `IN_CAR` or `WALK_FROM_DROP_OFF` to be a final state,
+        // and the path can't be traversed by car.
+        assertPath(
+                A, B,
+                "null - IN_CAR - null, WALK - WALK_FROM_DROP_OFF - AB street",
+                "null - WALK_TO_PICKUP - null, WALK - WALK_TO_PICKUP - AB street"
+        );
+    }
+
+    private void assertPath(Vertex fromVertex, Vertex toVertex, String descriptor) {
+        String departAt = runStreetSearchAndCreateDescriptor(fromVertex, toVertex, false);
+        String arriveBy = runStreetSearchAndCreateDescriptor(fromVertex, toVertex, true);
+
+        assertDescriptors(descriptor, descriptor, arriveBy, departAt);
+    }
+
+    private void assertPath(
+            Vertex fromVertex,
+            Vertex toVertex,
+            String expectedDepartAt,
+            String expectedArriveBy
+    ) {
+        String departAt = runStreetSearchAndCreateDescriptor(fromVertex, toVertex, false);
+        String arriveBy = runStreetSearchAndCreateDescriptor(fromVertex, toVertex, true);
+
+        assertDescriptors(expectedDepartAt, expectedArriveBy, arriveBy, departAt);
+    }
+
+    private void assertDescriptors(
+            String expectedDepartAt,
+            String expectedArriveBy,
+            String arriveBy,
+            String departAt
+    ) {
+        String formatString = "DepartAt: %s%nArriveBy: %s";
+
+        assertEquals(
+                String.format(
+                        formatString,
+                        expectedDepartAt,
+                        expectedArriveBy
+                ),
+                String.format(
+                        formatString,
+                        departAt,
+                        arriveBy
+                )
+        );
+    }
+
+    private String runStreetSearchAndCreateDescriptor(
+            Vertex fromVertex,
+            Vertex toVertex,
+            boolean arriveBy
+    ) {
+        var options = new RoutingRequest();
+        options.arriveBy = arriveBy;
+        options.worstTime = arriveBy ? Long.MIN_VALUE : Long.MAX_VALUE;
+
+        var carPickupOptions = options.getStreetSearchRequest(StreetMode.CAR_PICKUP);
+        carPickupOptions.setRoutingContext(graph, fromVertex, toVertex);
+        var tree = new AStar().getShortestPathTree(carPickupOptions);
+        var path = tree.getPath(
+                arriveBy ? fromVertex : toVertex,
+                false
+        );
+
+        return path != null ? path.states.stream().map(s -> String.format(
+                "%s - %s - %s",
+                s.getBackMode(),
+                s.getCarPickupState(),
+                s.getBackEdge() != null ? s.getBackEdge().getName() : null
+        )).collect(Collectors.joining(", ")) : "path not found";
+    }
+}


### PR DESCRIPTION
### Summary

CarPickup contains a few inconsistencies (based on #3389), which this fixes:
 * Adds _Kiss and Ride (car drop off)_ and _Ride and Kiss (car pickup)_ options to the client
 * Correctly clones the `stateData` when the `carPickupState` changes and copies the value of `carPickupState` when reversing a `State`
 * Renames `StateEditor#setTaxiState()` to `StateEditor#setCarPickupState()`
 * Handles `arriveBy` searches in `StreetTransitEntityLink`
 * Adds parallel initial states so that the forward/reverse searches may result in the same path. This implicitly also allows walk-only itineraries so a station only reachable by walking all the way is now an accepted possibility.
 
   A depart at search may end in a `IN_CAR` or `WALK_FROM_DROP_OFF` state. To achieve the same path an `arriveBy` search needs to start in both states.

   To assist this `DominanceFunction#betterOrEqualAndComparable()` is extended so that states with differing `carPickupStates` are considered different.

### Unit tests

`CarPickupTest` is added to verify that:
 * `departAt` and `arriveBy` searches produce the same result
 * mode (`WALK / CAR`) and state (`WALK_TO_PICKUP / IN_CAR / WALK_FROM_DROP_OFF`) transitions happen in the expected places

### Code style

:ballot_box_with_check: 

### Documentation

No changes needed. 

### Changelog

No changes needed.