### PR TITLE
Capture code coverage with jacoco and codecov.io

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -9,7 +9,6 @@ on:
       - master
       - dev-1.x
       - dev-2.x
-      - coverage
   pull_request:
     branches:
       - master
@@ -38,10 +37,11 @@ jobs:
       - name: Prepare coverage agent, build and test
         run: mvn --batch-mode --update-snapshots jacoco:prepare-agent verify jacoco:report
 
-      - uses: codecov/codecov-action@v2
+      - name: Send coverage data to codecov.io
+        if: github.repository_owner == 'opentripplanner'
+        uses: codecov/codecov-action@v2
         with:
           files: target/site/jacoco/jacoco.xml
-          verbose: true # optional (default = false)
 
       - name: Deploy to Github Package Registry
         if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev-1.x' || github.ref == 'refs/heads/dev-2.x')

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -9,6 +9,7 @@ on:
       - master
       - dev-1.x
       - dev-2.x
+      - coverage
   pull_request:
     branches:
       - master

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -34,8 +34,14 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - name: Build and Test
-        run: mvn --batch-mode --update-snapshots verify
+      - name: Prepare coverage agent, build and test
+        run: mvn --batch-mode --update-snapshots jacoco:prepare-agent verify jacoco:report
+
+      - uses: codecov/codecov-action@v2
+        with:
+          files: target/site/jacoco/jacoco.xml
+          verbose: true # optional (default = false)
+
       - name: Deploy to Github Package Registry
         if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev-1.x' || github.ref == 'refs/heads/dev-2.x')
         env:

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Additional information and instructions are available in the [main documentation
 
 ## Development 
 
+[![codecov](https://codecov.io/gh/opentripplanner/OpenTripPlanner/branch/dev-2.x/graph/badge.svg?token=ak4PbIKgZ1)](https://codecov.io/gh/opentripplanner/OpenTripPlanner)
+
 OpenTripPlanner is a collaborative project incorporating code, translation, and documentation from contributors around the world. We welcome new contributions. Further [development guidelines](http://docs.opentripplanner.org/en/latest/Developers-Guide/) can be found in the documentation.
 
 ### Development history

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,10 @@
         <!-- Other properties -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <GITHUB_REPOSITORY>opentripplanner/OpenTripPlanner</GITHUB_REPOSITORY>
+        <!-- Set argLine to an empty string so that running the tests without the coverage agent works.
+             When running `mvn jacoco:prepare-agent test` argLine is replaced with the one activating the agent.
+        -->
+        <argLine></argLine>
     </properties>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -222,8 +222,11 @@
                 <configuration>
                     <!-- we have to fork the JVM during tests so that the argLine is passed along -->
                     <forkCount>3</forkCount>
-                    <!-- enable the restricted reflection under Java 11 so that the ObjectDiffer works -->
+                    <!-- enable the restricted reflection under Java 11 so that the ObjectDiffer works
+                         the @{argLine} part is there to allow jacoco to insert its arguments as well
+                    -->
                     <argLine>
+                        @{argLine}
                         -Xmx2G
                         -Dfile.encoding=UTF-8
                         --illegal-access=permit
@@ -240,6 +243,26 @@
                     <!-- Jenkins needs XML test reports to determine whether the build is stable. -->
                     <disableXmlReport>false</disableXmlReport>
                 </configuration>
+            </plugin>
+            <!-- code coverage report -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.7</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>jacoco-report</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <!-- Get current Git commit information for use in MavenVersion class.

--- a/pom.xml
+++ b/pom.xml
@@ -249,20 +249,6 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>0.8.7</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>jacoco-report</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <!-- Get current Git commit information for use in MavenVersion class.


### PR DESCRIPTION
### Summary

It adds and agent to the JVM when executing the tests on CI and uploads the coverage reports to codecov.io a free cloud service to display coverage data.

Here is an example of how it looks like: https://codecov.io/gh/leonardehrenfried/OpenTripPlanner/tree/1292b054aa86d2aaafa9bea478d66397241cade9/src/main/java

### Issue
no issue.

### Unit tests
n/a

### Code style
n/a

### Documentation

I've added a badge to the readme.