### PR TITLE
Adding back feature from OTP 1: ability to override FE UI files

### DIFF
--- a/src/main/java/org/opentripplanner/standalone/config/CommandLineParameters.java
+++ b/src/main/java/org/opentripplanner/standalone/config/CommandLineParameters.java
@@ -98,6 +98,14 @@ public class CommandLineParameters implements Cloneable {
                     + "interfaces.")
     public String bindAddress = DEFAULT_BIND_ADDRESS;
 
+    @Parameter(names = {"--clientPath"},
+            description = "Path to serve local client files at.")
+    public String clientPath = null;
+
+    @Parameter(names = {"--disableNativeClient"},
+            description = "Disable native client.")
+    public boolean disableNativeClient = false;
+    
     @Parameter(names = {"--clientFiles"}, validateWith = ReadableDirectory.class,
             description = "Path to directory containing local client files to serve.")
     public File clientDirectory = null;

--- a/src/main/java/org/opentripplanner/standalone/config/CommandLineParameters.java
+++ b/src/main/java/org/opentripplanner/standalone/config/CommandLineParameters.java
@@ -102,9 +102,9 @@ public class CommandLineParameters implements Cloneable {
             description = "Path to serve local client files at.")
     public String clientPath = null;
 
-    @Parameter(names = {"--disableNativeClient"},
-            description = "Disable native client.")
-    public boolean disableNativeClient = false;
+    @Parameter(names = {"--disableDebugClient"},
+            description = "Disable embedded debug client that comes included with OTP.")
+    public boolean disableDebugClient = false;
     
     @Parameter(names = {"--clientFiles"}, validateWith = ReadableDirectory.class,
             description = "Path to directory containing local client files to serve.")

--- a/src/main/java/org/opentripplanner/standalone/server/GrizzlyServer.java
+++ b/src/main/java/org/opentripplanner/standalone/server/GrizzlyServer.java
@@ -120,7 +120,7 @@ public class GrizzlyServer {
         httpServer.getServerConfiguration().addHttpHandler(dynamicHandler, "/otp/");
 
         /* 2. A static content handler to serve the client JS apps etc. from the classpath. */
-        if(params.disableNativeClient != true) {
+        if(params.disableDebugClient != true) {
 	        CLStaticHttpHandler staticHandler = new CLStaticHttpHandler(GrizzlyServer.class.getClassLoader(), "/client/");
 	        if (params.disableFileCache) {
 	            LOG.info("Disabling HTTP server static file cache.");

--- a/src/main/java/org/opentripplanner/standalone/server/GrizzlyServer.java
+++ b/src/main/java/org/opentripplanner/standalone/server/GrizzlyServer.java
@@ -120,19 +120,26 @@ public class GrizzlyServer {
         httpServer.getServerConfiguration().addHttpHandler(dynamicHandler, "/otp/");
 
         /* 2. A static content handler to serve the client JS apps etc. from the classpath. */
-        CLStaticHttpHandler staticHandler = new CLStaticHttpHandler(GrizzlyServer.class.getClassLoader(), "/client/");
-        if (params.disableFileCache) {
-            LOG.info("Disabling HTTP server static file cache.");
-            staticHandler.setFileCacheEnabled(false);
+        if(params.disableNativeClient != true) {
+	        CLStaticHttpHandler staticHandler = new CLStaticHttpHandler(GrizzlyServer.class.getClassLoader(), "/client/");
+	        if (params.disableFileCache) {
+	            LOG.info("Disabling HTTP server static file cache.");
+	            staticHandler.setFileCacheEnabled(false);
+	        }
+	        httpServer.getServerConfiguration().addHttpHandler(staticHandler, "/");
         }
-        httpServer.getServerConfiguration().addHttpHandler(staticHandler, "/");
-
+        
         /* 3. A static content handler to serve local files from the filesystem, under the "local" path. */
         if (params.clientDirectory != null) {
-            StaticHttpHandler localHandler = new StaticHttpHandler(
+        	String path = "/local";
+        	if(params.clientPath != null) {
+        		path = params.clientPath;
+        	}
+        	
+        	StaticHttpHandler localHandler = new StaticHttpHandler(
                     params.clientDirectory.getAbsolutePath());
             localHandler.setFileCacheEnabled(false);
-            httpServer.getServerConfiguration().addHttpHandler(localHandler, "/local");
+            httpServer.getServerConfiguration().addHttpHandler(localHandler, path);
         }
 
         /* 3. Test alternate HTTP handling without Jersey. */


### PR DESCRIPTION
Adding back a feature that seems to have been removed from OTP 2 but was in OTP 1 (I think? Or our branch at least?): the ability to override the FE UI files to a custom set of files using CLI parameters. 
