### PR TITLE
Parallelise computing of trip pattern geometries

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/module/geometry/GeometryAndBlockProcessor.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/geometry/GeometryAndBlockProcessor.java
@@ -137,7 +137,7 @@ public class GeometryAndBlockProcessor {
         );
         LOG.info(progress.startMessage());
 
-        tripPatterns.stream().parallel().forEach(tripPattern -> {
+        tripPatterns.parallelStream().forEach(tripPattern -> {
             for (Trip trip : tripPattern.getTrips()) {
                 // create geometries if they aren't already created
                 // note that this is not only done on new trip patterns, because it is possible that

--- a/src/main/java/org/opentripplanner/util/ProgressTracker.java
+++ b/src/main/java/org/opentripplanner/util/ProgressTracker.java
@@ -232,7 +232,7 @@ public class ProgressTracker {
         // Add 1 millisecond to prevent / by zero.
         String stepsPerSecond = toStr(Math.round(1000d * ii / (totalTime.toMillis()+1)));
       return String.format(
-                "%s progress tracking complete. %s done in %s (%s pr second). ",
+                "%s progress tracking complete. %s done in %s (%s per second). ",
                 actionName, toStr(ii), DurationUtils.durationToStr(totalTime), stepsPerSecond
         );
     }


### PR DESCRIPTION
### Summary
I noticed that when building a Norway graph 7 out of 20 minutes is taken up computing the trip pattern geometries. This process is run serially when it's quite parallelisable.

With these minor modifications I managed to reduce the graph build time from 20 to 13 minutes on my 16 core test machine.

### Unit tests
n/a

### Code style
yes

### Documentation
n/a