### PR TITLE
Add support for include-file-directive in config files.

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -142,9 +142,9 @@ possible to keep part of the configuration in separate files. To include the con
 `${includeFile:FILE_NAME}`. The `FILE_NAME` must be the name of a file in the configuration 
 directory. Relative paths are not supported. 
 <p>
-To allow both files (the configuration file and the injected file) to be valid JSON files a special
-case is supported; If the include file directive is quoted, then the quotes are removed if the 
-text inserted is valid JSON (start with `{` and ends with ``}). 
+To allow both files (the configuration file and the injected file) to be valid JSON files, a special
+case is supported. If the include file directive is quoted, then the quotes are removed, if the 
+text inserted is valid JSON (starts with `{` and ends with `}`). 
 
 Variable substitution is performed on configuration file after the include file directive; Hence
 variable substitution is also performed on the text in the injected file.

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -137,8 +137,8 @@ messages and all OTP APIs can be used to get the OTP Serialization Version Id.
 
 ## Include file directive
 
-It is possible to inject the content of another file into a configuration file. This make it 
-possible to keep part of the configuration in separate files. To include the content of a file use
+It is possible to inject the contents of another file into a configuration file. This makes it 
+possible to keep parts of the configuration in separate files. To include the contents of a file, use
 `${includeFile:FILE_NAME}`. The `FILE_NAME` must be the name of a file in the configuration 
 directory. Relative paths are not supported. 
 <p>

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -133,7 +133,46 @@ you can run the following bash command:
  
 The Maven _pom.xml_, the _META-INF/MANIFEST.MF_, the OTP command line(`--serVerId`), log start-up
 messages and all OTP APIs can be used to get the OTP Serialization Version Id.  
-              
+
+
+## Include file directive
+
+It is possible to inject the content of another file into a configuration file. This make it 
+possible to keep part of the configuration in separate files. To include the content of a file use
+`${includeFile:FILE_NAME}`. The `FILE_NAME` must be the name of a file in the configuration 
+directory. Relative paths are not supported. 
+<p>
+To allow both files (the configuration file and the injected file) to be valid JSON files a special
+case is supported; If the include file directive is quoted, then the quotes are removed if the 
+text inserted is valid JSON (start with `{` and ends with ``}). 
+
+Variable substitution is performed on configuration file after the include file directive; Hence
+variable substitution is also performed on the text in the injected file.
+
+Here is an example including variable substitution, assuming version 2.1.0 of OTP:
+
+```JSON
+// build-config.json
+{
+  "storage" : "${includeFile:storage.json}"
+} 
+``` 
+
+```JSON
+// storage.json
+{
+  "streetGraph": "street-graph-v${maven.version}.obj"
+}
+``` 
+The result will look like this:
+```JSON
+{
+  "storage" : {
+    "streetGraph": "street-graph-v2.1.0.obj"
+  }
+} 
+``` 
+
  
 # System-wide Configuration
 

--- a/src/main/java/org/opentripplanner/standalone/config/ConfigLoader.java
+++ b/src/main/java/org/opentripplanner/standalone/config/ConfigLoader.java
@@ -1,24 +1,24 @@
 package org.opentripplanner.standalone.config;
 
+import static org.opentripplanner.standalone.config.EnvironmentVariableReplacer.insertEnvironmentVariables;
+import static org.opentripplanner.standalone.config.IncludeFileDirective.includeFileDirective;
+
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.MissingNode;
 import com.fasterxml.jackson.databind.node.TextNode;
