### PR TITLE
Use the whole duration of the filtered transit data for the raptor heuristic search

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -64,6 +64,7 @@
 - Stop linking to area/platform edges obeys area boundaries and traverse modes [#3201](https://github.com/opentripplanner/OpenTripPlanner/issues/3201)
 - Add service day mapping to REST API [#3659](https://github.com/opentripplanner/OpenTripPlanner/pull/3659)
 - Cost on transfer in Raptor [#3629](https://github.com/opentripplanner/OpenTripPlanner/pull/3629)
+- Use the whole duration of the filtered transit data for the raptor heuristic search [#3664](https://github.com/opentripplanner/OpenTripPlanner/pull/3664)
 
 
 ## 2.0.0 (2020-11-27)

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -66,7 +66,6 @@
 - Cost on transfer in Raptor [#3629](https://github.com/opentripplanner/OpenTripPlanner/pull/3629)
 - Add two new filters for use within grouping filter [#3638](https://github.com/opentripplanner/OpenTripPlanner/pull/3638)
 - Use correct slack in transfer optimizer [#3668](https://github.com/opentripplanner/OpenTripPlanner/pull/3668)
-- Use the whole duration of the filtered transit data for the raptor heuristic search [#3664](https://github.com/opentripplanner/OpenTripPlanner/pull/3664)
 
 
 ## 2.0.0 (2020-11-27)

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/router/TransitRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/router/TransitRouter.java
@@ -228,7 +228,8 @@ public class TransitRouter {
                     graph.getTransferService(),
                     transitLayer,
                     request.getDateTime().toInstant(),
-                    request.additionalSearchDaysAfterToday,
+                    request.arriveBy ? request.additionalSearchDaysBeforeToday : 0,
+                    request.arriveBy ? 0 : request.additionalSearchDaysAfterToday,
                     createRequestTransitDataProviderFilter(graph.index),
                     transferRoutingRequest
             );

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/request/RaptorRoutingRequestTransitDataCreator.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/request/RaptorRoutingRequestTransitDataCreator.java
@@ -43,11 +43,13 @@ class RaptorRoutingRequestTransitDataCreator {
   }
 
   List<List<TripPatternForDates>> createTripPatternsPerStop(
+      int additionalPastSearchDays,
       int additionalFutureSearchDays,
       TransitDataProviderFilter filter
   ) {
 
     List<TripPatternForDate> tripPatternForDates = getTripPatternsForDateRange(
+        additionalPastSearchDays,
         additionalFutureSearchDays,
         filter
     );
@@ -58,13 +60,14 @@ class RaptorRoutingRequestTransitDataCreator {
   }
 
   private List<TripPatternForDate> getTripPatternsForDateRange(
+      int additionalPastSearchDays,
       int additionalFutureSearchDays,
       TransitDataProviderFilter filter
   ) {
     List<TripPatternForDate> tripPatternForDates = new ArrayList<>();
 
     // This filters trips by the search date as well as additional dates before and after
-    for (int d = 0; d <= additionalFutureSearchDays; ++d) {
+    for (int d = -additionalPastSearchDays; d <= additionalFutureSearchDays; ++d) {
       tripPatternForDates.addAll(
         filterActiveTripPatterns(
           transitLayer,

--- a/src/main/java/org/opentripplanner/transit/raptor/api/transit/RaptorTransitDataProvider.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/transit/RaptorTransitDataProvider.java
@@ -106,14 +106,16 @@ public interface RaptorTransitDataProvider<T extends RaptorTripSchedule> {
     RaptorStopNameResolver stopNameResolver();
 
     /**
-     * Returns the beginning of valid transit data, in seconds since midnight of the day of the
-     * search. All trips running even partially after this time are included.
+     * Returns the beginning of valid transit data. All trips running even partially after this time are included.
+     * <p>
+     * Unit: seconds since midnight of the day of the search.
      */
     int getValidTransitDataStartTime();
 
     /**
-     * Returns the end time of valid transit data, in seconds since midnight of the day of the
-     * search. All trips running even partially before this time are included.
+     * Returns the end time of valid transit data. All trips running even partially before this time are included.
+     * <p>
+     * Unit: seconds since midnight of the day of the search
      */
     int getValidTransitDataEndTime();
 }

--- a/src/main/java/org/opentripplanner/transit/raptor/api/transit/RaptorTransitDataProvider.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/transit/RaptorTransitDataProvider.java
@@ -8,7 +8,7 @@ import javax.validation.constraints.NotNull;
 
 /**
  * This interface defines the data needed for the StdTransitWorker to do transit. This interface
- * define that role, and make it possible to write small adapter in between the "OTP Transit Layer"
+ * defines that role, and make it possible to write small adapter in between the "OTP Transit Layer"
  * and the Raptor algorithm. This also simplify the use of the Worker with other data sources,
  * importing and adapting this code into other software like OTP.
  *
@@ -105,4 +105,16 @@ public interface RaptorTransitDataProvider<T extends RaptorTripSchedule> {
      */
     @NotNull
     IntFunction<String> stopIndexTranslatorForDebugging();
+
+    /**
+     * Returns the beginning of valid transit data, in seconds since midnight of the day of the
+     * search. All trips running even partially after this time are included.
+     */
+    int getValidTransitDataStartTime();
+
+    /**
+     * Returns the end time of valid transit data, in seconds since midnight of the day of the
+     * search. All trips running even partially before this time are included.
+     */
+    int getValidTransitDataEndTime();
 }

--- a/src/main/java/org/opentripplanner/transit/raptor/service/RangeRaptorDynamicSearch.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/service/RangeRaptorDynamicSearch.java
@@ -223,7 +223,7 @@ public class RangeRaptorDynamicSearch<T extends RaptorTripSchedule> {
             return originalRequest;
         }
         return originalRequest.mutate().searchParams()
-                .earliestDepartureTime(dynamicSearchParamsCalculator.getEarliestDepartureTime())
+                .earliestDepartureTime(transitData.getValidTransitDataStartTime())
                 .build();
     }
 
@@ -232,7 +232,7 @@ public class RangeRaptorDynamicSearch<T extends RaptorTripSchedule> {
             return originalRequest;
         }
         return originalRequest.mutate().searchParams()
-                .latestArrivalTime(dynamicSearchParamsCalculator.getLatestArrivalTime())
+                .latestArrivalTime(transitData.getValidTransitDataEndTime())
                 .build();
     }
 

--- a/src/main/java/org/opentripplanner/transit/raptor/service/RaptorSearchWindowCalculator.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/service/RaptorSearchWindowCalculator.java
@@ -85,9 +85,6 @@ public class RaptorSearchWindowCalculator {
         // TravelWindow is the time from the earliest-departure-time to the latest-arrival-time
         int travelWindow = searchWindowSeconds + roundUpToNearestMinute(heuristicMinTransitTime);
 
-        if (!params.isLatestArrivalTimeSet()) {
-            latestArrivalTime = earliestDepartureTime + travelWindow;
-        }
         if (!params.isEarliestDepartureTimeSet()) {
             earliestDepartureTime = latestArrivalTime - travelWindow;
         }

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/TransitSnapshotTest.snap
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/TransitSnapshotTest.snap
@@ -296,463 +296,6 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
     },
     {
       "arrivedAtDestinationWithRentedVehicle": false,
-      "durationSeconds": 2261,
-      "elevationGained": 0.0,
-      "elevationLost": 0.0,
-      "fare": {
-        "details": {
-          "regular": [
-            {
-              "fareId": {
-                "feedId": "prt",
-                "id": "8"
-              },
-              "price": {
-                "cents": 200,
-                "currency": {
-                  "value": "USD"
-                }
-              },
-              "routes": [
-                {
-                  "feedId": "prt",
-                  "id": "20"
-                }
-              ]
-            }
-          ]
-        },
-        "fare": {
-          "regular": {
-            "cents": 200,
-            "currency": {
-              "value": "USD"
-            }
-          }
-        }
-      },
-      "flaggedForDeletion": false,
-      "generalizedCost": 4281,
-      "legs": [
-        {
-          "agencyTimeZoneOffset": -28800000,
-          "arrivalDelay": 0,
-          "departureDelay": 0,
-          "distanceMeters": 920.3299999999999,
-          "endTime": "2009-11-17T18:12:58.000+00:00",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.51726,
-              "longitude": -122.64847
-            },
-            "name": "SE Morrison St. & SE 17th Ave. (P1)",
-            "vertexType": "NORMAL"
-          },
-          "generalizedCost": 1398,
-          "interlinedWithPreviousLeg": false,
-          "legGeometry": {
-            "length": 45,
-            "points": "kaytG~wqkV?T?fCAl@?RmC?oCAmCAoC?_CAM?aC??A?A?A?A??AA?AAA??AAA???A?A?A???A@A??@A@?@??A@?@?BcC?mCAmCAmC?QBIYIWOH"
-          },
-          "mode": "WALK",
-          "onStreetNonTransit": true,
-          "pathway": false,
-          "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
-          "startTime": "2009-11-17T18:01:00.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.524581,
-              "longitude": -122.649367
-            },
-            "name": "NE Sandy & 16th",
-            "stop": {
-              "code": "5060",
-              "coordinate": {
-                "latitude": 45.524581,
-                "longitude": -122.649367
-              },
-              "description": "Westbound stop in Portland (Stop ID 5060)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "5060"
-              },
-              "name": "NE Sandy & 16th",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
-            "stopIndex": 92,
-            "stopSequence": 93,
-            "vertexType": "TRANSIT"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
-            {
-              "absoluteDirection": "WEST",
-              "angle": -1.5670436023962588,
-              "area": false,
-              "bogusName": false,
-              "distance": 87.669,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.51718601153089,
-                "longitude": -122.64847039626407
-              },
-              "stayOn": false,
-              "streetName": "Southeast Morrison Street",
-              "streetNotes": [ ]
-            },
-            {
-              "absoluteDirection": "NORTH",
-              "angle": 0.005200430917673284,
-              "area": false,
-              "bogusName": false,
-              "distance": 641.033,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5171903,
-                "longitude": -122.64959560000001
-              },
-              "stayOn": false,
-              "streetName": "Southeast 16th Avenue",
-              "streetNotes": [ ]
-            },
-            {
-              "absoluteDirection": "NORTH",
-              "angle": 0.002739847065377106,
-              "area": false,
-              "bogusName": false,
-              "distance": 168.885,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "CONTINUE",
-              "startLocation": {
-                "latitude": 45.522891200000004,
-                "longitude": -122.64955280000001
-              },
-              "stayOn": false,
-              "streetName": "Northeast 16th Avenue",
-              "streetNotes": [ ]
-            },
-            {
-              "absoluteDirection": "NORTHEAST",
-              "angle": 1.0638286720243149,
-              "area": false,
-              "bogusName": false,
-              "distance": 22.743,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.524409000000006,
-                "longitude": -122.6495675
-              },
-              "stayOn": false,
-              "streetName": "Northeast Sandy Boulevard",
-              "streetNotes": [ ]
-            }
-          ],
-          "walkingBike": false,
-          "walkingLeg": true
-        },
-        {
-          "agencyTimeZoneOffset": 0,
-          "arrivalDelay": 0,
-          "departureDelay": 0,
-          "distanceMeters": 3602.7301325109484,
-          "endTime": "2009-11-17T18:25:49.000+00:00",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.524581,
-              "longitude": -122.649367
-            },
-            "name": "NE Sandy & 16th",
-            "stop": {
-              "code": "5060",
-              "coordinate": {
-                "latitude": 45.524581,
-                "longitude": -122.649367
-              },
-              "description": "Westbound stop in Portland (Stop ID 5060)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "5060"
-              },
-              "name": "NE Sandy & 16th",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
-            "stopIndex": 92,
-            "stopSequence": 93,
-            "vertexType": "TRANSIT"
-          },
-          "generalizedCost": 1371,
-          "headsign": "Beaverton TC",
-          "interlinedWithPreviousLeg": false,
-          "intermediateStops": [ ],
-          "legGeometry": {
-            "length": 94,
-            "points": "coztGd}qkVNl@r@`CZhA`A`D??Ph@l@tBb@rARh@Pd@???BPj@@jA?jEAhE?pD???VAjE?hE?dB?b@???`AAhE?dD???l@C`EAhEEhE?bAA|@?XAZ@\\AzACnGKbKAjC?bE???JEnE@fEDlE@hE@~A??@rBBzDBpE@~A???Z@tD@RBnEB|A???@BdB?lEBjA??BnBApF@dB?X?^@r@?f@@bCAx@EtB???VChAE|BGnD??AXKnEGnD???XGjD??AZEfCC`AEzB"
-          },
-          "mode": "BUS",
-          "onStreetNonTransit": false,
-          "pathway": false,
-          "realTime": false,
-          "scheduled": true,
-          "serviceDate": {
-            "day": 17,
-            "minMax": false,
-            "month": 11,
-            "sequenceNumber": 20091117,
-            "year": 2009
-          },
-          "startTime": "2009-11-17T18:12:58.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.523312,
-              "longitude": -122.694901
-            },
-            "name": "W Burnside & NW King",
-            "stop": {
-              "code": "747",
-              "coordinate": {
-                "latitude": 45.523312,
-                "longitude": -122.694901
-              },
-              "description": "Westbound stop in Portland (Stop ID 747)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "747"
-              },
-              "name": "W Burnside & NW King",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
-            "stopIndex": 107,
-            "stopSequence": 108,
-            "vertexType": "TRANSIT"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": true,
-          "trip": {
-            "alteration": "PLANNED",
-            "bikesAllowed": "UNKNOWN",
-            "blockId": "2002",
-            "direction": "OUTBOUND",
-            "id": {
-              "feedId": "prt",
-              "id": "200W1200"
-            },
-            "route": {
-              "agency": {
-                "fareUrl": "http://trimet.org/fares/index.htm",
-                "id": {
-                  "feedId": "prt",
-                  "id": "prt"
-                },
-                "lang": "en",
-                "name": "TriMet",
-                "phone": "503-238-7433",
-                "timezone": "America/Los_Angeles",
-                "url": "http://trimet.org"
-              },
-              "bikesAllowed": "UNKNOWN",
-              "id": {
-                "feedId": "prt",
-                "id": "20"
-              },
-              "longName": "Burnside/Stark",
-              "mode": "BUS",
-              "shortName": "20",
-              "sortOrder": -999,
-              "sortOrderSet": false,
-              "type": 3,
-              "url": "http://trimet.org/schedules/r020.htm"
-            },
-            "serviceId": {
-              "feedId": "prt",
-              "id": "W"
-            },
-            "shapeId": {
-              "feedId": "prt",
-              "id": "20.0.1"
-            },
-            "wheelchairAccessible": 0
-          },
-          "walkSteps": [ ],
-          "walkingLeg": false
-        },
-        {
-          "agencyTimeZoneOffset": -28800000,
-          "arrivalDelay": 0,
-          "departureDelay": 0,
-          "distanceMeters": 999.0980000000001,
-          "endTime": "2009-11-17T18:38:41.000+00:00",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.523312,
-              "longitude": -122.694901
-            },
-            "name": "W Burnside & NW King",
-            "stop": {
-              "code": "747",
-              "coordinate": {
-                "latitude": 45.523312,
-                "longitude": -122.694901
-              },
-              "description": "Westbound stop in Portland (Stop ID 747)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "747"
-              },
-              "name": "W Burnside & NW King",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
-            "stopIndex": 107,
-            "stopSequence": 108,
-            "vertexType": "TRANSIT"
-          },
-          "generalizedCost": 1511,
-          "interlinedWithPreviousLeg": false,
-          "legGeometry": {
-            "length": 29,
-            "points": "ugztGdzzkVL?ATClAI|DK?G?mCBkCDoCDmCBoCDkCBoCB[?sBD]?Y@eA@K?C?K?W@{A@M@C@I?_CB?G"
-          },
-          "mode": "WALK",
-          "onStreetNonTransit": true,
-          "pathway": false,
-          "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
-          "startTime": "2009-11-17T18:25:49.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.53122,
-              "longitude": -122.69659
-            },
-            "name": "NW Northrup St. & NW 22nd Ave. (P2)",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
-            {
-              "absoluteDirection": "WEST",
-              "angle": -1.5070160169213977,
-              "area": false,
-              "bogusName": false,
-              "distance": 113.262,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.523249092859054,
-                "longitude": -122.69490673448706
-              },
-              "stayOn": false,
-              "streetName": "West Burnside Street",
-              "streetNotes": [ ]
-            },
-            {
-              "absoluteDirection": "NORTH",
-              "angle": 0.04135150879789886,
-              "area": false,
-              "bogusName": false,
-              "distance": 882.161,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5233204,
-                "longitude": -122.696357
-              },
-              "stayOn": false,
-              "streetName": "Northwest 22nd Avenue",
-              "streetNotes": [ ]
-            },
-            {
-              "absoluteDirection": "EAST",
-              "angle": 1.53914562034506,
-              "area": false,
-              "bogusName": false,
-              "distance": 3.675,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5312508,
-                "longitude": -122.69663860000001
-              },
-              "stayOn": false,
-              "streetName": "Northwest Northrup Street",
-              "streetNotes": [ ]
-            }
-          ],
-          "walkingBike": false,
-          "walkingLeg": true
-        }
-      ],
-      "nTransfers": 0,
-      "nonTransitDistanceMeters": 1919.4279999999999,
-      "nonTransitTimeSeconds": 1490,
-      "onStreetAllTheWay": false,
-      "streetOnly": false,
-      "systemNotices": [ ],
-      "tooSloped": false,
-      "transferPriorityCost": 0,
-      "transitTimeSeconds": 771,
-      "waitTimeOptimizedCost": 0,
-      "waitingTimeSeconds": 0,
-      "walkOnly": false,
-      "walkingAllTheWay": false
-    },
-    {
-      "arrivedAtDestinationWithRentedVehicle": false,
       "durationSeconds": 1467,
       "elevationGained": 0.0,
       "elevationLost": 0.0,
@@ -1186,463 +729,6 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
       "tooSloped": false,
       "transferPriorityCost": 0,
       "transitTimeSeconds": 1160,
-      "waitTimeOptimizedCost": 0,
-      "waitingTimeSeconds": 0,
-      "walkOnly": false,
-      "walkingAllTheWay": false
-    },
-    {
-      "arrivedAtDestinationWithRentedVehicle": false,
-      "durationSeconds": 2275,
-      "elevationGained": 0.0,
-      "elevationLost": 0.0,
-      "fare": {
-        "details": {
-          "regular": [
-            {
-              "fareId": {
-                "feedId": "prt",
-                "id": "8"
-              },
-              "price": {
-                "cents": 200,
-                "currency": {
-                  "value": "USD"
-                }
-              },
-              "routes": [
-                {
-                  "feedId": "prt",
-                  "id": "20"
-                }
-              ]
-            }
-          ]
-        },
-        "fare": {
-          "regular": {
-            "cents": 200,
-            "currency": {
-              "value": "USD"
-            }
-          }
-        }
-      },
-      "flaggedForDeletion": false,
-      "generalizedCost": 4295,
-      "legs": [
-        {
-          "agencyTimeZoneOffset": -28800000,
-          "arrivalDelay": 0,
-          "departureDelay": 0,
-          "distanceMeters": 920.3299999999999,
-          "endTime": "2009-11-17T18:27:58.000+00:00",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.51726,
-              "longitude": -122.64847
-            },
-            "name": "SE Morrison St. & SE 17th Ave. (P1)",
-            "vertexType": "NORMAL"
-          },
-          "generalizedCost": 1398,
-          "interlinedWithPreviousLeg": false,
-          "legGeometry": {
-            "length": 45,
-            "points": "kaytG~wqkV?T?fCAl@?RmC?oCAmCAoC?_CAM?aC??A?A?A?A??AA?AAA??AAA???A?A?A???A@A??@A@?@??A@?@?BcC?mCAmCAmC?QBIYIWOH"
-          },
-          "mode": "WALK",
-          "onStreetNonTransit": true,
-          "pathway": false,
-          "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
-          "startTime": "2009-11-17T18:16:00.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.524581,
-              "longitude": -122.649367
-            },
-            "name": "NE Sandy & 16th",
-            "stop": {
-              "code": "5060",
-              "coordinate": {
-                "latitude": 45.524581,
-                "longitude": -122.649367
-              },
-              "description": "Westbound stop in Portland (Stop ID 5060)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "5060"
-              },
-              "name": "NE Sandy & 16th",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
-            "stopIndex": 92,
-            "stopSequence": 93,
-            "vertexType": "TRANSIT"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
-            {
-              "absoluteDirection": "WEST",
-              "angle": -1.5670436023962588,
-              "area": false,
-              "bogusName": false,
-              "distance": 87.669,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.51718601153089,
-                "longitude": -122.64847039626407
-              },
-              "stayOn": false,
-              "streetName": "Southeast Morrison Street",
-              "streetNotes": [ ]
-            },
-            {
-              "absoluteDirection": "NORTH",
-              "angle": 0.005200430917673284,
-              "area": false,
-              "bogusName": false,
-              "distance": 641.033,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5171903,
-                "longitude": -122.64959560000001
-              },
-              "stayOn": false,
-              "streetName": "Southeast 16th Avenue",
-              "streetNotes": [ ]
-            },
-            {
-              "absoluteDirection": "NORTH",
-              "angle": 0.002739847065377106,
-              "area": false,
-              "bogusName": false,
-              "distance": 168.885,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "CONTINUE",
-              "startLocation": {
-                "latitude": 45.522891200000004,
-                "longitude": -122.64955280000001
-              },
-              "stayOn": false,
-              "streetName": "Northeast 16th Avenue",
-              "streetNotes": [ ]
-            },
-            {
-              "absoluteDirection": "NORTHEAST",
-              "angle": 1.0638286720243149,
-              "area": false,
-              "bogusName": false,
-              "distance": 22.743,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.524409000000006,
-                "longitude": -122.6495675
-              },
-              "stayOn": false,
-              "streetName": "Northeast Sandy Boulevard",
-              "streetNotes": [ ]
-            }
-          ],
-          "walkingBike": false,
-          "walkingLeg": true
-        },
-        {
-          "agencyTimeZoneOffset": 0,
-          "arrivalDelay": 0,
-          "departureDelay": 0,
-          "distanceMeters": 3602.7301325109484,
-          "endTime": "2009-11-17T18:41:03.000+00:00",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.524581,
-              "longitude": -122.649367
-            },
-            "name": "NE Sandy & 16th",
-            "stop": {
-              "code": "5060",
-              "coordinate": {
-                "latitude": 45.524581,
-                "longitude": -122.649367
-              },
-              "description": "Westbound stop in Portland (Stop ID 5060)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "5060"
-              },
-              "name": "NE Sandy & 16th",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
-            "stopIndex": 92,
-            "stopSequence": 93,
-            "vertexType": "TRANSIT"
-          },
-          "generalizedCost": 1385,
-          "headsign": "23rd Ave to Tichner",
-          "interlinedWithPreviousLeg": false,
-          "intermediateStops": [ ],
-          "legGeometry": {
-            "length": 94,
-            "points": "coztGd}qkVNl@r@`CZhA`A`D??Ph@l@tBb@rARh@Pd@???BPj@@jA?jEAhE?pD???VAjE?hE?dB?b@???`AAhE?dD???l@C`EAhEEhE?bAA|@?XAZ@\\AzACnGKbKAjC?bE???JEnE@fEDlE@hE@~A??@rBBzDBpE@~A???Z@tD@RBnEB|A???@BdB?lEBjA??BnBApF@dB?X?^@r@?f@@bCAx@EtB???VChAE|BGnD??AXKnEGnD???XGjD??AZEfCC`AEzB"
-          },
-          "mode": "BUS",
-          "onStreetNonTransit": false,
-          "pathway": false,
-          "realTime": false,
-          "scheduled": true,
-          "serviceDate": {
-            "day": 17,
-            "minMax": false,
-            "month": 11,
-            "sequenceNumber": 20091117,
-            "year": 2009
-          },
-          "startTime": "2009-11-17T18:27:58.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.523312,
-              "longitude": -122.694901
-            },
-            "name": "W Burnside & NW King",
-            "stop": {
-              "code": "747",
-              "coordinate": {
-                "latitude": 45.523312,
-                "longitude": -122.694901
-              },
-              "description": "Westbound stop in Portland (Stop ID 747)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "747"
-              },
-              "name": "W Burnside & NW King",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
-            "stopIndex": 107,
-            "stopSequence": 108,
-            "vertexType": "TRANSIT"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": true,
-          "trip": {
-            "alteration": "PLANNED",
-            "bikesAllowed": "UNKNOWN",
-            "blockId": "2071",
-            "direction": "OUTBOUND",
-            "id": {
-              "feedId": "prt",
-              "id": "200W1210"
-            },
-            "route": {
-              "agency": {
-                "fareUrl": "http://trimet.org/fares/index.htm",
-                "id": {
-                  "feedId": "prt",
-                  "id": "prt"
-                },
-                "lang": "en",
-                "name": "TriMet",
-                "phone": "503-238-7433",
-                "timezone": "America/Los_Angeles",
-                "url": "http://trimet.org"
-              },
-              "bikesAllowed": "UNKNOWN",
-              "id": {
-                "feedId": "prt",
-                "id": "20"
-              },
-              "longName": "Burnside/Stark",
-              "mode": "BUS",
-              "shortName": "20",
-              "sortOrder": -999,
-              "sortOrderSet": false,
-              "type": 3,
-              "url": "http://trimet.org/schedules/r020.htm"
-            },
-            "serviceId": {
-              "feedId": "prt",
-              "id": "W"
-            },
-            "shapeId": {
-              "feedId": "prt",
-              "id": "20.0.6"
-            },
-            "wheelchairAccessible": 0
-          },
-          "walkSteps": [ ],
-          "walkingLeg": false
-        },
-        {
-          "agencyTimeZoneOffset": -28800000,
-          "arrivalDelay": 0,
-          "departureDelay": 0,
-          "distanceMeters": 999.0980000000001,
-          "endTime": "2009-11-17T18:53:55.000+00:00",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.523312,
-              "longitude": -122.694901
-            },
-            "name": "W Burnside & NW King",
-            "stop": {
-              "code": "747",
-              "coordinate": {
-                "latitude": 45.523312,
-                "longitude": -122.694901
-              },
-              "description": "Westbound stop in Portland (Stop ID 747)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "747"
-              },
-              "name": "W Burnside & NW King",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
-            "stopIndex": 107,
-            "stopSequence": 108,
-            "vertexType": "TRANSIT"
-          },
-          "generalizedCost": 1511,
-          "interlinedWithPreviousLeg": false,
-          "legGeometry": {
-            "length": 29,
-            "points": "ugztGdzzkVL?ATClAI|DK?G?mCBkCDoCDmCBoCDkCBoCB[?sBD]?Y@eA@K?C?K?W@{A@M@C@I?_CB?G"
-          },
-          "mode": "WALK",
-          "onStreetNonTransit": true,
-          "pathway": false,
-          "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
-          "startTime": "2009-11-17T18:41:03.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.53122,
-              "longitude": -122.69659
-            },
-            "name": "NW Northrup St. & NW 22nd Ave. (P2)",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
-            {
-              "absoluteDirection": "WEST",
-              "angle": -1.5070160169213977,
-              "area": false,
-              "bogusName": false,
-              "distance": 113.262,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.523249092859054,
-                "longitude": -122.69490673448706
-              },
-              "stayOn": false,
-              "streetName": "West Burnside Street",
-              "streetNotes": [ ]
-            },
-            {
-              "absoluteDirection": "NORTH",
-              "angle": 0.04135150879789886,
-              "area": false,
-              "bogusName": false,
-              "distance": 882.161,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5233204,
-                "longitude": -122.696357
-              },
-              "stayOn": false,
-              "streetName": "Northwest 22nd Avenue",
-              "streetNotes": [ ]
-            },
-            {
-              "absoluteDirection": "EAST",
-              "angle": 1.53914562034506,
-              "area": false,
-              "bogusName": false,
-              "distance": 3.675,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5312508,
-                "longitude": -122.69663860000001
-              },
-              "stayOn": false,
-              "streetName": "Northwest Northrup Street",
-              "streetNotes": [ ]
-            }
-          ],
-          "walkingBike": false,
-          "walkingLeg": true
-        }
-      ],
-      "nTransfers": 0,
-      "nonTransitDistanceMeters": 1919.4279999999999,
-      "nonTransitTimeSeconds": 1490,
-      "onStreetAllTheWay": false,
-      "streetOnly": false,
-      "systemNotices": [ ],
-      "tooSloped": false,
-      "transferPriorityCost": 0,
-      "transitTimeSeconds": 785,
       "waitTimeOptimizedCost": 0,
       "waitingTimeSeconds": 0,
       "walkOnly": false,
