### PR TITLE
Fix NPE when access/egress mode not specified

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/router/FilterTransitWhenDirectModeIsEmpty.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/router/FilterTransitWhenDirectModeIsEmpty.java
@@ -59,18 +59,18 @@ public class FilterTransitWhenDirectModeIsEmpty {
   }
 
   public StreetMode resolveDirectMode() {
-    return directSearchEmpty() ? StreetMode.WALK : originalDirectMode;
+    return directSearchNotSet() ? StreetMode.WALK : originalDirectMode;
   }
 
   public boolean removeWalkAllTheWayResults() {
-    return directSearchEmpty();
+    return directSearchNotSet();
   }
 
   public StreetMode originalDirectMode() {
     return originalDirectMode;
   }
 
-  private boolean directSearchEmpty() {
-    return originalDirectMode == null;
+  private boolean directSearchNotSet() {
+    return originalDirectMode == StreetMode.NOT_SET;
   }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/router/street/DirectStreetRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/router/street/DirectStreetRouter.java
@@ -21,7 +21,7 @@ public class DirectStreetRouter {
   private static final Logger LOG = LoggerFactory.getLogger(DirectStreetRouter.class);
 
   public static List<Itinerary> route(Router router, RoutingRequest request) {
-    if (request.modes.directMode == null) {
+    if (request.modes.directMode == StreetMode.NOT_SET) {
       return Collections.emptyList();
     }
 

--- a/src/main/java/org/opentripplanner/routing/api/request/RequestModes.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/RequestModes.java
@@ -3,16 +3,22 @@ package org.opentripplanner.routing.api.request;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.opentripplanner.model.TransitMode;
 
+import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
 public class RequestModes {
 
+  @Nonnull
   public StreetMode accessMode;
+  @Nonnull
   public StreetMode transferMode;
+  @Nonnull
   public StreetMode egressMode;
+  @Nonnull
   public StreetMode directMode;
+  @Nonnull
   public Set<TransitMode> transitModes;
 
   public static RequestModes defaultRequestModes = new RequestModes(
@@ -30,11 +36,11 @@ public class RequestModes {
       StreetMode directMode,
       Set<TransitMode> transitModes
   ) {
-    this.accessMode = (accessMode != null && accessMode.access) ? accessMode : null;
-    this.transferMode = (transferMode != null && transferMode.transfer) ? transferMode : null;
-    this.egressMode = (egressMode != null && egressMode.egress) ? egressMode : null;
-    this.directMode = directMode;
-    this.transitModes = transitModes;
+    this.accessMode = (accessMode != null && accessMode.access) ? accessMode : StreetMode.NOT_SET;
+    this.transferMode = (transferMode != null && transferMode.transfer) ? transferMode : StreetMode.NOT_SET;
+    this.egressMode = (egressMode != null && egressMode.egress) ? egressMode : StreetMode.NOT_SET;
+    this.directMode = directMode != null ? directMode : StreetMode.NOT_SET;
+    this.transitModes = transitModes != null ? transitModes : Set.of();
   }
 
   public boolean contains(StreetMode streetMode) {
@@ -54,7 +60,7 @@ public class RequestModes {
     if (accessMode != that.accessMode) return false;
     if (egressMode != that.egressMode) return false;
     if (directMode != that.directMode) return false;
-    return transitModes != null ? transitModes.equals(that.transitModes) : that.transitModes == null;
+    return transitModes.equals(that.transitModes);
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/routing/api/request/StreetMode.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/StreetMode.java
@@ -2,6 +2,11 @@ package org.opentripplanner.routing.api.request;
 
 public enum StreetMode {
   /**
+   * No street mode is set. This option is used if we do not want street routing at all in this part
+   * of the search.
+   */
+  NOT_SET(true, true, true, false, false, false),
+  /**
    * Walk only
    */
   WALK(true, true, true, true, false, false),

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetTransitEntityLink.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetTransitEntityLink.java
@@ -87,6 +87,8 @@ public abstract class StreetTransitEntityLink<T extends Vertex> extends Edge imp
 
         StateEditor s1 = s0.edit(this);
 
+        if (s0.getNonTransitMode() == null) { return null; }
+
         switch (s0.getNonTransitMode()) {
             case BICYCLE:
                 // Forbid taking your own bike in the station if bike P+R activated.

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetTransitEntityLink.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetTransitEntityLink.java
@@ -87,8 +87,6 @@ public abstract class StreetTransitEntityLink<T extends Vertex> extends Edge imp
 
         StateEditor s1 = s0.edit(this);
 
-        if (s0.getNonTransitMode() == null) { return null; }
-
         switch (s0.getNonTransitMode()) {
             case BICYCLE:
                 // Forbid taking your own bike in the station if bike P+R activated.

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptor/router/FilterTransitWhenDirectModeIsEmptyTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptor/router/FilterTransitWhenDirectModeIsEmptyTest.java
@@ -38,6 +38,6 @@ public class FilterTransitWhenDirectModeIsEmptyTest {
 
     assertEquals(StreetMode.WALK, subject.resolveDirectMode());
     assertTrue(subject.removeWalkAllTheWayResults());
-    assertNull(subject.originalDirectMode());
+    assertEquals(StreetMode.NOT_SET, subject.originalDirectMode());
   }
 }


### PR DESCRIPTION
### Summary
It is not commonly used, but it is possible to set access/egress mode to null. This will terminate the access/egress searches immediately. This means you will only be able to travel from the specified stop/station ids. If a coordinate is specified, you will not get any results.

This PR fixes a NPE in the StreetTransitEntityLink when the `nonTransitMode` is null.

We should probably discuss a way to make this more explicit, but in the meantime I think this PR should be merged.