### PR TITLE
Adding support for including realtime-added trips in trip-requests

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
@@ -500,7 +500,12 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
 //        }
 
         ServiceDate serviceDate = getServiceDateForEstimatedVehicleJourney(estimatedVehicleJourney);
+
+        if(serviceDate == null) { return false; }
+
         FeedScopedId calServiceId = graph.getOrCreateServiceIdForDate(serviceDate);
+
+        if(calServiceId == null) { return false; }
 
         trip.setServiceId(calServiceId);
 

--- a/src/main/java/org/opentripplanner/routing/graph/Graph.java
+++ b/src/main/java/org/opentripplanner/routing/graph/Graph.java
@@ -674,7 +674,14 @@ public class Graph implements Serializable {
         FeedScopedId serviceId = ((CalendarServiceImpl)getCalendarService()).getOrCreateServiceIdForDate(serviceDate);
 
         if (!serviceCodes.containsKey(serviceId)) {
-            serviceCodes.put(serviceId, serviceCodes.size());
+            // Calculating new unique serviceCode based on size (!)
+            final int serviceCode = serviceCodes.size();
+            serviceCodes.put(serviceId, serviceCode);
+
+            if (index.getServiceCodesRunningForDate().containsKey(serviceDate)) {
+                // Need to add to serviceCodeRunningForDate-index so it is included in trip-requests
+                index.getServiceCodesRunningForDate().get(serviceDate).add(serviceCode);
+            }
         }
         return serviceId;
     }

--- a/src/main/java/org/opentripplanner/routing/graph/Graph.java
+++ b/src/main/java/org/opentripplanner/routing/graph/Graph.java
@@ -12,6 +12,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import gnu.trove.list.TDoubleList;
 import gnu.trove.list.linked.TDoubleLinkedList;
+import gnu.trove.set.hash.TIntHashSet;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
@@ -35,6 +36,7 @@ import java.util.prefs.Preferences;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import javax.annotation.Nullable;
 import org.apache.commons.math3.stat.descriptive.rank.Median;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Envelope;
@@ -660,14 +662,27 @@ public class Graph implements Serializable {
 
     /**
      * Get or create a serviceId for a given date. This method is used when a new trip is
-     * added from a realtime data update.
+     * added from a realtime data update. It make sure the date is in the existing transit service
+     * period.
      *
      * TODO OTP2 - This is NOT THREAD-SAFE and is used in the real-time updaters, we need to fix
      *           - this when doing the issue #3030.
      *
      * @param serviceDate service date for the added service id
+     *
+     * @return service-id for date if it exist or is created. If the given service date is outside
+     * the service period {@code null} is returned.
      */
+    @Nullable
     public FeedScopedId getOrCreateServiceIdForDate(ServiceDate serviceDate) {
+
+        // Start of day
+        long time = serviceDate.toZonedDateTime(getTimeZone().toZoneId(), 0).toEpochSecond();
+
+        if(time < transitServiceStarts || time >= transitServiceEnds) {
+            return null;
+        }
+
         // We make an explicit cast here to avoid adding the 'getOrCreateServiceIdForDate(..)'
         // method to the {@link CalendarService} interface. We do not want to expose it because it
         // is not thread-safe - and we want to limit the usage. See JavaDoc above as well.
@@ -678,10 +693,9 @@ public class Graph implements Serializable {
             final int serviceCode = serviceCodes.size();
             serviceCodes.put(serviceId, serviceCode);
 
-            if (index.getServiceCodesRunningForDate().containsKey(serviceDate)) {
-                // Need to add to serviceCodeRunningForDate-index so it is included in trip-requests
-                index.getServiceCodesRunningForDate().get(serviceDate).add(serviceCode);
-            }
+            index.getServiceCodesRunningForDate()
+                    .computeIfAbsent(serviceDate, (ignored) -> new TIntHashSet())
+                    .add(serviceCode);
         }
         return serviceId;
     }


### PR DESCRIPTION
When adding a trip in realtime-data, it is added to the graph, but it also needs to be added to the graph-index to be considered when calculating possible trips.