### PR TITLE
Read leg mode from trip, instead of route

### DIFF
--- a/src/main/java/org/opentripplanner/model/plan/Leg.java
+++ b/src/main/java/org/opentripplanner/model/plan/Leg.java
@@ -197,7 +197,7 @@ public class Leg {
   }
 
   public Leg(Trip trip) {
-    this.mode = TraverseMode.fromTransitMode(trip.getRoute().getMode());
+    this.mode = TraverseMode.fromTransitMode(trip.getMode());
     this.trip = trip;
   }
 


### PR DESCRIPTION
### Summary
Change the `Leg` mapper, so that the `mode` is read from the `Trip`, instead of the `Route`. The `mode` getter in trip will fallback to the route, if it is not overridden.

### Issue
Fixes #3818

### Unit tests
Not changed

### Code style
✅ 

### Documentation
None required

### Changelog
The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md) 
is generated from the pull-request title, make sure the title describe the feature or issue fixed. 
To exclude the PR from the changelog add `[changelog skip]` in the title.
