### PR TITLE
fix: Reduce log level for RT update

### DIFF
--- a/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
+++ b/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
@@ -417,7 +417,7 @@ public class TripTimes implements Serializable, Comparable<TripTimes>, Cloneable
     /**
      * When creating a scheduled TripTimes or wrapping it in updates, we could potentially imply
      * negative running or dwell times. We really don't want those being used in routing.
-     * This method check that all times are increasing, and logs errors if this is not the case.
+     * This method check that all times are increasing, and logs warnings if this is not the case.
      * @return whether the times were found to be increasing.
      */
     public boolean timesIncreasing() {
@@ -428,11 +428,11 @@ public class TripTimes implements Serializable, Comparable<TripTimes>, Cloneable
             final int dep = getDepartureTime(s);
 
             if (dep < arr) {
-                LOG.error("Negative dwell time in TripTimes at stop index {}.", s);
+                LOG.warn("Negative dwell time in TripTimes at stop index {}.", s);
                 return false;
             }
             if (prevDep > arr) {
-                LOG.error("Negative running time in TripTimes after stop index {}.", s);
+                LOG.warn("Negative running time in TripTimes after stop index {}.", s);
                 return false;
             }
             prevDep = dep;


### PR DESCRIPTION
This is a small PR witch reduced the log level for Real-Time updates when the input data is of poor quality. The log level is  changed from error to warning. These error "spam" our Entur log, and causes "real" errors to drown - no actions. 

There are no issue, tests or doc for this simple PR.
