### PR TITLE
Use Netex enums to check for ferries

### DIFF
--- a/src/main/java/org/opentripplanner/netex/mapping/RouteMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/RouteMapper.java
@@ -11,6 +11,7 @@ import org.opentripplanner.model.TransitMode;
 import org.opentripplanner.model.impl.EntityById;
 import org.opentripplanner.netex.index.api.NetexEntityIndexReadOnlyView;
 import org.opentripplanner.netex.mapping.support.FeedScopedIdFactory;
+import org.rutebanken.netex.model.AllVehicleModesOfTransportEnumeration;
 import org.rutebanken.netex.model.FlexibleLine_VersionStructure;
 import org.rutebanken.netex.model.Line_VersionStructure;
 import org.rutebanken.netex.model.Network;
@@ -91,7 +92,7 @@ class RouteMapper {
         // but currently it doesn't look it is being parsed.
         // until there is better information from the operators we assume that all ferries allow
         // bicycles on board.
-        if(mode == TransitMode.FERRY) {
+        if(line.getTransportMode().equals(AllVehicleModesOfTransportEnumeration.WATER)) {
             if(ferryIdsNotAllowedForBicycle.contains(line.getId())) {
                 otpRoute.setBikesAllowed(BikeAccess.NOT_ALLOWED);
             } else {


### PR DESCRIPTION
### Summary
When creating #3596 I didn't notice a key difference between the Entur fork and upstream OTP: Entur has made the `TransitMode` a class with submodes whereby in upstream it's an enum. What makes this a little problematic that it still compiled because the imports were not touched!

That's why the previous check if a line/route is a ferry was never true as object identity was never the same. `equals` would also be unlikely to help as for that to work the submodes would have to be identical.

For this reason I'm using the Netex enum rather than the `TransitType`.

I've now used the Entur fork to check for the result and get what I expect, namely routes like this:

![Screenshot from 2021-09-15 10-11-56](https://user-images.githubusercontent.com/151346/133396019-c70391d4-db80-47e4-bfeb-1f8b2c37c022.png)


