### PR TITLE
Update logback dependency to 1.2.8 (1.2.5) [changelog skip]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -390,7 +390,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.5</version>
+            <version>1.2.8</version>
         </dependency>
         <!-- Jersey uses java.util logging, redirect it to slf4j API (we use the Logback implementation) -->
         <dependency>


### PR DESCRIPTION
See vulnerability [LOGBACK-1591](http://logback.qos.ch/news.html)

### Summary
Minor update of the OTP logging framework used, due to a security vulnerability in the previous version.

Let me reiterate that this is not the same thing as the log4j vulnerability - far from it!

You have to create an extremely unsecured environment in order for this to be used for remote code execution.

Nevertheless, lets upgrade to remove this pretty contrived vulnerability.

### Issue

closes #3785


### Unit tests
Not relevant

### Code style
Not relevant

### Documentation
No

### Changelog
This "day-to-day maintenance" and not included in the changelog.