### PR TITLE
Make plan data fetcher async for Legacy GraphQL API

### DIFF
--- a/docs/sandbox/LegacyGraphQLApi.md
+++ b/docs/sandbox/LegacyGraphQLApi.md
@@ -13,6 +13,7 @@
 - Updated to ignore modes which are not valid in OTP2 (June 2021, https://github.com/opentripplanner/OpenTripPlanner/pull/3464)
 - Add Leg#walkingBike (June 2021, https://github.com/opentripplanner/OpenTripPlanner/pull/3550)
 - Add GBFS bike rental URIs to bike rental stations (June 2021, https://github.com/opentripplanner/OpenTripPlanner/pull/3543)
+- Make the `plan` DataFetcher async, honour timeout (September 2021, https://github.com/opentripplanner/OpenTripPlanner/pull/3618)
 
 ## Documentation
 

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
@@ -586,6 +586,8 @@ public class LegacyGraphQLQueryTypeImpl
   @Override
   public DataFetcher<RoutingResponse> plan() {
     var syncFetcher = planFetcher();
+    // yes the extra variable is necessary to "remove" the type information
+    // https://www.graphql-java.com/documentation/v17/execution/
     DataFetcher f = AsyncDataFetcher.async(syncFetcher);
     return f;
   }

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
@@ -6,6 +6,7 @@ import com.google.common.collect.Multimaps;
 import graphql.relay.Connection;
 import graphql.relay.Relay;
 import graphql.relay.SimpleListConnection;
+import graphql.schema.AsyncDataFetcher;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.DataFetchingEnvironmentImpl;
@@ -584,6 +585,12 @@ public class LegacyGraphQLQueryTypeImpl
 
   @Override
   public DataFetcher<RoutingResponse> plan() {
+    var syncFetcher = planFetcher();
+    DataFetcher f = AsyncDataFetcher.async(syncFetcher);
+    return f;
+  }
+
+  public DataFetcher<RoutingResponse> planFetcher() {
     return environment -> {
       LegacyGraphQLRequestContext context = environment.<LegacyGraphQLRequestContext>getContext();
       RoutingRequest request = context.getRouter().defaultRoutingRequest.clone();


### PR DESCRIPTION
### Summary
We noticed that the HTTP header `OTPTimeout` in the LegacyGraphQL API is not honoured and request can take forever.

After a bit of debugging I saw that the timeout is applied _after_ the query has finished leading it to become useless.

I read the [documentation](https://www.graphql-java.com/documentation/v17/execution/) a bit and noticed that there are `AsyncDataFetchers` which do what we expect: they return immediately and are resolve when the underlying query is finished. This has restored the timeout behaviour. It has also given us a speed boost for batch queries as the now run in parallel rather then serially.

However, while looking into this issue I noticed a number of other problems with the current implementation: when you're executing a batch request and one of the queries times out, I'd expect a only one result to show an error but instead all of them fail.

I think this can be resolved by rewriting the API handlers to be fully asynchronous, making use of all the facilities of `CompleteableFuture`. I started this on [a branch](https://github.com/mfdz/OpenTripPlanner/tree/async-graphql) but at this moment I'm not able to continue, hence this minimal fix.

### Unit tests
n/a

### Code style
n/a

### Documentation
n/a

### Changelog
yes