### PR TITLE
Use reusable method to fix the build [changelog skip]

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/flex/FlexTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/flex/FlexTest.java
@@ -1,13 +1,14 @@
 package org.opentripplanner.ext.flex;
 
 import gnu.trove.set.hash.TIntHashSet;
-import java.io.File;
+import java.net.URISyntaxException;
 import java.time.LocalTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.opentripplanner.ext.flex.flexpathcalculator.DirectFlexPathCalculator;
 import org.opentripplanner.graph_builder.model.GtfsBundle;
+import org.opentripplanner.graph_builder.module.FakeGraph;
 import org.opentripplanner.graph_builder.module.GtfsModule;
 import org.opentripplanner.model.calendar.ServiceDate;
 import org.opentripplanner.model.calendar.ServiceDateInterval;
@@ -24,9 +25,11 @@ abstract public class FlexTest {
     static final FlexParameters params = new FlexParameters(300);
 
 
-    static Graph buildFlexGraph(String fileName) {
+    static Graph buildFlexGraph(String fileName) throws URISyntaxException {
+        var file = FakeGraph.getFileForResource(fileName);
+
         var graph = new Graph();
-        GtfsBundle gtfsBundle = new GtfsBundle(new File(fileName));
+        GtfsBundle gtfsBundle = new GtfsBundle(file);
         GtfsModule module = new GtfsModule(
                 List.of(gtfsBundle),
                 new ServiceDateInterval(

--- a/src/ext-test/java/org/opentripplanner/ext/flex/ScheduledDeviatedTripTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/flex/ScheduledDeviatedTripTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -24,8 +25,7 @@ import org.opentripplanner.routing.graphfinder.NearbyStop;
  */
 public class ScheduledDeviatedTripTest extends FlexTest {
 
-    static final String COBB_COUNTY_GTFS =
-            "src/ext-test/resources/flex/cobblinc-scheduled-deviated-flex.gtfs.zip";
+    static final String COBB_COUNTY_GTFS = "/flex/cobblinc-scheduled-deviated-flex.gtfs.zip";
 
     static Graph graph;
 
@@ -81,7 +81,7 @@ public class ScheduledDeviatedTripTest extends FlexTest {
     }
 
     @BeforeAll
-    static void setup() {
+    static void setup() throws URISyntaxException {
         graph = FlexTest.buildFlexGraph(COBB_COUNTY_GTFS);
     }
 

--- a/src/ext-test/java/org/opentripplanner/ext/flex/UnscheduledTripTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/flex/UnscheduledTripTest.java
@@ -3,6 +3,7 @@ package org.opentripplanner.ext.flex;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
+import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -24,7 +25,7 @@ import org.opentripplanner.routing.graphfinder.NearbyStop;
  */
 public class UnscheduledTripTest extends FlexTest {
 
-    static final String ASPEN_GTFS = "src/ext-test/resources/flex/aspen-flex-on-demand.gtfs.zip";
+    static final String ASPEN_GTFS = "/flex/aspen-flex-on-demand.gtfs.zip";
 
     static Graph graph;
 
@@ -84,7 +85,7 @@ public class UnscheduledTripTest extends FlexTest {
     }
 
     @BeforeAll
-    static void setup() {
+    static void setup() throws URISyntaxException {
         graph = FlexTest.buildFlexGraph(ASPEN_GTFS);
     }
 


### PR DESCRIPTION
In a previous PR I broke the `mvn install` functionality as I was using relative paths rather than loading a ressource. This fixes the problem.