### PR TITLE
Do not skip update just because there are no EstimatedCalls

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/siri/TimetableHelper.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/TimetableHelper.java
@@ -455,11 +455,12 @@ public class TimetableHelper {
 
         EstimatedVehicleJourney.EstimatedCalls journeyCalls = journey.getEstimatedCalls();
 
-        if (journeyCalls == null) {
-            return null;
+        List<EstimatedCall> estimatedCalls;
+        if (journeyCalls != null) {
+            estimatedCalls = journeyCalls.getEstimatedCalls();
+        } else {
+            estimatedCalls = new ArrayList<>();
         }
-
-        List<EstimatedCall> estimatedCalls = journeyCalls.getEstimatedCalls();
 
         List<Stop> stops = createModifiedStops(timetable, journey, routingService);
 
@@ -519,7 +520,7 @@ public class TimetableHelper {
                         } else if (estimatedCall.getArrivalBoardingActivity() == ArrivalBoardingActivityEnumeration.NO_ALIGHTING) {
                             stopTime.setDropOffType(NONE);
                         } else if (estimatedCall.getArrivalBoardingActivity() == null && i == 0) {
-                            //First stop - default no pickup
+                            //First stop - default no dropoff
                             stopTime.setDropOffType(NONE);
                         }
 
@@ -531,7 +532,7 @@ public class TimetableHelper {
                         } else if (estimatedCall.getDepartureBoardingActivity() == DepartureBoardingActivityEnumeration.NO_BOARDING) {
                             stopTime.setPickupType(NONE);
                         } else if (estimatedCall.getDepartureBoardingActivity() == null && i == (stops.size()-1)) {
-                            //Last stop - default no dropoff
+                            //Last stop - default no pickup
                             stopTime.setPickupType(NONE);
                         }
 

--- a/src/ext/java/org/opentripplanner/ext/siri/TimetableHelper.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/TimetableHelper.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.TimeZone;
 
+import static java.util.Collections.EMPTY_LIST;
 import static org.opentripplanner.model.PickDrop.NONE;
 import static org.opentripplanner.model.PickDrop.SCHEDULED;
 
@@ -81,14 +82,14 @@ public class TimetableHelper {
         if (journeyEstimatedCalls != null) {
             estimatedCalls = journeyEstimatedCalls.getEstimatedCalls();
         } else {
-            estimatedCalls = new ArrayList<>();
+            estimatedCalls = EMPTY_LIST;
         }
 
         List<RecordedCall> recordedCalls;
         if (journeyRecordedCalls != null) {
             recordedCalls = journeyRecordedCalls.getRecordedCalls();
         } else {
-            recordedCalls = new ArrayList<>();
+            recordedCalls = EMPTY_LIST;
         }
 
         boolean stopPatternChanged = false;
@@ -357,14 +358,14 @@ public class TimetableHelper {
         if (journeyEstimatedCalls != null) {
             estimatedCalls = journeyEstimatedCalls.getEstimatedCalls();
         } else {
-            estimatedCalls = new ArrayList<>();
+            estimatedCalls = EMPTY_LIST;
         }
 
         List<RecordedCall> recordedCalls;
         if (journeyRecordedCalls != null) {
             recordedCalls = journeyRecordedCalls.getRecordedCalls();
         } else {
-            recordedCalls = new ArrayList<>();
+            recordedCalls = EMPTY_LIST;
         }
 
         //Get all scheduled stops
@@ -459,7 +460,7 @@ public class TimetableHelper {
         if (journeyCalls != null) {
             estimatedCalls = journeyCalls.getEstimatedCalls();
         } else {
-            estimatedCalls = new ArrayList<>();
+            estimatedCalls = EMPTY_LIST;
         }
 
         List<Stop> stops = createModifiedStops(timetable, journey, routingService);


### PR DESCRIPTION
Minor changes in sandbox for SIRI-handling.

SIRI ET-updates with only "RecordedCalls" have been explicitly ignored although existing code already support these. (E.g. updates that flag arrival at last stop.) 

This PR allows these to be processed as any other update.


