### PR TITLE
Adds the ability to search by station entrances rather than just the …

### DIFF
--- a/src/main/java/org/opentripplanner/routing/graph/Graph.java
+++ b/src/main/java/org/opentripplanner/routing/graph/Graph.java
@@ -49,16 +49,17 @@ import org.opentripplanner.graph_builder.linking.VertexLinker;
 import org.opentripplanner.model.Agency;
 import org.opentripplanner.model.FeedInfo;
 import org.opentripplanner.model.FeedScopedId;
-import org.opentripplanner.model.FlexLocationGroup;
-import org.opentripplanner.model.FlexStopLocation;
 import org.opentripplanner.model.GraphBundle;
 import org.opentripplanner.model.GroupOfStations;
+import org.opentripplanner.model.FlexStopLocation;
+import org.opentripplanner.model.FlexLocationGroup;
 import org.opentripplanner.model.MultiModalStation;
 import org.opentripplanner.model.Notice;
 import org.opentripplanner.model.Operator;
 import org.opentripplanner.model.SimpleTransfer;
 import org.opentripplanner.model.Station;
 import org.opentripplanner.model.Stop;
+import org.opentripplanner.model.Entrance;
 import org.opentripplanner.model.StopLocation;
 import org.opentripplanner.model.TimetableSnapshot;
 import org.opentripplanner.model.TimetableSnapshotProvider;
@@ -888,6 +889,15 @@ public class Graph implements Serializable {
         return null;
     }
 
+    private Collection<Entrance> getEntranceForId(FeedScopedId id) {
+        Entrance entrance = index.getEntranceforId(id);
+        if (entrance != null) {
+            return Collections.singleton(entrance);
+        }
+
+        return null;
+    }
+
     /**
      *
      * @param id Id of Stop, Station, MultiModalStation or GroupOfStations
@@ -897,6 +907,12 @@ public class Graph implements Serializable {
         Collection<Stop> stops = getStopsForId(id);
 
         if (stops == null) {
+            Collection<Entrance> entrance = getEntranceForId(id);
+
+            if ( entrance != null ) {
+                return entrance.stream().map(index.getEntranceVertexForEntrance()::get).collect(Collectors.toSet());
+            }
+
             return null;
         }
 

--- a/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
+++ b/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
@@ -18,12 +18,14 @@ import org.opentripplanner.model.Operator;
 import org.opentripplanner.model.Route;
 import org.opentripplanner.model.Station;
 import org.opentripplanner.model.Stop;
+import org.opentripplanner.model.Entrance;
 import org.opentripplanner.model.StopLocation;
 import org.opentripplanner.model.TimetableSnapshot;
 import org.opentripplanner.model.Trip;
 import org.opentripplanner.model.TripPattern;
 import org.opentripplanner.model.calendar.CalendarService;
 import org.opentripplanner.model.calendar.ServiceDate;
+import org.opentripplanner.routing.vertextype.TransitEntranceVertex;
 import org.opentripplanner.routing.vertextype.TransitStopVertex;
 import org.opentripplanner.util.OTPFeature;
 import org.slf4j.Logger;
@@ -43,9 +45,11 @@ public class GraphIndex {
     private final Map<FeedScopedId, Agency> agencyForId = Maps.newHashMap();
     private final Map<FeedScopedId, Operator> operatorForId = Maps.newHashMap();
     private final Map<FeedScopedId, Stop> stopForId = Maps.newHashMap();
+    private final Map<FeedScopedId, Entrance> entranceForId = Maps.newHashMap();
     private final Map<FeedScopedId, Trip> tripForId = Maps.newHashMap();
     private final Map<FeedScopedId, Route> routeForId = Maps.newHashMap();
     private final Map<Stop, TransitStopVertex> stopVertexForStop = Maps.newHashMap();
+    private final Map<Entrance, TransitEntranceVertex> entranceVertexForEntrance = Maps.newHashMap();
     private final Map<Trip, TripPattern> patternForTrip = Maps.newHashMap();
     private final Multimap<String, TripPattern> patternsForFeedId = ArrayListMultimap.create();
     private final Multimap<Route, TripPattern> patternsForRoute = ArrayListMultimap.create();
@@ -75,6 +79,13 @@ public class GraphIndex {
                 Stop stop = stopVertex.getStop();
                 stopForId.put(stop.getId(), stop);
                 stopVertexForStop.put(stop, stopVertex);
+            }
+
+            if (vertex instanceof TransitEntranceVertex) {
+                TransitEntranceVertex transitEntranceVertex = (TransitEntranceVertex) vertex;
+                Entrance entrance = transitEntranceVertex.getEntrance();
+                entranceForId.put(entrance.getId(), entrance);
+                entranceVertexForEntrance.put(entrance, transitEntranceVertex);
             }
         }
         for (TransitStopVertex stopVertex : stopVertexForStop.values()) {
@@ -159,6 +170,8 @@ public class GraphIndex {
         return stopForId.get(id);
     }
 
+    public Entrance getEntranceforId(FeedScopedId id) { return entranceForId.get(id); }
+
     public Route getRouteForId(FeedScopedId id) {
         return routeForId.get(id);
     }
@@ -218,6 +231,8 @@ public class GraphIndex {
         return stopForId.values();
     }
 
+    public Collection<Entrance> getAllEntrances(){ return entranceForId.values(); }
+
     public Map<FeedScopedId, Trip> getTripForId() {
         return tripForId;
     }
@@ -226,9 +241,9 @@ public class GraphIndex {
         return routeForId.values();
     }
 
-    public Map<Stop, TransitStopVertex> getStopVertexForStop() {
-        return stopVertexForStop;
-    }
+    public Map<Stop, TransitStopVertex> getStopVertexForStop() { return stopVertexForStop; }
+
+    public Map<Entrance, TransitEntranceVertex> getEntranceVertexForEntrance() { return entranceVertexForEntrance; }
 
     public Map<Trip, TripPattern> getPatternForTrip() {
         return patternForTrip;


### PR DESCRIPTION
…parent station.  This is achieved by adding a map of Entrances and TransitEntranceVertices to the graph index.

The graph then searches entrances as part of getStopVerticesById

## PR Instructions
When creating a pull request, please follow the format below. For each section, *replace* the guidance text with your own text, keeping the section heading. If you have nothing to say in a particular section, you can completely delete the section including its heading to indicate that you have taken the requested steps. None of these instructions or the guidance text (non-heading text) should be present in the submitted PR. These sections serve as a checklist: when you have replaced or deleted all of them, the PR is considered complete.

### Summary
Allows the search API to use entrance IDs, currently OTP 2 can only support the parent station ID

### Issue
https://github.com/opentripplanner/OpenTripPlanner/issues/3310

closes #3310 

### Changelog
Adds the ability to search by station entrances rather than just the parent station.  
Two files changed GraphIndex.java
GraphIndex
* adds a collection of Entrances
* adds getEntranceforId  
* adds getStopVertexForStop
* adds getEntranceVertexForEntrance


Graph.java
* adds getEntranceForId which uses GraphIndex.getEntranceForId
* Uses getEntranceForId in getStopVerticesById
 

This is achieved by adding a map of Entrances and TransitEntranceVertices to the graph index.

The graph then searches entrances as part of getStopVerticesById