### PR TITLE
Serialize nulls in Transmodel GraphQL API

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/LegacyGraphQLAPI.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/LegacyGraphQLAPI.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.ext.legacygraphqlapi;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.opentripplanner.standalone.server.OTPServer;
 import org.opentripplanner.standalone.server.Router;
@@ -18,8 +17,6 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ContextResolver;
-import javax.ws.rs.ext.Providers;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -33,7 +30,7 @@ import java.util.concurrent.Future;
 
 // TODO move to org.opentripplanner.api.resource, this is a Jersey resource class
 
-@Path("/routers/{routerId}/index/graphql")
+@Path("/routers/{ignoreRouterId}/index/graphql")
 @Produces(MediaType.APPLICATION_JSON) // One @Produces annotation for all endpoints.
 public class LegacyGraphQLAPI {
 
@@ -43,17 +40,15 @@ public class LegacyGraphQLAPI {
   private final Router router;
   private final ObjectMapper deserializer = new ObjectMapper();
 
-  public LegacyGraphQLAPI(
-      @Context OTPServer otpServer,
-      @Context Providers providers,
-      @PathParam("routerId") String routerId
-  ) {
-    this.router = otpServer.getRouter();
+  /**
+   * @deprecated The support for multiple routers are removed from OTP2.
+   * See https://github.com/opentripplanner/OpenTripPlanner/issues/2760
+   */
+  @Deprecated @PathParam("ignoreRouterId")
+  private String ignoreRouterId;
 
-    ContextResolver<ObjectMapper> resolver =
-        providers.getContextResolver(ObjectMapper.class, MediaType.APPLICATION_JSON_TYPE);
-    ObjectMapper mapper = resolver.getContext(ObjectMapper.class);
-    mapper.setDefaultPropertyInclusion(JsonInclude.Include.ALWAYS);
+  public LegacyGraphQLAPI(@Context OTPServer otpServer) {
+    this.router = otpServer.getRouter();
   }
 
   @POST

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/LegacyGraphQLIndex.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/LegacyGraphQLIndex.java
@@ -1,5 +1,7 @@
 package org.opentripplanner.ext.legacygraphqlapi;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.client.util.Charsets;
 import com.google.common.io.Resources;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -35,6 +37,8 @@ import java.util.stream.Collectors;
 class LegacyGraphQLIndex {
 
   static final Logger LOG = LoggerFactory.getLogger(LegacyGraphQLIndex.class);
+
+  static private final ObjectMapper objectMapper = new ObjectMapper();
 
   static private final GraphQLSchema indexSchema = buildSchema();
 
@@ -157,7 +161,12 @@ class LegacyGraphQLIndex {
         timeoutMs,
         locale
     );
-    return res.entity(content).build();
+
+    try {
+      return res.entity(objectMapper.writeValueAsString(content)).build();
+    } catch (JsonProcessingException e) {
+      return Response.serverError().build();
+    }
   }
 
   static private List<Map<String, Object>> mapErrors(Collection<?> errors) {

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraph.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraph.java
@@ -1,5 +1,7 @@
 package org.opentripplanner.ext.transmodelapi;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import graphql.ExecutionInput;
 import graphql.ExecutionResult;
@@ -25,6 +27,8 @@ import java.util.stream.Collectors;
 class TransmodelGraph {
 
     static final Logger LOG = LoggerFactory.getLogger(TransmodelGraph.class);
+
+    static private final ObjectMapper objectMapper = new ObjectMapper();
 
     private final GraphQLSchema indexSchema;
 
@@ -83,7 +87,11 @@ class TransmodelGraph {
         HashMap<String, Object> content = getGraphQLExecutionResult(
                 query, router, variables, operationName, maxResolves
         );
-        return res.entity(content).build();
+        try {
+            return res.entity(objectMapper.writeValueAsString(content)).build();
+        } catch (JsonProcessingException e) {
+            return Response.serverError().build();
+        }
     }
 
     private List<Map<String, Object>> mapErrors(Collection<?> errors) {

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraph.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraph.java
@@ -1,34 +1,26 @@
 package org.opentripplanner.ext.transmodelapi;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import graphql.ExecutionInput;
 import graphql.ExecutionResult;
 import graphql.GraphQL;
-import graphql.GraphQLError;
 import graphql.analysis.MaxQueryComplexityInstrumentation;
 import graphql.schema.GraphQLSchema;
+import org.opentripplanner.api.json.GraphQLResponseSerializer;
 import org.opentripplanner.routing.RoutingService;
 import org.opentripplanner.standalone.server.Router;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.core.Response;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.stream.Collectors;
 
 class TransmodelGraph {
 
     static final Logger LOG = LoggerFactory.getLogger(TransmodelGraph.class);
-
-    static private final ObjectMapper objectMapper = new ObjectMapper();
 
     private final GraphQLSchema indexSchema;
 
@@ -41,7 +33,7 @@ class TransmodelGraph {
         this.indexSchema = schema;
     }
 
-    HashMap<String, Object> getGraphQLExecutionResult(
+    ExecutionResult getGraphQLExecutionResult(
             String query,
             Router router,
             Map<String, Object> variables,
@@ -65,53 +57,11 @@ class TransmodelGraph {
                                                 .root(router)
                                                 .variables(variables)
                                                 .build();
-        HashMap<String, Object> content = new HashMap<>();
-        ExecutionResult executionResult;
-        try {
-            executionResult = graphQL.execute(executionInput);
-            if (!executionResult.getErrors().isEmpty()) {
-                content.put("errors", mapErrors(executionResult.getErrors()));
-            }
-            if (executionResult.getData() != null) {
-                content.put("data", executionResult.getData());
-            }
-        } catch (RuntimeException ge) {
-            LOG.warn("Exception during graphQL.execute: " + ge.getMessage(), ge);
-            content.put("errors", mapErrors(Arrays.asList(ge)));
-        }
-        return content;
+        return graphQL.execute(executionInput);
     }
 
     Response getGraphQLResponse(String query, Router router, Map<String, Object> variables, String operationName, int maxResolves) {
-        Response.ResponseBuilder res = Response.status(Response.Status.OK);
-        HashMap<String, Object> content = getGraphQLExecutionResult(
-                query, router, variables, operationName, maxResolves
-        );
-        try {
-            return res.entity(objectMapper.writeValueAsString(content)).build();
-        } catch (JsonProcessingException e) {
-            return Response.serverError().build();
-        }
-    }
-
-    private List<Map<String, Object>> mapErrors(Collection<?> errors) {
-        return errors.stream().map(e -> {
-            HashMap<String, Object> response = new HashMap<>();
-
-            if (e instanceof GraphQLError) {
-                GraphQLError graphQLError=(GraphQLError) e;
-                response.put("message", graphQLError.getMessage());
-                response.put("errorType", graphQLError.getErrorType());
-                response.put("locations", graphQLError.getLocations());
-                response.put("path", graphQLError.getPath());
-            } else {
-                if (e instanceof Exception) {
-                    response.put("message", ((Exception) e).getMessage());
-                }
-                response.put("errorType", e.getClass().getSimpleName());
-            }
-
-            return response;
-        }).collect(Collectors.toList());
+        ExecutionResult result = getGraphQLExecutionResult(query, router, variables, operationName, maxResolves);
+        return Response.status(Response.Status.OK).entity(GraphQLResponseSerializer.serialize(result)).build();
     }
 }

--- a/src/main/java/org/opentripplanner/api/json/GraphQLResponseSerializer.java
+++ b/src/main/java/org/opentripplanner/api/json/GraphQLResponseSerializer.java
@@ -1,0 +1,59 @@
+package org.opentripplanner.api.json;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import graphql.ExecutionResult;
+import graphql.execution.AbortExecutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+/**
+ * This class is responsible for serializing GraphQL {@link ExecutionResult} into Strings, which can be returned as the
+ * body of the HTTP response. This differs from the mapper provided by {@link JSONObjectMapperProvider}, by serializing
+ * all fields in the objects, including null fields.
+ */
+public class GraphQLResponseSerializer {
+    static final Logger LOG = LoggerFactory.getLogger(GraphQLResponseSerializer.class);
+
+    static private final ObjectMapper objectMapper = new ObjectMapper();
+
+    static public String serialize(ExecutionResult executionResult) {
+        try {
+            return objectMapper.writeValueAsString(executionResult.toSpecification());
+        } catch (JsonProcessingException e) {
+            LOG.error("Unable to serialize response", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    static public String serializeBatch(List<HashMap<String, Object>> queries, List<Future<ExecutionResult>> futures) {
+        List<Map<String, Object>> responses = new LinkedList<>();
+        for (int i = 0; i < queries.size(); i++) {
+            ExecutionResult executionResult;
+            // Try each request separately, returning both completed and failed responses is ok
+            try {
+                executionResult = futures.get(i).get();
+            } catch (InterruptedException | ExecutionException e) {
+                executionResult = new AbortExecutionException(e).toExecutionResult();
+            }
+            responses.add(Map.of(
+                    "id", queries.get(i).get("id"),
+                    "payload", executionResult.toSpecification()
+            ));
+        }
+
+        try {
+            return objectMapper.writeValueAsString(responses);
+        } catch (JsonProcessingException e) {
+            LOG.error("Unable to serialize response", e);
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/org/opentripplanner/api/json/GraphQLResponseSerializer.java
+++ b/src/main/java/org/opentripplanner/api/json/GraphQLResponseSerializer.java
@@ -15,9 +15,9 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
 /**
- * This class is responsible for serializing GraphQL {@link ExecutionResult} into Strings, which can be returned as the
- * body of the HTTP response. This differs from the mapper provided by {@link JSONObjectMapperProvider}, by serializing
- * all fields in the objects, including null fields.
+ * This class is responsible for serializing a GraphQL {@link ExecutionResult} into a String, which can be returned as 
+ * the body of the HTTP response. This differs from the mapper provided by {@link JSONObjectMapperProvider}, by 
+ * serializing all fields in the objects, including null fields.
  */
 public class GraphQLResponseSerializer {
     static final Logger LOG = LoggerFactory.getLogger(GraphQLResponseSerializer.class);


### PR DESCRIPTION
### Summary

After updating the Jackson version, I noticed that the Transmodel API started omitting nulls when serializing. This is not permitted according to the [GraphQL specification](https://spec.graphql.org/June2018/#sec-Value-Completion). This PR applies a similar fix, which has been in place for [`LegacyGraphQLAPI`](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/LegacyGraphQLAPI.java#L53-L56) since before. It changes the serialization config for all OTP APIs when using the Transmodel API, but I did not find a solution, which would be used only for the duration of the API call.
