### PR TITLE
Add pickup and dropoff booking info to REST API

### DIFF
--- a/docs/sandbox/ActuatorAPI.md
+++ b/docs/sandbox/ActuatorAPI.md
@@ -5,13 +5,13 @@
 
 ## Changelog
 - Initial implementation of readiness endpoint (November 2019)
-- Promethues metrics added using Micrometer (October 2021)
+- Prometheus metrics added using Micrometer (October 2021)
 
 ## Documentation
 This provides endpoints for checking the health status of the OTP instance. It can be useful when
 running OTP in a container.
 
-The API will be at the endpoint http://localhost:8080/otp/actuators and follows the Spring Boot
+The API will be at the endpoint `http://localhost:8080/otp/actuators` and follows the Spring Boot
 actuator API standard.
 
 ### Endpoints

--- a/src/main/java/org/opentripplanner/api/mapping/BookingInfoMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/BookingInfoMapper.java
@@ -1,0 +1,25 @@
+package org.opentripplanner.api.mapping;
+
+import org.opentripplanner.api.model.ApiBookingInfo;
+import org.opentripplanner.model.BookingInfo;
+
+public class BookingInfoMapper {
+
+    static ApiBookingInfo mapBookingInfo(BookingInfo info, boolean isPickup) {
+        if (info == null) {return null;}
+
+        return new ApiBookingInfo(
+                ContactInfoMapper.mapContactInfo(info.getContactInfo()),
+                BookingMethodMapper.mapBookingMethods(info.bookingMethods()),
+                BookingTimeMapper.mapBookingTime(info.getEarliestBookingTime()),
+                BookingTimeMapper.mapBookingTime(info.getLatestBookingTime()),
+                info.getMinimumBookingNotice(),
+                info.getMaximumBookingNotice(),
+                info.getMessage(),
+                // we only want to show the pick up message for pickups
+                isPickup ? info.getPickupMessage() : null,
+                // and only the drop off message for drop offs
+                !isPickup ? info.getDropOffMessage() : null
+        );
+    }
+}

--- a/src/main/java/org/opentripplanner/api/mapping/BookingMethodMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/BookingMethodMapper.java
@@ -1,0 +1,34 @@
+package org.opentripplanner.api.mapping;
+
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.opentripplanner.model.BookingMethod;
+
+public class BookingMethodMapper {
+
+    static Set<String> mapBookingMethods(EnumSet<BookingMethod> m) {
+        if (m == null) {return null;}
+        return m.stream()
+                .map(BookingMethodMapper::mapBookingMethods)
+                .collect(Collectors.toSet());
+    }
+
+    private static String mapBookingMethods(BookingMethod m) {
+        switch (m) {
+            case CALL_DRIVER:
+                return "CALL_DRIVER";
+            case CALL_OFFICE:
+                return "CALL_OFFICE";
+            case ONLINE:
+                return "ONLINE";
+            case PHONE_AT_STOP:
+                return "PHONE_AT_STOP";
+            case TEXT_MESSAGE:
+                return "TEXT_MESSAGE";
+            default:
+                return null;
+        }
+
+    }
+}

--- a/src/main/java/org/opentripplanner/api/mapping/BookingTimeMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/BookingTimeMapper.java
@@ -1,0 +1,13 @@
+package org.opentripplanner.api.mapping;
+
+import org.opentripplanner.api.model.ApiBookingTime;
+import org.opentripplanner.model.BookingTime;
+
+public class BookingTimeMapper {
+
+    static ApiBookingTime mapBookingTime(BookingTime time) {
+        if (time == null) {return null;}
+        return new ApiBookingTime(time.getTime().toSecondOfDay(), time.getDaysPrior());
+    }
+
+}

--- a/src/main/java/org/opentripplanner/api/mapping/ContactInfoMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/ContactInfoMapper.java
@@ -1,0 +1,20 @@
+package org.opentripplanner.api.mapping;
+
+import org.opentripplanner.api.model.ApiContactInfo;
+import org.opentripplanner.model.ContactInfo;
+
+public class ContactInfoMapper {
+    static ApiContactInfo mapContactInfo(ContactInfo info) {
+        if (info == null) {return null;}
+        return new ApiContactInfo(
+                info.getContactPerson(),
+                info.getPhoneNumber(),
+                info.geteMail(),
+                info.getFaxNumber(),
+                info.getInfoUrl(),
+                info.getBookingUrl(),
+                info.getAdditionalDetails()
+        );
+    }
+
+}

--- a/src/main/java/org/opentripplanner/api/mapping/LegMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/LegMapper.java
@@ -2,10 +2,20 @@ package org.opentripplanner.api.mapping;
 
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.stream.Collectors;
 import org.opentripplanner.api.model.ApiAlert;
+import org.opentripplanner.api.model.ApiBookingInfo;
+import org.opentripplanner.api.model.ApiBookingMethod;
+import org.opentripplanner.api.model.ApiBookingTime;
+import org.opentripplanner.api.model.ApiContactInfo;
 import org.opentripplanner.api.model.ApiLeg;
