### PR TITLE
Map GTFS BookingRules to BookingInfo for pickup and drop off

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/flex/FlexLegMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/FlexLegMapper.java
@@ -29,6 +29,7 @@ public class FlexLegMapper {
       leg.boardRule = GraphPathToItineraryMapper.getBoardAlightMessage(2);
       leg.alightRule = GraphPathToItineraryMapper.getBoardAlightMessage(3);
 
-      leg.bookingInfo = flexTripEdge.getFlexTrip().getBookingInfo(leg.from.stopIndex);
+      leg.dropOffBookingInfo = flexTripEdge.getFlexTrip().getDropOffBookingInfo(leg.from.stopIndex);
+      leg.pickupBookingInfo = flexTripEdge.getFlexTrip().getPickupBookingInfo(leg.from.stopIndex);
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/flex/trip/FlexTrip.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/trip/FlexTrip.java
@@ -46,5 +46,7 @@ public abstract class FlexTrip extends TransitEntity {
     return trip;
   }
 
-  public abstract BookingInfo getBookingInfo(int i);
+  public abstract BookingInfo getDropOffBookingInfo(int i);
+
+  public abstract BookingInfo getPickupBookingInfo(int i);
 }

--- a/src/ext/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTrip.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTrip.java
@@ -34,7 +34,8 @@ public class ScheduledDeviatedTrip extends FlexTrip {
 
   private final ScheduledDeviatedStopTime[] stopTimes;
 
-  private final BookingInfo[] bookingInfos;
+  private final BookingInfo[] dropOffBookingInfos;
+  private final BookingInfo[] pickupBookingInfos;
 
   public static boolean isScheduledFlexTrip(List<StopTime> stopTimes) {
     Predicate<StopTime> notStopType = Predicate.not(st -> st.getStop() instanceof Stop);
@@ -53,11 +54,13 @@ public class ScheduledDeviatedTrip extends FlexTrip {
 
     int nStops = stopTimes.size();
     this.stopTimes = new ScheduledDeviatedStopTime[nStops];
-    this.bookingInfos = new BookingInfo[nStops];
+    this.dropOffBookingInfos = new BookingInfo[nStops];
+    this.pickupBookingInfos = new BookingInfo[nStops];
 
     for (int i = 0; i < nStops; i++) {
       this.stopTimes[i] = new ScheduledDeviatedStopTime(stopTimes.get(i));
-      this.bookingInfos[i] = stopTimes.get(i).getBookingInfo();
+      this.dropOffBookingInfos[i] = stopTimes.get(i).getDropOffBookingInfo();
+      this.pickupBookingInfos[i] = stopTimes.get(i).getPickupBookingInfo();
     }
   }
 
@@ -134,8 +137,13 @@ public class ScheduledDeviatedTrip extends FlexTrip {
   }
 
   @Override
-  public BookingInfo getBookingInfo(int i) {
-    return bookingInfos[i];
+  public BookingInfo getDropOffBookingInfo(int i) {
+    return dropOffBookingInfos[i];
+  }
+
+  @Override
+  public BookingInfo getPickupBookingInfo(int i) {
+    return pickupBookingInfos[i];
   }
 
   private Collection<StopLocation> expandStops(StopLocation stop) {

--- a/src/ext/java/org/opentripplanner/ext/flex/trip/UnscheduledTrip.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/trip/UnscheduledTrip.java
@@ -35,7 +35,8 @@ public class UnscheduledTrip extends FlexTrip {
 
   private final UnscheduledStopTime[] stopTimes;
 
-  private final BookingInfo[] bookingInfos;
+  private final BookingInfo[] dropOffBookingInfos;
+  private final BookingInfo[] pickupBookingInfos;
 
   public static boolean isUnscheduledTrip(List<StopTime> stopTimes) {
     Predicate<StopTime> noExplicitTimes = Predicate.not(st -> st.isArrivalTimeSet() || st.isDepartureTimeSet());
@@ -54,11 +55,13 @@ public class UnscheduledTrip extends FlexTrip {
     }
 
     this.stopTimes = new UnscheduledStopTime[N_STOPS];
-    this.bookingInfos = new BookingInfo[N_STOPS];
+    this.dropOffBookingInfos = new BookingInfo[N_STOPS];
+    this.pickupBookingInfos = new BookingInfo[N_STOPS];
 
     for (int i = 0; i < N_STOPS; i++) {
       this.stopTimes[i] = new UnscheduledStopTime(stopTimes.get(i));
-      this.bookingInfos[i] = stopTimes.get(0).getBookingInfo();
+      this.dropOffBookingInfos[i] = stopTimes.get(0).getDropOffBookingInfo();
+      this.pickupBookingInfos[i] = stopTimes.get(0).getPickupBookingInfo();
     }
   }
 
@@ -135,8 +138,13 @@ public class UnscheduledTrip extends FlexTrip {
   }
 
   @Override
-  public BookingInfo getBookingInfo(int i) {
-    return bookingInfos[i];
+  public BookingInfo getDropOffBookingInfo(int i) {
+    return dropOffBookingInfos[i];
+  }
+
+  @Override
+  public BookingInfo getPickupBookingInfo(int i) {
+    return pickupBookingInfos[i];
   }
 
   private Collection<StopLocation> expandStops(StopLocation stop) {

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/LegacyGraphQLIndex.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/LegacyGraphQLIndex.java
@@ -81,6 +81,9 @@ class LegacyGraphQLIndex {
           .type(IntrospectionTypeWiring.build(LegacyGraphQLStoptimesInPatternImpl.class))
           .type(IntrospectionTypeWiring.build(LegacyGraphQLTranslatedStringImpl.class))
           .type(IntrospectionTypeWiring.build(LegacyGraphQLTripImpl.class))
+          .type(IntrospectionTypeWiring.build(LegacyGraphQLContactInfoImpl.class))
+          .type(IntrospectionTypeWiring.build(LegacyGraphQLBookingTimeImpl.class))
+          .type(IntrospectionTypeWiring.build(LegacyGraphQLBookingInfoImpl.class))
           .build();
       SchemaGenerator schemaGenerator = new SchemaGenerator();
       return schemaGenerator.makeExecutableSchema(typeRegistry, runtimeWiring);

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLBookingInfoImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLBookingInfoImpl.java
@@ -1,0 +1,54 @@
+package org.opentripplanner.ext.legacygraphqlapi.datafetchers;
+
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import org.opentripplanner.ext.legacygraphqlapi.generated.LegacyGraphQLDataFetchers;
+import org.opentripplanner.model.BookingInfo;
+import org.opentripplanner.model.BookingTime;
+import org.opentripplanner.model.ContactInfo;
+
+public class LegacyGraphQLBookingInfoImpl implements LegacyGraphQLDataFetchers.LegacyGraphQLBookingInfo {
+    @Override
+    public DataFetcher<ContactInfo> contactInfo() {
+        return environment -> getSource(environment).getContactInfo();
+    }
+
+    @Override
+    public DataFetcher<BookingTime> earliestBookingTime() {
+        return environment -> getSource(environment).getEarliestBookingTime();
+    }
+
+    @Override
+    public DataFetcher<BookingTime> latestBookingTime() {
+        return environment -> getSource(environment).getLatestBookingTime();
+    }
+
+    @Override
+    public DataFetcher<Long> minimumBookingNoticeSeconds() {
+        return environment -> getSource(environment).getMinimumBookingNotice().toSeconds();
+    }
+
+    @Override
+    public DataFetcher<Long> maximumBookingNoticeSeconds() {
+        return environment -> getSource(environment).getMaximumBookingNotice().toSeconds();
+    }
+
+    @Override
+    public DataFetcher<String> message() {
+        return environment -> getSource(environment).getMessage();
+    }
+
+    @Override
+    public DataFetcher<String> pickupMessage() {
+        return environment -> getSource(environment).getPickupMessage();
+    }
+
+    @Override
+    public DataFetcher<String> dropOffMessage() {
+        return environment -> getSource(environment).getDropOffMessage();
+    }
+
+    private BookingInfo getSource(DataFetchingEnvironment environment) {
+        return environment.getSource();
+    }
+}

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLBookingTimeImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLBookingTimeImpl.java
@@ -1,0 +1,23 @@
+package org.opentripplanner.ext.legacygraphqlapi.datafetchers;
+
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import java.time.format.DateTimeFormatter;
+import org.opentripplanner.ext.legacygraphqlapi.generated.LegacyGraphQLDataFetchers;
+import org.opentripplanner.model.BookingTime;
+
+public class LegacyGraphQLBookingTimeImpl implements LegacyGraphQLDataFetchers.LegacyGraphQLBookingTime {
+    @Override
+    public DataFetcher<String> time() {
+        return environment -> getSource(environment).getTime().format(DateTimeFormatter.ISO_LOCAL_TIME);
+    }
+
+    @Override
+    public DataFetcher<Integer> daysPrior() {
+        return environment -> getSource(environment).getDaysPrior();
+    }
+
+    private BookingTime getSource(DataFetchingEnvironment environment) {
+        return environment.getSource();
+    }
+}

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLContactInfoImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLContactInfoImpl.java
@@ -1,0 +1,47 @@
+package org.opentripplanner.ext.legacygraphqlapi.datafetchers;
+
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import org.opentripplanner.ext.legacygraphqlapi.generated.LegacyGraphQLDataFetchers;
+import org.opentripplanner.model.ContactInfo;
+
+public class LegacyGraphQLContactInfoImpl implements LegacyGraphQLDataFetchers.LegacyGraphQLContactInfo {
+    @Override
+    public DataFetcher<String> contactPerson() {
+        return environment -> getSource(environment).getContactPerson();
+    }
+
+    @Override
+    public DataFetcher<String> phoneNumber() {
+        return environment -> getSource(environment).getPhoneNumber();
+    }
+
+    @Override
+    public DataFetcher<String> eMail() {
+        return environment -> getSource(environment).geteMail();
+    }
+
+    @Override
+    public DataFetcher<String> faxNumber() {
+        return environment -> getSource(environment).getFaxNumber();
+    }
+
+    @Override
+    public DataFetcher<String> infoUrl() {
+        return environment -> getSource(environment).getInfoUrl();
+    }
+
+    @Override
+    public DataFetcher<String> bookingUrl() {
+        return environment -> getSource(environment).getBookingUrl();
+    }
+
+    @Override
+    public DataFetcher<String> additionalDetails() {
+        return environment -> getSource(environment).getAdditionalDetails();
+    }
+
+    private ContactInfo getSource(DataFetchingEnvironment environment) {
+        return environment.getSource();
+    }
+}

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLLegImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLLegImpl.java
@@ -6,6 +6,7 @@ import org.opentripplanner.api.mapping.ServiceDateMapper;
 import org.opentripplanner.ext.legacygraphqlapi.LegacyGraphQLRequestContext;
 import org.opentripplanner.ext.legacygraphqlapi.generated.LegacyGraphQLDataFetchers;
 import org.opentripplanner.model.Agency;
+import org.opentripplanner.model.BookingInfo;
 import org.opentripplanner.model.Route;
 import org.opentripplanner.model.Trip;
 import org.opentripplanner.model.plan.Leg;
@@ -182,6 +183,16 @@ public class LegacyGraphQLLegImpl implements LegacyGraphQLDataFetchers.LegacyGra
   @Override
   public DataFetcher<Boolean> interlineWithPreviousLeg() {
     return environment -> getSource(environment).interlineWithPreviousLeg;
+  }
+
+  @Override
+  public DataFetcher<BookingInfo> dropOffBookingInfo() {
+    return environment -> getSource(environment).dropOffBookingInfo;
+  }
+
+  @Override
+  public DataFetcher<BookingInfo> pickupBookingInfo() {
+    return environment -> getSource(environment).pickupBookingInfo;
   }
 
   private RoutingService getRoutingService(DataFetchingEnvironment environment) {

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/LegacyGraphQLDataFetchers.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/LegacyGraphQLDataFetchers.java
@@ -2,6 +2,9 @@
 package org.opentripplanner.ext.legacygraphqlapi.generated;
 
 import org.opentripplanner.model.Agency;
+import org.opentripplanner.model.BookingInfo;
+import org.opentripplanner.model.BookingTime;
+import org.opentripplanner.model.ContactInfo;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.routing.bike_park.BikePark;
 import org.opentripplanner.routing.bike_rental.BikeRentalStation;
@@ -211,6 +214,46 @@ public class LegacyGraphQLDataFetchers {
         public DataFetcher<Iterable<FareComponent>> components();
     }
 
+    public interface LegacyGraphQLBookingInfo {
+        public DataFetcher<ContactInfo> contactInfo();
+
+        public DataFetcher<BookingTime> earliestBookingTime();
+
+        public DataFetcher<BookingTime> latestBookingTime();
+
+        public DataFetcher<Long> minimumBookingNoticeSeconds();
+
+        public DataFetcher<Long> maximumBookingNoticeSeconds();
+
+        public DataFetcher<String> message();
+
+        public DataFetcher<String> pickupMessage();
+
+        public DataFetcher<String> dropOffMessage();
+    }
+
+    public interface LegacyGraphQLContactInfo {
+        public DataFetcher<String> contactPerson();
+
+        public DataFetcher<String> phoneNumber();
+
+        public DataFetcher<String> eMail();
+
+        public DataFetcher<String> faxNumber();
+
+        public DataFetcher<String> infoUrl();
+
+        public DataFetcher<String> bookingUrl();
+
+        public DataFetcher<String> additionalDetails();
+    }
+
+    public interface LegacyGraphQLBookingTime {
+        public DataFetcher<String> time();
+
+        public DataFetcher<Integer> daysPrior();
+    }
+
     /**
      * Component of the fare (i.e. ticket) for a part of the itinerary
      */
@@ -323,6 +366,10 @@ public class LegacyGraphQLDataFetchers {
         public DataFetcher<String> dropoffType();
 
         public DataFetcher<Boolean> interlineWithPreviousLeg();
+
+        public DataFetcher<BookingInfo> dropOffBookingInfo();
+
+        public DataFetcher<BookingInfo> pickupBookingInfo();
     }
 
     /**

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/graphql-codegen.yml
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/graphql-codegen.yml
@@ -32,7 +32,10 @@ config:
     BikePark: org.opentripplanner.routing.bike_park.BikePark#BikePark
     BikeRentalStation: org.opentripplanner.routing.bike_rental.BikeRentalStation#BikeRentalStation
     BikesAllowed: String
+    BookingInfo: org.opentripplanner.model.BookingInfo
+    BookingTime: org.opentripplanner.model.BookingTime
     CarPark: Object
+    ContactInfo: org.opentripplanner.model.ContactInfo
     Cluster: Object
     Coordinates: org.locationtech.jts.geom.Coordinate#Coordinate
     debugOutput: org.opentripplanner.api.resource.DebugOutput#DebugOutput

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/LegType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/LegType.java
@@ -286,7 +286,7 @@ public class LegType {
             .newFieldDefinition()
             .name("bookingArrangements")
             .type(bookingArrangementType)
-            .dataFetcher(env -> leg(env).bookingInfo)
+            .dataFetcher(env -> leg(env).pickupBookingInfo)
             .build())
         .field(GraphQLFieldDefinition
             .newFieldDefinition()

--- a/src/ext/resources/legacygraphqlapi/schema.graphqls
+++ b/src/ext/resources/legacygraphqlapi/schema.graphqls
@@ -821,6 +821,10 @@ type Leg {
     and passenger can stay inside the vehicle.
     """
     interlineWithPreviousLeg: Boolean
+
+    dropOffBookingInfo: BookingInfo
+
+    pickupBookingInfo: BookingInfo
 }
 
 """Identifies whether this stop represents a stop or station."""
@@ -999,6 +1003,32 @@ enum PickupDropoffType {
 
     """Must coordinate with driver to arrange pickup / drop off."""
     COORDINATE_WITH_DRIVER
+}
+
+type ContactInfo {
+    contactPerson: String
+    phoneNumber: String
+    eMail: String
+    faxNumber: String
+    infoUrl: String
+    bookingUrl: String
+    additionalDetails: String
+}
+
+type BookingTime {
+    time: String
+    daysPrior: Int
+}
+
+type BookingInfo {
+    contactInfo: ContactInfo
+    earliestBookingTime: BookingTime
+    latestBookingTime: BookingTime
+    minimumBookingNoticeSeconds: Long
+    maximumBookingNoticeSeconds: Long
+    message: String
+    pickupMessage: String
+    dropOffMessage: String
 }
 
 type Place {

--- a/src/main/java/org/opentripplanner/gtfs/mapping/BookingRuleMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/BookingRuleMapper.java
@@ -1,0 +1,84 @@
+package org.opentripplanner.gtfs.mapping;
+
+import org.onebusaway.gtfs.model.AgencyAndId;
+import org.onebusaway.gtfs.model.BookingRule;
+import org.opentripplanner.model.BookingInfo;
+import org.opentripplanner.model.BookingMethod;
+import org.opentripplanner.model.ContactInfo;
+import org.opentripplanner.model.BookingTime;
+
+import java.time.Duration;
+import java.time.LocalTime;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+
+/** Responsible for mapping GTFS BookingRule into the OTP model. */
+class BookingRuleMapper {
+
+    private final Map<AgencyAndId, BookingInfo> cachedBookingInfos = new HashMap<>();
+
+    /** Map from GTFS to OTP model, {@code null} safe.  */
+    BookingInfo map(
+            BookingRule rule
+    ) {
+        if (rule == null) {
+            return null;
+        }
+
+        return cachedBookingInfos.computeIfAbsent(rule.getId(), k -> new BookingInfo(
+                contactInfo(rule),
+                bookingMethods(rule),
+                earliestBookingTime(rule),
+                latestBookingTime(rule),
+                minimumBookingNotice(rule),
+                maximumBookingNotice(rule),
+                message(rule),
+                dropOffMessage(rule),
+                pickupMessage(rule)
+
+        ));
+    }
+
+    private ContactInfo contactInfo(BookingRule rule) {
+        return new ContactInfo(null,
+                rule.getPhoneNumber(),
+                null,
+                null,
+                rule.getInfoUrl(),
+                rule.getUrl(),
+                null);
+    }
+
+    private EnumSet<BookingMethod> bookingMethods(BookingRule rule) {
+        return null;
+    }
+
+    private BookingTime earliestBookingTime(BookingRule rule) {
+        return new BookingTime(LocalTime.ofSecondOfDay(rule.getPriorNoticeStartTime()), rule.getPriorNoticeStartDay());
+    }
+
+    private BookingTime latestBookingTime(BookingRule rule) {
+        return new BookingTime(LocalTime.ofSecondOfDay(rule.getPriorNoticeLastTime()), rule.getPriorNoticeLastDay());
+    }
+
+    private Duration minimumBookingNotice(BookingRule rule) {
+        return Duration.ofSeconds(rule.getPriorNoticeDurationMin());
+    }
+
+    private Duration maximumBookingNotice(BookingRule rule) {
+        return Duration.ofSeconds(rule.getPriorNoticeDurationMax());
+    }
+
+    private String message(BookingRule rule) {
+        return rule.getMessage();
+    }
+
+    private String pickupMessage(BookingRule rule) {
+        return rule.getPickupMessage();
+    }
+
+    private String dropOffMessage(BookingRule rule) {
+        return rule.getDropOffMessage();
+    }
+}

--- a/src/main/java/org/opentripplanner/gtfs/mapping/GTFSToOtpTransitServiceMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/GTFSToOtpTransitServiceMapper.java
@@ -56,6 +56,8 @@ public class GTFSToOtpTransitServiceMapper {
 
     private final TripMapper tripMapper;
 
+    private final BookingRuleMapper bookingRuleMapper;
+
     private final StopTimeMapper stopTimeMapper;
 
     private final FrequencyMapper frequencyMapper;
@@ -80,7 +82,8 @@ public class GTFSToOtpTransitServiceMapper {
         agencyMapper = new AgencyMapper(feedId);
         routeMapper = new RouteMapper(agencyMapper);
         tripMapper = new TripMapper(routeMapper);
-        stopTimeMapper = new StopTimeMapper(stopMapper, locationMapper, locationGroupMapper, tripMapper);
+        bookingRuleMapper = new BookingRuleMapper();
+        stopTimeMapper = new StopTimeMapper(stopMapper, locationMapper, locationGroupMapper, tripMapper, bookingRuleMapper);
         frequencyMapper = new FrequencyMapper(tripMapper);
         fareRuleMapper = new FareRuleMapper(
             routeMapper, fareAttributeMapper

--- a/src/main/java/org/opentripplanner/gtfs/mapping/StopTimeMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/StopTimeMapper.java
@@ -21,19 +21,22 @@ class StopTimeMapper {
     private final LocationGroupMapper locationGroupMapper;
 
     private final TripMapper tripMapper;
+    private final BookingRuleMapper bookingRuleMapper;
 
     private final Map<org.onebusaway.gtfs.model.StopTime, StopTime> mappedStopTimes = new HashMap<>();
 
     StopTimeMapper(
-        StopMapper stopMapper,
-        LocationMapper locationMapper,
-        LocationGroupMapper locationGroupMapper,
-        TripMapper tripMapper
+            StopMapper stopMapper,
+            LocationMapper locationMapper,
+            LocationGroupMapper locationGroupMapper,
+            TripMapper tripMapper,
+            BookingRuleMapper bookingRuleMapper
     ) {
         this.stopMapper = stopMapper;
         this.locationMapper = locationMapper;
         this.locationGroupMapper = locationGroupMapper;
         this.tripMapper = tripMapper;
+        this.bookingRuleMapper = bookingRuleMapper;
     }
 
     Collection<StopTime> map(Collection<org.onebusaway.gtfs.model.StopTime> times) {
@@ -70,6 +73,8 @@ class StopTimeMapper {
         lhs.setFlexWindowEnd(rhs.getEndPickupDropOffWindow());
         lhs.setFlexContinuousPickup(rhs.getContinuousPickup());
         lhs.setFlexContinuousDropOff(rhs.getContinuousDropOff());
+        lhs.setPickupBookingInfo(bookingRuleMapper.map(rhs.getPickupBookingRule()));
+        lhs.setDropOffBookingInfo(bookingRuleMapper.map(rhs.getDropOffBookingRule()));
 
         // Skip mapping of proxy
         // private transient StopTimeProxy proxy;

--- a/src/main/java/org/opentripplanner/model/BookingInfo.java
+++ b/src/main/java/org/opentripplanner/model/BookingInfo.java
@@ -1,7 +1,5 @@
 package org.opentripplanner.model;
 
-import org.opentripplanner.netex.mapping.BookingTime;
-
 import java.io.Serializable;
 import java.time.Duration;
 import java.util.EnumSet;

--- a/src/main/java/org/opentripplanner/model/BookingTime.java
+++ b/src/main/java/org/opentripplanner/model/BookingTime.java
@@ -1,4 +1,4 @@
-package org.opentripplanner.netex.mapping;
+package org.opentripplanner.model;
 
 import java.io.Serializable;
 import java.time.LocalTime;

--- a/src/main/java/org/opentripplanner/model/StopTime.java
+++ b/src/main/java/org/opentripplanner/model/StopTime.java
@@ -51,7 +51,9 @@ public final class StopTime implements Comparable<StopTime> {
     // Disabled by default
     private int flexContinuousDropOff = MISSING_VALUE;
 
-    private BookingInfo bookingInfo;
+    private BookingInfo dropOffBookingInfo;
+
+    private BookingInfo pickupBookingInfo;
 
     public StopTime() { }
 
@@ -72,7 +74,8 @@ public final class StopTime implements Comparable<StopTime> {
         this.flexWindowEnd = st.flexWindowEnd;
         this.flexContinuousPickup = st.flexContinuousPickup;
         this.flexContinuousDropOff = st.flexContinuousDropOff;
-        this.bookingInfo = st.bookingInfo;
+        this.dropOffBookingInfo = st.dropOffBookingInfo;
+        this.pickupBookingInfo = st.pickupBookingInfo;
     }
 
     /**
@@ -257,12 +260,20 @@ public final class StopTime implements Comparable<StopTime> {
         this.flexContinuousDropOff = flexContinuousDropOff;
     }
 
-    public BookingInfo getBookingInfo() {
-        return bookingInfo;
+    public BookingInfo getDropOffBookingInfo() {
+        return dropOffBookingInfo;
     }
 
-    public void setBookingInfo(BookingInfo bookingInfo) {
-        this.bookingInfo = bookingInfo;
+    public void setDropOffBookingInfo(BookingInfo dropOffBookingInfo) {
+        this.dropOffBookingInfo = dropOffBookingInfo;
+    }
+
+    public BookingInfo getPickupBookingInfo() {
+        return pickupBookingInfo;
+    }
+
+    public void setPickupBookingInfo(BookingInfo pickupBookingInfo) {
+        this.pickupBookingInfo = pickupBookingInfo;
     }
 
     public int compareTo(StopTime o) {

--- a/src/main/java/org/opentripplanner/model/plan/Leg.java
+++ b/src/main/java/org/opentripplanner/model/plan/Leg.java
@@ -169,7 +169,9 @@ public class Leg {
 
    public String alightRule;
 
-   public BookingInfo bookingInfo = null;
+   public BookingInfo dropOffBookingInfo = null;
+
+   public BookingInfo pickupBookingInfo = null;
 
     public Transfer transferFromPrevLeg = null;
 

--- a/src/main/java/org/opentripplanner/netex/mapping/BookingInfoMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/BookingInfoMapper.java
@@ -3,6 +3,7 @@ package org.opentripplanner.netex.mapping;
 import com.esotericsoftware.minlog.Log;
 import org.opentripplanner.model.BookingInfo;
 import org.opentripplanner.model.BookingMethod;
+import org.opentripplanner.model.BookingTime;
 import org.opentripplanner.model.ContactInfo;
 import org.rutebanken.netex.model.BookingArrangementsStructure;
 import org.rutebanken.netex.model.BookingMethodEnumeration;

--- a/src/main/java/org/opentripplanner/netex/mapping/StopTimesMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/StopTimesMapper.java
@@ -10,6 +10,8 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
 import javax.xml.bind.JAXBElement;
+
+import org.opentripplanner.model.BookingInfo;
 import org.opentripplanner.model.FlexLocationGroup;
 import org.opentripplanner.model.FlexStopLocation;
 import org.opentripplanner.model.Stop;
@@ -130,11 +132,14 @@ class StopTimesMapper {
                 return null;
             }
 
-            stopTime.setBookingInfo(BookingInfoMapper.map(
-                stopPoint,
-                serviceJourney,
-                lookUpFlexibleLine(serviceJourney, journeyPattern)
-            ));
+
+            BookingInfo bookingInfo = BookingInfoMapper.map(
+                    stopPoint,
+                    serviceJourney,
+                    lookUpFlexibleLine(serviceJourney, journeyPattern)
+            );
+            stopTime.setDropOffBookingInfo(bookingInfo);
+            stopTime.setPickupBookingInfo(bookingInfo);
 
             result.addStopTime(currentPassingTime.getId(), stopTime);
         }

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
@@ -198,7 +198,8 @@ public class RaptorPathToItineraryMapper {
         leg.walkSteps = new ArrayList<>();
         leg.generalizedCost = pathLeg.generalizedCost();
 
-        leg.bookingInfo = tripTimes.getBookingInfo(boardStopIndexInPattern);
+        leg.dropOffBookingInfo = tripTimes.getDropOffBookingInfo(boardStopIndexInPattern);
+        leg.pickupBookingInfo = tripTimes.getPickupBookingInfo(boardStopIndexInPattern);
 
         if(optPath != null) {
             var transfer = optPath.getTransferTo(pathLeg);

--- a/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
+++ b/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
@@ -119,8 +119,9 @@ public class TripTimes implements Serializable, Comparable<TripTimes>, Cloneable
      */
     int[] dropoffs;
 
-    List<BookingInfo> bookingInfos;
+    List<BookingInfo> dropOffBookingInfos;
 
+    List<BookingInfo> pickupBookingInfos;
 
     /**
      * These are the GTFS stop sequence numbers, which show the order in which the vehicle visits
@@ -156,7 +157,8 @@ public class TripTimes implements Serializable, Comparable<TripTimes>, Cloneable
         timeShift = stopTimes.iterator().next().getArrivalTime();
         final int[] pickups   = new int[nStops];
         final int[] dropoffs   = new int[nStops];
-        final List<BookingInfo> bookingInfos = new ArrayList<>();
+        final List<BookingInfo> dropOffBookingInfos = new ArrayList<>();
+        final List<BookingInfo> pickupBookingInfos = new ArrayList<>();
         int s = 0;
         for (final StopTime st : stopTimes) {
             departures[s] = st.getDepartureTime() - timeShift;
@@ -166,7 +168,8 @@ public class TripTimes implements Serializable, Comparable<TripTimes>, Cloneable
 
             pickups[s] = st.getPickupType();
             dropoffs[s] = st.getDropOffType();
-            bookingInfos.add(st.getBookingInfo());
+            dropOffBookingInfos.add(st.getDropOffBookingInfo());
+            pickupBookingInfos.add(st.getPickupBookingInfo());
             s++;
         }
         this.scheduledDepartureTimes = deduplicator.deduplicateIntArray(departures);
@@ -175,7 +178,8 @@ public class TripTimes implements Serializable, Comparable<TripTimes>, Cloneable
         this.headsigns = deduplicator.deduplicateStringArray(makeHeadsignsArray(stopTimes));
         this.pickups = deduplicator.deduplicateIntArray(pickups);
         this.dropoffs = deduplicator.deduplicateIntArray(dropoffs);
-        this.bookingInfos = deduplicator.deduplicateImmutableList(BookingInfo.class, bookingInfos);
+        this.dropOffBookingInfos = deduplicator.deduplicateImmutableList(BookingInfo.class, dropOffBookingInfos);
+        this.pickupBookingInfos = deduplicator.deduplicateImmutableList(BookingInfo.class, pickupBookingInfos);
         // We set these to null to indicate that this is a non-updated/scheduled TripTimes.
         // We cannot point to the scheduled times because they are shifted, and updated times are not.
         this.arrivalTimes = null;
@@ -199,7 +203,8 @@ public class TripTimes implements Serializable, Comparable<TripTimes>, Cloneable
         this.timepoints = object.timepoints;
         this.pickups = object.pickups;
         this.dropoffs = object.dropoffs;
-        this.bookingInfos = object.bookingInfos;
+        this.dropOffBookingInfos = object.dropOffBookingInfos;
+        this.pickupBookingInfos = object.pickupBookingInfos;
     }
 
     /**
@@ -372,8 +377,12 @@ public class TripTimes implements Serializable, Comparable<TripTimes>, Cloneable
         return dropoffs[stop];
     }
 
-    public BookingInfo getBookingInfo(int stop) {
-        return bookingInfos.get(stop);
+    public BookingInfo getDropOffBookingInfo(int stop) {
+        return dropOffBookingInfos.get(stop);
+    }
+
+    public BookingInfo getPickupBookingInfo(int stop) {
+        return pickupBookingInfos.get(stop);
     }
 
     /**

--- a/src/test/java/org/opentripplanner/gtfs/mapping/StopTimesMapperTest.java
+++ b/src/test/java/org/opentripplanner/gtfs/mapping/StopTimesMapperTest.java
@@ -1,20 +1,19 @@
 package org.opentripplanner.gtfs.mapping;
 
-import org.junit.Test;
-import org.onebusaway.gtfs.model.AgencyAndId;
-import org.onebusaway.gtfs.model.Stop;
-import org.onebusaway.gtfs.model.StopTime;
-import org.onebusaway.gtfs.model.Trip;
-
-import java.util.Collection;
-import java.util.Collections;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+
+import java.util.Collection;
+import java.util.Collections;
+import org.junit.Test;
+import org.onebusaway.gtfs.model.AgencyAndId;
+import org.onebusaway.gtfs.model.Stop;
+import org.onebusaway.gtfs.model.StopTime;
+import org.onebusaway.gtfs.model.Trip;
 
 public class StopTimesMapperTest {
     private static final String FEED_ID = "FEED";
@@ -69,6 +68,7 @@ public class StopTimesMapperTest {
     }
 
     private final StopMapper stopMapper = new StopMapper();
+    private final BookingRuleMapper bookingRuleMapper = new BookingRuleMapper();
     private final LocationMapper locationMapper = new LocationMapper();
     private final LocationGroupMapper locationGroupMapper = new LocationGroupMapper(stopMapper, locationMapper);
 
@@ -76,7 +76,8 @@ public class StopTimesMapperTest {
             stopMapper,
             locationMapper,
             locationGroupMapper,
-            new TripMapper(new RouteMapper(new AgencyMapper(FEED_ID)))
+            new TripMapper(new RouteMapper(new AgencyMapper(FEED_ID))),
+            bookingRuleMapper
     );
 
     @Test


### PR DESCRIPTION
### Summary

Currently OTP2 has support for a single `BookingInfo` per `StopTime`, while GTFS has support for a separate field for pickup and drop off.

* The internal OTP2 `StopTime` is extended to have dropoff and pickup `BookingInfo` fields
* A mapper for [GTFS `BookingRule`s](https://github.com/MobilityData/gtfs-flex/blob/master/spec/reference.md#gtfs-bookingrules) is added to the internal OTP2 model
* The NeTEx mapper is modified to fill both dropoff and pickup values with the same value
* The Legacy GraphQL API is modified to contain both `BookingInfo`s
* The Transmodel GraphQL API always returns the pickup booking info

### Issue

closes #3498

### Unit tests

None.

### Code style

:heavy_check_mark: 

### Documentation

No changes.

### Changelog

No changes.
