### PR TITLE
Fix reading cached elevation files

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -18,6 +18,7 @@
 - Avoid turns across traffic on bicycles [#3359](https://github.com/opentripplanner/OpenTripPlanner/pull/3405)
 - Remove request parameter `driveOnRight` and derive information from way property set [#3359](https://github.com/opentripplanner/OpenTripPlanner/pull/3405)
 - Add basic support for routing using floating bikes [#3370](https://github.com/opentripplanner/OpenTripPlanner/pull/3370)
+- Fix reading of cached elevation files [#3455](https://github.com/opentripplanner/OpenTripPlanner/pull/3455)
 
 ## 2.0.0 (2020-11-27)
 

--- a/src/main/java/org/opentripplanner/graph_builder/issues/Graphwide.java
+++ b/src/main/java/org/opentripplanner/graph_builder/issues/Graphwide.java
@@ -12,7 +12,7 @@ public class Graphwide implements DataImportIssue {
 
     @Override
     public String getMessage() {
-        return String.format("graph-wide: " + message);
+        return "graph-wide: " + message;
     }
     
 }

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -731,7 +731,8 @@ public class ElevationModule implements GraphBuilderModule {
             if (Files.exists(cachedElevationsFile.toPath())) {
                 log.info("Cached elevations file found!");
             } else {
-                log.warn("No cached elevations file found or read access not allowed! Unable to load in cached elevations. This could take a while...");
+                log.warn("No cached elevations file found at {} or read access not allowed! Unable to load in cached elevations. This could take a while...", cachedElevationsFile.toPath()
+                        .toAbsolutePath());
             }
         } else {
             log.warn("Not using cached elevations! This could take a while...");


### PR DESCRIPTION
When trying out the cached elevation file feature introduced by @evansiroky a while back, the following exception stopped my graph build.

```
java.util.UnknownFormatConversionException: Conversion = ')'
         at java.base/java.util.Formatter.checkText(Formatter.java:2732) ~[na:na]
         at java.base/java.util.Formatter.parse(Formatter.java:2718) ~[na:na]
         at java.base/java.util.Formatter.format(Formatter.java:2655) ~[na:na]
         at java.base/java.util.Formatter.format(Formatter.java:2609) ~[na:na]
         at java.base/java.lang.String.format(String.java:2897) ~[na:na]
         at org.opentripplanner.graph_builder.issues.Graphwide.getMessage(Graphwide.java:15) ~[otp-shaded.jar:1.1]
         at org.opentripplanner.graph_builder.DataImportIssueStore.add(DataImportIssueStore.java:24) ~[otp-shaded.jar:1.1]
         at org.opentripplanner.graph_builder.module.ned.ElevationModule.buildGraph(ElevationModule.java:226) ~[otp-shaded.jar:1.1]
         at org.opentripplanner.graph_builder.GraphBuilder.run(GraphBuilder.java:80) ~[otp-shaded.jar:1.1]
         at org.opentripplanner.standalone.OTPMain.startOTPServer(OTPMain.java:136) ~[otp-shaded.jar:1.1]
         at org.opentripplanner.standalone.OTPMain.main(OTPMain.java:52) ~[otp-shaded.jar:1.1]
```
`String.format` is running into trouble however that function is totally unnecessary and can be removed without replacement.

### Changelog
Added.