### PR TITLE
Allow fetching notices on stop times

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/et/EstimatedCallType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/et/EstimatedCallType.java
@@ -211,9 +211,8 @@ public class EstimatedCallType {
                     .name("notices")
                     .type(new GraphQLNonNull(new GraphQLList(noticeType)))
                     .dataFetcher(environment -> {
-                        // TODO OTP2 - Fix it!
-                        //TripTimeShort tripTimeShort = environment.getSource();
-                        return Collections.emptyList(); //index.getNoticesByEntity(tripTimeShort.stopTimeId);
+                        TripTimeShort tripTimeShort = environment.getSource();
+                        return GqlUtil.getRoutingService(environment).getNoticesByEntity(tripTimeShort.getStopTimeKey());
                     })
                     .build())
             .field(GraphQLFieldDefinition.newFieldDefinition()

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/TimetabledPassingTimeType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/TimetabledPassingTimeType.java
@@ -116,9 +116,8 @@ public class TimetabledPassingTimeType {
             .name("notices")
             .type(new GraphQLNonNull(new GraphQLList(noticeType)))
             .dataFetcher(environment -> {
-              // TODO OTP2 - fix this
-              // TripTimeShort tripTimeShort = environment.getSource();
-              return null; //index.getNoticesByEntity(tripTimeShort.);
+              TripTimeShort tripTimeShort = environment.getSource();
+              return GqlUtil.getRoutingService(environment).getNoticesByEntity(tripTimeShort.getStopTimeKey());
             })
             .build())
         .field(GraphQLFieldDefinition

--- a/src/main/java/org/opentripplanner/model/TripTimeShort.java
+++ b/src/main/java/org/opentripplanner/model/TripTimeShort.java
@@ -200,4 +200,8 @@ public class TripTimeShort {
     public int getDropoffType() {
         return dropoffType;
     }
+
+    public StopTimeKey getStopTimeKey() {
+        return new StopTimeKey(trip.getId(), stopIndex);
+    }
 }


### PR DESCRIPTION
### Summary
This allows the transmodel API to fetch notices on `PassingTime` and `EstimatedCall`. A new method has been added to StopTimeShort in order to provide the correct key for the `getNoticesByEntity` method.

### Unit tests
Tested manually