### PR TITLE
Log epsilon validity errors but process the area

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilder.java
@@ -243,9 +243,9 @@ public class WalkableAreaBuilder {
             }
 
             if (!areaEnv.is_valid(VISIBILITY_EPSILON)) {
-                issueStore.add(
-                        new AreaNotEpsilonValid(group.getSomeOSMObject().getId()));
-                continue;
+                issueStore.add(new AreaNotEpsilonValid(group.getSomeOSMObject().getId()));
+                // these errors seem not to harm area visibility processing
+                // so just log an error (most likely OSM mapping error)
             }
 
             edgeList.setOriginalEdges(ring.toJtsPolygon());


### PR DESCRIPTION
I tested scandic countries and they have about 20 errors of this kind. In all cases, a polygon touches another one at one point. Usually there is some sort of inaccurate OSM modeling causing the problem. Most errors are very small  (a  tiny 3 point hole geometry touches outer edge).

Such errors do not seem to harm visibility edge generation at all, so OTP should process those areas.

In this PR, epsilon validity logging is kept so that data can be fixed, but area visibility computation continues.

An example: the royal palace at Oslo. Two holes touch each other, and a very large area is left without walking graph generation. After the change, the area works as expected. See attached pictures.

![royalpalace](https://user-images.githubusercontent.com/13776096/136062028-a1f55806-941d-4ce4-8199-5c8c86033fa5.png)

![royalpalace_graph](https://user-images.githubusercontent.com/13776096/136062037-b24621d2-5882-4e2a-a334-d2539cf15d3c.png)

