### PR TITLE
Add no-thru traffic debug layer

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -18,6 +18,7 @@
 - Avoid turns across traffic on bicycles [#3359](https://github.com/opentripplanner/OpenTripPlanner/pull/3405)
 - Remove request parameter `driveOnRight` and derive information from way property set [#3359](https://github.com/opentripplanner/OpenTripPlanner/pull/3405)
 - Add basic support for routing using floating bikes [#3370](https://github.com/opentripplanner/OpenTripPlanner/pull/3370)
+- Add no thru traffic debug layer [#3443](https://github.com/opentripplanner/OpenTripPlanner/issues/3443)
 
 ## 2.0.0 (2020-11-27)
 

--- a/docs/Troubleshooting-Routing.md
+++ b/docs/Troubleshooting-Routing.md
@@ -52,11 +52,13 @@ It can be hard to use on large graphs since, whole graph is displayed at once. A
  travel on them (Pedestrian, cycling, car are currently supported)) Traversal permissions layer also
  draws links from transit stops/bike rentals and P+R to graph. And also draws transit stops, bike rentals
   and P+R vertices with different color.
+- No thru traffic - streets are colored if the edge has thru traffic restrictions (car and bicycle = `red`, car only = `orange`, bicycle only = `blue`, and no-restriction = `light gray`)
 
 ### Interpretation Traversal permissions layer
 
 A sample traversal permissions layer looks like the following 
 ![screen shot 2015-06-26 at 11 45 22](https://cloud.githubusercontent.com/assets/4493762/8374829/df05c438-1bf8-11e5-8ead-c1dea41af122.png)
+
 * Yellow lines is the link between a stop and the street graph.
 * Grey lines are streets one can travel with the mode walk, bike, or car
 * Green lines are paths one can travel with the mode walk only

--- a/src/main/java/org/opentripplanner/inspector/NoThruTrafficEdgeRenderer.java
+++ b/src/main/java/org/opentripplanner/inspector/NoThruTrafficEdgeRenderer.java
@@ -1,0 +1,64 @@
+package org.opentripplanner.inspector;
+
+import java.awt.Color;
+import org.opentripplanner.inspector.EdgeVertexTileRenderer.EdgeVertexRenderer;
+import org.opentripplanner.inspector.EdgeVertexTileRenderer.EdgeVisualAttributes;
+import org.opentripplanner.inspector.EdgeVertexTileRenderer.VertexVisualAttributes;
+import org.opentripplanner.routing.edgetype.StreetEdge;
+import org.opentripplanner.routing.graph.Edge;
+import org.opentripplanner.routing.graph.Vertex;
+
+/**
+ * Render no thru traffic restrictions for each street edge, along with a label describing the
+ * restriction.
+ */
+public class NoThruTrafficEdgeRenderer implements EdgeVertexRenderer {
+
+    private static final Color THRU_TRAFFIC_COLOR = Color.LIGHT_GRAY;
+
+    private static final Color NO_THRU_TRAFFIC_COLOR = Color.RED;
+
+    private static final Color NO_BICYCLE_THRU_TRAFFIC_COLOR = Color.BLUE;
+
+    private static final Color NO_CAR_THRU_TRAFFIC_COLOR = Color.ORANGE;
+
+    public NoThruTrafficEdgeRenderer() {
+    }
+
+    @Override
+    public boolean renderEdge(Edge e, EdgeVisualAttributes attrs) {
+        if (e instanceof StreetEdge) {
+            StreetEdge pse = (StreetEdge) e;
+            if (pse.isBicycleNoThruTraffic() && pse.isMotorVehicleNoThruTraffic()) {
+                attrs.color = NO_THRU_TRAFFIC_COLOR;
+                attrs.label = "no thru traffic";
+            }
+            else if (pse.isBicycleNoThruTraffic()) {
+                attrs.color = NO_BICYCLE_THRU_TRAFFIC_COLOR;
+                attrs.label = "no bicycle thru traffic";
+            }
+            else if (pse.isMotorVehicleNoThruTraffic()) {
+                attrs.color = NO_CAR_THRU_TRAFFIC_COLOR;
+                attrs.label = "no car thru traffic";
+            }
+            else {
+                attrs.color = THRU_TRAFFIC_COLOR;
+                attrs.label = "";
+            }
+        }
+        else {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public boolean renderVertex(Vertex v, VertexVisualAttributes attrs) {
+        return false;
+    }
+
+    @Override
+    public String getName() {
+        return "No thru traffic";
+    }
+}

--- a/src/main/java/org/opentripplanner/inspector/TileRendererManager.java
+++ b/src/main/java/org/opentripplanner/inspector/TileRendererManager.java
@@ -38,6 +38,7 @@ public class TileRendererManager {
 
         // Register layers.
         renderers.put("bike-safety", new EdgeVertexTileRenderer(new BikeSafetyEdgeRenderer()));
+        renderers.put("thru-traffic", new EdgeVertexTileRenderer(new NoThruTrafficEdgeRenderer()));
         renderers.put("traversal", new EdgeVertexTileRenderer(
                 new TraversalPermissionsEdgeRenderer()));
         renderers.put("wheelchair", new EdgeVertexTileRenderer(new WheelchairEdgeRenderer()));

--- a/src/main/java/org/opentripplanner/inspector/TraversalPermissionsEdgeRenderer.java
+++ b/src/main/java/org/opentripplanner/inspector/TraversalPermissionsEdgeRenderer.java
@@ -26,8 +26,6 @@ public class TraversalPermissionsEdgeRenderer implements EdgeVertexRenderer {
 
     private static final Color TRANSIT_STOP_COLOR_VERTEX = new Color(0.0f, 0.0f, 0.8f);
 
-    private static final Color TRANSIT_STATION_COLOR_VERTEX = new Color(0.4f, 0.0f, 0.8f);
-
     private static final Color BIKE_RENTAL_COLOR_VERTEX = new Color(0.0f, 0.7f, 0.0f);
 
     private static final Color PARK_AND_RIDE_COLOR_VERTEX = Color.RED;
@@ -52,17 +50,9 @@ public class TraversalPermissionsEdgeRenderer implements EdgeVertexRenderer {
             if(pse.isBicycleNoThruTraffic()) {
                 attrs.label+=" bicycle NTT";
             }
-        } else if (e instanceof StreetTransitStopLink) {
-            attrs.color = LINK_COLOR_EDGE;
-            attrs.label = "link";
-        } else if (e instanceof StreetBikeRentalLink) {
-            attrs.color = LINK_COLOR_EDGE;
-            attrs.label = "link";
-        } else if (e instanceof ParkAndRideLinkEdge) {
-            attrs.color = LINK_COLOR_EDGE;
-            attrs.label = "link";
         } else {
-            return false;
+            attrs.color = LINK_COLOR_EDGE;
+            attrs.label = "link";
         }
         return true;
     }
@@ -74,13 +64,13 @@ public class TraversalPermissionsEdgeRenderer implements EdgeVertexRenderer {
             if (v instanceof BarrierVertex) {
                 attrs.color = BARRIER_COLOR_VERTEX;
             }
-        } else if (v instanceof TransitStopVertex) {
+        } else if (v instanceof TransitStopVertex || v instanceof TransitEntranceVertex || v instanceof TransitPathwayNodeVertex || v instanceof TransitBoardingAreaVertex) {
             attrs.color = TRANSIT_STOP_COLOR_VERTEX;
             attrs.label = v.getName();
         } else if (v instanceof BikeRentalStationVertex) {
             attrs.color = BIKE_RENTAL_COLOR_VERTEX;
             attrs.label = v.getName();
-        } else if (v instanceof ParkAndRideVertex) {
+        } else if (v instanceof ParkAndRideVertex || v instanceof BikeParkVertex) {
             attrs.color = PARK_AND_RIDE_COLOR_VERTEX;
             attrs.label = v.getName();
         } else {

--- a/src/main/java/org/opentripplanner/inspector/TraversalPermissionsEdgeRenderer.java
+++ b/src/main/java/org/opentripplanner/inspector/TraversalPermissionsEdgeRenderer.java
@@ -44,11 +44,11 @@ public class TraversalPermissionsEdgeRenderer implements EdgeVertexRenderer {
                 attrs.color = getColor(pse.getPermission());
                 attrs.label = getLabel(pse.getPermission());
             }
-            if(pse.isMotorVehicleNoThruTraffic()) {
-                attrs.label+=" motor NTT";
+            if (pse.isMotorVehicleNoThruTraffic()) {
+                attrs.label += " car NTT";
             }
-            if(pse.isBicycleNoThruTraffic()) {
-                attrs.label+=" bicycle NTT";
+            if (pse.isBicycleNoThruTraffic()) {
+                attrs.label += " bicycle NTT";
             }
         } else {
             attrs.color = LINK_COLOR_EDGE;


### PR DESCRIPTION
### Summary

This updates the debug layers:
 * Adds an explicit debug layer for no thru traffic restrictions on edges. The `traversal permissions` layer already contains this information, but is not as explicit.
   ![image](https://user-images.githubusercontent.com/58879/116659200-82846980-a991-11eb-9f2f-d6ae13595040.png)    ![image](https://user-images.githubusercontent.com/58879/116659371-c8d9c880-a991-11eb-9a7d-627baf00299f.png)
 * Updates the `Traversal permissions` layer to display all edges -- if an edge is not a `StreetEdge` it is displayed in orange as a link edge.
 * Updates the transit stop coloring in `Traversal permissions` to include all transit nodes (stops, entrances, pathways, boarding areas)

### Issue

closes #3443 

### Unit tests

None.

### Code style

:ballot_box_with_check: 

### Documentation

`Troubleshooting-Routing.md` is updated with details of the new layer.

### Changelog

> Add no thru traffic debug layer [#3443](https://github.com/opentripplanner/OpenTripPlanner/issues/3443)