### PR TITLE
Minor performance improvements

### DIFF
--- a/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
@@ -1279,6 +1279,12 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
     }
 
     public Set<FeedScopedId> getBannedRoutes(Collection<Route> routes) {
+        if (bannedRoutes.isEmpty() && bannedAgencies.isEmpty() &&
+            whiteListedRoutes.isEmpty() && whiteListedAgencies.isEmpty()
+        ) {
+            return Set.of();
+        }
+
         Set<FeedScopedId> bannedRoutes = new HashSet<>();
         for (Route route : routes) {
             if (routeIsBanned(route)) {
@@ -1303,14 +1309,14 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
      */
     private boolean routeIsBanned(Route route) {
         /* check if agency is banned for this plan */
-        if (bannedAgencies != null) {
+        if (!bannedAgencies.isEmpty()) {
             if (bannedAgencies.contains(route.getAgency().getId())) {
                 return true;
             }
         }
 
         /* check if route banned for this plan */
-        if (bannedRoutes != null) {
+        if (!bannedRoutes.isEmpty()) {
             if (bannedRoutes.matches(route)) {
                 return true;
             }
@@ -1320,7 +1326,7 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
         boolean whiteListInUse = false;
 
         /* check if agency is whitelisted for this plan */
-        if (whiteListedAgencies != null && whiteListedAgencies.size() > 0) {
+        if (!whiteListedAgencies.isEmpty()) {
             whiteListInUse = true;
             if (whiteListedAgencies.contains(route.getAgency().getId())) {
                 whiteListed = true;
@@ -1328,7 +1334,7 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
         }
 
         /* check if route is whitelisted for this plan */
-        if (whiteListedRoutes != null && !whiteListedRoutes.isEmpty()) {
+        if (!whiteListedRoutes.isEmpty()) {
             whiteListInUse = true;
             if (whiteListedRoutes.matches(route)) {
                 whiteListed = true;

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetTraversalPermission.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetTraversalPermission.java
@@ -1,7 +1,5 @@
 package org.opentripplanner.routing.edgetype;
 
-import java.util.Map;
-import java.util.HashMap;
 import java.util.EnumSet;
 
 import org.opentripplanner.routing.core.TraverseMode;
@@ -20,11 +18,12 @@ public enum StreetTraversalPermission {
     BICYCLE_AND_CAR(4 | 2),
     ALL(4 | 2 | 1);
 
-    private static final Map<Integer, StreetTraversalPermission> lookup = new HashMap<Integer, StreetTraversalPermission>();
+    private static final StreetTraversalPermission[] lookup = new StreetTraversalPermission[8];
 
     static {
-        for (StreetTraversalPermission s : EnumSet.allOf(StreetTraversalPermission.class))
-            lookup.put(s.code, s);
+        for (StreetTraversalPermission s : EnumSet.allOf(StreetTraversalPermission.class)) {
+            lookup[s.code] = s;
+        }
     }
 
     public int code;
@@ -34,7 +33,7 @@ public enum StreetTraversalPermission {
     }
 
     public static StreetTraversalPermission get(int code) {
-        return lookup.get(code);
+        return lookup[code];
     }
 
     public StreetTraversalPermission add(StreetTraversalPermission perm) {

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetTraversalPermission.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetTraversalPermission.java
@@ -1,7 +1,5 @@
 package org.opentripplanner.routing.edgetype;
 
-import java.util.EnumSet;
-
 import org.opentripplanner.routing.core.TraverseMode;
 import org.opentripplanner.routing.core.TraverseModeSet;
 
@@ -18,10 +16,11 @@ public enum StreetTraversalPermission {
     BICYCLE_AND_CAR(4 | 2),
     ALL(4 | 2 | 1);
 
-    private static final StreetTraversalPermission[] lookup = new StreetTraversalPermission[8];
+    private static final StreetTraversalPermission[] lookup =
+            new StreetTraversalPermission[StreetTraversalPermission.values().length];
 
     static {
-        for (StreetTraversalPermission s : EnumSet.allOf(StreetTraversalPermission.class)) {
+        for (StreetTraversalPermission s : StreetTraversalPermission.values()) {
             lookup[s.code] = s;
         }
     }


### PR DESCRIPTION
### Summary

When profiling the walkable area builder, I also took a look at the routing performance, and found these two low hanging fruits for performance increases.

There are two potential additional easy wins, which should be looked at
- Moving turn restrictions from graph to edges
- Not using a HashSet in `RaptorRoutingRequestTransitData#routeIterator`