### PR TITLE
Correctly link edges where streets which allow cars are required

### DIFF
--- a/src/client/js/otp/config.js
+++ b/src/client/js/otp/config.js
@@ -293,40 +293,40 @@ i18n.init(options, function(t) {
 
 otp.config.modes = {
     //TRANSLATORS: Travel by: mode of transport (Used in selection in Travel Options widgets)
-    "TRANSIT,WALK"        : _tr("Transit"),
+    "TRANSIT,WALK"             : _tr("Transit"),
     //TRANSLATORS: Travel by: mode of transport (Used in selection in Travel Options widgets)
-    "BUS,WALK"         : _tr("Bus Only"),
+    "BUS,WALK"                 : _tr("Bus Only"),
     //TRANSLATORS: Travel by: mode of transport (Used in selection in Travel Options widgets)
-    "TRAM,RAIL,SUBWAY,FUNICULAR,GONDOLA,WALK"       : _tr("Rail Only"),
+    "TRAM,RAIL,SUBWAY,FUNICULAR,GONDOLA,WALK": _tr("Rail Only"),
     //TRANSLATORS: Travel by: mode of transport (Used in selection in Travel Options widgets)
-    "AIRPLANE,WALK"       : _tr("Airplane Only"),
+    "AIRPLANE,WALK"            : _tr("Airplane Only"),
     //TRANSLATORS: Travel by: mode of transport (Used in selection in Travel Options widgets)
     "BUS,TRAM,RAIL,FERRY,SUBWAY,FUNICULAR,GONDOLA,WALK" : _tr("Transit, No Airplane"),
     //TRANSLATORS: Travel by: mode of transport (Used in selection in Travel Options widgets)
-    "BICYCLE"             : _tr('Bicycle Only'),
+    "BICYCLE"                  : _tr('Bicycle Only'),
     //TRANSLATORS: Travel by: mode of transport (Used in selection in Travel Options widgets)
-    "TRANSIT,BICYCLE"     : _tr("Bicycle &amp; Transit"),
+    "TRANSIT,BICYCLE"          : _tr("Bicycle &amp; Transit"),
     //TRANSLATORS: Travel by: mode of transport (Used in selection in Travel Options widgets)
-    "WALK"                : _tr('Walk Only'),
+    "WALK"                     : _tr('Walk Only'),
     //TRANSLATORS: Travel by: mode of transport (Used in selection in Travel Options widgets)
-    "CAR"                 : _tr('Drive Only'),
-    "CAR_PICKUP,WALK"     : _tr('Taxi'),
+    "CAR"                      : _tr('Car Only'),
+    "CAR_PICKUP"               : _tr('Taxi'),
     //TRANSLATORS: Travel by: mode of transport (Used in selection in Travel Options widgets)
-    "CAR_PARK,WALK,TRANSIT"     : _tr('Park and Ride'),
+    "CAR_PARK,TRANSIT"         : _tr('Park and Ride'),
     //TRANSLATORS: Travel by: mode of transport (Used in selection in Travel Options widgets)
-    "CAR_PICKUP,WALK,TRANSIT"   : _tr('Ride and Kiss (Car Pickup)'),
+    "CAR_PICKUP,TRANSIT"       : _tr('Ride and Kiss (Car Pickup)'),
     //TRANSLATORS: Travel by: mode of transport (Used in selection in Travel Options widgets)
-    "CAR_DROPOFF,WALK,TRANSIT"   : _tr('Kiss and Ride (Car Dropoff)'),
+    "CAR_DROPOFF,TRANSIT"      : _tr('Kiss and Ride (Car Dropoff)'),
     //TRANSLATORS: Travel by: mode of transport (Used in selection in Travel Options widgets)
-    "BICYCLE_PARK,WALK,TRANSIT" : _tr('Bike and Ride'),
+    "BICYCLE_PARK,TRANSIT"     : _tr('Bike and Ride'),
     //uncomment only if bike rental exists in a map
     // TODO: remove this hack, and provide code that allows the mode array to be configured with different transit modes.
     //       (note that we've been broken for awhile here, since many agencies don't have a 'Train' mode either...this needs attention)
     // IDEA: maybe we start with a big array (like below), and the pull out modes from this array when turning off various modes...
     //TRANSLATORS: Travel by: mode of transport (Used in selection in Travel Options widgets)
-    'WALK,BICYCLE_RENT'        : _tr('Rented Bicycle'),
+    'BICYCLE_RENT'             : _tr('Rented Bicycle'),
     //TRANSLATORS: Travel by: mode of transport (Used in selection in Travel Options widgets)
-    'TRANSIT,WALK,BICYCLE_RENT': _tr('Transit & Rented Bicycle'),
+    'TRANSIT,BICYCLE_RENT'     : _tr('Transit & Rented Bicycle'),
     //TRANSLATORS: Travel by: mode of transport (Used in selection in Travel Options widgets)
     "FLEX_ACCESS,WALK,TRANSIT" : _tr('Transit with flex access'),
     //TRANSLATORS: Travel by: mode of transport (Used in selection in Travel Options widgets)
@@ -334,5 +334,5 @@ otp.config.modes = {
     //TRANSLATORS: Travel by: mode of transport (Used in selection in Travel Options widgets)
     "FLEX_ACCESS,FLEX_EGRESS,TRANSIT" : _tr('Transit with flex access and egress'),
     //TRANSLATORS: Travel by: mode of transport (Used in selection in Travel Options widgets)
-    "FLEX_DIRECT" : _tr('Direct flex search')
+    "FLEX_DIRECT"              : _tr('Direct flex search')
 };

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModule.java
@@ -318,6 +318,10 @@ public class OpenStreetMapModule implements GraphBuilderModule {
                 //TODO: use wayPropertySet.getCreativeNameForWay(node)
                 //Currently this names them as platform n
                 I18NString creativeName = node.getAssumedName();
+                if (creativeName == null) {
+                    creativeName = new NonLocalizedString("" + node.getId());
+                }
+
                 int capacity = Integer.MAX_VALUE;
                 if (node.hasTag("capacity")) {
                     try {

--- a/src/main/java/org/opentripplanner/routing/RoutingService.java
+++ b/src/main/java/org/opentripplanner/routing/RoutingService.java
@@ -50,18 +50,8 @@ public class RoutingService {
 
     // TODO We should probably not have the Router as a parameter here
     public RoutingResponse route(RoutingRequest request, Router router) {
-        RoutingResponse response = null;
-        try {
-            RoutingWorker worker = new RoutingWorker(router.raptorConfig, request);
-            response = worker.route(router);
-        } catch (Exception e) {
-            if (request != null) {
-                request.cleanup();
-            }
-            throw e;
-        }
-        request.cleanup();
-        return response;
+        RoutingWorker worker = new RoutingWorker(router.raptorConfig, request);
+        return worker.route(router);
     }
 
     /**

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/GraphPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/GraphPathToItineraryMapper.java
@@ -533,7 +533,7 @@ public abstract class GraphPathToItineraryMapper {
             // before or will come after
             if (edge instanceof ElevatorAlightEdge) {
                 // don't care what came before or comes after
-                step = createWalkStep(graph, forwardState, requestedLocale);
+                step = createWalkStep(graph, forwardState, backState, requestedLocale);
                 createdNewStep = true;
                 disableZagRemovalForThisStep = true;
 
@@ -561,7 +561,7 @@ public abstract class GraphPathToItineraryMapper {
 
             if (step == null) {
                 // first step
-                step = createWalkStep(graph, forwardState, requestedLocale);
+                step = createWalkStep(graph, forwardState, backState, requestedLocale);
                 createdNewStep = true;
 
                 steps.add(step);
@@ -589,7 +589,7 @@ public abstract class GraphPathToItineraryMapper {
                     roundaboutExit = 0;
                 }
                 /* start a new step */
-                step = createWalkStep(graph, forwardState, requestedLocale);
+                step = createWalkStep(graph, forwardState, backState, requestedLocale);
                 createdNewStep = true;
 
                 steps.add(step);
@@ -676,7 +676,7 @@ public abstract class GraphPathToItineraryMapper {
 
                     if (shouldGenerateContinue) {
                         // turn to stay on same-named street
-                        step = createWalkStep(graph, forwardState, requestedLocale);
+                        step = createWalkStep(graph, forwardState, backState, requestedLocale);
                         createdNewStep = true;
                         steps.add(step);
                         step.setDirections(lastAngle, thisAngle, false);
@@ -808,21 +808,21 @@ public abstract class GraphPathToItineraryMapper {
         return angleDiff;
     }
 
-    private static WalkStep createWalkStep(Graph graph, State s, Locale wantedLocale) {
-        Edge en = s.getBackEdge();
+    private static WalkStep createWalkStep(Graph graph, State forwardState, State backState, Locale wantedLocale) {
+        Edge en = forwardState.getBackEdge();
         WalkStep step;
         step = new WalkStep();
         step.streetName = en.getName(wantedLocale);
         step.startLocation = new WgsCoordinate(
-                en.getFromVertex().getLat(),
-                en.getFromVertex().getLon()
+                backState.getVertex().getLat(),
+                backState.getVertex().getLon()
         );
-        step.elevation = encodeElevationProfile(s.getBackEdge(), 0,
-                s.getOptions().geoidElevation ? -graph.ellipsoidToGeoidDifference : 0);
+        step.elevation = encodeElevationProfile(forwardState.getBackEdge(), 0,
+                forwardState.getOptions().geoidElevation ? -graph.ellipsoidToGeoidDifference : 0);
         step.bogusName = en.hasBogusName();
-        step.addStreetNotes(graph.streetNotesService.getNotes(s));
-        step.angle = DirectionUtils.getFirstAngle(s.getBackEdge().getGeometry());
-        if (s.getBackEdge() instanceof AreaEdge) {
+        step.addStreetNotes(graph.streetNotesService.getNotes(forwardState));
+        step.angle = DirectionUtils.getFirstAngle(forwardState.getBackEdge().getGeometry());
+        if (forwardState.getBackEdge() instanceof AreaEdge) {
             step.area = true;
         }
         return step;

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
@@ -24,10 +24,12 @@ import org.opentripplanner.routing.algorithm.raptor.transit.TripSchedule;
 import org.opentripplanner.routing.algorithm.raptor.transit.request.TransferWithDuration;
 import org.opentripplanner.routing.algorithm.transferoptimization.api.OptimizedPath;
 import org.opentripplanner.routing.api.request.RoutingRequest;
+import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.core.StateEditor;
 import org.opentripplanner.routing.core.TraverseMode;
 import org.opentripplanner.routing.graph.Edge;
+import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.spt.GraphPath;
 import org.opentripplanner.routing.trippattern.TripTimes;
 import org.opentripplanner.transit.raptor.api.path.AccessPathLeg;
@@ -46,6 +48,8 @@ import org.opentripplanner.util.PolylineEncoder;
  */
 public class RaptorPathToItineraryMapper {
 
+    private final Graph graph;
+
     private final TransitLayer transitLayer;
 
     private final RoutingRequest request;
@@ -56,16 +60,19 @@ public class RaptorPathToItineraryMapper {
     /**
      * Constructs an itinerary mapper for a request and a set of results
      *
+     * @param graph
      * @param transitLayer the currently active transit layer (may have real-time data applied)
      * @param startOfTime the point in time all times in seconds are counted from
      * @param request the current routing request
      */
     public RaptorPathToItineraryMapper(
+            Graph graph,
             TransitLayer transitLayer,
             ZonedDateTime startOfTime,
             RoutingRequest request
     ) {
 
+        this.graph = graph;
         this.transitLayer = transitLayer;
         this.startOfTime = startOfTime;
         this.request = request;
@@ -213,7 +220,7 @@ public class RaptorPathToItineraryMapper {
         // leg.boardRule =  <Assign here>;
 
         AlertToLegMapper.addAlertPatchesToLeg(
-            request.getRoutingContext().graph,
+            graph,
             leg,
             firstLeg,
             request.locale
@@ -269,41 +276,46 @@ public class RaptorPathToItineraryMapper {
                 return List.of(leg);
             }
         } else {
-            RoutingRequest traverseRequest = request.clone();
-            traverseRequest.arriveBy = false;
-            StateEditor se = new StateEditor(traverseRequest, edges.get(0).getFromVertex());
-            se.setTimeSeconds(startOfTime.plusSeconds(pathLeg.fromTime()).toEpochSecond());
-            //se.setNonTransitOptionsFromState(states[0]);
-            State s = se.makeState();
-            ArrayList<State> transferStates = new ArrayList<>();
-            transferStates.add(s);
-            for (Edge e : edges) {
-                s = e.traverse(s);
+            // A RoutingRequest with a RoutingContext must be constructed so that the edges
+            // may be re-traversed to create the leg(s) from the list of edges.
+            try (RoutingRequest traverseRequest = request.getStreetSearchRequest(StreetMode.WALK)) {
+                traverseRequest.setRoutingContext(graph);
+                traverseRequest.arriveBy = false;
+
+                StateEditor se = new StateEditor(traverseRequest, edges.get(0).getFromVertex());
+                se.setTimeSeconds(startOfTime.plusSeconds(pathLeg.fromTime()).toEpochSecond());
+                //se.setNonTransitOptionsFromState(states[0]);
+                State s = se.makeState();
+                ArrayList<State> transferStates = new ArrayList<>();
                 transferStates.add(s);
-            }
+                for (Edge e : edges) {
+                    s = e.traverse(s);
+                    transferStates.add(s);
+                }
 
-            State[] states = transferStates.toArray(new State[0]);
-            GraphPath graphPath = new GraphPath(states[states.length - 1]);
+                State[] states = transferStates.toArray(new State[0]);
+                GraphPath graphPath = new GraphPath(states[states.length - 1]);
 
-            Itinerary subItinerary = GraphPathToItineraryMapper
-                    .generateItinerary(graphPath, request.locale);
+                Itinerary subItinerary = GraphPathToItineraryMapper
+                        .generateItinerary(graphPath, request.locale);
 
-            if (subItinerary.legs.isEmpty()) {
-                return List.of();
-            }
+                if (subItinerary.legs.isEmpty()) {
+                    return List.of();
+                }
 
-            // TODO OTP2 - We use the duration initially calculated for use during routing because
-            //           - they do not always match up and we risk getting negative wait times
-            //           - Issue https://github.com/opentripplanner/OpenTripPlanner/issues/2955
-            if (subItinerary.legs.size() != 1) {
-                throw new IllegalArgumentException("Sub itineraries should only contain one leg.");
-            }
-            subItinerary.legs.get(0).startTime = createCalendar(pathLeg.fromTime());
-            subItinerary.legs.get(0).endTime = createCalendar(pathLeg.toTime());
+                // TODO OTP2 - We use the duration initially calculated for use during routing because
+                //           - they do not always match up and we risk getting negative wait times
+                //           - Issue https://github.com/opentripplanner/OpenTripPlanner/issues/2955
+                if (subItinerary.legs.size() != 1) {
+                    throw new IllegalArgumentException("Sub itineraries should only contain one leg.");
+                }
+                subItinerary.legs.get(0).startTime = createCalendar(pathLeg.fromTime());
+                subItinerary.legs.get(0).endTime = createCalendar(pathLeg.toTime());
 
-            if (!onlyIfNonZeroDistance || subItinerary.nonTransitDistanceMeters > 0) {
-                applyCostFromRaptorPathToAccessEgressTransfer(subItinerary.legs, pathLeg);
-                return subItinerary.legs;
+                if (!onlyIfNonZeroDistance || subItinerary.nonTransitDistanceMeters > 0) {
+                    applyCostFromRaptorPathToAccessEgressTransfer(subItinerary.legs, pathLeg);
+                    return subItinerary.legs;
+                }
             }
         }
         return List.of();

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/router/street/DirectFlexRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/router/street/DirectFlexRouter.java
@@ -10,38 +10,46 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import org.opentripplanner.standalone.server.Router;
 
 public class DirectFlexRouter {
 
   public static List<Itinerary> route(
+      Router router,
       RoutingRequest request
   ) {
     if (!StreetMode.FLEXIBLE.equals(request.modes.directMode)) {
       return Collections.emptyList();
     }
 
-    // Prepare access/egress transfers
-    Collection<NearbyStop> accessStops = AccessEgressRouter.streetSearch(request,
-        StreetMode.WALK,
-        false,
-        2000
-    );
-    Collection<NearbyStop> egressStops = AccessEgressRouter.streetSearch(request,
-        StreetMode.WALK,
-        true,
-        2000
-    );
+    try (RoutingRequest directRequest = request.getStreetSearchRequest(request.modes.directMode)) {
+      directRequest.setRoutingContext(router.graph);
 
-    FlexRouter flexRouter = new FlexRouter(
-        request.rctx.graph,
-        request.getDateTime().toInstant(),
-        request.arriveBy,
-        request.additionalSearchDaysBeforeToday,
-        request.additionalSearchDaysAfterToday,
-        accessStops,
-        egressStops
-    );
+      // Prepare access/egress transfers
+      Collection<NearbyStop> accessStops = AccessEgressRouter.streetSearch(
+              directRequest,
+              StreetMode.WALK,
+              false,
+              2000
+      );
+      Collection<NearbyStop> egressStops = AccessEgressRouter.streetSearch(
+              directRequest,
+              StreetMode.WALK,
+              true,
+              2000
+      );
 
-    return new ArrayList<>(flexRouter.createFlexOnlyItineraries());
+      FlexRouter flexRouter = new FlexRouter(
+              router.graph,
+              directRequest.getDateTime().toInstant(),
+              directRequest.arriveBy,
+              directRequest.additionalSearchDaysBeforeToday,
+              directRequest.additionalSearchDaysAfterToday,
+              accessStops,
+              egressStops
+      );
+
+      return new ArrayList<>(flexRouter.createFlexOnlyItineraries());
+    }
   }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/request/RoutingRequestTransitDataProviderFilter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/request/RoutingRequestTransitDataProviderFilter.java
@@ -7,6 +7,7 @@ import org.opentripplanner.model.Trip;
 import org.opentripplanner.routing.algorithm.raptor.transit.TripPatternForDate;
 import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
+import org.opentripplanner.routing.graph.GraphIndex;
 import org.opentripplanner.routing.trippattern.TripTimes;
 
 import java.util.EnumSet;
@@ -40,13 +41,16 @@ public class RoutingRequestTransitDataProviderFilter implements TransitDataProvi
     this.bannedRoutes = bannedRoutes;
   }
 
-  public RoutingRequestTransitDataProviderFilter(RoutingRequest request) {
+  public RoutingRequestTransitDataProviderFilter(
+          RoutingRequest request,
+          GraphIndex graphIndex
+  ) {
     this(
         request.modes.directMode == StreetMode.BIKE,
         request.wheelchairAccessible,
         request.includePlannedCancellations,
         request.modes.transitModes,
-        request.rctx.bannedRoutes
+        request.getBannedRoutes(graphIndex.getAllRoutes())
     );
   }
 

--- a/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
@@ -71,7 +71,7 @@ import org.slf4j.LoggerFactory;
  *           class, but we want to keep it in the RoutingResource as long as we support the
  *           REST API.
  */
-public class RoutingRequest implements Cloneable, Serializable {
+public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
 
     private static final long serialVersionUID = 1L;
 
@@ -1078,6 +1078,7 @@ public class RoutingRequest implements Cloneable, Serializable {
         if (streetMode != null) {
             switch (streetMode) {
                 case WALK:
+                case FLEXIBLE:
                     streetRequest.streetSubRequestModes.setWalk(true);
                     break;
                 case BIKE:
@@ -1235,6 +1236,11 @@ public class RoutingRequest implements Cloneable, Serializable {
             rctx.destroy();
             LOG.debug("routing context destroyed");
         }
+    }
+
+    @Override
+    public void close() {
+        cleanup();
     }
 
     /**

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
@@ -193,7 +193,7 @@ public class StreetEdge extends Edge implements Cloneable, CarPickupableEdge {
      * @return
      */
     private boolean canTraverse(RoutingRequest options, TraverseMode mode) {
-        if (options.wheelchairAccessible) {
+        if (mode.isWalking() && options.wheelchairAccessible) {
             if (!isWheelchairAccessible()) {
                 return false;
             }

--- a/src/main/java/org/opentripplanner/routing/edgetype/TemporaryPartialStreetEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/TemporaryPartialStreetEdge.java
@@ -20,7 +20,11 @@ final public class TemporaryPartialStreetEdge extends StreetWithElevationEdge im
     /**
      * The edge on which this lies.
      */
-    private StreetEdge parentEdge;
+    private final StreetEdge parentEdge;
+
+    // An explicit geometry is stored, so that it may still be retrieved after this edge is removed
+    // from the graph and the from/to vertices are set to null.
+    private final LineString geometry;
 
 
     /**
@@ -32,6 +36,7 @@ final public class TemporaryPartialStreetEdge extends StreetWithElevationEdge im
             LineString geometry, I18NString name, double length) {
         super(v1, v2, geometry, name, length, parentEdge.getPermission(), false);
         this.parentEdge = parentEdge;
+        this.geometry = super.getGeometry();
         setCarSpeed(parentEdge.getCarSpeed());
         setElevationProfileUsingParents();
     }
@@ -45,11 +50,17 @@ final public class TemporaryPartialStreetEdge extends StreetWithElevationEdge im
             LineString geometry, I18NString name) {
         super(v1, v2, geometry, name, 0, parentEdge.getPermission(), false);
         this.parentEdge = parentEdge;
+        this.geometry = super.getGeometry();
         setCarSpeed(parentEdge.getCarSpeed());
 
         // No length is known, so we use the provided geometry to estimate it
         calculateLengthFromGeometry();
         setElevationProfileUsingParents();
+    }
+
+    @Override
+    public LineString getGeometry() {
+        return geometry;
     }
 
     /**

--- a/src/main/java/org/opentripplanner/routing/graph/Edge.java
+++ b/src/main/java/org/opentripplanner/routing/graph/Edge.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.routing.graph;
 
+import java.util.Objects;
 import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.model.Trip;
 import org.opentripplanner.routing.core.State;
@@ -87,7 +88,7 @@ public abstract class Edge implements Serializable {
 
     @Override
     public int hashCode() {
-        return fromv.hashCode() * 31 + tov.hashCode();
+        return Objects.hash(fromv, tov);
     }
 
     /**

--- a/src/main/java/org/opentripplanner/routing/impl/StreetVertexIndex.java
+++ b/src/main/java/org/opentripplanner/routing/impl/StreetVertexIndex.java
@@ -273,11 +273,11 @@ public class StreetVertexIndex {
     //It can be null in tests
     if (options != null) {
       TraverseModeSet modes = options.streetSubRequestModes;
-      if (modes.getCar()) {
-        // for park and ride we will start in car mode and walk to the end vertex
-        if (!endVertex && options.parkAndRide) {
-          nonTransitMode = TraverseMode.CAR;
-        }
+      // for park and ride we will start in car mode and walk to the end vertex
+      boolean parkAndRideDepart = modes.getCar() && options.parkAndRide && !endVertex;
+      boolean onlyCarAvailable = modes.getCar() && !(modes.getWalk() || modes.getBicycle());
+      if (onlyCarAvailable || parkAndRideDepart) {
+        nonTransitMode = TraverseMode.CAR;
       }
     }
     return nonTransitMode;

--- a/src/test/java/org/opentripplanner/routing/algorithm/StreetModeLinkingTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/StreetModeLinkingTest.java
@@ -1,0 +1,208 @@
+package org.opentripplanner.routing.algorithm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.model.GenericLocation;
+import org.opentripplanner.routing.api.request.RoutingRequest;
+import org.opentripplanner.routing.api.request.StreetMode;
+import org.opentripplanner.routing.edgetype.StreetTraversalPermission;
+import org.opentripplanner.routing.graph.Graph;
+
+/**
+ * This tests linking of GenericLocations to streets for each StreetMode. The test has 5 parallel
+ * streets and a linking is performed for each mode in the middle of each street. Currently linking
+ * is handled in three different ways: for CAR, CAR_PARK and everything else, which is reflected in
+ * the tests.
+ */
+public class StreetModeLinkingTest extends GraphRoutingTest {
+
+    private Graph graph;
+
+    @BeforeEach
+    protected void setUp() throws Exception {
+        graph = graphOf(new GraphRoutingTest.Builder() {
+            @Override
+            public void build() {
+                street(
+                        intersection("A1", 47.5000, 19.00),
+                        intersection("A2", 47.5020, 19.00),
+                        100, StreetTraversalPermission.CAR
+                );
+
+                street(
+                        intersection("B1", 47.5000, 19.01),
+                        intersection("B2", 47.5020, 19.01),
+                        100, StreetTraversalPermission.ALL
+                );
+
+                street(
+                        intersection("C1", 47.5000, 19.02),
+                        intersection("C2", 47.5020, 19.02),
+                        100, StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE
+                );
+
+                street(
+                        intersection("D1", 47.500, 19.03),
+                        intersection("D2", 47.502, 19.03),
+                        100, StreetTraversalPermission.PEDESTRIAN
+                ).setWheelchairAccessible(false);
+
+                street(
+                        intersection("E1", 47.500, 19.04),
+                        intersection("E2", 47.502, 19.04),
+                        100, StreetTraversalPermission.BICYCLE_AND_CAR
+                );
+            }
+        });
+    }
+
+    @Test
+    public void testCarLinking() {
+        assertLinkedFromTo(47.501, 19.00, "A1A2 street", StreetMode.CAR);
+        assertLinkedFromTo(47.501, 19.01, "B1B2 street", StreetMode.CAR);
+        assertLinkedFromTo(47.501, 19.02, "B1B2 street", StreetMode.CAR);
+        assertLinkedFromTo(47.501, 19.03, "E1E2 street", StreetMode.CAR);
+        assertLinkedFromTo(47.501, 19.04, "E1E2 street", StreetMode.CAR);
+    }
+
+    @Test
+    public void testCarParkLinking() {
+        var setup =
+                (BiFunction<Double, Double, Consumer<RoutingRequest>>) (Double latitude, Double longitude) -> {
+                    return (RoutingRequest rr) -> {
+                        rr.from = new GenericLocation(latitude, longitude);
+                        rr.to = new GenericLocation(latitude, longitude);
+                        rr.parkAndRide = true;
+                    };
+                };
+
+        assertLinking(
+                setup.apply(47.501, 19.00), "A1A2 street", "B1B2 street", StreetMode.CAR_TO_PARK);
+        assertLinking(
+                setup.apply(47.501, 19.01), "B1B2 street", "B1B2 street", StreetMode.CAR_TO_PARK);
+        assertLinking(
+                setup.apply(47.501, 19.02), "B1B2 street", "C1C2 street", StreetMode.CAR_TO_PARK);
+        assertLinking(
+                setup.apply(47.501, 19.03), "E1E2 street", "D1D2 street", StreetMode.CAR_TO_PARK);
+        assertLinking(
+                setup.apply(47.501, 19.04), "E1E2 street", "D1D2 street", StreetMode.CAR_TO_PARK);
+    }
+
+    // Only CAR linking is handled specially, since walking with a bike is always a possibility,
+    // and so no difference is made between BIKE/WALK:
+    @Test
+    public void testDefaultLinking() {
+        var streetModes = new StreetMode[]{
+                StreetMode.WALK,
+                StreetMode.BIKE,
+                StreetMode.BIKE_TO_PARK,
+                StreetMode.BIKE_RENTAL,
+                StreetMode.FLEXIBLE,
+                StreetMode.CAR_PICKUP,
+                StreetMode.CAR_RENTAL
+        };
+
+        assertLinkedFromTo(47.501, 19.00, "B1B2 street", streetModes);
+        assertLinkedFromTo(47.501, 19.01, "B1B2 street", streetModes);
+        assertLinkedFromTo(47.501, 19.02, "C1C2 street", streetModes);
+        assertLinkedFromTo(47.501, 19.03, "D1D2 street", streetModes);
+        assertLinkedFromTo(47.501, 19.04, "D1D2 street", streetModes);
+    }
+
+    // Linking to wheelchair accessible streets is currently not implemented.
+    @Test
+    @Disabled
+    public void testWheelchairLinking() {
+        assertLinking((rr) -> {
+            rr.from = new GenericLocation(47.5010, 19.03);
+            rr.to = new GenericLocation(47.5010, 19.03);
+            rr.wheelchairAccessible = true;
+        }, "C1C2 street", "C1C2 street", StreetMode.WALK);
+    }
+
+    private void assertLinkedFromTo(
+            double latitude,
+            double longitude,
+            String streetName,
+            StreetMode... streetModes
+    ) {
+        assertLinking(
+                (rr) -> {
+                    rr.from = new GenericLocation(latitude, longitude);
+                    rr.to = new GenericLocation(latitude, longitude);
+                },
+                streetName,
+                streetName,
+                streetModes
+        );
+    }
+
+    private void assertLinking(
+            Consumer<RoutingRequest> consumer,
+            String fromStreetName,
+            String toStreetName,
+            StreetMode... streetModes
+    ) {
+        for (final StreetMode streetMode : streetModes) {
+            try (var routingRequest = new RoutingRequest().getStreetSearchRequest(streetMode)) {
+                consumer.accept(routingRequest);
+
+                routingRequest.setRoutingContext(graph);
+
+                if (fromStreetName != null) {
+                    assertFromLink(fromStreetName, streetMode, routingRequest);
+                }
+
+                if (toStreetName != null) {
+                    assertToLink(toStreetName, streetMode, routingRequest);
+                }
+            }
+        }
+    }
+
+    private void assertFromLink(
+            String streetName,
+            StreetMode streetMode,
+            RoutingRequest routingRequest
+    ) {
+        var fromVertex = routingRequest.rctx.fromVertices.iterator().next();
+        var outgoing = fromVertex.getOutgoing()
+                .iterator()
+                .next()
+                .getToVertex()
+                .getOutgoing()
+                .iterator()
+                .next();
+        assertEquals(
+                streetName,
+                outgoing.getName(),
+                String.format("%s should be linked to %s", streetMode, streetName)
+        );
+    }
+
+    private void assertToLink(
+            String streetName,
+            StreetMode streetMode,
+            RoutingRequest routingRequest
+    ) {
+        var toVertex = routingRequest.rctx.toVertices.iterator().next();
+        var outgoing = toVertex.getIncoming()
+                .iterator()
+                .next()
+                .getFromVertex()
+                .getIncoming()
+                .iterator()
+                .next();
+
+        assertEquals(
+                streetName,
+                outgoing.getName(),
+                streetMode + " should be linked to " + streetName
+        );
+    }
+}


### PR DESCRIPTION
### Summary

Linking `CAR` and `CAR_PARK` edges sometimes results in edges which were not car accessible being chosen, which meant that no trip plan was returned.

This fixes the issue, with a few side-effects:
 * the lifecycle of `RoutingRequests` in `RoutingWorker` is explicit using try-with-resources. A few modifications were required so that itineraries could be generated after temporary edges were removed.
 * the list of modes in the debug client is simplified to reflect how it should be specified
 * an NPE during bike-rental planning with data from OSM is fixed

### Issue

closes #3428 

### Unit tests

No changes -- linking with the modes available in UI was manually tested.

### Code style

:ballot_box_with_check: 

### Documentation

No changes.

### Changelog

None.