### PR TITLE
debug-client: add url handling and extend the displayed fields

### DIFF
--- a/src/client/js/otp/modules/multimodal/MultimodalPlannerModule.js
+++ b/src/client/js/otp/modules/multimodal/MultimodalPlannerModule.js
@@ -23,7 +23,7 @@ otp.modules.multimodal.MultimodalPlannerModule =
 
     itinWidget  : null,
 
-    showIntermediateStops : false,
+    showIntermediateStops : true,
 
     stopsWidget: false,
 

--- a/src/client/js/otp/modules/planner/ItinerariesWidget.js
+++ b/src/client/js/otp/modules/planner/ItinerariesWidget.js
@@ -587,14 +587,15 @@ otp.widgets.ItinerariesWidget =
                 this_.module.drawAllStartBubbles(this_.itineraries[this_.activeIndex]);
             });
 
-            var stopHtml = '<div class="otp-itin-leg-endpointDescSub">';
-            if( typeof leg.from.stopCode != 'undefined' ) {
-                stopHtml += _tr("Stop") + ' #'+leg.from.stopCode+ ' ';
-            }
-            stopHtml += '[<a href="#">' + _tr("Stop Viewer") +'</a>]</div>';
-
-            $(stopHtml)
+            $(
+                '<div class="otp-itin-leg-endpointDescSub">'
+                 + _tr("Stop")
+                 + ' #' + (leg.from.stopCode || leg.from.stopId)
+                 + ' [<a href="#">' + _tr("Stop Viewer") + '</a>]'
+                 + '</div>'
+            )
             .appendTo(legDiv)
