### PR TITLE
bug: Fix NPE in NeTEx Booking Method mapping

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -51,7 +51,8 @@
 - Extract GBFS loading logic [#3608](https://github.com/opentripplanner/OpenTripPlanner/pull/3608)
 - Route not found in some conditions with boarding/alighting restrictions [#3621](https://github.com/opentripplanner/OpenTripPlanner/pull/3621)
 - Load additional data from GBFS and expose it [#3610](https://github.com/opentripplanner/OpenTripPlanner/pull/3610)
-- Allow transfers to use customizable request options [#3324](https://github.com/opentripplanner/OpenTripPlanner/issues/3324).
+- Allow transfers to use customizable request options [#3324](https://github.com/opentripplanner/OpenTripPlanner/issues/3324)
+- Fix NPE in NeTEx Booking Method mapping #3633 [#3633](https://github.com/opentripplanner/OpenTripPlanner/issues/3633)
 
 
 ## 2.0.0 (2020-11-27)

--- a/src/main/java/org/opentripplanner/netex/issues/StopPlaceWithoutQuays.java
+++ b/src/main/java/org/opentripplanner/netex/issues/StopPlaceWithoutQuays.java
@@ -1,0 +1,19 @@
+package org.opentripplanner.netex.issues;
+
+import org.opentripplanner.graph_builder.DataImportIssue;
+
+public class StopPlaceWithoutQuays implements DataImportIssue {
+
+    public static final String FMT = "%s  does not contain any quays.";
+
+    final String stopPlaceId;
+
+    public StopPlaceWithoutQuays(String stopPlaceId) {
+        this.stopPlaceId = stopPlaceId;
+    }
+
+    @Override
+    public String getMessage() {
+        return String.format(FMT, stopPlaceId);
+    }
+}

--- a/src/main/java/org/opentripplanner/netex/mapping/BookingInfoMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/BookingInfoMapper.java
@@ -1,6 +1,12 @@
 package org.opentripplanner.netex.mapping;
 
 import com.esotericsoftware.minlog.Log;
+import java.time.Duration;
+import java.time.LocalTime;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import org.opentripplanner.model.BookingInfo;
 import org.opentripplanner.model.BookingMethod;
 import org.opentripplanner.model.BookingTime;
@@ -14,12 +20,6 @@ import org.rutebanken.netex.model.MultilingualString;
 import org.rutebanken.netex.model.PurchaseWhenEnumeration;
 import org.rutebanken.netex.model.ServiceJourney;
 import org.rutebanken.netex.model.StopPointInJourneyPattern;
-
-import java.time.Duration;
-import java.time.LocalTime;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Maps booking info from NeTEx BookingArrangements, FlexibleServiceProperties, and FlexibleLine
@@ -113,6 +113,7 @@ public class BookingInfoMapper {
     EnumSet<BookingMethod> bookingMethods = bookingMethodEnum
         .stream()
         .map(BookingMethodMapper::map)
+        .filter(Objects::nonNull)
         .collect(Collectors.toCollection(() -> EnumSet.noneOf(BookingMethod.class)));
 
     BookingTime otpEarliestBookingTime = null;

--- a/src/main/java/org/opentripplanner/netex/mapping/BookingMethodMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/BookingMethodMapper.java
@@ -2,13 +2,21 @@ package org.opentripplanner.netex.mapping;
 
 import org.opentripplanner.model.BookingMethod;
 import org.rutebanken.netex.model.BookingMethodEnumeration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Maps from NeTEx BookingMethodEnumeration into OTP BookingMethod.
  */
 public class BookingMethodMapper {
 
+  private static final Logger LOG = LoggerFactory.getLogger(BookingMethodMapper.class);
+
   public static BookingMethod map(BookingMethodEnumeration bookingMethodEnumeration) {
+    if(bookingMethodEnumeration == null) {
+      return null;
+    }
+
     switch (bookingMethodEnumeration) {
       case CALL_DRIVER:
         return BookingMethod.CALL_DRIVER;
@@ -21,6 +29,9 @@ public class BookingMethodMapper {
       case TEXT:
         return BookingMethod.TEXT_MESSAGE;
       default:
+        LOG.warn(
+                "Booking method unknown/not supported will be ignored: " + bookingMethodEnumeration
+        );
         return null;
     }
   }

--- a/src/main/java/org/opentripplanner/netex/mapping/BookingMethodMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/BookingMethodMapper.java
@@ -12,7 +12,14 @@ public class BookingMethodMapper {
 
   private static final Logger LOG = LoggerFactory.getLogger(BookingMethodMapper.class);
 
-  public static BookingMethod map(BookingMethodEnumeration bookingMethodEnumeration) {
+  /**
+   * @param sourceRef The entity with the booking-method, used to include a reference to the
+   *                  entity in the log, in case of a problem with the mapping.
+   */
+  public static BookingMethod map(
+          String sourceRef,
+          BookingMethodEnumeration bookingMethodEnumeration
+  ) {
     if(bookingMethodEnumeration == null) {
       return null;
     }
@@ -30,7 +37,9 @@ public class BookingMethodMapper {
         return BookingMethod.TEXT_MESSAGE;
       default:
         LOG.warn(
-                "Booking method unknown/not supported will be ignored: " + bookingMethodEnumeration
+                "Booking method unknown/not supported will be ignored: {}. Entity: {}",
+                bookingMethodEnumeration,
+                sourceRef
         );
         return null;
     }

--- a/src/main/java/org/opentripplanner/netex/mapping/StopAndStationMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/StopAndStationMapper.java
@@ -17,6 +17,7 @@ import org.opentripplanner.model.FareZone;
 import org.opentripplanner.model.Station;
 import org.opentripplanner.model.Stop;
 import org.opentripplanner.netex.index.api.ReadOnlyHierarchicalVersionMapById;
+import org.opentripplanner.netex.issues.StopPlaceWithoutQuays;
 import org.opentripplanner.netex.mapping.support.FeedScopedIdFactory;
 import org.opentripplanner.netex.mapping.support.StopPlaceVersionAndValidityComparator;
 import org.rutebanken.netex.model.Quay;
@@ -45,6 +46,8 @@ class StopAndStationMapper {
     private final StationMapper stationMapper;
     private final StopMapper stopMapper;
     private final TariffZoneMapper tariffZoneMapper;
+    private final DataImportIssueStore issueStore;
+
 
     /**
      * Quay ids for all processed stop places
@@ -66,6 +69,7 @@ class StopAndStationMapper {
         this.stopMapper = new StopMapper(idFactory, issueStore);
         this.tariffZoneMapper = tariffZoneMapper;
         this.quayIndex = quayIndex;
+        this.issueStore = issueStore;
     }
 
     /**
@@ -165,11 +169,11 @@ class StopAndStationMapper {
      * We do not support quay references, all quays must be included as part of the
      * given stopPlace.
      */
-    private static List<Quay> listOfQuays(StopPlace stopPlace) {
+    private List<Quay> listOfQuays(StopPlace stopPlace) {
         Quays_RelStructure quays = stopPlace.getQuays();
 
         if(quays == null) {
-            LOG.warn("StopPlace {} has no quays.", stopPlace.getId());
+            issueStore.add(new StopPlaceWithoutQuays(stopPlace.getId()));
             return Collections.emptyList();
         }
 

--- a/src/main/java/org/opentripplanner/transit/raptor/api/request/RaptorRequest.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/request/RaptorRequest.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.transit.raptor.api.request;
 
-import com.esotericsoftware.minlog.Log;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Objects;
@@ -8,6 +7,8 @@ import java.util.Set;
 import org.opentripplanner.transit.raptor.api.transit.RaptorSlackProvider;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTransitDataProvider;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -17,6 +18,8 @@ import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
  * @param <T> The TripSchedule type defined by the user of the raptor API.
  */
 public class RaptorRequest<T extends RaptorTripSchedule> {
+    private static final Logger LOG = LoggerFactory.getLogger(RaptorRequest.class);
+
     private final SearchParams searchParams;
     private final RaptorProfile profile;
     private final SearchDirection searchDirection;
@@ -169,7 +172,7 @@ public class RaptorRequest<T extends RaptorTripSchedule> {
         searchParams.verify();
         if(!profile.is(RaptorProfile.MULTI_CRITERIA)) {
             if(useDestinationPruning()) {
-                Log.warn("Destination pruning is only supported using McRangeRaptor");
+                LOG.warn("Destination pruning is only supported using McRangeRaptor");
             }
         }
     }


### PR DESCRIPTION
### Summary
This PR fixex a NPE in the NeTEx import. Booking methods `OTHER` is mapped to `null`, witch again causes the NeTEx import to fail and the graph build to terminate. 

There are also a few other minor changes to improve the error handling and logging.

The `com.esotericsoftware.minlog.Log` was used in the BookingInfoMapper, this is clearly a mistake and I searched for other usages of the Log class. It was used in the `org.opentripplanner.transit.raptor.api.request.RaptorRequest` as well, this was also fixed.

### Issue
We have not created an issue for this simple fix. 

### Unit tests
No tests are added.

### Changelog
✅ 