### PR TITLE
Restore ability to filter by private code [changelog skip]

### DIFF
--- a/docs/sandbox/TransmodelApi.md
+++ b/docs/sandbox/TransmodelApi.md
@@ -18,6 +18,7 @@
 - Use correct capitalization for GraphQL fields [#3707](https://github.com/opentripplanner/OpenTripPlanner/pull/3707)
 - Allow filtering by a list of ids [#3738](https://github.com/opentripplanner/OpenTripPlanner/pull/3738)
 - Don't filter out stops who don't have multimodal parents in the nearest query [#3752](https://github.com/opentripplanner/OpenTripPlanner/pull/3752)
+- Restore ability to filter by private code [#3764](https://github.com/opentripplanner/OpenTripPlanner/pull/3764)
 
 ## Documentation
 

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
@@ -38,6 +38,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.opentripplanner.ext.transmodelapi.mapping.PlaceMapper;
 import org.opentripplanner.ext.transmodelapi.mapping.TransitIdMapper;
 import org.opentripplanner.ext.transmodelapi.model.DefaultRoutingRequestType;
@@ -920,7 +921,7 @@ public class TransmodelGraphQLSchema {
                 .build())
             .dataFetcher(environment -> {
               List<FeedScopedId> lineIds = mapIDsToDomain(environment.getArgument("lines"));
-              //List<String> privateCodes=environment.getArgument("privateCodes");
+              List<String> privateCodes = environment.getArgument("privateCodes");
               List<Long> activeDates = environment.getArgument("activeDates");
               // TODO OTP2 - Use FeedScoped ID
               List<String> authorities = environment.getArgument("authorities");
@@ -931,7 +932,7 @@ public class TransmodelGraphQLSchema {
                   .filter(t -> lineIds == null || lineIds.isEmpty() || lineIds.contains(t
                       .getRoute()
                       .getId()))
-                  //.filter(t -> CollectionUtils.isEmpty(privateCodes) || privateCodes.contains(t.getTripPrivateCode()))
+                  .filter(t -> CollectionUtils.isEmpty(privateCodes) || privateCodes.contains(t.getInternalPlanningCode()))
                   .filter(t -> authorities == null || authorities.isEmpty()  || authorities.contains(t
                       .getRoute()
                       .getAgency()


### PR DESCRIPTION
### Summary

Add filtering by private code to the Transmodel GraphQL API for service journeys. This is a regression from OTP1

### Changelog
The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md) 
is generated from the pull-request title, make sure the title describe the feature or issue fixed. 
To exclude the PR from the changelog add `[changelog skip]` in the title.
