### PR TITLE
WIP: Add transfer flex itineraries

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/flex/FlexRouter.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/FlexRouter.java
@@ -9,7 +9,9 @@ import org.opentripplanner.ext.flex.flexpathcalculator.StreetFlexPathCalculator;
 import org.opentripplanner.ext.flex.template.FlexAccessTemplate;
 import org.opentripplanner.ext.flex.template.FlexEgressTemplate;
 import org.opentripplanner.ext.flex.trip.FlexTrip;
+import org.opentripplanner.model.Stop;
 import org.opentripplanner.model.StopLocation;
+import org.opentripplanner.model.Transfer;
 import org.opentripplanner.model.calendar.ServiceDate;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.routing.algorithm.raptor.transit.mappers.DateMapper;
@@ -49,6 +51,7 @@ public class FlexRouter {
   /* State */
   private List<FlexAccessTemplate> flexAccessTemplates = null;
   private List<FlexEgressTemplate> flexEgressTemplates = null;
+  private Collection<Transfer> transitTransfers;
 
   public FlexRouter(
       Graph graph,
@@ -62,6 +65,7 @@ public class FlexRouter {
     this.graph = graph;
     this.streetAccesses = streetAccesses;
     this.streetEgresses = egressTransfers;
+    this.transitTransfers = graph.getTransferTable().getTransfers();
     this.flexIndex = graph.index.getFlexIndex();
     this.flexPathCalculator = new StreetFlexPathCalculator(graph);
 
@@ -96,6 +100,15 @@ public class FlexRouter {
 
     Set<StopLocation> egressStops = streetEgressByStop.keySet();
 
+    Map<Stop, List<Transfer>> transfersFromStop = transitTransfers
+        .stream()
+        .collect(Collectors.groupingBy(Transfer::getFromStop));
+
+    Map<Stop, List<FlexEgressTemplate>> flexEgressByStop = flexEgressTemplates
+        .stream()
+        .filter(template -> template.getTransferStop() instanceof Stop)
+        .collect(Collectors.groupingBy(template -> (Stop) template.getTransferStop()));
+
     Collection<Itinerary> itineraries = new ArrayList<>();
 
     for (FlexAccessTemplate template : this.flexAccessTemplates) {
@@ -105,6 +118,34 @@ public class FlexRouter {
           Itinerary itinerary = template.createDirectItinerary(egress, arriveBy, departureTime, startOfTime);
           if (itinerary != null) {
             itineraries.add(itinerary);
+          }
+        }
+      }
+      if (transferStop instanceof Stop && transfersFromStop.containsKey(transferStop)) {
+        for (Transfer transfer : transfersFromStop.get(transferStop)) {
+          // TODO: Handle other than route-to-route transfers
+          if (transfer.getFromRoute() == null
+              || transfer.getFromRoute().equals(template.getFlexTrip().getTrip().getRoute())
+          ) {
+            List<FlexEgressTemplate> templates = flexEgressByStop.get(transfer.getToStop());
+            if (templates == null) { continue; }
+            for (FlexEgressTemplate egress : templates) {
+              if (transfer.getToRoute() == null
+                  || transfer.getToRoute().equals(egress.getFlexTrip().getTrip().getRoute())
+              ) {
+                Itinerary itinerary = template.getTransferItinerary(
+                    transfer,
+                    egress,
+                    arriveBy,
+                    departureTime,
+                    startOfTime,
+                    graph.index.getStopVertexForStop()
+                );
+                if (itinerary != null) {
+                  itineraries.add(itinerary);
+                }
+              }
+            }
           }
         }
       }

--- a/src/ext/java/org/opentripplanner/ext/flex/edgetype/FlexTransferEdge.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/edgetype/FlexTransferEdge.java
@@ -1,0 +1,45 @@
+package org.opentripplanner.ext.flex.edgetype;
+
+import org.opentripplanner.routing.core.State;
+import org.opentripplanner.routing.core.StateEditor;
+import org.opentripplanner.routing.core.TraverseMode;
+import org.opentripplanner.routing.graph.Edge;
+import org.opentripplanner.routing.graph.Vertex;
+import org.opentripplanner.routing.vertextype.TransitStopVertex;
+
+import java.util.Locale;
+
+public class FlexTransferEdge extends Edge {
+
+  private int minTransferTimeSeconds;
+
+  public FlexTransferEdge(
+      TransitStopVertex transferFromVertex, TransitStopVertex transferToVertex,
+      int minTransferTimeSeconds
+  ) {
+    super(new Vertex(null, null, 0.0, 0.0) {}, new Vertex(null, null, 0.0, 0.0) {});
+    this.minTransferTimeSeconds = minTransferTimeSeconds;
+    this.fromv = transferFromVertex;
+    this.tov = transferToVertex;
+    // Why is this code so dirty? Because we don't want this edge to be added to the edge lists.
+  }
+
+  @Override
+  public State traverse(State s0) {
+    StateEditor editor = s0.edit(this);
+    editor.setBackMode(TraverseMode.WALK);
+    editor.incrementWeight(minTransferTimeSeconds);
+    editor.incrementTimeInSeconds(minTransferTimeSeconds);
+    return editor.makeState();
+  }
+
+  @Override
+  public String getName() {
+    return null;
+  }
+
+  @Override
+  public String getName(Locale locale) {
+    return null;
+  }
+}


### PR DESCRIPTION
### Summary

This PR enables transfers between two flex trips, by combining a `FlexAccessTemplate` and a `FlexEgressTemplate` into an itinerary

### Unit tests
TODO

### Code style
Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Developers-Guide.md#code-style)? Yes

### Documentation
TODO

### Changelog
Was a bullet point added to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md) with description and link to the linked issue?
