### PR TITLE
fix: Use URI instead of file path string to load test files

### DIFF
--- a/src/test/java/org/opentripplanner/graph_builder/module/FakeGraph.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/FakeGraph.java
@@ -15,6 +15,9 @@ import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.vertextype.TransitStopVertex;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -26,7 +29,7 @@ import java.util.List;
 public class FakeGraph {
 
     /** Build a graph in Columbus, OH with no transit */
-    public static Graph buildGraphNoTransit () {
+    public static Graph buildGraphNoTransit () throws URISyntaxException {
         Graph gg = new Graph();
 
         OpenStreetMapModule loader = new OpenStreetMapModule();
@@ -40,15 +43,15 @@ public class FakeGraph {
         return gg;
     }
 
-    public static File getFileForResource(String resource) {
+    public static File getFileForResource(String resource) throws URISyntaxException {
         URL resourceUrl = FakeGraph.class.getResource(resource);
-        return new File(resourceUrl.getPath());
+        return new File(resourceUrl.toURI());
     }
 
     /**
      * Add many transit lines to a lot of stops. This is only used by InitialStopsTest.
      */
-    public static void addTransitMultipleLines (Graph g) {
+    public static void addTransitMultipleLines (Graph g) throws URISyntaxException {
         GtfsModule gtfs = new GtfsModule(
                 Arrays.asList(new GtfsBundle(getFileForResource("addTransitMultipleLines.gtfs.zip"))),
                 ServiceDateInterval.unbounded()
@@ -59,7 +62,7 @@ public class FakeGraph {
     /**
      * This introduces a 1MB test resource but is only used by TestIntermediatePlaces.
      */
-    public static void addPerpendicularRoutes (Graph graph) {
+    public static void addPerpendicularRoutes (Graph graph) throws URISyntaxException {
         GtfsModule gtfs = new GtfsModule(Arrays.asList(
                 new GtfsBundle(getFileForResource("addPerpendicularRoutes.gtfs.zip"))),
                 ServiceDateInterval.unbounded()

--- a/src/test/java/org/opentripplanner/graph_builder/module/linking/LinkingTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/linking/LinkingTest.java
@@ -18,7 +18,7 @@ import org.opentripplanner.routing.vertextype.SplitterVertex;
 import org.opentripplanner.routing.vertextype.TransitStopVertex;
 import org.opentripplanner.routing.vertextype.StreetVertex;
 
-import java.io.UnsupportedEncodingException;
+import java.net.URISyntaxException;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -77,7 +77,7 @@ public class LinkingTest {
      * We do this by building the graphs and then comparing the stop tree caches.
      */
     @Test
-    public void testStopsLinkedIdentically () throws UnsupportedEncodingException {
+    public void testStopsLinkedIdentically () throws URISyntaxException {
         // build the graph without the added stops
         Graph g1 = buildGraphNoTransit();
         addRegularStopGrid(g1);

--- a/src/test/java/org/opentripplanner/graph_builder/module/osm/TestUnconnectedAreas.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/osm/TestUnconnectedAreas.java
@@ -12,6 +12,7 @@ import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.routing.vertextype.ParkAndRideVertex;
 
 import java.io.File;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -35,7 +36,7 @@ public class TestUnconnectedAreas extends TestCase {
 
         OpenStreetMapModule loader = new OpenStreetMapModule();
         loader.setDefaultWayPropertySetSource(new DefaultWayPropertySetSource());
-        File file = new File(getClass().getResource("P+R.osm.pbf").getFile());
+        File file = new File(getClass().getResource("P+R.osm.pbf").toURI());
         BinaryOpenStreetMapProvider provider = new BinaryOpenStreetMapProvider(file, false);
         loader.setProvider(provider);
         loader.buildGraph(gg, new HashMap<Class<?>, Object>(), issueStore);
@@ -64,13 +65,13 @@ public class TestUnconnectedAreas extends TestCase {
      * Hackettstown, NJ, which demonstrates this behavior. See discussion in ticket 1605.
      */
     @Test
-    public void testCoincidentNodeUnconnectedParkAndRide () {
+    public void testCoincidentNodeUnconnectedParkAndRide () throws URISyntaxException {
     	
     	Graph g = new Graph();
     	
         OpenStreetMapModule loader = new OpenStreetMapModule();
         loader.setDefaultWayPropertySetSource(new DefaultWayPropertySetSource());
-        File file = new File(getClass().getResource("hackett_pr.osm.pbf").getFile());
+        File file = new File(getClass().getResource("hackett_pr.osm.pbf").toURI());
         BinaryOpenStreetMapProvider provider = new BinaryOpenStreetMapProvider(file, false);
         loader.setProvider(provider);
         loader.buildGraph(g, new HashMap<Class<?>, Object>());
@@ -151,7 +152,7 @@ public class TestUnconnectedAreas extends TestCase {
       * Additionally, the node of the ring is duplicated to test this corner case.
       */
      @Test
-     public void testRoadPassingOverDuplicatedNode () {
+     public void testRoadPassingOverDuplicatedNode () throws URISyntaxException {
     	 List<String> connections = testGeometricGraphWithClasspathFile("coincident_pr.osm.pbf", 1, 2);
     	 
     	 // depending on what order everything comes out of the spatial index, we will inject one of
@@ -163,13 +164,13 @@ public class TestUnconnectedAreas extends TestCase {
      /**
       * We've written several OSM files that exhibit different situations but should show the same results. Test with this code.
       */
-     public List<String> testGeometricGraphWithClasspathFile(String fn, int prCount, int prlCount) {
+     public List<String> testGeometricGraphWithClasspathFile(String fn, int prCount, int prlCount) throws URISyntaxException {
     	 
      	Graph g = new Graph();
      	
          OpenStreetMapModule loader = new OpenStreetMapModule();
          loader.setDefaultWayPropertySetSource(new DefaultWayPropertySetSource());
-         File file = new File(getClass().getResource(fn).getFile());
+         File file = new File(getClass().getResource(fn).toURI());
          BinaryOpenStreetMapProvider provider = new BinaryOpenStreetMapProvider(file, false);
          loader.setProvider(provider);
          loader.buildGraph(g, new HashMap<>());


### PR DESCRIPTION
### Summary
As explained in https://github.com/opentripplanner/OpenTripPlanner/issues/2339#issuecomment-954241766, the tests that load files currently fail under certain contains on Windows (e.g., when there is a space in the directory path name). 

This is because the file path is passed as a `String` when creating a new `File`.

In other words, strangely, `URL.getFile()` in Java returns a String and not a `File`:
https://docs.oracle.com/javase/7/docs/api/java/net/URL.html#getFile()

This PR fixes this issue by passing the `URL` as a `URI` (via `toUri()`) when creating a new file, avoiding the `String` representation entirely. 

This requires adding `throws URISyntaxException` to these methods. I've also remove `UnsupportedEncodingException` from some of these message signatures as IntelliJ says it won't be thrown.

If these changes pass on GitHub CI then it successfully works across Linux and Windows.

### Issue

Closes #2339

### Unit tests

Unit tests are fixed and have been tested on a Windows 7 Enterprise machine with Java version "11.0.12" 2021-07-20 LTS via IntelliJ and running `mvn --batch-mode --update-snapshots verify` from command line.