### PR TITLE
Additional parameters in trip request in debug client

### DIFF
--- a/src/client/js/otp/locale/en.json
+++ b/src/client/js/otp/locale/en.json
@@ -223,5 +223,6 @@
     "Depart_itinerary": "Depart",
     "depart_itinerary": "depart",
     "Start_popup": "Start",
-    "Depart_tripoptions": "Depart"
+    "Depart_tripoptions": "Depart",
+    "Additional parameters": "Additional parameters"
 }

--- a/src/client/js/otp/locale/no.json
+++ b/src/client/js/otp/locale/no.json
@@ -223,5 +223,6 @@
     "Depart_itinerary": "Avgang",
     "depart_itinerary": "Avreise",
     "Start_popup": "Start",
-    "Depart_tripoptions": "Avgang"
+    "Depart_tripoptions": "Avgang",
+    "Additional parameters": "Ekstra parametre"
 }

--- a/src/client/js/otp/modules/multimodal/MultimodalPlannerModule.js
+++ b/src/client/js/otp/modules/multimodal/MultimodalPlannerModule.js
@@ -81,6 +81,9 @@ otp.modules.multimodal.MultimodalPlannerModule =
         modeSelector.refreshModeControls();
 
         this.optionsWidget.addSeparator();
+        this.optionsWidget.addControl("additionalParameters", new otp.widgets.tripoptions.AdditionalTripParameters(this.optionsWidget))
+
+        this.optionsWidget.addSeparator();
         this.optionsWidget.addControl("submit", new otp.widgets.tripoptions.Submit(this.optionsWidget));
 
         this.optionsWidget.applyQueryParams(this.defaultQueryParams);

--- a/src/client/js/otp/modules/planner/PlannerModule.js
+++ b/src/client/js/otp/modules/planner/PlannerModule.js
@@ -368,6 +368,10 @@ otp.modules.planner.PlannerModule =
             if(otp.config.routerId !== undefined) {
                 queryParams.routerId = otp.config.routerId;
             }
+
+            if(this.additionalParameters) {
+                _.extend(queryParams, this.additionalParameters);
+            }
         }
         $('#otp-spinner').show();
 

