### PR TITLE
Do not link stops connected by pathways in StreetLinkerModule

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/module/StreetLinkerModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/StreetLinkerModule.java
@@ -69,6 +69,12 @@ public class StreetLinkerModule implements GraphBuilderModule {
   private void linkTransitStops(Graph graph) {
     LOG.info("Linking transit stops to graph...");
     for (TransitStopVertex tStop : graph.getVerticesOfType(TransitStopVertex.class)) {
+
+      // Stops with pathways do not need to be connected to the street network, since there are explicit entraces defined for that
+      if (tStop.hasPathways()) {
+        continue;
+      }
+
       TraverseModeSet modes = new TraverseModeSet(TraverseMode.WALK);
 
       if (OTPFeature.FlexRouting.isOn()) {


### PR DESCRIPTION
### Summary

The recent changes to the street linker module removed the check for pathways when linking stops to the street networks. This restores the check.

Stops with pathways don't need to be linked to the street network, since they are connected to entrances which are linked.

### Issue

closes #3420

### Unit tests

No changes.

### Code style

:ballot_box_with_check: 

### Documentation

No changes.

### Changelog

None.