### PR TITLE
Logging first time instance reports it is ready to use

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/siri/SiriAlertsUpdateHandlerTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/siri/SiriAlertsUpdateHandlerTest.java
@@ -1,5 +1,11 @@
 package org.opentripplanner.ext.siri;
 
+import java.math.BigInteger;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
 import org.junit.Test;
 import org.opentripplanner.GtfsTest;
 import org.opentripplanner.model.FeedScopedId;
@@ -12,14 +18,27 @@ import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
 import org.opentripplanner.updater.GraphUpdaterManager;
 import uk.org.ifopt.siri20.StopPlaceRef;
-import uk.org.siri.siri20.*;
-
-import java.math.BigInteger;
-import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
+import uk.org.siri.siri20.AffectedLineStructure;
+import uk.org.siri.siri20.AffectedRouteStructure;
+import uk.org.siri.siri20.AffectedStopPlaceStructure;
+import uk.org.siri.siri20.AffectedStopPointStructure;
+import uk.org.siri.siri20.AffectedVehicleJourneyStructure;
+import uk.org.siri.siri20.AffectsScopeStructure;
+import uk.org.siri.siri20.DataFrameRefStructure;
+import uk.org.siri.siri20.DefaultedTextStructure;
+import uk.org.siri.siri20.FramedVehicleJourneyRefStructure;
+import uk.org.siri.siri20.HalfOpenTimestampOutputRangeStructure;
+import uk.org.siri.siri20.InfoLinkStructure;
+import uk.org.siri.siri20.LineRef;
+import uk.org.siri.siri20.PtSituationElement;
+import uk.org.siri.siri20.RoutePointTypeEnumeration;
+import uk.org.siri.siri20.ServiceDelivery;
+import uk.org.siri.siri20.SeverityEnumeration;
+import uk.org.siri.siri20.SituationExchangeDeliveryStructure;
+import uk.org.siri.siri20.SituationNumber;
+import uk.org.siri.siri20.StopPointRef;
+import uk.org.siri.siri20.VehicleJourneyRef;
+import uk.org.siri.siri20.WorkflowStatusEnumeration;
 
 public class SiriAlertsUpdateHandlerTest extends GtfsTest {
   private static final String FEED_ID = "FEED";
@@ -51,7 +70,7 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
         createAffectsStop(stopConditions, stopId.getId())
     );
 
-    Integer priorityValue = Integer.valueOf(3);
+    Integer priorityValue = 3;
     ptSituation.setPriority(BigInteger.valueOf(priorityValue));
 
     InfoLinkStructure infoLink = new InfoLinkStructure();
