### PR TITLE
fix: Progress tracker unit test

### DIFF
--- a/src/test/java/org/opentripplanner/util/ProgressTrackerTest.java
+++ b/src/test/java/org/opentripplanner/util/ProgressTrackerTest.java
@@ -34,6 +34,7 @@ public class ProgressTrackerTest {
         msg = null;
         p.step(m -> msg = m);
         assertNull(msg, msg);
+        assertNull("Pete progress: 2 bytes of 200 bytes ( 1%)", msg);
 
         msg = null;
         p.step(m -> msg = m);
@@ -44,38 +45,29 @@ public class ProgressTrackerTest {
     }
 
     @Test
-    public void testStepEvery20ms() {
-        // We want to track the progress every 100 ms
-        long WAIT = 100;
+    public void testNoOutputInQuietPeriod() {
+        long QUIET_PERIOD = 1000;
+        ProgressTracker subject = new ProgressTracker("Pete", 1,100, QUIET_PERIOD, true);
         long start = System.currentTimeMillis();
 
-        // and if the test takes more than 200 millisec we want to abort the test
-        long endFuse = start + 2 * WAIT;
+        sleep10ms();
+        subject.step(m -> breakOut = true);
 
-        // When tracking every step, but not more often than WAIT time
-        ProgressTracker subject = new ProgressTracker("Pete", 1, -1, WAIT, false);
-        int i = 0;
+        sleep10ms();
+        subject.step(m -> breakOut = true);
 
-        while (!breakOut && System.currentTimeMillis() < endFuse) {
-            sleep(WAIT/10);
-            subject.step(m -> breakOut = true);
-            ++i;
-        }
-
-        // Then the expected duration of the test should be around the WAIT time
         long time = System.currentTimeMillis() - start;
-        assertTrue(
-                "Time should be close to the wait time: " + WAIT + " but is " + time,
-                Math.abs(time - WAIT) < WAIT
-        );
-        assertTrue(
-                "We expect the loop to be performed between 5 and 12 times: " + i,
-                i > 5 && i < 12
-        );
+        // If test was able to run within the quiet period
+        if(time < QUIET_PERIOD) {
+            assertFalse(
+                    "No steps should log anything within the quiet period. Time: " + time,
+                    breakOut
+            );
+        }
     }
 
-    void sleep(long timeMs) {
-        try { Thread.sleep(timeMs); }
+    void sleep10ms() {
+        try { Thread.sleep(10); }
         catch (InterruptedException e) { throw new RuntimeException(e.getMessage(), e); }
     }
 }


### PR DESCRIPTION
### Summary
This fixes the `ProgressTracker` unit test, so it does not fail, even if the unit tests halts for a while. The ´ProgressTracker´is a utility and OTP do not depend on it been accurate, so having a water proof test of the timer inside it is not necessary - it only causes noice. 


### Issue
closes #3435 

### Unit tests
This only changes on unit test.

- The codestyle is followed.
- No documentation or changelog item is added.