### PR TITLE
Fix reverse raptor search with boarding/alighting restrictions

### DIFF
--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/RangeRaptorWorker.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/RangeRaptorWorker.java
@@ -228,7 +228,7 @@ public final class RangeRaptorWorker<T extends RaptorTripSchedule> implements Wo
 
                     // attempt to alight if we're on board, this is done above the board search
                     // so that we don't alight on first stop boarded
-                    if (pattern.alightingPossibleAt(stopPos)) {
+                    if (calculator.alightingPossibleAt(pattern, stopPos)) {
                         transitWorker.alight(
                                 stopIndex,
                                 stopPos,
@@ -236,7 +236,7 @@ public final class RangeRaptorWorker<T extends RaptorTripSchedule> implements Wo
                         );
                     }
 
-                    if(pattern.boardingPossibleAt(stopPos)) {
+                    if(calculator.boardingPossibleAt(pattern, stopPos)) {
                         // MC Raptor have many, while RR have one boarding
                         transitWorker.forEachBoarding(stopIndex, (int prevArrivalTime) -> {
                             RaptorTripScheduleBoardOrAlightEvent<T> result = null;

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/transit/ForwardTransitCalculator.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/transit/ForwardTransitCalculator.java
@@ -7,6 +7,7 @@ import org.opentripplanner.transit.raptor.api.transit.RaptorGuaranteedTransferPr
 import org.opentripplanner.transit.raptor.api.transit.RaptorRoute;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTimeTable;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
+import org.opentripplanner.transit.raptor.api.transit.RaptorTripPattern;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
 import org.opentripplanner.transit.raptor.util.IntIterators;
 import org.opentripplanner.util.time.TimeUtils;
@@ -118,6 +119,16 @@ final class ForwardTransitCalculator<T extends RaptorTripSchedule> implements Tr
     @Override
     public RaptorGuaranteedTransferProvider<T> guaranteedTransfers(RaptorRoute<T> route) {
         return route.getGuaranteedTransfersTo();
+    }
+
+    @Override
+    public boolean alightingPossibleAt(RaptorTripPattern pattern, int stopPos) {
+        return pattern.alightingPossibleAt(stopPos);
+    }
+
+    @Override
+    public boolean boardingPossibleAt(RaptorTripPattern pattern, int stopPos) {
+        return pattern.boardingPossibleAt(stopPos);
     }
 
     @Override

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/transit/ReverseTransitCalculator.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/transit/ReverseTransitCalculator.java
@@ -7,6 +7,7 @@ import org.opentripplanner.transit.raptor.api.transit.RaptorGuaranteedTransferPr
 import org.opentripplanner.transit.raptor.api.transit.RaptorRoute;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTimeTable;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
+import org.opentripplanner.transit.raptor.api.transit.RaptorTripPattern;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
 import org.opentripplanner.transit.raptor.util.IntIterators;
 import org.opentripplanner.util.time.TimeUtils;
@@ -134,6 +135,16 @@ final class ReverseTransitCalculator<T extends RaptorTripSchedule> implements Tr
     @Override
     public RaptorGuaranteedTransferProvider<T> guaranteedTransfers(RaptorRoute<T> route) {
         return route.getGuaranteedTransfersFrom();
+    }
+
+    @Override
+    public boolean alightingPossibleAt(RaptorTripPattern pattern, int stopPos) {
+        return pattern.boardingPossibleAt(stopPos);
+    }
+
+    @Override
+    public boolean boardingPossibleAt(RaptorTripPattern pattern, int stopPos) {
+        return pattern.alightingPossibleAt(stopPos);
     }
 
     @Override

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/transit/TransitCalculator.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/transit/TransitCalculator.java
@@ -9,6 +9,7 @@ import org.opentripplanner.transit.raptor.api.transit.RaptorGuaranteedTransferPr
 import org.opentripplanner.transit.raptor.api.transit.RaptorRoute;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTimeTable;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
+import org.opentripplanner.transit.raptor.api.transit.RaptorTripPattern;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
 
 /**
@@ -190,4 +191,17 @@ public interface TransitCalculator<T extends RaptorTripSchedule> {
                         60
                 );
     }
+
+    /**
+     * Return {@code true} if it is allowed/possible to board at a particular stop index, on a
+     * normal search. For a backwards search, it checks for alighting instead. This should include
+     * checks like: Does the pattern allow boarding at the given stop? Is this accessible to
+     * wheelchairs (if requested).
+     */
+    boolean boardingPossibleAt(RaptorTripPattern pattern, int stopPos);
+
+    /**
+     * Same as {@link #boardingPossibleAt(RaptorTripPattern, int)}, but for switched alighting/boarding.
+     */
+    boolean alightingPossibleAt(RaptorTripPattern pattern, int stopPos);
 }

--- a/src/test/java/org/opentripplanner/transit/raptor/_data/transit/TestTripPattern.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/_data/transit/TestTripPattern.java
@@ -41,7 +41,7 @@ public class TestTripPattern implements RaptorTripPattern {
    *   W : Wheelchair
    *   * : Board, Alight, Wheelchair
    *
-   * Example:   B BA BAW AW
+   * Example:   B BA * AW
    */
   public void restrictions(String codes) {
     String[] split = codes.split(" ");

--- a/src/test/java/org/opentripplanner/transit/raptor/_data/transit/TestTripPattern.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/_data/transit/TestTripPattern.java
@@ -26,12 +26,41 @@ public class TestTripPattern implements RaptorTripPattern {
   }
 
   public static TestTripPattern pattern(String name, int ... stopIndexes) {
-    return new TestTripPattern(name, stopIndexes, null);
+    return new TestTripPattern(name, stopIndexes, new int[stopIndexes.length]);
   }
 
   /** Create a pattern with name 'R1' and given stop indexes */
   public static TestTripPattern pattern(int ... stopIndexes) {
     return new TestTripPattern("R1", stopIndexes, new int[stopIndexes.length]);
+  }
+
+  /**
+   * Codes:
+   *   B : Board
+   *   A : Alight
+   *   W : Wheelchair
+   *   * : Board, Alight, Wheelchair
+   *
+   * Example:   B BA BAW AW
+   */
+  public void restrictions(String codes) {
+    String[] split = codes.split(" ");
+    for (int i = 0; i < split.length; i++) {
+      String restriction = split[i];
+      restrictions[i] = 0;
+      if (restriction.contains("*")) {
+        continue;
+      }
+      if (!restriction.contains("B")) {
+        restrictions[i] |= BOARDING_MASK;
+      }
+      if (!restriction.contains("A")) {
+        restrictions[i] |= ALIGHTING_MASK;
+      }
+      if (!restriction.contains("W")) {
+        restrictions[i] |= WHEELCHAIR_MASK;
+      }
+    }
   }
 
   @Override public int stopIndex(int stopPositionInPattern) {

--- a/src/test/java/org/opentripplanner/transit/raptor/moduletests/A02_SingeRouteRestrictionsTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/moduletests/A02_SingeRouteRestrictionsTest.java
@@ -1,0 +1,114 @@
+package org.opentripplanner.transit.raptor.moduletests;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.transit.raptor.RaptorService;
+import org.opentripplanner.transit.raptor._data.RaptorTestConstants;
+import org.opentripplanner.transit.raptor._data.transit.TestTransitData;
+import org.opentripplanner.transit.raptor._data.transit.TestTripPattern;
+import org.opentripplanner.transit.raptor._data.transit.TestTripSchedule;
+import org.opentripplanner.transit.raptor.api.request.RaptorProfile;
+import org.opentripplanner.transit.raptor.api.request.RaptorRequestBuilder;
+import org.opentripplanner.transit.raptor.api.request.SearchDirection;
+import org.opentripplanner.transit.raptor.rangeraptor.configure.RaptorConfig;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.transit.raptor._data.api.PathUtils.pathsToString;
+import static org.opentripplanner.transit.raptor._data.transit.TestRoute.route;
+import static org.opentripplanner.transit.raptor._data.transit.TestTransfer.walk;
+import static org.opentripplanner.transit.raptor._data.transit.TestTripPattern.pattern;
+import static org.opentripplanner.transit.raptor._data.transit.TestTripSchedule.schedule;
+
+/**
+ * FEATURE UNDER TEST
+ * <p>
+ * Raptor should return a path if it exists for a basic case with one route with one trip including boarding/alighting
+ * restrictions and, an access and an egress path.
+ */
+public class A02_SingeRouteRestrictionsTest implements RaptorTestConstants {
+
+  private final TestTransitData data = new TestTransitData();
+  private final RaptorRequestBuilder<TestTripSchedule> requestBuilder = new RaptorRequestBuilder<>();
+  private final RaptorService<TestTripSchedule> raptorService = new RaptorService<>(RaptorConfig.defaultConfigForTest());
+
+  /**
+   * Stops: 0..3
+   *
+   * Stop on route (stop indexes with restrictions):
+   *   R1:  1 (BW) - 2 (BA) - 3 (AW)
+   *
+   * Schedule:
+   *   R1: 00:01 - 00:03 - 00:05
+   *
+   * Access (toStop & duration):
+   *   1  30s
+   *
+   * Egress (fromStop & duration):
+   *   3  20s
+   *
+   */
+  @BeforeEach
+  public void setup() {
+    TestTripPattern pattern = pattern("R1", STOP_B, STOP_C, STOP_D);
+    pattern.restrictions("BW BA AW");
+    data.withRoute(
+        route(
+            pattern
+        )
+        .withTimetable(
+            schedule("00:01, 00:03, 00:05")
+        )
+    );
+    requestBuilder.searchParams()
+        .addAccessPaths(walk(STOP_B, D30s))
+        .addEgressPaths(walk(STOP_D, D20s))
+        .earliestDepartureTime(T00_00)
+        .latestArrivalTime(T00_10)
+        .timetableEnabled(true);
+
+    ModuleTestDebugLogging.setupDebugLogging(data, requestBuilder);
+  }
+
+  @Test
+  public void standard() {
+    var request = requestBuilder
+        .profile(RaptorProfile.STANDARD)
+        .build();
+
+    var response = raptorService.route(request, data);
+
+    assertEquals(
+        "Walk 30s ~ 2 ~ BUS R1 0:01 0:05 ~ 4 ~ Walk 20s [0:00:30 0:05:20 4m50s]",
+        pathsToString(response)
+    );
+  }
+
+  @Test
+  public void standardReverse() {
+    var request = requestBuilder
+        .searchDirection(SearchDirection.REVERSE)
+        .profile(RaptorProfile.STANDARD)
+        .build();
+
+    var response = raptorService.route(request, data);
+
+    assertEquals(
+        "Walk 30s ~ 2 ~ BUS R1 0:01 0:05 ~ 4 ~ Walk 20s [0:00:30 0:05:20 4m50s]",
+        pathsToString(response)
+    );
+  }
+
+  @Test
+  public void multiCriteria() {
+    var request = requestBuilder
+        .profile(RaptorProfile.MULTI_CRITERIA)
+        .build();
+
+    var response = raptorService.route(request, data);
+
+    assertEquals(
+        "Walk 30s ~ 2 ~ BUS R1 0:01 0:05 ~ 4 ~ Walk 20s [0:00:30 0:05:20 4m50s $940]",
+        pathsToString(response)
+    );
+  }
+}


### PR DESCRIPTION
### Summary

Add boardingPossibleAt and alightingPossibleAt in TransitCalculator and use these in raptor the raptor search. Tis way they are swapped in the reverse search, checking for the correct permission.

### Issue

Fixes #3621

### Unit tests
Added failing unit test

