### PR TITLE
Fix string formatting in NeTEx import issue report [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/netex/mapping/StationMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/StationMapper.java
@@ -32,7 +32,7 @@ class StationMapper {
     if (station.getCoordinate() == null) {
       issueStore.add(
               "StationWithoutCoordinates",
-              "Station %i does not contain any coordinates.",
+              "Station %s does not contain any coordinates.",
               station.getId()
       );
     }

--- a/src/main/java/org/opentripplanner/netex/mapping/StopTimesMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/StopTimesMapper.java
@@ -205,7 +205,7 @@ class StopTimesMapper {
         }
 
         if (passingTime.getArrivalTime() == null && passingTime.getDepartureTime() == null) {
-            issueStore.add("TripWithoutTime","Time missing for trip %i", trip.getId());
+            issueStore.add("TripWithoutTime","Time missing for trip %s", trip.getId());
         }
 
         if (currentHeadSign != null) {
@@ -226,7 +226,7 @@ class StopTimesMapper {
         if (stopId == null && flexibleStopPlaceId == null) {
             issueStore.add(
                     "PassengerStopAssignmentNotFound",
-                    "No passengerStopAssignment found for %i",
+                    "No passengerStopAssignment found for %s",
                     stopPointRef
             );
             return null;


### PR DESCRIPTION
### Summary
After merging https://github.com/opentripplanner/OpenTripPlanner/pull/3719, the graph build started to fail due to invalid string formatting. This fixes those places where invalid format specifiers were used.

### Unit tests
None changed

### Code style
Style followed

### Documentation
None needed

### Changelog
The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md) 
is generated from the pull-request title, make sure the title describe the feature or issue fixed. 
To exclude the PR from the changelog add `[changelog skip]` in the title.
