### PR TITLE
Improve concurrency handling in GeometryAndBlockProcessor [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/module/geometry/GeometryAndBlockProcessor.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/geometry/GeometryAndBlockProcessor.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;

--- a/src/main/java/org/opentripplanner/graph_builder/module/geometry/GeometryAndBlockProcessor.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/geometry/GeometryAndBlockProcessor.java
@@ -645,7 +645,9 @@ public class GeometryAndBlockProcessor {
         geometry = geometryFactory.createLineString(sequence);
         geometriesByShapeId.put(shapeId, geometry);
 
-        if(distances != null) {
+        // If we don't have distances here, we can't calculate them ourselves because we can't
+        // assume the units will match
+        if(hasAllDistances) {
             distancesByShapeId.put(shapeId, distances);
         }
 

--- a/src/main/java/org/opentripplanner/graph_builder/module/geometry/GeometryAndBlockProcessor.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/geometry/GeometryAndBlockProcessor.java
@@ -53,6 +53,8 @@ import org.slf4j.LoggerFactory;
  * Once transit model entities have been loaded into the graph, this post-processes them to extract and prepare
  * geometries. It also does some other postprocessing involving fares and interlined blocks.
  *
+ * <p>
+ * THREAD SAFTY
  * The computation runs in parallel so be careful about threadsafety when modifying the logic here.
  */
 public class GeometryAndBlockProcessor {

--- a/src/main/java/org/opentripplanner/graph_builder/module/geometry/GeometryAndBlockProcessor.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/geometry/GeometryAndBlockProcessor.java
@@ -54,7 +54,7 @@ import org.slf4j.LoggerFactory;
  * geometries. It also does some other postprocessing involving fares and interlined blocks.
  *
  * <p>
- * THREAD SAFTY
+ * THREAD SAFETY
  * The computation runs in parallel so be careful about threadsafety when modifying the logic here.
  */
 public class GeometryAndBlockProcessor {
@@ -111,7 +111,7 @@ public class GeometryAndBlockProcessor {
     /**
      * Generate the edges. Assumes that there are already vertices in the graph for the stops.
      * <p>
-     * THREAD SAFTY
+     * THREAD SAFETY
      * The geometries for the trip patterns are computed in parallel. The collections needed for
      * this are concurrent implementations and therefore threadsafe but the issue store, the graph,
      * the OtpTransitService and others are not.
@@ -649,12 +649,6 @@ public class GeometryAndBlockProcessor {
             if (!point.isDistTraveledSet())
                 hasAllDistances = false;
             i++;
-        }
-
-        // If we don't have distances here, we can't calculate them ourselves because we can't
-        // assume the units will match
-        if (!hasAllDistances) {
-            distances = null;
         }
 
         CoordinateSequence sequence = new PackedCoordinateSequence.Double(coordinates, 2);

--- a/src/main/java/org/opentripplanner/graph_builder/module/geometry/GeometryAndBlockProcessor.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/geometry/GeometryAndBlockProcessor.java
@@ -110,7 +110,8 @@ public class GeometryAndBlockProcessor {
 
     /**
      * Generate the edges. Assumes that there are already vertices in the graph for the stops.
-     *
+     * <p>
+     * THREAD SAFTY
      * The geometries for the trip patterns are computed in parallel. The collections needed for
      * this are concurrent implementations and therefore threadsafe but the issue store, the graph,
      * the OtpTransitService and others are not.

--- a/src/main/java/org/opentripplanner/graph_builder/module/geometry/GeometryAndBlockProcessor.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/geometry/GeometryAndBlockProcessor.java
@@ -1,10 +1,17 @@
 package org.opentripplanner.graph_builder.module.geometry;
 
-import com.beust.jcommander.internal.Maps;
 import com.google.common.base.Strings;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.commons.math3.util.FastMath;
 import org.locationtech.jts.geom.Coordinate;
@@ -32,24 +39,14 @@ import org.opentripplanner.model.StopTime;
 import org.opentripplanner.model.Timetable;
 import org.opentripplanner.model.Trip;
 import org.opentripplanner.model.TripPattern;
-import org.opentripplanner.routing.graph.Graph;
-import org.opentripplanner.routing.fares.impl.DefaultFareServiceFactory;
 import org.opentripplanner.routing.fares.FareService;
 import org.opentripplanner.routing.fares.FareServiceFactory;
+import org.opentripplanner.routing.fares.impl.DefaultFareServiceFactory;
+import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.trippattern.TripTimes;
 import org.opentripplanner.util.ProgressTracker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
 
 /**
  * Once transit model entities have been loaded into the graph, this post-processes them to extract and prepare
@@ -65,11 +62,11 @@ public class GeometryAndBlockProcessor {
 
     private OtpTransitService transitService;
 
-    private Map<ShapeSegmentKey, LineString> geometriesByShapeSegmentKey = new HashMap<ShapeSegmentKey, LineString>();
+    private Map<ShapeSegmentKey, LineString> geometriesByShapeSegmentKey = new ConcurrentHashMap<>();
 
-    private Map<FeedScopedId, LineString> geometriesByShapeId = new HashMap<FeedScopedId, LineString>();
+    private Map<FeedScopedId, LineString> geometriesByShapeId = new ConcurrentHashMap<>();
 
-    private Map<FeedScopedId, double[]> distancesByShapeId = new HashMap<>();
+    private Map<FeedScopedId, double[]> distancesByShapeId = new ConcurrentHashMap<>();
 
     private FareServiceFactory fareServiceFactory;
 
@@ -186,7 +183,7 @@ public class GeometryAndBlockProcessor {
     private void interline(Collection<TripPattern> tripPatterns, Graph graph) {
 
         /* Record which Pattern each interlined TripTimes belongs to. */
-        Map<TripTimes, TripPattern> patternForTripTimes = Maps.newHashMap();
+        Map<TripTimes, TripPattern> patternForTripTimes = new ConcurrentHashMap<>();
 
         /* TripTimes grouped by the block ID and service ID of their trips. Must be a ListMultimap to allow sorting. */
         ListMultimap<BlockIdAndServiceId, TripTimes> tripTimesForBlock = ArrayListMultimap.create();

--- a/src/main/java/org/opentripplanner/graph_builder/module/geometry/GeometryAndBlockProcessor.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/geometry/GeometryAndBlockProcessor.java
@@ -644,7 +644,10 @@ public class GeometryAndBlockProcessor {
         CoordinateSequence sequence = new PackedCoordinateSequence.Double(coordinates, 2);
         geometry = geometryFactory.createLineString(sequence);
         geometriesByShapeId.put(shapeId, geometry);
-        distancesByShapeId.put(shapeId, distances);
+
+        if(distances != null) {
+            distancesByShapeId.put(shapeId, distances);
+        }
 
         return geometry;
     }

--- a/src/main/java/org/opentripplanner/graph_builder/module/geometry/GeometryAndBlockProcessor.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/geometry/GeometryAndBlockProcessor.java
@@ -183,7 +183,7 @@ public class GeometryAndBlockProcessor {
     private void interline(Collection<TripPattern> tripPatterns, Graph graph) {
 
         /* Record which Pattern each interlined TripTimes belongs to. */
-        Map<TripTimes, TripPattern> patternForTripTimes = new ConcurrentHashMap<>();
+        Map<TripTimes, TripPattern> patternForTripTimes = new HashMap<>();
 
         /* TripTimes grouped by the block ID and service ID of their trips. Must be a ListMultimap to allow sorting. */
         ListMultimap<BlockIdAndServiceId, TripTimes> tripTimesForBlock = ArrayListMultimap.create();


### PR DESCRIPTION
### Summary
In my previous PR #3766 I converted a single instance of HashMap to a ConcurrentHashMap. I tested this with the Norway graph and that worked.

However, today I tried it out with another data set and saw the following error:
```
Caused by: java.lang.ClassCastException: class java.util.HashMap$Node cannot be cast to class java.util.HashMap$TreeNode (java.util.HashMap$Node and java.util.HashMap$TreeNode are in module java.base of loader 'bootstrap')
	at java.base/java.util.HashMap$TreeNode.moveRootToFront(HashMap.java:1900)
	at java.base/java.util.HashMap$TreeNode.putTreeVal(HashMap.java:2079)
	at java.base/java.util.HashMap.putVal(HashMap.java:634)
	at java.base/java.util.HashMap.put(HashMap.java:608)
	at org.opentripplanner.graph_builder.module.geometry.GeometryAndBlockProcessor.getSegmentGeometry(GeometryAndBlockProcessor.java:577)
	at org.opentripplanner.graph_builder.module.geometry.GeometryAndBlockProcessor.getHopGeometryViaShapeDistTraveled(GeometryAndBlockProcessor.java:503)
	at org.opentripplanner.graph_builder.module.geometry.GeometryAndBlockProcessor.getHopGeometriesViaShapeDistTravelled(GeometryAndBlockProcessor.java:439)
	at org.opentripplanner.graph_builder.module.geometry.GeometryAndBlockProcessor.createGeometry(GeometryAndBlockProcessor.java:274)
	at org.opentripplanner.graph_builder.module.geometry.GeometryAndBlockProcessor.lambda$run$1(GeometryAndBlockProcessor.java:149)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1655)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.ForEachOps$ForEachTask.compute(ForEachOps.java:290)
	at java.base/java.util.concurrent.CountedCompleter.exec(CountedCompleter.java:746)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
```

So there are some other cases where the instances of HashMap and ConcurrentHashMap interact with each other and are seemingly incompatible even though the code compiles.

For this reason I converted all instances of HashMap to ConcurrentHashMap.

### Unit tests

n/a

### Code style
yes

### Documentation
n/a