### PR TITLE
Read in flex window from Netex feeds

### DIFF
--- a/src/main/java/org/opentripplanner/netex/mapping/StopTimesMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/StopTimesMapper.java
@@ -168,20 +168,30 @@ class StopTimesMapper {
         stopTime.setStop(stop);
         if (passingTime.getArrivalTime() != null || passingTime.getDepartureTime() != null) {
             stopTime.setArrivalTime(calculateOtpTime(
-                passingTime.getArrivalTime(), passingTime.getArrivalDayOffset(),
-                passingTime.getDepartureTime(), passingTime.getDepartureDayOffset()
+                passingTime.getArrivalTime(),                 
+                passingTime.getArrivalDayOffset(),
+                passingTime.getDepartureTime(),
+                passingTime.getDepartureDayOffset()
             ));
             stopTime.setDepartureTime(calculateOtpTime(
-                passingTime.getDepartureTime(), passingTime.getDepartureDayOffset(),
-                passingTime.getArrivalTime(), passingTime.getArrivalDayOffset()
+                passingTime.getDepartureTime(),
+                passingTime.getDepartureDayOffset(),
+                passingTime.getArrivalTime(),
+                passingTime.getArrivalDayOffset()
             ));
         } else if (passingTime.getEarliestDepartureTime() != null && passingTime.getLatestArrivalTime() != null) {
-            stopTime.setFlexWindowStart(calculateOtpTime(
-                passingTime.getEarliestDepartureTime(), passingTime.getEarliestDepartureDayOffset()
-            ));
-            stopTime.setFlexWindowEnd(calculateOtpTime(
-                passingTime.getLatestArrivalTime(), passingTime.getLatestArrivalDayOffset()
-            ));
+            stopTime.setFlexWindowStart(
+                    calculateOtpTime(
+                            passingTime.getEarliestDepartureTime(),
+                            passingTime.getEarliestDepartureDayOffset()
+                    )
+            );
+            stopTime.setFlexWindowEnd(
+                    calculateOtpTime(
+                            passingTime.getLatestArrivalTime(),
+                            passingTime.getLatestArrivalDayOffset()
+                    )
+            );
         } else {
             return null;
         }

--- a/src/main/java/org/opentripplanner/netex/mapping/StopTimesMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/StopTimesMapper.java
@@ -166,17 +166,25 @@ class StopTimesMapper {
         stopTime.setTrip(trip);
         stopTime.setStopSequence(stopSequence);
         stopTime.setStop(stop);
-        // TODO PassingTimes containing EarliestArrivalTime or LatestDepartureTime only not yet
-        //      supported
-        if (passingTime.getArrivalTime() == null && passingTime.getDepartureTime() == null) {
+        if (passingTime.getArrivalTime() != null || passingTime.getDepartureTime() != null) {
+            stopTime.setArrivalTime(calculateOtpTime(
+                passingTime.getArrivalTime(), passingTime.getArrivalDayOffset(),
+                passingTime.getDepartureTime(), passingTime.getDepartureDayOffset()
+            ));
+            stopTime.setDepartureTime(calculateOtpTime(
+                passingTime.getDepartureTime(), passingTime.getDepartureDayOffset(),
+                passingTime.getArrivalTime(), passingTime.getArrivalDayOffset()
+            ));
+        } else if (passingTime.getEarliestDepartureTime() != null && passingTime.getLatestArrivalTime() != null) {
+            stopTime.setFlexWindowStart(calculateOtpTime(
+                passingTime.getEarliestDepartureTime(), passingTime.getEarliestDepartureDayOffset()
+            ));
+            stopTime.setFlexWindowEnd(calculateOtpTime(
+                passingTime.getLatestArrivalTime(), passingTime.getLatestArrivalDayOffset()
+            ));
+        } else {
             return null;
         }
-        stopTime.setArrivalTime(
-                calculateOtpTime(passingTime.getArrivalTime(), passingTime.getArrivalDayOffset(),
-                        passingTime.getDepartureTime(), passingTime.getDepartureDayOffset()));
-        stopTime.setDepartureTime(calculateOtpTime(passingTime.getDepartureTime(),
-                passingTime.getDepartureDayOffset(), passingTime.getArrivalTime(),
-                passingTime.getArrivalDayOffset()));
 
         if (stopPoint != null) {
             if (isFalse(stopPoint.isForAlighting())) {
@@ -204,7 +212,9 @@ class StopTimesMapper {
             }
         }
 
-        if (passingTime.getArrivalTime() == null && passingTime.getDepartureTime() == null) {
+        if (passingTime.getArrivalTime() == null && passingTime.getDepartureTime() == null &&
+            passingTime.getEarliestDepartureTime() == null && passingTime.getLatestArrivalTime() == null
+        ) {
             issueStore.add("TripWithoutTime","Time missing for trip %s", trip.getId());
         }
 


### PR DESCRIPTION
### Summary
Currently Netex feeds only support reading in a fixed stop time even for flex trips. There is a [workaround](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/src/main/java/org/opentripplanner/netex/mapping/StopTimesMapper.java#L298-L317) for converting these to flex windows. There has been since a clarification on the standard regarding how to read these windows. This adds support for reading those.

### Unit tests
None changed

### Code style
Code style followed

### Documentation
No updates required

### Changelog
The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md) 
is generated from the pull-request title, make sure the title describe the feature or issue fixed. 
To exclude the PR from the changelog add `[changelog skip]` in the title.
