### PR TITLE
refactor: Rename SpeedTest config parameter to maxWalkDurationSeconds [changelog skip]

### DIFF
--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTestRequest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTestRequest.java
@@ -77,8 +77,8 @@ public class SpeedTestRequest {
         return config.walkSpeedMeterPrSecond;
     }
 
-    public double getAccessEgressMaxWalkDistanceMeters() {
-        return config.maxWalkDistanceMeters;
+    public double getAccessEgressMaxWalkDurationSeconds() {
+        return config.maxWalkDurationSeconds;
     }
 
 

--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/options/SpeedTestConfig.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/options/SpeedTestConfig.java
@@ -21,6 +21,12 @@ public class SpeedTestConfig {
     private static final Logger LOG = LoggerFactory.getLogger(SpeedTestConfig.class);
     public static final String FILE_NAME = "speed-test-config.json";
 
+    /**
+     * Set the default max walk duration for access/egress to the OTP default value of 45 minutes.
+     * Unit: seconds
+     */
+    private static final int ACCESS_MAX_WALK = 45 * 60;
+
     private final JsonNode rawNode;
 
     /**
@@ -31,7 +37,7 @@ public class SpeedTestConfig {
     /** The speed test run all its test on an existing pre-build graph. */
     public final URI graph;
 
-    public final int maxWalkDistanceMeters;
+    public final int maxWalkDurationSeconds;
     public final double walkSpeedMeterPrSecond;
     public final TransitRoutingConfig transitRoutingParams;
     public final RoutingRequest request;
@@ -41,7 +47,7 @@ public class SpeedTestConfig {
         this.rawNode = node;
         testDate = adapter.asDateOrRelativePeriod("testDate", "PT0D");
         graph = adapter.asUri("graph", null);
-        maxWalkDistanceMeters = adapter.asInt("maxWalkDistanceMeters", 1000);
+        maxWalkDurationSeconds = adapter.asInt("maxWalkDurationSeconds", ACCESS_MAX_WALK);
         walkSpeedMeterPrSecond = adapter.asDouble("walkSpeedMeterPrSecond", 1.4);
         transitRoutingParams = new TransitRoutingConfig(adapter.path("tuningParameters"));
         request = mapRoutingRequest(adapter.path("routingDefaults"));
@@ -50,14 +56,6 @@ public class SpeedTestConfig {
     @Override
     public String toString() {
         return rawNode.toPrettyString();
-    }
-
-    public RaptorTuningParameters raptorTuningParameters() {
-        return transitRoutingParams;
-    }
-
-    public TransitTuningParameters transitTuningParameters() {
-        return transitRoutingParams;
     }
 
     public static SpeedTestConfig config(File dir) {

--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/transit/EgressAccessRouter.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/transit/EgressAccessRouter.java
@@ -31,7 +31,7 @@ public class EgressAccessRouter {
         routeTimer.record(() -> {
             // Search for access to / egress from transit on streets.
             NearbyStopFinder nearbyStopFinder = new NearbyStopFinder(
-                    graph, request.getAccessEgressMaxWalkDistanceMeters(), true
+                    graph, request.getAccessEgressMaxWalkDurationSeconds(), true
             );
             accessSearch = new StreetSearch(transitLayer, graph, linker, nearbyStopFinder);
             egressSearch = new StreetSearch(transitLayer, graph, linker, nearbyStopFinder);

--- a/src/test/resources/raptor/speedtest/norway/speed-test-config.json
+++ b/src/test/resources/raptor/speedtest/norway/speed-test-config.json
@@ -2,7 +2,8 @@
   // Run all test-cases on the given date
   testDate: "2020-01-15",
 
-  accessEgressMaxWalkDistanceMeters: 1000,
+  // OTP Default is 45 minutes (2700 seconds)
+  // maxWalkDurationSeconds: 2700,
 
   // Default is 1.4 m/s = ~ 5.0 km/t
   walkSpeedMeterPrSecond: 1.4,
@@ -16,9 +17,6 @@
 
     // Default is 60
     // iterationDepartureStepInSeconds: 60,
-
-    // Default is 0
-    searchThreadPoolSize: 8,
 
     dynamicSearchWindow: {
       // Default is 0.4


### PR DESCRIPTION
The `maxWalkDistanceMeters` in the SpeedTest was passed into the NearByStopFined as `maxWalkDurationSeconds`. This is of cause very confusing. This PR changes the SpeedTest config parameter name to reflect what it is used for.

### Issue
No, issue for this.

### Unit tests
The SpeedTest is a test without unit tests :-)

### Code style
✅ 

### Documentation
Example config updated as well as JavaDoc


### Changelog
No