### PR TITLE
Fix bug in optimize transfer service decorating path

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -41,6 +41,7 @@
 - Refactor StopPattern/TripPattern/TripTimes [#3571](https://github.com/opentripplanner/OpenTripPlanner/issues/3571)
 - Do not allow bicycle traversal on ways tagged with mtb:scale [#3578](https://github.com/opentripplanner/OpenTripPlanner/pull/3578)
 - Changes to the StopTimes call [#3576](https://github.com/opentripplanner/OpenTripPlanner/issues/3576)
+- Fix bug in optimize transfer service decorating path [#3587](https://github.com/opentripplanner/OpenTripPlanner/issues/3587)
 
 
 ## 2.0.0 (2020-11-27)

--- a/src/main/java/org/opentripplanner/model/transfer/TransferPriority.java
+++ b/src/main/java/org/opentripplanner/model/transfer/TransferPriority.java
@@ -35,7 +35,6 @@ public enum TransferPriority {
    */
   RECOMMENDED(-1),
 
-
   /**
    * The highest priority there exist.
    * <p>

--- a/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/model/TripToTripTransfer.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/model/TripToTripTransfer.java
@@ -21,20 +21,12 @@ public class TripToTripTransfer<T extends RaptorTripSchedule> {
       TripStopTime<T> from,
       TripStopTime<T> to,
       RaptorTransfer pathTransfer,
-      Transfer guaranteedTransfer
+      @Nullable Transfer guaranteedTransfer
   ) {
     this.from = from;
     this.to = to;
     this.pathTransfer = pathTransfer;
     this.guaranteedTransfer = guaranteedTransfer;
-  }
-
-  public TripToTripTransfer(
-          TripStopTime<T> from,
-          TripStopTime<T> to,
-          RaptorTransfer pathTransfer
-  ) {
-    this(from, to, pathTransfer, null);
   }
 
   public TripStopTime<T> from() {

--- a/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/services/OptimizePathService.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/services/OptimizePathService.java
@@ -223,7 +223,12 @@ public class OptimizePathService<T extends RaptorTripSchedule> {
             costCalculator, slackProvider, firstRide, earliestDepartureTime
     );
 
-    return optimizedPathFactory.createPathLeg(fromTransitLeg, tx.guaranteedTransfer(), tail);
+    return optimizedPathFactory.createPathLeg(
+            fromTransitLeg,
+            tx.guaranteedTransfer(),
+            tail.getTransfersTo(),
+            toTransitLeg
+    );
   }
 
   private PathLeg<T> createTransferLegIfExist(

--- a/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/services/OptimizedPathFactory.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/services/OptimizedPathFactory.java
@@ -59,11 +59,10 @@ class OptimizedPathFactory<T extends RaptorTripSchedule> {
     OptimizedPathTail<T> createPathLeg(
             TransitPathLeg<T> leg,
             @Nullable Transfer tx,
-            OptimizedPathTail<T> tail
+            Map<PathLeg<T>, Transfer> transfersTo,
+            TransitPathLeg<T> toTransitLeg
     ) {
-        Map<PathLeg<T>, Transfer> transfers = createTransfers(
-                tail.getLeg(), tx, tail.getTransfersTo()
-        );
+        var transfers = createTransfers(toTransitLeg, tx, transfersTo);
         return new OptimizedPathTail<>(
                 leg,
                 transfers,

--- a/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/services/OptimizePathServiceConstrainedTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/services/OptimizePathServiceConstrainedTest.java
@@ -19,23 +19,26 @@ import org.opentripplanner.transit.raptor._data.transit.TestTripSchedule;
 
 /**
  * <pre>
- * DEPARTURE TIMES
- * Stop        A      B-C        C-D         D-E         E-F         F-G        H
- * Tx time            1m         2m          3m          4m          5m
+ * POSSIBLE TRANSFERS
+ * Transfers        B-C 1m     C-D 2m       D-E 3m     E-F 4m      F-G 5m
  * Constraint       ALLOWED  RECOMMENDED  PREFERRED  GUARANTIED  STAY_SEATED
- * Trip 1    10:02  10:10      10:15       10:20       10:25       10:30
- * Trip 2             10:13      10:18       10:24       10:30       10:36    10:40
+ * Trip 1    10:02  B 10:10    C 10:15     D 10:20     E 10:25     F 10:30
+ * Trip 2           C 10:13    D 10:18     E 10:24     G 10:30     G 10:36    10:40
  * </pre>
- * <p>
+ *
  * Case: There is 5 possible places to transfer in this setup. We want to test that the correct one
- * is picked according to the constraint. We can test all relevant cases by changing the egress
- * stop, since the transfers are ordered with the highest priority last. Transfer in the same stop
- * is NOT_ALLOWED.
- * <p>
+ *     is picked according to the constraint. We can test all relevant cases by changing the egress
+ *     stop, since the transfers are ordered with the highest priority last. Transfer in the same stop
+ *     is NOT_ALLOWED.
+ *
  * Expect: The highest priority should be picked
- * <p>
+ *
+ * Module under test: We are testing the Optimized Transfer Service, not Routing it self. So, the 
+ *     path will always include two trips with one transfer selected even where single trip might 
+ *     be found by the router. 
+ *
  * Note! This test uses some of the constants and utility methods of {@link
- * OptimizePathServiceTest}
+ *     OptimizePathServiceTest}
  */
 @SuppressWarnings("SameParameterValue")
 public class OptimizePathServiceConstrainedTest implements RaptorTestConstants {

--- a/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/services/OptimizePathServiceConstrainedTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/services/OptimizePathServiceConstrainedTest.java
@@ -1,0 +1,163 @@
+package org.opentripplanner.routing.algorithm.transferoptimization.services;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.opentripplanner.model.transfer.TransferPriority.ALLOWED;
+import static org.opentripplanner.model.transfer.TransferPriority.NOT_ALLOWED;
+import static org.opentripplanner.model.transfer.TransferPriority.PREFERRED;
+import static org.opentripplanner.model.transfer.TransferPriority.RECOMMENDED;
+import static org.opentripplanner.routing.algorithm.transferoptimization.services.TestTransferBuilder.txConstrained;
+import static org.opentripplanner.routing.algorithm.transferoptimization.services.TransferGeneratorDummy.dummyTransferGenerator;
+import static org.opentripplanner.routing.algorithm.transferoptimization.services.TransferGeneratorDummy.tx;
+import static org.opentripplanner.util.time.TimeUtils.time;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.model.transfer.TransferPriority;
+import org.opentripplanner.transit.raptor._data.RaptorTestConstants;
+import org.opentripplanner.transit.raptor._data.transit.TestTripSchedule;
+
+/**
+ * <pre>
+ * DEPARTURE TIMES
+ * Stop        A      B-C        C-D         D-E         E-F         F-G        H
+ * Tx time            1m         2m          3m          4m          5m
+ * Constraint       ALLOWED  RECOMMENDED  PREFERRED  GUARANTIED  STAY_SEATED
+ * Trip 1    10:02  10:10      10:15       10:20       10:25       10:30
+ * Trip 2             10:13      10:18       10:24       10:30       10:36    10:40
+ * </pre>
+ * <p>
+ * Case: There is 5 possible places to transfer in this setup. We want to test that the correct one
+ * is picked according to the constraint. We can test all relevant cases by changing the egress
+ * stop, since the transfers are ordered with the highest priority last. Transfer in the same stop
+ * is NOT_ALLOWED.
+ * <p>
+ * Expect: The highest priority should be picked
+ * <p>
+ * Note! This test uses some of the constants and utility methods of {@link
+ * OptimizePathServiceTest}
+ */
+@SuppressWarnings("SameParameterValue")
+public class OptimizePathServiceConstrainedTest implements RaptorTestConstants {
+
+    /**
+     * The exact start time to walk to stop A to catch Trip_1 with 40s board slack
+     */
+    private final int START_TIME_T1 = time("10:00:20");
+
+
+    // Given
+    TestTripSchedule trip1 = TestTripSchedule.schedule()
+            .pattern("T1", STOP_A, STOP_B, STOP_C, STOP_D, STOP_E, STOP_F)
+            .times("10:02 10:10 10:15 10:20 10:25 10:30").build();
+
+    TestTripSchedule trip2 = TestTripSchedule.schedule()
+            .pattern("T2", STOP_C, STOP_D, STOP_E, STOP_F, STOP_G, STOP_H)
+            .times("10:13 10:18 10:24 10:30 10:36 10:40").build();
+
+    TransferGenerator<TestTripSchedule> transfers = dummyTransferGenerator(
+            List.of(
+                    tx(txConstrained(trip1, STOP_B, trip2, STOP_C).priority(ALLOWED), D1m),
+                    tx(txConstrained(trip1, STOP_C, trip2, STOP_D).priority(RECOMMENDED), D2m),
+                    tx(txConstrained(trip1, STOP_D, trip2, STOP_E).priority(PREFERRED), D3m),
+                    tx(txConstrained(trip1, STOP_E, trip2, STOP_F).guaranteed(), D4m),
+                    tx(txConstrained(trip1, STOP_F, trip2, STOP_G).staySeated(), D5m),
+                    tx(txConstrained(trip1, STOP_C, trip2, STOP_C).priority(NOT_ALLOWED)),
+                    tx(txConstrained(trip1, STOP_D, trip2, STOP_D).priority(NOT_ALLOWED)),
+                    tx(txConstrained(trip1, STOP_E, trip2, STOP_E).priority(NOT_ALLOWED)),
+                    tx(txConstrained(trip1, STOP_F, trip2, STOP_F).priority(NOT_ALLOWED))
+            )
+    );
+
+    @Test
+    public void testTransferPriorityAllowed() {
+        testPriority(
+                STOP_D, ALLOWED,
+                "1 ~ BUS T1 10:02 10:10 ~ 2 ~ Walk 1m ~ 3 ~ BUS T2 10:13 10:18 ~ 4 [10:00:20 10:18:20 18m $1180]"
+        );
+    }
+
+    @Test
+    public void testTransferPriorityRecommended() {
+        testPriority(
+                STOP_E, RECOMMENDED,
+                "1 ~ BUS T1 10:02 10:15 ~ 3 ~ Walk 2m ~ 4 ~ BUS T2 10:18 10:24 ~ 5 [10:00:20 10:24:20 24m $1600]"
+        );
+    }
+
+    @Test
+    public void testTransferPriorityPreferred() {
+        testPriority(
+                STOP_F, PREFERRED,
+                "1 ~ BUS T1 10:02 10:20 ~ 4 ~ Walk 3m ~ 5 ~ BUS T2 10:24 10:30 ~ 6 [10:00:20 10:30:20 30m $2020]"
+        );
+    }
+
+    @Test
+    public void testTransferGuaranteed() {
+        testGuaranteed(
+                STOP_G,
+                "1 ~ BUS T1 10:02 10:25 ~ 5 ~ Walk 4m ~ 6 ~ BUS T2 10:30 10:36 ~ 7 [10:00:20 10:36:20 36m $2440]"
+        );
+    }
+    @Test
+    public void testTransferStaySeated() {
+        testStaySeated(
+                STOP_H,
+                "1 ~ BUS T1 10:02 10:30 ~ 6 ~ Walk 5m ~ 7 ~ BUS T2 10:36 10:40 ~ 8 [10:00:20 10:40:20 40m $2740]"
+        );
+    }
+
+
+    /* private methods */
+
+    private void testStaySeated(int egressStop, String expItinerary) {
+        doTest(egressStop, true, false, ALLOWED, expItinerary);
+    }
+
+    private void testGuaranteed(int egressStop, String expItinerary) {
+        doTest(egressStop, false, true, ALLOWED, expItinerary);
+    }
+
+    private void testPriority(int egressStop, TransferPriority expPriority, String expItinerary) {
+        doTest(egressStop, false, false, expPriority, expItinerary);
+    }
+
+    private void doTest(
+            int egressStop,
+            boolean expStaySeated,
+            boolean expGuaranteed,
+            TransferPriority expPriority,
+            String expItinerary
+    ) {
+        var original = OptimizePathServiceTest.pathBuilder()
+                .access(START_TIME_T1, 0, STOP_A)
+                .bus(trip1, STOP_B)
+                .walk(D1m, STOP_C)
+                .bus(trip2, egressStop)
+                .egress(D0s);
+
+        var subject = OptimizePathServiceTest.subject(transfers);
+
+        // Find the path with the lowest cost
+        var result = subject.findBestTransitPath(original);
+
+        assertEquals(1, result.size(), result.toString());
+
+        var it = result.iterator().next();
+
+        assertEquals(expItinerary, it.toString());
+
+        // Verify the attached Transfer is exist and is valid
+        var transfer = it.getTransferTo(it.accessLeg().nextLeg().nextTransitLeg());
+
+        if (expPriority != null) {
+            assertNotNull(transfer);
+        }
+        if (transfer != null) {
+            assertEquals(expPriority, transfer.getPriority(), transfer.toString());
+            assertEquals(expStaySeated, transfer.isStaySeated(), transfer.toString());
+            assertEquals(expGuaranteed, transfer.isGuaranteed(), transfer.toString());
+        }
+    }
+}

--- a/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/services/TestTransferBuilder.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/services/TestTransferBuilder.java
@@ -1,0 +1,110 @@
+package org.opentripplanner.routing.algorithm.transferoptimization.services;
+
+import org.opentripplanner.model.FeedScopedId;
+import org.opentripplanner.model.Trip;
+import org.opentripplanner.model.transfer.Transfer;
+import org.opentripplanner.model.transfer.TransferPriority;
+import org.opentripplanner.model.transfer.TripTransferPoint;
+import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
+import org.opentripplanner.util.time.TimeUtils;
+
+
+/**
+ * This builder is used to create a {@link Transfer} for use in unit-tests. It build a valid
+ * instance with dummy trip reference.
+ */
+@SuppressWarnings("UnusedReturnValue")
+public class TestTransferBuilder<T extends RaptorTripSchedule> {
+    private final T fromTrip;
+    private final int fromStopIndex;
+    private final T toTrip;
+    private final int toStopIndex;
+    private boolean staySeated = false;
+    private boolean guaranteed = false;
+    private TransferPriority priority = TransferPriority.ALLOWED;
+    private int maxWaitTime = Transfer.MAX_WAIT_TIME_NOT_SET;
+
+    private TestTransferBuilder(
+            T fromTrip,
+            int fromStopIndex,
+            T toTrip,
+            int toStopIndex
+    ) {
+        this.fromTrip = fromTrip;
+        this.fromStopIndex = fromStopIndex;
+        this.toTrip = toTrip;
+        this.toStopIndex = toStopIndex;
+    }
+
+    public static <T extends RaptorTripSchedule> TestTransferBuilder<T> txConstrained(
+            T fromTrip,
+            int fromStopIndex,
+            T toTrip,
+            int toStopIndex
+    ) {
+        return new TestTransferBuilder<>(fromTrip, fromStopIndex, toTrip, toStopIndex);
+    }
+
+    public T getFromTrip() {
+        return fromTrip;
+    }
+
+    public int getFromStopIndex() {
+        return fromStopIndex;
+    }
+
+    public T getToTrip() {
+        return toTrip;
+    }
+
+    public int getToStopIndex() {
+        return toStopIndex;
+    }
+
+    public TestTransferBuilder<T> staySeated() {
+        this.staySeated = true;
+        return this;
+    }
+
+    public TestTransferBuilder<T> guaranteed() {
+        this.guaranteed = true;
+        return this;
+    }
+
+    public TestTransferBuilder<T> maxWaitTime(int maxWaitTime) {
+        this.maxWaitTime = maxWaitTime;
+        return this;
+    }
+
+    public TestTransferBuilder<T> priority(TransferPriority priority) {
+        this.priority = priority;
+        return this;
+    }
+
+    public Transfer build() {
+        if(fromTrip == null) { throw new NullPointerException(); }
+        if(toTrip == null) { throw new NullPointerException(); }
+
+        int fromStopPos =fromTrip.pattern().findStopPositionAfter(0, fromStopIndex);
+        int toStopPos = toTrip.pattern().findStopPositionAfter(0, toStopIndex);
+
+        return new Transfer(
+                new TripTransferPoint(createDummyTrip(fromTrip), fromStopPos),
+                new TripTransferPoint(createDummyTrip(toTrip), toStopPos),
+                priority,
+                staySeated,
+                guaranteed,
+                maxWaitTime
+        );
+    }
+
+    private static <T extends RaptorTripSchedule> Trip createDummyTrip(T trip) {
+        // Set a uniq id: pattern + the first stop departure time
+        return new Trip(
+                new FeedScopedId(
+                        trip.pattern().debugInfo(),
+                        TimeUtils.timeToStrCompact(trip.departure(0))
+                )
+        );
+    }
+}

--- a/src/test/java/org/opentripplanner/transit/raptor/_data/RaptorTestConstants.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/_data/RaptorTestConstants.java
@@ -5,7 +5,9 @@ import static org.opentripplanner.util.time.TimeUtils.hm2time;
 
 public interface RaptorTestConstants {
 
+
   // Time duration(D) constants, all values are in seconds
+  int D0s = 0;
   int D1s = 1;
   int D10s = 10;
   int D20s = 20;
@@ -13,18 +15,15 @@ public interface RaptorTestConstants {
   int D40s = 40;
   int D1m = duration("1m");
   int D2m = duration("2m");
-  int D2m1s = duration("2m1s");
   int D3m = duration("3m");
   int D4m = duration("4m");
   int D5m = duration("5m");
-  int D6m = duration("6m");
   int D7m = duration("7m");
   int D10m = duration("10m");
   int D20m = duration("20m");
 
   // Time constants, all values are in seconds
   int T00_00 = hm2time(0, 0);
-  int T00_04 = hm2time(0, 4);
   int T00_10 = hm2time(0, 10);
   int T00_30 = hm2time(0, 30);
   int T01_00 = hm2time(1, 0);


### PR DESCRIPTION

### Summary

When Raptor return a path with a transfer at another stop then the optimal stop to transfer, then optimized transfer service will find the correct stop/path, but the transfer information is not attached to the new path in a correct way. The OptimizedPath map of transfers(transfersTo) are updated with the correct transfer, but the key used is the old leg, not the new. This causes the lookup to fail later.

### Issue

No issue is created for this "small" bugfix.


### Unit tests

The second commit add extensive unit-tests for this case. It also improve the tests on TransferPriority, witch was not properly tested. The tests are "semi" high level. They test the OptimizePathService, low level tests already exist. 


### Documentation

Only JavaDoc is updated.


### Changelog

`Changelog.md` is updated.