### PR TITLE
Fix NullPointerException when loading Baden-Wuerttemberg GTFS data

### DIFF
--- a/src/main/java/org/opentripplanner/model/impl/OtpTransitServiceImpl.java
+++ b/src/main/java/org/opentripplanner/model/impl/OtpTransitServiceImpl.java
@@ -190,7 +190,11 @@ class OtpTransitServiceImpl implements OtpTransitService {
 
     @Override
     public List<ShapePoint> getShapePointsForShapeId(FeedScopedId shapeId) {
-        return immutableList(shapePointsByShapeId.get(shapeId));
+        List<ShapePoint> shapePoints = shapePointsByShapeId.get(shapeId);
+        if (shapePoints == null) {
+            return List.of();
+        }
+        return immutableList(shapePoints);
     }
 
     @Override


### PR DESCRIPTION
### Summary
OpenTripPlanner was throwing a NullPointerException upon loading the Baden-Württemberg GTFS data. The cause was fairly obvious looking at the code location in the stack trace.

### Unit tests
The main test was that building the graph with OTP after applying this fix no longer failed.
