### PR TITLE
Show route names in the debug client

### DIFF
--- a/src/client/js/otp/modules/planner/ItinerariesWidget.js
+++ b/src/client/js/otp/modules/planner/ItinerariesWidget.js
@@ -304,8 +304,12 @@ otp.widgets.ItinerariesWidget =
 
             //div.append('<div class="otp-itinsAccord-header-segment" style="width: '+widthPx+'px; left: '+leftPx+'px; background: '+this.getModeColor(leg.mode)+' url(images/mode/'+leg.mode.toLowerCase()+'.png) center no-repeat;"></div>');
 
+            var routeTitle = _.chain([leg.mode, leg.agencyName, leg.routeShortName, leg.routeLongName])
+                    .filter(function (value) { return !!value; })
+                    .reduce(function (l, r) { return l ? l + " " + r : r; }, "")
+                    .value();
             var showRouteLabel = widthPx > 40 && otp.util.Itin.isTransit(leg.mode) && leg.routeShortName && leg.routeShortName.length <= 6;
-            var segment = $('<div class="otp-itinsAccord-header-segment" />')
+            var segment = $('<div class="otp-itinsAccord-header-segment" title="' + routeTitle + '" />')
             .css({
                 width: widthPx,
                 left: leftPx,

--- a/src/client/js/otp/modules/planner/ItinerariesWidget.js
+++ b/src/client/js/otp/modules/planner/ItinerariesWidget.js
@@ -379,12 +379,12 @@ otp.widgets.ItinerariesWidget =
                 }
             }
             else if(leg.agencyId !== null) {
-                headerHtml += ": "+leg.agencyName+", ";
-                if(leg.route !== leg.routeLongName) {
-                    headerHtml += "("+leg.route+") ";
+                headerHtml += ": " + leg.agencyName + ", ";
+                if (leg.routeShortName) {
+                    headerHtml += leg.routeShortName + " ";
                 }
                 if (leg.routeLongName) {
-                    headerHtml += leg.routeLongName;
+                    headerHtml += leg.routeLongName + " ";
                 }
 
                 if(leg.headsign) {


### PR DESCRIPTION
### Summary

The route details are missing in some cases in the debug client, and so this PR makes two minor changes so that is is always shown:

1. The leg details only contains the `agencyName`, since the API doesn't have a `route` field:
    ![image](https://user-images.githubusercontent.com/58879/132335887-99e1a6bb-967c-43bf-9f1d-cc840471532a.png)
    The details are extended to included the `routeShortName` and `routeLongName` if set.
    ![image](https://user-images.githubusercontent.com/58879/132346705-16a98380-47fb-41cd-b5ae-5a523a8e85b2.png)
2. Adds the `mode`, `agencyName`, `routeShortName` and `routeLongName` (if set) to the summary item tooltips:
     ![image](https://user-images.githubusercontent.com/58879/132346430-ffb2a5da-c829-49cb-9ce6-8edf4adc8823.png)

### Unit tests

None.

### Code style

N/A

### Documentation

No changes.

### Changelog

None.