### PR TITLE
Log warnings on missing/invalid pathways

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/module/AddTransitModelEntitiesToGraph.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/AddTransitModelEntitiesToGraph.java
@@ -221,14 +221,10 @@ public class AddTransitModelEntitiesToGraph {
             }
             else {
                 if (fromVertex == null) {
-                    LOG.warn("The 'fromVertex' is missing for pathway from stop: " + pathway
-                        .getFromStop()
-                        .getId());
+                    LOG.warn("The 'fromVertex' is missing for pathway from stop {}", pathway.getFromStop());
                 }
                 if (toVertex == null) {
-                    LOG.warn("The 'toVertex' is missing for pathway to stop: " + pathway
-                        .getToStop()
-                        .getId());
+                    LOG.warn("The 'toVertex' is missing for pathway to stop {}", pathway.getToStop());
                 }
             }
         }

--- a/src/main/java/org/opentripplanner/gtfs/mapping/PathwayMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/PathwayMapper.java
@@ -1,6 +1,8 @@
 package org.opentripplanner.gtfs.mapping;
 
+import org.onebusaway.gtfs.model.Stop;
 import org.opentripplanner.model.Pathway;
+import org.opentripplanner.model.StationElement;
 import org.opentripplanner.util.MapUtils;
 
 import java.util.Collection;
@@ -53,42 +55,26 @@ class PathwayMapper {
         if (rhs.isMaxSlopeSet()) { lhs.setSlope(rhs.getMaxSlope()); }
         lhs.setBidirectional(rhs.getIsBidirectional() == 1);
 
-        org.onebusaway.gtfs.model.Stop fromStop = rhs.getFromStop();
-        if (fromStop != null) {
-            switch (rhs.getFromStop().getLocationType()) {
-                case org.onebusaway.gtfs.model.Stop.LOCATION_TYPE_STOP:
-                    lhs.setFromStop(stopMapper.map(fromStop));
-                    break;
-                case org.onebusaway.gtfs.model.Stop.LOCATION_TYPE_ENTRANCE_EXIT:
-                    lhs.setFromStop(entranceMapper.map(fromStop));
-                    break;
-                case org.onebusaway.gtfs.model.Stop.LOCATION_TYPE_NODE:
-                    lhs.setFromStop(nodeMapper.map(fromStop));
-                    break;
-                case org.onebusaway.gtfs.model.Stop.LOCATION_TYPE_BOARDING_AREA:
-                    lhs.setFromStop(boardingAreaMapper.map(fromStop));
-                    break;
-            }
-        }
-
-        org.onebusaway.gtfs.model.Stop toStop = rhs.getToStop();
-        if (toStop != null) {
-            switch (toStop.getLocationType()) {
-                case org.onebusaway.gtfs.model.Stop.LOCATION_TYPE_STOP:
-                    lhs.setToStop(stopMapper.map(toStop));
-                    break;
-                case org.onebusaway.gtfs.model.Stop.LOCATION_TYPE_ENTRANCE_EXIT:
-                    lhs.setToStop(entranceMapper.map(toStop));
-                    break;
-                case org.onebusaway.gtfs.model.Stop.LOCATION_TYPE_NODE:
-                    lhs.setToStop(nodeMapper.map(toStop));
-                    break;
-                case org.onebusaway.gtfs.model.Stop.LOCATION_TYPE_BOARDING_AREA:
-                    lhs.setToStop(boardingAreaMapper.map(toStop));
-                    break;
-            }
-        }
-
+        lhs.setFromStop(mapStationElement(rhs.getFromStop()));
+        lhs.setToStop(mapStationElement(rhs.getToStop()));
         return lhs;
     }
+
+    private StationElement mapStationElement (Stop stop) {
+        if (stop != null) {
+            switch (stop.getLocationType()) {
+                case org.onebusaway.gtfs.model.Stop.LOCATION_TYPE_STOP:
+                    return stopMapper.map(stop);
+                case org.onebusaway.gtfs.model.Stop.LOCATION_TYPE_ENTRANCE_EXIT:
+                    return entranceMapper.map(stop);
+                case org.onebusaway.gtfs.model.Stop.LOCATION_TYPE_NODE:
+                    return nodeMapper.map(stop);
+                case org.onebusaway.gtfs.model.Stop.LOCATION_TYPE_BOARDING_AREA:
+                    return boardingAreaMapper.map(stop);
+            }
+        }
+        // Stop was missing (null) or locationType was not valid (e.g. it was a station or missing)
+        return null;
+    }
+
 }


### PR DESCRIPTION
### Summary
A problem was reported on the dev mailing list where a null pointer exception was thrown by a logging statement, which was triggered by calling toString on a null value. The person reporting the bug hinted that the to_stop_id of the pathway in question referred to a station node, which seems to be invalid input data based on pathways.txt guidance documents. In the pathway mapper, we just silently store null or incorrect values as nulls in the internal model.

Simply using the logging framwork's `{}` placeholder avoids the immediate problem with the logging. It should log null values correctly without trying to call toString on them.

However, this could still confuse the user. The log message implies that that the to-stop of the pathway is missing, but in fact it's probably just of an invalid type (station instead of entrance or platform). This would be hard to understand for someone who is not tracing execution in a debugger. Should we somehow log or record this fact? It seems that we do not perform any logging or error recording in the mapper classes that I examined. Do we have a standard way to record this information to warn the user of problems in their input data?

While working on this I also factored out the repeated code block that maps the GTFS station node types to the internal model, so any improvements will apply to both from-stop and to-stop.

### Unit tests
No additional tests were created. Do we want to test behavior on bad input data? There would be a huge number of cases like this to test.

### Documentation
We may want to update our code style documents to remind developers not to call toString in log statements, but instead pass the non-string value as a logging method parameter. We should probably search the codebase for other explicit calls to toString and remove them from any error handling code where there's some chance that the value will be null.