### PR TITLE
Use the provided url for GBFS auto-discovery when configuring a bike rental updater

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -985,31 +985,31 @@ connect to a network resource is the `url` field.
     ]
 }
 ```
+
 #### GBFS Configuration
 
-Steps to add a GBFS feed to a router:
+[GBFS](https://github.com/NABSA/gbfs) is used for a variety of shared mobility services, with partial support for both v1 and v2.2 ([list of known GBFS feeds](https://github.com/NABSA/gbfs/blob/master/systems.csv)).
 
-- Add one entry in the `updater` field of `router-config.json` in the format
+To add a GBFS feed to the router add one entry in the `updater` field of `router-config.json` in the format:
 
 ```JSON
 // router-config.json
 {
-     "type": "bike-rental",
-     "frequencySec": 60,
-     "sourceType": "gbfs",
-     "url": "http://coast.socialbicycles.com/opendata/"
+   "type": "bike-rental",
+   "sourceType": "gbfs",
+   // frequency in seconds in which the GBFS service will be polled
+   "frequencySec": 60,
+   // The URL of the GBFS feed auto-discovery file
+   "url": "http://coast.socialbicycles.com/opendata/gbfs.json"
 }
 ```
 
-- Follow these instructions to fill these fields:
+If there is no GBFS autodiscovery file, specify the base `url` under which the files may be found
+using their standard names:
 
+```JSON
+  "url": "http://coast.socialbicycles.com/opendata/"
 ```
-type: "bike-rental"
-frequencySec: frequency in seconds in which the GBFS service will be polled
-sourceType: "gbfs"
-url: the URL of the GBFS feed (do not include the gbfs.json at the end) *
-```
-\* For a list of known GBFS feeds see the [list of known GBFS feeds](https://github.com/NABSA/gbfs/blob/master/systems.csv)
 
 #### Bike Rental Service Directory configuration (sandbox feature)
 

--- a/src/ext/java/org/opentripplanner/ext/bikerentalservicedirectory/BikeRentalParameters.java
+++ b/src/ext/java/org/opentripplanner/ext/bikerentalservicedirectory/BikeRentalParameters.java
@@ -7,10 +7,9 @@ public class BikeRentalParameters extends BikeRentalUpdaterParameters {
 
   public BikeRentalParameters(
       String configRef,
-      String url,
       int frequencySec,
       BikeRentalDataSourceParameters sourceParameters
   ) {
-    super(configRef, url, null, frequencySec, sourceParameters);
+    super(configRef, null, frequencySec, sourceParameters);
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/bikerentalservicedirectory/BikeRentalServiceDirectoryFetcher.java
+++ b/src/ext/java/org/opentripplanner/ext/bikerentalservicedirectory/BikeRentalServiceDirectoryFetcher.java
@@ -2,17 +2,15 @@ package org.opentripplanner.ext.bikerentalservicedirectory;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
 import org.opentripplanner.ext.bikerentalservicedirectory.api.BikeRentalServiceDirectoryFetcherParameters;
 import org.opentripplanner.updater.GraphUpdater;
-import org.opentripplanner.updater.bike_rental.BikeRentalDataSource;
 import org.opentripplanner.updater.bike_rental.BikeRentalUpdater;
 import org.opentripplanner.util.HttpUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Fetches GBFS endpoints from the Bikeservice component located at
@@ -60,11 +58,8 @@ public class BikeRentalServiceDirectoryFetcher {
           return updaters;
         }
 
-        String adjustedUpdaterUrl = adjustUrlForUpdater(updaterUrl.asText());
-
         BikeRentalParameters bikeRentalParameters = new BikeRentalParameters(
             "bike-rental-service-directory:" + network,
-            adjustedUpdaterUrl,
             DEFAULT_FREQUENCY_SEC,
             new GbfsDataSourceParameters(updaterUrl.asText(), network.asText())
         );
@@ -81,17 +76,5 @@ public class BikeRentalServiceDirectoryFetcher {
     LOG.info("{} updaters fetched", updaters.size());
 
     return updaters;
-  }
-
-  /**
-   * The GBFS standard defines "gbfs.json" as the entrypoint, while
-   * {@link BikeRentalDataSource} expects the base url and
-   * does not look at "gbfs.json". This method adjusts the URL to what the BikeRentalDataSource
-   * expects.
-   */
-  private static String adjustUrlForUpdater(String url) {
-    return url.endsWith(GBFS_JSON_FILENAME)
-        ? url.substring(0, url.length() - GBFS_JSON_FILENAME.length())
-        : url;
   }
 }

--- a/src/main/java/org/opentripplanner/standalone/config/updaters/BikeRentalUpdaterConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/updaters/BikeRentalUpdaterConfig.java
@@ -10,7 +10,6 @@ public class BikeRentalUpdaterConfig {
     String sourceType = c.asText("sourceType");
     return new BikeRentalUpdaterParameters(
         configRef + "." + sourceType,
-        c.asText("url", null),
         c.asText("networks", null),
         c.asInt("frequencySec", 60),
         BikeRentalSourceFactory.create(sourceType, c)

--- a/src/main/java/org/opentripplanner/updater/bike_rental/BikeRentalUpdaterParameters.java
+++ b/src/main/java/org/opentripplanner/updater/bike_rental/BikeRentalUpdaterParameters.java
@@ -5,20 +5,17 @@ import org.opentripplanner.updater.bike_rental.datasources.params.BikeRentalData
 
 public class BikeRentalUpdaterParameters implements PollingGraphUpdaterParameters {
   private final String configRef;
-  private final String url;
   private final String networks;
   private final int frequencySec;
   private final BikeRentalDataSourceParameters source;
 
   public BikeRentalUpdaterParameters(
       String configRef,
-      String url,
       String networks,
       int frequencySec,
       BikeRentalDataSourceParameters source
   ) {
     this.configRef = configRef;
-    this.url = url;
     this.networks = networks;
     this.frequencySec = frequencySec;
     this.source = source;
@@ -26,10 +23,6 @@ public class BikeRentalUpdaterParameters implements PollingGraphUpdaterParameter
 
   // TODO OTP2 - What is the difference between this and the "network" in the source
   String getNetworks() { return networks; }
-
-  public String getUrl() {
-    return url;
-  }
 
   @Override
   public int getFrequencySec() {


### PR DESCRIPTION
### Summary

For GBFS v2.2 auto-discovery a path suffix of `gbfs` is hardcoded in `GbfsBikeRentalDataSource`, which doesn't allow using a custom file name.

This modifies to auto-discovery logic to use the supplied `url` as the path to the auto-discovery file.

### Issue

closes #3441

### Unit tests

No changes.

### Code style

:ballot_box_with_check: 

### Documentation

The documentation is updated to document both the usage of auto-discovery, and that the full path to `gbfs.json` should be passed as a parameter, which allows the file to have a differing name.

### Changelog

No changes.