### PR TITLE
Store / Add GBFS rental URIs to the internal model / legacy API

### DIFF
--- a/docs/sandbox/LegacyGraphQLApi.md
+++ b/docs/sandbox/LegacyGraphQLApi.md
@@ -12,6 +12,7 @@
 - Implemented modeWeight and added debugItineraryFilter to plan query. Added systemNotices to itineraries (May 2021, https://github.com/opentripplanner/OpenTripPlanner/pull/3503)
 - Updated to ignore modes which are not valid in OTP2 (June 2021, https://github.com/opentripplanner/OpenTripPlanner/pull/3464)
 - Add Leg#walkingBike (June 2021, https://github.com/opentripplanner/OpenTripPlanner/pull/3550)
+- Add GBFS bike rental URIs to bike rental stations (June 2021, https://github.com/opentripplanner/OpenTripPlanner/pull/3543)
 
 ## Documentation
 

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLBikeRentalStationImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLBikeRentalStationImpl.java
@@ -5,6 +5,7 @@ import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import org.opentripplanner.ext.legacygraphqlapi.generated.LegacyGraphQLDataFetchers;
 import org.opentripplanner.routing.bike_rental.BikeRentalStation;
+import org.opentripplanner.routing.bike_rental.BikeRentalStationUris;
 
 public class LegacyGraphQLBikeRentalStationImpl implements LegacyGraphQLDataFetchers.LegacyGraphQLBikeRentalStation {
     @Override
@@ -76,6 +77,11 @@ public class LegacyGraphQLBikeRentalStationImpl implements LegacyGraphQLDataFetc
     public DataFetcher<Integer> capacity() {
         // TODO implement this
         return environment -> 0;
+    }
+
+    @Override
+    public DataFetcher<BikeRentalStationUris> rentalUris() {
+        return environment -> getSource(environment).rentalUris;
     }
 
     private BikeRentalStation getSource(DataFetchingEnvironment environment) {

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/LegacyGraphQLDataFetchers.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/LegacyGraphQLDataFetchers.java
@@ -10,6 +10,7 @@ import org.opentripplanner.routing.bike_park.BikePark;
 import org.opentripplanner.routing.bike_rental.BikeRentalStation;
 import org.locationtech.jts.geom.Coordinate;
 import org.opentripplanner.api.resource.DebugOutput;
+import org.opentripplanner.routing.bike_rental.BikeRentalStationUris;
 import org.opentripplanner.routing.graphfinder.PatternAtStop;
 import org.opentripplanner.common.model.P2;
 import java.util.Map;
@@ -26,12 +27,9 @@ import org.opentripplanner.routing.api.response.RoutingResponse;
 import org.opentripplanner.model.Route;
 import org.opentripplanner.model.plan.WalkStep;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
-import graphql.relay.Connection;
-import graphql.relay.Edge;
 import org.opentripplanner.model.TripTimeShort;
 import org.opentripplanner.model.StopTimesInPattern;
 import org.opentripplanner.routing.core.FareRuleSet;
-import java.util.Map;
 import org.opentripplanner.model.Trip;
 import org.opentripplanner.model.SystemNotice;
 import graphql.schema.TypeResolver;
@@ -115,6 +113,17 @@ public class LegacyGraphQLDataFetchers {
         public DataFetcher<Integer> capacity();
 
         public DataFetcher<Boolean> allowOverloading();
+
+        public DataFetcher<BikeRentalStationUris> rentalUris();
+    }
+
+    public interface LegacyGraphQLBikeRentalStationUris {
+
+        public DataFetcher<String> android();
+
+        public DataFetcher<String> ios();
+
+        public DataFetcher<String> web();
     }
 
     /**

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/graphql-codegen.yml
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/graphql-codegen.yml
@@ -31,6 +31,7 @@ config:
     AlertSeverityLevelType: String
     BikePark: org.opentripplanner.routing.bike_park.BikePark#BikePark
     BikeRentalStation: org.opentripplanner.routing.bike_rental.BikeRentalStation#BikeRentalStation
+    BikeRentalStationUris: org.opentripplanner.routing.bike_rental.BikeRentalStationUris#BikeRentalStationUris
     BikesAllowed: String
     BookingInfo: org.opentripplanner.model.BookingInfo
     BookingTime: org.opentripplanner.model.BookingTime

--- a/src/ext/resources/legacygraphqlapi/schema.graphqls
+++ b/src/ext/resources/legacygraphqlapi/schema.graphqls
@@ -289,6 +289,31 @@ type BikeRentalStation implements Node & PlaceInterface {
 
     """If true, bikes can be returned even if spacesAvailable is zero or bikes > capacity."""
     allowOverloading: Boolean
+
+    """Platform-specific URLs to begin renting a bike from this station."""
+    rentalUris: BikeRentalStationUris
+}
+
+type BikeRentalStationUris {
+    """
+    A URI that can be passed to an Android app with an {@code android.intent.action.VIEW} Android
+    intent to support Android Deep Links.
+    May be null if a rental URI does not exist.
+    """
+    android: String
+
+    """
+    A URI that can be used on iOS to launch the rental app for this station.
+    May be {@code null} if a rental URI does not exist.
+    """
+    ios: String
+
+    """
+    A URL that can be used by a web browser to show more information about renting a vehicle at
+    this station.
+    May be {@code null} if a rental URL does not exist.
+    """
+    web: String
 }
 
 enum BikesAllowed {

--- a/src/main/java/org/opentripplanner/routing/bike_rental/BikeRentalStation.java
+++ b/src/main/java/org/opentripplanner/routing/bike_rental/BikeRentalStation.java
@@ -64,6 +64,9 @@ public class BikeRentalStation implements Serializable, Cloneable {
     @JsonIgnore
     public transient Locale locale = ResourceBundleSingleton.INSTANCE.getLocale(null);
 
+    @JsonSerialize
+    public BikeRentalStationUris rentalUris;
+
     /**
      * FIXME nonstandard definition of equals, relying on only the station field.
      * We should probably be keying collections on station ID rather than the station object with nonstandard equals.
@@ -100,4 +103,5 @@ public class BikeRentalStation implements Serializable, Cloneable {
     public String getName() {
         return name.toString(locale);
     }
+
 }

--- a/src/main/java/org/opentripplanner/routing/bike_rental/BikeRentalStationUris.java
+++ b/src/main/java/org/opentripplanner/routing/bike_rental/BikeRentalStationUris.java
@@ -1,0 +1,43 @@
+package org.opentripplanner.routing.bike_rental;
+
+import javax.annotation.Nullable;
+
+/**
+ * Contains rental URIs for Android, iOS, and web in the android, ios, and web fields. See the
+ * <a href="https://github.com/NABSA/gbfs/blob/v2.2/gbfs.md#station_informationjson">GBFS station_information.json specification</a>
+ * for more details.
+ */
+public class BikeRentalStationUris {
+
+    /**
+     * A URI that can be passed to an Android app with an {@code android.intent.action.VIEW} Android
+     * intent to support Android Deep Links.
+     *
+     * May be {@code null} if a rental URI does not exist.
+     */
+    @Nullable
+    public final String android;
+
+    /**
+     * A URI that can be used on iOS to launch the rental app for this station.
+     *
+     * May be {@code null} if a rental URI does not exist.
+     */
+    @Nullable
+    public final String ios;
+
+    /**
+     * At URL that can be used by a web browser to show more information about renting a vehicle at
+     * this station.
+     *
+     * May be {@code null} if a rental URL does not exist.
+     */
+    @Nullable
+    public final String web;
+
+    public BikeRentalStationUris(String android, String ios, String web) {
+        this.android = android;
+        this.ios = ios;
+        this.web = web;
+    }
+}

--- a/src/main/java/org/opentripplanner/updater/bike_rental/datasources/GbfsBikeRentalDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/bike_rental/datasources/GbfsBikeRentalDataSource.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Sets;
 import org.opentripplanner.routing.bike_rental.BikeRentalStation;
+import org.opentripplanner.routing.bike_rental.BikeRentalStationUris;
 import org.opentripplanner.updater.bike_rental.BikeRentalDataSource;
 import org.opentripplanner.updater.bike_rental.datasources.params.GbfsBikeRentalDataSourceParameters;
 import org.opentripplanner.util.HttpUtils;
@@ -184,6 +185,15 @@ class GbfsBikeRentalDataSource implements BikeRentalDataSource {
             brstation.name =  new NonLocalizedString(stationNode.path("name").asText());
             brstation.isKeepingBicycleRentalAtDestinationAllowed = config.allowKeepingRentedBicycleAtDestination();
             brstation.isCarStation = routeAsCar;
+
+            if (stationNode.has("rental_uris")) {
+                var rentalUrisObject = stationNode.path("rental_uris");
+                String androidUri = rentalUrisObject.has("android") ? rentalUrisObject.get("android").asText() : null;
+                String iosUri = rentalUrisObject.has("ios") ? rentalUrisObject.get("ios").asText() : null;
+                String webUri = rentalUrisObject.has("web") ? rentalUrisObject.get("web").asText() : null;
+                brstation.rentalUris = new BikeRentalStationUris(androidUri, iosUri, webUri);
+            }
+
             return brstation;
         }
     }


### PR DESCRIPTION
### Summary

Currently the deep-links for renting bikes in GBFS are not parsed -- this modifies the parsing to:
 * store the deep-links on `BikeRentalStation`
 * and adds the new values to the LegacyGraphQL API

### Issue

closes #3507 

### Unit tests

No changes.

### Code style

:ballot_box_with_check: 

### Documentation

No changes.

### Changelog

No changes -- an entry is added for the LegacyGraphQL API.