-import org.apache.commons.io.IOUtils;
-import org.opentripplanner.util.OtpAppException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.annotation.Nullable;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Set;
-
-import static org.opentripplanner.standalone.config.EnvironmentVariableReplacer.insertEnvironmentVariables;
+import javax.annotation.Nullable;
+import org.apache.commons.io.IOUtils;
+import org.opentripplanner.util.OtpAppException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Generic config file loader. This is used to load all configuration files.
@@ -202,6 +202,7 @@ public class ConfigLoader {
             if(jsonAsString == null || jsonAsString.isBlank()) {
                 return MissingNode.getInstance();
             }
+            jsonAsString = includeFileDirective(configDir, jsonAsString, source);
             jsonAsString = insertEnvironmentVariables(jsonAsString, source);
 
             return mapper.readTree(jsonAsString);

--- a/src/main/java/org/opentripplanner/standalone/config/IncludeFileDirective.java
+++ b/src/main/java/org/opentripplanner/standalone/config/IncludeFileDirective.java
@@ -1,0 +1,117 @@
+package org.opentripplanner.standalone.config;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.val;
+import org.apache.commons.io.IOUtils;
+import org.opentripplanner.util.OtpAppException;
+
+/**
+ * Replaces a file include directive with the text content of the file "as is". For example:
+ * <pre>
+ * {
+ *   "my-config" : "${includeFile:myConfig.json}"
+ * }
+ * </pre>
+ * The {@code ${includeFile:myConfig.json}} will tell the config parser to find the
+ * <em>myConfig.json</em> in the local config directory and insert the content into the
+ * configuration. This is done before the environment variables are resolved, enabling
+ * environment variable replacement in the included file as well as the config file.
+ */
+class IncludeFileDirective {
+
+    public static final String QUOTE = "\"";
+    private final File configDir;
+
+    private IncludeFileDirective(File configDir) {
+        this.configDir = configDir;
+    }
+
+    /**
+     * A pattern matching a placeholder like '${includeFile:my-own-config.json}'. The placeholder
+     * must start with '${includeFile:' and end with '}'. The file name must consist of only
+     * alphanumerical characters(a-z, A-Z, 0-9), dot `.` and underscore '_'.
+     */
+    private final static Pattern INCLUDE_FILE_PATTERN = Pattern.compile("\"?\\$\\{includeFile:([.\\w]+)}\"?");
+
+    /**
+     * Search for {@link #INCLUDE_FILE_PATTERN}s and replace each placeholder with the value of the
+     * corresponding environment variable.
+     *
+     * @param source is used only to generate human friendly error message in case the text
+     *               contain a placeholder whitch can not be found.
+     * @throws IllegalArgumentException if a placeholder exist in the {@code text}, but the
+     *                                  environment variable do not exist.
+     */
+    public static String includeFileDirective(File configDir, String text, String source) {
+        return new IncludeFileDirective(configDir).includeFileDirective(text, source);
+    }
+
+    private String includeFileDirective(String text, String source) {
+        Matcher matcher = INCLUDE_FILE_PATTERN.matcher(text);
+        Map<String, File> replacements = new HashMap<>();
+
+        while (matcher.find()) {
+            String directive = matcher.group(0);
+            String fileName = matcher.group(1);
+            File file = new File(configDir, fileName);
+
+            if (!file.exists() || !file.canRead()) {
+                throw new OtpAppException(
+                        "The file is not found for directive '" + directive + "' in config '"
+                                + source + "'."
+                );
+            }
+            replacements.put(directive, file);
+        }
+
+        for (Entry<String, File> entry : replacements.entrySet()) {
+            String directive = entry.getKey();
+            String fileText = loadFile(entry.getValue(), directive, source);
+
+            // If the insert text is a legal JSON object "[white-space]{ ... }[white-space]", then
+            // ignore the optional quotes matched by the directive pattern
+            val json = fileText.trim();
+            if(json.startsWith("{") && json.endsWith("}")) {
+                text = text.replace(entry.getKey(), fileText);
+            }
+            else {
+                // Add back quotes if matched part of directive pattern
+                String startQuote = directive.startsWith(QUOTE) ? QUOTE : "";
+                String endQuote = directive.endsWith(QUOTE) ? QUOTE : "";
+                text = text.replace(entry.getKey(), startQuote + fileText + endQuote);
+            }
+        }
+        return text;
+    }
+
+    private static String loadFile(File file, String directive, String source) {
+        try {
+            return IOUtils.toString(
+                    new FileInputStream(file), StandardCharsets.UTF_8
+            );
+        }
+        catch (FileNotFoundException ex) {
+            throw new OtpAppException(
+                    "File '{}' is not present. Can not include "
+                    + "directive '{}' in config file '{}'.",
+                    file.getPath(), directive, source
+            );
+        }
+        catch (IOException e) {
+            throw new OtpAppException(
+                    "Error while parsing file '{}'. Can not include "
+                    + "directive '{}' in config file '{}'.",
+                    file.getPath(), directive, source
+            );
+        }
+    }
+}

--- a/src/main/java/org/opentripplanner/standalone/config/IncludeFileDirective.java
+++ b/src/main/java/org/opentripplanner/standalone/config/IncludeFileDirective.java
@@ -38,9 +38,9 @@ class IncludeFileDirective {
     /**
      * A pattern matching a placeholder like '${includeFile:my-own-config.json}'. The placeholder
      * must start with '${includeFile:' and end with '}'. The file name must consist of only
-     * alphanumerical characters(a-z, A-Z, 0-9), dot `.` and underscore '_'.
+     * alphanumerical characters(a-z, A-Z, 0-9), dot '.', dash '-', and underscore '_'.
      */
-    private final static Pattern INCLUDE_FILE_PATTERN = Pattern.compile("\"?\\$\\{includeFile:([.\\w]+)}\"?");
+    private final static Pattern INCLUDE_FILE_PATTERN = Pattern.compile("\"?\\$\\{includeFile:([-.\\w]+)}\"?");
 
     /**
      * Search for {@link #INCLUDE_FILE_PATTERN}s and replace each placeholder with the value of the

--- a/src/test/java/org/opentripplanner/standalone/config/IncludeFileDirectiveTest.java
+++ b/src/test/java/org/opentripplanner/standalone/config/IncludeFileDirectiveTest.java
@@ -1,0 +1,64 @@
+package org.opentripplanner.standalone.config;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+
+class IncludeFileDirectiveTest {
+    private static final String FILE_PREFIX = "o_o_standalone_config_IncludeFileDirectiveTest_";
+    private static final String PART_FILE_NAME = FILE_PREFIX + "part.json";
+    private static final File CONFIG_DIR = new File(".");
+    private static final File PART_FILE = new File(CONFIG_DIR, PART_FILE_NAME);
+
+    @Test
+    void includeFileWithoutQuotes() throws IOException {
+        savePartialFile(quote("value"));
+        String result = IncludeFileDirective.includeFileDirective(
+                CONFIG_DIR,
+                quote("{${includeFile:" + PART_FILE_NAME + "}}"),
+                PART_FILE_NAME
+        );
+        assertEquals(quote("{value}"), result);
+    }
+
+    @Test
+    void includeFileWithQuotesAndProperJsonInput() throws IOException {
+        savePartialFile(quote("\t {\n  'foo' : 'bar' \n  }\n"));
+        String result = IncludeFileDirective.includeFileDirective(
+                CONFIG_DIR,
+                quote("{ 'key' : '${includeFile:" + PART_FILE_NAME + "}'}"),
+                PART_FILE_NAME
+        );
+        assertEquals(quote("{ 'key' : \t {\n  'foo' : 'bar' \n  }\n}"), result);
+    }
+
+    @Test
+    void includeFileWithQuotesWithNoJsonInput() throws IOException {
+        savePartialFile("value");
+        String result = IncludeFileDirective.includeFileDirective(
+                CONFIG_DIR,
+                quote("{ 'key' : '${includeFile:" + PART_FILE_NAME + "}' }"),
+                PART_FILE_NAME
+        );
+        assertEquals(quote("{ 'key' : 'value' }"), result);
+    }
+
+    private static String quote(String text) {
+        return text.replace('\'', '"');
+    }
+
+    private static void savePartialFile(String text) throws IOException {
+        FileUtils.write(PART_FILE, text, UTF_8);
+    }
+
+    @AfterAll
+    static void teardown() {
+        //noinspection ResultOfMethodCallIgnored
+        PART_FILE.delete();
+    }
+}


### PR DESCRIPTION
### Summary

This feature make it possible to inject the content of another file into a configuration file. It make it possible to keep part of the configuration in separate files. To include the content of a file use `${includeFile:FILE_NAME}`. The `FILE_NAME` must be the name of a file in the configuration directory. Relative paths are not supported. 
<p>
To allow both files (the configuration file and the injected file) to be valid JSON files a special case is supported; If the include file directive is quoted, then the quotes are removed if the text inserted is valid JSON. We check that the text to inject start with a `{` and ends with `}`. 

Variable substitution is performed on the configuration file after the include file directive; Hence
variable substitution is also performed on the text in the injected file, but not inside the `${includeFile:FILE_NAME}`.

Here is an example including variable substitution, assuming version 2.1.0 of OTP:

```JSON
// build-config.json
{
  "storage" : "${includeFile:storage.json}"
} 
``` 

```JSON
// storage.json
{
  "streetGraph": "street-graph-v${maven.version}.obj"
}
``` 
The result will look like this:
```JSON
{
  "storage" : {
    "streetGraph": "street-graph-v2.1.0.obj"
  }
} 
``` 

### Issue
There is no issue for this, but this feature where requested as part of the #3760.


### Unit tests
✅ 

### Code style
✅ 

### Documentation
✅ 
