### PR TITLE
Fix performance issues with the StreetFlexPathCalculator

### DIFF
--- a/docs/sandbox/Flex.md
+++ b/docs/sandbox/Flex.md
@@ -13,6 +13,7 @@
 - Initial implementation of Flexible transit routing
 - Use one-to-many search in order to make the performance of the StreetFlexPathCalculator acceptable. (April 2021)
 - Also link transit stops used by flex trips to the closest car traversable edge. This allows flex street routing all the way to the stop. (April 2021)
+- Fix performance issues with the StreetFlexPathCalculator [#3460](https://github.com/opentripplanner/OpenTripPlanner/pull/3460)
 
 ## Documentation
 To enable this turn on `FlexRouting` as a feature in `otp-config.json`. The GTFS feeds should conform to the [GTFS-Flex v2.1 draft](https://docs.google.com/document/d/1PyYK6JVzz52XEx3FXqAJmoVefHFqZTHS4Mpn20dTuKE/)

--- a/src/ext/java/org/opentripplanner/ext/flex/FlexRouter.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/FlexRouter.java
@@ -3,7 +3,6 @@ package org.opentripplanner.ext.flex;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import org.opentripplanner.common.model.T2;
-import org.opentripplanner.ext.flex.flexpathcalculator.DirectFlexPathCalculator;
 import org.opentripplanner.ext.flex.flexpathcalculator.FlexPathCalculator;
 import org.opentripplanner.ext.flex.flexpathcalculator.StreetFlexPathCalculator;
 import org.opentripplanner.ext.flex.template.FlexAccessTemplate;
@@ -37,7 +36,8 @@ public class FlexRouter {
   private final Collection<NearbyStop> streetAccesses;
   private final Collection<NearbyStop> streetEgresses;
   private final FlexIndex flexIndex;
-  private final FlexPathCalculator flexPathCalculator;
+  private final FlexPathCalculator accessFlexPathCalculator;
+  private final FlexPathCalculator egressFlexPathCalculator;
 
   /* Request data */
   private final ZonedDateTime startOfTime;
@@ -63,7 +63,8 @@ public class FlexRouter {
     this.streetAccesses = streetAccesses;
     this.streetEgresses = egressTransfers;
     this.flexIndex = graph.index.getFlexIndex();
-    this.flexPathCalculator = new StreetFlexPathCalculator(graph);
+    this.accessFlexPathCalculator = new StreetFlexPathCalculator(graph, false);
+    this.egressFlexPathCalculator = new StreetFlexPathCalculator(graph, true);
 
     ZoneId tz = graph.getTimeZone().toZoneId();
     LocalDate searchDate = LocalDate.ofInstant(searchInstant, tz);
@@ -141,7 +142,9 @@ public class FlexRouter {
             // Discard if service is not running on date
             .filter(date -> date.isFlexTripRunning(t2.second, this.graph))
             // Create templates from trip, boarding at the nearbyStop
-            .flatMap(date -> t2.second.getFlexAccessTemplates(t2.first, date, flexPathCalculator)))
+            .flatMap(date -> t2.second.getFlexAccessTemplates(t2.first, date,
+                accessFlexPathCalculator
+            )))
         .collect(Collectors.toList());
   }
 
@@ -155,7 +158,9 @@ public class FlexRouter {
             // Discard if service is not running on date
             .filter(date -> date.isFlexTripRunning(t2.second, this.graph))
             // Create templates from trip, alighting at the nearbyStop
-            .flatMap(date -> t2.second.getFlexEgressTemplates(t2.first, date, flexPathCalculator)))
+            .flatMap(date -> t2.second.getFlexEgressTemplates(t2.first, date,
+                egressFlexPathCalculator
+            )))
         .collect(Collectors.toList());;
   }
 

