### PR TITLE
Stoptimes should return tripId on the REST API

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -105,7 +105,7 @@ See the [OTP2 Migration Guide](OTP2-MigrationGuide.md) on changes to the REST AP
 - Fix: The `BusRouteStreetMatcher` and `TransitToTaggedStopsModule` graph builder modules are not run if the graph is build in two steps, and add progress tracker to BusRouteStreetMatcher. [#3195](https://github.com/opentripplanner/OpenTripPlanner/issues/3195)
 - Improvement: Insert project information like Maven version number into configuration files. [#3254](https://github.com/opentripplanner/OpenTripPlanner/pull/3254)   
 - Added pathway FeedScopedId as the route text to trip plan responses. [#3287](https://github.com/opentripplanner/OpenTripPlanner/issues/3287)
-
+- Stoptimes should return tripId on the REST API. [#3589](https://github.com/opentripplanner/OpenTripPlanner/issues/3589)
 
 ## Ported over from 1.4 and 1.5
 

--- a/src/main/java/org/opentripplanner/api/mapping/TripTimeMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/TripTimeMapper.java
@@ -35,6 +35,7 @@ public class TripTimeMapper {
         api.realtimeState      = ApiRealTimeState.RealTimeState(domain.getRealtimeState());
         api.blockId            = domain.getBlockId();
         api.headsign           = domain.getHeadsign();
+        api.tripId             = FeedScopedIdMapper.mapToApi(domain.getTrip().getId());
 
         return api;
     }


### PR DESCRIPTION

### Summary
Add mapping for tripId to StopTimes in the REST API. 


### Issue
closes #3589

### Unit tests
No unit tests exist for this mapper. Test not added.


### Documentation
No doc added for this simple fix.


### Changelog
✅ 