### PR TITLE
Add empty to line to correctly display list

### DIFF
--- a/docs/sandbox/MapboxVectorTilesApi.md
+++ b/docs/sandbox/MapboxVectorTilesApi.md
@@ -53,7 +53,8 @@ The feature must be configured in `router-config.json` as follows
 }
 ```
 
-For each layer, the configuration includes,
+For each layer, the configuration includes:
+
  - `name` which is used in the url to fetch tiles, and as the layer name in the vector tiles.
  - `type` which tells the type of the layer. Currently `Stop`, `Station` and `BikeRental` are supported.
  - `mapper` which describes the mapper converting the properties from the OTP model entities to the vector tile properties. Currently `Digitransit` is supported for all layer types.


### PR DESCRIPTION
This is an extremely simple PR that only adds a newline to the README in order so that the list is rendered correctly.

### Before

![Screenshot from 2021-06-03 16-45-38](https://user-images.githubusercontent.com/151346/120664520-490cb580-c48b-11eb-86cd-a90abfb0f8b9.png)

### After

![Screenshot from 2021-06-03 16-43-31](https://user-images.githubusercontent.com/151346/120664553-5033c380-c48b-11eb-8e5e-a918cb44b543.png)
