### PR TITLE
Fix checking allowed boarding/alighting for unscheduled flex trips

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/flex/trip/UnscheduledTrip.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/trip/UnscheduledTrip.java
@@ -72,14 +72,23 @@ public class UnscheduledTrip extends FlexTrip {
   public Stream<FlexAccessTemplate> getFlexAccessTemplates(
       NearbyStop access, FlexServiceDate date, FlexPathCalculator calculator, FlexParameters params
   ) {
+    // Find boarding index
     int fromIndex = getFromIndex(access);
-    int toIndex = getToIndex(access);
 
-    if (stopTimes[fromIndex].dropOffType == NONE.getGtfsCode()) { return Stream.empty(); }
+    // Alighting is always at the last stop for unscheduled trips
+    int toIndex = stopTimes.length - 1;
+
+    // Check if trip is possible
+    if (fromIndex == -1 ||
+        fromIndex > toIndex ||
+        stopTimes[toIndex].dropOffType == NONE.getGtfsCode()
+    ) {
+      return Stream.empty();
+    }
 
     ArrayList<FlexAccessTemplate> res = new ArrayList<>();
 
-    for (StopLocation stop : expandStops(stopTimes[fromIndex].stop)) {
+    for (StopLocation stop : expandStops(stopTimes[toIndex].stop)) {
       res.add(new FlexAccessTemplate(access, this, fromIndex, toIndex, stop, date, calculator, params));
     }
 
@@ -90,14 +99,23 @@ public class UnscheduledTrip extends FlexTrip {
   public Stream<FlexEgressTemplate> getFlexEgressTemplates(
       NearbyStop egress, FlexServiceDate date, FlexPathCalculator calculator, FlexParameters params
   ) {
-    int fromIndex = getFromIndex(egress);
+    // Boarding is always at the last stop for unscheduled trips
+    int fromIndex = 0;
+
+    // Find alighting index
     int toIndex = getToIndex(egress);
 
-    if (stopTimes[toIndex].pickupType == NONE.getGtfsCode()) { return Stream.empty(); }
+    // Check if trip is possible
+    if (toIndex == -1 ||
+        fromIndex > toIndex ||
+        stopTimes[fromIndex].pickupType == NONE.getGtfsCode()
+    ) {
+      return Stream.empty();
+    }
 
     ArrayList<FlexEgressTemplate> res = new ArrayList<>();
 
-    for (StopLocation stop : expandStops(stopTimes[toIndex].stop)) {
+    for (StopLocation stop : expandStops(stopTimes[fromIndex].stop)) {
       res.add(new FlexEgressTemplate(egress, this, fromIndex, toIndex, stop, date, calculator, params));
     }
 

--- a/src/ext/java/org/opentripplanner/ext/flex/trip/UnscheduledTrip.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/trip/UnscheduledTrip.java
@@ -99,7 +99,7 @@ public class UnscheduledTrip extends FlexTrip {
   public Stream<FlexEgressTemplate> getFlexEgressTemplates(
       NearbyStop egress, FlexServiceDate date, FlexPathCalculator calculator, FlexParameters params
   ) {
-    // Boarding is always at the last stop for unscheduled trips
+    // Boarding is always at the first stop for unscheduled trips
     int fromIndex = 0;
 
     // Find alighting index

--- a/src/main/java/org/opentripplanner/api/parameter/QualifiedModeSet.java
+++ b/src/main/java/org/opentripplanner/api/parameter/QualifiedModeSet.java
@@ -192,6 +192,11 @@ public class QualifiedModeSet implements Serializable {
             }
         }
 
+        // If we search eg. Transit + flex access and egress, fallback to walking transfers
+        if (transferMode == null) {
+            transferMode = StreetMode.WALK;
+        }
+
         return new RequestModes(
             accessMode,
             transferMode,

--- a/src/main/java/org/opentripplanner/netex/mapping/NetexMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/NetexMapper.java
@@ -287,9 +287,17 @@ public class NetexMapper {
     }
 
     private void mapFlexibleStopPlaces() {
+        Collection<FlexibleStopPlace> flexibleStopPlaces =
+                currentNetexIndex.getFlexibleStopPlacesById().localValues();
+
+        // Building the indices in FlexStopLocationMapper is expensive, so skip it if not needed
+        if (flexibleStopPlaces.size() == 0) {
+            return;
+        }
+
         FlexStopLocationMapper flexStopLocationMapper = new FlexStopLocationMapper(idFactory, transitBuilder.getStops().values());
 
-        for (FlexibleStopPlace flexibleStopPlace : currentNetexIndex.getFlexibleStopPlacesById().localValues()) {
+        for (FlexibleStopPlace flexibleStopPlace : flexibleStopPlaces) {
             StopLocation stopLocation = flexStopLocationMapper.map(flexibleStopPlace);
             if (stopLocation instanceof FlexStopLocation) {
                 transitBuilder.getLocations().add((FlexStopLocation) stopLocation);


### PR DESCRIPTION
### Summary

Since https://github.com/opentripplanner/OpenTripPlanner/pull/3720 the boarding/alighting constraints for unscheduled trips are checked from the wrong stop index. This fixes that 

### Unit tests
None

### Code style
Code style followed

### Documentation
No updates required

### Changelog
The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md) 
is generated from the pull-request title, make sure the title describe the feature or issue fixed. 
To exclude the PR from the changelog add `[changelog skip]` in the title.
