### PR TITLE
Don't create free-floating bikes for GBFS bikes at stations

### DIFF
--- a/src/main/java/org/opentripplanner/updater/bike_rental/datasources/GbfsBikeRentalDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/bike_rental/datasources/GbfsBikeRentalDataSource.java
@@ -213,17 +213,24 @@ class GbfsBikeRentalDataSource implements BikeRentalDataSource {
 
         @Override
         public BikeRentalStation makeStation(JsonNode stationNode) {
-            BikeRentalStation brstation = new BikeRentalStation();
-            brstation.id = stationNode.path("bike_id").asText();
-            brstation.name = new NonLocalizedString(stationNode.path("name").asText());
-            brstation.x = stationNode.path("lon").asDouble();
-            brstation.y = stationNode.path("lat").asDouble();
-            brstation.bikesAvailable = 1;
-            brstation.spacesAvailable = 0;
-            brstation.allowDropoff = false;
-            brstation.isFloatingBike = true;
-            brstation.isCarStation = routeAsCar;
-            return brstation;
+            if (stationNode.path("station_id").asText().isBlank() &&
+                    stationNode.has("lon") &&
+                    stationNode.has("lat")
+            ) {
+                BikeRentalStation brstation = new BikeRentalStation();
+                brstation.id = stationNode.path("bike_id").asText();
+                brstation.name = new NonLocalizedString(stationNode.path("name").asText());
+                brstation.x = stationNode.path("lon").asDouble();
+                brstation.y = stationNode.path("lat").asDouble();
+                brstation.bikesAvailable = 1;
+                brstation.spacesAvailable = 0;
+                brstation.allowDropoff = false;
+                brstation.isFloatingBike = true;
+                brstation.isCarStation = routeAsCar;
+                return brstation;
+            } else {
+                return null;
+            }
         }
     }
 


### PR DESCRIPTION
### Summary

Currently free-floating bike rental stations are created for all bicycles within [GBFS free_bike_status.json](https://github.com/NABSA/gbfs/blob/v2.2/gbfs.md#free_bike_statusjson).

This limits the creation of bikes to cases where `lon` and `lat` are defined and `stationId` is blank.

### Issue

closes #3442

### Unit tests

N/A

### Code style

:ballot_box_with_check: 

### Documentation

No changes.

### Changelog

No changes.