@@ -2090,7 +1176,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
     },
     {
       "arrivedAtDestinationWithRentedVehicle": false,
-      "durationSeconds": 1849,
+      "durationSeconds": 1527,
       "elevationGained": 0.0,
       "elevationLost": 0.0,
       "fare": {
@@ -2110,11 +1196,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "routes": [
                 {
                   "feedId": "prt",
-                  "id": "70"
-                },
-                {
-                  "feedId": "prt",
-                  "id": "77"
+                  "id": "15"
                 }
               ]
             }
@@ -2130,14 +1212,14 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
         }
       },
       "flaggedForDeletion": false,
-      "generalizedCost": 3375,
+      "generalizedCost": 2409,
       "legs": [
         {
           "agencyTimeZoneOffset": -28800000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 419.61499999999995,
-          "endTime": "2009-11-17T18:42:54.000+00:00",
+          "distanceMeters": 62.012,
+          "endTime": "2009-11-17T18:45:40.000+00:00",
           "flexibleTrip": false,
           "from": {
             "coordinate": {
@@ -2147,11 +1229,11 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "name": "SE Morrison St. & SE 17th Ave. (P1)",
             "vertexType": "NORMAL"
           },
-          "generalizedCost": 636,
+          "generalizedCost": 95,
           "interlinedWithPreviousLeg": false,
           "legGeometry": {
-            "length": 14,
-            "points": "kaytG~wqkV?T?fCAl@?R?jE?rC?t@?hEAvD?RN?L??O"
+            "length": 4,
+            "points": "kaytG~wqkV?T?fCG?"
           },
           "mode": "WALK",
           "onStreetNonTransit": true,
@@ -2159,21 +1241,21 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           "realTime": false,
           "rentedVehicle": false,
           "scheduled": false,
-          "startTime": "2009-11-17T18:37:30.000+00:00",
+          "startTime": "2009-11-17T18:44:52.000+00:00",
           "streetNotes": [ ],
           "to": {
             "coordinate": {
-              "latitude": 45.517059,
-              "longitude": -122.65358
+              "latitude": 45.517226,
+              "longitude": -122.649266
             },
-            "name": "SE 12th & Morrison",
+            "name": "SE Morrison & 16th",
             "stop": {
-              "code": "6588",
+              "code": "4019",
               "coordinate": {
-                "latitude": 45.517059,
-                "longitude": -122.65358
+                "latitude": 45.517226,
+                "longitude": -122.649266
               },
-              "description": "Northbound stop in Portland (Stop ID 6588)",
+              "description": "Westbound stop in Portland (Stop ID 4019)",
               "fareZones": [
                 {
                   "id": {
@@ -2184,14 +1266,14 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               ],
               "id": {
                 "feedId": "prt",
-                "id": "6588"
+                "id": "4019"
               },
-              "name": "SE 12th & Morrison",
+              "name": "SE Morrison & 16th",
               "partOfStation": false,
               "wheelchairBoarding": "NO_INFORMATION"
             },
-            "stopIndex": 31,
-            "stopSequence": 32,
+            "stopIndex": 50,
+            "stopSequence": 51,
             "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
@@ -2202,7 +1284,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "angle": -1.5670436023962588,
               "area": false,
               "bogusName": false,
-              "distance": 403.65599999999995,
+              "distance": 62.012,
               "edges": [ ],
               "elevation": [ ],
               "relativeDirection": "DEPART",
@@ -2213,23 +1295,6 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "stayOn": false,
               "streetName": "Southeast Morrison Street",
               "streetNotes": [ ]
-            },
-            {
-              "absoluteDirection": "SOUTH",
-              "angle": -3.132186938587986,
-              "area": false,
-              "bogusName": false,
-              "distance": 15.959,
-              "edges": [ ],
-              "elevation": [ ],
-              "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.5172031,
-                "longitude": -122.6536511
-              },
-              "stayOn": false,
-              "streetName": "Southeast 12th Avenue",
-              "streetNotes": [ ]
             }
           ],
           "walkingBike": false,
@@ -2239,22 +1304,22 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           "agencyTimeZoneOffset": 0,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 2347.5602438577907,
-          "endTime": "2009-11-17T18:52:12.000+00:00",
+          "distanceMeters": 4943.103319311616,
+          "endTime": "2009-11-17T19:06:00.000+00:00",
           "flexibleTrip": false,
           "from": {
             "coordinate": {
-              "latitude": 45.517059,
-              "longitude": -122.65358
+              "latitude": 45.517226,
+              "longitude": -122.649266
             },
-            "name": "SE 12th & Morrison",
+            "name": "SE Morrison & 16th",
             "stop": {
-              "code": "6588",
+              "code": "4019",
               "coordinate": {
-                "latitude": 45.517059,
-                "longitude": -122.65358
+                "latitude": 45.517226,
+                "longitude": -122.649266
               },
-              "description": "Northbound stop in Portland (Stop ID 6588)",
+              "description": "Westbound stop in Portland (Stop ID 4019)",
               "fareZones": [
                 {
                   "id": {
@@ -2265,168 +1330,23 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               ],
               "id": {
                 "feedId": "prt",
-                "id": "6588"
+                "id": "4019"
               },
-              "name": "SE 12th & Morrison",
+              "name": "SE Morrison & 16th",
               "partOfStation": false,
               "wheelchairBoarding": "NO_INFORMATION"
             },
-            "stopIndex": 31,
-            "stopSequence": 32,
+            "stopIndex": 50,
+            "stopSequence": 51,
             "vertexType": "TRANSIT"
           },
-          "generalizedCost": 1158,
-          "headsign": "Rose Qtr TC",
-          "interlinedWithPreviousLeg": false,
-          "intermediateStops": [ ],
-          "legGeometry": {
-            "length": 62,
-            "points": "s`ytGhxrkV[?mCAmC?wBA??W?mC?{BA??Q?oC?mC?kBAa@?w@???wA?mCAmC?oCA}C?sDC??aBAm@@k@AY?uABU@I@IBQFb@fC}@d@OFO@q@???Q?]?gGA??[??nJ???b@?vK?rA???tBCfD???^?nE?V@Z?PH\\Nb@`@~@Rf@"
-          },
-          "mode": "BUS",
-          "onStreetNonTransit": false,
-          "pathway": false,
-          "realTime": false,
-          "scheduled": true,
-          "serviceDate": {
-            "day": 17,
-            "minMax": false,
-            "month": 11,
-            "sequenceNumber": 20091117,
-            "year": 2009
-          },
-          "startTime": "2009-11-17T18:42:54.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.531159,
-              "longitude": -122.66293
-            },
-            "name": "NE Multnomah & 3rd",
-            "stop": {
-              "code": "11492",
-              "coordinate": {
-                "latitude": 45.531159,
-                "longitude": -122.66293
-              },
-              "description": "Westbound stop in Portland (Stop ID 11492)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "0"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "11492"
-              },
-              "name": "NE Multnomah & 3rd",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
-            "stopIndex": 41,
-            "stopSequence": 42,
-            "vertexType": "TRANSIT"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": true,
-          "trip": {
-            "alteration": "PLANNED",
-            "bikesAllowed": "UNKNOWN",
-            "blockId": "7002",
-            "direction": "OUTBOUND",
-            "id": {
-              "feedId": "prt",
-              "id": "700W1170"
-            },
-            "route": {
-              "agency": {
-                "fareUrl": "http://trimet.org/fares/index.htm",
-                "id": {
-                  "feedId": "prt",
-                  "id": "prt"
-                },
-                "lang": "en",
-                "name": "TriMet",
-                "phone": "503-238-7433",
-                "timezone": "America/Los_Angeles",
-                "url": "http://trimet.org"
-              },
-              "bikesAllowed": "UNKNOWN",
-              "id": {
-                "feedId": "prt",
-                "id": "70"
-              },
-              "longName": "12th Ave",
-              "mode": "BUS",
-              "shortName": "70",
-              "sortOrder": -999,
-              "sortOrderSet": false,
-              "type": 3,
-              "url": "http://trimet.org/schedules/r070.htm"
-            },
-            "serviceId": {
-              "feedId": "prt",
-              "id": "W"
-            },
-            "shapeId": {
-              "feedId": "prt",
-              "id": "70.0.7"
-            },
-            "wheelchairAccessible": 0
-          },
-          "walkSteps": [ ],
-          "walkingLeg": false
-        },
-        {
-          "agencyTimeZoneOffset": 0,
-          "arrivalDelay": 0,
-          "departureDelay": 0,
-          "distanceMeters": 3248.2996826174576,
-          "endTime": "2009-11-17T19:07:55.000+00:00",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.531159,
-              "longitude": -122.66293
-            },
-            "name": "NE Multnomah & 3rd",
-            "stop": {
-              "code": "11492",
-              "coordinate": {
-                "latitude": 45.531159,
-                "longitude": -122.66293
-              },
-              "description": "Westbound stop in Portland (Stop ID 11492)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "0"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "11492"
-              },
-              "name": "NE Multnomah & 3rd",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
-            "stopIndex": 83,
-            "stopSequence": 84,
-            "vertexType": "TRANSIT"
-          },
-          "generalizedCost": 1543,
+          "generalizedCost": 1820,
           "headsign": "Montgomery Park",
           "interlinedWithPreviousLeg": false,
           "intermediateStops": [ ],
           "legGeometry": {
-            "length": 91,
-            "points": "kx{tG~qtkV`@bANb@FV@R?P?pE?jA@h@AnAbBl@LFJN\\f@LT??NXJPPVJFf@Vf@Pp@Nd@NRLB@RNXZR\\vAhC@BhAhD`AhClAbDBrDCnG@n@@^@d@HdAP`CBjEDvD???LqCFmCDYBGDEBGJkAzAQR??KNa@b@MJuBBY?OHW@u@~@aD`EcBhBBrD@xC??@l@BlE@lD???XBjEBpD???VBlE?dA@t@?b@?h@BfEBrD???VBhEFtKDvJ??@\\DnJ"
+            "length": 129,
+            "points": "kaytG||qkVA~@?jE?tC???r@AhE?jE?rA???tBAjE?nD???X?hE?xC??Ah@?pE?~C???J?`@?vAAvBEbE?jEAlE?`BAbB@d@??@tAAj@Cx@Cb@Cp@_@dEcAtFoA`IS~@i@`BmAzDi@zAc@pAi@~C??Id@u@jEm@bD??If@u@jEk@bD??If@u@|DW`B??CPs@|Du@lElBz@??VJbCfAk@dD??Id@w@rEWvAId@AF??Q~@s@`Ei@~C??Ib@u@dEWzA??]jB]MQSe@WOKOKIIQe@GWE]GnD??AXKnEGnD???XGjD??AZEfCC`AEzB??AXCfAGxDE|AEtBIlC??APkAh@o@?sCB{BD??S?mCDmCDyBB??U?mCDmCDyBB"
           },
           "mode": "BUS",
           "onStreetNonTransit": false,
@@ -2440,21 +1360,21 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "sequenceNumber": 20091117,
             "year": 2009
           },
-          "startTime": "2009-11-17T18:56:09.000+00:00",
+          "startTime": "2009-11-17T18:45:40.000+00:00",
           "streetNotes": [ ],
           "to": {
             "coordinate": {
-              "latitude": 45.531308,
-              "longitude": -122.696445
+              "latitude": 45.529681,
+              "longitude": -122.698529
             },
-            "name": "NW Northrup & 22nd",
+            "name": "NW 23rd & Lovejoy",
             "stop": {
-              "code": "10778",
+              "code": "7163",
               "coordinate": {
-                "latitude": 45.531308,
-                "longitude": -122.696445
+                "latitude": 45.529681,
+                "longitude": -122.698529
               },
-              "description": "Westbound stop in Portland (Stop ID 10778)",
+              "description": "Northbound stop in Portland (Stop ID 7163)",
               "fareZones": [
                 {
                   "id": {
@@ -2465,14 +1385,14 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               ],
               "id": {
                 "feedId": "prt",
-                "id": "10778"
+                "id": "7163"
               },
-              "name": "NW Northrup & 22nd",
+              "name": "NW 23rd & Lovejoy",
               "partOfStation": false,
               "wheelchairBoarding": "NO_INFORMATION"
             },
-            "stopIndex": 92,
-            "stopSequence": 93,
+            "stopIndex": 73,
+            "stopSequence": 74,
             "vertexType": "TRANSIT"
           },
           "transitAlerts": [ ],
@@ -2480,11 +1400,11 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           "trip": {
             "alteration": "PLANNED",
             "bikesAllowed": "UNKNOWN",
-            "blockId": "7702",
-            "direction": "INBOUND",
+            "blockId": "1543",
+            "direction": "OUTBOUND",
             "id": {
               "feedId": "prt",
-              "id": "771W1180"
+              "id": "150W1420"
             },
             "route": {
               "agency": {
@@ -2502,15 +1422,15 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "bikesAllowed": "UNKNOWN",
               "id": {
                 "feedId": "prt",
-                "id": "77"
+                "id": "15"
               },
-              "longName": "Broadway/Halsey",
+              "longName": "Belmont/NW 23rd",
               "mode": "BUS",
-              "shortName": "77",
+              "shortName": "15",
               "sortOrder": -999,
               "sortOrderSet": false,
               "type": 3,
-              "url": "http://trimet.org/schedules/r077.htm"
+              "url": "http://trimet.org/schedules/r015.htm"
             },
             "serviceId": {
               "feedId": "prt",
@@ -2518,7 +1438,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             },
             "shapeId": {
               "feedId": "prt",
-              "id": "77.1.3"
+              "id": "15.0.21"
             },
             "wheelchairAccessible": 0
           },
@@ -2529,22 +1449,22 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           "agencyTimeZoneOffset": -28800000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 18.806,
-          "endTime": "2009-11-17T19:08:19.000+00:00",
+          "distanceMeters": 321.94500000000005,
+          "endTime": "2009-11-17T19:10:19.000+00:00",
           "flexibleTrip": false,
           "from": {
             "coordinate": {
-              "latitude": 45.531308,
-              "longitude": -122.696445
+              "latitude": 45.529681,
+              "longitude": -122.698529
             },
-            "name": "NW Northrup & 22nd",
+            "name": "NW 23rd & Lovejoy",
             "stop": {
-              "code": "10778",
+              "code": "7163",
               "coordinate": {
-                "latitude": 45.531308,
-                "longitude": -122.696445
+                "latitude": 45.529681,
+                "longitude": -122.698529
               },
-              "description": "Westbound stop in Portland (Stop ID 10778)",
+              "description": "Northbound stop in Portland (Stop ID 7163)",
               "fareZones": [
                 {
                   "id": {
@@ -2555,21 +1475,21 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               ],
               "id": {
                 "feedId": "prt",
-                "id": "10778"
+                "id": "7163"
               },
-              "name": "NW Northrup & 22nd",
+              "name": "NW 23rd & Lovejoy",
               "partOfStation": false,
               "wheelchairBoarding": "NO_INFORMATION"
             },
-            "stopIndex": 92,
-            "stopSequence": 93,
+            "stopIndex": 73,
+            "stopSequence": 74,
             "vertexType": "TRANSIT"
           },
-          "generalizedCost": 37,
+          "generalizedCost": 493,
           "interlinedWithPreviousLeg": false,
           "legGeometry": {
-            "length": 7,
-            "points": "sy{tGxc{kV???LABF?B??J"
+            "length": 18,
+            "points": "oo{tGxp{kVG@?GCwAAaF?G?i@?SK?C?K?W@{A@M@C@I?_CB?G"
           },
           "mode": "WALK",
           "onStreetNonTransit": true,
@@ -2577,7 +1497,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           "realTime": false,
           "rentedVehicle": false,
           "scheduled": false,
-          "startTime": "2009-11-17T19:07:55.000+00:00",
+          "startTime": "2009-11-17T19:06:00.000+00:00",
           "streetNotes": [ ],
           "to": {
             "coordinate": {
@@ -2591,17 +1511,85 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           "transitLeg": false,
           "walkSteps": [
             {
-              "absoluteDirection": "WEST",
-              "angle": -1.3892041323260338,
+              "absoluteDirection": "EAST",
+              "angle": 1.5519664675850313,
               "area": false,
-              "bogusName": false,
-              "distance": 18.806,
+              "bogusName": true,
+              "distance": 2.418,
               "edges": [ ],
               "elevation": [ ],
               "relativeDirection": "DEPART",
               "startLocation": {
-                "latitude": 45.53130187189895,
-                "longitude": -122.69644484256081
+                "latitude": 45.529726790620664,
+                "longitude": -122.69853023095405
+              },
+              "stayOn": false,
+              "streetName": "way 158083864 from 0",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "EAST",
+              "angle": 1.5293125423902536,
+              "area": false,
+              "bogusName": false,
+              "distance": 142.155,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "CONTINUE",
+              "startLocation": {
+                "latitude": 45.5297272,
+                "longitude": -122.6984992
+              },
+              "stayOn": false,
+              "streetName": "Northwest Lovejoy Street",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "EAST",
+              "angle": 1.5678920159151593,
+              "area": false,
+              "bogusName": true,
+              "distance": 7.657,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "CONTINUE",
+              "startLocation": {
+                "latitude": 45.529758300000005,
+                "longitude": -122.6966749
+              },
+              "stayOn": false,
+              "streetName": "way 158083863 from 2",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "NORTH",
+              "angle": -0.02805287330123452,
+              "area": false,
+              "bogusName": false,
+              "distance": 166.04000000000002,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "LEFT",
+              "startLocation": {
+                "latitude": 45.5297585,
+                "longitude": -122.69657660000001
+              },
+              "stayOn": false,
+              "streetName": "Northwest 22nd Avenue",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "EAST",
+              "angle": 1.53914562034506,
+              "area": false,
+              "bogusName": false,
+              "distance": 3.675,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "RIGHT",
+              "startLocation": {
+                "latitude": 45.5312508,
+                "longitude": -122.69663860000001
               },
               "stayOn": false,
               "streetName": "Northwest Northrup Street",
@@ -2612,17 +1600,897 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           "walkingLeg": true
         }
       ],
-      "nTransfers": 1,
-      "nonTransitDistanceMeters": 438.42099999999994,
-      "nonTransitTimeSeconds": 348,
+      "nTransfers": 0,
+      "nonTransitDistanceMeters": 383.95700000000005,
+      "nonTransitTimeSeconds": 307,
       "onStreetAllTheWay": false,
       "streetOnly": false,
       "systemNotices": [ ],
       "tooSloped": false,
-      "transferPriorityCost": 33,
-      "transitTimeSeconds": 1264,
-      "waitTimeOptimizedCost": 26,
-      "waitingTimeSeconds": 237,
+      "transferPriorityCost": 0,
+      "transitTimeSeconds": 1220,
+      "waitTimeOptimizedCost": 0,
+      "waitingTimeSeconds": 0,
+      "walkOnly": false,
+      "walkingAllTheWay": false
+    },
+    {
+      "arrivedAtDestinationWithRentedVehicle": false,
+      "durationSeconds": 1527,
+      "elevationGained": 0.0,
+      "elevationLost": 0.0,
+      "fare": {
+        "details": {
+          "regular": [
+            {
+              "fareId": {
+                "feedId": "prt",
+                "id": "8"
+              },
+              "price": {
+                "cents": 200,
+                "currency": {
+                  "value": "USD"
+                }
+              },
+              "routes": [
+                {
+                  "feedId": "prt",
+                  "id": "15"
+                }
+              ]
+            }
+          ]
+        },
+        "fare": {
+          "regular": {
+            "cents": 200,
+            "currency": {
+              "value": "USD"
+            }
+          }
+        }
+      },
+      "flaggedForDeletion": false,
+      "generalizedCost": 2409,
+      "legs": [
+        {
+          "agencyTimeZoneOffset": -28800000,
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distanceMeters": 62.012,
+          "endTime": "2009-11-17T19:00:40.000+00:00",
+          "flexibleTrip": false,
+          "from": {
+            "coordinate": {
+              "latitude": 45.51726,
+              "longitude": -122.64847
+            },
+            "name": "SE Morrison St. & SE 17th Ave. (P1)",
+            "vertexType": "NORMAL"
+          },
+          "generalizedCost": 95,
+          "interlinedWithPreviousLeg": false,
+          "legGeometry": {
+            "length": 4,
+            "points": "kaytG~wqkV?T?fCG?"
+          },
+          "mode": "WALK",
+          "onStreetNonTransit": true,
+          "pathway": false,
+          "realTime": false,
+          "rentedVehicle": false,
+          "scheduled": false,
+          "startTime": "2009-11-17T18:59:52.000+00:00",
+          "streetNotes": [ ],
+          "to": {
+            "coordinate": {
+              "latitude": 45.517226,
+              "longitude": -122.649266
+            },
+            "name": "SE Morrison & 16th",
+            "stop": {
+              "code": "4019",
+              "coordinate": {
+                "latitude": 45.517226,
+                "longitude": -122.649266
+              },
+              "description": "Westbound stop in Portland (Stop ID 4019)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "4019"
+              },
+              "name": "SE Morrison & 16th",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
+            },
+            "stopIndex": 50,
+            "stopSequence": 51,
+            "vertexType": "TRANSIT"
+          },
+          "transitAlerts": [ ],
+          "transitLeg": false,
+          "walkSteps": [
+            {
+              "absoluteDirection": "WEST",
+              "angle": -1.5670436023962588,
+              "area": false,
+              "bogusName": false,
+              "distance": 62.012,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "DEPART",
+              "startLocation": {
+                "latitude": 45.51718601153089,
+                "longitude": -122.64847039626407
+              },
+              "stayOn": false,
+              "streetName": "Southeast Morrison Street",
+              "streetNotes": [ ]
+            }
+          ],
+          "walkingBike": false,
+          "walkingLeg": true
+        },
+        {
+          "agencyTimeZoneOffset": 0,
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distanceMeters": 4943.103319311616,
+          "endTime": "2009-11-17T19:21:00.000+00:00",
+          "flexibleTrip": false,
+          "from": {
+            "coordinate": {
+              "latitude": 45.517226,
+              "longitude": -122.649266
+            },
+            "name": "SE Morrison & 16th",
+            "stop": {
+              "code": "4019",
+              "coordinate": {
+                "latitude": 45.517226,
+                "longitude": -122.649266
+              },
+              "description": "Westbound stop in Portland (Stop ID 4019)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "4019"
+              },
+              "name": "SE Morrison & 16th",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
+            },
+            "stopIndex": 50,
+            "stopSequence": 51,
+            "vertexType": "TRANSIT"
+          },
+          "generalizedCost": 1820,
+          "headsign": "NW 27th & Thurman",
+          "interlinedWithPreviousLeg": false,
+          "intermediateStops": [ ],
+          "legGeometry": {
+            "length": 129,
+            "points": "kaytG||qkVA~@?jE?tC???r@AhE?jE?rA???tBAjE?nD???X?hE?xC??Ah@?pE?~C???J?`@?vAAvBEbE?jEAlE?`BAbB@d@??@tAAj@Cx@Cb@Cp@_@dEcAtFoA`IS~@i@`BmAzDi@zAc@pAi@~C??Id@u@jEm@bD??If@u@jEk@bD??If@u@|DW`B??CPs@|Du@lElBz@??VJbCfAk@dD??Id@w@rEWvAId@AF??Q~@s@`Ei@~C??Ib@u@dEWzA??]jB]MQSe@WOKOKIIQe@GWE]GnD??AXKnEGnD???XGjD??AZEfCC`AEzB??AXCfAGxDE|AEtBIlC??APkAh@o@?sCB{BD??S?mCDmCDyBB??U?mCDmCDyBB"
+          },
+          "mode": "BUS",
+          "onStreetNonTransit": false,
+          "pathway": false,
+          "realTime": false,
+          "scheduled": true,
+          "serviceDate": {
+            "day": 17,
+            "minMax": false,
+            "month": 11,
+            "sequenceNumber": 20091117,
+            "year": 2009
+          },
+          "startTime": "2009-11-17T19:00:40.000+00:00",
+          "streetNotes": [ ],
+          "to": {
+            "coordinate": {
+              "latitude": 45.529681,
+              "longitude": -122.698529
+            },
+            "name": "NW 23rd & Lovejoy",
+            "stop": {
+              "code": "7163",
+              "coordinate": {
+                "latitude": 45.529681,
+                "longitude": -122.698529
+              },
+              "description": "Northbound stop in Portland (Stop ID 7163)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "7163"
+              },
+              "name": "NW 23rd & Lovejoy",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
+            },
+            "stopIndex": 73,
+            "stopSequence": 74,
+            "vertexType": "TRANSIT"
+          },
+          "transitAlerts": [ ],
+          "transitLeg": true,
+          "trip": {
+            "alteration": "PLANNED",
+            "bikesAllowed": "UNKNOWN",
+            "blockId": "1550",
+            "direction": "OUTBOUND",
+            "id": {
+              "feedId": "prt",
+              "id": "150W1430"
+            },
+            "route": {
+              "agency": {
+                "fareUrl": "http://trimet.org/fares/index.htm",
+                "id": {
+                  "feedId": "prt",
+                  "id": "prt"
+                },
+                "lang": "en",
+                "name": "TriMet",
+                "phone": "503-238-7433",
+                "timezone": "America/Los_Angeles",
+                "url": "http://trimet.org"
+              },
+              "bikesAllowed": "UNKNOWN",
+              "id": {
+                "feedId": "prt",
+                "id": "15"
+              },
+              "longName": "Belmont/NW 23rd",
+              "mode": "BUS",
+              "shortName": "15",
+              "sortOrder": -999,
+              "sortOrderSet": false,
+              "type": 3,
+              "url": "http://trimet.org/schedules/r015.htm"
+            },
+            "serviceId": {
+              "feedId": "prt",
+              "id": "W"
+            },
+            "shapeId": {
+              "feedId": "prt",
+              "id": "15.0.23"
+            },
+            "wheelchairAccessible": 0
+          },
+          "walkSteps": [ ],
+          "walkingLeg": false
+        },
+        {
+          "agencyTimeZoneOffset": -28800000,
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distanceMeters": 321.94500000000005,
+          "endTime": "2009-11-17T19:25:19.000+00:00",
+          "flexibleTrip": false,
+          "from": {
+            "coordinate": {
+              "latitude": 45.529681,
+              "longitude": -122.698529
+            },
+            "name": "NW 23rd & Lovejoy",
+            "stop": {
+              "code": "7163",
+              "coordinate": {
+                "latitude": 45.529681,
+                "longitude": -122.698529
+              },
+              "description": "Northbound stop in Portland (Stop ID 7163)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "7163"
+              },
+              "name": "NW 23rd & Lovejoy",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
+            },
+            "stopIndex": 73,
+            "stopSequence": 74,
+            "vertexType": "TRANSIT"
+          },
+          "generalizedCost": 493,
+          "interlinedWithPreviousLeg": false,
+          "legGeometry": {
+            "length": 18,
+            "points": "oo{tGxp{kVG@?GCwAAaF?G?i@?SK?C?K?W@{A@M@C@I?_CB?G"
+          },
+          "mode": "WALK",
+          "onStreetNonTransit": true,
+          "pathway": false,
+          "realTime": false,
+          "rentedVehicle": false,
+          "scheduled": false,
+          "startTime": "2009-11-17T19:21:00.000+00:00",
+          "streetNotes": [ ],
+          "to": {
+            "coordinate": {
+              "latitude": 45.53122,
+              "longitude": -122.69659
+            },
+            "name": "NW Northrup St. & NW 22nd Ave. (P2)",
+            "vertexType": "NORMAL"
+          },
+          "transitAlerts": [ ],
+          "transitLeg": false,
+          "walkSteps": [
+            {
+              "absoluteDirection": "EAST",
+              "angle": 1.5519664675850313,
+              "area": false,
+              "bogusName": true,
+              "distance": 2.418,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "DEPART",
+              "startLocation": {
+                "latitude": 45.529726790620664,
+                "longitude": -122.69853023095405
+              },
+              "stayOn": false,
+              "streetName": "way 158083864 from 0",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "EAST",
+              "angle": 1.5293125423902536,
+              "area": false,
+              "bogusName": false,
+              "distance": 142.155,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "CONTINUE",
+              "startLocation": {
+                "latitude": 45.5297272,
+                "longitude": -122.6984992
+              },
+              "stayOn": false,
+              "streetName": "Northwest Lovejoy Street",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "EAST",
+              "angle": 1.5678920159151593,
+              "area": false,
+              "bogusName": true,
+              "distance": 7.657,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "CONTINUE",
+              "startLocation": {
+                "latitude": 45.529758300000005,
+                "longitude": -122.6966749
+              },
+              "stayOn": false,
+              "streetName": "way 158083863 from 2",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "NORTH",
+              "angle": -0.02805287330123452,
+              "area": false,
+              "bogusName": false,
+              "distance": 166.04000000000002,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "LEFT",
+              "startLocation": {
+                "latitude": 45.5297585,
+                "longitude": -122.69657660000001
+              },
+              "stayOn": false,
+              "streetName": "Northwest 22nd Avenue",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "EAST",
+              "angle": 1.53914562034506,
+              "area": false,
+              "bogusName": false,
+              "distance": 3.675,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "RIGHT",
+              "startLocation": {
+                "latitude": 45.5312508,
+                "longitude": -122.69663860000001
+              },
+              "stayOn": false,
+              "streetName": "Northwest Northrup Street",
+              "streetNotes": [ ]
+            }
+          ],
+          "walkingBike": false,
+          "walkingLeg": true
+        }
+      ],
+      "nTransfers": 0,
+      "nonTransitDistanceMeters": 383.95700000000005,
+      "nonTransitTimeSeconds": 307,
+      "onStreetAllTheWay": false,
+      "streetOnly": false,
+      "systemNotices": [ ],
+      "tooSloped": false,
+      "transferPriorityCost": 0,
+      "transitTimeSeconds": 1220,
+      "waitTimeOptimizedCost": 0,
+      "waitingTimeSeconds": 0,
+      "walkOnly": false,
+      "walkingAllTheWay": false
+    },
+    {
+      "arrivedAtDestinationWithRentedVehicle": false,
+      "durationSeconds": 1527,
+      "elevationGained": 0.0,
+      "elevationLost": 0.0,
+      "fare": {
+        "details": {
+          "regular": [
+            {
+              "fareId": {
+                "feedId": "prt",
+                "id": "8"
+              },
+              "price": {
+                "cents": 200,
+                "currency": {
+                  "value": "USD"
+                }
+              },
+              "routes": [
+                {
+                  "feedId": "prt",
+                  "id": "15"
+                }
+              ]
+            }
+          ]
+        },
+        "fare": {
+          "regular": {
+            "cents": 200,
+            "currency": {
+              "value": "USD"
+            }
+          }
+        }
+      },
+      "flaggedForDeletion": false,
+      "generalizedCost": 2409,
+      "legs": [
+        {
+          "agencyTimeZoneOffset": -28800000,
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distanceMeters": 62.012,
+          "endTime": "2009-11-17T19:15:40.000+00:00",
+          "flexibleTrip": false,
+          "from": {
+            "coordinate": {
+              "latitude": 45.51726,
+              "longitude": -122.64847
+            },
+            "name": "SE Morrison St. & SE 17th Ave. (P1)",
+            "vertexType": "NORMAL"
+          },
+          "generalizedCost": 95,
+          "interlinedWithPreviousLeg": false,
+          "legGeometry": {
+            "length": 4,
+            "points": "kaytG~wqkV?T?fCG?"
+          },
+          "mode": "WALK",
+          "onStreetNonTransit": true,
+          "pathway": false,
+          "realTime": false,
+          "rentedVehicle": false,
+          "scheduled": false,
+          "startTime": "2009-11-17T19:14:52.000+00:00",
+          "streetNotes": [ ],
+          "to": {
+            "coordinate": {
+              "latitude": 45.517226,
+              "longitude": -122.649266
+            },
+            "name": "SE Morrison & 16th",
+            "stop": {
+              "code": "4019",
+              "coordinate": {
+                "latitude": 45.517226,
+                "longitude": -122.649266
+              },
+              "description": "Westbound stop in Portland (Stop ID 4019)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "4019"
+              },
+              "name": "SE Morrison & 16th",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
+            },
+            "stopIndex": 50,
+            "stopSequence": 51,
+            "vertexType": "TRANSIT"
+          },
+          "transitAlerts": [ ],
+          "transitLeg": false,
+          "walkSteps": [
+            {
+              "absoluteDirection": "WEST",
+              "angle": -1.5670436023962588,
+              "area": false,
+              "bogusName": false,
+              "distance": 62.012,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "DEPART",
+              "startLocation": {
+                "latitude": 45.51718601153089,
+                "longitude": -122.64847039626407
+              },
+              "stayOn": false,
+              "streetName": "Southeast Morrison Street",
+              "streetNotes": [ ]
+            }
+          ],
+          "walkingBike": false,
+          "walkingLeg": true
+        },
+        {
+          "agencyTimeZoneOffset": 0,
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distanceMeters": 4943.103319311616,
+          "endTime": "2009-11-17T19:36:00.000+00:00",
+          "flexibleTrip": false,
+          "from": {
+            "coordinate": {
+              "latitude": 45.517226,
+              "longitude": -122.649266
+            },
+            "name": "SE Morrison & 16th",
+            "stop": {
+              "code": "4019",
+              "coordinate": {
+                "latitude": 45.517226,
+                "longitude": -122.649266
+              },
+              "description": "Westbound stop in Portland (Stop ID 4019)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "4019"
+              },
+              "name": "SE Morrison & 16th",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
+            },
+            "stopIndex": 50,
+            "stopSequence": 51,
+            "vertexType": "TRANSIT"
+          },
+          "generalizedCost": 1820,
+          "headsign": "Montgomery Park",
+          "interlinedWithPreviousLeg": false,
+          "intermediateStops": [ ],
+          "legGeometry": {
+            "length": 129,
+            "points": "kaytG||qkVA~@?jE?tC???r@AhE?jE?rA???tBAjE?nD???X?hE?xC??Ah@?pE?~C???J?`@?vAAvBEbE?jEAlE?`BAbB@d@??@tAAj@Cx@Cb@Cp@_@dEcAtFoA`IS~@i@`BmAzDi@zAc@pAi@~C??Id@u@jEm@bD??If@u@jEk@bD??If@u@|DW`B??CPs@|Du@lElBz@??VJbCfAk@dD??Id@w@rEWvAId@AF??Q~@s@`Ei@~C??Ib@u@dEWzA??]jB]MQSe@WOKOKIIQe@GWE]GnD??AXKnEGnD???XGjD??AZEfCC`AEzB??AXCfAGxDE|AEtBIlC??APkAh@o@?sCB{BD??S?mCDmCDyBB??U?mCDmCDyBB"
+          },
+          "mode": "BUS",
+          "onStreetNonTransit": false,
+          "pathway": false,
+          "realTime": false,
+          "scheduled": true,
+          "serviceDate": {
+            "day": 17,
+            "minMax": false,
+            "month": 11,
+            "sequenceNumber": 20091117,
+            "year": 2009
+          },
+          "startTime": "2009-11-17T19:15:40.000+00:00",
+          "streetNotes": [ ],
+          "to": {
+            "coordinate": {
+              "latitude": 45.529681,
+              "longitude": -122.698529
+            },
+            "name": "NW 23rd & Lovejoy",
+            "stop": {
+              "code": "7163",
+              "coordinate": {
+                "latitude": 45.529681,
+                "longitude": -122.698529
+              },
+              "description": "Northbound stop in Portland (Stop ID 7163)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "7163"
+              },
+              "name": "NW 23rd & Lovejoy",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
+            },
+            "stopIndex": 73,
+            "stopSequence": 74,
+            "vertexType": "TRANSIT"
+          },
+          "transitAlerts": [ ],
+          "transitLeg": true,
+          "trip": {
+            "alteration": "PLANNED",
+            "bikesAllowed": "UNKNOWN",
+            "blockId": "1537",
+            "direction": "OUTBOUND",
+            "id": {
+              "feedId": "prt",
+              "id": "150W1440"
+            },
+            "route": {
+              "agency": {
+                "fareUrl": "http://trimet.org/fares/index.htm",
+                "id": {
+                  "feedId": "prt",
+                  "id": "prt"
+                },
+                "lang": "en",
+                "name": "TriMet",
+                "phone": "503-238-7433",
+                "timezone": "America/Los_Angeles",
+                "url": "http://trimet.org"
+              },
+              "bikesAllowed": "UNKNOWN",
+              "id": {
+                "feedId": "prt",
+                "id": "15"
+              },
+              "longName": "Belmont/NW 23rd",
+              "mode": "BUS",
+              "shortName": "15",
+              "sortOrder": -999,
+              "sortOrderSet": false,
+              "type": 3,
+              "url": "http://trimet.org/schedules/r015.htm"
+            },
+            "serviceId": {
+              "feedId": "prt",
+              "id": "W"
+            },
+            "shapeId": {
+              "feedId": "prt",
+              "id": "15.0.21"
+            },
+            "wheelchairAccessible": 0
+          },
+          "walkSteps": [ ],
+          "walkingLeg": false
+        },
+        {
+          "agencyTimeZoneOffset": -28800000,
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distanceMeters": 321.94500000000005,
+          "endTime": "2009-11-17T19:40:19.000+00:00",
+          "flexibleTrip": false,
+          "from": {
+            "coordinate": {
+              "latitude": 45.529681,
+              "longitude": -122.698529
+            },
+            "name": "NW 23rd & Lovejoy",
+            "stop": {
+              "code": "7163",
+              "coordinate": {
+                "latitude": 45.529681,
+                "longitude": -122.698529
+              },
+              "description": "Northbound stop in Portland (Stop ID 7163)",
+              "fareZones": [
+                {
+                  "id": {
+                    "feedId": "prt",
+                    "id": "1"
+                  }
+                }
+              ],
+              "id": {
+                "feedId": "prt",
+                "id": "7163"
+              },
+              "name": "NW 23rd & Lovejoy",
+              "partOfStation": false,
+              "wheelchairBoarding": "NO_INFORMATION"
+            },
+            "stopIndex": 73,
+            "stopSequence": 74,
+            "vertexType": "TRANSIT"
+          },
+          "generalizedCost": 493,
+          "interlinedWithPreviousLeg": false,
+          "legGeometry": {
+            "length": 18,
+            "points": "oo{tGxp{kVG@?GCwAAaF?G?i@?SK?C?K?W@{A@M@C@I?_CB?G"
+          },
+          "mode": "WALK",
+          "onStreetNonTransit": true,
+          "pathway": false,
+          "realTime": false,
+          "rentedVehicle": false,
+          "scheduled": false,
+          "startTime": "2009-11-17T19:36:00.000+00:00",
+          "streetNotes": [ ],
+          "to": {
+            "coordinate": {
+              "latitude": 45.53122,
+              "longitude": -122.69659
+            },
+            "name": "NW Northrup St. & NW 22nd Ave. (P2)",
+            "vertexType": "NORMAL"
+          },
+          "transitAlerts": [ ],
+          "transitLeg": false,
+          "walkSteps": [
+            {
+              "absoluteDirection": "EAST",
+              "angle": 1.5519664675850313,
+              "area": false,
+              "bogusName": true,
+              "distance": 2.418,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "DEPART",
+              "startLocation": {
+                "latitude": 45.529726790620664,
+                "longitude": -122.69853023095405
+              },
+              "stayOn": false,
+              "streetName": "way 158083864 from 0",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "EAST",
+              "angle": 1.5293125423902536,
+              "area": false,
+              "bogusName": false,
+              "distance": 142.155,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "CONTINUE",
+              "startLocation": {
+                "latitude": 45.5297272,
+                "longitude": -122.6984992
+              },
+              "stayOn": false,
+              "streetName": "Northwest Lovejoy Street",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "EAST",
+              "angle": 1.5678920159151593,
+              "area": false,
+              "bogusName": true,
+              "distance": 7.657,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "CONTINUE",
+              "startLocation": {
+                "latitude": 45.529758300000005,
+                "longitude": -122.6966749
+              },
+              "stayOn": false,
+              "streetName": "way 158083863 from 2",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "NORTH",
+              "angle": -0.02805287330123452,
+              "area": false,
+              "bogusName": false,
+              "distance": 166.04000000000002,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "LEFT",
+              "startLocation": {
+                "latitude": 45.5297585,
+                "longitude": -122.69657660000001
+              },
+              "stayOn": false,
+              "streetName": "Northwest 22nd Avenue",
+              "streetNotes": [ ]
+            },
+            {
+              "absoluteDirection": "EAST",
+              "angle": 1.53914562034506,
+              "area": false,
+              "bogusName": false,
+              "distance": 3.675,
+              "edges": [ ],
+              "elevation": [ ],
+              "relativeDirection": "RIGHT",
+              "startLocation": {
+                "latitude": 45.5312508,
+                "longitude": -122.69663860000001
+              },
+              "stayOn": false,
+              "streetName": "Northwest Northrup Street",
+              "streetNotes": [ ]
+            }
+          ],
+          "walkingBike": false,
+          "walkingLeg": true
+        }
+      ],
+      "nTransfers": 0,
+      "nonTransitDistanceMeters": 383.95700000000005,
+      "nonTransitTimeSeconds": 307,
+      "onStreetAllTheWay": false,
+      "streetOnly": false,
+      "systemNotices": [ ],
+      "tooSloped": false,
+      "transferPriorityCost": 0,
+      "transitTimeSeconds": 1220,
+      "waitTimeOptimizedCost": 0,
+      "waitingTimeSeconds": 0,
       "walkOnly": false,
       "walkingAllTheWay": false
     }

