### PR TITLE
Fix several small bugs with transfers and board and alight slack [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/netex/mapping/TransferMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/TransferMapper.java
@@ -79,11 +79,11 @@ public class TransferMapper {
             ScheduledStopPointRefStructure pointRef
     ) {
         var sjId = sjRef.getRef();
-        var fromTrip = findTrip(label + "Journey", interchangeId, sjId);
-        int fromStopPos = findStopPosition(interchangeId, label + "Point", sjId, pointRef);
-        return (fromTrip==null || fromStopPos<0)
+        var trip = findTrip(label + "Journey", interchangeId, sjId);
+        int stopPos = findStopPosition(interchangeId, label + "Point", sjId, pointRef);
+        return (trip==null || stopPos<0)
                 ? null
-                : new TripTransferPoint(fromTrip, fromStopPos);
+                : new TripTransferPoint(trip, stopPos);
     }
 
     @Nullable

--- a/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/services/TransferGenerator.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/services/TransferGenerator.java
@@ -181,8 +181,9 @@ public class TransferGenerator<T extends RaptorTripSchedule> {
       return fromTime;
     }
     return fromTime
-            + transferDurationInSeconds
             + slackProvider.alightSlack(fromTrip.pattern())
+            + transferDurationInSeconds
+            + slackProvider.transferSlack()
             + slackProvider.boardSlack(toTrip.pattern());
   }
 

--- a/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
@@ -509,7 +509,7 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
      * <p>
      * Unit is seconds. Default value is not-set(empty map).
      */
-    public EnumMap<TransitMode, Integer> boardSlackForMode = new EnumMap<>(TransitMode.class);
+    public Map<TransitMode, Integer> boardSlackForMode = new EnumMap<>(TransitMode.class);
 
     /**
      * The number of seconds to add after alighting a transit leg. It is recommended to use the
@@ -529,7 +529,7 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
      * <p>
      * Unit is seconds. Default value is not-set(empty map).
      */
-    public EnumMap<TransitMode, Integer> alightSlackForMode = new EnumMap<>(TransitMode.class);
+    public Map<TransitMode, Integer> alightSlackForMode = new EnumMap<>(TransitMode.class);
 
     /**
      * Ideally maxTransfers should be set in the router config, not here. Instead the client should

--- a/src/main/java/org/opentripplanner/standalone/config/NodeAdapter.java
+++ b/src/main/java/org/opentripplanner/standalone/config/NodeAdapter.java
@@ -224,7 +224,7 @@ public class NodeAdapter {
      *               The second argument to the function is the enum NAME(String).
      * @return a map of listed enum values as keys with value, or an empty map if not set.
      */
