### PR TITLE
Fix NPE when checking for access/egress mode

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/RoutingWorker.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/RoutingWorker.java
@@ -168,8 +168,7 @@ public class RoutingWorker {
             accessList = accessEgressMapper.mapNearbyStops(accessStops, false);
 
             // Special handling of flex accesses
-            if (OTPFeature.FlexRouting.isOn() && request.modes.accessMode.equals(
-                    StreetMode.FLEXIBLE)) {
+            if (OTPFeature.FlexRouting.isOn() && request.modes.accessMode == StreetMode.FLEXIBLE) {
                 Collection<FlexAccessEgress> flexAccessList =
                         FlexAccessEgressRouter.routeAccessEgress(
                                 accessRequest,
@@ -190,8 +189,7 @@ public class RoutingWorker {
             egressList = accessEgressMapper.mapNearbyStops(egressStops, true);
 
             // Special handling of flex egresses
-            if (OTPFeature.FlexRouting.isOn() && request.modes.egressMode.equals(
-                    StreetMode.FLEXIBLE)) {
+            if (OTPFeature.FlexRouting.isOn() && request.modes.egressMode == StreetMode.FLEXIBLE) {
                 Collection<FlexAccessEgress> flexEgressList =
                         FlexAccessEgressRouter.routeAccessEgress(
                                 egressRequest,


### PR DESCRIPTION
### Summary
It is rarely used, but access and egress mode can actually be null. This fixes two equality checks so that they don't throw NPEs in that case.