--- a/src/test/java/org/opentripplanner/transit/raptor/_data/transit/TestTransitData.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/_data/transit/TestTransitData.java
@@ -23,8 +23,10 @@ import org.opentripplanner.transit.raptor.api.transit.IntIterator;
 import org.opentripplanner.transit.raptor.api.transit.RaptorConstrainedTransfer;
 import org.opentripplanner.transit.raptor.api.transit.RaptorPathConstrainedTransferSearch;
 import org.opentripplanner.transit.raptor.api.transit.RaptorRoute;
+import org.opentripplanner.transit.raptor.api.transit.RaptorTimeTable;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTransitDataProvider;
+import org.opentripplanner.transit.raptor.api.transit.RaptorTripPattern;
 import org.opentripplanner.transit.raptor.util.ReversedRaptorTransfer;
 
 @SuppressWarnings("UnusedReturnValue")
@@ -103,6 +105,27 @@ public class TestTransitData implements RaptorTransitDataProvider<TestTripSchedu
   public IntFunction<String> stopIndexTranslatorForDebugging() {
     // Index is translated: 1->'A', 2->'B', 3->'C' ...
     return this::stopIndexToName;
+  }
+
+  @Override
+  public int getValidTransitDataStartTime() {
+    return this.routes.stream()
+        .mapToInt(route -> route.timetable().getTripSchedule(0).departure(0))
+        .min()
+        .getAsInt();
+  }
+
+  @Override
+  public int getValidTransitDataEndTime() {
+    return this.routes.stream()
+        .mapToInt(route -> {
+          RaptorTimeTable<TestTripSchedule> timetable = route.timetable();
+          RaptorTripPattern pattern = route.pattern();
+          return timetable.getTripSchedule(timetable.numberOfTripSchedules() - 1)
+                  .departure(pattern.numberOfStopsInPattern() - 1);
+        })
+        .max()
+        .getAsInt();
   }
 
   public TestRoute getRoute(int index) {

--- a/src/test/java/org/opentripplanner/transit/raptor/service/RaptorSearchWindowCalculatorTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/service/RaptorSearchWindowCalculatorTest.java
@@ -76,9 +76,9 @@ public class RaptorSearchWindowCalculatorTest {
            LAT = 10_200 + (840 + roundUp_60(300)) = 11_340
          */
         assertEquals(840, subject.getSearchWindowSeconds());
-        assertEquals(11_340, subject.getLatestArrivalTime());
         // Given - verify not changed
         assertEquals(10_200, subject.getEarliestDepartureTime());
+        assertEquals(SearchParams.TIME_NOT_SET, subject.getLatestArrivalTime());
     }
 
     @Test
@@ -104,9 +104,9 @@ public class RaptorSearchWindowCalculatorTest {
            LAT = 12_000 + (1_500 + roundUp_60(1_800)) = 15_300
          */
         assertEquals(1_800, subject.getSearchWindowSeconds());
-        assertEquals(15_300, subject.getLatestArrivalTime());
         // Given - verify not changed
         assertEquals(12_000, subject.getEarliestDepartureTime());
+        assertEquals(SearchParams.TIME_NOT_SET, subject.getLatestArrivalTime());
     }
 
     @Test

--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTest.java
@@ -382,6 +382,7 @@ public class SpeedTest {
                 null,
                 transitLayer,
                 request.getDepartureDateWithZone().toInstant(),
+                0,
                 1,
                 transitDataProviderFilter,
                 Transfer.prepareTransferRoutingRequest(routingRequest)


### PR DESCRIPTION
### Summary

Update the heuristic search to use the EDT and LAT from the selected transit coverage instead of the calculated search window. This makes it possible to always get results, if they exist within the filtered transit data. Previously if there was any waiting during the trip, it might not show up in the reverse heuristic, as the latest arrival time might be too conservative for those.

### Issue

Fixes #3662 
Fixes #3663

### Unit tests
Updated to match the new functionality

### Documentation
Only internal workings were updated 

### Changelog
Added
