### PR TITLE
Store stop indices in leg and use them to simplify logic in TripTimeShortHelper

### DIFF
--- a/src/main/java/org/opentripplanner/model/plan/Leg.java
+++ b/src/main/java/org/opentripplanner/model/plan/Leg.java
@@ -169,6 +169,10 @@ public class Leg {
 
     public ConstrainedTransfer transferToNextLeg = null;
 
+    public Integer boardStopPosInPattern = null;
+
+    public Integer alightStopPosInPattern = null;
+
     /**
      * Is this leg walking with a bike?
      */

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
@@ -204,6 +204,9 @@ public class RaptorPathToItineraryMapper {
         leg.transferToNextLeg = (ConstrainedTransfer) pathLeg.getConstrainedTransferAfterLeg();
         leg.transferFromPrevLeg = prevTransitLeg == null ? null : prevTransitLeg.transferToNextLeg;
 
+        leg.boardStopPosInPattern = boardStopIndexInPattern;
+        leg.alightStopPosInPattern = alightStopIndexInPattern;
+
         // TODO OTP2 - alightRule and boardRule needs mapping
         //    Under Raptor, for transit trips, ItineraryMapper converts Path<TripSchedule> directly to Itinerary
         //    (the old API response element, within TripPlan). Non-transit trips still use GraphPathToTripPlanConverter


### PR DESCRIPTION
### Summary
Currently the matching for the estimated calls sometimes fail. This simplifies the logic and stores the proper stop indices in the leg. These indices could be used in the future to remove things from the `Leg`, which could be fetched in the mappers.

### Unit tests
None changed

### Code style
✅ 

### Documentation
None needed

### Changelog
The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md) 
is generated from the pull-request title, make sure the title describe the feature or issue fixed. 
To exclude the PR from the changelog add `[changelog skip]` in the title.
