### PR TITLE
Reuse the default routing request within the Legacy GraphQL API

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
@@ -586,7 +586,7 @@ public class LegacyGraphQLQueryTypeImpl
   public DataFetcher<RoutingResponse> plan() {
     return environment -> {
       LegacyGraphQLRequestContext context = environment.<LegacyGraphQLRequestContext>getContext();
-      RoutingRequest request = new RoutingRequest();
+      RoutingRequest request = context.getRouter().defaultRoutingRequest.clone();
 
       CallerWithEnvironment callWith = new CallerWithEnvironment(environment);
 


### PR DESCRIPTION
### Summary

The Legacy GraphQL API currently creates a `new RoutingRequest()` for each request, which doesn't allow setting defaults within `router-config.json`. This updates the API to clone the `defaultRoutingRequest` so that the defaults are applied.

### Issue

N/A

### Unit tests

N/A

### Code style

:ballot_box_with_check: 

### Documentation

N/A

### Changelog

N/A
