### PR TITLE
Correct locale handling in resource bundles

### DIFF
--- a/src/main/java/org/opentripplanner/util/LocalizedString.java
+++ b/src/main/java/org/opentripplanner/util/LocalizedString.java
@@ -125,7 +125,7 @@ public class LocalizedString implements I18NString, Serializable {
      */
     @Override
     public String toString() {
-        return this.toString(ResourceBundleSingleton.INSTANCE.getDefaultLocale());
+        return this.toString(null);
     }    
 
      /**

--- a/src/main/java/org/opentripplanner/util/ResourceBundleSingleton.java
+++ b/src/main/java/org/opentripplanner/util/ResourceBundleSingleton.java
@@ -3,6 +3,7 @@ package org.opentripplanner.util;
 import java.util.Locale;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
+import java.util.ResourceBundle.Control;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -15,13 +16,11 @@ public enum ResourceBundleSingleton {
 
     private final static Logger LOG = LoggerFactory.getLogger(ResourceBundleSingleton.class);
 
-    //TODO: this is not the only place default is specified
-    //It is also specified in RoutingResource and RoutingRequest
-    private final Locale defaultLocale = new Locale("en");
+    final static ResourceBundle.Control noFallbackControl = Control.getNoFallbackControl(Control.FORMAT_PROPERTIES);
 
-    public Locale getDefaultLocale() {
-        return defaultLocale;
-    }
+    // The default locale to use if none is provided. This avoids using the system locale, which
+    // would lead to nondeterministic results.
+    private final static Locale defaultLocale = Locale.ENGLISH;
 
     //in singleton because resurce bundles are cached based on calling class
     //http://java2go.blogspot.com/2010/03/dont-be-smart-never-implement-resource.html
@@ -30,14 +29,14 @@ public enum ResourceBundleSingleton {
             return null;
         }
         if (locale == null) {
-            locale = getDefaultLocale();
+            locale = Locale.ROOT;
         }
         try {
             ResourceBundle resourceBundle = null;
             if (key.equals("corner") || key.equals("unnamedStreet")) {
-                resourceBundle = ResourceBundle.getBundle("internals", locale);
+                resourceBundle = ResourceBundle.getBundle("internals", locale, noFallbackControl);
             } else {
-                resourceBundle = ResourceBundle.getBundle("WayProperties", locale);
+                resourceBundle = ResourceBundle.getBundle("WayProperties", locale, noFallbackControl);
             }
             String retval = resourceBundle.getString(key);
             //LOG.debug(String.format("Localized '%s' using '%s'", key, retval));
@@ -61,22 +60,17 @@ public enum ResourceBundleSingleton {
         }
         //TODO: This should probably use Locale.forLanguageTag
         //but format is little (IETF language tag) different - instead of _
-        Locale locale;
         String[] localeSpecParts = localeSpec.split("_");
         switch (localeSpecParts.length) {
             case 1:
-                locale = new Locale(localeSpecParts[0]);
-                break;
+                return new Locale(localeSpecParts[0]);
             case 2:
-                locale = new Locale(localeSpecParts[0]);
-                break;
+                return new Locale(localeSpecParts[0]);
             case 3:
-                locale = new Locale(localeSpecParts[0]);
-                break;
+                return new Locale(localeSpecParts[0]);
             default:
-                LOG.debug("Bogus locale " + localeSpec + ", defaulting to " + defaultLocale.toLanguageTag());
-                locale = defaultLocale;
+                LOG.debug("Bogus locale " + localeSpec + ", using default");
+                return defaultLocale;
         }
-        return locale;
     }
 }

--- a/src/main/resources/internals_hu.properties
+++ b/src/main/resources/internals_hu.properties
@@ -1,2 +1,2 @@
-corner = %s és %s sarok
-unnamedStreet = névtelen
+corner = %s Ã©s %s sarok
+unnamedStreet = nÃ©vtelen

--- a/src/test/java/org/opentripplanner/routing/algorithm/TestAStar.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/TestAStar.java
@@ -64,7 +64,7 @@ public class TestAStar extends TestCase {
 
     public void testMaxTime() {
 
-        Graph graph = ConstantsForTests.getInstance().getPortlandGraph();
+        Graph graph = ConstantsForTests.getInstance().getCachedPortlandGraph();
         String feedId = graph.getFeedIds().iterator().next();
         Vertex start = graph.getVertex(feedId + ":8371");
         Vertex end = graph.getVertex(feedId + ":8374");

--- a/src/test/java/org/opentripplanner/routing/algorithm/TestFares.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/TestFares.java
@@ -60,7 +60,7 @@ public class TestFares extends TestCase {
 
     public void testPortland() throws Exception {
 
-        Graph gg = ConstantsForTests.getInstance().getPortlandGraph();
+        Graph gg = ConstantsForTests.getInstance().getCachedPortlandGraph();
         String feedId = gg.getFeedIds().iterator().next();
         RoutingRequest options = new RoutingRequest();
         ShortestPathTree spt;

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/SnapshotTestBase.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/SnapshotTestBase.java
@@ -66,12 +66,12 @@ public abstract class SnapshotTestBase {
     protected Router router;
 
     public static void loadGraphBeforeClass() {
-        ConstantsForTests.getInstance().getPortlandGraph();
+        ConstantsForTests.getInstance().getCachedPortlandGraph();
     }
 
     protected Router getRouter() {
         if (router == null) {
-            Graph graph = ConstantsForTests.getInstance().getPortlandGraph();
+            Graph graph = ConstantsForTests.getInstance().getCachedPortlandGraph();
 
             router = new Router(graph, RouterConfig.DEFAULT);
             router.startup();

--- a/src/test/java/org/opentripplanner/routing/graph/GraphSerializationTest.java
+++ b/src/test/java/org/opentripplanner/routing/graph/GraphSerializationTest.java
@@ -42,7 +42,7 @@ public class GraphSerializationTest {
     public void testRoundTripSerializationForGTFSGraph() throws Exception {
         // This graph does not make an ideal test because it doesn't have any street data.
         // TODO switch to another graph that has both GTFS and OSM data
-        testRoundTrip(ConstantsForTests.getInstance().getPortlandGraph());
+        testRoundTrip(ConstantsForTests.buildNewPortlandGraph());
     }
 
     /**
@@ -50,7 +50,7 @@ public class GraphSerializationTest {
      */
     @Test
     public void testRoundTripSerializationForNetexGraph() throws Exception {
-        testRoundTrip(ConstantsForTests.getInstance().getMinimalNetexGraph());
+        testRoundTrip(ConstantsForTests.buildNewMinimalNetexGraph());
     }
 
     // Ideally we'd also test comparing two separate but identical complex graphs, built separately from the same inputs.
@@ -74,7 +74,7 @@ public class GraphSerializationTest {
     public void compareGraphToItself () {
         // This graph does not make an ideal test because it doesn't have any street data.
         // TODO switch to another graph that has both GTFS and OSM data
-        Graph originalGraph = ConstantsForTests.getInstance().getPortlandGraph();
+        Graph originalGraph = ConstantsForTests.getInstance().getCachedPortlandGraph();
         originalGraph.index();
         // We can exclude relatively few classes here, because the object trees are of course perfectly identical.
         // We do skip edge lists - otherwise we trigger a depth-first search of the graph causing a stack overflow.

--- a/src/test/java/org/opentripplanner/util/LocalizedStringTest.java
+++ b/src/test/java/org/opentripplanner/util/LocalizedStringTest.java
@@ -1,0 +1,33 @@
+package org.opentripplanner.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Locale;
+import org.junit.jupiter.api.Test;
+
+class LocalizedStringTest {
+
+    @Test
+    public void locale() {
+        assertEquals(
+                "corner of First and Second",
+                new LocalizedString("corner", new String[] {"First", "Second"}).toString()
+        );
+    }
+
+    @Test
+    public void localeWithTranslation() {
+        assertEquals(
+                "Kreuzung First mit Second",
+                new LocalizedString("corner", new String[] {"First", "Second"}).toString(Locale.GERMANY)
+        );
+    }
+
+    @Test
+    public void localeWithoutTranslation() {
+        assertEquals(
+                "corner of First and Second",
+                new LocalizedString("corner", new String[] {"First", "Second"}).toString(Locale.CHINESE)
+        );
+    }
+}


### PR DESCRIPTION
### Summary

Certain tests failed depending on the ordering or system locale.

* `ResourceBundle` is used to translate strings which by default fallbacks to the system locale. Explicitly disabling the fallback locale makes the used locale deterministic
* `GraphSerializationTest` failed if the graph was used due to `transient` fields being populated when creating a `Router`. A new `Graph` is always created for the serialization tests.