### PR TITLE
ci: Changelog - generate from PR title [changelog skip]

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -34,3 +34,8 @@ Have you followed the [suggested code style](https://github.com/opentripplanner/
 - Have you added documentation in code covering design and rationale behind the code?
 - Were all non-trivial public classes and methods documented with Javadoc?
 - Were any new configuration options added? If so were the tables in the [configuration documentation](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Configuration.md) updated?
+
+### Changelog
+The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md) 
+is generated from the pull-request title, make sure the title describe the feature or issue fixed. 
+To exclude the PR from the changelog add `[changelog skip]` in the title.

--- a/.github/workflows/automatic-changelog.yml
+++ b/.github/workflows/automatic-changelog.yml
@@ -1,0 +1,46 @@
+name: Automatic changelog entry
+on:
+  pull_request:
+    branches:
+      - dev-2.x
+    types: [closed]
+
+jobs:
+  changelog-entry:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout
+        if: github.event.pull_request.merged
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.ADMIN_TOKEN }}
+
+      - name: Configure Git User
+        run: |
+          git config --global user.name 'OTP Changelog Bot'
+          git config --global user.email 'changelog-bot@opentripplanner.org'
+
+      - name: Generate changelog entry from PR information
+        if: github.event.pull_request.merged
+        run: |
+          # if the title contains "changelog skip" we don't generate an entry
+          TITLE_LOWER_CASE=`echo $TITLE | awk '{print tolower($0)}'`
+          if  [[ "${TITLE_LOWER_CASE}" =~ "changelog skip" ]]; then
+            echo "Skipping changelog entry generation"
+          else
+            # add a line above the one which contains AUTOMATIC_CHANGELOG_PLACEHOLDER
+            ITEM="${TITLE} [#${NUMBER}](${URL})"
+            TEMP_FILE=docs/Changelog.generated.md
+            FILE=docs/Changelog.md
+            awk "/CHANGELOG_PLACEHOLDER/{print \"- $ITEM\"}1" $FILE > $TEMP_FILE
+            mv $TEMP_FILE $FILE
+            git add $FILE
+            git commit -m "Add changelog entry for #${NUMBER} [ci skip]"
+            git push ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git HEAD:dev-2.x
+          fi
+        env:
+          # Use environment variables to prevent injection attack
+          TITLE: ${{ github.event.pull_request.title }}
+          NUMBER: ${{ github.event.pull_request.number }}
+          URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
### Summary
This PR add a workflow to auto generate Changelog items based on the PR title and number. The workflow uses a secret token to bypass the "require a pull request before merging with approvals" . The token expires on Fri, Nov 26 2021. The token is a "Personal access tokens" generated with my account. We should probably create a "system user" with push rights and no workflow rights and use that system user to generate the token. 

### Issue
Not relevant

### Unit tests
Not relevant - I have tested this in a temporary protected branch

### Code style
Not relevant

### Documentation
The pull request template is updated.