### PR TITLE
Transmodel API: Allow filtering by a list of ids [changelog skip] 

### DIFF
--- a/docs/sandbox/TransmodelApi.md
+++ b/docs/sandbox/TransmodelApi.md
@@ -16,6 +16,7 @@
 - Fix NPE in BookingArrangementType data fetchers [#3649](https://github.com/opentripplanner/OpenTripPlanner/pull/3649)
 - Add BookingInfo to TimetabledPassingTime and EstimatedCall [#3666](https://github.com/opentripplanner/OpenTripPlanner/pull/3666)
 - Use correct capitalization for GraphQL fields [#3707](https://github.com/opentripplanner/OpenTripPlanner/pull/3707)
+- Allow filtering by a list of ids [#3738](https://github.com/opentripplanner/OpenTripPlanner/pull/3738)
 
 ## Documentation
 

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
@@ -812,7 +812,9 @@ public class TransmodelGraphQLSchema {
                     .getArguments()
                     .entrySet()
                     .stream()
-                    .filter(it -> it.getValue() != null)
+                    .filter(it -> it.getValue() != null &&
+                            !(it.getKey().equals("flexibleOnly") && it.getValue().equals(false))
+                    )
                     .count() != 1) {
                   throw new IllegalArgumentException("Unable to combine other filters with ids");
                 }


### PR DESCRIPTION
### Summary
This fixes filtering lines by a list of ids, even tough `flexibleOnly` has a default value set. This worked before adding the new argument with a default value.

### Changelog
The feature-is sandbox-only and the sandbox changelog is updated.