@@ -106,7 +125,7 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
   public void init() {
     if (routingService == null) {
       routingService = new RoutingService(graph);
-      graph.updaterManager = new GraphUpdaterManager(graph);
+      graph.updaterManager = new GraphUpdaterManager(graph, List.of());
 
     }
     else {

--- a/src/ext/java/org/opentripplanner/ext/actuator/ActuatorAPI.java
+++ b/src/ext/java/org/opentripplanner/ext/actuator/ActuatorAPI.java
@@ -45,6 +45,8 @@ public class ActuatorAPI {
 
     private final Router router;
 
+    private static boolean isReadinessLogged = false;
+
     public ActuatorAPI(@Context OTPServer otpServer) {
         this.router = otpServer.getRouter();
 
@@ -138,6 +140,11 @@ public class ActuatorAPI {
                     .type("text/plain")
                     .build());
             }
+        }
+
+        if (!isReadinessLogged) {
+            LOG.info("All updaters initialized");
+            isReadinessLogged = true;
         }
 
         return Response.status(Response.Status.OK).entity(

--- a/src/ext/java/org/opentripplanner/ext/actuator/ActuatorAPI.java
+++ b/src/ext/java/org/opentripplanner/ext/actuator/ActuatorAPI.java
@@ -127,13 +127,13 @@ public class ActuatorAPI {
     @Path("/health")
     public Response health() {
         if (router.graph.updaterManager != null) {
-            var waitingForUpdaters = router.graph.updaterManager.listNonePrimedUpdaters();
+            var listUnprimedUpdaters = router.graph.updaterManager.listUnprimedUpdaters();
 
-            if (!waitingForUpdaters.isEmpty()) {
-                LOG.info("Graph ready, waiting for updaters: {}", waitingForUpdaters);
+            if (!listUnprimedUpdaters.isEmpty()) {
+                LOG.info("Graph ready, waiting for updaters: {}", listUnprimedUpdaters);
                 throw new WebApplicationException(Response
                     .status(Response.Status.NOT_FOUND)
-                    .entity("Graph ready, waiting for updaters: " + waitingForUpdaters + "\n")
+                    .entity("Graph ready, waiting for updaters: " + listUnprimedUpdaters + "\n")
                     .type("text/plain")
                     .build());
             }

--- a/src/ext/java/org/opentripplanner/ext/actuator/ActuatorAPI.java
+++ b/src/ext/java/org/opentripplanner/ext/actuator/ActuatorAPI.java
@@ -127,13 +127,13 @@ public class ActuatorAPI {
     @Path("/health")
     public Response health() {
         if (router.graph.updaterManager != null) {
-            int waitingUpdaters = router.graph.updaterManager.numberOfNonePrimedUpdaters();
+            var waitingForUpdaters = router.graph.updaterManager.listNonePrimedUpdaters();
 
-            if (waitingUpdaters > 0) {
-                LOG.info("Graph ready, waiting for updaters: {}", waitingUpdaters);
+            if (!waitingForUpdaters.isEmpty()) {
+                LOG.info("Graph ready, waiting for updaters: {}", waitingForUpdaters);
                 throw new WebApplicationException(Response
                     .status(Response.Status.NOT_FOUND)
-                    .entity("Graph ready, waiting for updaters: " + waitingUpdaters + "\n")
+                    .entity("Graph ready, waiting for updaters: " + waitingForUpdaters + "\n")
                     .type("text/plain")
                     .build());
             }

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETGooglePubsubUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETGooglePubsubUpdater.java
@@ -13,20 +13,6 @@ import com.google.pubsub.v1.ProjectTopicName;
 import com.google.pubsub.v1.PubsubMessage;
 import com.google.pubsub.v1.PushConfig;
 import com.google.pubsub.v1.Subscription;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.time.DurationFormatUtils;
-import org.entur.protobuf.mapper.SiriMapper;
-import org.opentripplanner.ext.siri.SiriTimetableSnapshotSource;
-import org.opentripplanner.routing.graph.Graph;
-import org.opentripplanner.updater.GraphUpdater;
-import org.opentripplanner.updater.GraphUpdaterManager;
-import org.opentripplanner.util.HttpUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import uk.org.siri.siri20.EstimatedTimetableDeliveryStructure;
-import uk.org.siri.siri20.Siri;
-import uk.org.siri.www.siri.SiriType;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -35,6 +21,19 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.time.DurationFormatUtils;
+import org.entur.protobuf.mapper.SiriMapper;
+import org.opentripplanner.ext.siri.SiriTimetableSnapshotSource;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.updater.GraphUpdater;
+import org.opentripplanner.updater.WriteToGraphCallback;
+import org.opentripplanner.util.HttpUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.org.siri.siri20.EstimatedTimetableDeliveryStructure;
+import uk.org.siri.siri20.Siri;
+import uk.org.siri.www.siri.SiriType;
 
 /**
  * This class starts a Google PubSub subscription
@@ -72,7 +71,7 @@ public class SiriETGooglePubsubUpdater implements GraphUpdater {
     /**
      * Parent update manager. Is used to execute graph writer runnables.
      */
-    private GraphUpdaterManager updaterManager;
+    private WriteToGraphCallback saveResultOnGraph;
 
     private SiriTimetableSnapshotSource snapshotSource;
 
@@ -158,8 +157,8 @@ public class SiriETGooglePubsubUpdater implements GraphUpdater {
     }
 
     @Override
-    public void setGraphUpdaterManager(GraphUpdaterManager updaterManager) {
-        this.updaterManager = updaterManager;
+    public void setGraphUpdaterManager(WriteToGraphCallback saveResultOnGraph) {
+        this.saveResultOnGraph = saveResultOnGraph;
     }
 
     @Override
@@ -340,7 +339,7 @@ public class SiriETGooglePubsubUpdater implements GraphUpdater {
                             getTimeSinceStartupString());
                 }
 
-                updaterManager.execute(graph -> {
+                saveResultOnGraph.execute(graph -> {
                     snapshotSource.applyEstimatedTimetable(graph, feedId, false, estimatedTimetableDeliveries);
                 });
             }

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETUpdater.java
@@ -1,17 +1,16 @@
 package org.opentripplanner.ext.siri.updater;
 
+import java.util.List;
 import org.apache.commons.lang3.BooleanUtils;
 import org.opentripplanner.ext.siri.SiriTimetableSnapshotSource;
 import org.opentripplanner.routing.graph.Graph;
-import org.opentripplanner.updater.GraphUpdaterManager;
 import org.opentripplanner.updater.PollingGraphUpdater;
+import org.opentripplanner.updater.WriteToGraphCallback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.org.siri.siri20.EstimatedTimetableDeliveryStructure;
 import uk.org.siri.siri20.ServiceDelivery;
 import uk.org.siri.siri20.Siri;
-
-import java.util.List;
 
 /**
  * Update OTP stop time tables from some (realtime) source
@@ -33,7 +32,7 @@ public class SiriETUpdater extends PollingGraphUpdater {
     /**
      * Parent update manager. Is used to execute graph writer runnables.
      */
-    protected GraphUpdaterManager updaterManager;
+    protected WriteToGraphCallback saveResultOnGraph;
 
     /**
      * Update streamer
@@ -89,8 +88,8 @@ public class SiriETUpdater extends PollingGraphUpdater {
     }
 
     @Override
-    public void setGraphUpdaterManager(GraphUpdaterManager updaterManager) {
-        this.updaterManager = updaterManager;
+    public void setGraphUpdaterManager(WriteToGraphCallback saveResultOnGraph) {
+        this.saveResultOnGraph = saveResultOnGraph;
     }
 
     @Override
@@ -133,7 +132,7 @@ public class SiriETUpdater extends PollingGraphUpdater {
                 final boolean markPrimed = !moreData;
                 List<EstimatedTimetableDeliveryStructure> etds = serviceDelivery.getEstimatedTimetableDeliveries();
                 if (etds != null) {
-                    updaterManager.execute(graph -> {
+                    saveResultOnGraph.execute(graph -> {
                         snapshotSource.applyEstimatedTimetable(graph, feedId, fullDataset, etds);
                         if (markPrimed) primed = true;
                     });

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriSXUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriSXUpdater.java
@@ -1,5 +1,11 @@
 package org.opentripplanner.ext.siri.updater;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
 import org.apache.commons.lang3.BooleanUtils;
 import org.opentripplanner.ext.siri.SiriAlertsUpdateHandler;
 import org.opentripplanner.ext.siri.SiriFuzzyTripMatcher;
@@ -8,25 +14,18 @@ import org.opentripplanner.routing.RoutingService;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
 import org.opentripplanner.routing.services.TransitAlertService;
-import org.opentripplanner.updater.GraphUpdaterManager;
 import org.opentripplanner.updater.PollingGraphUpdater;
+import org.opentripplanner.updater.WriteToGraphCallback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.org.siri.siri20.ServiceDelivery;
 import uk.org.siri.siri20.Siri;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.time.ZonedDateTime;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
-
 public class SiriSXUpdater extends PollingGraphUpdater {
     private static final Logger LOG = LoggerFactory.getLogger(SiriSXUpdater.class);
     private static final long RETRY_INTERVAL_MILLIS = 5000;
 
-    private GraphUpdaterManager updaterManager;
+    private WriteToGraphCallback saveResultOnGraph;
 
     private ZonedDateTime lastTimestamp = ZonedDateTime.now().minusWeeks(1);
 
@@ -78,8 +77,8 @@ public class SiriSXUpdater extends PollingGraphUpdater {
     }
 
     @Override
-    public void setGraphUpdaterManager(GraphUpdaterManager updaterManager) {
-        this.updaterManager = updaterManager;
+    public void setGraphUpdaterManager(WriteToGraphCallback saveResultOnGraph) {
+        this.saveResultOnGraph = saveResultOnGraph;
     }
 
     @Override
@@ -107,7 +106,7 @@ public class SiriSXUpdater extends PollingGraphUpdater {
                     moreData = BooleanUtils.isTrue(serviceDelivery.isMoreData());
                     final boolean markPrimed = !moreData;
                     if (serviceDelivery.getSituationExchangeDeliveries() != null) {
-                        updaterManager.execute(graph -> {
+                        saveResultOnGraph.execute(graph -> {
                             updateHandler.update(serviceDelivery);
                             if (markPrimed) primed = true;
                         });

--- a/src/main/java/org/opentripplanner/routing/graph/Graph.java
+++ b/src/main/java/org/opentripplanner/routing/graph/Graph.java
@@ -113,9 +113,6 @@ public class Graph implements Serializable {
 
     private final OtpProjectInfo projectInfo = projectInfo();
 
-    // TODO Remove this field, use Router.routerId ?
-    public String routerId;
-
     private final Map<Edge, List<TurnRestriction>> turnRestrictions = Maps.newHashMap();
 
     public final StreetNotesService streetNotesService = new StreetNotesService();

--- a/src/main/java/org/opentripplanner/updater/GraphUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/GraphUpdater.java
@@ -18,26 +18,26 @@ public interface GraphUpdater {
      * Graph updaters must be aware of their manager to be able to execute GraphWriterRunnables.
      * GraphUpdaterConfigurator should take care of calling this function.
      */
-    void setGraphUpdaterManager (GraphUpdaterManager updaterManager);
+    void setGraphUpdaterManager(WriteToGraphCallback saveResultOnGraph);
 
     /**
      * Here the updater can be initialized. If it throws, the updater won't be started (i.e. the run
      * method won't be called). All updaters' setup methods will be run sequentially in a single-threaded manner
      * before updates begin, in order to avoid concurrent reads/writes.
      */
-    void setup (Graph graph) throws Exception;
+    void setup(Graph graph) throws Exception;
 
     /**
      * This method will run in its own thread. It pulls or receives updates and applies them to the graph.
      * It must perform any writes to the graph by passing GraphWriterRunnables to GraphUpdaterManager.execute().
      * This queues up the write operations, ensuring that only one updater performs writes at a time.
      */
-    void run () throws Exception;
+    void run() throws Exception;
 
     /**
      * Here the updater can clean up after itself.
      */
-    void teardown ();
+    void teardown();
 
     /**
      * Allow clients to wait for all realtime data to be loaded before submitting any travel plan requests.
@@ -45,7 +45,7 @@ public interface GraphUpdater {
      * TODO OTP2 This is really a bit backward. We should just run() the updaters once before scheduling them to poll,
      *           and not bring the router online until they have finished.
      */
-    default boolean isPrimed () {
+    default boolean isPrimed() {
         return true;
     }
 

--- a/src/main/java/org/opentripplanner/updater/GraphUpdaterConfigurator.java
+++ b/src/main/java/org/opentripplanner/updater/GraphUpdaterConfigurator.java
@@ -1,7 +1,7 @@
 package org.opentripplanner.updater;
 
-import org.opentripplanner.ext.vehiclerentalservicedirectory.VehicleRentalServiceDirectoryFetcher;
-import org.opentripplanner.ext.vehiclerentalservicedirectory.api.VehicleRentalServiceDirectoryFetcherParameters;
+import java.util.ArrayList;
+import java.util.List;
 import org.opentripplanner.ext.siri.updater.SiriETGooglePubsubUpdater;
 import org.opentripplanner.ext.siri.updater.SiriETGooglePubsubUpdaterParameters;
 import org.opentripplanner.ext.siri.updater.SiriETUpdater;
@@ -10,13 +10,11 @@ import org.opentripplanner.ext.siri.updater.SiriSXUpdater;
 import org.opentripplanner.ext.siri.updater.SiriSXUpdaterParameters;
 import org.opentripplanner.ext.siri.updater.SiriVMUpdater;
 import org.opentripplanner.ext.siri.updater.SiriVMUpdaterParameters;
+import org.opentripplanner.ext.vehiclerentalservicedirectory.VehicleRentalServiceDirectoryFetcher;
+import org.opentripplanner.ext.vehiclerentalservicedirectory.api.VehicleRentalServiceDirectoryFetcherParameters;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.updater.alerts.GtfsRealtimeAlertsUpdater;
 import org.opentripplanner.updater.alerts.GtfsRealtimeAlertsUpdaterParameters;
-import org.opentripplanner.updater.vehicle_parking.VehicleParkingUpdater;
-import org.opentripplanner.updater.vehicle_parking.VehicleParkingUpdaterParameters;
-import org.opentripplanner.updater.vehicle_rental.VehicleRentalUpdater;
-import org.opentripplanner.updater.vehicle_rental.VehicleRentalUpdaterParameters;
 import org.opentripplanner.updater.stoptime.MqttGtfsRealtimeUpdater;
 import org.opentripplanner.updater.stoptime.MqttGtfsRealtimeUpdaterParameters;
 import org.opentripplanner.updater.stoptime.PollingStoptimeUpdater;
@@ -25,11 +23,12 @@ import org.opentripplanner.updater.stoptime.WebsocketGtfsRealtimeUpdater;
 import org.opentripplanner.updater.stoptime.WebsocketGtfsRealtimeUpdaterParameters;
 import org.opentripplanner.updater.street_notes.WFSNotePollingGraphUpdaterParameters;
 import org.opentripplanner.updater.street_notes.WinkkiPollingGraphUpdater;
+import org.opentripplanner.updater.vehicle_parking.VehicleParkingUpdater;
+import org.opentripplanner.updater.vehicle_parking.VehicleParkingUpdaterParameters;
+import org.opentripplanner.updater.vehicle_rental.VehicleRentalUpdater;
+import org.opentripplanner.updater.vehicle_rental.VehicleRentalUpdaterParameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Sets up and starts all the graph updaters.
@@ -63,7 +62,7 @@ public abstract class GraphUpdaterConfigurator {
         updaterManager.startUpdaters();
 
         // Stop the updater manager if it contains nothing
-        if (updaterManager.size() == 0) {
+        if (updaterManager.numberOfUpdaters() == 0) {
             updaterManager.stop();
         }
         // Otherwise add it to the graph
@@ -75,7 +74,7 @@ public abstract class GraphUpdaterConfigurator {
     public static void shutdownGraph(Graph graph) {
         GraphUpdaterManager updaterManager = graph.updaterManager;
         if (updaterManager != null) {
-            LOG.info("Stopping updater manager with " + updaterManager.size() + " updaters.");
+            LOG.info("Stopping updater manager with " + updaterManager.numberOfUpdaters() + " updaters.");
             updaterManager.stop();
         }
     }

--- a/src/main/java/org/opentripplanner/updater/GraphUpdaterManager.java
+++ b/src/main/java/org/opentripplanner/updater/GraphUpdaterManager.java
@@ -54,13 +54,6 @@ public class GraphUpdaterManager implements WriteToGraphCallback {
      */
     private final List<GraphUpdater> updaterList = new ArrayList<>();
 
-
-    /**
-     * This is set to true after all updaters are ready and the initial set of updates are
-     * processed.
-     */
-    private boolean allUpdatersPrimed = false;
-
     /**
      * The Graph that will be updated.
      */
@@ -155,7 +148,7 @@ public class GraphUpdaterManager implements WriteToGraphCallback {
      * Return the number of updaters started, but not ready.
      * @see GraphUpdater#isPrimed()
      */
-    public List<String> listNonePrimedUpdaters() {
+    public List<String> listUnprimedUpdaters() {
         return updaterList.stream()
                 .filter(Predicate.not(GraphUpdater::isPrimed))
                 .map(GraphUpdater::getConfigRef)
@@ -197,8 +190,10 @@ public class GraphUpdaterManager implements WriteToGraphCallback {
     }
 
     /**
-     * This method start a task during startup, witch update the 'numberOfNonePrimedUpdaters'. It
-     * does so in its own thread, using busy-wait(anti-pattern). The ideal would be to add a
+     * This method start a task during startup and log a message when all updaters are initialized.
+     * When all updaters are ready, then OTP is ready for processing routing requests.
+     * <p>
+     * It starts its own thread using busy-wait(anti-pattern). The ideal would be to add a
      * callback from each updater to notify the manager about 'isPrimed'. But, this is simple, the
      * thread is mostly idle, and it is short-lived, so the busy-wait is a compromise.
      */
@@ -207,8 +202,7 @@ public class GraphUpdaterManager implements WriteToGraphCallback {
             while (true) {
                 try {
                     if (updaterList.stream().allMatch(GraphUpdater::isPrimed)) {
-                        allUpdatersPrimed = true;
-                        LOG.info("All updaters initialized");
+                        LOG.info("OTP UPDATERS INITIALIZED - OTP is read for routing!");
                         return;
                     }
                     //noinspection BusyWait

--- a/src/main/java/org/opentripplanner/updater/GraphUpdaterManager.java
+++ b/src/main/java/org/opentripplanner/updater/GraphUpdaterManager.java
@@ -2,10 +2,6 @@ package org.opentripplanner.updater;
 
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import org.opentripplanner.routing.graph.Graph;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -13,8 +9,10 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import org.opentripplanner.routing.graph.Graph;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class is attached to the graph:
@@ -28,19 +26,9 @@ import java.util.concurrent.TimeUnit;
  * between graph write operations.
  * 
  */
-public class GraphUpdaterManager {
+public class GraphUpdaterManager implements WriteToGraphCallback {
 
-    private static Logger LOG = LoggerFactory.getLogger(GraphUpdaterManager.class);
-    
-    /**
-     * Text used for naming threads when the graph lacks a routerId.
-     */
-    private static String DEFAULT_ROUTER_ID = "(default)";
-    
-    /**
-     * Thread factory used to create new threads, giving them more human-readable names including the routerId.
-     */
-    private ThreadFactory threadFactory;
+    private static final Logger LOG = LoggerFactory.getLogger(GraphUpdaterManager.class);
 
     /**
      * OTP's multi-version concurrency control model for graph updating allows simultaneous reads,
@@ -51,46 +39,56 @@ public class GraphUpdaterManager {
      *        We're scheduling for immediate execution from separate threads that sleep in a loop.
      *        We should perhaps switch to having polling GraphUpdaters call scheduleAtFixedInterval.
      */
-    private ScheduledExecutorService scheduler;
+    private final ScheduledExecutorService scheduler;
 
     /**
      * A pool of threads on which the updaters will run.
      * This creates a pool that will auto-scale up to any size (maximum pool size is MAX_INT).
      * FIXME The polling updaters occupy an entire thread, sleeping in between polling operations.
      */
-    private ExecutorService updaterPool;
+    private final ExecutorService updaterPool;
 
     /**
      * Keep track of all updaters so we can cleanly free resources associated with them at shutdown.
      */
-    private List<GraphUpdater> updaterList = new ArrayList<>();
+    private final List<GraphUpdater> updaterList = new ArrayList<>();
 
     /**
      * The Graph that will be updated.
      */
-    private Graph graph;
+    private final Graph graph;
 
     /**
      * Constructor.
      * @param graph is the Graph that will be updated.
      */
-    public GraphUpdaterManager(Graph graph) {
+    public GraphUpdaterManager(Graph graph, List<GraphUpdater> updaters) {
         this.graph = graph;
-        
-        String routerId = graph.routerId;
-        if(routerId == null || routerId.isEmpty())
-            routerId = DEFAULT_ROUTER_ID;
-        
-        threadFactory = new ThreadFactoryBuilder().setNameFormat("GraphUpdater-" + routerId + "-%d").build();
-        scheduler = Executors.newSingleThreadScheduledExecutor(threadFactory);
-        updaterPool = Executors.newCachedThreadPool(threadFactory);
+         // Thread factory used to create new threads, giving them more human-readable names.
+        var threadFactory = new ThreadFactoryBuilder().setNameFormat("GraphUpdater-%d").build();
+        this.scheduler = Executors.newSingleThreadScheduledExecutor(threadFactory);
+        this.updaterPool = Executors.newCachedThreadPool(threadFactory);
+
+        for (GraphUpdater updater : updaters) {
+            updaterList.add(updater);
+            updater.setGraphUpdaterManager(this);
+        }
     }
 
-    public GraphUpdaterManager(Graph graph, List<GraphUpdater> updaters) {
-        this(graph);
-        for (GraphUpdater updater : updaters) {
-            this.addUpdater(updater);
-            updater.setGraphUpdaterManager(this);
+    /**
+     * This should be called only once at startup to kick off every updater in its own thread, and only after all
+     * the updaters have had their setup methods called.
+     */
+    public void startUpdaters() {
+        for (GraphUpdater updater : updaterList) {
+            LOG.info("Starting new thread for updater {}", updater.toString());
+            updaterPool.execute(() -> {
+                try {
+                    updater.run();
+                } catch (Exception e) {
+                    LOG.error("Error while running updater {}:", updater.getClass().getName(), e);
+                }
+            });
         }
     }
 
@@ -129,20 +127,11 @@ public class GraphUpdaterManager {
     }
 
     /**
-     * Adds an updater to the manager and runs it immediately in its own thread.
-     * 
-     * @param updater is the updater to add and run
-     */
-    public void addUpdater(final GraphUpdater updater) {
-        updaterList.add(updater);
-    }
-
-    /**
      * This is the method to use to modify the graph from the updaters. The runnables will be
      * scheduled after each other, guaranteeing that only one of these runnables will be active at
      * any time. If a particular GraphUpdater calls this method on more than one GraphWriterRunnable, they should be
      * executed in the same order that GraphUpdater made the calls.
-     * 
+     *
      * @param runnable is a graph writer runnable
      */
     public void execute(GraphWriterRunnable runnable) {
@@ -157,23 +146,6 @@ public class GraphUpdaterManager {
 
     public int size() {
         return updaterList.size();
-    }
-
-    /**
-     * This should be called only once at startup to kick off every updater in its own thread, and only after all
-     * the updaters have had their setup methods called.
-     */
-    public void startUpdaters() {
-        for (GraphUpdater updater : updaterList) {
-            LOG.info("Starting new thread for updater {}", updater.toString());
-            updaterPool.execute(() -> {
-                try {
-                    updater.run();
-                } catch (Exception e) {
-                    LOG.error("Error while running updater {}:", updater.getClass().getName(), e);
-                }
-            });
-        }
     }
 
     /**

--- a/src/main/java/org/opentripplanner/updater/WriteToGraphCallback.java
+++ b/src/main/java/org/opentripplanner/updater/WriteToGraphCallback.java
@@ -1,0 +1,15 @@
+package org.opentripplanner.updater;
+
+public interface WriteToGraphCallback {
+
+    /**
+     * This is the method to use to modify the graph from the updaters. The runnables will be
+     * scheduled after each other, guaranteeing that only one of these runnables will be active at
+     * any time. If a particular GraphUpdater calls this method on more than one
+     * GraphWriterRunnable, they should be executed in the same order that GraphUpdater made the
+     * calls.
+     *
+     * @param runnable is a graph writer runnable
+     */
+    void execute(GraphWriterRunnable runnable);
+}

--- a/src/main/java/org/opentripplanner/updater/alerts/GtfsRealtimeAlertsUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/alerts/GtfsRealtimeAlertsUpdater.java
@@ -1,20 +1,19 @@
 package org.opentripplanner.updater.alerts;
 
 import com.google.transit.realtime.GtfsRealtime.FeedMessage;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Map;
 import org.opentripplanner.routing.RoutingService;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
 import org.opentripplanner.routing.services.TransitAlertService;
-import org.opentripplanner.updater.GraphUpdaterManager;
 import org.opentripplanner.updater.GtfsRealtimeFuzzyTripMatcher;
 import org.opentripplanner.updater.PollingGraphUpdater;
+import org.opentripplanner.updater.WriteToGraphCallback;
 import org.opentripplanner.util.HttpUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.InputStream;
-import java.net.URI;
-import java.util.Map;
 
 /**
  * GTFS-RT alerts updater
@@ -32,7 +31,7 @@ import java.util.Map;
 public class GtfsRealtimeAlertsUpdater extends PollingGraphUpdater {
     private static final Logger LOG = LoggerFactory.getLogger(GtfsRealtimeAlertsUpdater.class);
 
-    private GraphUpdaterManager updaterManager;
+    private WriteToGraphCallback saveResultOnGraph;
 
     private Long lastTimestamp = Long.MIN_VALUE;
 
@@ -51,8 +50,8 @@ public class GtfsRealtimeAlertsUpdater extends PollingGraphUpdater {
     private TransitAlertService transitAlertService;
 
     @Override
-    public void setGraphUpdaterManager(GraphUpdaterManager updaterManager) {
-        this.updaterManager = updaterManager;
+    public void setGraphUpdaterManager(WriteToGraphCallback saveResultOnGraph) {
+        this.saveResultOnGraph = saveResultOnGraph;
     }
 
     public GtfsRealtimeAlertsUpdater(GtfsRealtimeAlertsUpdaterParameters config) {
@@ -101,7 +100,7 @@ public class GtfsRealtimeAlertsUpdater extends PollingGraphUpdater {
             }
 
             // Handle update in graph writer runnable
-            updaterManager.execute(graph -> updateHandler.update(feed));
+            saveResultOnGraph.execute(graph -> updateHandler.update(feed));
 
             lastTimestamp = feedTimestamp;
         } catch (Exception e) {

--- a/src/main/java/org/opentripplanner/updater/stoptime/MqttGtfsRealtimeUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/MqttGtfsRealtimeUpdater.java
@@ -2,6 +2,9 @@ package org.opentripplanner.updater.stoptime;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.transit.realtime.GtfsRealtime;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
 import org.eclipse.paho.client.mqttv3.IMqttDeliveryToken;
 import org.eclipse.paho.client.mqttv3.MqttCallbackExtended;
 import org.eclipse.paho.client.mqttv3.MqttClient;
@@ -12,14 +15,10 @@ import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
 import org.opentripplanner.routing.RoutingService;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.updater.GraphUpdater;
-import org.opentripplanner.updater.GraphUpdaterManager;
 import org.opentripplanner.updater.GtfsRealtimeFuzzyTripMatcher;
+import org.opentripplanner.updater.WriteToGraphCallback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * This class starts an Paho MQTT client which opens a connection to a GTFS-RT data source.
@@ -43,7 +42,7 @@ import java.util.List;
 public class MqttGtfsRealtimeUpdater implements GraphUpdater {
     private static final Logger LOG = LoggerFactory.getLogger(MqttGtfsRealtimeUpdater.class);
 
-    private GraphUpdaterManager updaterManager;
+    private WriteToGraphCallback saveResultOnGraph;
 
     private final String url;
 
@@ -73,8 +72,8 @@ public class MqttGtfsRealtimeUpdater implements GraphUpdater {
     }
 
     @Override
-    public void setGraphUpdaterManager(GraphUpdaterManager updaterManager) {
-        this.updaterManager = updaterManager;
+    public void setGraphUpdaterManager(WriteToGraphCallback saveResultOnGraph) {
+        this.saveResultOnGraph = saveResultOnGraph;
     }
 
     @Override
@@ -167,7 +166,7 @@ public class MqttGtfsRealtimeUpdater implements GraphUpdater {
 
             if (updates != null) {
                 // Handle trip updates via graph writer runnable
-                updaterManager.execute(new TripUpdateGraphWriterRunnable(
+                saveResultOnGraph.execute(new TripUpdateGraphWriterRunnable(
                     fullDataset,
                     updates,
                     feedId

--- a/src/main/java/org/opentripplanner/updater/stoptime/PollingStoptimeUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/PollingStoptimeUpdater.java
@@ -1,15 +1,14 @@
 package org.opentripplanner.updater.stoptime;
 
 import com.google.transit.realtime.GtfsRealtime.TripUpdate;
+import java.util.List;
 import org.opentripplanner.routing.RoutingService;
 import org.opentripplanner.routing.graph.Graph;
-import org.opentripplanner.updater.GraphUpdaterManager;
 import org.opentripplanner.updater.GtfsRealtimeFuzzyTripMatcher;
 import org.opentripplanner.updater.PollingGraphUpdater;
+import org.opentripplanner.updater.WriteToGraphCallback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.List;
 
 /**
  * Update OTP stop time tables from some (realtime) source
@@ -31,7 +30,7 @@ public class PollingStoptimeUpdater extends PollingGraphUpdater {
     /**
      * Parent update manager. Is used to execute graph writer runnables.
      */
-    private GraphUpdaterManager updaterManager;
+    private WriteToGraphCallback saveResultOnGraph;
 
     /**
      * Update streamer
@@ -87,8 +86,8 @@ public class PollingStoptimeUpdater extends PollingGraphUpdater {
     }
 
     @Override
-    public void setGraphUpdaterManager(GraphUpdaterManager updaterManager) {
-        this.updaterManager = updaterManager;
+    public void setGraphUpdaterManager(WriteToGraphCallback saveResultOnGraph) {
+        this.saveResultOnGraph = saveResultOnGraph;
     }
 
     @Override
@@ -130,7 +129,7 @@ public class PollingStoptimeUpdater extends PollingGraphUpdater {
             // Handle trip updates via graph writer runnable
             TripUpdateGraphWriterRunnable runnable =
                     new TripUpdateGraphWriterRunnable(fullDataset, updates, feedId);
-            updaterManager.execute(runnable);
+            saveResultOnGraph.execute(runnable);
         }
     }
 

--- a/src/main/java/org/opentripplanner/updater/stoptime/WebsocketGtfsRealtimeUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/WebsocketGtfsRealtimeUpdater.java
@@ -10,15 +10,14 @@ import com.ning.http.client.websocket.DefaultWebSocketListener;
 import com.ning.http.client.websocket.WebSocket;
 import com.ning.http.client.websocket.WebSocketListener;
 import com.ning.http.client.websocket.WebSocketUpgradeHandler;
-import org.opentripplanner.routing.graph.Graph;
-import org.opentripplanner.updater.GraphUpdater;
-import org.opentripplanner.updater.GraphUpdaterManager;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.updater.GraphUpdater;
+import org.opentripplanner.updater.WriteToGraphCallback;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class starts an HTTP client which opens a websocket connection to a GTFS-RT data source. A
@@ -43,7 +42,7 @@ public class WebsocketGtfsRealtimeUpdater implements GraphUpdater {
     /**
      * Parent update manager. Is used to execute graph writer runnables.
      */
-    private GraphUpdaterManager updaterManager;
+    private WriteToGraphCallback saveResultOnGraph;
 
     /**
      * Url of the websocket server
@@ -70,8 +69,8 @@ public class WebsocketGtfsRealtimeUpdater implements GraphUpdater {
     }
 
     @Override
-    public void setGraphUpdaterManager(GraphUpdaterManager updaterManager) {
-        this.updaterManager = updaterManager;
+    public void setGraphUpdaterManager(WriteToGraphCallback saveResultOnGraph) {
+        this.saveResultOnGraph = saveResultOnGraph;
     }
 
     @Override
@@ -174,7 +173,7 @@ public class WebsocketGtfsRealtimeUpdater implements GraphUpdater {
                 TripUpdateGraphWriterRunnable runnable = new TripUpdateGraphWriterRunnable(
                         fullDataset, updates, feedId
                 );
-                updaterManager.execute(runnable);
+                saveResultOnGraph.execute(runnable);
             }
         }
     }

--- a/src/main/java/org/opentripplanner/updater/street_notes/WFSNotePollingGraphUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/street_notes/WFSNotePollingGraphUpdater.java
@@ -2,6 +2,12 @@ package org.opentripplanner.updater.street_notes;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.SetMultimap;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 import org.geotools.data.FeatureSource;
 import org.geotools.data.Query;
 import org.geotools.data.wfs.WFSDataStore;
@@ -22,18 +28,11 @@ import org.opentripplanner.routing.services.notes.DynamicStreetNotesSource;
 import org.opentripplanner.routing.services.notes.MatcherAndStreetNote;
 import org.opentripplanner.routing.services.notes.NoteMatcher;
 import org.opentripplanner.routing.services.notes.StreetNotesService;
-import org.opentripplanner.updater.GraphUpdaterManager;
 import org.opentripplanner.updater.GraphWriterRunnable;
 import org.opentripplanner.updater.PollingGraphUpdater;
+import org.opentripplanner.updater.WriteToGraphCallback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * A graph updater that reads a WFS-interface and updates a DynamicStreetNotesSource.
@@ -50,7 +49,7 @@ import java.util.Map;
 public abstract class WFSNotePollingGraphUpdater extends PollingGraphUpdater {
     protected Graph graph;
 
-    private GraphUpdaterManager updaterManager;
+    private WriteToGraphCallback saveResultOnGraph;
 
     private SetMultimap<Edge, MatcherAndStreetNote> notesForEdge;
 
@@ -96,8 +95,8 @@ public abstract class WFSNotePollingGraphUpdater extends PollingGraphUpdater {
      * Here the updater gets to know its parent manager to execute GraphWriterRunnables.
      */
     @Override
-    public void setGraphUpdaterManager(GraphUpdaterManager updaterManager) {
-        this.updaterManager = updaterManager;
+    public void setGraphUpdaterManager(WriteToGraphCallback saveResultOnGraph) {
+        this.saveResultOnGraph = saveResultOnGraph;
     }
 
     /**
@@ -151,7 +150,7 @@ public abstract class WFSNotePollingGraphUpdater extends PollingGraphUpdater {
                 }
             }
         }
-        updaterManager.execute(new WFSGraphWriter());
+        saveResultOnGraph.execute(new WFSGraphWriter());
     }
 
     /**

--- a/src/main/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingUpdater.java
@@ -1,24 +1,5 @@
 package org.opentripplanner.updater.vehicle_parking;
 
-import org.opentripplanner.graph_builder.linking.LinkingDirection;
-import org.opentripplanner.graph_builder.linking.VertexLinker;
-import org.opentripplanner.model.FeedScopedId;
-import org.opentripplanner.routing.core.TraverseMode;
-import org.opentripplanner.routing.core.TraverseModeSet;
-import org.opentripplanner.routing.edgetype.StreetVehicleParkingLink;
-import org.opentripplanner.graph_builder.linking.DisposableEdgeCollection;
-import org.opentripplanner.routing.edgetype.VehicleParkingEdge;
-import org.opentripplanner.routing.graph.Graph;
-import org.opentripplanner.routing.vehicle_parking.VehicleParking;
-import org.opentripplanner.routing.vehicle_parking.VehicleParkingHelper;
-import org.opentripplanner.routing.vehicle_parking.VehicleParkingService;
-import org.opentripplanner.routing.vertextype.VehicleParkingEntranceVertex;
-import org.opentripplanner.updater.GraphUpdaterManager;
-import org.opentripplanner.updater.GraphWriterRunnable;
-import org.opentripplanner.updater.PollingGraphUpdater;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -27,6 +8,24 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.opentripplanner.graph_builder.linking.DisposableEdgeCollection;
+import org.opentripplanner.graph_builder.linking.LinkingDirection;
+import org.opentripplanner.graph_builder.linking.VertexLinker;
+import org.opentripplanner.model.FeedScopedId;
+import org.opentripplanner.routing.core.TraverseMode;
+import org.opentripplanner.routing.core.TraverseModeSet;
+import org.opentripplanner.routing.edgetype.StreetVehicleParkingLink;
+import org.opentripplanner.routing.edgetype.VehicleParkingEdge;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.routing.vehicle_parking.VehicleParking;
+import org.opentripplanner.routing.vehicle_parking.VehicleParkingHelper;
+import org.opentripplanner.routing.vehicle_parking.VehicleParkingService;
+import org.opentripplanner.routing.vertextype.VehicleParkingEntranceVertex;
+import org.opentripplanner.updater.GraphWriterRunnable;
+import org.opentripplanner.updater.PollingGraphUpdater;
+import org.opentripplanner.updater.WriteToGraphCallback;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Graph updater that dynamically sets availability information on vehicle parking lots.
@@ -36,7 +35,7 @@ public class VehicleParkingUpdater extends PollingGraphUpdater {
 
     private static final Logger LOG = LoggerFactory.getLogger(VehicleParkingUpdater.class);
 
-    private GraphUpdaterManager updaterManager;
+    private WriteToGraphCallback saveResultOnGraph;
 
     private final Map<VehicleParking, List<VehicleParkingEntranceVertex>> verticesByPark = new HashMap<>();
 
@@ -57,8 +56,8 @@ public class VehicleParkingUpdater extends PollingGraphUpdater {
     }
 
     @Override
-    public void setGraphUpdaterManager(GraphUpdaterManager updaterManager) {
-        this.updaterManager = updaterManager;
+    public void setGraphUpdaterManager(WriteToGraphCallback saveResultOnGraph) {
+        this.saveResultOnGraph = saveResultOnGraph;
     }
 
     @Override
@@ -80,7 +79,7 @@ public class VehicleParkingUpdater extends PollingGraphUpdater {
 
         // Create graph writer runnable to apply these stations to the graph
         VehicleParkingGraphWriterRunnable graphWriterRunnable = new VehicleParkingGraphWriterRunnable(vehicleParkings, verticesByPark.keySet());
-        updaterManager.execute(graphWriterRunnable);
+        saveResultOnGraph.execute(graphWriterRunnable);
     }
 
     @Override

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdater.java
@@ -1,25 +1,5 @@
 package org.opentripplanner.updater.vehicle_rental;
 
-import org.opentripplanner.graph_builder.linking.LinkingDirection;
-import org.opentripplanner.graph_builder.linking.VertexLinker;
-import org.opentripplanner.model.FeedScopedId;
-import org.opentripplanner.model.base.ToStringBuilder;
-import org.opentripplanner.routing.vehicle_rental.VehicleRentalPlace;
-import org.opentripplanner.routing.vehicle_rental.VehicleRentalStationService;
-import org.opentripplanner.routing.core.TraverseMode;
-import org.opentripplanner.routing.core.TraverseModeSet;
-import org.opentripplanner.routing.edgetype.VehicleRentalEdge;
-import org.opentripplanner.routing.edgetype.StreetVehicleRentalLink;
-import org.opentripplanner.graph_builder.linking.DisposableEdgeCollection;
-import org.opentripplanner.routing.graph.Graph;
-import org.opentripplanner.routing.vertextype.VehicleRentalStationVertex;
-import org.opentripplanner.updater.GraphUpdaterManager;
-import org.opentripplanner.updater.GraphWriterRunnable;
-import org.opentripplanner.updater.PollingGraphUpdater;
-import org.opentripplanner.updater.vehicle_rental.datasources.VehicleRentalDataSourceFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -27,6 +7,25 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import org.opentripplanner.graph_builder.linking.DisposableEdgeCollection;
+import org.opentripplanner.graph_builder.linking.LinkingDirection;
+import org.opentripplanner.graph_builder.linking.VertexLinker;
+import org.opentripplanner.model.FeedScopedId;
+import org.opentripplanner.model.base.ToStringBuilder;
+import org.opentripplanner.routing.core.TraverseMode;
+import org.opentripplanner.routing.core.TraverseModeSet;
+import org.opentripplanner.routing.edgetype.StreetVehicleRentalLink;
+import org.opentripplanner.routing.edgetype.VehicleRentalEdge;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.routing.vehicle_rental.VehicleRentalPlace;
+import org.opentripplanner.routing.vehicle_rental.VehicleRentalStationService;
+import org.opentripplanner.routing.vertextype.VehicleRentalStationVertex;
+import org.opentripplanner.updater.GraphWriterRunnable;
+import org.opentripplanner.updater.PollingGraphUpdater;
+import org.opentripplanner.updater.WriteToGraphCallback;
+import org.opentripplanner.updater.vehicle_rental.datasources.VehicleRentalDataSourceFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Dynamic vehicle-rental station updater which updates the Graph with vehicle rental stations from one VehicleRentalDataSource.
@@ -35,7 +34,7 @@ public class VehicleRentalUpdater extends PollingGraphUpdater {
 
     private static final Logger LOG = LoggerFactory.getLogger(VehicleRentalUpdater.class);
 
-    private GraphUpdaterManager updaterManager;
+    private WriteToGraphCallback saveResultOnGraph;
 
     Map<FeedScopedId, VehicleRentalStationVertex> verticesByStation = new HashMap<>();
 
@@ -63,8 +62,8 @@ public class VehicleRentalUpdater extends PollingGraphUpdater {
     }
 
     @Override
-    public void setGraphUpdaterManager(GraphUpdaterManager updaterManager) {
-        this.updaterManager = updaterManager;
+    public void setGraphUpdaterManager(WriteToGraphCallback saveResultOnGraph) {
+        this.saveResultOnGraph = saveResultOnGraph;
     }
 
     @Override
@@ -88,7 +87,7 @@ public class VehicleRentalUpdater extends PollingGraphUpdater {
 
         // Create graph writer runnable to apply these stations to the graph
         VehicleRentalGraphWriterRunnable graphWriterRunnable = new VehicleRentalGraphWriterRunnable(stations);
-        updaterManager.execute(graphWriterRunnable);
+        saveResultOnGraph.execute(graphWriterRunnable);
     }
 
     @Override


### PR DESCRIPTION


Logging the first time all updaters report being initialized and instance is ready to process requests. This makes it easier to calculate complete startup-time.