### PR TITLE
Filter modes for the nearest query to avoid errors in the Legacy GraphQL API

### DIFF
--- a/docs/sandbox/LegacyGraphQLApi.md
+++ b/docs/sandbox/LegacyGraphQLApi.md
@@ -10,6 +10,7 @@
 - Added capacity and allowOverloading fields to bike rental stations (not yet properly implemented) (May 2021, https://github.com/opentripplanner/OpenTripPlanner/pull/3450)
 - Updated documentation and process for generating Java code from GraphQL schema definition (May 2021, https://github.com/opentripplanner/OpenTripPlanner/pull/3450)
 - Implemented modeWeight and added debugItineraryFilter to plan query. Added systemNotices to itineraries (May 2021, https://github.com/opentripplanner/OpenTripPlanner/pull/3503)
+- Updated to ignore modes which are not valid in OTP2 (June 2021, https://github.com/opentripplanner/OpenTripPlanner/pull/3464)
 
 ## Documentation
 

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
@@ -267,8 +267,11 @@ public class LegacyGraphQLQueryTypeImpl
 
       List<TransitMode> filterByModes = args.getLegacyGraphQLFilterByModes() != null ? StreamSupport
           .stream(args.getLegacyGraphQLFilterByModes().spliterator(), false)
-          .map(mode -> mode.label)
-          .map(TransitMode::valueOf)
+          .map(mode -> {
+            try { return TransitMode.valueOf(mode.label); }
+            catch (IllegalArgumentException ignored) { return null; }
+          })
+          .filter(Objects::nonNull)
           .collect(Collectors.toList()) : null;
       List<PlaceType> filterByPlaceTypes =
           args.getLegacyGraphQLFilterByPlaceTypes() != null ? StreamSupport

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/LegacyGraphQLTypes.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/LegacyGraphQLTypes.java
@@ -417,7 +417,9 @@ public class LegacyGraphQLTypes {
         Bus("BUS"),
         CableCar("CABLE_CAR"),
         Car("CAR"),
+        Coach("COACH"),
         Ferry("FERRY"),
+        Flex("FLEX"),
         Flexible("FLEXIBLE"),
         Funicular("FUNICULAR"),
         Gondola("GONDOLA"),
@@ -527,7 +529,10 @@ public class LegacyGraphQLTypes {
         Park("PARK"),
         Keep("KEEP"),
         Pickup("PICKUP"),
-        Dropoff("DROPOFF");
+        Dropoff("DROPOFF"),
+        Access("ACCESS"),
+        Egress("EGRESS"),
+        Direct("DIRECT");
 
         public final String label;
 

--- a/src/ext/resources/legacygraphqlapi/schema.graphqls
+++ b/src/ext/resources/legacygraphqlapi/schema.graphqls
@@ -864,11 +864,17 @@ enum Mode {
     """CAR"""
     CAR
 
+    """COACH"""
+    COACH
+
     """FERRY"""
     FERRY
 
     """Enables flexible transit for access and egress legs"""
-    FLEXIBLE
+    FLEX
+
+    """Enables flexible transit for access and egress legs"""
+    FLEXIBLE   @deprecated(reason: "Use FLEX instead")
 
     """FUNICULAR"""
     FUNICULAR
@@ -1179,7 +1185,7 @@ enum Qualifier {
     ~~HAVE~~
     **Currently not used**
     """
-    HAVE
+    HAVE    @deprecated(reason: "Currently not used")
 
     """
     The vehicle used must be left to a parking area before continuing the journey.
@@ -1194,13 +1200,22 @@ enum Qualifier {
     ~~KEEP~~
     **Currently not used**
     """
-    KEEP
+    KEEP    @deprecated(reason: "Currently not used")
 
     """The user can be picked up by someone else riding a vehicle"""
     PICKUP
 
     """The user can be dropped off by someone else riding a vehicle"""
     DROPOFF
+
+    """The mode is used for the access part of the search."""
+    ACCESS,
+
+    """The mode is used for the egress part of the search."""
+    EGRESS,
+
+    """The mode is used for the direct street search."""
+    DIRECT
 }
 
 type QueryType {


### PR DESCRIPTION
### Summary

The "Legacy GraphQL API" allows searching for nearby places and filtering by mode (`filterByModes`). Any `TraverseMode` may be specified, but it must be converted to `TransitMode`, which causes errors despite the query being valid. This is a simple solution to handle these errors, without significantly changing the API.

### Unit tests

N/A - manually tested.

### Code style

:ballot_box_with_check: 

### Documentation

N/A

### Changelog

N/A
