### PR TITLE
fix: Error in NeTEx Interchange mapping

### DIFF
--- a/src/main/java/org/opentripplanner/netex/mapping/TransferMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/TransferMapper.java
@@ -59,7 +59,7 @@ public class TransferMapper {
     public ConstrainedTransfer mapToTransfer(ServiceJourneyInterchange it) {
         var id = it.getId();
         var from = mapPoint("from", id, it.getFromJourneyRef(), it.getFromPointRef());
-        var to = mapPoint("to", id, it.getToJourneyRef(), it.getFromPointRef());
+        var to = mapPoint("to", id, it.getToJourneyRef(), it.getToPointRef());
 
         if(from==null ||to==null) { return null; }
 


### PR DESCRIPTION
### Summary
The interchange toPointRef was wrong (used fromPointRef).

### Issue
No issue for this.


### Unit tests
Unfortunately there are very little unit-tests on the import. I hope to do a proper test one day, but this small fix is not the right time to do it.

### Changelog
✅ 
