### PR TITLE
Wheelchair surfaces

### DIFF
--- a/src/main/java/org/opentripplanner/api/common/RoutingResource.java
+++ b/src/main/java/org/opentripplanner/api/common/RoutingResource.java
@@ -191,6 +191,15 @@ public abstract class RoutingResource {
     @QueryParam("waitAtBeginningFactor")
     protected Double waitAtBeginningFactor;
 
+    /**
+     * How should different road/surface types be preferred? Each "surfaceReluctance" would be a
+     * comma-separated pair, of "surface_key" * (as detailed at
+     * https://wiki.openstreetmap.org/wiki/Key:surface) and the reluctance factor (>1). Each
+     * "surfaceReluctance" pair should be separated by a semi-colon (;).
+     */
+    @QueryParam("surfaceReluctances")
+    protected String surfaceReluctances;
+
     /** The user's walking speed in meters/second. Defaults to approximately 3 MPH. */
     @QueryParam("walkSpeed")
     protected Double walkSpeed;
@@ -699,6 +708,9 @@ public abstract class RoutingResource {
 
         if (waitAtBeginningFactor != null)
             request.setWaitAtBeginningFactor(waitAtBeginningFactor);
+
+        if (surfaceReluctances != null)
+            request.setSurfaceReluctances(surfaceReluctances);
 
         if (walkSpeed != null)
             request.walkSpeed = walkSpeed;

--- a/src/main/java/org/opentripplanner/api/resource/PlannerResource.java
+++ b/src/main/java/org/opentripplanner/api/resource/PlannerResource.java
@@ -1,7 +1,9 @@
 package org.opentripplanner.api.resource;
 
+import javax.ws.rs.WebApplicationException;
 import org.glassfish.grizzly.http.server.Request;
 import org.opentripplanner.api.common.Message;
+import org.opentripplanner.api.common.ParameterException;
 import org.opentripplanner.api.common.RoutingResource;
 import org.opentripplanner.api.mapping.PlannerErrorMapper;
 import org.opentripplanner.api.mapping.TripPlanMapper;
@@ -91,6 +93,12 @@ public class PlannerResource extends RoutingResource {
             response.elevationMetadata.geoidElevation = request.geoidElevation;
 
             response.debugOutput = res.getDebugAggregator().finishedRendering();
+        }
+        catch (ParameterException ex) {
+            // probably shouldn't log it, since it is a user/parameter error, just report it back
+            PlannerError error = new PlannerError();
+            error.setMsg(ex.message);
+            response.setError(error);
         }
         catch (Exception e) {
             LOG.error("System error", e);

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModule.java
@@ -3,6 +3,7 @@ package org.opentripplanner.graph_builder.module.osm;
 import com.google.common.collect.Iterables;
 import gnu.trove.iterator.TLongIterator;
 import gnu.trove.list.TLongList;
+import java.util.Optional;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
@@ -1174,6 +1175,7 @@ public class OpenStreetMapModule implements GraphBuilderModule {
                 street.setHasBogusName(true);
             }
             street.setStairs(steps);
+            Optional.ofNullable(way.getSurface()).ifPresent(street::setSurface);
 
             /* TODO: This should probably generalized somehow? */
             if (!ignoreWheelchairAccessibility

--- a/src/main/java/org/opentripplanner/openstreetmap/model/OSMWay.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/model/OSMWay.java
@@ -3,9 +3,6 @@ package org.opentripplanner.openstreetmap.model;
 import gnu.trove.list.TLongList;
 import gnu.trove.list.array.TLongArrayList;
 
-import java.util.ArrayList;
-import java.util.List;
-
 public class OSMWay extends OSMWithTags {
 
     private TLongList nodes = new TLongArrayList();

--- a/src/main/java/org/opentripplanner/openstreetmap/model/OSMWay.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/model/OSMWay.java
@@ -128,4 +128,15 @@ public class OSMWay extends OSMWithTags {
                 || (cyclewayLeft != null && cyclewayLeft.startsWith("opposite"))
                 || (cyclewayRight != null && cyclewayRight.startsWith("opposite"));
     }
+
+    /**
+     * The possible surface values' documentation can be <a
+     * href="https://wiki.openstreetmap.org/wiki/Key:surface">seen here</a>. And an enumeration of
+     * all existing values <a href="https://taginfo.openstreetmap.org/keys/surface#values">can be
+     * found here</a>.
+     * @return The value of the {@code surface} tag of this way.
+     */
+    public String getSurface() {
+        return getTag("surface");
+    }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/mappers/RaptorRequestMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/mappers/RaptorRequestMapper.java
@@ -66,6 +66,7 @@ public class RaptorRequestMapper {
         }
 
         builder.mcCostFactors()
+                .surfaceReluctanceFactors(request.surfaceReluctances)
                 .waitReluctanceFactor(request.waitReluctance);
 
         if(request.modes.accessMode == StreetMode.WALK) {

--- a/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
@@ -1,5 +1,7 @@
 package org.opentripplanner.routing.api.request;
 
+import gnu.trove.map.TObjectDoubleMap;
+import gnu.trove.map.hash.TObjectDoubleHashMap;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.Serializable;
@@ -427,7 +429,7 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
     @Deprecated
     public double waitAtBeginningFactor = 0.4;
 
-    public Map<String, Double> surfaceReluctances;
+    public TObjectDoubleMap<String> surfaceReluctances;
 
     /**
      * This prevents unnecessary transfers by adding a cost for boarding a vehicle. This is in
@@ -1331,11 +1333,13 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
     }
 
     public void setSurfaceReluctances(String surfaceReluctances) throws ParameterException {
-        this.surfaceReluctances = new HashMap<>();
         if (surfaceReluctances == null) {
+            this.surfaceReluctances = new TObjectDoubleHashMap<>(0);
             return;
         }
-        for (String reluctanceWithSurface : surfaceReluctances.split(";")) {
+        String[] reluctanceSegments = surfaceReluctances.split(";");
+        this.surfaceReluctances = new TObjectDoubleHashMap<>(reluctanceSegments.length);
+        for (String reluctanceWithSurface : reluctanceSegments) {
             String[] surfaceAndReluctance = reluctanceWithSurface.split(",");
             if (surfaceAndReluctance.length != 2) {
                 throw new ParameterException(Message.BOGUS_PARAMETER);

--- a/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
@@ -429,7 +429,7 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
     @Deprecated
     public double waitAtBeginningFactor = 0.4;
 
-    public TObjectDoubleMap<String> surfaceReluctances;
+    public TObjectDoubleMap<String> surfaceReluctances = new TObjectDoubleHashMap<>(0);
 
     /**
      * This prevents unnecessary transfers by adding a cost for boarding a vehicle. This is in
@@ -1334,7 +1334,6 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
 
     public void setSurfaceReluctances(String surfaceReluctances) throws ParameterException {
         if (surfaceReluctances == null) {
-            this.surfaceReluctances = new TObjectDoubleHashMap<>(0);
             return;
         }
         String[] reluctanceSegments = surfaceReluctances.split(";");

--- a/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
@@ -427,6 +427,8 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
     @Deprecated
     public double waitAtBeginningFactor = 0.4;
 
+    public Map<String, Double> surfaceReluctances;
+
     /**
      * This prevents unnecessary transfers by adding a cost for boarding a vehicle. This is in
      * addition to the cost of the transfer(walking) and waiting-time. It is also in addition to
@@ -1325,6 +1327,29 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
     public void setWaitAtBeginningFactor(double waitAtBeginningFactor) {
         if (waitAtBeginningFactor > 0) {
             this.waitAtBeginningFactor = waitAtBeginningFactor;
+        }
+    }
+
+    public void setSurfaceReluctances(String surfaceReluctances) throws ParameterException {
+        this.surfaceReluctances = new HashMap<>();
+        if (surfaceReluctances == null) {
+            return;
+        }
+        for (String reluctanceWithSurface : surfaceReluctances.split(";")) {
+            String[] surfaceAndReluctance = reluctanceWithSurface.split(",");
+            if (surfaceAndReluctance.length != 2) {
+                throw new ParameterException(Message.BOGUS_PARAMETER);
+            }
+            String surface = surfaceAndReluctance[0];
+            try {
+                double reluctance = Double.parseDouble(surfaceAndReluctance[1]);
+                if (reluctance < 1) {
+                    throw new ParameterException(Message.BOGUS_PARAMETER);
+                }
+                this.surfaceReluctances.put(surface, reluctance);
+            } catch (NumberFormatException ex) {
+                throw new ParameterException(Message.BOGUS_PARAMETER);
+            }
         }
     }
 

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
@@ -117,6 +117,8 @@ public class StreetEdge extends Edge implements Cloneable, CarPickupableEdge {
     /** The angle at the start of the edge geometry. Internal representation like that of inAngle. */
     private byte outAngle;
 
+    private String surface;
+
     public StreetEdge(StreetVertex v1, StreetVertex v2, LineString geometry,
                       I18NString name, double length,
                       StreetTraversalPermission permission, boolean back) {
@@ -380,6 +382,13 @@ public class StreetEdge extends Edge implements Cloneable, CarPickupableEdge {
         } else {
             // TODO: this is being applied even when biking or driving.
             weight *= options.walkReluctance;
+        }
+        for (String surfaceToCheck : options.surfaceReluctances.keys(new String[0])) {
+            if (surfaceToCheck.equals(this.surface)) {
+                weight *= options.surfaceReluctances.get(surfaceToCheck);
+                // only up to one surface can match
+                break;
+            }
         }
 
         StateEditor s1 = s0.edit(this);
@@ -735,6 +744,14 @@ public class StreetEdge extends Edge implements Cloneable, CarPickupableEdge {
 	public void setSlopeOverride(boolean slopeOverride) {
 	    flags = BitSetUtils.set(flags, SLOPEOVERRIDE_FLAG_INDEX, slopeOverride);
 	}
+
+    public String getSurface() {
+        return surface;
+    }
+
+    public void setSurface(String surface) {
+        this.surface = surface;
+    }
 
     /**
      * Return the azimuth of the first segment in this edge in integer degrees clockwise from South.

--- a/src/main/java/org/opentripplanner/transit/raptor/api/request/McCostParams.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/request/McCostParams.java
@@ -1,6 +1,8 @@
 package org.opentripplanner.transit.raptor.api.request;
 
 
+import java.util.Collections;
+import java.util.Map;
 import javax.annotation.Nullable;
 import org.opentripplanner.routing.api.request.RoutingRequest;
 
@@ -20,6 +22,7 @@ public class McCostParams {
     private final double[] transitReluctanceFactors;
     private final double walkReluctanceFactor;
     private final double waitReluctanceFactor;
+    private final Map<String, Double> surfaceReluctanceFactors;
 
     /**
      * Default constructor defines default values. These defaults are
@@ -31,6 +34,7 @@ public class McCostParams {
         this.transitReluctanceFactors = null;
         this.walkReluctanceFactor = 4.0;
         this.waitReluctanceFactor = 1.0;
+        this.surfaceReluctanceFactors = Map.of();
     }
 
     McCostParams(McCostParamsBuilder builder) {
@@ -39,6 +43,7 @@ public class McCostParams {
         this.transitReluctanceFactors = builder.transitReluctanceFactors();
         this.walkReluctanceFactor = builder.walkReluctanceFactor();
         this.waitReluctanceFactor = builder.waitReluctanceFactor();
+        this.surfaceReluctanceFactors = Collections.unmodifiableMap(builder.surfaceReluctanceFactors());
     }
 
     public int boardCost() {
@@ -77,6 +82,10 @@ public class McCostParams {
         return waitReluctanceFactor;
     }
 
+    public Map<String, Double> surfaceReluctanceFactors() {
+        return surfaceReluctanceFactors;
+    }
+
     @Override
     public String toString() {
         return "McCostParams{" +
@@ -84,6 +93,7 @@ public class McCostParams {
                 ", transferCost=" + transferCost +
                 ", transferReluctanceFactor=" + walkReluctanceFactor +
                 ", waitReluctanceFactor=" + waitReluctanceFactor +
+                ", surfaceReluctanceFactors=" + surfaceReluctanceFactors +
                 '}';
     }
 
@@ -94,12 +104,13 @@ public class McCostParams {
         McCostParams that = (McCostParams) o;
         return boardCost == that.boardCost &&
                 transferCost == that.transferCost &&
+                surfaceReluctanceFactors.equals(that.surfaceReluctanceFactors) &&
                 Double.compare(that.walkReluctanceFactor, walkReluctanceFactor) == 0 &&
                 Double.compare(that.waitReluctanceFactor, waitReluctanceFactor) == 0;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(boardCost, transferCost, walkReluctanceFactor, waitReluctanceFactor);
+        return Objects.hash(boardCost, transferCost, walkReluctanceFactor, waitReluctanceFactor, surfaceReluctanceFactors);
     }
 }

--- a/src/main/java/org/opentripplanner/transit/raptor/api/request/McCostParams.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/request/McCostParams.java
@@ -1,8 +1,9 @@
 package org.opentripplanner.transit.raptor.api.request;
 
 
-import java.util.Collections;
-import java.util.Map;
+import gnu.trove.TCollections;
+import gnu.trove.map.TObjectDoubleMap;
+import gnu.trove.map.hash.TObjectDoubleHashMap;
 import javax.annotation.Nullable;
 import org.opentripplanner.routing.api.request.RoutingRequest;
 
@@ -22,7 +23,7 @@ public class McCostParams {
     private final double[] transitReluctanceFactors;
     private final double walkReluctanceFactor;
     private final double waitReluctanceFactor;
-    private final Map<String, Double> surfaceReluctanceFactors;
+    private final TObjectDoubleMap<String> surfaceReluctanceFactors;
 
     /**
      * Default constructor defines default values. These defaults are
@@ -34,7 +35,7 @@ public class McCostParams {
         this.transitReluctanceFactors = null;
         this.walkReluctanceFactor = 4.0;
         this.waitReluctanceFactor = 1.0;
-        this.surfaceReluctanceFactors = Map.of();
+        this.surfaceReluctanceFactors = new TObjectDoubleHashMap<>(0);
     }
 
     McCostParams(McCostParamsBuilder builder) {
@@ -43,7 +44,7 @@ public class McCostParams {
         this.transitReluctanceFactors = builder.transitReluctanceFactors();
         this.walkReluctanceFactor = builder.walkReluctanceFactor();
         this.waitReluctanceFactor = builder.waitReluctanceFactor();
-        this.surfaceReluctanceFactors = Collections.unmodifiableMap(builder.surfaceReluctanceFactors());
+        this.surfaceReluctanceFactors = TCollections.unmodifiableMap(builder.surfaceReluctanceFactors());
     }
 
     public int boardCost() {
@@ -82,7 +83,7 @@ public class McCostParams {
         return waitReluctanceFactor;
     }
 
-    public Map<String, Double> surfaceReluctanceFactors() {
+    public TObjectDoubleMap<String> surfaceReluctanceFactors() {
         return surfaceReluctanceFactors;
     }
 

--- a/src/main/java/org/opentripplanner/transit/raptor/api/request/McCostParamsBuilder.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/request/McCostParamsBuilder.java
@@ -1,6 +1,8 @@
 package org.opentripplanner.transit.raptor.api.request;
 
 
+import java.util.Map;
+
 /**
  * Mutable version of the {@link McCostParams}.
  */
@@ -11,6 +13,7 @@ public class McCostParamsBuilder {
     private double[] transitReluctanceFactors;
     private double walkReluctanceFactor;
     private double waitReluctanceFactor;
+    private Map<String, Double> surfaceReluctanceFactors;
 
 
     McCostParamsBuilder(McCostParams defaults) {
@@ -19,6 +22,7 @@ public class McCostParamsBuilder {
         this.transitReluctanceFactors = defaults.transitReluctanceFactors();
         this.walkReluctanceFactor = defaults.walkReluctanceFactor();
         this.waitReluctanceFactor = defaults.waitReluctanceFactor();
+        this.surfaceReluctanceFactors = defaults.surfaceReluctanceFactors();
     }
 
     public int boardCost() {
@@ -63,6 +67,15 @@ public class McCostParamsBuilder {
 
     public McCostParamsBuilder waitReluctanceFactor(double waitReluctanceFactor) {
         this.waitReluctanceFactor = waitReluctanceFactor;
+        return this;
+    }
+
+    public Map<String, Double> surfaceReluctanceFactors() {
+        return surfaceReluctanceFactors;
+    }
+
+    public McCostParamsBuilder surfaceReluctanceFactors(Map<String,Double> surfaceReluctanceFactors) {
+        this.surfaceReluctanceFactors = surfaceReluctanceFactors;
         return this;
     }
 }

--- a/src/main/java/org/opentripplanner/transit/raptor/api/request/McCostParamsBuilder.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/request/McCostParamsBuilder.java
@@ -1,7 +1,7 @@
 package org.opentripplanner.transit.raptor.api.request;
 
 
-import java.util.Map;
+import gnu.trove.map.TObjectDoubleMap;
 
 /**
  * Mutable version of the {@link McCostParams}.
@@ -13,7 +13,7 @@ public class McCostParamsBuilder {
     private double[] transitReluctanceFactors;
     private double walkReluctanceFactor;
     private double waitReluctanceFactor;
-    private Map<String, Double> surfaceReluctanceFactors;
+    private TObjectDoubleMap<String> surfaceReluctanceFactors;
 
 
     McCostParamsBuilder(McCostParams defaults) {
@@ -70,11 +70,11 @@ public class McCostParamsBuilder {
         return this;
     }
 
-    public Map<String, Double> surfaceReluctanceFactors() {
+    public TObjectDoubleMap<String> surfaceReluctanceFactors() {
         return surfaceReluctanceFactors;
     }
 
-    public McCostParamsBuilder surfaceReluctanceFactors(Map<String,Double> surfaceReluctanceFactors) {
+    public McCostParamsBuilder surfaceReluctanceFactors(TObjectDoubleMap<String> surfaceReluctanceFactors) {
         this.surfaceReluctanceFactors = surfaceReluctanceFactors;
         return this;
     }


### PR DESCRIPTION
## PR Instructions
When creating a pull request, please follow the format below. For each section, *replace* the guidance text with your own text, keeping the section heading. If you have nothing to say in a particular section, you can completely delete the section including its heading to indicate that you have taken the requested steps. None of these instructions or the guidance text (non-heading text) should be present in the submitted PR. These sections serve as a checklist: when you have replaced or deleted all of them, the PR is considered complete.

### Summary
Add an query parameter called "surfaceReluctances" to the routing plan API, allowing API users to penalize certain surfaces of roads.

### Issue
`closes #3524`

### Unit tests
A unit test for the new RoutingRequest parameter was added. Some integration tests could/should probably be added. 

I manually tested with cURL and saw that a different path was selected based on adding the reluctances. I tried to verify that the graph.obj file is not growing too much (after adding the "surface" attribute to the StreetEdge): before the change a graph.obj of Rheinland-Pfalz was 189 MB, and after it was 192 MB.

I also added a "surfaceReluctances" query parameter to the JS client-side code, and visually verified that adding and removing the reluctance for paving_stones, in my example, correctly routed around the paving stones path to a slightly longer path. A "Copy as cURL" dump of the request done by the web client of OTP is:

    curl 'http://localhost:8080/otp/routers/default/plan?surfaceReluctances=paving_stones%2C10&fromPlace=50.35674240253804%2C7.604073286056518&toPlace=50.35962408398314%2C7.604813575744628&time=12%3A03pm&date=06-05-2021&mode=TRANSIT%2CWALK&maxWalkDistance=4828.032&arriveBy=false&wheelchair=false&debugItineraryFilter=false&locale=en' -H 'Accept: application/json, text/javascript, */*; q=0.01' --compressed

I made the changes as small as possible, and I also incorporated usage of the GNU Trove library, which I saw was being used in several spaces to improve performance.

### Documentation
I added some Javadoc to the relevant methods, but I am not sure whether or not further documentation would need to be added to the API query parameter.
