### PR TITLE
Improve bicycle safety report and documentation 

### DIFF
--- a/docs/Troubleshooting-Routing.md
+++ b/docs/Troubleshooting-Routing.md
@@ -85,15 +85,25 @@ As a default, foot and bicycle traffic is ''not'' allowed on `highway=trunk`, `h
 
 Both *are* allowed on `highway=pedestrian`, `highway=cycleway`, and `highway=footway`. 
 
-Finally, bicycles are *not*allowed on *highway=footway* when any of the following tags appear on a footway: `footway=sidewalk`, `public_transport=platform`, or `railway=platform`.
+Finally, bicycles are *not* allowed on *highway=footway* when any of the following tags appear on a footway: `footway=sidewalk`, `public_transport=platform`, or `railway=platform`.
 
 Other access tags (such as `access=no` and `access=private` affect routing as well, and can be overridden similarly. While `access=no` prohibits all traffic, `access=private` disallows through traffic.
 
 ### Bicycle safety factor
 
 Bicycle routing is even more configurable than the other traverse modes: during graph build a so-called bicycle safety score is
-computed for each street. How this is calculated depends on the slope of the way and its OSM tags. At request time you can
-then use the `triangleFactors` to decide how important bicycle safety is compared to speed and flatness.
+computed for each street. You can think of this score as a penalty for traversing this way so the lower the score the better.
+
+For example if a way is tagged with `surface=sand` it receives a safety score of 100 which means that it's 100 times worse to 
+cycle on when compared to a way which has a safety score of 1.
+
+How this is calculated depends on two things
+
+- the incline of the way (not read from OSM but from the [separately configured elevation data](Configuration.md#Elevation data))
+- its OSM tags
+ 
+At request time you can then use the `triangleFactors` to decide how important bicycle safety 
+is compared to shorter distances and flatness.
 
 Each `WayPropertySet` contains rules for a given set of tag matchers that influence the bicycle safety score. For example, a rule looks like this:
 
@@ -102,8 +112,16 @@ props.setProperties("highway=track", StreetTraversalPermission.ALL, 1.3, 1.3);
 ```
 
 This means that an OSM way with the tag `highway=track` is traversable by all modes (pedestrian, bicycle, car) and that
-its bicycle safety score is `1.3` (smaller is better). If there is a more specific matcher like `highway=track;bicycle=no`
-and it matches a given OSM way, it is chosen instead and its settings applied.
+its bicycle safety score when you traverse in order of the way is `1.3` and also `1.3` when going the other way 
+(smaller means more cycle-friendly).
+
+If there is a more specific matcher like `highway=track;bicycle=no` and it matches a given OSM way, 
+it is chosen instead and its settings applied.
+
+The score can be any positive number but the range (as of writing this) goes from `0.6` for bike lanes
+to `100` for ways that consist of sand. To figure out a good value for your set of tags you should
+read the bicycle safety report (see below) or the source code of your `WayPropertySetSource` to get
+a feeling for how much certain tags are penalised or rewarded.
 
 There are also so-called mixins. These are applied on top of the most specific matchers and a single
 OSM way can match many mixins. The mixins' safety values are multiplied with the value of the base 

--- a/src/ext/java/org/opentripplanner/ext/reportapi/resource/ReportResource.java
+++ b/src/ext/java/org/opentripplanner/ext/reportapi/resource/ReportResource.java
@@ -39,7 +39,7 @@ public class ReportResource {
     @GET
     @Path("/bicycle-safety.html")
     @Produces(MediaType.TEXT_HTML)
-    public Response getBicycleSafetyPage(String wayPropertySet) {
+    public Response getBicycleSafetyPage() {
         var is = getClass().getResourceAsStream("/reportapi/report.html");
         try {
             return Response.ok(new String(is.readAllBytes(), StandardCharsets.UTF_8)).build();

--- a/src/ext/resources/reportapi/report.html
+++ b/src/ext/resources/reportapi/report.html
@@ -46,13 +46,17 @@
             <th>OSM tag match expression</th>
             <th>Mixin?</th>
             <th>Traversal permissions</th>
-            <th>Safety factor there</th>
-            <th>Safety factor back</th>
+            <th>Safety factor there<sup>1</sup></th>
+            <th>Safety factor back<sup>1</sup></th>
           </tr>
           </thead>
           <tbody>
           </tbody>
         </table>
+      </div>
+
+      <div class="col-md-12">
+        <sup>1</sup>: Smaller means more cycling friendly. Larger means less cycle friendly. Think of at as a multiplier for the cost of traversing the way.
       </div>
     </div>
   </main>


### PR DESCRIPTION
### Summary

After some feedback from the users of the bicycle safety report and documentation I improved both.

The change in the Java file is a fix for an embarrassing oversight: the method param was unused and hence the route was never actually served by OTP.

### Unit tests
n/a

### Code style
Yes.

### Documentation
n/a

### Changelog
n/a (or is it?)