### PR TITLE
Fix NPE when routing on a graph without transit data.

### DIFF
--- a/src/main/java/org/opentripplanner/routing/RoutingService.java
+++ b/src/main/java/org/opentripplanner/routing/RoutingService.java
@@ -53,7 +53,7 @@ public class RoutingService {
     // TODO We should probably not have the Router as a parameter here
     public RoutingResponse route(RoutingRequest request, Router router) {
         try {
-            var zoneId = graph.getTransitLayer().getTransitDataZoneId();
+            var zoneId = graph.getTimeZone().toZoneId();
             RoutingWorker worker = new RoutingWorker(router, request, zoneId);
             return worker.route();
         } finally {


### PR DESCRIPTION
### Summary
Allow routing without a transit graph. This patch fixes a null pointer exception when reading the time zone from the (non-existant) transit layer by using the existing helper function in the graph object.

### Unit tests
I have tested the change by routing on a graph without transit data.

### Code style
Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Developers-Guide.md#code-style)? 
