### PR TITLE
Sort and deterministically display edges without geometry in the traversal permissions debug layer

### DIFF
--- a/src/main/java/org/opentripplanner/routing/impl/StreetVertexIndex.java
+++ b/src/main/java/org/opentripplanner/routing/impl/StreetVertexIndex.java
@@ -169,7 +169,7 @@ public class StreetVertexIndex {
     List<Edge> edges = edgeTree.query(envelope);
     for (Iterator<Edge> ie = edges.iterator(); ie.hasNext(); ) {
       Edge e = ie.next();
-      Envelope eenv = e.getGeometry().getEnvelopeInternal();
+      Envelope eenv = edgeGeometryOrStraightLine(e).getEnvelopeInternal();
       //Envelope eenv = e.getEnvelope();
         if (!envelope.intersects(eenv)) { ie.remove(); }
     }
@@ -296,10 +296,7 @@ public class StreetVertexIndex {
        * rasterizing splitting long segments.
        */
       for (Edge e : gv.getOutgoing()) {
-        LineString geometry = e.getGeometry();
-        if (geometry == null) {
-          continue;
-        }
+        LineString geometry = edgeGeometryOrStraightLine(e);
         Envelope env = geometry.getEnvelopeInternal();
           if (edgeTree instanceof HashGridSpatialIndex) {
               ((HashGridSpatialIndex) edgeTree).insert(geometry, e);
@@ -396,5 +393,14 @@ public class StreetVertexIndex {
     }
     location.setWheelchairAccessible(wheelchairAccessible);
     return location;
+  }
+
+  private static LineString edgeGeometryOrStraightLine(Edge e) {
+    LineString geometry = e.getGeometry();
+    if (geometry == null) {
+      Coordinate[] coordinates = new Coordinate[]{e.getFromVertex().getCoordinate(), e.getToVertex().getCoordinate()};
+      geometry = GeometryUtils.getGeometryFactory().createLineString(coordinates);
+    }
+    return geometry;
   }
 }


### PR DESCRIPTION
### Summary

The rendering of the traversal debug layer is modified so that:
 1. the rendering of vertices is ordered so that `StreetVertex` is painted first, and other vertices are layered on top. With these changes less-common (stops, bike rental, parking, ...) vertices are not covered by intersections.
 2. the rendering of edges is ordered so that edges without geometry, non-street edges and finally streed edges are painted. With this change there is less clutter and layering between the rendered eges.
 3. Edges without geometry are added to `StreetVertexIndex` using a straight line so that the edges may be displayed in all tiles.
 

Before:
![image](https://user-images.githubusercontent.com/58879/118042189-13851880-b374-11eb-85cc-1a08741ab728.png)

After:
![image](https://user-images.githubusercontent.com/58879/118041803-8d68d200-b373-11eb-8f1c-004ceabb45a3.png)

### Issue

None.

### Unit tests

No changes.

### Code style

:ballot_box_with_check: 

### Documentation

None.

### Changelog

None.