### PR TITLE
Fix invalid cast in situations resolver for line in Transmodel API [changelog skip]

### DIFF
--- a/docs/sandbox/TransmodelApi.md
+++ b/docs/sandbox/TransmodelApi.md
@@ -21,6 +21,7 @@
 - Restore ability to filter by private code [#3764](https://github.com/opentripplanner/OpenTripPlanner/pull/3764)
 - Narrow down non-null types type [#3803](https://github.com/opentripplanner/OpenTripPlanner/pull/3803)
 - Fix issue with fetching parent StopPlaces in nearest query in Transmodel API [#3807](https://github.com/opentripplanner/OpenTripPlanner/pull/3807)
+- Fix invalid cast in situations resolver for line type [#3810](https://github.com/opentripplanner/OpenTripPlanner/pull/3810)
 
 ## Documentation
 

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/network/LineType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/network/LineType.java
@@ -158,10 +158,9 @@ public class LineType {
                     .name("situations")
                     .description("Get all situations active for the line.")
                     .type(new GraphQLNonNull(new GraphQLList(ptSituationElementType)))
-                .dataFetcher(environment -> {
-                  return GqlUtil.getRoutingService(environment).getTransitAlertService().getRouteAlerts(
-                      environment.getSource());
-                })
+                .dataFetcher(environment -> GqlUtil.getRoutingService(environment)
+                        .getTransitAlertService()
+                        .getRouteAlerts(((Route) environment.getSource()).getId()))
                 .build())
             .field(GraphQLFieldDefinition.newFieldDefinition()
                 .name("flexibleLineType")


### PR DESCRIPTION
### Summary

There was an invalid cast in the Transmodel API. We should fetch the id under the `Route` entity instead

### Unit tests
None changed

### Code style
✅ 

### Documentation
None needed

### Changelog
The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md) 
is generated from the pull-request title, make sure the title describe the feature or issue fixed. 
To exclude the PR from the changelog add `[changelog skip]` in the title.
