### PR TITLE
GitHub Actions: deploy to the actually used repository / fork

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -40,4 +40,4 @@ jobs:
         if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev-1.x' || github.ref == 'refs/heads/dev-2.x')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: mvn --batch-mode deploy --settings maven-settings.xml -DskipTests
+        run: mvn --batch-mode deploy --settings maven-settings.xml -DskipTests -DGITHUB_REPOSITORY=$GITHUB_REPOSITORY

--- a/pom.xml
+++ b/pom.xml
@@ -31,13 +31,14 @@
         <junit.version>5.7.1</junit.version>
         <!-- Other properties -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <GITHUB_REPOSITORY>opentripplanner/OpenTripPlanner</GITHUB_REPOSITORY>
     </properties>
 
     <distributionManagement>
         <repository>
             <id>github</id>
             <name>OpenTripPlanner Maven Repository on Github Packages</name>
-            <url>https://maven.pkg.github.com/opentripplanner/OpenTripPlanner/</url>
+            <url>https://maven.pkg.github.com/${GITHUB_REPOSITORY}/</url>
         </repository>
     </distributionManagement>
 


### PR DESCRIPTION
This updates the GitHub Actions `deploy` step and the maven configuration to deploy to the actually used fork instead of `opentripplanner/OpenTripPlanner` in every case.

Without this builds of `dev-2.x` fail in forks due to not having permission to deploy to `opentripplanner/OpenTripPlanner` ([example](https://github.com/realCity/OpenTripPlanner/runs/2737946387?check_suite_focus=true#step:6:462), and [successful build](https://github.com/realCity/OpenTripPlanner/actions/runs/903331163))