### PR TITLE
Show debug layers by default in layer dialogue

### DIFF
--- a/src/client/js/otp/config.js
+++ b/src/client/js/otp/config.js
@@ -5,7 +5,7 @@ otp.config = {
     //If enabled it shows inspector layers overlays which can be used for Graph
     //debugging
     //Can be also enabled in URL parameters as ?debug_layers=true
-    debug_layers: false,
+    debug_layers: true,
 
     //This is default locale when wanted locale isn't found
     //Locale language is set based on wanted language in url >


### PR DESCRIPTION
### Summary
Enables debug layers in layer dialogue by default. We think this makes sense since this is after all a debug client.

### Issue
Relates to #3407

### Unit tests
Tested manually
