### PR TITLE
Add option to include cancellations in StopTimes call

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -33,6 +33,7 @@
 - Allow http headers to be specified for bike rental updaters [#3533](https://github.com/opentripplanner/OpenTripPlanner/pull/3533)
 - Per-mode reluctance parameters are added so that itineraries with multiple modes may have varying reluctances. [#3501](https://github.com/opentripplanner/OpenTripPlanner/issues/3501)
 - Add `maxAreaNodes` configuration parameter for changing an area visibility calculation limit (https://github.com/opentripplanner/OpenTripPlanner/issues/3534)
+- Add option to include cancellations in StopTimes call (https://github.com/opentripplanner/OpenTripPlanner/pull/3567)
 
 ## 2.0.0 (2020-11-27)
 

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/QuayType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/QuayType.java
@@ -158,13 +158,14 @@ public class QuayType {
                           .type(GraphQLList.list(TRANSPORT_MODE))
                           .build())
                     .argument(GraphQLArgument.newArgument()
-                        .name("includeCancelledTrips")
-                        .description("Indicates that realtime-cancelled trips should also be included. NOT IMPLEMENTED")
-                        .type(Scalars.GraphQLBoolean)
-                        .defaultValue(false)
-                        .build())
+                          .name("includeCancelledTrips")
+                          .description("Indicates that realtime-cancelled or planned cancelled trips should also be included.")
+                          .type(Scalars.GraphQLBoolean)
+                          .defaultValue(false)
+                          .build())
                     .dataFetcher(environment -> {
                         boolean omitNonBoarding = environment.getArgument("omitNonBoarding");
+                        boolean includeCancelledTrips = environment.getArgument("includeCancelledTrips");
                         int numberOfDepartures = environment.getArgument("numberOfDepartures");
                         Integer departuresPerLineAndDestinationDisplay = environment.getArgument("numberOfDeparturesPerLineAndDestinationDisplay");
                         int timeRange = environment.getArgument("timeRange");
@@ -181,6 +182,7 @@ public class QuayType {
                           startTimeSeconds,
                           timeRange,
                           omitNonBoarding,
+                          includeCancelledTrips,
                           numberOfDepartures,
                           departuresPerLineAndDestinationDisplay,
                           whiteListed.authorityIds,

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/StopPlaceType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/StopPlaceType.java
@@ -182,6 +182,12 @@ public class StopPlaceType {
                 .defaultValue(false)
                 .build())
             .argument(GraphQLArgument.newArgument()
+                .name("includeCancelledTrips")
+                .description("Indicates that realtime-cancelled trips should also be included.")
+                .type(Scalars.GraphQLBoolean)
+                .defaultValue(false)
+                .build())
+            .argument(GraphQLArgument.newArgument()
                 .name("whiteListed")
                 .description("Whitelisted")
                 .description("Parameters for indicating the only authorities and/or lines or quays to list estimatedCalls for")
@@ -194,6 +200,7 @@ public class StopPlaceType {
                 .build())
             .dataFetcher(environment -> {
               boolean omitNonBoarding = environment.getArgument("omitNonBoarding");
+              boolean includeCancelledTrips = environment.getArgument("includeCancelledTrips");
               int numberOfDepartures = environment.getArgument("numberOfDepartures");
               Integer departuresPerLineAndDestinationDisplay = environment.getArgument("numberOfDeparturesPerLineAndDestinationDisplay");
               int timeRage = environment.getArgument("timeRange");
@@ -213,6 +220,7 @@ public class StopPlaceType {
                           startTimeSeconds,
                           timeRage,
                           omitNonBoarding,
+                          includeCancelledTrips,
                           numberOfDepartures,
                           departuresPerLineAndDestinationDisplay,
                           whiteListed.authorityIds,
@@ -235,6 +243,7 @@ public class StopPlaceType {
       Long startTimeSeconds,
       int timeRage,
       boolean omitNonBoarding,
+      boolean includeCancelledTrips,
       int numberOfDepartures,
       Integer departuresPerLineAndDestinationDisplay,
       Collection<FeedScopedId> authorityIdsWhiteListed,
@@ -257,7 +266,7 @@ public class StopPlaceType {
         timeRage,
         departuresPerTripPattern,
         omitNonBoarding,
-        false
+        includeCancelledTrips
     );
 
     // TODO OTP2 - Applying filters here is not correct - the `departuresPerTripPattern` is used

--- a/src/main/java/org/opentripplanner/netex/mapping/TripMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/TripMapper.java
@@ -3,6 +3,7 @@ package org.opentripplanner.netex.mapping;
 import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.model.Operator;
 import org.opentripplanner.model.Trip;
+import org.opentripplanner.model.TripAlteration;
 import org.opentripplanner.model.impl.EntityById;
 import org.opentripplanner.netex.index.api.ReadOnlyHierarchicalMap;
 import org.opentripplanner.netex.mapping.support.FeedScopedIdFactory;

--- a/src/main/java/org/opentripplanner/routing/StopTimesHelper.java
+++ b/src/main/java/org/opentripplanner/routing/StopTimesHelper.java
@@ -266,12 +266,9 @@ public class StopTimesHelper {
       int stopIndex = 0;
       for (Stop currentStop : pattern.stopPattern.stops) {
         if (currentStop == requestedStop) {
-          // Short-circuiting must be delayed in the case of includeRealTimeCancellations
-          if (!includeRealTimeCancellations) {
-            if (omitNonPickups
-                && pattern.stopPattern.pickups[stopIndex] == StopPattern.PICKDROP_NONE) {
-              continue;
-            }
+          if (omitNonPickups
+              && pattern.stopPattern.pickups[stopIndex] == StopPattern.PICKDROP_NONE) {
+            continue;
           }
           for (TripTimes tripTimes : timetable.tripTimes) {
             // Short-circuiting must be delayed in the case of includeRealTimeCancellations

--- a/src/main/java/org/opentripplanner/routing/StopTimesHelper.java
+++ b/src/main/java/org/opentripplanner/routing/StopTimesHelper.java
@@ -278,8 +278,7 @@ public class StopTimesHelper {
             if (!includeRealTimeCancellations
                 && !serviceDay.serviceRunning(tripTimes.serviceCode)) { continue; }
 
-            boolean stopOrTripIsCancelled = tripTimes.stopOrTripIsCancelled(stopIndex)
-                || !(tripTimes.getPickupType(stopIndex) == StopPattern.PICKDROP_SCHEDULED);
+            boolean stopOrTripIsCancelled = tripTimes.stopOrTripIsCancelled(stopIndex);
 
             boolean includeByCancellation = !stopOrTripIsCancelled
                 || includePlannedCancellations

--- a/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
+++ b/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
@@ -561,6 +561,11 @@ public class TripTimes implements Serializable, Comparable<TripTimes>, Cloneable
         return timepoints.get(stopIndex);
     }
 
+    /** Return {code true} if stop is cancelled, or trip is canceled/replaced */
+    public boolean stopOrTripIsCancelled(int stop) {
+        return isCancelledStop(stop) || trip.getTripAlteration().isCanceledOrReplaced();
+    }
+
     /**
      * Hash the scheduled arrival/departure times. Used in creating stable IDs for trips across GTFS feed versions.
      * Use hops rather than stops because:

--- a/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
+++ b/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
@@ -565,8 +565,7 @@ public class TripTimes implements Serializable, Comparable<TripTimes>, Cloneable
     /** Return {code true} if stop is cancelled, or trip is canceled/replaced */
     public boolean stopOrTripIsCancelled(int stop) {
         return isCancelledStop(stop)
-            || trip.getTripAlteration().isCanceledOrReplaced()
-            || getPickupType(stop) != PICKDROP_NONE;
+            || trip.getTripAlteration().isCanceledOrReplaced();
     }
 
     /**

--- a/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
+++ b/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
@@ -12,6 +12,7 @@ import java.util.BitSet;
 import java.util.Collection;
 import java.util.List;
 import org.opentripplanner.model.BookingInfo;
+import org.opentripplanner.model.StopPattern;
 import org.opentripplanner.model.StopTime;
 import org.opentripplanner.model.Trip;
 import org.slf4j.Logger;
@@ -563,7 +564,9 @@ public class TripTimes implements Serializable, Comparable<TripTimes>, Cloneable
 
     /** Return {code true} if stop is cancelled, or trip is canceled/replaced */
     public boolean stopOrTripIsCancelled(int stop) {
-        return isCancelledStop(stop) || trip.getTripAlteration().isCanceledOrReplaced();
+        return isCancelledStop(stop)
+            || trip.getTripAlteration().isCanceledOrReplaced()
+            || getPickupType(stop) != PICKDROP_NONE;
     }
 
     /**


### PR DESCRIPTION
### Summary
This adds the option of including both planned and realtime cancellations when doing the StopTimes call. 

It makes two calls to the `listTripTimeShortsForPatternAtStop` method. First with the planned patterns, and then with the realtime added patterns.

The `listTripTimeShortsForPatternAtStop` is then modified with a new parameter that checks for whether the cancelled departure should be included or not. This is done via the following method:

```
    /** Return {code true} if stop is cancelled, or trip is canceled/replaced */
    public boolean stopOrTripIsCancelled(int stop) {
        return isCancelledStop(stop)
            || trip.getTripAlteration().isCanceledOrReplaced()
            || getPickupType(stop) != PICKDROP_NONE;
    }
```

### Issue
Closes #3566

### Unit tests
I have tested this manually with real data. I would really like to unit test this, but you have to build up a pretty complex structure of objects to do so. Maybe it's better to do this after we have redesigned the OTP model.
