### PR TITLE
Don't run performance tests on pull requests [changelog skip]

### DIFF
--- a/.github/workflows/performance-test.yml
+++ b/.github/workflows/performance-test.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - dev-2.x
-  pull_request:
-    branches:
-      - dev-2.x
 
 jobs:
   perf-test:


### PR DESCRIPTION
In my previous PR I overlooked the fact that we run the performance tests for pull requests which we should not do.