### PR TITLE
Fix combination of flex access and constrained transfer

### DIFF
--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/stoparrivals/Stops.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/stoparrivals/Stops.java
@@ -134,6 +134,9 @@ public final class Stops<T extends RaptorTripSchedule> implements BestNumberOfTr
         if(state.arrivedByTransfer()) {
             stopIndex = state.transferFromStop();
             state = stops[prevRound][stopIndex];
+            if(!state.arrivedByTransit()) {
+                return null;
+            }
         }
         return TransitArrival.create(state.trip(), stopIndex, state.transitTime());
     }

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/stoparrivals/view/Transfer.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/stoparrivals/view/Transfer.java
@@ -46,6 +46,9 @@ final class Transfer<T extends RaptorTripSchedule>
 
     @Override
     public ArrivalView<T> previous() {
+        if (!arrival.arrivedByTransit()) {
+            return cursor.stop(round(), arrival.transferFromStop());
+        }
         return cursor.transit(round(), arrival.transferFromStop());
     }
 

--- a/src/test/java/org/opentripplanner/transit/raptor/moduletests/B10_FlexAccessTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/moduletests/B10_FlexAccessTest.java
@@ -25,7 +25,7 @@ import org.opentripplanner.transit.raptor.rangeraptor.configure.RaptorConfig;
 /**
  * FEATURE UNDER TEST
  * <p>
- * With FLEX access Raptor must support access paths with more then one leg.
+ * With FLEX access Raptor must support access paths with more than one leg.
  * These access paths have more transfers that regular paths, hence should not dominate
  * access walking, but only get accepted when they are better on time and/or cost.
  */

