### PR TITLE
Fix issue with fetching parent StopPlaces in nearest query in Transmodel API [changelog skip]

### DIFF
--- a/docs/sandbox/TransmodelApi.md
+++ b/docs/sandbox/TransmodelApi.md
@@ -19,6 +19,7 @@
 - Allow filtering by a list of ids [#3738](https://github.com/opentripplanner/OpenTripPlanner/pull/3738)
 - Don't filter out stops who don't have multimodal parents in the nearest query [#3752](https://github.com/opentripplanner/OpenTripPlanner/pull/3752)
 - Restore ability to filter by private code [#3764](https://github.com/opentripplanner/OpenTripPlanner/pull/3764)
+- Fix issue with fetching parent StopPlaces in nearest query in Transmodel API [#3807](https://github.com/opentripplanner/OpenTripPlanner/pull/3807)
 
 ## Documentation
 

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/PlaceAtDistanceType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/PlaceAtDistanceType.java
@@ -6,8 +6,12 @@ import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLInterfaceType;
 import graphql.schema.GraphQLNonNull;
 import graphql.schema.GraphQLObjectType;
+import java.util.ArrayList;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
 import org.opentripplanner.ext.transmodelapi.model.TransmodelPlaceType;
 import org.opentripplanner.model.MultiModalStation;
+import org.opentripplanner.model.Station;
 import org.opentripplanner.model.Stop;
 import org.opentripplanner.routing.RoutingService;
 import org.opentripplanner.routing.graphfinder.PlaceAtDistance;
@@ -63,35 +67,21 @@ public class PlaceAtDistanceType {
       String multiModalMode,
       RoutingService routingService
   ) {
-    if (placeTypes==null || placeTypes.contains(TransmodelPlaceType.STOP_PLACE)) {
-      // Convert quays to stop places
-      List<PlaceAtDistance> stations = places
-          .stream()
-          .filter(p -> p.place instanceof Stop)
-          .map(p -> new PlaceAtDistance(new MonoOrMultiModalStation(((Stop) p.place).getParentStation(),
-              null
-          ), p.distance))
-          .collect(Collectors.toList());
+      if (placeTypes == null || placeTypes.contains(TransmodelPlaceType.STOP_PLACE)) {
+          // Convert quays to stop places
+          List<PlaceAtDistance> stations = places
+              .stream()
+              // Find all stops
+              .filter(p -> p.place instanceof Stop)
+              // Get their parent stations (possibly including multimodal parents)
+              .flatMap(p -> getStopPlaces(p, multiModalMode, routingService))
+              // Sort by distance
+              .sorted(Comparator.comparing(p -> p.distance))
+              // Make sure each parent appears exactly once
+              .filter(new SeenPlacePredicate())
+              .collect(Collectors.toList());
 
-      if ("parent".equals(multiModalMode)) {
-        // Replace monomodal children with their multimodal parents, if it exists
-        stations = stations.stream()
-          .map(p -> {
-            MultiModalStation parent = routingService.getMultiModalStationForStations().get(p.place);
-            return parent != null ? new PlaceAtDistance(parent, p.distance) : p;
-          })
-          .collect(Collectors.toList());
-      } else if ("all".equals(multiModalMode)) {
-        // Add multimodal parents in addition to their monomodal children
-        List<PlaceAtDistance> parentStations = stations.stream()
-          .filter(p -> routingService.getMultiModalStationForStations().containsKey(p.place))
-          .map(p -> new PlaceAtDistance( routingService.getMultiModalStationForStations().get(p.place), p.distance))
-          .collect(Collectors.toList());
-
-        places.addAll(parentStations);
-      }
-
-      places.addAll(stations);
+          places.addAll(stations);
 
       if (placeTypes != null && !placeTypes.contains(TransmodelPlaceType.QUAY)) {
         // Remove quays if only stop places are requested
@@ -105,4 +95,50 @@ public class PlaceAtDistanceType {
     return places.stream().filter(s -> uniquePlaces.add(s.place)).collect(Collectors.toList());
   }
 
+    private static Stream<PlaceAtDistance> getStopPlaces(
+        PlaceAtDistance p,
+        String multiModalMode,
+        RoutingService routingService
+    ) {
+        Station stopPlace = ((Stop) p.place).getParentStation();
+
+        if (stopPlace == null) {
+            return Stream.of();
+        }
+
+        List<PlaceAtDistance> res = new ArrayList<>();
+
+        MultiModalStation multiModalStation = routingService
+            .getMultiModalStationForStations()
+            .get(stopPlace);
+
+        if ("child".equals(multiModalMode) ||
+            "all".equals(multiModalMode) ||
+            multiModalStation == null
+        ) {
+            res.add(new PlaceAtDistance(
+                new MonoOrMultiModalStation(stopPlace, multiModalStation),
+                p.distance
+            ));
+        }
+
+        if (multiModalStation == null) {
+            return res.stream();
+        }
+
+        if ("parent".equals(multiModalMode) || "all".equals(multiModalMode)) {
+            res.add(new PlaceAtDistance(new MonoOrMultiModalStation(multiModalStation), p.distance));
+        }
+        return res.stream();
+    }
+
+    static class SeenPlacePredicate implements Predicate<PlaceAtDistance> {
+
+      Set<Object> seen = new HashSet<>();
+
+      @Override
+      public boolean test(PlaceAtDistance p) {
+          return seen.add(p.place);
+      }
+  }
 }


### PR DESCRIPTION
### Summary

Currently the `nearest` query does not find any multiModal stop places, as the search in the index is done on the wrong type (`MonoOrMultiModalStation` vs `Station`). This refactors the search for parent stop places to fix this.

### Unit tests
None changed

### Code style
✅ 

### Documentation
None needed

### Changelog
The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md) 
is generated from the pull-request title, make sure the title describe the feature or issue fixed. 
To exclude the PR from the changelog add `[changelog skip]` in the title.
