### PR TITLE
Map Station to correct Transmodel type

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -42,7 +42,7 @@
 - Do not allow bicycle traversal on ways tagged with mtb:scale [#3578](https://github.com/opentripplanner/OpenTripPlanner/pull/3578)
 - Changes to the StopTimes call [#3576](https://github.com/opentripplanner/OpenTripPlanner/issues/3576)
 - Fix bug in optimize transfer service decorating path [#3587](https://github.com/opentripplanner/OpenTripPlanner/issues/3587)
-
+- Fix bug in Transmodel API when querying stopPlaves [#3591](https://github.com/opentripplanner/OpenTripPlanner/pull/3591)
 
 ## 2.0.0 (2020-11-27)
 

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
@@ -65,6 +65,7 @@ import org.opentripplanner.ext.transmodelapi.model.siri.et.EstimatedCallType;
 import org.opentripplanner.ext.transmodelapi.model.siri.sx.PtSituationElementType;
 import org.opentripplanner.ext.transmodelapi.model.stop.BikeParkType;
 import org.opentripplanner.ext.transmodelapi.model.stop.BikeRentalStationType;
+import org.opentripplanner.ext.transmodelapi.model.stop.MonoOrMultiModalStation;
 import org.opentripplanner.ext.transmodelapi.model.stop.PlaceAtDistanceType;
 import org.opentripplanner.ext.transmodelapi.model.stop.PlaceInterfaceType;
 import org.opentripplanner.ext.transmodelapi.model.stop.QuayAtDistanceType;
@@ -305,7 +306,15 @@ public class TransmodelGraphQLSchema {
                     )
                     .collect(Collectors.toList());
               }
-              return new ArrayList<>(GqlUtil.getRoutingService(env).getStations());
+              RoutingService routingService = GqlUtil.getRoutingService(env);
+              return routingService
+                  .getStations()
+                  .stream()
+                  .map(station -> new MonoOrMultiModalStation(
+                          station,
+                          routingService.getMultiModalStationForStations().get(station)
+                  ))
+                  .collect(Collectors.toList());
             })
             .build())
         .field(GraphQLFieldDefinition


### PR DESCRIPTION
### Summary

Currently the `stopPlaces` data fetcher returns a collection off `Station` objects, if no ids are given as filters, while the data fetchers for the `StopPlace` expects to handle instances of `MonoOrMultiModalStation`. This fixes the issue by applying a correct mapper between the two types.

### Changelog
Added
