### PR TITLE
Also copy bookingInfo when copying TripTimes

### DIFF
--- a/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
+++ b/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
@@ -200,6 +200,7 @@ public class TripTimes implements Serializable, Comparable<TripTimes>, Cloneable
         this.timepoints = object.timepoints;
         this.pickups = object.pickups;
         this.dropoffs = object.dropoffs;
+        this.bookingInfos = object.bookingInfos;
     }
 
     /**


### PR DESCRIPTION
### Summary
This fixes and oversight where the booking infos would not be copied over when a TripTimes object is copied as part of a realtime update.

### Issue
No issue