### PR TITLE
Add Micrometer monitoring for GraphQL [changelog skip]

### DIFF
--- a/docs/sandbox/ActuatorAPI.md
+++ b/docs/sandbox/ActuatorAPI.md
@@ -6,6 +6,7 @@
 ## Changelog
 - Initial implementation of readiness endpoint (November 2019)
 - Prometheus metrics added using Micrometer (October 2021)
+- GraphQL metrics added to prometheus export (November 2021)
 
 ## Documentation
 This provides endpoints for checking the health status of the OTP instance. It can be useful when
@@ -24,6 +25,9 @@ Otherwise, a 404 NOT FOUND is returned.
 #### /prometheus
 
 Prometheus metrics are returned using Micrometer. The default JVM and jersey metrics are enabled.
+
+Also, GraphQL timing metrics are exported under `graphql.timer.query` and `graphql.timer.resolver`,
+if the GraphQL endpoints are enabled.
 
 ### Configuration
 To enable this you need to add the feature `ActuatorAPI`.

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/LegacyGraphQLIndex.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/LegacyGraphQLIndex.java
@@ -8,6 +8,8 @@ import graphql.ExecutionResult;
 import graphql.GraphQL;
 import graphql.analysis.MaxQueryComplexityInstrumentation;
 import graphql.execution.AbortExecutionException;
+import graphql.execution.instrumentation.ChainedInstrumentation;
+import graphql.execution.instrumentation.Instrumentation;
 import graphql.scalars.ExtendedScalars;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.idl.RuntimeWiring;
@@ -16,8 +18,11 @@ import graphql.schema.idl.SchemaParser;
 import graphql.schema.idl.TypeDefinitionRegistry;
 import org.opentripplanner.api.json.GraphQLResponseSerializer;
 import org.opentripplanner.ext.legacygraphqlapi.datafetchers.*;
+import org.opentripplanner.ext.readiness_endpoint.ActuatorAPI;
+import org.opentripplanner.ext.readiness_endpoint.MicrometerGraphQLInstrumentation;
 import org.opentripplanner.routing.RoutingService;
 import org.opentripplanner.standalone.server.Router;
