### PR TITLE
Reduce memory usage by deduplicate StopTimes in NeTEx import. [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/netex/mapping/TripPatternMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/TripPatternMapper.java
@@ -172,7 +172,10 @@ class TripPatternMapper {
         }
 
         // Create StopPattern from any trip (since they are part of the same JourneyPattern)
-        StopPattern stopPattern = new StopPattern(result.tripStopTimes.get(trips.get(0)));
+        StopPattern stopPattern = deduplicator.deduplicateObject(
+                StopPattern.class,
+                new StopPattern(result.tripStopTimes.get(trips.get(0)))
+        );
 
         TripPattern tripPattern = new TripPattern(
             idFactory.createId(journeyPattern.getId()),


### PR DESCRIPTION
### Summary
This reduced the memory consumption for StopTimes with ca 20%
for the Norwegian NeTEx dataset (26.7'-> 22.6' StopPattern entries).
Explain in one or two sentences what this PR achieves. 

### Issue
There is no issue for this.

### Unit tests
No


### Code style
✅ 


### Documentation
No.

### Changelog
This is a none-functonal change; Hence not included in the changelog.