### PR TITLE
Update StreetGraphFinder to find nearby bike rental stations

### DIFF
--- a/src/main/java/org/opentripplanner/routing/edgetype/BikeParkEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/BikeParkEdge.java
@@ -37,6 +37,10 @@ public class BikeParkEdge extends Edge {
     @Override
     public State traverse(State s0) {
         RoutingRequest options = s0.getOptions();
+        if (!options.bikeParkAndRide) {
+            return null;
+        }
+
         if (options.arriveBy) {
             return traverseUnpark(s0);
         } else {

--- a/src/main/java/org/opentripplanner/routing/edgetype/ParkAndRideLinkEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/ParkAndRideLinkEdge.java
@@ -83,10 +83,6 @@ public class ParkAndRideLinkEdge extends Edge {
 
     @Override
     public State traverse(State s0) {
-        // Do not enter park and ride mechanism if it's not activated in the routing request.
-        if ( ! s0.getOptions().parkAndRide) {
-            return null;
-        }
         Edge backEdge = s0.getBackEdge();
         boolean back = s0.getOptions().arriveBy;
         // If we are exiting (or entering-backward), check if we

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetBikeParkLink.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetBikeParkLink.java
@@ -61,10 +61,6 @@ public class StreetBikeParkLink extends Edge {
     }
 
     public State traverse(State s0) {
-        // Do not even consider bike park vertices unless bike P+R is enabled.
-        if (!s0.getOptions().bikeParkAndRide) {
-            return null;
-        }
         // Disallow traversing two StreetBikeParkLinks in a row.
         // Prevents router using bike rental stations as shortcuts to get around
         // turn restrictions.

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetBikeRentalLink.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetBikeRentalLink.java
@@ -52,10 +52,6 @@ public class StreetBikeRentalLink extends Edge {
     }
 
     public State traverse(State s0) {
-        // Do not even consider bike rental vertices unless bike rental is enabled.
-        if ( ! s0.getOptions().bikeRental) {
-            return null;
-        }
         // Disallow traversing two StreetBikeRentalLinks in a row.
         // This prevents the router from using bike rental stations as shortcuts to get around
         // turn restrictions.

--- a/src/main/java/org/opentripplanner/routing/graphfinder/DirectGraphFinder.java
+++ b/src/main/java/org/opentripplanner/routing/graphfinder/DirectGraphFinder.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.routing.graphfinder;
 
 import com.beust.jcommander.internal.Lists;
+import java.util.List;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.opentripplanner.common.geometry.GeometryUtils;
@@ -11,8 +12,6 @@ import org.opentripplanner.routing.RoutingService;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.impl.StreetVertexIndex;
 import org.opentripplanner.routing.vertextype.TransitStopVertex;
-
-import java.util.List;
 
 /**
  * A Graph finder used in conjunction with a graph, which does not have a street network included.
@@ -50,6 +49,9 @@ public class DirectGraphFinder implements GraphFinder {
         stopsFound.add(sd);
       }
     }
+
+    stopsFound.sort(NearbyStop::compareTo);
+
     return stopsFound;
   }
 

--- a/src/main/java/org/opentripplanner/routing/graphfinder/DirectGraphFinder.java
+++ b/src/main/java/org/opentripplanner/routing/graphfinder/DirectGraphFinder.java
@@ -37,7 +37,7 @@ public class DirectGraphFinder implements GraphFinder {
     List<NearbyStop> stopsFound = Lists.newArrayList();
     Coordinate coordinate = new Coordinate(lon, lat);
     for (TransitStopVertex it : streetIndex.getNearbyTransitStops(coordinate, radiusMeters)) {
-      double distance = SphericalDistanceLibrary.distance(coordinate, it.getCoordinate());
+      double distance = Math.round(SphericalDistanceLibrary.distance(coordinate, it.getCoordinate()));
       if (distance < radiusMeters) {
         Coordinate coordinates[] = new Coordinate[] {coordinate, it.getCoordinate()};
         NearbyStop sd = new NearbyStop(

--- a/src/main/java/org/opentripplanner/routing/graphfinder/NearbyStop.java
+++ b/src/main/java/org/opentripplanner/routing/graphfinder/NearbyStop.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.routing.graphfinder;
 
+import lombok.EqualsAndHashCode;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.LineString;
@@ -20,9 +21,10 @@ import java.util.Objects;
  * A specific stop at a distance. Also includes a geometry and potentially a list of edges and a
  * state of how to reach the stop from the search origin
  */
+@EqualsAndHashCode
 public class NearbyStop implements Comparable<NearbyStop> {
 
-  private static GeometryFactory geometryFactory = GeometryUtils.getGeometryFactory();
+  private static final GeometryFactory geometryFactory = GeometryUtils.getGeometryFactory();
 
   public final StopLocation stop;
   public final double distance;
@@ -56,7 +58,14 @@ public class NearbyStop implements Comparable<NearbyStop> {
   }
 
   public String toString() {
-    return String.format("stop %s at %.1f meters", stop, distance);
+    return String.format(
+            "stop %s at %.1f meters%s%s%s",
+            stop, distance,
+            distanceIndependentTime > 0 ? " +" + distanceIndependentTime + " seconds" : "",
+            edges != null ? " (" + edges.size() + " edges)" : "",
+            geometry != null ? " w/geometry" : "",
+            state != null ? " w/state" : ""
+    );
   }
 
   /**

--- a/src/main/java/org/opentripplanner/routing/graphfinder/NearbyStop.java
+++ b/src/main/java/org/opentripplanner/routing/graphfinder/NearbyStop.java
@@ -1,6 +1,8 @@
 package org.opentripplanner.routing.graphfinder;
 
-import lombok.EqualsAndHashCode;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.LineString;
@@ -13,15 +15,10 @@ import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.spt.GraphPath;
 import org.opentripplanner.routing.vertextype.TransitStopVertex;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-
 /**
  * A specific stop at a distance. Also includes a geometry and potentially a list of edges and a
  * state of how to reach the stop from the search origin
  */
-@EqualsAndHashCode
 public class NearbyStop implements Comparable<NearbyStop> {
 
   private static final GeometryFactory geometryFactory = GeometryUtils.getGeometryFactory();
@@ -57,9 +54,27 @@ public class NearbyStop implements Comparable<NearbyStop> {
     return (int) (this.distance) - (int) (that.distance);
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) { return true; }
+    if (o == null || getClass() != o.getClass()) { return false; }
+    final NearbyStop that = (NearbyStop) o;
+    return Double.compare(that.distance, distance) == 0
+            && distanceIndependentTime == that.distanceIndependentTime
+            && stop.equals(that.stop)
+            && Objects.equals(edges, that.edges)
+            && Objects.equals(geometry, that.geometry)
+            && Objects.equals(state, that.state);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(stop, distance, distanceIndependentTime, edges, geometry, state);
+  }
+
   public String toString() {
     return String.format(
-            "stop %s at %.1f meters%s%s%s",
+            "stop %s at %.1f meters%s%s%s%s",
             stop, distance,
             distanceIndependentTime > 0 ? " +" + distanceIndependentTime + " seconds" : "",
             edges != null ? " (" + edges.size() + " edges)" : "",

--- a/src/main/java/org/opentripplanner/routing/graphfinder/PatternAtStop.java
+++ b/src/main/java/org/opentripplanner/routing/graphfinder/PatternAtStop.java
@@ -1,24 +1,21 @@
 package org.opentripplanner.routing.graphfinder;
 
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.Objects;
 import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.model.Stop;
 import org.opentripplanner.model.TripPattern;
 import org.opentripplanner.model.TripTimeShort;
+import org.opentripplanner.model.base.ToStringBuilder;
 import org.opentripplanner.routing.RoutingService;
-
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
-import java.util.List;
 
 /**
  * A reference to a pattern at a specific stop.
  *
  * TODO Is this the right package for this?
  */
-@ToString
-@EqualsAndHashCode
 public class PatternAtStop {
 
   public String id;
@@ -80,5 +77,29 @@ public class PatternAtStop {
         numberOfDepartures,
         omitNonPickups
     );
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) { return true; }
+    if (o == null || getClass() != o.getClass()) { return false; }
+    final PatternAtStop that = (PatternAtStop) o;
+    return Objects.equals(id, that.id)
+            && Objects.equals(stop, that.stop)
+            && Objects.equals(pattern, that.pattern);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, stop, pattern);
+  }
+
+  @Override
+  public String toString() {
+    return ToStringBuilder.of(getClass())
+            .addStr("id", id)
+            .addObj("stop", stop)
+            .addObj("pattern", pattern)
+            .toString();
   }
 }

--- a/src/main/java/org/opentripplanner/routing/graphfinder/PatternAtStop.java
+++ b/src/main/java/org/opentripplanner/routing/graphfinder/PatternAtStop.java
@@ -1,5 +1,7 @@
 package org.opentripplanner.routing.graphfinder;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.model.Stop;
 import org.opentripplanner.model.TripPattern;
@@ -15,6 +17,8 @@ import java.util.List;
  *
  * TODO Is this the right package for this?
  */
+@ToString
+@EqualsAndHashCode
 public class PatternAtStop {
 
   public String id;

--- a/src/main/java/org/opentripplanner/routing/graphfinder/PlaceAtDistance.java
+++ b/src/main/java/org/opentripplanner/routing/graphfinder/PlaceAtDistance.java
@@ -1,15 +1,13 @@
 package org.opentripplanner.routing.graphfinder;
 
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
+import java.util.Objects;
+import org.opentripplanner.model.base.ToStringBuilder;
 
 /**
  * A place of any of the types defined in PlaceType at a specified distance.
  *
  * @see PlaceType
  */
-@ToString
-@EqualsAndHashCode
 public class PlaceAtDistance {
 
   public final Object place;
@@ -18,5 +16,27 @@ public class PlaceAtDistance {
   public PlaceAtDistance(Object place, double distance) {
     this.place = place;
     this.distance = distance;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) { return true; }
+    if (o == null || getClass() != o.getClass()) { return false; }
+    final PlaceAtDistance that = (PlaceAtDistance) o;
+    return Double.compare(that.distance, distance) == 0
+            && Objects.equals(place, that.place);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(place, distance);
+  }
+
+  @Override
+  public String toString() {
+    return ToStringBuilder.of(getClass())
+            .addObj("place", place)
+            .addNum("distance", distance)
+            .toString();
   }
 }

--- a/src/main/java/org/opentripplanner/routing/graphfinder/PlaceAtDistance.java
+++ b/src/main/java/org/opentripplanner/routing/graphfinder/PlaceAtDistance.java
@@ -1,10 +1,15 @@
 package org.opentripplanner.routing.graphfinder;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
 /**
  * A place of any of the types defined in PlaceType at a specified distance.
  *
  * @see PlaceType
  */
+@ToString
+@EqualsAndHashCode
 public class PlaceAtDistance {
 
   public final Object place;

--- a/src/test/java/org/opentripplanner/routing/algorithm/GraphRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/GraphRoutingTest.java
@@ -324,7 +324,7 @@ public abstract class GraphRoutingTest {
         // -- Car P+R
         public ParkAndRideVertex carPark(String id, double latitude, double longitude) {
             var vertex =
-                    new ParkAndRideVertex(graph, id, id, latitude, longitude, null);
+                    new ParkAndRideVertex(graph, id, id, longitude, latitude, null);
             new ParkAndRideEdge(vertex);
             return vertex;
         }

--- a/src/test/java/org/opentripplanner/routing/algorithm/GraphRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/GraphRoutingTest.java
@@ -9,6 +9,7 @@ import org.opentripplanner.common.geometry.GeometryUtils;
 import org.opentripplanner.model.Entrance;
 import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.model.Stop;
+import org.opentripplanner.model.TripPattern;
 import org.opentripplanner.model.WgsCoordinate;
 import org.opentripplanner.model.WheelChairBoarding;
 import org.opentripplanner.routing.bike_park.BikePark;
@@ -60,7 +61,6 @@ public abstract class GraphRoutingTest {
             build();
             return graph;
         }
-
 
         public <T> T v(String label) {
             return vertex(label);
@@ -339,6 +339,11 @@ public abstract class GraphRoutingTest {
 
         public List<ParkAndRideLinkEdge> biLink(StreetVertex from, ParkAndRideVertex to) {
             return List.of(link(from, to), link(to, from));
+        }
+
+        // Transit
+        public void tripPattern(TripPattern tripPattern) {
+            graph.tripPatternForId.put(tripPattern.getId(), tripPattern);
         }
     }
 }

--- a/src/test/java/org/opentripplanner/routing/graphfinder/DirectGraphFinderTest.java
+++ b/src/test/java/org/opentripplanner/routing/graphfinder/DirectGraphFinderTest.java
@@ -47,7 +47,7 @@ class DirectGraphFinderTest extends GraphRoutingTest {
         );
 
         assertEquals(
-                List.of(ns2, ns1),
+                List.of(ns1, ns2),
                 testee.findClosestStops(47.500, 19.000, 2000)
         );
     }

--- a/src/test/java/org/opentripplanner/routing/graphfinder/DirectGraphFinderTest.java
+++ b/src/test/java/org/opentripplanner/routing/graphfinder/DirectGraphFinderTest.java
@@ -1,0 +1,66 @@
+package org.opentripplanner.routing.graphfinder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LineString;
+import org.opentripplanner.common.geometry.GeometryUtils;
+import org.opentripplanner.routing.algorithm.GraphRoutingTest;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.routing.vertextype.TransitStopVertex;
+
+class DirectGraphFinderTest extends GraphRoutingTest {
+
+    private static GeometryFactory geometryFactory = GeometryUtils.getGeometryFactory();
+
+    private Graph graph;
+
+    private TransitStopVertex S1, S2, S3;
+
+    @BeforeEach
+    protected void setUp() throws Exception {
+        graph = graphOf(new Builder() {
+            @Override
+            public void build() {
+                S1 = stop("S1", 47.500, 19);
+                S2 = stop("S2", 47.510, 19);
+                S3 = stop("S3", 47.520, 19);
+            }
+        });
+    }
+
+    @Test
+    void findClosestStops() {
+        var ns1 = new NearbyStop(S1, 0, null, linestring(47.500, 19.000, 47.500, 19.000), null);
+        var ns2 = new NearbyStop(S2, 1112, null, linestring(47.500, 19.000, 47.510, 19.000), null);
+
+        var testee = new DirectGraphFinder(graph);
+        assertEquals(
+                List.of(ns1),
+                testee.findClosestStops(47.500, 19.000, 100)
+        );
+
+        assertEquals(
+                List.of(ns2, ns1),
+                testee.findClosestStops(47.500, 19.000, 2000)
+        );
+    }
+
+    static LineString linestring(double ... latlon) {
+        if (latlon.length % 2 != 0) {
+            throw new IllegalArgumentException("Uneven number of parameters: " + Arrays.toString(latlon));
+        }
+
+        return geometryFactory.createLineString(
+                IntStream.range(0, latlon.length / 2)
+                .mapToObj(i -> new Coordinate(latlon[i * 2 + 1], latlon[i * 2]))
+                .toArray(Coordinate[]::new)
+        );
+    }
+}

--- a/src/test/java/org/opentripplanner/routing/graphfinder/StreetGraphFinderTest.java
+++ b/src/test/java/org/opentripplanner/routing/graphfinder/StreetGraphFinderTest.java
@@ -1,0 +1,308 @@
+package org.opentripplanner.routing.graphfinder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.routing.graphfinder.DirectGraphFinderTest.linestring;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.model.Agency;
+import org.opentripplanner.model.FeedScopedId;
+import org.opentripplanner.model.Route;
+import org.opentripplanner.model.StopPattern;
+import org.opentripplanner.model.StopTime;
+import org.opentripplanner.model.TransitMode;
+import org.opentripplanner.model.TripPattern;
+import org.opentripplanner.routing.RoutingService;
+import org.opentripplanner.routing.algorithm.GraphRoutingTest;
+import org.opentripplanner.routing.edgetype.StreetTraversalPermission;
+import org.opentripplanner.routing.graph.GraphIndex;
+import org.opentripplanner.routing.vertextype.BikeParkVertex;
+import org.opentripplanner.routing.vertextype.BikeRentalStationVertex;
+import org.opentripplanner.routing.vertextype.IntersectionVertex;
+import org.opentripplanner.routing.vertextype.ParkAndRideVertex;
+import org.opentripplanner.routing.vertextype.TransitStopVertex;
+
+class StreetGraphFinderTest extends GraphRoutingTest {
+
+    private TransitStopVertex S1, S2, S3;
+    private IntersectionVertex A, B, C, D;
+    private BikeRentalStationVertex BR1, BR2;
+    private BikeParkVertex BP1;
+    private ParkAndRideVertex PR1, PR2;
+    private RoutingService routingService;
+    private StreetGraphFinder graphFinder;
+    private Route R1, R2;
+    private TripPattern TP1, TP2;
+
+    @BeforeEach
+    protected void setUp() throws Exception {
+        var a = new Agency(new FeedScopedId("F", "Agency"), "Agency", null);
+
+        R1 = new Route(new FeedScopedId("F", "R1"));
+        R1.setAgency(a);
+        R1.setMode(TransitMode.BUS);
+
+        R2 = new Route(new FeedScopedId("F", "R2"));
+        R2.setAgency(a);
+        R2.setMode(TransitMode.TRAM);
+
+        var graph = graphOf(new Builder() {
+            @Override
+            public void build() {
+                S1 = stop("S1", 47.500, 19.001);
+                S2 = stop("S2", 47.510, 19.001);
+                S3 = stop("S3", 47.520, 19.001);
+
+                BR1 = bikeRentalStation("BR1", 47.500, 18.999);
+                BR2 = bikeRentalStation("BR2", 47.520, 18.999);
+
+                BP1 = bikePark("BP1", 47.520, 18.999);
+
+                PR1 = carPark("PR1", 47.510, 18.999);
+                PR2 = carPark("PR2", 47.530, 18.999);
+
+                A = intersection("A", 47.500, 19.00);
+                B = intersection("B", 47.510, 19.00);
+                C = intersection("C", 47.520, 19.00);
+                D = intersection("D", 47.530, 19.00);
+
+                biLink(A, S1);
+                biLink(A, BR1);
+                biLink(B, S2);
+                biLink(B, PR1);
+                biLink(C, S3);
+                biLink(C, BP1);
+                biLink(C, BR2);
+                biLink(D, PR2);
+
+                street(A, B, 100, StreetTraversalPermission.ALL);
+                street(B, C, 100, StreetTraversalPermission.ALL);
+                street(C, D, 100, StreetTraversalPermission.ALL);
+
+                tripPattern(TP1 = new TripPattern(new FeedScopedId("F", "TP1"), R1,
+                        new StopPattern(List.of(st(S1), st(S2)))
+                ));
+                tripPattern(TP2 = new TripPattern(new FeedScopedId("F", "TP2"), R2,
+                        new StopPattern(List.of(st(S1), st(S3)))
+                ));
+            }
+        });
+
+        graph.index = new GraphIndex(graph);
+
+        routingService = new RoutingService(graph);
+        graphFinder = new StreetGraphFinder(graph);
+    }
+
+    @Test
+    void findClosestStops() {
+        var ns1 = new NearbyStop(S1, 0, null, linestring(47.500, 19.000, 47.500, 19.001), null);
+        var ns2 = new NearbyStop(S2, 100, null, linestring(47.500, 19.000, 47.510, 19.000, 47.510, 19.001), null);
+
+        assertEquals(
+                List.of(ns1),
+                simplify(graphFinder.findClosestStops(47.500, 19.000, 10))
+        );
+
+        assertEquals(
+                List.of(ns1, ns2),
+                simplify(graphFinder.findClosestStops(47.500, 19.000, 100))
+        );
+    }
+
+    @Test
+    void findClosestPlacesLimiting() {
+        var ns1 = new PlaceAtDistance(S1.getStop(), 0);
+        var ns2 = new PlaceAtDistance(S2.getStop(), 100);
+        var ns3 = new PlaceAtDistance(S3.getStop(), 200);
+        var br1 = new PlaceAtDistance(BR1.getStation(), 0);
+        var br2 = new PlaceAtDistance(BR2.getStation(), 200);
+        var ps11 = new PlaceAtDistance(new PatternAtStop(S1.getStop(), TP1), 0);
+        var ps21 = new PlaceAtDistance(new PatternAtStop(S1.getStop(), TP2), 0);
+
+        assertEquals(
+                List.of(ns1, ps21, ps11, br1),
+                graphFinder.findClosestPlaces(
+                        47.500, 19.000, 10.0, 10,
+                        null, null, null, null, null, null, null,
+                        routingService
+                )
+        );
+
+        assertEquals(
+                List.of(ns1, ps21, ps11, br1, ns2, ns3, br2),
+                graphFinder.findClosestPlaces(
+                        47.500, 19.000, 200.0, 100,
+                        null, null, null, null, null, null, null,
+                        routingService
+                )
+        );
+
+        assertEquals(
+                List.of(ns1, ps21, ps11),
+                graphFinder.findClosestPlaces(
+                        47.500, 19.000, 200.0, 3,
+                        null, null, null, null, null, null, null,
+                        routingService
+                )
+        );
+    }
+
+    @Test
+    void findClosestPlacesWithAModeFilter() {
+        var ns1 = new PlaceAtDistance(S1.getStop(), 0);
+        var ns2 = new PlaceAtDistance(S2.getStop(), 100);
+        var ns3 = new PlaceAtDistance(S3.getStop(), 200);
+
+        assertEquals(
+                List.of(ns1, ns2, ns3),
+                graphFinder.findClosestPlaces(
+                        47.500, 19.000, 200.0, 100,
+                        null, List.of(PlaceType.STOP), null, null, null, null, null,
+                        routingService
+                )
+        );
+
+        assertEquals(
+                List.of(ns1, ns2),
+                graphFinder.findClosestPlaces(
+                        47.500, 19.000, 200.0, 100,
+                        List.of(TransitMode.BUS), List.of(PlaceType.STOP), null, null, null, null, null,
+                        routingService
+                )
+        );
+    }
+
+    @Test
+    void findClosestPlacesWithAStopFilter() {
+        var ns1 = new PlaceAtDistance(S1.getStop(), 0);
+        var ns2 = new PlaceAtDistance(S2.getStop(), 100);
+        var ps11 = new PlaceAtDistance(new PatternAtStop(S1.getStop(), TP1), 0);
+        var ps21 = new PlaceAtDistance(new PatternAtStop(S1.getStop(), TP2), 0);
+
+        assertEquals(
+                List.of(ns1, ps21, ps11, ns2),
+                graphFinder.findClosestPlaces(
+                        47.500, 19.000, 100.0, 100,
+                        null, List.of(PlaceType.STOP, PlaceType.PATTERN_AT_STOP), null, null, null, null, null,
+                        routingService
+                )
+        );
+
+        assertEquals(
+                List.of(ps21, ps11, ns2),
+                graphFinder.findClosestPlaces(
+                        47.500, 19.000, 100.0, 100,
+                        null, List.of(PlaceType.STOP, PlaceType.PATTERN_AT_STOP), List.of(S2.getStop().getId()), null, null, null, null,
+                        routingService
+                )
+        );
+    }
+
+    @Test
+    void findClosestPlacesWithAStopAndRouteFilter() {
+        var ns1 = new PlaceAtDistance(S1.getStop(), 0);
+        var ns2 = new PlaceAtDistance(S2.getStop(), 100);
+        var ps11 = new PlaceAtDistance(new PatternAtStop(S1.getStop(), TP1), 0);
+        var ps21 = new PlaceAtDistance(new PatternAtStop(S1.getStop(), TP2), 0);
+
+        assertEquals(
+                List.of(ns1, ps21, ps11, ns2),
+                graphFinder.findClosestPlaces(
+                        47.500, 19.000, 100.0, 100,
+                        null, List.of(PlaceType.STOP, PlaceType.PATTERN_AT_STOP), null, null, null, null, null,
+                        routingService
+                )
+        );
+
+        assertEquals(
+                List.of(ps11, ns2),
+                graphFinder.findClosestPlaces(
+                        47.500, 19.000, 100.0, 100,
+                        null, List.of(PlaceType.STOP, PlaceType.PATTERN_AT_STOP), List.of(S2.getStop().getId()), List.of(R1.getId()), null, null, null,
+                        routingService
+                )
+        );
+    }
+
+    @Test
+    void findClosestPlacesWithARouteFilter() {
+        var ns1 = new PlaceAtDistance(S1.getStop(), 0);
+        var ns2 = new PlaceAtDistance(S2.getStop(), 100);
+        var ns3 = new PlaceAtDistance(S3.getStop(), 200);
+        var ps11 = new PlaceAtDistance(new PatternAtStop(S1.getStop(), TP1), 0);
+        var ps21 = new PlaceAtDistance(new PatternAtStop(S1.getStop(), TP2), 0);
+
+        assertEquals(
+                List.of(ns1, ps21, ps11, ns2, ns3),
+                graphFinder.findClosestPlaces(
+                        47.500, 19.000, 200.0, 100,
+                        null, List.of(PlaceType.STOP, PlaceType.PATTERN_AT_STOP), null, null, null, null, null,
+                        routingService
+                )
+        );
+
+        assertEquals(
+                List.of(ns1, ps21, ns2, ns3),
+                graphFinder.findClosestPlaces(
+                        47.500, 19.000, 200.0, 100,
+                        null, List.of(PlaceType.STOP, PlaceType.PATTERN_AT_STOP), null, List.of(R2.getId()), null, null, null,
+                        routingService
+                )
+        );
+    }
+
+    @Test
+    void findClosestPlacesWithABikeRentalFilter() {
+        var br1 = new PlaceAtDistance(BR1.getStation(), 0);
+        var br2 = new PlaceAtDistance(BR2.getStation(), 200);
+
+        assertEquals(
+                List.of(br1, br2),
+                graphFinder.findClosestPlaces(
+                        47.500, 19.000, 300.0, 100,
+                        null, List.of(PlaceType.BICYCLE_RENT), null, null, null, null, null,
+                        routingService
+                )
+        );
+
+        assertEquals(
+                List.of(br2),
+                graphFinder.findClosestPlaces(
+                        47.500, 19.000, 300.0, 100,
+                        null, List.of(PlaceType.BICYCLE_RENT), null, null, List.of("BR2"), null, null,
+                        routingService
+                )
+        );
+    }
+
+    @Test
+    @Disabled
+    void findClosestPlacesWithABikeParkFilter() {
+        // This is not implemented in StreetGraphFinder
+    }
+
+    @Test
+    @Disabled
+    void findClosestPlacesWithACarParkFilter() {
+        // This is not implemented in StreetGraphFinder
+    }
+
+    private List<NearbyStop> simplify(List<NearbyStop> closestStops) {
+        return closestStops.stream().map(
+                ns -> new NearbyStop(
+                        ns.stop, ns.distance, ns.distanceIndependentTime, null, ns.geometry, null
+                )
+        )
+                .collect(Collectors.toList());
+    }
+
+    private StopTime st(TransitStopVertex s1) {
+        var st = new StopTime();
+        st.setStop(s1.getStop());
+        return st;
+    }
+}


### PR DESCRIPTION
### Summary

Currently the `StreetGraphFinder` doesn't find nearby bike rental stations.

The feature checks from `*Link` edges are removed, so that the appropriate vertices may be reached, while also making sure that the rental/parking edges have a check for the required features.

### Issue

closes #3469

### Unit tests

A test is added for both `DirectGraphFinder` and `StreetGraphFinder`.

### Code style

:ballot_box_with_check: 

### Documentation

No changes.

### Changelog

None.