+import org.opentripplanner.util.OTPFeature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -103,8 +108,16 @@ class LegacyGraphQLIndex {
       String query, Router router, Map<String, Object> variables, String operationName,
       int maxResolves, int timeoutMs, Locale locale
   ) {
-    MaxQueryComplexityInstrumentation instrumentation = new MaxQueryComplexityInstrumentation(
+    Instrumentation instrumentation = new MaxQueryComplexityInstrumentation(
         maxResolves);
+
+    if (OTPFeature.ActuatorAPI.isOn()) {
+      instrumentation = new ChainedInstrumentation(
+              new MicrometerGraphQLInstrumentation(ActuatorAPI.prometheusRegistry),
+              instrumentation
+      );
+    }
+
     GraphQL graphQL = GraphQL.newGraphQL(indexSchema).instrumentation(instrumentation).build();
 
     if (variables == null) {

--- a/src/ext/java/org/opentripplanner/ext/readiness_endpoint/MicrometerGraphQLInstrumentation.java
+++ b/src/ext/java/org/opentripplanner/ext/readiness_endpoint/MicrometerGraphQLInstrumentation.java
@@ -1,0 +1,152 @@
+package org.opentripplanner.ext.readiness_endpoint;
+
+import static graphql.execution.instrumentation.SimpleInstrumentationContext.noOp;
+import static graphql.execution.instrumentation.SimpleInstrumentationContext.whenCompleted;
+
+import graphql.ExecutionResult;
+import graphql.execution.instrumentation.ExecutionStrategyInstrumentationContext;
+import graphql.execution.instrumentation.Instrumentation;
+import graphql.execution.instrumentation.InstrumentationContext;
+import graphql.execution.instrumentation.InstrumentationState;
+import graphql.execution.instrumentation.parameters.InstrumentationCreateStateParameters;
+import graphql.execution.instrumentation.parameters.InstrumentationExecuteOperationParameters;
+import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters;
+import graphql.execution.instrumentation.parameters.InstrumentationExecutionStrategyParameters;
+import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters;
+import graphql.execution.instrumentation.parameters.InstrumentationFieldParameters;
+import graphql.execution.instrumentation.parameters.InstrumentationValidationParameters;
+import graphql.language.Document;
+import graphql.schema.GraphQLTypeUtil;
+import graphql.validation.ValidationError;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import javax.annotation.Nonnull;
+
+/**
+ * Using this instrumentation we can precisely measure how queries and data fetchers are executed
+ * and export the metrics to [micrometer](https://micrometer.io).
+ *
+ * There are two types of metrics: one for query execution, and another for resolver timing. The
+ * timers are registered to micrometer using graphql.timer.query and graphql.timer.resolver.
+ *
+ * ### See also:
+ * - https://github.com/symbaloo/graphql-micrometer/blob/main/src/main/kotlin/com/symbaloo/graphqlmicrometer/MicrometerInstrumentation.kt
+ * - https://github.com/graphql-java-kickstart/graphql-spring-boot/blob/master/graphql-spring-boot-autoconfigure/src/main/java/graphql/kickstart/autoconfigure/web/servlet/metrics/MetricsInstrumentation.java
+ * - https://github.com/apollographql/apollo-tracing - [TracingInstrumentation]
+ */
+public class MicrometerGraphQLInstrumentation implements Instrumentation {
+
+    private static final String QUERY_TIME_METRIC_NAME = "graphql.timer.query";
+    private static final String RESOLVER_TIME_METRIC_NAME = "graphql.timer.resolver";
+    private static final String OPERATION_NAME_TAG = "operationName";
+    private static final String OPERATION = "operation";
+    private static final String PARENT = "parent";
+    private static final String FIELD = "field";
+    private static final String TIMER_DESCRIPTION =
+            "Timer that records the time to fetch the data by Operation Name";
+
+    private final MeterRegistry meterRegistry;
+
+    public MicrometerGraphQLInstrumentation(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+    }
+
+    @Override
+    public InstrumentationState createState(InstrumentationCreateStateParameters parameters) {
+        return new TraceState(parameters.getExecutionInput().getOperationName());
+    }
+
+    @Override
+    public InstrumentationContext<ExecutionResult> beginExecution(
+            InstrumentationExecutionParameters parameters
+    ) {
+        TraceState state = parameters.getInstrumentationState();
+        Timer.Sample sample = Timer.start(meterRegistry);
+        return whenCompleted((res, err) -> sample.stop(
+                buildQueryTimer(state.operationName, "execution")));
+    }
+
+    @Override
+    public InstrumentationContext<Document> beginParse(InstrumentationExecutionParameters parameters) {
+        TraceState state = parameters.getInstrumentationState();
+        Timer.Sample sample = Timer.start(meterRegistry);
+        return whenCompleted((res, err) -> sample.stop(
+                buildQueryTimer(state.operationName, "parse")));
+    }
+
+    @Override
+    public InstrumentationContext<List<ValidationError>> beginValidation(
+            InstrumentationValidationParameters parameters
+    ) {
+        TraceState state = parameters.getInstrumentationState();
+        Timer.Sample sample = Timer.start(meterRegistry);
+        return whenCompleted((res, err) -> sample.stop(
+                buildQueryTimer(state.operationName, "validation")));
+    }
+
+    @Override
+    public InstrumentationContext<ExecutionResult> beginExecuteOperation(
+            InstrumentationExecuteOperationParameters parameters
+    ) {
+        return noOp();
+    }
+
+    @Override
+    public ExecutionStrategyInstrumentationContext beginExecutionStrategy(
+            InstrumentationExecutionStrategyParameters parameters
+    ) {
+        return new ExecutionStrategyInstrumentationContext() {
+            @Override
+            public void onDispatched(CompletableFuture<ExecutionResult> result) {}
+
+            @Override
+            public void onCompleted(ExecutionResult result, Throwable t) {}
+        };
+    }
+
+    @Override
+    public InstrumentationContext<ExecutionResult> beginField(InstrumentationFieldParameters parameters) {
+        return noOp();
+    }
+
+    @Override
+    public InstrumentationContext<Object> beginFieldFetch(InstrumentationFieldFetchParameters parameters) {
+        if (parameters.getField().getDirective("timingData") == null) {
+            return noOp();
+        }
+        TraceState state = parameters.getInstrumentationState();
+        Timer.Sample sample = Timer.start(meterRegistry);
+        return whenCompleted((res, err) -> {
+            String parentType = GraphQLTypeUtil.simplePrint(parameters.getExecutionStepInfo().getParent().getUnwrappedNonNullType());
+            String fieldName = parameters.getExecutionStepInfo().getFieldDefinition().getName();
+            sample.stop(buildFieldTimer(state.operationName, parentType, fieldName));
+        });
+    }
+
+    private Timer buildQueryTimer(String operationName, String operation) {
+        return Timer.builder(QUERY_TIME_METRIC_NAME)
+                .description(TIMER_DESCRIPTION)
+                .tag(OPERATION_NAME_TAG, operationName)
+                .tag(OPERATION, operation)
+                .register(meterRegistry);
+    }
+
+    private Timer buildFieldTimer(String operationName, String parent, String field) {
+        return Timer.builder(RESOLVER_TIME_METRIC_NAME)
+                .description(TIMER_DESCRIPTION)
+                .tag(OPERATION_NAME_TAG, operationName)
+                .tag(PARENT, parent)
+                .tag(FIELD, field)
+                .register(meterRegistry);
+    }
+
+    private static class TraceState implements InstrumentationState {
+        private final String operationName;
+
+        private TraceState(String operationName) {
+            this.operationName = operationName == null ? "__UNKNOWN__" : operationName;
+        }
+    }
+}

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraph.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraph.java
@@ -5,10 +5,15 @@ import graphql.ExecutionInput;
 import graphql.ExecutionResult;
 import graphql.GraphQL;
 import graphql.analysis.MaxQueryComplexityInstrumentation;
+import graphql.execution.instrumentation.ChainedInstrumentation;
+import graphql.execution.instrumentation.Instrumentation;
 import graphql.schema.GraphQLSchema;
 import org.opentripplanner.api.json.GraphQLResponseSerializer;
+import org.opentripplanner.ext.readiness_endpoint.ActuatorAPI;
+import org.opentripplanner.ext.readiness_endpoint.MicrometerGraphQLInstrumentation;
 import org.opentripplanner.routing.RoutingService;
 import org.opentripplanner.standalone.server.Router;
+import org.opentripplanner.util.OTPFeature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,7 +45,14 @@ class TransmodelGraph {
             String operationName,
             int maxResolves
     ) {
-        MaxQueryComplexityInstrumentation instrumentation = new MaxQueryComplexityInstrumentation(maxResolves);
+        Instrumentation instrumentation = new MaxQueryComplexityInstrumentation(maxResolves);
+        if (OTPFeature.ActuatorAPI.isOn()) {
+            instrumentation = new ChainedInstrumentation(
+                    new MicrometerGraphQLInstrumentation(ActuatorAPI.prometheusRegistry),
+                    instrumentation
+            );
+        }
+
         GraphQL graphQL = GraphQL.newGraphQL(indexSchema).instrumentation(instrumentation).build();
 
         if (variables == null) {

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
@@ -278,6 +278,7 @@ public class TransmodelGraphQLSchema {
             .newFieldDefinition()
             .name("stopPlace")
             .description("Get a single stopPlace based on its id)")
+            .withDirective(gqlUtil.timingData)
             .type(stopPlaceType)
             .argument(GraphQLArgument
                 .newArgument()
@@ -295,6 +296,7 @@ public class TransmodelGraphQLSchema {
             .newFieldDefinition()
             .name("stopPlaces")
             .description("Get all stopPlaces")
+            .withDirective(gqlUtil.timingData)
             .type(new GraphQLNonNull(new GraphQLList(stopPlaceType)))
             .argument(GraphQLArgument
                 .newArgument()
@@ -326,6 +328,7 @@ public class TransmodelGraphQLSchema {
             .newFieldDefinition()
             .name("stopPlacesByBbox")
             .description("Get all stop places within the specified bounding box")
+            .withDirective(gqlUtil.timingData)
             .type(new GraphQLNonNull(new GraphQLList(stopPlaceType)))
             .argument(GraphQLArgument
                 .newArgument()
@@ -385,6 +388,7 @@ public class TransmodelGraphQLSchema {
             .newFieldDefinition()
             .name("quay")
             .description("Get a single quay based on its id)")
+            .withDirective(gqlUtil.timingData)
             .type(quayType)
             .argument(GraphQLArgument
                 .newArgument()
@@ -400,6 +404,7 @@ public class TransmodelGraphQLSchema {
             .newFieldDefinition()
             .name("quays")
             .description("Get all quays")
+            .withDirective(gqlUtil.timingData)
             .type(new GraphQLNonNull(new GraphQLList(quayType)))
             .argument(GraphQLArgument
                 .newArgument()
@@ -443,6 +448,7 @@ public class TransmodelGraphQLSchema {
             .newFieldDefinition()
             .name("quaysByBbox")
             .description("Get all quays within the specified bounding box")
+            .withDirective(gqlUtil.timingData)
             .type(new GraphQLNonNull(new GraphQLList(quayType)))
             .argument(GraphQLArgument
                 .newArgument()
@@ -505,6 +511,7 @@ public class TransmodelGraphQLSchema {
             .name("quaysByRadius")
             .description(
                 "Get all quays within the specified walking radius from a location. The returned type has two fields quay and distance")
+            .withDirective(gqlUtil.timingData)
             .type(relay.connectionType("quayAtDistance",
                 relay.edgeType("quayAtDistance", quayAtDistance, null, new ArrayList<>()),
                 new ArrayList<>()
@@ -571,6 +578,8 @@ public class TransmodelGraphQLSchema {
           .name("nearest")
           .description(
               "Get all places (quays, stop places, car parks etc. with coordinates) within the specified radius from a location. The returned type has two fields place and distance. The search is done by walking so the distance is according to the network of walkables.")
+
+          .withDirective(gqlUtil.timingData)
           .type(relay.connectionType("placeAtDistance",
               relay.edgeType("placeAtDistance", placeAtDistanceType, null, new ArrayList<>()),
               new ArrayList<>()))
@@ -688,6 +697,7 @@ public class TransmodelGraphQLSchema {
             .newFieldDefinition()
             .name("authority")
             .description("Get an authority by ID")
+            .withDirective(gqlUtil.timingData)
             .type(authorityType)
             .argument(GraphQLArgument
                 .newArgument()
@@ -703,6 +713,7 @@ public class TransmodelGraphQLSchema {
             .newFieldDefinition()
             .name("authorities")
             .description("Get all authorities")
+            .withDirective(gqlUtil.timingData)
             .type(new GraphQLNonNull(new GraphQLList(authorityType)))
             .dataFetcher(environment -> {
               return new ArrayList<>(GqlUtil.getRoutingService(environment).getAgencies());
@@ -712,6 +723,7 @@ public class TransmodelGraphQLSchema {
             .newFieldDefinition()
             .name("operator")
             .description("Get a operator by ID")
+            .withDirective(gqlUtil.timingData)
             .type(operatorType)
             .argument(GraphQLArgument
                 .newArgument()
@@ -728,6 +740,7 @@ public class TransmodelGraphQLSchema {
             .newFieldDefinition()
             .name("operators")
             .description("Get all operators")
+            .withDirective(gqlUtil.timingData)
             .type(new GraphQLNonNull(new GraphQLList(operatorType)))
             .dataFetcher(environment -> {
               return new ArrayList<>(GqlUtil.getRoutingService(environment).getAllOperators());
@@ -737,6 +750,7 @@ public class TransmodelGraphQLSchema {
             .newFieldDefinition()
             .name("line")
             .description("Get a single line based on its id")
+            .withDirective(gqlUtil.timingData)
             .type(lineType)
             .argument(GraphQLArgument
                 .newArgument()
@@ -752,6 +766,7 @@ public class TransmodelGraphQLSchema {
             .newFieldDefinition()
             .name("lines")
             .description("Get all lines")
+            .withDirective(gqlUtil.timingData)
             .type(new GraphQLNonNull(new GraphQLList(lineType)))
             .argument(GraphQLArgument
                 .newArgument()
@@ -857,6 +872,7 @@ public class TransmodelGraphQLSchema {
             .newFieldDefinition()
             .name("serviceJourney")
             .description("Get a single service journey based on its id")
+            .withDirective(gqlUtil.timingData)
             .type(serviceJourneyType)
             .argument(GraphQLArgument
                 .newArgument()
@@ -873,6 +889,7 @@ public class TransmodelGraphQLSchema {
             .newFieldDefinition()
             .name("serviceJourneys")
             .description("Get all service journeys")
+            .withDirective(gqlUtil.timingData)
             .type(new GraphQLNonNull(new GraphQLList(serviceJourneyType)))
             .argument(GraphQLArgument
                 .newArgument()
@@ -933,6 +950,7 @@ public class TransmodelGraphQLSchema {
             .newFieldDefinition()
             .name("bikeRentalStations")
             .description("Get all bike rental stations")
+            .withDirective(gqlUtil.timingData)
             .argument(GraphQLArgument
                 .newArgument()
                 .name("ids")
@@ -958,6 +976,7 @@ public class TransmodelGraphQLSchema {
             .newFieldDefinition()
             .name("bikeRentalStation")
             .description("Get all bike rental stations")
+            .withDirective(gqlUtil.timingData)
             .type(bikeRentalStationType)
             .argument(GraphQLArgument
                 .newArgument()
@@ -981,6 +1000,7 @@ public class TransmodelGraphQLSchema {
             .name("bikeRentalStationsByBbox")
             .description(
                 "Get all bike rental stations within the specified bounding box.")
+            .withDirective(gqlUtil.timingData)
             .type(new GraphQLNonNull(new GraphQLList(bikeRentalStationType)))
             .argument(GraphQLArgument
                 .newArgument()
@@ -1015,6 +1035,7 @@ public class TransmodelGraphQLSchema {
             .newFieldDefinition()
             .name("bikePark")
             .description("Get a single bike park based on its id")
+            .withDirective(gqlUtil.timingData)
             .type(bikeParkType)
             .argument(GraphQLArgument
                 .newArgument()
@@ -1035,6 +1056,7 @@ public class TransmodelGraphQLSchema {
             .newFieldDefinition()
             .name("bikeParks")
             .description("Get all bike parks")
+            .withDirective(gqlUtil.timingData)
             .type(new GraphQLNonNull(new GraphQLList(bikeParkType)))
             .dataFetcher(environment -> {
               return new ArrayList<>(GqlUtil.getRoutingService(environment)
@@ -1046,6 +1068,7 @@ public class TransmodelGraphQLSchema {
             .newFieldDefinition()
             .name("routingParameters")
             .description("Get default routing parameters.")
+            .withDirective(gqlUtil.timingData)
             .type(this.routing.graphQLType)
             .dataFetcher(environment -> routing.request)
             .build())
@@ -1053,6 +1076,7 @@ public class TransmodelGraphQLSchema {
             .newFieldDefinition()
             .name("situations")
             .description("Get all active situations.")
+            .withDirective(gqlUtil.timingData)
             .type(new GraphQLNonNull(new GraphQLList(ptSituationElementType)))
             .argument(GraphQLArgument
                 .newArgument()
@@ -1091,6 +1115,7 @@ public class TransmodelGraphQLSchema {
             .newFieldDefinition()
             .name("situation")
             .description("Get a single situation based on its situationNumber")
+            .withDirective(gqlUtil.timingData)
             .type(ptSituationElementType)
             .argument(GraphQLArgument
                 .newArgument()
@@ -1108,6 +1133,7 @@ public class TransmodelGraphQLSchema {
             .newFieldDefinition()
             .name("serverInfo")
             .description("Get OTP server information")
+            .withDirective(gqlUtil.timingData)
             .type(new GraphQLNonNull(serverInfoType))
             .dataFetcher(e -> projectInfo())
             .build())

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/TripQuery.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/TripQuery.java
@@ -29,6 +29,7 @@ public class TripQuery {
             + "trip patterns describing suggested alternatives for the trip."
         )
         .type(tripType)
+        .withDirective(gqlUtil.timingData)
         .argument(GraphQLArgument.newArgument()
             .name("dateTime")
             .description(

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/support/GqlUtil.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/support/GqlUtil.java
@@ -1,7 +1,9 @@
 package org.opentripplanner.ext.transmodelapi.support;
 
 import graphql.Scalars;
+import graphql.introspection.Introspection.DirectiveLocation;
 import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.GraphQLDirective;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLInputObjectField;
 import graphql.schema.GraphQLList;
@@ -32,6 +34,7 @@ public class GqlUtil {
   public final GraphQLScalarType localTimeScalar;
   public final GraphQLObjectType timeScalar;
   public final ServiceDateMapper serviceDateMapper;
+  public final GraphQLDirective timingData;
 
   /** private to prevent util class from instantiation */
   public GqlUtil(TimeZone timeZone) {
@@ -41,6 +44,11 @@ public class GqlUtil {
     this.localTimeScalar = LocalTimeScalarFactory.createLocalTimeScalar();
     this.timeScalar = TimeScalarFactory.createSecondsSinceMidnightAsTimeObject();
     this.serviceDateMapper =  new ServiceDateMapper(timeZone);
+    this.timingData = GraphQLDirective.newDirective()
+            .name("timingData")
+            .description("Add timing data to prometheus, if Actuator API is enabled")
+            .validLocation(DirectiveLocation.FIELD_DEFINITION)
+            .build();
   }
 
   public static RoutingService getRoutingService(DataFetchingEnvironment environment) {


### PR DESCRIPTION
### Summary
Add performance monitoring usable via the Actuator API for the GraphQL APIs. This is done using a graphql-java instrumentation, which is added to the field resolvers marked using the `timingData` directive in the schema, as well as to query parsing, validation and execution.

### Issue
Relates to #2958

### Unit tests
None added

### Code style
Formatted using IDEA autoformatter

### Documentation
TODO

### Changelog
The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md) 
is generated from the pull-request title, make sure the title describe the feature or issue fixed. 
To exclude the PR from the changelog add `[changelog skip]` in the title.
