### PR TITLE
Do not parse pass-through information in GBFS mappers

### DIFF
--- a/src/main/java/org/opentripplanner/routing/vehicle_rental/VehicleRentalSystem.java
+++ b/src/main/java/org/opentripplanner/routing/vehicle_rental/VehicleRentalSystem.java
@@ -1,44 +1,43 @@
 package org.opentripplanner.routing.vehicle_rental;
 
-import java.net.URI;
-import java.net.URL;
-import java.time.LocalDate;
-import java.util.Locale;
 import java.util.TimeZone;
 
+/**
+ * Based on https://github.com/NABSA/gbfs/blob/master/gbfs.md#system_informationjson
+ */
 public class VehicleRentalSystem {
     public final String systemId;
-    public final Locale language;
+    public final String language;
     public final String name;
     public final String shortName;
     public final String operator;
-    public final URL url;
-    public final URL purchaseUrl;
-    public final LocalDate startDate;
+    public final String url;
+    public final String purchaseUrl;
+    public final String startDate;
     public final String phoneNumber;
     public final String email;
     public final String feedContactEmail;
     public final TimeZone timezone;
     public final String licenseUrl;
-    public final AppInformation androidApp;
-    public final AppInformation iosApp;
+    public final VehicleRentalSystemAppInformation androidApp;
+    public final VehicleRentalSystemAppInformation iosApp;
 
     public VehicleRentalSystem(
             String systemId,
-            Locale language,
+            String language,
             String name,
             String shortName,
             String operator,
-            URL url,
-            URL purchaseUrl,
-            LocalDate startDate,
+            String url,
+            String purchaseUrl,
+            String startDate,
             String phoneNumber,
             String email,
             String feedContactEmail,
             TimeZone timezone,
             String licenseUrl,
-            AppInformation androidApp,
-            AppInformation iosApp
+            VehicleRentalSystemAppInformation androidApp,
+            VehicleRentalSystemAppInformation iosApp
     ) {
         this.systemId = systemId;
         this.language = language;
@@ -57,13 +56,4 @@ public class VehicleRentalSystem {
         this.iosApp = iosApp;
     }
 
-    public static class AppInformation {
-        public final URI storeUri;
-        public final URI discoveryUri;
-
-        public AppInformation(URI storeUri, URI discoveryUri) {
-            this.storeUri = storeUri;
-            this.discoveryUri = discoveryUri;
-        }
-    }
 }

--- a/src/main/java/org/opentripplanner/routing/vehicle_rental/VehicleRentalSystemAppInformation.java
+++ b/src/main/java/org/opentripplanner/routing/vehicle_rental/VehicleRentalSystemAppInformation.java
@@ -1,0 +1,15 @@
+package org.opentripplanner.routing.vehicle_rental;
+
+/**
+ * Based on the field rental_apps in {@ https://github.com/NABSA/gbfs/blob/master/gbfs.md#system_informationjson
+ */
+public class VehicleRentalSystemAppInformation {
+
+    public final String storeUri;
+    public final String discoveryUri;
+
+    public VehicleRentalSystemAppInformation(String storeUri, String discoveryUri) {
+        this.storeUri = storeUri;
+        this.discoveryUri = discoveryUri;
+    }
+}

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsSystemInformationMapper.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsSystemInformationMapper.java
@@ -2,76 +2,39 @@ package org.opentripplanner.updater.vehicle_rental.datasources;
 
 import org.entur.gbfs.v2_2.system_information.GBFSData;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalSystem;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.opentripplanner.routing.vehicle_rental.VehicleRentalSystemAppInformation;
 
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.time.LocalDate;
-import java.util.Locale;
 import java.util.TimeZone;
 
 public class GbfsSystemInformationMapper {
-    private static final Logger LOG = LoggerFactory.getLogger(GbfsSystemInformationMapper.class);
-
     public VehicleRentalSystem mapSystemInformation(GBFSData systemInformation) {
-        VehicleRentalSystem.AppInformation android = null;
-        VehicleRentalSystem.AppInformation ios = null;
+        VehicleRentalSystemAppInformation android = null;
+        VehicleRentalSystemAppInformation ios = null;
 
         if (systemInformation.getRentalApps() != null) {
             if (systemInformation.getRentalApps().getAndroid() != null) {
-                try {
-                    android = new VehicleRentalSystem.AppInformation(
-                            new URI(systemInformation.getRentalApps().getAndroid().getStoreUri()),
-                            new URI(systemInformation.getRentalApps().getAndroid().getDiscoveryUri())
-                    );
-                } catch (URISyntaxException e) {
-                    LOG.warn("Unable to parse rental URIs");
-                }
+                android = new VehicleRentalSystemAppInformation(
+                    systemInformation.getRentalApps().getAndroid().getStoreUri(),
+                    systemInformation.getRentalApps().getAndroid().getDiscoveryUri()
+                );
             }
             if (systemInformation.getRentalApps().getIos() != null) {
-                try {
-                    ios = new VehicleRentalSystem.AppInformation(
-                            new URI(systemInformation.getRentalApps().getIos().getStoreUri()),
-                            new URI(systemInformation.getRentalApps().getIos().getDiscoveryUri())
-                    );
-                } catch (URISyntaxException e) {
-                    LOG.warn("Unable to parse rental URIs");
-                }
-            }
-        }
-
-        URL url = null;
-        if (systemInformation.getUrl() != null) {
-            try {
-                url = new URL(systemInformation.getUrl());
-            } catch (MalformedURLException e) {
-                LOG.warn("Unable to parse system URL");
-            }
-        }
-
-        URL purchaseUrl = null;
-        if (systemInformation.getPurchaseUrl() != null) {
-            try {
-                purchaseUrl = new URL(systemInformation.getPurchaseUrl());
-            } catch (MalformedURLException e) {
-                LOG.warn("Unable to parse system URL");
+                ios = new VehicleRentalSystemAppInformation(
+                    systemInformation.getRentalApps().getIos().getStoreUri(),
+                    systemInformation.getRentalApps().getIos().getDiscoveryUri()
+                );
             }
         }
 
         return new VehicleRentalSystem(
                 systemInformation.getSystemId(),
-                Locale.forLanguageTag(systemInformation.getLanguage()),
+                systemInformation.getLanguage(),
                 systemInformation.getName(),
                 systemInformation.getShortName(),
                 systemInformation.getOperator(),
-                url,
-                purchaseUrl,
-                systemInformation.getStartDate() != null
-                        ? LocalDate.parse(systemInformation.getStartDate())
-                        : null,
+                systemInformation.getUrl(),
+                systemInformation.getPurchaseUrl(),
+                systemInformation.getStartDate(),
                 systemInformation.getPhoneNumber(),
                 systemInformation.getEmail(),
                 systemInformation.getFeedContactEmail(),


### PR DESCRIPTION
### Summary

Remove parsing of data in GBFS mappers, which can be presented as strings to the user.

### Issue
`closes #3708`

### Unit tests
None updated

### Documentation
None needed
