### PR TITLE
Minor fixes [changelog skip]

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
@@ -760,8 +760,10 @@ public class TransmodelGraphQLSchema {
                 .type(new GraphQLNonNull(Scalars.GraphQLID))
                 .build())
             .dataFetcher(environment -> {
-              return GqlUtil.getRoutingService(environment).getRouteForId(TransitIdMapper
-                  .mapIDToDomain(environment.getArgument("id")));
+                final String id = environment.getArgument("id");
+                if (id.isBlank()) { return null; }
+                return GqlUtil.getRoutingService(environment)
+                        .getRouteForId(TransitIdMapper.mapIDToDomain(id));
             })
             .build())
         .field(GraphQLFieldDefinition

--- a/src/main/java/org/opentripplanner/model/StationElement.java
+++ b/src/main/java/org/opentripplanner/model/StationElement.java
@@ -116,6 +116,10 @@ public abstract class StationElement extends TransitEntity {
    * (element).
    */
   public boolean isPartOfSameStationAs(StopLocation other) {
+    if (other == null) {
+      return false;
+    }
+
     return isPartOfStation() && parentStation.equals(other.getParentStation());
   }
 

--- a/src/main/java/org/opentripplanner/routing/RoutingService.java
+++ b/src/main/java/org/opentripplanner/routing/RoutingService.java
@@ -57,7 +57,7 @@ public class RoutingService {
             RoutingWorker worker = new RoutingWorker(router, request, zoneId);
             return worker.route();
         } finally {
-            if (request != null) {
+            if (request != null && request.rctx != null) {
                 request.cleanup();
             }
         }

--- a/src/main/java/org/opentripplanner/routing/core/StateEditor.java
+++ b/src/main/java/org/opentripplanner/routing/core/StateEditor.java
@@ -47,6 +47,11 @@ public class StateEditor {
             child.backState = null;
             child.vertex = parent.vertex;
             child.stateData = child.stateData.clone();
+        } else if (e.getFromVertex() == null || e.getToVertex() == null) {
+            child.vertex = parent.vertex;
+            child.stateData = child.stateData.clone();
+            LOG.error("From or to vertex is null for {}", e);
+            defectiveTraversal = true;
         } else {
             // be clever
             // Note that we use equals(), not ==, here to allow for dynamically


### PR DESCRIPTION
### Summary

- Guard against null station in isPartOfSameStationAs
- Do not try cleanup routing context, if it is not set, removing an unnecessary warning in logs
- Log when creating a state editor with an invalid edge, which is missing either from or to vertex
- Guard against invalid id in Transmodel API `line` data fetcher

### Unit tests
None changed

### Code style
✅ 

### Documentation
None needed

### Changelog
The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md) 
is generated from the pull-request title, make sure the title describe the feature or issue fixed. 
To exclude the PR from the changelog add `[changelog skip]` in the title.
