### PR TITLE
Remove build parameter 'useTransfersTxt'

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -216,7 +216,6 @@ config key | description | value type | value default | notes
 `transit` | Include all transit input files (GTFS) from scanned directory | boolean | true |
 `transitServiceStart` | Limit the import of transit services to the given *start* date. *Inclusive*. Use an absolute date or a period relative to the day the graph is build. To specify a week before the build date use a negative period like `-P1W`. | date or period | &minus;P1Y | _2020&#8209;01&#8209;01, &minus;P1M3D, &minus;P3W_
 `transitServiceEnd` | Limit the import of transit services to the given *end* date. *Inclusive*. Use an absolute date or a period relative to the day the graph is build. | date or period | P3Y | _2022&#8209;12&#8209;31, P1Y6M10D, P12W_
-`useTransfersTxt` | Create direct transfer edges from transfers.txt in GTFS, instead of based on distance | boolean | false |
 `writeCachedElevations` | If true, writes the calculated elevation data. | boolean | false | see [Elevation Data Calculation Optimizations](#elevation-data-calculation-optimizations)
 `maxAreaNodes` | Visibility calculations for an area will not be done if there are more nodes than this limit | integer | 500 |
 

--- a/docs/examples/entur/build-config.json
+++ b/docs/examples/entur/build-config.json
@@ -1,7 +1,6 @@
 {
   "dataImportReport": true,
   "transit": true,
-  "useTransfersTxt": false,
   "parentStopLinking": true,
   "stationTransfers": false,
   "subwayAccessTime": 0,

--- a/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
@@ -134,13 +134,6 @@ public class GraphBuilder implements Runnable {
 
                 GtfsBundle gtfsBundle = new GtfsBundle((CompositeDataSource)gtfsData);
 
-                // TODO OTP2 - In OTP2 we have deleted the transfer edges from the street graph.
-                //           - The new transfer generation do not take this config param into
-                //           - account any more. This needs some investigation and probably
-                //           - a fix, but we are unsure if this is used any more. The Pathways.txt
-                //           - and osm import replaces this functionality.
-                gtfsBundle.setTransfersTxtDefinesStationPaths(config.useTransfersTxt);
-
                 if (config.parentStopLinking) {
                     gtfsBundle.linkStopsToParentStations = true;
                 }
@@ -222,11 +215,10 @@ public class GraphBuilder implements Runnable {
             if (OTPFeature.FlexRouting.isOn()) {
                 graphBuilder.addModule(new FlexLocationsToStreetEdgesMapper());
             }
-            // The stops can be linked to each other once they are already linked to the street network.
-            if ( ! config.useTransfersTxt) {
-                // This module will use streets or straight line distance depending on whether OSM data is found in the graph.
-                graphBuilder.addModule(new DirectTransferGenerator(config.maxTransferDurationSeconds, config.transferRequests));
-            }
+
+            // This module will use streets or straight line distance depending on whether OSM data is found in the graph.
+            graphBuilder.addModule(new DirectTransferGenerator(config.maxTransferDurationSeconds, config.transferRequests));
+
             // Analyze routing between stops to generate report
             if (OTPFeature.TransferAnalyzer.isOn()) {
                 graphBuilder.addModule(new DirectTransferAnalyzer(

--- a/src/main/java/org/opentripplanner/graph_builder/model/GtfsBundle.java
+++ b/src/main/java/org/opentripplanner/graph_builder/model/GtfsBundle.java
@@ -29,9 +29,7 @@ public class GtfsBundle {
 
     private CsvInputSource csvInputSource;
 
-    private boolean transfersTxtDefinesStationPaths = false;
-
-    /** 
+    /**
      * Create direct transfers between the constituent stops of each parent station.
      * This is different from "linking stops to parent stations" below.
      */
@@ -111,24 +109,6 @@ public class GtfsBundle {
 
     public void setFeedId(GtfsFeedId feedId) {
         this.feedId = feedId;
-    }
-
-    /**
-     * Transfers.txt usually specifies where the transit operator prefers people to transfer, 
-     * due to schedule structure and other factors.
-     * 
-     * However, in systems like the NYC subway system, transfers.txt can partially substitute 
-     * for the missing pathways.txt file.  In this case, transfer edges will be created between
-     * stops where transfers are defined.
-     * 
-     * @return
-     */
-    public boolean doesTransfersTxtDefineStationPaths() {
-        return transfersTxtDefinesStationPaths;
-    }
-
-    public void setTransfersTxtDefinesStationPaths(boolean transfersTxtDefinesStationPaths) {
-        this.transfersTxtDefinesStationPaths = transfersTxtDefinesStationPaths;
     }
 
     public void checkInputs() {

--- a/src/main/java/org/opentripplanner/standalone/config/BuildConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/BuildConfig.java
@@ -80,11 +80,6 @@ public class BuildConfig {
     public final boolean transit;
 
     /**
-     * Create direct transfer edges from transfers.txt in GTFS, instead of based on distance.
-     */
-    public final boolean useTransfersTxt;
-
-    /**
      * Link GTFS stops to their parent stops.
      */
     public final boolean parentStopLinking;
@@ -351,7 +346,6 @@ public class BuildConfig {
         transit = c.asBoolean("transit", true);
         transitServiceStart = c.asDateOrRelativePeriod("transitServiceStart", "-P1Y");
         transitServiceEnd = c.asDateOrRelativePeriod( "transitServiceEnd", "P3Y");
-        useTransfersTxt = c.asBoolean("useTransfersTxt", false);
         writeCachedElevations = c.asBoolean("writeCachedElevations", false);
         maxAreaNodes = c.asInt("maxAreaNodes", 500);
 

--- a/src/test/java/org/opentripplanner/GtfsTest.java
+++ b/src/test/java/org/opentripplanner/GtfsTest.java
@@ -66,7 +66,6 @@ public abstract class GtfsTest extends TestCase {
         graph = new Graph();
         router = new Router(graph, RouterConfig.DEFAULT);
 
-        gtfsBundle.setTransfersTxtDefinesStationPaths(true);
         gtfsGraphBuilderImpl.buildGraph(graph, null);
         // Set the agency ID to be used for tests to the first one in the feed.
         agencyId = graph.getAgencies().iterator().next().getId().getId();


### PR DESCRIPTION
### Summary

As discussed in the dev meeting today we decided the parameter `useTransfersTxt`. Reasons for removal are the following:

- the name is wrong: it doesn't enable or disable the transfers.txt but the calculation of the OSM transfers 
- none of us found a use case were turning off the OSM transfers was a good idea

Instead we want to implement a fallback logic like this:

- if we have a transfer in transfers.txt use that
- if not then use pathways.txt
- if not then use OSM based transfers

This will happen in a separate PR.

### Issue
n/a

### Unit tests
n/a

### Code style
Yes.

### Documentation
Documentation removed.