### PR TITLE
Add reference to Stop in Place

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/flex/FlexLegMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/FlexLegMapper.java
@@ -11,11 +11,11 @@ import java.util.ArrayList;
 public class FlexLegMapper {
 
   static public void fixFlexTripLeg(Leg leg, FlexTripEdge flexTripEdge) {
-      leg.from.stopId = flexTripEdge.s1.getId();
+      leg.from.stop = flexTripEdge.s1;
       // TODO: Should flex be of its own type
       leg.from.vertexType = flexTripEdge.s1 instanceof Stop ? VertexType.TRANSIT : VertexType.NORMAL;
       leg.from.stopIndex = flexTripEdge.flexTemplate.fromStopIndex;
-      leg.to.stopId = flexTripEdge.s2.getId();
+      leg.to.stop = flexTripEdge.s2;
       leg.to.vertexType = flexTripEdge.s2 instanceof Stop ? VertexType.TRANSIT : VertexType.NORMAL;
       leg.to.stopIndex = flexTripEdge.flexTemplate.toStopIndex;
 

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLLegImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLLegImpl.java
@@ -133,11 +133,8 @@ public class LegacyGraphQLLegImpl implements LegacyGraphQLDataFetchers.LegacyGra
     return environment -> {
       List<StopArrival> intermediateStops = getSource(environment).intermediateStops;
       if (intermediateStops == null) { return null; }
-      RoutingService routingService = getRoutingService(environment);
       return intermediateStops.stream()
-          .map(intermediateStop -> intermediateStop.place)
-          .filter(place -> place.stopId != null)
-          .map(place -> routingService.getStopForId(place.stopId))
+          .map(intermediateStop -> intermediateStop.place.stop)
           .filter(Objects::nonNull)
           .collect(Collectors.toList());
     };

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLPlaceImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLPlaceImpl.java
@@ -46,11 +46,7 @@ public class LegacyGraphQLPlaceImpl implements LegacyGraphQLDataFetchers.LegacyG
 
   @Override
   public DataFetcher<Object> stop() {
-    return environment -> {
-      Place place = getSource(environment).place;
-      return place.vertexType.equals(VertexType.TRANSIT) ?
-          getRoutingService(environment).getStopForId(place.stopId) : null;
-    };
+    return environment -> getSource(environment).place.stop;
   }
 
   @Override

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/TripTimeShortHelper.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/TripTimeShortHelper.java
@@ -3,6 +3,7 @@ package org.opentripplanner.ext.transmodelapi.model;
 import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.model.Station;
 import org.opentripplanner.model.Stop;
+import org.opentripplanner.model.StopLocation;
 import org.opentripplanner.model.TripTimeOnDate;
 import org.opentripplanner.model.calendar.ServiceDate;
 import org.opentripplanner.model.plan.Leg;
@@ -41,11 +42,11 @@ public class TripTimeShortHelper {
          */
 
         if (leg.realTime) {
-            return tripTimes.stream().filter(tripTime -> tripTime.getRealtimeDeparture() == startTimeSeconds && matchesQuayOrSiblingQuay(leg.from.stopId,
-                tripTime.getStopId(), routingService)).findFirst().orElse(null);
+            return tripTimes.stream().filter(tripTime -> tripTime.getRealtimeDeparture() == startTimeSeconds && matchesQuayOrSiblingQuay(leg.from.stop,
+                tripTime.getStopId())).findFirst().orElse(null);
         }
-        return tripTimes.stream().filter(tripTime -> tripTime.getScheduledDeparture() == startTimeSeconds && matchesQuayOrSiblingQuay(leg.from.stopId,
-            tripTime.getStopId(), routingService)).findFirst().orElse(null);
+        return tripTimes.stream().filter(tripTime -> tripTime.getScheduledDeparture() == startTimeSeconds && matchesQuayOrSiblingQuay(leg.from.stop,
+            tripTime.getStopId())).findFirst().orElse(null);
     }
 
     /**
@@ -72,11 +73,11 @@ public class TripTimeShortHelper {
         */
 
         if (leg.realTime) {
-            return tripTimes.stream().filter(tripTime -> tripTime.getRealtimeArrival() == endTimeSeconds && matchesQuayOrSiblingQuay(leg.to.stopId,
-                tripTime.getStopId(), routingService)).findFirst().orElse(null);
+            return tripTimes.stream().filter(tripTime -> tripTime.getRealtimeArrival() == endTimeSeconds && matchesQuayOrSiblingQuay(leg.to.stop,
+                tripTime.getStopId())).findFirst().orElse(null);
         }
-        return tripTimes.stream().filter(tripTime -> tripTime.getScheduledArrival() == endTimeSeconds && matchesQuayOrSiblingQuay(leg.to.stopId,
-            tripTime.getStopId(), routingService)).findFirst().orElse(null);
+        return tripTimes.stream().filter(tripTime -> tripTime.getScheduledArrival() == endTimeSeconds && matchesQuayOrSiblingQuay(leg.to.stop,
+            tripTime.getStopId())).findFirst().orElse(null);
     }
 
 
@@ -108,20 +109,16 @@ public class TripTimeShortHelper {
         boolean boardingStopFound = false;
         for (TripTimeOnDate tripTime : tripTimes) {
 
-            long boardingTime = leg.realTime ? tripTime.getRealtimeDeparture()
-                : tripTime.getScheduledDeparture();
+            long boardingTime = leg.realTime ? tripTime.getRealtimeDeparture() : tripTime.getScheduledDeparture();
 
             if (!boardingStopFound) {
                 boardingStopFound = boardingTime == startTimeSeconds
-                    && matchesQuayOrSiblingQuay(leg.from.stopId,
-                    tripTime.getStopId(), routingService);
+                    && matchesQuayOrSiblingQuay(leg.from.stop, tripTime.getStopId());
                 continue;
             }
 
-            long arrivalTime = leg.realTime ? tripTime.getRealtimeArrival()
-                : tripTime.getScheduledArrival();
-            if (arrivalTime == endTimeSeconds && matchesQuayOrSiblingQuay(leg.to.stopId,
-                tripTime.getStopId(), routingService)) {
+            long arrivalTime = leg.realTime ? tripTime.getRealtimeArrival() : tripTime.getScheduledArrival();
+            if (arrivalTime == endTimeSeconds && matchesQuayOrSiblingQuay(leg.to.stop, tripTime.getStopId())) {
                 break;
             }
 
@@ -134,13 +131,12 @@ public class TripTimeShortHelper {
 
     /* private methods */
 
-    private static boolean matchesQuayOrSiblingQuay(FeedScopedId quayId, FeedScopedId candidate, RoutingService routingService) {
-        boolean foundMatch = quayId.equals(candidate);
-        if (!foundMatch) {
-            //Check parentStops
-            Stop stop = routingService.getStopForId(quayId);
-            if (stop != null && stop.isPartOfStation()) {
-                Station parentStation = stop.getParentStation();
+    private static boolean matchesQuayOrSiblingQuay(StopLocation stop, FeedScopedId candidate) {
+        if (stop == null) return false;
+        boolean foundMatch = stop.getId().equals(candidate);
+        if (!foundMatch && stop instanceof Stop) {
+            if (((Stop) stop).isPartOfStation()) {
+                Station parentStation = ((Stop) stop).getParentStation();
                 for (Stop childStop : parentStation.getChildStops()) {
                     if (childStop.getId().equals(candidate)) {
                         return true;

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/LegType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/LegType.java
@@ -227,9 +227,7 @@ public class LegType {
               }
               else {
                 return (
-                    stops.stream().filter(stop -> stop.place.stopId != null).map(s -> {
-                      return GqlUtil.getRoutingService(env).getStopForId(s.place.stopId);
-                    }).filter(Objects::nonNull).collect(Collectors.toList())
+                    stops.stream().map(stop -> stop.place.stop).filter(Objects::nonNull).collect(Collectors.toList())
                 );
               }
             })

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/PlanPlaceType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/PlanPlaceType.java
@@ -8,6 +8,9 @@ import graphql.schema.GraphQLOutputType;
 import org.opentripplanner.ext.transmodelapi.model.EnumTypes;
 import org.opentripplanner.ext.transmodelapi.model.scalars.GeoJSONCoordinatesScalar;
 import org.opentripplanner.ext.transmodelapi.support.GqlUtil;
+import org.opentripplanner.model.FlexStopLocation;
+import org.opentripplanner.model.Stop;
+import org.opentripplanner.model.StopLocation;
 import org.opentripplanner.model.plan.Place;
 import org.opentripplanner.model.plan.VertexType;
 
@@ -57,19 +60,17 @@ public class PlanPlaceType {
             .name("quay")
             .description("The quay related to the place.")
             .type(quayType)
-            .dataFetcher(environment -> ((Place) environment.getSource()).stopId != null
-                ? GqlUtil.getRoutingService(environment)
-                .getStopForId(((Place) environment.getSource()).stopId) : null)
+            .dataFetcher(environment -> ((Place) environment.getSource()).stop instanceof Stop
+                ? ((Stop) ((Place) environment.getSource()).stop)
+                : null)
             .build())
         .field(GraphQLFieldDefinition
             .newFieldDefinition()
             .name("flexibleArea")
             .description("The flexible area related to the place.")
             .type(GeoJSONCoordinatesScalar.getGraphQGeoJSONCoordinatesScalar())
-            .dataFetcher(environment -> ((Place) environment.getSource()).stopId != null
-                ? GqlUtil.getRoutingService(environment)
-                .getLocationById(((Place) environment.getSource()).stopId)
-                .getGeometry().getCoordinates()
+            .dataFetcher(environment -> ((Place) environment.getSource()).stop instanceof FlexStopLocation
+                ? ((FlexStopLocation) ((Place) environment.getSource()).stop).getGeometry().getCoordinates()
                 : null)
             .build())
         .field(GraphQLFieldDefinition

--- a/src/main/java/org/opentripplanner/api/mapping/PlaceMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/PlaceMapper.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.api.mapping;
 
 import org.opentripplanner.api.model.ApiPlace;
+import org.opentripplanner.model.Stop;
 import org.opentripplanner.model.plan.Place;
 import org.opentripplanner.model.plan.StopArrival;
 
@@ -27,17 +28,22 @@ public class PlaceMapper {
         ApiPlace api = new ApiPlace();
 
         api.name = domain.name;
-        api.stopId = FeedScopedIdMapper.mapToApi(domain.stopId);
-        api.stopCode = domain.stopCode;
-        api.platformCode = domain.platformCode;
+
+        if (domain.stop != null) {
+            api.stopId = FeedScopedIdMapper.mapToApi(domain.stop.getId());
+            api.stopCode = domain.stop != null ? domain.stop.getCode() : null;
+            api.platformCode = domain.stop instanceof Stop ? ((Stop) domain.stop).getPlatformCode() : null;
+            api.zoneId = domain.stop instanceof Stop ? ((Stop) domain.stop).getFirstZoneAsString() : null;
+        }
+
         if(domain.coordinate != null) {
             api.lon = domain.coordinate.longitude();
             api.lat = domain.coordinate.latitude();
         }
+
         api.arrival = arrival;
         api.departure = departure;
         api.orig = domain.orig;
-        api.zoneId = domain.zoneId;
         api.stopIndex = domain.stopIndex;
         api.stopSequence = domain.stopSequence;
         api.vertexType = VertexTypeMapper.mapVertexType(domain.vertexType);

--- a/src/main/java/org/opentripplanner/api/mapping/PlaceMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/PlaceMapper.java
@@ -31,7 +31,7 @@ public class PlaceMapper {
 
         if (domain.stop != null) {
             api.stopId = FeedScopedIdMapper.mapToApi(domain.stop.getId());
-            api.stopCode = domain.stop != null ? domain.stop.getCode() : null;
+            api.stopCode = domain.stop.getCode();
             api.platformCode = domain.stop instanceof Stop ? ((Stop) domain.stop).getPlatformCode() : null;
             api.zoneId = domain.stop instanceof Stop ? ((Stop) domain.stop).getFirstZoneAsString() : null;
         }

--- a/src/main/java/org/opentripplanner/model/Station.java
+++ b/src/main/java/org/opentripplanner/model/Station.java
@@ -1,5 +1,7 @@
 package org.opentripplanner.model;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
+
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -32,6 +34,8 @@ public class Station extends TransitEntity implements StopCollection {
 
   private final TimeZone timezone;
 
+  // We serialize this class to json only for snapshot tests, and this creates cyclical structures
+  @JsonBackReference
   private final Set<Stop> childStops = new HashSet<>();
 
   public Station(

--- a/src/main/java/org/opentripplanner/model/plan/Place.java
+++ b/src/main/java/org/opentripplanner/model/plan/Place.java
@@ -1,5 +1,7 @@
 package org.opentripplanner.model.plan;
 
+import org.opentripplanner.model.Stop;
+import org.opentripplanner.model.StopLocation;
 import org.opentripplanner.model.WgsCoordinate;
 import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.model.base.ToStringBuilder;
@@ -14,22 +16,10 @@ public class Place {
      */
     public final String name;
 
-    /** 
-     * The ID of the stop. This is often something that users don't care about.
-     */
-    public FeedScopedId stopId = null;
-
-    /** 
-     * The "code" of the stop. Depending on the transit agency, this is often
-     * something that users care about.
-     */
-    public String stopCode = null;
-
     /**
-      * The code or name identifying the quay/platform the vehicle will arrive at or depart from
-      *
-    */
-    public String platformCode = null;
+     * Reference to the stop.
+     */
+    public StopLocation stop;
 
     /**
      * The coordinate of the place.
@@ -37,8 +27,6 @@ public class Place {
     public final WgsCoordinate coordinate;
 
     public String orig;
-
-    public String zoneId;
 
     /**
      * For transit trips, the stop index (numbered from zero from the start of the trip).
@@ -67,6 +55,13 @@ public class Place {
         this.coordinate = WgsCoordinate.creatOptionalCoordinate(lat, lon);
     }
 
+    public Place(Stop stop) {
+        this.name = stop.getName();
+        this.stop = stop;
+        this.coordinate = stop.getCoordinate();
+        this.vertexType = VertexType.TRANSIT;
+    }
+
     /**
      * Test if the place is likely to be at the same location. First check the coordinates
      * then check the stopId [if it exist].
@@ -76,7 +71,7 @@ public class Place {
         if(coordinate != null) {
             return coordinate.sameLocation(other.coordinate);
         }
-        return stopId != null && stopId.equals(other.stopId);
+        return stop != null && stop.equals(other.stop);
     }
 
     /**
@@ -85,8 +80,8 @@ public class Place {
      */
     public String toStringShort() {
         StringBuilder buf = new StringBuilder(name);
-        if(stopId != null) {
-            buf.append(" (").append(stopId).append(")");
+        if(stop != null) {
+            buf.append(" (").append(stop.getId()).append(")");
         } else {
             buf.append(" ").append(coordinate.toString());
         }
@@ -98,12 +93,9 @@ public class Place {
     public String toString() {
         return ToStringBuilder.of(Place.class)
                 .addStr("name", name)
-                .addObj("stopId", stopId)
-                .addStr("stopCode", stopCode)
-                .addStr("platformCode", platformCode)
+                .addObj("stop", stop)
                 .addObj("coordinate", coordinate)
                 .addStr("orig", orig)
-                .addStr("zoneId", zoneId)
                 .addNum("stopIndex", stopIndex)
                 .addNum("stopSequence", stopSequence)
                 .addEnum("vertexType", vertexType)

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/AlertToLegMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/AlertToLegMapper.java
@@ -2,6 +2,7 @@ package org.opentripplanner.routing.algorithm.mapping;
 
 import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.model.Stop;
+import org.opentripplanner.model.StopLocation;
 import org.opentripplanner.model.calendar.ServiceDate;
 import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.model.plan.Place;
@@ -31,72 +32,38 @@ public class AlertToLegMapper {
 
         Date legStartTime = leg.startTime.getTime();
         Date legEndTime = leg.endTime.getTime();
-        FeedScopedId fromStopId = leg.from==null ? null : leg.from.stopId;
-        FeedScopedId toStopId = leg.to==null ? null : leg.to.stopId;
+        StopLocation fromStop = leg.from == null ? null : leg.from.stop;
+        StopLocation toStop = leg.to == null ? null : leg.to.stop;
 
         FeedScopedId routeId = leg.getRoute().getId();
-        if (fromStopId != null) {
-            Collection<TransitAlert> alerts = getAlertsForStopAndRoute(graph, fromStopId, routeId);
+        FeedScopedId tripId = leg.getTrip().getId();
+        if (fromStop instanceof Stop) {
+            Collection<TransitAlert> alerts = getAlertsForStopAndRoute(graph, (Stop) fromStop, routeId);
+            alerts.addAll(getAlertsForStopAndTrip(graph, (Stop) fromStop, tripId, leg.serviceDate));
+            alerts.addAll(getAlertsForStop(graph, (Stop) fromStop));
             addTransitAlertPatchesToLeg(leg, departingStopConditions, alerts, requestedLocale, legStartTime, legEndTime);
         }
-        if (toStopId != null) {
-            Collection<TransitAlert> alerts = getAlertsForStopAndRoute(graph, toStopId, routeId);
+        if (toStop instanceof Stop) {
+            Collection<TransitAlert> alerts = getAlertsForStopAndRoute(graph, (Stop) toStop, routeId);
+            alerts.addAll(getAlertsForStopAndTrip(graph, (Stop) toStop, tripId, leg.serviceDate));
+            alerts.addAll(getAlertsForStop(graph, (Stop) toStop));
             addTransitAlertPatchesToLeg(leg, StopCondition.ARRIVING, alerts, requestedLocale, legStartTime, legEndTime);
         }
 
         if (leg.intermediateStops != null) {
             for (StopArrival visit : leg.intermediateStops) {
-                Place place = visit.place;
-                if (place.stopId != null) {
-                    Collection<TransitAlert> alerts = getAlertsForStopAndRoute(graph, place.stopId, routeId);
+                if (visit.place.stop instanceof Stop) {
+                    Stop stop = (Stop) visit.place.stop;
+                    Collection<TransitAlert> alerts = getAlertsForStopAndRoute(graph, stop, routeId);
+                    alerts.addAll(getAlertsForStopAndTrip(graph, stop, tripId, leg.serviceDate));
+                    alerts.addAll(getAlertsForStop(graph, stop));
+
                     Date stopArrival = visit.arrival.getTime();
                     Date stopDepature = visit.departure.getTime();
+
                     addTransitAlertPatchesToLeg(leg, StopCondition.PASSING, alerts, requestedLocale, stopArrival, stopDepature);
                 }
             }
-
-            FeedScopedId tripId = leg.getTrip().getId();
-            if (fromStopId != null) {
-                Collection<TransitAlert> alerts = getAlertsForStopAndTrip(graph, fromStopId, tripId, leg.serviceDate);
-                addTransitAlertPatchesToLeg(leg, departingStopConditions, alerts, requestedLocale, legStartTime, legEndTime);
-            }
-            if (toStopId != null) {
-                Collection<TransitAlert> alerts = getAlertsForStopAndTrip(graph, toStopId, tripId, leg.serviceDate);
-                addTransitAlertPatchesToLeg(leg, StopCondition.ARRIVING, alerts, requestedLocale, legStartTime, legEndTime);
-            }
-            if (leg.intermediateStops != null) {
-                for (StopArrival visit : leg.intermediateStops) {
-                    Place place = visit.place;
-                    if (place.stopId != null) {
-                        Collection<TransitAlert> alerts = getAlertsForStopAndTrip(graph, place.stopId, tripId, leg.serviceDate);
-                        Date stopArrival = visit.arrival.getTime();
-                        Date stopDepature = visit.departure.getTime();
-                        addTransitAlertPatchesToLeg(leg, StopCondition.PASSING, alerts, requestedLocale, stopArrival, stopDepature);
-                    }
-                }
-            }
-        }
-
-        if (leg.intermediateStops != null) {
-            for (StopArrival visit : leg.intermediateStops) {
-                Place place = visit.place;
-                if (place.stopId != null) {
-                    Collection<TransitAlert> alerts = getAlertsForStop(graph, place.stopId);
-                    Date stopArrival = visit.arrival.getTime();
-                    Date stopDepature = visit.departure.getTime();
-                    addTransitAlertPatchesToLeg(leg, StopCondition.PASSING, alerts, requestedLocale, stopArrival, stopDepature);
-                }
-            }
-        }
-
-        if (leg.from != null && fromStopId != null) {
-            Collection<TransitAlert> alerts = getAlertsForStop(graph, fromStopId);
-            addTransitAlertPatchesToLeg(leg, departingStopConditions, alerts, requestedLocale, legStartTime, legEndTime);
-        }
-
-        if (leg.to != null && toStopId != null) {
-            Collection<TransitAlert> alerts = getAlertsForStop(graph, toStopId);
-            addTransitAlertPatchesToLeg(leg, StopCondition.ARRIVING, alerts, requestedLocale, legStartTime, legEndTime);
         }
 
         Collection<TransitAlert> patches;
@@ -125,18 +92,17 @@ public class AlertToLegMapper {
         return g.getTransitAlertService();
     }
 
-    private static Collection<TransitAlert> getAlertsForStopAndRoute(Graph graph, FeedScopedId stopId, FeedScopedId routeId) {
-        return getAlertsForStopAndRoute(graph, stopId, routeId, true);
+    private static Collection<TransitAlert> getAlertsForStopAndRoute(Graph graph, Stop stop, FeedScopedId routeId) {
+        return getAlertsForStopAndRoute(graph, stop, routeId, true);
     }
 
 
-    private static Collection<TransitAlert> getAlertsForStopAndRoute(Graph graph, FeedScopedId stopId, FeedScopedId routeId, boolean checkParentStop) {
+    private static Collection<TransitAlert> getAlertsForStopAndRoute(Graph graph, Stop stop, FeedScopedId routeId, boolean checkParentStop) {
 
-        Stop stop = graph.index.getStopForId(stopId);
         if (stop == null) {
             return new ArrayList<>();
         }
-        Collection<TransitAlert> alertsForStopAndRoute = graph.getTransitAlertService().getStopAndRouteAlerts(stopId, routeId);
+        Collection<TransitAlert> alertsForStopAndRoute = graph.getTransitAlertService().getStopAndRouteAlerts(stop.getId(), routeId);
         if (checkParentStop) {
             if (alertsForStopAndRoute == null) {
                 alertsForStopAndRoute = new HashSet<>();
@@ -173,12 +139,12 @@ public class AlertToLegMapper {
         return alertsForStopAndRoute;
     }
 
-    private static Collection<TransitAlert> getAlertsForStopAndTrip(Graph graph, FeedScopedId stopId, FeedScopedId tripId, ServiceDate serviceDate) {
+    private static Collection<TransitAlert> getAlertsForStopAndTrip(Graph graph, Stop stop, FeedScopedId tripId, ServiceDate serviceDate) {
 
         // Finding alerts for ServiceDate
         final Collection<TransitAlert> alerts = getAlertsForStopAndTrip(
             graph,
-            stopId,
+            stop,
             tripId,
             true,
             serviceDate
@@ -187,7 +153,7 @@ public class AlertToLegMapper {
         // Finding alerts for any date
         alerts.addAll(getAlertsForStopAndTrip(
             graph,
-            stopId,
+            stop,
             tripId,
             true,
             null
@@ -196,14 +162,13 @@ public class AlertToLegMapper {
         return alerts;
     }
 
-    private static Collection<TransitAlert> getAlertsForStopAndTrip(Graph graph, FeedScopedId stopId, FeedScopedId tripId, boolean checkParentStop, ServiceDate serviceDate) {
+    private static Collection<TransitAlert> getAlertsForStopAndTrip(Graph graph, Stop stop, FeedScopedId tripId, boolean checkParentStop, ServiceDate serviceDate) {
 
-        Stop stop = graph.index.getStopForId(stopId);
         if (stop == null) {
             return new ArrayList<>();
         }
 
-        Collection<TransitAlert> alertsForStopAndTrip = graph.getTransitAlertService().getStopAndTripAlerts(stopId, tripId, serviceDate);
+        Collection<TransitAlert> alertsForStopAndTrip = graph.getTransitAlertService().getStopAndTripAlerts(stop.getId(), tripId, serviceDate);
         if (checkParentStop) {
             if (alertsForStopAndTrip == null) {
                 alertsForStopAndTrip = new HashSet<>();
@@ -239,17 +204,16 @@ public class AlertToLegMapper {
         return alertsForStopAndTrip;
     }
 
-    private static Collection<TransitAlert> getAlertsForStop(Graph graph, FeedScopedId stopId) {
+    private static Collection<TransitAlert> getAlertsForStop(Graph graph, Stop stopId) {
         return getAlertsForStop(graph, stopId, true);
     }
 
-    private static Collection<TransitAlert> getAlertsForStop(Graph graph, FeedScopedId stopId, boolean checkParentStop) {
-        Stop stop = graph.index.getStopForId(stopId);
+    private static Collection<TransitAlert> getAlertsForStop(Graph graph, Stop stop, boolean checkParentStop) {
         if (stop == null) {
             return new ArrayList<>();
         }
 
-        Collection<TransitAlert> alertsForStop  = graph.getTransitAlertService().getStopAlerts(stopId);
+        Collection<TransitAlert> alertsForStop  = graph.getTransitAlertService().getStopAlerts(stop.getId());
         if (checkParentStop) {
             if (alertsForStop == null) {
                 alertsForStop = new HashSet<>();

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/GraphPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/GraphPathToItineraryMapper.java
@@ -445,24 +445,22 @@ public abstract class GraphPathToItineraryMapper {
         Vertex firstVertex = states[0].getVertex();
         Vertex lastVertex = states[states.length - 1].getVertex();
 
-        Stop firstStop = firstVertex instanceof TransitStopVertex ?
-                ((TransitStopVertex) firstVertex).getStop(): null;
-        Stop lastStop = lastVertex instanceof TransitStopVertex ?
-                ((TransitStopVertex) lastVertex).getStop(): null;
-
-        leg.from = makePlace(firstVertex, firstStop, requestedLocale);
-        leg.to = makePlace(lastVertex, lastStop, requestedLocale);
+        leg.from = makePlace(firstVertex, requestedLocale);
+        leg.to = makePlace(lastVertex, requestedLocale);
     }
 
     /**
      * Make a {@link Place} to add to a {@link Leg}.
      *
      * @param vertex The {@link Vertex} at the {@link State}.
-     * @param stop The {@link Stop} associated with the {@link Vertex}.
      * @param requestedLocale The locale to use for all text attributes.
      * @return The resulting {@link Place} object.
      */
-    private static Place makePlace(Vertex vertex, Stop stop, Locale requestedLocale) {
+    private static Place makePlace(Vertex vertex, Locale requestedLocale) {
+        if (vertex instanceof TransitStopVertex) {
+            return new Place(((TransitStopVertex) vertex).getStop());
+        }
+
         String name = vertex.getName(requestedLocale);
 
         //This gets nicer names instead of osm:node:id when changing mode of transport
@@ -477,13 +475,7 @@ public abstract class GraphPathToItineraryMapper {
                 name
         );
 
-        if (vertex instanceof TransitStopVertex) {
-            place.stopId = stop.getId();
-            place.stopCode = stop.getCode();
-            place.platformCode = stop.getPlatformCode();
-            place.zoneId = stop.getFirstZoneAsString();
-            place.vertexType = VertexType.TRANSIT;
-        } else if(vertex instanceof VehicleRentalStationVertex) {
+        if(vertex instanceof VehicleRentalStationVertex) {
             place.bikeShareId = ((VehicleRentalStationVertex) vertex).getId();
             LOG.trace("Added bike share Id {} to place", place.bikeShareId);
             place.vertexType = VertexType.BIKESHARE;

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
@@ -16,7 +16,6 @@ import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.model.plan.Place;
 import org.opentripplanner.model.plan.StopArrival;
-import org.opentripplanner.model.plan.VertexType;
 import org.opentripplanner.routing.algorithm.raptor.transit.AccessEgress;
 import org.opentripplanner.routing.algorithm.raptor.transit.Transfer;
 import org.opentripplanner.routing.algorithm.raptor.transit.TransitLayer;
@@ -235,8 +234,8 @@ public class RaptorPathToItineraryMapper {
         Stop transferToStop = transitLayer.getStopByIndex(pathLeg.toStop());
         Transfer transfer = ((TransferWithDuration) pathLeg.transfer()).transfer();
 
-        Place from = mapStopToPlace(transferFromStop);
-        Place to = mapStopToPlace(transferToStop);
+        Place from = new Place(transferFromStop);
+        Place to = new Place(transferToStop);
         return mapNonTransitLeg(pathLeg, transfer, from, to, false);
     }
 
@@ -331,23 +330,10 @@ public class RaptorPathToItineraryMapper {
     }
 
     /**
-     * Maps stops for non-transit (transfer) legs.
-     */
-    private Place mapStopToPlace(Stop stop) {
-        Place place = new Place(stop.getLat(), stop.getLon(), stop.getName());
-        place.stopId = stop.getId();
-        place.stopCode = stop.getCode();
-        place.platformCode = stop.getPlatformCode();
-        place.zoneId = stop.getFirstZoneAsString();
-        place.vertexType = VertexType.TRANSIT;
-        return place;
-    }
-
-    /**
      * Maps stops for transit legs.
      */
     private Place mapStopToPlace(Stop stop, Integer stopIndex, TripTimes tripTimes) {
-        Place place = mapStopToPlace(stop);
+        Place place = new Place(stop);
         place.stopIndex = stopIndex;
         place.stopSequence = tripTimes.getOriginalGtfsStopSequence(stopIndex);
         return place;

--- a/src/test/java/org/opentripplanner/GtfsTest.java
+++ b/src/test/java/org/opentripplanner/GtfsTest.java
@@ -159,13 +159,13 @@ public abstract class GtfsTest extends TestCase {
     ) {
         assertEquals(startTime, leg.startTime.getTimeInMillis());
         assertEquals(endTime, leg.endTime.getTimeInMillis());
-        assertEquals(toStopId, leg.to.stopId.getId());
-        assertEquals(feedId.getId(), leg.to.stopId.getFeedId());
+        assertEquals(toStopId, leg.to.stop.getId().getId());
+        assertEquals(feedId.getId(), leg.to.stop.getId().getFeedId());
         if (fromStopId != null) {
-            assertEquals(feedId.getId(), leg.from.stopId.getFeedId());
-            assertEquals(fromStopId, leg.from.stopId.getId());
+            assertEquals(feedId.getId(), leg.from.stop.getId().getFeedId());
+            assertEquals(fromStopId, leg.from.stop.getId().getId());
         } else {
-            assertNull(leg.from.stopId);
+            assertNull(leg.from.stop.getId());
         }
         if (alert != null) {
             assertNotNull(leg.streetNotes);

--- a/src/test/java/org/opentripplanner/model/plan/PlaceTest.java
+++ b/src/test/java/org/opentripplanner/model/plan/PlaceTest.java
@@ -2,6 +2,7 @@ package org.opentripplanner.model.plan;
 
 import org.junit.Test;
 import org.opentripplanner.model.FeedScopedId;
+import org.opentripplanner.model.Stop;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -40,7 +41,20 @@ public class PlaceTest {
 
     private static Place place(String name, String stopId) {
         Place p = new Place(null, null, name);
-        p.stopId = new FeedScopedId("S", stopId);
+        p.stop = new Stop(
+                new FeedScopedId("S", stopId),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
         return p;
     }
 }

--- a/src/test/java/org/opentripplanner/model/plan/PlanTestConstants.java
+++ b/src/test/java/org/opentripplanner/model/plan/PlanTestConstants.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.model.plan;
 
 import org.opentripplanner.model.FeedScopedId;
+import org.opentripplanner.model.Stop;
 import org.opentripplanner.model.calendar.ServiceDate;
 import org.opentripplanner.util.time.DurationUtils;
 
@@ -71,7 +72,20 @@ public interface PlanTestConstants {
 
   private static Place place(String name, double lat, double lon) {
     Place p = new Place(lat, lon, name);
-    p.stopId = new FeedScopedId(FEED_ID, name);
+    p.stop = new Stop(
+            new FeedScopedId(FEED_ID, name),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+    );
     return p;
   }
 }

--- a/src/test/java/org/opentripplanner/model/plan/TestItineraryBuilder.java
+++ b/src/test/java/org/opentripplanner/model/plan/TestItineraryBuilder.java
@@ -204,7 +204,7 @@ public class TestItineraryBuilder implements PlanTestConstants {
 
   private static Place stop(Place source, int stopIndex) {
     Place p = new Place(source.coordinate.latitude(), source.coordinate.longitude(), source.name);
-    p.stopId = source.stopId;
+    p.stop = source.stop;
     p.stopIndex = stopIndex;
     return p;
   }

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/BikeRentalSnapshotTest.snap
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/BikeRentalSnapshotTest.snap
@@ -315,15 +315,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "longitude": -122.694539
             },
             "name": "NW 21st & Irving",
-            "stopCode": "7114",
-            "stopId": {
-              "feedId": "prt",
-              "id": "7114"
+            "stop": {
+              "code": "7114",
+              "coordinate": {
+                "latitude": 45.527818,
+                "longitude": -122.694539
+              },
+              "description": "Southbound stop in Portland (Stop ID 7114)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "7114"
+              },
+              "name": "NW 21st & Irving",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 15,
             "stopSequence": 16,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
           "transitLeg": false,
@@ -385,15 +402,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "longitude": -122.694539
             },
             "name": "NW 21st & Irving",
-            "stopCode": "7114",
-            "stopId": {
-              "feedId": "prt",
-              "id": "7114"
+            "stop": {
+              "code": "7114",
+              "coordinate": {
+                "latitude": 45.527818,
+                "longitude": -122.694539
+              },
+              "description": "Southbound stop in Portland (Stop ID 7114)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "7114"
+              },
+              "name": "NW 21st & Irving",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 15,
             "stopSequence": 16,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 1175,
           "headsign": "136th Ave",
@@ -422,15 +456,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "longitude": -122.677664
             },
             "name": "NW Everett & Broadway",
-            "stopCode": "1606",
-            "stopId": {
-              "feedId": "prt",
-              "id": "1606"
+            "stop": {
+              "code": "1606",
+              "coordinate": {
+                "latitude": 45.525112,
+                "longitude": -122.677664
+              },
+              "description": "Eastbound stop in Portland (Stop ID 1606)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "0"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "1606"
+              },
+              "name": "NW Everett & Broadway",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 22,
             "stopSequence": 23,
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
+            "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
           "transitLeg": true,
@@ -495,15 +546,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "longitude": -122.677664
             },
             "name": "NW Everett & Broadway",
-            "stopCode": "1606",
-            "stopId": {
-              "feedId": "prt",
-              "id": "1606"
+            "stop": {
+              "code": "1606",
+              "coordinate": {
+                "latitude": 45.525112,
+                "longitude": -122.677664
+              },
+              "description": "Eastbound stop in Portland (Stop ID 1606)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "0"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "1606"
+              },
+              "name": "NW Everett & Broadway",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 22,
             "stopSequence": 23,
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 285,
           "interlineWithPreviousLeg": false,
@@ -639,15 +707,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "longitude": -122.700988
             },
             "name": "W Burnside & SW Osage",
-            "stopCode": "9354",
-            "stopId": {
-              "feedId": "prt",
-              "id": "9354"
+            "stop": {
+              "code": "9354",
+              "coordinate": {
+                "latitude": 45.523773,
+                "longitude": -122.700988
+              },
+              "description": "Eastbound stop in Portland (Stop ID 9354)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "9354"
+              },
+              "name": "W Burnside & SW Osage",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 36,
             "stopSequence": 37,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
           "transitLeg": false,
@@ -754,15 +839,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "longitude": -122.700988
             },
             "name": "W Burnside & SW Osage",
-            "stopCode": "9354",
-            "stopId": {
-              "feedId": "prt",
-              "id": "9354"
+            "stop": {
+              "code": "9354",
+              "coordinate": {
+                "latitude": 45.523773,
+                "longitude": -122.700988
+              },
+              "description": "Eastbound stop in Portland (Stop ID 9354)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "9354"
+              },
+              "name": "W Burnside & SW Osage",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 36,
             "stopSequence": 37,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 1133,
           "headsign": "Gresham TC",
@@ -791,15 +893,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "longitude": -122.676924
             },
             "name": "W Burnside & SW 6th",
-            "stopCode": "792",
-            "stopId": {
-              "feedId": "prt",
-              "id": "792"
+            "stop": {
+              "code": "792",
+              "coordinate": {
+                "latitude": 45.522961,
+                "longitude": -122.676924
+              },
+              "description": "Eastbound stop in Portland (Stop ID 792)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "0"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "792"
+              },
+              "name": "W Burnside & SW 6th",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 45,
             "stopSequence": 46,
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
+            "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
           "transitLeg": true,
@@ -864,15 +983,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "longitude": -122.676924
             },
             "name": "W Burnside & SW 6th",
-            "stopCode": "792",
-            "stopId": {
-              "feedId": "prt",
-              "id": "792"
+            "stop": {
+              "code": "792",
+              "coordinate": {
+                "latitude": 45.522961,
+                "longitude": -122.676924
+              },
+              "description": "Eastbound stop in Portland (Stop ID 792)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "0"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "792"
+              },
+              "name": "W Burnside & SW 6th",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 45,
             "stopSequence": 46,
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 579,
           "interlineWithPreviousLeg": false,
@@ -1059,15 +1195,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "longitude": -122.700988
             },
             "name": "W Burnside & SW Osage",
-            "stopCode": "9354",
-            "stopId": {
-              "feedId": "prt",
-              "id": "9354"
+            "stop": {
+              "code": "9354",
+              "coordinate": {
+                "latitude": 45.523773,
+                "longitude": -122.700988
+              },
+              "description": "Eastbound stop in Portland (Stop ID 9354)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "9354"
+              },
+              "name": "W Burnside & SW Osage",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 36,
             "stopSequence": 37,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
           "transitLeg": false,
@@ -1174,15 +1327,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "longitude": -122.700988
             },
             "name": "W Burnside & SW Osage",
-            "stopCode": "9354",
-            "stopId": {
-              "feedId": "prt",
-              "id": "9354"
+            "stop": {
+              "code": "9354",
+              "coordinate": {
+                "latitude": 45.523773,
+                "longitude": -122.700988
+              },
+              "description": "Eastbound stop in Portland (Stop ID 9354)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "9354"
+              },
+              "name": "W Burnside & SW Osage",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 36,
             "stopSequence": 37,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 1201,
           "headsign": "Gresham TC",
@@ -1211,15 +1381,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "longitude": -122.674799
             },
             "name": "W Burnside & SW 4th",
-            "stopCode": "772",
-            "stopId": {
-              "feedId": "prt",
-              "id": "772"
+            "stop": {
+              "code": "772",
+              "coordinate": {
+                "latitude": 45.522974,
+                "longitude": -122.674799
+              },
+              "description": "Eastbound stop in Portland (Stop ID 772)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "0"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "772"
+              },
+              "name": "W Burnside & SW 4th",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 46,
             "stopSequence": 47,
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
+            "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
           "transitLeg": true,
@@ -1284,15 +1471,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "longitude": -122.674799
             },
             "name": "W Burnside & SW 4th",
-            "stopCode": "772",
-            "stopId": {
-              "feedId": "prt",
-              "id": "772"
+            "stop": {
+              "code": "772",
+              "coordinate": {
+                "latitude": 45.522974,
+                "longitude": -122.674799
+              },
+              "description": "Eastbound stop in Portland (Stop ID 772)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "0"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "772"
+              },
+              "name": "W Burnside & SW 4th",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 46,
             "stopSequence": 47,
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 472,
           "interlineWithPreviousLeg": false,
@@ -1479,15 +1683,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "longitude": -122.701423
             },
             "name": "2400 Block NW Lovejoy",
-            "stopCode": "3589",
-            "stopId": {
-              "feedId": "prt",
-              "id": "3589"
+            "stop": {
+              "code": "3589",
+              "coordinate": {
+                "latitude": 45.529662,
+                "longitude": -122.701423
+              },
+              "description": "Eastbound stop in Portland (Stop ID 3589)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "3589"
+              },
+              "name": "2400 Block NW Lovejoy",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 6,
             "stopSequence": 7,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
           "transitLeg": false,
@@ -1543,15 +1764,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "longitude": -122.701423
             },
             "name": "2400 Block NW Lovejoy",
-            "stopCode": "3589",
-            "stopId": {
-              "feedId": "prt",
-              "id": "3589"
+            "stop": {
+              "code": "3589",
+              "coordinate": {
+                "latitude": 45.529662,
+                "longitude": -122.701423
+              },
+              "description": "Eastbound stop in Portland (Stop ID 3589)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "3589"
+              },
+              "name": "2400 Block NW Lovejoy",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 6,
             "stopSequence": 7,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 1391,
           "headsign": "Troutdale",
@@ -1580,15 +1818,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "longitude": -122.674607
             },
             "name": "NW Everett & 4th",
-            "stopCode": "9546",
-            "stopId": {
-              "feedId": "prt",
-              "id": "9546"
+            "stop": {
+              "code": "9546",
+              "coordinate": {
+                "latitude": 45.525183,
+                "longitude": -122.674607
+              },
+              "description": "Eastbound stop in Portland (Stop ID 9546)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "0"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "9546"
+              },
+              "name": "NW Everett & 4th",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 14,
             "stopSequence": 15,
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
+            "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
           "transitLeg": true,
@@ -1653,15 +1908,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "longitude": -122.674607
             },
             "name": "NW Everett & 4th",
-            "stopCode": "9546",
-            "stopId": {
-              "feedId": "prt",
-              "id": "9546"
+            "stop": {
+              "code": "9546",
+              "coordinate": {
+                "latitude": 45.525183,
+                "longitude": -122.674607
+              },
+              "description": "Eastbound stop in Portland (Stop ID 9546)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "0"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "9546"
+              },
+              "name": "NW Everett & 4th",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 14,
             "stopSequence": 15,
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 77,
           "interlineWithPreviousLeg": false,
@@ -2038,15 +2310,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "longitude": -122.694539
             },
             "name": "NW 21st & Irving",
-            "stopCode": "7114",
-            "stopId": {
-              "feedId": "prt",
-              "id": "7114"
+            "stop": {
+              "code": "7114",
+              "coordinate": {
+                "latitude": 45.527818,
+                "longitude": -122.694539
+              },
+              "description": "Southbound stop in Portland (Stop ID 7114)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "7114"
+              },
+              "name": "NW 21st & Irving",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 15,
             "stopSequence": 16,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
           "transitLeg": false,
@@ -2108,15 +2397,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "longitude": -122.694539
             },
             "name": "NW 21st & Irving",
-            "stopCode": "7114",
-            "stopId": {
-              "feedId": "prt",
-              "id": "7114"
+            "stop": {
+              "code": "7114",
+              "coordinate": {
+                "latitude": 45.527818,
+                "longitude": -122.694539
+              },
+              "description": "Southbound stop in Portland (Stop ID 7114)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "7114"
+              },
+              "name": "NW 21st & Irving",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 15,
             "stopSequence": 16,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 1175,
           "headsign": "136th Ave",
@@ -2145,15 +2451,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "longitude": -122.677664
             },
             "name": "NW Everett & Broadway",
-            "stopCode": "1606",
-            "stopId": {
-              "feedId": "prt",
-              "id": "1606"
+            "stop": {
+              "code": "1606",
+              "coordinate": {
+                "latitude": 45.525112,
+                "longitude": -122.677664
+              },
+              "description": "Eastbound stop in Portland (Stop ID 1606)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "0"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "1606"
+              },
+              "name": "NW Everett & Broadway",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 22,
             "stopSequence": 23,
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
+            "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
           "transitLeg": true,
@@ -2218,15 +2541,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "longitude": -122.677664
             },
             "name": "NW Everett & Broadway",
-            "stopCode": "1606",
-            "stopId": {
-              "feedId": "prt",
-              "id": "1606"
+            "stop": {
+              "code": "1606",
+              "coordinate": {
+                "latitude": 45.525112,
+                "longitude": -122.677664
+              },
+              "description": "Eastbound stop in Portland (Stop ID 1606)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "0"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "1606"
+              },
+              "name": "NW Everett & Broadway",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 22,
             "stopSequence": 23,
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 285,
           "interlineWithPreviousLeg": false,
@@ -2603,15 +2943,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "longitude": -122.694539
             },
             "name": "NW 21st & Irving",
-            "stopCode": "7114",
-            "stopId": {
-              "feedId": "prt",
-              "id": "7114"
+            "stop": {
+              "code": "7114",
+              "coordinate": {
+                "latitude": 45.527818,
+                "longitude": -122.694539
+              },
+              "description": "Southbound stop in Portland (Stop ID 7114)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "7114"
+              },
+              "name": "NW 21st & Irving",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 50,
             "stopSequence": 51,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
           "transitLeg": false,
@@ -2673,15 +3030,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "longitude": -122.694539
             },
             "name": "NW 21st & Irving",
-            "stopCode": "7114",
-            "stopId": {
-              "feedId": "prt",
-              "id": "7114"
+            "stop": {
+              "code": "7114",
+              "coordinate": {
+                "latitude": 45.527818,
+                "longitude": -122.694539
+              },
+              "description": "Southbound stop in Portland (Stop ID 7114)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "7114"
+              },
+              "name": "NW 21st & Irving",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 50,
             "stopSequence": 51,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 1175,
           "headsign": "136th Ave",
@@ -2710,15 +3084,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "longitude": -122.677664
             },
             "name": "NW Everett & Broadway",
-            "stopCode": "1606",
-            "stopId": {
-              "feedId": "prt",
-              "id": "1606"
+            "stop": {
+              "code": "1606",
+              "coordinate": {
+                "latitude": 45.525112,
+                "longitude": -122.677664
+              },
+              "description": "Eastbound stop in Portland (Stop ID 1606)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "0"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "1606"
+              },
+              "name": "NW Everett & Broadway",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 57,
             "stopSequence": 58,
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
+            "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
           "transitLeg": true,
@@ -2783,15 +3174,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "longitude": -122.677664
             },
             "name": "NW Everett & Broadway",
-            "stopCode": "1606",
-            "stopId": {
-              "feedId": "prt",
-              "id": "1606"
+            "stop": {
+              "code": "1606",
+              "coordinate": {
+                "latitude": 45.525112,
+                "longitude": -122.677664
+              },
+              "description": "Eastbound stop in Portland (Stop ID 1606)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "0"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "1606"
+              },
+              "name": "NW Everett & Broadway",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 57,
             "stopSequence": 58,
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 285,
           "interlineWithPreviousLeg": false,
@@ -3908,15 +4316,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "longitude": -122.676422
             },
             "name": "NW 6th & Flanders",
-            "stopCode": "9300",
-            "stopId": {
-              "feedId": "prt",
-              "id": "9300"
+            "stop": {
+              "code": "9300",
+              "coordinate": {
+                "latitude": 45.52583,
+                "longitude": -122.676422
+              },
+              "description": "Northbound stop in Portland (Stop ID 9300)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "0"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "9300"
+              },
+              "name": "NW 6th & Flanders",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 66,
             "stopSequence": 67,
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
+            "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
           "transitLeg": false,
@@ -3989,15 +4414,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "longitude": -122.676422
             },
             "name": "NW 6th & Flanders",
-            "stopCode": "9300",
-            "stopId": {
-              "feedId": "prt",
-              "id": "9300"
+            "stop": {
+              "code": "9300",
+              "coordinate": {
+                "latitude": 45.52583,
+                "longitude": -122.676422
+              },
+              "description": "Northbound stop in Portland (Stop ID 9300)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "0"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "9300"
+              },
+              "name": "NW 6th & Flanders",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 66,
             "stopSequence": 67,
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 1122,
           "headsign": "Sauvie Is. via St.Johns",
@@ -4026,15 +4468,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "longitude": -122.694407
             },
             "name": "NW 21st & Irving",
-            "stopCode": "7113",
-            "stopId": {
-              "feedId": "prt",
-              "id": "7113"
+            "stop": {
+              "code": "7113",
+              "coordinate": {
+                "latitude": 45.527648,
+                "longitude": -122.694407
+              },
+              "description": "Northbound stop in Portland (Stop ID 7113)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "7113"
+              },
+              "name": "NW 21st & Irving",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 75,
             "stopSequence": 76,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
           "transitLeg": true,
@@ -4099,15 +4558,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "longitude": -122.694407
             },
             "name": "NW 21st & Irving",
-            "stopCode": "7113",
-            "stopId": {
-              "feedId": "prt",
-              "id": "7113"
+            "stop": {
+              "code": "7113",
+              "coordinate": {
+                "latitude": 45.527648,
+                "longitude": -122.694407
+              },
+              "description": "Northbound stop in Portland (Stop ID 7113)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "7113"
+              },
+              "name": "NW 21st & Irving",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 75,
             "stopSequence": 76,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 167,
           "interlineWithPreviousLeg": false,
@@ -4507,15 +4983,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "longitude": -122.675893
             },
             "name": "W Burnside & NW 5th",
-            "stopCode": "782",
-            "stopId": {
-              "feedId": "prt",
-              "id": "782"
+            "stop": {
+              "code": "782",
+              "coordinate": {
+                "latitude": 45.523169,
+                "longitude": -122.675893
+              },
+              "description": "Westbound stop in Portland (Stop ID 782)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "0"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "782"
+              },
+              "name": "W Burnside & NW 5th",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 99,
             "stopSequence": 100,
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
+            "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
           "transitLeg": false,
@@ -4588,15 +5081,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "longitude": -122.675893
             },
             "name": "W Burnside & NW 5th",
-            "stopCode": "782",
-            "stopId": {
-              "feedId": "prt",
-              "id": "782"
+            "stop": {
+              "code": "782",
+              "coordinate": {
+                "latitude": 45.523169,
+                "longitude": -122.675893
+              },
+              "description": "Westbound stop in Portland (Stop ID 782)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "0"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "782"
+              },
+              "name": "W Burnside & NW 5th",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 99,
             "stopSequence": 100,
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 1203,
           "headsign": "Beaverton TC",
@@ -4625,15 +5135,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "longitude": -122.700681
             },
             "name": "W Burnside & NW 23rd Pl",
-            "stopCode": "9555",
-            "stopId": {
-              "feedId": "prt",
-              "id": "9555"
+            "stop": {
+              "code": "9555",
+              "coordinate": {
+                "latitude": 45.523897,
+                "longitude": -122.700681
+              },
+              "description": "Westbound stop in Portland (Stop ID 9555)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "9555"
+              },
+              "name": "W Burnside & NW 23rd Pl",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 109,
             "stopSequence": 110,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
           "transitLeg": true,
@@ -4698,15 +5225,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "longitude": -122.700681
             },
             "name": "W Burnside & NW 23rd Pl",
-            "stopCode": "9555",
-            "stopId": {
-              "feedId": "prt",
-              "id": "9555"
+            "stop": {
+              "code": "9555",
+              "coordinate": {
+                "latitude": 45.523897,
+                "longitude": -122.700681
+              },
+              "description": "Westbound stop in Portland (Stop ID 9555)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "9555"
+              },
+              "name": "W Burnside & NW 23rd Pl",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 109,
             "stopSequence": 110,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 858,
           "interlineWithPreviousLeg": false,
@@ -4893,15 +5437,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "longitude": -122.676462
             },
             "name": "NW Glisan & 6th",
-            "stopCode": "10803",
-            "stopId": {
-              "feedId": "prt",
-              "id": "10803"
+            "stop": {
+              "code": "10803",
+              "coordinate": {
+                "latitude": 45.526655,
+                "longitude": -122.676462
+              },
+              "description": "Westbound stop in Portland (Stop ID 10803)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "0"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "10803"
+              },
+              "name": "NW Glisan & 6th",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 85,
             "stopSequence": 86,
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
+            "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
           "transitLeg": false,
@@ -4991,15 +5552,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "longitude": -122.676462
             },
             "name": "NW Glisan & 6th",
-            "stopCode": "10803",
-            "stopId": {
-              "feedId": "prt",
-              "id": "10803"
+            "stop": {
+              "code": "10803",
+              "coordinate": {
+                "latitude": 45.526655,
+                "longitude": -122.676462
+              },
+              "description": "Westbound stop in Portland (Stop ID 10803)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "0"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "10803"
+              },
+              "name": "NW Glisan & 6th",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 85,
             "stopSequence": 86,
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 1077,
           "headsign": "Montgomery Park",
@@ -5028,15 +5606,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "longitude": -122.698634
             },
             "name": "NW 23rd & Overton",
-            "stopCode": "8981",
-            "stopId": {
-              "feedId": "prt",
-              "id": "8981"
+            "stop": {
+              "code": "8981",
+              "coordinate": {
+                "latitude": 45.532159,
+                "longitude": -122.698634
+              },
+              "description": "Northbound stop in Portland (Stop ID 8981)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "8981"
+              },
+              "name": "NW 23rd & Overton",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 93,
             "stopSequence": 94,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
           "transitLeg": true,
@@ -5101,15 +5696,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "longitude": -122.698634
             },
             "name": "NW 23rd & Overton",
-            "stopCode": "8981",
-            "stopId": {
-              "feedId": "prt",
-              "id": "8981"
+            "stop": {
+              "code": "8981",
+              "coordinate": {
+                "latitude": 45.532159,
+                "longitude": -122.698634
+              },
+              "description": "Northbound stop in Portland (Stop ID 8981)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "8981"
+              },
+              "name": "NW 23rd & Overton",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 93,
             "stopSequence": 94,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 881,
           "interlineWithPreviousLeg": false,
@@ -5279,15 +5891,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "longitude": -122.676422
             },
             "name": "NW 6th & Flanders",
-            "stopCode": "9300",
-            "stopId": {
-              "feedId": "prt",
-              "id": "9300"
+            "stop": {
+              "code": "9300",
+              "coordinate": {
+                "latitude": 45.52583,
+                "longitude": -122.676422
+              },
+              "description": "Northbound stop in Portland (Stop ID 9300)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "0"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "9300"
+              },
+              "name": "NW 6th & Flanders",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 66,
             "stopSequence": 67,
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
+            "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
           "transitLeg": false,
@@ -5360,15 +5989,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "longitude": -122.676422
             },
             "name": "NW 6th & Flanders",
-            "stopCode": "9300",
-            "stopId": {
-              "feedId": "prt",
-              "id": "9300"
+            "stop": {
+              "code": "9300",
+              "coordinate": {
+                "latitude": 45.52583,
+                "longitude": -122.676422
+              },
+              "description": "Northbound stop in Portland (Stop ID 9300)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "0"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "9300"
+              },
+              "name": "NW 6th & Flanders",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 66,
             "stopSequence": 67,
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 1122,
           "headsign": "31st & Industrial",
@@ -5397,15 +6043,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "longitude": -122.694407
             },
             "name": "NW 21st & Irving",
-            "stopCode": "7113",
-            "stopId": {
-              "feedId": "prt",
-              "id": "7113"
+            "stop": {
+              "code": "7113",
+              "coordinate": {
+                "latitude": 45.527648,
+                "longitude": -122.694407
+              },
+              "description": "Northbound stop in Portland (Stop ID 7113)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "7113"
+              },
+              "name": "NW 21st & Irving",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 75,
             "stopSequence": 76,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
           "transitLeg": true,
@@ -5470,15 +6133,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "longitude": -122.694407
             },
             "name": "NW 21st & Irving",
-            "stopCode": "7113",
-            "stopId": {
-              "feedId": "prt",
-              "id": "7113"
+            "stop": {
+              "code": "7113",
+              "coordinate": {
+                "latitude": 45.527648,
+                "longitude": -122.694407
+              },
+              "description": "Northbound stop in Portland (Stop ID 7113)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "7113"
+              },
+              "name": "NW 21st & Irving",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 75,
             "stopSequence": 76,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 167,
           "interlineWithPreviousLeg": false,
@@ -5878,15 +6558,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "longitude": -122.675893
             },
             "name": "W Burnside & NW 5th",
-            "stopCode": "782",
-            "stopId": {
-              "feedId": "prt",
-              "id": "782"
+            "stop": {
+              "code": "782",
+              "coordinate": {
+                "latitude": 45.523169,
+                "longitude": -122.675893
+              },
+              "description": "Westbound stop in Portland (Stop ID 782)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "0"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "782"
+              },
+              "name": "W Burnside & NW 5th",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 99,
             "stopSequence": 100,
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
+            "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
           "transitLeg": false,
@@ -5959,15 +6656,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "longitude": -122.675893
             },
             "name": "W Burnside & NW 5th",
-            "stopCode": "782",
-            "stopId": {
-              "feedId": "prt",
-              "id": "782"
+            "stop": {
+              "code": "782",
+              "coordinate": {
+                "latitude": 45.523169,
+                "longitude": -122.675893
+              },
+              "description": "Westbound stop in Portland (Stop ID 782)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "0"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "782"
+              },
+              "name": "W Burnside & NW 5th",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 99,
             "stopSequence": 100,
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 1263,
           "headsign": "Beaverton TC",
@@ -5996,15 +6710,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "longitude": -122.700681
             },
             "name": "W Burnside & NW 23rd Pl",
-            "stopCode": "9555",
-            "stopId": {
-              "feedId": "prt",
-              "id": "9555"
+            "stop": {
+              "code": "9555",
+              "coordinate": {
+                "latitude": 45.523897,
+                "longitude": -122.700681
+              },
+              "description": "Westbound stop in Portland (Stop ID 9555)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "9555"
+              },
+              "name": "W Burnside & NW 23rd Pl",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 109,
             "stopSequence": 110,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
           "transitLeg": true,
@@ -6069,15 +6800,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "longitude": -122.700681
             },
             "name": "W Burnside & NW 23rd Pl",
-            "stopCode": "9555",
-            "stopId": {
-              "feedId": "prt",
-              "id": "9555"
+            "stop": {
+              "code": "9555",
+              "coordinate": {
+                "latitude": 45.523897,
+                "longitude": -122.700681
+              },
+              "description": "Westbound stop in Portland (Stop ID 9555)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "9555"
+              },
+              "name": "W Burnside & NW 23rd Pl",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 109,
             "stopSequence": 110,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 858,
           "interlineWithPreviousLeg": false,
@@ -6264,15 +7012,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "longitude": -122.676462
             },
             "name": "NW Glisan & 6th",
-            "stopCode": "10803",
-            "stopId": {
-              "feedId": "prt",
-              "id": "10803"
+            "stop": {
+              "code": "10803",
+              "coordinate": {
+                "latitude": 45.526655,
+                "longitude": -122.676462
+              },
+              "description": "Westbound stop in Portland (Stop ID 10803)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "0"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "10803"
+              },
+              "name": "NW Glisan & 6th",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 85,
             "stopSequence": 86,
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
+            "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
           "transitLeg": false,
@@ -6362,15 +7127,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "longitude": -122.676462
             },
             "name": "NW Glisan & 6th",
-            "stopCode": "10803",
-            "stopId": {
-              "feedId": "prt",
-              "id": "10803"
+            "stop": {
+              "code": "10803",
+              "coordinate": {
+                "latitude": 45.526655,
+                "longitude": -122.676462
+              },
+              "description": "Westbound stop in Portland (Stop ID 10803)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "0"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "10803"
+              },
+              "name": "NW Glisan & 6th",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 85,
             "stopSequence": 86,
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 1077,
           "headsign": "Montgomery Park",
@@ -6399,15 +7181,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "longitude": -122.698634
             },
             "name": "NW 23rd & Overton",
-            "stopCode": "8981",
-            "stopId": {
-              "feedId": "prt",
-              "id": "8981"
+            "stop": {
+              "code": "8981",
+              "coordinate": {
+                "latitude": 45.532159,
+                "longitude": -122.698634
+              },
+              "description": "Northbound stop in Portland (Stop ID 8981)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "8981"
+              },
+              "name": "NW 23rd & Overton",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 93,
             "stopSequence": 94,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
           "transitLeg": true,
@@ -6472,15 +7271,32 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "longitude": -122.698634
             },
             "name": "NW 23rd & Overton",
-            "stopCode": "8981",
-            "stopId": {
-              "feedId": "prt",
-              "id": "8981"
+            "stop": {
+              "code": "8981",
+              "coordinate": {
+                "latitude": 45.532159,
+                "longitude": -122.698634
+              },
+              "description": "Northbound stop in Portland (Stop ID 8981)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "8981"
+              },
+              "name": "NW 23rd & Overton",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 93,
             "stopSequence": 94,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 881,
           "interlineWithPreviousLeg": false,

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/TransitSnapshotTest.snap
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/TransitSnapshotTest.snap
@@ -366,15 +366,32 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.649367
             },
             "name": "NE Sandy & 16th",
-            "stopCode": "5060",
-            "stopId": {
-              "feedId": "prt",
-              "id": "5060"
+            "stop": {
+              "code": "5060",
+              "coordinate": {
+                "latitude": 45.524581,
+                "longitude": -122.649367
+              },
+              "description": "Westbound stop in Portland (Stop ID 5060)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "5060"
+              },
+              "name": "NE Sandy & 16th",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 92,
             "stopSequence": 93,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
           "transitLeg": false,
@@ -464,15 +481,32 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.649367
             },
             "name": "NE Sandy & 16th",
-            "stopCode": "5060",
-            "stopId": {
-              "feedId": "prt",
-              "id": "5060"
+            "stop": {
+              "code": "5060",
+              "coordinate": {
+                "latitude": 45.524581,
+                "longitude": -122.649367
+              },
+              "description": "Westbound stop in Portland (Stop ID 5060)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "5060"
+              },
+              "name": "NE Sandy & 16th",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 92,
             "stopSequence": 93,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 1371,
           "headsign": "Beaverton TC",
@@ -501,15 +535,32 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.694901
             },
             "name": "W Burnside & NW King",
-            "stopCode": "747",
-            "stopId": {
-              "feedId": "prt",
-              "id": "747"
+            "stop": {
+              "code": "747",
+              "coordinate": {
+                "latitude": 45.523312,
+                "longitude": -122.694901
+              },
+              "description": "Westbound stop in Portland (Stop ID 747)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "747"
+              },
+              "name": "W Burnside & NW King",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 107,
             "stopSequence": 108,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
           "transitLeg": true,
@@ -574,15 +625,32 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.694901
             },
             "name": "W Burnside & NW King",
-            "stopCode": "747",
-            "stopId": {
-              "feedId": "prt",
-              "id": "747"
+            "stop": {
+              "code": "747",
+              "coordinate": {
+                "latitude": 45.523312,
+                "longitude": -122.694901
+              },
+              "description": "Westbound stop in Portland (Stop ID 747)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "747"
+              },
+              "name": "W Burnside & NW King",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 107,
             "stopSequence": 108,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 1511,
           "interlineWithPreviousLeg": false,
@@ -752,15 +820,32 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.649266
             },
             "name": "SE Morrison & 16th",
-            "stopCode": "4019",
-            "stopId": {
-              "feedId": "prt",
-              "id": "4019"
+            "stop": {
+              "code": "4019",
+              "coordinate": {
+                "latitude": 45.517226,
+                "longitude": -122.649266
+              },
+              "description": "Westbound stop in Portland (Stop ID 4019)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "4019"
+              },
+              "name": "SE Morrison & 16th",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 50,
             "stopSequence": 51,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
           "transitLeg": false,
@@ -799,15 +884,32 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.649266
             },
             "name": "SE Morrison & 16th",
-            "stopCode": "4019",
-            "stopId": {
-              "feedId": "prt",
-              "id": "4019"
+            "stop": {
+              "code": "4019",
+              "coordinate": {
+                "latitude": 45.517226,
+                "longitude": -122.649266
+              },
+              "description": "Westbound stop in Portland (Stop ID 4019)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "4019"
+              },
+              "name": "SE Morrison & 16th",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 50,
             "stopSequence": 51,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 1814,
           "headsign": "Montgomery Park",
@@ -836,15 +938,32 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.698634
             },
             "name": "NW 23rd & Overton",
-            "stopCode": "8981",
-            "stopId": {
-              "feedId": "prt",
-              "id": "8981"
+            "stop": {
+              "code": "8981",
+              "coordinate": {
+                "latitude": 45.532159,
+                "longitude": -122.698634
+              },
+              "description": "Northbound stop in Portland (Stop ID 8981)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "8981"
+              },
+              "name": "NW 23rd & Overton",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 74,
             "stopSequence": 75,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
           "transitLeg": true,
@@ -909,15 +1028,32 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.698634
             },
             "name": "NW 23rd & Overton",
-            "stopCode": "8981",
-            "stopId": {
-              "feedId": "prt",
-              "id": "8981"
+            "stop": {
+              "code": "8981",
+              "coordinate": {
+                "latitude": 45.532159,
+                "longitude": -122.698634
+              },
+              "description": "Northbound stop in Portland (Stop ID 8981)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "8981"
+              },
+              "name": "NW 23rd & Overton",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 74,
             "stopSequence": 75,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 405,
           "interlineWithPreviousLeg": false,
@@ -1070,15 +1206,32 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.649367
             },
             "name": "NE Sandy & 16th",
-            "stopCode": "5060",
-            "stopId": {
-              "feedId": "prt",
-              "id": "5060"
+            "stop": {
+              "code": "5060",
+              "coordinate": {
+                "latitude": 45.524581,
+                "longitude": -122.649367
+              },
+              "description": "Westbound stop in Portland (Stop ID 5060)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "5060"
+              },
+              "name": "NE Sandy & 16th",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 92,
             "stopSequence": 93,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
           "transitLeg": false,
@@ -1168,15 +1321,32 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.649367
             },
             "name": "NE Sandy & 16th",
-            "stopCode": "5060",
-            "stopId": {
-              "feedId": "prt",
-              "id": "5060"
+            "stop": {
+              "code": "5060",
+              "coordinate": {
+                "latitude": 45.524581,
+                "longitude": -122.649367
+              },
+              "description": "Westbound stop in Portland (Stop ID 5060)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "5060"
+              },
+              "name": "NE Sandy & 16th",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 92,
             "stopSequence": 93,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 1385,
           "headsign": "23rd Ave to Tichner",
@@ -1205,15 +1375,32 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.694901
             },
             "name": "W Burnside & NW King",
-            "stopCode": "747",
-            "stopId": {
-              "feedId": "prt",
-              "id": "747"
+            "stop": {
+              "code": "747",
+              "coordinate": {
+                "latitude": 45.523312,
+                "longitude": -122.694901
+              },
+              "description": "Westbound stop in Portland (Stop ID 747)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "747"
+              },
+              "name": "W Burnside & NW King",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 107,
             "stopSequence": 108,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
           "transitLeg": true,
@@ -1278,15 +1465,32 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.694901
             },
             "name": "W Burnside & NW King",
-            "stopCode": "747",
-            "stopId": {
-              "feedId": "prt",
-              "id": "747"
+            "stop": {
+              "code": "747",
+              "coordinate": {
+                "latitude": 45.523312,
+                "longitude": -122.694901
+              },
+              "description": "Westbound stop in Portland (Stop ID 747)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "747"
+              },
+              "name": "W Burnside & NW King",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 107,
             "stopSequence": 108,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 1511,
           "interlineWithPreviousLeg": false,
@@ -1456,15 +1660,32 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.649266
             },
             "name": "SE Morrison & 16th",
-            "stopCode": "4019",
-            "stopId": {
-              "feedId": "prt",
-              "id": "4019"
+            "stop": {
+              "code": "4019",
+              "coordinate": {
+                "latitude": 45.517226,
+                "longitude": -122.649266
+              },
+              "description": "Westbound stop in Portland (Stop ID 4019)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "4019"
+              },
+              "name": "SE Morrison & 16th",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 50,
             "stopSequence": 51,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
           "transitLeg": false,
@@ -1503,15 +1724,32 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.649266
             },
             "name": "SE Morrison & 16th",
-            "stopCode": "4019",
-            "stopId": {
-              "feedId": "prt",
-              "id": "4019"
+            "stop": {
+              "code": "4019",
+              "coordinate": {
+                "latitude": 45.517226,
+                "longitude": -122.649266
+              },
+              "description": "Westbound stop in Portland (Stop ID 4019)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "4019"
+              },
+              "name": "SE Morrison & 16th",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 50,
             "stopSequence": 51,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 1884,
           "headsign": "NW 27th & Thurman",
@@ -1540,15 +1778,32 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.698634
             },
             "name": "NW 23rd & Overton",
-            "stopCode": "8981",
-            "stopId": {
-              "feedId": "prt",
-              "id": "8981"
+            "stop": {
+              "code": "8981",
+              "coordinate": {
+                "latitude": 45.532159,
+                "longitude": -122.698634
+              },
+              "description": "Northbound stop in Portland (Stop ID 8981)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "8981"
+              },
+              "name": "NW 23rd & Overton",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 74,
             "stopSequence": 75,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
           "transitLeg": true,
@@ -1613,15 +1868,32 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.698634
             },
             "name": "NW 23rd & Overton",
-            "stopCode": "8981",
-            "stopId": {
-              "feedId": "prt",
-              "id": "8981"
+            "stop": {
+              "code": "8981",
+              "coordinate": {
+                "latitude": 45.532159,
+                "longitude": -122.698634
+              },
+              "description": "Northbound stop in Portland (Stop ID 8981)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "8981"
+              },
+              "name": "NW 23rd & Overton",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 74,
             "stopSequence": 75,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 405,
           "interlineWithPreviousLeg": false,
@@ -1778,15 +2050,32 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.65358
             },
             "name": "SE 12th & Morrison",
-            "stopCode": "6588",
-            "stopId": {
-              "feedId": "prt",
-              "id": "6588"
+            "stop": {
+              "code": "6588",
+              "coordinate": {
+                "latitude": 45.517059,
+                "longitude": -122.65358
+              },
+              "description": "Northbound stop in Portland (Stop ID 6588)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "6588"
+              },
+              "name": "SE 12th & Morrison",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 31,
             "stopSequence": 32,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
           "transitLeg": false,
@@ -1842,15 +2131,32 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.65358
             },
             "name": "SE 12th & Morrison",
-            "stopCode": "6588",
-            "stopId": {
-              "feedId": "prt",
-              "id": "6588"
+            "stop": {
+              "code": "6588",
+              "coordinate": {
+                "latitude": 45.517059,
+                "longitude": -122.65358
+              },
+              "description": "Northbound stop in Portland (Stop ID 6588)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "6588"
+              },
+              "name": "SE 12th & Morrison",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 31,
             "stopSequence": 32,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 1158,
           "headsign": "Rose Qtr TC",
@@ -1879,15 +2185,32 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.66293
             },
             "name": "NE Multnomah & 3rd",
-            "stopCode": "11492",
-            "stopId": {
-              "feedId": "prt",
-              "id": "11492"
+            "stop": {
+              "code": "11492",
+              "coordinate": {
+                "latitude": 45.531159,
+                "longitude": -122.66293
+              },
+              "description": "Westbound stop in Portland (Stop ID 11492)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "0"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "11492"
+              },
+              "name": "NE Multnomah & 3rd",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 41,
             "stopSequence": 42,
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
+            "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
           "transitLeg": true,
@@ -1952,15 +2275,32 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.66293
             },
             "name": "NE Multnomah & 3rd",
-            "stopCode": "11492",
-            "stopId": {
-              "feedId": "prt",
-              "id": "11492"
+            "stop": {
+              "code": "11492",
+              "coordinate": {
+                "latitude": 45.531159,
+                "longitude": -122.66293
+              },
+              "description": "Westbound stop in Portland (Stop ID 11492)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "0"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "11492"
+              },
+              "name": "NE Multnomah & 3rd",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 83,
             "stopSequence": 84,
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 1543,
           "headsign": "Montgomery Park",
@@ -1989,15 +2329,32 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.696445
             },
             "name": "NW Northrup & 22nd",
-            "stopCode": "10778",
-            "stopId": {
-              "feedId": "prt",
-              "id": "10778"
+            "stop": {
+              "code": "10778",
+              "coordinate": {
+                "latitude": 45.531308,
+                "longitude": -122.696445
+              },
+              "description": "Westbound stop in Portland (Stop ID 10778)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "10778"
+              },
+              "name": "NW Northrup & 22nd",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 92,
             "stopSequence": 93,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
           "transitLeg": true,
@@ -2062,15 +2419,32 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.696445
             },
             "name": "NW Northrup & 22nd",
-            "stopCode": "10778",
-            "stopId": {
-              "feedId": "prt",
-              "id": "10778"
+            "stop": {
+              "code": "10778",
+              "coordinate": {
+                "latitude": 45.531308,
+                "longitude": -122.696445
+              },
+              "description": "Westbound stop in Portland (Stop ID 10778)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "10778"
+              },
+              "name": "NW Northrup & 22nd",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 92,
             "stopSequence": 93,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 37,
           "interlineWithPreviousLeg": false,
@@ -2163,13 +2537,30 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             },
             "name": "NE 12th & Couch",
             "orig": "NE 12th & Couch",
-            "stopCode": "6577",
-            "stopId": {
-              "feedId": "prt",
-              "id": "6577"
+            "stop": {
+              "code": "6577",
+              "coordinate": {
+                "latitude": 45.52337,
+                "longitude": -122.653725
+              },
+              "description": "Southbound stop in Portland (Stop ID 6577)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "6577"
+              },
+              "name": "NE 12th & Couch",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 6717,
           "interlineWithPreviousLeg": false,
@@ -2437,13 +2828,30 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.653725
             },
             "name": "NE 12th & Couch",
-            "stopCode": "6577",
-            "stopId": {
-              "feedId": "prt",
-              "id": "6577"
+            "stop": {
+              "code": "6577",
+              "coordinate": {
+                "latitude": 45.52337,
+                "longitude": -122.653725
+              },
+              "description": "Southbound stop in Portland (Stop ID 6577)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "6577"
+              },
+              "name": "NE 12th & Couch",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 137,
           "interlineWithPreviousLeg": false,
@@ -2465,15 +2873,32 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.653064
             },
             "name": "NE Sandy & 12th",
-            "stopCode": "5055",
-            "stopId": {
-              "feedId": "prt",
-              "id": "5055"
+            "stop": {
+              "code": "5055",
+              "coordinate": {
+                "latitude": 45.523103,
+                "longitude": -122.653064
+              },
+              "description": "Westbound stop in Portland (Stop ID 5055)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "5055"
+              },
+              "name": "NE Sandy & 12th",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 94,
             "stopSequence": 95,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
           "transitLeg": false,
@@ -2529,15 +2954,32 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.653064
             },
             "name": "NE Sandy & 12th",
-            "stopCode": "5055",
-            "stopId": {
-              "feedId": "prt",
-              "id": "5055"
+            "stop": {
+              "code": "5055",
+              "coordinate": {
+                "latitude": 45.523103,
+                "longitude": -122.653064
+              },
+              "description": "Westbound stop in Portland (Stop ID 5055)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "5055"
+              },
+              "name": "NE Sandy & 12th",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 94,
             "stopSequence": 95,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 1369,
           "headsign": "Beaverton TC",
@@ -2566,15 +3008,32 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.700681
             },
             "name": "W Burnside & NW 23rd Pl",
-            "stopCode": "9555",
-            "stopId": {
-              "feedId": "prt",
-              "id": "9555"
+            "stop": {
+              "code": "9555",
+              "coordinate": {
+                "latitude": 45.523897,
+                "longitude": -122.700681
+              },
+              "description": "Westbound stop in Portland (Stop ID 9555)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "9555"
+              },
+              "name": "W Burnside & NW 23rd Pl",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 109,
             "stopSequence": 110,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
           "transitLeg": true,
@@ -2639,15 +3098,32 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.700681
             },
             "name": "W Burnside & NW 23rd Pl",
-            "stopCode": "9555",
-            "stopId": {
-              "feedId": "prt",
-              "id": "9555"
+            "stop": {
+              "code": "9555",
+              "coordinate": {
+                "latitude": 45.523897,
+                "longitude": -122.700681
+              },
+              "description": "Westbound stop in Portland (Stop ID 9555)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "9555"
+              },
+              "name": "W Burnside & NW 23rd Pl",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 109,
             "stopSequence": 110,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 1388,
           "interlineWithPreviousLeg": false,
@@ -2829,13 +3305,30 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.653725
             },
             "name": "NE 12th & Couch",
-            "stopCode": "6577",
-            "stopId": {
-              "feedId": "prt",
-              "id": "6577"
+            "stop": {
+              "code": "6577",
+              "coordinate": {
+                "latitude": 45.52337,
+                "longitude": -122.653725
+              },
+              "description": "Southbound stop in Portland (Stop ID 6577)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "6577"
+              },
+              "name": "NE 12th & Couch",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 137,
           "interlineWithPreviousLeg": false,
@@ -2857,15 +3350,32 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.653064
             },
             "name": "NE Sandy & 12th",
-            "stopCode": "5055",
-            "stopId": {
-              "feedId": "prt",
-              "id": "5055"
+            "stop": {
+              "code": "5055",
+              "coordinate": {
+                "latitude": 45.523103,
+                "longitude": -122.653064
+              },
+              "description": "Westbound stop in Portland (Stop ID 5055)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "5055"
+              },
+              "name": "NE Sandy & 12th",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 94,
             "stopSequence": 95,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
           "transitLeg": false,
@@ -2921,15 +3431,32 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.653064
             },
             "name": "NE Sandy & 12th",
-            "stopCode": "5055",
-            "stopId": {
-              "feedId": "prt",
-              "id": "5055"
+            "stop": {
+              "code": "5055",
+              "coordinate": {
+                "latitude": 45.523103,
+                "longitude": -122.653064
+              },
+              "description": "Westbound stop in Portland (Stop ID 5055)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "5055"
+              },
+              "name": "NE Sandy & 12th",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 94,
             "stopSequence": 95,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 1399,
           "headsign": "23rd Ave to Tichner",
@@ -2958,15 +3485,32 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.700681
             },
             "name": "W Burnside & NW 23rd Pl",
-            "stopCode": "9555",
-            "stopId": {
-              "feedId": "prt",
-              "id": "9555"
+            "stop": {
+              "code": "9555",
+              "coordinate": {
+                "latitude": 45.523897,
+                "longitude": -122.700681
+              },
+              "description": "Westbound stop in Portland (Stop ID 9555)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "9555"
+              },
+              "name": "W Burnside & NW 23rd Pl",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 109,
             "stopSequence": 110,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
           "transitLeg": true,
@@ -3031,15 +3575,32 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.700681
             },
             "name": "W Burnside & NW 23rd Pl",
-            "stopCode": "9555",
-            "stopId": {
-              "feedId": "prt",
-              "id": "9555"
+            "stop": {
+              "code": "9555",
+              "coordinate": {
+                "latitude": 45.523897,
+                "longitude": -122.700681
+              },
+              "description": "Westbound stop in Portland (Stop ID 9555)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "9555"
+              },
+              "name": "W Burnside & NW 23rd Pl",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 109,
             "stopSequence": 110,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 1388,
           "interlineWithPreviousLeg": false,
@@ -3221,13 +3782,30 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.653725
             },
             "name": "NE 12th & Couch",
-            "stopCode": "6577",
-            "stopId": {
-              "feedId": "prt",
-              "id": "6577"
+            "stop": {
+              "code": "6577",
+              "coordinate": {
+                "latitude": 45.52337,
+                "longitude": -122.653725
+              },
+              "description": "Southbound stop in Portland (Stop ID 6577)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "6577"
+              },
+              "name": "NE 12th & Couch",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 137,
           "interlineWithPreviousLeg": false,
@@ -3249,15 +3827,32 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.653064
             },
             "name": "NE Sandy & 12th",
-            "stopCode": "5055",
-            "stopId": {
-              "feedId": "prt",
-              "id": "5055"
+            "stop": {
+              "code": "5055",
+              "coordinate": {
+                "latitude": 45.523103,
+                "longitude": -122.653064
+              },
+              "description": "Westbound stop in Portland (Stop ID 5055)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "5055"
+              },
+              "name": "NE Sandy & 12th",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 94,
             "stopSequence": 95,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
           "transitLeg": false,
@@ -3313,15 +3908,32 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.653064
             },
             "name": "NE Sandy & 12th",
-            "stopCode": "5055",
-            "stopId": {
-              "feedId": "prt",
-              "id": "5055"
+            "stop": {
+              "code": "5055",
+              "coordinate": {
+                "latitude": 45.523103,
+                "longitude": -122.653064
+              },
+              "description": "Westbound stop in Portland (Stop ID 5055)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "5055"
+              },
+              "name": "NE Sandy & 12th",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 94,
             "stopSequence": 95,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 1369,
           "headsign": "Beaverton TC",
@@ -3350,15 +3962,32 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.700681
             },
             "name": "W Burnside & NW 23rd Pl",
-            "stopCode": "9555",
-            "stopId": {
-              "feedId": "prt",
-              "id": "9555"
+            "stop": {
+              "code": "9555",
+              "coordinate": {
+                "latitude": 45.523897,
+                "longitude": -122.700681
+              },
+              "description": "Westbound stop in Portland (Stop ID 9555)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "9555"
+              },
+              "name": "W Burnside & NW 23rd Pl",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 109,
             "stopSequence": 110,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
           "transitLeg": true,
@@ -3423,15 +4052,32 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.700681
             },
             "name": "W Burnside & NW 23rd Pl",
-            "stopCode": "9555",
-            "stopId": {
-              "feedId": "prt",
-              "id": "9555"
+            "stop": {
+              "code": "9555",
+              "coordinate": {
+                "latitude": 45.523897,
+                "longitude": -122.700681
+              },
+              "description": "Westbound stop in Portland (Stop ID 9555)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "9555"
+              },
+              "name": "W Burnside & NW 23rd Pl",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 109,
             "stopSequence": 110,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 1388,
           "interlineWithPreviousLeg": false,
@@ -3617,13 +4263,30 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.653725
             },
             "name": "NE 12th & Couch",
-            "stopCode": "6577",
-            "stopId": {
-              "feedId": "prt",
-              "id": "6577"
+            "stop": {
+              "code": "6577",
+              "coordinate": {
+                "latitude": 45.52337,
+                "longitude": -122.653725
+              },
+              "description": "Southbound stop in Portland (Stop ID 6577)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "6577"
+              },
+              "name": "NE 12th & Couch",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 33,
           "interlineWithPreviousLeg": false,
@@ -3645,15 +4308,32 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.653507
             },
             "name": "NE 12th & Sandy",
-            "stopCode": "6592",
-            "stopId": {
-              "feedId": "prt",
-              "id": "6592"
+            "stop": {
+              "code": "6592",
+              "coordinate": {
+                "latitude": 45.52318,
+                "longitude": -122.653507
+              },
+              "description": "Northbound stop in Portland (Stop ID 6592)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "6592"
+              },
+              "name": "NE 12th & Sandy",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 34,
             "stopSequence": 35,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
           "transitLeg": false,
@@ -3692,15 +4372,32 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.653507
             },
             "name": "NE 12th & Sandy",
-            "stopCode": "6592",
-            "stopId": {
-              "feedId": "prt",
-              "id": "6592"
+            "stop": {
+              "code": "6592",
+              "coordinate": {
+                "latitude": 45.52318,
+                "longitude": -122.653507
+              },
+              "description": "Northbound stop in Portland (Stop ID 6592)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "6592"
+              },
+              "name": "NE 12th & Sandy",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 34,
             "stopSequence": 35,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 972,
           "headsign": "Rose Qtr TC",
@@ -3729,15 +4426,32 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.66293
             },
             "name": "NE Multnomah & 3rd",
-            "stopCode": "11492",
-            "stopId": {
-              "feedId": "prt",
-              "id": "11492"
+            "stop": {
+              "code": "11492",
+              "coordinate": {
+                "latitude": 45.531159,
+                "longitude": -122.66293
+              },
+              "description": "Westbound stop in Portland (Stop ID 11492)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "0"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "11492"
+              },
+              "name": "NE Multnomah & 3rd",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 41,
             "stopSequence": 42,
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
+            "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
           "transitLeg": true,
@@ -3802,15 +4516,32 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.66293
             },
             "name": "NE Multnomah & 3rd",
-            "stopCode": "11492",
-            "stopId": {
-              "feedId": "prt",
-              "id": "11492"
+            "stop": {
+              "code": "11492",
+              "coordinate": {
+                "latitude": 45.531159,
+                "longitude": -122.66293
+              },
+              "description": "Westbound stop in Portland (Stop ID 11492)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "0"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "11492"
+              },
+              "name": "NE Multnomah & 3rd",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 83,
             "stopSequence": 84,
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 1598,
           "headsign": "Montgomery Park",
@@ -3839,15 +4570,32 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.698634
             },
             "name": "NW 23rd & Overton",
-            "stopCode": "8981",
-            "stopId": {
-              "feedId": "prt",
-              "id": "8981"
+            "stop": {
+              "code": "8981",
+              "coordinate": {
+                "latitude": 45.532159,
+                "longitude": -122.698634
+              },
+              "description": "Northbound stop in Portland (Stop ID 8981)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "8981"
+              },
+              "name": "NW 23rd & Overton",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 93,
             "stopSequence": 94,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
           "transitLeg": true,
@@ -3912,15 +4660,32 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.698634
             },
             "name": "NW 23rd & Overton",
-            "stopCode": "8981",
-            "stopId": {
-              "feedId": "prt",
-              "id": "8981"
+            "stop": {
+              "code": "8981",
+              "coordinate": {
+                "latitude": 45.532159,
+                "longitude": -122.698634
+              },
+              "description": "Northbound stop in Portland (Stop ID 8981)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "8981"
+              },
+              "name": "NW 23rd & Overton",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 93,
             "stopSequence": 94,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 353,
           "interlineWithPreviousLeg": false,
@@ -4051,13 +4816,30 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.653725
             },
             "name": "NE 12th & Couch",
-            "stopCode": "6577",
-            "stopId": {
-              "feedId": "prt",
-              "id": "6577"
+            "stop": {
+              "code": "6577",
+              "coordinate": {
+                "latitude": 45.52337,
+                "longitude": -122.653725
+              },
+              "description": "Southbound stop in Portland (Stop ID 6577)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "6577"
+              },
+              "name": "NE 12th & Couch",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 1087,
           "interlineWithPreviousLeg": false,
@@ -4079,15 +4861,32 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.654067
             },
             "name": "SE Morrison & 12th",
-            "stopCode": "4014",
-            "stopId": {
-              "feedId": "prt",
-              "id": "4014"
+            "stop": {
+              "code": "4014",
+              "coordinate": {
+                "latitude": 45.517299,
+                "longitude": -122.654067
+              },
+              "description": "Westbound stop in Portland (Stop ID 4014)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "4014"
+              },
+              "name": "SE Morrison & 12th",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 52,
             "stopSequence": 53,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
           "transitLeg": false,
@@ -4160,15 +4959,32 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.654067
             },
             "name": "SE Morrison & 12th",
-            "stopCode": "4014",
-            "stopId": {
-              "feedId": "prt",
-              "id": "4014"
+            "stop": {
+              "code": "4014",
+              "coordinate": {
+                "latitude": 45.517299,
+                "longitude": -122.654067
+              },
+              "description": "Westbound stop in Portland (Stop ID 4014)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "4014"
+              },
+              "name": "SE Morrison & 12th",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 52,
             "stopSequence": 53,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 1740,
           "headsign": "NW 27th & Thurman",
@@ -4197,15 +5013,32 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.698529
             },
             "name": "NW 23rd & Lovejoy",
-            "stopCode": "7163",
-            "stopId": {
-              "feedId": "prt",
-              "id": "7163"
+            "stop": {
+              "code": "7163",
+              "coordinate": {
+                "latitude": 45.529681,
+                "longitude": -122.698529
+              },
+              "description": "Northbound stop in Portland (Stop ID 7163)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "7163"
+              },
+              "name": "NW 23rd & Lovejoy",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 73,
             "stopSequence": 74,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
           "transitLeg": true,
@@ -4270,15 +5103,32 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "longitude": -122.698529
             },
             "name": "NW 23rd & Lovejoy",
-            "stopCode": "7163",
-            "stopId": {
-              "feedId": "prt",
-              "id": "7163"
+            "stop": {
+              "code": "7163",
+              "coordinate": {
+                "latitude": 45.529681,
+                "longitude": -122.698529
+              },
+              "description": "Northbound stop in Portland (Stop ID 7163)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "7163"
+              },
+              "name": "NW 23rd & Lovejoy",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
             "stopIndex": 73,
             "stopSequence": 74,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 462,
           "interlineWithPreviousLeg": false,
@@ -4839,13 +5689,30 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             },
             "name": "NE 12th & Couch",
             "orig": "NE 12th & Couch",
-            "stopCode": "6577",
-            "stopId": {
-              "feedId": "prt",
-              "id": "6577"
+            "stop": {
+              "code": "6577",
+              "coordinate": {
+                "latitude": 45.52337,
+                "longitude": -122.653725
+              },
+              "description": "Southbound stop in Portland (Stop ID 6577)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "6577"
+              },
+              "name": "NE 12th & Couch",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 6283,
           "interlineWithPreviousLeg": false,
@@ -5092,13 +5959,43 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             },
             "name": "Interstate/Rose Quarter MAX Station",
             "orig": "Rose Quarter Transit Center",
-            "stopCode": "11508",
-            "stopId": {
-              "feedId": "prt",
-              "id": "11508"
+            "stop": {
+              "code": "11508",
+              "coordinate": {
+                "latitude": 45.530244,
+                "longitude": -122.667794
+              },
+              "description": "Northbound stop in Portland (Stop ID 11508)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "0"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "11508"
+              },
+              "name": "Interstate/Rose Quarter MAX Station",
+              "parentStation": {
+                "code": "79-tc",
+                "coordinate": {
+                  "latitude": 45.530205,
+                  "longitude": -122.666118
+                },
+                "id": {
+                  "feedId": "prt",
+                  "id": "79-tc"
+                },
+                "name": "Rose Quarter Transit Center",
+                "priority": "ALLOWED"
+              },
+              "partOfStation": true,
+              "wheelchairBoarding": "NO_INFORMATION"
             },
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
+            "vertexType": "TRANSIT"
           },
           "generalizedCost": 4557,
           "interlineWithPreviousLeg": false,


### PR DESCRIPTION
### Summary

This pull request changes the internal model, in order to have a reference to `Stop` object in the `Place` object, rather than having just individual fields copied over. This is needed for filtering, where we need access to the parent station form the leg, which is not included today.

At the same time I refactored some places generating `Place` objects, as well as alert mapping for legs.

### Unit tests

No changes. Needed to add annotation for JSON serialization in Station, in order not to have cyclical references serialized.

### Documentation

No updates needed

### Changelog
Was a bullet point added to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md) with description and link to the linked issue?
