### PR TITLE
Correct the handling of itinerary links in the debug client

### DIFF
--- a/src/client/js/otp/widgets/tripoptions/TripOptionsWidget.js
+++ b/src/client/js/otp/widgets/tripoptions/TripOptionsWidget.js
@@ -1078,10 +1078,34 @@ otp.widgets.tripoptions.AdditionalTripParameters =
                     }
                 })
 
-                this_.tripWidget.module.additionalParameters = params;
+                var keys = _(params).keys().join(',');
+                if (keys) {
+                    params['additionalParameters'] = keys;
+                    this_.tripWidget.module.additionalParameters = params;
+                } else {
+                    this_.tripWidget.module.additionalParameters = null;
+                }
             });
         },
-});
+
+        restorePlan : function(data) {
+            if (data.queryParams.additionalParameters) {
+                var str = '';
+                var keys = data.queryParams.additionalParameters.split(',');
+                var params = {};
+
+                _.each(keys, function (key) {
+                    str += key + '=' + data.queryParams[key] + '\n';
+                    params[key] = data.queryParams[key];
+                });
+
+                $('#'+this.id+'-value').val(str);
+
+                this.tripWidget.module.additionalParameters = params;
+            }
+        },
+    }
+);
 
 /*otp.widgets.TW_GroupTripSubmit =
     otp.Class(otp.widgets.tripoptions.TripOptionsWidgetControl, {

--- a/src/client/js/otp/widgets/tripoptions/TripOptionsWidget.js
+++ b/src/client/js/otp/widgets/tripoptions/TripOptionsWidget.js
@@ -420,7 +420,7 @@ otp.widgets.tripoptions.WheelChairSelector =
 
     id           :  null,
     //TRANSLATORS: label for checkbox
-    label        : _tr("Wheelchair accesible trip:"),
+    label        : _tr("Wheelchair accessible trip:"),
 
     initialize : function(tripWidget) {
 
@@ -445,9 +445,7 @@ otp.widgets.tripoptions.WheelChairSelector =
     },
 
     restorePlan : function(data) {
-        if(data.queryParams.wheelchair) {
-            $("#"+this.id+"-wheelchair-input").prop("checked", data.queryParams.wheelchair);
-        }
+        $("#"+this.id+"-wheelchair-input").prop("checked", data.queryParams.wheelchair === 'true');
     },
 
     isApplicableForMode : function(mode) {
@@ -485,9 +483,7 @@ otp.widgets.tripoptions.DebugItineraryFiltersSelector = otp.Class(
             });
         },
         restorePlan: function (data) {
-            if (data.queryParams.debugItineraryFilter) {
-                $("#" + this.id + "-debug-filters-input").prop("checked", data.queryParams.debugItineraryFilter);
-            }
+            $("#" + this.id + "-debug-filters-input").prop("checked", data.queryParams.debugItineraryFilter === 'true');
         },
         isApplicableForMode : function(mode) { return true; }
     }


### PR DESCRIPTION
### Summary

The debug client has _itinerary links_ so that the plans may be linked to, reproduced. In certain cases the links aren't restored correctly in the UI:
 * the `Wheelchair accessible trip` and `Show filtered itineraries` check boxes are always checked
 * the parameters set from `Additional parameters` is not filled out

This fixes both problems by:
 * correctly parsing the boolean values from the url
 * storing the list of values set from `Additional properties` in the url so that the texbox may be repopulated

### Code style

No changes.

### Documentation

No changes.

### Changelog

No changes.