### PR TITLE
Walkable area builder improvements

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
@@ -93,7 +93,9 @@ public class GraphBuilder implements Runnable {
     public static GraphBuilder create(
             BuildConfig config,
             GraphBuilderDataSources dataSources,
-            Graph baseGraph
+            Graph baseGraph,
+            boolean loadStreetGraph,
+            boolean saveStreetGraph
     ) {
 
         boolean hasOsm  = dataSources.has(OSM);
@@ -172,7 +174,7 @@ public class GraphBuilder implements Runnable {
         // Prune graph connectivity islands after transit stop linking, so that pruning can take into account
         // existence of stops in islands. If an island has a stop, it actually may be a real island and should
         // not be removed quite as easily
-        if ( hasOsm ) {
+        if ((hasOsm && !saveStreetGraph) || loadStreetGraph) {
             PruneNoThruIslands pruneNoThruIslands = new PruneNoThruIslands(streetLinkerModule);
             pruneNoThruIslands.setPruningThresholdIslandWithoutStops(config.pruningThresholdIslandWithoutStops);
             pruneNoThruIslands.setPruningThresholdIslandWithStops(config.pruningThresholdIslandWithStops);

--- a/src/main/java/org/opentripplanner/graph_builder/linking/VertexLinker.java
+++ b/src/main/java/org/opentripplanner/graph_builder/linking/VertexLinker.java
@@ -333,12 +333,13 @@ public class VertexLinker {
     LineString transformed = equirectangularProject(orig, xScale);
     LocationIndexedLine il = new LocationIndexedLine(transformed);
     LinearLocation ll = il.project(new Coordinate(vertex.getLon() * xScale, vertex.getLat()));
+    double length = SphericalDistanceLibrary.length(orig);
 
     // if we're very close to one end of the line or the other, or endwise, don't bother to split,
     // cut to the chase and link directly
     // We use a really tiny epsilon here because we only want points that actually snap to exactly the same location on the
     // street to use the same vertices. Otherwise the order the stops are loaded in will affect where they are snapped.
-    if (ll.getSegmentIndex() == 0 && ll.getSegmentFraction() < 1e-8) {
+    if (ll.getSegmentIndex() == 0 && (ll.getSegmentFraction() < 1e-8 || ll.getSegmentFraction() * length < 0.1)) {
       return (StreetVertex) edge.getFromVertex();
     }
     // -1 converts from count to index. Because of the fencepost problem, npoints - 1 is the "segment"
@@ -348,8 +349,9 @@ public class VertexLinker {
     }
 
     // nPoints - 2: -1 to correct for index vs count, -1 to account for fencepost problem
-    else if (ll.getSegmentIndex() == orig.getNumPoints() - 2
-        && ll.getSegmentFraction() > 1 - 1e-8) {
+    else if (ll.getSegmentIndex() == orig.getNumPoints() - 2 && (
+      ll.getSegmentFraction() > 1 - 1e-8 || (1 - ll.getSegmentFraction()) * length < 0.1)
+    ) {
       return (StreetVertex) edge.getToVertex();
     }
 

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilder.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.graph_builder.module.osm;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.locationtech.jts.geom.Coordinate;
@@ -288,6 +289,13 @@ public class WalkableAreaBuilder {
                                 maxAreaNodes
                         ));
                 continue;
+            }
+
+            if (edgeList.visibilityVertices.size() == 0) {
+                issueStore.add(
+                    "UnconnectedArea",
+                    "Area %s has no connection to street network",
+                    osmWayIds.stream().map(Object::toString).collect(Collectors.joining(", ")));
             }
 
             createNamedAreas(edgeList, ring, group.areas);

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilder.java
@@ -241,9 +241,13 @@ public class WalkableAreaBuilder {
                         );
                         edges.addAll(newEdges);
                         ringEdges.addAll(newEdges);
-                        // TODO: this is really needed only for convex nodes, could be a perf optimization
-                        visibilityNodes.add(node);
+                        // A node can only be a visibility node only if it is an entrance to the
+                        // area or a convex point, i.e. the angle is over 180 degrees.
+                        if (outerRing.isNodeConvex(i)) {
+                            visibilityNodes.add(node);
+                        }
                         if (isStartingNode(node, osmWayIds)) {
+                            visibilityNodes.add(node);
                             startingNodes.add(node);
                         }
                     }
@@ -252,11 +256,15 @@ public class WalkableAreaBuilder {
                             OSMNode node = innerRing.nodes.get(j);
                             edges.addAll(createEdgesForRingSegment(edgeList, area, innerRing, j,
                                     alreadyAddedEdges));
-                            // TODO: this is really needed only for convex nodes, could be a perf optimization
-                            visibilityNodes.add(node);
+                            // A node can only be a visibility node only if it is an entrance to the
+                            // area or a convex point, i.e. the angle is over 180 degrees.
+                            // For holes, the internal angle is calculated, so we must swap the sign
+                            if (!innerRing.isNodeConvex(j)) {
+                                visibilityNodes.add(node);
+                            }
                             if (isStartingNode(node, osmWayIds)) {
+                                visibilityNodes.add(node);
                                 startingNodes.add(node);
-
                             }
                         }
                     }

--- a/src/main/java/org/opentripplanner/openstreetmap/model/OSMNode.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/model/OSMNode.java
@@ -1,5 +1,7 @@
 package org.opentripplanner.openstreetmap.model;
 
+import org.locationtech.jts.geom.Coordinate;
+
 public class OSMNode extends OSMWithTags {
 
     public double lat;
@@ -7,6 +9,10 @@ public class OSMNode extends OSMWithTags {
 
     public String toString() {
         return "osm node " + id;
+    }
+
+    public Coordinate getCoordinate() {
+        return new Coordinate(this.lon, this.lat);
     }
 
     /**

--- a/src/main/java/org/opentripplanner/routing/edgetype/AreaEdgeList.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/AreaEdgeList.java
@@ -54,6 +54,8 @@ public class AreaEdgeList implements Serializable {
             geometryFactory.createPoint(newVertex.getCoordinate())
         );
 
+        int added = 0;
+
         for (IntersectionVertex v : visibilityVertices) {
             LineString newGeometry = geometryFactory.createLineString(
                 new Coordinate[] {nearestPoints[0], v.getCoordinate() }
@@ -68,6 +70,15 @@ public class AreaEdgeList implements Serializable {
             // check to see if this splits multiple NamedAreas. This code is rather similar to
             // code in OSMGBI, but the data structures are different
             createSegments(newVertex, v, areas);
+            added++;
+        }
+
+        // TODO: Temporary fix for unconnected area edges. This should go away when moving walkable
+        // area calculation to be done after stop linking
+        if (added == 0) {
+            for (IntersectionVertex v : visibilityVertices) {
+                createSegments(newVertex, v, areas);
+            }
         }
 
         visibilityVertices.add(newVertex);

--- a/src/main/java/org/opentripplanner/standalone/configure/OTPAppConstruction.java
+++ b/src/main/java/org/opentripplanner/standalone/configure/OTPAppConstruction.java
@@ -86,7 +86,9 @@ public class OTPAppConstruction {
         return GraphBuilder.create(
                 config.buildConfig(),
                 graphBuilderDataSources(),
-                baseGraph
+                baseGraph,
+                config.getCli().doLoadStreetGraph(),
+                config.getCli().doSaveStreetGraph()
         );
     }
 

--- a/src/test/java/org/opentripplanner/graph_builder/module/osm/RingTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/osm/RingTest.java
@@ -1,0 +1,66 @@
+package org.opentripplanner.graph_builder.module.osm;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.openstreetmap.model.OSMNode;
+
+class RingTest {
+
+    @Test
+    void testIsNodeConvex() {
+        OSMNode a = new OSMNode();
+        a.lat = 0.0;
+        a.lon = 0.0;
+        OSMNode b = new OSMNode();
+        b.lat = 1.0;
+        b.lon = 0.0;
+        OSMNode c = new OSMNode();
+        c.lat = 1.0;
+        c.lon = 1.0;
+        OSMNode d = new OSMNode();
+        d.lat = 0.0;
+        d.lon = 1.0;
+        OSMNode e = new OSMNode();
+        e.lat = 0.5;
+        e.lon = 0.5;
+
+        Ring ring = new Ring(List.of(a, b, c, d, a));
+
+        assertFalse(ring.isNodeConvex(0));
+        assertFalse(ring.isNodeConvex(1));
+        assertFalse(ring.isNodeConvex(2));
+        assertFalse(ring.isNodeConvex(3));
+        assertFalse(ring.isNodeConvex(4));
+
+        ring = new Ring(List.of(a, d, c, b, a));
+
+        assertFalse(ring.isNodeConvex(0));
+        assertFalse(ring.isNodeConvex(1));
+        assertFalse(ring.isNodeConvex(2));
+        assertFalse(ring.isNodeConvex(3));
+        assertFalse(ring.isNodeConvex(4));
+
+        ring = new Ring(List.of(a, e, b, c, d, a));
+
+        assertFalse(ring.isNodeConvex(0));
+        assertTrue(ring.isNodeConvex(1));
+        assertFalse(ring.isNodeConvex(2));
+        assertFalse(ring.isNodeConvex(3));
+        assertFalse(ring.isNodeConvex(4));
+        assertFalse(ring.isNodeConvex(5));
+
+        ring = new Ring(List.of(a, e, d, c, b, a));
+
+        // Ring has been reversed
+        assertEquals(0.5, ring.nodes.get(4).lat);
+
+        assertFalse(ring.isNodeConvex(0));
+        assertFalse(ring.isNodeConvex(1));
+        assertFalse(ring.isNodeConvex(2));
+        assertFalse(ring.isNodeConvex(3));
+        assertTrue(ring.isNodeConvex(4));
+        assertFalse(ring.isNodeConvex(5));
+    }
+}


### PR DESCRIPTION
### Summary

As discussed in OTP meeting last week, we decided to do performance improvements for the walkable area builder at a later stage. This pull request contains two of those. The first one is limiting the visibility nodes to only use convex points in a polygon. This reduces the build time of the Norwegian graph from ~3 minutes and 45 seconds to ~2min 15 seconds. The second one caches the way properties, which further reduces the build time to ~2minutes.

This also fixes a couple of issues with the builder:
 - Do not split edges less than 10 cm.
 - Make sure that all area edges are connected properly
 - Run island pruning only after stop linking, even when building the street graph separately
 - Add issue about unconnected areas

### Unit tests
Unit test for calculating convex points in a polygon added

### Code style
Code style followed

### Documentation
No updates required

### Changelog
The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md) 
is generated from the pull-request title, make sure the title describe the feature or issue fixed. 
To exclude the PR from the changelog add `[changelog skip]` in the title.