--- a/src/ext/java/org/opentripplanner/ext/flex/FlexRouter.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/FlexRouter.java
@@ -142,7 +142,9 @@ public class FlexRouter {
             // Discard if service is not running on date
             .filter(date -> date.isFlexTripRunning(t2.second, this.graph))
             // Create templates from trip, boarding at the nearbyStop
-            .flatMap(date -> t2.second.getFlexAccessTemplates(t2.first, date,
+            .flatMap(date -> t2.second.getFlexAccessTemplates(
+                t2.first,
+                date,
                 accessFlexPathCalculator
             )))
         .collect(Collectors.toList());
@@ -158,7 +160,9 @@ public class FlexRouter {
             // Discard if service is not running on date
             .filter(date -> date.isFlexTripRunning(t2.second, this.graph))
             // Create templates from trip, alighting at the nearbyStop
-            .flatMap(date -> t2.second.getFlexEgressTemplates(t2.first, date,
+            .flatMap(date -> t2.second.getFlexEgressTemplates(
+                t2.first, 
+                date,
                 egressFlexPathCalculator
             )))
         .collect(Collectors.toList());;

--- a/src/ext/java/org/opentripplanner/ext/flex/FlexRouter.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/FlexRouter.java
@@ -101,7 +101,7 @@ public class FlexRouter {
 
     for (FlexAccessTemplate template : this.flexAccessTemplates) {
       StopLocation transferStop = template.getTransferStop();
-      if (egressStops.contains(transferStop)) {
+      if (this.flexEgressTemplates.stream().anyMatch(t -> t.getAccessEgressStop().equals(transferStop))) {
         for(NearbyStop egress : streetEgressByStop.get(transferStop)) {
           Itinerary itinerary = template.createDirectItinerary(egress, arriveBy, departureTime, startOfTime);
           if (itinerary != null) {

--- a/src/ext/java/org/opentripplanner/ext/flex/flexpathcalculator/StreetFlexPathCalculator.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/flexpathcalculator/StreetFlexPathCalculator.java
@@ -22,6 +22,12 @@ import java.util.Map;
  * Note that it caches the whole ShortestPathTree the first time it encounters a new fromVertex.
  * Subsequents requests from the same fromVertex can fetch the path to the toVertex from the
  * existing ShortestPathTree. This one-to-many approach is needed to make the performance acceptable.
+ *
+ * Because we will have lots of searches with the same origin when doing access searches and a lot
+ * of searches with the same destination when doing egress searches, the calculator needs to be
+ * configured so that the caching is done with either the origin or destination vertex as the key.
+ * The one-to-many search will then either be done in the forward or the reverse direction depending
+ * on this configuration.
  */
 public class StreetFlexPathCalculator implements FlexPathCalculator {
 
@@ -29,24 +35,33 @@ public class StreetFlexPathCalculator implements FlexPathCalculator {
 
   private final Graph graph;
   private final Map<Vertex, ShortestPathTree> cache = new HashMap<>();
+  private final boolean reverseDirection;
 
-  public StreetFlexPathCalculator(Graph graph) {
+  public StreetFlexPathCalculator(Graph graph, boolean reverseDirection) {
     this.graph = graph;
+    this.reverseDirection = reverseDirection;
   }
 
   @Override
   public FlexPath calculateFlexPath(Vertex fromv, Vertex tov, int fromStopIndex, int toStopIndex) {
 
+    // These are the origin and destination vertices from the perspective of the one-to-many search,
+    // which may be reversed
+    Vertex originVertex = reverseDirection ? tov : fromv;
+    Vertex destinationVertex = reverseDirection ? fromv : tov;
+
     ShortestPathTree shortestPathTree;
-    if (cache.containsKey(fromv)) {
-      shortestPathTree = cache.get(fromv);
+    if (cache.containsKey(originVertex)) {
+      shortestPathTree = cache.get(originVertex);
     } else {
-      shortestPathTree = routeToMany(fromv);
-      cache.put(fromv, shortestPathTree);
+      shortestPathTree = routeToMany(originVertex);
+      cache.put(originVertex, shortestPathTree);
     }
 
-    GraphPath path = shortestPathTree.getPath(tov, false);
-    if (path == null) { return null; }
+    GraphPath path = shortestPathTree.getPath(destinationVertex, false);
+    if (path == null) {
+      return null;
+    }
 
     int distance = (int) path.getDistanceMeters();
     int duration = path.getDuration();
@@ -55,10 +70,16 @@ public class StreetFlexPathCalculator implements FlexPathCalculator {
     return new FlexPath(distance, duration, geometry);
   }
 
-  private ShortestPathTree routeToMany(Vertex fromv) {
+  private ShortestPathTree routeToMany(Vertex vertex) {
     RoutingRequest routingRequest = new RoutingRequest(TraverseMode.CAR);
-    routingRequest.setRoutingContext(graph, fromv, null);
-    routingRequest.worstTime = routingRequest.dateTime + MAX_FLEX_TRIP_DURATION_SECONDS;
+    routingRequest.arriveBy = reverseDirection;
+    if (reverseDirection) {
+      routingRequest.setRoutingContext(graph, null, vertex);
+      routingRequest.worstTime = routingRequest.dateTime - MAX_FLEX_TRIP_DURATION_SECONDS;
+    } else {
+      routingRequest.setRoutingContext(graph, vertex, null);
+      routingRequest.worstTime = routingRequest.dateTime + MAX_FLEX_TRIP_DURATION_SECONDS;
+    }
     routingRequest.disableRemainingWeightHeuristic = true;
     routingRequest.rctx.remainingWeightHeuristic = new TrivialRemainingWeightHeuristic();
     routingRequest.dominanceFunction = new DominanceFunction.EarliestArrival();

--- a/src/ext/java/org/opentripplanner/ext/flex/template/FlexAccessEgressTemplate.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/template/FlexAccessEgressTemplate.java
@@ -64,6 +64,10 @@ public abstract class FlexAccessEgressTemplate {
     return transferStop;
   }
 
+  public StopLocation getAccessEgressStop() {
+    return accessEgress.stop;
+  }
+
   public FlexTrip getFlexTrip() {
     return trip;
   }


### PR DESCRIPTION
### Summary
This PR changes the caching of the StreetFlexPathCalculator so that it is also optimized for egress searches. When doing access searches, we would have lots of different searches from the same origin vertex to many destinations. This was improved earlier by doing a one-to-many search and caching the entire SearchPathTree. This would fail when doing flex egress searches, as in that case the destination with be the same, while the origin was different.

A new parameter has been added to the StreetFlexPathCalculator constructor, to specify which direction the one-to-many search and caching should be done. The FlexRouter then instantiate a StreetFlexPathCalculator for each direction.

In addition, a fix from #3439 which prevents duplicate direct flex itineraries has been included.

### Issue
https://github.com/mfdz/OpenTripPlanner/issues/64

### Unit tests
No new tests added

### Documentation
Javadoc on the StreetFlexPathCalculator has been expanded.

### Changelog
Changelog entry added to the sandbox documentation.
