### PR TITLE
Disable non-working map layers and change default

### DIFF
--- a/src/client/js/otp/config.js
+++ b/src/client/js/otp/config.js
@@ -72,9 +72,25 @@ otp.config = {
 
     baseLayers: [
         {
+            name: 'Stamen Terrain',
+            tileUrl: 'http://tile.stamen.com/terrain/{z}/{x}/{y}.png',
+            attribution : 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.'
+        },
+        {
             name: 'Carto Positron',
             tileUrl: 'http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png',
             attribution : 'Map tiles by Carto/MapZen. Map data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.'
+        },
+        {
+            name: 'Transport Tiles',
+            tileUrl: 'http://{s}.tile.thunderforest.com/transport/{z}/{x}/{y}.png',
+            subdomains : ['a','b','c'],
+            attribution: 'Data from <a href="http://www.openstreetmap.org/" target="_blank">OpenStreetMap</a> and contributors. Tiles from <a href="http://www.thunderforest.com/transport/">Andy Allan</a>'
+        },
+        {
+            name: 'Stamen Toner Lite',
+            tileUrl: 'http://tile.stamen.com/toner-lite/{z}/{x}/{y}.png',
+            attribution : 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.'
         },
         {
             name: 'Carto Dark Matter',

--- a/src/client/js/otp/config.js
+++ b/src/client/js/otp/config.js
@@ -72,25 +72,9 @@ otp.config = {
 
     baseLayers: [
         {
-            name: 'Stamen Terrain',
-            tileUrl: 'http://tile.stamen.com/terrain/{z}/{x}/{y}.png',
-            attribution : 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.'
-        },
-        {
             name: 'Carto Positron',
             tileUrl: 'http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png',
             attribution : 'Map tiles by Carto/MapZen. Map data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.'
-        },
-        {
-            name: 'Transport Tiles',
-            tileUrl: 'http://{s}.tile.thunderforest.com/transport/{z}/{x}/{y}.png',
-            subdomains : ['a','b','c'],
-            attribution: 'Data from <a href="http://www.openstreetmap.org/" target="_blank">OpenStreetMap</a> and contributors. Tiles from <a href="http://www.thunderforest.com/transport/">Andy Allan</a>'
-        },
-        {
-            name: 'Stamen Toner Lite',
-            tileUrl: 'http://tile.stamen.com/toner-lite/{z}/{x}/{y}.png',
-            attribution : 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.'
         },
         {
             name: 'Carto Dark Matter',
@@ -152,7 +136,7 @@ otp.config = {
         {
             id : 'planner',
             className : 'otp.modules.multimodal.MultimodalPlannerModule',
-            defaultBaseLayer : 'Stamen Terrain',
+            defaultBaseLayer : 'OSM Standard Tiles',
             isDefault: true
         },
         {


### PR DESCRIPTION
### Summary
Some of the map layers in the debug client don't work because of missing API keys or invalid ssl certificate on the remote tile server. This PR disables non-working map layers and changes the default map layer to `OSM Standard Tiles`

See issue #3407

### Unit tests
The change was manually tested in the debug client locally.