### PR TITLE
Add tags and openingHours to CarPark and BikePark in legacy api [changelog skip]

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLBikeParkImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLBikeParkImpl.java
@@ -52,6 +52,17 @@ public class LegacyGraphQLBikeParkImpl implements LegacyGraphQLDataFetchers.Lega
         return environment -> getSource(environment).getY();
     }
 
+    @Override
+    public DataFetcher<Iterable<String>> tags() {
+        return environment -> getSource(environment).getTags();
+    }
+
+    // TODO
+    @Override
+    public DataFetcher<Iterable<Object>> openingHours() {
+        return environment -> null;
+    }
+
     private VehicleParking getSource(DataFetchingEnvironment environment) {
         return environment.getSource();
     }

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLCarParkImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLCarParkImpl.java
@@ -63,6 +63,17 @@ public class LegacyGraphQLCarParkImpl implements LegacyGraphQLDataFetchers.Legac
         return environment -> getSource(environment).getY();
     }
 
+    @Override
+    public DataFetcher<Iterable<String>> tags() {
+        return environment -> getSource(environment).getTags();
+    }
+
+    // TODO
+    @Override
+    public DataFetcher<Iterable<Object>> openingHours() {
+        return environment -> null;
+    }
+
     private VehicleParking getSource(DataFetchingEnvironment environment) {
         return environment.getSource();
     }

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/LegacyGraphQLDataFetchers.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/LegacyGraphQLDataFetchers.java
@@ -139,9 +139,13 @@ public class LegacyGraphQLDataFetchers {
 
         public DataFetcher<String> name();
 
+        public DataFetcher<Iterable<Object>> openingHours();
+
         public DataFetcher<Boolean> realtime();
 
         public DataFetcher<Integer> spacesAvailable();
+
+        public DataFetcher<Iterable<String>> tags();
     }
 
     /**
@@ -238,9 +242,13 @@ public class LegacyGraphQLDataFetchers {
 
         public DataFetcher<String> name();
 
+        public DataFetcher<Iterable<Object>> openingHours();
+
         public DataFetcher<Boolean> realtime();
 
         public DataFetcher<Integer> spacesAvailable();
+
+        public DataFetcher<Iterable<String>> tags();
     }
 
     /**
@@ -411,6 +419,26 @@ public class LegacyGraphQLDataFetchers {
         public DataFetcher<Trip> trip();
 
         public DataFetcher<Boolean> walkingBike();
+    }
+
+    /**
+     * A span of time.
+     */
+    public interface LegacyGraphQLLocalTimeSpan {
+
+        public DataFetcher<Integer> from();
+
+        public DataFetcher<Integer> to();
+    }
+
+    /**
+     * A date using the local timezone of the object that can contain timespans.
+     */
+    public interface LegacyGraphQLLocalTimeSpanDate {
+
+        public DataFetcher<String> date();
+
+        public DataFetcher<Iterable<Object>> timeSpans();
     }
 
     /**

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/LegacyGraphQLTypes.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/LegacyGraphQLTypes.java
@@ -109,6 +109,19 @@ public class LegacyGraphQLTypes {
         }
     }
 
+    public static class LegacyGraphQLBikeParkOpeningHoursArgs {
+
+        private Iterable<String> _dates;
+
+        public LegacyGraphQLBikeParkOpeningHoursArgs(Map<String, Object> args) {
+            if (args != null) {
+                this._dates = (Iterable<String>) args.get("dates");
+            }
+        }
+
+        public Iterable<String> getLegacyGraphQLDates() {return this._dates;}
+    }
+
 
     public enum LegacyGraphQLBikesAllowed {
         Allowed("ALLOWED"),
@@ -132,6 +145,20 @@ public class LegacyGraphQLTypes {
         public static LegacyGraphQLBikesAllowed valueOfLabel(String label) {
             return BY_LABEL.get(label);
         }
+    }
+
+
+    public static class LegacyGraphQLCarParkOpeningHoursArgs {
+
+        private Iterable<String> _dates;
+
+        public LegacyGraphQLCarParkOpeningHoursArgs(Map<String, Object> args) {
+            if (args != null) {
+                this._dates = (Iterable<String>) args.get("dates");
+            }
+        }
+
+        public Iterable<String> getLegacyGraphQLDates() {return this._dates;}
     }
 
 

--- a/src/ext/resources/legacygraphqlapi/schema.graphqls
+++ b/src/ext/resources/legacygraphqlapi/schema.graphqls
@@ -267,6 +267,22 @@ type BikePark implements Node & PlaceInterface {
 
     """Latitude of the bike park (WGS 84)"""
     lat: Float
+
+    """
+    Source specific tags of the bike park, which describe the available features.
+    """
+    tags: [String]
+
+    """
+    Opening hours for the selected dates using the local time of the park.
+    Each date can have multiple time spans.
+    """
+    openingHours(
+        """
+        Opening hours will be returned for these dates. Dates should use YYYYMMDD format.
+        """
+        dates: [String!]!
+    ): [LocalTimeSpanDate]
 }
 
 """Vehicle parking represents a location where bicycles or cars can be parked."""
@@ -667,6 +683,22 @@ type CarPark implements Node & PlaceInterface {
 
     """Latitude of the car park (WGS 84)"""
     lat: Float
+
+    """
+    Source specific tags of the car park, which describe the available features.
+    """
+    tags: [String]
+
+    """
+    Opening hours for the selected dates using the local time of the park.
+    Each date can have multiple time spans.
+    """
+    openingHours(
+        """
+        Opening hours will be returned for these dates. Dates should use YYYYMMDD format.
+        """
+        dates: [String!]!
+    ): [LocalTimeSpanDate]
 }
 
 """Cluster is a list of stops grouped by name and proximity"""
@@ -1186,6 +1218,24 @@ type Leg {
     dropOffBookingInfo: BookingInfo
 
     pickupBookingInfo: BookingInfo
+}
+
+"""A span of time."""
+type LocalTimeSpan {
+    """The start of the time timespan as seconds from midnight."""
+    from: Int!
+
+    """The end of the timespan as seconds from midnight."""
+    to: Int!
+}
+
+"""A date using the local timezone of the object that can contain timespans."""
+type LocalTimeSpanDate {
+    """The time spans for this date."""
+    timeSpans: [LocalTimeSpan]
+
+    """The date of this time span. Format: YYYYMMDD."""
+    date: String!
 }
 
 """Identifies whether this stop represents a stop or station."""


### PR DESCRIPTION
### Summary
Adds tags and openingHours (not yet implemented) to CarPark and BikePark types in legacy graphQL API for backwards compatability with hsldevcom OTP1 API.

### Issue
Not needed here as minor changes.

### Unit tests
Not needed.

### Code style
Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Developers-Guide.md#code-style)? 
yes

### Documentation
Not needed

### Changelog
Not needed
