### PR TITLE
[CI] Make cache key depend on the contents of pom.xml

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -27,11 +27,13 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
-      - uses: actions/cache@v2
-        id: cache
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
         with:
-          path: ~/.m2
-          key: maven-local-repo
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
       - name: Build and Test
         run: mvn --batch-mode --update-snapshots verify
       - name: Deploy to Github Package Registry


### PR DESCRIPTION
After having introduced a new dependency (Junit 5) I noticed that it is being downloaded in each CI run:

https://github.com/opentripplanner/OpenTripPlanner/pull/3417/checks#step:5:13

This is because the cache key configured is fixed and doesn't change when the dependencies change and at the end of the run the newly downloaded dependencies are not added to the cache.

```
Post job cleanup.
Cache hit occurred on the primary key maven-local-repo, not saving cache.
```
https://github.com/opentripplanner/OpenTripPlanner/pull/3417/checks#step:10:1

This PR fixes this by using the configuration from the official example: https://github.com/actions/cache/blob/main/examples.md#java---maven

If left as is this problem will exacerbate in the future.