### PR TITLE
Reduce log-level to warning on transfer colliding message

### DIFF
--- a/src/main/java/org/opentripplanner/model/transfer/TransferService.java
+++ b/src/main/java/org/opentripplanner/model/transfer/TransferService.java
@@ -170,8 +170,8 @@ public class TransferService implements Serializable {
         if (existingTransfer.equals(newTransfer)) {
             return false;
         }
-        LOG.error(
-                "To colliding transfers A abd B with the same specificity-ranking is imported, B is "
+        LOG.warn(
+                "Two colliding transfers A and B with the same specificity-ranking is imported, B is "
                         + "dropped. A={}, B={}", existingTransfer, newTransfer
         );
         return false;


### PR DESCRIPTION
### Summary
This reduces the log level on the log message that occurs when two transfers are imported and one of them is dropped.