### PR TITLE
Do not throw NPE in Place constructor [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/model/plan/Place.java
+++ b/src/main/java/org/opentripplanner/model/plan/Place.java
@@ -121,7 +121,7 @@ public class Place {
                 .toString();
     }
 
-    public static Place normal(double lat, double lon, String name) {
+    public static Place normal(Double lat, Double lon, String name) {
         return new Place(
                 name,
                 null,

--- a/src/test/java/org/opentripplanner/model/plan/PlaceTest.java
+++ b/src/test/java/org/opentripplanner/model/plan/PlaceTest.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.model.plan;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
@@ -41,6 +42,12 @@ public class PlaceTest {
         assertTrue("same place(symmetric)", samePlace.sameLocation(aPlace));
         assertFalse("other place", aPlace.sameLocation(otherPlace));
         assertFalse("other place(symmetric)", otherPlace.sameLocation(aPlace));
+    }
+
+    @Test
+    public void acceptsNullCoordinates() {
+        var p = Place.normal(null, null, "Test");
+        assertNull(p.coordinate);
     }
 
     private static Stop stop(String stopId, double lat, double lon) {


### PR DESCRIPTION
### Summary
In https://github.com/opentripplanner/OpenTripPlanner/pull/3480 a small bug was introduced, whereby the Place factory would throw an error, if null coordinates were used, due to the type being migrated form the boxed type to the primitive type.  This reverts that change, and adds a small test for avoiding regressions.

