### PR TITLE
Tiny bugfix: Remove unused parameter to enable route on report API

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/reportapi/resource/ReportResource.java
+++ b/src/ext/java/org/opentripplanner/ext/reportapi/resource/ReportResource.java
@@ -39,7 +39,7 @@ public class ReportResource {
     @GET
     @Path("/bicycle-safety.html")
     @Produces(MediaType.TEXT_HTML)
-    public Response getBicycleSafetyPage(String wayPropertySet) {
+    public Response getBicycleSafetyPage() {
         var is = getClass().getResourceAsStream("/reportapi/report.html");
         try {
             return Response.ok(new String(is.readAllBytes(), StandardCharsets.UTF_8)).build();


### PR DESCRIPTION
### Summary
In my previous PR #3563 I added a resource to the report API, however, I made a small mistake which resulted in a 404 when calling the route: the method has an unused parameter which would lead to the HTML page not being shown.

This is a tiny, one-line change to a sandbox feature.

### Code style
n/a

### Documentation
I added documentation in my previous PR. This just fixes it the feature.

### Changelog
I don't think that it's needed - or is it?