-    public <T, E extends Enum<E>> EnumMap<E, T> asEnumMap(
+    public <T, E extends Enum<E>> Map<E, T> asEnumMap(
             String paramName,
             Class<E> enumClass,
             BiFunction<NodeAdapter, String, T> mapper

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/RangeRaptorWorker.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/RangeRaptorWorker.java
@@ -217,9 +217,8 @@ public final class RangeRaptorWorker<T extends RaptorTripSchedule> implements Wo
                 var txService = enableTransferConstraints
                         ? calculator.transferConstraintsSearch(route) : null;
 
-                slackProvider.setCurrentPattern(pattern);
-                int alightSlack = slackProvider.alightSlack();
-                int boardSlack = slackProvider.boardSlack();
+                int alightSlack = slackProvider.alightSlack(pattern);
+                int boardSlack = slackProvider.boardSlack(pattern);
 
                 transitWorker.prepareForTransitWith(pattern);
 
@@ -292,10 +291,11 @@ public final class RangeRaptorWorker<T extends RaptorTripSchedule> implements Wo
         TransitArrival<T> sourceStopArrival = transitWorker.previousTransit(targetStopIndex);
         if(sourceStopArrival == null) { return false; }
 
-        slackProvider.setCurrentPattern(sourceStopArrival.trip().pattern());
+        int prevStopArrivalTime = sourceStopArrival.arrivalTime();
+
         int earliestBoardTime = calculator.minusDuration(
-                sourceStopArrival.arrivalTime(),
-                slackProvider.alightSlack()
+                prevStopArrivalTime,
+                slackProvider.alightSlack(sourceStopArrival.trip().pattern())
         );
 
         var result = txService.find(

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/RoutingStrategy.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/RoutingStrategy.java
@@ -40,7 +40,7 @@ public interface RoutingStrategy<T extends RaptorTripSchedule> {
     /**
      * Alight the current trip at the given stop with the arrival times.
      */
-    void alight(final int stopIndex, final int stopPos, ToIntFunction<T> getStopArrivalTime);
+    void alight(final int stopIndex, final int stopPos, final int alightSlack);
 
     /**
      * Board trip for each stopArrival (Std have only one "best" arrival, while Mc may have many).

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/SlackProvider.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/SlackProvider.java
@@ -19,7 +19,11 @@ public interface SlackProvider {
 
     /**
      * Set the trip pattern to use when finding the {@code boardSlack} and {@code alightSlack}.
-     */
+     *
+     * @deprecated The {@link #boardSlack()} and {@link #alightSlack()} methods are only called
+     *             once pr pattern, so simplify this by adding the pattern to those methods.
+      */
+    @Deprecated
     void setCurrentPattern(RaptorTripPattern pattern);
 
     /**

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/SlackProvider.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/SlackProvider.java
@@ -18,15 +18,6 @@ import org.opentripplanner.transit.raptor.api.transit.RaptorTripPattern;
 public interface SlackProvider {
 
     /**
-     * Set the trip pattern to use when finding the {@code boardSlack} and {@code alightSlack}.
-     *
-     * @deprecated The {@link #boardSlack()} and {@link #alightSlack()} methods are only called
-     *             once pr pattern, so simplify this by adding the pattern to those methods.
-      */
-    @Deprecated
-    void setCurrentPattern(RaptorTripPattern pattern);
-
-    /**
      * The board-slack (duration time in seconds) to add to the stop arrival time,
      * before boarding the given trip pattern.
      * <p>
@@ -34,7 +25,7 @@ public interface SlackProvider {
      * <p>
      * Unit: seconds.
      */
-    int boardSlack();
+    int boardSlack(RaptorTripPattern pattern);
 
     /**
      * The alight-slack (duration time in seconds) to add to the trip alight time for
@@ -44,7 +35,7 @@ public interface SlackProvider {
      * <p>
      * Unit: seconds.
      */
-    int alightSlack();
+    int alightSlack(RaptorTripPattern pattern);
 
 
     /**

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/McTransitWorker.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/McTransitWorker.java
@@ -63,13 +63,13 @@ public final class McTransitWorker<T extends RaptorTripSchedule> implements Rout
     }
 
     @Override
-    public void alight(final int stopIndex, final int stopPos, ToIntFunction<T> stopArrivalTimeOp) {
+    public void alight(final int stopIndex, final int stopPos, int alightSlack) {
         for (PatternRide<T> ride : patternRides) {
             state.transitToStop(
                     ride,
                     stopIndex,
                     ride.trip.arrival(stopPos),
-                    slackProvider.alightSlack()
+                    alightSlack
             );
         }
     }

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/NoWaitTransitWorker.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/NoWaitTransitWorker.java
@@ -8,6 +8,7 @@ import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripScheduleBoardOrAlightEvent;
 import org.opentripplanner.transit.raptor.api.transit.TransitArrival;
 import org.opentripplanner.transit.raptor.rangeraptor.RoutingStrategy;
+import org.opentripplanner.transit.raptor.rangeraptor.transit.TransitCalculator;
 
 
 /**
@@ -20,6 +21,7 @@ public final class NoWaitTransitWorker<T extends RaptorTripSchedule> implements 
 
     private static final int NOT_SET = -1;
 
+    private final TransitCalculator<T> calculator;
     private final StdWorkerState<T> state;
 
     private int onTripIndex;
@@ -28,7 +30,8 @@ public final class NoWaitTransitWorker<T extends RaptorTripSchedule> implements 
     private T onTrip;
     private int onTripTimeShift;
 
-    public NoWaitTransitWorker(StdWorkerState<T> state) {
+    public NoWaitTransitWorker(TransitCalculator<T> calculator, StdWorkerState<T> state) {
+        this.calculator = calculator;
         this.state = state;
     }
 
@@ -57,11 +60,11 @@ public final class NoWaitTransitWorker<T extends RaptorTripSchedule> implements 
     }
 
     @Override
-    public void alight(int stopIndex, int stopPos, ToIntFunction<T> getStopArrivalTime) {
+    public void alight(int stopIndex, int stopPos, int alightSlack) {
         // attempt to alight if we're on board
         if (onTripIndex != NOT_SET) {
             // Trip alightTime + alight-slack(forward-search) or board-slack(reverse-search)
-            final int stopArrivalTime0 = getStopArrivalTime.applyAsInt(onTrip);
+            final int stopArrivalTime0 = calculator.stopArrivalTime(onTrip, stopPos, alightSlack);
 
             // Remove the wait time from the arrival-time. We don´t need to use the transit
             // calculator because of the way we compute the time-shift. It is positive in the case

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/StdTransitWorker.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/StdTransitWorker.java
@@ -8,6 +8,7 @@ import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripScheduleBoardOrAlightEvent;
 import org.opentripplanner.transit.raptor.api.transit.TransitArrival;
 import org.opentripplanner.transit.raptor.rangeraptor.RoutingStrategy;
+import org.opentripplanner.transit.raptor.rangeraptor.transit.TransitCalculator;
 
 
 /**
@@ -19,6 +20,7 @@ public final class StdTransitWorker<T extends RaptorTripSchedule> implements Rou
 
     private static final int NOT_SET = -1;
 
+    private final TransitCalculator<T> calculator;
     private final StdWorkerState<T> state;
 
     private int onTripIndex;
@@ -26,7 +28,8 @@ public final class StdTransitWorker<T extends RaptorTripSchedule> implements Rou
     private int onTripBoardStop;
     private T onTrip;
 
-    public StdTransitWorker(StdWorkerState<T> state) {
+    public StdTransitWorker(TransitCalculator<T> calculator, StdWorkerState<T> state) {
+        this.calculator = calculator;
         this.state = state;
     }
 
@@ -53,9 +56,9 @@ public final class StdTransitWorker<T extends RaptorTripSchedule> implements Rou
     }
 
     @Override
-    public void alight(final int stopIndex, final int stopPos, ToIntFunction<T> stopArrivalTimeOp) {
+    public void alight(final int stopIndex, final int stopPos, final int alightSlack) {
         if (onTripIndex != NOT_SET) {
-            final int stopArrivalTime = stopArrivalTimeOp.applyAsInt(onTrip);
+            final int stopArrivalTime = calculator.stopArrivalTime(onTrip, stopPos, alightSlack);
             state.transitToStop(stopIndex, stopArrivalTime, onTripBoardStop, onTripBoardTime, onTrip);
         }
     }

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/configure/StdRangeRaptorConfig.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/configure/StdRangeRaptorConfig.java
@@ -93,10 +93,10 @@ public class StdRangeRaptorConfig<T extends RaptorTripSchedule> {
         switch (ctx.profile()) {
             case STANDARD:
             case BEST_TIME:
-                return new StdTransitWorker<>(state);
+                return new StdTransitWorker<>(ctx.calculator(), state);
             case NO_WAIT_STD:
             case NO_WAIT_BEST_TIME:
-                return new NoWaitTransitWorker<>(state);
+                return new NoWaitTransitWorker<>(ctx.calculator(), state);
         }
         throw new IllegalArgumentException(ctx.profile().toString());
     }

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/transit/SlackProviderAdapter.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/transit/SlackProviderAdapter.java
@@ -1,17 +1,16 @@
 package org.opentripplanner.transit.raptor.rangeraptor.transit;
 
+import java.util.function.IntSupplier;
+import java.util.function.ToIntFunction;
 import org.opentripplanner.transit.raptor.api.transit.RaptorSlackProvider;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripPattern;
 import org.opentripplanner.transit.raptor.rangeraptor.SlackProvider;
 import org.opentripplanner.transit.raptor.rangeraptor.WorkerLifeCycle;
 
-import java.util.function.IntSupplier;
-import java.util.function.ToIntFunction;
-
 /**
  * This class is an adapter for the internal {@link SlackProvider} witch wrap the
  * api {@link RaptorSlackProvider}. The Adapter is needed to swap board/alight
- * in the reverse search. It also incorporate the transfer slack into the bordSlack,
+ * in the reverse search. It also incorporates the transfer slack into the bordSlack,
  * so the algorithm have one thing less to account for.
  * <p>
  * Uses the adapter design pattern.

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/transit/TransitCalculator.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/transit/TransitCalculator.java
@@ -77,13 +77,14 @@ public interface TransitCalculator<T extends RaptorTripSchedule> {
     int duration(int timeA, int timeB);
 
     /**
-     * For a normal search return the trip arrival time at stop position including alightSlack.
-     * For a reverse search return the next trips departure time at stop position with the boardSlack added.
+     * For a forward search return the trip arrival time at stop position including alightSlack.
+     * For a reverse search return the next trips departure time at stop position with the
+     * boardSlack added.
      *
-     * @param onTrip the current boarded trip
+     * @param trip the current boarded trip
      * @param stopPositionInPattern the stop position/index
      */
-    int stopArrivalTime(T onTrip, int stopPositionInPattern, int slack);
+    int stopArrivalTime(T trip, int stopPositionInPattern, int slack);
 
     /**
      * Stop the search when the time exceeds the latest-acceptable-arrival-time.

--- a/src/test/java/org/opentripplanner/transit/raptor/rangeraptor/transit/SlackProviderAdapterTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/rangeraptor/transit/SlackProviderAdapterTest.java
@@ -1,5 +1,8 @@
 package org.opentripplanner.transit.raptor.rangeraptor.transit;
 
+import static org.junit.Assert.assertEquals;
+import static org.opentripplanner.transit.raptor.api.transit.RaptorSlackProvider.defaultSlackProvider;
+
 import org.junit.Test;
 import org.opentripplanner.transit.raptor._data.RaptorTestConstants;
 import org.opentripplanner.transit.raptor._data.transit.TestTripPattern;
@@ -7,9 +10,6 @@ import org.opentripplanner.transit.raptor.api.transit.RaptorSlackProvider;
 import org.opentripplanner.transit.raptor.rangeraptor.SlackProvider;
 import org.opentripplanner.transit.raptor.rangeraptor.workerlifecycle.LifeCycleEventPublisher;
 import org.opentripplanner.transit.raptor.rangeraptor.workerlifecycle.LifeCycleSubscriptions;
-
-import static org.junit.Assert.assertEquals;
-import static org.opentripplanner.transit.raptor.api.transit.RaptorSlackProvider.defaultSlackProvider;
 
 public class SlackProviderAdapterTest implements RaptorTestConstants {
 
@@ -33,19 +33,16 @@ public class SlackProviderAdapterTest implements RaptorTestConstants {
     var lifeCycle = new LifeCycleEventPublisher(subscriptions);
 
     lifeCycle.prepareForNextRound(0);
-    subject.setCurrentPattern(PATTERN);
-    assertEquals(ALIGHT_SLACK, subject.alightSlack());
-    assertEquals(BOARD_SLACK, subject.boardSlack());
+    assertEquals(ALIGHT_SLACK, subject.alightSlack(PATTERN));
+    assertEquals(BOARD_SLACK, subject.boardSlack(PATTERN));
 
     lifeCycle.prepareForNextRound(1);
-    subject.setCurrentPattern(PATTERN);
-    assertEquals(ALIGHT_SLACK, subject.alightSlack());
-    assertEquals(BOARD_SLACK, subject.boardSlack());
+    assertEquals(ALIGHT_SLACK, subject.alightSlack(PATTERN));
+    assertEquals(BOARD_SLACK, subject.boardSlack(PATTERN));
 
     lifeCycle.prepareForNextRound(2);
-    subject.setCurrentPattern(PATTERN);
-    assertEquals(ALIGHT_SLACK, subject.alightSlack());
-    assertEquals(BOARD_SLACK + TRANSFER_SLACK, subject.boardSlack());
+    assertEquals(ALIGHT_SLACK, subject.alightSlack(PATTERN));
+    assertEquals(BOARD_SLACK + TRANSFER_SLACK, subject.boardSlack(PATTERN));
   }
 
   @Test
@@ -58,18 +55,15 @@ public class SlackProviderAdapterTest implements RaptorTestConstants {
     var lifeCycle = new LifeCycleEventPublisher(subscriptions);
 
     lifeCycle.prepareForNextRound(0);
-    subject.setCurrentPattern(PATTERN);
-    assertEquals(BOARD_SLACK, subject.alightSlack());
-    assertEquals(ALIGHT_SLACK, subject.boardSlack());
+    assertEquals(BOARD_SLACK, subject.alightSlack(PATTERN));
+    assertEquals(ALIGHT_SLACK, subject.boardSlack(PATTERN));
 
     lifeCycle.prepareForNextRound(1);
-    subject.setCurrentPattern(PATTERN);
-    assertEquals(BOARD_SLACK, subject.alightSlack());
-    assertEquals(ALIGHT_SLACK, subject.boardSlack());
+    assertEquals(BOARD_SLACK, subject.alightSlack(PATTERN));
+    assertEquals(ALIGHT_SLACK, subject.boardSlack(PATTERN));
 
     lifeCycle.prepareForNextRound(2);
-    subject.setCurrentPattern(PATTERN);
-    assertEquals(BOARD_SLACK, subject.alightSlack());
-    assertEquals(ALIGHT_SLACK + TRANSFER_SLACK, subject.boardSlack());
+    assertEquals(BOARD_SLACK, subject.alightSlack(PATTERN));
+    assertEquals(ALIGHT_SLACK + TRANSFER_SLACK, subject.boardSlack(PATTERN));
   }
 }


### PR DESCRIPTION
### Summary
This PR contains several small fixes and refactorings for issues found during testing of the new constrained transfer support. Most of it is related to alight- and board-slack.

- Respect transfer slack in Optimize transfer. The correct slack between to trips A and B, is A´s alight-slack + transfer-slack + B´s board-slack. Previously transfer-slack was not added, witch made it possible to board trips with insufficient transfer-time. This more of a theoretical problem, because it would not likely be the best transfer - and for the path to exist a better option exist. 
- When searching for a constrained transfer from a given trip to a pattern, we stopped the search when on the first trip found. But, this trip would not necessarily run on the given service  day, so the search should continue if the trip did not match the target trip.
- Use correct mode when removing alight-slack for constrained transfers. The SlackProvider requires the current trip pattern to be set before retrieving slack. If the setCurrentPattern method is not called, the previous pattern mode is used. This caused problems when we needed to subtract the alight-slack for the previous stop arrival. This is originally a optimization, but the SlackProvider handshake is error prune and should be removed. 
- There are also a few refactorings in this PR.

### Issue

This is related to issue #3688. 


### Unit tests
Are updated.


### Code style
✅ 


### Documentation
✅ 

### Changelog
No