### PR TITLE
Fix flex tests by taking into account that stops are a Set [changelog skip]

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/flex/ScheduledDeviatedTripTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/flex/ScheduledDeviatedTripTest.java
@@ -2,7 +2,6 @@ package org.opentripplanner.ext.flex;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URISyntaxException;
 import java.util.List;
@@ -12,6 +11,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.ext.flex.trip.FlexTrip;
 import org.opentripplanner.ext.flex.trip.ScheduledDeviatedTrip;
+import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.model.FlexStopLocation;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
@@ -86,13 +86,19 @@ public class ScheduledDeviatedTripTest extends FlexTest {
     }
 
     private static NearbyStop getNearbyStop(FlexTrip trip) {
-        var stopLocation = trip.getStops().stream().collect(Collectors.toList()).get(2);
-        assertTrue(stopLocation instanceof FlexStopLocation);
+        // getStops() returns a set of stops and the order doesn't correspond to the stop times
+        // of the trip
+        var stopLocation = trip.getStops()
+                .stream()
+                .filter(s -> s instanceof FlexStopLocation)
+                .findFirst()
+                .get();
         return new NearbyStop(stopLocation, 0, List.of(), null, null);
     }
 
     private static FlexTrip getFlexTrip() {
-        var flexTrips = graph.flexTripsById.values();
-        return flexTrips.iterator().next();
+        var feedId = graph.getFeedIds().iterator().next();
+        var tripId = new FeedScopedId(feedId, "a326c618-d42c-4bd1-9624-c314fbf8ecd8");
+        return graph.flexTripsById.get(tripId);
     }
 }

--- a/src/ext-test/java/org/opentripplanner/ext/flex/UnscheduledTripTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/flex/UnscheduledTripTest.java
@@ -90,6 +90,7 @@ public class UnscheduledTripTest extends FlexTest {
     }
 
     private static NearbyStop getNearbyStop(FlexTrip trip) {
+        assertEquals(1, trip.getStops().size());
         var stopLocation = trip.getStops().iterator().next();
         return new NearbyStop(stopLocation, 0, List.of(), null, null);
     }

--- a/src/ext/java/org/opentripplanner/ext/flex/trip/FlexTrip.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/trip/FlexTrip.java
@@ -1,5 +1,8 @@
 package org.opentripplanner.ext.flex.trip;
 
+import java.util.Set;
+import java.util.stream.Stream;
+import org.opentripplanner.ext.flex.FlexParameters;
 import org.opentripplanner.ext.flex.FlexServiceDate;
 import org.opentripplanner.ext.flex.flexpathcalculator.FlexPathCalculator;
 import org.opentripplanner.ext.flex.template.FlexAccessTemplate;
@@ -9,10 +12,6 @@ import org.opentripplanner.model.StopLocation;
 import org.opentripplanner.model.TransitEntity;
 import org.opentripplanner.model.Trip;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
-
-import java.util.Collection;
-import java.util.stream.Stream;
-import org.opentripplanner.ext.flex.FlexParameters;
 
 /**
  * This class represents the different variations of what is considered flexible transit, and its
@@ -40,7 +39,15 @@ public abstract class FlexTrip extends TransitEntity {
 
   public abstract int latestArrivalTime(int arrivalTime, int fromStopIndex, int toStopIndex, int flexTime);
 
-  public abstract Collection<StopLocation> getStops();
+  /**
+   * Returns all the stops that are in this trip.
+   *
+   * Note that they are in no specific order and don't correspond 1-to-1 to the stop times of the
+   * trip.
+   *
+   * Location groups are expanded into their constituent stops.
+   */
+  public abstract Set<StopLocation> getStops();
 
   public Trip getTrip() {
     return trip;

--- a/src/ext/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTrip.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTrip.java
@@ -9,9 +9,11 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.opentripplanner.ext.flex.FlexParameters;
 import org.opentripplanner.ext.flex.FlexServiceDate;
 import org.opentripplanner.ext.flex.flexpathcalculator.FlexPathCalculator;
 import org.opentripplanner.ext.flex.flexpathcalculator.ScheduledFlexPathCalculator;
@@ -24,7 +26,6 @@ import org.opentripplanner.model.StopLocation;
 import org.opentripplanner.model.StopTime;
 import org.opentripplanner.model.Trip;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
-import org.opentripplanner.ext.flex.FlexParameters;
 
 /**
  * A scheduled deviated trip is similar to a regular scheduled trip, except that is continues stop
@@ -147,7 +148,7 @@ public class ScheduledDeviatedTrip extends FlexTrip {
   }
 
   @Override
-  public Collection<StopLocation> getStops() {
+  public Set<StopLocation> getStops() {
     return Arrays
         .stream(stopTimes)
         .map(scheduledDeviatedStopTime -> scheduledDeviatedStopTime.stop)

--- a/src/ext/java/org/opentripplanner/ext/flex/trip/UnscheduledTrip.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/trip/UnscheduledTrip.java
@@ -133,7 +133,7 @@ public class UnscheduledTrip extends FlexTrip {
   }
 
   @Override
-  public Collection<StopLocation> getStops() {
+  public Set<StopLocation> getStops() {
     return Arrays
         .stream(stopTimes)
         .map(scheduledDeviatedStopTime -> scheduledDeviatedStopTime.stop)


### PR DESCRIPTION
### Summary
@t2gran has alerted me to the fact that `ScheduledDeviatedTripTest` fails when running `mvn install`. We at first thought that it's because I not using a resource loader when loading the GTFS file.

Today I saw the problem again and after some head scratching I noticed that I made the wrong assumption about the `getStops` method. It returns a `Set<Stop>` not an ordered list, as I had assumed. So I fixed the test by taking this into account.

### Issue
n/a

### Unit tests
Tests were fixed :)

### Code style
Yes.

### Documentation
Added Javadoc.