### PR TITLE
Fix flex egress itinerary generation to not fail with an NPE

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/RoutingWorker.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/RoutingWorker.java
@@ -165,7 +165,7 @@ public class RoutingWorker {
                                 accessRequest,
                                 false
                         );
-                accessList = accessEgressMapper.mapFlexAccessEgresses(flexAccessList);
+                accessList = accessEgressMapper.mapFlexAccessEgresses(flexAccessList, false);
             }
             // Regular access routing
             else {
@@ -190,7 +190,7 @@ public class RoutingWorker {
                                 egressRequest,
                                 true
                         );
-                egressList = accessEgressMapper.mapFlexAccessEgresses(flexEgressList);
+                egressList = accessEgressMapper.mapFlexAccessEgresses(flexEgressList, true);
             }
             // Regular egress routing
             else {

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/FlexAccessEgressAdapter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/FlexAccessEgressAdapter.java
@@ -9,12 +9,12 @@ public class FlexAccessEgressAdapter extends AccessEgress {
   private final FlexAccessEgress flexAccessEgress;
 
   public FlexAccessEgressAdapter(
-      FlexAccessEgress flexAccessEgress, StopIndexForRaptor stopIndex
+          FlexAccessEgress flexAccessEgress, boolean isEgress, StopIndexForRaptor stopIndex
   ) {
     super(
         stopIndex.indexByStop.get(flexAccessEgress.stop),
         flexAccessEgress.preFlexTime + flexAccessEgress.flexTime + flexAccessEgress.postFlexTime,
-        flexAccessEgress.lastState
+        isEgress ? flexAccessEgress.lastState.reverse() : flexAccessEgress.lastState
     );
 
     this.flexAccessEgress = flexAccessEgress;

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/mappers/AccessEgressMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/mappers/AccessEgressMapper.java
@@ -38,10 +38,11 @@ public class AccessEgressMapper {
   }
 
   public Collection<AccessEgress> mapFlexAccessEgresses(
-      Collection<FlexAccessEgress> flexAccessEgresses
+          Collection<FlexAccessEgress> flexAccessEgresses,
+          boolean isEgress
   ) {
     return flexAccessEgresses.stream()
-        .map(flexAccessEgress -> new FlexAccessEgressAdapter(flexAccessEgress, stopIndex))
+        .map(flexAccessEgress -> new FlexAccessEgressAdapter(flexAccessEgress, isEgress, stopIndex))
         .collect(Collectors.toList());
   }
 


### PR DESCRIPTION
### Summary

Reversing FLEX egress may fail with an NPE when reversing the path to create itineraries.

This fixes that by reversing the states within `FlexAccessEgressAdapter` so that is happens while the temporary edges are still connected to the graph. This is also how normal egress paths are handled.

### Issue

closes #3484

### Unit tests

None.

### Code style

:ballot_box_with_check: 

### Documentation

N/A

### Changelog

N/A