### PR TITLE
Bugfix: ClassCastException when planning flex routes

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/model/OptimizedPathTail.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/model/OptimizedPathTail.java
@@ -85,9 +85,22 @@ public class OptimizedPathTail<T extends RaptorTripSchedule>
 
     /** Start by adding the last transit leg with the egress leg attached. */
     public OptimizedPathTail<T> addTransitTail(TransitPathLeg<T> leg) {
-        egress(leg.nextLeg().asEgressLeg().egress());
-        var times = new BoardAndAlightTime(leg.trip(), leg.getFromStopPosition(), leg.getToStopPosition());
-        transit(leg.trip(), times);
+        var next = leg.nextLeg();
+        // this could also be a transfer to a flex leg
+        if(next.isTransferLeg()) {
+            next = next.nextLeg();
+        }
+        if (next.isEgressLeg()) {
+            egress(next.asEgressLeg().egress());
+            var times = new BoardAndAlightTime(
+                    leg.trip(),
+                    leg.getFromStopPosition(),
+                    leg.getToStopPosition()
+            );
+            transit(leg.trip(), times);
+        } else {
+            throw new IllegalStateException("We expect an egress leg at the end of the RAPTOR path.");
+        }
         return this;
     }
 

--- a/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/model/OptimizedPathTailTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/model/OptimizedPathTailTest.java
@@ -15,6 +15,8 @@ import org.opentripplanner.transit.raptor.api.path.TransitPathLeg;
 class OptimizedPathTailTest implements RaptorTestConstants {
     private final Path<TestTripSchedule> orgPath = BasicPathTestCase.basicTripAsPath();
 
+    private final Path<TestTripSchedule> flexPath = BasicPathTestCase.flexTripAsPath();
+
     private final TransitPathLeg<TestTripSchedule> t1 = orgPath.accessLeg().nextTransitLeg();
     @SuppressWarnings("ConstantConditions")
     private final TransitPathLeg<TestTripSchedule> t2 = t1.nextTransitLeg();
@@ -61,7 +63,7 @@ class OptimizedPathTailTest implements RaptorTestConstants {
     }
 
     @Test
-    void testToSting() {
+    void testToString() {
         subject.addTransitTail(t3);
         subject.addTransitAndTransferLeg(t2, tx23);
         subject.addTransitAndTransferLeg(t1, tx12);
@@ -74,6 +76,19 @@ class OptimizedPathTailTest implements RaptorTestConstants {
                 + "~ BUS L31 11:40 11:52 ~ E "
                 + "~ Walk 7m45s "
                 + "[$8019 $46pri $-101126wtc]";
+
+        assertEquals(exp, subject.toString());
+    }
+
+    @Test
+    void shouldHandleATransferAfterLastTransit() {
+        subject.addTransitTail(flexPath.accessLeg().nextTransitLeg());
+        subject.access(orgPath.accessLeg().access());
+
+        var exp = "Walk 3m15s ~ A "
+                + "~ BUS L11 10:04 10:35 ~ B "
+                + "~ Walk 7m45s "
+                + "[$3318 $0pri $60wtc]";
 
         assertEquals(exp, subject.toString());
     }

--- a/src/test/java/org/opentripplanner/transit/raptor/_data/stoparrival/BasicPathTestCase.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/_data/stoparrival/BasicPathTestCase.java
@@ -10,6 +10,12 @@ import static org.opentripplanner.util.time.TimeUtils.time;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.ext.flex.FlexAccessEgress;
+import org.opentripplanner.model.Stop;
+import org.opentripplanner.routing.algorithm.GraphRoutingTest;
+import org.opentripplanner.routing.algorithm.raptor.transit.FlexAccessEgressAdapter;
+import org.opentripplanner.routing.algorithm.raptor.transit.StopIndexForRaptor;
+import org.opentripplanner.routing.algorithm.raptor.transit.TransitTuningParameters;
 import org.opentripplanner.routing.algorithm.raptor.transit.cost.DefaultCostCalculator;
 import org.opentripplanner.transit.raptor._data.RaptorTestConstants;
 import org.opentripplanner.transit.raptor._data.transit.TestTransfer;
@@ -141,6 +147,8 @@ public class BasicPathTestCase implements RaptorTestConstants {
 
     private static final RaptorTransfer ACCESS = walk(STOP_A, ACCESS_DURATION, ACCESS_COST);
     private static final RaptorTransfer EGRESS = walk(STOP_E, EGRESS_DURATION, EGRESS_COST);
+    // this is of course not a real flex egress
+    private static final RaptorTransfer FLEX = walk(STOP_E, EGRESS_DURATION, EGRESS_COST);
 
     public static final String LINE_11 = "L11";
     public static final String LINE_21 = "L21";
@@ -247,6 +255,22 @@ public class BasicPathTestCase implements RaptorTestConstants {
         var leg2 = new TransitPathLeg<>(TRIP_1, times2, EMPTY_CONSTRAINTS, LINE_11_COST, leg3);
         AccessPathLeg<TestTripSchedule> leg1 = new AccessPathLeg<>(
             ACCESS, ACCESS_START, ACCESS_END, ACCESS_COST, leg2.asTransitLeg()
+        );
+        return new Path<>(RAPTOR_ITERATION_START_TIME, leg1, TOTAL_COST);
+    }
+
+    public static Path<TestTripSchedule> flexTripAsPath() {
+        PathLeg<TestTripSchedule> leg6 = new EgressPathLeg<>(
+                FLEX, EGRESS_START, EGRESS_END, EGRESS_COST
+        );
+        var transfer = TestTransfer.walk(STOP_C, TX_END - TX_START);
+        PathLeg<TestTripSchedule> leg3 = new TransferPathLeg<>(
+                STOP_B, TX_START, TX_END, transfer.generalizedCost(), transfer, leg6
+        );
+        var times2 = BoardAndAlightTime.create(TRIP_1, STOP_A, L11_START, STOP_B, L11_END);
+        var leg2 = new TransitPathLeg<>(TRIP_1, times2, EMPTY_CONSTRAINTS, LINE_11_COST, leg3);
+        AccessPathLeg<TestTripSchedule> leg1 = new AccessPathLeg<>(
+                ACCESS, ACCESS_START, ACCESS_END, ACCESS_COST, leg2.asTransitLeg()
         );
         return new Path<>(RAPTOR_ITERATION_START_TIME, leg1, TOTAL_COST);
     }


### PR DESCRIPTION
### Summary

When the transit tails for a Raptor path with a flex egress were calculated it a transfer leg was attempted to be cast to an egress leg which threw an exception.

If we get a transfer we then skip to the next leg.

### Issue
closes #3761 

### Unit tests
Unit test added.

### Code style
yes

### Documentation
n/a