### PR TITLE
Allow limiting the used vehicle rentals and parkings

### DIFF
--- a/src/client/js/otp/widgets/tripoptions/TripOptionsWidget.js
+++ b/src/client/js/otp/widgets/tripoptions/TripOptionsWidget.js
@@ -1072,9 +1072,9 @@ otp.widgets.tripoptions.AdditionalTripParameters =
                 var params = {};
 
                 keyvalues.forEach(function(keyvalue) {
-                    var split = keyvalue.trim().split('=');
-                    if (!split[0].startsWith('#')) {
-                        params[split[0]] = split[1];
+                    var split = keyvalue.trim().match(/^((?!#)[^=]+)=(.*)$/);
+                    if (split) {
+                        params[split[1]] = split[2];
                     }
                 })
 

--- a/src/main/java/org/opentripplanner/api/common/RoutingResource.java
+++ b/src/main/java/org/opentripplanner/api/common/RoutingResource.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.api.common;
 
+import java.util.Set;
 import org.opentripplanner.api.parameter.QualifiedModeSet;
 import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.routing.core.BicycleOptimizeType;
@@ -361,6 +362,14 @@ public abstract class RoutingResource {
 
     @QueryParam("keepingRentedBicycleAtDestinationCost")
     protected Double keepingRentedBicycleAtDestinationCost;
+
+    /** The vehicle rental networks which may be used. If empty all networks may be used. */
+    @QueryParam("allowedVehicleRentalNetworks")
+    protected Set<String> allowedVehicleRentalNetworks;
+
+    /** The vehicle rental networks which may not be used. If empty, no networks are banned. */
+    @QueryParam("bannedVehicleRentalNetworks")
+    protected Set<String> bannedVehicleRentalNetworks;
 
     /**
      * The comma-separated list of banned routes. The format is agency_[routename][_routeid], so
@@ -738,6 +747,12 @@ public abstract class RoutingResource {
 
         if (keepingRentedBicycleAtDestinationCost != null)
             request.keepingRentedVehicleAtDestinationCost = keepingRentedBicycleAtDestinationCost;
+
+        if (allowedVehicleRentalNetworks != null)
+            request.allowedVehicleRentalNetworks = allowedVehicleRentalNetworks;
+
+        if (bannedVehicleRentalNetworks != null)
+            request.allowedVehicleRentalNetworks = bannedVehicleRentalNetworks;
 
         if (optimize != null) {
             // Optimize types are basically combined presets of routing parameters, except for triangle

--- a/src/main/java/org/opentripplanner/api/common/RoutingResource.java
+++ b/src/main/java/org/opentripplanner/api/common/RoutingResource.java
@@ -371,6 +371,14 @@ public abstract class RoutingResource {
     @QueryParam("bannedVehicleRentalNetworks")
     protected Set<String> bannedVehicleRentalNetworks;
 
+    /** Tags which are required to use a vehicle parking. If empty, no tags are required. */
+    @QueryParam("requiredVehicleParkingTags")
+    protected Set<String> requiredVehicleParkingTags = Set.of();
+
+    /** Tags with which a vehicle parking will not be used. If empty, no tags are banned. */
+    @QueryParam("bannedVehicleParkingTags")
+    protected Set<String> bannedVehicleParkingTags = Set.of();
+
     /**
      * The comma-separated list of banned routes. The format is agency_[routename][_routeid], so
      * TriMet_100 (100 is route short name) or Trimet__42 (two underscores, 42 is the route
@@ -752,7 +760,13 @@ public abstract class RoutingResource {
             request.allowedVehicleRentalNetworks = allowedVehicleRentalNetworks;
 
         if (bannedVehicleRentalNetworks != null)
-            request.allowedVehicleRentalNetworks = bannedVehicleRentalNetworks;
+            request.bannedVehicleRentalNetworks = bannedVehicleRentalNetworks;
+
+        if (bannedVehicleParkingTags != null)
+            request.bannedVehicleParkingTags = bannedVehicleParkingTags;
+
+        if (requiredVehicleParkingTags != null)
+            request.requiredVehicleParkingTags = requiredVehicleParkingTags;
 
         if (optimize != null) {
             // Optimize types are basically combined presets of routing parameters, except for triangle

--- a/src/main/java/org/opentripplanner/api/common/RoutingResource.java
+++ b/src/main/java/org/opentripplanner/api/common/RoutingResource.java
@@ -371,6 +371,22 @@ public abstract class RoutingResource {
     @QueryParam("bannedVehicleRentalNetworks")
     protected Set<String> bannedVehicleRentalNetworks;
 
+    /** Time to park a bike */
+    @QueryParam("bikeParkTime")
+    protected Integer bikeParkTime;
+
+    /** Cost of parking a bike. */
+    @QueryParam("bikeParkCost")
+    protected Integer bikeParkCost;
+
+    /** Time to park a car */
+    @QueryParam("carParkTime")
+    protected Integer carParkTime = 60;
+
+    /** Cost of parking a car. */
+    @QueryParam("carParkCost")
+    protected Integer carParkCost = 120;
+
     /** Tags which are required to use a vehicle parking. If empty, no tags are required. */
     @QueryParam("requiredVehicleParkingTags")
     protected Set<String> requiredVehicleParkingTags = Set.of();
@@ -761,6 +777,18 @@ public abstract class RoutingResource {
 
         if (bannedVehicleRentalNetworks != null)
             request.bannedVehicleRentalNetworks = bannedVehicleRentalNetworks;
+
+        if (bikeParkCost != null)
+            request.bikeParkCost = bikeParkCost;
+
+        if (bikeParkTime != null)
+            request.bikeParkTime = bikeParkTime;
+
+        if (carParkCost != null)
+            request.carParkCost = carParkCost;
+
+        if (carParkTime != null)
+            request.carParkTime = carParkTime;
 
         if (bannedVehicleParkingTags != null)
             request.bannedVehicleParkingTags = bannedVehicleParkingTags;

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModule.java
@@ -562,11 +562,30 @@ public class OpenStreetMapModule implements GraphBuilderModule {
                     String.format("%s/%d", entity.getClass().getSimpleName(), entity.getId())
             );
 
+            var tags = new ArrayList<String>();
+
+            tags.add(isCarParkAndRide ? "osm:amenity=parking" : "osm:amenity=bicycle_parking");
+
+            if (entity.isTagTrue("fee")) {
+                tags.add("osm:fee");
+            }
+            if (entity.hasTag("supervised") && !entity.isTagTrue("supervised")) {
+                tags.add("osm:supervised");
+            }
+            if (entity.hasTag("covered") && !entity.isTagFalse("covered")) {
+                tags.add("osm:covered");
+            }
+            if (entity.hasTag("surveillance") && !entity.isTagFalse("surveillance")) {
+                tags.add("osm:surveillance");
+            }
+
             return VehicleParking.builder()
                     .id(id)
                     .name(creativeName)
                     .x(lon)
                     .y(lat)
+                    .tags(tags)
+                    .detailsUrl(entity.getTag("website"))
                     .bicyclePlaces(bicyclePlaces)
                     .carPlaces(carPlaces)
                     .wheelchairAccessibleCarPlaces(wheelchairAccessibleCarPlaces)

--- a/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
@@ -349,6 +349,12 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
     /** Cost of dropping-off a rented bike */
     public int bikeRentalDropoffCost = 30;
 
+    /** The vehicle rental networks which may be used. If empty all networks may be used. */
+    public Set<String> allowedVehicleRentalNetworks = Set.of();
+
+    /** The vehicle rental networks which may not be used. If empty, no networks are banned. */
+    public Set<String> bannedVehicleRentalNetworks = Set.of();
+
     /** Time to park a bike */
     public int bikeParkTime = 60;
 
@@ -1055,6 +1061,9 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
         try {
             RoutingRequest clone = (RoutingRequest) super.clone();
             clone.streetSubRequestModes = streetSubRequestModes.clone();
+
+            clone.allowedVehicleRentalNetworks = Set.copyOf(allowedVehicleRentalNetworks);
+            clone.bannedVehicleRentalNetworks = Set.copyOf(bannedVehicleRentalNetworks);
 
             clone.preferredAgencies = Set.copyOf(preferredAgencies);
             clone.unpreferredAgencies = Set.copyOf(unpreferredAgencies);

--- a/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
@@ -367,6 +367,12 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
     /** Cost of parking a car. */
     public int carParkCost = 120;
 
+    /** Tags which are required to use a vehicle parking. If empty, no tags are required. */
+    public Set<String> requiredVehicleParkingTags = Set.of();
+
+    /** Tags with which a vehicle parking will not be used. If empty, no tags are banned. */
+    public Set<String> bannedVehicleParkingTags = Set.of();
+
     /**
      * Time to park a car in a park and ride, w/o taking into account driving and walking cost
      * (time to park, switch off, pick your stuff, lock the car, etc...)
@@ -1064,6 +1070,9 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
 
             clone.allowedVehicleRentalNetworks = Set.copyOf(allowedVehicleRentalNetworks);
             clone.bannedVehicleRentalNetworks = Set.copyOf(bannedVehicleRentalNetworks);
+
+            clone.requiredVehicleParkingTags = Set.copyOf(requiredVehicleParkingTags);
+            clone.bannedVehicleParkingTags = Set.copyOf(bannedVehicleParkingTags);
 
             clone.preferredAgencies = Set.copyOf(preferredAgencies);
             clone.unpreferredAgencies = Set.copyOf(unpreferredAgencies);

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetVehicleRentalLink.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetVehicleRentalLink.java
@@ -1,14 +1,13 @@
 package org.opentripplanner.routing.edgetype;
 
+import java.util.Locale;
 import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.core.StateEditor;
 import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Vertex;
-import org.opentripplanner.routing.vertextype.VehicleRentalStationVertex;
 import org.opentripplanner.routing.vertextype.StreetVertex;
-
-import java.util.Locale;
+import org.opentripplanner.routing.vertextype.VehicleRentalStationVertex;
 
 /**
  * This represents the connection between a street vertex and a bike rental station vertex.
@@ -56,6 +55,10 @@ public class StreetVehicleRentalLink extends Edge {
         // This prevents the router from using bike rental stations as shortcuts to get around
         // turn restrictions.
         if (s0.getBackEdge() instanceof StreetVehicleRentalLink) {
+            return null;
+        }
+
+        if (vehicleRentalStationVertex.getStation().networkIsNotAllowed(s0.getOptions())) {
             return null;
         }
 

--- a/src/main/java/org/opentripplanner/routing/edgetype/VehicleRentalEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/VehicleRentalEdge.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.routing.edgetype;
 
 import java.util.Locale;
-
 import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.core.State;
@@ -35,6 +34,10 @@ public class VehicleRentalEdge extends Edge {
         VehicleRentalPlace station = stationVertex.getStation();
         TraverseMode vehicleMode = stationVertex.getVehicleMode();
         String network = station.getNetwork();
+
+        if (station.networkIsNotAllowed(s0.getOptions())) {
+            return null;
+        }
 
         boolean pickedUp;
         if (options.arriveBy) {

--- a/src/main/java/org/opentripplanner/routing/vehicle_parking/VehicleParking.java
+++ b/src/main/java/org/opentripplanner/routing/vehicle_parking/VehicleParking.java
@@ -3,9 +3,11 @@ package org.opentripplanner.routing.vehicle_parking;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.Set;
 import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.util.I18NString;
 
@@ -46,7 +48,7 @@ public class VehicleParking implements Serializable {
    * Source specific tags of the vehicle parking, which describe the available features. For example
    * park_and_ride, bike_lockers, or static_osm_data.
    */
-  private final List<String> tags;
+  private final Set<String> tags;
 
   /**
    * A short translatable note containing details of this vehicle parking.
@@ -95,7 +97,7 @@ public class VehicleParking implements Serializable {
           double y,
           String detailsUrl,
           String imageUrl,
-          List<String> tags,
+          Set<String> tags,
           I18NString note,
           VehicleParkingState state,
           boolean bicyclePlaces,
@@ -144,7 +146,7 @@ public class VehicleParking implements Serializable {
     return imageUrl;
   }
 
-  public List<String> getTags() {
+  public Set<String> getTags() {
     return tags;
   }
 
@@ -244,7 +246,7 @@ public class VehicleParking implements Serializable {
 
   @SuppressWarnings("unused")
   public static class VehicleParkingBuilder {
-    private List<String> tags = new ArrayList<>();
+    private Set<String> tags = Set.of();
     private final List<VehicleParkingEntranceCreator> entranceCreators = new ArrayList<>();
     private FeedScopedId id;
     private I18NString name;
@@ -264,7 +266,7 @@ public class VehicleParking implements Serializable {
     VehicleParkingBuilder() {}
 
     public VehicleParkingBuilder tags(Collection<String> tags) {
-      this.tags = new ArrayList<>(tags);
+      this.tags = new HashSet<>(tags);
       return this;
     }
 

--- a/src/main/java/org/opentripplanner/routing/vehicle_rental/VehicleRentalPlace.java
+++ b/src/main/java/org/opentripplanner/routing/vehicle_rental/VehicleRentalPlace.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.routing.vehicle_rental;
 
 import org.opentripplanner.model.FeedScopedId;
+import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.util.I18NString;
 
 /**
@@ -67,4 +68,23 @@ public interface VehicleRentalPlace {
 
     /** Deep links for this rental station or individual vehicle */
     VehicleRentalStationUris getRentalUris();
+
+    default boolean networkIsNotAllowed(RoutingRequest options) {
+        if (getNetwork() == null && (
+                !options.allowedVehicleRentalNetworks.isEmpty() ||
+                        !options.bannedVehicleRentalNetworks.isEmpty()
+        )) {
+            return false;
+        }
+
+        if (options.bannedVehicleRentalNetworks.contains(getNetwork())) {
+            return true;
+        }
+
+        if (options.allowedVehicleRentalNetworks.isEmpty()) {
+            return false;
+        }
+
+        return !options.allowedVehicleRentalNetworks.contains(getNetwork());
+    }
 }

--- a/src/main/java/org/opentripplanner/standalone/config/NodeAdapter.java
+++ b/src/main/java/org/opentripplanner/standalone/config/NodeAdapter.java
@@ -11,6 +11,7 @@ import java.util.Arrays;
 import java.util.EnumMap;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -491,5 +492,22 @@ public class NodeAdapter {
             result.put(key, mapper.apply(node, key));
         }
         return result;
+    }
+
+    public Set<String> asStringSet(
+            String paramName,
+            Set<String> defaultValue
+    ) {
+        if (!exist(paramName)) { return Set.of(); }
+
+        JsonNode param = param(paramName);
+        if (param.isArray()) {
+            Set<String> result = new HashSet<>(param.size());
+            for (JsonNode it : param) {
+                result.add(it.asText());
+            }
+            return result;
+        }
+        return defaultValue;
     }
 }

--- a/src/main/java/org/opentripplanner/standalone/config/NodeAdapter.java
+++ b/src/main/java/org/opentripplanner/standalone/config/NodeAdapter.java
@@ -21,7 +21,6 @@ import java.util.function.BiFunction;
 import java.util.function.DoubleFunction;
 import java.util.function.Function;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import javax.validation.constraints.NotNull;
 import org.opentripplanner.api.parameter.QualifiedModeSet;
 import org.opentripplanner.model.FeedScopedId;
@@ -174,7 +173,7 @@ public class NodeAdapter {
 
     public Set<String> asTextSet(String paramName, Set<String> defaultValue) {
         if(!exist(paramName)) return defaultValue;
-        return arrayAsList(paramName, JsonNode::asText).stream().collect(Collectors.toSet());
+        return new HashSet<>(arrayAsList(paramName, JsonNode::asText));
     }
 
     public RequestModes asRequestModes(String paramName, RequestModes defaultValue) {
@@ -492,22 +491,5 @@ public class NodeAdapter {
             result.put(key, mapper.apply(node, key));
         }
         return result;
-    }
-
-    public Set<String> asStringSet(
-            String paramName,
-            Set<String> defaultValue
-    ) {
-        if (!exist(paramName)) { return Set.of(); }
-
-        JsonNode param = param(paramName);
-        if (param.isArray()) {
-            Set<String> result = new HashSet<>(param.size());
-            for (JsonNode it : param) {
-                result.add(it.asText());
-            }
-            return result;
-        }
-        return defaultValue;
     }
 }

--- a/src/main/java/org/opentripplanner/standalone/config/RoutingRequestMapper.java
+++ b/src/main/java/org/opentripplanner/standalone/config/RoutingRequestMapper.java
@@ -24,11 +24,11 @@ public class RoutingRequestMapper {
         // mapping or duplicate exist.
         request.alightSlack = c.asInt("alightSlack", dft.alightSlack);
         request.alightSlackForMode = c.asEnumMap("alightSlackForMode", TransitMode.class, NodeAdapter::asInt);
-        request.allowedVehicleRentalNetworks = c.asStringSet("allowedVehicleRentalNetworks", dft.allowedVehicleRentalNetworks);
+        request.allowedVehicleRentalNetworks = c.asTextSet("allowedVehicleRentalNetworks", dft.allowedVehicleRentalNetworks);
         request.bikeRental = c.asBoolean("allowBikeRental", dft.bikeRental);
         request.arriveBy = c.asBoolean("arriveBy", dft.arriveBy);
-        request.bannedVehicleParkingTags = c.asStringSet("bannedVehicleParkingTags", dft.bannedVehicleParkingTags);
-        request.bannedVehicleRentalNetworks = c.asStringSet("bannedVehicleRentalNetworks", dft.bannedVehicleRentalNetworks);
+        request.bannedVehicleParkingTags = c.asTextSet("bannedVehicleParkingTags", dft.bannedVehicleParkingTags);
+        request.bannedVehicleRentalNetworks = c.asTextSet("bannedVehicleRentalNetworks", dft.bannedVehicleRentalNetworks);
         request.bikeBoardCost = c.asInt("bikeBoardCost", dft.bikeBoardCost);
         request.bikeParkTime = c.asInt("bikeParkTime", dft.bikeParkTime);
         request.bikeParkCost = c.asInt("bikeParkCost", dft.bikeParkCost);
@@ -81,7 +81,7 @@ public class RoutingRequestMapper {
         request.otherThanPreferredRoutesPenalty = c.asInt("otherThanPreferredRoutesPenalty", dft.otherThanPreferredRoutesPenalty);
         request.parkAndRide = c.asBoolean("parkAndRide", dft.parkAndRide);
         request.pathComparator = c.asText("pathComparator", dft.pathComparator);
-        request.requiredVehicleParkingTags = c.asStringSet("requiredVehicleParkingTags", dft.requiredVehicleParkingTags);
+        request.requiredVehicleParkingTags = c.asTextSet("requiredVehicleParkingTags", dft.requiredVehicleParkingTags);
         request.showIntermediateStops = c.asBoolean("showIntermediateStops", dft.showIntermediateStops);
         request.stairsReluctance = c.asDouble("stairsReluctance", dft.stairsReluctance);
         request.startingTransitTripId = c.asFeedScopedId("startingTransitTripId", dft.startingTransitTripId);

--- a/src/main/java/org/opentripplanner/standalone/config/RoutingRequestMapper.java
+++ b/src/main/java/org/opentripplanner/standalone/config/RoutingRequestMapper.java
@@ -27,6 +27,7 @@ public class RoutingRequestMapper {
         request.allowedVehicleRentalNetworks = c.asStringSet("allowedVehicleRentalNetworks", dft.allowedVehicleRentalNetworks);
         request.bikeRental = c.asBoolean("allowBikeRental", dft.bikeRental);
         request.arriveBy = c.asBoolean("arriveBy", dft.arriveBy);
+        request.bannedVehicleParkingTags = c.asStringSet("bannedVehicleParkingTags", dft.bannedVehicleParkingTags);
         request.bannedVehicleRentalNetworks = c.asStringSet("bannedVehicleRentalNetworks", dft.bannedVehicleRentalNetworks);
         request.bikeBoardCost = c.asInt("bikeBoardCost", dft.bikeBoardCost);
         request.bikeParkTime = c.asInt("bikeParkTime", dft.bikeParkTime);
@@ -80,6 +81,7 @@ public class RoutingRequestMapper {
         request.otherThanPreferredRoutesPenalty = c.asInt("otherThanPreferredRoutesPenalty", dft.otherThanPreferredRoutesPenalty);
         request.parkAndRide = c.asBoolean("parkAndRide", dft.parkAndRide);
         request.pathComparator = c.asText("pathComparator", dft.pathComparator);
+        request.requiredVehicleParkingTags = c.asStringSet("requiredVehicleParkingTags", dft.requiredVehicleParkingTags);
         request.showIntermediateStops = c.asBoolean("showIntermediateStops", dft.showIntermediateStops);
         request.stairsReluctance = c.asDouble("stairsReluctance", dft.stairsReluctance);
         request.startingTransitTripId = c.asFeedScopedId("startingTransitTripId", dft.startingTransitTripId);

--- a/src/main/java/org/opentripplanner/standalone/config/RoutingRequestMapper.java
+++ b/src/main/java/org/opentripplanner/standalone/config/RoutingRequestMapper.java
@@ -24,8 +24,10 @@ public class RoutingRequestMapper {
         // mapping or duplicate exist.
         request.alightSlack = c.asInt("alightSlack", dft.alightSlack);
         request.alightSlackForMode = c.asEnumMap("alightSlackForMode", TransitMode.class, NodeAdapter::asInt);
+        request.allowedVehicleRentalNetworks = c.asStringSet("allowedVehicleRentalNetworks", dft.allowedVehicleRentalNetworks);
         request.bikeRental = c.asBoolean("allowBikeRental", dft.bikeRental);
         request.arriveBy = c.asBoolean("arriveBy", dft.arriveBy);
+        request.bannedVehicleRentalNetworks = c.asStringSet("bannedVehicleRentalNetworks", dft.bannedVehicleRentalNetworks);
         request.bikeBoardCost = c.asInt("bikeBoardCost", dft.bikeBoardCost);
         request.bikeParkTime = c.asInt("bikeParkTime", dft.bikeParkTime);
         request.bikeParkCost = c.asInt("bikeParkCost", dft.bikeParkCost);

--- a/src/test/java/org/opentripplanner/routing/algorithm/BikeRentalTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/BikeRentalTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -38,6 +40,8 @@ public class BikeRentalTest extends GraphRoutingTest {
     private StreetVertex A, B, C, D;
     private VehicleRentalStationVertex B1, B2;
     private StreetEdge SE1, SE2, SE3;
+
+    private String NON_NETWORK = "non network";
 
     @BeforeEach
     public void setUp() {
@@ -356,6 +360,79 @@ public class BikeRentalTest extends GraphRoutingTest {
         );
     }
 
+    @Test
+    public void noPathIfNoAllowedNetworks() {
+        assertNoRental(B, C, Set.of(), Set.of(NON_NETWORK));
+    }
+
+    @Test
+    public void noPathIfBannedAndAllowedNetwork() {
+        assertNoRental(B, C, Set.of(TEST_VEHICLE_RENTAL_NETWORK), Set.of(TEST_VEHICLE_RENTAL_NETWORK));
+    }
+
+    @Test
+    public void pathIfWithOnlyAllowedNetworks() {
+        assertPathWithNetwork(B, C, Set.of(), Set.of(TEST_VEHICLE_RENTAL_NETWORK), Set.of(TEST_VEHICLE_RENTAL_NETWORK));
+    }
+
+    @Test
+    public void noPathIfNetworkIsBanned() {
+        assertNoRental(B, C, Set.of(TEST_VEHICLE_RENTAL_NETWORK), Set.of());
+    }
+
+    @Test
+    public void pathIfWithoutBannedNetworks() {
+        assertPathWithNetwork(B, C, Set.of(NON_NETWORK), Set.of(), Set.of(TEST_VEHICLE_RENTAL_NETWORK));
+    }
+
+    private void assertNoRental(StreetVertex fromVertex, StreetVertex toVertex, Set<String> bannedNetworks, Set<String> allowedNetworks) {
+        Consumer<RoutingRequest> setter = options -> {
+            options.allowedVehicleRentalNetworks = allowedNetworks;
+            options.bannedVehicleRentalNetworks = bannedNetworks;
+        };
+
+        assertEquals(
+                List.of(
+                        "WALK - BEFORE_RENTING - BC street (1,503.76, 752)"
+                ),
+                runStreetSearchAndCreateDescriptor(fromVertex, toVertex, false, setter),
+                "departAt"
+        );
+
+        assertEquals(
+                List.of(
+                        "WALK - HAVE_RENTED - BC street (1,503.76, 752)"
+                ),
+                runStreetSearchAndCreateDescriptor(fromVertex, toVertex, true, setter),
+                "arriveBy"
+        );
+    }
+
+    private void assertPathWithNetwork(StreetVertex fromVertex, StreetVertex toVertex, Set<String> bannedNetworks, Set<String> allowedNetworks, Set<String> usedNetworks) {
+        Consumer<RoutingRequest> setter = options -> {
+            options.allowedVehicleRentalNetworks = allowedNetworks;
+            options.bannedVehicleRentalNetworks = bannedNetworks;
+        };
+
+        assertEquals(
+                List.of(
+                        "BICYCLE - RENTING_FROM_STATION - BC street (464.00, 242)",
+                        "null - HAVE_RENTED - B2 (499.00, 257)"
+                ),
+                runStreetSearchAndCreateDescriptor(fromVertex, toVertex, false, setter),
+                "departAt"
+        );
+
+        assertEquals(
+                List.of(
+                        "BICYCLE - RENTING_FROM_STATION - BC street (464.00, 242)",
+                        "null - HAVE_RENTED - B2 (499.00, 257)"
+                ),
+                runStreetSearchAndCreateDescriptor(fromVertex, toVertex, true, setter),
+                "arriveBy"
+        );
+    }
+
     private void assertPath(Vertex fromVertex, Vertex toVertex, String... descriptor) {
         assertPath(fromVertex, toVertex, true, List.of(descriptor), List.of(descriptor));
     }
@@ -428,15 +505,27 @@ public class BikeRentalTest extends GraphRoutingTest {
             boolean useAvailabilityInformation,
             int keepRentedBicycleCost
     ) {
+        return runStreetSearchAndCreateDescriptor(fromVertex, toVertex, arriveBy, options -> {
+            options.useVehicleRentalAvailabilityInformation = useAvailabilityInformation;
+            options.allowKeepingRentedVehicleAtDestination = keepRentedBicycleCost > 0;
+            options.keepingRentedVehicleAtDestinationCost = keepRentedBicycleCost;
+        });
+    }
+
+    private List<String> runStreetSearchAndCreateDescriptor(
+            Vertex fromVertex,
+            Vertex toVertex,
+            boolean arriveBy,
+            Consumer<RoutingRequest> optionsSetter
+    ) {
         var options = new RoutingRequest();
         options.arriveBy = arriveBy;
         options.bikeRentalPickupTime = 42;
         options.bikeRentalPickupCost = 62;
         options.bikeRentalDropoffCost = 33;
         options.bikeRentalDropoffTime = 15;
-        options.useVehicleRentalAvailabilityInformation = useAvailabilityInformation;
-        options.allowKeepingRentedVehicleAtDestination = keepRentedBicycleCost > 0;
-        options.keepingRentedVehicleAtDestinationCost = keepRentedBicycleCost;
+
+        optionsSetter.accept(options);
 
         return runStreetSearchAndCreateDescriptor(
                 fromVertex, toVertex, arriveBy, options, StreetMode.BIKE_RENTAL);

--- a/src/test/java/org/opentripplanner/routing/algorithm/CarParkAndRideTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/CarParkAndRideTest.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.routing.algorithm;
 
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.routing.api.request.StreetMode;
@@ -41,7 +42,8 @@ public class CarParkAndRideTest extends ParkAndRideTest {
                         List.of(
                                 vehicleParkingEntrance(A, "CarPark #1 Entrance A", false, true),
                                 vehicleParkingEntrance(B, "CarPark #1 Entrance B", true, false)
-                        )
+                        ),
+                        "tag1", "tag2", "tag3"
                 );
 
                 vehicleParking("AllPark", 47.520, 19.001, true, true,
@@ -128,5 +130,30 @@ public class CarParkAndRideTest extends ParkAndRideTest {
                 "WALK (parked) - DE street (372.83, 246)",
                 "WALK (parked) - EF street (503.65, 312)"
         );
+    }
+
+    @Test
+    public void noPathIfContainsBannedTags() {
+        assertNoPathWithParking(A, B, StreetMode.CAR_TO_PARK, Set.of("tag1"), Set.of());
+    }
+
+    @Test
+    public void pathIfNoBannedTagsPresent() {
+        assertPathWithParking(A, B, StreetMode.CAR_TO_PARK, Set.of("no-such-tag"), Set.of());
+    }
+
+    @Test
+    public void noPathIfContainsMissingRequiredTags() {
+        assertNoPathWithParking(A, B, StreetMode.CAR_TO_PARK, Set.of(), Set.of("no-such-tag"));
+    }
+
+    @Test
+    public void pathWithRequiredTags() {
+        assertPathWithParking(A, B, StreetMode.CAR_TO_PARK, Set.of(), Set.of("tag2"));
+    }
+
+    @Test
+    public void bannedTagsTakePrecedence() {
+        assertNoPathWithParking(A, B, StreetMode.CAR_TO_PARK, Set.of("tag1"), Set.of("tag2"));
     }
 }

--- a/src/test/java/org/opentripplanner/routing/algorithm/GraphRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/GraphRoutingTest.java
@@ -44,6 +44,7 @@ import org.opentripplanner.routing.location.TemporaryStreetLocation;
 import org.opentripplanner.routing.spt.GraphPath;
 import org.opentripplanner.routing.spt.ShortestPathTree;
 import org.opentripplanner.routing.vehicle_parking.VehicleParking;
+import org.opentripplanner.routing.vehicle_parking.VehicleParking.VehicleParkingEntranceCreator;
 import org.opentripplanner.routing.vehicle_parking.VehicleParkingHelper;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalPlace;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalStation;
@@ -350,11 +351,11 @@ public abstract class GraphRoutingTest {
             return List.of(link(from, to), link(to, from));
         }
 
-        public void vehicleParking(String id, double x, double y, boolean bicyclePlaces, boolean carPlaces, List<VehicleParking.VehicleParkingEntranceCreator> entrances) {
-            vehicleParking(id, x, y, bicyclePlaces, carPlaces, false, entrances);
+        public VehicleParking vehicleParking(String id, double x, double y, boolean bicyclePlaces, boolean carPlaces, List<VehicleParkingEntranceCreator> entrances, String ... tags) {
+            return vehicleParking(id, x, y, bicyclePlaces, carPlaces, false, entrances, tags);
         }
 
-        public void vehicleParking(String id, double x, double y, boolean bicyclePlaces, boolean carPlaces, boolean wheelchairAccessibleCarPlaces, List<VehicleParking.VehicleParkingEntranceCreator> entrances) {
+        public VehicleParking vehicleParking(String id, double x, double y, boolean bicyclePlaces, boolean carPlaces, boolean wheelchairAccessibleCarPlaces, List<VehicleParkingEntranceCreator> entrances, String ... tags) {
             var vehicleParking = VehicleParking.builder()
                 .id(new FeedScopedId(TEST_FEED_ID, id))
                 .x(x)
@@ -363,11 +364,13 @@ public abstract class GraphRoutingTest {
                 .carPlaces(carPlaces)
                 .entrances(entrances)
                 .wheelchairAccessibleCarPlaces(wheelchairAccessibleCarPlaces)
+                .tags(List.of(tags))
                 .build();
 
             var vertices = VehicleParkingHelper.createVehicleParkingVertices(graph, vehicleParking);
             VehicleParkingHelper.linkVehicleParkingEntrances(vertices);
             vertices.forEach(v -> biLink(v.getParkingEntrance().getVertex(), v));
+            return vehicleParking;
         }
 
         public VehicleParking.VehicleParkingEntranceCreator vehicleParkingEntrance(StreetVertex streetVertex, String id, boolean carAccessible, boolean walkAccessible) {

--- a/src/test/java/org/opentripplanner/routing/algorithm/GraphRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/GraphRoutingTest.java
@@ -307,6 +307,7 @@ public abstract class GraphRoutingTest {
         ) {
             var vehicleRentalStation = new VehicleRentalStation();
             vehicleRentalStation.id = new FeedScopedId(network, id);
+            vehicleRentalStation.name = new NonLocalizedString(id);
             vehicleRentalStation.longitude = longitude;
             vehicleRentalStation.latitude = latitude;
             vehicleRentalStation.vehiclesAvailable = 2;


### PR DESCRIPTION
### Summary

Four new parameters are added to `RoutingRequest` and `RoutingResource`, which allow limiting the used vehicle rental / parking place by `network` / `tags`:
 * `allowedVehicleRentalNetworks` / `bannedVehicleRentalNetworks`
 * `requiredVehicleParkingTags` / `bannedVehicleParkingTags`

A few missing parameters are also added to `RoutingResource`: `bikeParkCost`, `bikeParkTime`, `carParkCost`, `carParkTime`.

For vehicle rental:
 * if there are only banned networks, everything not banned is allowed
 * if there are allowed networks, only those may be used
 * if there are both allowed and banned networks, banning takes precedence

For vehicle parking -- tags are currently created from OSM tags (`fee`, `supervised`, `covered`, `surveillance`):
 * if `requiredVehicleParkingTags` is specified, than all tags must be present
 * if `bannedVehicleParkingTags` is specified, than non of the tags may be present

### Issue

#3432

### Unit tests

:ballot_box_with_check: 

### Code style

:ballot_box_with_check: 

### Documentation

No changes.