### PR TITLE
Merge two changelogs for LegacyGraphQLApi

### DIFF
--- a/docs/sandbox/LegacyGraphQLApi.md
+++ b/docs/sandbox/LegacyGraphQLApi.md
@@ -6,6 +6,9 @@
 
 ## Changelog
 - Initial version of Legacy Graph QL API (September 2020)
+- Added ids parameter to bikeRentalStations query (May 2021, https://github.com/opentripplanner/OpenTripPlanner/pull/3450)
+- Added capacity and allowOverloading fields to bike rental stations (not yet properly implemented) (May 2021, https://github.com/opentripplanner/OpenTripPlanner/pull/3450)
+- Updated documentation and process for generating Java code from GraphQL schema definition (May 2021, https://github.com/opentripplanner/OpenTripPlanner/pull/3450)
 
 ## Documentation
 

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/README.md
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/README.md
@@ -18,10 +18,3 @@ yarn generate
 ```
 npx -p @graphql-codegen/add -p @graphql-codegen/cli -p @graphql-codegen/java -p @graphql-codegen/java-resolvers -p graphql graphql-codegen -c graphql-codegen.yml 
 ```
-
-## Changelog
-
-### 2.1.0
-- Added ids parameter to bikeRentalStations query (https://github.com/opentripplanner/OpenTripPlanner/pull/3450)
-- Added capacity and allowOverloading fields to bike rental stations (not yet properly implemented) (https://github.com/opentripplanner/OpenTripPlanner/pull/3450)
-- Updated documentation and process for generating Java code from GraphQL schema definition (https://github.com/opentripplanner/OpenTripPlanner/pull/3450)


### PR DESCRIPTION
### Summary
Noticed that there was already a changelog for this sandbox feature in a different folder and I created a new one in an earlier pull request. This just merges the new one into the old one so the changelog is in the same place as for other sandbox features.

### Documentation
- This is just documentation update

### Changelog
- Updates changelog for a sandbox feature
