### PR TITLE
Do not add alert patches to legs that are not transit legs

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/AlertToLegMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/AlertToLegMapper.java
@@ -20,6 +20,10 @@ import java.util.Set;
 public class AlertToLegMapper {
 
     public static void addAlertPatchesToLeg(Graph graph, Leg leg, boolean isFirstLeg, Locale requestedLocale) {
+
+        // Alert patches are only relevant for transit legs
+        if (!leg.isTransitLeg()) { return; }
+
         Set<StopCondition> departingStopConditions = isFirstLeg
                 ? StopCondition.DEPARTURE
                 : StopCondition.FIRST_DEPARTURE;
@@ -29,7 +33,7 @@ public class AlertToLegMapper {
         FeedScopedId fromStopId = leg.from==null ? null : leg.from.stopId;
         FeedScopedId toStopId = leg.to==null ? null : leg.to.stopId;
 
-        if (leg.isTransitLeg()) {
+        {
             FeedScopedId routeId = leg.getRoute().getId();
             if (fromStopId != null) {
                 Collection<TransitAlert> alerts = getAlertsForStopAndRoute(graph, fromStopId, routeId);
@@ -96,7 +100,7 @@ public class AlertToLegMapper {
             addAlertPatchesToLeg(leg, StopCondition.ARRIVING, alerts, requestedLocale, legStartTime, legEndTime);
         }
 
-        if(leg.isTransitLeg()) {
+        {
             Collection<TransitAlert> patches;
 
             // trips

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/AlertToLegMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/AlertToLegMapper.java
@@ -33,26 +33,24 @@ public class AlertToLegMapper {
         FeedScopedId fromStopId = leg.from==null ? null : leg.from.stopId;
         FeedScopedId toStopId = leg.to==null ? null : leg.to.stopId;
 
-        {
-            FeedScopedId routeId = leg.getRoute().getId();
-            if (fromStopId != null) {
-                Collection<TransitAlert> alerts = getAlertsForStopAndRoute(graph, fromStopId, routeId);
-                addAlertPatchesToLeg(leg, departingStopConditions, alerts, requestedLocale, legStartTime, legEndTime);
-            }
-            if (toStopId != null) {
-                Collection<TransitAlert> alerts = getAlertsForStopAndRoute(graph, toStopId, routeId);
-                addAlertPatchesToLeg(leg, StopCondition.ARRIVING, alerts, requestedLocale, legStartTime, legEndTime);
-            }
+        FeedScopedId routeId = leg.getRoute().getId();
+        if (fromStopId != null) {
+            Collection<TransitAlert> alerts = getAlertsForStopAndRoute(graph, fromStopId, routeId);
+            addAlertPatchesToLeg(leg, departingStopConditions, alerts, requestedLocale, legStartTime, legEndTime);
+        }
+        if (toStopId != null) {
+            Collection<TransitAlert> alerts = getAlertsForStopAndRoute(graph, toStopId, routeId);
+            addAlertPatchesToLeg(leg, StopCondition.ARRIVING, alerts, requestedLocale, legStartTime, legEndTime);
+        }
 
-            if (leg.intermediateStops != null) {
-                for (StopArrival visit : leg.intermediateStops) {
-                    Place place = visit.place;
-                    if (place.stopId != null) {
-                        Collection<TransitAlert> alerts = getAlertsForStopAndRoute(graph, place.stopId, routeId);
-                        Date stopArrival = visit.arrival.getTime();
-                        Date stopDepature = visit.departure.getTime();
-                        addAlertPatchesToLeg(leg, StopCondition.PASSING, alerts, requestedLocale, stopArrival, stopDepature);
-                    }
+        if (leg.intermediateStops != null) {
+            for (StopArrival visit : leg.intermediateStops) {
+                Place place = visit.place;
+                if (place.stopId != null) {
+                    Collection<TransitAlert> alerts = getAlertsForStopAndRoute(graph, place.stopId, routeId);
+                    Date stopArrival = visit.arrival.getTime();
+                    Date stopDepature = visit.departure.getTime();
+                    addAlertPatchesToLeg(leg, StopCondition.PASSING, alerts, requestedLocale, stopArrival, stopDepature);
                 }
             }
 
@@ -100,21 +98,19 @@ public class AlertToLegMapper {
             addAlertPatchesToLeg(leg, StopCondition.ARRIVING, alerts, requestedLocale, legStartTime, legEndTime);
         }
 
-        {
-            Collection<TransitAlert> patches;
+        Collection<TransitAlert> patches;
 
-            // trips
-            patches = alertPatchService(graph).getTripAlerts(leg.getTrip().getId());
-            addAlertPatchesToLeg(leg, patches, requestedLocale, legStartTime, legEndTime);
+        // trips
+        patches = alertPatchService(graph).getTripAlerts(leg.getTrip().getId());
+        addAlertPatchesToLeg(leg, patches, requestedLocale, legStartTime, legEndTime);
 
-            // route
-            patches = alertPatchService(graph).getRouteAlerts(leg.getRoute().getId());
-            addAlertPatchesToLeg(leg, patches, requestedLocale, legStartTime, legEndTime);
+        // route
+        patches = alertPatchService(graph).getRouteAlerts(leg.getRoute().getId());
+        addAlertPatchesToLeg(leg, patches, requestedLocale, legStartTime, legEndTime);
 
-            // agency
-            patches = alertPatchService(graph).getAgencyAlerts(leg.getAgency().getId());
-            addAlertPatchesToLeg(leg, patches, requestedLocale, legStartTime, legEndTime);
-        }
+        // agency
+        patches = alertPatchService(graph).getAgencyAlerts(leg.getAgency().getId());
+        addAlertPatchesToLeg(leg, patches, requestedLocale, legStartTime, legEndTime);
 
         // Filter alerts when there are multiple timePeriods for each alert
         leg.transitAlerts.removeIf(alertPatch ->  !alertPatch.displayDuring(leg.startTime.getTimeInMillis()/1000, leg.endTime.getTimeInMillis()/1000));

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/AlertToLegMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/AlertToLegMapper.java
@@ -19,7 +19,7 @@ import java.util.Set;
 
 public class AlertToLegMapper {
 
-    public static void addAlertPatchesToLeg(Graph graph, Leg leg, boolean isFirstLeg, Locale requestedLocale) {
+    public static void addTransitAlertPatchesToLeg(Graph graph, Leg leg, boolean isFirstLeg, Locale requestedLocale) {
 
         // Alert patches are only relevant for transit legs
         if (!leg.isTransitLeg()) { return; }
@@ -36,11 +36,11 @@ public class AlertToLegMapper {
         FeedScopedId routeId = leg.getRoute().getId();
         if (fromStopId != null) {
             Collection<TransitAlert> alerts = getAlertsForStopAndRoute(graph, fromStopId, routeId);
-            addAlertPatchesToLeg(leg, departingStopConditions, alerts, requestedLocale, legStartTime, legEndTime);
+            addTransitAlertPatchesToLeg(leg, departingStopConditions, alerts, requestedLocale, legStartTime, legEndTime);
         }
         if (toStopId != null) {
             Collection<TransitAlert> alerts = getAlertsForStopAndRoute(graph, toStopId, routeId);
-            addAlertPatchesToLeg(leg, StopCondition.ARRIVING, alerts, requestedLocale, legStartTime, legEndTime);
+            addTransitAlertPatchesToLeg(leg, StopCondition.ARRIVING, alerts, requestedLocale, legStartTime, legEndTime);
         }
 
         if (leg.intermediateStops != null) {
@@ -50,18 +50,18 @@ public class AlertToLegMapper {
                     Collection<TransitAlert> alerts = getAlertsForStopAndRoute(graph, place.stopId, routeId);
                     Date stopArrival = visit.arrival.getTime();
                     Date stopDepature = visit.departure.getTime();
-                    addAlertPatchesToLeg(leg, StopCondition.PASSING, alerts, requestedLocale, stopArrival, stopDepature);
+                    addTransitAlertPatchesToLeg(leg, StopCondition.PASSING, alerts, requestedLocale, stopArrival, stopDepature);
                 }
             }
 
             FeedScopedId tripId = leg.getTrip().getId();
             if (fromStopId != null) {
                 Collection<TransitAlert> alerts = getAlertsForStopAndTrip(graph, fromStopId, tripId);
-                addAlertPatchesToLeg(leg, departingStopConditions, alerts, requestedLocale, legStartTime, legEndTime);
+                addTransitAlertPatchesToLeg(leg, departingStopConditions, alerts, requestedLocale, legStartTime, legEndTime);
             }
             if (toStopId != null) {
                 Collection<TransitAlert> alerts = getAlertsForStopAndTrip(graph, toStopId, tripId);
-                addAlertPatchesToLeg(leg, StopCondition.ARRIVING, alerts, requestedLocale, legStartTime, legEndTime);
+                addTransitAlertPatchesToLeg(leg, StopCondition.ARRIVING, alerts, requestedLocale, legStartTime, legEndTime);
             }
             if (leg.intermediateStops != null) {
                 for (StopArrival visit : leg.intermediateStops) {
@@ -70,7 +70,7 @@ public class AlertToLegMapper {
                         Collection<TransitAlert> alerts = getAlertsForStopAndTrip(graph, place.stopId, tripId);
                         Date stopArrival = visit.arrival.getTime();
                         Date stopDepature = visit.departure.getTime();
-                        addAlertPatchesToLeg(leg, StopCondition.PASSING, alerts, requestedLocale, stopArrival, stopDepature);
+                        addTransitAlertPatchesToLeg(leg, StopCondition.PASSING, alerts, requestedLocale, stopArrival, stopDepature);
                     }
                 }
             }
@@ -83,34 +83,34 @@ public class AlertToLegMapper {
                     Collection<TransitAlert> alerts = getAlertsForStop(graph, place.stopId);
                     Date stopArrival = visit.arrival.getTime();
                     Date stopDepature = visit.departure.getTime();
-                    addAlertPatchesToLeg(leg, StopCondition.PASSING, alerts, requestedLocale, stopArrival, stopDepature);
+                    addTransitAlertPatchesToLeg(leg, StopCondition.PASSING, alerts, requestedLocale, stopArrival, stopDepature);
                 }
             }
         }
 
         if (leg.from != null && fromStopId != null) {
             Collection<TransitAlert> alerts = getAlertsForStop(graph, fromStopId);
-            addAlertPatchesToLeg(leg, departingStopConditions, alerts, requestedLocale, legStartTime, legEndTime);
+            addTransitAlertPatchesToLeg(leg, departingStopConditions, alerts, requestedLocale, legStartTime, legEndTime);
         }
 
         if (leg.to != null && toStopId != null) {
             Collection<TransitAlert> alerts = getAlertsForStop(graph, toStopId);
-            addAlertPatchesToLeg(leg, StopCondition.ARRIVING, alerts, requestedLocale, legStartTime, legEndTime);
+            addTransitAlertPatchesToLeg(leg, StopCondition.ARRIVING, alerts, requestedLocale, legStartTime, legEndTime);
         }
 
         Collection<TransitAlert> patches;
 
         // trips
         patches = alertPatchService(graph).getTripAlerts(leg.getTrip().getId());
-        addAlertPatchesToLeg(leg, patches, requestedLocale, legStartTime, legEndTime);
+        addTransitAlertPatchesToLeg(leg, patches, requestedLocale, legStartTime, legEndTime);
 
         // route
         patches = alertPatchService(graph).getRouteAlerts(leg.getRoute().getId());
-        addAlertPatchesToLeg(leg, patches, requestedLocale, legStartTime, legEndTime);
+        addTransitAlertPatchesToLeg(leg, patches, requestedLocale, legStartTime, legEndTime);
 
         // agency
         patches = alertPatchService(graph).getAgencyAlerts(leg.getAgency().getId());
-        addAlertPatchesToLeg(leg, patches, requestedLocale, legStartTime, legEndTime);
+        addTransitAlertPatchesToLeg(leg, patches, requestedLocale, legStartTime, legEndTime);
 
         // Filter alerts when there are multiple timePeriods for each alert
         leg.transitAlerts.removeIf(alertPatch ->  !alertPatch.displayDuring(leg.startTime.getTimeInMillis()/1000, leg.endTime.getTimeInMillis()/1000));
@@ -264,7 +264,7 @@ public class AlertToLegMapper {
     }
 
 
-    private static void addAlertPatchesToLeg(Leg leg, Collection<StopCondition> stopConditions, Collection<TransitAlert> alertPatches, Locale requestedLocale, Date fromTime, Date toTime) {
+    private static void addTransitAlertPatchesToLeg(Leg leg, Collection<StopCondition> stopConditions, Collection<TransitAlert> alertPatches, Locale requestedLocale, Date fromTime, Date toTime) {
         if (alertPatches != null) {
             for (TransitAlert alert : alertPatches) {
                 if (alert.displayDuring(fromTime.getTime() / 1000, toTime.getTime() / 1000)) {
@@ -284,7 +284,7 @@ public class AlertToLegMapper {
         }
     }
 
-    private static void addAlertPatchesToLeg(Leg leg, Collection<TransitAlert> alertPatches, Locale requestedLocale, Date fromTime, Date toTime) {
-        addAlertPatchesToLeg(leg, null, alertPatches, requestedLocale, fromTime, toTime);
+    private static void addTransitAlertPatchesToLeg(Leg leg, Collection<TransitAlert> alertPatches, Locale requestedLocale, Date fromTime, Date toTime) {
+        addTransitAlertPatchesToLeg(leg, null, alertPatches, requestedLocale, fromTime, toTime);
     }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/GraphPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/GraphPathToItineraryMapper.java
@@ -129,7 +129,7 @@ public abstract class GraphPathToItineraryMapper {
 
         boolean first = true;
         for (Leg leg : legs) {
-            AlertToLegMapper.addAlertPatchesToLeg(graph, leg, first, requestedLocale);
+            AlertToLegMapper.addTransitAlertPatchesToLeg(graph, leg, first, requestedLocale);
             first = false;
         }
 
@@ -303,7 +303,7 @@ public abstract class GraphPathToItineraryMapper {
             }
         }
 
-        addAlerts(graph, leg, states);
+        addStreetNotes(graph, leg, states);
 
         if (flexEdge != null) {
             FlexLegMapper.fixFlexTripLeg(leg, flexEdge);
@@ -424,7 +424,7 @@ public abstract class GraphPathToItineraryMapper {
      * @param leg The leg to add the mode and alerts to
      * @param states The states that go with the leg
      */
-    private static void addAlerts(Graph graph, Leg leg, State[] states) {
+    private static void addStreetNotes(Graph graph, Leg leg, State[] states) {
         for (State state : states) {
             Set<StreetNote> streetNotes = graph.streetNotesService.getNotes(state);
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
@@ -222,7 +222,7 @@ public class RaptorPathToItineraryMapper {
         // leg.alightRule = <Assign here>;
         // leg.boardRule =  <Assign here>;
 
-        AlertToLegMapper.addAlertPatchesToLeg(
+        AlertToLegMapper.addTransitAlertPatchesToLeg(
             graph,
             leg,
             firstLeg,


### PR DESCRIPTION
### Summary
Now and then we would get alerts on non-transit legs. This happened when searching to/from a stop and the alert was added to the stop itself. We do not want these alerts on non-transit legs.

This PR adds a check to the top of the AlertToLegMapper::addAlertPatchesToLeg method that returns if the leg is not a transit leg.

### Issue
No issue

### Unit tests
Tested manually