+            .children('a')
             .click(function(evt) {
                 if(!this_.module.stopViewerWidget) {
                     this_.module.stopViewerWidget = new otp.widgets.transit.StopViewerWidget("otp-"+this_.module.id+"-stopViewerWidget", this_.module);
@@ -699,6 +700,25 @@ otp.widgets.ItinerariesWidget =
                 this_.module.drawAllStartBubbles(this_.itineraries[this_.activeIndex]);
             });
 
+            $(
+                '<div class="otp-itin-leg-endpointDescSub">'
+                + _tr("Stop")
+                + ' #' + (leg.to.stopCode || leg.to.stopId)
+                + ' [<a href="#">' + _tr("Stop Viewer") + '</a>]'
+                + '</div>'
+            )
+                .appendTo(legDiv)
+                .children('a')
+                .click(function(evt) {
+                    if(!this_.module.stopViewerWidget) {
+                        this_.module.stopViewerWidget = new otp.widgets.transit.StopViewerWidget("otp-"+this_.module.id+"-stopViewerWidget", this_.module);
+                        this_.module.stopViewerWidget.$().offset({top: evt.clientY, left: evt.clientX});
+                    }
+                    this_.module.stopViewerWidget.show();
+                    this_.module.stopViewerWidget.setActiveTime(leg.endTime);
+                    this_.module.stopViewerWidget.setStop(leg.to.stopId, leg.to.name);
+                    this_.module.stopViewerWidget.bringToFront();
+                });
 
             // render any alerts
 

--- a/src/client/js/otp/modules/planner/ItinerariesWidget.js
+++ b/src/client/js/otp/modules/planner/ItinerariesWidget.js
@@ -376,7 +376,7 @@ otp.widgets.ItinerariesWidget =
             }
 
             if(leg.mode === "WALK" || leg.mode === "BICYCLE" || leg.mode === "CAR") {
-                headerHtml += " "+otp.util.Itin.distanceString(leg.distance)+ pgettext("direction", " to ")+otp.util.Itin.getName(leg.to);
+                headerHtml += " "+otp.util.Itin.distanceString(leg.distance) + ", " + otp.util.Itin.durationString(leg.startTime, leg.endTime) + pgettext("direction", " to ")+otp.util.Itin.getName(leg.to);
                 if(otp.config.municoderHostname) {
                     var spanId = this.newMunicoderRequest(leg.to.lat, leg.to.lon);
                     headerHtml += '<span id="'+spanId+'"></span>';

--- a/src/client/js/otp/modules/planner/ItinerariesWidget.js
+++ b/src/client/js/otp/modules/planner/ItinerariesWidget.js
@@ -616,6 +616,14 @@ otp.widgets.ItinerariesWidget =
 
             $('<span><i>' + _tr("Time in transit") + ": " + otp.util.Time.secsToHrMin(leg.duration)+'</i></span>').appendTo(inTransitDiv);
 
+            $('<div class="otp-itin-leg-ids"></div>')
+                .append($('<table></table>').append([
+                    '<tr><td>' + _tr("Route ID") + ":</td><td>" + leg.routeId + '</td></tr>',
+                    '<tr><td>' + _tr("Trip ID") + ":</td><td>" + leg.tripId + '</td></tr>',
+                    '<tr><td>' + _tr("Service Date") + ":</td><td>" + leg.serviceDate + '</td></tr>'
+                ]))
+                .appendTo(legDiv);
+
             $('<span>&nbsp;[<a href="#">' + _tr("Trip Viewer") + '</a>]</span>')
             .appendTo(inTransitDiv)
             .click(function(evt) {

--- a/src/client/js/otp/modules/planner/ItinerariesWidget.js
+++ b/src/client/js/otp/modules/planner/ItinerariesWidget.js
@@ -607,7 +607,6 @@ otp.widgets.ItinerariesWidget =
                 this_.module.stopViewerWidget.bringToFront();
             });
 
-
             $('<div class="otp-itin-leg-buffer"></div>').appendTo(legDiv);
 
             // show the "time in transit" line
@@ -639,7 +638,7 @@ otp.widgets.ItinerariesWidget =
 
             // show the intermediate stops, if applicable -- REPLACED BY TRIP VIEWER
 
-            /*if(this.module.showIntermediateStops) {
+            if(this.module.showIntermediateStops) {
 
                 $('<div class="otp-itin-leg-buffer"></div>').appendTo(legDiv);
                 var intStopsDiv = $('<div class="otp-itin-leg-intStops"></div>').appendTo(legDiv);
@@ -656,8 +655,12 @@ otp.widgets.ItinerariesWidget =
 
                 for(var i=0; i < leg.intermediateStops.length; i++) {
                     var stop = leg.intermediateStops[i];
-                    $('<div class="otp-itin-leg-intStopsListItem">'+(i+1)+'. '+stop.name+' (ID #'+stop.stopId.id+')</div>').
-                    appendTo(intStopsListDiv)
+                    var time = stop.arrival === stop.departure
+                                ? otp.util.Time.formatItinTime(stop.arrival, otp.config.locale.time.time_format)
+                                : otp.util.Time.formatItinTime(stop.arrival, otp.config.locale.time.time_format) + " - " + otp.util.Time.formatItinTime(stop.departure, otp.config.locale.time.time_format);
+                    $('<div class="otp-itin-leg-intStopsListItem"><span>'+time+' '+stop.name+' <i>(#'+(stop.stopCode || stop.stopId)+')</i></span></div>')
+                    .appendTo(intStopsListDiv)
+                    .children('span')
                     .data("stop", stop)
                     .click(function(evt) {
                         var stop = $(this).data("stop");
@@ -665,7 +668,7 @@ otp.widgets.ItinerariesWidget =
                     }).hover(function(evt) {
                         var stop = $(this).data("stop");
                         $(this).css('color', 'red');
-                        var popup = L.popup()
+                        L.popup()
                             .setLatLng(new L.LatLng(stop.lat, stop.lon))
                             .setContent(stop.name)
                             .openOn(this_.module.webapp.map.lmap);
@@ -675,7 +678,7 @@ otp.widgets.ItinerariesWidget =
                     });
                 }
                 intStopsListDiv.hide();
-            }*/
+            }
 
             // show the end time and stop
 

--- a/src/client/js/otp/modules/planner/PlannerModule.js
+++ b/src/client/js/otp/modules/planner/PlannerModule.js
@@ -181,6 +181,10 @@ otp.modules.planner.PlannerModule =
 
         this.noTripWidget = new otp.widgets.Widget('otp-noTripWidget', this);
         this.addWidget(this.noTripWidget);*/
+
+        window.onpopstate = function (event) {
+            this_.restoreTrip(event.state);
+        };
     },
 
     restore : function() {
@@ -378,6 +382,11 @@ otp.modules.planner.PlannerModule =
         //sends wanted translation to server
         _.extend(queryParams, {locale : otp.config.locale.config.locale_short} );
 
+        // Only save the state if 1) we are not loading from an existing state and 2) it differs from the previous state
+        if (window.history.pushState && !existingQueryParams && !_.isEqual(this.lastQueryParams, queryParams)) {
+          window.history.pushState(queryParams, null, this.constructLink(queryParams, {}));
+        }
+
         this.lastQueryParams = queryParams;
 
         this.planTripRequestCount = 0;
@@ -487,6 +496,12 @@ otp.modules.planner.PlannerModule =
         if(error.id) msg += ' (' + _tr('Error %(error_id)d', {'error_id': error.id}) + ')';
         //TRANSLATORS: Title of no trip dialog
         otp.widgets.Dialogs.showOkDialog(msg, _tr('No Trip Found'));
+    },
+
+    constructLink : function(queryParams, additionalParams) {
+        additionalParams = additionalParams ||  { };
+        return otp.config.siteUrl + '?module=' + this.id + "&" +
+            otp.util.Text.constructUrlParamString(_.extend(_.clone(queryParams), additionalParams));
     },
 
     drawItinerary : function(itin) {

--- a/src/client/js/otp/modules/planner/planner-style.css
+++ b/src/client/js/otp/modules/planner/planner-style.css
@@ -219,6 +219,19 @@ h3.sysNotice {
     padding-left: 5px;
 }
 
+.otp-itin-leg-ids {
+    font-size: .9em;
+    border-left: 1px solid #ccc;
+    color: gray;
+    margin-left: 55px;
+    padding-left: 5px;
+    font-style: italic;
+}
+
+.otp-itin-leg-ids td:first-child {
+    padding-right: 5px;
+}
+
 .otp-itin-leg-intStops {
     background: #ddd;
     font-size: .9em;

--- a/src/client/js/otp/modules/planner/planner-style.css
+++ b/src/client/js/otp/modules/planner/planner-style.css
@@ -255,9 +255,15 @@ h3.sysNotice {
 
 .otp-itin-leg-intStopsListItem {
     padding-bottom: .3em;
+}
+
+.otp-itin-leg-intStopsListItem span {
     cursor: pointer;
 }
 
+.otp-itin-leg-intStopsListItem i {
+    font-size: 0.8em;
+}
 
 .otp-itin-iconModeSymbol {
     width: 16px;

--- a/src/client/js/otp/modules/planner/planner-style.css
+++ b/src/client/js/otp/modules/planner/planner-style.css
@@ -202,7 +202,6 @@ h3.sysNotice {
     margin-left: 55px;
     padding: .0em 0 0 5px;
     color: gray;
-    cursor: pointer;
 }
 
 .otp-itin-leg-buffer {

--- a/src/client/js/otp/util/Itin.js
+++ b/src/client/js/otp/util/Itin.js
@@ -187,6 +187,10 @@ otp.util.Itin = {
         return otp.util.Geo.distanceString(m);
     },
 
+    durationString : function (startTime, endTime) {
+      return otp.util.Time.secsToHrMin( (endTime - startTime)/1000.0 );
+    },
+
     modeStrings : {
         //TRANSLATORS: Walk distance to place (itinerary header)
         'WALK': _tr('Walk'),

--- a/src/client/js/otp/widgets/tripoptions/TripOptionsWidget.js
+++ b/src/client/js/otp/widgets/tripoptions/TripOptionsWidget.js
@@ -1092,7 +1092,9 @@ otp.widgets.tripoptions.AdditionalTripParameters =
             if (data.queryParams.additionalParameters) {
                 var str = '';
                 var keys = data.queryParams.additionalParameters.split(',');
-                var params = {};
+                var params = {
+                  additionalParameters: data.queryParams.additionalParameters
+                };
 
                 _.each(keys, function (key) {
                     str += key + '=' + data.queryParams[key] + '\n';

--- a/src/client/js/otp/widgets/tripoptions/TripOptionsWidget.js
+++ b/src/client/js/otp/widgets/tripoptions/TripOptionsWidget.js
@@ -445,7 +445,9 @@ otp.widgets.tripoptions.WheelChairSelector =
     },
 
     restorePlan : function(data) {
-        $("#"+this.id+"-wheelchair-input").prop("checked", data.queryParams.wheelchair === 'true');
+        var checked = data.queryParams.wheelchair === true || data.queryParams.wheelchair === 'true';
+        this.tripWidget.module.wheelchair = checked;
+        $("#"+this.id+"-wheelchair-input").prop("checked", checked);
     },
 
     isApplicableForMode : function(mode) {
@@ -483,7 +485,9 @@ otp.widgets.tripoptions.DebugItineraryFiltersSelector = otp.Class(
             });
         },
         restorePlan: function (data) {
-            $("#" + this.id + "-debug-filters-input").prop("checked", data.queryParams.debugItineraryFilter === 'true');
+            var checked = data.queryParams.debugItineraryFilter === true || data.queryParams.debugItineraryFilter === 'true';
+            this.tripWidget.module.debugItineraryFilter = checked;
+            $("#" + this.id + "-debug-filters-input").prop("checked", checked);
         },
         isApplicableForMode : function(mode) { return true; }
     }


### PR DESCRIPTION
### Summary

The debug client is extended with a few features to ease its usage. If any are controversial, I can split this into separate PRs.

1. URL handling is updated so that
    * the `boolean` parameters and the `additional parameters` fields are always restored correctly
    * the current parameters are saved to the browser history using `pushState()`, with which the browser URL always reflects the actual trip plan. This also allows the back/forward buttons to navigate between different searches.
 2. For non-transit legs in addition to the distance the duration is also displayed: 
![image](https://user-images.githubusercontent.com/58879/139793754-d49ca170-7d5e-45c0-9480-36e2707fc831.png)
3. The existing option to display the `intermediateStops` is enabled: 
![image](https://user-images.githubusercontent.com/58879/139793901-34f5fe96-8f56-49a4-b488-4a3514fad0a2.png)
![image](https://user-images.githubusercontent.com/58879/139793879-c3235d34-ee27-4825-b0b3-b5aec3e4f528.png)
4. For transit legs the `tripId` / `routeId` / `serviceDate` fields are displayed:
![image](https://user-images.githubusercontent.com/58879/139794075-61c66a80-9067-429d-b2a4-a8efda09b9e4.png)
5. The boarding and alighting `stopCode` (or `stopId`) is updated to always be visible: 
![image](https://user-images.githubusercontent.com/58879/139794353-9e7e92f1-b5eb-4d16-a45f-e8f5e3357a57.png)
![image](https://user-images.githubusercontent.com/58879/139794239-1d2108ec-3ac9-4a79-bdaa-79197086a4f5.png)
