### PR TITLE
Entur add infolinks to transmodel api

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/sx/PtSituationElementType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/sx/PtSituationElementType.java
@@ -167,7 +167,13 @@ public class PtSituationElementType {
                     .name("infoLinks")
                     .type(new GraphQLList(infoLinkType))
                     .description("Optional links to more information.")
-                    .dataFetcher(environment -> null)
+                    .dataFetcher(environment -> {
+                        TransitAlert alert = environment.getSource();
+                        if (!alert.getAlertUrlList().isEmpty()) {
+                            return alert.getAlertUrlList();
+                        }
+                        return null;
+                    })
                     .build())
             .field(GraphQLFieldDefinition.newFieldDefinition()
                     .name("validityPeriod")


### PR DESCRIPTION
Sandbox-changes only.

Adds support for returning InfoLinks provided in SIRI SX in the Transmodel-API.
