### PR TITLE
Add new types of PurchaseWhenEnumeration in BookingInfoMapper

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -43,6 +43,8 @@
 - Changes to the StopTimes call [#3576](https://github.com/opentripplanner/OpenTripPlanner/issues/3576)
 - Fix bug in optimize transfer service decorating path [#3587](https://github.com/opentripplanner/OpenTripPlanner/issues/3587)
 - Fix bug in Transmodel API when querying stopPlaves [#3591](https://github.com/opentripplanner/OpenTripPlanner/pull/3591)
+- Add new types of PurchaseWhenEnumeration in BookingInfoMapper [#3592](https://github.com/opentripplanner/OpenTripPlanner/pull/3592)
+
 
 ## 2.0.0 (2020-11-27)
 

--- a/src/main/java/org/opentripplanner/netex/mapping/BookingInfoMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/BookingInfoMapper.java
@@ -151,7 +151,10 @@ public class BookingInfoMapper {
         return new BookingTime(latestBookingTime, 1);
       case DAY_OF_TRAVEL_ONLY:
       case ADVANCE_ONLY:
+      case ADVANCE_AND_DAY_OF_TRAVEL:
         return new BookingTime(latestBookingTime, 0);
+      case TIME_OF_TRAVEL_ONLY:
+        return null;
       default:
         throw new IllegalArgumentException("Value not supported: " + purchaseWhen.toString());
     }
@@ -161,6 +164,8 @@ public class BookingInfoMapper {
     switch (purchaseWhen) {
       case UNTIL_PREVIOUS_DAY:
       case ADVANCE_ONLY:
+      case ADVANCE_AND_DAY_OF_TRAVEL:
+      case TIME_OF_TRAVEL_ONLY:
         return null;
       case DAY_OF_TRAVEL_ONLY:
         return new BookingTime(LocalTime.MIDNIGHT, 0);

--- a/src/test/java/org/opentripplanner/netex/mapping/BookingInfoMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/BookingInfoMapperTest.java
@@ -129,6 +129,19 @@ public class BookingInfoMapperTest {
     assertEquals(0, bookingInfo3.getLatestBookingTime().getDaysPrior());
     assertEquals(0, bookingInfo3.getEarliestBookingTime().getDaysPrior());
     assertEquals(LocalTime.MIDNIGHT, bookingInfo3.getEarliestBookingTime().getTime());
+
+    bookingArrangements.setBookWhen(PurchaseWhenEnumeration.ADVANCE_AND_DAY_OF_TRAVEL);
+
+    BookingInfo bookingInfo4 = BookingInfoMapper.map(stopPoint, null, null);
+    assertEquals(FIVE_THIRTY,  bookingInfo4.getLatestBookingTime().getTime());
+    assertEquals(0, bookingInfo4.getLatestBookingTime().getDaysPrior());
+    assertNull(bookingInfo4.getEarliestBookingTime());
+
+    bookingArrangements.setBookWhen(PurchaseWhenEnumeration.TIME_OF_TRAVEL_ONLY);
+
+    BookingInfo bookingInfo5 = BookingInfoMapper.map(stopPoint, null, null);
+    assertNull(bookingInfo5.getLatestBookingTime());
+    assertNull(bookingInfo5.getEarliestBookingTime());
   }
 
   @Test


### PR DESCRIPTION
### Summary
Currently not all types of PurchaseWhenEnumeration are mapped in BookingInfoMapper. This PR adds support for `ADVANCE_AND_DAY_OF_TRAVEL` and `TIME_OF_TRAVEL_ONLY`

### Unit tests
Add new enum values to existing tests

### Changelog
Added
