### PR TITLE
Do not allow bicycle traversal on ways tagged with mtb:scale

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -37,6 +37,7 @@
 - Optimize Transfers performance issue [#3513](https://github.com/opentripplanner/OpenTripPlanner/issues/3513)
 - Refactor StopPattern/TripPattern/TripTimes [#3571](https://github.com/opentripplanner/OpenTripPlanner/issues/3571)
 - Don't allow bicycle loops in A* [#3574](https://github.com/opentripplanner/OpenTripPlanner/pull/3574)
+- Do not allow bicycle traversal on ways tagged with mtb:scale [#3578](https://github.com/opentripplanner/OpenTripPlanner/pull/3578)
 
 
 ## 2.0.0 (2020-11-27)

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
@@ -678,7 +678,7 @@ public class LegacyGraphQLQueryTypeImpl
         }
 
         if (optimize != null) {
-          request.optimize = optimize;
+          request.bicycleOptimizeType = optimize;
         }
       }
 

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/TripQuery.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/TripQuery.java
@@ -199,10 +199,10 @@ public class TripQuery {
             .description(
                 "The set of characteristics that the user wants to optimise for during bicycle "
                 + "searches -- defaults to "
-                + enumValAsString(EnumTypes.BICYCLE_OPTIMISATION_METHOD, routing.request.optimize)
+                + enumValAsString(EnumTypes.BICYCLE_OPTIMISATION_METHOD, routing.request.bicycleOptimizeType)
             )
             .type(EnumTypes.BICYCLE_OPTIMISATION_METHOD)
-            .defaultValue(routing.request.optimize)
+            .defaultValue(routing.request.bicycleOptimizeType)
             .build()
         )
         .argument(GraphQLArgument.newArgument()

--- a/src/main/java/org/opentripplanner/api/common/RoutingResource.java
+++ b/src/main/java/org/opentripplanner/api/common/RoutingResource.java
@@ -741,7 +741,7 @@ public abstract class RoutingResource {
 
         if (optimize != null) {
             // Optimize types are basically combined presets of routing parameters, except for triangle
-            request.setOptimize(optimize);
+            request.setBicycleOptimizeType(optimize);
             if (optimize == BicycleOptimizeType.TRIANGLE) {
                 RoutingRequest.assertTriangleParameters(
                         triangleSafetyFactor, triangleTimeFactor, triangleSlopeFactor
@@ -808,7 +808,7 @@ public abstract class RoutingResource {
         }
 
         if (optimize != null) {
-            request.setOptimize(optimize);
+            request.setBicycleOptimizeType(optimize);
         }
         /* Temporary code to get bike/car parking and renting working. */
         if (modes != null && !modes.qModes.isEmpty()) {

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/DefaultWayPropertySetSource.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/DefaultWayPropertySetSource.java
@@ -43,6 +43,10 @@ public class DefaultWayPropertySetSource implements WayPropertySetSource {
         /* NONE */
         props.setProperties("highway=raceway", StreetTraversalPermission.NONE);
         props.setProperties("highway=construction", StreetTraversalPermission.NONE);
+        props.setProperties("mtb:scale=3", StreetTraversalPermission.NONE);
+        props.setProperties("mtb:scale=4", StreetTraversalPermission.NONE);
+        props.setProperties("mtb:scale=5", StreetTraversalPermission.NONE);
+        props.setProperties("mtb:scale=6", StreetTraversalPermission.NONE);
 
         /* PEDESTRIAN */
 		props.setProperties("highway=corridor", StreetTraversalPermission.PEDESTRIAN);
@@ -53,8 +57,11 @@ public class DefaultWayPropertySetSource implements WayPropertySetSource {
         props.setProperties("railway=platform", StreetTraversalPermission.PEDESTRIAN);
         props.setProperties("footway=sidewalk;highway=footway",
                 StreetTraversalPermission.PEDESTRIAN);
+        props.setProperties("mtb:scale=1", StreetTraversalPermission.PEDESTRIAN);
+        props.setProperties("mtb:scale=2", StreetTraversalPermission.PEDESTRIAN);
 
         /* PEDESTRIAN_AND_BICYCLE */
+        props.setProperties("mtb:scale=0", StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE);
         props.setProperties("highway=cycleway", StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE,
                 0.60, 0.60);
         props.setProperties("highway=path", StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE,

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/request/RaptorRequestTransferCache.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/request/RaptorRequestTransferCache.java
@@ -133,7 +133,7 @@ public class RaptorRequestTransferCache {
         public StreetRelevantOptions(RoutingRequest routingRequest) {
             this.transferMode = routingRequest.modes.transferMode;
 
-            this.optimize = routingRequest.optimize;
+            this.optimize = routingRequest.bicycleOptimizeType;
             this.bikeTriangleSafetyFactor = routingRequest.bikeTriangleSafetyFactor;
             this.bikeTriangleSlopeFactor = routingRequest.bikeTriangleSlopeFactor;
             this.bikeTriangleTimeFactor = routingRequest.bikeTriangleTimeFactor;

--- a/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
@@ -144,17 +144,9 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
     public TraverseModeSet streetSubRequestModes = new TraverseModeSet(TraverseMode.WALK); // defaults in constructor overwrite this
 
     /**
-     * The set of characteristics that the user wants to optimize for -- defaults to QUICK, or
-     * optimize for transit time.
-     *
-     * @deprecated TODO OTP2 this should be completely removed and done only with individual cost
-     *                       parameters
-     *                       Also: apparently OptimizeType only affects BICYCLE mode traversal of
-     *                       street segments. If this is the case it should be very well
-     *                       documented and carried over into the Enum name.
+     * The set of characteristics that the user wants to optimize for -- defaults to SAFE.
      */
-    @Deprecated
-    public BicycleOptimizeType optimize = BicycleOptimizeType.QUICK;
+    public BicycleOptimizeType bicycleOptimizeType = BicycleOptimizeType.SAFE;
 
     /** The epoch date/time that the trip should depart (or arrive, for requests where arriveBy is true) */
     public long dateTime = new Date().getTime() / 1000;
@@ -725,13 +717,13 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
         this.setStreetSubRequestModes(new TraverseModeSet(mode));
     }
 
-    public RoutingRequest(TraverseMode mode, BicycleOptimizeType optimize) {
-        this(new TraverseModeSet(mode), optimize);
+    public RoutingRequest(TraverseMode mode, BicycleOptimizeType bicycleOptimizeType) {
+        this(new TraverseModeSet(mode), bicycleOptimizeType);
     }
 
-    public RoutingRequest(TraverseModeSet modeSet, BicycleOptimizeType optimize) {
+    public RoutingRequest(TraverseModeSet modeSet, BicycleOptimizeType bicycleOptimizeType) {
         this();
-        this.optimize = optimize;
+        this.bicycleOptimizeType = bicycleOptimizeType;
         this.setStreetSubRequestModes(modeSet);
     }
 
@@ -757,8 +749,8 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
         this.streetSubRequestModes = streetSubRequestModes;
     }
 
-    public void setOptimize(BicycleOptimizeType optimize) {
-        this.optimize = optimize;
+    public void setBicycleOptimizeType(BicycleOptimizeType bicycleOptimizeType) {
+        this.bicycleOptimizeType = bicycleOptimizeType;
     }
 
     public void setWheelchairAccessible(boolean wheelchairAccessible) {
@@ -943,7 +935,7 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
 
     public String toString(String sep) {
         return from + sep + to + sep + getDateTime() + sep
-                + arriveBy + sep + optimize + sep + streetSubRequestModes.getAsStr() + sep
+                + arriveBy + sep + bicycleOptimizeType + sep + streetSubRequestModes.getAsStr() + sep
                 + getNumItineraries();
     }
 

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
@@ -331,7 +331,7 @@ public class StreetEdge extends Edge implements BikeWalkableEdge, Cloneable, Car
         switch (traverseMode) {
             case BICYCLE:
                 time = getEffectiveBikeDistance() / speed;
-                switch (options.optimize) {
+                switch (options.bicycleOptimizeType) {
                     case SAFE:
                         weight = bicycleSafetyFactor * getDistanceMeters() / speed;
                         break;

--- a/src/main/java/org/opentripplanner/standalone/config/RoutingRequestMapper.java
+++ b/src/main/java/org/opentripplanner/standalone/config/RoutingRequestMapper.java
@@ -72,7 +72,7 @@ public class RoutingRequestMapper {
         request.nonpreferredTransferCost = c.asInt("nonpreferredTransferPenalty", dft.nonpreferredTransferCost);
         request.numItineraries = c.asInt("numItineraries", dft.numItineraries);
         request.onlyTransitTrips = c.asBoolean("onlyTransitTrips", dft.onlyTransitTrips);
-        request.optimize = c.asEnum("optimize", dft.optimize);
+        request.bicycleOptimizeType = c.asEnum("optimize", dft.bicycleOptimizeType);
         request.otherThanPreferredRoutesPenalty = c.asInt("otherThanPreferredRoutesPenalty", dft.otherThanPreferredRoutesPenalty);
         request.parkAndRide = c.asBoolean("parkAndRide", dft.parkAndRide);
         request.pathComparator = c.asText("pathComparator", dft.pathComparator);

--- a/src/main/java/org/opentripplanner/visualizer/GraphVisualizer.java
+++ b/src/main/java/org/opentripplanner/visualizer/GraphVisualizer.java
@@ -1363,7 +1363,7 @@ public class GraphVisualizer extends JFrame implements VertexSelectionListener {
         // TODO LG Add ui element for bike board cost (for now bike = 2 * walk)
         options.setBikeBoardCost(Integer.parseInt(boardingPenaltyField.getText()) * 60 * 2);
         // there should be a ui element for walk distance and optimize type
-        options.setOptimize( getSelectedOptimizeType() );
+        options.setBicycleOptimizeType( getSelectedOptimizeType() );
         options.setDateTime(when);
         options.setFromString(from);
         options.setToString(to);

--- a/src/test/java/org/opentripplanner/graph_builder/module/osm/NorwayWayPropertySetSourceTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/osm/NorwayWayPropertySetSourceTest.java
@@ -17,21 +17,35 @@ public class NorwayWayPropertySetSourceTest {
   @Test
   public void testMtbScaleNone() {
     // https://www.openstreetmap.org/way/302610220
-    var way = new OSMWithTags();
-    way.addTag("highway", "path");
-    way.addTag("mtb:scale", "3");
+    var way1 = new OSMWithTags();
+    way1.addTag("highway", "path");
+    way1.addTag("mtb:scale", "3");
 
     assertEquals(
-        wps.getDataForWay(way).getPermission(), StreetTraversalPermission.NONE);
+        wps.getDataForWay(way1).getPermission(), StreetTraversalPermission.NONE);
+
+    var way2 = new OSMWithTags();
+    way2.addTag("highway", "track");
+    way2.addTag("mtb:scale", "3");
+
+    assertEquals(
+        wps.getDataForWay(way2).getPermission(), StreetTraversalPermission.NONE);
   }
 
   @Test
   public void testMtbScalePedestrian() {
-    var way = new OSMWithTags();
-    way.addTag("highway", "path");
-    way.addTag("mtb:scale", "1");
+    var way1 = new OSMWithTags();
+    way1.addTag("highway", "path");
+    way1.addTag("mtb:scale", "1");
 
     assertEquals(
-        wps.getDataForWay(way).getPermission(), StreetTraversalPermission.PEDESTRIAN);
+        wps.getDataForWay(way1).getPermission(), StreetTraversalPermission.PEDESTRIAN);
+
+    var way2 = new OSMWithTags();
+    way2.addTag("highway", "track");
+    way2.addTag("mtb:scale", "1");
+
+    assertEquals(
+        wps.getDataForWay(way2).getPermission(), StreetTraversalPermission.PEDESTRIAN);
   }
 }

--- a/src/test/java/org/opentripplanner/graph_builder/module/osm/NorwayWayPropertySetSourceTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/osm/NorwayWayPropertySetSourceTest.java
@@ -1,0 +1,37 @@
+package org.opentripplanner.graph_builder.module.osm;
+
+import org.junit.Test;
+import org.opentripplanner.openstreetmap.model.OSMWithTags;
+import org.opentripplanner.routing.edgetype.StreetTraversalPermission;
+
+import static org.junit.Assert.assertEquals;
+
+public class NorwayWayPropertySetSourceTest {
+  static WayPropertySet wps = new WayPropertySet();
+
+  static {
+    var source = new NorwayWayPropertySetSource();
+    source.populateProperties(wps);
+  }
+
+  @Test
+  public void testMtbScaleNone() {
+    // https://www.openstreetmap.org/way/302610220
+    var way = new OSMWithTags();
+    way.addTag("highway", "path");
+    way.addTag("mtb:scale", "3");
+
+    assertEquals(
+        wps.getDataForWay(way).getPermission(), StreetTraversalPermission.NONE);
+  }
+
+  @Test
+  public void testMtbScalePedestrian() {
+    var way = new OSMWithTags();
+    way.addTag("highway", "path");
+    way.addTag("mtb:scale", "1");
+
+    assertEquals(
+        wps.getDataForWay(way).getPermission(), StreetTraversalPermission.PEDESTRIAN);
+  }
+}

--- a/src/test/java/org/opentripplanner/routing/edgetype/TestTriangle.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/TestTriangle.java
@@ -49,7 +49,7 @@ public class TestTriangle extends TestCase {
         double slopeSpeedLength = testStreet.getEffectiveBikeDistance();
 
         RoutingRequest options = new RoutingRequest(TraverseMode.BICYCLE);
-        options.optimize = BicycleOptimizeType.TRIANGLE;
+        options.bicycleOptimizeType = BicycleOptimizeType.TRIANGLE;
         options.bikeSpeed = 6.0;
         options.setNonTransitReluctance(1);
 

--- a/src/test/java/org/opentripplanner/routing/edgetype/loader/TestGeometryAndBlockProcessor.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/loader/TestGeometryAndBlockProcessor.java
@@ -429,7 +429,7 @@ public class TestGeometryAndBlockProcessor extends TestCase {
         Vertex stop_c = graph.getVertex(feedId + ":C");
         Vertex stop_d = graph.getVertex(feedId + ":D");
         RoutingRequest options = new RoutingRequest();
-        options.optimize = BicycleOptimizeType.QUICK;
+        options.bicycleOptimizeType = BicycleOptimizeType.QUICK;
         options.dateTime = TestUtils.dateInSeconds("America/New_York", 2009, 8, 1, 16, 0, 0);
         options.setRoutingContext(graph, stop_c, stop_d);  
                 

--- a/src/test/java/org/opentripplanner/routing/street/BicycleRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/street/BicycleRoutingTest.java
@@ -9,6 +9,7 @@ import org.opentripplanner.ConstantsForTests;
 import org.opentripplanner.model.GenericLocation;
 import org.opentripplanner.routing.algorithm.mapping.GraphPathToItineraryMapper;
 import org.opentripplanner.routing.api.request.RoutingRequest;
+import org.opentripplanner.routing.core.BicycleOptimizeType;
 import org.opentripplanner.routing.core.TraverseMode;
 import org.opentripplanner.routing.core.TraverseModeSet;
 import org.opentripplanner.routing.graph.Graph;
@@ -59,6 +60,7 @@ public class BicycleRoutingTest {
         request.dateTime = dateTime;
         request.from = from;
         request.to = to;
+        request.bicycleOptimizeType = BicycleOptimizeType.QUICK;
 
         request.streetSubRequestModes = new TraverseModeSet(TraverseMode.BICYCLE);
         request.setRoutingContext(graph);


### PR DESCRIPTION
### Summary
This PR restricts the traversal of `mtb:scale` tagged ways:
mtb:scale=0 - Pedestrian and bicycle
mtb:scale=1 - Pedestrian only
mtb:scale=2 - Pedestrian only
mtb:scale=3 - No traversal
mtb:scale=4 - No traversal
mtb:scale=5 - No traversal
mtb:scale=6 - No traversal

It also renames the `RoutingRequest.optimize` field to `bicycleOptimizeType` and sets the default to `SAFE` instead of `QUICK`.

Also, the Transmodel API now reads the correct field when applying `bicycleOptimizeType` to the `RoutingRequest`.

### Issue
No issue

### Unit tests
Added new unit tests for the WayPropertySource

### Changelog
Added changelog
