### PR TITLE
Handle miscellaneous service as BUS instead of crashing build

### DIFF
--- a/src/main/java/org/opentripplanner/gtfs/mapping/GTFSToOtpTransitServiceMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/GTFSToOtpTransitServiceMapper.java
@@ -80,7 +80,7 @@ public class GTFSToOtpTransitServiceMapper {
         this.data = data;
         feedInfoMapper = new FeedInfoMapper(feedId);
         agencyMapper = new AgencyMapper(feedId);
-        routeMapper = new RouteMapper(agencyMapper);
+        routeMapper = new RouteMapper(agencyMapper, issueStore);
         tripMapper = new TripMapper(routeMapper);
         bookingRuleMapper = new BookingRuleMapper();
         stopTimeMapper = new StopTimeMapper(stopMapper, locationMapper, locationGroupMapper, tripMapper, bookingRuleMapper);

--- a/src/main/java/org/opentripplanner/gtfs/mapping/RouteMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/RouteMapper.java
@@ -1,7 +1,10 @@
 package org.opentripplanner.gtfs.mapping;
 
+import static org.opentripplanner.gtfs.mapping.TransitModeMapper.mapMode;
+
 import org.opentripplanner.graph_builder.DataImportIssueStore;
 import org.opentripplanner.model.Route;
+import org.opentripplanner.model.TransitMode;
 import org.opentripplanner.util.MapUtils;
 
 import java.util.Collection;
@@ -38,7 +41,17 @@ class RouteMapper {
         lhs.setLongName(rhs.getLongName());
         int routeType = rhs.getType();
         lhs.setType(routeType);
-        lhs.setMode(TransitModeMapper.mapModeForRoute(routeType, lhs, issueStore));
+        TransitMode mode = mapMode(routeType);
+        if (mode == null) {
+            issueStore.add(
+                    "RouteMapper", "Treating %s route type for route %s as BUS.", routeType,
+                    lhs.getId().toString()
+            );
+            lhs.setMode(TransitMode.BUS);
+        }
+        else {
+            lhs.setMode(mode);
+        }
         lhs.setDesc(rhs.getDesc());
         lhs.setUrl(rhs.getUrl());
         lhs.setColor(rhs.getColor());

--- a/src/main/java/org/opentripplanner/gtfs/mapping/RouteMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/RouteMapper.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.gtfs.mapping;
 
+import org.opentripplanner.graph_builder.DataImportIssueStore;
 import org.opentripplanner.model.Route;
 import org.opentripplanner.util.MapUtils;
 
@@ -11,10 +12,13 @@ import java.util.Map;
 class RouteMapper {
     private final AgencyMapper agencyMapper;
 
+    private final DataImportIssueStore issueStore;
+
     private final Map<org.onebusaway.gtfs.model.Route, Route> mappedRoutes = new HashMap<>();
 
-    RouteMapper(AgencyMapper agencyMapper) {
+    RouteMapper(AgencyMapper agencyMapper, DataImportIssueStore issueStore) {
         this.agencyMapper = agencyMapper;
+        this.issueStore = issueStore;
     }
 
     Collection<Route> map(Collection<org.onebusaway.gtfs.model.Route> agencies) {
@@ -32,8 +36,9 @@ class RouteMapper {
         lhs.setAgency(agencyMapper.map(rhs.getAgency()));
         lhs.setShortName(rhs.getShortName());
         lhs.setLongName(rhs.getLongName());
-        lhs.setType(rhs.getType());
-        lhs.setMode(TransitModeMapper.mapMode(rhs.getType()));
+        int routeType = rhs.getType();
+        lhs.setType(routeType);
+        lhs.setMode(TransitModeMapper.mapModeForRoute(routeType, lhs, issueStore));
         lhs.setDesc(rhs.getDesc());
         lhs.setUrl(rhs.getUrl());
         lhs.setColor(rhs.getColor());

--- a/src/main/java/org/opentripplanner/gtfs/mapping/RouteMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/RouteMapper.java
@@ -1,7 +1,5 @@
 package org.opentripplanner.gtfs.mapping;
 
-import static org.opentripplanner.gtfs.mapping.TransitModeMapper.mapMode;
-
 import org.opentripplanner.graph_builder.DataImportIssueStore;
 import org.opentripplanner.model.Route;
 import org.opentripplanner.model.TransitMode;
@@ -41,7 +39,7 @@ class RouteMapper {
         lhs.setLongName(rhs.getLongName());
         int routeType = rhs.getType();
         lhs.setType(routeType);
-        TransitMode mode = mapMode(routeType);
+        TransitMode mode = TransitModeMapper.mapMode(routeType);
         if (mode == null) {
             issueStore.add(
                     "RouteMapper", "Treating %s route type for route %s as BUS.", routeType,

--- a/src/main/java/org/opentripplanner/gtfs/mapping/TransitModeMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/TransitModeMapper.java
@@ -81,28 +81,4 @@ public class TransitModeMapper {
                 throw new IllegalArgumentException("unknown gtfs route type " + routeType);
         }
     }
-
-    /**
-     * For routes a mode must be set. If {@link #mapMode} returns it as null, we use BUS as
-     * default.
-     *
-     * @param routeType  Original route type that was mapped into a mode
-     * @param route      The route for which the mode is for
-     * @param issueStore Issue store
-     */
-    public static TransitMode mapModeForRoute(
-            int routeType,
-            Route route,
-            DataImportIssueStore issueStore
-    ) {
-        TransitMode mode = mapMode(routeType);
-        if (mode == null) {
-            issueStore.add(
-                    "TransitModeMapper", "Treating %s route type for route %s as BUS.", routeType,
-                    route.getId().toString()
-            );
-            return TransitMode.BUS;
-        }
-        return mode;
-    }
 }

--- a/src/main/java/org/opentripplanner/gtfs/mapping/TransitModeMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/TransitModeMapper.java
@@ -50,6 +50,8 @@ public class TransitModeMapper {
             return TransitMode.BUS;
         } else if (routeType >= 1600 && routeType < 1700) { //Self drive
             return TransitMode.BUS;
+        } else if (routeType >= 1700 && routeType < 1800) { //Miscellaneous Service
+            return TransitMode.BUS;
         }
         /* Original GTFS route types. Should these be checked before TPEG types? */
         switch (routeType) {

--- a/src/main/java/org/opentripplanner/gtfs/mapping/TransitModeMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/TransitModeMapper.java
@@ -99,7 +99,7 @@ public class TransitModeMapper {
         if (mode == null) {
             issueStore.add(
                     "TransitModeMapper", "Treating %s route type for route %s as BUS.", routeType,
-                    route.getId().getId()
+                    route.getId().toString()
             );
             return TransitMode.BUS;
         }

--- a/src/main/java/org/opentripplanner/netex/mapping/RouteMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/RouteMapper.java
@@ -8,6 +8,7 @@ import org.opentripplanner.gtfs.mapping.TransitModeMapper;
 import org.opentripplanner.model.Agency;
 import org.opentripplanner.model.BikeAccess;
 import org.opentripplanner.model.Operator;
+import org.opentripplanner.model.TransitMode;
 import org.opentripplanner.model.impl.EntityById;
 import org.opentripplanner.netex.index.api.NetexEntityIndexReadOnlyView;
 import org.opentripplanner.netex.mapping.support.FeedScopedIdFactory;
@@ -65,7 +66,17 @@ class RouteMapper {
                 line.getTransportSubmode()
         );
         otpRoute.setType(transportType);
-        otpRoute.setMode(TransitModeMapper.mapModeForRoute(transportType, otpRoute, issueStore));
+        TransitMode mode = TransitModeMapper.mapMode(transportType);
+        if (mode == null) {
+            issueStore.add(
+                    "RouteMapper", "Treating %s route type for route %s as BUS.", transportType,
+                    otpRoute.getId().toString()
+            );
+            otpRoute.setMode(TransitMode.BUS);
+        }
+        else {
+            otpRoute.setMode(mode);
+        }
         if (line instanceof FlexibleLine_VersionStructure) {
             otpRoute.setFlexibleLineType(((FlexibleLine_VersionStructure) line)
                 .getFlexibleLineType().value());

--- a/src/main/java/org/opentripplanner/netex/mapping/RouteMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/RouteMapper.java
@@ -8,7 +8,6 @@ import org.opentripplanner.gtfs.mapping.TransitModeMapper;
 import org.opentripplanner.model.Agency;
 import org.opentripplanner.model.BikeAccess;
 import org.opentripplanner.model.Operator;
-import org.opentripplanner.model.TransitMode;
 import org.opentripplanner.model.impl.EntityById;
 import org.opentripplanner.netex.index.api.NetexEntityIndexReadOnlyView;
 import org.opentripplanner.netex.mapping.support.FeedScopedIdFactory;
@@ -66,8 +65,7 @@ class RouteMapper {
                 line.getTransportSubmode()
         );
         otpRoute.setType(transportType);
-        TransitMode mode = TransitModeMapper.mapMode(transportType);
-        otpRoute.setMode(mode);
+        otpRoute.setMode(TransitModeMapper.mapModeForRoute(transportType, otpRoute, issueStore));
         if (line instanceof FlexibleLine_VersionStructure) {
             otpRoute.setFlexibleLineType(((FlexibleLine_VersionStructure) line)
                 .getFlexibleLineType().value());

--- a/src/test/java/org/opentripplanner/gtfs/mapping/FareRuleMapperTest.java
+++ b/src/test/java/org/opentripplanner/gtfs/mapping/FareRuleMapperTest.java
@@ -8,6 +8,7 @@ import org.onebusaway.gtfs.model.Route;
 
 import java.util.Collection;
 import java.util.Collections;
+import org.opentripplanner.graph_builder.DataImportIssueStore;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -45,8 +46,10 @@ public class FareRuleMapperTest {
         FARE_RULE.setRoute(ROUTE);
     }
 
-    private FareRuleMapper subject = new FareRuleMapper(new RouteMapper(new AgencyMapper(FEED_ID)),
-            new FareAttributeMapper());
+    private FareRuleMapper subject = new FareRuleMapper(
+            new RouteMapper(new AgencyMapper(FEED_ID), new DataImportIssueStore(false)),
+            new FareAttributeMapper()
+    );
 
     @Test
     public void testMapCollection() throws Exception {

--- a/src/test/java/org/opentripplanner/gtfs/mapping/FrequencyMapperTest.java
+++ b/src/test/java/org/opentripplanner/gtfs/mapping/FrequencyMapperTest.java
@@ -7,6 +7,7 @@ import org.onebusaway.gtfs.model.Trip;
 
 import java.util.Collection;
 import java.util.Collections;
+import org.opentripplanner.graph_builder.DataImportIssueStore;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -47,7 +48,8 @@ public class FrequencyMapperTest {
     }
 
     private FrequencyMapper subject = new FrequencyMapper(
-            new TripMapper(new RouteMapper(new AgencyMapper(FEED_ID))));
+            new TripMapper(
+                    new RouteMapper(new AgencyMapper(FEED_ID), new DataImportIssueStore(false))));
 
     @Test
     public void testMapCollection() throws Exception {

--- a/src/test/java/org/opentripplanner/gtfs/mapping/RouteMapperTest.java
+++ b/src/test/java/org/opentripplanner/gtfs/mapping/RouteMapperTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 import org.onebusaway.gtfs.model.Agency;
 import org.onebusaway.gtfs.model.AgencyAndId;
 import org.onebusaway.gtfs.model.Route;
+import org.opentripplanner.graph_builder.DataImportIssueStore;
 import org.opentripplanner.model.BikeAccess;
 
 import java.util.Collection;
@@ -63,7 +64,8 @@ public class RouteMapperTest {
         ROUTE.setBrandingUrl(BRANDING_URL);
     }
 
-    private final RouteMapper subject = new RouteMapper(new AgencyMapper(FEED_ID));
+    private final RouteMapper subject =
+            new RouteMapper(new AgencyMapper(FEED_ID), new DataImportIssueStore(false));
 
     @Test
     public void testMapCollection() throws Exception {

--- a/src/test/java/org/opentripplanner/gtfs/mapping/StopTimesMapperTest.java
+++ b/src/test/java/org/opentripplanner/gtfs/mapping/StopTimesMapperTest.java
@@ -14,6 +14,7 @@ import org.onebusaway.gtfs.model.AgencyAndId;
 import org.onebusaway.gtfs.model.Stop;
 import org.onebusaway.gtfs.model.StopTime;
 import org.onebusaway.gtfs.model.Trip;
+import org.opentripplanner.graph_builder.DataImportIssueStore;
 
 public class StopTimesMapperTest {
     private static final String FEED_ID = "FEED";
@@ -76,7 +77,7 @@ public class StopTimesMapperTest {
             stopMapper,
             locationMapper,
             locationGroupMapper,
-            new TripMapper(new RouteMapper(new AgencyMapper(FEED_ID))),
+            new TripMapper(new RouteMapper(new AgencyMapper(FEED_ID), new DataImportIssueStore(false))),
             bookingRuleMapper
     );
 

--- a/src/test/java/org/opentripplanner/gtfs/mapping/TransferMapperTest.java
+++ b/src/test/java/org/opentripplanner/gtfs/mapping/TransferMapperTest.java
@@ -5,12 +5,14 @@ import org.onebusaway.gtfs.model.Route;
 import org.onebusaway.gtfs.model.Stop;
 import org.onebusaway.gtfs.model.Transfer;
 import org.onebusaway.gtfs.model.Trip;
+import org.opentripplanner.graph_builder.DataImportIssueStore;
 import org.opentripplanner.model.TripStopTimes;
 
 public class TransferMapperTest {
     private static final String FEED_ID = "FEED";
 
-    private static final RouteMapper ROUTE_MAPPER = new RouteMapper(new AgencyMapper(FEED_ID));
+    private static final RouteMapper ROUTE_MAPPER =
+            new RouteMapper(new AgencyMapper(FEED_ID), new DataImportIssueStore(false));
 
     private static final TripMapper TRIP_MAPPER = new TripMapper(ROUTE_MAPPER);
 

--- a/src/test/java/org/opentripplanner/gtfs/mapping/TripMapperTest.java
+++ b/src/test/java/org/opentripplanner/gtfs/mapping/TripMapperTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 import org.onebusaway.gtfs.model.AgencyAndId;
 import org.onebusaway.gtfs.model.Route;
 import org.onebusaway.gtfs.model.Trip;
+import org.opentripplanner.graph_builder.DataImportIssueStore;
 import org.opentripplanner.model.BikeAccess;
 
 import java.util.Collection;
@@ -56,7 +57,8 @@ public class TripMapperTest {
         TRIP.setWheelchairAccessible(WHEELCHAIR_ACCESSIBLE);
     }
 
-    private TripMapper subject = new TripMapper(new RouteMapper(new AgencyMapper(FEED_ID)));
+    private TripMapper subject = new TripMapper(
+            new RouteMapper(new AgencyMapper(FEED_ID), new DataImportIssueStore(false)));
 
     @Test
     public void testMapCollection() throws Exception {


### PR DESCRIPTION
### Summary
Naive support for miscellaneous service route type (17xx) from GTFS. It is now handled as BUS instead of crashing build.

### Issue
closes #3754

### Unit tests
Tested manually

### Code style
Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Developers-Guide.md#code-style)? 
Yes

### Documentation
RoutingModes.md is the only relevant file I can think of but it might be updated at some point when support for submodes is added.

### Changelog
From title