### PR TITLE
fix: debug client trip widget was broken due to missing data

### DIFF
--- a/src/main/java/org/opentripplanner/index/IndexAPI.java
+++ b/src/main/java/org/opentripplanner/index/IndexAPI.java
@@ -479,7 +479,7 @@ public class IndexAPI {
     @Path("/patterns/{patternId}")
     public ApiPatternShort getPattern(@PathParam("patternId") String patternId) {
         TripPattern pattern = getTripPattern(createRoutingService(), patternId);
-        return TripPatternMapper.mapToApiShort(pattern);
+        return TripPatternMapper.mapToApiDetailed(pattern);
     }
 
     @GET


### PR DESCRIPTION
### Summary

Debug client expects stops and trips to be present on patterns, but index api returned "short" model. This PR changes the api to return the detailed model.

### Issue

#3407 

### Unit tests

The change was manually tested.