--- a/src/test/java/org/opentripplanner/transit/raptor/moduletests/E01_GuaranteedTransferTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/moduletests/E01_GuaranteedTransferTest.java
@@ -22,9 +22,9 @@ import org.opentripplanner.transit.raptor.rangeraptor.configure.RaptorConfig;
 /**
  * FEATURE UNDER TEST
  * <p>
- * Raptor should return a path if it exist when a transfer is only possible because it is
+ * Raptor should return a path if it exists when a transfer is only possible because it is
  * guaranteed/stay-seated. A guarantied transfer should be able even if there is zero time to do the transfer.
- * In these cases the transfer-slack should be ignored and the connection should be possible. .
+ * In these cases the transfer-slack should be ignored and the connection should be possible.
  */
 public class E01_GuaranteedTransferTest implements RaptorTestConstants {
 

--- a/src/test/java/org/opentripplanner/transit/raptor/moduletests/E11_GuaranteedTransferFlexAccessTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/moduletests/E11_GuaranteedTransferFlexAccessTest.java
@@ -1,0 +1,108 @@
+package org.opentripplanner.transit.raptor.moduletests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.transit.raptor._data.api.PathUtils.pathsToString;
+import static org.opentripplanner.transit.raptor._data.transit.TestRoute.route;
+import static org.opentripplanner.transit.raptor._data.transit.TestTransfer.flex;
+import static org.opentripplanner.transit.raptor._data.transit.TestTransfer.walk;
+import static org.opentripplanner.transit.raptor._data.transit.TestTripSchedule.schedule;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.routing.algorithm.raptor.transit.cost.RaptorCostConverter;
+import org.opentripplanner.transit.raptor.RaptorService;
+import org.opentripplanner.transit.raptor._data.RaptorTestConstants;
+import org.opentripplanner.transit.raptor._data.transit.TestTransitData;
+import org.opentripplanner.transit.raptor._data.transit.TestTripSchedule;
+import org.opentripplanner.transit.raptor.api.request.RaptorProfile;
+import org.opentripplanner.transit.raptor.api.request.RaptorRequestBuilder;
+import org.opentripplanner.transit.raptor.api.request.SearchDirection;
+import org.opentripplanner.transit.raptor.rangeraptor.configure.RaptorConfig;
+
+/**
+ * FEATURE UNDER TEST
+ * <p>
+ * Raptor should support combining multiple features, like Flexible access paths and constrained
+ * transfers. This test has only one path available, and it is expected that it should be retuned
+ * irrespective of the profile.
+ */
+public class E11_GuaranteedTransferFlexAccessTest implements RaptorTestConstants {
+    private static final int COST_ONE_STOP = RaptorCostConverter.toRaptorCost(2 * 60);
+
+    private final TestTransitData data = new TestTransitData();
+    private final RaptorRequestBuilder<TestTripSchedule> requestBuilder =
+            new RaptorRequestBuilder<>();
+    private final RaptorService<TestTripSchedule> raptorService = new RaptorService<>(
+            RaptorConfig.defaultConfigForTest()
+    );
+
+    @BeforeEach
+    public void setup() {
+        var r1 = route("R1", STOP_B, STOP_C)
+                .withTimetable(schedule("0:30 0:45"));
+        var r2 = route("R2", STOP_C, STOP_D)
+                .withTimetable(schedule("0:45 0:55"));
+
+        var tripA = r1.timetable().getTripSchedule(0);
+        var tripB = r2.timetable().getTripSchedule(0);
+
+        data.withRoutes(r1, r2);
+        data.withGuaranteedTransfer(tripA, STOP_C, tripB, STOP_C);
+        data.withTransfer(STOP_A, walk(STOP_B, D10m));
+        data.mcCostParamsBuilder().transferCost(100);
+
+        requestBuilder.searchParams()
+                .addAccessPaths(
+                        flex(STOP_A, D3m, ONE_RIDE, 2 * COST_ONE_STOP)
+                )
+                .addEgressPaths(walk(STOP_D, D1m));
+
+        requestBuilder.searchParams()
+                .earliestDepartureTime(T00_00)
+                .latestArrivalTime(T01_00)
+                .constrainedTransfersEnabled(true);
+
+        ModuleTestDebugLogging.setupDebugLogging(data, requestBuilder);
+    }
+
+    @Test
+    public void standard() {
+        requestBuilder.profile(RaptorProfile.STANDARD);
+
+        var response = raptorService.route(requestBuilder.build(), data);
+
+        assertEquals(
+                "Flex 3m 1x ~ A ~ Walk 10m ~ B ~ BUS R1 0:30 0:45 ~ C ~ BUS R2 0:45 0:55 ~ D ~ Walk 1m [0:16 0:56 40m]",
+                pathsToString(response)
+        );
+    }
+
+    @Test
+    @Disabled
+    public void standardReverse() {
+        requestBuilder
+                .profile(RaptorProfile.STANDARD)
+                .searchDirection(SearchDirection.REVERSE);
+
+        var response = raptorService.route(requestBuilder.build(), data);
+
+        assertEquals(
+                "Flex 3m 1x ~ A ~ Walk 10m ~ B ~ BUS R1 0:30 0:45 ~ C ~ BUS R2 0:45 0:55 ~ D ~ Walk 1m [0:16 0:56 40m]",
+                pathsToString(response)
+        );
+    }
+
+    @Test
+    public void multiCriteria() {
+        requestBuilder.profile(RaptorProfile.MULTI_CRITERIA);
+
+        var response = raptorService.route(requestBuilder.build(), data);
+
+        assertEquals(
+                "Flex 3m 1x ~ A ~ Walk 10m ~ B ~ BUS R1 0:30 0:45 ~ C ~ BUS R2 0:45 0:55 ~ D ~ Walk 1m [0:16 0:56 40m $3820]",
+                pathsToString(response)
+        );
+    }
+}
+

--- a/src/test/java/org/opentripplanner/transit/raptor/moduletests/E11_GuaranteedTransferFlexAccessTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/moduletests/E11_GuaranteedTransferFlexAccessTest.java
@@ -78,6 +78,7 @@ public class E11_GuaranteedTransferFlexAccessTest implements RaptorTestConstants
         );
     }
 
+    //TODO: Enable after #3725 is fixed
     @Test
     @Disabled
     public void standardReverse() {


### PR DESCRIPTION

### Summary

Currently RAPTOR crashes when combining a flexible access with constrained transfers. This PS fixes that

### Unit tests
Added unit test for this feature combination.

### Code style
Code style followed

### Documentation
Nonen required

### Changelog
The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md) 
is generated from the pull-request title, make sure the title describe the feature or issue fixed. 
To exclude the PR from the changelog add `[changelog skip]` in the title.