+import org.opentripplanner.model.BookingInfo;
+import org.opentripplanner.model.BookingMethod;
+import org.opentripplanner.model.BookingTime;
+import org.opentripplanner.model.ContactInfo;
 import org.opentripplanner.model.plan.Leg;
 
 public class LegMapper {
@@ -100,10 +110,88 @@ public class LegMapper {
         );
         api.boardRule = domain.boardRule;
         api.alightRule = domain.alightRule;
+
+        api.pickupBookingInfo = toApi(domain.pickupBookingInfo);
+        api.dropOffBookingInfo = toApi(domain.dropOffBookingInfo);
+
         api.rentedBike = domain.rentedVehicle;
         api.walkingBike = domain.walkingBike;
 
         return api;
+    }
+
+    private ApiBookingInfo toApi(BookingInfo info) {
+        if (info != null) {
+
+            return new ApiBookingInfo(
+                    toApi(info.getContactInfo()),
+                    toApi(info.bookingMethods()),
+                    toApi(info.getEarliestBookingTime()),
+                    toApi(info.getLatestBookingTime()),
+                    info.getMinimumBookingNotice(),
+                    info.getMaximumBookingNotice(),
+                    info.getMessage(),
+                    info.getPickupMessage(),
+                    info.getDropOffMessage()
+            );
+        }
+        else {
+            return null;
+        }
+    }
+
+    private ApiContactInfo toApi(ContactInfo info) {
+        if (info != null) {
+            return new ApiContactInfo(
+                    info.getContactPerson(),
+                    info.getPhoneNumber(),
+                    info.geteMail(),
+                    info.getFaxNumber(),
+                    info.getInfoUrl(),
+                    info.getBookingUrl(),
+                    info.getAdditionalDetails()
+            );
+        }
+        else {
+            return null;
+        }
+    }
+
+    private EnumSet<ApiBookingMethod> toApi(EnumSet<BookingMethod> m) {
+           if(m !=null) {
+
+        return m.stream()
+                .map(this::toApi)
+                .collect(Collectors.toCollection(() -> EnumSet.noneOf(ApiBookingMethod.class)));
+        } else {
+            return null;
+        }
+    }
+
+    private ApiBookingTime toApi(BookingTime time) {
+        if(time != null) {
+            return new ApiBookingTime(time.getTime().toSecondOfDay(), time.getDaysPrior());
+        } else {
+            return null;
+        }
+    }
+
+    private ApiBookingMethod toApi(BookingMethod m) {
+        switch (m) {
+            case CALL_DRIVER:
+                return ApiBookingMethod.CALL_DRIVER;
+            case CALL_OFFICE:
+                return ApiBookingMethod.CALL_OFFICE;
+            case ONLINE:
+                return ApiBookingMethod.ONLINE;
+            case PHONE_AT_STOP:
+                return ApiBookingMethod.PHONE_AT_STOP;
+            case TEXT_MESSAGE:
+                return ApiBookingMethod.TEXT_MESSAGE;
+            default:
+                return null;
+        }
+
     }
 
     private static List<ApiAlert> concatenateAlerts(List<ApiAlert> a, List<ApiAlert> b) {

--- a/src/main/java/org/opentripplanner/api/mapping/LegMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/LegMapper.java
@@ -120,61 +120,63 @@ public class LegMapper {
         return api;
     }
 
-    private ApiBookingInfo toApi(BookingInfo info) {
-        if (info != null) {
+    private static ApiBookingInfo toApi(BookingInfo info) {
+        if (info == null) {return null;}
 
-            return new ApiBookingInfo(
-                    toApi(info.getContactInfo()),
-                    toApi(info.bookingMethods()),
-                    toApi(info.getEarliestBookingTime()),
-                    toApi(info.getLatestBookingTime()),
-                    info.getMinimumBookingNotice(),
-                    info.getMaximumBookingNotice(),
-                    info.getMessage(),
-                    info.getPickupMessage(),
-                    info.getDropOffMessage()
-            );
-        }
-        else {
-            return null;
-        }
+        return new ApiBookingInfo(
+                toApi(info.getContactInfo()),
+                toApi(info.bookingMethods()),
+                toApi(info.getEarliestBookingTime()),
+                toApi(info.getLatestBookingTime()),
+                info.getMinimumBookingNotice(),
+                info.getMaximumBookingNotice(),
+                info.getMessage(),
+                info.getPickupMessage(),
+                info.getDropOffMessage()
+        );
     }
 
-    private ApiContactInfo toApi(ContactInfo info) {
-        if (info != null) {
-            return new ApiContactInfo(
-                    info.getContactPerson(),
-                    info.getPhoneNumber(),
-                    info.geteMail(),
-                    info.getFaxNumber(),
-                    info.getInfoUrl(),
-                    info.getBookingUrl(),
-                    info.getAdditionalDetails()
-            );
-        }
-        else {
-            return null;
-        }
+    private static ApiContactInfo toApi(ContactInfo info) {
+        if (info == null) {return null;}
+        return new ApiContactInfo(
+                info.getContactPerson(),
+                info.getPhoneNumber(),
+                info.geteMail(),
+                info.getFaxNumber(),
+                info.getInfoUrl(),
+                info.getBookingUrl(),
+                info.getAdditionalDetails()
+        );
     }
 
-    private Set<String> toApi(EnumSet<BookingMethod> m) {
-        if (m != null) {
-            return m.stream()
-                    .map(Enum::toString)
-                    .collect(Collectors.toSet());
-        }
-        else {
-            return null;
-        }
+    private static Set<String> toApi(EnumSet<BookingMethod> m) {
+        if (m == null) {return null;}
+        return m.stream()
+                .map(LegMapper::toApi)
+                .collect(Collectors.toSet());
     }
 
-    private ApiBookingTime toApi(BookingTime time) {
-        if (time != null) {
-            return new ApiBookingTime(time.getTime().toSecondOfDay(), time.getDaysPrior());
+    private static String toApi(BookingMethod m) {
+        switch (m) {
+            case CALL_DRIVER:
+                return "CALL_DRIVER";
+            case CALL_OFFICE:
+                return "CALL_OFFICE";
+            case ONLINE:
+                return "ONLINE";
+            case PHONE_AT_STOP:
+                return "PHONE_AT_STOP";
+            case TEXT_MESSAGE:
+                return "TEXT_MESSAGE";
+            default:
+                return null;
         }
-        else {
-            return null;
-        }
+
+    }
+
+    private static ApiBookingTime toApi(BookingTime time) {
+        if (time == null) {return null;}
+        return new ApiBookingTime(time.getTime().toSecondOfDay(), time.getDaysPrior());
     }
 
     private static List<ApiAlert> concatenateAlerts(List<ApiAlert> a, List<ApiAlert> b) {

--- a/src/main/java/org/opentripplanner/api/mapping/LegMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/LegMapper.java
@@ -5,10 +5,10 @@ import java.util.Calendar;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.opentripplanner.api.model.ApiAlert;
 import org.opentripplanner.api.model.ApiBookingInfo;
-import org.opentripplanner.api.model.ApiBookingMethod;
 import org.opentripplanner.api.model.ApiBookingTime;
 import org.opentripplanner.api.model.ApiContactInfo;
 import org.opentripplanner.api.model.ApiLeg;
@@ -157,41 +157,24 @@ public class LegMapper {
         }
     }
 
-    private EnumSet<ApiBookingMethod> toApi(EnumSet<BookingMethod> m) {
-           if(m !=null) {
-
-        return m.stream()
-                .map(this::toApi)
-                .collect(Collectors.toCollection(() -> EnumSet.noneOf(ApiBookingMethod.class)));
-        } else {
+    private Set<String> toApi(EnumSet<BookingMethod> m) {
+        if (m != null) {
+            return m.stream()
+                    .map(Enum::toString)
+                    .collect(Collectors.toSet());
+        }
+        else {
             return null;
         }
     }
 
     private ApiBookingTime toApi(BookingTime time) {
-        if(time != null) {
+        if (time != null) {
             return new ApiBookingTime(time.getTime().toSecondOfDay(), time.getDaysPrior());
-        } else {
+        }
+        else {
             return null;
         }
-    }
-
-    private ApiBookingMethod toApi(BookingMethod m) {
-        switch (m) {
-            case CALL_DRIVER:
-                return ApiBookingMethod.CALL_DRIVER;
-            case CALL_OFFICE:
-                return ApiBookingMethod.CALL_OFFICE;
-            case ONLINE:
-                return ApiBookingMethod.ONLINE;
-            case PHONE_AT_STOP:
-                return ApiBookingMethod.PHONE_AT_STOP;
-            case TEXT_MESSAGE:
-                return ApiBookingMethod.TEXT_MESSAGE;
-            default:
-                return null;
-        }
-
     }
 
     private static List<ApiAlert> concatenateAlerts(List<ApiAlert> a, List<ApiAlert> b) {

--- a/src/main/java/org/opentripplanner/api/mapping/LegMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/LegMapper.java
@@ -111,73 +111,13 @@ public class LegMapper {
         api.boardRule = domain.boardRule;
         api.alightRule = domain.alightRule;
 
-        api.pickupBookingInfo = toApi(domain.pickupBookingInfo, true);
-        api.dropOffBookingInfo = toApi(domain.dropOffBookingInfo, false);
+        api.pickupBookingInfo = BookingInfoMapper.mapBookingInfo(domain.pickupBookingInfo, true);
+        api.dropOffBookingInfo = BookingInfoMapper.mapBookingInfo(domain.dropOffBookingInfo, false);
 
         api.rentedBike = domain.rentedVehicle;
         api.walkingBike = domain.walkingBike;
 
         return api;
-    }
-
-    private static ApiBookingInfo toApi(BookingInfo info, boolean isPickup) {
-        if (info == null) {return null;}
-
-        return new ApiBookingInfo(
-                toApi(info.getContactInfo()),
-                toApi(info.bookingMethods()),
-                toApi(info.getEarliestBookingTime()),
-                toApi(info.getLatestBookingTime()),
-                info.getMinimumBookingNotice(),
-                info.getMaximumBookingNotice(),
-                info.getMessage(),
-                // we only want to show the pick up message for pickups versa
-                isPickup ? info.getPickupMessage() : null,
-                !isPickup ? info.getDropOffMessage() : null
-        );
-    }
-
-    private static ApiContactInfo toApi(ContactInfo info) {
-        if (info == null) {return null;}
-        return new ApiContactInfo(
-                info.getContactPerson(),
-                info.getPhoneNumber(),
-                info.geteMail(),
-                info.getFaxNumber(),
-                info.getInfoUrl(),
-                info.getBookingUrl(),
-                info.getAdditionalDetails()
-        );
-    }
-
-    private static Set<String> toApi(EnumSet<BookingMethod> m) {
-        if (m == null) {return null;}
-        return m.stream()
-                .map(LegMapper::toApi)
-                .collect(Collectors.toSet());
-    }
-
-    private static String toApi(BookingMethod m) {
-        switch (m) {
-            case CALL_DRIVER:
-                return "CALL_DRIVER";
-            case CALL_OFFICE:
-                return "CALL_OFFICE";
-            case ONLINE:
-                return "ONLINE";
-            case PHONE_AT_STOP:
-                return "PHONE_AT_STOP";
-            case TEXT_MESSAGE:
-                return "TEXT_MESSAGE";
-            default:
-                return null;
-        }
-
-    }
-
-    private static ApiBookingTime toApi(BookingTime time) {
-        if (time == null) {return null;}
-        return new ApiBookingTime(time.getTime().toSecondOfDay(), time.getDaysPrior());
     }
 
     private static List<ApiAlert> concatenateAlerts(List<ApiAlert> a, List<ApiAlert> b) {

--- a/src/main/java/org/opentripplanner/api/mapping/LegMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/LegMapper.java
@@ -111,8 +111,8 @@ public class LegMapper {
         api.boardRule = domain.boardRule;
         api.alightRule = domain.alightRule;
 
-        api.pickupBookingInfo = toApi(domain.pickupBookingInfo);
-        api.dropOffBookingInfo = toApi(domain.dropOffBookingInfo);
+        api.pickupBookingInfo = toApi(domain.pickupBookingInfo, true);
+        api.dropOffBookingInfo = toApi(domain.dropOffBookingInfo, false);
 
         api.rentedBike = domain.rentedVehicle;
         api.walkingBike = domain.walkingBike;
@@ -120,7 +120,7 @@ public class LegMapper {
         return api;
     }
 
-    private static ApiBookingInfo toApi(BookingInfo info) {
+    private static ApiBookingInfo toApi(BookingInfo info, boolean isPickup) {
         if (info == null) {return null;}
 
         return new ApiBookingInfo(
@@ -131,8 +131,9 @@ public class LegMapper {
                 info.getMinimumBookingNotice(),
                 info.getMaximumBookingNotice(),
                 info.getMessage(),
-                info.getPickupMessage(),
-                info.getDropOffMessage()
+                // we only want to show the pick up message for pickups versa
+                isPickup ? info.getPickupMessage() : null,
+                !isPickup ? info.getDropOffMessage() : null
         );
     }
 

--- a/src/main/java/org/opentripplanner/api/model/ApiBookingInfo.java
+++ b/src/main/java/org/opentripplanner/api/model/ApiBookingInfo.java
@@ -3,93 +3,107 @@ package org.opentripplanner.api.model;
 import java.io.Serializable;
 import java.time.Duration;
 import java.util.Set;
+import org.opentripplanner.model.base.ToStringBuilder;
 
 /**
  * Info about how a trip might be booked at a particular stop. All of this is pass-through
  * information, except information about booking time and booking notice.
- *
  */
 public class ApiBookingInfo implements Serializable {
 
-  /**
-   * How to contact the agency to book a trip or requests information.
-   */
-  public final ApiContactInfo contactInfo;
+    /**
+     * How to contact the agency to book a trip or requests information.
+     */
+    public final ApiContactInfo contactInfo;
 
-  /**
-   * What booking methods are available at this stop time.
-   */
-  public final Set<String> bookingMethods;
+    /**
+     * What booking methods are available at this stop time.
+     */
+    public final Set<String> bookingMethods;
 
-  /**
-   * Cannot be set at the same time as minimumBookingNotice or maximumBookingNotice
-   */
-  public final ApiBookingTime earliestBookingTime;
+    /**
+     * Cannot be set at the same time as minimumBookingNotice or maximumBookingNotice
+     */
+    public final ApiBookingTime earliestBookingTime;
 
-  /**
-   * Cannot be set at the same time as minimumBookingNotice or maximumBookingNotice
-   */
-  public final ApiBookingTime latestBookingTime;
+    /**
+     * Cannot be set at the same time as minimumBookingNotice or maximumBookingNotice
+     */
+    public final ApiBookingTime latestBookingTime;
 
-  /**
-   * Cannot be set at the same time as earliestBookingTime or latestBookingTime
-   */
-  public final Integer minimumBookingNoticeSeconds;
+    /**
+     * Cannot be set at the same time as earliestBookingTime or latestBookingTime
+     */
+    public final Integer minimumBookingNoticeSeconds;
 
-  /**
-   * Cannot be set at the same time as earliestBookingTime or latestBookingTime
-   */
-  public final Integer maximumBookingNoticeSeconds;
+    /**
+     * Cannot be set at the same time as earliestBookingTime or latestBookingTime
+     */
+    public final Integer maximumBookingNoticeSeconds;
 
-  /**
-   * Message to riders utilizing service at a stop_time when booking on-demand pickup and drop off.
-   * Meant to provide minimal information to be transmitted within a user interface about the action
-   * a rider must take in order to utilize the service.
-   */
-  public final String message;
+    /**
+     * Message to riders utilizing service at a stop_time when booking on-demand pickup and drop
+     * off. Meant to provide minimal information to be transmitted within a user interface about the
+     * action a rider must take in order to utilize the service.
+     */
+    public final String message;
 
-  /**
-   * Functions in the same way as message but used when riders have on-demand pickup only.
-   */
-  public final String pickupMessage;
+    /**
+     * Functions in the same way as message but used when riders have on-demand pickup only.
+     */
+    public final String pickupMessage;
 
-  /**
-   * Functions in the same way as message but used when riders have on-demand drop off only.
-   */
-  public final String dropOffMessage;
+    /**
+     * Functions in the same way as message but used when riders have on-demand drop off only.
+     */
+    public final String dropOffMessage;
 
-  public ApiBookingInfo(
-      ApiContactInfo contactInfo,
-      Set<String> bookingMethods,
-      ApiBookingTime earliestBookingTime,
-      ApiBookingTime latestBookingTime,
-      Duration minimumBookingNotice,
-      Duration maximumBookingNotice,
-      String message,
-      String pickupMessage,
-      String dropOffMessage
-  ) {
-    this.contactInfo = contactInfo;
-    this.bookingMethods = bookingMethods;
-    this.message = message;
-    this.pickupMessage = pickupMessage;
-    this.dropOffMessage = dropOffMessage;
+    public ApiBookingInfo(
+            ApiContactInfo contactInfo,
+            Set<String> bookingMethods,
+            ApiBookingTime earliestBookingTime,
+            ApiBookingTime latestBookingTime,
+            Duration minimumBookingNotice,
+            Duration maximumBookingNotice,
+            String message,
+            String pickupMessage,
+            String dropOffMessage
+    ) {
+        this.contactInfo = contactInfo;
+        this.bookingMethods = bookingMethods;
+        this.message = message;
+        this.pickupMessage = pickupMessage;
+        this.dropOffMessage = dropOffMessage;
 
-    this.earliestBookingTime = earliestBookingTime;
-    this.latestBookingTime = latestBookingTime;
-    if (minimumBookingNotice != null) {
-      this.minimumBookingNoticeSeconds = (int) minimumBookingNotice.toSeconds();
+        this.earliestBookingTime = earliestBookingTime;
+        this.latestBookingTime = latestBookingTime;
+        if (minimumBookingNotice != null) {
+            this.minimumBookingNoticeSeconds = (int) minimumBookingNotice.toSeconds();
+        }
+        else {
+            this.minimumBookingNoticeSeconds = null;
+        }
+
+        if (maximumBookingNotice != null) {
+            this.maximumBookingNoticeSeconds = (int) maximumBookingNotice.toSeconds();
+        }
+        else {
+            this.maximumBookingNoticeSeconds = null;
+        }
     }
-    else {
-      this.minimumBookingNoticeSeconds = null;
-    }
 
-    if (maximumBookingNotice != null) {
-      this.maximumBookingNoticeSeconds = (int) maximumBookingNotice.toSeconds();
+    @Override
+    public String toString() {
+        return ToStringBuilder.of(getClass())
+                .addObj("contactInfo", contactInfo)
+                .addCol("bookingMethods", bookingMethods)
+                .addObj("earliestBookingTime", earliestBookingTime)
+                .addObj("latestBookingTime", latestBookingTime)
+                .addNum("minimumBookingNoticeSeconds", minimumBookingNoticeSeconds)
+                .addNum("maximumBookingNoticeSeconds", maximumBookingNoticeSeconds)
+                .addStr("message", message)
+                .addStr("pickupMessage", pickupMessage)
+                .addStr("dropOffMessage", dropOffMessage)
+                .toString();
     }
-    else {
-      this.maximumBookingNoticeSeconds = null;
-    }
-  }
-
 }

--- a/src/main/java/org/opentripplanner/api/model/ApiBookingInfo.java
+++ b/src/main/java/org/opentripplanner/api/model/ApiBookingInfo.java
@@ -1,0 +1,81 @@
+package org.opentripplanner.api.model;
+
+import java.io.Serializable;
+import java.time.Duration;
+import java.util.EnumSet;
+
+/**
+ * Info about how a trip might be booked at a particular stop. All of this is pass-through
+ * information, except information about booking time and booking notice.
+ *
+ */
+public class ApiBookingInfo implements Serializable {
+
+  public final ApiContactInfo contactInfo;
+
+  public final EnumSet<ApiBookingMethod> bookingMethods;
+
+  /**
+   * Cannot be set at the same time as minimumBookingNotice or maximumBookingNotice
+   */
+  public final ApiBookingTime earliestBookingTime;
+
+  /**
+   * Cannot be set at the same time as minimumBookingNotice or maximumBookingNotice
+   */
+  public final ApiBookingTime latestBookingTime;
+
+  /**
+   * Cannot be set at the same time as earliestBookingTime or latestBookingTime
+   */
+  public final Duration minimumBookingNotice;
+
+  /**
+   * Cannot be set at the same time as earliestBookingTime or latestBookingTime
+   */
+  public final Duration maximumBookingNotice;
+
+  public final String message;
+
+  public final String pickupMessage;
+
+  public final String dropOffMessage;
+
+  public ApiBookingInfo(
+      ApiContactInfo contactInfo,
+      EnumSet<ApiBookingMethod> bookingMethods,
+      ApiBookingTime earliestBookingTime,
+      ApiBookingTime latestBookingTime,
+      Duration minimumBookingNotice,
+      Duration maximumBookingNotice,
+      String message,
+      String pickupMessage,
+      String dropOffMessage
+  ) {
+    this.contactInfo = contactInfo;
+    this.bookingMethods = bookingMethods;
+    this.message = message;
+    this.pickupMessage = pickupMessage;
+    this.dropOffMessage = dropOffMessage;
+
+    // Ensure that earliestBookingTime/latestBookingTime is not set at the same time as
+    // minimumBookingNotice/maximumBookingNotice
+    if (earliestBookingTime != null || latestBookingTime != null) {
+      this.earliestBookingTime = earliestBookingTime;
+      this.latestBookingTime = latestBookingTime;
+      this.minimumBookingNotice = null;
+      this.maximumBookingNotice = null;
+    } else if (minimumBookingNotice != null || maximumBookingNotice != null) {
+      this.earliestBookingTime = null;
+      this.latestBookingTime = null;
+      this.minimumBookingNotice = minimumBookingNotice;
+      this.maximumBookingNotice = maximumBookingNotice;
+    } else {
+      this.earliestBookingTime = null;
+      this.latestBookingTime = null;
+      this.minimumBookingNotice = null;
+      this.maximumBookingNotice = null;
+    }
+  }
+
+}

--- a/src/main/java/org/opentripplanner/api/model/ApiBookingInfo.java
+++ b/src/main/java/org/opentripplanner/api/model/ApiBookingInfo.java
@@ -11,8 +11,14 @@ import java.util.Set;
  */
 public class ApiBookingInfo implements Serializable {
 
+  /**
+   * How to contact the agency to book a trip or requests information.
+   */
   public final ApiContactInfo contactInfo;
 
+  /**
+   * What booking methods are available at this stop time.
+   */
   public final Set<String> bookingMethods;
 
   /**
@@ -35,10 +41,21 @@ public class ApiBookingInfo implements Serializable {
    */
   public final Integer maximumBookingNoticeSeconds;
 
+  /**
+   * Message to riders utilizing service at a stop_time when booking on-demand pickup and drop off.
+   * Meant to provide minimal information to be transmitted within a user interface about the action
+   * a rider must take in order to utilize the service.
+   */
   public final String message;
 
+  /**
+   * Functions in the same way as message but used when riders have on-demand pickup only.
+   */
   public final String pickupMessage;
 
+  /**
+   * Functions in the same way as message but used when riders have on-demand drop off only.
+   */
   public final String dropOffMessage;
 
   public ApiBookingInfo(

--- a/src/main/java/org/opentripplanner/api/model/ApiBookingInfo.java
+++ b/src/main/java/org/opentripplanner/api/model/ApiBookingInfo.java
@@ -2,7 +2,7 @@ package org.opentripplanner.api.model;
 
 import java.io.Serializable;
 import java.time.Duration;
-import java.util.EnumSet;
+import java.util.Set;
 
 /**
  * Info about how a trip might be booked at a particular stop. All of this is pass-through
@@ -13,7 +13,7 @@ public class ApiBookingInfo implements Serializable {
 
   public final ApiContactInfo contactInfo;
 
-  public final EnumSet<ApiBookingMethod> bookingMethods;
+  public final Set<String> bookingMethods;
 
   /**
    * Cannot be set at the same time as minimumBookingNotice or maximumBookingNotice
@@ -28,12 +28,12 @@ public class ApiBookingInfo implements Serializable {
   /**
    * Cannot be set at the same time as earliestBookingTime or latestBookingTime
    */
-  public final Duration minimumBookingNotice;
+  public final Integer minimumBookingNoticeSeconds;
 
   /**
    * Cannot be set at the same time as earliestBookingTime or latestBookingTime
    */
-  public final Duration maximumBookingNotice;
+  public final Integer maximumBookingNoticeSeconds;
 
   public final String message;
 
@@ -43,7 +43,7 @@ public class ApiBookingInfo implements Serializable {
 
   public ApiBookingInfo(
       ApiContactInfo contactInfo,
-      EnumSet<ApiBookingMethod> bookingMethods,
+      Set<String> bookingMethods,
       ApiBookingTime earliestBookingTime,
       ApiBookingTime latestBookingTime,
       Duration minimumBookingNotice,
@@ -58,23 +58,20 @@ public class ApiBookingInfo implements Serializable {
     this.pickupMessage = pickupMessage;
     this.dropOffMessage = dropOffMessage;
 
-    // Ensure that earliestBookingTime/latestBookingTime is not set at the same time as
-    // minimumBookingNotice/maximumBookingNotice
-    if (earliestBookingTime != null || latestBookingTime != null) {
-      this.earliestBookingTime = earliestBookingTime;
-      this.latestBookingTime = latestBookingTime;
-      this.minimumBookingNotice = null;
-      this.maximumBookingNotice = null;
-    } else if (minimumBookingNotice != null || maximumBookingNotice != null) {
-      this.earliestBookingTime = null;
-      this.latestBookingTime = null;
-      this.minimumBookingNotice = minimumBookingNotice;
-      this.maximumBookingNotice = maximumBookingNotice;
-    } else {
-      this.earliestBookingTime = null;
-      this.latestBookingTime = null;
-      this.minimumBookingNotice = null;
-      this.maximumBookingNotice = null;
+    this.earliestBookingTime = earliestBookingTime;
+    this.latestBookingTime = latestBookingTime;
+    if (minimumBookingNotice != null) {
+      this.minimumBookingNoticeSeconds = (int) minimumBookingNotice.toSeconds();
+    }
+    else {
+      this.minimumBookingNoticeSeconds = null;
+    }
+
+    if (maximumBookingNotice != null) {
+      this.maximumBookingNoticeSeconds = (int) maximumBookingNotice.toSeconds();
+    }
+    else {
+      this.maximumBookingNoticeSeconds = null;
     }
   }
 

--- a/src/main/java/org/opentripplanner/api/model/ApiBookingMethod.java
+++ b/src/main/java/org/opentripplanner/api/model/ApiBookingMethod.java
@@ -1,0 +1,9 @@
+package org.opentripplanner.api.model;
+
+public enum ApiBookingMethod {
+  CALL_DRIVER,
+  CALL_OFFICE,
+  ONLINE,
+  PHONE_AT_STOP,
+  TEXT_MESSAGE
+}

--- a/src/main/java/org/opentripplanner/api/model/ApiBookingMethod.java
+++ b/src/main/java/org/opentripplanner/api/model/ApiBookingMethod.java
@@ -1,9 +1,0 @@
-package org.opentripplanner.api.model;
-
-public enum ApiBookingMethod {
-  CALL_DRIVER,
-  CALL_OFFICE,
-  ONLINE,
-  PHONE_AT_STOP,
-  TEXT_MESSAGE
-}

--- a/src/main/java/org/opentripplanner/api/model/ApiBookingTime.java
+++ b/src/main/java/org/opentripplanner/api/model/ApiBookingTime.java
@@ -8,8 +8,17 @@ import java.time.LocalTime;
  * of the trip.
  */
 public class ApiBookingTime implements Serializable {
+
+  /**
+   * The latest time at which the trip must be booked.
+   *
+   * Unit: seconds since midnight
+   */
   public final int time;
 
+  /**
+   * How many days in advance this trip must be booked.
+   */
   public final int daysPrior;
 
   public ApiBookingTime(int time, int daysPrior) {

--- a/src/main/java/org/opentripplanner/api/model/ApiBookingTime.java
+++ b/src/main/java/org/opentripplanner/api/model/ApiBookingTime.java
@@ -1,0 +1,20 @@
+package org.opentripplanner.api.model;
+
+import java.io.Serializable;
+import java.time.LocalTime;
+
+/**
+ * Represents either an earliest or latest time a trip can be booked relative to the departure day
+ * of the trip.
+ */
+public class ApiBookingTime implements Serializable {
+  public final int time;
+
+  public final int daysPrior;
+
+  public ApiBookingTime(int time, int daysPrior) {
+    this.time = time;
+    this.daysPrior = daysPrior;
+  }
+
+}

--- a/src/main/java/org/opentripplanner/api/model/ApiBookingTime.java
+++ b/src/main/java/org/opentripplanner/api/model/ApiBookingTime.java
@@ -1,7 +1,7 @@
 package org.opentripplanner.api.model;
 
 import java.io.Serializable;
-import java.time.LocalTime;
+import org.opentripplanner.model.base.ToStringBuilder;
 
 /**
  * Represents either an earliest or latest time a trip can be booked relative to the departure day
@@ -9,21 +9,28 @@ import java.time.LocalTime;
  */
 public class ApiBookingTime implements Serializable {
 
-  /**
-   * The latest time at which the trip must be booked.
-   *
-   * Unit: seconds since midnight
-   */
-  public final int time;
+    /**
+     * The latest time at which the trip must be booked.
+     * <p>
+     * Unit: seconds since midnight
+     */
+    public final int time;
 
-  /**
-   * How many days in advance this trip must be booked.
-   */
-  public final int daysPrior;
+    /**
+     * How many days in advance this trip must be booked.
+     */
+    public final int daysPrior;
 
-  public ApiBookingTime(int time, int daysPrior) {
-    this.time = time;
-    this.daysPrior = daysPrior;
-  }
+    public ApiBookingTime(int time, int daysPrior) {
+        this.time = time;
+        this.daysPrior = daysPrior;
+    }
 
+    @Override
+    public String toString() {
+        return ToStringBuilder.of(getClass())
+                .addNum("time", time)
+                .addNum("daysPrior", time)
+                .toString();
+    }
 }

--- a/src/main/java/org/opentripplanner/api/model/ApiContactInfo.java
+++ b/src/main/java/org/opentripplanner/api/model/ApiContactInfo.java
@@ -2,20 +2,44 @@ package org.opentripplanner.api.model;
 
 import java.io.Serializable;
 
+/**
+ * How to contact the agency to book a trip or requests information.
+ */
 public class ApiContactInfo implements Serializable {
 
+  /**
+   * The person's name responsible to administer the trip.
+   */
   public final String contactPerson;
 
+  /**
+   * Phone number to book the trip or request information.
+   */
   public final String phoneNumber;
 
-  public final String eMail;
+/**
+ * Email address to book the trip or request information.
+ */
+ public final String eMail;
 
+/**
+ * Fax number to book the trip or request information. Very important.
+ */
   public final String faxNumber;
 
+  /**
+   * URL to a website about general information about the service.
+   */
   public final String infoUrl;
 
+  /**
+   * URL to a website to book the service.
+   */
   public final String bookingUrl;
 
+  /**
+   * Any other comment that does not fit anywhere else.
+   */
   public final String additionalDetails;
 
   public ApiContactInfo(

--- a/src/main/java/org/opentripplanner/api/model/ApiContactInfo.java
+++ b/src/main/java/org/opentripplanner/api/model/ApiContactInfo.java
@@ -1,62 +1,77 @@
 package org.opentripplanner.api.model;
 
 import java.io.Serializable;
+import org.opentripplanner.model.base.ToStringBuilder;
 
 /**
  * How to contact the agency to book a trip or requests information.
  */
 public class ApiContactInfo implements Serializable {
 
-  /**
-   * The person's name responsible to administer the trip.
-   */
-  public final String contactPerson;
+    /**
+     * The person's name responsible to administer the trip.
+     */
+    public final String contactPerson;
 
-  /**
-   * Phone number to book the trip or request information.
-   */
-  public final String phoneNumber;
+    /**
+     * Phone number to book the trip or request information.
+     */
+    public final String phoneNumber;
 
-/**
- * Email address to book the trip or request information.
- */
- public final String eMail;
+    /**
+     * Email address to book the trip or request information.
+     */
+    public final String eMail;
 
-/**
- * Fax number to book the trip or request information. Very important.
- */
-  public final String faxNumber;
+    /**
+     * Fax number to book the trip or request information. Very important.
+     */
+    public final String faxNumber;
 
-  /**
-   * URL to a website about general information about the service.
-   */
-  public final String infoUrl;
+    /**
+     * URL to a website about general information about the service.
+     */
+    public final String infoUrl;
 
-  /**
-   * URL to a website to book the service.
-   */
-  public final String bookingUrl;
+    /**
+     * URL to a website to book the service.
+     */
+    public final String bookingUrl;
 
-  /**
-   * Any other comment that does not fit anywhere else.
-   */
-  public final String additionalDetails;
+    /**
+     * Any other comment that does not fit anywhere else.
+     */
+    public final String additionalDetails;
 
-  public ApiContactInfo(
-      String contactPerson,
-      String phoneNumber,
-      String eMail,
-      String faxNumber,
-      String infoUrl,
-      String bookingUrl,
-      String additionalDetails
-  ) {
-    this.contactPerson = contactPerson;
-    this.phoneNumber = phoneNumber;
-    this.eMail = eMail;
-    this.faxNumber = faxNumber;
-    this.infoUrl = infoUrl;
-    this.bookingUrl = bookingUrl;
-    this.additionalDetails = additionalDetails;
-  }
+    public ApiContactInfo(
+            String contactPerson,
+            String phoneNumber,
+            String eMail,
+            String faxNumber,
+            String infoUrl,
+            String bookingUrl,
+            String additionalDetails
+    ) {
+        this.contactPerson = contactPerson;
+        this.phoneNumber = phoneNumber;
+        this.eMail = eMail;
+        this.faxNumber = faxNumber;
+        this.infoUrl = infoUrl;
+        this.bookingUrl = bookingUrl;
+        this.additionalDetails = additionalDetails;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.of(getClass())
+                .addStr("contactPerson", contactPerson)
+                .addStr("phoneNumber", phoneNumber)
+                .addStr("eMail", eMail)
+                .addStr("faxNumber", faxNumber)
+                .addStr("infoUrl", infoUrl)
+                .addStr("bookingUrl", bookingUrl)
+                .addStr("additionalDetails", additionalDetails)
+
+                .toString();
+    }
 }

--- a/src/main/java/org/opentripplanner/api/model/ApiContactInfo.java
+++ b/src/main/java/org/opentripplanner/api/model/ApiContactInfo.java
@@ -1,0 +1,38 @@
+package org.opentripplanner.api.model;
+
+import java.io.Serializable;
+
+public class ApiContactInfo implements Serializable {
+
+  public final String contactPerson;
+
+  public final String phoneNumber;
+
+  public final String eMail;
+
+  public final String faxNumber;
+
+  public final String infoUrl;
+
+  public final String bookingUrl;
+
+  public final String additionalDetails;
+
+  public ApiContactInfo(
+      String contactPerson,
+      String phoneNumber,
+      String eMail,
+      String faxNumber,
+      String infoUrl,
+      String bookingUrl,
+      String additionalDetails
+  ) {
+    this.contactPerson = contactPerson;
+    this.phoneNumber = phoneNumber;
+    this.eMail = eMail;
+    this.faxNumber = faxNumber;
+    this.infoUrl = infoUrl;
+    this.bookingUrl = bookingUrl;
+    this.additionalDetails = additionalDetails;
+  }
+}

--- a/src/main/java/org/opentripplanner/api/model/ApiLeg.java
+++ b/src/main/java/org/opentripplanner/api/model/ApiLeg.java
@@ -203,6 +203,10 @@ public class ApiLeg {
 
     public String alightRule;
 
+    public ApiBookingInfo pickupBookingInfo;
+
+    public ApiBookingInfo dropOffBookingInfo;
+
     public Boolean rentedBike;
 
      /**


### PR DESCRIPTION
### Summary
Expose the fields pickup and dropoff booking info, which are returned by flex legs, to the REST API.

As per convention, I copied all the classes from the model package.

Instances of `LocalTime` are converted to seconds since midnight as the REST API expresses all times like this. Am I seeing this correct?

### Issue
No issue.

### Unit tests

Are there tests for this layer? If yes, I'd love to add one.

### Code style
Yes.

### Documentation
Lots of JavaDoc added.