### PR TITLE
Sandbox: Increase expansion factor of bike rental vector layer

### DIFF
--- a/docs/sandbox/MapboxVectorTilesApi.md
+++ b/docs/sandbox/MapboxVectorTilesApi.md
@@ -7,7 +7,8 @@
 
 
 ## Changelog
-- Initial version of Mapbox vector tiles api API
+- 2020-07-09: Initial version of Mapbox vector tiles API
+- 2021-05-12: Make expansion factor configurable
 
 ## Documentation
 
@@ -45,7 +46,8 @@ The feature must be configured in `router-config.json` as follows
       "mapper": "Digitransit",
       "maxZoom": 20,
       "minZoom": 14,
-      "cacheMaxSeconds": 60
+      "cacheMaxSeconds": 60,
+      "expansionFactor": 0.25
     }
   ]
 }
@@ -57,7 +59,9 @@ For each layer, the configuration includes,
  - `mapper` which describes the mapper converting the properties from the OTP model entities to the vector tile properties. Currently `Digitransit` is supported for all layer types.
  - `minZoom` and `maxZoom` which describe the zoom levels the layer is active for.
  - `cacheMaxSeconds` which sets the cache header in the response. The lowest value of the layers included is selected.
- 
+ - `expansionFactor` How far outside its boundaries should the tile contain information. The value is a fraction of the tile size. 
+    If you are having problem with icons and shapes being clipped at tile edges, then increase this number.
+
 ### Extending
 
 If more generic layers are created for this API, it should be moved out from the sandbox, into the core code, with potentially leaving specific property mappers in place.

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/LayerBuilder.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/LayerBuilder.java
@@ -12,6 +12,7 @@ import org.locationtech.jts.geom.GeometryFactory;
 import org.opentripplanner.common.geometry.GeometryUtils;
 
 import java.util.List;
+import org.opentripplanner.ext.vectortiles.VectorTilesResource.LayerParameters;
 
 public abstract class LayerBuilder<T> {
   static private final GeometryFactory GEOMETRY_FACTORY = GeometryUtils.getGeometryFactory();
@@ -24,11 +25,11 @@ public abstract class LayerBuilder<T> {
     this.layerBuilder = MvtLayerBuild.newLayerBuilder(layerName, MvtLayerParams.DEFAULT);
   }
 
-  VectorTile.Tile.Layer build(Envelope envelope) {
+  VectorTile.Tile.Layer build(Envelope envelope, LayerParameters params) {
     Envelope query = new Envelope(envelope);
     query.expandBy(
-        envelope.getWidth() * getExpansionFactor(),
-        envelope.getHeight() * getExpansionFactor());
+        envelope.getWidth() * params.expansionFactor(),
+        envelope.getHeight() * params.expansionFactor());
 
     TileGeomResult tileGeom = JtsAdapter.createTileGeom(
         getGeometries(query),
@@ -51,10 +52,4 @@ public abstract class LayerBuilder<T> {
    * an object of type T as their userData.
    */
   abstract protected List<Geometry> getGeometries(Envelope query);
-
-  /**
-   * How far outside its boundaries should the tile contain information. The value is a fraction of
-   * the tile size.
-   */
-  abstract protected double getExpansionFactor();
 }

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/VectorTilesResource.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/VectorTilesResource.java
@@ -88,7 +88,7 @@ public class VectorTilesResource {
         mvtBuilder.addLayers(VectorTilesResource.layers
             .get(LayerType.valueOf(layerParameters.type()))
             .apply(router.graph, layerParameters)
-            .build(envelope));
+            .build(envelope, layerParameters));
       }
     }
 
@@ -188,5 +188,6 @@ public class VectorTilesResource {
     int maxZoom();
     int minZoom();
     int cacheMaxSeconds();
+    double expansionFactor();
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/layers/bikerental/BikeRentalLayerBuilder.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/layers/bikerental/BikeRentalLayerBuilder.java
@@ -52,6 +52,6 @@ public class BikeRentalLayerBuilder extends LayerBuilder<BikeRentalStation> {
 
   @Override
   protected double getExpansionFactor() {
-    return 0.1;
+    return 0.25;
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/layers/bikerental/BikeRentalLayerBuilder.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/layers/bikerental/BikeRentalLayerBuilder.java
@@ -49,9 +49,4 @@ public class BikeRentalLayerBuilder extends LayerBuilder<BikeRentalStation> {
         })
         .collect(Collectors.toList());
   }
-
-  @Override
-  protected double getExpansionFactor() {
-    return 0.25;
-  }
 }

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stations/StationsLayerBuilder.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stations/StationsLayerBuilder.java
@@ -41,9 +41,4 @@ public class StationsLayerBuilder extends LayerBuilder<Station> {
       return point;
     }).collect(Collectors.toList());
   }
-
-  @Override
-  protected double getExpansionFactor() {
-    return 0.25;
-  }
 }

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/StopsLayerBuilder.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/StopsLayerBuilder.java
@@ -44,10 +44,4 @@ public class StopsLayerBuilder extends LayerBuilder<TransitStopVertex> {
       return point;
     }).collect(Collectors.toList());
   }
-
-  @Override
-  protected double getExpansionFactor() {
-    return 0.1;
-  }
-
 }

--- a/src/main/java/org/opentripplanner/standalone/config/VectorTileConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/VectorTileConfig.java
@@ -9,6 +9,7 @@ public class VectorTileConfig implements VectorTilesResource.LayersParameters {
   public static final int MIN_ZOOM = 9;
   public static final int MAX_ZOOM = 20;
   public static final int CACHE_MAX_SECONDS = -1;
+  public static final double EXPANSION_FACTOR = 0.25d;
 
   List<VectorTilesResource.LayerParameters> layers;
 
@@ -29,6 +30,7 @@ public class VectorTileConfig implements VectorTilesResource.LayersParameters {
     private final Integer maxZoom;
     private final Integer minZoom;
     private final Integer cacheMaxSeconds;
+    private final double expansionFactor;
 
     public Layer(NodeAdapter node) {
       name = node.asText("name");
@@ -37,6 +39,7 @@ public class VectorTileConfig implements VectorTilesResource.LayersParameters {
       maxZoom = node.asInt("maxZoom", MAX_ZOOM);
       minZoom = node.asInt("minZoom", MIN_ZOOM);
       cacheMaxSeconds = node.asInt("cacheMaxSeconds", CACHE_MAX_SECONDS);
+      expansionFactor = node.asDouble("expansionFactor", EXPANSION_FACTOR);
     }
 
     @Override public String name() { return name; }
@@ -45,5 +48,6 @@ public class VectorTileConfig implements VectorTilesResource.LayersParameters {
     @Override public int maxZoom() { return maxZoom; }
     @Override public int minZoom() { return minZoom; }
     @Override public int cacheMaxSeconds() {return cacheMaxSeconds; }
+    @Override public double expansionFactor() { return expansionFactor; }
   }
 }


### PR DESCRIPTION
When trying out @hannesj great vector tiles feature in OTP2 we noticed the some of our bike rental icons are clipped when they are on a tile layer.

![Screenshot from 2021-05-12 14-35-57](https://user-images.githubusercontent.com/151346/117979886-ace00a80-b333-11eb-8f65-8c8632e961a5.png)

I was wondering why this didn't happen for the stops and the stations layer and the reason was that they had an expansion factor of 0.25 and the bike rental layer one of 0.1.

This PR fixes that.