### PR TITLE
Only run automatic changelog in the upstream repository [changelog skip]

### DIFF
--- a/.github/workflows/automatic-changelog.yml
+++ b/.github/workflows/automatic-changelog.yml
@@ -23,7 +23,7 @@ jobs:
           git config --global user.email 'changelog-bot@opentripplanner.org'
 
       - name: Generate changelog entry from PR information
-        if: github.event.pull_request.merged
+        if: github.event.pull_request.merged && github.repository_owner == "opentripplanner"
         run: |
           # if the title contains "changelog skip" we don't generate an entry
           TITLE_LOWER_CASE=`echo $TITLE | awk '{print tolower($0)}'`

--- a/.github/workflows/automatic-changelog.yml
+++ b/.github/workflows/automatic-changelog.yml
@@ -11,13 +11,13 @@ jobs:
     steps:
 
       - name: Checkout
-        if: github.event.pull_request.merged
+        if: github.event.pull_request.merged && github.repository_owner == "opentripplanner"
         uses: actions/checkout@v2
         with:
-          token: ${{ secrets.ADMIN_TOKEN }}
+          token: ${{ secrets.CHANGELOG_TOKEN }}
 
       - name: Configure Git User
-        if: github.event.pull_request.merged
+        if: github.event.pull_request.merged && github.repository_owner == "opentripplanner"
         run: |
           git config --global user.name 'OTP Changelog Bot'
           git config --global user.email 'changelog-bot@opentripplanner.org'


### PR DESCRIPTION
### Summary
In order to not activate the automatic changelog in downstream forks, add a check so that the workflow is only run inside the repo owned by the "opentripplanner" org.

### Issue
No issue.

### Unit tests
n/a

### Code style
n/a

### Documentation
n/a