### PR TITLE
Flex: check pickup/dropoff restrictions before finding the closest stop

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/flex/FlexRouter.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/FlexRouter.java
@@ -136,7 +136,7 @@ public class FlexRouter {
     if (this.flexAccessTemplates != null) { return; }
 
     // Fetch the closest flexTrips reachable from the access stops
-    this.flexAccessTemplates = getClosestFlexTrips(streetAccesses)
+    this.flexAccessTemplates = getClosestFlexTrips(streetAccesses, true)
         // For each date the router has data for
         .flatMap(t2 -> Arrays.stream(dates)
             // Discard if service is not running on date
@@ -154,7 +154,7 @@ public class FlexRouter {
     if (this.flexEgressTemplates != null) { return; }
 
     // Fetch the closest flexTrips reachable from the egress stops
-    this.flexEgressTemplates = getClosestFlexTrips(streetEgresses)
+    this.flexEgressTemplates = getClosestFlexTrips(streetEgresses, false)
         // For each date the router has data for
         .flatMap(t2 -> Arrays.stream(dates)
             // Discard if service is not running on date
@@ -168,12 +168,13 @@ public class FlexRouter {
         .collect(Collectors.toList());;
   }
 
-  private Stream<T2<NearbyStop, FlexTrip>> getClosestFlexTrips(Collection<NearbyStop> nearbyStops) {
+  private Stream<T2<NearbyStop, FlexTrip>> getClosestFlexTrips(Collection<NearbyStop> nearbyStops, boolean pickup) {
     // Find all trips reachable from the nearbyStops
     Stream<T2<NearbyStop, FlexTrip>> flexTripsReachableFromNearbyStops = nearbyStops
         .stream()
         .flatMap(accessEgress -> flexIndex
             .getFlexTripsByStop(accessEgress.stop)
+            .filter(flexTrip -> pickup ? flexTrip.isBoardingPossible(accessEgress) : flexTrip.isAlightingPossible(accessEgress))
             .map(flexTrip -> new T2<>(accessEgress, flexTrip)));
 
     // Group all (NearbyStop, FlexTrip) tuples by flexTrip

--- a/src/ext/java/org/opentripplanner/ext/flex/trip/FlexTrip.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/trip/FlexTrip.java
@@ -49,4 +49,8 @@ public abstract class FlexTrip extends TransitEntity {
   public abstract BookingInfo getDropOffBookingInfo(int i);
 
   public abstract BookingInfo getPickupBookingInfo(int i);
+
+  public abstract boolean isBoardingPossible(NearbyStop stop);
+
+  public abstract boolean isAlightingPossible(NearbyStop stop);
 }

--- a/src/ext/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTrip.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTrip.java
@@ -146,6 +146,16 @@ public class ScheduledDeviatedTrip extends FlexTrip {
     return pickupBookingInfos[i];
   }
 
+  @Override
+  public boolean isBoardingPossible(NearbyStop stop) {
+    return getFromIndex(stop) != -1;
+  }
+
+  @Override
+  public boolean isAlightingPossible(NearbyStop stop) {
+    return getToIndex(stop) != -1;
+  }
+
   private Collection<StopLocation> expandStops(StopLocation stop) {
     return stop instanceof FlexLocationGroup
         ? ((FlexLocationGroup) stop).getLocations()

--- a/src/ext/java/org/opentripplanner/ext/flex/trip/UnscheduledTrip.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/trip/UnscheduledTrip.java
@@ -147,6 +147,16 @@ public class UnscheduledTrip extends FlexTrip {
     return pickupBookingInfos[i];
   }
 
+  @Override
+  public boolean isBoardingPossible(NearbyStop stop) {
+    return getFromIndex(stop) != -1;
+  }
+
+  @Override
+  public boolean isAlightingPossible(NearbyStop stop) {
+    return getToIndex(stop) != -1;
+  }
+
   private Collection<StopLocation> expandStops(StopLocation stop) {
     return stop instanceof FlexLocationGroup
         ? ((FlexLocationGroup) stop).getLocations()


### PR DESCRIPTION
### Summary

When searching for flex trips the closest `StopLocation` is found without checkout the pick up / drop off type. This means that it might not actually be usable for boarding / alighting.

This is fixed by updating `closestFlexTrip()` to make sure that the found stop/trip combinations can be used for boarding / alighting as intended.

### Issue


### Unit tests

None.

### Code style

:ballot_box_with_check: 

### Documentation

No changes.

### Changelog

No changes.