### PR TITLE
WIP: Flex continuous stops implementation

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/flex/FlexAccessEgress.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/FlexAccessEgress.java
@@ -4,15 +4,15 @@ import org.opentripplanner.ext.flex.trip.FlexTrip;
 import org.opentripplanner.model.Stop;
 import org.opentripplanner.routing.core.State;
 
-public class FlexAccessEgress {
+public class FlexAccessEgress<T> {
   public final Stop stop;
   public final int preFlexTime;
   public final int flexTime;
   public final int postFlexTime;
-  private final int fromStopIndex;
-  private final int toStopIndex;
+  private final T fromStopIndex;
+  private final T toStopIndex;
   private final int differenceFromStartOfTime;
-  private final FlexTrip trip;
+  private final FlexTrip<T> trip;
   public final State lastState;
   public final boolean directToStop;
 
@@ -21,10 +21,10 @@ public class FlexAccessEgress {
       int preFlexTime,
       int flexTime,
       int postFlexTime,
-      int fromStopIndex,
-      int toStopIndex,
+      T fromStopIndex,
+      T toStopIndex,
       int differenceFromStartOfTime,
-      FlexTrip trip,
+      FlexTrip<T> trip,
       State lastState,
       boolean directToStop
   ) {

--- a/src/ext/java/org/opentripplanner/ext/flex/FlexIndex.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/FlexIndex.java
@@ -21,11 +21,11 @@ import java.util.stream.Stream;
 public class FlexIndex {
   public Multimap<StopLocation, SimpleTransfer> transfersToStop = ArrayListMultimap.create();
 
-  public Multimap<StopLocation, FlexTrip> flexTripsByStop = HashMultimap.create();
+  public Multimap<StopLocation, FlexTrip<?>> flexTripsByStop = HashMultimap.create();
 
   public Multimap<StopLocation, FlexLocationGroup> locationGroupsByStop = ArrayListMultimap.create();
 
-  public HashGridSpatialIndex<FlexStopLocation> locationIndex = new HashGridSpatialIndex<FlexStopLocation>();
+  public HashGridSpatialIndex<FlexStopLocation> locationIndex = new HashGridSpatialIndex<>();
 
   public Map<FeedScopedId, Route> routeById = new HashMap<>();
 
@@ -35,7 +35,7 @@ public class FlexIndex {
     for (SimpleTransfer transfer : graph.transfersByStop.values()) {
       transfersToStop.put(transfer.to, transfer);
     }
-    for (FlexTrip flexTrip : graph.flexTripsById.values()) {
+    for (FlexTrip<?> flexTrip : graph.flexTripsById.values()) {
       routeById.put(flexTrip.getTrip().getRoute().getId(), flexTrip.getTrip().getRoute());
       tripById.put(flexTrip.getTrip().getId(), flexTrip.getTrip());
       for (StopLocation stop : flexTrip.getStops()) {
@@ -58,7 +58,7 @@ public class FlexIndex {
     }
   }
 
-  Stream<FlexTrip> getFlexTripsByStop(StopLocation stopLocation) {
+  Stream<FlexTrip<?>> getFlexTripsByStop(StopLocation stopLocation) {
     return flexTripsByStop.get(stopLocation).stream();
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/flex/FlexLegMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/FlexLegMapper.java
@@ -10,14 +10,18 @@ import java.util.ArrayList;
 
 public class FlexLegMapper {
 
-  static public void fixFlexTripLeg(Leg leg, FlexTripEdge flexTripEdge) {
+  static public void fixFlexTripLeg(Leg leg, FlexTripEdge<?> flexTripEdge) {
       leg.from.stopId = flexTripEdge.s1.getId();
       // TODO: Should flex be of its own type
       leg.from.vertexType = flexTripEdge.s1 instanceof Stop ? VertexType.TRANSIT : VertexType.NORMAL;
-      leg.from.stopIndex = flexTripEdge.flexTemplate.fromStopIndex;
+      if (flexTripEdge.flexTemplate.fromStopIndex instanceof Integer) {
+          leg.from.stopIndex = (Integer) flexTripEdge.flexTemplate.fromStopIndex;
+      }
       leg.to.stopId = flexTripEdge.s2.getId();
       leg.to.vertexType = flexTripEdge.s2 instanceof Stop ? VertexType.TRANSIT : VertexType.NORMAL;
-      leg.to.stopIndex = flexTripEdge.flexTemplate.toStopIndex;
+      if (flexTripEdge.flexTemplate.toStopIndex instanceof Integer) {
+          leg.to.stopIndex = (Integer) flexTripEdge.flexTemplate.toStopIndex;
+      }
 
       leg.intermediateStops = new ArrayList<>();
       leg.distanceMeters = flexTripEdge.getDistanceMeters();

--- a/src/ext/java/org/opentripplanner/ext/flex/FlexServiceDate.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/FlexServiceDate.java
@@ -31,7 +31,7 @@ public class FlexServiceDate {
     this.servicesRunning = servicesRunning;
   }
 
-  boolean isFlexTripRunning(FlexTrip flexTrip, Graph graph) {
+  boolean isFlexTripRunning(FlexTrip<?> flexTrip, Graph graph) {
     return servicesRunning != null
         && servicesRunning.contains(graph.getServiceCodes().get(flexTrip.getTrip().getServiceId()));
   }

--- a/src/ext/java/org/opentripplanner/ext/flex/FlexTripsMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/FlexTripsMapper.java
@@ -1,7 +1,7 @@
 package org.opentripplanner.ext.flex;
 
 import org.opentripplanner.ext.flex.trip.FlexTrip;
-// import org.opentripplanner.ext.flex.trip.ContinuousPickupDropOffTrip;
+import org.opentripplanner.ext.flex.trip.ContinuousPickupDropOffTrip;
 import org.opentripplanner.ext.flex.trip.ScheduledDeviatedTrip;
 import org.opentripplanner.ext.flex.trip.UnscheduledTrip;
 import org.opentripplanner.model.StopTime;
@@ -13,8 +13,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import static org.opentripplanner.model.StopPattern.PICKDROP_NONE;
 
 public class FlexTripsMapper {
 
@@ -39,8 +37,8 @@ public class FlexTripsMapper {
         result.add(new UnscheduledTrip(trip, stopTimes));
       } else if (ScheduledDeviatedTrip.isScheduledFlexTrip(stopTimes)) {
         result.add(new ScheduledDeviatedTrip(trip, stopTimes));
-      } else if (hasContinuousStops(stopTimes)) {
-        // result.add(new ContinuousPickupDropOffTrip(trip, stopTimes));
+      } else if (ContinuousPickupDropOffTrip.hasContinuousStops(stopTimes)) {
+        result.add(new ContinuousPickupDropOffTrip(trip, stopTimes));
       }
 
       //Keep lambda! A method-ref would causes incorrect class and line number to be logged
@@ -50,12 +48,6 @@ public class FlexTripsMapper {
     LOG.info(progress.completeMessage());
     LOG.info("Done creating flex trips. Created a total of {} trips.", result.size());
     return result;
-  }
-
-  private static boolean hasContinuousStops(List<StopTime> stopTimes) {
-    return stopTimes
-        .stream()
-        .anyMatch(st -> st.getFlexContinuousPickup() != PICKDROP_NONE || st.getFlexContinuousDropOff() != PICKDROP_NONE);
   }
 
 }

--- a/src/ext/java/org/opentripplanner/ext/flex/FlexTripsMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/FlexTripsMapper.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.ext.flex;
 
 import org.opentripplanner.ext.flex.trip.FlexTrip;
+// import org.opentripplanner.ext.flex.trip.ContinuousPickupDropOffTrip;
 import org.opentripplanner.ext.flex.trip.ScheduledDeviatedTrip;
 import org.opentripplanner.ext.flex.trip.UnscheduledTrip;
 import org.opentripplanner.model.StopTime;
@@ -19,8 +20,8 @@ public class FlexTripsMapper {
 
   private static final Logger LOG = LoggerFactory.getLogger(FlexTripsMapper.class);
 
-  static public List<FlexTrip> createFlexTrips(OtpTransitServiceBuilder builder) {
-    List<FlexTrip> result = new ArrayList<>();
+  static public List<FlexTrip<?>> createFlexTrips(OtpTransitServiceBuilder builder) {
+    List<FlexTrip<?>> result = new ArrayList<>();
     TripStopTimes stopTimesByTrip = builder.getStopTimesSortedByTrip();
 
     final int tripSize = stopTimesByTrip.size();

--- a/src/ext/java/org/opentripplanner/ext/flex/FlexTripsMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/FlexTripsMapper.java
@@ -4,9 +4,11 @@ import org.opentripplanner.ext.flex.trip.FlexTrip;
 import org.opentripplanner.ext.flex.trip.ContinuousPickupDropOffTrip;
 import org.opentripplanner.ext.flex.trip.ScheduledDeviatedTrip;
 import org.opentripplanner.ext.flex.trip.UnscheduledTrip;
+import org.opentripplanner.graph_builder.module.map.StreetMatcher;
 import org.opentripplanner.model.StopTime;
 import org.opentripplanner.model.TripStopTimes;
 import org.opentripplanner.model.impl.OtpTransitServiceBuilder;
+import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.util.ProgressTracker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,4 +52,16 @@ public class FlexTripsMapper {
     return result;
   }
 
+  public static void addGeometriesToContinuousStops(Graph graph) {
+    graph.index();
+
+    StreetMatcher matcher = new StreetMatcher(graph);
+
+    graph.flexTripsById
+        .values()
+        .stream()
+        .filter(ContinuousPickupDropOffTrip.class::isInstance)
+        .map(ContinuousPickupDropOffTrip.class::cast)
+        .forEach(continuousPickupDropOffTrip -> continuousPickupDropOffTrip.addGeometries(graph, matcher));
+  }
 }

--- a/src/ext/java/org/opentripplanner/ext/flex/edgetype/FlexTripEdge.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/edgetype/FlexTripEdge.java
@@ -19,7 +19,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Locale;
 
-public class FlexTripEdge extends Edge {
+public class FlexTripEdge<T> extends Edge {
 
   private static final Logger LOG = LoggerFactory.getLogger(FlexTripEdge.class);
 
@@ -27,13 +27,13 @@ public class FlexTripEdge extends Edge {
 
   public StopLocation s1;
   public StopLocation s2;
-  private FlexTrip trip;
-  public FlexAccessEgressTemplate flexTemplate;
+  private final FlexTrip<T> trip;
+  public FlexAccessEgressTemplate<T> flexTemplate;
   public FlexPath flexPath;
 
   public FlexTripEdge(
-      Vertex v1, Vertex v2, StopLocation s1, StopLocation s2, FlexTrip trip,
-      FlexAccessEgressTemplate flexTemplate, FlexPathCalculator calculator
+      Vertex v1, Vertex v2, StopLocation s1, StopLocation s2, FlexTrip<T> trip,
+      FlexAccessEgressTemplate<T> flexTemplate, FlexPathCalculator<T> calculator
   ) {
     // Why is this code so dirty? Because we don't want this edge to be added to the edge lists.
     // The first parameter in Vertex constructor is graph. If it is null, the vertex isn't added to it.

--- a/src/ext/java/org/opentripplanner/ext/flex/flexpathcalculator/ContinuousStopsFlexPathCalculator.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/flexpathcalculator/ContinuousStopsFlexPathCalculator.java
@@ -1,0 +1,31 @@
+package org.opentripplanner.ext.flex.flexpathcalculator;
+
+import org.opentripplanner.common.geometry.GeometryUtils;
+import org.opentripplanner.ext.flex.trip.ContinuousPickupDropOffTrip;
+import org.opentripplanner.routing.graph.Vertex;
+
+public class ContinuousStopsFlexPathCalculator implements FlexPathCalculator<Double> {
+
+  private final ContinuousPickupDropOffTrip trip;
+
+  public ContinuousStopsFlexPathCalculator(ContinuousPickupDropOffTrip trip) {
+    this.trip = trip;
+  }
+
+  @Override
+  public FlexPath calculateFlexPath(
+      Vertex fromv, Vertex tov, Double fromStopIndex, Double toStopIndex
+  ) {
+    int distance = 0;
+    int departureTime = trip.earliestDepartureTime(Integer.MIN_VALUE, fromStopIndex, toStopIndex, 0);
+    int arrivalTime = trip.latestArrivalTime(Integer.MAX_VALUE, fromStopIndex, toStopIndex, 0);
+
+    if (departureTime >= arrivalTime) return null;
+    //TODO: Generate geometry from edges
+    return new FlexPath(
+            distance,
+            arrivalTime - departureTime,
+            GeometryUtils.makeLineString(fromv.getLon(), fromv.getLat(), tov.getLon(), tov.getLat())
+    );
+  }
+}

--- a/src/ext/java/org/opentripplanner/ext/flex/flexpathcalculator/DirectFlexPathCalculator.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/flexpathcalculator/DirectFlexPathCalculator.java
@@ -10,12 +10,12 @@ import org.opentripplanner.routing.graph.Vertex;
 /**
  * Calculated driving times and distance based on direct distance and fixed average driving speed.
  */
-public class DirectFlexPathCalculator implements FlexPathCalculator {
+public class DirectFlexPathCalculator implements FlexPathCalculator<Integer> {
   public static final double FLEX_SPEED = 8.0;
 
   private static final int DIRECT_EXTRA_TIME = 5 * 60;
 
-  private double flexSpeed;
+  private final double flexSpeed;
 
   public DirectFlexPathCalculator(Graph graph) {
     this.flexSpeed = FLEX_SPEED;
@@ -23,7 +23,7 @@ public class DirectFlexPathCalculator implements FlexPathCalculator {
 
   @Override
   public FlexPath calculateFlexPath(
-      Vertex fromv, Vertex tov, int fromStopIndex, int toStopIndex
+      Vertex fromv, Vertex tov, Integer fromStopIndex, Integer toStopIndex
   ) {
     double distance = SphericalDistanceLibrary.distance(fromv.getCoordinate(), tov.getCoordinate());
     LineString geometry = GeometryUtils.getGeometryFactory().createLineString(

--- a/src/ext/java/org/opentripplanner/ext/flex/flexpathcalculator/FlexPathCalculator.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/flexpathcalculator/FlexPathCalculator.java
@@ -7,9 +7,9 @@ import javax.annotation.Nullable;
 /**
  * FlexPathCalculator is used to calculate the driving times and distances during flex routing
  */
-public interface FlexPathCalculator {
+public interface FlexPathCalculator<T> {
 
   @Nullable
-  FlexPath calculateFlexPath(Vertex fromv, Vertex tov, int fromStopIndex, int toStopIndex);
+  FlexPath calculateFlexPath(Vertex fromv, Vertex tov, T fromStopIndex, T toStopIndex);
 
 }

--- a/src/ext/java/org/opentripplanner/ext/flex/flexpathcalculator/ScheduledFlexPathCalculator.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/flexpathcalculator/ScheduledFlexPathCalculator.java
@@ -6,18 +6,18 @@ import org.opentripplanner.routing.graph.Vertex;
 /**
  * Calculate the driving times based on the shcheduled timetable for the route.
  */
-public class ScheduledFlexPathCalculator implements FlexPathCalculator {
-  private final FlexPathCalculator flexPathCalculator;
-  private final FlexTrip trip;
+public class ScheduledFlexPathCalculator implements FlexPathCalculator<Integer> {
+  private final FlexPathCalculator<Integer> flexPathCalculator;
+  private final FlexTrip<Integer> trip;
 
-  public ScheduledFlexPathCalculator(FlexPathCalculator flexPathCalculator, FlexTrip trip) {
+  public ScheduledFlexPathCalculator(FlexPathCalculator<Integer> flexPathCalculator, FlexTrip<Integer> trip) {
     this.flexPathCalculator = flexPathCalculator;
     this.trip = trip;
   }
 
   @Override
   public FlexPath calculateFlexPath(
-      Vertex fromv, Vertex tov, int fromStopIndex, int toStopIndex
+      Vertex fromv, Vertex tov, Integer fromStopIndex, Integer toStopIndex
   ) {
     FlexPath flexPath = flexPathCalculator.calculateFlexPath(
         fromv,

--- a/src/ext/java/org/opentripplanner/ext/flex/flexpathcalculator/StreetFlexPathCalculator.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/flexpathcalculator/StreetFlexPathCalculator.java
@@ -23,7 +23,7 @@ import java.util.Map;
  * Subsequents requests from the same fromVertex can fetch the path to the toVertex from the
  * existing ShortestPathTree. This one-to-many approach is needed to make the performance acceptable.
  */
-public class StreetFlexPathCalculator implements FlexPathCalculator {
+public class StreetFlexPathCalculator implements FlexPathCalculator<Integer> {
 
   private static final long MAX_FLEX_TRIP_DURATION_SECONDS = Duration.ofMinutes(45).toSeconds();
 
@@ -35,7 +35,7 @@ public class StreetFlexPathCalculator implements FlexPathCalculator {
   }
 
   @Override
-  public FlexPath calculateFlexPath(Vertex fromv, Vertex tov, int fromStopIndex, int toStopIndex) {
+  public FlexPath calculateFlexPath(Vertex fromv, Vertex tov, Integer fromStopIndex, Integer toStopIndex) {
 
     ShortestPathTree shortestPathTree;
     if (cache.containsKey(fromv)) {

--- a/src/ext/java/org/opentripplanner/ext/flex/template/FlexAccessEgressTemplate.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/template/FlexAccessEgressTemplate.java
@@ -21,15 +21,15 @@ import java.util.Collection;
 import java.util.List;
 import java.util.stream.Stream;
 
-public abstract class FlexAccessEgressTemplate {
+public abstract class FlexAccessEgressTemplate<T> {
   protected final NearbyStop accessEgress;
-  protected final FlexTrip trip;
-  public final int fromStopIndex;
-  public final int toStopIndex;
+  protected final FlexTrip<T> trip;
+  public final T fromStopIndex;
+  public final T toStopIndex;
   protected final StopLocation transferStop;
   protected final int secondsFromStartOfTime;
   public final ServiceDate serviceDate;
-  protected final FlexPathCalculator calculator;
+  protected final FlexPathCalculator<T> calculator;
 
   /**
    *
@@ -43,12 +43,12 @@ public abstract class FlexAccessEgressTemplate {
    */
   FlexAccessEgressTemplate(
       NearbyStop accessEgress,
-      FlexTrip trip,
-      int fromStopIndex,
-      int toStopIndex,
+      FlexTrip<T> trip,
+      T fromStopIndex,
+      T toStopIndex,
       StopLocation transferStop,
       FlexServiceDate date,
-      FlexPathCalculator calculator
+      FlexPathCalculator<T> calculator
   ) {
     this.accessEgress = accessEgress;
     this.trip = trip;
@@ -64,7 +64,7 @@ public abstract class FlexAccessEgressTemplate {
     return transferStop;
   }
 
-  public FlexTrip getFlexTrip() {
+  public FlexTrip<T> getFlexTrip() {
     return trip;
   }
 
@@ -93,19 +93,19 @@ public abstract class FlexAccessEgressTemplate {
   /**
    * Get the times in seconds, before during and after the flex ride.
    */
-  abstract protected int[] getFlexTimes(FlexTripEdge flexEdge, State state);
+  abstract protected int[] getFlexTimes(FlexTripEdge<T> flexEdge, State state);
 
   /**
    * Get the FlexTripEdge for the flex ride.
    */
-  abstract protected FlexTripEdge getFlexEdge(Vertex flexFromVertex, StopLocation transferStop);
+  abstract protected FlexTripEdge<T> getFlexEdge(Vertex flexFromVertex, StopLocation transferStop);
 
   /**
    * Checks whether the routing is possible
    */
   abstract protected boolean isRouteable(Vertex flexVertex);
 
-  public Stream<FlexAccessEgress> createFlexAccessEgressStream(Graph graph) {
+  public Stream<FlexAccessEgress<T>> createFlexAccessEgressStream(Graph graph) {
     if (transferStop instanceof Stop) {
       TransitStopVertex flexVertex = graph.index.getStopVertexForStop().get(transferStop);
       if (isRouteable(flexVertex)) {
@@ -129,8 +129,8 @@ public abstract class FlexAccessEgressTemplate {
     }
   }
 
-  protected FlexAccessEgress getFlexAccessEgress(List<Edge> transferEdges, Vertex flexVertex, Stop stop) {
-    FlexTripEdge flexEdge = getFlexEdge(flexVertex, transferStop);
+  protected FlexAccessEgress<T> getFlexAccessEgress(List<Edge> transferEdges, Vertex flexVertex, Stop stop) {
+    FlexTripEdge<T> flexEdge = getFlexEdge(flexVertex, transferStop);
 
     State state = flexEdge.traverse(accessEgress.state);
     for (Edge e : transferEdges) {
@@ -139,13 +139,14 @@ public abstract class FlexAccessEgressTemplate {
 
     int[] times = getFlexTimes(flexEdge, state);
 
-    return new FlexAccessEgress(
+    return new FlexAccessEgress<>(
         stop,
         times[0],
         times[1],
         times[2],
         fromStopIndex,
-        toStopIndex, secondsFromStartOfTime,
+        toStopIndex,
+        secondsFromStartOfTime,
         trip,
         state,
         transferEdges.isEmpty()

--- a/src/ext/java/org/opentripplanner/ext/flex/template/FlexAccessTemplate.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/template/FlexAccessTemplate.java
@@ -23,12 +23,12 @@ import java.util.List;
 import java.util.Locale;
 import java.util.TimeZone;
 
-public class FlexAccessTemplate extends FlexAccessEgressTemplate {
+public class FlexAccessTemplate<T> extends FlexAccessEgressTemplate<T> {
   public FlexAccessTemplate(
-      NearbyStop accessEgress, FlexTrip trip, int fromStopTime, int toStopTime,
-      StopLocation transferStop, FlexServiceDate date, FlexPathCalculator calculator
+      NearbyStop accessEgress, FlexTrip<T> trip, T fromStopIndex, T toStopIndex,
+      StopLocation transferStop, FlexServiceDate date, FlexPathCalculator<T> calculator
   ) {
-    super(accessEgress, trip, fromStopTime, toStopTime, transferStop, date, calculator);
+    super(accessEgress, trip, fromStopIndex, toStopIndex, transferStop, date, calculator);
   }
 
   public Itinerary createDirectItinerary(
@@ -42,7 +42,7 @@ public class FlexAccessTemplate extends FlexAccessEgressTemplate {
       return null;
     }
 
-    FlexTripEdge flexEdge = getFlexEdge(flexToVertex, egress.stop);
+    FlexTripEdge<T> flexEdge = getFlexEdge(flexToVertex, egress.stop);
 
     State state = flexEdge.traverse(accessEgress.state);
 
@@ -56,7 +56,7 @@ public class FlexAccessTemplate extends FlexAccessEgressTemplate {
     int flexTime = flexTimes[1];
     int postFlexTime = flexTimes[2];
 
-    Integer timeShift = null;
+    int timeShift;
 
     if (arriveBy) {
       int lastStopArrivalTime = departureTime - postFlexTime - secondsFromStartOfTime;
@@ -124,17 +124,17 @@ public class FlexAccessTemplate extends FlexAccessEgressTemplate {
           fromStopIndex,
           toStopIndex
       ) != null;
-  };
+  }
 
-  protected int[] getFlexTimes(FlexTripEdge flexEdge, State state) {
+  protected int[] getFlexTimes(FlexTripEdge<T> flexEdge, State state) {
     int preFlexTime = (int) accessEgress.state.getElapsedTimeSeconds();
     int edgeTimeInSeconds = flexEdge.getTimeInSeconds();
     int postFlexTime = (int) state.getElapsedTimeSeconds() - preFlexTime - edgeTimeInSeconds;
     return new int[]{ preFlexTime, edgeTimeInSeconds, postFlexTime };
   }
 
-  protected FlexTripEdge getFlexEdge(Vertex flexToVertex, StopLocation transferStop) {
-    return new FlexTripEdge(
+  protected FlexTripEdge<T> getFlexEdge(Vertex flexToVertex, StopLocation transferStop) {
+    return new FlexTripEdge<>(
         accessEgress.state.getVertex(),
         flexToVertex,
         accessEgress.stop,

--- a/src/ext/java/org/opentripplanner/ext/flex/template/FlexEgressTemplate.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/template/FlexEgressTemplate.java
@@ -17,12 +17,12 @@ import org.opentripplanner.routing.graphfinder.NearbyStop;
 import java.util.Collection;
 import java.util.List;
 
-public class FlexEgressTemplate extends FlexAccessEgressTemplate {
+public class FlexEgressTemplate<T> extends FlexAccessEgressTemplate<T> {
   public FlexEgressTemplate(
-      NearbyStop accessEgress, FlexTrip trip, int fromStopTime, int toStopTime,
-      StopLocation transferStop, FlexServiceDate date, FlexPathCalculator calculator
+      NearbyStop accessEgress, FlexTrip<T> trip, T fromStopIndex, T toStopIndex,
+      StopLocation transferStop, FlexServiceDate date, FlexPathCalculator<T> calculator
   ) {
-    super(accessEgress, trip, fromStopTime, toStopTime, transferStop, date, calculator);
+    super(accessEgress, trip, fromStopIndex, toStopIndex, transferStop, date, calculator);
   }
 
   protected List<Edge> getTransferEdges(SimpleTransfer simpleTransfer) {
@@ -50,17 +50,17 @@ public class FlexEgressTemplate extends FlexAccessEgressTemplate {
           fromStopIndex,
           toStopIndex
       ) != null;
-  };
+  }
 
-  protected int[] getFlexTimes(FlexTripEdge flexEdge, State state) {
+  protected int[] getFlexTimes(FlexTripEdge<T> flexEdge, State state) {
     int postFlexTime = (int) accessEgress.state.getElapsedTimeSeconds();
     int edgeTimeInSeconds = flexEdge.getTimeInSeconds();
     int preFlexTime = (int) state.getElapsedTimeSeconds() - postFlexTime - edgeTimeInSeconds;
     return new int[]{ preFlexTime, edgeTimeInSeconds, postFlexTime };
   }
 
-  protected FlexTripEdge getFlexEdge(Vertex flexFromVertex, StopLocation transferStop) {
-    return new FlexTripEdge(
+  protected FlexTripEdge<T> getFlexEdge(Vertex flexFromVertex, StopLocation transferStop) {
+    return new FlexTripEdge<>(
         flexFromVertex,
         accessEgress.state.getVertex(),
         transferStop,

--- a/src/ext/java/org/opentripplanner/ext/flex/trip/ContinuousPickupDropOffTrip.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/trip/ContinuousPickupDropOffTrip.java
@@ -1,24 +1,60 @@
 package org.opentripplanner.ext.flex.trip;
 
+import org.apache.commons.lang3.ArrayUtils;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.LineString;
+import org.opentripplanner.common.geometry.GeometryUtils;
 import org.opentripplanner.ext.flex.FlexServiceDate;
+import org.opentripplanner.ext.flex.flexpathcalculator.ContinuousStopsFlexPathCalculator;
 import org.opentripplanner.ext.flex.flexpathcalculator.FlexPathCalculator;
 import org.opentripplanner.ext.flex.template.FlexAccessTemplate;
 import org.opentripplanner.ext.flex.template.FlexEgressTemplate;
-import org.opentripplanner.model.StopLocation;
-import org.opentripplanner.model.StopTime;
-import org.opentripplanner.model.Trip;
+import org.opentripplanner.graph_builder.module.map.StreetMatcher;
+import org.opentripplanner.model.*;
+import org.opentripplanner.routing.edgetype.StreetEdge;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
+import org.opentripplanner.routing.vertextype.StreetVertex;
 
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Stream;
 
+import static org.opentripplanner.model.StopLocation.expandStops;
 import static org.opentripplanner.model.StopPattern.PICKDROP_NONE;
+
 
 public class ContinuousPickupDropOffTrip extends FlexTrip<Double> {
 
-  public ContinuousPickupDropOffTrip(Trip trip, List<StopTime> stopTimes) {super(trip);}
+  private final ContinuousPickupDropOffStopTime[] stopTimes;
+  private final FlexStopLocation[] continuousStops;
+  private Vertex[] vertices;
+  private double[] stopIndices;
+  private double[] distances;
+  private final BookingInfo[] bookingInfos;
+
+  public ContinuousPickupDropOffTrip(Trip trip, List<StopTime> stopTimes) {
+    super(trip);
+
+    if (!hasContinuousStops(stopTimes)) {
+      throw new IllegalArgumentException("Incompatible stopTimes for continuous stops flex trip");
+    }
+
+    int nStops = stopTimes.size();
+    this.stopTimes = new ContinuousPickupDropOffStopTime[nStops];
+    this.continuousStops = new FlexStopLocation[nStops - 1];
+    this.bookingInfos = new BookingInfo[nStops];
+
+    for (int i = 0; i < nStops; i++) {
+      this.stopTimes[i] = new ContinuousPickupDropOffStopTime(stopTimes.get(i));
+      this.bookingInfos[i] = stopTimes.get(i).getBookingInfo();
+    }
+  }
 
   public static boolean hasContinuousStops(List<StopTime> stopTimes) {
     return stopTimes
@@ -30,32 +66,210 @@ public class ContinuousPickupDropOffTrip extends FlexTrip<Double> {
   public Stream<FlexAccessTemplate<Double>> getFlexAccessTemplates(
       NearbyStop access, FlexServiceDate date, FlexPathCalculator<Integer> calculator
   ) {
-    return Stream.empty();
+    int stopArrayIndex = ArrayUtils.indexOf(vertices, access.state.getVertex());
+    if (stopArrayIndex == -1) { return Stream.empty(); }
+    double fromIndex = stopIndices[stopArrayIndex];
+
+    ArrayList<FlexAccessTemplate<Double>> res = new ArrayList<>();
+
+    ContinuousStopsFlexPathCalculator continuousCalculator = new ContinuousStopsFlexPathCalculator(this);
+
+    boolean isFromStop = Math.rint(fromIndex) == fromIndex;
+
+    // This would return only trips which can be found by raptor
+    if (isFromStop) { return Stream.empty(); }
+
+    for (int toIndex = (int) Math.ceil(fromIndex); toIndex < stopTimes.length; toIndex++) {
+      if (stopTimes[toIndex].dropOffType == PICKDROP_NONE) continue;
+      for (StopLocation stop : expandStops(stopTimes[toIndex].stop)) {
+        res.add(new FlexAccessTemplate<>(access, this, fromIndex, (double) toIndex, stop, date, continuousCalculator));
+      }
+    }
+
+    return res.stream();
   }
 
   @Override
   public Stream<FlexEgressTemplate<Double>> getFlexEgressTemplates(
       NearbyStop egress, FlexServiceDate date, FlexPathCalculator<Integer> calculator
   ) {
-    return Stream.empty();
+    int stopArrayIndex = ArrayUtils.indexOf(vertices, egress.state.getVertex());
+    if (stopArrayIndex == -1) { return Stream.empty(); }
+    double toIndex = stopIndices[stopArrayIndex];
+
+    ArrayList<FlexEgressTemplate<Double>> res = new ArrayList<>();
+
+    ContinuousStopsFlexPathCalculator continuousCalculator = new ContinuousStopsFlexPathCalculator(this);
+
+    boolean isToStop = Math.rint(toIndex) == toIndex;
+
+    // This would return only trips which can be found by raptor
+    if (isToStop) { return Stream.empty(); }
+
+    for (int fromIndex = (int) Math.floor(toIndex); fromIndex >= 0; fromIndex--) {
+      if (stopTimes[fromIndex].pickupType == PICKDROP_NONE) continue;
+      for (StopLocation stop : expandStops(stopTimes[fromIndex].stop)) {
+        res.add(new FlexEgressTemplate<>(egress, this, (double) fromIndex, toIndex, stop, date, continuousCalculator));
+      }
+    }
+
+    return res.stream();
   }
 
   @Override
   public int earliestDepartureTime(
       int departureTime, Double fromStopIndex, Double toStopIndex, int flexTime
   ) {
-    return departureTime;
+    if (Math.rint(fromStopIndex) == fromStopIndex) {
+      return stopTimes[(int) (double) fromStopIndex].departureTime;
+    }
+    int stopTime = getStopTime(fromStopIndex);
+    return stopTime >= departureTime ? stopTime : -1;
   }
 
   @Override
   public int latestArrivalTime(
       int arrivalTime, Double fromStopIndex, Double toStopIndex, int flexTime
   ) {
-    return arrivalTime;
+    if (Math.rint(toStopIndex) == toStopIndex) {
+      return stopTimes[(int) (double) toStopIndex].arrivalTime;
+    }
+    int stopTime = getStopTime(toStopIndex);
+    return stopTime <= arrivalTime ? stopTime : -1;
+  }
+
+  private int getStopTime(Double stopIndex) {
+    int prevStop = (int) Math.floor(stopIndex);
+    int nextStop = (int) Math.ceil(stopIndex);
+
+    int departureFromPrevious = stopTimes[prevStop].departureTime;
+    int arrivalToNext = stopTimes[nextStop].arrivalTime;
+
+    return departureFromPrevious + (int) ((arrivalToNext - departureFromPrevious) * (stopIndex - prevStop));
   }
 
   @Override
   public Collection<StopLocation> getStops() {
-    return Collections.EMPTY_LIST;
+    List<StopLocation> stops = new ArrayList<>(Arrays.asList(continuousStops));
+    Arrays.stream(stopTimes).forEach(stopTime -> stops.add(stopTime.stop));
+
+    return stops;
+  }
+
+  @Override
+  public BookingInfo getBookingInfo(int i) {
+    return bookingInfos[i];
+  }
+
+  public void addGeometries(
+      Graph graph, StreetMatcher matcher
+  ) {
+    TripPattern pattern = graph.index.getPatternForTrip().get(trip);
+
+    if (pattern == null || pattern.getGeometry() == null) { return; }
+
+    FeedScopedId tripId = trip.getId();
+
+    ArrayList<Vertex> tempVertices = new ArrayList<>();
+    ArrayList<Double> tempStopIndices = new ArrayList<>();
+    ArrayList<Double> tempDistances = new ArrayList<>();
+
+    double cumulativeDistance = 0;
+
+    for (int i = 0; i < pattern.numHopGeometries(); i++) {
+      ContinuousPickupDropOffStopTime stopTime = stopTimes[i];
+      if (stopTime.continuousPickupType == PICKDROP_NONE
+          && stopTime.continuousDropOffType == PICKDROP_NONE) {
+        continue;
+      }
+
+      List<StreetEdge> edges = matcher.match(pattern.getHopGeometry(i));
+      if (edges == null || edges.isEmpty()) { continue; }
+
+      StopLocation stop = stopTime.stop;
+      // TODO: How to generate id?
+      String id = tripId.getId() + "_" + stop.getId().getId();
+      FeedScopedId feedScopedId = new FeedScopedId(tripId.getFeedId(), id);
+      var location = new FlexStopLocation(feedScopedId);
+      location.setName(stop.getName() + " -> " + stopTimes[i + 1].stop.getName());
+      continuousStops[i] = location;
+      graph.locationsById.put(feedScopedId, location);
+
+      int size = edges.size();
+
+      List<Coordinate> coordinates = new ArrayList<>();
+      double[] times = new double[size];
+      double cumulativeTime = 0;
+      tempDistances.add(cumulativeDistance);
+
+      for (int j = 0; j < size; j++) {
+        StreetEdge e = edges.get(j);
+        coordinates.addAll(Arrays.asList(e.getGeometry().getCoordinates()));
+        double distanceMeters = e.getDistanceMeters();
+        cumulativeDistance += distanceMeters;
+        tempDistances.add(cumulativeDistance);
+        double time = distanceMeters / e.getCarSpeed();
+        cumulativeTime += time;
+        times[j] = cumulativeTime;
+      }
+
+      Vertex vertex = edges.get(0).getFromVertex();
+      StreetVertex sv;
+      if (vertex instanceof StreetVertex) {
+        sv = (StreetVertex) vertex;
+        if (sv.flexStopLocations == null) {
+          sv.flexStopLocations = new HashSet<>();
+        }
+        sv.flexStopLocations.add(location);
+      }
+
+      tempVertices.add(vertex);
+      tempStopIndices.add((double) i);
+
+      for (int j = 0; j < size; j++) {
+        vertex = edges.get(j).getToVertex();
+        if (vertex instanceof StreetVertex) {
+          sv = (StreetVertex) vertex;
+          if (sv.flexStopLocations == null) {
+            sv.flexStopLocations = new HashSet<>();
+          }
+          sv.flexStopLocations.add(location);
+        }
+        tempVertices.add(vertex);
+        tempStopIndices.add(i + (times[j] / cumulativeTime));
+      }
+
+      Coordinate[] coordinateArray = new Coordinate[coordinates.size()];
+      LineString ls = GeometryUtils.getGeometryFactory().createLineString(coordinates.toArray(coordinateArray));
+      location.setGeometry(ls);
+    }
+
+    this.vertices = tempVertices.toArray(new Vertex[0]);
+    this.stopIndices = tempStopIndices.stream().mapToDouble(i -> i).toArray();
+    this.distances = tempDistances.stream().mapToDouble(i -> i).toArray();
+  }
+
+  private static class ContinuousPickupDropOffStopTime implements Serializable {
+    private final StopLocation stop;
+    private final int departureTime;
+    private final int arrivalTime;
+    private final int pickupType;
+    private final int dropOffType;
+    private final int continuousPickupType;
+    private final int continuousDropOffType;
+
+
+    private ContinuousPickupDropOffStopTime(StopTime st) {
+      this.stop = st.getStop();
+
+      this.arrivalTime = st.getArrivalTime();
+      this.departureTime = st.getDepartureTime();
+
+      this.pickupType = st.getPickupType();
+      this.dropOffType = st.getDropOffType();
+
+      this.continuousPickupType = st.getFlexContinuousPickup();
+      this.continuousDropOffType = st.getFlexContinuousDropOff();
+    }
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/flex/trip/ContinuousPickupDropOffTrip.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/trip/ContinuousPickupDropOffTrip.java
@@ -1,0 +1,61 @@
+package org.opentripplanner.ext.flex.trip;
+
+import org.opentripplanner.ext.flex.FlexServiceDate;
+import org.opentripplanner.ext.flex.flexpathcalculator.FlexPathCalculator;
+import org.opentripplanner.ext.flex.template.FlexAccessTemplate;
+import org.opentripplanner.ext.flex.template.FlexEgressTemplate;
+import org.opentripplanner.model.StopLocation;
+import org.opentripplanner.model.StopTime;
+import org.opentripplanner.model.Trip;
+import org.opentripplanner.routing.graphfinder.NearbyStop;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.opentripplanner.model.StopPattern.PICKDROP_NONE;
+
+public class ContinuousPickupDropOffTrip extends FlexTrip<Double> {
+
+  public ContinuousPickupDropOffTrip(Trip trip, List<StopTime> stopTimes) {super(trip);}
+
+  public static boolean hasContinuousStops(List<StopTime> stopTimes) {
+    return stopTimes
+        .stream()
+        .anyMatch(st -> st.getFlexContinuousPickup() != PICKDROP_NONE || st.getFlexContinuousDropOff() != PICKDROP_NONE);
+  }
+
+  @Override
+  public Stream<FlexAccessTemplate<Double>> getFlexAccessTemplates(
+      NearbyStop access, FlexServiceDate date, FlexPathCalculator<Integer> calculator
+  ) {
+    return Stream.empty();
+  }
+
+  @Override
+  public Stream<FlexEgressTemplate<Double>> getFlexEgressTemplates(
+      NearbyStop egress, FlexServiceDate date, FlexPathCalculator<Integer> calculator
+  ) {
+    return Stream.empty();
+  }
+
+  @Override
+  public int earliestDepartureTime(
+      int departureTime, Double fromStopIndex, Double toStopIndex, int flexTime
+  ) {
+    return departureTime;
+  }
+
+  @Override
+  public int latestArrivalTime(
+      int arrivalTime, Double fromStopIndex, Double toStopIndex, int flexTime
+  ) {
+    return arrivalTime;
+  }
+
+  @Override
+  public Collection<StopLocation> getStops() {
+    return Collections.EMPTY_LIST;
+  }
+}

--- a/src/ext/java/org/opentripplanner/ext/flex/trip/FlexTrip.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/trip/FlexTrip.java
@@ -6,7 +6,6 @@ import org.opentripplanner.ext.flex.template.FlexAccessTemplate;
 import org.opentripplanner.ext.flex.template.FlexEgressTemplate;
 import org.opentripplanner.model.BookingInfo;
 import org.opentripplanner.model.StopLocation;
-import org.opentripplanner.model.StopTime;
 import org.opentripplanner.model.TransitEntity;
 import org.opentripplanner.model.Trip;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
@@ -19,7 +18,7 @@ import java.util.stream.Stream;
  * subclasses encapsulates the different business logic, which the different types of services
  * adhere to.
  */
-public abstract class FlexTrip extends TransitEntity {
+public abstract class FlexTrip<T> extends TransitEntity {
 
   protected final Trip trip;
 
@@ -28,17 +27,17 @@ public abstract class FlexTrip extends TransitEntity {
     this.trip = trip;
   }
 
-  public abstract Stream<FlexAccessTemplate> getFlexAccessTemplates(
-      NearbyStop access, FlexServiceDate date, FlexPathCalculator calculator
+  public abstract Stream<FlexAccessTemplate<T>> getFlexAccessTemplates(
+      NearbyStop access, FlexServiceDate date, FlexPathCalculator<Integer> calculator
   );
 
-  public abstract Stream<FlexEgressTemplate> getFlexEgressTemplates(
-      NearbyStop egress, FlexServiceDate date, FlexPathCalculator calculator
+  public abstract Stream<FlexEgressTemplate<T>> getFlexEgressTemplates(
+      NearbyStop egress, FlexServiceDate date, FlexPathCalculator<Integer> calculator
   );
 
-  public abstract int earliestDepartureTime(int departureTime, int fromStopIndex, int toStopIndex, int flexTime);
+  public abstract int earliestDepartureTime(int departureTime, T fromStopIndex, T toStopIndex, int flexTime);
 
-  public abstract int latestArrivalTime(int arrivalTime, int fromStopIndex, int toStopIndex, int flexTime);
+  public abstract int latestArrivalTime(int arrivalTime, T fromStopIndex, T toStopIndex, int flexTime);
 
   public abstract Collection<StopLocation> getStops();
 

--- a/src/ext/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTrip.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTrip.java
@@ -17,12 +17,12 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.opentripplanner.model.StopLocation.expandStops;
 import static org.opentripplanner.model.StopPattern.PICKDROP_NONE;
 import static org.opentripplanner.model.StopTime.MISSING_VALUE;
 
@@ -136,12 +136,6 @@ public class ScheduledDeviatedTrip extends FlexTrip<Integer> {
   @Override
   public BookingInfo getBookingInfo(int i) {
     return bookingInfos[i];
-  }
-
-  private Collection<StopLocation> expandStops(StopLocation stop) {
-    return stop instanceof FlexLocationGroup
-        ? ((FlexLocationGroup) stop).getLocations()
-        : Collections.singleton(stop);
   }
 
   private int getFromIndex(NearbyStop accessEgress) {

--- a/src/ext/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTrip.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTrip.java
@@ -30,7 +30,7 @@ import static org.opentripplanner.model.StopTime.MISSING_VALUE;
  * A scheduled deviated trip is similar to a regular scheduled trip, except that is continues stop
  * locations, which are not stops, but other types, such as groups of stops or location areas.
  */
-public class ScheduledDeviatedTrip extends FlexTrip {
+public class ScheduledDeviatedTrip extends FlexTrip<Integer> {
 
   private final ScheduledDeviatedStopTime[] stopTimes;
 
@@ -62,21 +62,21 @@ public class ScheduledDeviatedTrip extends FlexTrip {
   }
 
   @Override
-  public Stream<FlexAccessTemplate> getFlexAccessTemplates(
-      NearbyStop access, FlexServiceDate date, FlexPathCalculator calculator
+  public Stream<FlexAccessTemplate<Integer>> getFlexAccessTemplates(
+      NearbyStop access, FlexServiceDate date, FlexPathCalculator<Integer> calculator
   ) {
-    FlexPathCalculator scheduledCalculator = new ScheduledFlexPathCalculator(calculator, this);
+    FlexPathCalculator<Integer> scheduledCalculator = new ScheduledFlexPathCalculator(calculator, this);
 
     int fromIndex = getFromIndex(access);
 
     if (fromIndex == -1) { return Stream.empty(); }
 
-    ArrayList<FlexAccessTemplate> res = new ArrayList<>();
+    ArrayList<FlexAccessTemplate<Integer>> res = new ArrayList<>();
 
     for (int toIndex = fromIndex + 1; toIndex < stopTimes.length; toIndex++) {
       if (stopTimes[toIndex].dropOffType == PICKDROP_NONE) continue;
       for (StopLocation stop : expandStops(stopTimes[toIndex].stop)) {
-        res.add(new FlexAccessTemplate(access, this, fromIndex, toIndex, stop, date, scheduledCalculator));
+        res.add(new FlexAccessTemplate<>(access, this, fromIndex, toIndex, stop, date, scheduledCalculator));
       }
     }
 
@@ -84,21 +84,21 @@ public class ScheduledDeviatedTrip extends FlexTrip {
   }
 
   @Override
-  public Stream<FlexEgressTemplate> getFlexEgressTemplates(
-      NearbyStop egress, FlexServiceDate date, FlexPathCalculator calculator
+  public Stream<FlexEgressTemplate<Integer>> getFlexEgressTemplates(
+      NearbyStop egress, FlexServiceDate date, FlexPathCalculator<Integer> calculator
   ) {
-    FlexPathCalculator scheduledCalculator = new ScheduledFlexPathCalculator(calculator, this);
+    FlexPathCalculator<Integer> scheduledCalculator = new ScheduledFlexPathCalculator(calculator, this);
 
     int toIndex = getToIndex(egress);
 
     if (toIndex == -1) { return Stream.empty(); }
 
-    ArrayList<FlexEgressTemplate> res = new ArrayList<>();
+    ArrayList<FlexEgressTemplate<Integer>> res = new ArrayList<>();
 
     for (int fromIndex = toIndex - 1; fromIndex >= 0; fromIndex--) {
       if (stopTimes[fromIndex].pickupType == PICKDROP_NONE) continue;
       for (StopLocation stop : expandStops(stopTimes[fromIndex].stop)) {
-        res.add(new FlexEgressTemplate(egress, this, fromIndex, toIndex, stop, date, scheduledCalculator));
+        res.add(new FlexEgressTemplate<>(egress, this, fromIndex, toIndex, stop, date, scheduledCalculator));
       }
     }
 
@@ -107,7 +107,7 @@ public class ScheduledDeviatedTrip extends FlexTrip {
 
   @Override
   public int earliestDepartureTime(
-      int departureTime, int fromStopIndex, int toStopIndex, int flexTime
+      int departureTime, Integer fromStopIndex, Integer toStopIndex, int flexTime
   ) {
     int stopTime = MISSING_VALUE;
     for (int i = fromStopIndex; stopTime == MISSING_VALUE && i >= 0; i--) {
@@ -117,7 +117,7 @@ public class ScheduledDeviatedTrip extends FlexTrip {
   }
 
   @Override
-  public int latestArrivalTime(int arrivalTime, int fromStopIndex, int toStopIndex, int flexTime) {
+  public int latestArrivalTime(int arrivalTime, Integer fromStopIndex, Integer toStopIndex, int flexTime) {
     int stopTime = MISSING_VALUE;
     for (int i = toStopIndex; stopTime == MISSING_VALUE && i < stopTimes.length; i++) {
       stopTime = stopTimes[i].arrivalTime;

--- a/src/ext/java/org/opentripplanner/ext/flex/trip/UnscheduledTrip.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/trip/UnscheduledTrip.java
@@ -30,7 +30,7 @@ import static org.opentripplanner.model.StopPattern.PICKDROP_NONE;
  * on the driving time between the stops, with the schedule times being used just for deciding if a
  * trip is possible.
  */
-public class UnscheduledTrip extends FlexTrip {
+public class UnscheduledTrip extends FlexTrip<Integer> {
   private static final int N_STOPS = 2;
 
   private final UnscheduledStopTime[] stopTimes;
@@ -63,36 +63,36 @@ public class UnscheduledTrip extends FlexTrip {
   }
 
   @Override
-  public Stream<FlexAccessTemplate> getFlexAccessTemplates(
-      NearbyStop access, FlexServiceDate date, FlexPathCalculator calculator
+  public Stream<FlexAccessTemplate<Integer>> getFlexAccessTemplates(
+      NearbyStop access, FlexServiceDate date, FlexPathCalculator<Integer> calculator
   ) {
     int fromIndex = getFromIndex(access);
 
     if (fromIndex != 0) { return Stream.empty(); }
     if (stopTimes[1].dropOffType == PICKDROP_NONE) { return Stream.empty(); }
 
-    ArrayList<FlexAccessTemplate> res = new ArrayList<>();
+    ArrayList<FlexAccessTemplate<Integer>> res = new ArrayList<>();
 
     for (StopLocation stop : expandStops(stopTimes[1].stop)) {
-      res.add(new FlexAccessTemplate(access, this, fromIndex, 1, stop, date, calculator));
+      res.add(new FlexAccessTemplate<>(access, this, fromIndex, 1, stop, date, calculator));
     }
 
     return res.stream();
   }
 
   @Override
-  public Stream<FlexEgressTemplate> getFlexEgressTemplates(
-      NearbyStop egress, FlexServiceDate date, FlexPathCalculator calculator
+  public Stream<FlexEgressTemplate<Integer>> getFlexEgressTemplates(
+      NearbyStop egress, FlexServiceDate date, FlexPathCalculator<Integer> calculator
   ) {
     int toIndex = getToIndex(egress);
 
     if (toIndex != 1) { return Stream.empty(); }
     if (stopTimes[0].pickupType == PICKDROP_NONE) { return Stream.empty(); }
 
-    ArrayList<FlexEgressTemplate> res = new ArrayList<>();
+    ArrayList<FlexEgressTemplate<Integer>> res = new ArrayList<>();
 
     for (StopLocation stop : expandStops(stopTimes[0].stop)) {
-      res.add(new FlexEgressTemplate(egress, this, 0, toIndex, stop, date, calculator));
+      res.add(new FlexEgressTemplate<>(egress, this, 0, toIndex, stop, date, calculator));
     }
 
     return res.stream();
@@ -100,7 +100,7 @@ public class UnscheduledTrip extends FlexTrip {
 
   @Override
   public int earliestDepartureTime(
-      int departureTime, int fromStopIndex, int toStopIndex, int flexTime
+      int departureTime, Integer fromStopIndex, Integer toStopIndex, int flexTime
   ) {
     UnscheduledStopTime fromStopTime = stopTimes[fromStopIndex];
     UnscheduledStopTime toStopTime = stopTimes[toStopIndex];
@@ -114,7 +114,7 @@ public class UnscheduledTrip extends FlexTrip {
   }
 
   @Override
-  public int latestArrivalTime(int arrivalTime, int fromStopIndex, int toStopIndex, int flexTime) {
+  public int latestArrivalTime(int arrivalTime, Integer fromStopIndex, Integer toStopIndex, int flexTime) {
     UnscheduledStopTime fromStopTime = stopTimes[fromStopIndex];
     UnscheduledStopTime toStopTime = stopTimes[toStopIndex];
     if (toStopTime.flexWindowStart > arrivalTime || fromStopTime.flexWindowStart > (

--- a/src/ext/java/org/opentripplanner/ext/flex/trip/UnscheduledTrip.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/trip/UnscheduledTrip.java
@@ -15,12 +15,12 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.opentripplanner.model.StopLocation.expandStops;
 import static org.opentripplanner.model.StopPattern.PICKDROP_NONE;
 
 
@@ -137,12 +137,6 @@ public class UnscheduledTrip extends FlexTrip<Integer> {
   @Override
   public BookingInfo getBookingInfo(int i) {
     return bookingInfos[i];
-  }
-
-  private Collection<StopLocation> expandStops(StopLocation stop) {
-    return stop instanceof FlexLocationGroup
-        ? ((FlexLocationGroup) stop).getLocations()
-        : Collections.singleton(stop);
   }
 
   private int getFromIndex(NearbyStop accessEgress) {

--- a/src/main/java/org/opentripplanner/graph_builder/module/AddTransitModelEntitiesToGraph.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/AddTransitModelEntitiesToGraph.java
@@ -358,7 +358,7 @@ public class AddTransitModelEntitiesToGraph {
     }
 
     private void addFlexTripsToGraph(Graph graph) {
-        for(FlexTrip flexTrip : transitService.getAllFlexTrips())
+        for(FlexTrip<?> flexTrip : transitService.getAllFlexTrips())
         graph.flexTripsById.put(flexTrip.getId(), flexTrip);
     }
 

--- a/src/main/java/org/opentripplanner/graph_builder/module/GtfsModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/GtfsModule.java
@@ -151,6 +151,10 @@ public class GtfsModule implements GraphBuilderModule {
                 addTransitModelToGraph(graph, gtfsBundle, transitModel);
 
                 createGeometryAndBlockProcessor(gtfsBundle, transitModel).run(graph, issueStore);
+
+                if (OTPFeature.FlexRouting.isOn()) {
+                    FlexTripsMapper.addGeometriesToContinuousStops(graph);
+                }
             }
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/src/main/java/org/opentripplanner/graph_builder/module/map/BusRouteStreetMatcher.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/map/BusRouteStreetMatcher.java
@@ -7,6 +7,7 @@ import org.opentripplanner.graph_builder.DataImportIssueStore;
 import org.opentripplanner.graph_builder.services.GraphBuilderModule;
 import org.opentripplanner.model.Route;
 import org.opentripplanner.model.TripPattern;
+import org.opentripplanner.routing.edgetype.StreetEdge;
 import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.model.TransitMode;
@@ -71,7 +72,7 @@ public class BusRouteStreetMatcher implements GraphBuilderModule {
                     for (int i = 0; i < pattern.numHopGeometries(); i++) {
                         LineString hopGeometry = pattern.getHopGeometry(i);
 
-                        List<Edge> edges = matcher.match(hopGeometry);
+                        List<StreetEdge> edges = matcher.match(hopGeometry);
                         if (edges == null || edges.isEmpty()) {
                             log.warn("Could not match to street network: {}", pattern);
                             continue;

--- a/src/main/java/org/opentripplanner/graph_builder/module/map/MatchState.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/map/MatchState.java
@@ -1,19 +1,18 @@
 package org.opentripplanner.graph_builder.module.map;
 
-import java.util.ArrayList;
-import java.util.List;
-
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.linearref.LinearLocation;
 import org.opentripplanner.common.geometry.SphericalDistanceLibrary;
+import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.core.TraverseMode;
-import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.edgetype.StreetEdge;
 import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Vertex;
 
-import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.Geometry;
-import org.locationtech.jts.linearref.LinearLocation;
+import java.util.ArrayList;
+import java.util.List;
 
 public abstract class MatchState {
     private static final RoutingRequest traverseOptions = new RoutingRequest(TraverseMode.CAR);
@@ -28,11 +27,11 @@ public abstract class MatchState {
 
     public MatchState parent;
 
-    protected Edge edge;
+    protected StreetEdge edge;
 
     private double distanceAlongRoute = 0;
 
-    public MatchState(MatchState parent, Edge edge, double distanceAlongRoute) {
+    public MatchState(MatchState parent, StreetEdge edge, double distanceAlongRoute) {
         this.distanceAlongRoute = distanceAlongRoute;
         this.parent = parent;
         this.edge = edge;
@@ -44,7 +43,7 @@ public abstract class MatchState {
 
     public abstract List<MatchState> getNextStates();
 
-    public Edge getEdge() {
+    public StreetEdge getEdge() {
         return edge;
     }
 
@@ -59,8 +58,8 @@ public abstract class MatchState {
         return s1 != null;
     }
 
-    protected List<Edge> getOutgoingMatchableEdges(Vertex vertex) {
-        List<Edge> edges = new ArrayList<Edge>();
+    protected List<StreetEdge> getOutgoingMatchableEdges(Vertex vertex) {
+        List<StreetEdge> edges = new ArrayList<>();
         for (Edge e : vertex.getOutgoing()) {
             if (!(e instanceof StreetEdge)) {
                 continue;
@@ -68,7 +67,7 @@ public abstract class MatchState {
             if (e.getGeometry() == null) {
                 continue;
             }
-            edges.add(e);
+            edges.add((StreetEdge) e);
         }
         return edges;
     }

--- a/src/main/java/org/opentripplanner/graph_builder/module/map/MidblockMatchState.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/map/MidblockMatchState.java
@@ -1,34 +1,33 @@
 package org.opentripplanner.graph_builder.module.map;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
-import org.opentripplanner.routing.graph.Edge;
-import org.opentripplanner.routing.graph.Vertex;
-
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.linearref.LinearLocation;
 import org.locationtech.jts.linearref.LocationIndexedLine;
 import org.locationtech.jts.util.AssertionFailedException;
+import org.opentripplanner.routing.edgetype.StreetEdge;
+import org.opentripplanner.routing.graph.Vertex;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 public class MidblockMatchState extends MatchState {
 
     private static final double MAX_ERROR = 1000;
 
-    private LinearLocation edgeIndex;
+    private final LinearLocation edgeIndex;
 
     public LinearLocation routeIndex;
 
     Geometry routeGeometry;
 
-    private Geometry edgeGeometry;
+    private final Geometry edgeGeometry;
 
-    private LocationIndexedLine indexedEdge;
+    private final LocationIndexedLine indexedEdge;
 
-    public MidblockMatchState(MatchState parent, Geometry routeGeometry, Edge edge,
+    public MidblockMatchState(MatchState parent, Geometry routeGeometry, StreetEdge edge,
             LinearLocation routeIndex, LinearLocation edgeIndex, double error,
             double distanceAlongRoute) {
         super(parent, edge, distanceAlongRoute);
@@ -134,7 +133,7 @@ public class MidblockMatchState extends MatchState {
                     return nextStates;
                 }
                 
-                for (Edge e : getOutgoingMatchableEdges(toVertex)) {
+                for (StreetEdge e : getOutgoingMatchableEdges(toVertex)) {
                     double cost = error + NEW_SEGMENT_PENALTY;
                     if (!carsCanTraverse(e)) {
                         cost += NO_TRAVERSE_PENALTY;
@@ -168,7 +167,7 @@ public class MidblockMatchState extends MatchState {
                 Vertex toVertex = edge.getToVertex();
                 double travelAlongOldEdge = distanceAlongGeometry(edgeGeometry, edgeIndex, null);
 
-                for (Edge e : getOutgoingMatchableEdges(toVertex)) {
+                for (StreetEdge e : getOutgoingMatchableEdges(toVertex)) {
                     Geometry newEdgeGeometry = e.getGeometry();
                     LocationIndexedLine newIndexedEdge = new LocationIndexedLine(newEdgeGeometry);
                     newEdgeIndex = newIndexedEdge.project(newRouteCoord);

--- a/src/main/java/org/opentripplanner/graph_builder/module/map/StreetMatcher.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/map/StreetMatcher.java
@@ -1,18 +1,5 @@
 package org.opentripplanner.graph_builder.module.map;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-
-import org.opentripplanner.routing.edgetype.StreetEdge;
-import org.opentripplanner.routing.graph.Edge;
-import org.opentripplanner.routing.graph.Graph;
-import org.opentripplanner.routing.graph.Vertex;
-import org.opentripplanner.common.pqueue.BinHeap;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
@@ -20,6 +7,18 @@ import org.locationtech.jts.index.strtree.STRtree;
 import org.locationtech.jts.linearref.LinearLocation;
 import org.locationtech.jts.linearref.LocationIndexedLine;
 import org.locationtech.jts.simplify.DouglasPeuckerSimplifier;
+import org.opentripplanner.common.pqueue.BinHeap;
+import org.opentripplanner.routing.edgetype.StreetEdge;
+import org.opentripplanner.routing.graph.Edge;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.routing.graph.Vertex;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
 
 /**
  * This Performs most of the work for the MapBuilder graph builder module.
@@ -57,7 +56,7 @@ public class StreetMatcher {
     }
 
     @SuppressWarnings("unchecked")
-    public List<Edge> match(Geometry routeGeometry) {
+    public List<StreetEdge> match(Geometry routeGeometry) {
         
         routeGeometry = removeDuplicatePoints(routeGeometry);
 
@@ -78,7 +77,7 @@ public class StreetMatcher {
         envelope.expandBy(distanceThreshold);
 
         BinHeap<MatchState> states = new BinHeap<MatchState>();
-        List<Edge> nearbyEdges = index.query(envelope);
+        List<StreetEdge> nearbyEdges = index.query(envelope);
         while (nearbyEdges.isEmpty()) {
             envelope.expandBy(distanceThreshold);
             distanceThreshold *= 2;
@@ -86,7 +85,7 @@ public class StreetMatcher {
         }
 
         // compute initial states
-        for (Edge initialEdge : nearbyEdges) {
+        for (StreetEdge initialEdge : nearbyEdges) {
             Geometry edgeGeometry = initialEdge.getGeometry();
             
             LocationIndexedLine indexedEdge = new LocationIndexedLine(edgeGeometry);
@@ -144,11 +143,11 @@ public class StreetMatcher {
         return routeGeometry.getFactory().createLineString(coords.toArray(coordArray));
     }
 
-    private List<Edge> toEdgeList(MatchState next) {
-        ArrayList<Edge> edges = new ArrayList<Edge>();
+    private List<StreetEdge> toEdgeList(MatchState next) {
+        ArrayList<StreetEdge> edges = new ArrayList<>();
         Edge lastEdge = null;
         while (next != null) {
-            Edge edge = next.getEdge();
+            StreetEdge edge = next.getEdge();
             if (edge != lastEdge) {
                 edges.add(edge);
                 lastEdge = edge;

--- a/src/main/java/org/opentripplanner/model/OtpTransitService.java
+++ b/src/main/java/org/opentripplanner/model/OtpTransitService.java
@@ -76,5 +76,5 @@ public interface OtpTransitService {
 
     Collection<Trip> getAllTrips();
 
-    Collection<FlexTrip> getAllFlexTrips();
+    Collection<FlexTrip<?>> getAllFlexTrips();
 }

--- a/src/main/java/org/opentripplanner/model/StopLocation.java
+++ b/src/main/java/org/opentripplanner/model/StopLocation.java
@@ -1,5 +1,8 @@
 package org.opentripplanner.model;
 
+import java.util.Collection;
+import java.util.Collections;
+
 /**
  * A StopLocation describes a place where a vehicle can be boarded or alighted, which is not
  * necessarily a marked stop, but can be of other shapes, such as a service area for flexible
@@ -21,4 +24,11 @@ public interface StopLocation {
    * the centroid of an area or line.
    */
   WgsCoordinate getCoordinate();
+
+  static Collection<StopLocation> expandStops(StopLocation stop) {
+    return stop instanceof FlexLocationGroup
+        ? ((FlexLocationGroup) stop).getLocations()
+        : Collections.singleton(stop);
+  }
+
 }

--- a/src/main/java/org/opentripplanner/model/impl/OtpTransitServiceBuilder.java
+++ b/src/main/java/org/opentripplanner/model/impl/OtpTransitServiceBuilder.java
@@ -106,7 +106,7 @@ public class OtpTransitServiceBuilder {
 
     private final Multimap<StopPattern, TripPattern> tripPatterns = ArrayListMultimap.create();
 
-    private final EntityById<FlexTrip> flexTripsById = new EntityById<>();
+    private final EntityById<FlexTrip<?>> flexTripsById = new EntityById<>();
 
     public OtpTransitServiceBuilder() {
     }
@@ -219,7 +219,7 @@ public class OtpTransitServiceBuilder {
         return tripPatterns;
     }
 
-    public EntityById<FlexTrip> getFlexTripsById() {
+    public EntityById<FlexTrip<?>> getFlexTripsById() {
         return flexTripsById;
     }
 

--- a/src/main/java/org/opentripplanner/model/impl/OtpTransitServiceImpl.java
+++ b/src/main/java/org/opentripplanner/model/impl/OtpTransitServiceImpl.java
@@ -96,7 +96,7 @@ class OtpTransitServiceImpl implements OtpTransitService {
 
     private final Collection<Trip> trips;
 
-    private final Collection<FlexTrip> flexTrips;
+    private final Collection<FlexTrip<?>> flexTrips;
 
     /**
      * Create a read only version of the {@link OtpTransitService}.
@@ -259,7 +259,7 @@ class OtpTransitServiceImpl implements OtpTransitService {
     }
 
     @Override
-    public Collection<FlexTrip> getAllFlexTrips() {
+    public Collection<FlexTrip<?>> getAllFlexTrips() {
         return flexTrips;
     }
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/RoutingWorker.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/RoutingWorker.java
@@ -156,7 +156,7 @@ public class RoutingWorker {
 
         // Special handling of flex accesses
         if (OTPFeature.FlexRouting.isOn() && request.modes.accessMode.equals(StreetMode.FLEXIBLE)) {
-            Collection<FlexAccessEgress> flexAccessList = FlexAccessEgressRouter.routeAccessEgress(
+            Collection<FlexAccessEgress<?>> flexAccessList = FlexAccessEgressRouter.routeAccessEgress(
                 request,
                 false
             );
@@ -175,7 +175,7 @@ public class RoutingWorker {
 
         // Special handling of flex egresses
         if (OTPFeature.FlexRouting.isOn() && request.modes.egressMode.equals(StreetMode.FLEXIBLE)) {
-            Collection<FlexAccessEgress> flexEgressList = FlexAccessEgressRouter.routeAccessEgress(
+            Collection<FlexAccessEgress<?>> flexEgressList = FlexAccessEgressRouter.routeAccessEgress(
                 request,
                 true
             );

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/router/street/FlexAccessEgressRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/router/street/FlexAccessEgressRouter.java
@@ -13,7 +13,7 @@ public class FlexAccessEgressRouter {
 
   private FlexAccessEgressRouter() {}
 
-  public static Collection<FlexAccessEgress> routeAccessEgress(
+  public static Collection<FlexAccessEgress<?>> routeAccessEgress(
       RoutingRequest request,
       boolean isEgress
   ) {

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/mappers/AccessEgressMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/mappers/AccessEgressMapper.java
@@ -38,7 +38,7 @@ public class AccessEgressMapper {
   }
 
   public Collection<AccessEgress> mapFlexAccessEgresses(
-      Collection<FlexAccessEgress> flexAccessEgresses
+      Collection<FlexAccessEgress<?>> flexAccessEgresses
   ) {
     return flexAccessEgresses.stream()
         .map(flexAccessEgress -> new FlexAccessEgressAdapter(flexAccessEgress, stopIndex))

--- a/src/main/java/org/opentripplanner/routing/graph/Graph.java
+++ b/src/main/java/org/opentripplanner/routing/graph/Graph.java
@@ -244,7 +244,7 @@ public class Graph implements Serializable {
 
     public Map<FeedScopedId, FlexLocationGroup> locationGroupsById = new HashMap<>();
 
-    public Map<FeedScopedId, FlexTrip> flexTripsById = new HashMap<>();
+    public Map<FeedScopedId, FlexTrip<?>> flexTripsById = new HashMap<>();
 
     /** The distance between elevation samples used in CompactElevationProfile. */
     private double distanceBetweenElevationSamples;

--- a/src/test/java/org/opentripplanner/graph_builder/module/map/TestStreetMatcher.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/map/TestStreetMatcher.java
@@ -1,30 +1,28 @@
 package org.opentripplanner.graph_builder.module.map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
-import java.util.List;
-
 import org.junit.Before;
 import org.junit.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.common.geometry.PackedCoordinateSequence;
+import org.opentripplanner.common.geometry.SphericalDistanceLibrary;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.core.StateEditor;
 import org.opentripplanner.routing.core.TraverseMode;
 import org.opentripplanner.routing.core.TraverseModeSet;
 import org.opentripplanner.routing.edgetype.StreetEdge;
 import org.opentripplanner.routing.edgetype.StreetTraversalPermission;
-import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Graph;
-import org.opentripplanner.common.geometry.SphericalDistanceLibrary;
 import org.opentripplanner.routing.vertextype.StreetVertex;
-
-import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.GeometryFactory;
-import org.locationtech.jts.geom.LineString;
-import java.util.Locale;
 import org.opentripplanner.util.I18NString;
 import org.opentripplanner.util.NonLocalizedString;
+
+import java.util.List;
+import java.util.Locale;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class TestStreetMatcher {
     static GeometryFactory gf = new GeometryFactory();
@@ -89,7 +87,7 @@ public class TestStreetMatcher {
 
         StreetMatcher matcher = new StreetMatcher(graph);
 
-        List<Edge> match = matcher.match(geometry);
+        List<StreetEdge> match = matcher.match(geometry);
         assertNotNull(match);
         assertEquals(1, match.size());
         assertEquals("56th_24th", match.get(0).getToVertex().getLabel());


### PR DESCRIPTION
### Summary

Currently OTP supports two types of flexible trips, unscheduled and scheduled deviated trips. this adds support for a third type, continuous stops. these trips operate like regular scheduled transit, but boarding and/or alighting is allowed on the way at least between a set of stops. This is modelled by having the stop index to be a floating point number, which represents the proportion of the length, which the vehicle has travelled between the stop pair the number is between.


### Unit tests
TODO

### Code style
Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Developers-Guide.md#code-style)? Yes

### Documentation
TODO

### Changelog
Was a bullet point added to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md) with description and link to the linked issue?
