### PR TITLE
Use A* costs within RAPTOR

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -815,6 +815,7 @@ config key | description | value type | value default
 `searchThreadPoolSize` | Split a travel search in smaller jobs and run them in parallel to improve performance. Use this parameter to set the total number of executable threads available across all searches. Multiple searches can run in parallel - this parameter have no effect with regard to that. If 0, no extra threads are started and the search is done in one thread. | int | `0`
 `dynamicSearchWindow` | The dynamic search window coefficients used to calculate the EDT(earliest-departure-time), LAT(latest-arrival-time) and SW(raptor-search-window) using heuristics. | object | `null`
 `stopTransferCost` | Use this to set a stop transfer cost for the given [TransferPriority](https://github.com/opentripplanner/OpenTripPlanner/blob/v2.0.0/src/main/java/org/opentripplanner/model/TransferPriority.java). The cost is applied to boarding and alighting at all stops. All stops have a transfer cost priority set, the default is `ALLOWED`. The `stopTransferCost` parameter is optional, but if listed all values must be set. | enum map | `null`
+`transferCacheMaxSize` | The maximum number of distinct transfers parameters (`RoutingRequest`s) to cache pre-calculated transfers for. If too low, requests may be slower. If too high, more memory may be used then required. | int | `25`
 
 ### Tuning transit routing - Dynamic search window
 Nested inside `transit : { dynamicSearchWindow : { ... } }` in `router-config.json`.

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
@@ -120,7 +120,7 @@ public class LegacyGraphQLQueryTypeImpl
           Stop stop = routingService.getStopForId(FeedScopedId.parseId(parts[1]));
 
           // TODO: Add geometry
-          return new NearbyStop(stop, Integer.parseInt(parts[0]), 0, null, null, null);
+          return new NearbyStop(stop, Integer.parseInt(parts[0]), null, null, null);
         }
         case "TicketType":
           return null; //TODO

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLStopImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLStopImpl.java
@@ -235,7 +235,6 @@ public class LegacyGraphQLStopImpl implements LegacyGraphQLDataFetchers.LegacyGr
               .map(transfer -> new NearbyStop(
                   transfer.to,
                   transfer.getDistanceMeters(),
-                  0,
                   transfer.getEdges(),
                   GeometryUtils.concatenateLineStrings(transfer
                         .getEdges()

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLPlanner.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLPlanner.java
@@ -199,6 +199,7 @@ public class TransmodelGraphQLPlanner {
 
             request.modes = new RequestModes(
                 accessMode.get(),
+                accessMode.get() == StreetMode.BIKE ? StreetMode.BIKE : StreetMode.WALK,
                 egressMode.get(),
                 directMode.get(),
                 new HashSet<>(transitModes.get())

--- a/src/main/java/org/opentripplanner/api/parameter/QualifiedModeSet.java
+++ b/src/main/java/org/opentripplanner/api/parameter/QualifiedModeSet.java
@@ -39,6 +39,7 @@ public class QualifiedModeSet implements Serializable {
         StreetMode accessMode = null;
         StreetMode egressMode = null;
         StreetMode directMode = null;
+        StreetMode transferMode = null;
         Set<TransitMode> transitModes = new HashSet<>();
 
         // Set transit modes
@@ -110,20 +111,24 @@ public class QualifiedModeSet implements Serializable {
             switch (requestMode.mode) {
                 case WALK:
                     accessMode = StreetMode.WALK;
+                    transferMode = StreetMode.WALK;
                     egressMode = StreetMode.WALK;
                     directMode = StreetMode.WALK;
                     break;
                 case BICYCLE:
                     if (requestMode.qualifiers.contains(Qualifier.RENT)) {
                         accessMode = StreetMode.BIKE_RENTAL;
+                        transferMode = StreetMode.BIKE_RENTAL;
                         egressMode = StreetMode.BIKE_RENTAL;
                         directMode = StreetMode.BIKE_RENTAL;
                     } else if (requestMode.qualifiers.contains(Qualifier.PARK)) {
                         accessMode = StreetMode.BIKE_TO_PARK;
+                        transferMode = StreetMode.WALK;
                         egressMode = StreetMode.WALK;
                         directMode = StreetMode.BIKE_TO_PARK;
                     } else {
                         accessMode = StreetMode.BIKE;
+                        transferMode = StreetMode.BIKE;
                         egressMode = StreetMode.BIKE;
                         directMode = StreetMode.BIKE;
                     }
@@ -131,22 +136,27 @@ public class QualifiedModeSet implements Serializable {
                 case CAR:
                     if (requestMode.qualifiers.contains(Qualifier.RENT)) {
                         accessMode = StreetMode.CAR_RENTAL;
+                        transferMode = StreetMode.CAR_RENTAL;
                         egressMode = StreetMode.CAR_RENTAL;
                         directMode = StreetMode.CAR_RENTAL;
                     } else if (requestMode.qualifiers.contains(Qualifier.PARK)) {
                         accessMode = StreetMode.CAR_TO_PARK;
+                        transferMode = StreetMode.WALK;
                         egressMode = StreetMode.WALK;
                         directMode = StreetMode.CAR_TO_PARK;
                     } else if (requestMode.qualifiers.contains(Qualifier.PICKUP)) {
                         accessMode = StreetMode.WALK;
+                        transferMode = StreetMode.WALK;
                         egressMode = StreetMode.CAR_PICKUP;
                         directMode = StreetMode.CAR_PICKUP;
                     } else if (requestMode.qualifiers.contains(Qualifier.DROPOFF)) {
                         accessMode = StreetMode.CAR_PICKUP;
+                        transferMode = StreetMode.WALK;
                         egressMode = StreetMode.WALK;
                         directMode = StreetMode.CAR_PICKUP;
                     } else {
                         accessMode = StreetMode.WALK;
+                        transferMode = StreetMode.WALK;
                         egressMode = StreetMode.WALK;
                         directMode = StreetMode.CAR;
                     }
@@ -169,6 +179,7 @@ public class QualifiedModeSet implements Serializable {
 
         return new RequestModes(
             accessMode,
+            transferMode,
             egressMode,
             directMode,
             transitModes

--- a/src/main/java/org/opentripplanner/model/SimpleTransfer.java
+++ b/src/main/java/org/opentripplanner/model/SimpleTransfer.java
@@ -2,6 +2,7 @@ package org.opentripplanner.model;
 
 import java.io.Serializable;
 import java.util.List;
+import org.opentripplanner.model.base.ToStringBuilder;
 import org.opentripplanner.routing.graph.Edge;
 
 /**
@@ -16,19 +17,19 @@ import org.opentripplanner.routing.graph.Edge;
  */
 public class SimpleTransfer implements Serializable {
     private static final long serialVersionUID = 20200316L;
+
     public final StopLocation from;
+
     public final StopLocation to;
 
-    private final double effectiveWalkDistance;
-    private final int distanceIndependentTime;
+    private final double distanceMeters;
 
     private final List<Edge> edges;
 
-    public SimpleTransfer(StopLocation from, StopLocation to, double effectiveWalkDistance, int distanceIndependentTime, List<Edge> edges) {
+    public SimpleTransfer(StopLocation from, StopLocation to, double distanceMeters, List<Edge> edges) {
         this.from = from;
         this.to = to;
-        this.effectiveWalkDistance = effectiveWalkDistance;
-        this.distanceIndependentTime = distanceIndependentTime;
+        this.distanceMeters = distanceMeters;
         this.edges = edges;
     }
 
@@ -37,38 +38,18 @@ public class SimpleTransfer implements Serializable {
     }
 
     public double getDistanceMeters() {
-        return edges.stream().mapToDouble(Edge::getDistanceMeters).sum();
-    }
-
-    /**
-     * The distance to walk adjusted for elevation and obstacles. This is used together
-     * with the walking speed to find the actual walking transfer time. This plus
-     * {@link #getDistanceIndependentTime()} is used to calculate the actual-transfer-time
-     * given a walking speed.
-     * <p>
-     * Unit: meters. Default: 0.
-     * @see Edge#getEffectiveWalkDistance()
-     */
-    public double getEffectiveWalkDistance(){
-    	return this.effectiveWalkDistance;
-    }
-
-    /**
-     * This is the transfer time(duration) spent NOT moving like time in in elevators, escalators
-     * and waiting on read light when crossing a street. This is used together with
-     * {@link #getEffectiveWalkDistance()} to calculate the actual-transfer-time.
-     * <p>
-     * Unit: seconds. Default: 0.
-     * @see Edge#getDistanceIndependentTime()
-     */
-    public int getDistanceIndependentTime() {
-        return distanceIndependentTime;
+        return distanceMeters;
     }
 
     public List<Edge> getEdges() { return this.edges; }
 
     @Override
     public String toString() {
-        return "SimpleTransfer " + getName();
+        return ToStringBuilder.of(getClass())
+                .addObj("from", from)
+                .addObj("to", to)
+                .addNum("distance", distanceMeters)
+                .addColSize("edges", edges)
+                .toString();
     }
 }

--- a/src/main/java/org/opentripplanner/model/base/ToStringBuilder.java
+++ b/src/main/java/org/opentripplanner/model/base/ToStringBuilder.java
@@ -108,6 +108,10 @@ public class ToStringBuilder {
         return addIfNotNull(name, c);
     }
 
+    public ToStringBuilder addColSize(String name, Collection<?> c) {
+        return addIfNotNull(name, c, x -> String.format("%d items", x.size()));
+    }
+
     /** Add the collection, truncate the number of elements at given maxLimit. */
     public ToStringBuilder addCollection(String name, Collection<?> c, int maxLimit) {
         if(c == null) { return this; }

--- a/src/main/java/org/opentripplanner/model/plan/Itinerary.java
+++ b/src/main/java/org/opentripplanner/model/plan/Itinerary.java
@@ -227,15 +227,15 @@ public class Itinerary {
 
     public void timeShiftToStartAt(Calendar afterTime) {
         Calendar startTimeFirstLeg = firstLeg().startTime;
-        int adjustmentMilliSeconds =
-            (int)(afterTime.getTimeInMillis() - startTimeFirstLeg.getTimeInMillis());
+        long adjustmentMilliSeconds =
+            afterTime.getTimeInMillis() - startTimeFirstLeg.getTimeInMillis();
         timeShift(adjustmentMilliSeconds);
     }
 
-    private void timeShift(int adjustmentMilliSeconds) {
+    private void timeShift(long adjustmentMilliSeconds) {
         for (Leg leg : this.legs) {
-            leg.startTime.add(Calendar.MILLISECOND, adjustmentMilliSeconds);
-            leg.endTime.add(Calendar.MILLISECOND, adjustmentMilliSeconds);
+            leg.startTime.setTimeInMillis(leg.startTime.getTimeInMillis() + adjustmentMilliSeconds);
+            leg.endTime.setTimeInMillis(leg.endTime.getTimeInMillis() + adjustmentMilliSeconds);
         }
     }
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/GraphPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/GraphPathToItineraryMapper.java
@@ -274,6 +274,8 @@ public abstract class GraphPathToItineraryMapper {
 
         leg.legGeometry = PolylineEncoder.createEncodings(geometry);
 
+        leg.generalizedCost = (int) (states[states.length - 1].getWeight() - states[0].getWeight());
+
         // Interlining information is now in a separate field in Graph, not in edges.
         // But in any case, with Raptor this method is only being used to translate non-transit legs of paths.
         leg.interlineWithPreviousLeg = false;

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
@@ -143,8 +143,6 @@ public class RaptorPathToItineraryMapper {
 
         subItinerary.timeShiftToStartAt(createCalendar(accessPathLeg.fromTime()));
 
-        applyCostFromRaptorPathToAccessEgressTransfer(subItinerary.legs, accessPathLeg);
-
         return subItinerary.legs;
     }
 
@@ -255,8 +253,6 @@ public class RaptorPathToItineraryMapper {
 
         subItinerary.timeShiftToStartAt(createCalendar(egressPathLeg.fromTime()));
 
-        applyCostFromRaptorPathToAccessEgressTransfer(subItinerary.legs, egressPathLeg);
-
         return subItinerary;
     }
 
@@ -306,7 +302,6 @@ public class RaptorPathToItineraryMapper {
                 }
 
                 if (!onlyIfNonZeroDistance || subItinerary.nonTransitDistanceMeters > 0) {
-                    applyCostFromRaptorPathToAccessEgressTransfer(subItinerary.legs, pathLeg);
                     return subItinerary.legs;
                 }
             }
@@ -400,24 +395,5 @@ public class RaptorPathToItineraryMapper {
             distance += SphericalDistanceLibrary.distance(coordinates.get(i), coordinates.get(i - 1));
         }
         return distance;
-    }
-
-    /**
-     * Add the cost to the first leg, and set all others to 0(zero) - we compute the cost for the
-     * entire street section as a hole, so there is no way to break it down to each individual
-     * sub-section. There might be more than on sub-section in the future. An access/egress/transfer
-     * raptor path is converted into a list of legs with zero to N elements. Cost is generated for
-     * the entire collection of sub-sections.
-     * <p>
-     * TODO OTP2 - Break cost down on sub-section legs.
-     *           - Issue https://github.com/opentripplanner/OpenTripPlanner/issues/3215
-     *
-     * @param legs the legs representing one raptor access/transfer/egress
-     * @param raptorLeg the cost taken from the RaptorPathLeg.
-     */
-    private static void applyCostFromRaptorPathToAccessEgressTransfer(List<Leg> legs, PathLeg<?> raptorLeg) {
-        if(legs.isEmpty()) { return; }
-        legs.forEach(l -> l.generalizedCost = 0);
-        legs.get(0).generalizedCost = raptorLeg.generalizedCost();
     }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/AccessEgress.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/AccessEgress.java
@@ -2,6 +2,7 @@ package org.opentripplanner.routing.algorithm.raptor.transit;
 
 import org.opentripplanner.model.base.ToStringBuilder;
 import org.opentripplanner.routing.core.State;
+import org.opentripplanner.transit.raptor.api.transit.RaptorCostConverter;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
 
 public class AccessEgress implements RaptorTransfer {
@@ -13,20 +14,28 @@ public class AccessEgress implements RaptorTransfer {
 
   private final int durationInSeconds;
 
+  private final int generalizedCost;
+
   /**
    * This should be the last state both in the case of access and egress.
    */
   private final State lastState;
 
-  public AccessEgress(int toFromStop, int durationInSeconds, State lastState) {
+  public AccessEgress(int toFromStop, State lastState) {
     this.toFromStop = toFromStop;
-    this.durationInSeconds = durationInSeconds;
+    this.durationInSeconds = (int) lastState.getElapsedTimeSeconds();
+    this.generalizedCost = RaptorCostConverter.toRaptorCost(lastState.getWeight());
     this.lastState = lastState;
   }
 
   @Override
   public int stop() {
     return toFromStop;
+  }
+
+  @Override
+  public int generalizedCost() {
+    return generalizedCost;
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/FlexAccessEgressAdapter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/FlexAccessEgressAdapter.java
@@ -13,7 +13,6 @@ public class FlexAccessEgressAdapter extends AccessEgress {
   ) {
     super(
         stopIndex.indexByStop.get(flexAccessEgress.stop),
-        flexAccessEgress.preFlexTime + flexAccessEgress.flexTime + flexAccessEgress.postFlexTime,
         isEgress ? flexAccessEgress.lastState.reverse() : flexAccessEgress.lastState
     );
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/Transfer.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/Transfer.java
@@ -83,6 +83,45 @@ public class Transfer {
         transferRoutingRequest.dateTime = 0;
         transferRoutingRequest.from = null;
         transferRoutingRequest.to = null;
+
+        // Some of the values are rounded to ease caching in RaptorRequestTransferCache
+        transferRoutingRequest.bikeTriangleSafetyFactor = roundTo(request.bikeTriangleSafetyFactor, 1);
+        transferRoutingRequest.bikeTriangleSlopeFactor = roundTo(request.bikeTriangleSlopeFactor, 1);
+        transferRoutingRequest.bikeTriangleTimeFactor = 1.0 - transferRoutingRequest.bikeTriangleSafetyFactor - transferRoutingRequest.bikeTriangleSlopeFactor;
+        transferRoutingRequest.bikeSwitchCost = roundTo100(request.bikeSwitchCost);
+        transferRoutingRequest.bikeSwitchTime = roundTo100(request.bikeSwitchTime);
+
+        transferRoutingRequest.wheelchairAccessible = request.wheelchairAccessible;
+        transferRoutingRequest.maxWheelchairSlope = request.maxWheelchairSlope;
+
+        transferRoutingRequest.walkSpeed = roundToHalf(request.walkSpeed);
+        transferRoutingRequest.bikeSpeed = roundToHalf(request.bikeSpeed);
+
+        transferRoutingRequest.walkReluctance = roundTo(request.walkReluctance, 1);
+        transferRoutingRequest.stairsReluctance = roundTo(request.stairsReluctance, 1);
+        transferRoutingRequest.turnReluctance = roundTo(request.turnReluctance, 1);
+
+        transferRoutingRequest.elevatorBoardCost = roundTo100(request.elevatorBoardCost);
+        transferRoutingRequest.elevatorBoardTime = roundTo100(request.elevatorBoardTime);
+        transferRoutingRequest.elevatorHopCost = roundTo100(request.elevatorHopCost);
+        transferRoutingRequest.elevatorHopTime = roundTo100(request.elevatorHopTime);
+
         return transferRoutingRequest;
+    }
+
+    private static double roundToHalf(double input) {
+        return ((int) (input * 2 + 0.5)) / 2.0;
+    }
+
+    private static double roundTo(double input, int decimals) {
+        return Math.round(input * Math.pow(10, decimals)) / Math.pow(10, decimals);
+    }
+
+    private static int roundTo100(int input) {
+        if (input > 0 && input < 100) {
+            return 100;
+        }
+
+        return ((input + 50) / 100) * 100;
     }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/Transfer.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/Transfer.java
@@ -10,6 +10,7 @@ import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.core.StateEditor;
 import org.opentripplanner.routing.graph.Edge;
+import org.opentripplanner.transit.raptor.api.transit.RaptorCostConverter;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
 
 public class Transfer {
@@ -54,9 +55,11 @@ public class Transfer {
 
     public Optional<RaptorTransfer> asRaptorTransfer(RoutingRequest routingRequest) {
         if (edges == null || edges.isEmpty()) {
+            int durationSeconds = (int) Math.ceil(distanceMeters / routingRequest.walkSpeed);
             return Optional.of(new TransferWithDuration(
                     this,
-                    (int) Math.ceil(distanceMeters / routingRequest.walkSpeed)
+                    durationSeconds,
+                    RaptorCostConverter.toRaptorCost((int) Math.ceil(durationSeconds * routingRequest.walkReluctance))
             ));
         }
 
@@ -73,7 +76,8 @@ public class Transfer {
 
         return Optional.of(new TransferWithDuration(
             this,
-            (int) s.getElapsedTimeSeconds()
+            (int) s.getElapsedTimeSeconds(),
+            RaptorCostConverter.toRaptorCost(s.getWeight())
         ));
     }
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/Transfer.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/Transfer.java
@@ -3,24 +3,32 @@ package org.opentripplanner.routing.algorithm.raptor.transit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import org.locationtech.jts.geom.Coordinate;
+import org.opentripplanner.routing.algorithm.raptor.transit.request.TransferWithDuration;
+import org.opentripplanner.routing.api.request.RoutingRequest;
+import org.opentripplanner.routing.core.State;
+import org.opentripplanner.routing.core.StateEditor;
 import org.opentripplanner.routing.graph.Edge;
+import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
 
 public class Transfer {
     private final int toStop;
 
-    private final int effectiveWalkDistanceMeters;
-    private final int distanceIndependentTime;
+    private final int distanceMeters;
 
     private final List<Edge> edges;
 
-    public Transfer(
-        int toStop, int effectiveWalkDistanceMeters, int distanceIndependentTime, List<Edge> edges
-    ) {
+    public Transfer(int toStop, List<Edge> edges) {
         this.toStop = toStop;
-        this.effectiveWalkDistanceMeters = effectiveWalkDistanceMeters;
-        this.distanceIndependentTime = distanceIndependentTime;
         this.edges = edges;
+        this.distanceMeters = (int) edges.stream().mapToDouble(Edge::getDistanceMeters).sum();
+    }
+
+    public Transfer(int toStopIndex, int distanceMeters) {
+        this.toStop = toStopIndex;
+        this.distanceMeters = distanceMeters;
+        this.edges = null;
     }
 
     public List<Coordinate> getCoordinates() {
@@ -36,29 +44,45 @@ public class Transfer {
 
     public int getToStop() { return toStop; }
 
-    /**
-     * The effective distance is defined as the value that divided by the speed will give the
-     * correct duration of the transfer. This takes into account slowdowns/speedups related to
-     * slopes. It can also account for other factors that affect the transfer duration, but all
-     * factors are required to be proportional to the speed. The reason we are doing this is so
-     * that we can calculate all transfer durations in a reasonable amount of time for each
-     * incoming request.
-     */
-    public int getEffectiveWalkDistanceMeters() {
-        return effectiveWalkDistanceMeters;
-    }
-
-    public int getDistanceIndependentTime() {
-        return distanceIndependentTime;
-    }
-
     public int getDistanceMeters() {
-        return edges != null
-            ? (int) edges.stream().mapToDouble(Edge::getDistanceMeters).sum()
-            : effectiveWalkDistanceMeters;
+        return distanceMeters;
     }
 
     public List<Edge> getEdges() {
         return edges;
+    }
+
+    public Optional<RaptorTransfer> asRaptorTransfer(RoutingRequest routingRequest) {
+        if (edges == null || edges.isEmpty()) {
+            return Optional.of(new TransferWithDuration(
+                    this,
+                    (int) Math.ceil(distanceMeters / routingRequest.walkSpeed)
+            ));
+        }
+
+        StateEditor se = new StateEditor(routingRequest, edges.get(0).getFromVertex());
+        se.setTimeSeconds(0);
+
+        State s = se.makeState();
+        for (Edge e : edges) {
+            s = e.traverse(s);
+            if (s == null) {
+                return Optional.empty();
+            }
+        }
+
+        return Optional.of(new TransferWithDuration(
+            this,
+            (int) s.getElapsedTimeSeconds()
+        ));
+    }
+
+    public static RoutingRequest prepareTransferRoutingRequest(RoutingRequest request) {
+        RoutingRequest transferRoutingRequest = request.getStreetSearchRequest(request.modes.transferMode);
+        transferRoutingRequest.arriveBy = false;
+        transferRoutingRequest.dateTime = 0;
+        transferRoutingRequest.from = null;
+        transferRoutingRequest.to = null;
+        return transferRoutingRequest;
     }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/TransitLayer.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/TransitLayer.java
@@ -11,6 +11,9 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.opentripplanner.model.Stop;
 import org.opentripplanner.model.transfer.TransferService;
+import org.opentripplanner.routing.algorithm.raptor.transit.request.RaptorRequestTransferCache;
+import org.opentripplanner.routing.api.request.RoutingRequest;
+import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
 
 public class TransitLayer {
 
@@ -38,6 +41,8 @@ public class TransitLayer {
 
   private final ZoneId transitDataZoneId;
 
+  private final RaptorRequestTransferCache transferCache;
+
   /**
    * Makes a shallow copy of the TransitLayer, except for the tripPatternsForDate, where a shallow
    * copy of the HashMap is made. This is sufficient, as the TransitLayerUpdater will replace
@@ -49,7 +54,8 @@ public class TransitLayer {
         transitLayer.simpleTransfersByStopIndex,
         transitLayer.transferService,
         transitLayer.stopIndex,
-        transitLayer.transitDataZoneId
+        transitLayer.transitDataZoneId,
+        transitLayer.transferCache
     );
   }
 
@@ -58,13 +64,15 @@ public class TransitLayer {
       List<List<Transfer>> simpleTransfers,
       TransferService transferService,
       StopIndexForRaptor stopIndex,
-      ZoneId transitDataZoneId
+      ZoneId transitDataZoneId,
+      RaptorRequestTransferCache transferCache
   ) {
     this.tripPatternsRunningOnDate = new HashMap<>(tripPatternsRunningOnDate);
     this.simpleTransfersByStopIndex = simpleTransfers;
     this.transferService = transferService;
     this.stopIndex = stopIndex;
     this.transitDataZoneId = transitDataZoneId;
+    this.transferCache = transferCache;
   }
 
   public int getIndexByStop(Stop stop) {
@@ -120,6 +128,10 @@ public class TransitLayer {
 
   public TransferService getTransferService() {
     return transferService;
+  }
+
+  public List<List<RaptorTransfer>> getRaptorTransfersForRequest(RoutingRequest routingRequest) {
+    return transferCache.get(simpleTransfersByStopIndex, routingRequest);
   }
 
   /**

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/TransitTuningParameters.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/TransitTuningParameters.java
@@ -26,6 +26,8 @@ public interface TransitTuningParameters {
       }
       throw new IllegalArgumentException("Unknown key: " + key);
     }
+
+    @Override public int transferCacheMaxSize() { return 5; }
   };
 
   /**
@@ -39,4 +41,11 @@ public interface TransitTuningParameters {
    * boarding and alighting all stops with the given priority.
    */
   Integer stopTransferCost(StopTransferPriority key);
+
+  /**
+   * The maximum number of transfer RoutingRequests for which the pre-calculated transfers should be
+   * cached. If too small, the average request may be slower due to the required re-calculating. If
+   * too large, more memory may be used than needed.
+   */
+  int transferCacheMaxSize();
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/mappers/AccessEgressMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/mappers/AccessEgressMapper.java
@@ -24,7 +24,6 @@ public class AccessEgressMapper {
     if (!(nearbyStop.stop instanceof Stop)) { return null; }
     return new AccessEgress(
         stopIndex.indexByStop.get(nearbyStop.stop),
-        (int) nearbyStop.state.getElapsedTimeSeconds(),
         isEgress ? nearbyStop.state.reverse() : nearbyStop.state
     );
   }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/mappers/RaptorRequestMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/mappers/RaptorRequestMapper.java
@@ -68,13 +68,13 @@ public class RaptorRequestMapper {
         builder.mcCostFactors()
                 .waitReluctanceFactor(request.waitReluctance);
 
-        if(request.modes.accessMode == StreetMode.WALK) {
+        if(request.modes.transferMode == StreetMode.WALK) {
             builder.mcCostFactors()
                     .walkReluctanceFactor(request.walkReluctance)
                     .boardCost(request.walkBoardCost)
                     .transferCost(request.transferCost);
         }
-        else if(request.modes.accessMode == StreetMode.BIKE) {
+        else if(request.modes.transferMode == StreetMode.BIKE) {
             builder.mcCostFactors()
                     .walkReluctanceFactor(request.walkReluctance)
                     .boardCost(request.bikeBoardCost);

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/mappers/RaptorRequestMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/mappers/RaptorRequestMapper.java
@@ -66,18 +66,16 @@ public class RaptorRequestMapper {
         }
 
         builder.mcCostFactors()
+                .transferCost(request.transferCost)
                 .waitReluctanceFactor(request.waitReluctance);
 
-        if(request.modes.transferMode == StreetMode.WALK) {
+        if (request.modes.transferMode == StreetMode.BIKE) {
             builder.mcCostFactors()
-                    .walkReluctanceFactor(request.walkReluctance)
-                    .boardCost(request.walkBoardCost)
-                    .transferCost(request.transferCost);
-        }
-        else if(request.modes.transferMode == StreetMode.BIKE) {
-            builder.mcCostFactors()
-                    .walkReluctanceFactor(request.walkReluctance)
                     .boardCost(request.bikeBoardCost);
+        }
+        else {
+            builder.mcCostFactors()
+                    .boardCost(request.walkBoardCost);
         }
         builder.mcCostFactors().transitReluctanceFactors(
             mapTransitReluctance(request.transitReluctanceForMode())

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/mappers/TransfersMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/mappers/TransfersMapper.java
@@ -28,15 +28,21 @@ class TransfersMapper {
             transferByStopIndex.add(list);
 
             for (SimpleTransfer simpleTransfer : transfersByStop.get(stop)) {
-                double effectiveDistance = simpleTransfer.getEffectiveWalkDistance();
                 if (simpleTransfer.to instanceof Stop) {
                     int toStopIndex = stopIndex.indexByStop.get(simpleTransfer.to);
-                    Transfer transfer = new Transfer(
-                        toStopIndex,
-                        (int) effectiveDistance,
-                        simpleTransfer.getDistanceIndependentTime(),
-                        simpleTransfer.getEdges()
-                    );
+                    Transfer transfer;
+                    if (simpleTransfer.getEdges() != null) {
+                        transfer = new Transfer(
+                            toStopIndex,
+                            simpleTransfer.getEdges()
+                        );
+                    }
+                    else {
+                        transfer = new Transfer(
+                            toStopIndex,
+                            (int) Math.ceil(simpleTransfer.getDistanceMeters())
+                        );
+                    }
 
                     list.add(transfer);
                 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/mappers/TransitLayerMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/mappers/TransitLayerMapper.java
@@ -23,6 +23,7 @@ import org.opentripplanner.routing.algorithm.raptor.transit.TransitLayer;
 import org.opentripplanner.routing.algorithm.raptor.transit.TransitTuningParameters;
 import org.opentripplanner.routing.algorithm.raptor.transit.TripPatternForDate;
 import org.opentripplanner.routing.algorithm.raptor.transit.TripPatternWithRaptorStopIndexes;
+import org.opentripplanner.routing.algorithm.raptor.transit.request.RaptorRequestTransferCache;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.trippattern.TripTimes;
 import org.opentripplanner.util.OTPFeature;
@@ -81,6 +82,7 @@ public class TransitLayerMapper {
             );
         }
 
+        var transferCache = new RaptorRequestTransferCache(tuningParameters.transferCacheMaxSize());
 
         LOG.info("Mapping complete.");
 
@@ -89,7 +91,8 @@ public class TransitLayerMapper {
             transferByStopIndex,
             graph.getTransferService(),
             stopIndex,
-            graph.getTimeZone().toZoneId()
+            graph.getTimeZone().toZoneId(),
+            transferCache
         );
     }
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/request/RaptorRequestTransferCache.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/request/RaptorRequestTransferCache.java
@@ -56,7 +56,7 @@ public class RaptorRequestTransferCache {
                 .collect(toMap(
                     RaptorTransfer::stop,
                     Function.identity(),
-                    (a, b) -> a.durationInSeconds() < b.durationInSeconds() ? a : b
+                    (a, b) -> a.generalizedCost() < b.generalizedCost() ? a : b
                 ))
                 .values()))
             .collect(toList());

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/request/RaptorRequestTransferCache.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/request/RaptorRequestTransferCache.java
@@ -1,0 +1,152 @@
+package org.opentripplanner.routing.algorithm.raptor.transit.request;
+
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+import lombok.EqualsAndHashCode;
+import lombok.SneakyThrows;
+import org.opentripplanner.routing.algorithm.raptor.transit.Transfer;
+import org.opentripplanner.routing.algorithm.raptor.transit.TransitLayer;
+import org.opentripplanner.routing.api.request.RoutingRequest;
+import org.opentripplanner.routing.api.request.StreetMode;
+import org.opentripplanner.routing.core.BicycleOptimizeType;
+import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
+
+public class RaptorRequestTransferCache {
+
+    private static final LoadingCache<CacheKey, List<List<RaptorTransfer>>> transferCache = CacheBuilder
+        .newBuilder()
+        .maximumSize(25)
+        .build(new CacheLoader<>() {
+            @Override
+            public List<List<RaptorTransfer>> load(@javax.annotation.Nonnull CacheKey cacheKey) {
+                return createRaptorTransfersForRequest(
+                    cacheKey.transfersByStopIndex,
+                    cacheKey.routingRequest
+                );
+            }
+        });
+
+    @SneakyThrows
+    public static List<List<RaptorTransfer>> get(
+        TransitLayer transitLayer,
+        RoutingRequest routingRequest
+    ) {
+        return transferCache.get(new CacheKey(
+            transitLayer.getSimpleTransferByStopIndex(),
+            routingRequest
+        ));
+    }
+
+    static List<List<RaptorTransfer>> createRaptorTransfersForRequest(
+        List<List<Transfer>> transfersByStopIndex,
+        RoutingRequest routingRequest
+    ) {
+        return transfersByStopIndex
+            .stream()
+            .map(t -> new ArrayList<>(t
+                .stream()
+                .flatMap(s -> s.asRaptorTransfer(routingRequest).stream())
+                .collect(toMap(
+                    RaptorTransfer::stop,
+                    Function.identity(),
+                    (a, b) -> a.durationInSeconds() < b.durationInSeconds() ? a : b
+                ))
+                .values()))
+            .collect(toList());
+    }
+
+    private static class CacheKey {
+
+        private final List<List<Transfer>> transfersByStopIndex;
+        private final RoutingRequest routingRequest;
+        private final StreetRelevantOptions options;
+
+        private CacheKey(
+                List<List<Transfer>> transfersByStopIndex,
+                RoutingRequest routingRequest
+        ) {
+            this.transfersByStopIndex = transfersByStopIndex;
+            this.routingRequest = routingRequest;
+            this.options = new StreetRelevantOptions(routingRequest);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) { return true; }
+            if (o == null || getClass() != o.getClass()) { return false; }
+            CacheKey cacheKey = (CacheKey) o;
+            // transfersByStopIndex is checked using == on purpose since the instance should not change
+            // (there is only one instance per graph)
+            return transfersByStopIndex == cacheKey.transfersByStopIndex
+                && options.equals(cacheKey.options);
+        }
+
+        @Override
+        public int hashCode() {
+            // transfersByStopIndex is ignored on purpose since it should not change (there is only
+            // one instance per graph) and calculating the hashCode() would be expensive
+            return options.hashCode();
+        }
+    }
+
+    /**
+     * This contains an extract of the parameters which may influence transfers.
+     *
+     * TODO: the bikeWalking options are not used.
+     */
+    @EqualsAndHashCode
+    private static class StreetRelevantOptions {
+
+        private final StreetMode transferMode;
+        private final BicycleOptimizeType optimize;
+        private final double bikeTriangleSafetyFactor;
+        private final double bikeTriangleSlopeFactor;
+        private final double bikeTriangleTimeFactor;
+        private final boolean wheelchairAccessible;
+        private final double maxWheelchairSlope;
+        private final double walkSpeed;
+        private final double bikeSpeed;
+        private final double walkReluctance;
+        private final double stairsReluctance;
+        private final double turnReluctance;
+        private final int elevatorBoardCost;
+        private final int elevatorBoardTime;
+        private final int elevatorHopCost;
+        private final int elevatorHopTime;
+        private final int bikeSwitchCost;
+        private final int bikeSwitchTime;
+
+        public StreetRelevantOptions(RoutingRequest routingRequest) {
+            this.transferMode = routingRequest.modes.transferMode;
+
+            this.optimize = routingRequest.optimize;
+            this.bikeTriangleSafetyFactor = routingRequest.bikeTriangleSafetyFactor;
+            this.bikeTriangleSlopeFactor = routingRequest.bikeTriangleSlopeFactor;
+            this.bikeTriangleTimeFactor = routingRequest.bikeTriangleTimeFactor;
+            this.bikeSwitchCost = routingRequest.bikeSwitchCost;
+            this.bikeSwitchTime = routingRequest.bikeSwitchTime;
+
+            this.wheelchairAccessible = routingRequest.wheelchairAccessible;
+            this.maxWheelchairSlope = routingRequest.maxWheelchairSlope;
+
+            this.walkSpeed = routingRequest.walkSpeed;
+            this.bikeSpeed = routingRequest.bikeSpeed;
+
+            this.walkReluctance = routingRequest.walkReluctance;
+            this.stairsReluctance = routingRequest.stairsReluctance;
+            this.turnReluctance = routingRequest.turnReluctance;
+
+            this.elevatorBoardCost = routingRequest.elevatorBoardCost;
+            this.elevatorBoardTime = routingRequest.elevatorBoardTime;
+            this.elevatorHopCost = routingRequest.elevatorHopCost;
+            this.elevatorHopTime = routingRequest.elevatorHopTime;
+        }
+    }
+}

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/request/RaptorRoutingRequestTransitData.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/request/RaptorRoutingRequestTransitData.java
@@ -59,7 +59,7 @@ public class RaptorRoutingRequestTransitData implements RaptorTransitDataProvide
         filter
     );
 
-    this.transfers = RaptorRequestTransferCache.get(transitLayer, routingRequest);
+    this.transfers = transitLayer.getRaptorTransfersForRequest(routingRequest);
   }
 
   /**

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/request/RaptorRoutingRequestTransitData.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/request/RaptorRoutingRequestTransitData.java
@@ -1,7 +1,9 @@
 package org.opentripplanner.routing.algorithm.raptor.transit.request;
 
+import org.opentripplanner.routing.algorithm.raptor.transit.Transfer;
 import org.opentripplanner.routing.algorithm.raptor.transit.TransitLayer;
 import org.opentripplanner.routing.algorithm.raptor.transit.TripSchedule;
+import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.transit.raptor.api.transit.IntIterator;
 import org.opentripplanner.transit.raptor.api.transit.RaptorRoute;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
@@ -34,7 +36,6 @@ public class RaptorRoutingRequestTransitData implements RaptorTransitDataProvide
    */
   private final List<List<RaptorTransfer>> transfers;
 
-
   private final ZonedDateTime startOfTime;
 
   public RaptorRoutingRequestTransitData(
@@ -42,7 +43,7 @@ public class RaptorRoutingRequestTransitData implements RaptorTransitDataProvide
       Instant departureTime,
       int additionalFutureSearchDays,
       TransitDataProviderFilter filter,
-      double walkSpeed
+      RoutingRequest routingRequest
   ) {
     // Delegate to the creator to construct the needed data structures. The code is messy so
     // it is nice to NOT have it in the class. It isolate this code to only be available at
@@ -58,7 +59,8 @@ public class RaptorRoutingRequestTransitData implements RaptorTransitDataProvide
         additionalFutureSearchDays,
         filter
     );
-    this.transfers = creator.calculateTransferDuration(walkSpeed);
+
+    this.transfers = creator.calculateTransferDuration(routingRequest);
   }
 
   /**

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/request/RaptorRoutingRequestTransitData.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/request/RaptorRoutingRequestTransitData.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.routing.algorithm.raptor.transit.request;
 
-import org.opentripplanner.routing.algorithm.raptor.transit.Transfer;
 import org.opentripplanner.routing.algorithm.raptor.transit.TransitLayer;
 import org.opentripplanner.routing.algorithm.raptor.transit.TripSchedule;
 import org.opentripplanner.routing.api.request.RoutingRequest;
@@ -60,7 +59,7 @@ public class RaptorRoutingRequestTransitData implements RaptorTransitDataProvide
         filter
     );
 
-    this.transfers = creator.calculateTransferDuration(routingRequest);
+    this.transfers = RaptorRequestTransferCache.get(transitLayer, routingRequest);
   }
 
   /**

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/request/RaptorRoutingRequestTransitDataCreator.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/request/RaptorRoutingRequestTransitDataCreator.java
@@ -18,6 +18,7 @@ import org.opentripplanner.routing.algorithm.raptor.transit.TransitLayer;
 import org.opentripplanner.routing.algorithm.raptor.transit.TripPatternForDate;
 import org.opentripplanner.routing.algorithm.raptor.transit.TripPatternWithRaptorStopIndexes;
 import org.opentripplanner.routing.algorithm.raptor.transit.mappers.DateMapper;
+import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
 
 
@@ -158,14 +159,14 @@ class RaptorRoutingRequestTransitDataCreator {
         .collect(Collectors.toList());
   }
 
-  List<List<RaptorTransfer>> calculateTransferDuration(double walkSpeed) {
+  List<List<RaptorTransfer>> calculateTransferDuration(RoutingRequest transferRoutingRequest) {
     return transitLayer
         .getSimpleTransferByStopIndex()
         .stream()
-        .map(t -> t
-            .stream()
-            .map(s -> new TransferWithDuration(s, walkSpeed))
-            .collect(Collectors.<RaptorTransfer>toList()))
+        .map(t -> t.stream()
+            .flatMap(s -> s.asRaptorTransfer(transferRoutingRequest).stream())
+            .collect(toList())
+        )
         .collect(toList());
   }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/request/RaptorRoutingRequestTransitDataCreator.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/request/RaptorRoutingRequestTransitDataCreator.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.routing.algorithm.raptor.transit.request;
 
 import static java.util.stream.Collectors.groupingBy;
-import static java.util.stream.Collectors.toList;
 import static org.opentripplanner.routing.algorithm.raptor.transit.mappers.DateMapper.secondsSinceStartOfTime;
 
 import java.time.Instant;
@@ -18,8 +17,6 @@ import org.opentripplanner.routing.algorithm.raptor.transit.TransitLayer;
 import org.opentripplanner.routing.algorithm.raptor.transit.TripPatternForDate;
 import org.opentripplanner.routing.algorithm.raptor.transit.TripPatternWithRaptorStopIndexes;
 import org.opentripplanner.routing.algorithm.raptor.transit.mappers.DateMapper;
-import org.opentripplanner.routing.api.request.RoutingRequest;
-import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
 
 
 /**
@@ -157,16 +154,5 @@ class RaptorRoutingRequestTransitDataCreator {
         .map(p -> p.newWithFilteredTripTimes(filter::tripTimesPredicate))
         .filter(Objects::nonNull)
         .collect(Collectors.toList());
-  }
-
-  List<List<RaptorTransfer>> calculateTransferDuration(RoutingRequest transferRoutingRequest) {
-    return transitLayer
-        .getSimpleTransferByStopIndex()
-        .stream()
-        .map(t -> t.stream()
-            .flatMap(s -> s.asRaptorTransfer(transferRoutingRequest).stream())
-            .collect(toList())
-        )
-        .collect(toList());
   }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/request/RoutingRequestTransitDataProviderFilter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/request/RoutingRequestTransitDataProviderFilter.java
@@ -46,7 +46,7 @@ public class RoutingRequestTransitDataProviderFilter implements TransitDataProvi
           GraphIndex graphIndex
   ) {
     this(
-        request.modes.directMode == StreetMode.BIKE,
+        request.modes.transferMode == StreetMode.BIKE,
         request.wheelchairAccessible,
         request.includePlannedCancellations,
         request.modes.transitModes,

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/request/TransferWithDuration.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/request/TransferWithDuration.java
@@ -9,10 +9,9 @@ public class TransferWithDuration implements RaptorTransfer {
 
     private final Transfer transfer;
 
-    public TransferWithDuration(Transfer transfer, double walkSpeed) {
+    public TransferWithDuration(Transfer transfer, int durationSeconds) {
         this.transfer = transfer;
-        this.durationSeconds = (int) Math.round(transfer.getEffectiveWalkDistanceMeters() / walkSpeed)
-            + transfer.getDistanceIndependentTime();
+        this.durationSeconds = durationSeconds;
     }
 
     public Transfer transfer() {

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/request/TransferWithDuration.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/request/TransferWithDuration.java
@@ -6,12 +6,14 @@ import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
 public class TransferWithDuration implements RaptorTransfer {
 
     private final int durationSeconds;
+    private final int cost;
 
     private final Transfer transfer;
 
-    public TransferWithDuration(Transfer transfer, int durationSeconds) {
+    public TransferWithDuration(Transfer transfer, int durationSeconds, int cost) {
         this.transfer = transfer;
         this.durationSeconds = durationSeconds;
+        this.cost = cost;
     }
 
     public Transfer transfer() {
@@ -21,6 +23,11 @@ public class TransferWithDuration implements RaptorTransfer {
     @Override
     public int stop() {
         return transfer.getToStop();
+    }
+
+    @Override
+    public int generalizedCost() {
+        return cost;
     }
 
     @Override

--- a/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/configure/TransferOptimizationServiceConfigurator.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/configure/TransferOptimizationServiceConfigurator.java
@@ -130,7 +130,6 @@ public class TransferOptimizationServiceConfigurator<T extends RaptorTripSchedul
     return new DefaultCostCalculator<>(
         p.boardCost(),
         p.transferCost(),
-        p.walkReluctanceFactor(),
         p.waitReluctanceFactor(),
         transitDataProvider.stopBoarAlightCost(),
         p.transitReluctanceFactors()

--- a/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/model/TripToTripTransfer.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/model/TripToTripTransfer.java
@@ -33,6 +33,10 @@ public class TripToTripTransfer<T extends RaptorTripSchedule> {
     return sameStop() ? 0 : transfer.durationInSeconds();
   }
 
+  public int generalizedCost() {
+    return sameStop() ? 0 : transfer.generalizedCost();
+  }
+
   public boolean sameStop() {
     return from.stop() == to.stop();
   }

--- a/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/services/TransfersPermutationService.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/services/TransfersPermutationService.java
@@ -131,7 +131,7 @@ public class TransfersPermutationService<T extends RaptorTripSchedule> {
                 tx.to().stop(),
                 arrivalTime,
                 RaptorCostConverter.toOtpDomainCost(
-                    costCalculator.walkCost(tx.transferDuration())
+                    tx.generalizedCost()
                 ),
                 tx.getTransfer(),
                 p

--- a/src/main/java/org/opentripplanner/routing/api/request/RequestModes.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/RequestModes.java
@@ -10,6 +10,7 @@ import java.util.Set;
 public class RequestModes {
 
   public StreetMode accessMode;
+  public StreetMode transferMode;
   public StreetMode egressMode;
   public StreetMode directMode;
   public Set<TransitMode> transitModes;
@@ -18,16 +19,19 @@ public class RequestModes {
       StreetMode.WALK,
       StreetMode.WALK,
       StreetMode.WALK,
+      StreetMode.WALK,
       new HashSet<>(Arrays.asList(TransitMode.values()))
   );
 
   public RequestModes(
       StreetMode accessMode,
+      StreetMode transferMode,
       StreetMode egressMode,
       StreetMode directMode,
       Set<TransitMode> transitModes
   ) {
     this.accessMode = (accessMode != null && accessMode.access) ? accessMode : null;
+    this.transferMode = (transferMode != null && transferMode.transfer) ? transferMode : null;
     this.egressMode = (egressMode != null && egressMode.egress) ? egressMode : null;
     this.directMode = directMode;
     this.transitModes = transitModes;

--- a/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
@@ -5,11 +5,11 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -32,12 +32,12 @@ import org.opentripplanner.model.Route;
 import org.opentripplanner.model.TransitMode;
 import org.opentripplanner.routing.algorithm.transferoptimization.api.TransferOptimizationParameters;
 import org.opentripplanner.routing.core.BicycleOptimizeType;
-import org.opentripplanner.routing.core.intersection_model.IntersectionTraversalCostModel;
 import org.opentripplanner.routing.core.RouteMatcher;
 import org.opentripplanner.routing.core.RoutingContext;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.core.TraverseMode;
 import org.opentripplanner.routing.core.TraverseModeSet;
+import org.opentripplanner.routing.core.intersection_model.IntersectionTraversalCostModel;
 import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
@@ -133,7 +133,8 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
         StreetMode.WALK,
         StreetMode.WALK,
         StreetMode.WALK,
-        Collections.emptySet()
+        StreetMode.WALK,
+        EnumSet.allOf(TransitMode.class)
     );
 
     /**
@@ -698,8 +699,6 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
         // http://en.wikipedia.org/wiki/Speed_limit
         carSpeed = 40; // 40 m/s, 144 km/h, above the maximum (finite) driving speed limit worldwide
         // Default to walk for access/egress/direct modes and all transit modes
-        this.modes = new RequestModes(StreetMode.WALK, StreetMode.WALK, StreetMode.WALK, new HashSet<>(
-            Arrays.asList(TransitMode.values())));
         bikeWalkingOptions = this;
 
         // So that they are never null.

--- a/src/main/java/org/opentripplanner/routing/api/request/StreetMode.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/StreetMode.java
@@ -4,55 +4,57 @@ public enum StreetMode {
   /**
    * Walk only
    */
-  WALK(true, true, true, false, false),
+  WALK(true, true, true, true, false, false),
   /**
    * Bike only
    *
    * This can be used as access/egress, but transfers will still be walk only.
    * // TODO OTP2 Implement bicycle transfers
    */
-  BIKE(true, true, true, true, false),
+  BIKE(true, true, true, true, true, false),
   /**
    * Bike to a bike parking area, then walk the rest of the way.
    *
    * Direct mode and access mode only.
    */
-  BIKE_TO_PARK(true, false, true, true, false),
+  BIKE_TO_PARK(true, false, false, true, true, false),
   /**
    * Walk to a bike rental point, bike to a bike rental drop-off point, and walk the rest of the
    * way. This can include bike rental at fixed locations or free-floating services.
    */
-  BIKE_RENTAL(true, true, true, true,false),
+  BIKE_RENTAL(true, true, true, true, true,false),
   /**
    * Car only
    *
    * Direct mode only.
    */
-  CAR(false, false, false, false, true),
+  CAR(true, false, false, false, false, true),
   /**
    * Start in the car, drive to a parking area, and walk the rest of the way.
    *
    * Direct mode and access mode only.
    */
-  CAR_TO_PARK(true, false, true, false, true),
+  CAR_TO_PARK(true, false, false, true, false, true),
   /**
    * Walk to a pickup point along the road, drive to a drop-off point along the road,
    * and walk the rest of the way. This can include various taxi-services or kiss & ride.
    */
-  CAR_PICKUP(true, true, true, false, true),
+  CAR_PICKUP(true, false, true, true, false, true),
   /**
    * Walk to a car rental point, drive to a car rental drop-off point and walk the rest of the way.
    * This can include car rental at fixed locations or free-floating services.
    */
   // TODO OTP2 Not implemented
-  CAR_RENTAL(true, true, true, false, true),
+  CAR_RENTAL(true, true, true, true, false, true),
 
   /**
    * Encompasses all types of on-demand and flexible transportation.
    */
-  FLEXIBLE(true, true, true, false, true);
+  FLEXIBLE(true, false, true, true, false, true);
 
   boolean access;
+
+  boolean transfer;
 
   boolean egress;
 
@@ -64,12 +66,14 @@ public enum StreetMode {
 
   StreetMode(
       boolean access,
+      boolean transfer,
       boolean egress,
       boolean includesWalking,
       boolean includesBiking,
       boolean includesDriving
   ) {
     this.access = access;
+    this.transfer = transfer;
     this.egress = egress;
     this.includesWalking = includesWalking;
     this.includesBiking = includesBiking;

--- a/src/main/java/org/opentripplanner/routing/graphfinder/DirectGraphFinder.java
+++ b/src/main/java/org/opentripplanner/routing/graphfinder/DirectGraphFinder.java
@@ -3,8 +3,6 @@ package org.opentripplanner.routing.graphfinder;
 import com.beust.jcommander.internal.Lists;
 import java.util.List;
 import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.GeometryFactory;
-import org.opentripplanner.common.geometry.GeometryUtils;
 import org.opentripplanner.common.geometry.SphericalDistanceLibrary;
 import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.model.TransitMode;
@@ -19,9 +17,7 @@ import org.opentripplanner.routing.vertextype.TransitStopVertex;
  */
 public class DirectGraphFinder implements GraphFinder {
 
-  private static GeometryFactory geometryFactory = GeometryUtils.getGeometryFactory();
-
-  private StreetVertexIndex streetIndex;
+  private final StreetVertexIndex streetIndex;
 
   public DirectGraphFinder(Graph graph) {
     this.streetIndex = graph.getStreetIndex();
@@ -38,12 +34,10 @@ public class DirectGraphFinder implements GraphFinder {
     for (TransitStopVertex it : streetIndex.getNearbyTransitStops(coordinate, radiusMeters)) {
       double distance = Math.round(SphericalDistanceLibrary.distance(coordinate, it.getCoordinate()));
       if (distance < radiusMeters) {
-        Coordinate coordinates[] = new Coordinate[] {coordinate, it.getCoordinate()};
         NearbyStop sd = new NearbyStop(
             it,
             distance,
             null,
-            geometryFactory.createLineString(coordinates),
             null
         );
         stopsFound.add(sd);

--- a/src/main/java/org/opentripplanner/routing/graphfinder/NearbyStop.java
+++ b/src/main/java/org/opentripplanner/routing/graphfinder/NearbyStop.java
@@ -3,12 +3,7 @@ package org.opentripplanner.routing.graphfinder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.LineString;
-import org.opentripplanner.api.resource.CoordinateArrayListSequence;
-import org.opentripplanner.common.geometry.GeometryUtils;
-import org.opentripplanner.common.geometry.PackedCoordinateSequence;
 import org.opentripplanner.model.StopLocation;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.graph.Edge;
@@ -21,32 +16,27 @@ import org.opentripplanner.routing.vertextype.TransitStopVertex;
  */
 public class NearbyStop implements Comparable<NearbyStop> {
 
-  private static final GeometryFactory geometryFactory = GeometryUtils.getGeometryFactory();
-
   public final StopLocation stop;
   public final double distance;
-  public final int distanceIndependentTime;
 
   public final List<Edge> edges;
   public final LineString geometry;
   public final State state;
 
   public NearbyStop(
-      StopLocation stop, double distance, int distanceIndependentTime, List<Edge> edges, LineString geometry, State state
+      StopLocation stop, double distance, List<Edge> edges, LineString geometry, State state
   ) {
     this.stop = stop;
     this.distance = distance;
-    this.distanceIndependentTime = distanceIndependentTime;
     this.edges = edges;
     this.geometry = geometry;
     this.state = state;
   }
 
   public NearbyStop(
-      TransitStopVertex stopVertex, double distance, List<Edge> edges, LineString geometry,
-      State state
+      TransitStopVertex stopVertex, double distance, List<Edge> edges, State state
   ) {
-    this(stopVertex.getStop(), distance, 0, edges, geometry, state);
+    this(stopVertex.getStop(), distance, edges, null, state);
   }
 
   @Override
@@ -60,7 +50,6 @@ public class NearbyStop implements Comparable<NearbyStop> {
     if (o == null || getClass() != o.getClass()) { return false; }
     final NearbyStop that = (NearbyStop) o;
     return Double.compare(that.distance, distance) == 0
-            && distanceIndependentTime == that.distanceIndependentTime
             && stop.equals(that.stop)
             && Objects.equals(edges, that.edges)
             && Objects.equals(geometry, that.geometry)
@@ -69,14 +58,13 @@ public class NearbyStop implements Comparable<NearbyStop> {
 
   @Override
   public int hashCode() {
-    return Objects.hash(stop, distance, distanceIndependentTime, edges, geometry, state);
+    return Objects.hash(stop, distance, edges, geometry, state);
   }
 
   public String toString() {
     return String.format(
-            "stop %s at %.1f meters%s%s%s%s",
+            "stop %s at %.1f meters%s%s%s",
             stop, distance,
-            distanceIndependentTime > 0 ? " +" + distanceIndependentTime + " seconds" : "",
             edges != null ? " (" + edges.size() + " edges)" : "",
             geometry != null ? " w/geometry" : "",
             state != null ? " w/state" : ""
@@ -89,38 +77,17 @@ public class NearbyStop implements Comparable<NearbyStop> {
    */
   public static NearbyStop nearbyStopForState(State state, StopLocation stop) {
     double effectiveWalkDistance = 0.0;
-    int distanceIndependentTime = 0;
-    GraphPath graphPath = new GraphPath(state);
-    CoordinateArrayListSequence coordinates = new CoordinateArrayListSequence();
-    List<Edge> edges = new ArrayList<>();
+    var graphPath = new GraphPath(state);
+    var edges = new ArrayList<Edge>();
     for (Edge edge : graphPath.edges) {
-      LineString geometry = edge.getGeometry();
-      if (geometry != null) {
-        if (coordinates.size() == 0) {
-          coordinates.extend(geometry.getCoordinates());
-        }
-        else {
-          coordinates.extend(geometry.getCoordinates(), 1);
-        }
-      }
       effectiveWalkDistance += edge.getEffectiveWalkDistance();
-      distanceIndependentTime += edge.getDistanceIndependentTime();
       edges.add(edge);
-    }
-    if (coordinates.size() < 2) {   // Otherwise the walk step generator breaks.
-      ArrayList<Coordinate> coordinateList = new ArrayList<>(2);
-      State lastState = graphPath.states.getLast();
-      coordinateList.add(lastState.getVertex().getCoordinate());
-      State backState = lastState.getBackState();
-      coordinateList.add(Objects.requireNonNullElse(backState, lastState).getVertex().getCoordinate());
-      coordinates = new CoordinateArrayListSequence(coordinateList);
     }
     return new NearbyStop(
         stop,
         effectiveWalkDistance,
-        distanceIndependentTime,
         edges,
-        geometryFactory.createLineString(new PackedCoordinateSequence.Double(coordinates.toCoordinateArray())),
+        null,
         state
     );
   }

--- a/src/main/java/org/opentripplanner/standalone/config/TransitRoutingConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/TransitRoutingConfig.java
@@ -19,6 +19,7 @@ public final class TransitRoutingConfig
     private final int scheduledTripBinarySearchThreshold;
     private final int iterationDepartureStepInSeconds;
     private final int searchThreadPoolSize;
+    private final int transferCacheMaxSize;
     private final Map<StopTransferPriority, Integer> stopTransferCost;
     private final DynamicSearchWindowCoefficients dynamicSearchWindowCoefficients;
 
@@ -49,6 +50,10 @@ public final class TransitRoutingConfig
             "stopTransferCost",
             StopTransferPriority.class,
             NodeAdapter::asInt
+        );
+        this.transferCacheMaxSize = c.asInt(
+                "transferCacheMaxSize",
+                25
         );
     }
 
@@ -85,6 +90,11 @@ public final class TransitRoutingConfig
     @Override
     public Integer stopTransferCost(StopTransferPriority key) {
         return stopTransferCost.get(key);
+    }
+
+    @Override
+    public int transferCacheMaxSize() {
+        return transferCacheMaxSize;
     }
 
     private static class DynamicSearchWindowConfig

--- a/src/main/java/org/opentripplanner/transit/raptor/api/request/McCostParams.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/request/McCostParams.java
@@ -18,7 +18,6 @@ public class McCostParams {
     private final int boardCost;
     private final int transferCost;
     private final double[] transitReluctanceFactors;
-    private final double walkReluctanceFactor;
     private final double waitReluctanceFactor;
 
     /**
@@ -29,7 +28,6 @@ public class McCostParams {
         this.boardCost = 600;
         this.transferCost = 0;
         this.transitReluctanceFactors = null;
-        this.walkReluctanceFactor = 4.0;
         this.waitReluctanceFactor = 1.0;
     }
 
@@ -37,7 +35,6 @@ public class McCostParams {
         this.boardCost = builder.boardCost();
         this.transferCost = builder.transferCost();
         this.transitReluctanceFactors = builder.transitReluctanceFactors();
-        this.walkReluctanceFactor = builder.walkReluctanceFactor();
         this.waitReluctanceFactor = builder.waitReluctanceFactor();
     }
 
@@ -65,14 +62,6 @@ public class McCostParams {
         return transitReluctanceFactors;
     }
 
-    /**
-     * A walk reluctance factor of 100 regarded as neutral. 400 means the rider
-     * would rater sit 4 minutes extra on a buss, than walk 1 minute extra.
-     */
-    public double walkReluctanceFactor() {
-        return walkReluctanceFactor;
-    }
-
     public double waitReluctanceFactor() {
         return waitReluctanceFactor;
     }
@@ -82,7 +71,6 @@ public class McCostParams {
         return "McCostParams{" +
                 "boardCost=" + boardCost +
                 ", transferCost=" + transferCost +
-                ", transferReluctanceFactor=" + walkReluctanceFactor +
                 ", waitReluctanceFactor=" + waitReluctanceFactor +
                 '}';
     }
@@ -94,12 +82,11 @@ public class McCostParams {
         McCostParams that = (McCostParams) o;
         return boardCost == that.boardCost &&
                 transferCost == that.transferCost &&
-                Double.compare(that.walkReluctanceFactor, walkReluctanceFactor) == 0 &&
                 Double.compare(that.waitReluctanceFactor, waitReluctanceFactor) == 0;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(boardCost, transferCost, walkReluctanceFactor, waitReluctanceFactor);
+        return Objects.hash(boardCost, transferCost, waitReluctanceFactor);
     }
 }

--- a/src/main/java/org/opentripplanner/transit/raptor/api/request/McCostParamsBuilder.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/request/McCostParamsBuilder.java
@@ -9,7 +9,6 @@ public class McCostParamsBuilder {
     private int boardCost;
     private int transferCost;
     private double[] transitReluctanceFactors;
-    private double walkReluctanceFactor;
     private double waitReluctanceFactor;
 
 
@@ -17,7 +16,6 @@ public class McCostParamsBuilder {
         this.boardCost = defaults.boardCost();
         this.transferCost = defaults.transferCost();
         this.transitReluctanceFactors = defaults.transitReluctanceFactors();
-        this.walkReluctanceFactor = defaults.walkReluctanceFactor();
         this.waitReluctanceFactor = defaults.waitReluctanceFactor();
     }
 
@@ -45,15 +43,6 @@ public class McCostParamsBuilder {
 
     public McCostParamsBuilder transitReluctanceFactors(double[] transitReluctanceFactors) {
         this.transitReluctanceFactors = transitReluctanceFactors;
-        return this;
-    }
-
-    public double walkReluctanceFactor() {
-        return walkReluctanceFactor;
-    }
-
-    public McCostParamsBuilder walkReluctanceFactor(double walkReluctanceFactor) {
-        this.walkReluctanceFactor = walkReluctanceFactor;
         return this;
     }
 

--- a/src/main/java/org/opentripplanner/transit/raptor/api/transit/CostCalculator.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/transit/CostCalculator.java
@@ -43,11 +43,6 @@ public interface CostCalculator<T extends RaptorTripSchedule> {
     );
 
     /**
-     * Calculate the value when arriving by transfer.
-     */
-    int walkCost(int walkTimeInSeconds);
-
-    /**
      * Calculate the value, when waiting between the last transit and egress paths
      */
     int waitCost(int waitTimeInSeconds);

--- a/src/main/java/org/opentripplanner/transit/raptor/api/transit/DefaultCostCalculator.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/transit/DefaultCostCalculator.java
@@ -13,7 +13,6 @@ import org.opentripplanner.transit.raptor.api.view.ArrivalView;
 public final class DefaultCostCalculator<T extends RaptorTripSchedule> implements CostCalculator<T> {
     private final int boardCostOnly;
     private final int boardAndTransferCost;
-    private final int walkFactor;
     private final int waitFactor;
     private final FactorStrategy transitFactors;
     private final int[] stopVisitCost;
@@ -29,7 +28,6 @@ public final class DefaultCostCalculator<T extends RaptorTripSchedule> implement
     public DefaultCostCalculator(
             int boardCost,
             int transferCost,
-            double walkReluctanceFactor,
             double waitReluctanceFactor,
             @Nullable int[] stopVisitCost,
             @Nullable double[] transitReluctanceFactors
@@ -37,7 +35,6 @@ public final class DefaultCostCalculator<T extends RaptorTripSchedule> implement
         this.stopVisitCost = stopVisitCost;
         this.boardCostOnly = RaptorCostConverter.toRaptorCost(boardCost);
         this.boardAndTransferCost = RaptorCostConverter.toRaptorCost(transferCost) + boardCostOnly;
-        this.walkFactor = RaptorCostConverter.toRaptorCost(walkReluctanceFactor);
         this.waitFactor = RaptorCostConverter.toRaptorCost(waitReluctanceFactor);
 
         this.transitFactors = transitReluctanceFactors == null
@@ -87,11 +84,6 @@ public final class DefaultCostCalculator<T extends RaptorTripSchedule> implement
             cost += stopVisitCost[fromStop] + stopVisitCost[toStop];
         }
         return cost;
-    }
-
-    @Override
-    public final int walkCost(int walkTimeInSeconds) {
-        return walkFactor * walkTimeInSeconds;
     }
 
     @Override

--- a/src/main/java/org/opentripplanner/transit/raptor/api/transit/RaptorTransfer.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/transit/RaptorTransfer.java
@@ -23,6 +23,17 @@ public interface RaptorTransfer {
     int stop();
 
     /**
+     * The generalized cost of this transfer in centi-seconds. The value is used to compare with
+     * riding transit, and will be one component of a full itinerary.
+     *
+     * This methods is called many times, so care needs to be taken that the value is stored, not
+     * calculated for each invocation.
+     *
+     * @see RaptorCostConverter#toRaptorCost(double)
+     */
+    int generalizedCost();
+
+    /**
      * The time duration to walk or travel the path in seconds. This is not the entire duration
      * from the journey origin, but just:
      * <ul>

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/CalculateTransferToDestination.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/CalculateTransferToDestination.java
@@ -49,7 +49,7 @@ public class CalculateTransferToDestination<T extends RaptorTripSchedule>
                 destinationArrivals.add(
                     transitStopArrival,
                     egress,
-                    costCalculator.walkCost(egress.durationInSeconds())
+                    egress.generalizedCost()
                 );
             }
         } else if (newElement instanceof TransferStopArrival) {
@@ -59,7 +59,7 @@ public class CalculateTransferToDestination<T extends RaptorTripSchedule>
                     destinationArrivals.add(
                         transferStopArrival,
                         egress,
-                        costCalculator.walkCost(egress.durationInSeconds())
+                        egress.generalizedCost()
                     );
                 }
             }

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/McRangeRaptorWorkerState.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/McRangeRaptorWorkerState.java
@@ -93,7 +93,7 @@ final public class McRangeRaptorWorkerState<T extends RaptorTripSchedule> implem
         addStopArrival(
             new AccessStopArrival<>(
                 departureTime,
-                costCalculator.walkCost(accessPath.durationInSeconds()),
+                accessPath.generalizedCost(),
                 accessPath
             )
         );
@@ -179,13 +179,13 @@ final public class McRangeRaptorWorkerState<T extends RaptorTripSchedule> implem
 
     private void transferToStop(Iterable<? extends AbstractStopArrival<T>> fromArrivals, RaptorTransfer transfer) {
         final int transferTimeInSeconds = transfer.durationInSeconds();
+        final int transferCost = transfer.generalizedCost();
 
         for (AbstractStopArrival<T> it : fromArrivals) {
             int arrivalTime = it.arrivalTime() + transferTimeInSeconds;
 
             if (!exceedsTimeLimit(arrivalTime)) {
-                int cost = costCalculator.walkCost(transferTimeInSeconds);
-                arrivalsCache.add(new TransferStopArrival<>(it, transfer, arrivalTime, cost));
+                arrivalsCache.add(new TransferStopArrival<>(it, transfer, arrivalTime, transferCost));
             }
         }
     }

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/transit/SearchContext.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/transit/SearchContext.java
@@ -248,7 +248,6 @@ public class SearchContext<T extends RaptorTripSchedule> {
         return new DefaultCostCalculator<T>(
                 f.boardCost(),
                 f.transferCost(),
-                f.walkReluctanceFactor(),
                 f.waitReluctanceFactor(),
                 stopVisitCost,
                 f.transitReluctanceFactors()

--- a/src/test/java/org/opentripplanner/api/parameter/QualifiedModeSetTest.java
+++ b/src/test/java/org/opentripplanner/api/parameter/QualifiedModeSetTest.java
@@ -1,11 +1,5 @@
 package org.opentripplanner.api.parameter;
 
-import org.junit.Test;
-import org.opentripplanner.routing.api.request.RequestModes;
-
-import javax.ws.rs.BadRequestException;
-import java.util.Set;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.opentripplanner.routing.api.request.StreetMode.BIKE;
@@ -13,6 +7,11 @@ import static org.opentripplanner.routing.api.request.StreetMode.BIKE_RENTAL;
 import static org.opentripplanner.routing.api.request.StreetMode.BIKE_TO_PARK;
 import static org.opentripplanner.routing.api.request.StreetMode.FLEXIBLE;
 import static org.opentripplanner.routing.api.request.StreetMode.WALK;
+
+import java.util.Set;
+import javax.ws.rs.BadRequestException;
+import org.junit.Test;
+import org.opentripplanner.routing.api.request.RequestModes;
 
 public class QualifiedModeSetTest {
     @Test
@@ -24,14 +23,14 @@ public class QualifiedModeSetTest {
     public void singleWalk() {
         QualifiedModeSet modeSet = new QualifiedModeSet("WALK");
         assertEquals(Set.of(new QualifiedMode("WALK")), modeSet.qModes);
-        assertEquals(new RequestModes(WALK, WALK, WALK, Set.of()), modeSet.getRequestModes());
+        assertEquals(new RequestModes(WALK, WALK, WALK, WALK, Set.of()), modeSet.getRequestModes());
     }
 
     @Test
     public void multipleWalks() {
         QualifiedModeSet modeSet = new QualifiedModeSet("WALK,WALK,WALK");
         assertEquals(Set.of(new QualifiedMode("WALK")), modeSet.qModes);
-        assertEquals(new RequestModes(WALK, WALK, WALK, Set.of()), modeSet.getRequestModes());
+        assertEquals(new RequestModes(WALK, WALK, WALK, WALK, Set.of()), modeSet.getRequestModes());
     }
 
     @Test
@@ -41,7 +40,7 @@ public class QualifiedModeSetTest {
                 new QualifiedMode("WALK"),
                 new QualifiedMode("BICYCLE")
         ), modeSet.qModes);
-        assertEquals(new RequestModes(BIKE, BIKE, BIKE, Set.of()), modeSet.getRequestModes());
+        assertEquals(new RequestModes(BIKE, BIKE, BIKE, BIKE, Set.of()), modeSet.getRequestModes());
     }
 
     @Test
@@ -51,7 +50,7 @@ public class QualifiedModeSetTest {
                 new QualifiedMode("WALK"),
                 new QualifiedMode("BICYCLE_RENT")
         ), modeSet.qModes);
-        assertEquals(new RequestModes(BIKE_RENTAL, BIKE_RENTAL, BIKE_RENTAL, Set.of()), modeSet.getRequestModes());
+        assertEquals(new RequestModes(BIKE_RENTAL, WALK, BIKE_RENTAL, BIKE_RENTAL, Set.of()), modeSet.getRequestModes());
     }
 
     @Test
@@ -61,7 +60,7 @@ public class QualifiedModeSetTest {
                 new QualifiedMode("WALK"),
                 new QualifiedMode("BICYCLE_PARK")
         ), modeSet.qModes);
-        assertEquals(new RequestModes(BIKE_TO_PARK, WALK, BIKE_TO_PARK, Set.of()), modeSet.getRequestModes());
+        assertEquals(new RequestModes(BIKE_TO_PARK, WALK, WALK, BIKE_TO_PARK, Set.of()), modeSet.getRequestModes());
     }
 
     @Test
@@ -71,7 +70,7 @@ public class QualifiedModeSetTest {
                 new QualifiedMode("WALK"),
                 new QualifiedMode("BICYCLE")
         ), modeSet.qModes);
-        assertEquals(new RequestModes(BIKE, BIKE, BIKE, Set.of()), modeSet.getRequestModes());
+        assertEquals(new RequestModes(BIKE, BIKE, BIKE, BIKE, Set.of()), modeSet.getRequestModes());
     }
 
     @Test
@@ -87,7 +86,7 @@ public class QualifiedModeSetTest {
                 new QualifiedMode("FLEX_EGRESS"),
                 new QualifiedMode("FLEX_ACCESS")
         ), modeSet.qModes);
-        assertEquals(new RequestModes(FLEXIBLE, FLEXIBLE, FLEXIBLE, Set.of()), modeSet.getRequestModes());
+        assertEquals(new RequestModes(FLEXIBLE, WALK, FLEXIBLE, FLEXIBLE, Set.of()), modeSet.getRequestModes());
     }
 
     @Test
@@ -97,6 +96,6 @@ public class QualifiedModeSetTest {
                 new QualifiedMode("FLEX_EGRESS"),
                 new QualifiedMode("BICYCLE_PARK")
         ), modeSet.qModes);
-        assertEquals(new RequestModes(BIKE_TO_PARK, FLEXIBLE, BIKE_TO_PARK, Set.of()), modeSet.getRequestModes());
+        assertEquals(new RequestModes(BIKE_TO_PARK, WALK, FLEXIBLE, BIKE_TO_PARK, Set.of()), modeSet.getRequestModes());
     }
 }

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/BikeRentalSnapshotTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/BikeRentalSnapshotTest.java
@@ -48,7 +48,7 @@ public class BikeRentalSnapshotTest
     public void directBikeRental() {
         RoutingRequest request = createTestRequest(2009, 9, 21, 16, 10, 0);
 
-        request.modes = new RequestModes(null, null, StreetMode.BIKE_RENTAL, Set.of());
+        request.modes = new RequestModes(null, null, null, StreetMode.BIKE_RENTAL, Set.of());
         request.from = p1;
         request.to = p2;
 
@@ -65,7 +65,7 @@ public class BikeRentalSnapshotTest
     @Test public void directBikeRentalArrivingAtDestination() {
         RoutingRequest request = createTestRequest(2009, 9, 21, 16, 10, 0);
 
-        request.modes = new RequestModes(null, null, StreetMode.BIKE_RENTAL, Set.of());
+        request.modes = new RequestModes(null, null, null, StreetMode.BIKE_RENTAL, Set.of());
         request.allowKeepingRentedBicycleAtDestination = true;
         request.from = p1;
         request.to = p2;
@@ -83,7 +83,7 @@ public class BikeRentalSnapshotTest
     @Test public void accessBikeRental() {
         RoutingRequest request = createTestRequest(2009, 9, 21, 16, 14, 0);
 
-        request.modes = new RequestModes(StreetMode.BIKE_RENTAL, StreetMode.WALK, null, Set.of(TransitMode.values()));
+        request.modes = new RequestModes(StreetMode.BIKE_RENTAL, StreetMode.WALK,  StreetMode.WALK, null, Set.of(TransitMode.values()));
         request.from = p1;
         request.to = p3;
 
@@ -94,7 +94,7 @@ public class BikeRentalSnapshotTest
     @Test public void egressBikeRental() {
         RoutingRequest request = createTestRequest(2009, 9, 21, 16, 10, 0);
 
-        request.modes = new RequestModes(StreetMode.WALK, StreetMode.BIKE_RENTAL, null, Set.of(TransitMode.values()));
+        request.modes = new RequestModes(StreetMode.WALK, StreetMode.WALK, StreetMode.BIKE_RENTAL, null, Set.of(TransitMode.values()));
         request.from = p3;
         request.to = p1;
 

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/BikeRentalSnapshotTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/BikeRentalSnapshotTest.java
@@ -58,6 +58,8 @@ public class BikeRentalSnapshotTest
              */
             arriveBy.legs.get(1).endTime = departAt.legs.get(1).endTime;
             arriveBy.legs.get(2).startTime = departAt.legs.get(2).startTime;
+
+            handleGeneralizedCost(departAt, arriveBy);
         });
     }
 
@@ -76,6 +78,8 @@ public class BikeRentalSnapshotTest
              */
             arriveBy.legs.get(1).endTime = departAt.legs.get(1).endTime;
             arriveBy.legs.get(2).startTime = departAt.legs.get(2).startTime;
+
+            handleGeneralizedCost(departAt, arriveBy);
         });
     }
 
@@ -98,6 +102,6 @@ public class BikeRentalSnapshotTest
         request.from = p3;
         request.to = p1;
 
-        expectArriveByToMatchDepartAtAndSnapshot(request);
+        expectArriveByToMatchDepartAtAndSnapshot(request, SnapshotTestBase::handleGeneralizedCost);
     }
 }

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/SnapshotTestBase.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/SnapshotTestBase.java
@@ -342,4 +342,17 @@ public abstract class SnapshotTestBase {
             return SerializerType.JSON.name();
         }
     }
+
+    /**
+     * The generalizedCost for non-transit legs may differ for departAt / arriveBy searches,
+     * depending on where the costs were applied.
+     */
+    public static void handleGeneralizedCost(Itinerary departAt, Itinerary arriveBy) {
+        departAt.legs.stream()
+                .filter(l -> !l.mode.isTransit())
+                .forEach(l -> l.generalizedCost = 0);
+        arriveBy.legs.stream()
+                .filter(l -> !l.mode.isTransit())
+                .forEach(l -> l.generalizedCost = 0);
+    }
 }

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/TransitSnapshotTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/TransitSnapshotTest.java
@@ -57,7 +57,7 @@ public class TransitSnapshotTest
     public void test_trip_planning_with_walk_only() {
         RoutingRequest request = createTestRequest(2009, 10, 17, 10, 0, 0);
 
-        request.modes = new RequestModes(StreetMode.WALK, StreetMode.WALK, StreetMode.WALK,
+        request.modes = new RequestModes(StreetMode.WALK, StreetMode.WALK, StreetMode.WALK, StreetMode.WALK,
                 emptySet()
         );
         request.from = p0;
@@ -70,7 +70,7 @@ public class TransitSnapshotTest
     public void test_trip_planning_with_walk_only_stop() {
         RoutingRequest request = createTestRequest(2009, 10, 17, 10, 0, 0);
 
-        request.modes = new RequestModes(StreetMode.WALK, StreetMode.WALK, StreetMode.WALK,
+        request.modes = new RequestModes(StreetMode.WALK, StreetMode.WALK, StreetMode.WALK, StreetMode.WALK,
                 emptySet()
         );
         request.from = ps;
@@ -83,7 +83,7 @@ public class TransitSnapshotTest
     public void test_trip_planning_with_walk_only_stop_collection() {
         RoutingRequest request = createTestRequest(2009, 10, 17, 10, 0, 0);
 
-        request.modes = new RequestModes(StreetMode.WALK, StreetMode.WALK, StreetMode.WALK,
+        request.modes = new RequestModes(StreetMode.WALK, StreetMode.WALK, StreetMode.WALK, StreetMode.WALK,
                 emptySet()
         );
         request.from = ptc;
@@ -97,7 +97,7 @@ public class TransitSnapshotTest
     public void test_trip_planning_with_transit() {
         RoutingRequest request = createTestRequest(2009, 10, 17, 10, 0, 0);
 
-        request.modes = new RequestModes(StreetMode.WALK, StreetMode.WALK, StreetMode.WALK,
+        request.modes = new RequestModes(StreetMode.WALK, StreetMode.WALK, StreetMode.WALK, StreetMode.WALK,
                 Set.of(TransitMode.values())
         );
         request.from = p1;
@@ -110,7 +110,7 @@ public class TransitSnapshotTest
     public void test_trip_planning_with_transit_stop() {
         RoutingRequest request = createTestRequest(2009, 10, 17, 10, 0, 0);
 
-        request.modes = new RequestModes(StreetMode.WALK, StreetMode.WALK, StreetMode.WALK,
+        request.modes = new RequestModes(StreetMode.WALK, StreetMode.WALK, StreetMode.WALK, StreetMode.WALK,
                 Set.of(TransitMode.values())
         );
         request.from = ps;
@@ -123,7 +123,7 @@ public class TransitSnapshotTest
     public void test_trip_planning_with_transit_stop_collection() {
         RoutingRequest request = createTestRequest(2009, 10, 17, 10, 0, 0);
 
-        request.modes = new RequestModes(StreetMode.WALK, StreetMode.WALK, StreetMode.WALK,
+        request.modes = new RequestModes(StreetMode.WALK, StreetMode.WALK, StreetMode.WALK, StreetMode.WALK,
                 Set.of(TransitMode.values())
         );
         request.from = ptc;

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/BikeRentalSnapshotTest.snap
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/BikeRentalSnapshotTest.snap
@@ -37,7 +37,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
           }
         }
       },
-      "generalizedCost": 3071,
+      "generalizedCost": 2057,
       "legs": [
         {
           "agencyTimeZoneOffset": -25200000,
@@ -55,7 +55,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "name": "SW Johnson St. & NW 24th Ave. (P1)",
             "vertexType": "NORMAL"
           },
-          "generalizedCost": 1320,
+          "generalizedCost": 288,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 4,
@@ -160,7 +160,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "name": "-102309",
             "vertexType": "BIKESHARE"
           },
-          "generalizedCost": 0,
+          "generalizedCost": 21,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 2,
@@ -223,7 +223,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "name": "corner of way -102328 from 0 and Northwest Irving Street",
             "vertexType": "NORMAL"
           },
-          "generalizedCost": 0,
+          "generalizedCost": 236,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 6,
@@ -286,7 +286,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "name": "-102323",
             "vertexType": "BIKESHARE"
           },
-          "generalizedCost": 0,
+          "generalizedCost": 49,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 5,
@@ -497,7 +497,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "vertexType": "TRANSIT",
             "zoneId": "0"
           },
-          "generalizedCost": 576,
+          "generalizedCost": 285,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 15,
@@ -558,6 +558,848 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
     },
     {
       "arrivedAtDestinationWithRentedBicycle": false,
+      "durationSeconds": 1281,
+      "elevationGained": 0.0,
+      "elevationLost": 0.0,
+      "fare": {
+        "details": {
+          "regular": [
+            {
+              "fareId": {
+                "feedId": "prt",
+                "id": "8"
+              },
+              "price": {
+                "cents": 200,
+                "currency": {
+                  "value": "USD"
+                }
+              },
+              "routes": [
+                {
+                  "feedId": "prt",
+                  "id": "20"
+                }
+              ]
+            }
+          ]
+        },
+        "fare": {
+          "regular": {
+            "cents": 200,
+            "currency": {
+              "value": "USD"
+            }
+          }
+        }
+      },
+      "generalizedCost": 2577,
+      "legs": [
+        {
+          "agencyTimeZoneOffset": -25200000,
+          "arrivalDelay": 0,
+          "bikeRentalNetworks": [ ],
+          "departureDelay": 0,
+          "distanceMeters": 565.958,
+          "endTime": "2009-10-21T23:23:59.000+0000",
+          "flexibleTrip": false,
+          "from": {
+            "coordinate": {
+              "latitude": 45.52832,
+              "longitude": -122.70059
+            },
+            "name": "SW Johnson St. & NW 24th Ave. (P1)",
+            "vertexType": "NORMAL"
+          },
+          "generalizedCost": 865,
+          "interlineWithPreviousLeg": false,
+          "legGeometry": {
+            "length": 34,
+            "points": "}f{tGv}{kVjCAjCEnCCFCFErACj@CLMHGFJLNNNDBDBDBF@FBLBH@FBDBNHNJLDPLb@Z^XPNNTBQT{ARJEP"
+          },
+          "mode": "WALK",
+          "onStreetNonTransit": true,
+          "pathway": false,
+          "realTime": false,
+          "rentedBike": false,
+          "scheduled": false,
+          "startTime": "2009-10-21T23:16:33.000+0000",
+          "streetNotes": [ ],
+          "to": {
+            "coordinate": {
+              "latitude": 45.523773,
+              "longitude": -122.700988
+            },
+            "name": "W Burnside & SW Osage",
+            "stopCode": "9354",
+            "stopId": {
+              "feedId": "prt",
+              "id": "9354"
+            },
+            "stopIndex": 36,
+            "stopSequence": 37,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "transitAlerts": [ ],
+          "transitLeg": false,
+          "walkSteps": [
+            {
+              "absoluteDirection": "SOUTH",
+              "angle": 3.1263917767722313,
+              "area": false,
+              "bogusName": false,
+              "distance": 317.401,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "DEPART",
+              "startLocation": {
+                "latitude": 45.52831993266165,
+                "longitude": -122.70059632295107
+              },
+              "stayOn": false,
+              "streetName": "Northwest 24th Avenue",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "SOUTHEAST",
+              "angle": 2.5526330127940713,
+              "area": false,
+              "bogusName": false,
+              "distance": 15.262,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "SLIGHTLY_LEFT",
+              "startLocation": {
+                "latitude": 45.525472400000005,
+                "longitude": -122.7004445
+              },
+              "stayOn": false,
+              "streetName": "Northwest Westover Road",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "SOUTHWEST",
+              "angle": -2.444809332621762,
+              "area": false,
+              "bogusName": false,
+              "distance": 176.41,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "RIGHT",
+              "startLocation": {
+                "latitude": 45.5253583,
+                "longitude": -122.70033570000001
+              },
+              "stayOn": false,
+              "streetName": "Northwest 24th Place",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "EAST",
+              "angle": 1.8983573391990143,
+              "area": false,
+              "bogusName": false,
+              "distance": 45.172,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "LEFT",
+              "startLocation": {
+                "latitude": 45.5239733,
+                "longitude": -122.701384
+              },
+              "stayOn": false,
+              "streetName": "West Burnside Street",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "SOUTHWEST",
+              "angle": -2.7486456202400182,
+              "area": false,
+              "bogusName": true,
+              "distance": 11.713,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "RIGHT",
+              "startLocation": {
+                "latitude": 45.5238426,
+                "longitude": -122.70083500000001
+              },
+              "stayOn": false,
+              "streetName": "way 113897002 from 7",
+              "streetNotes": [ ]
+            }
+          ],
+          "walkingLeg": true
+        },
+        {
+          "agencyTimeZoneOffset": 0,
+          "arrivalDelay": 0,
+          "bikeRentalNetworks": [ ],
+          "departureDelay": 0,
+          "distanceMeters": 1879.0379409561187,
+          "endTime": "2009-10-21T23:32:52.000+0000",
+          "flexibleTrip": false,
+          "from": {
+            "coordinate": {
+              "latitude": 45.523773,
+              "longitude": -122.700988
+            },
+            "name": "W Burnside & SW Osage",
+            "stopCode": "9354",
+            "stopId": {
+              "feedId": "prt",
+              "id": "9354"
+            },
+            "stopIndex": 36,
+            "stopSequence": 37,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "generalizedCost": 1133,
+          "headsign": "Gresham TC",
+          "intermediateStops": [ ],
+          "legGeometry": {
+            "length": 53,
+            "points": "gkztGz_|kVTmALiBt@mJJ_DBoA??@e@D}AFyDBgADwB??@]BaADgCDmC??By@FiEJoEBuA??DsBD}BBiADmC@y@AiB???Y?g@As@?_@?YAeB@uD???{@G{D?mECeBAu@??Ai@CoEASAuDAmB???MCqEA_B"
+          },
+          "mode": "BUS",
+          "onStreetNonTransit": false,
+          "pathway": false,
+          "realTime": false,
+          "scheduled": true,
+          "serviceDate": {
+            "day": 21,
+            "minMax": false,
+            "month": 10,
+            "sequenceNumber": 20091021,
+            "year": 2009
+          },
+          "startTime": "2009-10-21T23:23:59.000+0000",
+          "streetNotes": [ ],
+          "to": {
+            "coordinate": {
+              "latitude": 45.522961,
+              "longitude": -122.676924
+            },
+            "name": "W Burnside & SW 6th",
+            "stopCode": "792",
+            "stopId": {
+              "feedId": "prt",
+              "id": "792"
+            },
+            "stopIndex": 45,
+            "stopSequence": 46,
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
+          },
+          "transitAlerts": [ ],
+          "transitLeg": true,
+          "trip": {
+            "alteration": "PLANNED",
+            "bikesAllowed": "UNKNOWN",
+            "blockId": "1237",
+            "direction": "INBOUND",
+            "id": {
+              "feedId": "prt",
+              "id": "201W1450"
+            },
+            "route": {
+              "agency": {
+                "fareUrl": "http://trimet.org/fares/index.htm",
+                "id": {
+                  "feedId": "prt",
+                  "id": "prt"
+                },
+                "lang": "en",
+                "name": "TriMet",
+                "phone": "503-238-7433",
+                "timezone": "America/Los_Angeles",
+                "url": "http://trimet.org"
+              },
+              "bikesAllowed": "UNKNOWN",
+              "id": {
+                "feedId": "prt",
+                "id": "20"
+              },
+              "longName": "Burnside/Stark",
+              "mode": "BUS",
+              "shortName": "20",
+              "sortOrder": -999,
+              "sortOrderSet": false,
+              "type": 3,
+              "url": "http://trimet.org/schedules/r020.htm"
+            },
+            "serviceId": {
+              "feedId": "prt",
+              "id": "W"
+            },
+            "shapeId": {
+              "feedId": "prt",
+              "id": "20.1.3"
+            },
+            "wheelchairAccessible": 0
+          },
+          "walkSteps": [ ],
+          "walkingLeg": false
+        },
+        {
+          "agencyTimeZoneOffset": -25200000,
+          "arrivalDelay": 0,
+          "bikeRentalNetworks": [ ],
+          "departureDelay": 0,
+          "distanceMeters": 379.27700000000004,
+          "endTime": "2009-10-21T23:37:54.000+0000",
+          "flexibleTrip": false,
+          "from": {
+            "coordinate": {
+              "latitude": 45.522961,
+              "longitude": -122.676924
+            },
+            "name": "W Burnside & SW 6th",
+            "stopCode": "792",
+            "stopId": {
+              "feedId": "prt",
+              "id": "792"
+            },
+            "stopIndex": 45,
+            "stopSequence": 46,
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
+          },
+          "generalizedCost": 579,
+          "interlineWithPreviousLeg": false,
+          "legGeometry": {
+            "length": 23,
+            "points": "oeztGxiwkVE?AgA?OKCKAM?iBBI?K?wBBK?K?sBDM@?E?MCgD?A?O?C?M?a@"
+          },
+          "mode": "WALK",
+          "onStreetNonTransit": true,
+          "pathway": false,
+          "realTime": false,
+          "rentedBike": false,
+          "scheduled": false,
+          "startTime": "2009-10-21T23:32:52.000+0000",
+          "streetNotes": [ ],
+          "to": {
+            "coordinate": {
+              "latitude": 45.52523,
+              "longitude": -122.67525
+            },
+            "name": "NW Everett St. & NW 5th Ave. (P3)",
+            "vertexType": "NORMAL"
+          },
+          "transitAlerts": [ ],
+          "transitLeg": false,
+          "walkSteps": [
+            {
+              "absoluteDirection": "EAST",
+              "angle": 1.5497787842228707,
+              "area": false,
+              "bogusName": false,
+              "distance": 34.205,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "DEPART",
+              "startLocation": {
+                "latitude": 45.52299572692338,
+                "longitude": -122.67692504190299
+              },
+              "stayOn": false,
+              "streetName": "West Burnside Street",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "NORTH",
+              "angle": 0.15756873585456135,
+              "area": false,
+              "bogusName": false,
+              "distance": 13.464,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "LEFT",
+              "startLocation": {
+                "latitude": 45.523002600000005,
+                "longitude": -122.6764861
+              },
+              "stayOn": false,
+              "streetName": "Southwest 6th Avenue",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "NORTH",
+              "angle": -0.01751656882715628,
+              "area": false,
+              "bogusName": false,
+              "distance": 231.502,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "CONTINUE",
+              "startLocation": {
+                "latitude": 45.5231221,
+                "longitude": -122.67645900000001
+              },
+              "stayOn": false,
+              "streetName": "Northwest 6th Avenue",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "EAST",
+              "angle": 1.5420709297121307,
+              "area": false,
+              "bogusName": false,
+              "distance": 100.106,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "RIGHT",
+              "startLocation": {
+                "latitude": 45.525202900000004,
+                "longitude": -122.6765342
+              },
+              "stayOn": false,
+              "streetName": "Northwest Everett Street",
+              "streetNotes": [ ]
+            }
+          ],
+          "walkingLeg": true
+        }
+      ],
+      "nTransfers": 0,
+      "nonTransitDistanceMeters": 945.235,
+      "nonTransitTimeSeconds": 748,
+      "onStreetAllTheWay": false,
+      "streetOnly": false,
+      "systemNotices": [ ],
+      "tooSloped": false,
+      "transitTimeSeconds": 533,
+      "waitTimeAdjustedGeneralizedCost": -999999,
+      "waitingTimeSeconds": 0,
+      "walkOnly": false,
+      "walkingAllTheWay": false
+    },
+    {
+      "arrivedAtDestinationWithRentedBicycle": false,
+      "durationSeconds": 1296,
+      "elevationGained": 0.0,
+      "elevationLost": 0.0,
+      "fare": {
+        "details": {
+          "regular": [
+            {
+              "fareId": {
+                "feedId": "prt",
+                "id": "8"
+              },
+              "price": {
+                "cents": 200,
+                "currency": {
+                  "value": "USD"
+                }
+              },
+              "routes": [
+                {
+                  "feedId": "prt",
+                  "id": "20"
+                }
+              ]
+            }
+          ]
+        },
+        "fare": {
+          "regular": {
+            "cents": 200,
+            "currency": {
+              "value": "USD"
+            }
+          }
+        }
+      },
+      "generalizedCost": 2539,
+      "legs": [
+        {
+          "agencyTimeZoneOffset": -25200000,
+          "arrivalDelay": 0,
+          "bikeRentalNetworks": [ ],
+          "departureDelay": 0,
+          "distanceMeters": 565.958,
+          "endTime": "2009-10-21T23:23:59.000+0000",
+          "flexibleTrip": false,
+          "from": {
+            "coordinate": {
+              "latitude": 45.52832,
+              "longitude": -122.70059
+            },
+            "name": "SW Johnson St. & NW 24th Ave. (P1)",
+            "vertexType": "NORMAL"
+          },
+          "generalizedCost": 865,
+          "interlineWithPreviousLeg": false,
+          "legGeometry": {
+            "length": 34,
+            "points": "}f{tGv}{kVjCAjCEnCCFCFErACj@CLMHGFJLNNNDBDBDBF@FBLBH@FBDBNHNJLDPLb@Z^XPNNTBQT{ARJEP"
+          },
+          "mode": "WALK",
+          "onStreetNonTransit": true,
+          "pathway": false,
+          "realTime": false,
+          "rentedBike": false,
+          "scheduled": false,
+          "startTime": "2009-10-21T23:16:33.000+0000",
+          "streetNotes": [ ],
+          "to": {
+            "coordinate": {
+              "latitude": 45.523773,
+              "longitude": -122.700988
+            },
+            "name": "W Burnside & SW Osage",
+            "stopCode": "9354",
+            "stopId": {
+              "feedId": "prt",
+              "id": "9354"
+            },
+            "stopIndex": 36,
+            "stopSequence": 37,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "transitAlerts": [ ],
+          "transitLeg": false,
+          "walkSteps": [
+            {
+              "absoluteDirection": "SOUTH",
+              "angle": 3.1263917767722313,
+              "area": false,
+              "bogusName": false,
+              "distance": 317.401,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "DEPART",
+              "startLocation": {
+                "latitude": 45.52831993266165,
+                "longitude": -122.70059632295107
+              },
+              "stayOn": false,
+              "streetName": "Northwest 24th Avenue",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "SOUTHEAST",
+              "angle": 2.5526330127940713,
+              "area": false,
+              "bogusName": false,
+              "distance": 15.262,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "SLIGHTLY_LEFT",
+              "startLocation": {
+                "latitude": 45.525472400000005,
+                "longitude": -122.7004445
+              },
+              "stayOn": false,
+              "streetName": "Northwest Westover Road",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "SOUTHWEST",
+              "angle": -2.444809332621762,
+              "area": false,
+              "bogusName": false,
+              "distance": 176.41,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "RIGHT",
+              "startLocation": {
+                "latitude": 45.5253583,
+                "longitude": -122.70033570000001
+              },
+              "stayOn": false,
+              "streetName": "Northwest 24th Place",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "EAST",
+              "angle": 1.8983573391990143,
+              "area": false,
+              "bogusName": false,
+              "distance": 45.172,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "LEFT",
+              "startLocation": {
+                "latitude": 45.5239733,
+                "longitude": -122.701384
+              },
+              "stayOn": false,
+              "streetName": "West Burnside Street",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "SOUTHWEST",
+              "angle": -2.7486456202400182,
+              "area": false,
+              "bogusName": true,
+              "distance": 11.713,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "RIGHT",
+              "startLocation": {
+                "latitude": 45.5238426,
+                "longitude": -122.70083500000001
+              },
+              "stayOn": false,
+              "streetName": "way 113897002 from 7",
+              "streetNotes": [ ]
+            }
+          ],
+          "walkingLeg": true
+        },
+        {
+          "agencyTimeZoneOffset": 0,
+          "arrivalDelay": 0,
+          "bikeRentalNetworks": [ ],
+          "departureDelay": 0,
+          "distanceMeters": 2044.4088086831664,
+          "endTime": "2009-10-21T23:34:00.000+0000",
+          "flexibleTrip": false,
+          "from": {
+            "coordinate": {
+              "latitude": 45.523773,
+              "longitude": -122.700988
+            },
+            "name": "W Burnside & SW Osage",
+            "stopCode": "9354",
+            "stopId": {
+              "feedId": "prt",
+              "id": "9354"
+            },
+            "stopIndex": 36,
+            "stopSequence": 37,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "generalizedCost": 1201,
+          "headsign": "Gresham TC",
+          "intermediateStops": [ ],
+          "legGeometry": {
+            "length": 57,
+            "points": "gkztGz_|kVTmALiBt@mJJ_DBoA??@e@D}AFyDBgADwB??@]BaADgCDmC??By@FiEJoEBuA??DsBD}BBiADmC@y@AiB???Y?g@As@?_@?YAeB@uD???{@G{D?mECeBAu@??Ai@CoEASAuDAmB???MCqEA_B??A{ACsEAwB"
+          },
+          "mode": "BUS",
+          "onStreetNonTransit": false,
+          "pathway": false,
+          "realTime": false,
+          "scheduled": true,
+          "serviceDate": {
+            "day": 21,
+            "minMax": false,
+            "month": 10,
+            "sequenceNumber": 20091021,
+            "year": 2009
+          },
+          "startTime": "2009-10-21T23:23:59.000+0000",
+          "streetNotes": [ ],
+          "to": {
+            "coordinate": {
+              "latitude": 45.522974,
+              "longitude": -122.674799
+            },
+            "name": "W Burnside & SW 4th",
+            "stopCode": "772",
+            "stopId": {
+              "feedId": "prt",
+              "id": "772"
+            },
+            "stopIndex": 46,
+            "stopSequence": 47,
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
+          },
+          "transitAlerts": [ ],
+          "transitLeg": true,
+          "trip": {
+            "alteration": "PLANNED",
+            "bikesAllowed": "UNKNOWN",
+            "blockId": "1237",
+            "direction": "INBOUND",
+            "id": {
+              "feedId": "prt",
+              "id": "201W1450"
+            },
+            "route": {
+              "agency": {
+                "fareUrl": "http://trimet.org/fares/index.htm",
+                "id": {
+                  "feedId": "prt",
+                  "id": "prt"
+                },
+                "lang": "en",
+                "name": "TriMet",
+                "phone": "503-238-7433",
+                "timezone": "America/Los_Angeles",
+                "url": "http://trimet.org"
+              },
+              "bikesAllowed": "UNKNOWN",
+              "id": {
+                "feedId": "prt",
+                "id": "20"
+              },
+              "longName": "Burnside/Stark",
+              "mode": "BUS",
+              "shortName": "20",
+              "sortOrder": -999,
+              "sortOrderSet": false,
+              "type": 3,
+              "url": "http://trimet.org/schedules/r020.htm"
+            },
+            "serviceId": {
+              "feedId": "prt",
+              "id": "W"
+            },
+            "shapeId": {
+              "feedId": "prt",
+              "id": "20.1.3"
+            },
+            "wheelchairAccessible": 0
+          },
+          "walkSteps": [ ],
+          "walkingLeg": false
+        },
+        {
+          "agencyTimeZoneOffset": -25200000,
+          "arrivalDelay": 0,
+          "bikeRentalNetworks": [ ],
+          "departureDelay": 0,
+          "distanceMeters": 308.24,
+          "endTime": "2009-10-21T23:38:09.000+0000",
+          "flexibleTrip": false,
+          "from": {
+            "coordinate": {
+              "latitude": 45.522974,
+              "longitude": -122.674799
+            },
+            "name": "W Burnside & SW 4th",
+            "stopCode": "772",
+            "stopId": {
+              "feedId": "prt",
+              "id": "772"
+            },
+            "stopIndex": 46,
+            "stopSequence": 47,
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
+          },
+          "generalizedCost": 472,
+          "interlineWithPreviousLeg": false,
+          "legGeometry": {
+            "length": 18,
+            "points": "qeztGn|vkVK@?v@@f@?RWBK@kBBI?K?wBBI?K?I?mBBK@?M?a@"
+          },
+          "mode": "WALK",
+          "onStreetNonTransit": true,
+          "pathway": false,
+          "realTime": false,
+          "rentedBike": false,
+          "scheduled": false,
+          "startTime": "2009-10-21T23:34:00.000+0000",
+          "streetNotes": [ ],
+          "to": {
+            "coordinate": {
+              "latitude": 45.52523,
+              "longitude": -122.67525
+            },
+            "name": "NW Everett St. & NW 5th Ave. (P3)",
+            "vertexType": "NORMAL"
+          },
+          "transitAlerts": [ ],
+          "transitLeg": false,
+          "walkSteps": [
+            {
+              "absoluteDirection": "WEST",
+              "angle": -1.6005588803815705,
+              "area": false,
+              "bogusName": false,
+              "distance": 45.562,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "DEPART",
+              "startLocation": {
+                "latitude": 45.52303774853131,
+                "longitude": -122.6748017088418
+              },
+              "stayOn": false,
+              "streetName": "West Burnside Street",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "NORTH",
+              "angle": -0.1012967237660391,
+              "area": false,
+              "bogusName": false,
+              "distance": 12.942,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "RIGHT",
+              "startLocation": {
+                "latitude": 45.5230254,
+                "longitude": -122.67538630000001
+              },
+              "stayOn": false,
+              "streetName": "Southwest 5th Avenue",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "NORTH",
+              "angle": -0.03473794392561525,
+              "area": false,
+              "bogusName": false,
+              "distance": 231.76099999999997,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "CONTINUE",
+              "startLocation": {
+                "latitude": 45.523141200000005,
+                "longitude": -122.67540310000001
+              },
+              "stayOn": false,
+              "streetName": "Northwest 5th Avenue",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "EAST",
+              "angle": 1.547640308928389,
+              "area": false,
+              "bogusName": false,
+              "distance": 17.975,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "RIGHT",
+              "startLocation": {
+                "latitude": 45.525224200000004,
+                "longitude": -122.67548060000001
+              },
+              "stayOn": false,
+              "streetName": "Northwest Everett Street",
+              "streetNotes": [ ]
+            }
+          ],
+          "walkingLeg": true
+        }
+      ],
+      "nTransfers": 0,
+      "nonTransitDistanceMeters": 874.198,
+      "nonTransitTimeSeconds": 695,
+      "onStreetAllTheWay": false,
+      "streetOnly": false,
+      "systemNotices": [ ],
+      "tooSloped": false,
+      "transitTimeSeconds": 601,
+      "waitTimeAdjustedGeneralizedCost": -999999,
+      "waitingTimeSeconds": 0,
+      "walkOnly": false,
+      "walkingAllTheWay": false
+    },
+    {
+      "arrivedAtDestinationWithRentedBicycle": false,
       "durationSeconds": 1001,
       "elevationGained": 0.0,
       "elevationLost": 0.0,
@@ -593,7 +1435,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
           }
         }
       },
-      "generalizedCost": 2231,
+      "generalizedCost": 1805,
       "legs": [
         {
           "agencyTimeZoneOffset": -25200000,
@@ -611,7 +1453,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "name": "SW Johnson St. & NW 24th Ave. (P1)",
             "vertexType": "NORMAL"
           },
-          "generalizedCost": 688,
+          "generalizedCost": 336,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 6,
@@ -816,7 +1658,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "vertexType": "TRANSIT",
             "zoneId": "0"
           },
-          "generalizedCost": 152,
+          "generalizedCost": 77,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 3,
@@ -912,7 +1754,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
           }
         }
       },
-      "generalizedCost": 3071,
+      "generalizedCost": 2057,
       "legs": [
         {
           "agencyTimeZoneOffset": -25200000,
@@ -930,7 +1772,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "name": "SW Johnson St. & NW 24th Ave. (P1)",
             "vertexType": "NORMAL"
           },
-          "generalizedCost": 1320,
+          "generalizedCost": 288,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 4,
@@ -1035,7 +1877,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "name": "-102309",
             "vertexType": "BIKESHARE"
           },
-          "generalizedCost": 0,
+          "generalizedCost": 21,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 2,
@@ -1098,7 +1940,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "name": "corner of way -102328 from 0 and Northwest Irving Street",
             "vertexType": "NORMAL"
           },
-          "generalizedCost": 0,
+          "generalizedCost": 236,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 6,
@@ -1161,7 +2003,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "name": "-102323",
             "vertexType": "BIKESHARE"
           },
-          "generalizedCost": 0,
+          "generalizedCost": 49,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 5,
@@ -1372,7 +2214,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "vertexType": "TRANSIT",
             "zoneId": "0"
           },
-          "generalizedCost": 576,
+          "generalizedCost": 285,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 15,
@@ -1468,7 +2310,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
           }
         }
       },
-      "generalizedCost": 3071,
+      "generalizedCost": 2057,
       "legs": [
         {
           "agencyTimeZoneOffset": -25200000,
@@ -1486,7 +2328,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "name": "SW Johnson St. & NW 24th Ave. (P1)",
             "vertexType": "NORMAL"
           },
-          "generalizedCost": 1320,
+          "generalizedCost": 288,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 4,
@@ -1591,7 +2433,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "name": "-102309",
             "vertexType": "BIKESHARE"
           },
-          "generalizedCost": 0,
+          "generalizedCost": 21,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 2,
@@ -1654,7 +2496,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "name": "corner of way -102328 from 0 and Northwest Irving Street",
             "vertexType": "NORMAL"
           },
-          "generalizedCost": 0,
+          "generalizedCost": 236,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 6,
@@ -1717,7 +2559,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "name": "-102323",
             "vertexType": "BIKESHARE"
           },
-          "generalizedCost": 0,
+          "generalizedCost": 49,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 5,
@@ -1928,7 +2770,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "vertexType": "TRANSIT",
             "zoneId": "0"
           },
-          "generalizedCost": 576,
+          "generalizedCost": 285,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 15,
@@ -1941,881 +2783,6 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
           "rentedBike": false,
           "scheduled": false,
           "startTime": "2009-10-21T23:52:00.000+0000",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.52523,
-              "longitude": -122.67525
-            },
-            "name": "NW Everett St. & NW 5th Ave. (P3)",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
-            {
-              "absoluteDirection": "EAST",
-              "angle": 1.5470481318922238,
-              "area": false,
-              "bogusName": false,
-              "distance": 188.35399999999998,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.52518265861028,
-                "longitude": -122.6776666369647
-              },
-              "stayOn": false,
-              "streetName": "Northwest Everett Street",
-              "streetNotes": [ ]
-            }
-          ],
-          "walkingLeg": true
-        }
-      ],
-      "nTransfers": 0,
-      "nonTransitDistanceMeters": 817.8299999999999,
-      "nonTransitTimeSeconds": 474,
-      "onStreetAllTheWay": false,
-      "streetOnly": false,
-      "systemNotices": [ ],
-      "tooSloped": false,
-      "transitTimeSeconds": 575,
-      "waitTimeAdjustedGeneralizedCost": -999999,
-      "waitingTimeSeconds": 0,
-      "walkOnly": false,
-      "walkingAllTheWay": false
-    },
-    {
-      "arrivedAtDestinationWithRentedBicycle": false,
-      "durationSeconds": 1001,
-      "elevationGained": 0.0,
-      "elevationLost": 0.0,
-      "fare": {
-        "details": {
-          "regular": [
-            {
-              "fareId": {
-                "feedId": "prt",
-                "id": "8"
-              },
-              "price": {
-                "cents": 200,
-                "currency": {
-                  "value": "USD"
-                }
-              },
-              "routes": [
-                {
-                  "feedId": "prt",
-                  "id": "77"
-                }
-              ]
-            }
-          ]
-        },
-        "fare": {
-          "regular": {
-            "cents": 200,
-            "currency": {
-              "value": "USD"
-            }
-          }
-        }
-      },
-      "generalizedCost": 2231,
-      "legs": [
-        {
-          "agencyTimeZoneOffset": -25200000,
-          "arrivalDelay": 0,
-          "bikeRentalNetworks": [ ],
-          "departureDelay": 0,
-          "distanceMeters": 220.14600000000002,
-          "endTime": "2009-10-21T23:42:21.000+0000",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.52832,
-              "longitude": -122.70059
-            },
-            "name": "SW Johnson St. & NW 24th Ave. (P1)",
-            "vertexType": "NORMAL"
-          },
-          "generalizedCost": 688,
-          "interlineWithPreviousLeg": false,
-          "legGeometry": {
-            "length": 6,
-            "points": "}f{tGv}{kVC?mCBmCD@zCN?"
-          },
-          "mode": "WALK",
-          "onStreetNonTransit": true,
-          "pathway": false,
-          "realTime": false,
-          "rentedBike": false,
-          "scheduled": false,
-          "startTime": "2009-10-21T23:39:29.000+0000",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.529662,
-              "longitude": -122.701423
-            },
-            "name": "2400 Block NW Lovejoy",
-            "stopCode": "3589",
-            "stopId": {
-              "feedId": "prt",
-              "id": "3589"
-            },
-            "stopIndex": 6,
-            "stopSequence": 7,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
-            {
-              "absoluteDirection": "NORTH",
-              "angle": -0.015200780078397704,
-              "area": false,
-              "bogusName": false,
-              "distance": 159.625,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.52831993266165,
-                "longitude": -122.70059632295107
-              },
-              "stayOn": false,
-              "streetName": "Northwest 24th Avenue",
-              "streetNotes": [ ]
-            },
-            {
-              "absoluteDirection": "WEST",
-              "angle": -1.5928981885811253,
-              "area": false,
-              "bogusName": false,
-              "distance": 60.521,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.529755,
-                "longitude": -122.70064880000001
-              },
-              "stayOn": false,
-              "streetName": "Northwest Lovejoy Street",
-              "streetNotes": [ ]
-            }
-          ],
-          "walkingLeg": true
-        },
-        {
-          "agencyTimeZoneOffset": 0,
-          "arrivalDelay": 0,
-          "bikeRentalNetworks": [ ],
-          "departureDelay": 0,
-          "distanceMeters": 2804.1297859664874,
-          "endTime": "2009-10-21T23:55:32.000+0000",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.529662,
-              "longitude": -122.701423
-            },
-            "name": "2400 Block NW Lovejoy",
-            "stopCode": "3589",
-            "stopId": {
-              "feedId": "prt",
-              "id": "3589"
-            },
-            "stopIndex": 6,
-            "stopSequence": 7,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
-          },
-          "generalizedCost": 1391,
-          "headsign": "Troutdale",
-          "intermediateStops": [ ],
-          "legGeometry": {
-            "length": 60,
-            "points": "yo{tG|b|kVC}CEuKGwI???}@G{J???YGsKEuKCuD???UCiECeEAgA?{@AkA?WAwDE{C???i@CiECkECcD??Ae@?mE{BDQ@q@@??{ADCsDbBiB`DaEt@_AVANIX?tBCLK`@c@\\c@l@w@??\\c@FKDCFEXCCgEvBEVAlCClCEnCECoD"
-          },
-          "mode": "BUS",
-          "onStreetNonTransit": false,
-          "pathway": false,
-          "realTime": false,
-          "scheduled": true,
-          "serviceDate": {
-            "day": 21,
-            "minMax": false,
-            "month": 10,
-            "sequenceNumber": 20091021,
-            "year": 2009
-          },
-          "startTime": "2009-10-21T23:42:21.000+0000",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.525183,
-              "longitude": -122.674607
-            },
-            "name": "NW Everett & 4th",
-            "stopCode": "9546",
-            "stopId": {
-              "feedId": "prt",
-              "id": "9546"
-            },
-            "stopIndex": 14,
-            "stopSequence": 15,
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": true,
-          "trip": {
-            "alteration": "PLANNED",
-            "bikesAllowed": "UNKNOWN",
-            "blockId": "7703",
-            "direction": "OUTBOUND",
-            "id": {
-              "feedId": "prt",
-              "id": "770W1400"
-            },
-            "route": {
-              "agency": {
-                "fareUrl": "http://trimet.org/fares/index.htm",
-                "id": {
-                  "feedId": "prt",
-                  "id": "prt"
-                },
-                "lang": "en",
-                "name": "TriMet",
-                "phone": "503-238-7433",
-                "timezone": "America/Los_Angeles",
-                "url": "http://trimet.org"
-              },
-              "bikesAllowed": "UNKNOWN",
-              "id": {
-                "feedId": "prt",
-                "id": "77"
-              },
-              "longName": "Broadway/Halsey",
-              "mode": "BUS",
-              "shortName": "77",
-              "sortOrder": -999,
-              "sortOrderSet": false,
-              "type": 3,
-              "url": "http://trimet.org/schedules/r077.htm"
-            },
-            "serviceId": {
-              "feedId": "prt",
-              "id": "W"
-            },
-            "shapeId": {
-              "feedId": "prt",
-              "id": "77.0.2"
-            },
-            "wheelchairAccessible": 0
-          },
-          "walkSteps": [ ],
-          "walkingLeg": false
-        },
-        {
-          "agencyTimeZoneOffset": -25200000,
-          "arrivalDelay": 0,
-          "bikeRentalNetworks": [ ],
-          "departureDelay": 0,
-          "distanceMeters": 49.938,
-          "endTime": "2009-10-21T23:56:10.000+0000",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.525183,
-              "longitude": -122.674607
-            },
-            "name": "NW Everett & 4th",
-            "stopCode": "9546",
-            "stopId": {
-              "feedId": "prt",
-              "id": "9546"
-            },
-            "stopIndex": 14,
-            "stopSequence": 15,
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
-          },
-          "generalizedCost": 152,
-          "interlineWithPreviousLeg": false,
-          "legGeometry": {
-            "length": 3,
-            "points": "ksztGh{vkVI?@~B"
-          },
-          "mode": "WALK",
-          "onStreetNonTransit": true,
-          "pathway": false,
-          "realTime": false,
-          "rentedBike": false,
-          "scheduled": false,
-          "startTime": "2009-10-21T23:55:32.000+0000",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.52523,
-              "longitude": -122.67525
-            },
-            "name": "NW Everett St. & NW 5th Ave. (P3)",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
-            {
-              "absoluteDirection": "WEST",
-              "angle": -1.5968688222706109,
-              "area": false,
-              "bogusName": false,
-              "distance": 49.938,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.525239650875925,
-                "longitude": -122.67460910872424
-              },
-              "stayOn": false,
-              "streetName": "Northwest Everett Street",
-              "streetNotes": [ ]
-            }
-          ],
-          "walkingLeg": true
-        }
-      ],
-      "nTransfers": 0,
-      "nonTransitDistanceMeters": 270.084,
-      "nonTransitTimeSeconds": 210,
-      "onStreetAllTheWay": false,
-      "streetOnly": false,
-      "systemNotices": [ ],
-      "tooSloped": false,
-      "transitTimeSeconds": 791,
-      "waitTimeAdjustedGeneralizedCost": -999999,
-      "waitingTimeSeconds": 0,
-      "walkOnly": false,
-      "walkingAllTheWay": false
-    },
-    {
-      "arrivedAtDestinationWithRentedBicycle": false,
-      "durationSeconds": 1049,
-      "elevationGained": 0.0,
-      "elevationLost": 0.0,
-      "fare": {
-        "details": {
-          "regular": [
-            {
-              "fareId": {
-                "feedId": "prt",
-                "id": "8"
-              },
-              "price": {
-                "cents": 200,
-                "currency": {
-                  "value": "USD"
-                }
-              },
-              "routes": [
-                {
-                  "feedId": "prt",
-                  "id": "17"
-                }
-              ]
-            }
-          ]
-        },
-        "fare": {
-          "regular": {
-            "cents": 200,
-            "currency": {
-              "value": "USD"
-            }
-          }
-        }
-      },
-      "generalizedCost": 3071,
-      "legs": [
-        {
-          "agencyTimeZoneOffset": -25200000,
-          "arrivalDelay": 0,
-          "bikeRentalNetworks": [ ],
-          "departureDelay": 0,
-          "distanceMeters": 106.589,
-          "endTime": "2009-10-21T23:48:26.000+0000",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.52832,
-              "longitude": -122.70059
-            },
-            "name": "SW Johnson St. & NW 24th Ave. (P1)",
-            "vertexType": "NORMAL"
-          },
-          "generalizedCost": 1320,
-          "interlineWithPreviousLeg": false,
-          "legGeometry": {
-            "length": 4,
-            "points": "}f{tGv}{kVjCA?e@WA"
-          },
-          "mode": "WALK",
-          "onStreetNonTransit": true,
-          "pathway": false,
-          "realTime": false,
-          "rentedBike": false,
-          "scheduled": false,
-          "startTime": "2009-10-21T23:45:55.000+0000",
-          "streetNotes": [ ],
-          "to": {
-            "bikeShareId": "-102309",
-            "coordinate": {
-              "latitude": 45.5277374,
-              "longitude": -122.70038790000001
-            },
-            "name": "-102309",
-            "vertexType": "BIKESHARE"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
-            {
-              "absoluteDirection": "SOUTH",
-              "angle": 3.1263917767722313,
-              "area": false,
-              "bogusName": false,
-              "distance": 78.527,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.52831993266165,
-                "longitude": -122.70059632295107
-              },
-              "stayOn": false,
-              "streetName": "Northwest 24th Avenue",
-              "streetNotes": [ ]
-            },
-            {
-              "absoluteDirection": "EAST",
-              "angle": 1.5443268101828453,
-              "area": false,
-              "bogusName": false,
-              "distance": 14.704,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.527613800000005,
-                "longitude": -122.70058100000001
-              },
-              "stayOn": false,
-              "streetName": "Northwest Irving Street",
-              "streetNotes": [ ]
-            },
-            {
-              "absoluteDirection": "NORTH",
-              "angle": 0.02566034822056683,
-              "area": false,
-              "bikeRentalOnStation": {
-                "id": "-102309",
-                "lat": 45.5277374,
-                "lon": -122.70038790000001,
-                "name": "-102309"
-              },
-              "bogusName": true,
-              "distance": 13.358,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.5276173,
-                "longitude": -122.7003923
-              },
-              "stayOn": false,
-              "streetName": "way -102328 from 0",
-              "streetNotes": [ ]
-            }
-          ],
-          "walkingLeg": true
-        },
-        {
-          "agencyTimeZoneOffset": -25200000,
-          "arrivalDelay": 0,
-          "bikeRentalNetworks": [
-            "test-network"
-          ],
-          "departureDelay": 0,
-          "distanceMeters": 13.358,
-          "endTime": "2009-10-21T23:48:37.000+0000",
-          "flexibleTrip": false,
-          "from": {
-            "bikeShareId": "-102309",
-            "coordinate": {
-              "latitude": 45.5277374,
-              "longitude": -122.70038790000001
-            },
-            "name": "-102309",
-            "vertexType": "BIKESHARE"
-          },
-          "generalizedCost": 0,
-          "interlineWithPreviousLeg": false,
-          "legGeometry": {
-            "length": 2,
-            "points": "ic{tGl|{kVV@"
-          },
-          "mode": "WALK",
-          "onStreetNonTransit": true,
-          "pathway": false,
-          "realTime": false,
-          "rentedBike": true,
-          "scheduled": false,
-          "startTime": "2009-10-21T23:48:26.000+0000",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.5276173,
-              "longitude": -122.7003923
-            },
-            "name": "corner of way -102328 from 0 and Northwest Irving Street",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
-            {
-              "absoluteDirection": "SOUTH",
-              "angle": -3.1159323053692263,
-              "area": false,
-              "bogusName": true,
-              "distance": 13.358,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "HARD_LEFT",
-              "startLocation": {
-                "latitude": 45.5277374,
-                "longitude": -122.70038790000001
-              },
-              "stayOn": false,
-              "streetName": "way -102328 from 0",
-              "streetNotes": [ ]
-            }
-          ],
-          "walkingLeg": true
-        },
-        {
-          "agencyTimeZoneOffset": -25200000,
-          "arrivalDelay": 0,
-          "bikeRentalNetworks": [
-            "test-network"
-          ],
-          "departureDelay": 0,
-          "distanceMeters": 480.068,
-          "endTime": "2009-10-21T23:50:58.000+0000",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.5276173,
-              "longitude": -122.7003923
-            },
-            "name": "corner of way -102328 from 0 and Northwest Irving Street",
-            "vertexType": "NORMAL"
-          },
-          "generalizedCost": 0,
-          "interlineWithPreviousLeg": false,
-          "legGeometry": {
-            "length": 6,
-            "points": "qb{tGn|{kVGsJEuKE}HAwAAo@"
-          },
-          "mode": "BICYCLE",
-          "onStreetNonTransit": true,
-          "pathway": false,
-          "realTime": false,
-          "rentedBike": true,
-          "scheduled": false,
-          "startTime": "2009-10-21T23:48:37.000+0000",
-          "streetNotes": [ ],
-          "to": {
-            "bikeShareId": "-102323",
-            "coordinate": {
-              "latitude": 45.527849100000005,
-              "longitude": -122.6942362
-            },
-            "name": "-102323",
-            "vertexType": "BIKESHARE"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
-            {
-              "absoluteDirection": "EAST",
-              "angle": 1.5441765471733384,
-              "area": false,
-              "bogusName": false,
-              "distance": 480.068,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.5276173,
-                "longitude": -122.7003923
-              },
-              "stayOn": false,
-              "streetName": "Northwest Irving Street",
-              "streetNotes": [ ]
-            }
-          ],
-          "walkingLeg": false
-        },
-        {
-          "agencyTimeZoneOffset": -25200000,
-          "arrivalDelay": 0,
-          "bikeRentalNetworks": [ ],
-          "departureDelay": 0,
-          "distanceMeters": 29.461000000000002,
-          "endTime": "2009-10-21T23:51:25.000+0000",
-          "flexibleTrip": false,
-          "from": {
-            "bikeShareId": "-102323",
-            "coordinate": {
-              "latitude": 45.527849100000005,
-              "longitude": -122.6942362
-            },
-            "name": "-102323",
-            "vertexType": "BIKESHARE"
-          },
-          "generalizedCost": 0,
-          "interlineWithPreviousLeg": false,
-          "legGeometry": {
-            "length": 5,
-            "points": "ic{tG~uzkV@n@M@C??H"
-          },
-          "mode": "WALK",
-          "onStreetNonTransit": true,
-          "pathway": false,
-          "realTime": false,
-          "rentedBike": false,
-          "scheduled": false,
-          "startTime": "2009-10-21T23:50:58.000+0000",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.527818,
-              "longitude": -122.694539
-            },
-            "name": "NW 21st & Irving",
-            "stopCode": "7114",
-            "stopId": {
-              "feedId": "prt",
-              "id": "7114"
-            },
-            "stopIndex": 8,
-            "stopSequence": 9,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
-            {
-              "absoluteDirection": "WEST",
-              "angle": -1.5973283920844321,
-              "area": false,
-              "bikeRentalOffStation": {
-                "id": "-102323",
-                "lat": 45.527849100000005,
-                "lon": -122.6942362,
-                "name": "-102323"
-              },
-              "bogusName": false,
-              "distance": 19.289,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "HARD_LEFT",
-              "startLocation": {
-                "latitude": 45.52773220198921,
-                "longitude": -122.69423177172958
-              },
-              "stayOn": false,
-              "streetName": "Northwest Irving Street",
-              "streetNotes": [ ]
-            },
-            {
-              "absoluteDirection": "NORTH",
-              "angle": -0.026543929838500624,
-              "area": false,
-              "bogusName": false,
-              "distance": 10.172,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.527727600000006,
-                "longitude": -122.69447930000001
-              },
-              "stayOn": false,
-              "streetName": "Northwest 21st Avenue",
-              "streetNotes": [ ]
-            }
-          ],
-          "walkingLeg": true
-        },
-        {
-          "agencyTimeZoneOffset": 0,
-          "arrivalDelay": 0,
-          "bikeRentalNetworks": [ ],
-          "departureDelay": 0,
-          "distanceMeters": 1629.4275918538026,
-          "endTime": "2009-10-22T00:01:00.000+0000",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.527818,
-              "longitude": -122.694539
-            },
-            "name": "NW 21st & Irving",
-            "stopCode": "7114",
-            "stopId": {
-              "feedId": "prt",
-              "id": "7114"
-            },
-            "stopIndex": 8,
-            "stopSequence": 9,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
-          },
-          "generalizedCost": 1175,
-          "headsign": "136th Ave",
-          "intermediateStops": [ ],
-          "legGeometry": {
-            "length": 39,
-            "points": "{c{tGnwzkVR?lCEvBC??VAlCClCEAkA??A}BCkEAkECaD???g@CiECiEEiE?c@?o@?]Aa@?w@AoD???YEkEAkECiEA_A??AiCCkECmD???[A_CCiD"
-          },
-          "mode": "BUS",
-          "onStreetNonTransit": false,
-          "pathway": false,
-          "realTime": false,
-          "scheduled": true,
-          "serviceDate": {
-            "day": 21,
-            "minMax": false,
-            "month": 10,
-            "sequenceNumber": 20091021,
-            "year": 2009
-          },
-          "startTime": "2009-10-21T23:51:25.000+0000",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.525112,
-              "longitude": -122.677664
-            },
-            "name": "NW Everett & Broadway",
-            "stopCode": "1606",
-            "stopId": {
-              "feedId": "prt",
-              "id": "1606"
-            },
-            "stopIndex": 15,
-            "stopSequence": 16,
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": true,
-          "trip": {
-            "alteration": "PLANNED",
-            "bikesAllowed": "UNKNOWN",
-            "blockId": "1717",
-            "direction": "OUTBOUND",
-            "id": {
-              "feedId": "prt",
-              "id": "170W1490"
-            },
-            "route": {
-              "agency": {
-                "fareUrl": "http://trimet.org/fares/index.htm",
-                "id": {
-                  "feedId": "prt",
-                  "id": "prt"
-                },
-                "lang": "en",
-                "name": "TriMet",
-                "phone": "503-238-7433",
-                "timezone": "America/Los_Angeles",
-                "url": "http://trimet.org"
-              },
-              "bikesAllowed": "UNKNOWN",
-              "id": {
-                "feedId": "prt",
-                "id": "17"
-              },
-              "longName": "Holgate/NW 21st",
-              "mode": "BUS",
-              "shortName": "17",
-              "sortOrder": -999,
-              "sortOrderSet": false,
-              "type": 3,
-              "url": "http://trimet.org/schedules/r017.htm"
-            },
-            "serviceId": {
-              "feedId": "prt",
-              "id": "W"
-            },
-            "shapeId": {
-              "feedId": "prt",
-              "id": "17.0.10"
-            },
-            "wheelchairAccessible": 0
-          },
-          "walkSteps": [ ],
-          "walkingLeg": false
-        },
-        {
-          "agencyTimeZoneOffset": -25200000,
-          "arrivalDelay": 0,
-          "bikeRentalNetworks": [ ],
-          "departureDelay": 0,
-          "distanceMeters": 188.35399999999998,
-          "endTime": "2009-10-22T00:03:24.000+0000",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.525112,
-              "longitude": -122.677664
-            },
-            "name": "NW Everett & Broadway",
-            "stopCode": "1606",
-            "stopId": {
-              "feedId": "prt",
-              "id": "1606"
-            },
-            "stopIndex": 15,
-            "stopSequence": 16,
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
-          },
-          "generalizedCost": 576,
-          "interlineWithPreviousLeg": false,
-          "legGeometry": {
-            "length": 15,
-            "points": "}rztGlnwkVM??C?[?SC_D?M?E?MCgD?A?O?C?M?a@"
-          },
-          "mode": "WALK",
-          "onStreetNonTransit": true,
-          "pathway": false,
-          "realTime": false,
-          "rentedBike": false,
-          "scheduled": false,
-          "startTime": "2009-10-22T00:01:00.000+0000",
           "streetNotes": [ ],
           "to": {
             "coordinate": {
@@ -2896,7 +2863,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
             "orig": "SW Johnson St. & NW 24th Ave. (P1)",
             "vertexType": "NORMAL"
           },
-          "generalizedCost": -1,
+          "generalizedCost": 288,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 4,
@@ -3001,7 +2968,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
             "name": "-102309",
             "vertexType": "BIKESHARE"
           },
-          "generalizedCost": -1,
+          "generalizedCost": 21,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 2,
@@ -3064,7 +3031,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
             "name": "corner of way -102328 from 0 and Northwest Irving Street",
             "vertexType": "NORMAL"
           },
-          "generalizedCost": -1,
+          "generalizedCost": 236,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 6,
@@ -3127,7 +3094,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
             "name": "-102323",
             "vertexType": "BIKESHARE"
           },
-          "generalizedCost": -1,
+          "generalizedCost": 338,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 4,
@@ -3261,7 +3228,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
             "orig": "SW Johnson St. & NW 24th Ave. (P1)",
             "vertexType": "NORMAL"
           },
-          "generalizedCost": -1,
+          "generalizedCost": 288,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 4,
@@ -3366,7 +3333,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
             "name": "-102309",
             "vertexType": "BIKESHARE"
           },
-          "generalizedCost": -1,
+          "generalizedCost": 21,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 2,
@@ -3429,7 +3396,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
             "name": "corner of way -102328 from 0 and Northwest Irving Street",
             "vertexType": "NORMAL"
           },
-          "generalizedCost": -1,
+          "generalizedCost": 312,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 10,
@@ -3566,7 +3533,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
           }
         }
       },
-      "generalizedCost": 2942,
+      "generalizedCost": 1968,
       "legs": [
         {
           "agencyTimeZoneOffset": -25200000,
@@ -3584,7 +3551,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "name": "NW Everett St. & NW 5th Ave. (P3)",
             "vertexType": "NORMAL"
           },
-          "generalizedCost": 544,
+          "generalizedCost": 261,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 10,
@@ -3806,7 +3773,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
-          "generalizedCost": 1276,
+          "generalizedCost": 167,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 4,
@@ -3894,7 +3861,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "name": "-102323",
             "vertexType": "BIKESHARE"
           },
-          "generalizedCost": 0,
+          "generalizedCost": 196,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 6,
@@ -3957,7 +3924,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "name": "corner of way -102328 from 0 and Northwest Irving Street",
             "vertexType": "NORMAL"
           },
-          "generalizedCost": 0,
+          "generalizedCost": 51,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 2,
@@ -4020,7 +3987,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "name": "-102309",
             "vertexType": "BIKESHARE"
           },
-          "generalizedCost": 0,
+          "generalizedCost": 168,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 4,
@@ -4121,6 +4088,780 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
     },
     {
       "arrivedAtDestinationWithRentedBicycle": false,
+      "durationSeconds": 1276,
+      "elevationGained": 0.0,
+      "elevationLost": 0.0,
+      "fare": {
+        "details": {
+          "regular": [
+            {
+              "fareId": {
+                "feedId": "prt",
+                "id": "8"
+              },
+              "price": {
+                "cents": 200,
+                "currency": {
+                  "value": "USD"
+                }
+              },
+              "routes": [
+                {
+                  "feedId": "prt",
+                  "id": "20"
+                }
+              ]
+            }
+          ]
+        },
+        "fare": {
+          "regular": {
+            "cents": 200,
+            "currency": {
+              "value": "USD"
+            }
+          }
+        }
+      },
+      "generalizedCost": 2503,
+      "legs": [
+        {
+          "agencyTimeZoneOffset": -25200000,
+          "arrivalDelay": 0,
+          "bikeRentalNetworks": [ ],
+          "departureDelay": 0,
+          "distanceMeters": 287.815,
+          "endTime": "2009-10-21T23:18:00.000+0000",
+          "flexibleTrip": false,
+          "from": {
+            "coordinate": {
+              "latitude": 45.52523,
+              "longitude": -122.67525
+            },
+            "name": "NW Everett St. & NW 5th Ave. (P3)",
+            "vertexType": "NORMAL"
+          },
+          "generalizedCost": 442,
+          "interlineWithPreviousLeg": false,
+          "legGeometry": {
+            "length": 17,
+            "points": "ssztGh_wkV?`@?LJAlBCH?J?H?vBCJ?H?jBCJA?D@L?lAE?"
+          },
+          "mode": "WALK",
+          "onStreetNonTransit": true,
+          "pathway": false,
+          "realTime": false,
+          "rentedBike": false,
+          "scheduled": false,
+          "startTime": "2009-10-21T23:14:08.000+0000",
+          "streetNotes": [ ],
+          "to": {
+            "coordinate": {
+              "latitude": 45.523169,
+              "longitude": -122.675893
+            },
+            "name": "W Burnside & NW 5th",
+            "stopCode": "782",
+            "stopId": {
+              "feedId": "prt",
+              "id": "782"
+            },
+            "stopIndex": 99,
+            "stopSequence": 100,
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
+          },
+          "transitAlerts": [ ],
+          "transitLeg": false,
+          "walkSteps": [
+            {
+              "absoluteDirection": "WEST",
+              "angle": -1.596868818888735,
+              "area": false,
+              "bogusName": false,
+              "distance": 17.975,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "DEPART",
+              "startLocation": {
+                "latitude": 45.52522794293369,
+                "longitude": -122.67524992342938
+              },
+              "stayOn": false,
+              "streetName": "Northwest Everett Street",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "SOUTH",
+              "angle": 3.1122681276306428,
+              "area": false,
+              "bogusName": false,
+              "distance": 231.76100000000002,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "LEFT",
+              "startLocation": {
+                "latitude": 45.525224200000004,
+                "longitude": -122.67548060000001
+              },
+              "stayOn": false,
+              "streetName": "Northwest 5th Avenue",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "WEST",
+              "angle": -1.5966159701088662,
+              "area": false,
+              "bogusName": false,
+              "distance": 38.079,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "RIGHT",
+              "startLocation": {
+                "latitude": 45.523141200000005,
+                "longitude": -122.67540310000001
+              },
+              "stayOn": false,
+              "streetName": "West Burnside Street",
+              "streetNotes": [ ]
+            }
+          ],
+          "walkingLeg": true
+        },
+        {
+          "agencyTimeZoneOffset": 0,
+          "arrivalDelay": 0,
+          "bikeRentalNetworks": [ ],
+          "departureDelay": 0,
+          "distanceMeters": 1942.2498485359197,
+          "endTime": "2009-10-21T23:28:03.000+0000",
+          "flexibleTrip": false,
+          "from": {
+            "coordinate": {
+              "latitude": 45.523169,
+              "longitude": -122.675893
+            },
+            "name": "W Burnside & NW 5th",
+            "stopCode": "782",
+            "stopId": {
+              "feedId": "prt",
+              "id": "782"
+            },
+            "stopIndex": 99,
+            "stopSequence": 100,
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
+          },
+          "generalizedCost": 1203,
+          "headsign": "Beaverton TC",
+          "intermediateStops": [ ],
+          "legGeometry": {
+            "length": 56,
+            "points": "efztGhcwkV@rBBzDBpE@~A???Z@tD@RBnEB|A???@BdB?lEBjA??BnBApF@dB?X?^@r@?f@@bCAx@EtB???VChAE|BGnD??AXKnEGnD???XGjD??AZEfCC`AEzB??AXCfAGxDE|AEtBIlC??APu@lJMhBI`@"
+          },
+          "mode": "BUS",
+          "onStreetNonTransit": false,
+          "pathway": false,
+          "realTime": false,
+          "scheduled": true,
+          "serviceDate": {
+            "day": 21,
+            "minMax": false,
+            "month": 10,
+            "sequenceNumber": 20091021,
+            "year": 2009
+          },
+          "startTime": "2009-10-21T23:18:00.000+0000",
+          "streetNotes": [ ],
+          "to": {
+            "coordinate": {
+              "latitude": 45.523897,
+              "longitude": -122.700681
+            },
+            "name": "W Burnside & NW 23rd Pl",
+            "stopCode": "9555",
+            "stopId": {
+              "feedId": "prt",
+              "id": "9555"
+            },
+            "stopIndex": 109,
+            "stopSequence": 110,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "transitAlerts": [ ],
+          "transitLeg": true,
+          "trip": {
+            "alteration": "PLANNED",
+            "bikesAllowed": "UNKNOWN",
+            "blockId": "2069",
+            "direction": "OUTBOUND",
+            "id": {
+              "feedId": "prt",
+              "id": "200W1440"
+            },
+            "route": {
+              "agency": {
+                "fareUrl": "http://trimet.org/fares/index.htm",
+                "id": {
+                  "feedId": "prt",
+                  "id": "prt"
+                },
+                "lang": "en",
+                "name": "TriMet",
+                "phone": "503-238-7433",
+                "timezone": "America/Los_Angeles",
+                "url": "http://trimet.org"
+              },
+              "bikesAllowed": "UNKNOWN",
+              "id": {
+                "feedId": "prt",
+                "id": "20"
+              },
+              "longName": "Burnside/Stark",
+              "mode": "BUS",
+              "shortName": "20",
+              "sortOrder": -999,
+              "sortOrderSet": false,
+              "type": 3,
+              "url": "http://trimet.org/schedules/r020.htm"
+            },
+            "serviceId": {
+              "feedId": "prt",
+              "id": "W"
+            },
+            "shapeId": {
+              "feedId": "prt",
+              "id": "20.0.1"
+            },
+            "wheelchairAccessible": 0
+          },
+          "walkSteps": [ ],
+          "walkingLeg": false
+        },
+        {
+          "agencyTimeZoneOffset": -25200000,
+          "arrivalDelay": 0,
+          "bikeRentalNetworks": [ ],
+          "departureDelay": 0,
+          "distanceMeters": 563.701,
+          "endTime": "2009-10-21T23:35:24.000+0000",
+          "flexibleTrip": false,
+          "from": {
+            "coordinate": {
+              "latitude": 45.523897,
+              "longitude": -122.700681
+            },
+            "name": "W Burnside & NW 23rd Pl",
+            "stopCode": "9555",
+            "stopId": {
+              "feedId": "prt",
+              "id": "9555"
+            },
+            "stopIndex": 109,
+            "stopSequence": 110,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "generalizedCost": 858,
+          "interlineWithPreviousLeg": false,
+          "legGeometry": {
+            "length": 34,
+            "points": "ikztGh~{kVNDEVUzACPOUQO_@Yc@[QMMEOKOIECGCIAMCGCGAECECECOOMOGKIFMLk@BsABGDGBoCBkCDkC@"
+          },
+          "mode": "WALK",
+          "onStreetNonTransit": true,
+          "pathway": false,
+          "realTime": false,
+          "rentedBike": false,
+          "scheduled": false,
+          "startTime": "2009-10-21T23:28:03.000+0000",
+          "streetNotes": [ ],
+          "to": {
+            "coordinate": {
+              "latitude": 45.52832,
+              "longitude": -122.70059
+            },
+            "name": "SW Johnson St. & NW 24th Ave. (P1)",
+            "vertexType": "NORMAL"
+          },
+          "transitAlerts": [ ],
+          "transitLeg": false,
+          "walkSteps": [
+            {
+              "absoluteDirection": "WEST",
+              "angle": -1.247661800162498,
+              "area": false,
+              "bogusName": false,
+              "distance": 54.628,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "DEPART",
+              "startLocation": {
+                "latitude": 45.523815597641374,
+                "longitude": -122.70071990797962
+              },
+              "stayOn": false,
+              "streetName": "West Burnside Street",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "NORTHEAST",
+              "angle": 0.7501559967245512,
+              "area": false,
+              "bogusName": false,
+              "distance": 176.41,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "RIGHT",
+              "startLocation": {
+                "latitude": 45.5239733,
+                "longitude": -122.701384
+              },
+              "stayOn": false,
+              "streetName": "Northwest 24th Place",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "NORTHWEST",
+              "angle": -0.5889596407957216,
+              "area": false,
+              "bogusName": false,
+              "distance": 15.262,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "LEFT",
+              "startLocation": {
+                "latitude": 45.5253583,
+                "longitude": -122.70033570000001
+              },
+              "stayOn": false,
+              "streetName": "Northwest Westover Road",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "NORTH",
+              "angle": -0.05815952978341337,
+              "area": false,
+              "bogusName": false,
+              "distance": 317.401,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "SLIGHTLY_RIGHT",
+              "startLocation": {
+                "latitude": 45.525472400000005,
+                "longitude": -122.7004445
+              },
+              "stayOn": false,
+              "streetName": "Northwest 24th Avenue",
+              "streetNotes": [ ]
+            }
+          ],
+          "walkingLeg": true
+        }
+      ],
+      "nTransfers": 0,
+      "nonTransitDistanceMeters": 851.5160000000001,
+      "nonTransitTimeSeconds": 673,
+      "onStreetAllTheWay": false,
+      "streetOnly": false,
+      "systemNotices": [ ],
+      "tooSloped": false,
+      "transitTimeSeconds": 603,
+      "waitTimeAdjustedGeneralizedCost": -999999,
+      "waitingTimeSeconds": 0,
+      "walkOnly": false,
+      "walkingAllTheWay": false
+    },
+    {
+      "arrivedAtDestinationWithRentedBicycle": false,
+      "durationSeconds": 1134,
+      "elevationGained": 0.0,
+      "elevationLost": 0.0,
+      "fare": {
+        "details": {
+          "regular": [
+            {
+              "fareId": {
+                "feedId": "prt",
+                "id": "8"
+              },
+              "price": {
+                "cents": 200,
+                "currency": {
+                  "value": "USD"
+                }
+              },
+              "routes": [
+                {
+                  "feedId": "prt",
+                  "id": "77"
+                }
+              ]
+            }
+          ]
+        },
+        "fare": {
+          "regular": {
+            "cents": 200,
+            "currency": {
+              "value": "USD"
+            }
+          }
+        }
+      },
+      "generalizedCost": 2351,
+      "legs": [
+        {
+          "agencyTimeZoneOffset": -25200000,
+          "arrivalDelay": 0,
+          "bikeRentalNetworks": [ ],
+          "departureDelay": 0,
+          "distanceMeters": 252.87499999999997,
+          "endTime": "2009-10-21T23:21:53.000+0000",
+          "flexibleTrip": false,
+          "from": {
+            "coordinate": {
+              "latitude": 45.52523,
+              "longitude": -122.67525
+            },
+            "name": "NW Everett St. & NW 5th Ave. (P3)",
+            "vertexType": "NORMAL"
+          },
+          "generalizedCost": 392,
+          "interlineWithPreviousLeg": false,
+          "legGeometry": {
+            "length": 15,
+            "points": "ssztGh_wkV?`@?LK?uBBK?K@sBBM??D?L@\\?lCC??E"
+          },
+          "mode": "WALK",
+          "onStreetNonTransit": true,
+          "pathway": false,
+          "realTime": false,
+          "rentedBike": false,
+          "scheduled": false,
+          "startTime": "2009-10-21T23:18:27.000+0000",
+          "streetNotes": [ ],
+          "to": {
+            "coordinate": {
+              "latitude": 45.526655,
+              "longitude": -122.676462
+            },
+            "name": "NW Glisan & 6th",
+            "stopCode": "10803",
+            "stopId": {
+              "feedId": "prt",
+              "id": "10803"
+            },
+            "stopIndex": 85,
+            "stopSequence": 86,
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
+          },
+          "transitAlerts": [ ],
+          "transitLeg": false,
+          "walkSteps": [
+            {
+              "absoluteDirection": "WEST",
+              "angle": -1.596868818888735,
+              "area": false,
+              "bogusName": false,
+              "distance": 17.975,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "DEPART",
+              "startLocation": {
+                "latitude": 45.52522794293369,
+                "longitude": -122.67524992342938
+              },
+              "stayOn": false,
+              "streetName": "Northwest Everett Street",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "NORTH",
+              "angle": -0.02939746732509391,
+              "area": false,
+              "bogusName": false,
+              "distance": 158.018,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "RIGHT",
+              "startLocation": {
+                "latitude": 45.525224200000004,
+                "longitude": -122.67548060000001
+              },
+              "stayOn": false,
+              "streetName": "Northwest 5th Avenue",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "WEST",
+              "angle": -1.6080284293804317,
+              "area": false,
+              "bogusName": false,
+              "distance": 74.227,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "LEFT",
+              "startLocation": {
+                "latitude": 45.526644700000006,
+                "longitude": -122.67553910000001
+              },
+              "stayOn": false,
+              "streetName": "Northwest Glisan Street",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "NORTH",
+              "angle": -0.03835551109631682,
+              "area": false,
+              "bogusName": true,
+              "distance": 2.655,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "RIGHT",
+              "startLocation": {
+                "latitude": 45.5266303,
+                "longitude": -122.67649170000001
+              },
+              "stayOn": false,
+              "streetName": "way 156261070 from 2",
+              "streetNotes": [ ]
+            }
+          ],
+          "walkingLeg": true
+        },
+        {
+          "agencyTimeZoneOffset": 0,
+          "arrivalDelay": 0,
+          "bikeRentalNetworks": [ ],
+          "departureDelay": 0,
+          "distanceMeters": 2232.3107878360292,
+          "endTime": "2009-10-21T23:29:50.000+0000",
+          "flexibleTrip": false,
+          "from": {
+            "coordinate": {
+              "latitude": 45.526655,
+              "longitude": -122.676462
+            },
+            "name": "NW Glisan & 6th",
+            "stopCode": "10803",
+            "stopId": {
+              "feedId": "prt",
+              "id": "10803"
+            },
+            "stopIndex": 85,
+            "stopSequence": 86,
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
+          },
+          "generalizedCost": 1077,
+          "headsign": "Montgomery Park",
+          "intermediateStops": [ ],
+          "legGeometry": {
+            "length": 53,
+            "points": "i|ztG|fwkV?LqCFmCDYBGDEBGJkAzAQR??KNa@b@MJuBBY?OHW@u@~@aD`EcBhBBrD@xC??@l@BlE@lD???XBjEBpD???VBlE?dA@t@?b@?h@BfEBrD???VBhEFtKDvJ??@\\DnJ???d@FtKmCBo@@"
+          },
+          "mode": "BUS",
+          "onStreetNonTransit": false,
+          "pathway": false,
+          "realTime": false,
+          "scheduled": true,
+          "serviceDate": {
+            "day": 21,
+            "minMax": false,
+            "month": 10,
+            "sequenceNumber": 20091021,
+            "year": 2009
+          },
+          "startTime": "2009-10-21T23:21:53.000+0000",
+          "streetNotes": [ ],
+          "to": {
+            "coordinate": {
+              "latitude": 45.532159,
+              "longitude": -122.698634
+            },
+            "name": "NW 23rd & Overton",
+            "stopCode": "8981",
+            "stopId": {
+              "feedId": "prt",
+              "id": "8981"
+            },
+            "stopIndex": 93,
+            "stopSequence": 94,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "transitAlerts": [ ],
+          "transitLeg": true,
+          "trip": {
+            "alteration": "PLANNED",
+            "bikesAllowed": "UNKNOWN",
+            "blockId": "7710",
+            "direction": "INBOUND",
+            "id": {
+              "feedId": "prt",
+              "id": "771W1370"
+            },
+            "route": {
+              "agency": {
+                "fareUrl": "http://trimet.org/fares/index.htm",
+                "id": {
+                  "feedId": "prt",
+                  "id": "prt"
+                },
+                "lang": "en",
+                "name": "TriMet",
+                "phone": "503-238-7433",
+                "timezone": "America/Los_Angeles",
+                "url": "http://trimet.org"
+              },
+              "bikesAllowed": "UNKNOWN",
+              "id": {
+                "feedId": "prt",
+                "id": "77"
+              },
+              "longName": "Broadway/Halsey",
+              "mode": "BUS",
+              "shortName": "77",
+              "sortOrder": -999,
+              "sortOrderSet": false,
+              "type": 3,
+              "url": "http://trimet.org/schedules/r077.htm"
+            },
+            "serviceId": {
+              "feedId": "prt",
+              "id": "W"
+            },
+            "shapeId": {
+              "feedId": "prt",
+              "id": "77.1.3"
+            },
+            "wheelchairAccessible": 0
+          },
+          "walkSteps": [ ],
+          "walkingLeg": false
+        },
+        {
+          "agencyTimeZoneOffset": -25200000,
+          "arrivalDelay": 0,
+          "bikeRentalNetworks": [ ],
+          "departureDelay": 0,
+          "distanceMeters": 580.63,
+          "endTime": "2009-10-21T23:37:21.000+0000",
+          "flexibleTrip": false,
+          "from": {
+            "coordinate": {
+              "latitude": 45.532159,
+              "longitude": -122.698634
+            },
+            "name": "NW 23rd & Overton",
+            "stopCode": "8981",
+            "stopId": {
+              "feedId": "prt",
+              "id": "8981"
+            },
+            "stopIndex": 93,
+            "stopSequence": 94,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "generalizedCost": 881,
+          "interlineWithPreviousLeg": false,
+          "legGeometry": {
+            "length": 12,
+            "points": "}~{tGnq{kV?LVAF?J?FtKlCClCEnCElCElCCB?"
+          },
+          "mode": "WALK",
+          "onStreetNonTransit": true,
+          "pathway": false,
+          "realTime": false,
+          "rentedBike": false,
+          "scheduled": false,
+          "startTime": "2009-10-21T23:29:50.000+0000",
+          "streetNotes": [ ],
+          "to": {
+            "coordinate": {
+              "latitude": 45.52832,
+              "longitude": -122.70059
+            },
+            "name": "SW Johnson St. & NW 24th Ave. (P1)",
+            "vertexType": "NORMAL"
+          },
+          "transitAlerts": [ ],
+          "transitLeg": false,
+          "walkSteps": [
+            {
+              "absoluteDirection": "SOUTH",
+              "angle": 3.117146926361324,
+              "area": false,
+              "bogusName": false,
+              "distance": 24.895,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "DEPART",
+              "startLocation": {
+                "latitude": 45.53215782420268,
+                "longitude": -122.69870264831422
+              },
+              "stayOn": false,
+              "streetName": "Northwest 23rd Avenue",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "WEST",
+              "angle": -1.6005554859058504,
+              "area": false,
+              "bogusName": false,
+              "distance": 158.45,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "RIGHT",
+              "startLocation": {
+                "latitude": 45.531934,
+                "longitude": -122.698695
+              },
+              "stayOn": false,
+              "streetName": "Northwest Overton Street",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "SOUTH",
+              "angle": 3.119908233299857,
+              "area": false,
+              "bogusName": false,
+              "distance": 397.28499999999997,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "LEFT",
+              "startLocation": {
+                "latitude": 45.5318916,
+                "longitude": -122.70072830000001
+              },
+              "stayOn": false,
+              "streetName": "Northwest 24th Avenue",
+              "streetNotes": [ ]
+            }
+          ],
+          "walkingLeg": true
+        }
+      ],
+      "nTransfers": 0,
+      "nonTransitDistanceMeters": 833.505,
+      "nonTransitTimeSeconds": 657,
+      "onStreetAllTheWay": false,
+      "streetOnly": false,
+      "systemNotices": [ ],
+      "tooSloped": false,
+      "transitTimeSeconds": 477,
+      "waitTimeAdjustedGeneralizedCost": -999999,
+      "waitingTimeSeconds": 0,
+      "walkOnly": false,
+      "walkingAllTheWay": false
+    },
+    {
+      "arrivedAtDestinationWithRentedBicycle": false,
       "durationSeconds": 977,
       "elevationGained": 0.0,
       "elevationLost": 0.0,
@@ -4156,7 +4897,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
           }
         }
       },
-      "generalizedCost": 2942,
+      "generalizedCost": 1968,
       "legs": [
         {
           "agencyTimeZoneOffset": -25200000,
@@ -4174,7 +4915,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "name": "NW Everett St. & NW 5th Ave. (P3)",
             "vertexType": "NORMAL"
           },
-          "generalizedCost": 544,
+          "generalizedCost": 261,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 10,
@@ -4396,7 +5137,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
-          "generalizedCost": 1276,
+          "generalizedCost": 167,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 4,
@@ -4484,7 +5225,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "name": "-102323",
             "vertexType": "BIKESHARE"
           },
-          "generalizedCost": 0,
+          "generalizedCost": 196,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 6,
@@ -4547,7 +5288,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "name": "corner of way -102328 from 0 and Northwest Irving Street",
             "vertexType": "NORMAL"
           },
-          "generalizedCost": 0,
+          "generalizedCost": 51,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 2,
@@ -4610,7 +5351,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "name": "-102309",
             "vertexType": "BIKESHARE"
           },
-          "generalizedCost": 0,
+          "generalizedCost": 168,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 4,
@@ -4711,7 +5452,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
     },
     {
       "arrivedAtDestinationWithRentedBicycle": false,
-      "durationSeconds": 977,
+      "durationSeconds": 1336,
       "elevationGained": 0.0,
       "elevationLost": 0.0,
       "fare": {
@@ -4731,7 +5472,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "routes": [
                 {
                   "feedId": "prt",
-                  "id": "17"
+                  "id": "20"
                 }
               ]
             }
@@ -4746,15 +5487,15 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
           }
         }
       },
-      "generalizedCost": 2942,
+      "generalizedCost": 2563,
       "legs": [
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "bikeRentalNetworks": [ ],
           "departureDelay": 0,
-          "distanceMeters": 167.86599999999999,
-          "endTime": "2009-10-21T23:44:50.000+0000",
+          "distanceMeters": 287.815,
+          "endTime": "2009-10-21T23:33:00.000+0000",
           "flexibleTrip": false,
           "from": {
             "coordinate": {
@@ -4764,11 +5505,11 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "name": "NW Everett St. & NW 5th Ave. (P3)",
             "vertexType": "NORMAL"
           },
-          "generalizedCost": 544,
+          "generalizedCost": 442,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
-            "length": 10,
-            "points": "ssztGh_wkV?`@?LK?uBBK??F?JBbDN?"
+            "length": 17,
+            "points": "ssztGh_wkV?`@?LJAlBCH?J?H?vBCJ?H?jBCJA?D@L?lAE?"
           },
           "mode": "WALK",
           "onStreetNonTransit": true,
@@ -4776,21 +5517,21 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
           "realTime": false,
           "rentedBike": false,
           "scheduled": false,
-          "startTime": "2009-10-21T23:42:34.000+0000",
+          "startTime": "2009-10-21T23:29:08.000+0000",
           "streetNotes": [ ],
           "to": {
             "coordinate": {
-              "latitude": 45.52583,
-              "longitude": -122.676422
+              "latitude": 45.523169,
+              "longitude": -122.675893
             },
-            "name": "NW 6th & Flanders",
-            "stopCode": "9300",
+            "name": "W Burnside & NW 5th",
+            "stopCode": "782",
             "stopId": {
               "feedId": "prt",
-              "id": "9300"
+              "id": "782"
             },
-            "stopIndex": 66,
-            "stopSequence": 67,
+            "stopIndex": 99,
+            "stopSequence": 100,
             "vertexType": "TRANSIT",
             "zoneId": "0"
           },
@@ -4815,14 +5556,14 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "streetNotes": [ ]
             },
             {
-              "absoluteDirection": "NORTH",
-              "angle": -0.02939746732509391,
+              "absoluteDirection": "SOUTH",
+              "angle": 3.1122681276306428,
               "area": false,
               "bogusName": false,
-              "distance": 78.514,
+              "distance": 231.76100000000002,
               "edges": [ ],
               "elevation": [ ],
-              "relativeDirection": "RIGHT",
+              "relativeDirection": "LEFT",
               "startLocation": {
                 "latitude": 45.525224200000004,
                 "longitude": -122.67548060000001
@@ -4833,19 +5574,19 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             },
             {
               "absoluteDirection": "WEST",
-              "angle": -1.5977129345986325,
+              "angle": -1.5966159701088662,
               "area": false,
               "bogusName": false,
-              "distance": 71.377,
+              "distance": 38.079,
               "edges": [ ],
               "elevation": [ ],
-              "relativeDirection": "LEFT",
+              "relativeDirection": "RIGHT",
               "startLocation": {
-                "latitude": 45.52593,
-                "longitude": -122.6755097
+                "latitude": 45.523141200000005,
+                "longitude": -122.67540310000001
               },
               "stayOn": false,
-              "streetName": "Northwest Flanders Street",
+              "streetName": "West Burnside Street",
               "streetNotes": [ ]
             }
           ],
@@ -4856,31 +5597,31 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
           "arrivalDelay": 0,
           "bikeRentalNetworks": [ ],
           "departureDelay": 0,
-          "distanceMeters": 1631.0313510234191,
-          "endTime": "2009-10-21T23:53:32.000+0000",
+          "distanceMeters": 1942.2498485359197,
+          "endTime": "2009-10-21T23:44:03.000+0000",
           "flexibleTrip": false,
           "from": {
             "coordinate": {
-              "latitude": 45.52583,
-              "longitude": -122.676422
+              "latitude": 45.523169,
+              "longitude": -122.675893
             },
-            "name": "NW 6th & Flanders",
-            "stopCode": "9300",
+            "name": "W Burnside & NW 5th",
+            "stopCode": "782",
             "stopId": {
               "feedId": "prt",
-              "id": "9300"
+              "id": "782"
             },
-            "stopIndex": 66,
-            "stopSequence": 67,
+            "stopIndex": 99,
+            "stopSequence": 100,
             "vertexType": "TRANSIT",
             "zoneId": "0"
           },
-          "generalizedCost": 1122,
-          "headsign": "Sauvie Is. via St.Johns",
+          "generalizedCost": 1263,
+          "headsign": "Beaverton TC",
           "intermediateStops": [ ],
           "legGeometry": {
-            "length": 39,
-            "points": "kwztGhgwkVQ?kC@@zD???PBjE?`B??@X@jEBjD???\\BhEBpD???XBhE@nD??@Z?hEBtA?h@@h@??@Z@nEBhEBhD???`@FtKDhH??@hBoCD}BB"
+            "length": 56,
+            "points": "efztGhcwkV@rBBzDBpE@~A???Z@tD@RBnEB|A???@BdB?lEBjA??BnBApF@dB?X?^@r@?f@@bCAx@EtB???VChAE|BGnD??AXKnEGnD???XGjD??AZEfCC`AEzB??AXCfAGxDE|AEtBIlC??APu@lJMhBI`@"
           },
           "mode": "BUS",
           "onStreetNonTransit": false,
@@ -4894,21 +5635,21 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "sequenceNumber": 20091021,
             "year": 2009
           },
-          "startTime": "2009-10-21T23:44:50.000+0000",
+          "startTime": "2009-10-21T23:33:00.000+0000",
           "streetNotes": [ ],
           "to": {
             "coordinate": {
-              "latitude": 45.527648,
-              "longitude": -122.694407
+              "latitude": 45.523897,
+              "longitude": -122.700681
             },
-            "name": "NW 21st & Irving",
-            "stopCode": "7113",
+            "name": "W Burnside & NW 23rd Pl",
+            "stopCode": "9555",
             "stopId": {
               "feedId": "prt",
-              "id": "7113"
+              "id": "9555"
             },
-            "stopIndex": 75,
-            "stopSequence": 76,
+            "stopIndex": 109,
+            "stopSequence": 110,
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
@@ -4917,11 +5658,11 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
           "trip": {
             "alteration": "PLANNED",
             "bikesAllowed": "UNKNOWN",
-            "blockId": "1703",
-            "direction": "INBOUND",
+            "blockId": "2003",
+            "direction": "OUTBOUND",
             "id": {
               "feedId": "prt",
-              "id": "171W1510"
+              "id": "200W1450"
             },
             "route": {
               "agency": {
@@ -4939,15 +5680,15 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "bikesAllowed": "UNKNOWN",
               "id": {
                 "feedId": "prt",
-                "id": "17"
+                "id": "20"
               },
-              "longName": "Holgate/NW 21st",
+              "longName": "Burnside/Stark",
               "mode": "BUS",
-              "shortName": "17",
+              "shortName": "20",
               "sortOrder": -999,
               "sortOrderSet": false,
               "type": 3,
-              "url": "http://trimet.org/schedules/r017.htm"
+              "url": "http://trimet.org/schedules/r020.htm"
             },
             "serviceId": {
               "feedId": "prt",
@@ -4955,7 +5696,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             },
             "shapeId": {
               "feedId": "prt",
-              "id": "17.1.15"
+              "id": "20.0.1"
             },
             "wheelchairAccessible": 0
           },
@@ -4967,30 +5708,30 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
           "arrivalDelay": 0,
           "bikeRentalNetworks": [ ],
           "departureDelay": 0,
-          "distanceMeters": 28.258000000000003,
-          "endTime": "2009-10-21T23:54:58.000+0000",
+          "distanceMeters": 563.701,
+          "endTime": "2009-10-21T23:51:24.000+0000",
           "flexibleTrip": false,
           "from": {
             "coordinate": {
-              "latitude": 45.527648,
-              "longitude": -122.694407
+              "latitude": 45.523897,
+              "longitude": -122.700681
             },
-            "name": "NW 21st & Irving",
-            "stopCode": "7113",
+            "name": "W Burnside & NW 23rd Pl",
+            "stopCode": "9555",
             "stopId": {
               "feedId": "prt",
-              "id": "7113"
+              "id": "9555"
             },
-            "stopIndex": 75,
-            "stopSequence": 76,
+            "stopIndex": 109,
+            "stopSequence": 110,
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
-          "generalizedCost": 1276,
+          "generalizedCost": 858,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
-            "length": 4,
-            "points": "wb{tG`wzkV?LO?Ao@"
+            "length": 34,
+            "points": "ikztGh~{kVNDEVUzACPOUQO_@Yc@[QMMEOKOIECGCIAMCGCGAECECECOOMOGKIFMLk@BsABGDGBoCBkCDkC@"
           },
           "mode": "WALK",
           "onStreetNonTransit": true,
@@ -4998,221 +5739,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
           "realTime": false,
           "rentedBike": false,
           "scheduled": false,
-          "startTime": "2009-10-21T23:53:32.000+0000",
-          "streetNotes": [ ],
-          "to": {
-            "bikeShareId": "-102323",
-            "coordinate": {
-              "latitude": 45.527849100000005,
-              "longitude": -122.6942362
-            },
-            "name": "-102323",
-            "vertexType": "BIKESHARE"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
-            {
-              "absoluteDirection": "NORTH",
-              "angle": -0.021151532022270547,
-              "area": false,
-              "bogusName": false,
-              "distance": 8.969,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.52764696458245,
-                "longitude": -122.69447686508221
-              },
-              "stayOn": false,
-              "streetName": "Northwest 21st Avenue",
-              "streetNotes": [ ]
-            },
-            {
-              "absoluteDirection": "EAST",
-              "angle": 1.5442642615053612,
-              "area": false,
-              "bikeRentalOnStation": {
-                "id": "-102323",
-                "lat": 45.527849100000005,
-                "lon": -122.6942362,
-                "name": "-102323"
-              },
-              "bogusName": false,
-              "distance": 19.289,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.527727600000006,
-                "longitude": -122.69447930000001
-              },
-              "stayOn": false,
-              "streetName": "Northwest Irving Street",
-              "streetNotes": [ ]
-            }
-          ],
-          "walkingLeg": true
-        },
-        {
-          "agencyTimeZoneOffset": -25200000,
-          "arrivalDelay": 0,
-          "bikeRentalNetworks": [
-            "test-network"
-          ],
-          "departureDelay": 0,
-          "distanceMeters": 480.068,
-          "endTime": "2009-10-21T23:56:39.000+0000",
-          "flexibleTrip": false,
-          "from": {
-            "bikeShareId": "-102323",
-            "coordinate": {
-              "latitude": 45.527849100000005,
-              "longitude": -122.6942362
-            },
-            "name": "-102323",
-            "vertexType": "BIKESHARE"
-          },
-          "generalizedCost": 0,
-          "interlineWithPreviousLeg": false,
-          "legGeometry": {
-            "length": 6,
-            "points": "ic{tG~uzkV@n@@vAD|HDtKFrJ"
-          },
-          "mode": "BICYCLE",
-          "onStreetNonTransit": true,
-          "pathway": false,
-          "realTime": false,
-          "rentedBike": true,
-          "scheduled": false,
-          "startTime": "2009-10-21T23:54:58.000+0000",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.5276173,
-              "longitude": -122.7003923
-            },
-            "name": "corner of way -102328 from 0 and Northwest Irving Street",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
-            {
-              "absoluteDirection": "WEST",
-              "angle": -1.5973283920844321,
-              "area": false,
-              "bogusName": false,
-              "distance": 480.068,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "HARD_LEFT",
-              "startLocation": {
-                "latitude": 45.52773220198921,
-                "longitude": -122.69423177172958
-              },
-              "stayOn": false,
-              "streetName": "Northwest Irving Street",
-              "streetNotes": [ ]
-            }
-          ],
-          "walkingLeg": false
-        },
-        {
-          "agencyTimeZoneOffset": -25200000,
-          "arrivalDelay": 0,
-          "bikeRentalNetworks": [
-            "test-network"
-          ],
-          "departureDelay": 0,
-          "distanceMeters": 13.358,
-          "endTime": "2009-10-21T23:57:20.000+0000",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.5276173,
-              "longitude": -122.7003923
-            },
-            "name": "corner of way -102328 from 0 and Northwest Irving Street",
-            "vertexType": "NORMAL"
-          },
-          "generalizedCost": 0,
-          "interlineWithPreviousLeg": false,
-          "legGeometry": {
-            "length": 2,
-            "points": "qb{tGn|{kVWA"
-          },
-          "mode": "WALK",
-          "onStreetNonTransit": true,
-          "pathway": false,
-          "realTime": false,
-          "rentedBike": true,
-          "scheduled": false,
-          "startTime": "2009-10-21T23:56:39.000+0000",
-          "streetNotes": [ ],
-          "to": {
-            "bikeShareId": "-102309",
-            "coordinate": {
-              "latitude": 45.5277374,
-              "longitude": -122.70038790000001
-            },
-            "name": "-102309",
-            "vertexType": "BIKESHARE"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
-            {
-              "absoluteDirection": "NORTH",
-              "angle": 0.02566034822056683,
-              "area": false,
-              "bogusName": true,
-              "distance": 13.358,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5276173,
-                "longitude": -122.7003923
-              },
-              "stayOn": false,
-              "streetName": "way -102328 from 0",
-              "streetNotes": [ ]
-            }
-          ],
-          "walkingLeg": true
-        },
-        {
-          "agencyTimeZoneOffset": -25200000,
-          "arrivalDelay": 0,
-          "bikeRentalNetworks": [ ],
-          "departureDelay": 0,
-          "distanceMeters": 106.589,
-          "endTime": "2009-10-21T23:58:51.000+0000",
-          "flexibleTrip": false,
-          "from": {
-            "bikeShareId": "-102309",
-            "coordinate": {
-              "latitude": 45.5277374,
-              "longitude": -122.70038790000001
-            },
-            "name": "-102309",
-            "vertexType": "BIKESHARE"
-          },
-          "generalizedCost": 0,
-          "interlineWithPreviousLeg": false,
-          "legGeometry": {
-            "length": 4,
-            "points": "ic{tGl|{kVV@?d@kC@"
-          },
-          "mode": "WALK",
-          "onStreetNonTransit": true,
-          "pathway": false,
-          "realTime": false,
-          "rentedBike": false,
-          "scheduled": false,
-          "startTime": "2009-10-21T23:57:20.000+0000",
+          "startTime": "2009-10-21T23:44:03.000+0000",
           "streetNotes": [ ],
           "to": {
             "coordinate": {
@@ -5226,57 +5753,68 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
           "transitLeg": false,
           "walkSteps": [
             {
-              "absoluteDirection": "SOUTH",
-              "angle": -3.1159323053692263,
+              "absoluteDirection": "WEST",
+              "angle": -1.247661800162498,
               "area": false,
-              "bikeRentalOffStation": {
-                "id": "-102309",
-                "lat": 45.5277374,
-                "lon": -122.70038790000001,
-                "name": "-102309"
-              },
-              "bogusName": true,
-              "distance": 13.358,
+              "bogusName": false,
+              "distance": 54.628,
               "edges": [ ],
               "elevation": [ ],
-              "relativeDirection": "HARD_LEFT",
+              "relativeDirection": "DEPART",
               "startLocation": {
-                "latitude": 45.5277374,
-                "longitude": -122.70038790000001
+                "latitude": 45.523815597641374,
+                "longitude": -122.70071990797962
               },
               "stayOn": false,
-              "streetName": "way -102328 from 0",
+              "streetName": "West Burnside Street",
               "streetNotes": [ ]
             },
             {
-              "absoluteDirection": "WEST",
-              "angle": -1.5972658434069475,
+              "absoluteDirection": "NORTHEAST",
+              "angle": 0.7501559967245512,
               "area": false,
               "bogusName": false,
-              "distance": 14.704,
+              "distance": 176.41,
               "edges": [ ],
               "elevation": [ ],
               "relativeDirection": "RIGHT",
               "startLocation": {
-                "latitude": 45.5276173,
-                "longitude": -122.7003923
+                "latitude": 45.5239733,
+                "longitude": -122.701384
               },
               "stayOn": false,
-              "streetName": "Northwest Irving Street",
+              "streetName": "Northwest 24th Place",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "NORTHWEST",
+              "angle": -0.5889596407957216,
+              "area": false,
+              "bogusName": false,
+              "distance": 15.262,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "LEFT",
+              "startLocation": {
+                "latitude": 45.5253583,
+                "longitude": -122.70033570000001
+              },
+              "stayOn": false,
+              "streetName": "Northwest Westover Road",
               "streetNotes": [ ]
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": -0.015200876817562168,
+              "angle": -0.05815952978341337,
               "area": false,
               "bogusName": false,
-              "distance": 78.527,
+              "distance": 317.401,
               "edges": [ ],
               "elevation": [ ],
-              "relativeDirection": "RIGHT",
+              "relativeDirection": "SLIGHTLY_RIGHT",
               "startLocation": {
-                "latitude": 45.527613800000005,
-                "longitude": -122.70058100000001
+                "latitude": 45.525472400000005,
+                "longitude": -122.7004445
               },
               "stayOn": false,
               "streetName": "Northwest 24th Avenue",
@@ -5287,13 +5825,13 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
         }
       ],
       "nTransfers": 0,
-      "nonTransitDistanceMeters": 796.1389999999999,
-      "nonTransitTimeSeconds": 455,
+      "nonTransitDistanceMeters": 851.5160000000001,
+      "nonTransitTimeSeconds": 673,
       "onStreetAllTheWay": false,
       "streetOnly": false,
       "systemNotices": [ ],
       "tooSloped": false,
-      "transitTimeSeconds": 522,
+      "transitTimeSeconds": 663,
       "waitTimeAdjustedGeneralizedCost": -999999,
       "waitingTimeSeconds": 0,
       "walkOnly": false,
@@ -5301,7 +5839,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
     },
     {
       "arrivedAtDestinationWithRentedBicycle": false,
-      "durationSeconds": 977,
+      "durationSeconds": 1134,
       "elevationGained": 0.0,
       "elevationLost": 0.0,
       "fare": {
@@ -5321,7 +5859,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "routes": [
                 {
                   "feedId": "prt",
-                  "id": "17"
+                  "id": "77"
                 }
               ]
             }
@@ -5336,15 +5874,15 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
           }
         }
       },
-      "generalizedCost": 2942,
+      "generalizedCost": 2351,
       "legs": [
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "bikeRentalNetworks": [ ],
           "departureDelay": 0,
-          "distanceMeters": 167.86599999999999,
-          "endTime": "2009-10-21T23:59:50.000+0000",
+          "distanceMeters": 252.87499999999997,
+          "endTime": "2009-10-21T23:40:53.000+0000",
           "flexibleTrip": false,
           "from": {
             "coordinate": {
@@ -5354,11 +5892,11 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "name": "NW Everett St. & NW 5th Ave. (P3)",
             "vertexType": "NORMAL"
           },
-          "generalizedCost": 544,
+          "generalizedCost": 392,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
-            "length": 10,
-            "points": "ssztGh_wkV?`@?LK?uBBK??F?JBbDN?"
+            "length": 15,
+            "points": "ssztGh_wkV?`@?LK?uBBK?K@sBBM??D?L@\\?lCC??E"
           },
           "mode": "WALK",
           "onStreetNonTransit": true,
@@ -5366,21 +5904,21 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
           "realTime": false,
           "rentedBike": false,
           "scheduled": false,
-          "startTime": "2009-10-21T23:57:34.000+0000",
+          "startTime": "2009-10-21T23:37:27.000+0000",
           "streetNotes": [ ],
           "to": {
             "coordinate": {
-              "latitude": 45.52583,
-              "longitude": -122.676422
+              "latitude": 45.526655,
+              "longitude": -122.676462
             },
-            "name": "NW 6th & Flanders",
-            "stopCode": "9300",
+            "name": "NW Glisan & 6th",
+            "stopCode": "10803",
             "stopId": {
               "feedId": "prt",
-              "id": "9300"
+              "id": "10803"
             },
-            "stopIndex": 66,
-            "stopSequence": 67,
+            "stopIndex": 85,
+            "stopSequence": 86,
             "vertexType": "TRANSIT",
             "zoneId": "0"
           },
@@ -5409,7 +5947,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "angle": -0.02939746732509391,
               "area": false,
               "bogusName": false,
-              "distance": 78.514,
+              "distance": 158.018,
               "edges": [ ],
               "elevation": [ ],
               "relativeDirection": "RIGHT",
@@ -5423,19 +5961,36 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             },
             {
               "absoluteDirection": "WEST",
-              "angle": -1.5977129345986325,
+              "angle": -1.6080284293804317,
               "area": false,
               "bogusName": false,
-              "distance": 71.377,
+              "distance": 74.227,
               "edges": [ ],
               "elevation": [ ],
               "relativeDirection": "LEFT",
               "startLocation": {
-                "latitude": 45.52593,
-                "longitude": -122.6755097
+                "latitude": 45.526644700000006,
+                "longitude": -122.67553910000001
               },
               "stayOn": false,
-              "streetName": "Northwest Flanders Street",
+              "streetName": "Northwest Glisan Street",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "NORTH",
+              "angle": -0.03835551109631682,
+              "area": false,
+              "bogusName": true,
+              "distance": 2.655,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "RIGHT",
+              "startLocation": {
+                "latitude": 45.5266303,
+                "longitude": -122.67649170000001
+              },
+              "stayOn": false,
+              "streetName": "way 156261070 from 2",
               "streetNotes": [ ]
             }
           ],
@@ -5446,31 +6001,31 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
           "arrivalDelay": 0,
           "bikeRentalNetworks": [ ],
           "departureDelay": 0,
-          "distanceMeters": 1631.0313510234191,
-          "endTime": "2009-10-22T00:08:32.000+0000",
+          "distanceMeters": 2232.3107878360292,
+          "endTime": "2009-10-21T23:48:50.000+0000",
           "flexibleTrip": false,
           "from": {
             "coordinate": {
-              "latitude": 45.52583,
-              "longitude": -122.676422
+              "latitude": 45.526655,
+              "longitude": -122.676462
             },
-            "name": "NW 6th & Flanders",
-            "stopCode": "9300",
+            "name": "NW Glisan & 6th",
+            "stopCode": "10803",
             "stopId": {
               "feedId": "prt",
-              "id": "9300"
+              "id": "10803"
             },
-            "stopIndex": 66,
-            "stopSequence": 67,
+            "stopIndex": 85,
+            "stopSequence": 86,
             "vertexType": "TRANSIT",
             "zoneId": "0"
           },
-          "generalizedCost": 1122,
+          "generalizedCost": 1077,
           "headsign": "Montgomery Park",
           "intermediateStops": [ ],
           "legGeometry": {
-            "length": 39,
-            "points": "kwztGhgwkVQ?kC@@zD???PBjE?`B??@X@jEBjD???\\BhEBpD???XBhE@nD??@Z?hEBtA?h@@h@??@Z@nEBhEBhD???`@FtKDhH??@hBoCD}BB"
+            "length": 53,
+            "points": "i|ztG|fwkV?LqCFmCDYBGDEBGJkAzAQR??KNa@b@MJuBBY?OHW@u@~@aD`EcBhBBrD@xC??@l@BlE@lD???XBjEBpD???VBlE?dA@t@?b@?h@BfEBrD???VBhEFtKDvJ??@\\DnJ???d@FtKmCBo@@"
           },
           "mode": "BUS",
           "onStreetNonTransit": false,
@@ -5484,21 +6039,21 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "sequenceNumber": 20091021,
             "year": 2009
           },
-          "startTime": "2009-10-21T23:59:50.000+0000",
+          "startTime": "2009-10-21T23:40:53.000+0000",
           "streetNotes": [ ],
           "to": {
             "coordinate": {
-              "latitude": 45.527648,
-              "longitude": -122.694407
+              "latitude": 45.532159,
+              "longitude": -122.698634
             },
-            "name": "NW 21st & Irving",
-            "stopCode": "7113",
+            "name": "NW 23rd & Overton",
+            "stopCode": "8981",
             "stopId": {
               "feedId": "prt",
-              "id": "7113"
+              "id": "8981"
             },
-            "stopIndex": 75,
-            "stopSequence": 76,
+            "stopIndex": 93,
+            "stopSequence": 94,
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
@@ -5507,11 +6062,11 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
           "trip": {
             "alteration": "PLANNED",
             "bikesAllowed": "UNKNOWN",
-            "blockId": "1706",
+            "blockId": "7708",
             "direction": "INBOUND",
             "id": {
               "feedId": "prt",
-              "id": "171W1520"
+              "id": "771W1380"
             },
             "route": {
               "agency": {
@@ -5529,15 +6084,15 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "bikesAllowed": "UNKNOWN",
               "id": {
                 "feedId": "prt",
-                "id": "17"
+                "id": "77"
               },
-              "longName": "Holgate/NW 21st",
+              "longName": "Broadway/Halsey",
               "mode": "BUS",
-              "shortName": "17",
+              "shortName": "77",
               "sortOrder": -999,
               "sortOrderSet": false,
               "type": 3,
-              "url": "http://trimet.org/schedules/r017.htm"
+              "url": "http://trimet.org/schedules/r077.htm"
             },
             "serviceId": {
               "feedId": "prt",
@@ -5545,7 +6100,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             },
             "shapeId": {
               "feedId": "prt",
-              "id": "17.1.14"
+              "id": "77.1.3"
             },
             "wheelchairAccessible": 0
           },
@@ -5557,30 +6112,30 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
           "arrivalDelay": 0,
           "bikeRentalNetworks": [ ],
           "departureDelay": 0,
-          "distanceMeters": 28.258000000000003,
-          "endTime": "2009-10-22T00:09:58.000+0000",
+          "distanceMeters": 580.63,
+          "endTime": "2009-10-21T23:56:21.000+0000",
           "flexibleTrip": false,
           "from": {
             "coordinate": {
-              "latitude": 45.527648,
-              "longitude": -122.694407
+              "latitude": 45.532159,
+              "longitude": -122.698634
             },
-            "name": "NW 21st & Irving",
-            "stopCode": "7113",
+            "name": "NW 23rd & Overton",
+            "stopCode": "8981",
             "stopId": {
               "feedId": "prt",
-              "id": "7113"
+              "id": "8981"
             },
-            "stopIndex": 75,
-            "stopSequence": 76,
+            "stopIndex": 93,
+            "stopSequence": 94,
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
-          "generalizedCost": 1276,
+          "generalizedCost": 881,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
-            "length": 4,
-            "points": "wb{tG`wzkV?LO?Ao@"
+            "length": 12,
+            "points": "}~{tGnq{kV?LVAF?J?FtKlCClCEnCElCElCCB?"
           },
           "mode": "WALK",
           "onStreetNonTransit": true,
@@ -5588,221 +6143,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
           "realTime": false,
           "rentedBike": false,
           "scheduled": false,
-          "startTime": "2009-10-22T00:08:32.000+0000",
-          "streetNotes": [ ],
-          "to": {
-            "bikeShareId": "-102323",
-            "coordinate": {
-              "latitude": 45.527849100000005,
-              "longitude": -122.6942362
-            },
-            "name": "-102323",
-            "vertexType": "BIKESHARE"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
-            {
-              "absoluteDirection": "NORTH",
-              "angle": -0.021151532022270547,
-              "area": false,
-              "bogusName": false,
-              "distance": 8.969,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.52764696458245,
-                "longitude": -122.69447686508221
-              },
-              "stayOn": false,
-              "streetName": "Northwest 21st Avenue",
-              "streetNotes": [ ]
-            },
-            {
-              "absoluteDirection": "EAST",
-              "angle": 1.5442642615053612,
-              "area": false,
-              "bikeRentalOnStation": {
-                "id": "-102323",
-                "lat": 45.527849100000005,
-                "lon": -122.6942362,
-                "name": "-102323"
-              },
-              "bogusName": false,
-              "distance": 19.289,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.527727600000006,
-                "longitude": -122.69447930000001
-              },
-              "stayOn": false,
-              "streetName": "Northwest Irving Street",
-              "streetNotes": [ ]
-            }
-          ],
-          "walkingLeg": true
-        },
-        {
-          "agencyTimeZoneOffset": -25200000,
-          "arrivalDelay": 0,
-          "bikeRentalNetworks": [
-            "test-network"
-          ],
-          "departureDelay": 0,
-          "distanceMeters": 480.068,
-          "endTime": "2009-10-22T00:11:39.000+0000",
-          "flexibleTrip": false,
-          "from": {
-            "bikeShareId": "-102323",
-            "coordinate": {
-              "latitude": 45.527849100000005,
-              "longitude": -122.6942362
-            },
-            "name": "-102323",
-            "vertexType": "BIKESHARE"
-          },
-          "generalizedCost": 0,
-          "interlineWithPreviousLeg": false,
-          "legGeometry": {
-            "length": 6,
-            "points": "ic{tG~uzkV@n@@vAD|HDtKFrJ"
-          },
-          "mode": "BICYCLE",
-          "onStreetNonTransit": true,
-          "pathway": false,
-          "realTime": false,
-          "rentedBike": true,
-          "scheduled": false,
-          "startTime": "2009-10-22T00:09:58.000+0000",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.5276173,
-              "longitude": -122.7003923
-            },
-            "name": "corner of way -102328 from 0 and Northwest Irving Street",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
-            {
-              "absoluteDirection": "WEST",
-              "angle": -1.5973283920844321,
-              "area": false,
-              "bogusName": false,
-              "distance": 480.068,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "HARD_LEFT",
-              "startLocation": {
-                "latitude": 45.52773220198921,
-                "longitude": -122.69423177172958
-              },
-              "stayOn": false,
-              "streetName": "Northwest Irving Street",
-              "streetNotes": [ ]
-            }
-          ],
-          "walkingLeg": false
-        },
-        {
-          "agencyTimeZoneOffset": -25200000,
-          "arrivalDelay": 0,
-          "bikeRentalNetworks": [
-            "test-network"
-          ],
-          "departureDelay": 0,
-          "distanceMeters": 13.358,
-          "endTime": "2009-10-22T00:12:20.000+0000",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.5276173,
-              "longitude": -122.7003923
-            },
-            "name": "corner of way -102328 from 0 and Northwest Irving Street",
-            "vertexType": "NORMAL"
-          },
-          "generalizedCost": 0,
-          "interlineWithPreviousLeg": false,
-          "legGeometry": {
-            "length": 2,
-            "points": "qb{tGn|{kVWA"
-          },
-          "mode": "WALK",
-          "onStreetNonTransit": true,
-          "pathway": false,
-          "realTime": false,
-          "rentedBike": true,
-          "scheduled": false,
-          "startTime": "2009-10-22T00:11:39.000+0000",
-          "streetNotes": [ ],
-          "to": {
-            "bikeShareId": "-102309",
-            "coordinate": {
-              "latitude": 45.5277374,
-              "longitude": -122.70038790000001
-            },
-            "name": "-102309",
-            "vertexType": "BIKESHARE"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
-            {
-              "absoluteDirection": "NORTH",
-              "angle": 0.02566034822056683,
-              "area": false,
-              "bogusName": true,
-              "distance": 13.358,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5276173,
-                "longitude": -122.7003923
-              },
-              "stayOn": false,
-              "streetName": "way -102328 from 0",
-              "streetNotes": [ ]
-            }
-          ],
-          "walkingLeg": true
-        },
-        {
-          "agencyTimeZoneOffset": -25200000,
-          "arrivalDelay": 0,
-          "bikeRentalNetworks": [ ],
-          "departureDelay": 0,
-          "distanceMeters": 106.589,
-          "endTime": "2009-10-22T00:13:51.000+0000",
-          "flexibleTrip": false,
-          "from": {
-            "bikeShareId": "-102309",
-            "coordinate": {
-              "latitude": 45.5277374,
-              "longitude": -122.70038790000001
-            },
-            "name": "-102309",
-            "vertexType": "BIKESHARE"
-          },
-          "generalizedCost": 0,
-          "interlineWithPreviousLeg": false,
-          "legGeometry": {
-            "length": 4,
-            "points": "ic{tGl|{kVV@?d@kC@"
-          },
-          "mode": "WALK",
-          "onStreetNonTransit": true,
-          "pathway": false,
-          "realTime": false,
-          "rentedBike": false,
-          "scheduled": false,
-          "startTime": "2009-10-22T00:12:20.000+0000",
+          "startTime": "2009-10-21T23:48:50.000+0000",
           "streetNotes": [ ],
           "to": {
             "coordinate": {
@@ -5817,646 +6158,50 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
           "walkSteps": [
             {
               "absoluteDirection": "SOUTH",
-              "angle": -3.1159323053692263,
-              "area": false,
-              "bikeRentalOffStation": {
-                "id": "-102309",
-                "lat": 45.5277374,
-                "lon": -122.70038790000001,
-                "name": "-102309"
-              },
-              "bogusName": true,
-              "distance": 13.358,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "HARD_LEFT",
-              "startLocation": {
-                "latitude": 45.5277374,
-                "longitude": -122.70038790000001
-              },
-              "stayOn": false,
-              "streetName": "way -102328 from 0",
-              "streetNotes": [ ]
-            },
-            {
-              "absoluteDirection": "WEST",
-              "angle": -1.5972658434069475,
+              "angle": 3.117146926361324,
               "area": false,
               "bogusName": false,
-              "distance": 14.704,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5276173,
-                "longitude": -122.7003923
-              },
-              "stayOn": false,
-              "streetName": "Northwest Irving Street",
-              "streetNotes": [ ]
-            },
-            {
-              "absoluteDirection": "NORTH",
-              "angle": -0.015200876817562168,
-              "area": false,
-              "bogusName": false,
-              "distance": 78.527,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.527613800000005,
-                "longitude": -122.70058100000001
-              },
-              "stayOn": false,
-              "streetName": "Northwest 24th Avenue",
-              "streetNotes": [ ]
-            }
-          ],
-          "walkingLeg": true
-        }
-      ],
-      "nTransfers": 0,
-      "nonTransitDistanceMeters": 796.1389999999999,
-      "nonTransitTimeSeconds": 455,
-      "onStreetAllTheWay": false,
-      "streetOnly": false,
-      "systemNotices": [ ],
-      "tooSloped": false,
-      "transitTimeSeconds": 522,
-      "waitTimeAdjustedGeneralizedCost": -999999,
-      "waitingTimeSeconds": 0,
-      "walkOnly": false,
-      "walkingAllTheWay": false
-    },
-    {
-      "arrivedAtDestinationWithRentedBicycle": false,
-      "durationSeconds": 977,
-      "elevationGained": 0.0,
-      "elevationLost": 0.0,
-      "fare": {
-        "details": {
-          "regular": [
-            {
-              "fareId": {
-                "feedId": "prt",
-                "id": "8"
-              },
-              "price": {
-                "cents": 200,
-                "currency": {
-                  "value": "USD"
-                }
-              },
-              "routes": [
-                {
-                  "feedId": "prt",
-                  "id": "17"
-                }
-              ]
-            }
-          ]
-        },
-        "fare": {
-          "regular": {
-            "cents": 200,
-            "currency": {
-              "value": "USD"
-            }
-          }
-        }
-      },
-      "generalizedCost": 2942,
-      "legs": [
-        {
-          "agencyTimeZoneOffset": -25200000,
-          "arrivalDelay": 0,
-          "bikeRentalNetworks": [ ],
-          "departureDelay": 0,
-          "distanceMeters": 167.86599999999999,
-          "endTime": "2009-10-22T00:14:50.000+0000",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.52523,
-              "longitude": -122.67525
-            },
-            "name": "NW Everett St. & NW 5th Ave. (P3)",
-            "vertexType": "NORMAL"
-          },
-          "generalizedCost": 544,
-          "interlineWithPreviousLeg": false,
-          "legGeometry": {
-            "length": 10,
-            "points": "ssztGh_wkV?`@?LK?uBBK??F?JBbDN?"
-          },
-          "mode": "WALK",
-          "onStreetNonTransit": true,
-          "pathway": false,
-          "realTime": false,
-          "rentedBike": false,
-          "scheduled": false,
-          "startTime": "2009-10-22T00:12:34.000+0000",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.52583,
-              "longitude": -122.676422
-            },
-            "name": "NW 6th & Flanders",
-            "stopCode": "9300",
-            "stopId": {
-              "feedId": "prt",
-              "id": "9300"
-            },
-            "stopIndex": 66,
-            "stopSequence": 67,
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
-            {
-              "absoluteDirection": "WEST",
-              "angle": -1.596868818888735,
-              "area": false,
-              "bogusName": false,
-              "distance": 17.975,
+              "distance": 24.895,
               "edges": [ ],
               "elevation": [ ],
               "relativeDirection": "DEPART",
               "startLocation": {
-                "latitude": 45.52522794293369,
-                "longitude": -122.67524992342938
+                "latitude": 45.53215782420268,
+                "longitude": -122.69870264831422
               },
               "stayOn": false,
-              "streetName": "Northwest Everett Street",
-              "streetNotes": [ ]
-            },
-            {
-              "absoluteDirection": "NORTH",
-              "angle": -0.02939746732509391,
-              "area": false,
-              "bogusName": false,
-              "distance": 78.514,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.525224200000004,
-                "longitude": -122.67548060000001
-              },
-              "stayOn": false,
-              "streetName": "Northwest 5th Avenue",
+              "streetName": "Northwest 23rd Avenue",
               "streetNotes": [ ]
             },
             {
               "absoluteDirection": "WEST",
-              "angle": -1.5977129345986325,
+              "angle": -1.6005554859058504,
               "area": false,
               "bogusName": false,
-              "distance": 71.377,
+              "distance": 158.45,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "RIGHT",
+              "startLocation": {
+                "latitude": 45.531934,
+                "longitude": -122.698695
+              },
+              "stayOn": false,
+              "streetName": "Northwest Overton Street",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "SOUTH",
+              "angle": 3.119908233299857,
+              "area": false,
+              "bogusName": false,
+              "distance": 397.28499999999997,
               "edges": [ ],
               "elevation": [ ],
               "relativeDirection": "LEFT",
               "startLocation": {
-                "latitude": 45.52593,
-                "longitude": -122.6755097
-              },
-              "stayOn": false,
-              "streetName": "Northwest Flanders Street",
-              "streetNotes": [ ]
-            }
-          ],
-          "walkingLeg": true
-        },
-        {
-          "agencyTimeZoneOffset": 0,
-          "arrivalDelay": 0,
-          "bikeRentalNetworks": [ ],
-          "departureDelay": 0,
-          "distanceMeters": 1631.0313510234191,
-          "endTime": "2009-10-22T00:23:32.000+0000",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.52583,
-              "longitude": -122.676422
-            },
-            "name": "NW 6th & Flanders",
-            "stopCode": "9300",
-            "stopId": {
-              "feedId": "prt",
-              "id": "9300"
-            },
-            "stopIndex": 66,
-            "stopSequence": 67,
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
-          },
-          "generalizedCost": 1122,
-          "headsign": "Sauvie Is. via St.Johns",
-          "intermediateStops": [ ],
-          "legGeometry": {
-            "length": 39,
-            "points": "kwztGhgwkVQ?kC@@zD???PBjE?`B??@X@jEBjD???\\BhEBpD???XBhE@nD??@Z?hEBtA?h@@h@??@Z@nEBhEBhD???`@FtKDhH??@hBoCD}BB"
-          },
-          "mode": "BUS",
-          "onStreetNonTransit": false,
-          "pathway": false,
-          "realTime": false,
-          "scheduled": true,
-          "serviceDate": {
-            "day": 21,
-            "minMax": false,
-            "month": 10,
-            "sequenceNumber": 20091021,
-            "year": 2009
-          },
-          "startTime": "2009-10-22T00:14:50.000+0000",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.527648,
-              "longitude": -122.694407
-            },
-            "name": "NW 21st & Irving",
-            "stopCode": "7113",
-            "stopId": {
-              "feedId": "prt",
-              "id": "7113"
-            },
-            "stopIndex": 75,
-            "stopSequence": 76,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": true,
-          "trip": {
-            "alteration": "PLANNED",
-            "bikesAllowed": "UNKNOWN",
-            "blockId": "1711",
-            "direction": "INBOUND",
-            "id": {
-              "feedId": "prt",
-              "id": "171W1530"
-            },
-            "route": {
-              "agency": {
-                "fareUrl": "http://trimet.org/fares/index.htm",
-                "id": {
-                  "feedId": "prt",
-                  "id": "prt"
-                },
-                "lang": "en",
-                "name": "TriMet",
-                "phone": "503-238-7433",
-                "timezone": "America/Los_Angeles",
-                "url": "http://trimet.org"
-              },
-              "bikesAllowed": "UNKNOWN",
-              "id": {
-                "feedId": "prt",
-                "id": "17"
-              },
-              "longName": "Holgate/NW 21st",
-              "mode": "BUS",
-              "shortName": "17",
-              "sortOrder": -999,
-              "sortOrderSet": false,
-              "type": 3,
-              "url": "http://trimet.org/schedules/r017.htm"
-            },
-            "serviceId": {
-              "feedId": "prt",
-              "id": "W"
-            },
-            "shapeId": {
-              "feedId": "prt",
-              "id": "17.1.15"
-            },
-            "wheelchairAccessible": 0
-          },
-          "walkSteps": [ ],
-          "walkingLeg": false
-        },
-        {
-          "agencyTimeZoneOffset": -25200000,
-          "arrivalDelay": 0,
-          "bikeRentalNetworks": [ ],
-          "departureDelay": 0,
-          "distanceMeters": 28.258000000000003,
-          "endTime": "2009-10-22T00:24:58.000+0000",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.527648,
-              "longitude": -122.694407
-            },
-            "name": "NW 21st & Irving",
-            "stopCode": "7113",
-            "stopId": {
-              "feedId": "prt",
-              "id": "7113"
-            },
-            "stopIndex": 75,
-            "stopSequence": 76,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
-          },
-          "generalizedCost": 1276,
-          "interlineWithPreviousLeg": false,
-          "legGeometry": {
-            "length": 4,
-            "points": "wb{tG`wzkV?LO?Ao@"
-          },
-          "mode": "WALK",
-          "onStreetNonTransit": true,
-          "pathway": false,
-          "realTime": false,
-          "rentedBike": false,
-          "scheduled": false,
-          "startTime": "2009-10-22T00:23:32.000+0000",
-          "streetNotes": [ ],
-          "to": {
-            "bikeShareId": "-102323",
-            "coordinate": {
-              "latitude": 45.527849100000005,
-              "longitude": -122.6942362
-            },
-            "name": "-102323",
-            "vertexType": "BIKESHARE"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
-            {
-              "absoluteDirection": "NORTH",
-              "angle": -0.021151532022270547,
-              "area": false,
-              "bogusName": false,
-              "distance": 8.969,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.52764696458245,
-                "longitude": -122.69447686508221
-              },
-              "stayOn": false,
-              "streetName": "Northwest 21st Avenue",
-              "streetNotes": [ ]
-            },
-            {
-              "absoluteDirection": "EAST",
-              "angle": 1.5442642615053612,
-              "area": false,
-              "bikeRentalOnStation": {
-                "id": "-102323",
-                "lat": 45.527849100000005,
-                "lon": -122.6942362,
-                "name": "-102323"
-              },
-              "bogusName": false,
-              "distance": 19.289,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.527727600000006,
-                "longitude": -122.69447930000001
-              },
-              "stayOn": false,
-              "streetName": "Northwest Irving Street",
-              "streetNotes": [ ]
-            }
-          ],
-          "walkingLeg": true
-        },
-        {
-          "agencyTimeZoneOffset": -25200000,
-          "arrivalDelay": 0,
-          "bikeRentalNetworks": [
-            "test-network"
-          ],
-          "departureDelay": 0,
-          "distanceMeters": 480.068,
-          "endTime": "2009-10-22T00:26:39.000+0000",
-          "flexibleTrip": false,
-          "from": {
-            "bikeShareId": "-102323",
-            "coordinate": {
-              "latitude": 45.527849100000005,
-              "longitude": -122.6942362
-            },
-            "name": "-102323",
-            "vertexType": "BIKESHARE"
-          },
-          "generalizedCost": 0,
-          "interlineWithPreviousLeg": false,
-          "legGeometry": {
-            "length": 6,
-            "points": "ic{tG~uzkV@n@@vAD|HDtKFrJ"
-          },
-          "mode": "BICYCLE",
-          "onStreetNonTransit": true,
-          "pathway": false,
-          "realTime": false,
-          "rentedBike": true,
-          "scheduled": false,
-          "startTime": "2009-10-22T00:24:58.000+0000",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.5276173,
-              "longitude": -122.7003923
-            },
-            "name": "corner of way -102328 from 0 and Northwest Irving Street",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
-            {
-              "absoluteDirection": "WEST",
-              "angle": -1.5973283920844321,
-              "area": false,
-              "bogusName": false,
-              "distance": 480.068,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "HARD_LEFT",
-              "startLocation": {
-                "latitude": 45.52773220198921,
-                "longitude": -122.69423177172958
-              },
-              "stayOn": false,
-              "streetName": "Northwest Irving Street",
-              "streetNotes": [ ]
-            }
-          ],
-          "walkingLeg": false
-        },
-        {
-          "agencyTimeZoneOffset": -25200000,
-          "arrivalDelay": 0,
-          "bikeRentalNetworks": [
-            "test-network"
-          ],
-          "departureDelay": 0,
-          "distanceMeters": 13.358,
-          "endTime": "2009-10-22T00:27:20.000+0000",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.5276173,
-              "longitude": -122.7003923
-            },
-            "name": "corner of way -102328 from 0 and Northwest Irving Street",
-            "vertexType": "NORMAL"
-          },
-          "generalizedCost": 0,
-          "interlineWithPreviousLeg": false,
-          "legGeometry": {
-            "length": 2,
-            "points": "qb{tGn|{kVWA"
-          },
-          "mode": "WALK",
-          "onStreetNonTransit": true,
-          "pathway": false,
-          "realTime": false,
-          "rentedBike": true,
-          "scheduled": false,
-          "startTime": "2009-10-22T00:26:39.000+0000",
-          "streetNotes": [ ],
-          "to": {
-            "bikeShareId": "-102309",
-            "coordinate": {
-              "latitude": 45.5277374,
-              "longitude": -122.70038790000001
-            },
-            "name": "-102309",
-            "vertexType": "BIKESHARE"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
-            {
-              "absoluteDirection": "NORTH",
-              "angle": 0.02566034822056683,
-              "area": false,
-              "bogusName": true,
-              "distance": 13.358,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5276173,
-                "longitude": -122.7003923
-              },
-              "stayOn": false,
-              "streetName": "way -102328 from 0",
-              "streetNotes": [ ]
-            }
-          ],
-          "walkingLeg": true
-        },
-        {
-          "agencyTimeZoneOffset": -25200000,
-          "arrivalDelay": 0,
-          "bikeRentalNetworks": [ ],
-          "departureDelay": 0,
-          "distanceMeters": 106.589,
-          "endTime": "2009-10-22T00:28:51.000+0000",
-          "flexibleTrip": false,
-          "from": {
-            "bikeShareId": "-102309",
-            "coordinate": {
-              "latitude": 45.5277374,
-              "longitude": -122.70038790000001
-            },
-            "name": "-102309",
-            "vertexType": "BIKESHARE"
-          },
-          "generalizedCost": 0,
-          "interlineWithPreviousLeg": false,
-          "legGeometry": {
-            "length": 4,
-            "points": "ic{tGl|{kVV@?d@kC@"
-          },
-          "mode": "WALK",
-          "onStreetNonTransit": true,
-          "pathway": false,
-          "realTime": false,
-          "rentedBike": false,
-          "scheduled": false,
-          "startTime": "2009-10-22T00:27:20.000+0000",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.52832,
-              "longitude": -122.70059
-            },
-            "name": "SW Johnson St. & NW 24th Ave. (P1)",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
-            {
-              "absoluteDirection": "SOUTH",
-              "angle": -3.1159323053692263,
-              "area": false,
-              "bikeRentalOffStation": {
-                "id": "-102309",
-                "lat": 45.5277374,
-                "lon": -122.70038790000001,
-                "name": "-102309"
-              },
-              "bogusName": true,
-              "distance": 13.358,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "HARD_LEFT",
-              "startLocation": {
-                "latitude": 45.5277374,
-                "longitude": -122.70038790000001
-              },
-              "stayOn": false,
-              "streetName": "way -102328 from 0",
-              "streetNotes": [ ]
-            },
-            {
-              "absoluteDirection": "WEST",
-              "angle": -1.5972658434069475,
-              "area": false,
-              "bogusName": false,
-              "distance": 14.704,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5276173,
-                "longitude": -122.7003923
-              },
-              "stayOn": false,
-              "streetName": "Northwest Irving Street",
-              "streetNotes": [ ]
-            },
-            {
-              "absoluteDirection": "NORTH",
-              "angle": -0.015200876817562168,
-              "area": false,
-              "bogusName": false,
-              "distance": 78.527,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.527613800000005,
-                "longitude": -122.70058100000001
+                "latitude": 45.5318916,
+                "longitude": -122.70072830000001
               },
               "stayOn": false,
               "streetName": "Northwest 24th Avenue",
@@ -6467,603 +6212,13 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
         }
       ],
       "nTransfers": 0,
-      "nonTransitDistanceMeters": 796.1389999999999,
-      "nonTransitTimeSeconds": 455,
+      "nonTransitDistanceMeters": 833.505,
+      "nonTransitTimeSeconds": 657,
       "onStreetAllTheWay": false,
       "streetOnly": false,
       "systemNotices": [ ],
       "tooSloped": false,
-      "transitTimeSeconds": 522,
-      "waitTimeAdjustedGeneralizedCost": -999999,
-      "waitingTimeSeconds": 0,
-      "walkOnly": false,
-      "walkingAllTheWay": false
-    },
-    {
-      "arrivedAtDestinationWithRentedBicycle": false,
-      "durationSeconds": 977,
-      "elevationGained": 0.0,
-      "elevationLost": 0.0,
-      "fare": {
-        "details": {
-          "regular": [
-            {
-              "fareId": {
-                "feedId": "prt",
-                "id": "8"
-              },
-              "price": {
-                "cents": 200,
-                "currency": {
-                  "value": "USD"
-                }
-              },
-              "routes": [
-                {
-                  "feedId": "prt",
-                  "id": "17"
-                }
-              ]
-            }
-          ]
-        },
-        "fare": {
-          "regular": {
-            "cents": 200,
-            "currency": {
-              "value": "USD"
-            }
-          }
-        }
-      },
-      "generalizedCost": 2942,
-      "legs": [
-        {
-          "agencyTimeZoneOffset": -25200000,
-          "arrivalDelay": 0,
-          "bikeRentalNetworks": [ ],
-          "departureDelay": 0,
-          "distanceMeters": 167.86599999999999,
-          "endTime": "2009-10-22T00:29:50.000+0000",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.52523,
-              "longitude": -122.67525
-            },
-            "name": "NW Everett St. & NW 5th Ave. (P3)",
-            "vertexType": "NORMAL"
-          },
-          "generalizedCost": 544,
-          "interlineWithPreviousLeg": false,
-          "legGeometry": {
-            "length": 10,
-            "points": "ssztGh_wkV?`@?LK?uBBK??F?JBbDN?"
-          },
-          "mode": "WALK",
-          "onStreetNonTransit": true,
-          "pathway": false,
-          "realTime": false,
-          "rentedBike": false,
-          "scheduled": false,
-          "startTime": "2009-10-22T00:27:34.000+0000",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.52583,
-              "longitude": -122.676422
-            },
-            "name": "NW 6th & Flanders",
-            "stopCode": "9300",
-            "stopId": {
-              "feedId": "prt",
-              "id": "9300"
-            },
-            "stopIndex": 66,
-            "stopSequence": 67,
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
-            {
-              "absoluteDirection": "WEST",
-              "angle": -1.596868818888735,
-              "area": false,
-              "bogusName": false,
-              "distance": 17.975,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.52522794293369,
-                "longitude": -122.67524992342938
-              },
-              "stayOn": false,
-              "streetName": "Northwest Everett Street",
-              "streetNotes": [ ]
-            },
-            {
-              "absoluteDirection": "NORTH",
-              "angle": -0.02939746732509391,
-              "area": false,
-              "bogusName": false,
-              "distance": 78.514,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.525224200000004,
-                "longitude": -122.67548060000001
-              },
-              "stayOn": false,
-              "streetName": "Northwest 5th Avenue",
-              "streetNotes": [ ]
-            },
-            {
-              "absoluteDirection": "WEST",
-              "angle": -1.5977129345986325,
-              "area": false,
-              "bogusName": false,
-              "distance": 71.377,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.52593,
-                "longitude": -122.6755097
-              },
-              "stayOn": false,
-              "streetName": "Northwest Flanders Street",
-              "streetNotes": [ ]
-            }
-          ],
-          "walkingLeg": true
-        },
-        {
-          "agencyTimeZoneOffset": 0,
-          "arrivalDelay": 0,
-          "bikeRentalNetworks": [ ],
-          "departureDelay": 0,
-          "distanceMeters": 1631.0313510234191,
-          "endTime": "2009-10-22T00:38:32.000+0000",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.52583,
-              "longitude": -122.676422
-            },
-            "name": "NW 6th & Flanders",
-            "stopCode": "9300",
-            "stopId": {
-              "feedId": "prt",
-              "id": "9300"
-            },
-            "stopIndex": 66,
-            "stopSequence": 67,
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
-          },
-          "generalizedCost": 1122,
-          "headsign": "Montgomery Park",
-          "intermediateStops": [ ],
-          "legGeometry": {
-            "length": 39,
-            "points": "kwztGhgwkVQ?kC@@zD???PBjE?`B??@X@jEBjD???\\BhEBpD???XBhE@nD??@Z?hEBtA?h@@h@??@Z@nEBhEBhD???`@FtKDhH??@hBoCD}BB"
-          },
-          "mode": "BUS",
-          "onStreetNonTransit": false,
-          "pathway": false,
-          "realTime": false,
-          "scheduled": true,
-          "serviceDate": {
-            "day": 21,
-            "minMax": false,
-            "month": 10,
-            "sequenceNumber": 20091021,
-            "year": 2009
-          },
-          "startTime": "2009-10-22T00:29:50.000+0000",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.527648,
-              "longitude": -122.694407
-            },
-            "name": "NW 21st & Irving",
-            "stopCode": "7113",
-            "stopId": {
-              "feedId": "prt",
-              "id": "7113"
-            },
-            "stopIndex": 75,
-            "stopSequence": 76,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": true,
-          "trip": {
-            "alteration": "PLANNED",
-            "bikesAllowed": "UNKNOWN",
-            "blockId": "1714",
-            "direction": "INBOUND",
-            "id": {
-              "feedId": "prt",
-              "id": "171W1540"
-            },
-            "route": {
-              "agency": {
-                "fareUrl": "http://trimet.org/fares/index.htm",
-                "id": {
-                  "feedId": "prt",
-                  "id": "prt"
-                },
-                "lang": "en",
-                "name": "TriMet",
-                "phone": "503-238-7433",
-                "timezone": "America/Los_Angeles",
-                "url": "http://trimet.org"
-              },
-              "bikesAllowed": "UNKNOWN",
-              "id": {
-                "feedId": "prt",
-                "id": "17"
-              },
-              "longName": "Holgate/NW 21st",
-              "mode": "BUS",
-              "shortName": "17",
-              "sortOrder": -999,
-              "sortOrderSet": false,
-              "type": 3,
-              "url": "http://trimet.org/schedules/r017.htm"
-            },
-            "serviceId": {
-              "feedId": "prt",
-              "id": "W"
-            },
-            "shapeId": {
-              "feedId": "prt",
-              "id": "17.1.14"
-            },
-            "wheelchairAccessible": 0
-          },
-          "walkSteps": [ ],
-          "walkingLeg": false
-        },
-        {
-          "agencyTimeZoneOffset": -25200000,
-          "arrivalDelay": 0,
-          "bikeRentalNetworks": [ ],
-          "departureDelay": 0,
-          "distanceMeters": 28.258000000000003,
-          "endTime": "2009-10-22T00:39:58.000+0000",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.527648,
-              "longitude": -122.694407
-            },
-            "name": "NW 21st & Irving",
-            "stopCode": "7113",
-            "stopId": {
-              "feedId": "prt",
-              "id": "7113"
-            },
-            "stopIndex": 75,
-            "stopSequence": 76,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
-          },
-          "generalizedCost": 1276,
-          "interlineWithPreviousLeg": false,
-          "legGeometry": {
-            "length": 4,
-            "points": "wb{tG`wzkV?LO?Ao@"
-          },
-          "mode": "WALK",
-          "onStreetNonTransit": true,
-          "pathway": false,
-          "realTime": false,
-          "rentedBike": false,
-          "scheduled": false,
-          "startTime": "2009-10-22T00:38:32.000+0000",
-          "streetNotes": [ ],
-          "to": {
-            "bikeShareId": "-102323",
-            "coordinate": {
-              "latitude": 45.527849100000005,
-              "longitude": -122.6942362
-            },
-            "name": "-102323",
-            "vertexType": "BIKESHARE"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
-            {
-              "absoluteDirection": "NORTH",
-              "angle": -0.021151532022270547,
-              "area": false,
-              "bogusName": false,
-              "distance": 8.969,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.52764696458245,
-                "longitude": -122.69447686508221
-              },
-              "stayOn": false,
-              "streetName": "Northwest 21st Avenue",
-              "streetNotes": [ ]
-            },
-            {
-              "absoluteDirection": "EAST",
-              "angle": 1.5442642615053612,
-              "area": false,
-              "bikeRentalOnStation": {
-                "id": "-102323",
-                "lat": 45.527849100000005,
-                "lon": -122.6942362,
-                "name": "-102323"
-              },
-              "bogusName": false,
-              "distance": 19.289,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.527727600000006,
-                "longitude": -122.69447930000001
-              },
-              "stayOn": false,
-              "streetName": "Northwest Irving Street",
-              "streetNotes": [ ]
-            }
-          ],
-          "walkingLeg": true
-        },
-        {
-          "agencyTimeZoneOffset": -25200000,
-          "arrivalDelay": 0,
-          "bikeRentalNetworks": [
-            "test-network"
-          ],
-          "departureDelay": 0,
-          "distanceMeters": 480.068,
-          "endTime": "2009-10-22T00:41:39.000+0000",
-          "flexibleTrip": false,
-          "from": {
-            "bikeShareId": "-102323",
-            "coordinate": {
-              "latitude": 45.527849100000005,
-              "longitude": -122.6942362
-            },
-            "name": "-102323",
-            "vertexType": "BIKESHARE"
-          },
-          "generalizedCost": 0,
-          "interlineWithPreviousLeg": false,
-          "legGeometry": {
-            "length": 6,
-            "points": "ic{tG~uzkV@n@@vAD|HDtKFrJ"
-          },
-          "mode": "BICYCLE",
-          "onStreetNonTransit": true,
-          "pathway": false,
-          "realTime": false,
-          "rentedBike": true,
-          "scheduled": false,
-          "startTime": "2009-10-22T00:39:58.000+0000",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.5276173,
-              "longitude": -122.7003923
-            },
-            "name": "corner of way -102328 from 0 and Northwest Irving Street",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
-            {
-              "absoluteDirection": "WEST",
-              "angle": -1.5973283920844321,
-              "area": false,
-              "bogusName": false,
-              "distance": 480.068,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "HARD_LEFT",
-              "startLocation": {
-                "latitude": 45.52773220198921,
-                "longitude": -122.69423177172958
-              },
-              "stayOn": false,
-              "streetName": "Northwest Irving Street",
-              "streetNotes": [ ]
-            }
-          ],
-          "walkingLeg": false
-        },
-        {
-          "agencyTimeZoneOffset": -25200000,
-          "arrivalDelay": 0,
-          "bikeRentalNetworks": [
-            "test-network"
-          ],
-          "departureDelay": 0,
-          "distanceMeters": 13.358,
-          "endTime": "2009-10-22T00:42:20.000+0000",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.5276173,
-              "longitude": -122.7003923
-            },
-            "name": "corner of way -102328 from 0 and Northwest Irving Street",
-            "vertexType": "NORMAL"
-          },
-          "generalizedCost": 0,
-          "interlineWithPreviousLeg": false,
-          "legGeometry": {
-            "length": 2,
-            "points": "qb{tGn|{kVWA"
-          },
-          "mode": "WALK",
-          "onStreetNonTransit": true,
-          "pathway": false,
-          "realTime": false,
-          "rentedBike": true,
-          "scheduled": false,
-          "startTime": "2009-10-22T00:41:39.000+0000",
-          "streetNotes": [ ],
-          "to": {
-            "bikeShareId": "-102309",
-            "coordinate": {
-              "latitude": 45.5277374,
-              "longitude": -122.70038790000001
-            },
-            "name": "-102309",
-            "vertexType": "BIKESHARE"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
-            {
-              "absoluteDirection": "NORTH",
-              "angle": 0.02566034822056683,
-              "area": false,
-              "bogusName": true,
-              "distance": 13.358,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5276173,
-                "longitude": -122.7003923
-              },
-              "stayOn": false,
-              "streetName": "way -102328 from 0",
-              "streetNotes": [ ]
-            }
-          ],
-          "walkingLeg": true
-        },
-        {
-          "agencyTimeZoneOffset": -25200000,
-          "arrivalDelay": 0,
-          "bikeRentalNetworks": [ ],
-          "departureDelay": 0,
-          "distanceMeters": 106.589,
-          "endTime": "2009-10-22T00:43:51.000+0000",
-          "flexibleTrip": false,
-          "from": {
-            "bikeShareId": "-102309",
-            "coordinate": {
-              "latitude": 45.5277374,
-              "longitude": -122.70038790000001
-            },
-            "name": "-102309",
-            "vertexType": "BIKESHARE"
-          },
-          "generalizedCost": 0,
-          "interlineWithPreviousLeg": false,
-          "legGeometry": {
-            "length": 4,
-            "points": "ic{tGl|{kVV@?d@kC@"
-          },
-          "mode": "WALK",
-          "onStreetNonTransit": true,
-          "pathway": false,
-          "realTime": false,
-          "rentedBike": false,
-          "scheduled": false,
-          "startTime": "2009-10-22T00:42:20.000+0000",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.52832,
-              "longitude": -122.70059
-            },
-            "name": "SW Johnson St. & NW 24th Ave. (P1)",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
-            {
-              "absoluteDirection": "SOUTH",
-              "angle": -3.1159323053692263,
-              "area": false,
-              "bikeRentalOffStation": {
-                "id": "-102309",
-                "lat": 45.5277374,
-                "lon": -122.70038790000001,
-                "name": "-102309"
-              },
-              "bogusName": true,
-              "distance": 13.358,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "HARD_LEFT",
-              "startLocation": {
-                "latitude": 45.5277374,
-                "longitude": -122.70038790000001
-              },
-              "stayOn": false,
-              "streetName": "way -102328 from 0",
-              "streetNotes": [ ]
-            },
-            {
-              "absoluteDirection": "WEST",
-              "angle": -1.5972658434069475,
-              "area": false,
-              "bogusName": false,
-              "distance": 14.704,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5276173,
-                "longitude": -122.7003923
-              },
-              "stayOn": false,
-              "streetName": "Northwest Irving Street",
-              "streetNotes": [ ]
-            },
-            {
-              "absoluteDirection": "NORTH",
-              "angle": -0.015200876817562168,
-              "area": false,
-              "bogusName": false,
-              "distance": 78.527,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.527613800000005,
-                "longitude": -122.70058100000001
-              },
-              "stayOn": false,
-              "streetName": "Northwest 24th Avenue",
-              "streetNotes": [ ]
-            }
-          ],
-          "walkingLeg": true
-        }
-      ],
-      "nTransfers": 0,
-      "nonTransitDistanceMeters": 796.1389999999999,
-      "nonTransitTimeSeconds": 455,
-      "onStreetAllTheWay": false,
-      "streetOnly": false,
-      "systemNotices": [ ],
-      "tooSloped": false,
-      "transitTimeSeconds": 522,
+      "transitTimeSeconds": 477,
       "waitTimeAdjustedGeneralizedCost": -999999,
       "waitingTimeSeconds": 0,
       "walkOnly": false,

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/BikeRentalSnapshotTest.snap
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/BikeRentalSnapshotTest.snap
@@ -3566,7 +3566,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
           }
         }
       },
-      "generalizedCost": 2032,
+      "generalizedCost": 2942,
       "legs": [
         {
           "agencyTimeZoneOffset": -25200000,
@@ -3584,7 +3584,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "name": "NW Everett St. & NW 5th Ave. (P3)",
             "vertexType": "NORMAL"
           },
-          "generalizedCost": 272,
+          "generalizedCost": 544,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 10,
@@ -3806,7 +3806,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
-          "generalizedCost": 638,
+          "generalizedCost": 1276,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 4,
@@ -4121,780 +4121,6 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
     },
     {
       "arrivedAtDestinationWithRentedBicycle": false,
-      "durationSeconds": 1276,
-      "elevationGained": 0.0,
-      "elevationLost": 0.0,
-      "fare": {
-        "details": {
-          "regular": [
-            {
-              "fareId": {
-                "feedId": "prt",
-                "id": "8"
-              },
-              "price": {
-                "cents": 200,
-                "currency": {
-                  "value": "USD"
-                }
-              },
-              "routes": [
-                {
-                  "feedId": "prt",
-                  "id": "20"
-                }
-              ]
-            }
-          ]
-        },
-        "fare": {
-          "regular": {
-            "cents": 200,
-            "currency": {
-              "value": "USD"
-            }
-          }
-        }
-      },
-      "generalizedCost": 2549,
-      "legs": [
-        {
-          "agencyTimeZoneOffset": -25200000,
-          "arrivalDelay": 0,
-          "bikeRentalNetworks": [ ],
-          "departureDelay": 0,
-          "distanceMeters": 287.815,
-          "endTime": "2009-10-21T23:18:00.000+0000",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.52523,
-              "longitude": -122.67525
-            },
-            "name": "NW Everett St. & NW 5th Ave. (P3)",
-            "vertexType": "NORMAL"
-          },
-          "generalizedCost": 464,
-          "interlineWithPreviousLeg": false,
-          "legGeometry": {
-            "length": 17,
-            "points": "ssztGh_wkV?`@?LJAlBCH?J?H?vBCJ?H?jBCJA?D@L?lAE?"
-          },
-          "mode": "WALK",
-          "onStreetNonTransit": true,
-          "pathway": false,
-          "realTime": false,
-          "rentedBike": false,
-          "scheduled": false,
-          "startTime": "2009-10-21T23:14:08.000+0000",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.523169,
-              "longitude": -122.675893
-            },
-            "name": "W Burnside & NW 5th",
-            "stopCode": "782",
-            "stopId": {
-              "feedId": "prt",
-              "id": "782"
-            },
-            "stopIndex": 99,
-            "stopSequence": 100,
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
-            {
-              "absoluteDirection": "WEST",
-              "angle": -1.596868818888735,
-              "area": false,
-              "bogusName": false,
-              "distance": 17.975,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.52522794293369,
-                "longitude": -122.67524992342938
-              },
-              "stayOn": false,
-              "streetName": "Northwest Everett Street",
-              "streetNotes": [ ]
-            },
-            {
-              "absoluteDirection": "SOUTH",
-              "angle": 3.1122681276306428,
-              "area": false,
-              "bogusName": false,
-              "distance": 231.76100000000002,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.525224200000004,
-                "longitude": -122.67548060000001
-              },
-              "stayOn": false,
-              "streetName": "Northwest 5th Avenue",
-              "streetNotes": [ ]
-            },
-            {
-              "absoluteDirection": "WEST",
-              "angle": -1.5966159701088662,
-              "area": false,
-              "bogusName": false,
-              "distance": 38.079,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.523141200000005,
-                "longitude": -122.67540310000001
-              },
-              "stayOn": false,
-              "streetName": "West Burnside Street",
-              "streetNotes": [ ]
-            }
-          ],
-          "walkingLeg": true
-        },
-        {
-          "agencyTimeZoneOffset": 0,
-          "arrivalDelay": 0,
-          "bikeRentalNetworks": [ ],
-          "departureDelay": 0,
-          "distanceMeters": 1942.2498485359197,
-          "endTime": "2009-10-21T23:28:03.000+0000",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.523169,
-              "longitude": -122.675893
-            },
-            "name": "W Burnside & NW 5th",
-            "stopCode": "782",
-            "stopId": {
-              "feedId": "prt",
-              "id": "782"
-            },
-            "stopIndex": 99,
-            "stopSequence": 100,
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
-          },
-          "generalizedCost": 1203,
-          "headsign": "Beaverton TC",
-          "intermediateStops": [ ],
-          "legGeometry": {
-            "length": 56,
-            "points": "efztGhcwkV@rBBzDBpE@~A???Z@tD@RBnEB|A???@BdB?lEBjA??BnBApF@dB?X?^@r@?f@@bCAx@EtB???VChAE|BGnD??AXKnEGnD???XGjD??AZEfCC`AEzB??AXCfAGxDE|AEtBIlC??APu@lJMhBI`@"
-          },
-          "mode": "BUS",
-          "onStreetNonTransit": false,
-          "pathway": false,
-          "realTime": false,
-          "scheduled": true,
-          "serviceDate": {
-            "day": 21,
-            "minMax": false,
-            "month": 10,
-            "sequenceNumber": 20091021,
-            "year": 2009
-          },
-          "startTime": "2009-10-21T23:18:00.000+0000",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.523897,
-              "longitude": -122.700681
-            },
-            "name": "W Burnside & NW 23rd Pl",
-            "stopCode": "9555",
-            "stopId": {
-              "feedId": "prt",
-              "id": "9555"
-            },
-            "stopIndex": 109,
-            "stopSequence": 110,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": true,
-          "trip": {
-            "alteration": "PLANNED",
-            "bikesAllowed": "UNKNOWN",
-            "blockId": "2069",
-            "direction": "OUTBOUND",
-            "id": {
-              "feedId": "prt",
-              "id": "200W1440"
-            },
-            "route": {
-              "agency": {
-                "fareUrl": "http://trimet.org/fares/index.htm",
-                "id": {
-                  "feedId": "prt",
-                  "id": "prt"
-                },
-                "lang": "en",
-                "name": "TriMet",
-                "phone": "503-238-7433",
-                "timezone": "America/Los_Angeles",
-                "url": "http://trimet.org"
-              },
-              "bikesAllowed": "UNKNOWN",
-              "id": {
-                "feedId": "prt",
-                "id": "20"
-              },
-              "longName": "Burnside/Stark",
-              "mode": "BUS",
-              "shortName": "20",
-              "sortOrder": -999,
-              "sortOrderSet": false,
-              "type": 3,
-              "url": "http://trimet.org/schedules/r020.htm"
-            },
-            "serviceId": {
-              "feedId": "prt",
-              "id": "W"
-            },
-            "shapeId": {
-              "feedId": "prt",
-              "id": "20.0.1"
-            },
-            "wheelchairAccessible": 0
-          },
-          "walkSteps": [ ],
-          "walkingLeg": false
-        },
-        {
-          "agencyTimeZoneOffset": -25200000,
-          "arrivalDelay": 0,
-          "bikeRentalNetworks": [ ],
-          "departureDelay": 0,
-          "distanceMeters": 563.701,
-          "endTime": "2009-10-21T23:35:24.000+0000",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.523897,
-              "longitude": -122.700681
-            },
-            "name": "W Burnside & NW 23rd Pl",
-            "stopCode": "9555",
-            "stopId": {
-              "feedId": "prt",
-              "id": "9555"
-            },
-            "stopIndex": 109,
-            "stopSequence": 110,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
-          },
-          "generalizedCost": 882,
-          "interlineWithPreviousLeg": false,
-          "legGeometry": {
-            "length": 34,
-            "points": "ikztGh~{kVNDEVUzACPOUQO_@Yc@[QMMEOKOIECGCIAMCGCGAECECECOOMOGKIFMLk@BsABGDGBoCBkCDkC@"
-          },
-          "mode": "WALK",
-          "onStreetNonTransit": true,
-          "pathway": false,
-          "realTime": false,
-          "rentedBike": false,
-          "scheduled": false,
-          "startTime": "2009-10-21T23:28:03.000+0000",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.52832,
-              "longitude": -122.70059
-            },
-            "name": "SW Johnson St. & NW 24th Ave. (P1)",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
-            {
-              "absoluteDirection": "WEST",
-              "angle": -1.247661800162498,
-              "area": false,
-              "bogusName": false,
-              "distance": 54.628,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.523815597641374,
-                "longitude": -122.70071990797962
-              },
-              "stayOn": false,
-              "streetName": "West Burnside Street",
-              "streetNotes": [ ]
-            },
-            {
-              "absoluteDirection": "NORTHEAST",
-              "angle": 0.7501559967245512,
-              "area": false,
-              "bogusName": false,
-              "distance": 176.41,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5239733,
-                "longitude": -122.701384
-              },
-              "stayOn": false,
-              "streetName": "Northwest 24th Place",
-              "streetNotes": [ ]
-            },
-            {
-              "absoluteDirection": "NORTHWEST",
-              "angle": -0.5889596407957216,
-              "area": false,
-              "bogusName": false,
-              "distance": 15.262,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.5253583,
-                "longitude": -122.70033570000001
-              },
-              "stayOn": false,
-              "streetName": "Northwest Westover Road",
-              "streetNotes": [ ]
-            },
-            {
-              "absoluteDirection": "NORTH",
-              "angle": -0.05815952978341337,
-              "area": false,
-              "bogusName": false,
-              "distance": 317.401,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "SLIGHTLY_RIGHT",
-              "startLocation": {
-                "latitude": 45.525472400000005,
-                "longitude": -122.7004445
-              },
-              "stayOn": false,
-              "streetName": "Northwest 24th Avenue",
-              "streetNotes": [ ]
-            }
-          ],
-          "walkingLeg": true
-        }
-      ],
-      "nTransfers": 0,
-      "nonTransitDistanceMeters": 851.5160000000001,
-      "nonTransitTimeSeconds": 673,
-      "onStreetAllTheWay": false,
-      "streetOnly": false,
-      "systemNotices": [ ],
-      "tooSloped": false,
-      "transitTimeSeconds": 603,
-      "waitTimeAdjustedGeneralizedCost": -999999,
-      "waitingTimeSeconds": 0,
-      "walkOnly": false,
-      "walkingAllTheWay": false
-    },
-    {
-      "arrivedAtDestinationWithRentedBicycle": false,
-      "durationSeconds": 1134,
-      "elevationGained": 0.0,
-      "elevationLost": 0.0,
-      "fare": {
-        "details": {
-          "regular": [
-            {
-              "fareId": {
-                "feedId": "prt",
-                "id": "8"
-              },
-              "price": {
-                "cents": 200,
-                "currency": {
-                  "value": "USD"
-                }
-              },
-              "routes": [
-                {
-                  "feedId": "prt",
-                  "id": "77"
-                }
-              ]
-            }
-          ]
-        },
-        "fare": {
-          "regular": {
-            "cents": 200,
-            "currency": {
-              "value": "USD"
-            }
-          }
-        }
-      },
-      "generalizedCost": 2391,
-      "legs": [
-        {
-          "agencyTimeZoneOffset": -25200000,
-          "arrivalDelay": 0,
-          "bikeRentalNetworks": [ ],
-          "departureDelay": 0,
-          "distanceMeters": 252.87499999999997,
-          "endTime": "2009-10-21T23:21:53.000+0000",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.52523,
-              "longitude": -122.67525
-            },
-            "name": "NW Everett St. & NW 5th Ave. (P3)",
-            "vertexType": "NORMAL"
-          },
-          "generalizedCost": 412,
-          "interlineWithPreviousLeg": false,
-          "legGeometry": {
-            "length": 15,
-            "points": "ssztGh_wkV?`@?LK?uBBK?K@sBBM??D?L@\\?lCC??E"
-          },
-          "mode": "WALK",
-          "onStreetNonTransit": true,
-          "pathway": false,
-          "realTime": false,
-          "rentedBike": false,
-          "scheduled": false,
-          "startTime": "2009-10-21T23:18:27.000+0000",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.526655,
-              "longitude": -122.676462
-            },
-            "name": "NW Glisan & 6th",
-            "stopCode": "10803",
-            "stopId": {
-              "feedId": "prt",
-              "id": "10803"
-            },
-            "stopIndex": 85,
-            "stopSequence": 86,
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
-            {
-              "absoluteDirection": "WEST",
-              "angle": -1.596868818888735,
-              "area": false,
-              "bogusName": false,
-              "distance": 17.975,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.52522794293369,
-                "longitude": -122.67524992342938
-              },
-              "stayOn": false,
-              "streetName": "Northwest Everett Street",
-              "streetNotes": [ ]
-            },
-            {
-              "absoluteDirection": "NORTH",
-              "angle": -0.02939746732509391,
-              "area": false,
-              "bogusName": false,
-              "distance": 158.018,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.525224200000004,
-                "longitude": -122.67548060000001
-              },
-              "stayOn": false,
-              "streetName": "Northwest 5th Avenue",
-              "streetNotes": [ ]
-            },
-            {
-              "absoluteDirection": "WEST",
-              "angle": -1.6080284293804317,
-              "area": false,
-              "bogusName": false,
-              "distance": 74.227,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.526644700000006,
-                "longitude": -122.67553910000001
-              },
-              "stayOn": false,
-              "streetName": "Northwest Glisan Street",
-              "streetNotes": [ ]
-            },
-            {
-              "absoluteDirection": "NORTH",
-              "angle": -0.03835551109631682,
-              "area": false,
-              "bogusName": true,
-              "distance": 2.655,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5266303,
-                "longitude": -122.67649170000001
-              },
-              "stayOn": false,
-              "streetName": "way 156261070 from 2",
-              "streetNotes": [ ]
-            }
-          ],
-          "walkingLeg": true
-        },
-        {
-          "agencyTimeZoneOffset": 0,
-          "arrivalDelay": 0,
-          "bikeRentalNetworks": [ ],
-          "departureDelay": 0,
-          "distanceMeters": 2232.3107878360292,
-          "endTime": "2009-10-21T23:29:50.000+0000",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.526655,
-              "longitude": -122.676462
-            },
-            "name": "NW Glisan & 6th",
-            "stopCode": "10803",
-            "stopId": {
-              "feedId": "prt",
-              "id": "10803"
-            },
-            "stopIndex": 85,
-            "stopSequence": 86,
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
-          },
-          "generalizedCost": 1077,
-          "headsign": "Montgomery Park",
-          "intermediateStops": [ ],
-          "legGeometry": {
-            "length": 53,
-            "points": "i|ztG|fwkV?LqCFmCDYBGDEBGJkAzAQR??KNa@b@MJuBBY?OHW@u@~@aD`EcBhBBrD@xC??@l@BlE@lD???XBjEBpD???VBlE?dA@t@?b@?h@BfEBrD???VBhEFtKDvJ??@\\DnJ???d@FtKmCBo@@"
-          },
-          "mode": "BUS",
-          "onStreetNonTransit": false,
-          "pathway": false,
-          "realTime": false,
-          "scheduled": true,
-          "serviceDate": {
-            "day": 21,
-            "minMax": false,
-            "month": 10,
-            "sequenceNumber": 20091021,
-            "year": 2009
-          },
-          "startTime": "2009-10-21T23:21:53.000+0000",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.532159,
-              "longitude": -122.698634
-            },
-            "name": "NW 23rd & Overton",
-            "stopCode": "8981",
-            "stopId": {
-              "feedId": "prt",
-              "id": "8981"
-            },
-            "stopIndex": 93,
-            "stopSequence": 94,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": true,
-          "trip": {
-            "alteration": "PLANNED",
-            "bikesAllowed": "UNKNOWN",
-            "blockId": "7710",
-            "direction": "INBOUND",
-            "id": {
-              "feedId": "prt",
-              "id": "771W1370"
-            },
-            "route": {
-              "agency": {
-                "fareUrl": "http://trimet.org/fares/index.htm",
-                "id": {
-                  "feedId": "prt",
-                  "id": "prt"
-                },
-                "lang": "en",
-                "name": "TriMet",
-                "phone": "503-238-7433",
-                "timezone": "America/Los_Angeles",
-                "url": "http://trimet.org"
-              },
-              "bikesAllowed": "UNKNOWN",
-              "id": {
-                "feedId": "prt",
-                "id": "77"
-              },
-              "longName": "Broadway/Halsey",
-              "mode": "BUS",
-              "shortName": "77",
-              "sortOrder": -999,
-              "sortOrderSet": false,
-              "type": 3,
-              "url": "http://trimet.org/schedules/r077.htm"
-            },
-            "serviceId": {
-              "feedId": "prt",
-              "id": "W"
-            },
-            "shapeId": {
-              "feedId": "prt",
-              "id": "77.1.3"
-            },
-            "wheelchairAccessible": 0
-          },
-          "walkSteps": [ ],
-          "walkingLeg": false
-        },
-        {
-          "agencyTimeZoneOffset": -25200000,
-          "arrivalDelay": 0,
-          "bikeRentalNetworks": [ ],
-          "departureDelay": 0,
-          "distanceMeters": 580.63,
-          "endTime": "2009-10-21T23:37:21.000+0000",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.532159,
-              "longitude": -122.698634
-            },
-            "name": "NW 23rd & Overton",
-            "stopCode": "8981",
-            "stopId": {
-              "feedId": "prt",
-              "id": "8981"
-            },
-            "stopIndex": 93,
-            "stopSequence": 94,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
-          },
-          "generalizedCost": 902,
-          "interlineWithPreviousLeg": false,
-          "legGeometry": {
-            "length": 12,
-            "points": "}~{tGnq{kV?LVAF?J?FtKlCClCEnCElCElCCB?"
-          },
-          "mode": "WALK",
-          "onStreetNonTransit": true,
-          "pathway": false,
-          "realTime": false,
-          "rentedBike": false,
-          "scheduled": false,
-          "startTime": "2009-10-21T23:29:50.000+0000",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.52832,
-              "longitude": -122.70059
-            },
-            "name": "SW Johnson St. & NW 24th Ave. (P1)",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
-            {
-              "absoluteDirection": "SOUTH",
-              "angle": 3.117146926361324,
-              "area": false,
-              "bogusName": false,
-              "distance": 24.895,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.53215782420268,
-                "longitude": -122.69870264831422
-              },
-              "stayOn": false,
-              "streetName": "Northwest 23rd Avenue",
-              "streetNotes": [ ]
-            },
-            {
-              "absoluteDirection": "WEST",
-              "angle": -1.6005554859058504,
-              "area": false,
-              "bogusName": false,
-              "distance": 158.45,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.531934,
-                "longitude": -122.698695
-              },
-              "stayOn": false,
-              "streetName": "Northwest Overton Street",
-              "streetNotes": [ ]
-            },
-            {
-              "absoluteDirection": "SOUTH",
-              "angle": 3.119908233299857,
-              "area": false,
-              "bogusName": false,
-              "distance": 397.28499999999997,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.5318916,
-                "longitude": -122.70072830000001
-              },
-              "stayOn": false,
-              "streetName": "Northwest 24th Avenue",
-              "streetNotes": [ ]
-            }
-          ],
-          "walkingLeg": true
-        }
-      ],
-      "nTransfers": 0,
-      "nonTransitDistanceMeters": 833.505,
-      "nonTransitTimeSeconds": 657,
-      "onStreetAllTheWay": false,
-      "streetOnly": false,
-      "systemNotices": [ ],
-      "tooSloped": false,
-      "transitTimeSeconds": 477,
-      "waitTimeAdjustedGeneralizedCost": -999999,
-      "waitingTimeSeconds": 0,
-      "walkOnly": false,
-      "walkingAllTheWay": false
-    },
-    {
-      "arrivedAtDestinationWithRentedBicycle": false,
       "durationSeconds": 977,
       "elevationGained": 0.0,
       "elevationLost": 0.0,
@@ -4930,7 +4156,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
           }
         }
       },
-      "generalizedCost": 2032,
+      "generalizedCost": 2942,
       "legs": [
         {
           "agencyTimeZoneOffset": -25200000,
@@ -4948,7 +4174,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "name": "NW Everett St. & NW 5th Ave. (P3)",
             "vertexType": "NORMAL"
           },
-          "generalizedCost": 272,
+          "generalizedCost": 544,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 10,
@@ -5170,7 +4396,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
-          "generalizedCost": 638,
+          "generalizedCost": 1276,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 4,
@@ -5485,7 +4711,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
     },
     {
       "arrivedAtDestinationWithRentedBicycle": false,
-      "durationSeconds": 1336,
+      "durationSeconds": 977,
       "elevationGained": 0.0,
       "elevationLost": 0.0,
       "fare": {
@@ -5505,7 +4731,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "routes": [
                 {
                   "feedId": "prt",
-                  "id": "20"
+                  "id": "17"
                 }
               ]
             }
@@ -5520,15 +4746,15 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
           }
         }
       },
-      "generalizedCost": 2609,
+      "generalizedCost": 2942,
       "legs": [
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "bikeRentalNetworks": [ ],
           "departureDelay": 0,
-          "distanceMeters": 287.815,
-          "endTime": "2009-10-21T23:33:00.000+0000",
+          "distanceMeters": 167.86599999999999,
+          "endTime": "2009-10-21T23:44:50.000+0000",
           "flexibleTrip": false,
           "from": {
             "coordinate": {
@@ -5538,11 +4764,11 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "name": "NW Everett St. & NW 5th Ave. (P3)",
             "vertexType": "NORMAL"
           },
-          "generalizedCost": 464,
+          "generalizedCost": 544,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
-            "length": 17,
-            "points": "ssztGh_wkV?`@?LJAlBCH?J?H?vBCJ?H?jBCJA?D@L?lAE?"
+            "length": 10,
+            "points": "ssztGh_wkV?`@?LK?uBBK??F?JBbDN?"
           },
           "mode": "WALK",
           "onStreetNonTransit": true,
@@ -5550,408 +4776,21 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
           "realTime": false,
           "rentedBike": false,
           "scheduled": false,
-          "startTime": "2009-10-21T23:29:08.000+0000",
+          "startTime": "2009-10-21T23:42:34.000+0000",
           "streetNotes": [ ],
           "to": {
             "coordinate": {
-              "latitude": 45.523169,
-              "longitude": -122.675893
+              "latitude": 45.52583,
+              "longitude": -122.676422
             },
-            "name": "W Burnside & NW 5th",
-            "stopCode": "782",
+            "name": "NW 6th & Flanders",
+            "stopCode": "9300",
             "stopId": {
               "feedId": "prt",
-              "id": "782"
+              "id": "9300"
             },
-            "stopIndex": 99,
-            "stopSequence": 100,
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
-            {
-              "absoluteDirection": "WEST",
-              "angle": -1.596868818888735,
-              "area": false,
-              "bogusName": false,
-              "distance": 17.975,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.52522794293369,
-                "longitude": -122.67524992342938
-              },
-              "stayOn": false,
-              "streetName": "Northwest Everett Street",
-              "streetNotes": [ ]
-            },
-            {
-              "absoluteDirection": "SOUTH",
-              "angle": 3.1122681276306428,
-              "area": false,
-              "bogusName": false,
-              "distance": 231.76100000000002,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.525224200000004,
-                "longitude": -122.67548060000001
-              },
-              "stayOn": false,
-              "streetName": "Northwest 5th Avenue",
-              "streetNotes": [ ]
-            },
-            {
-              "absoluteDirection": "WEST",
-              "angle": -1.5966159701088662,
-              "area": false,
-              "bogusName": false,
-              "distance": 38.079,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.523141200000005,
-                "longitude": -122.67540310000001
-              },
-              "stayOn": false,
-              "streetName": "West Burnside Street",
-              "streetNotes": [ ]
-            }
-          ],
-          "walkingLeg": true
-        },
-        {
-          "agencyTimeZoneOffset": 0,
-          "arrivalDelay": 0,
-          "bikeRentalNetworks": [ ],
-          "departureDelay": 0,
-          "distanceMeters": 1942.2498485359197,
-          "endTime": "2009-10-21T23:44:03.000+0000",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.523169,
-              "longitude": -122.675893
-            },
-            "name": "W Burnside & NW 5th",
-            "stopCode": "782",
-            "stopId": {
-              "feedId": "prt",
-              "id": "782"
-            },
-            "stopIndex": 99,
-            "stopSequence": 100,
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
-          },
-          "generalizedCost": 1263,
-          "headsign": "Beaverton TC",
-          "intermediateStops": [ ],
-          "legGeometry": {
-            "length": 56,
-            "points": "efztGhcwkV@rBBzDBpE@~A???Z@tD@RBnEB|A???@BdB?lEBjA??BnBApF@dB?X?^@r@?f@@bCAx@EtB???VChAE|BGnD??AXKnEGnD???XGjD??AZEfCC`AEzB??AXCfAGxDE|AEtBIlC??APu@lJMhBI`@"
-          },
-          "mode": "BUS",
-          "onStreetNonTransit": false,
-          "pathway": false,
-          "realTime": false,
-          "scheduled": true,
-          "serviceDate": {
-            "day": 21,
-            "minMax": false,
-            "month": 10,
-            "sequenceNumber": 20091021,
-            "year": 2009
-          },
-          "startTime": "2009-10-21T23:33:00.000+0000",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.523897,
-              "longitude": -122.700681
-            },
-            "name": "W Burnside & NW 23rd Pl",
-            "stopCode": "9555",
-            "stopId": {
-              "feedId": "prt",
-              "id": "9555"
-            },
-            "stopIndex": 109,
-            "stopSequence": 110,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": true,
-          "trip": {
-            "alteration": "PLANNED",
-            "bikesAllowed": "UNKNOWN",
-            "blockId": "2003",
-            "direction": "OUTBOUND",
-            "id": {
-              "feedId": "prt",
-              "id": "200W1450"
-            },
-            "route": {
-              "agency": {
-                "fareUrl": "http://trimet.org/fares/index.htm",
-                "id": {
-                  "feedId": "prt",
-                  "id": "prt"
-                },
-                "lang": "en",
-                "name": "TriMet",
-                "phone": "503-238-7433",
-                "timezone": "America/Los_Angeles",
-                "url": "http://trimet.org"
-              },
-              "bikesAllowed": "UNKNOWN",
-              "id": {
-                "feedId": "prt",
-                "id": "20"
-              },
-              "longName": "Burnside/Stark",
-              "mode": "BUS",
-              "shortName": "20",
-              "sortOrder": -999,
-              "sortOrderSet": false,
-              "type": 3,
-              "url": "http://trimet.org/schedules/r020.htm"
-            },
-            "serviceId": {
-              "feedId": "prt",
-              "id": "W"
-            },
-            "shapeId": {
-              "feedId": "prt",
-              "id": "20.0.1"
-            },
-            "wheelchairAccessible": 0
-          },
-          "walkSteps": [ ],
-          "walkingLeg": false
-        },
-        {
-          "agencyTimeZoneOffset": -25200000,
-          "arrivalDelay": 0,
-          "bikeRentalNetworks": [ ],
-          "departureDelay": 0,
-          "distanceMeters": 563.701,
-          "endTime": "2009-10-21T23:51:24.000+0000",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.523897,
-              "longitude": -122.700681
-            },
-            "name": "W Burnside & NW 23rd Pl",
-            "stopCode": "9555",
-            "stopId": {
-              "feedId": "prt",
-              "id": "9555"
-            },
-            "stopIndex": 109,
-            "stopSequence": 110,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
-          },
-          "generalizedCost": 882,
-          "interlineWithPreviousLeg": false,
-          "legGeometry": {
-            "length": 34,
-            "points": "ikztGh~{kVNDEVUzACPOUQO_@Yc@[QMMEOKOIECGCIAMCGCGAECECECOOMOGKIFMLk@BsABGDGBoCBkCDkC@"
-          },
-          "mode": "WALK",
-          "onStreetNonTransit": true,
-          "pathway": false,
-          "realTime": false,
-          "rentedBike": false,
-          "scheduled": false,
-          "startTime": "2009-10-21T23:44:03.000+0000",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.52832,
-              "longitude": -122.70059
-            },
-            "name": "SW Johnson St. & NW 24th Ave. (P1)",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
-            {
-              "absoluteDirection": "WEST",
-              "angle": -1.247661800162498,
-              "area": false,
-              "bogusName": false,
-              "distance": 54.628,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.523815597641374,
-                "longitude": -122.70071990797962
-              },
-              "stayOn": false,
-              "streetName": "West Burnside Street",
-              "streetNotes": [ ]
-            },
-            {
-              "absoluteDirection": "NORTHEAST",
-              "angle": 0.7501559967245512,
-              "area": false,
-              "bogusName": false,
-              "distance": 176.41,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5239733,
-                "longitude": -122.701384
-              },
-              "stayOn": false,
-              "streetName": "Northwest 24th Place",
-              "streetNotes": [ ]
-            },
-            {
-              "absoluteDirection": "NORTHWEST",
-              "angle": -0.5889596407957216,
-              "area": false,
-              "bogusName": false,
-              "distance": 15.262,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.5253583,
-                "longitude": -122.70033570000001
-              },
-              "stayOn": false,
-              "streetName": "Northwest Westover Road",
-              "streetNotes": [ ]
-            },
-            {
-              "absoluteDirection": "NORTH",
-              "angle": -0.05815952978341337,
-              "area": false,
-              "bogusName": false,
-              "distance": 317.401,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "SLIGHTLY_RIGHT",
-              "startLocation": {
-                "latitude": 45.525472400000005,
-                "longitude": -122.7004445
-              },
-              "stayOn": false,
-              "streetName": "Northwest 24th Avenue",
-              "streetNotes": [ ]
-            }
-          ],
-          "walkingLeg": true
-        }
-      ],
-      "nTransfers": 0,
-      "nonTransitDistanceMeters": 851.5160000000001,
-      "nonTransitTimeSeconds": 673,
-      "onStreetAllTheWay": false,
-      "streetOnly": false,
-      "systemNotices": [ ],
-      "tooSloped": false,
-      "transitTimeSeconds": 663,
-      "waitTimeAdjustedGeneralizedCost": -999999,
-      "waitingTimeSeconds": 0,
-      "walkOnly": false,
-      "walkingAllTheWay": false
-    },
-    {
-      "arrivedAtDestinationWithRentedBicycle": false,
-      "durationSeconds": 1134,
-      "elevationGained": 0.0,
-      "elevationLost": 0.0,
-      "fare": {
-        "details": {
-          "regular": [
-            {
-              "fareId": {
-                "feedId": "prt",
-                "id": "8"
-              },
-              "price": {
-                "cents": 200,
-                "currency": {
-                  "value": "USD"
-                }
-              },
-              "routes": [
-                {
-                  "feedId": "prt",
-                  "id": "77"
-                }
-              ]
-            }
-          ]
-        },
-        "fare": {
-          "regular": {
-            "cents": 200,
-            "currency": {
-              "value": "USD"
-            }
-          }
-        }
-      },
-      "generalizedCost": 2391,
-      "legs": [
-        {
-          "agencyTimeZoneOffset": -25200000,
-          "arrivalDelay": 0,
-          "bikeRentalNetworks": [ ],
-          "departureDelay": 0,
-          "distanceMeters": 252.87499999999997,
-          "endTime": "2009-10-21T23:40:53.000+0000",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.52523,
-              "longitude": -122.67525
-            },
-            "name": "NW Everett St. & NW 5th Ave. (P3)",
-            "vertexType": "NORMAL"
-          },
-          "generalizedCost": 412,
-          "interlineWithPreviousLeg": false,
-          "legGeometry": {
-            "length": 15,
-            "points": "ssztGh_wkV?`@?LK?uBBK?K@sBBM??D?L@\\?lCC??E"
-          },
-          "mode": "WALK",
-          "onStreetNonTransit": true,
-          "pathway": false,
-          "realTime": false,
-          "rentedBike": false,
-          "scheduled": false,
-          "startTime": "2009-10-21T23:37:27.000+0000",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.526655,
-              "longitude": -122.676462
-            },
-            "name": "NW Glisan & 6th",
-            "stopCode": "10803",
-            "stopId": {
-              "feedId": "prt",
-              "id": "10803"
-            },
-            "stopIndex": 85,
-            "stopSequence": 86,
+            "stopIndex": 66,
+            "stopSequence": 67,
             "vertexType": "TRANSIT",
             "zoneId": "0"
           },
@@ -5980,7 +4819,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "angle": -0.02939746732509391,
               "area": false,
               "bogusName": false,
-              "distance": 158.018,
+              "distance": 78.514,
               "edges": [ ],
               "elevation": [ ],
               "relativeDirection": "RIGHT",
@@ -5994,36 +4833,19 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             },
             {
               "absoluteDirection": "WEST",
-              "angle": -1.6080284293804317,
+              "angle": -1.5977129345986325,
               "area": false,
               "bogusName": false,
-              "distance": 74.227,
+              "distance": 71.377,
               "edges": [ ],
               "elevation": [ ],
               "relativeDirection": "LEFT",
               "startLocation": {
-                "latitude": 45.526644700000006,
-                "longitude": -122.67553910000001
+                "latitude": 45.52593,
+                "longitude": -122.6755097
               },
               "stayOn": false,
-              "streetName": "Northwest Glisan Street",
-              "streetNotes": [ ]
-            },
-            {
-              "absoluteDirection": "NORTH",
-              "angle": -0.03835551109631682,
-              "area": false,
-              "bogusName": true,
-              "distance": 2.655,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5266303,
-                "longitude": -122.67649170000001
-              },
-              "stayOn": false,
-              "streetName": "way 156261070 from 2",
+              "streetName": "Northwest Flanders Street",
               "streetNotes": [ ]
             }
           ],
@@ -6034,31 +4856,31 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
           "arrivalDelay": 0,
           "bikeRentalNetworks": [ ],
           "departureDelay": 0,
-          "distanceMeters": 2232.3107878360292,
-          "endTime": "2009-10-21T23:48:50.000+0000",
+          "distanceMeters": 1631.0313510234191,
+          "endTime": "2009-10-21T23:53:32.000+0000",
           "flexibleTrip": false,
           "from": {
             "coordinate": {
-              "latitude": 45.526655,
-              "longitude": -122.676462
+              "latitude": 45.52583,
+              "longitude": -122.676422
             },
-            "name": "NW Glisan & 6th",
-            "stopCode": "10803",
+            "name": "NW 6th & Flanders",
+            "stopCode": "9300",
             "stopId": {
               "feedId": "prt",
-              "id": "10803"
+              "id": "9300"
             },
-            "stopIndex": 85,
-            "stopSequence": 86,
+            "stopIndex": 66,
+            "stopSequence": 67,
             "vertexType": "TRANSIT",
             "zoneId": "0"
           },
-          "generalizedCost": 1077,
-          "headsign": "Montgomery Park",
+          "generalizedCost": 1122,
+          "headsign": "Sauvie Is. via St.Johns",
           "intermediateStops": [ ],
           "legGeometry": {
-            "length": 53,
-            "points": "i|ztG|fwkV?LqCFmCDYBGDEBGJkAzAQR??KNa@b@MJuBBY?OHW@u@~@aD`EcBhBBrD@xC??@l@BlE@lD???XBjEBpD???VBlE?dA@t@?b@?h@BfEBrD???VBhEFtKDvJ??@\\DnJ???d@FtKmCBo@@"
+            "length": 39,
+            "points": "kwztGhgwkVQ?kC@@zD???PBjE?`B??@X@jEBjD???\\BhEBpD???XBhE@nD??@Z?hEBtA?h@@h@??@Z@nEBhEBhD???`@FtKDhH??@hBoCD}BB"
           },
           "mode": "BUS",
           "onStreetNonTransit": false,
@@ -6072,21 +4894,21 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "sequenceNumber": 20091021,
             "year": 2009
           },
-          "startTime": "2009-10-21T23:40:53.000+0000",
+          "startTime": "2009-10-21T23:44:50.000+0000",
           "streetNotes": [ ],
           "to": {
             "coordinate": {
-              "latitude": 45.532159,
-              "longitude": -122.698634
+              "latitude": 45.527648,
+              "longitude": -122.694407
             },
-            "name": "NW 23rd & Overton",
-            "stopCode": "8981",
+            "name": "NW 21st & Irving",
+            "stopCode": "7113",
             "stopId": {
               "feedId": "prt",
-              "id": "8981"
+              "id": "7113"
             },
-            "stopIndex": 93,
-            "stopSequence": 94,
+            "stopIndex": 75,
+            "stopSequence": 76,
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
@@ -6095,11 +4917,11 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
           "trip": {
             "alteration": "PLANNED",
             "bikesAllowed": "UNKNOWN",
-            "blockId": "7708",
+            "blockId": "1703",
             "direction": "INBOUND",
             "id": {
               "feedId": "prt",
-              "id": "771W1380"
+              "id": "171W1510"
             },
             "route": {
               "agency": {
@@ -6117,15 +4939,15 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "bikesAllowed": "UNKNOWN",
               "id": {
                 "feedId": "prt",
-                "id": "77"
+                "id": "17"
               },
-              "longName": "Broadway/Halsey",
+              "longName": "Holgate/NW 21st",
               "mode": "BUS",
-              "shortName": "77",
+              "shortName": "17",
               "sortOrder": -999,
               "sortOrderSet": false,
               "type": 3,
-              "url": "http://trimet.org/schedules/r077.htm"
+              "url": "http://trimet.org/schedules/r017.htm"
             },
             "serviceId": {
               "feedId": "prt",
@@ -6133,7 +4955,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             },
             "shapeId": {
               "feedId": "prt",
-              "id": "77.1.3"
+              "id": "17.1.15"
             },
             "wheelchairAccessible": 0
           },
@@ -6145,30 +4967,30 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
           "arrivalDelay": 0,
           "bikeRentalNetworks": [ ],
           "departureDelay": 0,
-          "distanceMeters": 580.63,
-          "endTime": "2009-10-21T23:56:21.000+0000",
+          "distanceMeters": 28.258000000000003,
+          "endTime": "2009-10-21T23:54:58.000+0000",
           "flexibleTrip": false,
           "from": {
             "coordinate": {
-              "latitude": 45.532159,
-              "longitude": -122.698634
+              "latitude": 45.527648,
+              "longitude": -122.694407
             },
-            "name": "NW 23rd & Overton",
-            "stopCode": "8981",
+            "name": "NW 21st & Irving",
+            "stopCode": "7113",
             "stopId": {
               "feedId": "prt",
-              "id": "8981"
+              "id": "7113"
             },
-            "stopIndex": 93,
-            "stopSequence": 94,
+            "stopIndex": 75,
+            "stopSequence": 76,
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
-          "generalizedCost": 902,
+          "generalizedCost": 1276,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
-            "length": 12,
-            "points": "}~{tGnq{kV?LVAF?J?FtKlCClCEnCElCElCCB?"
+            "length": 4,
+            "points": "wb{tG`wzkV?LO?Ao@"
           },
           "mode": "WALK",
           "onStreetNonTransit": true,
@@ -6176,7 +4998,221 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
           "realTime": false,
           "rentedBike": false,
           "scheduled": false,
-          "startTime": "2009-10-21T23:48:50.000+0000",
+          "startTime": "2009-10-21T23:53:32.000+0000",
+          "streetNotes": [ ],
+          "to": {
+            "bikeShareId": "-102323",
+            "coordinate": {
+              "latitude": 45.527849100000005,
+              "longitude": -122.6942362
+            },
+            "name": "-102323",
+            "vertexType": "BIKESHARE"
+          },
+          "transitAlerts": [ ],
+          "transitLeg": false,
+          "walkSteps": [
+            {
+              "absoluteDirection": "NORTH",
+              "angle": -0.021151532022270547,
+              "area": false,
+              "bogusName": false,
+              "distance": 8.969,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "DEPART",
+              "startLocation": {
+                "latitude": 45.52764696458245,
+                "longitude": -122.69447686508221
+              },
+              "stayOn": false,
+              "streetName": "Northwest 21st Avenue",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "EAST",
+              "angle": 1.5442642615053612,
+              "area": false,
+              "bikeRentalOnStation": {
+                "id": "-102323",
+                "lat": 45.527849100000005,
+                "lon": -122.6942362,
+                "name": "-102323"
+              },
+              "bogusName": false,
+              "distance": 19.289,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "RIGHT",
+              "startLocation": {
+                "latitude": 45.527727600000006,
+                "longitude": -122.69447930000001
+              },
+              "stayOn": false,
+              "streetName": "Northwest Irving Street",
+              "streetNotes": [ ]
+            }
+          ],
+          "walkingLeg": true
+        },
+        {
+          "agencyTimeZoneOffset": -25200000,
+          "arrivalDelay": 0,
+          "bikeRentalNetworks": [
+            "test-network"
+          ],
+          "departureDelay": 0,
+          "distanceMeters": 480.068,
+          "endTime": "2009-10-21T23:56:39.000+0000",
+          "flexibleTrip": false,
+          "from": {
+            "bikeShareId": "-102323",
+            "coordinate": {
+              "latitude": 45.527849100000005,
+              "longitude": -122.6942362
+            },
+            "name": "-102323",
+            "vertexType": "BIKESHARE"
+          },
+          "generalizedCost": 0,
+          "interlineWithPreviousLeg": false,
+          "legGeometry": {
+            "length": 6,
+            "points": "ic{tG~uzkV@n@@vAD|HDtKFrJ"
+          },
+          "mode": "BICYCLE",
+          "onStreetNonTransit": true,
+          "pathway": false,
+          "realTime": false,
+          "rentedBike": true,
+          "scheduled": false,
+          "startTime": "2009-10-21T23:54:58.000+0000",
+          "streetNotes": [ ],
+          "to": {
+            "coordinate": {
+              "latitude": 45.5276173,
+              "longitude": -122.7003923
+            },
+            "name": "corner of way -102328 from 0 and Northwest Irving Street",
+            "vertexType": "NORMAL"
+          },
+          "transitAlerts": [ ],
+          "transitLeg": false,
+          "walkSteps": [
+            {
+              "absoluteDirection": "WEST",
+              "angle": -1.5973283920844321,
+              "area": false,
+              "bogusName": false,
+              "distance": 480.068,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "HARD_LEFT",
+              "startLocation": {
+                "latitude": 45.52773220198921,
+                "longitude": -122.69423177172958
+              },
+              "stayOn": false,
+              "streetName": "Northwest Irving Street",
+              "streetNotes": [ ]
+            }
+          ],
+          "walkingLeg": false
+        },
+        {
+          "agencyTimeZoneOffset": -25200000,
+          "arrivalDelay": 0,
+          "bikeRentalNetworks": [
+            "test-network"
+          ],
+          "departureDelay": 0,
+          "distanceMeters": 13.358,
+          "endTime": "2009-10-21T23:57:20.000+0000",
+          "flexibleTrip": false,
+          "from": {
+            "coordinate": {
+              "latitude": 45.5276173,
+              "longitude": -122.7003923
+            },
+            "name": "corner of way -102328 from 0 and Northwest Irving Street",
+            "vertexType": "NORMAL"
+          },
+          "generalizedCost": 0,
+          "interlineWithPreviousLeg": false,
+          "legGeometry": {
+            "length": 2,
+            "points": "qb{tGn|{kVWA"
+          },
+          "mode": "WALK",
+          "onStreetNonTransit": true,
+          "pathway": false,
+          "realTime": false,
+          "rentedBike": true,
+          "scheduled": false,
+          "startTime": "2009-10-21T23:56:39.000+0000",
+          "streetNotes": [ ],
+          "to": {
+            "bikeShareId": "-102309",
+            "coordinate": {
+              "latitude": 45.5277374,
+              "longitude": -122.70038790000001
+            },
+            "name": "-102309",
+            "vertexType": "BIKESHARE"
+          },
+          "transitAlerts": [ ],
+          "transitLeg": false,
+          "walkSteps": [
+            {
+              "absoluteDirection": "NORTH",
+              "angle": 0.02566034822056683,
+              "area": false,
+              "bogusName": true,
+              "distance": 13.358,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "RIGHT",
+              "startLocation": {
+                "latitude": 45.5276173,
+                "longitude": -122.7003923
+              },
+              "stayOn": false,
+              "streetName": "way -102328 from 0",
+              "streetNotes": [ ]
+            }
+          ],
+          "walkingLeg": true
+        },
+        {
+          "agencyTimeZoneOffset": -25200000,
+          "arrivalDelay": 0,
+          "bikeRentalNetworks": [ ],
+          "departureDelay": 0,
+          "distanceMeters": 106.589,
+          "endTime": "2009-10-21T23:58:51.000+0000",
+          "flexibleTrip": false,
+          "from": {
+            "bikeShareId": "-102309",
+            "coordinate": {
+              "latitude": 45.5277374,
+              "longitude": -122.70038790000001
+            },
+            "name": "-102309",
+            "vertexType": "BIKESHARE"
+          },
+          "generalizedCost": 0,
+          "interlineWithPreviousLeg": false,
+          "legGeometry": {
+            "length": 4,
+            "points": "ic{tGl|{kVV@?d@kC@"
+          },
+          "mode": "WALK",
+          "onStreetNonTransit": true,
+          "pathway": false,
+          "realTime": false,
+          "rentedBike": false,
+          "scheduled": false,
+          "startTime": "2009-10-21T23:57:20.000+0000",
           "streetNotes": [ ],
           "to": {
             "coordinate": {
@@ -6191,50 +5227,56 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
           "walkSteps": [
             {
               "absoluteDirection": "SOUTH",
-              "angle": 3.117146926361324,
+              "angle": -3.1159323053692263,
               "area": false,
-              "bogusName": false,
-              "distance": 24.895,
+              "bikeRentalOffStation": {
+                "id": "-102309",
+                "lat": 45.5277374,
+                "lon": -122.70038790000001,
+                "name": "-102309"
+              },
+              "bogusName": true,
+              "distance": 13.358,
               "edges": [ ],
               "elevation": [ ],
-              "relativeDirection": "DEPART",
+              "relativeDirection": "HARD_LEFT",
               "startLocation": {
-                "latitude": 45.53215782420268,
-                "longitude": -122.69870264831422
+                "latitude": 45.5277374,
+                "longitude": -122.70038790000001
               },
               "stayOn": false,
-              "streetName": "Northwest 23rd Avenue",
+              "streetName": "way -102328 from 0",
               "streetNotes": [ ]
             },
             {
               "absoluteDirection": "WEST",
-              "angle": -1.6005554859058504,
+              "angle": -1.5972658434069475,
               "area": false,
               "bogusName": false,
-              "distance": 158.45,
+              "distance": 14.704,
               "edges": [ ],
               "elevation": [ ],
               "relativeDirection": "RIGHT",
               "startLocation": {
-                "latitude": 45.531934,
-                "longitude": -122.698695
+                "latitude": 45.5276173,
+                "longitude": -122.7003923
               },
               "stayOn": false,
-              "streetName": "Northwest Overton Street",
+              "streetName": "Northwest Irving Street",
               "streetNotes": [ ]
             },
             {
-              "absoluteDirection": "SOUTH",
-              "angle": 3.119908233299857,
+              "absoluteDirection": "NORTH",
+              "angle": -0.015200876817562168,
               "area": false,
               "bogusName": false,
-              "distance": 397.28499999999997,
+              "distance": 78.527,
               "edges": [ ],
               "elevation": [ ],
-              "relativeDirection": "LEFT",
+              "relativeDirection": "RIGHT",
               "startLocation": {
-                "latitude": 45.5318916,
-                "longitude": -122.70072830000001
+                "latitude": 45.527613800000005,
+                "longitude": -122.70058100000001
               },
               "stayOn": false,
               "streetName": "Northwest 24th Avenue",
@@ -6245,13 +5287,1783 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
         }
       ],
       "nTransfers": 0,
-      "nonTransitDistanceMeters": 833.505,
-      "nonTransitTimeSeconds": 657,
+      "nonTransitDistanceMeters": 796.1389999999999,
+      "nonTransitTimeSeconds": 455,
       "onStreetAllTheWay": false,
       "streetOnly": false,
       "systemNotices": [ ],
       "tooSloped": false,
-      "transitTimeSeconds": 477,
+      "transitTimeSeconds": 522,
+      "waitTimeAdjustedGeneralizedCost": -999999,
+      "waitingTimeSeconds": 0,
+      "walkOnly": false,
+      "walkingAllTheWay": false
+    },
+    {
+      "arrivedAtDestinationWithRentedBicycle": false,
+      "durationSeconds": 977,
+      "elevationGained": 0.0,
+      "elevationLost": 0.0,
+      "fare": {
+        "details": {
+          "regular": [
+            {
+              "fareId": {
+                "feedId": "prt",
+                "id": "8"
+              },
+              "price": {
+                "cents": 200,
+                "currency": {
+                  "value": "USD"
+                }
+              },
+              "routes": [
+                {
+                  "feedId": "prt",
+                  "id": "17"
+                }
+              ]
+            }
+          ]
+        },
+        "fare": {
+          "regular": {
+            "cents": 200,
+            "currency": {
+              "value": "USD"
+            }
+          }
+        }
+      },
+      "generalizedCost": 2942,
+      "legs": [
+        {
+          "agencyTimeZoneOffset": -25200000,
+          "arrivalDelay": 0,
+          "bikeRentalNetworks": [ ],
+          "departureDelay": 0,
+          "distanceMeters": 167.86599999999999,
+          "endTime": "2009-10-21T23:59:50.000+0000",
+          "flexibleTrip": false,
+          "from": {
+            "coordinate": {
+              "latitude": 45.52523,
+              "longitude": -122.67525
+            },
+            "name": "NW Everett St. & NW 5th Ave. (P3)",
+            "vertexType": "NORMAL"
+          },
+          "generalizedCost": 544,
+          "interlineWithPreviousLeg": false,
+          "legGeometry": {
+            "length": 10,
+            "points": "ssztGh_wkV?`@?LK?uBBK??F?JBbDN?"
+          },
+          "mode": "WALK",
+          "onStreetNonTransit": true,
+          "pathway": false,
+          "realTime": false,
+          "rentedBike": false,
+          "scheduled": false,
+          "startTime": "2009-10-21T23:57:34.000+0000",
+          "streetNotes": [ ],
+          "to": {
+            "coordinate": {
+              "latitude": 45.52583,
+              "longitude": -122.676422
+            },
+            "name": "NW 6th & Flanders",
+            "stopCode": "9300",
+            "stopId": {
+              "feedId": "prt",
+              "id": "9300"
+            },
+            "stopIndex": 66,
+            "stopSequence": 67,
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
+          },
+          "transitAlerts": [ ],
+          "transitLeg": false,
+          "walkSteps": [
+            {
+              "absoluteDirection": "WEST",
+              "angle": -1.596868818888735,
+              "area": false,
+              "bogusName": false,
+              "distance": 17.975,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "DEPART",
+              "startLocation": {
+                "latitude": 45.52522794293369,
+                "longitude": -122.67524992342938
+              },
+              "stayOn": false,
+              "streetName": "Northwest Everett Street",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "NORTH",
+              "angle": -0.02939746732509391,
+              "area": false,
+              "bogusName": false,
+              "distance": 78.514,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "RIGHT",
+              "startLocation": {
+                "latitude": 45.525224200000004,
+                "longitude": -122.67548060000001
+              },
+              "stayOn": false,
+              "streetName": "Northwest 5th Avenue",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "WEST",
+              "angle": -1.5977129345986325,
+              "area": false,
+              "bogusName": false,
+              "distance": 71.377,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "LEFT",
+              "startLocation": {
+                "latitude": 45.52593,
+                "longitude": -122.6755097
+              },
+              "stayOn": false,
+              "streetName": "Northwest Flanders Street",
+              "streetNotes": [ ]
+            }
+          ],
+          "walkingLeg": true
+        },
+        {
+          "agencyTimeZoneOffset": 0,
+          "arrivalDelay": 0,
+          "bikeRentalNetworks": [ ],
+          "departureDelay": 0,
+          "distanceMeters": 1631.0313510234191,
+          "endTime": "2009-10-22T00:08:32.000+0000",
+          "flexibleTrip": false,
+          "from": {
+            "coordinate": {
+              "latitude": 45.52583,
+              "longitude": -122.676422
+            },
+            "name": "NW 6th & Flanders",
+            "stopCode": "9300",
+            "stopId": {
+              "feedId": "prt",
+              "id": "9300"
+            },
+            "stopIndex": 66,
+            "stopSequence": 67,
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
+          },
+          "generalizedCost": 1122,
+          "headsign": "Montgomery Park",
+          "intermediateStops": [ ],
+          "legGeometry": {
+            "length": 39,
+            "points": "kwztGhgwkVQ?kC@@zD???PBjE?`B??@X@jEBjD???\\BhEBpD???XBhE@nD??@Z?hEBtA?h@@h@??@Z@nEBhEBhD???`@FtKDhH??@hBoCD}BB"
+          },
+          "mode": "BUS",
+          "onStreetNonTransit": false,
+          "pathway": false,
+          "realTime": false,
+          "scheduled": true,
+          "serviceDate": {
+            "day": 21,
+            "minMax": false,
+            "month": 10,
+            "sequenceNumber": 20091021,
+            "year": 2009
+          },
+          "startTime": "2009-10-21T23:59:50.000+0000",
+          "streetNotes": [ ],
+          "to": {
+            "coordinate": {
+              "latitude": 45.527648,
+              "longitude": -122.694407
+            },
+            "name": "NW 21st & Irving",
+            "stopCode": "7113",
+            "stopId": {
+              "feedId": "prt",
+              "id": "7113"
+            },
+            "stopIndex": 75,
+            "stopSequence": 76,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "transitAlerts": [ ],
+          "transitLeg": true,
+          "trip": {
+            "alteration": "PLANNED",
+            "bikesAllowed": "UNKNOWN",
+            "blockId": "1706",
+            "direction": "INBOUND",
+            "id": {
+              "feedId": "prt",
+              "id": "171W1520"
+            },
+            "route": {
+              "agency": {
+                "fareUrl": "http://trimet.org/fares/index.htm",
+                "id": {
+                  "feedId": "prt",
+                  "id": "prt"
+                },
+                "lang": "en",
+                "name": "TriMet",
+                "phone": "503-238-7433",
+                "timezone": "America/Los_Angeles",
+                "url": "http://trimet.org"
+              },
+              "bikesAllowed": "UNKNOWN",
+              "id": {
+                "feedId": "prt",
+                "id": "17"
+              },
+              "longName": "Holgate/NW 21st",
+              "mode": "BUS",
+              "shortName": "17",
+              "sortOrder": -999,
+              "sortOrderSet": false,
+              "type": 3,
+              "url": "http://trimet.org/schedules/r017.htm"
+            },
+            "serviceId": {
+              "feedId": "prt",
+              "id": "W"
+            },
+            "shapeId": {
+              "feedId": "prt",
+              "id": "17.1.14"
+            },
+            "wheelchairAccessible": 0
+          },
+          "walkSteps": [ ],
+          "walkingLeg": false
+        },
+        {
+          "agencyTimeZoneOffset": -25200000,
+          "arrivalDelay": 0,
+          "bikeRentalNetworks": [ ],
+          "departureDelay": 0,
+          "distanceMeters": 28.258000000000003,
+          "endTime": "2009-10-22T00:09:58.000+0000",
+          "flexibleTrip": false,
+          "from": {
+            "coordinate": {
+              "latitude": 45.527648,
+              "longitude": -122.694407
+            },
+            "name": "NW 21st & Irving",
+            "stopCode": "7113",
+            "stopId": {
+              "feedId": "prt",
+              "id": "7113"
+            },
+            "stopIndex": 75,
+            "stopSequence": 76,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "generalizedCost": 1276,
+          "interlineWithPreviousLeg": false,
+          "legGeometry": {
+            "length": 4,
+            "points": "wb{tG`wzkV?LO?Ao@"
+          },
+          "mode": "WALK",
+          "onStreetNonTransit": true,
+          "pathway": false,
+          "realTime": false,
+          "rentedBike": false,
+          "scheduled": false,
+          "startTime": "2009-10-22T00:08:32.000+0000",
+          "streetNotes": [ ],
+          "to": {
+            "bikeShareId": "-102323",
+            "coordinate": {
+              "latitude": 45.527849100000005,
+              "longitude": -122.6942362
+            },
+            "name": "-102323",
+            "vertexType": "BIKESHARE"
+          },
+          "transitAlerts": [ ],
+          "transitLeg": false,
+          "walkSteps": [
+            {
+              "absoluteDirection": "NORTH",
+              "angle": -0.021151532022270547,
+              "area": false,
+              "bogusName": false,
+              "distance": 8.969,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "DEPART",
+              "startLocation": {
+                "latitude": 45.52764696458245,
+                "longitude": -122.69447686508221
+              },
+              "stayOn": false,
+              "streetName": "Northwest 21st Avenue",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "EAST",
+              "angle": 1.5442642615053612,
+              "area": false,
+              "bikeRentalOnStation": {
+                "id": "-102323",
+                "lat": 45.527849100000005,
+                "lon": -122.6942362,
+                "name": "-102323"
+              },
+              "bogusName": false,
+              "distance": 19.289,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "RIGHT",
+              "startLocation": {
+                "latitude": 45.527727600000006,
+                "longitude": -122.69447930000001
+              },
+              "stayOn": false,
+              "streetName": "Northwest Irving Street",
+              "streetNotes": [ ]
+            }
+          ],
+          "walkingLeg": true
+        },
+        {
+          "agencyTimeZoneOffset": -25200000,
+          "arrivalDelay": 0,
+          "bikeRentalNetworks": [
+            "test-network"
+          ],
+          "departureDelay": 0,
+          "distanceMeters": 480.068,
+          "endTime": "2009-10-22T00:11:39.000+0000",
+          "flexibleTrip": false,
+          "from": {
+            "bikeShareId": "-102323",
+            "coordinate": {
+              "latitude": 45.527849100000005,
+              "longitude": -122.6942362
+            },
+            "name": "-102323",
+            "vertexType": "BIKESHARE"
+          },
+          "generalizedCost": 0,
+          "interlineWithPreviousLeg": false,
+          "legGeometry": {
+            "length": 6,
+            "points": "ic{tG~uzkV@n@@vAD|HDtKFrJ"
+          },
+          "mode": "BICYCLE",
+          "onStreetNonTransit": true,
+          "pathway": false,
+          "realTime": false,
+          "rentedBike": true,
+          "scheduled": false,
+          "startTime": "2009-10-22T00:09:58.000+0000",
+          "streetNotes": [ ],
+          "to": {
+            "coordinate": {
+              "latitude": 45.5276173,
+              "longitude": -122.7003923
+            },
+            "name": "corner of way -102328 from 0 and Northwest Irving Street",
+            "vertexType": "NORMAL"
+          },
+          "transitAlerts": [ ],
+          "transitLeg": false,
+          "walkSteps": [
+            {
+              "absoluteDirection": "WEST",
+              "angle": -1.5973283920844321,
+              "area": false,
+              "bogusName": false,
+              "distance": 480.068,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "HARD_LEFT",
+              "startLocation": {
+                "latitude": 45.52773220198921,
+                "longitude": -122.69423177172958
+              },
+              "stayOn": false,
+              "streetName": "Northwest Irving Street",
+              "streetNotes": [ ]
+            }
+          ],
+          "walkingLeg": false
+        },
+        {
+          "agencyTimeZoneOffset": -25200000,
+          "arrivalDelay": 0,
+          "bikeRentalNetworks": [
+            "test-network"
+          ],
+          "departureDelay": 0,
+          "distanceMeters": 13.358,
+          "endTime": "2009-10-22T00:12:20.000+0000",
+          "flexibleTrip": false,
+          "from": {
+            "coordinate": {
+              "latitude": 45.5276173,
+              "longitude": -122.7003923
+            },
+            "name": "corner of way -102328 from 0 and Northwest Irving Street",
+            "vertexType": "NORMAL"
+          },
+          "generalizedCost": 0,
+          "interlineWithPreviousLeg": false,
+          "legGeometry": {
+            "length": 2,
+            "points": "qb{tGn|{kVWA"
+          },
+          "mode": "WALK",
+          "onStreetNonTransit": true,
+          "pathway": false,
+          "realTime": false,
+          "rentedBike": true,
+          "scheduled": false,
+          "startTime": "2009-10-22T00:11:39.000+0000",
+          "streetNotes": [ ],
+          "to": {
+            "bikeShareId": "-102309",
+            "coordinate": {
+              "latitude": 45.5277374,
+              "longitude": -122.70038790000001
+            },
+            "name": "-102309",
+            "vertexType": "BIKESHARE"
+          },
+          "transitAlerts": [ ],
+          "transitLeg": false,
+          "walkSteps": [
+            {
+              "absoluteDirection": "NORTH",
+              "angle": 0.02566034822056683,
+              "area": false,
+              "bogusName": true,
+              "distance": 13.358,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "RIGHT",
+              "startLocation": {
+                "latitude": 45.5276173,
+                "longitude": -122.7003923
+              },
+              "stayOn": false,
+              "streetName": "way -102328 from 0",
+              "streetNotes": [ ]
+            }
+          ],
+          "walkingLeg": true
+        },
+        {
+          "agencyTimeZoneOffset": -25200000,
+          "arrivalDelay": 0,
+          "bikeRentalNetworks": [ ],
+          "departureDelay": 0,
+          "distanceMeters": 106.589,
+          "endTime": "2009-10-22T00:13:51.000+0000",
+          "flexibleTrip": false,
+          "from": {
+            "bikeShareId": "-102309",
+            "coordinate": {
+              "latitude": 45.5277374,
+              "longitude": -122.70038790000001
+            },
+            "name": "-102309",
+            "vertexType": "BIKESHARE"
+          },
+          "generalizedCost": 0,
+          "interlineWithPreviousLeg": false,
+          "legGeometry": {
+            "length": 4,
+            "points": "ic{tGl|{kVV@?d@kC@"
+          },
+          "mode": "WALK",
+          "onStreetNonTransit": true,
+          "pathway": false,
+          "realTime": false,
+          "rentedBike": false,
+          "scheduled": false,
+          "startTime": "2009-10-22T00:12:20.000+0000",
+          "streetNotes": [ ],
+          "to": {
+            "coordinate": {
+              "latitude": 45.52832,
+              "longitude": -122.70059
+            },
+            "name": "SW Johnson St. & NW 24th Ave. (P1)",
+            "vertexType": "NORMAL"
+          },
+          "transitAlerts": [ ],
+          "transitLeg": false,
+          "walkSteps": [
+            {
+              "absoluteDirection": "SOUTH",
+              "angle": -3.1159323053692263,
+              "area": false,
+              "bikeRentalOffStation": {
+                "id": "-102309",
+                "lat": 45.5277374,
+                "lon": -122.70038790000001,
+                "name": "-102309"
+              },
+              "bogusName": true,
+              "distance": 13.358,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "HARD_LEFT",
+              "startLocation": {
+                "latitude": 45.5277374,
+                "longitude": -122.70038790000001
+              },
+              "stayOn": false,
+              "streetName": "way -102328 from 0",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "WEST",
+              "angle": -1.5972658434069475,
+              "area": false,
+              "bogusName": false,
+              "distance": 14.704,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "RIGHT",
+              "startLocation": {
+                "latitude": 45.5276173,
+                "longitude": -122.7003923
+              },
+              "stayOn": false,
+              "streetName": "Northwest Irving Street",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "NORTH",
+              "angle": -0.015200876817562168,
+              "area": false,
+              "bogusName": false,
+              "distance": 78.527,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "RIGHT",
+              "startLocation": {
+                "latitude": 45.527613800000005,
+                "longitude": -122.70058100000001
+              },
+              "stayOn": false,
+              "streetName": "Northwest 24th Avenue",
+              "streetNotes": [ ]
+            }
+          ],
+          "walkingLeg": true
+        }
+      ],
+      "nTransfers": 0,
+      "nonTransitDistanceMeters": 796.1389999999999,
+      "nonTransitTimeSeconds": 455,
+      "onStreetAllTheWay": false,
+      "streetOnly": false,
+      "systemNotices": [ ],
+      "tooSloped": false,
+      "transitTimeSeconds": 522,
+      "waitTimeAdjustedGeneralizedCost": -999999,
+      "waitingTimeSeconds": 0,
+      "walkOnly": false,
+      "walkingAllTheWay": false
+    },
+    {
+      "arrivedAtDestinationWithRentedBicycle": false,
+      "durationSeconds": 977,
+      "elevationGained": 0.0,
+      "elevationLost": 0.0,
+      "fare": {
+        "details": {
+          "regular": [
+            {
+              "fareId": {
+                "feedId": "prt",
+                "id": "8"
+              },
+              "price": {
+                "cents": 200,
+                "currency": {
+                  "value": "USD"
+                }
+              },
+              "routes": [
+                {
+                  "feedId": "prt",
+                  "id": "17"
+                }
+              ]
+            }
+          ]
+        },
+        "fare": {
+          "regular": {
+            "cents": 200,
+            "currency": {
+              "value": "USD"
+            }
+          }
+        }
+      },
+      "generalizedCost": 2942,
+      "legs": [
+        {
+          "agencyTimeZoneOffset": -25200000,
+          "arrivalDelay": 0,
+          "bikeRentalNetworks": [ ],
+          "departureDelay": 0,
+          "distanceMeters": 167.86599999999999,
+          "endTime": "2009-10-22T00:14:50.000+0000",
+          "flexibleTrip": false,
+          "from": {
+            "coordinate": {
+              "latitude": 45.52523,
+              "longitude": -122.67525
+            },
+            "name": "NW Everett St. & NW 5th Ave. (P3)",
+            "vertexType": "NORMAL"
+          },
+          "generalizedCost": 544,
+          "interlineWithPreviousLeg": false,
+          "legGeometry": {
+            "length": 10,
+            "points": "ssztGh_wkV?`@?LK?uBBK??F?JBbDN?"
+          },
+          "mode": "WALK",
+          "onStreetNonTransit": true,
+          "pathway": false,
+          "realTime": false,
+          "rentedBike": false,
+          "scheduled": false,
+          "startTime": "2009-10-22T00:12:34.000+0000",
+          "streetNotes": [ ],
+          "to": {
+            "coordinate": {
+              "latitude": 45.52583,
+              "longitude": -122.676422
+            },
+            "name": "NW 6th & Flanders",
+            "stopCode": "9300",
+            "stopId": {
+              "feedId": "prt",
+              "id": "9300"
+            },
+            "stopIndex": 66,
+            "stopSequence": 67,
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
+          },
+          "transitAlerts": [ ],
+          "transitLeg": false,
+          "walkSteps": [
+            {
+              "absoluteDirection": "WEST",
+              "angle": -1.596868818888735,
+              "area": false,
+              "bogusName": false,
+              "distance": 17.975,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "DEPART",
+              "startLocation": {
+                "latitude": 45.52522794293369,
+                "longitude": -122.67524992342938
+              },
+              "stayOn": false,
+              "streetName": "Northwest Everett Street",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "NORTH",
+              "angle": -0.02939746732509391,
+              "area": false,
+              "bogusName": false,
+              "distance": 78.514,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "RIGHT",
+              "startLocation": {
+                "latitude": 45.525224200000004,
+                "longitude": -122.67548060000001
+              },
+              "stayOn": false,
+              "streetName": "Northwest 5th Avenue",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "WEST",
+              "angle": -1.5977129345986325,
+              "area": false,
+              "bogusName": false,
+              "distance": 71.377,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "LEFT",
+              "startLocation": {
+                "latitude": 45.52593,
+                "longitude": -122.6755097
+              },
+              "stayOn": false,
+              "streetName": "Northwest Flanders Street",
+              "streetNotes": [ ]
+            }
+          ],
+          "walkingLeg": true
+        },
+        {
+          "agencyTimeZoneOffset": 0,
+          "arrivalDelay": 0,
+          "bikeRentalNetworks": [ ],
+          "departureDelay": 0,
+          "distanceMeters": 1631.0313510234191,
+          "endTime": "2009-10-22T00:23:32.000+0000",
+          "flexibleTrip": false,
+          "from": {
+            "coordinate": {
+              "latitude": 45.52583,
+              "longitude": -122.676422
+            },
+            "name": "NW 6th & Flanders",
+            "stopCode": "9300",
+            "stopId": {
+              "feedId": "prt",
+              "id": "9300"
+            },
+            "stopIndex": 66,
+            "stopSequence": 67,
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
+          },
+          "generalizedCost": 1122,
+          "headsign": "Sauvie Is. via St.Johns",
+          "intermediateStops": [ ],
+          "legGeometry": {
+            "length": 39,
+            "points": "kwztGhgwkVQ?kC@@zD???PBjE?`B??@X@jEBjD???\\BhEBpD???XBhE@nD??@Z?hEBtA?h@@h@??@Z@nEBhEBhD???`@FtKDhH??@hBoCD}BB"
+          },
+          "mode": "BUS",
+          "onStreetNonTransit": false,
+          "pathway": false,
+          "realTime": false,
+          "scheduled": true,
+          "serviceDate": {
+            "day": 21,
+            "minMax": false,
+            "month": 10,
+            "sequenceNumber": 20091021,
+            "year": 2009
+          },
+          "startTime": "2009-10-22T00:14:50.000+0000",
+          "streetNotes": [ ],
+          "to": {
+            "coordinate": {
+              "latitude": 45.527648,
+              "longitude": -122.694407
+            },
+            "name": "NW 21st & Irving",
+            "stopCode": "7113",
+            "stopId": {
+              "feedId": "prt",
+              "id": "7113"
+            },
+            "stopIndex": 75,
+            "stopSequence": 76,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "transitAlerts": [ ],
+          "transitLeg": true,
+          "trip": {
+            "alteration": "PLANNED",
+            "bikesAllowed": "UNKNOWN",
+            "blockId": "1711",
+            "direction": "INBOUND",
+            "id": {
+              "feedId": "prt",
+              "id": "171W1530"
+            },
+            "route": {
+              "agency": {
+                "fareUrl": "http://trimet.org/fares/index.htm",
+                "id": {
+                  "feedId": "prt",
+                  "id": "prt"
+                },
+                "lang": "en",
+                "name": "TriMet",
+                "phone": "503-238-7433",
+                "timezone": "America/Los_Angeles",
+                "url": "http://trimet.org"
+              },
+              "bikesAllowed": "UNKNOWN",
+              "id": {
+                "feedId": "prt",
+                "id": "17"
+              },
+              "longName": "Holgate/NW 21st",
+              "mode": "BUS",
+              "shortName": "17",
+              "sortOrder": -999,
+              "sortOrderSet": false,
+              "type": 3,
+              "url": "http://trimet.org/schedules/r017.htm"
+            },
+            "serviceId": {
+              "feedId": "prt",
+              "id": "W"
+            },
+            "shapeId": {
+              "feedId": "prt",
+              "id": "17.1.15"
+            },
+            "wheelchairAccessible": 0
+          },
+          "walkSteps": [ ],
+          "walkingLeg": false
+        },
+        {
+          "agencyTimeZoneOffset": -25200000,
+          "arrivalDelay": 0,
+          "bikeRentalNetworks": [ ],
+          "departureDelay": 0,
+          "distanceMeters": 28.258000000000003,
+          "endTime": "2009-10-22T00:24:58.000+0000",
+          "flexibleTrip": false,
+          "from": {
+            "coordinate": {
+              "latitude": 45.527648,
+              "longitude": -122.694407
+            },
+            "name": "NW 21st & Irving",
+            "stopCode": "7113",
+            "stopId": {
+              "feedId": "prt",
+              "id": "7113"
+            },
+            "stopIndex": 75,
+            "stopSequence": 76,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "generalizedCost": 1276,
+          "interlineWithPreviousLeg": false,
+          "legGeometry": {
+            "length": 4,
+            "points": "wb{tG`wzkV?LO?Ao@"
+          },
+          "mode": "WALK",
+          "onStreetNonTransit": true,
+          "pathway": false,
+          "realTime": false,
+          "rentedBike": false,
+          "scheduled": false,
+          "startTime": "2009-10-22T00:23:32.000+0000",
+          "streetNotes": [ ],
+          "to": {
+            "bikeShareId": "-102323",
+            "coordinate": {
+              "latitude": 45.527849100000005,
+              "longitude": -122.6942362
+            },
+            "name": "-102323",
+            "vertexType": "BIKESHARE"
+          },
+          "transitAlerts": [ ],
+          "transitLeg": false,
+          "walkSteps": [
+            {
+              "absoluteDirection": "NORTH",
+              "angle": -0.021151532022270547,
+              "area": false,
+              "bogusName": false,
+              "distance": 8.969,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "DEPART",
+              "startLocation": {
+                "latitude": 45.52764696458245,
+                "longitude": -122.69447686508221
+              },
+              "stayOn": false,
+              "streetName": "Northwest 21st Avenue",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "EAST",
+              "angle": 1.5442642615053612,
+              "area": false,
+              "bikeRentalOnStation": {
+                "id": "-102323",
+                "lat": 45.527849100000005,
+                "lon": -122.6942362,
+                "name": "-102323"
+              },
+              "bogusName": false,
+              "distance": 19.289,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "RIGHT",
+              "startLocation": {
+                "latitude": 45.527727600000006,
+                "longitude": -122.69447930000001
+              },
+              "stayOn": false,
+              "streetName": "Northwest Irving Street",
+              "streetNotes": [ ]
+            }
+          ],
+          "walkingLeg": true
+        },
+        {
+          "agencyTimeZoneOffset": -25200000,
+          "arrivalDelay": 0,
+          "bikeRentalNetworks": [
+            "test-network"
+          ],
+          "departureDelay": 0,
+          "distanceMeters": 480.068,
+          "endTime": "2009-10-22T00:26:39.000+0000",
+          "flexibleTrip": false,
+          "from": {
+            "bikeShareId": "-102323",
+            "coordinate": {
+              "latitude": 45.527849100000005,
+              "longitude": -122.6942362
+            },
+            "name": "-102323",
+            "vertexType": "BIKESHARE"
+          },
+          "generalizedCost": 0,
+          "interlineWithPreviousLeg": false,
+          "legGeometry": {
+            "length": 6,
+            "points": "ic{tG~uzkV@n@@vAD|HDtKFrJ"
+          },
+          "mode": "BICYCLE",
+          "onStreetNonTransit": true,
+          "pathway": false,
+          "realTime": false,
+          "rentedBike": true,
+          "scheduled": false,
+          "startTime": "2009-10-22T00:24:58.000+0000",
+          "streetNotes": [ ],
+          "to": {
+            "coordinate": {
+              "latitude": 45.5276173,
+              "longitude": -122.7003923
+            },
+            "name": "corner of way -102328 from 0 and Northwest Irving Street",
+            "vertexType": "NORMAL"
+          },
+          "transitAlerts": [ ],
+          "transitLeg": false,
+          "walkSteps": [
+            {
+              "absoluteDirection": "WEST",
+              "angle": -1.5973283920844321,
+              "area": false,
+              "bogusName": false,
+              "distance": 480.068,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "HARD_LEFT",
+              "startLocation": {
+                "latitude": 45.52773220198921,
+                "longitude": -122.69423177172958
+              },
+              "stayOn": false,
+              "streetName": "Northwest Irving Street",
+              "streetNotes": [ ]
+            }
+          ],
+          "walkingLeg": false
+        },
+        {
+          "agencyTimeZoneOffset": -25200000,
+          "arrivalDelay": 0,
+          "bikeRentalNetworks": [
+            "test-network"
+          ],
+          "departureDelay": 0,
+          "distanceMeters": 13.358,
+          "endTime": "2009-10-22T00:27:20.000+0000",
+          "flexibleTrip": false,
+          "from": {
+            "coordinate": {
+              "latitude": 45.5276173,
+              "longitude": -122.7003923
+            },
+            "name": "corner of way -102328 from 0 and Northwest Irving Street",
+            "vertexType": "NORMAL"
+          },
+          "generalizedCost": 0,
+          "interlineWithPreviousLeg": false,
+          "legGeometry": {
+            "length": 2,
+            "points": "qb{tGn|{kVWA"
+          },
+          "mode": "WALK",
+          "onStreetNonTransit": true,
+          "pathway": false,
+          "realTime": false,
+          "rentedBike": true,
+          "scheduled": false,
+          "startTime": "2009-10-22T00:26:39.000+0000",
+          "streetNotes": [ ],
+          "to": {
+            "bikeShareId": "-102309",
+            "coordinate": {
+              "latitude": 45.5277374,
+              "longitude": -122.70038790000001
+            },
+            "name": "-102309",
+            "vertexType": "BIKESHARE"
+          },
+          "transitAlerts": [ ],
+          "transitLeg": false,
+          "walkSteps": [
+            {
+              "absoluteDirection": "NORTH",
+              "angle": 0.02566034822056683,
+              "area": false,
+              "bogusName": true,
+              "distance": 13.358,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "RIGHT",
+              "startLocation": {
+                "latitude": 45.5276173,
+                "longitude": -122.7003923
+              },
+              "stayOn": false,
+              "streetName": "way -102328 from 0",
+              "streetNotes": [ ]
+            }
+          ],
+          "walkingLeg": true
+        },
+        {
+          "agencyTimeZoneOffset": -25200000,
+          "arrivalDelay": 0,
+          "bikeRentalNetworks": [ ],
+          "departureDelay": 0,
+          "distanceMeters": 106.589,
+          "endTime": "2009-10-22T00:28:51.000+0000",
+          "flexibleTrip": false,
+          "from": {
+            "bikeShareId": "-102309",
+            "coordinate": {
+              "latitude": 45.5277374,
+              "longitude": -122.70038790000001
+            },
+            "name": "-102309",
+            "vertexType": "BIKESHARE"
+          },
+          "generalizedCost": 0,
+          "interlineWithPreviousLeg": false,
+          "legGeometry": {
+            "length": 4,
+            "points": "ic{tGl|{kVV@?d@kC@"
+          },
+          "mode": "WALK",
+          "onStreetNonTransit": true,
+          "pathway": false,
+          "realTime": false,
+          "rentedBike": false,
+          "scheduled": false,
+          "startTime": "2009-10-22T00:27:20.000+0000",
+          "streetNotes": [ ],
+          "to": {
+            "coordinate": {
+              "latitude": 45.52832,
+              "longitude": -122.70059
+            },
+            "name": "SW Johnson St. & NW 24th Ave. (P1)",
+            "vertexType": "NORMAL"
+          },
+          "transitAlerts": [ ],
+          "transitLeg": false,
+          "walkSteps": [
+            {
+              "absoluteDirection": "SOUTH",
+              "angle": -3.1159323053692263,
+              "area": false,
+              "bikeRentalOffStation": {
+                "id": "-102309",
+                "lat": 45.5277374,
+                "lon": -122.70038790000001,
+                "name": "-102309"
+              },
+              "bogusName": true,
+              "distance": 13.358,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "HARD_LEFT",
+              "startLocation": {
+                "latitude": 45.5277374,
+                "longitude": -122.70038790000001
+              },
+              "stayOn": false,
+              "streetName": "way -102328 from 0",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "WEST",
+              "angle": -1.5972658434069475,
+              "area": false,
+              "bogusName": false,
+              "distance": 14.704,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "RIGHT",
+              "startLocation": {
+                "latitude": 45.5276173,
+                "longitude": -122.7003923
+              },
+              "stayOn": false,
+              "streetName": "Northwest Irving Street",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "NORTH",
+              "angle": -0.015200876817562168,
+              "area": false,
+              "bogusName": false,
+              "distance": 78.527,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "RIGHT",
+              "startLocation": {
+                "latitude": 45.527613800000005,
+                "longitude": -122.70058100000001
+              },
+              "stayOn": false,
+              "streetName": "Northwest 24th Avenue",
+              "streetNotes": [ ]
+            }
+          ],
+          "walkingLeg": true
+        }
+      ],
+      "nTransfers": 0,
+      "nonTransitDistanceMeters": 796.1389999999999,
+      "nonTransitTimeSeconds": 455,
+      "onStreetAllTheWay": false,
+      "streetOnly": false,
+      "systemNotices": [ ],
+      "tooSloped": false,
+      "transitTimeSeconds": 522,
+      "waitTimeAdjustedGeneralizedCost": -999999,
+      "waitingTimeSeconds": 0,
+      "walkOnly": false,
+      "walkingAllTheWay": false
+    },
+    {
+      "arrivedAtDestinationWithRentedBicycle": false,
+      "durationSeconds": 977,
+      "elevationGained": 0.0,
+      "elevationLost": 0.0,
+      "fare": {
+        "details": {
+          "regular": [
+            {
+              "fareId": {
+                "feedId": "prt",
+                "id": "8"
+              },
+              "price": {
+                "cents": 200,
+                "currency": {
+                  "value": "USD"
+                }
+              },
+              "routes": [
+                {
+                  "feedId": "prt",
+                  "id": "17"
+                }
+              ]
+            }
+          ]
+        },
+        "fare": {
+          "regular": {
+            "cents": 200,
+            "currency": {
+              "value": "USD"
+            }
+          }
+        }
+      },
+      "generalizedCost": 2942,
+      "legs": [
+        {
+          "agencyTimeZoneOffset": -25200000,
+          "arrivalDelay": 0,
+          "bikeRentalNetworks": [ ],
+          "departureDelay": 0,
+          "distanceMeters": 167.86599999999999,
+          "endTime": "2009-10-22T00:29:50.000+0000",
+          "flexibleTrip": false,
+          "from": {
+            "coordinate": {
+              "latitude": 45.52523,
+              "longitude": -122.67525
+            },
+            "name": "NW Everett St. & NW 5th Ave. (P3)",
+            "vertexType": "NORMAL"
+          },
+          "generalizedCost": 544,
+          "interlineWithPreviousLeg": false,
+          "legGeometry": {
+            "length": 10,
+            "points": "ssztGh_wkV?`@?LK?uBBK??F?JBbDN?"
+          },
+          "mode": "WALK",
+          "onStreetNonTransit": true,
+          "pathway": false,
+          "realTime": false,
+          "rentedBike": false,
+          "scheduled": false,
+          "startTime": "2009-10-22T00:27:34.000+0000",
+          "streetNotes": [ ],
+          "to": {
+            "coordinate": {
+              "latitude": 45.52583,
+              "longitude": -122.676422
+            },
+            "name": "NW 6th & Flanders",
+            "stopCode": "9300",
+            "stopId": {
+              "feedId": "prt",
+              "id": "9300"
+            },
+            "stopIndex": 66,
+            "stopSequence": 67,
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
+          },
+          "transitAlerts": [ ],
+          "transitLeg": false,
+          "walkSteps": [
+            {
+              "absoluteDirection": "WEST",
+              "angle": -1.596868818888735,
+              "area": false,
+              "bogusName": false,
+              "distance": 17.975,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "DEPART",
+              "startLocation": {
+                "latitude": 45.52522794293369,
+                "longitude": -122.67524992342938
+              },
+              "stayOn": false,
+              "streetName": "Northwest Everett Street",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "NORTH",
+              "angle": -0.02939746732509391,
+              "area": false,
+              "bogusName": false,
+              "distance": 78.514,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "RIGHT",
+              "startLocation": {
+                "latitude": 45.525224200000004,
+                "longitude": -122.67548060000001
+              },
+              "stayOn": false,
+              "streetName": "Northwest 5th Avenue",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "WEST",
+              "angle": -1.5977129345986325,
+              "area": false,
+              "bogusName": false,
+              "distance": 71.377,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "LEFT",
+              "startLocation": {
+                "latitude": 45.52593,
+                "longitude": -122.6755097
+              },
+              "stayOn": false,
+              "streetName": "Northwest Flanders Street",
+              "streetNotes": [ ]
+            }
+          ],
+          "walkingLeg": true
+        },
+        {
+          "agencyTimeZoneOffset": 0,
+          "arrivalDelay": 0,
+          "bikeRentalNetworks": [ ],
+          "departureDelay": 0,
+          "distanceMeters": 1631.0313510234191,
+          "endTime": "2009-10-22T00:38:32.000+0000",
+          "flexibleTrip": false,
+          "from": {
+            "coordinate": {
+              "latitude": 45.52583,
+              "longitude": -122.676422
+            },
+            "name": "NW 6th & Flanders",
+            "stopCode": "9300",
+            "stopId": {
+              "feedId": "prt",
+              "id": "9300"
+            },
+            "stopIndex": 66,
+            "stopSequence": 67,
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
+          },
+          "generalizedCost": 1122,
+          "headsign": "Montgomery Park",
+          "intermediateStops": [ ],
+          "legGeometry": {
+            "length": 39,
+            "points": "kwztGhgwkVQ?kC@@zD???PBjE?`B??@X@jEBjD???\\BhEBpD???XBhE@nD??@Z?hEBtA?h@@h@??@Z@nEBhEBhD???`@FtKDhH??@hBoCD}BB"
+          },
+          "mode": "BUS",
+          "onStreetNonTransit": false,
+          "pathway": false,
+          "realTime": false,
+          "scheduled": true,
+          "serviceDate": {
+            "day": 21,
+            "minMax": false,
+            "month": 10,
+            "sequenceNumber": 20091021,
+            "year": 2009
+          },
+          "startTime": "2009-10-22T00:29:50.000+0000",
+          "streetNotes": [ ],
+          "to": {
+            "coordinate": {
+              "latitude": 45.527648,
+              "longitude": -122.694407
+            },
+            "name": "NW 21st & Irving",
+            "stopCode": "7113",
+            "stopId": {
+              "feedId": "prt",
+              "id": "7113"
+            },
+            "stopIndex": 75,
+            "stopSequence": 76,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "transitAlerts": [ ],
+          "transitLeg": true,
+          "trip": {
+            "alteration": "PLANNED",
+            "bikesAllowed": "UNKNOWN",
+            "blockId": "1714",
+            "direction": "INBOUND",
+            "id": {
+              "feedId": "prt",
+              "id": "171W1540"
+            },
+            "route": {
+              "agency": {
+                "fareUrl": "http://trimet.org/fares/index.htm",
+                "id": {
+                  "feedId": "prt",
+                  "id": "prt"
+                },
+                "lang": "en",
+                "name": "TriMet",
+                "phone": "503-238-7433",
+                "timezone": "America/Los_Angeles",
+                "url": "http://trimet.org"
+              },
+              "bikesAllowed": "UNKNOWN",
+              "id": {
+                "feedId": "prt",
+                "id": "17"
+              },
+              "longName": "Holgate/NW 21st",
+              "mode": "BUS",
+              "shortName": "17",
+              "sortOrder": -999,
+              "sortOrderSet": false,
+              "type": 3,
+              "url": "http://trimet.org/schedules/r017.htm"
+            },
+            "serviceId": {
+              "feedId": "prt",
+              "id": "W"
+            },
+            "shapeId": {
+              "feedId": "prt",
+              "id": "17.1.14"
+            },
+            "wheelchairAccessible": 0
+          },
+          "walkSteps": [ ],
+          "walkingLeg": false
+        },
+        {
+          "agencyTimeZoneOffset": -25200000,
+          "arrivalDelay": 0,
+          "bikeRentalNetworks": [ ],
+          "departureDelay": 0,
+          "distanceMeters": 28.258000000000003,
+          "endTime": "2009-10-22T00:39:58.000+0000",
+          "flexibleTrip": false,
+          "from": {
+            "coordinate": {
+              "latitude": 45.527648,
+              "longitude": -122.694407
+            },
+            "name": "NW 21st & Irving",
+            "stopCode": "7113",
+            "stopId": {
+              "feedId": "prt",
+              "id": "7113"
+            },
+            "stopIndex": 75,
+            "stopSequence": 76,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "generalizedCost": 1276,
+          "interlineWithPreviousLeg": false,
+          "legGeometry": {
+            "length": 4,
+            "points": "wb{tG`wzkV?LO?Ao@"
+          },
+          "mode": "WALK",
+          "onStreetNonTransit": true,
+          "pathway": false,
+          "realTime": false,
+          "rentedBike": false,
+          "scheduled": false,
+          "startTime": "2009-10-22T00:38:32.000+0000",
+          "streetNotes": [ ],
+          "to": {
+            "bikeShareId": "-102323",
+            "coordinate": {
+              "latitude": 45.527849100000005,
+              "longitude": -122.6942362
+            },
+            "name": "-102323",
+            "vertexType": "BIKESHARE"
+          },
+          "transitAlerts": [ ],
+          "transitLeg": false,
+          "walkSteps": [
+            {
+              "absoluteDirection": "NORTH",
+              "angle": -0.021151532022270547,
+              "area": false,
+              "bogusName": false,
+              "distance": 8.969,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "DEPART",
+              "startLocation": {
+                "latitude": 45.52764696458245,
+                "longitude": -122.69447686508221
+              },
+              "stayOn": false,
+              "streetName": "Northwest 21st Avenue",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "EAST",
+              "angle": 1.5442642615053612,
+              "area": false,
+              "bikeRentalOnStation": {
+                "id": "-102323",
+                "lat": 45.527849100000005,
+                "lon": -122.6942362,
+                "name": "-102323"
+              },
+              "bogusName": false,
+              "distance": 19.289,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "RIGHT",
+              "startLocation": {
+                "latitude": 45.527727600000006,
+                "longitude": -122.69447930000001
+              },
+              "stayOn": false,
+              "streetName": "Northwest Irving Street",
+              "streetNotes": [ ]
+            }
+          ],
+          "walkingLeg": true
+        },
+        {
+          "agencyTimeZoneOffset": -25200000,
+          "arrivalDelay": 0,
+          "bikeRentalNetworks": [
+            "test-network"
+          ],
+          "departureDelay": 0,
+          "distanceMeters": 480.068,
+          "endTime": "2009-10-22T00:41:39.000+0000",
+          "flexibleTrip": false,
+          "from": {
+            "bikeShareId": "-102323",
+            "coordinate": {
+              "latitude": 45.527849100000005,
+              "longitude": -122.6942362
+            },
+            "name": "-102323",
+            "vertexType": "BIKESHARE"
+          },
+          "generalizedCost": 0,
+          "interlineWithPreviousLeg": false,
+          "legGeometry": {
+            "length": 6,
+            "points": "ic{tG~uzkV@n@@vAD|HDtKFrJ"
+          },
+          "mode": "BICYCLE",
+          "onStreetNonTransit": true,
+          "pathway": false,
+          "realTime": false,
+          "rentedBike": true,
+          "scheduled": false,
+          "startTime": "2009-10-22T00:39:58.000+0000",
+          "streetNotes": [ ],
+          "to": {
+            "coordinate": {
+              "latitude": 45.5276173,
+              "longitude": -122.7003923
+            },
+            "name": "corner of way -102328 from 0 and Northwest Irving Street",
+            "vertexType": "NORMAL"
+          },
+          "transitAlerts": [ ],
+          "transitLeg": false,
+          "walkSteps": [
+            {
+              "absoluteDirection": "WEST",
+              "angle": -1.5973283920844321,
+              "area": false,
+              "bogusName": false,
+              "distance": 480.068,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "HARD_LEFT",
+              "startLocation": {
+                "latitude": 45.52773220198921,
+                "longitude": -122.69423177172958
+              },
+              "stayOn": false,
+              "streetName": "Northwest Irving Street",
+              "streetNotes": [ ]
+            }
+          ],
+          "walkingLeg": false
+        },
+        {
+          "agencyTimeZoneOffset": -25200000,
+          "arrivalDelay": 0,
+          "bikeRentalNetworks": [
+            "test-network"
+          ],
+          "departureDelay": 0,
+          "distanceMeters": 13.358,
+          "endTime": "2009-10-22T00:42:20.000+0000",
+          "flexibleTrip": false,
+          "from": {
+            "coordinate": {
+              "latitude": 45.5276173,
+              "longitude": -122.7003923
+            },
+            "name": "corner of way -102328 from 0 and Northwest Irving Street",
+            "vertexType": "NORMAL"
+          },
+          "generalizedCost": 0,
+          "interlineWithPreviousLeg": false,
+          "legGeometry": {
+            "length": 2,
+            "points": "qb{tGn|{kVWA"
+          },
+          "mode": "WALK",
+          "onStreetNonTransit": true,
+          "pathway": false,
+          "realTime": false,
+          "rentedBike": true,
+          "scheduled": false,
+          "startTime": "2009-10-22T00:41:39.000+0000",
+          "streetNotes": [ ],
+          "to": {
+            "bikeShareId": "-102309",
+            "coordinate": {
+              "latitude": 45.5277374,
+              "longitude": -122.70038790000001
+            },
+            "name": "-102309",
+            "vertexType": "BIKESHARE"
+          },
+          "transitAlerts": [ ],
+          "transitLeg": false,
+          "walkSteps": [
+            {
+              "absoluteDirection": "NORTH",
+              "angle": 0.02566034822056683,
+              "area": false,
+              "bogusName": true,
+              "distance": 13.358,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "RIGHT",
+              "startLocation": {
+                "latitude": 45.5276173,
+                "longitude": -122.7003923
+              },
+              "stayOn": false,
+              "streetName": "way -102328 from 0",
+              "streetNotes": [ ]
+            }
+          ],
+          "walkingLeg": true
+        },
+        {
+          "agencyTimeZoneOffset": -25200000,
+          "arrivalDelay": 0,
+          "bikeRentalNetworks": [ ],
+          "departureDelay": 0,
+          "distanceMeters": 106.589,
+          "endTime": "2009-10-22T00:43:51.000+0000",
+          "flexibleTrip": false,
+          "from": {
+            "bikeShareId": "-102309",
+            "coordinate": {
+              "latitude": 45.5277374,
+              "longitude": -122.70038790000001
+            },
+            "name": "-102309",
+            "vertexType": "BIKESHARE"
+          },
+          "generalizedCost": 0,
+          "interlineWithPreviousLeg": false,
+          "legGeometry": {
+            "length": 4,
+            "points": "ic{tGl|{kVV@?d@kC@"
+          },
+          "mode": "WALK",
+          "onStreetNonTransit": true,
+          "pathway": false,
+          "realTime": false,
+          "rentedBike": false,
+          "scheduled": false,
+          "startTime": "2009-10-22T00:42:20.000+0000",
+          "streetNotes": [ ],
+          "to": {
+            "coordinate": {
+              "latitude": 45.52832,
+              "longitude": -122.70059
+            },
+            "name": "SW Johnson St. & NW 24th Ave. (P1)",
+            "vertexType": "NORMAL"
+          },
+          "transitAlerts": [ ],
+          "transitLeg": false,
+          "walkSteps": [
+            {
+              "absoluteDirection": "SOUTH",
+              "angle": -3.1159323053692263,
+              "area": false,
+              "bikeRentalOffStation": {
+                "id": "-102309",
+                "lat": 45.5277374,
+                "lon": -122.70038790000001,
+                "name": "-102309"
+              },
+              "bogusName": true,
+              "distance": 13.358,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "HARD_LEFT",
+              "startLocation": {
+                "latitude": 45.5277374,
+                "longitude": -122.70038790000001
+              },
+              "stayOn": false,
+              "streetName": "way -102328 from 0",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "WEST",
+              "angle": -1.5972658434069475,
+              "area": false,
+              "bogusName": false,
+              "distance": 14.704,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "RIGHT",
+              "startLocation": {
+                "latitude": 45.5276173,
+                "longitude": -122.7003923
+              },
+              "stayOn": false,
+              "streetName": "Northwest Irving Street",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "NORTH",
+              "angle": -0.015200876817562168,
+              "area": false,
+              "bogusName": false,
+              "distance": 78.527,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "RIGHT",
+              "startLocation": {
+                "latitude": 45.527613800000005,
+                "longitude": -122.70058100000001
+              },
+              "stayOn": false,
+              "streetName": "Northwest 24th Avenue",
+              "streetNotes": [ ]
+            }
+          ],
+          "walkingLeg": true
+        }
+      ],
+      "nTransfers": 0,
+      "nonTransitDistanceMeters": 796.1389999999999,
+      "nonTransitTimeSeconds": 455,
+      "onStreetAllTheWay": false,
+      "streetOnly": false,
+      "systemNotices": [ ],
+      "tooSloped": false,
+      "transitTimeSeconds": 522,
       "waitTimeAdjustedGeneralizedCost": -999999,
       "waitingTimeSeconds": 0,
       "walkOnly": false,

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/TransitSnapshotTest.snap
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/TransitSnapshotTest.snap
@@ -329,7 +329,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           }
         }
       },
-      "generalizedCost": 4351,
+      "generalizedCost": 7331,
       "legs": [
         {
           "agencyTimeZoneOffset": -28800000,
@@ -347,7 +347,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "name": "SE Morrison St. & SE 17th Ave. (P1)",
             "vertexType": "NORMAL"
           },
-          "generalizedCost": 1436,
+          "generalizedCost": 2872,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 45,
@@ -586,7 +586,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
-          "generalizedCost": 1544,
+          "generalizedCost": 3088,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 29,
@@ -716,7 +716,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           }
         }
       },
-      "generalizedCost": 2326,
+      "generalizedCost": 2838,
       "legs": [
         {
           "agencyTimeZoneOffset": -28800000,
@@ -734,7 +734,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "name": "SE Morrison St. & SE 17th Ave. (P1)",
             "vertexType": "NORMAL"
           },
-          "generalizedCost": 96,
+          "generalizedCost": 192,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 4,
@@ -922,7 +922,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
-          "generalizedCost": 416,
+          "generalizedCost": 832,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 13,
@@ -1035,7 +1035,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           }
         }
       },
-      "generalizedCost": 4365,
+      "generalizedCost": 7345,
       "legs": [
         {
           "agencyTimeZoneOffset": -28800000,
@@ -1053,7 +1053,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "name": "SE Morrison St. & SE 17th Ave. (P1)",
             "vertexType": "NORMAL"
           },
-          "generalizedCost": 1436,
+          "generalizedCost": 2872,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 45,
@@ -1292,7 +1292,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
-          "generalizedCost": 1544,
+          "generalizedCost": 3088,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 29,
@@ -1422,7 +1422,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           }
         }
       },
-      "generalizedCost": 2396,
+      "generalizedCost": 2908,
       "legs": [
         {
           "agencyTimeZoneOffset": -28800000,
@@ -1440,7 +1440,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "name": "SE Morrison St. & SE 17th Ave. (P1)",
             "vertexType": "NORMAL"
           },
-          "generalizedCost": 96,
+          "generalizedCost": 192,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 4,
@@ -1628,7 +1628,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
-          "generalizedCost": 416,
+          "generalizedCost": 832,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 13,
@@ -1745,7 +1745,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           }
         }
       },
-      "generalizedCost": 3397,
+      "generalizedCost": 4093,
       "legs": [
         {
           "agencyTimeZoneOffset": -28800000,
@@ -1763,7 +1763,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "name": "SE Morrison St. & SE 17th Ave. (P1)",
             "vertexType": "NORMAL"
           },
-          "generalizedCost": 648,
+          "generalizedCost": 1296,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 14,
@@ -2079,7 +2079,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
-          "generalizedCost": 48,
+          "generalizedCost": 96,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 7,
@@ -2133,7 +2133,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
       "systemNotices": [ ],
       "tooSloped": false,
       "transitTimeSeconds": 1264,
-      "waitTimeAdjustedGeneralizedCost": 225307,
+      "waitTimeAdjustedGeneralizedCost": 294907,
       "waitingTimeSeconds": 237,
       "walkOnly": false,
       "walkingAllTheWay": false
@@ -2428,7 +2428,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           }
         }
       },
-      "generalizedCost": 2937,
+      "generalizedCost": 4505,
       "legs": [
         {
           "agencyTimeZoneOffset": -28800000,
@@ -2452,7 +2452,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
-          "generalizedCost": 146,
+          "generalizedCost": 292,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 9,
@@ -2657,7 +2657,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
-          "generalizedCost": 1422,
+          "generalizedCost": 2844,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 39,
@@ -2786,6 +2786,429 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
     },
     {
       "arrivedAtDestinationWithRentedBicycle": false,
+      "durationSeconds": 2296,
+      "elevationGained": 0.0,
+      "elevationLost": 0.0,
+      "fare": {
+        "details": {
+          "regular": [
+            {
+              "fareId": {
+                "feedId": "prt",
+                "id": "8"
+              },
+              "price": {
+                "cents": 200,
+                "currency": {
+                  "value": "USD"
+                }
+              },
+              "routes": [
+                {
+                  "feedId": "prt",
+                  "id": "70"
+                },
+                {
+                  "feedId": "prt",
+                  "id": "77"
+                }
+              ]
+            }
+          ]
+        },
+        "fare": {
+          "regular": {
+            "cents": 200,
+            "currency": {
+              "value": "USD"
+            }
+          }
+        }
+      },
+      "generalizedCost": 4279,
+      "legs": [
+        {
+          "agencyTimeZoneOffset": -28800000,
+          "arrivalDelay": 0,
+          "bikeRentalNetworks": [ ],
+          "departureDelay": 0,
+          "distanceMeters": 20.74,
+          "endTime": "2009-11-17T18:01:00.000+0000",
+          "flexibleTrip": false,
+          "from": {
+            "coordinate": {
+              "latitude": 45.52337,
+              "longitude": -122.653725
+            },
+            "name": "NE 12th & Couch",
+            "stopCode": "6577",
+            "stopId": {
+              "feedId": "prt",
+              "id": "6577"
+            },
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "generalizedCost": 64,
+          "interlineWithPreviousLeg": false,
+          "legGeometry": {
+            "length": 4,
+            "points": "ahztGxxrkV@Sb@??W"
+          },
+          "mode": "WALK",
+          "onStreetNonTransit": true,
+          "pathway": false,
+          "realTime": false,
+          "rentedBike": false,
+          "scheduled": false,
+          "startTime": "2009-11-17T18:00:44.000+0000",
+          "streetNotes": [ ],
+          "to": {
+            "coordinate": {
+              "latitude": 45.52318,
+              "longitude": -122.653507
+            },
+            "name": "NE 12th & Sandy",
+            "stopCode": "6592",
+            "stopId": {
+              "feedId": "prt",
+              "id": "6592"
+            },
+            "stopIndex": 31,
+            "stopSequence": 32,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "transitAlerts": [ ],
+          "transitLeg": false,
+          "walkSteps": [
+            {
+              "absoluteDirection": "SOUTH",
+              "angle": -3.1191187064694192,
+              "area": false,
+              "bogusName": false,
+              "distance": 20.74,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "DEPART",
+              "startLocation": {
+                "latitude": 45.52336838632084,
+                "longitude": -122.65362253301092
+              },
+              "stayOn": false,
+              "streetName": "Northeast 12th Avenue",
+              "streetNotes": [ ]
+            }
+          ],
+          "walkingLeg": true
+        },
+        {
+          "agencyTimeZoneOffset": 0,
+          "arrivalDelay": 0,
+          "bikeRentalNetworks": [ ],
+          "departureDelay": 0,
+          "distanceMeters": 1667.1475209896525,
+          "endTime": "2009-11-17T18:07:12.000+0000",
+          "flexibleTrip": false,
+          "from": {
+            "coordinate": {
+              "latitude": 45.52318,
+              "longitude": -122.653507
+            },
+            "name": "NE 12th & Sandy",
+            "stopCode": "6592",
+            "stopId": {
+              "feedId": "prt",
+              "id": "6592"
+            },
+            "stopIndex": 31,
+            "stopSequence": 32,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "generalizedCost": 972,
+          "headsign": "Rose Qtr TC",
+          "intermediateStops": [ ],
+          "legGeometry": {
+            "length": 46,
+            "points": "{fztG`xrkVwA?mCAmC?oCA}C?sDC??aBAm@@k@AY?uABU@I@IBQFb@fC}@d@OFO@q@???Q?]?gGA??[??nJ???b@?vK?rA???tBCfD???^?nE?V@Z?PH\\Nb@`@~@Rf@"
+          },
+          "mode": "BUS",
+          "onStreetNonTransit": false,
+          "pathway": false,
+          "realTime": false,
+          "scheduled": true,
+          "serviceDate": {
+            "day": 17,
+            "minMax": false,
+            "month": 11,
+            "sequenceNumber": 20091117,
+            "year": 2009
+          },
+          "startTime": "2009-11-17T18:01:00.000+0000",
+          "streetNotes": [ ],
+          "to": {
+            "coordinate": {
+              "latitude": 45.531159,
+              "longitude": -122.66293
+            },
+            "name": "NE Multnomah & 3rd",
+            "stopCode": "11492",
+            "stopId": {
+              "feedId": "prt",
+              "id": "11492"
+            },
+            "stopIndex": 38,
+            "stopSequence": 39,
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
+          },
+          "transitAlerts": [ ],
+          "transitLeg": true,
+          "trip": {
+            "alteration": "PLANNED",
+            "bikesAllowed": "UNKNOWN",
+            "blockId": "7001",
+            "direction": "OUTBOUND",
+            "id": {
+              "feedId": "prt",
+              "id": "700W1140"
+            },
+            "route": {
+              "agency": {
+                "fareUrl": "http://trimet.org/fares/index.htm",
+                "id": {
+                  "feedId": "prt",
+                  "id": "prt"
+                },
+                "lang": "en",
+                "name": "TriMet",
+                "phone": "503-238-7433",
+                "timezone": "America/Los_Angeles",
+                "url": "http://trimet.org"
+              },
+              "bikesAllowed": "UNKNOWN",
+              "id": {
+                "feedId": "prt",
+                "id": "70"
+              },
+              "longName": "12th Ave",
+              "mode": "BUS",
+              "shortName": "70",
+              "sortOrder": -999,
+              "sortOrderSet": false,
+              "type": 3,
+              "url": "http://trimet.org/schedules/r070.htm"
+            },
+            "serviceId": {
+              "feedId": "prt",
+              "id": "W"
+            },
+            "shapeId": {
+              "feedId": "prt",
+              "id": "70.0.1"
+            },
+            "wheelchairAccessible": 0
+          },
+          "walkSteps": [ ],
+          "walkingLeg": false
+        },
+        {
+          "agencyTimeZoneOffset": 0,
+          "arrivalDelay": 0,
+          "bikeRentalNetworks": [ ],
+          "departureDelay": 0,
+          "distanceMeters": 3248.2996826174576,
+          "endTime": "2009-11-17T18:34:55.000+0000",
+          "flexibleTrip": false,
+          "from": {
+            "coordinate": {
+              "latitude": 45.531159,
+              "longitude": -122.66293
+            },
+            "name": "NE Multnomah & 3rd",
+            "stopCode": "11492",
+            "stopId": {
+              "feedId": "prt",
+              "id": "11492"
+            },
+            "stopIndex": 83,
+            "stopSequence": 84,
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
+          },
+          "generalizedCost": 2263,
+          "headsign": "Montgomery Park",
+          "intermediateStops": [ ],
+          "legGeometry": {
+            "length": 91,
+            "points": "kx{tG~qtkV`@bANb@FV@R?P?pE?jA@h@AnAbBl@LFJN\\f@LT??NXJPPVJFf@Vf@Pp@Nd@NRLB@RNXZR\\vAhC@BhAhD`AhClAbDBrDCnG@n@@^@d@HdAP`CBjEDvD???LqCFmCDYBGDEBGJkAzAQR??KNa@b@MJuBBY?OHW@u@~@aD`EcBhBBrD@xC??@l@BlE@lD???XBjEBpD???VBlE?dA@t@?b@?h@BfEBrD???VBhEFtKDvJ??@\\DnJ"
+          },
+          "mode": "BUS",
+          "onStreetNonTransit": false,
+          "pathway": false,
+          "realTime": false,
+          "scheduled": true,
+          "serviceDate": {
+            "day": 17,
+            "minMax": false,
+            "month": 11,
+            "sequenceNumber": 20091117,
+            "year": 2009
+          },
+          "startTime": "2009-11-17T18:23:09.000+0000",
+          "streetNotes": [ ],
+          "to": {
+            "coordinate": {
+              "latitude": 45.531308,
+              "longitude": -122.696445
+            },
+            "name": "NW Northrup & 22nd",
+            "stopCode": "10778",
+            "stopId": {
+              "feedId": "prt",
+              "id": "10778"
+            },
+            "stopIndex": 92,
+            "stopSequence": 93,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "transitAlerts": [ ],
+          "transitLeg": true,
+          "trip": {
+            "alteration": "PLANNED",
+            "bikesAllowed": "UNKNOWN",
+            "blockId": "7736",
+            "direction": "INBOUND",
+            "id": {
+              "feedId": "prt",
+              "id": "771W1160"
+            },
+            "route": {
+              "agency": {
+                "fareUrl": "http://trimet.org/fares/index.htm",
+                "id": {
+                  "feedId": "prt",
+                  "id": "prt"
+                },
+                "lang": "en",
+                "name": "TriMet",
+                "phone": "503-238-7433",
+                "timezone": "America/Los_Angeles",
+                "url": "http://trimet.org"
+              },
+              "bikesAllowed": "UNKNOWN",
+              "id": {
+                "feedId": "prt",
+                "id": "77"
+              },
+              "longName": "Broadway/Halsey",
+              "mode": "BUS",
+              "shortName": "77",
+              "sortOrder": -999,
+              "sortOrderSet": false,
+              "type": 3,
+              "url": "http://trimet.org/schedules/r077.htm"
+            },
+            "serviceId": {
+              "feedId": "prt",
+              "id": "W"
+            },
+            "shapeId": {
+              "feedId": "prt",
+              "id": "77.1.3"
+            },
+            "wheelchairAccessible": 0
+          },
+          "walkSteps": [ ],
+          "walkingLeg": false
+        },
+        {
+          "agencyTimeZoneOffset": -28800000,
+          "arrivalDelay": 0,
+          "bikeRentalNetworks": [ ],
+          "departureDelay": 0,
+          "distanceMeters": 307.572,
+          "endTime": "2009-11-17T18:39:00.000+0000",
+          "flexibleTrip": false,
+          "from": {
+            "coordinate": {
+              "latitude": 45.531308,
+              "longitude": -122.696445
+            },
+            "name": "NW Northrup & 22nd",
+            "stopCode": "10778",
+            "stopId": {
+              "feedId": "prt",
+              "id": "10778"
+            },
+            "stopIndex": 92,
+            "stopSequence": 93,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "generalizedCost": 980,
+          "interlineWithPreviousLeg": false,
+          "legGeometry": {
+            "length": 13,
+            "points": "sy{tGxc{kV???LABF?B??RDbH@xA?D?P?RDpH"
+          },
+          "mode": "WALK",
+          "onStreetNonTransit": true,
+          "pathway": false,
+          "realTime": false,
+          "rentedBike": false,
+          "scheduled": false,
+          "startTime": "2009-11-17T18:34:55.000+0000",
+          "streetNotes": [ ],
+          "to": {
+            "coordinate": {
+              "latitude": 45.531,
+              "longitude": -122.70029
+            },
+            "name": "NW Northrup St. & NW 24th Ave. (P3)",
+            "vertexType": "NORMAL"
+          },
+          "transitAlerts": [ ],
+          "transitLeg": false,
+          "walkSteps": [
+            {
+              "absoluteDirection": "WEST",
+              "angle": -1.3892041323260338,
+              "area": false,
+              "bogusName": false,
+              "distance": 307.572,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "DEPART",
+              "startLocation": {
+                "latitude": 45.53130187189895,
+                "longitude": -122.69644484256081
+              },
+              "stayOn": false,
+              "streetName": "Northwest Northrup Street",
+              "streetNotes": [ ]
+            }
+          ],
+          "walkingLeg": true
+        }
+      ],
+      "nTransfers": 1,
+      "nonTransitDistanceMeters": 328.312,
+      "nonTransitTimeSeconds": 261,
+      "onStreetAllTheWay": false,
+      "streetOnly": false,
+      "systemNotices": [ ],
+      "tooSloped": false,
+      "transitTimeSeconds": 1078,
+      "waitTimeAdjustedGeneralizedCost": 185592,
+      "waitingTimeSeconds": 957,
+      "walkOnly": false,
+      "walkingAllTheWay": false
+    },
+    {
+      "arrivedAtDestinationWithRentedBicycle": false,
       "durationSeconds": 1583,
       "elevationGained": 0.0,
       "elevationLost": 0.0,
@@ -2821,7 +3244,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           }
         }
       },
-      "generalizedCost": 2967,
+      "generalizedCost": 4535,
       "legs": [
         {
           "agencyTimeZoneOffset": -28800000,
@@ -2845,7 +3268,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
-          "generalizedCost": 146,
+          "generalizedCost": 292,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 9,
@@ -3050,7 +3473,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
-          "generalizedCost": 1422,
+          "generalizedCost": 2844,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 39,
@@ -3214,7 +3637,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           }
         }
       },
-      "generalizedCost": 2937,
+      "generalizedCost": 4505,
       "legs": [
         {
           "agencyTimeZoneOffset": -28800000,
@@ -3238,7 +3661,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
-          "generalizedCost": 146,
+          "generalizedCost": 292,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 9,
@@ -3443,7 +3866,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
-          "generalizedCost": 1422,
+          "generalizedCost": 2844,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 39,
@@ -3611,7 +4034,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           }
         }
       },
-      "generalizedCost": 2964,
+      "generalizedCost": 3358,
       "legs": [
         {
           "agencyTimeZoneOffset": -28800000,
@@ -3635,7 +4058,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
-          "generalizedCost": 32,
+          "generalizedCost": 64,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 4,
@@ -3934,7 +4357,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
-          "generalizedCost": 362,
+          "generalizedCost": 724,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 10,
@@ -4005,367 +4428,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
       "systemNotices": [ ],
       "tooSloped": false,
       "transitTimeSeconds": 1133,
-      "waitTimeAdjustedGeneralizedCost": 211540,
+      "waitTimeAdjustedGeneralizedCost": 250940,
       "waitingTimeSeconds": 237,
-      "walkOnly": false,
-      "walkingAllTheWay": false
-    },
-    {
-      "arrivedAtDestinationWithRentedBicycle": false,
-      "durationSeconds": 1941,
-      "elevationGained": 0.0,
-      "elevationLost": 0.0,
-      "fare": {
-        "details": {
-          "regular": [
-            {
-              "fareId": {
-                "feedId": "prt",
-                "id": "8"
-              },
-              "price": {
-                "cents": 200,
-                "currency": {
-                  "value": "USD"
-                }
-              },
-              "routes": [
-                {
-                  "feedId": "prt",
-                  "id": "15"
-                }
-              ]
-            }
-          ]
-        },
-        "fare": {
-          "regular": {
-            "cents": 200,
-            "currency": {
-              "value": "USD"
-            }
-          }
-        }
-      },
-      "generalizedCost": 3278,
-      "legs": [
-        {
-          "agencyTimeZoneOffset": -28800000,
-          "arrivalDelay": 0,
-          "bikeRentalNetworks": [ ],
-          "departureDelay": 0,
-          "distanceMeters": 718.722,
-          "endTime": "2009-11-17T19:02:00.000+0000",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.52337,
-              "longitude": -122.653725
-            },
-            "name": "NE 12th & Couch",
-            "stopCode": "6577",
-            "stopId": {
-              "feedId": "prt",
-              "id": "6577"
-            },
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
-          },
-          "generalizedCost": 1112,
-          "interlineWithPreviousLeg": false,
-          "legGeometry": {
-            "length": 24,
-            "points": "ahztGxxrkV@Sb@?`@@T?T@NBRIrA?lC@lC?R?zB@`C?J?J?J@tB?nC?|B?N@?R?|@Q?"
-          },
-          "mode": "WALK",
-          "onStreetNonTransit": true,
-          "pathway": false,
-          "realTime": false,
-          "rentedBike": false,
-          "scheduled": false,
-          "startTime": "2009-11-17T18:52:44.000+0000",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.517299,
-              "longitude": -122.654067
-            },
-            "name": "SE Morrison & 12th",
-            "stopCode": "4014",
-            "stopId": {
-              "feedId": "prt",
-              "id": "4014"
-            },
-            "stopIndex": 52,
-            "stopSequence": 53,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
-            {
-              "absoluteDirection": "SOUTH",
-              "angle": -3.1191187064694192,
-              "area": false,
-              "bogusName": false,
-              "distance": 51.525,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.52336838632084,
-                "longitude": -122.65362253301092
-              },
-              "stayOn": false,
-              "streetName": "Northeast 12th Avenue",
-              "streetNotes": [ ]
-            },
-            {
-              "absoluteDirection": "SOUTH",
-              "angle": -3.0798698707609136,
-              "area": false,
-              "bogusName": false,
-              "distance": 634.751,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "CONTINUE",
-              "startLocation": {
-                "latitude": 45.5229051,
-                "longitude": -122.6536312
-              },
-              "stayOn": false,
-              "streetName": "Southeast 12th Avenue",
-              "streetNotes": [ ]
-            },
-            {
-              "absoluteDirection": "WEST",
-              "angle": -1.5753805308488518,
-              "area": false,
-              "bogusName": false,
-              "distance": 32.446,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5172031,
-                "longitude": -122.6536511
-              },
-              "stayOn": false,
-              "streetName": "Southeast Morrison Street",
-              "streetNotes": [ ]
-            }
-          ],
-          "walkingLeg": true
-        },
-        {
-          "agencyTimeZoneOffset": 0,
-          "arrivalDelay": 0,
-          "bikeRentalNetworks": [ ],
-          "departureDelay": 0,
-          "distanceMeters": 4844.785407243491,
-          "endTime": "2009-11-17T19:22:04.000+0000",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.517299,
-              "longitude": -122.654067
-            },
-            "name": "SE Morrison & 12th",
-            "stopCode": "4014",
-            "stopId": {
-              "feedId": "prt",
-              "id": "4014"
-            },
-            "stopIndex": 52,
-            "stopSequence": 53,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
-          },
-          "generalizedCost": 1804,
-          "headsign": "NW 27th & Thurman",
-          "intermediateStops": [ ],
-          "legGeometry": {
-            "length": 126,
-            "points": "oaytG|zrkV?tBAjE?nD???X?hE?xC??Ah@?pE?~C???J?`@?vAAvBEbE?jEAlE?`BAbB@d@??@tAAj@Cx@Cb@Cp@_@dEcAtFoA`IS~@i@`BmAzDi@zAc@pAi@~C??Id@u@jEm@bD??If@u@jEk@bD??If@u@|DW`B??CPs@|Du@lElBz@??VJbCfAk@dD??Id@w@rEWvAId@AF??Q~@s@`Ei@~C??Ib@u@dEWzA??]jB]MQSe@WOKOKIIQe@GWE]GnD??AXKnEGnD???XGjD??AZEfCC`AEzB??AXCfAGxDE|AEtBIlC??APkAh@o@?sCB{BD??S?mCDmCDyBB??U?mCDmCDyBB??S?oCDmCDmCBo@@"
-          },
-          "mode": "BUS",
-          "onStreetNonTransit": false,
-          "pathway": false,
-          "realTime": false,
-          "scheduled": true,
-          "serviceDate": {
-            "day": 17,
-            "minMax": false,
-            "month": 11,
-            "sequenceNumber": 20091117,
-            "year": 2009
-          },
-          "startTime": "2009-11-17T19:02:00.000+0000",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.532159,
-              "longitude": -122.698634
-            },
-            "name": "NW 23rd & Overton",
-            "stopCode": "8981",
-            "stopId": {
-              "feedId": "prt",
-              "id": "8981"
-            },
-            "stopIndex": 74,
-            "stopSequence": 75,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": true,
-          "trip": {
-            "alteration": "PLANNED",
-            "bikesAllowed": "UNKNOWN",
-            "blockId": "1550",
-            "direction": "OUTBOUND",
-            "id": {
-              "feedId": "prt",
-              "id": "150W1430"
-            },
-            "route": {
-              "agency": {
-                "fareUrl": "http://trimet.org/fares/index.htm",
-                "id": {
-                  "feedId": "prt",
-                  "id": "prt"
-                },
-                "lang": "en",
-                "name": "TriMet",
-                "phone": "503-238-7433",
-                "timezone": "America/Los_Angeles",
-                "url": "http://trimet.org"
-              },
-              "bikesAllowed": "UNKNOWN",
-              "id": {
-                "feedId": "prt",
-                "id": "15"
-              },
-              "longName": "Belmont/NW 23rd",
-              "mode": "BUS",
-              "shortName": "15",
-              "sortOrder": -999,
-              "sortOrderSet": false,
-              "type": 3,
-              "url": "http://trimet.org/schedules/r015.htm"
-            },
-            "serviceId": {
-              "feedId": "prt",
-              "id": "W"
-            },
-            "shapeId": {
-              "feedId": "prt",
-              "id": "15.0.23"
-            },
-            "wheelchairAccessible": 0
-          },
-          "walkSteps": [ ],
-          "walkingLeg": false
-        },
-        {
-          "agencyTimeZoneOffset": -28800000,
-          "arrivalDelay": 0,
-          "bikeRentalNetworks": [ ],
-          "departureDelay": 0,
-          "distanceMeters": 231.459,
-          "endTime": "2009-11-17T19:25:05.000+0000",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.532159,
-              "longitude": -122.698634
-            },
-            "name": "NW 23rd & Overton",
-            "stopCode": "8981",
-            "stopId": {
-              "feedId": "prt",
-              "id": "8981"
-            },
-            "stopIndex": 74,
-            "stopSequence": 75,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
-          },
-          "generalizedCost": 362,
-          "interlineWithPreviousLeg": false,
-          "legGeometry": {
-            "length": 10,
-            "points": "}~{tGnq{kV?LVAF?J?L?rBCLA?RDpH"
-          },
-          "mode": "WALK",
-          "onStreetNonTransit": true,
-          "pathway": false,
-          "realTime": false,
-          "rentedBike": false,
-          "scheduled": false,
-          "startTime": "2009-11-17T19:22:04.000+0000",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.531,
-              "longitude": -122.70029
-            },
-            "name": "NW Northrup St. & NW 24th Ave. (P3)",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
-            {
-              "absoluteDirection": "SOUTH",
-              "angle": 3.117146926361324,
-              "area": false,
-              "bogusName": false,
-              "distance": 104.452,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.53215782420268,
-                "longitude": -122.69870264831422
-              },
-              "stayOn": false,
-              "streetName": "Northwest 23rd Avenue",
-              "streetNotes": [ ]
-            },
-            {
-              "absoluteDirection": "WEST",
-              "angle": -1.576477897189337,
-              "area": false,
-              "bogusName": false,
-              "distance": 127.007,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.531218800000005,
-                "longitude": -122.69866750000001
-              },
-              "stayOn": false,
-              "streetName": "Northwest Northrup Street",
-              "streetNotes": [ ]
-            }
-          ],
-          "walkingLeg": true
-        }
-      ],
-      "nTransfers": 0,
-      "nonTransitDistanceMeters": 950.181,
-      "nonTransitTimeSeconds": 737,
-      "onStreetAllTheWay": false,
-      "streetOnly": false,
-      "systemNotices": [ ],
-      "tooSloped": false,
-      "transitTimeSeconds": 1204,
-      "waitTimeAdjustedGeneralizedCost": -999999,
-      "waitingTimeSeconds": 0,
       "walkOnly": false,
       "walkingAllTheWay": false
     }

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/TransitSnapshotTest.snap
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/TransitSnapshotTest.snap
@@ -28,7 +28,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "orig": "SE Morrison St. & SE 17th Ave. (P1)",
             "vertexType": "NORMAL"
           },
-          "generalizedCost": -1,
+          "generalizedCost": 7447,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 205,
@@ -329,7 +329,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           }
         }
       },
-      "generalizedCost": 7331,
+      "generalizedCost": 4281,
       "legs": [
         {
           "agencyTimeZoneOffset": -28800000,
@@ -347,7 +347,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "name": "SE Morrison St. & SE 17th Ave. (P1)",
             "vertexType": "NORMAL"
           },
-          "generalizedCost": 2872,
+          "generalizedCost": 1398,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 45,
@@ -586,7 +586,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
-          "generalizedCost": 3088,
+          "generalizedCost": 1511,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 29,
@@ -716,7 +716,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           }
         }
       },
-      "generalizedCost": 2838,
+      "generalizedCost": 2315,
       "legs": [
         {
           "agencyTimeZoneOffset": -28800000,
@@ -734,7 +734,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "name": "SE Morrison St. & SE 17th Ave. (P1)",
             "vertexType": "NORMAL"
           },
-          "generalizedCost": 192,
+          "generalizedCost": 95,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 4,
@@ -922,7 +922,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
-          "generalizedCost": 832,
+          "generalizedCost": 405,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 13,
@@ -1035,7 +1035,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           }
         }
       },
-      "generalizedCost": 7345,
+      "generalizedCost": 4295,
       "legs": [
         {
           "agencyTimeZoneOffset": -28800000,
@@ -1053,7 +1053,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "name": "SE Morrison St. & SE 17th Ave. (P1)",
             "vertexType": "NORMAL"
           },
-          "generalizedCost": 2872,
+          "generalizedCost": 1398,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 45,
@@ -1292,7 +1292,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
-          "generalizedCost": 3088,
+          "generalizedCost": 1511,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 29,
@@ -1422,7 +1422,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           }
         }
       },
-      "generalizedCost": 2908,
+      "generalizedCost": 2385,
       "legs": [
         {
           "agencyTimeZoneOffset": -28800000,
@@ -1440,7 +1440,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "name": "SE Morrison St. & SE 17th Ave. (P1)",
             "vertexType": "NORMAL"
           },
-          "generalizedCost": 192,
+          "generalizedCost": 95,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 4,
@@ -1628,7 +1628,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
-          "generalizedCost": 832,
+          "generalizedCost": 405,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 13,
@@ -1745,7 +1745,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           }
         }
       },
-      "generalizedCost": 4093,
+      "generalizedCost": 3374,
       "legs": [
         {
           "agencyTimeZoneOffset": -28800000,
@@ -1763,7 +1763,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "name": "SE Morrison St. & SE 17th Ave. (P1)",
             "vertexType": "NORMAL"
           },
-          "generalizedCost": 1296,
+          "generalizedCost": 636,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 14,
@@ -2079,7 +2079,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
-          "generalizedCost": 96,
+          "generalizedCost": 37,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 7,
@@ -2133,7 +2133,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
       "systemNotices": [ ],
       "tooSloped": false,
       "transitTimeSeconds": 1264,
-      "waitTimeAdjustedGeneralizedCost": 294907,
+      "waitTimeAdjustedGeneralizedCost": 223007,
       "waitingTimeSeconds": 237,
       "walkOnly": false,
       "walkingAllTheWay": false
@@ -2178,7 +2178,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
-          "generalizedCost": -1,
+          "generalizedCost": 6717,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 208,
@@ -2428,7 +2428,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           }
         }
       },
-      "generalizedCost": 4505,
+      "generalizedCost": 2895,
       "legs": [
         {
           "agencyTimeZoneOffset": -28800000,
@@ -2452,7 +2452,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
-          "generalizedCost": 292,
+          "generalizedCost": 137,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 9,
@@ -2657,7 +2657,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
-          "generalizedCost": 2844,
+          "generalizedCost": 1388,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 39,
@@ -2786,429 +2786,6 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
     },
     {
       "arrivedAtDestinationWithRentedBicycle": false,
-      "durationSeconds": 2296,
-      "elevationGained": 0.0,
-      "elevationLost": 0.0,
-      "fare": {
-        "details": {
-          "regular": [
-            {
-              "fareId": {
-                "feedId": "prt",
-                "id": "8"
-              },
-              "price": {
-                "cents": 200,
-                "currency": {
-                  "value": "USD"
-                }
-              },
-              "routes": [
-                {
-                  "feedId": "prt",
-                  "id": "70"
-                },
-                {
-                  "feedId": "prt",
-                  "id": "77"
-                }
-              ]
-            }
-          ]
-        },
-        "fare": {
-          "regular": {
-            "cents": 200,
-            "currency": {
-              "value": "USD"
-            }
-          }
-        }
-      },
-      "generalizedCost": 4279,
-      "legs": [
-        {
-          "agencyTimeZoneOffset": -28800000,
-          "arrivalDelay": 0,
-          "bikeRentalNetworks": [ ],
-          "departureDelay": 0,
-          "distanceMeters": 20.74,
-          "endTime": "2009-11-17T18:01:00.000+0000",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.52337,
-              "longitude": -122.653725
-            },
-            "name": "NE 12th & Couch",
-            "stopCode": "6577",
-            "stopId": {
-              "feedId": "prt",
-              "id": "6577"
-            },
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
-          },
-          "generalizedCost": 64,
-          "interlineWithPreviousLeg": false,
-          "legGeometry": {
-            "length": 4,
-            "points": "ahztGxxrkV@Sb@??W"
-          },
-          "mode": "WALK",
-          "onStreetNonTransit": true,
-          "pathway": false,
-          "realTime": false,
-          "rentedBike": false,
-          "scheduled": false,
-          "startTime": "2009-11-17T18:00:44.000+0000",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.52318,
-              "longitude": -122.653507
-            },
-            "name": "NE 12th & Sandy",
-            "stopCode": "6592",
-            "stopId": {
-              "feedId": "prt",
-              "id": "6592"
-            },
-            "stopIndex": 31,
-            "stopSequence": 32,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
-            {
-              "absoluteDirection": "SOUTH",
-              "angle": -3.1191187064694192,
-              "area": false,
-              "bogusName": false,
-              "distance": 20.74,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.52336838632084,
-                "longitude": -122.65362253301092
-              },
-              "stayOn": false,
-              "streetName": "Northeast 12th Avenue",
-              "streetNotes": [ ]
-            }
-          ],
-          "walkingLeg": true
-        },
-        {
-          "agencyTimeZoneOffset": 0,
-          "arrivalDelay": 0,
-          "bikeRentalNetworks": [ ],
-          "departureDelay": 0,
-          "distanceMeters": 1667.1475209896525,
-          "endTime": "2009-11-17T18:07:12.000+0000",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.52318,
-              "longitude": -122.653507
-            },
-            "name": "NE 12th & Sandy",
-            "stopCode": "6592",
-            "stopId": {
-              "feedId": "prt",
-              "id": "6592"
-            },
-            "stopIndex": 31,
-            "stopSequence": 32,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
-          },
-          "generalizedCost": 972,
-          "headsign": "Rose Qtr TC",
-          "intermediateStops": [ ],
-          "legGeometry": {
-            "length": 46,
-            "points": "{fztG`xrkVwA?mCAmC?oCA}C?sDC??aBAm@@k@AY?uABU@I@IBQFb@fC}@d@OFO@q@???Q?]?gGA??[??nJ???b@?vK?rA???tBCfD???^?nE?V@Z?PH\\Nb@`@~@Rf@"
-          },
-          "mode": "BUS",
-          "onStreetNonTransit": false,
-          "pathway": false,
-          "realTime": false,
-          "scheduled": true,
-          "serviceDate": {
-            "day": 17,
-            "minMax": false,
-            "month": 11,
-            "sequenceNumber": 20091117,
-            "year": 2009
-          },
-          "startTime": "2009-11-17T18:01:00.000+0000",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.531159,
-              "longitude": -122.66293
-            },
-            "name": "NE Multnomah & 3rd",
-            "stopCode": "11492",
-            "stopId": {
-              "feedId": "prt",
-              "id": "11492"
-            },
-            "stopIndex": 38,
-            "stopSequence": 39,
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": true,
-          "trip": {
-            "alteration": "PLANNED",
-            "bikesAllowed": "UNKNOWN",
-            "blockId": "7001",
-            "direction": "OUTBOUND",
-            "id": {
-              "feedId": "prt",
-              "id": "700W1140"
-            },
-            "route": {
-              "agency": {
-                "fareUrl": "http://trimet.org/fares/index.htm",
-                "id": {
-                  "feedId": "prt",
-                  "id": "prt"
-                },
-                "lang": "en",
-                "name": "TriMet",
-                "phone": "503-238-7433",
-                "timezone": "America/Los_Angeles",
-                "url": "http://trimet.org"
-              },
-              "bikesAllowed": "UNKNOWN",
-              "id": {
-                "feedId": "prt",
-                "id": "70"
-              },
-              "longName": "12th Ave",
-              "mode": "BUS",
-              "shortName": "70",
-              "sortOrder": -999,
-              "sortOrderSet": false,
-              "type": 3,
-              "url": "http://trimet.org/schedules/r070.htm"
-            },
-            "serviceId": {
-              "feedId": "prt",
-              "id": "W"
-            },
-            "shapeId": {
-              "feedId": "prt",
-              "id": "70.0.1"
-            },
-            "wheelchairAccessible": 0
-          },
-          "walkSteps": [ ],
-          "walkingLeg": false
-        },
-        {
-          "agencyTimeZoneOffset": 0,
-          "arrivalDelay": 0,
-          "bikeRentalNetworks": [ ],
-          "departureDelay": 0,
-          "distanceMeters": 3248.2996826174576,
-          "endTime": "2009-11-17T18:34:55.000+0000",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.531159,
-              "longitude": -122.66293
-            },
-            "name": "NE Multnomah & 3rd",
-            "stopCode": "11492",
-            "stopId": {
-              "feedId": "prt",
-              "id": "11492"
-            },
-            "stopIndex": 83,
-            "stopSequence": 84,
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
-          },
-          "generalizedCost": 2263,
-          "headsign": "Montgomery Park",
-          "intermediateStops": [ ],
-          "legGeometry": {
-            "length": 91,
-            "points": "kx{tG~qtkV`@bANb@FV@R?P?pE?jA@h@AnAbBl@LFJN\\f@LT??NXJPPVJFf@Vf@Pp@Nd@NRLB@RNXZR\\vAhC@BhAhD`AhClAbDBrDCnG@n@@^@d@HdAP`CBjEDvD???LqCFmCDYBGDEBGJkAzAQR??KNa@b@MJuBBY?OHW@u@~@aD`EcBhBBrD@xC??@l@BlE@lD???XBjEBpD???VBlE?dA@t@?b@?h@BfEBrD???VBhEFtKDvJ??@\\DnJ"
-          },
-          "mode": "BUS",
-          "onStreetNonTransit": false,
-          "pathway": false,
-          "realTime": false,
-          "scheduled": true,
-          "serviceDate": {
-            "day": 17,
-            "minMax": false,
-            "month": 11,
-            "sequenceNumber": 20091117,
-            "year": 2009
-          },
-          "startTime": "2009-11-17T18:23:09.000+0000",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.531308,
-              "longitude": -122.696445
-            },
-            "name": "NW Northrup & 22nd",
-            "stopCode": "10778",
-            "stopId": {
-              "feedId": "prt",
-              "id": "10778"
-            },
-            "stopIndex": 92,
-            "stopSequence": 93,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": true,
-          "trip": {
-            "alteration": "PLANNED",
-            "bikesAllowed": "UNKNOWN",
-            "blockId": "7736",
-            "direction": "INBOUND",
-            "id": {
-              "feedId": "prt",
-              "id": "771W1160"
-            },
-            "route": {
-              "agency": {
-                "fareUrl": "http://trimet.org/fares/index.htm",
-                "id": {
-                  "feedId": "prt",
-                  "id": "prt"
-                },
-                "lang": "en",
-                "name": "TriMet",
-                "phone": "503-238-7433",
-                "timezone": "America/Los_Angeles",
-                "url": "http://trimet.org"
-              },
-              "bikesAllowed": "UNKNOWN",
-              "id": {
-                "feedId": "prt",
-                "id": "77"
-              },
-              "longName": "Broadway/Halsey",
-              "mode": "BUS",
-              "shortName": "77",
-              "sortOrder": -999,
-              "sortOrderSet": false,
-              "type": 3,
-              "url": "http://trimet.org/schedules/r077.htm"
-            },
-            "serviceId": {
-              "feedId": "prt",
-              "id": "W"
-            },
-            "shapeId": {
-              "feedId": "prt",
-              "id": "77.1.3"
-            },
-            "wheelchairAccessible": 0
-          },
-          "walkSteps": [ ],
-          "walkingLeg": false
-        },
-        {
-          "agencyTimeZoneOffset": -28800000,
-          "arrivalDelay": 0,
-          "bikeRentalNetworks": [ ],
-          "departureDelay": 0,
-          "distanceMeters": 307.572,
-          "endTime": "2009-11-17T18:39:00.000+0000",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.531308,
-              "longitude": -122.696445
-            },
-            "name": "NW Northrup & 22nd",
-            "stopCode": "10778",
-            "stopId": {
-              "feedId": "prt",
-              "id": "10778"
-            },
-            "stopIndex": 92,
-            "stopSequence": 93,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
-          },
-          "generalizedCost": 980,
-          "interlineWithPreviousLeg": false,
-          "legGeometry": {
-            "length": 13,
-            "points": "sy{tGxc{kV???LABF?B??RDbH@xA?D?P?RDpH"
-          },
-          "mode": "WALK",
-          "onStreetNonTransit": true,
-          "pathway": false,
-          "realTime": false,
-          "rentedBike": false,
-          "scheduled": false,
-          "startTime": "2009-11-17T18:34:55.000+0000",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.531,
-              "longitude": -122.70029
-            },
-            "name": "NW Northrup St. & NW 24th Ave. (P3)",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
-            {
-              "absoluteDirection": "WEST",
-              "angle": -1.3892041323260338,
-              "area": false,
-              "bogusName": false,
-              "distance": 307.572,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.53130187189895,
-                "longitude": -122.69644484256081
-              },
-              "stayOn": false,
-              "streetName": "Northwest Northrup Street",
-              "streetNotes": [ ]
-            }
-          ],
-          "walkingLeg": true
-        }
-      ],
-      "nTransfers": 1,
-      "nonTransitDistanceMeters": 328.312,
-      "nonTransitTimeSeconds": 261,
-      "onStreetAllTheWay": false,
-      "streetOnly": false,
-      "systemNotices": [ ],
-      "tooSloped": false,
-      "transitTimeSeconds": 1078,
-      "waitTimeAdjustedGeneralizedCost": 185592,
-      "waitingTimeSeconds": 957,
-      "walkOnly": false,
-      "walkingAllTheWay": false
-    },
-    {
-      "arrivedAtDestinationWithRentedBicycle": false,
       "durationSeconds": 1583,
       "elevationGained": 0.0,
       "elevationLost": 0.0,
@@ -3244,7 +2821,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           }
         }
       },
-      "generalizedCost": 4535,
+      "generalizedCost": 2925,
       "legs": [
         {
           "agencyTimeZoneOffset": -28800000,
@@ -3268,7 +2845,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
-          "generalizedCost": 292,
+          "generalizedCost": 137,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 9,
@@ -3473,7 +3050,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
-          "generalizedCost": 2844,
+          "generalizedCost": 1388,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 39,
@@ -3637,7 +3214,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           }
         }
       },
-      "generalizedCost": 4505,
+      "generalizedCost": 2895,
       "legs": [
         {
           "agencyTimeZoneOffset": -28800000,
@@ -3661,7 +3238,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
-          "generalizedCost": 292,
+          "generalizedCost": 137,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 9,
@@ -3866,7 +3443,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
-          "generalizedCost": 2844,
+          "generalizedCost": 1388,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 39,
@@ -4034,7 +3611,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           }
         }
       },
-      "generalizedCost": 3358,
+      "generalizedCost": 2957,
       "legs": [
         {
           "agencyTimeZoneOffset": -28800000,
@@ -4058,7 +3635,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
-          "generalizedCost": 64,
+          "generalizedCost": 33,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 4,
@@ -4357,7 +3934,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
-          "generalizedCost": 724,
+          "generalizedCost": 353,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 10,
@@ -4428,8 +4005,367 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
       "systemNotices": [ ],
       "tooSloped": false,
       "transitTimeSeconds": 1133,
-      "waitTimeAdjustedGeneralizedCost": 250940,
+      "waitTimeAdjustedGeneralizedCost": 210840,
       "waitingTimeSeconds": 237,
+      "walkOnly": false,
+      "walkingAllTheWay": false
+    },
+    {
+      "arrivedAtDestinationWithRentedBicycle": false,
+      "durationSeconds": 1941,
+      "elevationGained": 0.0,
+      "elevationLost": 0.0,
+      "fare": {
+        "details": {
+          "regular": [
+            {
+              "fareId": {
+                "feedId": "prt",
+                "id": "8"
+              },
+              "price": {
+                "cents": 200,
+                "currency": {
+                  "value": "USD"
+                }
+              },
+              "routes": [
+                {
+                  "feedId": "prt",
+                  "id": "15"
+                }
+              ]
+            }
+          ]
+        },
+        "fare": {
+          "regular": {
+            "cents": 200,
+            "currency": {
+              "value": "USD"
+            }
+          }
+        }
+      },
+      "generalizedCost": 3245,
+      "legs": [
+        {
+          "agencyTimeZoneOffset": -28800000,
+          "arrivalDelay": 0,
+          "bikeRentalNetworks": [ ],
+          "departureDelay": 0,
+          "distanceMeters": 718.722,
+          "endTime": "2009-11-17T19:02:00.000+0000",
+          "flexibleTrip": false,
+          "from": {
+            "coordinate": {
+              "latitude": 45.52337,
+              "longitude": -122.653725
+            },
+            "name": "NE 12th & Couch",
+            "stopCode": "6577",
+            "stopId": {
+              "feedId": "prt",
+              "id": "6577"
+            },
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "generalizedCost": 1087,
+          "interlineWithPreviousLeg": false,
+          "legGeometry": {
+            "length": 24,
+            "points": "ahztGxxrkV@Sb@?`@@T?T@NBRIrA?lC@lC?R?zB@`C?J?J?J@tB?nC?|B?N@?R?|@Q?"
+          },
+          "mode": "WALK",
+          "onStreetNonTransit": true,
+          "pathway": false,
+          "realTime": false,
+          "rentedBike": false,
+          "scheduled": false,
+          "startTime": "2009-11-17T18:52:44.000+0000",
+          "streetNotes": [ ],
+          "to": {
+            "coordinate": {
+              "latitude": 45.517299,
+              "longitude": -122.654067
+            },
+            "name": "SE Morrison & 12th",
+            "stopCode": "4014",
+            "stopId": {
+              "feedId": "prt",
+              "id": "4014"
+            },
+            "stopIndex": 52,
+            "stopSequence": 53,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "transitAlerts": [ ],
+          "transitLeg": false,
+          "walkSteps": [
+            {
+              "absoluteDirection": "SOUTH",
+              "angle": -3.1191187064694192,
+              "area": false,
+              "bogusName": false,
+              "distance": 51.525,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "DEPART",
+              "startLocation": {
+                "latitude": 45.52336838632084,
+                "longitude": -122.65362253301092
+              },
+              "stayOn": false,
+              "streetName": "Northeast 12th Avenue",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "SOUTH",
+              "angle": -3.0798698707609136,
+              "area": false,
+              "bogusName": false,
+              "distance": 634.751,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "CONTINUE",
+              "startLocation": {
+                "latitude": 45.5229051,
+                "longitude": -122.6536312
+              },
+              "stayOn": false,
+              "streetName": "Southeast 12th Avenue",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "WEST",
+              "angle": -1.5753805308488518,
+              "area": false,
+              "bogusName": false,
+              "distance": 32.446,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "RIGHT",
+              "startLocation": {
+                "latitude": 45.5172031,
+                "longitude": -122.6536511
+              },
+              "stayOn": false,
+              "streetName": "Southeast Morrison Street",
+              "streetNotes": [ ]
+            }
+          ],
+          "walkingLeg": true
+        },
+        {
+          "agencyTimeZoneOffset": 0,
+          "arrivalDelay": 0,
+          "bikeRentalNetworks": [ ],
+          "departureDelay": 0,
+          "distanceMeters": 4844.785407243491,
+          "endTime": "2009-11-17T19:22:04.000+0000",
+          "flexibleTrip": false,
+          "from": {
+            "coordinate": {
+              "latitude": 45.517299,
+              "longitude": -122.654067
+            },
+            "name": "SE Morrison & 12th",
+            "stopCode": "4014",
+            "stopId": {
+              "feedId": "prt",
+              "id": "4014"
+            },
+            "stopIndex": 52,
+            "stopSequence": 53,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "generalizedCost": 1804,
+          "headsign": "NW 27th & Thurman",
+          "intermediateStops": [ ],
+          "legGeometry": {
+            "length": 126,
+            "points": "oaytG|zrkV?tBAjE?nD???X?hE?xC??Ah@?pE?~C???J?`@?vAAvBEbE?jEAlE?`BAbB@d@??@tAAj@Cx@Cb@Cp@_@dEcAtFoA`IS~@i@`BmAzDi@zAc@pAi@~C??Id@u@jEm@bD??If@u@jEk@bD??If@u@|DW`B??CPs@|Du@lElBz@??VJbCfAk@dD??Id@w@rEWvAId@AF??Q~@s@`Ei@~C??Ib@u@dEWzA??]jB]MQSe@WOKOKIIQe@GWE]GnD??AXKnEGnD???XGjD??AZEfCC`AEzB??AXCfAGxDE|AEtBIlC??APkAh@o@?sCB{BD??S?mCDmCDyBB??U?mCDmCDyBB??S?oCDmCDmCBo@@"
+          },
+          "mode": "BUS",
+          "onStreetNonTransit": false,
+          "pathway": false,
+          "realTime": false,
+          "scheduled": true,
+          "serviceDate": {
+            "day": 17,
+            "minMax": false,
+            "month": 11,
+            "sequenceNumber": 20091117,
+            "year": 2009
+          },
+          "startTime": "2009-11-17T19:02:00.000+0000",
+          "streetNotes": [ ],
+          "to": {
+            "coordinate": {
+              "latitude": 45.532159,
+              "longitude": -122.698634
+            },
+            "name": "NW 23rd & Overton",
+            "stopCode": "8981",
+            "stopId": {
+              "feedId": "prt",
+              "id": "8981"
+            },
+            "stopIndex": 74,
+            "stopSequence": 75,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "transitAlerts": [ ],
+          "transitLeg": true,
+          "trip": {
+            "alteration": "PLANNED",
+            "bikesAllowed": "UNKNOWN",
+            "blockId": "1550",
+            "direction": "OUTBOUND",
+            "id": {
+              "feedId": "prt",
+              "id": "150W1430"
+            },
+            "route": {
+              "agency": {
+                "fareUrl": "http://trimet.org/fares/index.htm",
+                "id": {
+                  "feedId": "prt",
+                  "id": "prt"
+                },
+                "lang": "en",
+                "name": "TriMet",
+                "phone": "503-238-7433",
+                "timezone": "America/Los_Angeles",
+                "url": "http://trimet.org"
+              },
+              "bikesAllowed": "UNKNOWN",
+              "id": {
+                "feedId": "prt",
+                "id": "15"
+              },
+              "longName": "Belmont/NW 23rd",
+              "mode": "BUS",
+              "shortName": "15",
+              "sortOrder": -999,
+              "sortOrderSet": false,
+              "type": 3,
+              "url": "http://trimet.org/schedules/r015.htm"
+            },
+            "serviceId": {
+              "feedId": "prt",
+              "id": "W"
+            },
+            "shapeId": {
+              "feedId": "prt",
+              "id": "15.0.23"
+            },
+            "wheelchairAccessible": 0
+          },
+          "walkSteps": [ ],
+          "walkingLeg": false
+        },
+        {
+          "agencyTimeZoneOffset": -28800000,
+          "arrivalDelay": 0,
+          "bikeRentalNetworks": [ ],
+          "departureDelay": 0,
+          "distanceMeters": 231.459,
+          "endTime": "2009-11-17T19:25:05.000+0000",
+          "flexibleTrip": false,
+          "from": {
+            "coordinate": {
+              "latitude": 45.532159,
+              "longitude": -122.698634
+            },
+            "name": "NW 23rd & Overton",
+            "stopCode": "8981",
+            "stopId": {
+              "feedId": "prt",
+              "id": "8981"
+            },
+            "stopIndex": 74,
+            "stopSequence": 75,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "generalizedCost": 353,
+          "interlineWithPreviousLeg": false,
+          "legGeometry": {
+            "length": 10,
+            "points": "}~{tGnq{kV?LVAF?J?L?rBCLA?RDpH"
+          },
+          "mode": "WALK",
+          "onStreetNonTransit": true,
+          "pathway": false,
+          "realTime": false,
+          "rentedBike": false,
+          "scheduled": false,
+          "startTime": "2009-11-17T19:22:04.000+0000",
+          "streetNotes": [ ],
+          "to": {
+            "coordinate": {
+              "latitude": 45.531,
+              "longitude": -122.70029
+            },
+            "name": "NW Northrup St. & NW 24th Ave. (P3)",
+            "vertexType": "NORMAL"
+          },
+          "transitAlerts": [ ],
+          "transitLeg": false,
+          "walkSteps": [
+            {
+              "absoluteDirection": "SOUTH",
+              "angle": 3.117146926361324,
+              "area": false,
+              "bogusName": false,
+              "distance": 104.452,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "DEPART",
+              "startLocation": {
+                "latitude": 45.53215782420268,
+                "longitude": -122.69870264831422
+              },
+              "stayOn": false,
+              "streetName": "Northwest 23rd Avenue",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "WEST",
+              "angle": -1.576477897189337,
+              "area": false,
+              "bogusName": false,
+              "distance": 127.007,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "RIGHT",
+              "startLocation": {
+                "latitude": 45.531218800000005,
+                "longitude": -122.69866750000001
+              },
+              "stayOn": false,
+              "streetName": "Northwest Northrup Street",
+              "streetNotes": [ ]
+            }
+          ],
+          "walkingLeg": true
+        }
+      ],
+      "nTransfers": 0,
+      "nonTransitDistanceMeters": 950.181,
+      "nonTransitTimeSeconds": 737,
+      "onStreetAllTheWay": false,
+      "streetOnly": false,
+      "systemNotices": [ ],
+      "tooSloped": false,
+      "transitTimeSeconds": 1204,
+      "waitTimeAdjustedGeneralizedCost": -999999,
+      "waitingTimeSeconds": 0,
       "walkOnly": false,
       "walkingAllTheWay": false
     }
@@ -4467,7 +4403,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "orig": "SE Stark    St. & SE 17th Ave. (P0)",
             "vertexType": "NORMAL"
           },
-          "generalizedCost": -1,
+          "generalizedCost": 7384,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 252,
@@ -4839,7 +4775,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
-          "generalizedCost": -1,
+          "generalizedCost": 6283,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 202,
@@ -5092,7 +5028,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "vertexType": "TRANSIT",
             "zoneId": "0"
           },
-          "generalizedCost": -1,
+          "generalizedCost": 4557,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 173,

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptor/router/FilterTransitWhenDirectModeIsEmptyTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptor/router/FilterTransitWhenDirectModeIsEmptyTest.java
@@ -10,7 +10,7 @@ public class FilterTransitWhenDirectModeIsEmptyTest {
 
   @Test
   public void directModeIsExistAndIsNotWalking() {
-    var modes = new RequestModes(null,null, StreetMode.BIKE,null);
+    var modes = new RequestModes(null, null, null, StreetMode.BIKE, null);
 
     var subject = new FilterTransitWhenDirectModeIsEmpty(modes);
 
@@ -21,7 +21,7 @@ public class FilterTransitWhenDirectModeIsEmptyTest {
 
   @Test
   public void directModeIsExistAndIsWalking() {
-    var modes = new RequestModes(null,null, StreetMode.WALK,null);
+    var modes = new RequestModes(null, null, null, StreetMode.WALK, null);
 
     var subject = new FilterTransitWhenDirectModeIsEmpty(modes);
 
@@ -32,7 +32,7 @@ public class FilterTransitWhenDirectModeIsEmptyTest {
 
   @Test
   public void directModeIsEmpty() {
-    var modes = new RequestModes(null,null, null,null);
+    var modes = new RequestModes(null, null, null, null, null);
 
     var subject = new FilterTransitWhenDirectModeIsEmpty(modes);
 

--- a/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/services/T2TTransferDummy.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/services/T2TTransferDummy.java
@@ -36,13 +36,13 @@ class T2TTransferDummy {
   /** Transfer from trip & stop, walk, to stop & trip */
   static TripToTripTransfer<TestTripSchedule> tx(
           TestTripSchedule fromTrip, int fromStop,
-          int walk,
+          int walk, int cost,
           int toStop, TestTripSchedule toTrip
   ) {
     return new TripToTripTransfer<>(
         arrival(fromTrip, fromTrip.pattern().findStopPositionAfter(0, fromStop)),
         departure(toTrip, toTrip.pattern().findStopPositionAfter(0, toStop)),
-        fromStop == toStop ? null : walk(toStop, walk)
+        fromStop == toStop ? null : walk(toStop, walk, cost)
     );
   }
 
@@ -52,6 +52,6 @@ class T2TTransferDummy {
       int sameStop,
       TestTripSchedule toTrip
   ) {
-    return tx(fromTrip, sameStop, D0s, sameStop, toTrip);
+    return tx(fromTrip, sameStop, D0s, 0, sameStop, toTrip);
   }
 }

--- a/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/services/TransfersPermutationServiceTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/services/TransfersPermutationServiceTest.java
@@ -3,7 +3,7 @@ package org.opentripplanner.routing.algorithm.transferoptimization.services;
 import static org.junit.Assert.assertEquals;
 import static org.opentripplanner.routing.algorithm.transferoptimization.services.T2TTransferDummy.dummyT2TTransferService;
 import static org.opentripplanner.routing.algorithm.transferoptimization.services.T2TTransferDummy.tx;
-import static org.opentripplanner.routing.algorithm.transferoptimization.services.T2TTransferDummy.tx;
+import static org.opentripplanner.transit.raptor._data.RaptorTestConstants.walkCost;
 import static org.opentripplanner.transit.raptor._data.stoparrival.BasicPathTestCase.COST_CALCULATOR;
 import static org.opentripplanner.transit.raptor._data.transit.TestTripPattern.pattern;
 import static org.opentripplanner.util.time.TimeUtils.time;
@@ -12,6 +12,7 @@ import java.util.List;
 import org.junit.Test;
 import org.opentripplanner.transit.raptor._data.RaptorTestConstants;
 import org.opentripplanner.transit.raptor._data.api.PathBuilder;
+import org.opentripplanner.transit.raptor._data.stoparrival.BasicPathTestCase;
 import org.opentripplanner.transit.raptor._data.transit.TestTripSchedule;
 import org.opentripplanner.transit.raptor.api.transit.RaptorSlackProvider;
 
@@ -90,15 +91,16 @@ public class TransfersPermutationServiceTest implements RaptorTestConstants {
   @Test
   public void testTripWithOneTransfer() {
     // Given
+    var walkCost = walkCost(D1m, BasicPathTestCase.WALK_RELUCTANCE);
     var original = pathBuilder
-        .access(START_TIME_T1, D1m, STOP_A)
+        .access(START_TIME_T1, D1m, STOP_A, walkCost)
         .bus(TRIP_1, STOP_B)
-        .walk(D1m, STOP_C)
+        .walk(D1m, STOP_C, walkCost)
         .bus(TRIP_2, STOP_D)
-        .egress(D1m);
+        .egress(D1m, walkCost);
     var transfers = dummyT2TTransferService(
         // Original transfer
-        tx(TRIP_1, STOP_B, D1m, STOP_C, TRIP_2)
+        tx(TRIP_1, STOP_B, D1m, walkCost(D1m, BasicPathTestCase.WALK_RELUCTANCE), STOP_C, TRIP_2)
     );
 
     var subject = new TransfersPermutationService<>(transfers, COST_CALCULATOR, SLACK_PROVIDER);
@@ -146,11 +148,11 @@ public class TransfersPermutationServiceTest implements RaptorTestConstants {
             .egress(0);
     var transfers = dummyT2TTransferService(
             tx(TRIP_1, STOP_B, TRIP_2),
-            tx(TRIP_1, STOP_B, D30s, STOP_C, TRIP_2),
+            tx(TRIP_1, STOP_B, D30s, walkCost(D30s, BasicPathTestCase.WALK_RELUCTANCE), STOP_C, TRIP_2),
             tx(TRIP_1, STOP_D, TRIP_2),
             tx(TRIP_1, STOP_G, TRIP_2),
             tx(TRIP_1, STOP_G, TRIP_3),
-            tx(TRIP_2, STOP_D, D30s, STOP_E, TRIP_3),
+            tx(TRIP_2, STOP_D, D30s, walkCost(D30s, BasicPathTestCase.WALK_RELUCTANCE), STOP_E, TRIP_3),
             tx(TRIP_2, STOP_F, TRIP_3),
             tx(TRIP_2, STOP_G, TRIP_3)
     );

--- a/src/test/java/org/opentripplanner/routing/graphfinder/DirectGraphFinderTest.java
+++ b/src/test/java/org/opentripplanner/routing/graphfinder/DirectGraphFinderTest.java
@@ -2,14 +2,10 @@ package org.opentripplanner.routing.graphfinder;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.Arrays;
 import java.util.List;
-import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
-import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.common.geometry.GeometryUtils;
 import org.opentripplanner.routing.algorithm.GraphRoutingTest;
 import org.opentripplanner.routing.graph.Graph;
@@ -37,8 +33,8 @@ class DirectGraphFinderTest extends GraphRoutingTest {
 
     @Test
     void findClosestStops() {
-        var ns1 = new NearbyStop(S1, 0, null, linestring(47.500, 19.000, 47.500, 19.000), null);
-        var ns2 = new NearbyStop(S2, 1112, null, linestring(47.500, 19.000, 47.510, 19.000), null);
+        var ns1 = new NearbyStop(S1.getStop(), 0, null, null, null);
+        var ns2 = new NearbyStop(S2.getStop(), 1112, null, null, null);
 
         var testee = new DirectGraphFinder(graph);
         assertEquals(
@@ -49,18 +45,6 @@ class DirectGraphFinderTest extends GraphRoutingTest {
         assertEquals(
                 List.of(ns1, ns2),
                 testee.findClosestStops(47.500, 19.000, 2000)
-        );
-    }
-
-    static LineString linestring(double ... latlon) {
-        if (latlon.length % 2 != 0) {
-            throw new IllegalArgumentException("Uneven number of parameters: " + Arrays.toString(latlon));
-        }
-
-        return geometryFactory.createLineString(
-                IntStream.range(0, latlon.length / 2)
-                .mapToObj(i -> new Coordinate(latlon[i * 2 + 1], latlon[i * 2]))
-                .toArray(Coordinate[]::new)
         );
     }
 }

--- a/src/test/java/org/opentripplanner/routing/graphfinder/StreetGraphFinderTest.java
+++ b/src/test/java/org/opentripplanner/routing/graphfinder/StreetGraphFinderTest.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.routing.graphfinder;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.opentripplanner.routing.graphfinder.DirectGraphFinderTest.linestring;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -99,8 +98,8 @@ class StreetGraphFinderTest extends GraphRoutingTest {
 
     @Test
     void findClosestStops() {
-        var ns1 = new NearbyStop(S1, 0, null, linestring(47.500, 19.000, 47.500, 19.001), null);
-        var ns2 = new NearbyStop(S2, 100, null, linestring(47.500, 19.000, 47.510, 19.000, 47.510, 19.001), null);
+        var ns1 = new NearbyStop(S1.getStop(), 0, null, null, null);
+        var ns2 = new NearbyStop(S2.getStop(), 100, null, null, null);
 
         assertEquals(
                 List.of(ns1),
@@ -294,7 +293,7 @@ class StreetGraphFinderTest extends GraphRoutingTest {
     private List<NearbyStop> simplify(List<NearbyStop> closestStops) {
         return closestStops.stream().map(
                 ns -> new NearbyStop(
-                        ns.stop, ns.distance, ns.distanceIndependentTime, null, ns.geometry, null
+                        ns.stop, ns.distance, null, null, null
                 )
         )
                 .collect(Collectors.toList());

--- a/src/test/java/org/opentripplanner/transit/raptor/_data/RaptorTestConstants.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/_data/RaptorTestConstants.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.transit.raptor._data;
 
+import static org.opentripplanner.transit.raptor.api.transit.RaptorCostConverter.toRaptorCost;
 import static org.opentripplanner.util.time.DurationUtils.duration;
 import static org.opentripplanner.util.time.TimeUtils.hm2time;
 
@@ -47,4 +48,14 @@ public interface RaptorTestConstants {
   int BOARD_SLACK = 45;
   int ALIGHT_SLACK = 15;
   int TRANSFER_SLACK = 60;
+
+  double WALK_RELUCTANCE = 4.0;
+
+  static int walkCost(int durationInSeconds) {
+    return toRaptorCost(durationInSeconds * WALK_RELUCTANCE);
+  }
+
+  static int walkCost(int durationInSeconds, double walkReluctance) {
+    return toRaptorCost(durationInSeconds * walkReluctance);
+  }
 }

--- a/src/test/java/org/opentripplanner/transit/raptor/_data/api/PathBuilderTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/_data/api/PathBuilderTest.java
@@ -1,10 +1,13 @@
 package org.opentripplanner.transit.raptor._data.api;
 
 import static org.junit.Assert.assertEquals;
+import static org.opentripplanner.transit.raptor._data.RaptorTestConstants.walkCost;
+import static org.opentripplanner.transit.raptor._data.stoparrival.BasicPathTestCase.ACCESS_COST;
 import static org.opentripplanner.transit.raptor._data.stoparrival.BasicPathTestCase.ACCESS_DURATION;
 import static org.opentripplanner.transit.raptor._data.stoparrival.BasicPathTestCase.ACCESS_START;
 import static org.opentripplanner.transit.raptor._data.stoparrival.BasicPathTestCase.BASIC_PATH_AS_STRING;
 import static org.opentripplanner.transit.raptor._data.stoparrival.BasicPathTestCase.COST_CALCULATOR;
+import static org.opentripplanner.transit.raptor._data.stoparrival.BasicPathTestCase.EGRESS_COST;
 import static org.opentripplanner.transit.raptor._data.stoparrival.BasicPathTestCase.EGRESS_DURATION;
 import static org.opentripplanner.transit.raptor._data.stoparrival.BasicPathTestCase.L11_DURATION;
 import static org.opentripplanner.transit.raptor._data.stoparrival.BasicPathTestCase.L11_START;
@@ -17,6 +20,7 @@ import static org.opentripplanner.transit.raptor._data.stoparrival.BasicPathTest
 import static org.opentripplanner.transit.raptor._data.stoparrival.BasicPathTestCase.LINE_31;
 import static org.opentripplanner.transit.raptor._data.stoparrival.BasicPathTestCase.TOTAL_COST;
 import static org.opentripplanner.transit.raptor._data.stoparrival.BasicPathTestCase.TRANSIT_RELUCTANCE_INDEX;
+import static org.opentripplanner.transit.raptor._data.stoparrival.BasicPathTestCase.TX_COST;
 import static org.opentripplanner.transit.raptor._data.stoparrival.BasicPathTestCase.TX_DURATION;
 import static org.opentripplanner.transit.raptor.api.transit.RaptorCostConverter.toOtpDomainCost;
 import static org.opentripplanner.util.time.DurationUtils.duration;
@@ -24,6 +28,7 @@ import static org.opentripplanner.util.time.TimeUtils.time;
 
 import org.junit.Test;
 import org.opentripplanner.transit.raptor._data.RaptorTestConstants;
+import org.opentripplanner.transit.raptor._data.stoparrival.BasicPathTestCase;
 import org.opentripplanner.transit.raptor.api.transit.RaptorCostConverter;
 
 
@@ -38,19 +43,20 @@ public class PathBuilderTest implements RaptorTestConstants {
   public void testSimplePathWithOneTransit() {
     int transitDuration = duration("5m");
 
-    var path = subject
-        .access(time("10:00:15"), D1m, STOP_A)
-        .bus("L1", time("10:02"), transitDuration, STOP_B)
-        .egress(D2m);
-
-    int walkCost = COST_CALCULATOR.walkCost(D1m + D2m);
+    int accessCost = walkCost(D1m, BasicPathTestCase.WALK_RELUCTANCE);
+    int egressCost = walkCost(D2m, BasicPathTestCase.WALK_RELUCTANCE);
     int waitTime = BOARD_SLACK + ALIGHT_SLACK;
+
+    var path = subject
+        .access(time("10:00:15"), D1m, STOP_A, accessCost)
+        .bus("L1", time("10:02"), transitDuration, STOP_B)
+        .egress(D2m, egressCost);
 
     int transitCost = COST_CALCULATOR.transitArrivalCost(
             true, STOP_A, waitTime, transitDuration, TRANSIT_RELUCTANCE_INDEX, STOP_B
     );
 
-    assertEquals(toOtpDomainCost(walkCost + transitCost), path.generalizedCost());
+    assertEquals(toOtpDomainCost(accessCost + egressCost + transitCost), path.generalizedCost());
     assertEquals(
         "Walk 1m ~ 1 ~ BUS L1 10:02 10:07 ~ 2 ~ Walk 2m [10:00:15 10:09:15 9m $798]",
         path.toString()
@@ -60,12 +66,12 @@ public class PathBuilderTest implements RaptorTestConstants {
   @Test
   public void testBasicPath() {
     var path = subject
-        .access(ACCESS_START, ACCESS_DURATION, STOP_A)
+        .access(ACCESS_START, ACCESS_DURATION, STOP_A, ACCESS_COST)
         .bus(LINE_11, L11_START, L11_DURATION, STOP_B)
-        .walk( TX_DURATION, STOP_C)
+        .walk(TX_DURATION, STOP_C, TX_COST)
         .bus(LINE_21, L21_START, L21_DURATION, STOP_D)
         .bus(LINE_31, L31_START, L31_DURATION, STOP_E)
-        .egress(EGRESS_DURATION);
+        .egress(EGRESS_DURATION, EGRESS_COST);
     assertEquals(BASIC_PATH_AS_STRING, path.toString());
     assertEquals(RaptorCostConverter.toOtpDomainCost(TOTAL_COST), path.generalizedCost());
   }

--- a/src/test/java/org/opentripplanner/transit/raptor/_data/stoparrival/Access.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/_data/stoparrival/Access.java
@@ -1,16 +1,16 @@
 package org.opentripplanner.transit.raptor._data.stoparrival;
 
+import static org.opentripplanner.transit.raptor._data.transit.TestTransfer.walk;
+
 import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
 import org.opentripplanner.transit.raptor.api.view.AccessPathView;
-
-import static org.opentripplanner.transit.raptor._data.transit.TestTransfer.walk;
 
 public class Access extends AbstractStopArrival {
 
     private final RaptorTransfer access;
 
     public Access(int stop, int departureTime, int arrivalTime, int cost) {
-        this(stop, arrivalTime, cost, walk(stop, Math.abs(arrivalTime - departureTime)));
+        this(stop, arrivalTime, cost, walk(stop, Math.abs(arrivalTime - departureTime), cost));
     }
 
     public Access(int stop, int arrivalTime, int cost, RaptorTransfer path) {

--- a/src/test/java/org/opentripplanner/transit/raptor/_data/stoparrival/FlexAccessAndEgressPathTestCase.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/_data/stoparrival/FlexAccessAndEgressPathTestCase.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.transit.raptor._data.stoparrival;
 
 import static org.junit.Assert.assertEquals;
+import static org.opentripplanner.transit.raptor._data.RaptorTestConstants.walkCost;
 import static org.opentripplanner.transit.raptor._data.stoparrival.BasicPathTestCase.TRANSIT_RELUCTANCE_INDEX;
 import static org.opentripplanner.transit.raptor._data.transit.TestTransfer.flex;
 import static org.opentripplanner.transit.raptor._data.transit.TestTripPattern.pattern;
@@ -45,13 +46,13 @@ public class FlexAccessAndEgressPathTestCase implements RaptorTestConstants {
     public static final int TRANSFER_COST_SEC = 120;
     // The COST_CALCULATOR is not under test, so we use it to calculate correct cost values.
     public static final DefaultCostCalculator<TestTripSchedule> COST_CALCULATOR = new DefaultCostCalculator<>(
-            BOARD_COST_SEC, TRANSFER_COST_SEC, WALK_RELUCTANCE, WAIT_RELUCTANCE, null, null
+            BOARD_COST_SEC, TRANSFER_COST_SEC, WAIT_RELUCTANCE, null, null
     );
     // FLEX Access 5m tx 1 ~ A. Note! The actual times might get time-shifted.
     public static final int ACCESS_DURATION = DurationUtils.duration("5m15s");
     // Using transfer reluctance is incorrect, we should use the cost from the access path
-    public static final int ACCESS_COST = COST_CALCULATOR.walkCost(ACCESS_DURATION);
-    public static final TestTransfer ACCESS = flex(STOP_A, ACCESS_DURATION);
+    public static final int ACCESS_COST = walkCost(ACCESS_DURATION, WALK_RELUCTANCE);
+    public static final TestTransfer ACCESS = flex(STOP_A, ACCESS_DURATION, ACCESS_COST);
     // Alternative Flex access with restricted opening hours: 09:00 - 09:50
     public static final int ACCESS_OPEN = time("09:00");
     public static final int ACCESS_CLOSE = time("09:50");
@@ -61,7 +62,7 @@ public class FlexAccessAndEgressPathTestCase implements RaptorTestConstants {
     public static final int TX1_START = time("10:05:15");
     public static final int TX1_END = time("10:06:15");
     public static final int TX1_DURATION = TX1_END - TX1_START;
-    public static final int TX1_COST = COST_CALCULATOR.walkCost(TX1_DURATION);
+    public static final int TX1_COST = walkCost(TX1_DURATION, WALK_RELUCTANCE);
     // Trip A (B ~ BUS L11 10:08 10:20 ~ C)
     public static final int L1_START = time("10:08");
     public static final int L1_END = time("10:20");
@@ -78,14 +79,14 @@ public class FlexAccessAndEgressPathTestCase implements RaptorTestConstants {
     public static final int TX2_START = time("10:20:15");
     public static final int TX2_END = time("10:22:15");
     public static final int TX2_DURATION = TX2_END - TX2_START;
-    public static final int TX2_COST = COST_CALCULATOR.walkCost(TX2_DURATION);
+    public static final int TX2_COST = walkCost(TX2_DURATION, WALK_RELUCTANCE);
 
     // Wait 15s (ALIGHT_SLACK)
     // D ~ FLEX Egress 6m tx 1 . Note! The actual times might get time-shifted.
     public static final int EGRESS_DURATION = DurationUtils.duration("6m");
     // Using transfer reluctance is incorrect, we should use the cost from the egress path
-    public static final int EGRESS_COST = COST_CALCULATOR.walkCost(EGRESS_DURATION);
-    public static final TestTransfer EGRESS = flex(STOP_D, EGRESS_DURATION);
+    public static final int EGRESS_COST = walkCost(EGRESS_DURATION, WALK_RELUCTANCE);
+    public static final TestTransfer EGRESS = flex(STOP_D, EGRESS_DURATION, EGRESS_COST);
     public static final TestTransfer EGRESS_W_OPENING_HOURS =
             EGRESS.openingHours(TimeUtils.time("10:30"), TimeUtils.time("11:00"));
     public static final String LINE_A = "A";
@@ -173,7 +174,6 @@ public class FlexAccessAndEgressPathTestCase implements RaptorTestConstants {
     @Test
     public void testSetup() {
         // Assert test data is configured correct
-        int cost;
 
         // Assert all durations
         assertEquals(TX1_END - TX1_START, TX1_DURATION);

--- a/src/test/java/org/opentripplanner/transit/raptor/_data/stoparrival/Walk.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/_data/stoparrival/Walk.java
@@ -1,5 +1,7 @@
 package org.opentripplanner.transit.raptor._data.stoparrival;
 
+import static org.opentripplanner.transit.raptor._data.RaptorTestConstants.walkCost;
+
 import org.opentripplanner.transit.raptor._data.transit.TestTripSchedule;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
 import org.opentripplanner.transit.raptor.api.view.ArrivalView;
@@ -25,6 +27,11 @@ public class Walk extends AbstractStopArrival {
 
             @Override public int durationInSeconds() {
                 return Math.abs(arrivalTime - departureTime);
+            }
+
+            @Override
+            public int generalizedCost() {
+                return walkCost(durationInSeconds());
             }
         };
     }

--- a/src/test/java/org/opentripplanner/transit/raptor/_data/transit/TestTransfer.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/_data/transit/TestTransfer.java
@@ -1,11 +1,12 @@
 package org.opentripplanner.transit.raptor._data.transit;
 
 
-import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
+import static org.opentripplanner.transit.raptor._data.RaptorTestConstants.walkCost;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
 
 /**
  * Simple implementation for {@link RaptorTransfer} for use in unit-tests.
@@ -18,6 +19,7 @@ public class TestTransfer implements RaptorTransfer {
     public static final boolean STOP_REACHED_ON_FOOT = false;
     private final int stop;
     private final int durationInSeconds;
+    private final int cost;
     private final int numberOfRides;
     private final boolean stopReachedOnBoard;
     private final Integer opening;
@@ -26,15 +28,17 @@ public class TestTransfer implements RaptorTransfer {
     private TestTransfer(
         int stop,
         int durationInSeconds,
+        int cost,
         int numberOfRides,
         boolean stopReachedOnBoard
     ) {
-        this(stop, durationInSeconds, numberOfRides, stopReachedOnBoard, null, null);
+        this(stop, durationInSeconds, cost, numberOfRides, stopReachedOnBoard, null, null);
     }
 
     private TestTransfer(
             int stop,
             int durationInSeconds,
+            int cost,
             int numberOfRides,
             boolean stopReachedOnBoard,
             Integer opening,
@@ -42,6 +46,7 @@ public class TestTransfer implements RaptorTransfer {
     ) {
         this.stop = stop;
         this.durationInSeconds = durationInSeconds;
+        this.cost = cost;
         this.numberOfRides = numberOfRides;
         this.stopReachedOnBoard = stopReachedOnBoard;
         this.opening = opening;
@@ -50,11 +55,15 @@ public class TestTransfer implements RaptorTransfer {
 
     /** Only use this to override this class, use factory methods to create instances. */
     protected TestTransfer(int stop, int durationInSeconds) {
-        this(stop, durationInSeconds, DEFAULT_NUMBER_OF_LEGS, STOP_REACHED_ON_FOOT);
+        this(stop, durationInSeconds, walkCost(durationInSeconds), DEFAULT_NUMBER_OF_LEGS, STOP_REACHED_ON_FOOT);
     }
 
     public static TestTransfer walk(int stop, int durationInSeconds) {
-        return new TestTransfer(stop, durationInSeconds, DEFAULT_NUMBER_OF_LEGS, STOP_REACHED_ON_FOOT, null, null);
+        return new TestTransfer(stop, durationInSeconds, walkCost(durationInSeconds), DEFAULT_NUMBER_OF_LEGS, STOP_REACHED_ON_FOOT, null, null);
+    }
+
+    public static TestTransfer walk(int stop, int durationInSeconds, int cost) {
+        return new TestTransfer(stop, durationInSeconds, cost, DEFAULT_NUMBER_OF_LEGS, STOP_REACHED_ON_FOOT, null, null);
     }
 
     /**
@@ -64,40 +73,54 @@ public class TestTransfer implements RaptorTransfer {
      * 08:00 and 16:00 every day.
      */
     public static TestTransfer walk(int stop, int durationInSeconds, int opening, int closing) {
-        return new TestTransfer(stop, durationInSeconds, DEFAULT_NUMBER_OF_LEGS, STOP_REACHED_ON_FOOT, opening, closing);
+        return new TestTransfer(stop, durationInSeconds, walkCost(durationInSeconds), DEFAULT_NUMBER_OF_LEGS, STOP_REACHED_ON_FOOT, opening, closing);
+    }
+
+    public static TestTransfer walk(int stop, int durationInSeconds, int cost, int opening, int closing) {
+        return new TestTransfer(stop, durationInSeconds, cost, DEFAULT_NUMBER_OF_LEGS, STOP_REACHED_ON_FOOT, opening, closing);
     }
 
     /** Create a new flex access and arrive stop onBoard with 1 ride/extra transfer. */
     public static TestTransfer flex(int stop, int durationInSeconds) {
-        return flex(stop, durationInSeconds, 1);
+        return flex(stop, durationInSeconds, 1, walkCost(durationInSeconds));
+    }
+
+    /** Create a new flex access and arrive stop onBoard with 1 ride/extra transfer. */
+    public static TestTransfer flex(int stop, int durationInSeconds, int cost) {
+        return flex(stop, durationInSeconds, 1, cost);
     }
 
     /** Create a new flex access and arrive stop onBoard. */
-    public static TestTransfer flex(int stop, int durationInSeconds, int nRides) {
+    public static TestTransfer flex(int stop, int durationInSeconds, int nRides, int cost) {
         assert nRides > DEFAULT_NUMBER_OF_LEGS;
-        return new TestTransfer(stop, durationInSeconds, nRides, STOP_REACHED_ON_BOARD);
+        return new TestTransfer(stop, durationInSeconds, cost, nRides, STOP_REACHED_ON_BOARD);
     }
 
     /** Create a flex access arriving at given stop by walking with 1 ride/extra transfer. */
     public static TestTransfer flexAndWalk(int stop, int durationInSeconds) {
-        return flexAndWalk(stop, durationInSeconds, 1);
+        return flexAndWalk(stop, durationInSeconds, 1, walkCost(durationInSeconds));
+    }
+
+    /** Create a flex access arriving at given stop by walking with 1 ride/extra transfer. */
+    public static TestTransfer flexAndWalk(int stop, int durationInSeconds, int cost) {
+        return flexAndWalk(stop, durationInSeconds, 1, cost);
     }
 
     /** Create a flex access arriving at given stop by walking. */
-    public static TestTransfer flexAndWalk(int stop, int durationInSeconds, int nRides) {
+    public static TestTransfer flexAndWalk(int stop, int durationInSeconds, int nRides, int cost) {
         assert nRides > DEFAULT_NUMBER_OF_LEGS;
-        return new TestTransfer(stop, durationInSeconds, nRides, STOP_REACHED_ON_FOOT);
+        return new TestTransfer(stop, durationInSeconds, cost, nRides, STOP_REACHED_ON_FOOT);
     }
 
     /** Set opening and closing hours and return a new object. */
     public TestTransfer openingHours(int opening, int closing) {
-        return new TestTransfer(stop, durationInSeconds, numberOfRides, stopReachedOnBoard, opening, closing);
+        return new TestTransfer(stop, durationInSeconds, cost, numberOfRides, stopReachedOnBoard, opening, closing);
     }
 
     public static Collection<RaptorTransfer> transfers(int ... stopTimes) {
         List<RaptorTransfer> legs = new ArrayList<>();
         for (int i = 0; i < stopTimes.length; i+=2) {
-            legs.add(walk(stopTimes[i], stopTimes[i+1]));
+            legs.add(walk(stopTimes[i], stopTimes[i+1], walkCost(stopTimes[i+1])));
         }
         return legs;
     }
@@ -105,6 +128,11 @@ public class TestTransfer implements RaptorTransfer {
     @Override
     public int stop() {
         return stop;
+    }
+
+    @Override
+    public int generalizedCost() {
+        return cost;
     }
 
     @Override

--- a/src/test/java/org/opentripplanner/transit/raptor/api/transit/CostCalculatorTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/api/transit/CostCalculatorTest.java
@@ -11,7 +11,6 @@ public class CostCalculatorTest {
 
     private static final int BOARD_COST = 5;
     private static final int TRANSFER_COST = 2;
-    private static final double WALK_RELUCTANCE_FACTOR = 2.0;
     private static final double WAIT_RELUCTANCE_FACTOR = 0.5;
     private static final double TRANSIT_RELUCTANCE_FACTOR_1 = 1.0;
     private static final double TRANSIT_RELUCTANCE_FACTOR_2 = 0.8;
@@ -21,7 +20,6 @@ public class CostCalculatorTest {
     private final CostCalculator<TestTripSchedule> subject = new DefaultCostCalculator<>(
             BOARD_COST,
             TRANSFER_COST,
-            WALK_RELUCTANCE_FACTOR,
             WAIT_RELUCTANCE_FACTOR,
             new int[] { 0, 25 },
             new double[] { TRANSIT_RELUCTANCE_FACTOR_1, TRANSIT_RELUCTANCE_FACTOR_2 }
@@ -44,12 +42,6 @@ public class CostCalculatorTest {
         // There is a small cost (2-1) * 0.5 * 100 = 50 added for the second transit leg
         assertEquals("Wait + board cost", 750, subject.transitArrivalCost(false, fromStop,1, 0, TRANSIT_RELUCTANCE_1, 0));
         assertEquals("wait + board + transit", 950, subject.transitArrivalCost(false, fromStop, 1, 2, TRANSIT_RELUCTANCE_1, 0));
-    }
-
-    @Test
-    public void walkCost() {
-        assertEquals(200, subject.walkCost(1));
-        assertEquals(600, subject.walkCost(3));
     }
 
     @Test

--- a/src/test/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/arrivals/TransferStopArrivalTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/arrivals/TransferStopArrivalTest.java
@@ -37,7 +37,7 @@ public class TransferStopArrivalTest {
     private static final AccessStopArrival<RaptorTripSchedule> ACCESS_ARRIVAL = new AccessStopArrival<>(
         ACCESS_DEPARTURE_TIME,
         ACCESS_COST,
-        walk(ACCESS_TO_STOP, ACCESS_DURATION)
+        walk(ACCESS_TO_STOP, ACCESS_DURATION, ACCESS_COST)
     );
 
     private static final TransitStopArrival<RaptorTripSchedule> TRANSIT_ARRIVAL = new TransitStopArrival<>(
@@ -50,7 +50,7 @@ public class TransferStopArrivalTest {
 
     private final TransferStopArrival<RaptorTripSchedule> subject = new TransferStopArrival<>(
             TRANSIT_ARRIVAL,
-            walk(TRANSFER_TO_STOP, TRANSFER_LEG_DURATION),
+            walk(TRANSFER_TO_STOP, TRANSFER_LEG_DURATION, TRANSFER_COST),
             TRANSFER_ALIGHT_TIME,
             TRANSFER_COST
     );

--- a/src/test/java/org/opentripplanner/transit/raptor/service/HeuristicToRunResolverTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/service/HeuristicToRunResolverTest.java
@@ -1,5 +1,10 @@
 package org.opentripplanner.transit.raptor.service;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.opentripplanner.transit.raptor._data.RaptorTestConstants.walkCost;
+import static org.opentripplanner.transit.raptor.service.HeuristicToRunResolver.resolveHeuristicToRunBasedOnOptimizationsAndSearchParameters;
+
 import org.junit.Test;
 import org.opentripplanner.transit.raptor._data.transit.TestTripSchedule;
 import org.opentripplanner.transit.raptor.api.request.Optimization;
@@ -7,10 +12,6 @@ import org.opentripplanner.transit.raptor.api.request.RaptorProfile;
 import org.opentripplanner.transit.raptor.api.request.RaptorRequest;
 import org.opentripplanner.transit.raptor.api.request.RaptorRequestBuilder;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.opentripplanner.transit.raptor.service.HeuristicToRunResolver.resolveHeuristicToRunBasedOnOptimizationsAndSearchParameters;
 
 public class HeuristicToRunResolverTest {
 
@@ -123,6 +124,7 @@ public class HeuristicToRunResolverTest {
         return new RaptorTransfer() {
             @Override public int stop() { return 1; }
             @Override public int durationInSeconds() { return 10; }
+            @Override public int generalizedCost() { return walkCost(durationInSeconds()); }
             @Override public String toString() { return asString(); }
         };
     }

--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTest.java
@@ -1,12 +1,14 @@
 package org.opentripplanner.transit.raptor.speed_test;
 
 import org.opentripplanner.datastore.OtpDataStore;
+import org.opentripplanner.routing.algorithm.raptor.transit.Transfer;
 import org.opentripplanner.routing.algorithm.raptor.transit.TransitLayer;
 import org.opentripplanner.routing.algorithm.raptor.transit.TripSchedule;
 import org.opentripplanner.routing.algorithm.raptor.transit.mappers.TransitLayerMapper;
 import org.opentripplanner.routing.algorithm.raptor.transit.request.RaptorRoutingRequestTransitData;
 import org.opentripplanner.routing.algorithm.raptor.transit.request.RoutingRequestTransitDataProviderFilter;
 import org.opentripplanner.routing.algorithm.raptor.transit.request.TransitDataProviderFilter;
+import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.SerializedGraphObject;
 import org.opentripplanner.standalone.OtpStartupInfo;
@@ -374,12 +376,15 @@ public class SpeedTest {
                 Set.of()
         );
 
+        RoutingRequest routingRequest = new RoutingRequest();
+        routingRequest.walkSpeed = config.walkSpeedMeterPrSecond;
+
         return new RaptorRoutingRequestTransitData(
                 transitLayer,
                 request.getDepartureDateWithZone().toInstant(),
                 1,
                 transitDataProviderFilter,
-                request.getWalkSpeedMeterPrSecond()
+                Transfer.prepareTransferRoutingRequest(routingRequest)
         );
     }
 

--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/transit/StreetSearch.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/transit/StreetSearch.java
@@ -20,6 +20,7 @@ import org.opentripplanner.routing.algorithm.raptor.transit.TransitLayer;
 import org.opentripplanner.routing.core.TraverseMode;
 import org.opentripplanner.routing.core.TraverseModeSet;
 import org.opentripplanner.routing.edgetype.TemporaryFreeEdge;
+import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
@@ -96,7 +97,7 @@ class StreetSearch {
         }
 
         List<NearbyStop> nearbyStopList = nearbyStopFinder.findNearbyStopsViaStreets(
-                Set.of(vertex), !fromOrigin, true
+                Set.of(vertex), !fromOrigin, true, new RoutingRequest(TraverseMode.WALK)
         );
 
         if(nearbyStopList.isEmpty()) {

--- a/src/test/java/org/opentripplanner/transit/raptor/util/PathStringBuilderTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/util/PathStringBuilderTest.java
@@ -60,10 +60,10 @@ public class PathStringBuilderTest {
         assertEquals(
                 "227 ~ BUS 10:46:05 10:55 ~ 112",
                 new PathStringBuilder()
-                        .accessEgress(TestTransfer.walk(227, 0)).sep()
+                        .accessEgress(TestTransfer.walk(227, 0, 0)).sep()
                         .stop(227).sep()
                         .transit(MODE, T_10_46_05, T_10_55).sep().stop(112).sep()
-                        .accessEgress(TestTransfer.walk(112, 0))
+                        .accessEgress(TestTransfer.walk(112, 0, 0))
                         .toString()
         );
     }


### PR DESCRIPTION
### Summary

This updates RAPTOR to use the weights calculated by A* for the cost of access, transfer and egress paths. To do this it reuses parts of #3375 and:
* adds an explicit `transferMode` to `RequestModes`, which is either `WALK` or `BIKE`
* modifies the transfers pre-calculated (`SimpleTransfer`) add build time to store the list of edges in the `GraphPath`, instead of the time. The edges are re-traversed for each request so that the parameters in the current request are reused
* a cache is added for the calculated Transfers, so that they may be reused between requests
* `RaptorTransfer` is modified to have an explicit `cost()` which is filled out using `State#getWeight()` when mapping entities to RAPTOR

### Issue

#3493 

### Unit tests

No new tests are added, existing one are modified to work.

### Code style

:ballot_box_with_check: 

### Documentation

No changes.

### Changelog

No changes.
