### PR TITLE
Config.package.md: adjusted documentation to improve readability

### DIFF
--- a/src/main/java/org/opentripplanner/standalone/config/package.md
+++ b/src/main/java/org/opentripplanner/standalone/config/package.md
@@ -28,7 +28,7 @@ The design goals are:
 
 For historic reasons the configuration loader uses jackson and parses the config into a JSON node 
 tree. Java objects are mapped explicit by wrapping each `JsonNode` in a `NodeAdapter`. The 
-`NodeAdapter` decorate the `JsonNode` to provide type-safe getters for rich basic types, like 
+`NodeAdapter` decorates the `JsonNode` to provide type-safe getters for rich basic types like 
 `Enum`, `List`(type-safe), `Map`(type-safe), `LocalDateTime`, `URI` and so on. It also helps with 
 validation and providing a list of unused parameters. 
 

--- a/src/main/java/org/opentripplanner/standalone/config/package.md
+++ b/src/main/java/org/opentripplanner/standalone/config/package.md
@@ -68,7 +68,7 @@ public class <ModuleNnnnParameters> {
 ```
 
 In the `org.opentripplanner.standalone.config` package there will be a class called 
-`ModuleNnnnConfig` that either extend the interface above or instantiate the POJO. The
+`ModuleNnnnConfig` that either extends the interface above or instantiates the POJO. The
 config class should map from JSON using the `NodeAdapter` into itself(extending the interface)
 or into the POJO.
 

--- a/src/main/java/org/opentripplanner/standalone/config/package.md
+++ b/src/main/java/org/opentripplanner/standalone/config/package.md
@@ -12,7 +12,8 @@ The design goals are:
 - Ignore unknown parameters, just print a warning message in the log. This will make the process of
   upgrading and downgrading OTP easier and less prune to service failure. Try to make reasonable
   default values instead of making a parameter required.
-- Encapsulate config parsing, so parsing and error handling is consistent - and stay consistent over time(maintenance).
+- Encapsulate config parsing, so parsing and error handling is consistent - and stay consistent over
+  time(maintenance).
 - Configuration should be injected into OTP components/modules in using inversion-of-control. Each module should define the needed config as an interface(or simple Java class). This ensures type-safety and provide a consistent way to document needed configuration for each module.
 - For Sandbox modules the configuration loading should be put in the `org.opentripplanner.standalone.config.sandbox` package. This keep all the configuration loading in one place, avoiding fragmentation, and make it easier to get an overview. The parameters(interface or POJO) injected into the Sandbox module itself, should be declared in the Sandbox module.
 

--- a/src/main/java/org/opentripplanner/standalone/config/package.md
+++ b/src/main/java/org/opentripplanner/standalone/config/package.md
@@ -39,7 +39,7 @@ Each OTP module in need for configuration should declare needs and document each
 using JavaDoc. It can be done using an interface or a simple plain-old-java-object(POJO):
 
 ```
-/** <Sumary doc goes here> */
+/** <Summary doc goes here> */
 interface <ModuleNnnnParameters> {
 
    /** 
@@ -53,7 +53,7 @@ interface <ModuleNnnnParameters> {
 
 or 
 
-/** <Sumary doc goes here> */
+/** <Summary doc goes here> */
 public class <ModuleNnnnParameters> {
     <fields>
 

--- a/src/main/java/org/opentripplanner/standalone/config/package.md
+++ b/src/main/java/org/opentripplanner/standalone/config/package.md
@@ -18,8 +18,8 @@ The design goals are:
   module should define the needed config as an interface(or simple Java class). This ensures
   type-safety and provides a consistent way to document needed configuration for each module.
 - For Sandbox modules the configuration loading should be put in the
-  `org.opentripplanner.standalone.config.sandbox` package. This keep all the configuration loading
-  in one place, avoiding fragmentation, and make it easier to get an overview. The parameters
+  `org.opentripplanner.standalone.config.sandbox` package. This keeps all the configuration loading
+  in one place, avoiding fragmentation and makes it easier to get an overview. The parameters
   (interface or POJO) injected into the Sandbox module itself, should be declared in the Sandbox
   module.
 

--- a/src/main/java/org/opentripplanner/standalone/config/package.md
+++ b/src/main/java/org/opentripplanner/standalone/config/package.md
@@ -9,7 +9,8 @@ The design goals are:
 - Load and validate the configuration early, before loading the graph or creating any 
   components/modules. This ensures fast feedback and early termination of the server if the
   configuration is not valid.
-- Ignore unknown parameters, just print a warning message in the log. This will make the process of upgrading and downgrading OTP easier, and less prune to service failure. Try to make reasonable default values instead of making a parameter required.
+- Ignore unknown parameters, just print a warning message in the log. This will make the process of
+  upgrading and downgrading OTP easier, and less prune to service failure. Try to make reasonable default values instead of making a parameter required.
 - Encapsulate config parsing, so parsing and error handling is consistent - and stay consistent over time(maintenance).
 - Configuration should be injected into OTP components/modules in using inversion-of-control. Each module should define the needed config as an interface(or simple Java class). This ensures type-safety and provide a consistent way to document needed configuration for each module.
 - For Sandbox modules the configuration loading should be put in the `org.opentripplanner.standalone.config.sandbox` package. This keep all the configuration loading in one place, avoiding fragmentation, and make it easier to get an overview. The parameters(interface or POJO) injected into the Sandbox module itself, should be declared in the Sandbox module.

--- a/src/main/java/org/opentripplanner/standalone/config/package.md
+++ b/src/main/java/org/opentripplanner/standalone/config/package.md
@@ -15,7 +15,8 @@ The design goals are:
 - Encapsulate config parsing, so parsing and error handling is consistent - and stay consistent over
   time(maintenance).
 - Configuration should be injected into OTP components/modules in using inversion-of-control. Each
-  module should define the needed config as an interface(or simple Java class). This ensures type-safety and provide a consistent way to document needed configuration for each module.
+  module should define the needed config as an interface(or simple Java class). This ensures
+  type-safety and provide a consistent way to document needed configuration for each module.
 - For Sandbox modules the configuration loading should be put in the `org.opentripplanner.standalone.config.sandbox` package. This keep all the configuration loading in one place, avoiding fragmentation, and make it easier to get an overview. The parameters(interface or POJO) injected into the Sandbox module itself, should be declared in the Sandbox module.
 
 

--- a/src/main/java/org/opentripplanner/standalone/config/package.md
+++ b/src/main/java/org/opentripplanner/standalone/config/package.md
@@ -14,7 +14,8 @@ The design goals are:
   default values instead of making a parameter required.
 - Encapsulate config parsing, so parsing and error handling is consistent - and stay consistent over
   time(maintenance).
-- Configuration should be injected into OTP components/modules in using inversion-of-control. Each module should define the needed config as an interface(or simple Java class). This ensures type-safety and provide a consistent way to document needed configuration for each module.
+- Configuration should be injected into OTP components/modules in using inversion-of-control. Each
+  module should define the needed config as an interface(or simple Java class). This ensures type-safety and provide a consistent way to document needed configuration for each module.
 - For Sandbox modules the configuration loading should be put in the `org.opentripplanner.standalone.config.sandbox` package. This keep all the configuration loading in one place, avoiding fragmentation, and make it easier to get an overview. The parameters(interface or POJO) injected into the Sandbox module itself, should be declared in the Sandbox module.
 
 

--- a/src/main/java/org/opentripplanner/standalone/config/package.md
+++ b/src/main/java/org/opentripplanner/standalone/config/package.md
@@ -17,7 +17,11 @@ The design goals are:
 - Configuration should be injected into OTP components/modules in using inversion-of-control. Each
   module should define the needed config as an interface(or simple Java class). This ensures
   type-safety and provides a consistent way to document needed configuration for each module.
-- For Sandbox modules the configuration loading should be put in the `org.opentripplanner.standalone.config.sandbox` package. This keep all the configuration loading in one place, avoiding fragmentation, and make it easier to get an overview. The parameters(interface or POJO) injected into the Sandbox module itself, should be declared in the Sandbox module.
+- For Sandbox modules the configuration loading should be put in the
+  `org.opentripplanner.standalone.config.sandbox` package. This keep all the configuration loading
+  in one place, avoiding fragmentation, and make it easier to get an overview. The parameters
+  (interface or POJO) injected into the Sandbox module itself, should be declared in the Sandbox
+  module.
 
 
 ## Implementation

--- a/src/main/java/org/opentripplanner/standalone/config/package.md
+++ b/src/main/java/org/opentripplanner/standalone/config/package.md
@@ -10,7 +10,7 @@ The design goals are:
   components/modules. This ensures fast feedback and early termination of the server if the
   configuration is not valid.
 - Ignore unknown parameters, just print a warning message in the log. This will make the process of
-  upgrading and downgrading OTP easier, and less prune to service failure. Try to make reasonable default values instead of making a parameter required.
+  upgrading and downgrading OTP easier and less prune to service failure. Try to make reasonable default values instead of making a parameter required.
 - Encapsulate config parsing, so parsing and error handling is consistent - and stay consistent over time(maintenance).
 - Configuration should be injected into OTP components/modules in using inversion-of-control. Each module should define the needed config as an interface(or simple Java class). This ensures type-safety and provide a consistent way to document needed configuration for each module.
 - For Sandbox modules the configuration loading should be put in the `org.opentripplanner.standalone.config.sandbox` package. This keep all the configuration loading in one place, avoiding fragmentation, and make it easier to get an overview. The parameters(interface or POJO) injected into the Sandbox module itself, should be declared in the Sandbox module.

--- a/src/main/java/org/opentripplanner/standalone/config/package.md
+++ b/src/main/java/org/opentripplanner/standalone/config/package.md
@@ -10,7 +10,8 @@ The design goals are:
   components/modules. This ensures fast feedback and early termination of the server if the
   configuration is not valid.
 - Ignore unknown parameters, just print a warning message in the log. This will make the process of
-  upgrading and downgrading OTP easier and less prune to service failure. Try to make reasonable default values instead of making a parameter required.
+  upgrading and downgrading OTP easier and less prune to service failure. Try to make reasonable
+  default values instead of making a parameter required.
 - Encapsulate config parsing, so parsing and error handling is consistent - and stay consistent over time(maintenance).
 - Configuration should be injected into OTP components/modules in using inversion-of-control. Each module should define the needed config as an interface(or simple Java class). This ensures type-safety and provide a consistent way to document needed configuration for each module.
 - For Sandbox modules the configuration loading should be put in the `org.opentripplanner.standalone.config.sandbox` package. This keep all the configuration loading in one place, avoiding fragmentation, and make it easier to get an overview. The parameters(interface or POJO) injected into the Sandbox module itself, should be declared in the Sandbox module.

--- a/src/main/java/org/opentripplanner/standalone/config/package.md
+++ b/src/main/java/org/opentripplanner/standalone/config/package.md
@@ -35,8 +35,8 @@ validation and providing a list of unused parameters.
 
 ### Config Injection
 
-Each module in OTP witch need configuration should declare what it needs and document each parameter
-with using JavaDoc. It can be done using a interface or a simple plain-old-java-object(POJO):
+Each OTP module in need for configuration should declare needs and document each parameter
+using JavaDoc. It can be done using an interface or a simple plain-old-java-object(POJO):
 
 ```
 /** <Sumary doc goes here> */

--- a/src/main/java/org/opentripplanner/standalone/config/package.md
+++ b/src/main/java/org/opentripplanner/standalone/config/package.md
@@ -16,7 +16,7 @@ The design goals are:
   time(maintenance).
 - Configuration should be injected into OTP components/modules in using inversion-of-control. Each
   module should define the needed config as an interface(or simple Java class). This ensures
-  type-safety and provide a consistent way to document needed configuration for each module.
+  type-safety and provides a consistent way to document needed configuration for each module.
 - For Sandbox modules the configuration loading should be put in the `org.opentripplanner.standalone.config.sandbox` package. This keep all the configuration loading in one place, avoiding fragmentation, and make it easier to get an overview. The parameters(interface or POJO) injected into the Sandbox module itself, should be declared in the Sandbox module.
 
 


### PR DESCRIPTION
Hi folks,
This PR shall improve the readability of the file [package.md](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/src/main/java/org/opentripplanner/standalone/config/package.md) by adjusting grammar and mode of expression.

Please feel free to use, study, share or improve this PR.

Cheers!