### PR TITLE
Add mode from parent StopPlace for Quays in Netex mapper

### DIFF
--- a/src/main/java/org/opentripplanner/netex/mapping/StopAndStationMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/StopAndStationMapper.java
@@ -14,9 +14,11 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.opentripplanner.graph_builder.DataImportIssueStore;
 import org.opentripplanner.graph_builder.Issue;
+import org.opentripplanner.gtfs.mapping.TransitModeMapper;
 import org.opentripplanner.model.FareZone;
 import org.opentripplanner.model.Station;
 import org.opentripplanner.model.Stop;
+import org.opentripplanner.model.TransitMode;
 import org.opentripplanner.netex.index.api.ReadOnlyHierarchicalVersionMapById;
 import org.opentripplanner.netex.issues.StopPlaceWithoutQuays;
 import org.opentripplanner.netex.mapping.support.FeedScopedIdFactory;
@@ -43,6 +45,7 @@ class StopAndStationMapper {
     private final StationMapper stationMapper;
     private final StopMapper stopMapper;
     private final TariffZoneMapper tariffZoneMapper;
+    private final StopPlaceTypeMapper stopPlaceTypeMapper = new StopPlaceTypeMapper();
     private final DataImportIssueStore issueStore;
 
 
@@ -82,12 +85,15 @@ class StopAndStationMapper {
 
         Station station = mapStopPlaceAllVersionsToStation(selectedStopPlace);
         Collection<FareZone> fareZones = mapTariffZones(selectedStopPlace);
+        TransitMode transitMode = TransitModeMapper.mapMode(
+            stopPlaceTypeMapper.getTransportMode(selectedStopPlace)
+        );
 
         // Loop through all versions of the StopPlace in order to collect all quays, even if they
         // were deleted in never versions of the StopPlace
         for (StopPlace stopPlace : stopPlaceAllVersions) {
             for (Quay quay : listOfQuays(stopPlace)) {
-                addNewStopToParentIfNotPresent(quay, station, fareZones, stopPlace);
+                addNewStopToParentIfNotPresent(quay, station, fareZones, transitMode);
             }
         }
     }
@@ -145,9 +151,9 @@ class StopAndStationMapper {
         Quay quay,
         Station station,
         Collection<FareZone> fareZones,
-        StopPlace stopPlace
+        TransitMode transitMode
     ) {
-        // TODO OTP2 - This assumtion is only valid because Norway have a
+        // TODO OTP2 - This assumption is only valid because Norway have a
         //           - national stop register, we should add all stops/quays
         //           - for version resolution.
         // Continue if this is not newest version of quay
@@ -158,7 +164,7 @@ class StopAndStationMapper {
             return;
         }
 
-        Stop stop = stopMapper.mapQuayToStop(quay, station, fareZones, stopPlace);
+        Stop stop = stopMapper.mapQuayToStop(quay, station, fareZones, transitMode);
         if (stop == null) return;
 
         station.addChildStop(stop);

--- a/src/main/java/org/opentripplanner/netex/mapping/StopAndStationMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/StopAndStationMapper.java
@@ -87,7 +87,7 @@ class StopAndStationMapper {
         // were deleted in never versions of the StopPlace
         for (StopPlace stopPlace : stopPlaceAllVersions) {
             for (Quay quay : listOfQuays(stopPlace)) {
-                addNewStopToParentIfNotPresent(quay, station, fareZones);
+                addNewStopToParentIfNotPresent(quay, station, fareZones, stopPlace);
             }
         }
     }
@@ -144,7 +144,8 @@ class StopAndStationMapper {
     private void addNewStopToParentIfNotPresent(
         Quay quay,
         Station station,
-        Collection<FareZone> fareZones
+        Collection<FareZone> fareZones,
+        StopPlace stopPlace
     ) {
         // TODO OTP2 - This assumtion is only valid because Norway have a
         //           - national stop register, we should add all stops/quays
@@ -157,7 +158,7 @@ class StopAndStationMapper {
             return;
         }
 
-        Stop stop = stopMapper.mapQuayToStop(quay, station, fareZones);
+        Stop stop = stopMapper.mapQuayToStop(quay, station, fareZones, stopPlace);
         if (stop == null) return;
 
         station.addChildStop(stop);

--- a/src/main/java/org/opentripplanner/netex/mapping/StopMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/StopMapper.java
@@ -3,19 +3,16 @@ package org.opentripplanner.netex.mapping;
 import java.util.Collection;
 import javax.annotation.Nullable;
 import org.opentripplanner.graph_builder.DataImportIssueStore;
-import org.opentripplanner.gtfs.mapping.TransitModeMapper;
 import org.opentripplanner.model.FareZone;
 import org.opentripplanner.model.Station;
 import org.opentripplanner.model.Stop;
+import org.opentripplanner.model.TransitMode;
 import org.opentripplanner.model.WgsCoordinate;
 import org.opentripplanner.netex.issues.QuayWithoutCoordinates;
 import org.opentripplanner.netex.mapping.support.FeedScopedIdFactory;
 import org.rutebanken.netex.model.Quay;
-import org.rutebanken.netex.model.StopPlace;
 
 class StopMapper {
-
-  private final StopPlaceTypeMapper stopPlaceTypeMapper = new StopPlaceTypeMapper();
 
   private final DataImportIssueStore issueStore;
 
@@ -37,7 +34,7 @@ class StopMapper {
           Quay quay,
           Station parentStation,
           Collection<FareZone> fareZones,
-          StopPlace stopPlace
+          TransitMode transitMode
   ) {
     WgsCoordinate coordinate = WgsCoordinateMapper.mapToDomain(quay.getCentroid());
 
@@ -58,7 +55,7 @@ class StopMapper {
         fareZones,
         null,
         null,
-        TransitModeMapper.mapMode(stopPlaceTypeMapper.getTransportMode(stopPlace))
+        transitMode
     );
     stop.setParentStation(parentStation);
 

--- a/src/main/java/org/opentripplanner/netex/mapping/StopMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/StopMapper.java
@@ -3,6 +3,7 @@ package org.opentripplanner.netex.mapping;
 import java.util.Collection;
 import javax.annotation.Nullable;
 import org.opentripplanner.graph_builder.DataImportIssueStore;
+import org.opentripplanner.gtfs.mapping.TransitModeMapper;
 import org.opentripplanner.model.FareZone;
 import org.opentripplanner.model.Station;
 import org.opentripplanner.model.Stop;
@@ -10,8 +11,11 @@ import org.opentripplanner.model.WgsCoordinate;
 import org.opentripplanner.netex.issues.QuayWithoutCoordinates;
 import org.opentripplanner.netex.mapping.support.FeedScopedIdFactory;
 import org.rutebanken.netex.model.Quay;
+import org.rutebanken.netex.model.StopPlace;
 
 class StopMapper {
+
+  private final StopPlaceTypeMapper stopPlaceTypeMapper = new StopPlaceTypeMapper();
 
   private final DataImportIssueStore issueStore;
 
@@ -29,7 +33,12 @@ class StopMapper {
    * Map Netex Quay to OTP Stop
    */
   @Nullable
-  Stop mapQuayToStop(Quay quay, Station parentStation, Collection<FareZone> fareZones) {
+  Stop mapQuayToStop(
+          Quay quay,
+          Station parentStation,
+          Collection<FareZone> fareZones,
+          StopPlace stopPlace
+  ) {
     WgsCoordinate coordinate = WgsCoordinateMapper.mapToDomain(quay.getCentroid());
 
     if (coordinate == null) {
@@ -49,7 +58,7 @@ class StopMapper {
         fareZones,
         null,
         null,
-        null
+        TransitModeMapper.mapMode(stopPlaceTypeMapper.getTransportMode(stopPlace))
     );
     stop.setParentStation(parentStation);
 


### PR DESCRIPTION
### Summary
Add mode from parent StopPlace for Quays in Netex mapper. It seems we already had the correct mapper, but it was not used anywhere.

### Unit tests
Mapper already has unit test coverage

### Code style
Code style followed

### Documentation
No need to update

### Changelog
The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md) 
is generated from the pull-request title, make sure the title describe the feature or issue fixed. 
To exclude the PR from the changelog add `[changelog skip]` in the title.