--- a/src/client/js/otp/widgets/tripoptions/TripOptionsWidget.js
+++ b/src/client/js/otp/widgets/tripoptions/TripOptionsWidget.js
@@ -1210,10 +1210,12 @@ otp.widgets.tripoptions.GroupTripOptions =
 otp.widgets.tripoptions.AdditionalTripParameters =
     otp.Class(otp.widgets.tripoptions.TripOptionsWidgetControl, {
 
-        initialize : function(tripWidget, label) {
+        initialize : function(tripWidget) {
             otp.widgets.tripoptions.TripOptionsWidgetControl.prototype.initialize.apply(this, arguments);
             this.id = tripWidget.id+"-additionalParameters";
-            label = label || "Additional parameters: ";
+
+            var label = _tr("Additional parameters");
+
             var placeholder = "searchWindow=366"
                 + "\n# timetableView=false"
                 + "\nwaitReluctance=0.5"

--- a/src/client/js/otp/widgets/tripoptions/TripOptionsWidget.js
+++ b/src/client/js/otp/widgets/tripoptions/TripOptionsWidget.js
@@ -1220,7 +1220,9 @@ otp.widgets.tripoptions.AdditionalTripParameters =
                 + "\n# walkSpeed=1.7"
                 + "\n# numItineraries=25";
 
-            var html = '<div class="notDraggable">'+label+'<textarea id="'+this.id+'-value" style="width:300px;" rows="5" placeholder="'+placeholder+'"></textarea>';
+            var html = '<div class="notDraggable">'+label+': ';
+            html += '<textarea id="'+this.id+'-value" style="width:300px;" rows="5" placeholder="'+placeholder+'">'
+            html += '</textarea>';
             html += "</div>";
 
             $(html).appendTo(this.$());

--- a/src/client/js/otp/widgets/tripoptions/TripOptionsWidget.js
+++ b/src/client/js/otp/widgets/tripoptions/TripOptionsWidget.js
@@ -1214,7 +1214,13 @@ otp.widgets.tripoptions.AdditionalTripParameters =
             otp.widgets.tripoptions.TripOptionsWidgetControl.prototype.initialize.apply(this, arguments);
             this.id = tripWidget.id+"-additionalParameters";
             label = label || "Additional parameters: ";
-            var html = '<div class="notDraggable">'+label+'<input id="'+this.id+'-value" type="text" style="width:300px;" value="" />';
+            var placeholder = "searchWindow=366"
+                + "\n# timetableView=false"
+                + "\nwaitReluctance=0.5"
+                + "\n# walkSpeed=1.7"
+                + "\n# numItineraries=25";
+
+            var html = '<div class="notDraggable">'+label+'<textarea id="'+this.id+'-value" style="width:300px;" rows="5" placeholder="'+placeholder+'"></textarea>';
             html += "</div>";
 
             $(html).appendTo(this.$());
@@ -1223,13 +1229,15 @@ otp.widgets.tripoptions.AdditionalTripParameters =
         doAfterLayout : function() {
             var this_ = this;
             $('#'+this.id+'-value').change(function() {
-                var keyvalues = $('#'+this_.id+'-value').val().split(',');
+                var keyvalues = $('#'+this_.id+'-value').val().trim().split('\n');
 
                 var params = {};
 
                 keyvalues.forEach(function(keyvalue) {
-                    var split = keyvalue.split('=');
-                    params[split[0]] = split[1];
+                    var split = keyvalue.trim().split('=');
+                    if (!split[0].startsWith('#')) {
+                        params[split[0]] = split[1];
+                    }
                 })
 
                 this_.tripWidget.module.additionalParameters = params;

--- a/src/client/js/otp/widgets/tripoptions/TripOptionsWidget.js
+++ b/src/client/js/otp/widgets/tripoptions/TripOptionsWidget.js
@@ -1207,6 +1207,36 @@ otp.widgets.tripoptions.GroupTripOptions =
     }
 });
 
+otp.widgets.tripoptions.AdditionalTripParameters =
+    otp.Class(otp.widgets.tripoptions.TripOptionsWidgetControl, {
+
+        initialize : function(tripWidget, label) {
+            otp.widgets.tripoptions.TripOptionsWidgetControl.prototype.initialize.apply(this, arguments);
+            this.id = tripWidget.id+"-additionalParameters";
+            label = label || "Additional parameters: ";
+            var html = '<div class="notDraggable">'+label+'<input id="'+this.id+'-value" type="text" style="width:300px;" value="" />';
+            html += "</div>";
+
+            $(html).appendTo(this.$());
+        },
+
+        doAfterLayout : function() {
+            var this_ = this;
+            $('#'+this.id+'-value').change(function() {
+                var keyvalues = $('#'+this_.id+'-value').val().split(',');
+
+                var params = {};
+
+                keyvalues.forEach(function(keyvalue) {
+                    var split = keyvalue.split('=');
+                    params[split[0]] = split[1];
+                })
+
+                this_.tripWidget.module.additionalParameters = params;
+            });
+        },
+});
+
 /*otp.widgets.TW_GroupTripSubmit =
     otp.Class(otp.widgets.tripoptions.TripOptionsWidgetControl, {
 


### PR DESCRIPTION
### Summary
Adds a textarea input to the TripOptionsWidget in the debug client, which allows adding arbitrary query parameters to the REST call in the following format:

```
key=value
anotherKey=anotherValue
#comments=allowed
```

which are translated to the following and appended to the API query parameters:

```
key=value&anotherKey=anotherValue
```

![Screenshot 2021-06-04 at 18 38 32](https://user-images.githubusercontent.com/231492/120835058-21d5e700-c564-11eb-95e6-634b3e59e655.png)

### Issue
#3407 

### Unit tests
This change was manually tested.
