### PR TITLE
Cancel individual stop on StopPattern instead of TripTimes

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -35,6 +35,7 @@
 - Add `maxAreaNodes` configuration parameter for changing an area visibility calculation limit [#3501](https://github.com/opentripplanner/OpenTripPlanner/issues/3534)
 - Add bicycle safety report to report API [#3563](https://github.com/opentripplanner/OpenTripPlanner/issues/3563)
 - Optimize Transfers performance issue [#3513](https://github.com/opentripplanner/OpenTripPlanner/issues/3513)
+- Cancel individual stop on StopPattern instead of TripTimes [#3575](https://github.com/opentripplanner/OpenTripPlanner/issues/3575)
 
 
 ## 2.0.0 (2020-11-27)

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     </scm>
 
     <properties>
-        <otp.serialization.version.id>8</otp.serialization.version.id>
+        <otp.serialization.version.id>9</otp.serialization.version.id>
         <!-- Lib versions - keep list sorted on property name -->
         <geotools.version>21.2</geotools.version>
         <geotools.wfs.version>16.5</geotools.wfs.version>

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLStoptimeImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLStoptimeImpl.java
@@ -63,7 +63,7 @@ public class LegacyGraphQLStoptimeImpl implements LegacyGraphQLDataFetchers.Lega
   @Override
   public DataFetcher<String> pickupType() {
     return environment -> {
-      switch (getSource(environment).getPickupType()) {
+      switch (getSource(environment).getPickupType().getGtfsCode()) {
         case 0: return "SCHEDULED";
         case 1: return "NONE";
         case 2: return "CALL_AGENCY";
@@ -76,7 +76,7 @@ public class LegacyGraphQLStoptimeImpl implements LegacyGraphQLDataFetchers.Lega
   @Override
   public DataFetcher<String> dropoffType() {
     return environment -> {
-      switch (getSource(environment).getDropoffType()) {
+      switch (getSource(environment).getDropoffType().getGtfsCode()) {
         case 0: return "SCHEDULED";
         case 1: return "NONE";
         case 2: return "CALL_AGENCY";

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLTripImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLTripImpl.java
@@ -170,7 +170,7 @@ public class LegacyGraphQLTripImpl implements LegacyGraphQLDataFetchers.LegacyGr
         );
 
         Stop stop = timetable.getPattern().getStop(0);
-        return new TripTimeOnDate(triptimes, 0, stop, serviceDate
+        return new TripTimeOnDate(triptimes, 0, tripPattern, serviceDate
         );
       } catch (ParseException e) {
         //Invalid date format
@@ -201,7 +201,7 @@ public class LegacyGraphQLTripImpl implements LegacyGraphQLDataFetchers.LegacyGr
           );
 
         Stop stop = timetable.getPattern().getStop(triptimes.getNumStops() - 1);
-        return new TripTimeOnDate(triptimes, triptimes.getNumStops() - 1, stop, serviceDate
+        return new TripTimeOnDate(triptimes, triptimes.getNumStops() - 1, tripPattern, serviceDate
         );
       } catch (ParseException e) {
         //Invalid date format

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
@@ -626,6 +626,10 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
                 tripTimes.updateDepartureDelay(i, expectedDepartureTime - aimedDepartureTime);
             }
 
+            if (estimatedCall.isCancellation() != null && estimatedCall.isCancellation()) {
+                tripTimes.setCancelled(i);
+            }
+
             boolean isCallPredictionInaccurate = estimatedCall.isPredictionInaccurate() != null && estimatedCall.isPredictionInaccurate();
             tripTimes.setPredictionInaccurate(i, (isJourneyPredictionInaccurate | isCallPredictionInaccurate));
 

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
@@ -590,6 +590,10 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
                 stopTime.setDepartureTime(stopTime.getArrivalTime());
             }
 
+            if (estimatedCall.isCancellation() != null && estimatedCall.isCancellation()) {
+                stopTime.cancel();
+            }
+
             addedStops.add(stop);
             aimedStopTimes.add(stopTime);
         }
@@ -620,10 +624,6 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
             if (expectedDeparture != null) {
                 int expectedDepartureTime = calculateSecondsSinceMidnight(departureTime, expectedDeparture);
                 tripTimes.updateDepartureDelay(i, expectedDepartureTime - aimedDepartureTime);
-            }
-
-            if (estimatedCall.isCancellation() != null && estimatedCall.isCancellation()) {
-                tripTimes.cancelStop(i);
             }
 
             boolean isCallPredictionInaccurate = estimatedCall.isPredictionInaccurate() != null && estimatedCall.isPredictionInaccurate();

--- a/src/ext/java/org/opentripplanner/ext/siri/TimetableHelper.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/TimetableHelper.java
@@ -154,6 +154,7 @@ public class TimetableHelper {
 
                     if (recordedCall.isCancellation() != null && recordedCall.isCancellation()) {
                         modifiedStopTimes.get(callCounter).cancel();
+                        newTimes.setCancelled(callCounter);
                     }
 
                     int arrivalTime = newTimes.getArrivalTime(callCounter);
@@ -224,6 +225,7 @@ public class TimetableHelper {
 
                         if (estimatedCall.isCancellation() != null && estimatedCall.isCancellation()) {
                             modifiedStopTimes.get(callCounter).cancel();
+                            newTimes.setCancelled(callCounter);
                         }
 
                         boolean isCallPredictionInaccurate = estimatedCall.isPredictionInaccurate() != null && estimatedCall.isPredictionInaccurate();

--- a/src/ext/java/org/opentripplanner/ext/siri/TimetableHelper.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/TimetableHelper.java
@@ -153,7 +153,7 @@ public class TimetableHelper {
                     }
 
                     if (recordedCall.isCancellation() != null && recordedCall.isCancellation()) {
-                        newTimes.cancelStop(callCounter);
+                        modifiedStopTimes.get(callCounter).cancel();
                     }
 
                     int arrivalTime = newTimes.getArrivalTime(callCounter);
@@ -223,7 +223,7 @@ public class TimetableHelper {
                         }
 
                         if (estimatedCall.isCancellation() != null && estimatedCall.isCancellation()) {
-                            newTimes.cancelStop(callCounter);
+                            modifiedStopTimes.get(callCounter).cancel();
                         }
 
                         boolean isCallPredictionInaccurate = estimatedCall.isPredictionInaccurate() != null && estimatedCall.isPredictionInaccurate();
@@ -234,12 +234,12 @@ public class TimetableHelper {
                         // Update dropoff-/pickuptype only if status is cancelled
                         CallStatusEnumeration arrivalStatus = estimatedCall.getArrivalStatus();
                         if (arrivalStatus == CallStatusEnumeration.CANCELLED) {
-                            newTimes.cancelDropOffForStop(callCounter);
+                            modifiedStopTimes.get(callCounter).cancelDropOff();
                         }
 
                         CallStatusEnumeration departureStatus = estimatedCall.getDepartureStatus();
                         if (departureStatus == CallStatusEnumeration.CANCELLED) {
-                            newTimes.cancelPickupForStop(callCounter);
+                            modifiedStopTimes.get(callCounter).cancelPickup();
                         }
 
                         int arrivalTime = newTimes.getArrivalTime(callCounter);
@@ -513,7 +513,7 @@ public class TimetableHelper {
 
                         CallStatusEnumeration arrivalStatus = estimatedCall.getArrivalStatus();
                         if (arrivalStatus == CallStatusEnumeration.CANCELLED) {
-                            stopTime.setDropOffType(NONE);
+                            stopTime.cancelDropOff();
                         } else if (estimatedCall.getArrivalBoardingActivity() == ArrivalBoardingActivityEnumeration.ALIGHTING) {
                             stopTime.setDropOffType(SCHEDULED);
                         } else if (estimatedCall.getArrivalBoardingActivity() == ArrivalBoardingActivityEnumeration.NO_ALIGHTING) {
@@ -525,7 +525,7 @@ public class TimetableHelper {
 
                         CallStatusEnumeration departureStatus = estimatedCall.getDepartureStatus();
                         if (departureStatus == CallStatusEnumeration.CANCELLED) {
-                            stopTime.setPickupType(NONE);
+                            stopTime.cancelPickup();
                         } else if (estimatedCall.getDepartureBoardingActivity() == DepartureBoardingActivityEnumeration.BOARDING) {
                             stopTime.setPickupType(SCHEDULED);
                         } else if (estimatedCall.getDepartureBoardingActivity() == DepartureBoardingActivityEnumeration.NO_BOARDING) {

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/et/EstimatedCallType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/et/EstimatedCallType.java
@@ -150,31 +150,15 @@ public class EstimatedCallType {
             .field(GraphQLFieldDefinition.newFieldDefinition()
                 .name("forBoarding")
                 .type(Scalars.GraphQLBoolean)
-                .description("Whether vehicle may be boarded at quay.")
-                .dataFetcher(environment -> {
-                    if (((TripTimeOnDate) environment.getSource()).getPickupType() >= 0) {
-                        //Realtime-updated
-                        return ((TripTimeOnDate) environment.getSource()).getPickupType() != NONE.getGtfsCode();
-                    }
-                  return GqlUtil.getRoutingService(environment).getPatternForTrip()
-                        .get(((TripTimeOnDate) environment.getSource()).getTrip())
-                        .getBoardType(((TripTimeOnDate) environment.getSource()).getStopIndex()) != NONE;
-                })
-                .build())
+                .description("Whether vehicle may be boarded at quay.").dataFetcher(environment ->
+                    ((TripTimeOnDate) environment.getSource()).getPickupType().isRoutable()
+                ).build())
             .field(GraphQLFieldDefinition.newFieldDefinition()
                 .name("forAlighting")
                 .type(Scalars.GraphQLBoolean)
-                .description("Whether vehicle may be alighted at quay.")
-                .dataFetcher(environment -> {
-                    if (((TripTimeOnDate) environment.getSource()).getDropoffType() >= 0) {
-                        //Realtime-updated
-                        return ((TripTimeOnDate) environment.getSource()).getDropoffType() != NONE.getGtfsCode();
-                    }
-                    return GqlUtil.getRoutingService(environment).getPatternForTrip()
-                            .get(((TripTimeOnDate) environment.getSource()).getTrip())
-                            .getAlightType(((TripTimeOnDate) environment.getSource()).getStopIndex()) != NONE;
-                })
-                .build())
+                .description("Whether vehicle may be boarded at quay.").dataFetcher(environment ->
+                    ((TripTimeOnDate) environment.getSource()).getDropoffType().isRoutable()
+                ).build())
             .field(GraphQLFieldDefinition.newFieldDefinition()
                     .name("requestStop")
                     .type(Scalars.GraphQLBoolean)

--- a/src/main/java/org/opentripplanner/model/StopTime.java
+++ b/src/main/java/org/opentripplanner/model/StopTime.java
@@ -279,6 +279,19 @@ public final class StopTime implements Comparable<StopTime> {
         return this.getStopSequence() - o.getStopSequence();
     }
 
+    public void cancel() {
+        pickupType = PickDrop.CANCELLED;
+        dropOffType = PickDrop.CANCELLED;
+    }
+
+    public void cancelDropOff() {
+        dropOffType = PickDrop.CANCELLED;
+    }
+
+    public void cancelPickup() {
+        pickupType = PickDrop.CANCELLED;
+    }
+
     @Override
     public String toString() {
       return "StopTime(seq=" + getStopSequence() + " stop=" + getStop().getId() + " trip="

--- a/src/main/java/org/opentripplanner/model/Timetable.java
+++ b/src/main/java/org/opentripplanner/model/Timetable.java
@@ -269,7 +269,7 @@ public class Timetable implements Serializable {
                             }
                         } else {
                             if (delay == null) {
-                                newTimes.cancelDropOffForStop(i);
+                                // newTimes.cancelDropOffForStop(i); TODO This needs to cancel on a StopTime object so that a new StopPattern/TripPattern can be constructed
                             } else {
                                 newTimes.updateArrivalDelay(i, delay);
                             }
@@ -295,7 +295,7 @@ public class Timetable implements Serializable {
                             }
                         } else {
                             if (delay == null) {
-                                newTimes.cancelPickupForStop(i);
+                                //newTimes.cancelPickupForStop(i); TODO This needs to cancel on a StopTime object so that a new StopPattern/TripPattern can be constructed
                             } else {
                                 newTimes.updateDepartureDelay(i, delay);
                             }
@@ -309,8 +309,8 @@ public class Timetable implements Serializable {
                     }
                 } else {
                     if (delay == null) {
-                        newTimes.cancelDropOffForStop(i);
-                        newTimes.cancelPickupForStop(i);
+                        // newTimes.cancelDropOffForStop(i); TODO This needs to cancel on a StopTime object so that a new StopPattern/TripPattern can be constructed
+                        // newTimes.cancelPickupForStop(i); TODO This needs to cancel on a StopTime object so that a new StopPattern/TripPattern can be constructed
                     } else {
                         newTimes.updateArrivalDelay(i, delay);
                         newTimes.updateDepartureDelay(i, delay);

--- a/src/main/java/org/opentripplanner/model/TripTimeOnDate.java
+++ b/src/main/java/org/opentripplanner/model/TripTimeOnDate.java
@@ -125,7 +125,8 @@ public class TripTimeOnDate {
     }
 
     public boolean isCancelledStop() {
-        return tripPattern.getStopPattern().getPickup(stopIndex) == PickDrop.CANCELLED
+        return tripTimes.isCancelledStop(stopIndex) ||
+            tripPattern.getStopPattern().getPickup(stopIndex) == PickDrop.CANCELLED
             && tripPattern.getStopPattern().getDropoff(stopIndex) == PickDrop.CANCELLED;
     }
 
@@ -157,13 +158,13 @@ public class TripTimeOnDate {
     }
 
     public PickDrop getPickupType() {
-        return tripTimes.isCanceled()
+        return tripTimes.isCanceled() || tripTimes.isCancelledStop(stopIndex)
             ? PickDrop.CANCELLED
             : tripPattern.getStopPattern().getPickup(stopIndex);
     }
 
     public PickDrop getDropoffType() {
-        return tripTimes.isCanceled()
+        return tripTimes.isCanceled() || tripTimes.isCancelledStop(stopIndex)
             ? PickDrop.CANCELLED
             : tripPattern.getStopPattern().getDropoff(stopIndex);
     }

--- a/src/main/java/org/opentripplanner/model/TripTimeOnDate.java
+++ b/src/main/java/org/opentripplanner/model/TripTimeOnDate.java
@@ -131,7 +131,9 @@ public class TripTimeOnDate {
 
     /** Return {code true} if stop is cancelled, or trip is canceled/replaced */
     public boolean isCanceledEffectively() {
-        return isCancelledStop() || tripTimes.getTrip().getTripAlteration().isCanceledOrReplaced();
+        return isCancelledStop()
+            || tripTimes.isCanceled()
+            || tripTimes.getTrip().getTripAlteration().isCanceledOrReplaced();
     }
 
     public RealTimeState getRealtimeState() {

--- a/src/main/java/org/opentripplanner/model/TripTimeOnDate.java
+++ b/src/main/java/org/opentripplanner/model/TripTimeOnDate.java
@@ -157,11 +157,15 @@ public class TripTimeOnDate {
     }
 
     public PickDrop getPickupType() {
-        return tripPattern.getStopPattern().getPickup(stopIndex);
+        return tripTimes.isCanceled()
+            ? PickDrop.CANCELLED
+            : tripPattern.getStopPattern().getPickup(stopIndex);
     }
 
     public PickDrop getDropoffType() {
-        return tripPattern.getStopPattern().getDropoff(stopIndex);
+        return tripTimes.isCanceled()
+            ? PickDrop.CANCELLED
+            : tripPattern.getStopPattern().getDropoff(stopIndex);
     }
 
     public StopTimeKey getStopTimeKey() {

--- a/src/main/java/org/opentripplanner/model/TripTimeOnDate.java
+++ b/src/main/java/org/opentripplanner/model/TripTimeOnDate.java
@@ -22,9 +22,6 @@ public class TripTimeOnDate {
     private final TripPattern tripPattern;
     private final ServiceDay serviceDay;
 
-    /**
-     * This is stop-specific, so the index i is a stop index, not a hop index.
-     */
     public TripTimeOnDate(TripTimes tripTimes, int stopIndex, TripPattern tripPattern, ServiceDay serviceDay) {
         this.tripTimes = tripTimes;
         this.stopIndex = stopIndex;
@@ -32,13 +29,10 @@ public class TripTimeOnDate {
         this.serviceDay = serviceDay;
     }
 
-    /**
-     * must pass in both table and trip, because tripTimes do not have stops.
-     */
+    /** Must pass in both Timetable and Trip, because TripTimes do not have a reference to StopPatterns. */
     public static List<TripTimeOnDate> fromTripTimes (Timetable table, Trip trip) {
         TripTimes times = table.getTripTimes(table.getTripIndex(trip.getId()));        
         List<TripTimeOnDate> out = new ArrayList<>();
-        // one per stop, not one per hop, thus the <= operator
         for (int i = 0; i < times.getNumStops(); ++i) {
             out.add(new TripTimeOnDate(times, i, table.getPattern(), null));
         }
@@ -46,14 +40,13 @@ public class TripTimeOnDate {
     }
 
     /**
-     * must pass in both table and trip, because tripTimes do not have stops.
+     * Must pass in both Timetable and Trip, because TripTimes do not have a reference to StopPatterns.
      * @param serviceDay service day to set, if null none is set
      */
     public static List<TripTimeOnDate> fromTripTimes(Timetable table, Trip trip,
             ServiceDay serviceDay) {
         TripTimes times = table.getTripTimes(table.getTripIndex(trip.getId()));
         List<TripTimeOnDate> out = new ArrayList<>();
-        // one per stop, not one per hop, thus the <= operator
         for (int i = 0; i < times.getNumStops(); ++i) {
             out.add(new TripTimeOnDate(times, i, table.getPattern(), serviceDay));
         }

--- a/src/main/java/org/opentripplanner/routing/StopTimesHelper.java
+++ b/src/main/java/org/opentripplanner/routing/StopTimesHelper.java
@@ -121,7 +121,7 @@ public class StopTimesHelper {
           if(omitNonPickups && pattern.getStopPattern().getPickup(sidx) == NONE) continue;
           for (TripTimes t : tt.getTripTimes()) {
             if (!sd.serviceRunning(t.getServiceCode())) { continue; }
-            stopTimes.times.add(new TripTimeOnDate(t, sidx, stop, sd));
+            stopTimes.times.add(new TripTimeOnDate(t, sidx, pattern, sd));
           }
         }
         sidx++;
@@ -226,7 +226,7 @@ public class StopTimesHelper {
             if (!sd.serviceRunning(t.getServiceCode())) continue;
             if (t.getDepartureTime(sidx) != -1 &&
                     t.getDepartureTime(sidx) >= secondsSinceMidnight) {
-              pq.add(new TripTimeOnDate(t, sidx, stop, sd));
+              pq.add(new TripTimeOnDate(t, sidx, pattern, sd));
             }
           }
 
@@ -243,7 +243,7 @@ public class StopTimesHelper {
                       new TripTimeOnDate(
                               freq.materialize(sidx, departureTime, true),
                               sidx,
-                              stop,
+                              pattern,
                               sd
                       )
               );

--- a/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
+++ b/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
@@ -84,10 +84,6 @@ public class TripTimes implements Serializable, Comparable<TripTimes> {
      */
     private boolean[] predictionInaccurateOnStops;
 
-    private final List<PickDrop> pickups;
-
-    private final List<PickDrop> dropoffs;
-
     private final List<BookingInfo> dropOffBookingInfos;
 
     private final List<BookingInfo> pickupBookingInfos;
@@ -124,8 +120,6 @@ public class TripTimes implements Serializable, Comparable<TripTimes> {
         final BitSet timepoints = new BitSet(nStops);
         // Times are always shifted to zero. This is essential for frequencies and deduplication.
         this.timeShift = stopTimes.iterator().next().getArrivalTime();
-        final List<PickDrop> pickups   = new ArrayList<>();
-        final List<PickDrop> dropoffs   = new ArrayList<>();
         final List<BookingInfo> dropOffBookingInfos = new ArrayList<>();
         final List<BookingInfo> pickupBookingInfos = new ArrayList<>();
         int s = 0;
@@ -135,8 +129,6 @@ public class TripTimes implements Serializable, Comparable<TripTimes> {
             sequences[s] = st.getStopSequence();
             timepoints.set(s, st.getTimepoint() == 1);
 
-            pickups.add(st.getPickupType());
-            dropoffs.add(st.getDropOffType());
             dropOffBookingInfos.add(st.getDropOffBookingInfo());
             pickupBookingInfos.add(st.getPickupBookingInfo());
             s++;
@@ -145,8 +137,6 @@ public class TripTimes implements Serializable, Comparable<TripTimes> {
         this.scheduledArrivalTimes = deduplicator.deduplicateIntArray(arrivals);
         this.originalGtfsStopSequence = deduplicator.deduplicateIntArray(sequences);
         this.headsigns = deduplicator.deduplicateStringArray(makeHeadsignsArray(stopTimes));
-        this.pickups = pickups;
-        this.dropoffs = dropoffs;
         this.dropOffBookingInfos = deduplicator.deduplicateImmutableList(BookingInfo.class, dropOffBookingInfos);
         this.pickupBookingInfos = deduplicator.deduplicateImmutableList(BookingInfo.class, pickupBookingInfos);
         // We set these to null to indicate that this is a non-updated/scheduled TripTimes.
@@ -170,8 +160,6 @@ public class TripTimes implements Serializable, Comparable<TripTimes> {
         this.departureTimes = null;
         this.recordedStops = object.recordedStops;
         this.predictionInaccurateOnStops = object.predictionInaccurateOnStops;
-        this.pickups = new ArrayList<>(object.pickups);
-        this.dropoffs = new ArrayList<>(object.dropoffs);
         this.pickupBookingInfos = object.pickupBookingInfos;
         this.dropOffBookingInfos = object.dropOffBookingInfos;
         this.originalGtfsStopSequence = object.originalGtfsStopSequence;
@@ -287,23 +275,6 @@ public class TripTimes implements Serializable, Comparable<TripTimes> {
         return recordedStops[stop];
     }
 
-    /**
-     * Cancels both pickup and dropoff for the specified stop
-     */
-    public void cancelStop(int stop) {
-        cancelDropOffForStop(stop);
-        cancelPickupForStop(stop);
-    }
-
-    // TODO OTP2 - Unused, but will be used by Transmodel API
-
-    /**
-     * Returns true if both pickup and dropoff is cancelled for the specified stop
-     */
-    public boolean isCancelledStop(int stop) {
-        return dropoffs.get(stop) == PickDrop.CANCELLED && pickups.get(stop) == PickDrop.CANCELLED;
-    }
-
     //Is prediction for single stop inaccurate
     public void setPredictionInaccurate(int stop, boolean predictionInaccurate) {
         prepareForRealTimeUpdates();
@@ -316,26 +287,6 @@ public class TripTimes implements Serializable, Comparable<TripTimes> {
             return false;
         }
         return predictionInaccurateOnStops[stop];
-    }
-
-    public void cancelPickupForStop(int stop) {
-        prepareForRealTimeUpdates();
-        pickups.set(stop, PickDrop.CANCELLED);
-    }
-
-    // TODO OTP2 - Unused, but will be used by Transmodel API
-    public PickDrop getPickupType(int stop) {
-        return pickups.get(stop);
-    }
-
-    public void cancelDropOffForStop(int stop) {
-        prepareForRealTimeUpdates();
-        dropoffs.set(stop, PickDrop.CANCELLED);
-    }
-
-    // TODO OTP2 - Unused, but will be used by Transmodel API
-    public PickDrop getDropoffType(int stop) {
-        return dropoffs.get(stop);
     }
 
     public BookingInfo getDropOffBookingInfo(int stop) {

--- a/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
+++ b/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
@@ -89,6 +89,11 @@ public class TripTimes implements Serializable, Comparable<TripTimes> {
      * this original (non-real-time) pattern is queried, even though this original pattern allows pickup and dropoff
      * at the canceled stop. This is only for API purposes and does not affect routing.
      *
+     * // TODO This seems to only be changed after a new TripTimes has been created by the realtime
+     * // TODO updater and the scheduled TripTimes is never changed. We should clean this up
+     * // TODO when refactoring the realtime model. Preferably so that a reference is kept between
+     * // TODO the realtime data and the scheduled data, so that data is not duplicated
+     *
      * Non-final to allow updates.
      */
     private boolean[] cancelledStops;

--- a/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
+++ b/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
@@ -11,8 +11,10 @@ import java.util.Collection;
 import java.util.List;
 import org.opentripplanner.model.BookingInfo;
 import org.opentripplanner.model.PickDrop;
+import org.opentripplanner.model.StopPattern;
 import org.opentripplanner.model.StopTime;
 import org.opentripplanner.model.Trip;
+import org.opentripplanner.model.TripPattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,12 +77,16 @@ public class TripTimes implements Serializable, Comparable<TripTimes> {
      * Flag to indicate that the stop has been passed without removing arrival/departure-times - i.e. "estimates" are
      * actual times, no longer estimates.
      *
-     * Non-final to allow updates.
+     * This is only for API-purposes. Non-final to allow updates.
      */
     private boolean[] recordedStops;
 
     /**
-     * Stop has been cancelled by realtime updates.
+     * Stop has been cancelled by realtime updates. This is only for API-purposes and does not
+     * affect routing. It duplicates information found in the {@link StopPattern} of the new
+     * {@link TripPattern} created by the realtime update.
+     *
+     * Non-final to allow updates.
      */
     private boolean[] cancelledStops;
 

--- a/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
+++ b/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
@@ -304,7 +304,7 @@ public class TripTimes implements Serializable, Comparable<TripTimes> {
      *         information is actually available in this TripTimes.
      */
     public boolean isScheduled() {
-        return departureTimes == null && arrivalTimes == null;
+        return realTimeState == RealTimeState.SCHEDULED;
     }
 
     /**

--- a/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
+++ b/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
@@ -80,6 +80,11 @@ public class TripTimes implements Serializable, Comparable<TripTimes> {
     private boolean[] recordedStops;
 
     /**
+     * Stop has been cancelled by realtime updates.
+     */
+    private boolean[] cancelledStops;
+
+    /**
      * Flag to indicate inaccurate predictions on each stop. Non-final to allow updates.
      */
     private boolean[] predictionInaccurateOnStops;
@@ -144,6 +149,7 @@ public class TripTimes implements Serializable, Comparable<TripTimes> {
         this.arrivalTimes = null;
         this.departureTimes = null;
         this.recordedStops = null;
+        this.cancelledStops = null;
         this.timepoints = deduplicator.deduplicateBitSet(timepoints);
         LOG.trace("trip {} has timepoint at indexes {}", trip, timepoints);
     }
@@ -267,6 +273,18 @@ public class TripTimes implements Serializable, Comparable<TripTimes> {
         recordedStops[stop] = recorded;
     }
 
+    public void setCancelled(int stop) {
+        prepareForRealTimeUpdates();
+        cancelledStops[stop] = true;
+    }
+
+    public boolean isCancelledStop(int stop) {
+        if (cancelledStops == null) {
+            return false;
+        }
+        return cancelledStops[stop];
+    }
+
     // TODO OTP2 - Unused, but will be used by Transmodel API
     public boolean isRecordedStop(int stop) {
         if (recordedStops == null) {
@@ -387,11 +405,13 @@ public class TripTimes implements Serializable, Comparable<TripTimes> {
             this.arrivalTimes = Arrays.copyOf(scheduledArrivalTimes, scheduledArrivalTimes.length);
             this.departureTimes = Arrays.copyOf(scheduledDepartureTimes, scheduledDepartureTimes.length);
             this.recordedStops = new boolean[arrivalTimes.length];
+            this.cancelledStops = new boolean[arrivalTimes.length];
             this.predictionInaccurateOnStops = new boolean[arrivalTimes.length];
             for (int i = 0; i < arrivalTimes.length; i++) {
                 arrivalTimes[i] += timeShift;
                 departureTimes[i] += timeShift;
                 recordedStops[i] = false;
+                cancelledStops[i] = false;
                 predictionInaccurateOnStops[i] = false;
             }
 

--- a/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
+++ b/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
@@ -82,9 +82,12 @@ public class TripTimes implements Serializable, Comparable<TripTimes> {
     private boolean[] recordedStops;
 
     /**
-     * Stop has been cancelled by realtime updates. This is only for API-purposes and does not
-     * affect routing. It duplicates information found in the {@link StopPattern} of the new
-     * {@link TripPattern} created by the realtime update.
+     * Whether each stop has been cancelled by realtime updates (in the most recent derived realtime StopPattern).
+     * The cancellation information here need not match the information in the StopPattern for this TripTimes.
+     * This is somewhat redundant: it duplicates cancellation information found in the {@link StopPattern} of the new
+     * {@link TripPattern} created by the realtime update. The use case is displaying cancellation information when
+     * this original (non-real-time) pattern is queried, even though this original pattern allows pickup and dropoff
+     * at the canceled stop. This is only for API purposes and does not affect routing.
      *
      * Non-final to allow updates.
      */

--- a/src/test/java/org/opentripplanner/model/TimetableTest.java
+++ b/src/test/java/org/opentripplanner/model/TimetableTest.java
@@ -191,9 +191,12 @@ public class TimetableTest {
         timetable.setTripTimes(trip_1_1_index, updatedTripTimes);
 
         TripTimes tripTimes = timetable.getTripTimes(trip_1_1_index);
+
+        // TODO This will not work since individual stops cannot be cancelled using GTFS updates
+        //      yet
         for (int i = 0; i < tripTimes.getNumStops(); i++) {
-            assertEquals(PickDrop.CANCELLED, tripTimes.getPickupType(i));
-            assertEquals(PickDrop.CANCELLED, tripTimes.getDropoffType(i));
+            assertEquals(PickDrop.CANCELLED, pattern.getStopPattern().getPickup(i) );
+            assertEquals(PickDrop.CANCELLED, pattern.getStopPattern().getDropoff(i) );
         }
 
         //---

--- a/src/test/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSourceTest.java
+++ b/src/test/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSourceTest.java
@@ -126,8 +126,8 @@ public class TimetableSnapshotSourceTest {
 
         final TripTimes tripTimes = forToday.getTripTimes(tripIndex);
         for (int i = 0; i < tripTimes.getNumStops(); i++) {
-            assertEquals(PickDrop.CANCELLED, tripTimes.getPickupType(i));
-            assertEquals(PickDrop.CANCELLED, tripTimes.getPickupType(i));
+            assertEquals(PickDrop.CANCELLED, pattern.getStopPattern().getPickup(i));
+            assertEquals(PickDrop.CANCELLED, pattern.getStopPattern().getDropoff(i));
         }
         assertEquals(RealTimeState.CANCELED, tripTimes.getRealTimeState());
     }


### PR DESCRIPTION
### Summary
This build on top of #3571.

Because Raptor only checks whether stops can be boarded/alighted on the `TripPattern` level, we need to do the actual cancellations in the `StopPattern` instead of the `TripTimes`.

This PR does the following:
- Change the `Stop` field on TripTimeOnDate to `TripPattern`. This allows checks for cancellations on the `Pattern` level.
- Change the SIRI implementation to cancel stops at the `StopPattern` level. This will make the Siri implementation create a new `TripPattern` for that `Trip`.
- Mark in the GTFS-RT implementation where cancelations at the `TripPattern` level is missing.
- Simplify the Transmodel API calls for `forBoarding` and `forAlighting` by replacing the more complex logic with a call to `PickUpType.isRouteable()`.
- Add back the cancellation flags on the `TripTimes` class. These are only for API-purposes and do not affect routing. This is documented with javadoc. The only reason these exist is that the current realtime model does not allow navigating to the updated version of the `TripTimes` object. This is duplicated information.

### Issue
#3119

### Unit tests
No new unit tests

### Changelog
Changelog added
