### PR TITLE
Correct usage of boardSlackForMode / alightSlackForMode

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/transmodelapi/model/TransportModeSlackTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/transmodelapi/model/TransportModeSlackTest.java
@@ -1,36 +1,35 @@
 package org.opentripplanner.ext.transmodelapi.model;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.opentripplanner.routing.core.TraverseMode;
-
 import java.util.List;
 import java.util.Map;
+import org.junit.Assert;
+import org.junit.Test;
+import org.opentripplanner.model.TransitMode;
 
 public class TransportModeSlackTest {
 
     @Test
     public void mapToApiList() {
         // Given
-        Map<TraverseMode, Integer> domain = Map.of(
-                TraverseMode.FUNICULAR, 600,
-                TraverseMode.CABLE_CAR, 600,
-                TraverseMode.RAIL, 1800,
-                TraverseMode.AIRPLANE, 3600
+        Map<TransitMode, Integer> domain = Map.of(
+                TransitMode.FUNICULAR, 600,
+                TransitMode.CABLE_CAR, 600,
+                TransitMode.RAIL, 1800,
+                TransitMode.AIRPLANE, 3600
         );
 
         // When
         List<TransportModeSlack> result = TransportModeSlack.mapToApiList(domain);
 
         Assert.assertEquals(600, result.get(0).slack);
-        Assert.assertTrue(result.get(0).modes.contains(TraverseMode.CABLE_CAR));
-        Assert.assertTrue(result.get(0).modes.contains(TraverseMode.FUNICULAR));
+        Assert.assertTrue(result.get(0).modes.contains(TransitMode.CABLE_CAR));
+        Assert.assertTrue(result.get(0).modes.contains(TransitMode.FUNICULAR));
 
         Assert.assertEquals(1800, result.get(1).slack);
-        Assert.assertTrue(result.get(1).modes.contains(TraverseMode.RAIL));
+        Assert.assertTrue(result.get(1).modes.contains(TransitMode.RAIL));
 
         Assert.assertEquals(3600, result.get(2).slack);
-        Assert.assertTrue(result.get(2).modes.contains(TraverseMode.AIRPLANE));
+        Assert.assertTrue(result.get(2).modes.contains(TransitMode.AIRPLANE));
     }
 
     @Test
@@ -39,29 +38,29 @@ public class TransportModeSlackTest {
         List<Object> apiSlackInput = List.of(
                 Map.of(
                         "slack", 600,
-                        "modes", List.of(TraverseMode.FUNICULAR, TraverseMode.CABLE_CAR)
+                        "modes", List.of(TransitMode.FUNICULAR, TransitMode.CABLE_CAR)
                 ),
                 Map.of(
                         "slack", 1800,
-                        "modes", List.of(TraverseMode.RAIL)
+                        "modes", List.of(TransitMode.RAIL)
                 ),
                 Map.of(
                         "slack", 3600,
-                        "modes", List.of(TraverseMode.AIRPLANE)
+                        "modes", List.of(TransitMode.AIRPLANE)
                 )
         );
 
 
-        Map<TraverseMode, Integer> result;
+        Map<TransitMode, Integer> result;
 
         // When
         result = TransportModeSlack.mapToDomain(apiSlackInput);
 
         // Then
-        Assert.assertNull(result.get(TraverseMode.BUS)  );
-        Assert.assertEquals(Integer.valueOf(600), result.get(TraverseMode.FUNICULAR));
-        Assert.assertEquals(Integer.valueOf(600), result.get(TraverseMode.CABLE_CAR));
-        Assert.assertEquals(Integer.valueOf(1800), result.get(TraverseMode.RAIL));
-        Assert.assertEquals(Integer.valueOf(3600), result.get(TraverseMode.AIRPLANE));
+        Assert.assertNull(result.get(TransitMode.BUS)  );
+        Assert.assertEquals(Integer.valueOf(600), result.get(TransitMode.FUNICULAR));
+        Assert.assertEquals(Integer.valueOf(600), result.get(TransitMode.CABLE_CAR));
+        Assert.assertEquals(Integer.valueOf(1800), result.get(TransitMode.RAIL));
+        Assert.assertEquals(Integer.valueOf(3600), result.get(TransitMode.AIRPLANE));
     }
 }

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/TransportModeSlack.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/TransportModeSlack.java
@@ -16,7 +16,7 @@ import graphql.schema.GraphQLOutputType;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -137,8 +137,8 @@ public class TransportModeSlack {
     }
 
     @SuppressWarnings("unchecked")
-    public static Map<TransitMode, Integer> mapToDomain(Object value) {
-        Map<TransitMode, Integer> result = new HashMap<>();
+    public static EnumMap<TransitMode, Integer> mapToDomain(Object value) {
+        var result = new EnumMap<TransitMode, Integer>(TransitMode.class);
         if(value instanceof List) {
             List<Map<String, Object>> list = (List<Map<String, Object>>) value;
             for (Map<String, Object> map : list) {

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/TransportModeSlack.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/TransportModeSlack.java
@@ -1,5 +1,9 @@
 package org.opentripplanner.ext.transmodelapi.model;
 
+import static graphql.schema.GraphQLInputObjectField.newInputObjectField;
+import static graphql.schema.GraphQLNonNull.nonNull;
+import static org.opentripplanner.ext.transmodelapi.model.EnumTypes.TRANSPORT_MODE;
+
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 import graphql.Scalars;
@@ -9,8 +13,6 @@ import graphql.schema.GraphQLList;
 import graphql.schema.GraphQLNonNull;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLOutputType;
-import org.opentripplanner.routing.core.TraverseMode;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -18,10 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
-import static graphql.schema.GraphQLInputObjectField.newInputObjectField;
-import static graphql.schema.GraphQLNonNull.nonNull;
-import static org.opentripplanner.ext.transmodelapi.model.EnumTypes.MODE;
+import org.opentripplanner.model.TransitMode;
 
 public class TransportModeSlack {
     private static final String BOARD_SLACK_DESCRIPTION;
@@ -43,7 +42,7 @@ public class TransportModeSlack {
             "The alightSlack is the minimum extra time after exiting a public transport vehicle.";
 
         INT_TYPE = nonNull(Scalars.GraphQLInt);
-        MODE_LIST_TYPE = nonNull(GraphQLList.list(nonNull(MODE)));
+        MODE_LIST_TYPE = nonNull(GraphQLList.list(nonNull(TRANSPORT_MODE)));
         SLACK_INPUT_TYPE = GraphQLInputObjectType.newInputObject()
                 .name("TransportModeSlack")
                 .description("Used to specify board and alight slack for a given modes.")
@@ -83,9 +82,9 @@ public class TransportModeSlack {
     }
 
     public final int slack;
-    public final List<TraverseMode> modes;
+    public final List<TransitMode> modes;
 
-    private TransportModeSlack(int slack, List<TraverseMode> modes) {
+    private TransportModeSlack(int slack, List<TransitMode> modes) {
         this.slack = slack;
         this.modes = modes;
     }
@@ -106,7 +105,7 @@ public class TransportModeSlack {
     public static String slackByGroupDescription(String name) {
         return String.format("List of %s for a given set of modes.", name);
     }
-    public static String slackByGroupDescription(String name, Map<TraverseMode, Integer> defaultValues) {
+    public static String slackByGroupDescription(String name, Map<TransitMode, Integer> defaultValues) {
         return slackByGroupDescription(name) + " " + defaultsToString(defaultValues);
     }
 
@@ -123,9 +122,9 @@ public class TransportModeSlack {
                 + "}";
     }
 
-    public static List<TransportModeSlack> mapToApiList(Map<TraverseMode, Integer> domain) {
+    public static List<TransportModeSlack> mapToApiList(Map<TransitMode, Integer> domain) {
         // Group modes by slack value
-        Multimap<Integer, TraverseMode> modesBySlack = ArrayListMultimap.create();
+        Multimap<Integer, TransitMode> modesBySlack = ArrayListMultimap.create();
         domain.forEach((k,v) -> modesBySlack.put(v, k));
 
         // Create a new entry for each group of modes
@@ -138,26 +137,26 @@ public class TransportModeSlack {
     }
 
     @SuppressWarnings("unchecked")
-    public static Map<TraverseMode, Integer> mapToDomain(Object value) {
-        Map<TraverseMode, Integer> result = new HashMap<>();
+    public static Map<TransitMode, Integer> mapToDomain(Object value) {
+        Map<TransitMode, Integer> result = new HashMap<>();
         if(value instanceof List) {
             List<Map<String, Object>> list = (List<Map<String, Object>>) value;
             for (Map<String, Object> map : list) {
                 int slack = (Integer) map.get("slack");
-                ((List<TraverseMode>) map.get("modes")).forEach(m -> result.put(m, slack));
+                ((List<TransitMode>) map.get("modes")).forEach(m -> result.put(m, slack));
             }
         }
         return result;
     }
 
-    private static String defaultsToString(Map<TraverseMode, Integer> byMode) {
+    private static String defaultsToString(Map<TransitMode, Integer> byMode) {
         List<String> groups = new ArrayList<>();
         byMode.forEach((m,v) -> groups.add(serializeTransportMode(m) + " : " + v));
         Collections.sort(groups);
         return "Defaults: " + groups;
     }
 
-    private static Object serializeTransportMode(TraverseMode m) {
-        return MODE.serialize(m);
+    private static Object serializeTransportMode(TransitMode m) {
+        return TRANSPORT_MODE.serialize(m);
     }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/SlackProvider.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/SlackProvider.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.routing.algorithm.raptor.transit;
 
+import java.util.EnumMap;
 import java.util.Map;
 import org.opentripplanner.model.TransitMode;
 import org.opentripplanner.routing.algorithm.raptor.transit.request.TripPatternForDates;
@@ -16,15 +17,25 @@ import org.opentripplanner.transit.raptor.api.transit.RaptorTripPattern;
  */
 public final class SlackProvider implements RaptorSlackProvider {
     /**
+     * Default boardSlack if an explicit value is not set for the mode.
+     */
+    private final int defaultBoardSlack;
+
+    /**
      * Keep a list of board-slack values for each mode.
      */
-    private final int[] boardSlack;
+    private final EnumMap<TransitMode, Integer> boardSlack;
+
+    /**
+     * Default alightSlack if an explicit value is not set for the mode.
+     */
+    private final int defaultAlightSlack;
 
     /**
      * Keep a list of alight-slack values for each mode.
      *
      */
-    private final int[] alightSlack;
+    private final EnumMap<TransitMode, Integer> alightSlack;
 
     /**
      * A constant value is used for alight slack.
@@ -35,23 +46,25 @@ public final class SlackProvider implements RaptorSlackProvider {
     public SlackProvider(
             int transferSlack,
             int defaultBoardSlack,
-            Map<TransitMode, Integer> modeBoardSlack,
+            EnumMap<TransitMode, Integer> modeBoardSlack,
             int defaultAlightSlack,
-            Map<TransitMode, Integer> modeAlightSlack
+            EnumMap<TransitMode, Integer> modeAlightSlack
     ) {
         this.transferSlack = transferSlack;
-        this.boardSlack = slackByMode(modeBoardSlack, defaultBoardSlack);
-        this.alightSlack = slackByMode(modeAlightSlack, defaultAlightSlack);
+        this.defaultBoardSlack = defaultBoardSlack;
+        this.boardSlack = modeBoardSlack;
+        this.defaultAlightSlack = defaultAlightSlack;
+        this.alightSlack = modeAlightSlack;
     }
 
     @Override
     public int boardSlack(RaptorTripPattern pattern) {
-        return boardSlack[index(pattern)];
+        return boardSlack.getOrDefault(index(pattern), defaultBoardSlack);
     }
 
     @Override
     public int alightSlack(RaptorTripPattern pattern) {
-        return alightSlack[index(pattern)];
+        return alightSlack.getOrDefault(index(pattern), defaultAlightSlack);
     }
 
     @Override
@@ -65,15 +78,7 @@ public final class SlackProvider implements RaptorSlackProvider {
     /**
      * Return the trip-pattern ordinal as an index.
      */
-    private static int index(RaptorTripPattern pattern) {
-        return ((TripPatternForDates)pattern).getTripPattern().getTransitMode().ordinal();
-    }
-
-    private static int[] slackByMode(Map<TransitMode, Integer> modeSlack, int defaultSlack) {
-        int[] result = new int[TransitMode.values().length];
-        for (TransitMode mode : TransitMode.values()) {
-            result[mode.ordinal()] = modeSlack.getOrDefault(mode, defaultSlack) ;
-        }
-        return result;
+    private static TransitMode index(RaptorTripPattern pattern) {
+        return ((TripPatternForDates)pattern).getTripPattern().getTransitMode();
     }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/SlackProvider.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/SlackProvider.java
@@ -59,12 +59,12 @@ public final class SlackProvider implements RaptorSlackProvider {
 
     @Override
     public int boardSlack(RaptorTripPattern pattern) {
-        return boardSlack.getOrDefault(index(pattern), defaultBoardSlack);
+        return boardSlack.getOrDefault(modeForPattern(pattern), defaultBoardSlack);
     }
 
     @Override
     public int alightSlack(RaptorTripPattern pattern) {
-        return alightSlack.getOrDefault(index(pattern), defaultAlightSlack);
+        return alightSlack.getOrDefault(modeForPattern(pattern), defaultAlightSlack);
     }
 
     @Override
@@ -76,9 +76,9 @@ public final class SlackProvider implements RaptorSlackProvider {
     /* private methods */
 
     /**
-     * Return the trip-pattern ordinal as an index.
+     * Return the mode for the trip pattern.
      */
-    private static TransitMode index(RaptorTripPattern pattern) {
+    private static TransitMode modeForPattern(RaptorTripPattern pattern) {
         return ((TripPatternForDates)pattern).getTripPattern().getTransitMode();
     }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/SlackProvider.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/SlackProvider.java
@@ -1,11 +1,10 @@
 package org.opentripplanner.routing.algorithm.raptor.transit;
 
+import java.util.Map;
+import org.opentripplanner.model.TransitMode;
 import org.opentripplanner.routing.algorithm.raptor.transit.request.TripPatternForDates;
-import org.opentripplanner.routing.core.TraverseMode;
 import org.opentripplanner.transit.raptor.api.transit.RaptorSlackProvider;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripPattern;
-
-import java.util.Map;
 
 
 /**
@@ -36,9 +35,9 @@ public final class SlackProvider implements RaptorSlackProvider {
     public SlackProvider(
             int transferSlack,
             int defaultBoardSlack,
-            Map<TraverseMode, Integer> modeBoardSlack,
+            Map<TransitMode, Integer> modeBoardSlack,
             int defaultAlightSlack,
-            Map<TraverseMode, Integer> modeAlightSlack
+            Map<TransitMode, Integer> modeAlightSlack
     ) {
         this.transferSlack = transferSlack;
         this.boardSlack = slackByMode(modeBoardSlack, defaultBoardSlack);
@@ -70,9 +69,9 @@ public final class SlackProvider implements RaptorSlackProvider {
         return ((TripPatternForDates)pattern).getTripPattern().getTransitMode().ordinal();
     }
 
-    private static int[] slackByMode(Map<TraverseMode, Integer> modeSlack, int defaultSlack) {
-        int[] result = new int[TraverseMode.values().length];
-        for (TraverseMode mode : TraverseMode.values()) {
+    private static int[] slackByMode(Map<TransitMode, Integer> modeSlack, int defaultSlack) {
+        int[] result = new int[TransitMode.values().length];
+        for (TransitMode mode : TransitMode.values()) {
             result[mode.ordinal()] = modeSlack.getOrDefault(mode, defaultSlack) ;
         }
         return result;

--- a/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
@@ -508,7 +508,7 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
      * <p>
      * Unit is seconds. Default value is not-set(empty map).
      */
-    public Map<TraverseMode, Integer> boardSlackForMode = new HashMap<>();
+    public Map<TransitMode, Integer> boardSlackForMode = new HashMap<>();
 
     /**
      * The number of seconds to add after alighting a transit leg. It is recommended to use the
@@ -528,7 +528,7 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
      * <p>
      * Unit is seconds. Default value is not-set(empty map).
      */
-    public Map<TraverseMode, Integer> alightSlackForMode = new HashMap<>();
+    public Map<TransitMode, Integer> alightSlackForMode = new HashMap<>();
 
     /**
      * Ideally maxTransfers should be set in the router config, not here. Instead the client should

--- a/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
@@ -9,6 +9,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
+import java.util.EnumMap;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -508,7 +509,7 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
      * <p>
      * Unit is seconds. Default value is not-set(empty map).
      */
-    public Map<TransitMode, Integer> boardSlackForMode = new HashMap<>();
+    public EnumMap<TransitMode, Integer> boardSlackForMode = new EnumMap<>(TransitMode.class);
 
     /**
      * The number of seconds to add after alighting a transit leg. It is recommended to use the
@@ -528,7 +529,7 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
      * <p>
      * Unit is seconds. Default value is not-set(empty map).
      */
-    public Map<TransitMode, Integer> alightSlackForMode = new HashMap<>();
+    public EnumMap<TransitMode, Integer> alightSlackForMode = new EnumMap<>(TransitMode.class);
 
     /**
      * Ideally maxTransfers should be set in the router config, not here. Instead the client should

--- a/src/main/java/org/opentripplanner/standalone/config/NodeAdapter.java
+++ b/src/main/java/org/opentripplanner/standalone/config/NodeAdapter.java
@@ -8,6 +8,7 @@ import java.time.Period;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.EnumMap;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -223,7 +224,7 @@ public class NodeAdapter {
      *               The second argument to the function is the enum NAME(String).
      * @return a map of listed enum values as keys with value, or an empty map if not set.
      */
-    public <T, E extends Enum<E>> Map<E, T> asEnumMap(
+    public <T, E extends Enum<E>> EnumMap<E, T> asEnumMap(
             String paramName,
             Class<E> enumClass,
             BiFunction<NodeAdapter, String, T> mapper
@@ -455,16 +456,16 @@ public class NodeAdapter {
         }
     }
 
-    private <T, E extends Enum<E>> Map<E, T> localAsEnumMap(
+    private <T, E extends Enum<E>> EnumMap<E, T> localAsEnumMap(
         String paramName, Class<E> enumClass,
         BiFunction<NodeAdapter, String, T> mapper,
         boolean requireAllValues
     ) {
         NodeAdapter node = path(paramName);
 
-        if(node.isEmpty()) { return Map.of(); }
+        EnumMap<E, T> result = new EnumMap<>(enumClass);
 
-        Map<E, T> result = new HashMap<>();
+        if(node.isEmpty()) { return result; }
 
         for (E v : enumClass.getEnumConstants()) {
             if(node.exist(v.name())) {

--- a/src/main/java/org/opentripplanner/standalone/config/RoutingRequestMapper.java
+++ b/src/main/java/org/opentripplanner/standalone/config/RoutingRequestMapper.java
@@ -5,7 +5,6 @@ import org.opentripplanner.routing.api.request.RequestModes;
 import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.routing.api.request.TransferOptimizationRequest;
-import org.opentripplanner.routing.core.TraverseMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,7 +23,7 @@ public class RoutingRequestMapper {
         // Keep this alphabetically sorted so it is easy to check if a parameter is missing from the
         // mapping or duplicate exist.
         request.alightSlack = c.asInt("alightSlack", dft.alightSlack);
-        request.alightSlackForMode = c.asEnumMap("alightSlackForMode", TraverseMode.class, NodeAdapter::asInt);
+        request.alightSlackForMode = c.asEnumMap("alightSlackForMode", TransitMode.class, NodeAdapter::asInt);
         request.bikeRental = c.asBoolean("allowBikeRental", dft.bikeRental);
         request.arriveBy = c.asBoolean("arriveBy", dft.arriveBy);
         request.bikeBoardCost = c.asInt("bikeBoardCost", dft.bikeBoardCost);
@@ -47,7 +46,7 @@ public class RoutingRequestMapper {
         request.allowKeepingRentedVehicleAtDestination = c.asBoolean("allowKeepingRentedBicycleAtDestination", dft.allowKeepingRentedVehicleAtDestination);
         request.keepingRentedVehicleAtDestinationCost = c.asDouble("keepingRentedBicycleAtDestinationCost", dft.keepingRentedVehicleAtDestinationCost);
         request.boardSlack = c.asInt("boardSlack", dft.boardSlack);
-        request.boardSlackForMode = c.asEnumMap("boardSlackForMode", TraverseMode.class, NodeAdapter::asInt);
+        request.boardSlackForMode = c.asEnumMap("boardSlackForMode", TransitMode.class, NodeAdapter::asInt);
         request.maxAccessEgressDurationSecondsForMode = c.asEnumMap("maxAccessEgressDurationSecondsForMode", StreetMode.class, NodeAdapter::asDouble);
         request.carAccelerationSpeed = c.asDouble("carAccelerationSpeed", dft.carAccelerationSpeed);
         request.carDecelerationSpeed = c.asDouble("carDecelerationSpeed", dft.carDecelerationSpeed);


### PR DESCRIPTION
### Summary

`TraverseMode` and `TransitMode` were used interchangeably in `boardSlackForMode` / `alightSlackForMode`. This is corrected to always use `TransitMode`.

`SlackProvider` uses the ordinals in `TraverseMode` when constructing the per-mode array, but uses `TransitMode` ordinals when accessing it.

### Issue

closes #3688 

### Unit tests

N/A

### Code style

:ballot_box_with_check: 

### Documentation

N/A