### PR TITLE
Use API mapping in snapshot tests

### DIFF
--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/BikeRentalSnapshotTest.snap
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/BikeRentalSnapshotTest.snap
@@ -1,10 +1,11 @@
 org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeRental=[
   [
     {
-      "arrivedAtDestinationWithRentedVehicle": false,
-      "durationSeconds": 1049,
+      "arrivedAtDestinationWithRentedBicycle": false,
+      "duration": 1049,
       "elevationGained": 0.0,
       "elevationLost": 0.0,
+      "endTime": "2009-10-21T23:32:24.000+00:00",
       "fare": {
         "details": {
           "regular": [
@@ -37,744 +38,359 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
           }
         }
       },
-      "flaggedForDeletion": false,
       "generalizedCost": 2087,
       "legs": [
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 106.589,
+          "distance": 106.589,
           "endTime": "2009-10-21T23:17:26.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.52832,
-              "longitude": -122.70059
-            },
+            "departure": "2009-10-21T23:14:55.000+00:00",
+            "lat": 45.52832,
+            "lon": -122.70059,
             "name": "SW Johnson St. & NW 24th Ave. (P1)",
             "vertexType": "NORMAL"
           },
           "generalizedCost": 288,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 4,
             "points": "}f{tGv}{kVjCA?e@WA"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-10-21T23:14:55.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.5277374,
-              "longitude": -122.7003879
-            },
-            "name": "-102309",
-            "vehicleRentalPlace": {
-              "allowDropoff": true,
-              "allowOverloading": false,
-              "allowPickup": true,
-              "carStation": false,
-              "floatingVehicle": false,
-              "id": {
-                "feedId": "test-network",
-                "id": "-102309"
-              },
-              "isInstalled": true,
-              "isKeepingVehicleRentalAtDestinationAllowed": true,
-              "isRenting": true,
-              "isReturning": true,
-              "isValetStation": false,
-              "isVirtualStation": false,
-              "keepingVehicleRentalAtDestinationAllowed": true,
-              "latitude": 45.5277374,
-              "longitude": -122.7003879,
-              "name": {
-                "name": "-102309"
-              },
-              "realTimeData": false,
-              "spacesAvailable": 0,
-              "spacesDisabled": 0,
-              "vehicleSpacesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehicleTypesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehiclesAvailable": 0,
-              "vehiclesDisabled": 0
-            },
-            "vertexType": "VEHICLERENTAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "SOUTH",
-              "angle": 3.1263917767722313,
               "area": false,
               "bogusName": false,
               "distance": 78.527,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.52831993266165,
+              "lon": -122.70059632295107,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.52831993266165,
-                "longitude": -122.70059632295107
-              },
               "stayOn": false,
-              "streetName": "Northwest 24th Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 24th Avenue"
             },
             {
               "absoluteDirection": "EAST",
-              "angle": 1.5443268101828453,
               "area": false,
               "bogusName": false,
               "distance": 14.704,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.527613800000005,
+              "lon": -122.70058100000001,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.527613800000005,
-                "longitude": -122.70058100000001
-              },
               "stayOn": false,
-              "streetName": "Northwest Irving Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Irving Street"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": 0.02566034822056683,
               "area": false,
               "bogusName": true,
               "distance": 13.358,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5276173,
+              "lon": -122.7003923,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.5276173,
-                "longitude": -122.7003923
-              },
               "stayOn": false,
-              "streetName": "way -102328 from 0",
-              "streetNotes": [ ],
-              "vehicleRentalOnStation": {
-                "id": "-102309",
-                "lat": 45.5277374,
-                "lon": -122.7003879,
-                "name": "-102309"
-              }
+              "streetName": "way -102328 from 0"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
+          "to": {
+            "arrival": "2009-10-21T23:17:26.000+00:00",
+            "bikeShareId": "-102309",
+            "departure": "2009-10-21T23:17:26.000+00:00",
+            "lat": 45.5277374,
+            "lon": -122.7003879,
+            "name": "-102309",
+            "vertexType": "BIKESHARE"
+          },
+          "transitLeg": false,
+          "walkingBike": false
         },
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 13.358,
+          "distance": 13.358,
           "endTime": "2009-10-21T23:17:37.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.5277374,
-              "longitude": -122.7003879
-            },
+            "arrival": "2009-10-21T23:17:26.000+00:00",
+            "bikeShareId": "-102309",
+            "departure": "2009-10-21T23:17:26.000+00:00",
+            "lat": 45.5277374,
+            "lon": -122.7003879,
             "name": "-102309",
-            "vehicleRentalPlace": {
-              "allowDropoff": true,
-              "allowOverloading": false,
-              "allowPickup": true,
-              "carStation": false,
-              "floatingVehicle": false,
-              "id": {
-                "feedId": "test-network",
-                "id": "-102309"
-              },
-              "isInstalled": true,
-              "isKeepingVehicleRentalAtDestinationAllowed": true,
-              "isRenting": true,
-              "isReturning": true,
-              "isValetStation": false,
-              "isVirtualStation": false,
-              "keepingVehicleRentalAtDestinationAllowed": true,
-              "latitude": 45.5277374,
-              "longitude": -122.7003879,
-              "name": {
-                "name": "-102309"
-              },
-              "realTimeData": false,
-              "spacesAvailable": 0,
-              "spacesDisabled": 0,
-              "vehicleSpacesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehicleTypesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehiclesAvailable": 0,
-              "vehiclesDisabled": 0
-            },
-            "vertexType": "VEHICLERENTAL"
+            "vertexType": "BIKESHARE"
           },
           "generalizedCost": 51,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 2,
             "points": "ic{tGl|{kVV@"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": true,
-          "scheduled": false,
+          "rentedBike": true,
+          "route": "",
           "startTime": "2009-10-21T23:17:26.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.5276173,
-              "longitude": -122.7003923
-            },
-            "name": "corner of way -102328 from 0 and Northwest Irving Street",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "vehicleRentalNetwork": "test-network",
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "SOUTH",
-              "angle": -3.1159323053692263,
               "area": false,
               "bogusName": true,
               "distance": 13.358,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5277374,
+              "lon": -122.70038790000001,
               "relativeDirection": "HARD_LEFT",
-              "startLocation": {
-                "latitude": 45.5277374,
-                "longitude": -122.70038790000001
-              },
               "stayOn": false,
-              "streetName": "way -102328 from 0",
-              "streetNotes": [ ]
+              "streetName": "way -102328 from 0"
             }
           ],
-          "walkingBike": true,
-          "walkingLeg": true
+          "to": {
+            "arrival": "2009-10-21T23:17:37.000+00:00",
+            "departure": "2009-10-21T23:17:37.000+00:00",
+            "lat": 45.5276173,
+            "lon": -122.7003923,
+            "name": "corner of way -102328 from 0 and Northwest Irving Street",
+            "vertexType": "NORMAL"
+          },
+          "transitLeg": false,
+          "walkingBike": true
         },
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 480.068,
+          "distance": 480.068,
           "endTime": "2009-10-21T23:19:58.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.5276173,
-              "longitude": -122.7003923
-            },
+            "arrival": "2009-10-21T23:17:37.000+00:00",
+            "departure": "2009-10-21T23:17:37.000+00:00",
+            "lat": 45.5276173,
+            "lon": -122.7003923,
             "name": "corner of way -102328 from 0 and Northwest Irving Street",
             "vertexType": "NORMAL"
           },
           "generalizedCost": 236,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 6,
             "points": "qb{tGn|{kVGsJEuKE}HAwAAo@"
           },
           "mode": "BICYCLE",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": true,
-          "scheduled": false,
+          "rentedBike": true,
+          "route": "",
           "startTime": "2009-10-21T23:17:37.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.5278491,
-              "longitude": -122.6942362
-            },
-            "name": "-102323",
-            "vehicleRentalPlace": {
-              "allowDropoff": true,
-              "allowOverloading": false,
-              "allowPickup": true,
-              "carStation": false,
-              "floatingVehicle": false,
-              "id": {
-                "feedId": "test-network",
-                "id": "-102323"
-              },
-              "isInstalled": true,
-              "isKeepingVehicleRentalAtDestinationAllowed": true,
-              "isRenting": true,
-              "isReturning": true,
-              "isValetStation": false,
-              "isVirtualStation": false,
-              "keepingVehicleRentalAtDestinationAllowed": true,
-              "latitude": 45.5278491,
-              "longitude": -122.6942362,
-              "name": {
-                "name": "-102323"
-              },
-              "realTimeData": false,
-              "spacesAvailable": 0,
-              "spacesDisabled": 0,
-              "vehicleSpacesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehicleTypesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehiclesAvailable": 0,
-              "vehiclesDisabled": 0
-            },
-            "vertexType": "VEHICLERENTAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "vehicleRentalNetwork": "test-network",
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "EAST",
-              "angle": 1.5441765471733384,
               "area": false,
               "bogusName": false,
               "distance": 480.068,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5276173,
+              "lon": -122.7003923,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.5276173,
-                "longitude": -122.7003923
-              },
               "stayOn": false,
-              "streetName": "Northwest Irving Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Irving Street"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": false
+          "to": {
+            "arrival": "2009-10-21T23:19:58.000+00:00",
+            "bikeShareId": "-102323",
+            "departure": "2009-10-21T23:19:58.000+00:00",
+            "lat": 45.5278491,
+            "lon": -122.6942362,
+            "name": "-102323",
+            "vertexType": "BIKESHARE"
+          },
+          "transitLeg": false,
+          "walkingBike": false
         },
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 29.461000000000002,
+          "distance": 29.461000000000002,
           "endTime": "2009-10-21T23:20:25.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.5278491,
-              "longitude": -122.6942362
-            },
+            "arrival": "2009-10-21T23:19:58.000+00:00",
+            "bikeShareId": "-102323",
+            "departure": "2009-10-21T23:19:58.000+00:00",
+            "lat": 45.5278491,
+            "lon": -122.6942362,
             "name": "-102323",
-            "vehicleRentalPlace": {
-              "allowDropoff": true,
-              "allowOverloading": false,
-              "allowPickup": true,
-              "carStation": false,
-              "floatingVehicle": false,
-              "id": {
-                "feedId": "test-network",
-                "id": "-102323"
-              },
-              "isInstalled": true,
-              "isKeepingVehicleRentalAtDestinationAllowed": true,
-              "isRenting": true,
-              "isReturning": true,
-              "isValetStation": false,
-              "isVirtualStation": false,
-              "keepingVehicleRentalAtDestinationAllowed": true,
-              "latitude": 45.5278491,
-              "longitude": -122.6942362,
-              "name": {
-                "name": "-102323"
-              },
-              "realTimeData": false,
-              "spacesAvailable": 0,
-              "spacesDisabled": 0,
-              "vehicleSpacesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehicleTypesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehiclesAvailable": 0,
-              "vehiclesDisabled": 0
-            },
-            "vertexType": "VEHICLERENTAL"
+            "vertexType": "BIKESHARE"
           },
           "generalizedCost": 49,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 5,
             "points": "ic{tG~uzkV@n@M@C??H"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-10-21T23:19:58.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.527818,
-              "longitude": -122.694539
-            },
-            "name": "NW 21st & Irving",
-            "stop": {
-              "code": "7114",
-              "coordinate": {
-                "latitude": 45.527818,
-                "longitude": -122.694539
-              },
-              "description": "Southbound stop in Portland (Stop ID 7114)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "7114"
-              },
-              "name": "NW 21st & Irving",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
-            "stopIndex": 15,
-            "stopSequence": 16,
-            "vertexType": "TRANSIT"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "WEST",
-              "angle": -1.5973283920844321,
               "area": false,
               "bogusName": false,
               "distance": 19.289,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.52773220198921,
+              "lon": -122.69423177172958,
               "relativeDirection": "HARD_LEFT",
-              "startLocation": {
-                "latitude": 45.52773220198921,
-                "longitude": -122.69423177172958
-              },
               "stayOn": false,
-              "streetName": "Northwest Irving Street",
-              "streetNotes": [ ],
-              "vehicleRentalOffStation": {
-                "id": "-102323",
-                "lat": 45.5278491,
-                "lon": -122.6942362,
-                "name": "-102323"
-              }
+              "streetName": "Northwest Irving Street"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": -0.026543929838500624,
               "area": false,
               "bogusName": false,
               "distance": 10.172,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.527727600000006,
+              "lon": -122.69447930000001,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.527727600000006,
-                "longitude": -122.69447930000001
-              },
               "stayOn": false,
-              "streetName": "Northwest 21st Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 21st Avenue"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
-        },
-        {
-          "agencyTimeZoneOffset": 0,
-          "arrivalDelay": 0,
-          "departureDelay": 0,
-          "distanceMeters": 1629.4275918538026,
-          "endTime": "2009-10-21T23:30:00.000+00:00",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.527818,
-              "longitude": -122.694539
-            },
+          "to": {
+            "arrival": "2009-10-21T23:20:25.000+00:00",
+            "departure": "2009-10-21T23:20:25.000+00:00",
+            "lat": 45.527818,
+            "lon": -122.694539,
             "name": "NW 21st & Irving",
-            "stop": {
-              "code": "7114",
-              "coordinate": {
-                "latitude": 45.527818,
-                "longitude": -122.694539
-              },
-              "description": "Southbound stop in Portland (Stop ID 7114)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "7114"
-              },
-              "name": "NW 21st & Irving",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "7114",
+            "stopId": "prt:7114",
             "stopIndex": 15,
             "stopSequence": 16,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "transitLeg": false,
+          "walkingBike": false
+        },
+        {
+          "agencyId": "prt:prt",
+          "agencyName": "TriMet",
+          "agencyTimeZoneOffset": 0,
+          "agencyUrl": "http://trimet.org",
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 1629.4275918538026,
+          "endTime": "2009-10-21T23:30:00.000+00:00",
+          "from": {
+            "arrival": "2009-10-21T23:20:25.000+00:00",
+            "departure": "2009-10-21T23:20:25.000+00:00",
+            "lat": 45.527818,
+            "lon": -122.694539,
+            "name": "NW 21st & Irving",
+            "stopCode": "7114",
+            "stopId": "prt:7114",
+            "stopIndex": 15,
+            "stopSequence": 16,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
           "generalizedCost": 1175,
           "headsign": "136th Ave",
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "intermediateStops": [
             {
               "arrival": "2009-10-21T23:21:20.000+00:00",
               "departure": "2009-10-21T23:21:20.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.526408,
-                  "longitude": -122.694503
-                },
-                "name": "NW 21st & Glisan",
-                "stop": {
-                  "code": "7112",
-                  "coordinate": {
-                    "latitude": 45.526408,
-                    "longitude": -122.694503
-                  },
-                  "description": "Southbound stop in Portland (Stop ID 7112)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "7112"
-                  },
-                  "name": "NW 21st & Glisan",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 16,
-                "stopSequence": 17,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.526408,
+              "lon": -122.694503,
+              "name": "NW 21st & Glisan",
+              "stopCode": "7112",
+              "stopId": "prt:7112",
+              "stopIndex": 16,
+              "stopSequence": 17,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:22:31.000+00:00",
               "departure": "2009-10-21T23:22:31.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.524833,
-                  "longitude": -122.69398
-                },
-                "name": "NW Everett & 21st",
-                "stop": {
-                  "code": "1615",
-                  "coordinate": {
-                    "latitude": 45.524833,
-                    "longitude": -122.69398
-                  },
-                  "description": "Eastbound stop in Portland (Stop ID 1615)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1615"
-                  },
-                  "name": "NW Everett & 21st",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 17,
-                "stopSequence": 18,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.524833,
+              "lon": -122.69398,
+              "name": "NW Everett & 21st",
+              "stopCode": "1615",
+              "stopId": "prt:1615",
+              "stopIndex": 17,
+              "stopSequence": 18,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:24:07.000+00:00",
               "departure": "2009-10-21T23:24:07.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.524935,
-                  "longitude": -122.690502
-                },
-                "name": "NW Everett & 19th",
-                "stop": {
-                  "code": "1611",
-                  "coordinate": {
-                    "latitude": 45.524935,
-                    "longitude": -122.690502
-                  },
-                  "description": "Eastbound stop in Portland (Stop ID 1611)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1611"
-                  },
-                  "name": "NW Everett & 19th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 18,
-                "stopSequence": 19,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.524935,
+              "lon": -122.690502,
+              "name": "NW Everett & 19th",
+              "stopCode": "1611",
+              "stopId": "prt:1611",
+              "stopIndex": 18,
+              "stopSequence": 19,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:26:28.000+00:00",
               "departure": "2009-10-21T23:26:28.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.524981,
-                  "longitude": -122.68537
-                },
-                "name": "NW Everett & 14th",
-                "stop": {
-                  "code": "1608",
-                  "coordinate": {
-                    "latitude": 45.524981,
-                    "longitude": -122.68537
-                  },
-                  "description": "Eastbound stop in Portland (Stop ID 1608)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1608"
-                  },
-                  "name": "NW Everett & 14th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 19,
-                "stopSequence": 20,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.524981,
+              "lon": -122.68537,
+              "name": "NW Everett & 14th",
+              "stopCode": "1608",
+              "stopId": "prt:1608",
+              "stopIndex": 19,
+              "stopSequence": 20,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-10-21T23:28:04.000+00:00",
               "departure": "2009-10-21T23:28:04.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.525061,
-                  "longitude": -122.68187
-                },
-                "name": "NW Everett & 11th",
-                "stop": {
-                  "code": "1607",
-                  "coordinate": {
-                    "latitude": 45.525061,
-                    "longitude": -122.68187
-                  },
-                  "description": "Eastbound stop in Portland (Stop ID 1607)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1607"
-                  },
-                  "name": "NW Everett & 11th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 20,
-                "stopSequence": 21,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.525061,
+              "lon": -122.68187,
+              "name": "NW Everett & 11th",
+              "stopCode": "1607",
+              "stopId": "prt:1607",
+              "stopIndex": 20,
+              "stopSequence": 21,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-10-21T23:29:15.000+00:00",
               "departure": "2009-10-21T23:29:15.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.525096,
-                  "longitude": -122.67929
-                },
-                "name": "NW Everett & Park",
-                "stop": {
-                  "code": "8402",
-                  "coordinate": {
-                    "latitude": 45.525096,
-                    "longitude": -122.67929
-                  },
-                  "description": "Eastbound stop in Portland (Stop ID 8402)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "8402"
-                  },
-                  "name": "NW Everett & Park",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 21,
-                "stopSequence": 22,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.525096,
+              "lon": -122.67929,
+              "name": "NW Everett & Park",
+              "stopCode": "8402",
+              "stopId": "prt:8402",
+              "stopIndex": 21,
+              "stopSequence": 22,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             }
           ],
           "legGeometry": {
@@ -782,208 +398,103 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "points": "{c{tGnwzkVR?lCEvBC??VAlCClCEAkA??A}BCkEAkECaD???g@CiECiEEiE?c@?o@?]Aa@?w@AoD???YEkEAkECiEA_A??AiCCkECmD???[A_CCiD"
           },
           "mode": "BUS",
-          "onStreetNonTransit": false,
           "pathway": false,
           "realTime": false,
-          "scheduled": true,
-          "serviceDate": {
-            "day": 21,
-            "minMax": false,
-            "month": 10,
-            "sequenceNumber": 20091021,
-            "year": 2009
-          },
+          "route": "Holgate/NW 21st",
+          "routeId": "prt:17",
+          "routeLongName": "Holgate/NW 21st",
+          "routeShortName": "17",
+          "serviceDate": "2009-10-21",
           "startTime": "2009-10-21T23:20:25.000+00:00",
-          "streetNotes": [ ],
+          "steps": [ ],
           "to": {
-            "coordinate": {
-              "latitude": 45.525112,
-              "longitude": -122.677664
-            },
+            "arrival": "2009-10-21T23:30:00.000+00:00",
+            "departure": "2009-10-21T23:30:00.000+00:00",
+            "lat": 45.525112,
+            "lon": -122.677664,
             "name": "NW Everett & Broadway",
-            "stop": {
-              "code": "1606",
-              "coordinate": {
-                "latitude": 45.525112,
-                "longitude": -122.677664
-              },
-              "description": "Eastbound stop in Portland (Stop ID 1606)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "0"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "1606"
-              },
-              "name": "NW Everett & Broadway",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "1606",
+            "stopId": "prt:1606",
             "stopIndex": 22,
             "stopSequence": 23,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
           },
-          "transitAlerts": [ ],
           "transitLeg": true,
-          "trip": {
-            "alteration": "PLANNED",
-            "bikesAllowed": "UNKNOWN",
-            "blockId": "1716",
-            "direction": "OUTBOUND",
-            "id": {
-              "feedId": "prt",
-              "id": "170W1460"
-            },
-            "route": {
-              "agency": {
-                "fareUrl": "http://trimet.org/fares/index.htm",
-                "id": {
-                  "feedId": "prt",
-                  "id": "prt"
-                },
-                "lang": "en",
-                "name": "TriMet",
-                "phone": "503-238-7433",
-                "timezone": "America/Los_Angeles",
-                "url": "http://trimet.org"
-              },
-              "bikesAllowed": "UNKNOWN",
-              "gtfsType": 3,
-              "id": {
-                "feedId": "prt",
-                "id": "17"
-              },
-              "longName": "Holgate/NW 21st",
-              "mode": "BUS",
-              "shortName": "17",
-              "sortOrder": -999,
-              "sortOrderSet": false,
-              "url": "http://trimet.org/schedules/r017.htm"
-            },
-            "serviceId": {
-              "feedId": "prt",
-              "id": "W"
-            },
-            "shapeId": {
-              "feedId": "prt",
-              "id": "17.0.13"
-            },
-            "wheelchairAccessible": 0
-          },
-          "walkSteps": [ ],
-          "walkingLeg": false
+          "tripBlockId": "1716",
+          "tripId": "prt:170W1460"
         },
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 188.35399999999998,
+          "distance": 188.35399999999998,
           "endTime": "2009-10-21T23:32:24.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.525112,
-              "longitude": -122.677664
-            },
+            "arrival": "2009-10-21T23:30:00.000+00:00",
+            "departure": "2009-10-21T23:30:00.000+00:00",
+            "lat": 45.525112,
+            "lon": -122.677664,
             "name": "NW Everett & Broadway",
-            "stop": {
-              "code": "1606",
-              "coordinate": {
-                "latitude": 45.525112,
-                "longitude": -122.677664
-              },
-              "description": "Eastbound stop in Portland (Stop ID 1606)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "0"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "1606"
-              },
-              "name": "NW Everett & Broadway",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "1606",
+            "stopId": "prt:1606",
             "stopIndex": 22,
             "stopSequence": 23,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
           },
           "generalizedCost": 285,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 15,
             "points": "}rztGlnwkVM??C?[?SC_D?M?E?MCgD?A?O?C?M?a@"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-10-21T23:30:00.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.52523,
-              "longitude": -122.67525
-            },
-            "name": "NW Everett St. & NW 5th Ave. (P3)",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "EAST",
-              "angle": 1.5470481318922238,
               "area": false,
               "bogusName": false,
               "distance": 188.35399999999998,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.52518265861028,
+              "lon": -122.6776666369647,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.52518265861028,
-                "longitude": -122.6776666369647
-              },
               "stayOn": false,
-              "streetName": "Northwest Everett Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Everett Street"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
+          "to": {
+            "arrival": "2009-10-21T23:32:24.000+00:00",
+            "lat": 45.52523,
+            "lon": -122.67525,
+            "name": "NW Everett St. & NW 5th Ave. (P3)",
+            "vertexType": "NORMAL"
+          },
+          "transitLeg": false,
+          "walkingBike": false
         }
       ],
-      "nTransfers": 0,
-      "nonTransitDistanceMeters": 817.8299999999999,
-      "nonTransitTimeSeconds": 474,
-      "onStreetAllTheWay": false,
-      "streetOnly": false,
-      "systemNotices": [ ],
+      "startTime": "2009-10-21T23:14:55.000+00:00",
       "tooSloped": false,
-      "transferPriorityCost": 0,
-      "transitTimeSeconds": 575,
-      "waitTimeOptimizedCost": 0,
-      "waitingTimeSeconds": 0,
-      "walkOnly": false,
-      "walkingAllTheWay": false
+      "transfers": 0,
+      "transitTime": 575,
+      "waitingTime": 0,
+      "walkDistance": 817.8299999999999,
+      "walkLimitExceeded": false,
+      "walkTime": 474
     },
     {
-      "arrivedAtDestinationWithRentedVehicle": false,
-      "durationSeconds": 1281,
+      "arrivedAtDestinationWithRentedBicycle": false,
+      "duration": 1281,
       "elevationGained": 0.0,
       "elevationLost": 0.0,
+      "endTime": "2009-10-21T23:37:54.000+00:00",
       "fare": {
         "details": {
           "regular": [
@@ -1016,502 +527,240 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
           }
         }
       },
-      "flaggedForDeletion": false,
       "generalizedCost": 2577,
       "legs": [
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 565.958,
+          "distance": 565.958,
           "endTime": "2009-10-21T23:23:59.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.52832,
-              "longitude": -122.70059
-            },
+            "departure": "2009-10-21T23:16:33.000+00:00",
+            "lat": 45.52832,
+            "lon": -122.70059,
             "name": "SW Johnson St. & NW 24th Ave. (P1)",
             "vertexType": "NORMAL"
           },
           "generalizedCost": 865,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 34,
             "points": "}f{tGv}{kVjCAjCEnCCFCFErACj@CLMHGFJLNNNDBDBDBF@FBLBH@FBDBNHNJLDPLb@Z^XPNNTBQT{ARJEP"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-10-21T23:16:33.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.523773,
-              "longitude": -122.700988
-            },
-            "name": "W Burnside & SW Osage",
-            "stop": {
-              "code": "9354",
-              "coordinate": {
-                "latitude": 45.523773,
-                "longitude": -122.700988
-              },
-              "description": "Eastbound stop in Portland (Stop ID 9354)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "9354"
-              },
-              "name": "W Burnside & SW Osage",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
-            "stopIndex": 36,
-            "stopSequence": 37,
-            "vertexType": "TRANSIT"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "SOUTH",
-              "angle": 3.1263917767722313,
               "area": false,
               "bogusName": false,
               "distance": 317.401,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.52831993266165,
+              "lon": -122.70059632295107,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.52831993266165,
-                "longitude": -122.70059632295107
-              },
               "stayOn": false,
-              "streetName": "Northwest 24th Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 24th Avenue"
             },
             {
               "absoluteDirection": "SOUTHEAST",
-              "angle": 2.5526330127940713,
               "area": false,
               "bogusName": false,
               "distance": 15.262,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.525472400000005,
+              "lon": -122.7004445,
               "relativeDirection": "SLIGHTLY_LEFT",
-              "startLocation": {
-                "latitude": 45.525472400000005,
-                "longitude": -122.7004445
-              },
               "stayOn": false,
-              "streetName": "Northwest Westover Road",
-              "streetNotes": [ ]
+              "streetName": "Northwest Westover Road"
             },
             {
               "absoluteDirection": "SOUTHWEST",
-              "angle": -2.444809332621762,
               "area": false,
               "bogusName": false,
               "distance": 176.41,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5253583,
+              "lon": -122.70033570000001,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5253583,
-                "longitude": -122.70033570000001
-              },
               "stayOn": false,
-              "streetName": "Northwest 24th Place",
-              "streetNotes": [ ]
+              "streetName": "Northwest 24th Place"
             },
             {
               "absoluteDirection": "EAST",
-              "angle": 1.8983573391990143,
               "area": false,
               "bogusName": false,
               "distance": 45.172,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5239733,
+              "lon": -122.701384,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.5239733,
-                "longitude": -122.701384
-              },
               "stayOn": false,
-              "streetName": "West Burnside Street",
-              "streetNotes": [ ]
+              "streetName": "West Burnside Street"
             },
             {
               "absoluteDirection": "SOUTHWEST",
-              "angle": -2.7486456202400182,
               "area": false,
               "bogusName": true,
               "distance": 11.713,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5238426,
+              "lon": -122.70083500000001,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5238426,
-                "longitude": -122.70083500000001
-              },
               "stayOn": false,
-              "streetName": "way 113897002 from 7",
-              "streetNotes": [ ]
+              "streetName": "way 113897002 from 7"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
-        },
-        {
-          "agencyTimeZoneOffset": 0,
-          "arrivalDelay": 0,
-          "departureDelay": 0,
-          "distanceMeters": 1879.0379409561187,
-          "endTime": "2009-10-21T23:32:52.000+00:00",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.523773,
-              "longitude": -122.700988
-            },
+          "to": {
+            "arrival": "2009-10-21T23:23:59.000+00:00",
+            "departure": "2009-10-21T23:23:59.000+00:00",
+            "lat": 45.523773,
+            "lon": -122.700988,
             "name": "W Burnside & SW Osage",
-            "stop": {
-              "code": "9354",
-              "coordinate": {
-                "latitude": 45.523773,
-                "longitude": -122.700988
-              },
-              "description": "Eastbound stop in Portland (Stop ID 9354)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "9354"
-              },
-              "name": "W Burnside & SW Osage",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "9354",
+            "stopId": "prt:9354",
             "stopIndex": 36,
             "stopSequence": 37,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "transitLeg": false,
+          "walkingBike": false
+        },
+        {
+          "agencyId": "prt:prt",
+          "agencyName": "TriMet",
+          "agencyTimeZoneOffset": 0,
+          "agencyUrl": "http://trimet.org",
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 1879.0379409561187,
+          "endTime": "2009-10-21T23:32:52.000+00:00",
+          "from": {
+            "arrival": "2009-10-21T23:23:59.000+00:00",
+            "departure": "2009-10-21T23:23:59.000+00:00",
+            "lat": 45.523773,
+            "lon": -122.700988,
+            "name": "W Burnside & SW Osage",
+            "stopCode": "9354",
+            "stopId": "prt:9354",
+            "stopIndex": 36,
+            "stopSequence": 37,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
           "generalizedCost": 1133,
           "headsign": "Gresham TC",
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "intermediateStops": [
             {
               "arrival": "2009-10-21T23:24:42.000+00:00",
               "departure": "2009-10-21T23:24:42.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523287,
-                  "longitude": -122.696995
-                },
-                "name": "W Burnside & SW St Clair",
-                "stop": {
-                  "code": "718",
-                  "coordinate": {
-                    "latitude": 45.523287,
-                    "longitude": -122.696995
-                  },
-                  "description": "Eastbound stop in Portland (Stop ID 718)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "718"
-                  },
-                  "name": "W Burnside & SW St Clair",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 37,
-                "stopSequence": 38,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523287,
+              "lon": -122.696995,
+              "name": "W Burnside & SW St Clair",
+              "stopCode": "718",
+              "stopId": "prt:718",
+              "stopIndex": 37,
+              "stopSequence": 38,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:25:10.000+00:00",
               "departure": "2009-10-21T23:25:10.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523106,
-                  "longitude": -122.69445
-                },
-                "name": "W Burnside & SW 21st",
-                "stop": {
-                  "code": "749",
-                  "coordinate": {
-                    "latitude": 45.523106,
-                    "longitude": -122.69445
-                  },
-                  "description": "Eastbound stop in Portland (Stop ID 749)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "749"
-                  },
-                  "name": "W Burnside & SW 21st",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 38,
-                "stopSequence": 39,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523106,
+              "lon": -122.69445,
+              "name": "W Burnside & SW 21st",
+              "stopCode": "749",
+              "stopId": "prt:749",
+              "stopIndex": 38,
+              "stopSequence": 39,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:25:30.000+00:00",
               "departure": "2009-10-21T23:25:30.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523089,
-                  "longitude": -122.692567
-                },
-                "name": "W Burnside & SW 20th",
-                "stop": {
-                  "code": "8511",
-                  "coordinate": {
-                    "latitude": 45.523089,
-                    "longitude": -122.692567
-                  },
-                  "description": "Eastbound stop in Portland (Stop ID 8511)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "8511"
-                  },
-                  "name": "W Burnside & SW 20th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 39,
-                "stopSequence": 40,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523089,
+              "lon": -122.692567,
+              "name": "W Burnside & SW 20th",
+              "stopCode": "8511",
+              "stopId": "prt:8511",
+              "stopIndex": 39,
+              "stopSequence": 40,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:26:00.000+00:00",
               "departure": "2009-10-21T23:26:00.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.522942,
-                  "longitude": -122.689797
-                },
-                "name": "W Burnside & SW 18th",
-                "stop": {
-                  "code": "9860",
-                  "coordinate": {
-                    "latitude": 45.522942,
-                    "longitude": -122.689797
-                  },
-                  "description": "Eastbound stop in Portland (Stop ID 9860)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "9860"
-                  },
-                  "name": "W Burnside & SW 18th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 40,
-                "stopSequence": 41,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.522942,
+              "lon": -122.689797,
+              "name": "W Burnside & SW 18th",
+              "stopCode": "9860",
+              "stopId": "prt:9860",
+              "stopIndex": 40,
+              "stopSequence": 41,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:27:40.000+00:00",
               "departure": "2009-10-21T23:27:40.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.522786,
-                  "longitude": -122.686682
-                },
-                "name": "W Burnside & SW 15th",
-                "stop": {
-                  "code": "725",
-                  "coordinate": {
-                    "latitude": 45.522786,
-                    "longitude": -122.686682
-                  },
-                  "description": "Eastbound stop in Portland (Stop ID 725)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "725"
-                  },
-                  "name": "W Burnside & SW 15th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 41,
-                "stopSequence": 42,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.522786,
+              "lon": -122.686682,
+              "name": "W Burnside & SW 15th",
+              "stopCode": "725",
+              "stopId": "prt:725",
+              "stopIndex": 41,
+              "stopSequence": 42,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:28:53.000+00:00",
               "departure": "2009-10-21T23:28:53.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.522829,
-                  "longitude": -122.68439
-                },
-                "name": "W Burnside & SW 13th",
-                "stop": {
-                  "code": "723",
-                  "coordinate": {
-                    "latitude": 45.522829,
-                    "longitude": -122.68439
-                  },
-                  "description": "Eastbound stop in Portland (Stop ID 723)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "723"
-                  },
-                  "name": "W Burnside & SW 13th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 42,
-                "stopSequence": 43,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.522829,
+              "lon": -122.68439,
+              "name": "W Burnside & SW 13th",
+              "stopCode": "723",
+              "stopId": "prt:723",
+              "stopIndex": 42,
+              "stopSequence": 43,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-10-21T23:30:31.000+00:00",
               "departure": "2009-10-21T23:30:31.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.522919,
-                  "longitude": -122.681327
-                },
-                "name": "W Burnside & SW 10th",
-                "stop": {
-                  "code": "10792",
-                  "coordinate": {
-                    "latitude": 45.522919,
-                    "longitude": -122.681327
-                  },
-                  "description": "Eastbound stop in Portland (Stop ID 10792)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "10792"
-                  },
-                  "name": "W Burnside & SW 10th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 43,
-                "stopSequence": 44,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.522919,
+              "lon": -122.681327,
+              "name": "W Burnside & SW 10th",
+              "stopCode": "10792",
+              "stopId": "prt:10792",
+              "stopIndex": 43,
+              "stopSequence": 44,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-10-21T23:32:01.000+00:00",
               "departure": "2009-10-21T23:32:01.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.522977,
-                  "longitude": -122.678526
-                },
-                "name": "W Burnside & SW 8th",
-                "stop": {
-                  "code": "715",
-                  "coordinate": {
-                    "latitude": 45.522977,
-                    "longitude": -122.678526
-                  },
-                  "description": "Eastbound stop in Portland (Stop ID 715)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "715"
-                  },
-                  "name": "W Burnside & SW 8th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 44,
-                "stopSequence": 45,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.522977,
+              "lon": -122.678526,
+              "name": "W Burnside & SW 8th",
+              "stopCode": "715",
+              "stopId": "prt:715",
+              "stopIndex": 44,
+              "stopSequence": 45,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             }
           ],
           "legGeometry": {
@@ -1519,259 +768,139 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "points": "gkztGz_|kVTmALiBt@mJJ_DBoA??@e@D}AFyDBgADwB??@]BaADgCDmC??By@FiEJoEBuA??DsBD}BBiADmC@y@AiB???Y?g@As@?_@?YAeB@uD???{@G{D?mECeBAu@??Ai@CoEASAuDAmB???MCqEA_B"
           },
           "mode": "BUS",
-          "onStreetNonTransit": false,
           "pathway": false,
           "realTime": false,
-          "scheduled": true,
-          "serviceDate": {
-            "day": 21,
-            "minMax": false,
-            "month": 10,
-            "sequenceNumber": 20091021,
-            "year": 2009
-          },
+          "route": "Burnside/Stark",
+          "routeId": "prt:20",
+          "routeLongName": "Burnside/Stark",
+          "routeShortName": "20",
+          "serviceDate": "2009-10-21",
           "startTime": "2009-10-21T23:23:59.000+00:00",
-          "streetNotes": [ ],
+          "steps": [ ],
           "to": {
-            "coordinate": {
-              "latitude": 45.522961,
-              "longitude": -122.676924
-            },
+            "arrival": "2009-10-21T23:32:52.000+00:00",
+            "departure": "2009-10-21T23:32:52.000+00:00",
+            "lat": 45.522961,
+            "lon": -122.676924,
             "name": "W Burnside & SW 6th",
-            "stop": {
-              "code": "792",
-              "coordinate": {
-                "latitude": 45.522961,
-                "longitude": -122.676924
-              },
-              "description": "Eastbound stop in Portland (Stop ID 792)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "0"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "792"
-              },
-              "name": "W Burnside & SW 6th",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "792",
+            "stopId": "prt:792",
             "stopIndex": 45,
             "stopSequence": 46,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
           },
-          "transitAlerts": [ ],
           "transitLeg": true,
-          "trip": {
-            "alteration": "PLANNED",
-            "bikesAllowed": "UNKNOWN",
-            "blockId": "1237",
-            "direction": "INBOUND",
-            "id": {
-              "feedId": "prt",
-              "id": "201W1450"
-            },
-            "route": {
-              "agency": {
-                "fareUrl": "http://trimet.org/fares/index.htm",
-                "id": {
-                  "feedId": "prt",
-                  "id": "prt"
-                },
-                "lang": "en",
-                "name": "TriMet",
-                "phone": "503-238-7433",
-                "timezone": "America/Los_Angeles",
-                "url": "http://trimet.org"
-              },
-              "bikesAllowed": "UNKNOWN",
-              "gtfsType": 3,
-              "id": {
-                "feedId": "prt",
-                "id": "20"
-              },
-              "longName": "Burnside/Stark",
-              "mode": "BUS",
-              "shortName": "20",
-              "sortOrder": -999,
-              "sortOrderSet": false,
-              "url": "http://trimet.org/schedules/r020.htm"
-            },
-            "serviceId": {
-              "feedId": "prt",
-              "id": "W"
-            },
-            "shapeId": {
-              "feedId": "prt",
-              "id": "20.1.3"
-            },
-            "wheelchairAccessible": 0
-          },
-          "walkSteps": [ ],
-          "walkingLeg": false
+          "tripBlockId": "1237",
+          "tripId": "prt:201W1450"
         },
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 379.27700000000004,
+          "distance": 379.27700000000004,
           "endTime": "2009-10-21T23:37:54.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.522961,
-              "longitude": -122.676924
-            },
+            "arrival": "2009-10-21T23:32:52.000+00:00",
+            "departure": "2009-10-21T23:32:52.000+00:00",
+            "lat": 45.522961,
+            "lon": -122.676924,
             "name": "W Burnside & SW 6th",
-            "stop": {
-              "code": "792",
-              "coordinate": {
-                "latitude": 45.522961,
-                "longitude": -122.676924
-              },
-              "description": "Eastbound stop in Portland (Stop ID 792)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "0"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "792"
-              },
-              "name": "W Burnside & SW 6th",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "792",
+            "stopId": "prt:792",
             "stopIndex": 45,
             "stopSequence": 46,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
           },
           "generalizedCost": 579,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 23,
             "points": "oeztGxiwkVE?AgA?OKCKAM?iBBI?K?wBBK?K?sBDM@?E?MCgD?A?O?C?M?a@"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-10-21T23:32:52.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.52523,
-              "longitude": -122.67525
-            },
-            "name": "NW Everett St. & NW 5th Ave. (P3)",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "EAST",
-              "angle": 1.5497787842228707,
               "area": false,
               "bogusName": false,
               "distance": 34.205,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.52299572692338,
+              "lon": -122.67692504190299,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.52299572692338,
-                "longitude": -122.67692504190299
-              },
               "stayOn": false,
-              "streetName": "West Burnside Street",
-              "streetNotes": [ ]
+              "streetName": "West Burnside Street"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": 0.15756873585456135,
               "area": false,
               "bogusName": false,
               "distance": 13.464,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.523002600000005,
+              "lon": -122.6764861,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.523002600000005,
-                "longitude": -122.6764861
-              },
               "stayOn": false,
-              "streetName": "Southwest 6th Avenue",
-              "streetNotes": [ ]
+              "streetName": "Southwest 6th Avenue"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": -0.01751656882715628,
               "area": false,
               "bogusName": false,
               "distance": 231.502,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5231221,
+              "lon": -122.67645900000001,
               "relativeDirection": "CONTINUE",
-              "startLocation": {
-                "latitude": 45.5231221,
-                "longitude": -122.67645900000001
-              },
               "stayOn": false,
-              "streetName": "Northwest 6th Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 6th Avenue"
             },
             {
               "absoluteDirection": "EAST",
-              "angle": 1.5420709297121307,
               "area": false,
               "bogusName": false,
               "distance": 100.106,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.525202900000004,
+              "lon": -122.6765342,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.525202900000004,
-                "longitude": -122.6765342
-              },
               "stayOn": false,
-              "streetName": "Northwest Everett Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Everett Street"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
+          "to": {
+            "arrival": "2009-10-21T23:37:54.000+00:00",
+            "lat": 45.52523,
+            "lon": -122.67525,
+            "name": "NW Everett St. & NW 5th Ave. (P3)",
+            "vertexType": "NORMAL"
+          },
+          "transitLeg": false,
+          "walkingBike": false
         }
       ],
-      "nTransfers": 0,
-      "nonTransitDistanceMeters": 945.235,
-      "nonTransitTimeSeconds": 748,
-      "onStreetAllTheWay": false,
-      "streetOnly": false,
-      "systemNotices": [ ],
+      "startTime": "2009-10-21T23:16:33.000+00:00",
       "tooSloped": false,
-      "transferPriorityCost": 0,
-      "transitTimeSeconds": 533,
-      "waitTimeOptimizedCost": 0,
-      "waitingTimeSeconds": 0,
-      "walkOnly": false,
-      "walkingAllTheWay": false
+      "transfers": 0,
+      "transitTime": 533,
+      "waitingTime": 0,
+      "walkDistance": 945.235,
+      "walkLimitExceeded": false,
+      "walkTime": 748
     },
     {
-      "arrivedAtDestinationWithRentedVehicle": false,
-      "durationSeconds": 1001,
+      "arrivedAtDestinationWithRentedBicycle": false,
+      "duration": 1001,
       "elevationGained": 0.0,
       "elevationLost": 0.0,
+      "endTime": "2009-10-21T23:40:10.000+00:00",
       "fare": {
         "details": {
           "regular": [
@@ -1804,414 +933,191 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
           }
         }
       },
-      "flaggedForDeletion": false,
       "generalizedCost": 1805,
       "legs": [
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 220.14600000000002,
+          "distance": 220.14600000000002,
           "endTime": "2009-10-21T23:26:21.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.52832,
-              "longitude": -122.70059
-            },
+            "departure": "2009-10-21T23:23:29.000+00:00",
+            "lat": 45.52832,
+            "lon": -122.70059,
             "name": "SW Johnson St. & NW 24th Ave. (P1)",
             "vertexType": "NORMAL"
           },
           "generalizedCost": 336,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 6,
             "points": "}f{tGv}{kVC?mCBmCD@zCN?"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-10-21T23:23:29.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.529662,
-              "longitude": -122.701423
-            },
-            "name": "2400 Block NW Lovejoy",
-            "stop": {
-              "code": "3589",
-              "coordinate": {
-                "latitude": 45.529662,
-                "longitude": -122.701423
-              },
-              "description": "Eastbound stop in Portland (Stop ID 3589)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "3589"
-              },
-              "name": "2400 Block NW Lovejoy",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
-            "stopIndex": 6,
-            "stopSequence": 7,
-            "vertexType": "TRANSIT"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "NORTH",
-              "angle": -0.015200780078397704,
               "area": false,
               "bogusName": false,
               "distance": 159.625,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.52831993266165,
+              "lon": -122.70059632295107,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.52831993266165,
-                "longitude": -122.70059632295107
-              },
               "stayOn": false,
-              "streetName": "Northwest 24th Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 24th Avenue"
             },
             {
               "absoluteDirection": "WEST",
-              "angle": -1.5928981885811253,
               "area": false,
               "bogusName": false,
               "distance": 60.521,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.529755,
+              "lon": -122.70064880000001,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.529755,
-                "longitude": -122.70064880000001
-              },
               "stayOn": false,
-              "streetName": "Northwest Lovejoy Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Lovejoy Street"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
-        },
-        {
-          "agencyTimeZoneOffset": 0,
-          "arrivalDelay": 0,
-          "departureDelay": 0,
-          "distanceMeters": 2804.1297859664874,
-          "endTime": "2009-10-21T23:39:32.000+00:00",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.529662,
-              "longitude": -122.701423
-            },
+          "to": {
+            "arrival": "2009-10-21T23:26:21.000+00:00",
+            "departure": "2009-10-21T23:26:21.000+00:00",
+            "lat": 45.529662,
+            "lon": -122.701423,
             "name": "2400 Block NW Lovejoy",
-            "stop": {
-              "code": "3589",
-              "coordinate": {
-                "latitude": 45.529662,
-                "longitude": -122.701423
-              },
-              "description": "Eastbound stop in Portland (Stop ID 3589)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "3589"
-              },
-              "name": "2400 Block NW Lovejoy",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "3589",
+            "stopId": "prt:3589",
             "stopIndex": 6,
             "stopSequence": 7,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "transitLeg": false,
+          "walkingBike": false
+        },
+        {
+          "agencyId": "prt:prt",
+          "agencyName": "TriMet",
+          "agencyTimeZoneOffset": 0,
+          "agencyUrl": "http://trimet.org",
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 2804.1297859664874,
+          "endTime": "2009-10-21T23:39:32.000+00:00",
+          "from": {
+            "arrival": "2009-10-21T23:26:21.000+00:00",
+            "departure": "2009-10-21T23:26:21.000+00:00",
+            "lat": 45.529662,
+            "lon": -122.701423,
+            "name": "2400 Block NW Lovejoy",
+            "stopCode": "3589",
+            "stopId": "prt:3589",
+            "stopIndex": 6,
+            "stopSequence": 7,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
           "generalizedCost": 1391,
           "headsign": "Troutdale",
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "intermediateStops": [
             {
               "arrival": "2009-10-21T23:27:54.000+00:00",
               "departure": "2009-10-21T23:27:54.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.529746,
-                  "longitude": -122.69688
-                },
-                "name": "NW Lovejoy & 22nd",
-                "stop": {
-                  "code": "3596",
-                  "coordinate": {
-                    "latitude": 45.529746,
-                    "longitude": -122.69688
-                  },
-                  "description": "Eastbound stop in Portland (Stop ID 3596)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "3596"
-                  },
-                  "name": "NW Lovejoy & 22nd",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 7,
-                "stopSequence": 8,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.529746,
+              "lon": -122.69688,
+              "name": "NW Lovejoy & 22nd",
+              "stopCode": "3596",
+              "stopId": "prt:3596",
+              "stopIndex": 7,
+              "stopSequence": 8,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:28:39.000+00:00",
               "departure": "2009-10-21T23:28:39.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.529833,
-                  "longitude": -122.694676
-                },
-                "name": "NW Lovejoy & 21st",
-                "stop": {
-                  "code": "3595",
-                  "coordinate": {
-                    "latitude": 45.529833,
-                    "longitude": -122.694676
-                  },
-                  "description": "Eastbound stop in Portland (Stop ID 3595)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "3595"
-                  },
-                  "name": "NW Lovejoy & 21st",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 8,
-                "stopSequence": 9,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.529833,
+              "lon": -122.694676,
+              "name": "NW Lovejoy & 21st",
+              "stopCode": "3595",
+              "stopId": "prt:3595",
+              "stopIndex": 8,
+              "stopSequence": 9,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:30:23.000+00:00",
               "departure": "2009-10-21T23:30:23.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.529925,
-                  "longitude": -122.689587
-                },
-                "name": "NW Lovejoy & 18th",
-                "stop": {
-                  "code": "10751",
-                  "coordinate": {
-                    "latitude": 45.529925,
-                    "longitude": -122.689587
-                  },
-                  "description": "Eastbound stop in Portland (Stop ID 10751)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "10751"
-                  },
-                  "name": "NW Lovejoy & 18th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 9,
-                "stopSequence": 10,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.529925,
+              "lon": -122.689587,
+              "name": "NW Lovejoy & 18th",
+              "stopCode": "10751",
+              "stopId": "prt:10751",
+              "stopIndex": 9,
+              "stopSequence": 10,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:32:05.000+00:00",
               "departure": "2009-10-21T23:32:05.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.529997,
-                  "longitude": -122.684611
-                },
-                "name": "NW Lovejoy & 13th",
-                "stop": {
-                  "code": "10752",
-                  "coordinate": {
-                    "latitude": 45.529997,
-                    "longitude": -122.684611
-                  },
-                  "description": "Eastbound stop in Portland (Stop ID 10752)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "10752"
-                  },
-                  "name": "NW Lovejoy & 13th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 10,
-                "stopSequence": 11,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.529997,
+              "lon": -122.684611,
+              "name": "NW Lovejoy & 13th",
+              "stopCode": "10752",
+              "stopId": "prt:10752",
+              "stopIndex": 10,
+              "stopSequence": 11,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:33:07.000+00:00",
               "departure": "2009-10-21T23:33:07.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.530034,
-                  "longitude": -122.68155
-                },
-                "name": "NW Lovejoy & 10th",
-                "stop": {
-                  "code": "11000",
-                  "coordinate": {
-                    "latitude": 45.530034,
-                    "longitude": -122.68155
-                  },
-                  "description": "Eastbound stop in Portland (Stop ID 11000)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "11000"
-                  },
-                  "name": "NW Lovejoy & 10th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 11,
-                "stopSequence": 12,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.530034,
+              "lon": -122.68155,
+              "name": "NW Lovejoy & 10th",
+              "stopCode": "11000",
+              "stopId": "prt:11000",
+              "stopIndex": 11,
+              "stopSequence": 12,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:34:00.000+00:00",
               "departure": "2009-10-21T23:34:00.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.531086,
-                  "longitude": -122.680302
-                },
-                "name": "NW 9th & Marshall",
-                "stop": {
-                  "code": "12803",
-                  "coordinate": {
-                    "latitude": 45.531086,
-                    "longitude": -122.680302
-                  },
-                  "description": "Northbound stop in Portland (Stop ID 12803)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "12803"
-                  },
-                  "name": "NW 9th & Marshall",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 12,
-                "stopSequence": 13,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.531086,
+              "lon": -122.680302,
+              "name": "NW 9th & Marshall",
+              "stopCode": "12803",
+              "stopId": "prt:12803",
+              "stopIndex": 12,
+              "stopSequence": 13,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:36:50.000+00:00",
               "departure": "2009-10-21T23:36:50.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.528405,
-                  "longitude": -122.676979
-                },
-                "name": "NW Station Way & Union Station",
-                "stop": {
-                  "code": "12804",
-                  "coordinate": {
-                    "latitude": 45.528405,
-                    "longitude": -122.676979
-                  },
-                  "description": "Southbound stop in Portland (Stop ID 12804)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "12804"
-                  },
-                  "name": "NW Station Way & Union Station",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 13,
-                "stopSequence": 14,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.528405,
+              "lon": -122.676979,
+              "name": "NW Station Way & Union Station",
+              "stopCode": "12804",
+              "stopId": "prt:12804",
+              "stopIndex": 13,
+              "stopSequence": 14,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             }
           ],
           "legGeometry": {
@@ -2219,208 +1125,103 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "points": "yo{tG|b|kVC}CEuKGwI???}@G{J???YGsKEuKCuD???UCiECeEAgA?{@AkA?WAwDE{C???i@CiECkECcD??Ae@?mE{BDQ@q@@??{ADCsDbBiB`DaEt@_AVANIX?tBCLK`@c@\\c@l@w@??\\c@FKDCFEXCCgEvBEVAlCClCEnCECoD"
           },
           "mode": "BUS",
-          "onStreetNonTransit": false,
           "pathway": false,
           "realTime": false,
-          "scheduled": true,
-          "serviceDate": {
-            "day": 21,
-            "minMax": false,
-            "month": 10,
-            "sequenceNumber": 20091021,
-            "year": 2009
-          },
+          "route": "Broadway/Halsey",
+          "routeId": "prt:77",
+          "routeLongName": "Broadway/Halsey",
+          "routeShortName": "77",
+          "serviceDate": "2009-10-21",
           "startTime": "2009-10-21T23:26:21.000+00:00",
-          "streetNotes": [ ],
+          "steps": [ ],
           "to": {
-            "coordinate": {
-              "latitude": 45.525183,
-              "longitude": -122.674607
-            },
+            "arrival": "2009-10-21T23:39:32.000+00:00",
+            "departure": "2009-10-21T23:39:32.000+00:00",
+            "lat": 45.525183,
+            "lon": -122.674607,
             "name": "NW Everett & 4th",
-            "stop": {
-              "code": "9546",
-              "coordinate": {
-                "latitude": 45.525183,
-                "longitude": -122.674607
-              },
-              "description": "Eastbound stop in Portland (Stop ID 9546)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "0"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "9546"
-              },
-              "name": "NW Everett & 4th",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "9546",
+            "stopId": "prt:9546",
             "stopIndex": 14,
             "stopSequence": 15,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
           },
-          "transitAlerts": [ ],
           "transitLeg": true,
-          "trip": {
-            "alteration": "PLANNED",
-            "bikesAllowed": "UNKNOWN",
-            "blockId": "7701",
-            "direction": "OUTBOUND",
-            "id": {
-              "feedId": "prt",
-              "id": "770W1390"
-            },
-            "route": {
-              "agency": {
-                "fareUrl": "http://trimet.org/fares/index.htm",
-                "id": {
-                  "feedId": "prt",
-                  "id": "prt"
-                },
-                "lang": "en",
-                "name": "TriMet",
-                "phone": "503-238-7433",
-                "timezone": "America/Los_Angeles",
-                "url": "http://trimet.org"
-              },
-              "bikesAllowed": "UNKNOWN",
-              "gtfsType": 3,
-              "id": {
-                "feedId": "prt",
-                "id": "77"
-              },
-              "longName": "Broadway/Halsey",
-              "mode": "BUS",
-              "shortName": "77",
-              "sortOrder": -999,
-              "sortOrderSet": false,
-              "url": "http://trimet.org/schedules/r077.htm"
-            },
-            "serviceId": {
-              "feedId": "prt",
-              "id": "W"
-            },
-            "shapeId": {
-              "feedId": "prt",
-              "id": "77.0.2"
-            },
-            "wheelchairAccessible": 0
-          },
-          "walkSteps": [ ],
-          "walkingLeg": false
+          "tripBlockId": "7701",
+          "tripId": "prt:770W1390"
         },
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 49.938,
+          "distance": 49.938,
           "endTime": "2009-10-21T23:40:10.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.525183,
-              "longitude": -122.674607
-            },
+            "arrival": "2009-10-21T23:39:32.000+00:00",
+            "departure": "2009-10-21T23:39:32.000+00:00",
+            "lat": 45.525183,
+            "lon": -122.674607,
             "name": "NW Everett & 4th",
-            "stop": {
-              "code": "9546",
-              "coordinate": {
-                "latitude": 45.525183,
-                "longitude": -122.674607
-              },
-              "description": "Eastbound stop in Portland (Stop ID 9546)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "0"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "9546"
-              },
-              "name": "NW Everett & 4th",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "9546",
+            "stopId": "prt:9546",
             "stopIndex": 14,
             "stopSequence": 15,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
           },
           "generalizedCost": 77,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 3,
             "points": "ksztGh{vkVI?@~B"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-10-21T23:39:32.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.52523,
-              "longitude": -122.67525
-            },
-            "name": "NW Everett St. & NW 5th Ave. (P3)",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "WEST",
-              "angle": -1.5968688222706109,
               "area": false,
               "bogusName": false,
               "distance": 49.938,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.525239650875925,
+              "lon": -122.67460910872424,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.525239650875925,
-                "longitude": -122.67460910872424
-              },
               "stayOn": false,
-              "streetName": "Northwest Everett Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Everett Street"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
+          "to": {
+            "arrival": "2009-10-21T23:40:10.000+00:00",
+            "lat": 45.52523,
+            "lon": -122.67525,
+            "name": "NW Everett St. & NW 5th Ave. (P3)",
+            "vertexType": "NORMAL"
+          },
+          "transitLeg": false,
+          "walkingBike": false
         }
       ],
-      "nTransfers": 0,
-      "nonTransitDistanceMeters": 270.084,
-      "nonTransitTimeSeconds": 210,
-      "onStreetAllTheWay": false,
-      "streetOnly": false,
-      "systemNotices": [ ],
+      "startTime": "2009-10-21T23:23:29.000+00:00",
       "tooSloped": false,
-      "transferPriorityCost": 0,
-      "transitTimeSeconds": 791,
-      "waitTimeOptimizedCost": 0,
-      "waitingTimeSeconds": 0,
-      "walkOnly": false,
-      "walkingAllTheWay": false
+      "transfers": 0,
+      "transitTime": 791,
+      "waitingTime": 0,
+      "walkDistance": 270.084,
+      "walkLimitExceeded": false,
+      "walkTime": 210
     },
     {
-      "arrivedAtDestinationWithRentedVehicle": false,
-      "durationSeconds": 1049,
+      "arrivedAtDestinationWithRentedBicycle": false,
+      "duration": 1049,
       "elevationGained": 0.0,
       "elevationLost": 0.0,
+      "endTime": "2009-10-21T23:45:24.000+00:00",
       "fare": {
         "details": {
           "regular": [
@@ -2453,744 +1254,359 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
           }
         }
       },
-      "flaggedForDeletion": false,
       "generalizedCost": 2087,
       "legs": [
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 106.589,
+          "distance": 106.589,
           "endTime": "2009-10-21T23:30:26.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.52832,
-              "longitude": -122.70059
-            },
+            "departure": "2009-10-21T23:27:55.000+00:00",
+            "lat": 45.52832,
+            "lon": -122.70059,
             "name": "SW Johnson St. & NW 24th Ave. (P1)",
             "vertexType": "NORMAL"
           },
           "generalizedCost": 288,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 4,
             "points": "}f{tGv}{kVjCA?e@WA"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-10-21T23:27:55.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.5277374,
-              "longitude": -122.7003879
-            },
-            "name": "-102309",
-            "vehicleRentalPlace": {
-              "allowDropoff": true,
-              "allowOverloading": false,
-              "allowPickup": true,
-              "carStation": false,
-              "floatingVehicle": false,
-              "id": {
-                "feedId": "test-network",
-                "id": "-102309"
-              },
-              "isInstalled": true,
-              "isKeepingVehicleRentalAtDestinationAllowed": true,
-              "isRenting": true,
-              "isReturning": true,
-              "isValetStation": false,
-              "isVirtualStation": false,
-              "keepingVehicleRentalAtDestinationAllowed": true,
-              "latitude": 45.5277374,
-              "longitude": -122.7003879,
-              "name": {
-                "name": "-102309"
-              },
-              "realTimeData": false,
-              "spacesAvailable": 0,
-              "spacesDisabled": 0,
-              "vehicleSpacesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehicleTypesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehiclesAvailable": 0,
-              "vehiclesDisabled": 0
-            },
-            "vertexType": "VEHICLERENTAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "SOUTH",
-              "angle": 3.1263917767722313,
               "area": false,
               "bogusName": false,
               "distance": 78.527,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.52831993266165,
+              "lon": -122.70059632295107,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.52831993266165,
-                "longitude": -122.70059632295107
-              },
               "stayOn": false,
-              "streetName": "Northwest 24th Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 24th Avenue"
             },
             {
               "absoluteDirection": "EAST",
-              "angle": 1.5443268101828453,
               "area": false,
               "bogusName": false,
               "distance": 14.704,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.527613800000005,
+              "lon": -122.70058100000001,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.527613800000005,
-                "longitude": -122.70058100000001
-              },
               "stayOn": false,
-              "streetName": "Northwest Irving Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Irving Street"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": 0.02566034822056683,
               "area": false,
               "bogusName": true,
               "distance": 13.358,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5276173,
+              "lon": -122.7003923,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.5276173,
-                "longitude": -122.7003923
-              },
               "stayOn": false,
-              "streetName": "way -102328 from 0",
-              "streetNotes": [ ],
-              "vehicleRentalOnStation": {
-                "id": "-102309",
-                "lat": 45.5277374,
-                "lon": -122.7003879,
-                "name": "-102309"
-              }
+              "streetName": "way -102328 from 0"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
+          "to": {
+            "arrival": "2009-10-21T23:30:26.000+00:00",
+            "bikeShareId": "-102309",
+            "departure": "2009-10-21T23:30:26.000+00:00",
+            "lat": 45.5277374,
+            "lon": -122.7003879,
+            "name": "-102309",
+            "vertexType": "BIKESHARE"
+          },
+          "transitLeg": false,
+          "walkingBike": false
         },
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 13.358,
+          "distance": 13.358,
           "endTime": "2009-10-21T23:30:37.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.5277374,
-              "longitude": -122.7003879
-            },
+            "arrival": "2009-10-21T23:30:26.000+00:00",
+            "bikeShareId": "-102309",
+            "departure": "2009-10-21T23:30:26.000+00:00",
+            "lat": 45.5277374,
+            "lon": -122.7003879,
             "name": "-102309",
-            "vehicleRentalPlace": {
-              "allowDropoff": true,
-              "allowOverloading": false,
-              "allowPickup": true,
-              "carStation": false,
-              "floatingVehicle": false,
-              "id": {
-                "feedId": "test-network",
-                "id": "-102309"
-              },
-              "isInstalled": true,
-              "isKeepingVehicleRentalAtDestinationAllowed": true,
-              "isRenting": true,
-              "isReturning": true,
-              "isValetStation": false,
-              "isVirtualStation": false,
-              "keepingVehicleRentalAtDestinationAllowed": true,
-              "latitude": 45.5277374,
-              "longitude": -122.7003879,
-              "name": {
-                "name": "-102309"
-              },
-              "realTimeData": false,
-              "spacesAvailable": 0,
-              "spacesDisabled": 0,
-              "vehicleSpacesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehicleTypesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehiclesAvailable": 0,
-              "vehiclesDisabled": 0
-            },
-            "vertexType": "VEHICLERENTAL"
+            "vertexType": "BIKESHARE"
           },
           "generalizedCost": 51,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 2,
             "points": "ic{tGl|{kVV@"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": true,
-          "scheduled": false,
+          "rentedBike": true,
+          "route": "",
           "startTime": "2009-10-21T23:30:26.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.5276173,
-              "longitude": -122.7003923
-            },
-            "name": "corner of way -102328 from 0 and Northwest Irving Street",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "vehicleRentalNetwork": "test-network",
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "SOUTH",
-              "angle": -3.1159323053692263,
               "area": false,
               "bogusName": true,
               "distance": 13.358,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5277374,
+              "lon": -122.70038790000001,
               "relativeDirection": "HARD_LEFT",
-              "startLocation": {
-                "latitude": 45.5277374,
-                "longitude": -122.70038790000001
-              },
               "stayOn": false,
-              "streetName": "way -102328 from 0",
-              "streetNotes": [ ]
+              "streetName": "way -102328 from 0"
             }
           ],
-          "walkingBike": true,
-          "walkingLeg": true
+          "to": {
+            "arrival": "2009-10-21T23:30:37.000+00:00",
+            "departure": "2009-10-21T23:30:37.000+00:00",
+            "lat": 45.5276173,
+            "lon": -122.7003923,
+            "name": "corner of way -102328 from 0 and Northwest Irving Street",
+            "vertexType": "NORMAL"
+          },
+          "transitLeg": false,
+          "walkingBike": true
         },
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 480.068,
+          "distance": 480.068,
           "endTime": "2009-10-21T23:32:58.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.5276173,
-              "longitude": -122.7003923
-            },
+            "arrival": "2009-10-21T23:30:37.000+00:00",
+            "departure": "2009-10-21T23:30:37.000+00:00",
+            "lat": 45.5276173,
+            "lon": -122.7003923,
             "name": "corner of way -102328 from 0 and Northwest Irving Street",
             "vertexType": "NORMAL"
           },
           "generalizedCost": 236,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 6,
             "points": "qb{tGn|{kVGsJEuKE}HAwAAo@"
           },
           "mode": "BICYCLE",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": true,
-          "scheduled": false,
+          "rentedBike": true,
+          "route": "",
           "startTime": "2009-10-21T23:30:37.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.5278491,
-              "longitude": -122.6942362
-            },
-            "name": "-102323",
-            "vehicleRentalPlace": {
-              "allowDropoff": true,
-              "allowOverloading": false,
-              "allowPickup": true,
-              "carStation": false,
-              "floatingVehicle": false,
-              "id": {
-                "feedId": "test-network",
-                "id": "-102323"
-              },
-              "isInstalled": true,
-              "isKeepingVehicleRentalAtDestinationAllowed": true,
-              "isRenting": true,
-              "isReturning": true,
-              "isValetStation": false,
-              "isVirtualStation": false,
-              "keepingVehicleRentalAtDestinationAllowed": true,
-              "latitude": 45.5278491,
-              "longitude": -122.6942362,
-              "name": {
-                "name": "-102323"
-              },
-              "realTimeData": false,
-              "spacesAvailable": 0,
-              "spacesDisabled": 0,
-              "vehicleSpacesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehicleTypesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehiclesAvailable": 0,
-              "vehiclesDisabled": 0
-            },
-            "vertexType": "VEHICLERENTAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "vehicleRentalNetwork": "test-network",
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "EAST",
-              "angle": 1.5441765471733384,
               "area": false,
               "bogusName": false,
               "distance": 480.068,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5276173,
+              "lon": -122.7003923,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.5276173,
-                "longitude": -122.7003923
-              },
               "stayOn": false,
-              "streetName": "Northwest Irving Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Irving Street"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": false
+          "to": {
+            "arrival": "2009-10-21T23:32:58.000+00:00",
+            "bikeShareId": "-102323",
+            "departure": "2009-10-21T23:32:58.000+00:00",
+            "lat": 45.5278491,
+            "lon": -122.6942362,
+            "name": "-102323",
+            "vertexType": "BIKESHARE"
+          },
+          "transitLeg": false,
+          "walkingBike": false
         },
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 29.461000000000002,
+          "distance": 29.461000000000002,
           "endTime": "2009-10-21T23:33:25.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.5278491,
-              "longitude": -122.6942362
-            },
+            "arrival": "2009-10-21T23:32:58.000+00:00",
+            "bikeShareId": "-102323",
+            "departure": "2009-10-21T23:32:58.000+00:00",
+            "lat": 45.5278491,
+            "lon": -122.6942362,
             "name": "-102323",
-            "vehicleRentalPlace": {
-              "allowDropoff": true,
-              "allowOverloading": false,
-              "allowPickup": true,
-              "carStation": false,
-              "floatingVehicle": false,
-              "id": {
-                "feedId": "test-network",
-                "id": "-102323"
-              },
-              "isInstalled": true,
-              "isKeepingVehicleRentalAtDestinationAllowed": true,
-              "isRenting": true,
-              "isReturning": true,
-              "isValetStation": false,
-              "isVirtualStation": false,
-              "keepingVehicleRentalAtDestinationAllowed": true,
-              "latitude": 45.5278491,
-              "longitude": -122.6942362,
-              "name": {
-                "name": "-102323"
-              },
-              "realTimeData": false,
-              "spacesAvailable": 0,
-              "spacesDisabled": 0,
-              "vehicleSpacesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehicleTypesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehiclesAvailable": 0,
-              "vehiclesDisabled": 0
-            },
-            "vertexType": "VEHICLERENTAL"
+            "vertexType": "BIKESHARE"
           },
           "generalizedCost": 49,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 5,
             "points": "ic{tG~uzkV@n@M@C??H"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-10-21T23:32:58.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.527818,
-              "longitude": -122.694539
-            },
-            "name": "NW 21st & Irving",
-            "stop": {
-              "code": "7114",
-              "coordinate": {
-                "latitude": 45.527818,
-                "longitude": -122.694539
-              },
-              "description": "Southbound stop in Portland (Stop ID 7114)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "7114"
-              },
-              "name": "NW 21st & Irving",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
-            "stopIndex": 15,
-            "stopSequence": 16,
-            "vertexType": "TRANSIT"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "WEST",
-              "angle": -1.5973283920844321,
               "area": false,
               "bogusName": false,
               "distance": 19.289,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.52773220198921,
+              "lon": -122.69423177172958,
               "relativeDirection": "HARD_LEFT",
-              "startLocation": {
-                "latitude": 45.52773220198921,
-                "longitude": -122.69423177172958
-              },
               "stayOn": false,
-              "streetName": "Northwest Irving Street",
-              "streetNotes": [ ],
-              "vehicleRentalOffStation": {
-                "id": "-102323",
-                "lat": 45.5278491,
-                "lon": -122.6942362,
-                "name": "-102323"
-              }
+              "streetName": "Northwest Irving Street"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": -0.026543929838500624,
               "area": false,
               "bogusName": false,
               "distance": 10.172,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.527727600000006,
+              "lon": -122.69447930000001,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.527727600000006,
-                "longitude": -122.69447930000001
-              },
               "stayOn": false,
-              "streetName": "Northwest 21st Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 21st Avenue"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
-        },
-        {
-          "agencyTimeZoneOffset": 0,
-          "arrivalDelay": 0,
-          "departureDelay": 0,
-          "distanceMeters": 1629.4275918538026,
-          "endTime": "2009-10-21T23:43:00.000+00:00",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.527818,
-              "longitude": -122.694539
-            },
+          "to": {
+            "arrival": "2009-10-21T23:33:25.000+00:00",
+            "departure": "2009-10-21T23:33:25.000+00:00",
+            "lat": 45.527818,
+            "lon": -122.694539,
             "name": "NW 21st & Irving",
-            "stop": {
-              "code": "7114",
-              "coordinate": {
-                "latitude": 45.527818,
-                "longitude": -122.694539
-              },
-              "description": "Southbound stop in Portland (Stop ID 7114)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "7114"
-              },
-              "name": "NW 21st & Irving",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "7114",
+            "stopId": "prt:7114",
             "stopIndex": 15,
             "stopSequence": 16,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "transitLeg": false,
+          "walkingBike": false
+        },
+        {
+          "agencyId": "prt:prt",
+          "agencyName": "TriMet",
+          "agencyTimeZoneOffset": 0,
+          "agencyUrl": "http://trimet.org",
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 1629.4275918538026,
+          "endTime": "2009-10-21T23:43:00.000+00:00",
+          "from": {
+            "arrival": "2009-10-21T23:33:25.000+00:00",
+            "departure": "2009-10-21T23:33:25.000+00:00",
+            "lat": 45.527818,
+            "lon": -122.694539,
+            "name": "NW 21st & Irving",
+            "stopCode": "7114",
+            "stopId": "prt:7114",
+            "stopIndex": 15,
+            "stopSequence": 16,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
           "generalizedCost": 1175,
           "headsign": "136th Ave",
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "intermediateStops": [
             {
               "arrival": "2009-10-21T23:34:20.000+00:00",
               "departure": "2009-10-21T23:34:20.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.526408,
-                  "longitude": -122.694503
-                },
-                "name": "NW 21st & Glisan",
-                "stop": {
-                  "code": "7112",
-                  "coordinate": {
-                    "latitude": 45.526408,
-                    "longitude": -122.694503
-                  },
-                  "description": "Southbound stop in Portland (Stop ID 7112)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "7112"
-                  },
-                  "name": "NW 21st & Glisan",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 16,
-                "stopSequence": 17,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.526408,
+              "lon": -122.694503,
+              "name": "NW 21st & Glisan",
+              "stopCode": "7112",
+              "stopId": "prt:7112",
+              "stopIndex": 16,
+              "stopSequence": 17,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:35:31.000+00:00",
               "departure": "2009-10-21T23:35:31.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.524833,
-                  "longitude": -122.69398
-                },
-                "name": "NW Everett & 21st",
-                "stop": {
-                  "code": "1615",
-                  "coordinate": {
-                    "latitude": 45.524833,
-                    "longitude": -122.69398
-                  },
-                  "description": "Eastbound stop in Portland (Stop ID 1615)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1615"
-                  },
-                  "name": "NW Everett & 21st",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 17,
-                "stopSequence": 18,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.524833,
+              "lon": -122.69398,
+              "name": "NW Everett & 21st",
+              "stopCode": "1615",
+              "stopId": "prt:1615",
+              "stopIndex": 17,
+              "stopSequence": 18,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:37:07.000+00:00",
               "departure": "2009-10-21T23:37:07.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.524935,
-                  "longitude": -122.690502
-                },
-                "name": "NW Everett & 19th",
-                "stop": {
-                  "code": "1611",
-                  "coordinate": {
-                    "latitude": 45.524935,
-                    "longitude": -122.690502
-                  },
-                  "description": "Eastbound stop in Portland (Stop ID 1611)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1611"
-                  },
-                  "name": "NW Everett & 19th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 18,
-                "stopSequence": 19,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.524935,
+              "lon": -122.690502,
+              "name": "NW Everett & 19th",
+              "stopCode": "1611",
+              "stopId": "prt:1611",
+              "stopIndex": 18,
+              "stopSequence": 19,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:39:28.000+00:00",
               "departure": "2009-10-21T23:39:28.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.524981,
-                  "longitude": -122.68537
-                },
-                "name": "NW Everett & 14th",
-                "stop": {
-                  "code": "1608",
-                  "coordinate": {
-                    "latitude": 45.524981,
-                    "longitude": -122.68537
-                  },
-                  "description": "Eastbound stop in Portland (Stop ID 1608)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1608"
-                  },
-                  "name": "NW Everett & 14th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 19,
-                "stopSequence": 20,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.524981,
+              "lon": -122.68537,
+              "name": "NW Everett & 14th",
+              "stopCode": "1608",
+              "stopId": "prt:1608",
+              "stopIndex": 19,
+              "stopSequence": 20,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-10-21T23:41:04.000+00:00",
               "departure": "2009-10-21T23:41:04.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.525061,
-                  "longitude": -122.68187
-                },
-                "name": "NW Everett & 11th",
-                "stop": {
-                  "code": "1607",
-                  "coordinate": {
-                    "latitude": 45.525061,
-                    "longitude": -122.68187
-                  },
-                  "description": "Eastbound stop in Portland (Stop ID 1607)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1607"
-                  },
-                  "name": "NW Everett & 11th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 20,
-                "stopSequence": 21,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.525061,
+              "lon": -122.68187,
+              "name": "NW Everett & 11th",
+              "stopCode": "1607",
+              "stopId": "prt:1607",
+              "stopIndex": 20,
+              "stopSequence": 21,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-10-21T23:42:15.000+00:00",
               "departure": "2009-10-21T23:42:15.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.525096,
-                  "longitude": -122.67929
-                },
-                "name": "NW Everett & Park",
-                "stop": {
-                  "code": "8402",
-                  "coordinate": {
-                    "latitude": 45.525096,
-                    "longitude": -122.67929
-                  },
-                  "description": "Eastbound stop in Portland (Stop ID 8402)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "8402"
-                  },
-                  "name": "NW Everett & Park",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 21,
-                "stopSequence": 22,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.525096,
+              "lon": -122.67929,
+              "name": "NW Everett & Park",
+              "stopCode": "8402",
+              "stopId": "prt:8402",
+              "stopIndex": 21,
+              "stopSequence": 22,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             }
           ],
           "legGeometry": {
@@ -3198,208 +1614,103 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "points": "{c{tGnwzkVR?lCEvBC??VAlCClCEAkA??A}BCkEAkECaD???g@CiECiEEiE?c@?o@?]Aa@?w@AoD???YEkEAkECiEA_A??AiCCkECmD???[A_CCiD"
           },
           "mode": "BUS",
-          "onStreetNonTransit": false,
           "pathway": false,
           "realTime": false,
-          "scheduled": true,
-          "serviceDate": {
-            "day": 21,
-            "minMax": false,
-            "month": 10,
-            "sequenceNumber": 20091021,
-            "year": 2009
-          },
+          "route": "Holgate/NW 21st",
+          "routeId": "prt:17",
+          "routeLongName": "Holgate/NW 21st",
+          "routeShortName": "17",
+          "serviceDate": "2009-10-21",
           "startTime": "2009-10-21T23:33:25.000+00:00",
-          "streetNotes": [ ],
+          "steps": [ ],
           "to": {
-            "coordinate": {
-              "latitude": 45.525112,
-              "longitude": -122.677664
-            },
+            "arrival": "2009-10-21T23:43:00.000+00:00",
+            "departure": "2009-10-21T23:43:00.000+00:00",
+            "lat": 45.525112,
+            "lon": -122.677664,
             "name": "NW Everett & Broadway",
-            "stop": {
-              "code": "1606",
-              "coordinate": {
-                "latitude": 45.525112,
-                "longitude": -122.677664
-              },
-              "description": "Eastbound stop in Portland (Stop ID 1606)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "0"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "1606"
-              },
-              "name": "NW Everett & Broadway",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "1606",
+            "stopId": "prt:1606",
             "stopIndex": 22,
             "stopSequence": 23,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
           },
-          "transitAlerts": [ ],
           "transitLeg": true,
-          "trip": {
-            "alteration": "PLANNED",
-            "bikesAllowed": "UNKNOWN",
-            "blockId": "1708",
-            "direction": "OUTBOUND",
-            "id": {
-              "feedId": "prt",
-              "id": "170W1470"
-            },
-            "route": {
-              "agency": {
-                "fareUrl": "http://trimet.org/fares/index.htm",
-                "id": {
-                  "feedId": "prt",
-                  "id": "prt"
-                },
-                "lang": "en",
-                "name": "TriMet",
-                "phone": "503-238-7433",
-                "timezone": "America/Los_Angeles",
-                "url": "http://trimet.org"
-              },
-              "bikesAllowed": "UNKNOWN",
-              "gtfsType": 3,
-              "id": {
-                "feedId": "prt",
-                "id": "17"
-              },
-              "longName": "Holgate/NW 21st",
-              "mode": "BUS",
-              "shortName": "17",
-              "sortOrder": -999,
-              "sortOrderSet": false,
-              "url": "http://trimet.org/schedules/r017.htm"
-            },
-            "serviceId": {
-              "feedId": "prt",
-              "id": "W"
-            },
-            "shapeId": {
-              "feedId": "prt",
-              "id": "17.0.13"
-            },
-            "wheelchairAccessible": 0
-          },
-          "walkSteps": [ ],
-          "walkingLeg": false
+          "tripBlockId": "1708",
+          "tripId": "prt:170W1470"
         },
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 188.35399999999998,
+          "distance": 188.35399999999998,
           "endTime": "2009-10-21T23:45:24.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.525112,
-              "longitude": -122.677664
-            },
+            "arrival": "2009-10-21T23:43:00.000+00:00",
+            "departure": "2009-10-21T23:43:00.000+00:00",
+            "lat": 45.525112,
+            "lon": -122.677664,
             "name": "NW Everett & Broadway",
-            "stop": {
-              "code": "1606",
-              "coordinate": {
-                "latitude": 45.525112,
-                "longitude": -122.677664
-              },
-              "description": "Eastbound stop in Portland (Stop ID 1606)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "0"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "1606"
-              },
-              "name": "NW Everett & Broadway",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "1606",
+            "stopId": "prt:1606",
             "stopIndex": 22,
             "stopSequence": 23,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
           },
           "generalizedCost": 285,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 15,
             "points": "}rztGlnwkVM??C?[?SC_D?M?E?MCgD?A?O?C?M?a@"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-10-21T23:43:00.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.52523,
-              "longitude": -122.67525
-            },
-            "name": "NW Everett St. & NW 5th Ave. (P3)",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "EAST",
-              "angle": 1.5470481318922238,
               "area": false,
               "bogusName": false,
               "distance": 188.35399999999998,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.52518265861028,
+              "lon": -122.6776666369647,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.52518265861028,
-                "longitude": -122.6776666369647
-              },
               "stayOn": false,
-              "streetName": "Northwest Everett Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Everett Street"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
+          "to": {
+            "arrival": "2009-10-21T23:45:24.000+00:00",
+            "lat": 45.52523,
+            "lon": -122.67525,
+            "name": "NW Everett St. & NW 5th Ave. (P3)",
+            "vertexType": "NORMAL"
+          },
+          "transitLeg": false,
+          "walkingBike": false
         }
       ],
-      "nTransfers": 0,
-      "nonTransitDistanceMeters": 817.8299999999999,
-      "nonTransitTimeSeconds": 474,
-      "onStreetAllTheWay": false,
-      "streetOnly": false,
-      "systemNotices": [ ],
+      "startTime": "2009-10-21T23:27:55.000+00:00",
       "tooSloped": false,
-      "transferPriorityCost": 0,
-      "transitTimeSeconds": 575,
-      "waitTimeOptimizedCost": 0,
-      "waitingTimeSeconds": 0,
-      "walkOnly": false,
-      "walkingAllTheWay": false
+      "transfers": 0,
+      "transitTime": 575,
+      "waitingTime": 0,
+      "walkDistance": 817.8299999999999,
+      "walkLimitExceeded": false,
+      "walkTime": 474
     },
     {
-      "arrivedAtDestinationWithRentedVehicle": false,
-      "durationSeconds": 1049,
+      "arrivedAtDestinationWithRentedBicycle": false,
+      "duration": 1049,
       "elevationGained": 0.0,
       "elevationLost": 0.0,
+      "endTime": "2009-10-21T23:54:24.000+00:00",
       "fare": {
         "details": {
           "regular": [
@@ -3432,744 +1743,359 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
           }
         }
       },
-      "flaggedForDeletion": false,
       "generalizedCost": 2087,
       "legs": [
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 106.589,
+          "distance": 106.589,
           "endTime": "2009-10-21T23:39:26.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.52832,
-              "longitude": -122.70059
-            },
+            "departure": "2009-10-21T23:36:55.000+00:00",
+            "lat": 45.52832,
+            "lon": -122.70059,
             "name": "SW Johnson St. & NW 24th Ave. (P1)",
             "vertexType": "NORMAL"
           },
           "generalizedCost": 288,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 4,
             "points": "}f{tGv}{kVjCA?e@WA"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-10-21T23:36:55.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.5277374,
-              "longitude": -122.7003879
-            },
-            "name": "-102309",
-            "vehicleRentalPlace": {
-              "allowDropoff": true,
-              "allowOverloading": false,
-              "allowPickup": true,
-              "carStation": false,
-              "floatingVehicle": false,
-              "id": {
-                "feedId": "test-network",
-                "id": "-102309"
-              },
-              "isInstalled": true,
-              "isKeepingVehicleRentalAtDestinationAllowed": true,
-              "isRenting": true,
-              "isReturning": true,
-              "isValetStation": false,
-              "isVirtualStation": false,
-              "keepingVehicleRentalAtDestinationAllowed": true,
-              "latitude": 45.5277374,
-              "longitude": -122.7003879,
-              "name": {
-                "name": "-102309"
-              },
-              "realTimeData": false,
-              "spacesAvailable": 0,
-              "spacesDisabled": 0,
-              "vehicleSpacesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehicleTypesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehiclesAvailable": 0,
-              "vehiclesDisabled": 0
-            },
-            "vertexType": "VEHICLERENTAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "SOUTH",
-              "angle": 3.1263917767722313,
               "area": false,
               "bogusName": false,
               "distance": 78.527,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.52831993266165,
+              "lon": -122.70059632295107,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.52831993266165,
-                "longitude": -122.70059632295107
-              },
               "stayOn": false,
-              "streetName": "Northwest 24th Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 24th Avenue"
             },
             {
               "absoluteDirection": "EAST",
-              "angle": 1.5443268101828453,
               "area": false,
               "bogusName": false,
               "distance": 14.704,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.527613800000005,
+              "lon": -122.70058100000001,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.527613800000005,
-                "longitude": -122.70058100000001
-              },
               "stayOn": false,
-              "streetName": "Northwest Irving Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Irving Street"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": 0.02566034822056683,
               "area": false,
               "bogusName": true,
               "distance": 13.358,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5276173,
+              "lon": -122.7003923,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.5276173,
-                "longitude": -122.7003923
-              },
               "stayOn": false,
-              "streetName": "way -102328 from 0",
-              "streetNotes": [ ],
-              "vehicleRentalOnStation": {
-                "id": "-102309",
-                "lat": 45.5277374,
-                "lon": -122.7003879,
-                "name": "-102309"
-              }
+              "streetName": "way -102328 from 0"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
+          "to": {
+            "arrival": "2009-10-21T23:39:26.000+00:00",
+            "bikeShareId": "-102309",
+            "departure": "2009-10-21T23:39:26.000+00:00",
+            "lat": 45.5277374,
+            "lon": -122.7003879,
+            "name": "-102309",
+            "vertexType": "BIKESHARE"
+          },
+          "transitLeg": false,
+          "walkingBike": false
         },
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 13.358,
+          "distance": 13.358,
           "endTime": "2009-10-21T23:39:37.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.5277374,
-              "longitude": -122.7003879
-            },
+            "arrival": "2009-10-21T23:39:26.000+00:00",
+            "bikeShareId": "-102309",
+            "departure": "2009-10-21T23:39:26.000+00:00",
+            "lat": 45.5277374,
+            "lon": -122.7003879,
             "name": "-102309",
-            "vehicleRentalPlace": {
-              "allowDropoff": true,
-              "allowOverloading": false,
-              "allowPickup": true,
-              "carStation": false,
-              "floatingVehicle": false,
-              "id": {
-                "feedId": "test-network",
-                "id": "-102309"
-              },
-              "isInstalled": true,
-              "isKeepingVehicleRentalAtDestinationAllowed": true,
-              "isRenting": true,
-              "isReturning": true,
-              "isValetStation": false,
-              "isVirtualStation": false,
-              "keepingVehicleRentalAtDestinationAllowed": true,
-              "latitude": 45.5277374,
-              "longitude": -122.7003879,
-              "name": {
-                "name": "-102309"
-              },
-              "realTimeData": false,
-              "spacesAvailable": 0,
-              "spacesDisabled": 0,
-              "vehicleSpacesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehicleTypesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehiclesAvailable": 0,
-              "vehiclesDisabled": 0
-            },
-            "vertexType": "VEHICLERENTAL"
+            "vertexType": "BIKESHARE"
           },
           "generalizedCost": 51,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 2,
             "points": "ic{tGl|{kVV@"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": true,
-          "scheduled": false,
+          "rentedBike": true,
+          "route": "",
           "startTime": "2009-10-21T23:39:26.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.5276173,
-              "longitude": -122.7003923
-            },
-            "name": "corner of way -102328 from 0 and Northwest Irving Street",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "vehicleRentalNetwork": "test-network",
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "SOUTH",
-              "angle": -3.1159323053692263,
               "area": false,
               "bogusName": true,
               "distance": 13.358,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5277374,
+              "lon": -122.70038790000001,
               "relativeDirection": "HARD_LEFT",
-              "startLocation": {
-                "latitude": 45.5277374,
-                "longitude": -122.70038790000001
-              },
               "stayOn": false,
-              "streetName": "way -102328 from 0",
-              "streetNotes": [ ]
+              "streetName": "way -102328 from 0"
             }
           ],
-          "walkingBike": true,
-          "walkingLeg": true
+          "to": {
+            "arrival": "2009-10-21T23:39:37.000+00:00",
+            "departure": "2009-10-21T23:39:37.000+00:00",
+            "lat": 45.5276173,
+            "lon": -122.7003923,
+            "name": "corner of way -102328 from 0 and Northwest Irving Street",
+            "vertexType": "NORMAL"
+          },
+          "transitLeg": false,
+          "walkingBike": true
         },
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 480.068,
+          "distance": 480.068,
           "endTime": "2009-10-21T23:41:58.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.5276173,
-              "longitude": -122.7003923
-            },
+            "arrival": "2009-10-21T23:39:37.000+00:00",
+            "departure": "2009-10-21T23:39:37.000+00:00",
+            "lat": 45.5276173,
+            "lon": -122.7003923,
             "name": "corner of way -102328 from 0 and Northwest Irving Street",
             "vertexType": "NORMAL"
           },
           "generalizedCost": 236,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 6,
             "points": "qb{tGn|{kVGsJEuKE}HAwAAo@"
           },
           "mode": "BICYCLE",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": true,
-          "scheduled": false,
+          "rentedBike": true,
+          "route": "",
           "startTime": "2009-10-21T23:39:37.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.5278491,
-              "longitude": -122.6942362
-            },
-            "name": "-102323",
-            "vehicleRentalPlace": {
-              "allowDropoff": true,
-              "allowOverloading": false,
-              "allowPickup": true,
-              "carStation": false,
-              "floatingVehicle": false,
-              "id": {
-                "feedId": "test-network",
-                "id": "-102323"
-              },
-              "isInstalled": true,
-              "isKeepingVehicleRentalAtDestinationAllowed": true,
-              "isRenting": true,
-              "isReturning": true,
-              "isValetStation": false,
-              "isVirtualStation": false,
-              "keepingVehicleRentalAtDestinationAllowed": true,
-              "latitude": 45.5278491,
-              "longitude": -122.6942362,
-              "name": {
-                "name": "-102323"
-              },
-              "realTimeData": false,
-              "spacesAvailable": 0,
-              "spacesDisabled": 0,
-              "vehicleSpacesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehicleTypesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehiclesAvailable": 0,
-              "vehiclesDisabled": 0
-            },
-            "vertexType": "VEHICLERENTAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "vehicleRentalNetwork": "test-network",
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "EAST",
-              "angle": 1.5441765471733384,
               "area": false,
               "bogusName": false,
               "distance": 480.068,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5276173,
+              "lon": -122.7003923,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.5276173,
-                "longitude": -122.7003923
-              },
               "stayOn": false,
-              "streetName": "Northwest Irving Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Irving Street"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": false
+          "to": {
+            "arrival": "2009-10-21T23:41:58.000+00:00",
+            "bikeShareId": "-102323",
+            "departure": "2009-10-21T23:41:58.000+00:00",
+            "lat": 45.5278491,
+            "lon": -122.6942362,
+            "name": "-102323",
+            "vertexType": "BIKESHARE"
+          },
+          "transitLeg": false,
+          "walkingBike": false
         },
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 29.461000000000002,
+          "distance": 29.461000000000002,
           "endTime": "2009-10-21T23:42:25.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.5278491,
-              "longitude": -122.6942362
-            },
+            "arrival": "2009-10-21T23:41:58.000+00:00",
+            "bikeShareId": "-102323",
+            "departure": "2009-10-21T23:41:58.000+00:00",
+            "lat": 45.5278491,
+            "lon": -122.6942362,
             "name": "-102323",
-            "vehicleRentalPlace": {
-              "allowDropoff": true,
-              "allowOverloading": false,
-              "allowPickup": true,
-              "carStation": false,
-              "floatingVehicle": false,
-              "id": {
-                "feedId": "test-network",
-                "id": "-102323"
-              },
-              "isInstalled": true,
-              "isKeepingVehicleRentalAtDestinationAllowed": true,
-              "isRenting": true,
-              "isReturning": true,
-              "isValetStation": false,
-              "isVirtualStation": false,
-              "keepingVehicleRentalAtDestinationAllowed": true,
-              "latitude": 45.5278491,
-              "longitude": -122.6942362,
-              "name": {
-                "name": "-102323"
-              },
-              "realTimeData": false,
-              "spacesAvailable": 0,
-              "spacesDisabled": 0,
-              "vehicleSpacesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehicleTypesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehiclesAvailable": 0,
-              "vehiclesDisabled": 0
-            },
-            "vertexType": "VEHICLERENTAL"
+            "vertexType": "BIKESHARE"
           },
           "generalizedCost": 49,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 5,
             "points": "ic{tG~uzkV@n@M@C??H"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-10-21T23:41:58.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.527818,
-              "longitude": -122.694539
-            },
-            "name": "NW 21st & Irving",
-            "stop": {
-              "code": "7114",
-              "coordinate": {
-                "latitude": 45.527818,
-                "longitude": -122.694539
-              },
-              "description": "Southbound stop in Portland (Stop ID 7114)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "7114"
-              },
-              "name": "NW 21st & Irving",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
-            "stopIndex": 50,
-            "stopSequence": 51,
-            "vertexType": "TRANSIT"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "WEST",
-              "angle": -1.5973283920844321,
               "area": false,
               "bogusName": false,
               "distance": 19.289,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.52773220198921,
+              "lon": -122.69423177172958,
               "relativeDirection": "HARD_LEFT",
-              "startLocation": {
-                "latitude": 45.52773220198921,
-                "longitude": -122.69423177172958
-              },
               "stayOn": false,
-              "streetName": "Northwest Irving Street",
-              "streetNotes": [ ],
-              "vehicleRentalOffStation": {
-                "id": "-102323",
-                "lat": 45.5278491,
-                "lon": -122.6942362,
-                "name": "-102323"
-              }
+              "streetName": "Northwest Irving Street"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": -0.026543929838500624,
               "area": false,
               "bogusName": false,
               "distance": 10.172,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.527727600000006,
+              "lon": -122.69447930000001,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.527727600000006,
-                "longitude": -122.69447930000001
-              },
               "stayOn": false,
-              "streetName": "Northwest 21st Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 21st Avenue"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
-        },
-        {
-          "agencyTimeZoneOffset": 0,
-          "arrivalDelay": 0,
-          "departureDelay": 0,
-          "distanceMeters": 1629.4275918538026,
-          "endTime": "2009-10-21T23:52:00.000+00:00",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.527818,
-              "longitude": -122.694539
-            },
+          "to": {
+            "arrival": "2009-10-21T23:42:25.000+00:00",
+            "departure": "2009-10-21T23:42:25.000+00:00",
+            "lat": 45.527818,
+            "lon": -122.694539,
             "name": "NW 21st & Irving",
-            "stop": {
-              "code": "7114",
-              "coordinate": {
-                "latitude": 45.527818,
-                "longitude": -122.694539
-              },
-              "description": "Southbound stop in Portland (Stop ID 7114)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "7114"
-              },
-              "name": "NW 21st & Irving",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "7114",
+            "stopId": "prt:7114",
             "stopIndex": 50,
             "stopSequence": 51,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "transitLeg": false,
+          "walkingBike": false
+        },
+        {
+          "agencyId": "prt:prt",
+          "agencyName": "TriMet",
+          "agencyTimeZoneOffset": 0,
+          "agencyUrl": "http://trimet.org",
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 1629.4275918538026,
+          "endTime": "2009-10-21T23:52:00.000+00:00",
+          "from": {
+            "arrival": "2009-10-21T23:42:25.000+00:00",
+            "departure": "2009-10-21T23:42:25.000+00:00",
+            "lat": 45.527818,
+            "lon": -122.694539,
+            "name": "NW 21st & Irving",
+            "stopCode": "7114",
+            "stopId": "prt:7114",
+            "stopIndex": 50,
+            "stopSequence": 51,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
           "generalizedCost": 1175,
           "headsign": "136th Ave",
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "intermediateStops": [
             {
               "arrival": "2009-10-21T23:43:20.000+00:00",
               "departure": "2009-10-21T23:43:20.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.526408,
-                  "longitude": -122.694503
-                },
-                "name": "NW 21st & Glisan",
-                "stop": {
-                  "code": "7112",
-                  "coordinate": {
-                    "latitude": 45.526408,
-                    "longitude": -122.694503
-                  },
-                  "description": "Southbound stop in Portland (Stop ID 7112)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "7112"
-                  },
-                  "name": "NW 21st & Glisan",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 51,
-                "stopSequence": 52,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.526408,
+              "lon": -122.694503,
+              "name": "NW 21st & Glisan",
+              "stopCode": "7112",
+              "stopId": "prt:7112",
+              "stopIndex": 51,
+              "stopSequence": 52,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:44:31.000+00:00",
               "departure": "2009-10-21T23:44:31.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.524833,
-                  "longitude": -122.69398
-                },
-                "name": "NW Everett & 21st",
-                "stop": {
-                  "code": "1615",
-                  "coordinate": {
-                    "latitude": 45.524833,
-                    "longitude": -122.69398
-                  },
-                  "description": "Eastbound stop in Portland (Stop ID 1615)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1615"
-                  },
-                  "name": "NW Everett & 21st",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 52,
-                "stopSequence": 53,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.524833,
+              "lon": -122.69398,
+              "name": "NW Everett & 21st",
+              "stopCode": "1615",
+              "stopId": "prt:1615",
+              "stopIndex": 52,
+              "stopSequence": 53,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:46:07.000+00:00",
               "departure": "2009-10-21T23:46:07.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.524935,
-                  "longitude": -122.690502
-                },
-                "name": "NW Everett & 19th",
-                "stop": {
-                  "code": "1611",
-                  "coordinate": {
-                    "latitude": 45.524935,
-                    "longitude": -122.690502
-                  },
-                  "description": "Eastbound stop in Portland (Stop ID 1611)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1611"
-                  },
-                  "name": "NW Everett & 19th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 53,
-                "stopSequence": 54,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.524935,
+              "lon": -122.690502,
+              "name": "NW Everett & 19th",
+              "stopCode": "1611",
+              "stopId": "prt:1611",
+              "stopIndex": 53,
+              "stopSequence": 54,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:48:28.000+00:00",
               "departure": "2009-10-21T23:48:28.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.524981,
-                  "longitude": -122.68537
-                },
-                "name": "NW Everett & 14th",
-                "stop": {
-                  "code": "1608",
-                  "coordinate": {
-                    "latitude": 45.524981,
-                    "longitude": -122.68537
-                  },
-                  "description": "Eastbound stop in Portland (Stop ID 1608)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1608"
-                  },
-                  "name": "NW Everett & 14th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 54,
-                "stopSequence": 55,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.524981,
+              "lon": -122.68537,
+              "name": "NW Everett & 14th",
+              "stopCode": "1608",
+              "stopId": "prt:1608",
+              "stopIndex": 54,
+              "stopSequence": 55,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-10-21T23:50:04.000+00:00",
               "departure": "2009-10-21T23:50:04.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.525061,
-                  "longitude": -122.68187
-                },
-                "name": "NW Everett & 11th",
-                "stop": {
-                  "code": "1607",
-                  "coordinate": {
-                    "latitude": 45.525061,
-                    "longitude": -122.68187
-                  },
-                  "description": "Eastbound stop in Portland (Stop ID 1607)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1607"
-                  },
-                  "name": "NW Everett & 11th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 55,
-                "stopSequence": 56,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.525061,
+              "lon": -122.68187,
+              "name": "NW Everett & 11th",
+              "stopCode": "1607",
+              "stopId": "prt:1607",
+              "stopIndex": 55,
+              "stopSequence": 56,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-10-21T23:51:15.000+00:00",
               "departure": "2009-10-21T23:51:15.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.525096,
-                  "longitude": -122.67929
-                },
-                "name": "NW Everett & Park",
-                "stop": {
-                  "code": "8402",
-                  "coordinate": {
-                    "latitude": 45.525096,
-                    "longitude": -122.67929
-                  },
-                  "description": "Eastbound stop in Portland (Stop ID 8402)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "8402"
-                  },
-                  "name": "NW Everett & Park",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 56,
-                "stopSequence": 57,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.525096,
+              "lon": -122.67929,
+              "name": "NW Everett & Park",
+              "stopCode": "8402",
+              "stopId": "prt:8402",
+              "stopIndex": 56,
+              "stopSequence": 57,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             }
           ],
           "legGeometry": {
@@ -4177,208 +2103,103 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "points": "{c{tGnwzkVR?lCEvBC??VAlCClCEAkA??A}BCkEAkECaD???g@CiECiEEiE?c@?o@?]Aa@?w@AoD???YEkEAkECiEA_A??AiCCkECmD???[A_CCiD"
           },
           "mode": "BUS",
-          "onStreetNonTransit": false,
           "pathway": false,
           "realTime": false,
-          "scheduled": true,
-          "serviceDate": {
-            "day": 21,
-            "minMax": false,
-            "month": 10,
-            "sequenceNumber": 20091021,
-            "year": 2009
-          },
+          "route": "Holgate/NW 21st",
+          "routeId": "prt:17",
+          "routeLongName": "Holgate/NW 21st",
+          "routeShortName": "17",
+          "serviceDate": "2009-10-21",
           "startTime": "2009-10-21T23:42:25.000+00:00",
-          "streetNotes": [ ],
+          "steps": [ ],
           "to": {
-            "coordinate": {
-              "latitude": 45.525112,
-              "longitude": -122.677664
-            },
+            "arrival": "2009-10-21T23:52:00.000+00:00",
+            "departure": "2009-10-21T23:52:00.000+00:00",
+            "lat": 45.525112,
+            "lon": -122.677664,
             "name": "NW Everett & Broadway",
-            "stop": {
-              "code": "1606",
-              "coordinate": {
-                "latitude": 45.525112,
-                "longitude": -122.677664
-              },
-              "description": "Eastbound stop in Portland (Stop ID 1606)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "0"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "1606"
-              },
-              "name": "NW Everett & Broadway",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "1606",
+            "stopId": "prt:1606",
             "stopIndex": 57,
             "stopSequence": 58,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
           },
-          "transitAlerts": [ ],
           "transitLeg": true,
-          "trip": {
-            "alteration": "PLANNED",
-            "bikesAllowed": "UNKNOWN",
-            "blockId": "1705",
-            "direction": "OUTBOUND",
-            "id": {
-              "feedId": "prt",
-              "id": "170W1480"
-            },
-            "route": {
-              "agency": {
-                "fareUrl": "http://trimet.org/fares/index.htm",
-                "id": {
-                  "feedId": "prt",
-                  "id": "prt"
-                },
-                "lang": "en",
-                "name": "TriMet",
-                "phone": "503-238-7433",
-                "timezone": "America/Los_Angeles",
-                "url": "http://trimet.org"
-              },
-              "bikesAllowed": "UNKNOWN",
-              "gtfsType": 3,
-              "id": {
-                "feedId": "prt",
-                "id": "17"
-              },
-              "longName": "Holgate/NW 21st",
-              "mode": "BUS",
-              "shortName": "17",
-              "sortOrder": -999,
-              "sortOrderSet": false,
-              "url": "http://trimet.org/schedules/r017.htm"
-            },
-            "serviceId": {
-              "feedId": "prt",
-              "id": "W"
-            },
-            "shapeId": {
-              "feedId": "prt",
-              "id": "17.0.30"
-            },
-            "wheelchairAccessible": 0
-          },
-          "walkSteps": [ ],
-          "walkingLeg": false
+          "tripBlockId": "1705",
+          "tripId": "prt:170W1480"
         },
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 188.35399999999998,
+          "distance": 188.35399999999998,
           "endTime": "2009-10-21T23:54:24.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.525112,
-              "longitude": -122.677664
-            },
+            "arrival": "2009-10-21T23:52:00.000+00:00",
+            "departure": "2009-10-21T23:52:00.000+00:00",
+            "lat": 45.525112,
+            "lon": -122.677664,
             "name": "NW Everett & Broadway",
-            "stop": {
-              "code": "1606",
-              "coordinate": {
-                "latitude": 45.525112,
-                "longitude": -122.677664
-              },
-              "description": "Eastbound stop in Portland (Stop ID 1606)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "0"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "1606"
-              },
-              "name": "NW Everett & Broadway",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "1606",
+            "stopId": "prt:1606",
             "stopIndex": 57,
             "stopSequence": 58,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
           },
           "generalizedCost": 285,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 15,
             "points": "}rztGlnwkVM??C?[?SC_D?M?E?MCgD?A?O?C?M?a@"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-10-21T23:52:00.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.52523,
-              "longitude": -122.67525
-            },
-            "name": "NW Everett St. & NW 5th Ave. (P3)",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "EAST",
-              "angle": 1.5470481318922238,
               "area": false,
               "bogusName": false,
               "distance": 188.35399999999998,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.52518265861028,
+              "lon": -122.6776666369647,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.52518265861028,
-                "longitude": -122.6776666369647
-              },
               "stayOn": false,
-              "streetName": "Northwest Everett Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Everett Street"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
+          "to": {
+            "arrival": "2009-10-21T23:54:24.000+00:00",
+            "lat": 45.52523,
+            "lon": -122.67525,
+            "name": "NW Everett St. & NW 5th Ave. (P3)",
+            "vertexType": "NORMAL"
+          },
+          "transitLeg": false,
+          "walkingBike": false
         }
       ],
-      "nTransfers": 0,
-      "nonTransitDistanceMeters": 817.8299999999999,
-      "nonTransitTimeSeconds": 474,
-      "onStreetAllTheWay": false,
-      "streetOnly": false,
-      "systemNotices": [ ],
+      "startTime": "2009-10-21T23:36:55.000+00:00",
       "tooSloped": false,
-      "transferPriorityCost": 0,
-      "transitTimeSeconds": 575,
-      "waitTimeOptimizedCost": 0,
-      "waitingTimeSeconds": 0,
-      "walkOnly": false,
-      "walkingAllTheWay": false
+      "transfers": 0,
+      "transitTime": 575,
+      "waitingTime": 0,
+      "walkDistance": 817.8299999999999,
+      "walkLimitExceeded": false,
+      "walkTime": 474
     },
     {
-      "arrivedAtDestinationWithRentedVehicle": false,
-      "durationSeconds": 1001,
+      "arrivedAtDestinationWithRentedBicycle": false,
+      "duration": 1001,
       "elevationGained": 0.0,
       "elevationLost": 0.0,
+      "endTime": "2009-10-21T23:56:10.000+00:00",
       "fare": {
         "details": {
           "regular": [
@@ -4411,414 +2232,191 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
           }
         }
       },
-      "flaggedForDeletion": false,
       "generalizedCost": 1805,
       "legs": [
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 220.14600000000002,
+          "distance": 220.14600000000002,
           "endTime": "2009-10-21T23:42:21.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.52832,
-              "longitude": -122.70059
-            },
+            "departure": "2009-10-21T23:39:29.000+00:00",
+            "lat": 45.52832,
+            "lon": -122.70059,
             "name": "SW Johnson St. & NW 24th Ave. (P1)",
             "vertexType": "NORMAL"
           },
           "generalizedCost": 336,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 6,
             "points": "}f{tGv}{kVC?mCBmCD@zCN?"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-10-21T23:39:29.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.529662,
-              "longitude": -122.701423
-            },
-            "name": "2400 Block NW Lovejoy",
-            "stop": {
-              "code": "3589",
-              "coordinate": {
-                "latitude": 45.529662,
-                "longitude": -122.701423
-              },
-              "description": "Eastbound stop in Portland (Stop ID 3589)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "3589"
-              },
-              "name": "2400 Block NW Lovejoy",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
-            "stopIndex": 6,
-            "stopSequence": 7,
-            "vertexType": "TRANSIT"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "NORTH",
-              "angle": -0.015200780078397704,
               "area": false,
               "bogusName": false,
               "distance": 159.625,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.52831993266165,
+              "lon": -122.70059632295107,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.52831993266165,
-                "longitude": -122.70059632295107
-              },
               "stayOn": false,
-              "streetName": "Northwest 24th Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 24th Avenue"
             },
             {
               "absoluteDirection": "WEST",
-              "angle": -1.5928981885811253,
               "area": false,
               "bogusName": false,
               "distance": 60.521,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.529755,
+              "lon": -122.70064880000001,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.529755,
-                "longitude": -122.70064880000001
-              },
               "stayOn": false,
-              "streetName": "Northwest Lovejoy Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Lovejoy Street"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
-        },
-        {
-          "agencyTimeZoneOffset": 0,
-          "arrivalDelay": 0,
-          "departureDelay": 0,
-          "distanceMeters": 2804.1297859664874,
-          "endTime": "2009-10-21T23:55:32.000+00:00",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.529662,
-              "longitude": -122.701423
-            },
+          "to": {
+            "arrival": "2009-10-21T23:42:21.000+00:00",
+            "departure": "2009-10-21T23:42:21.000+00:00",
+            "lat": 45.529662,
+            "lon": -122.701423,
             "name": "2400 Block NW Lovejoy",
-            "stop": {
-              "code": "3589",
-              "coordinate": {
-                "latitude": 45.529662,
-                "longitude": -122.701423
-              },
-              "description": "Eastbound stop in Portland (Stop ID 3589)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "3589"
-              },
-              "name": "2400 Block NW Lovejoy",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "3589",
+            "stopId": "prt:3589",
             "stopIndex": 6,
             "stopSequence": 7,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "transitLeg": false,
+          "walkingBike": false
+        },
+        {
+          "agencyId": "prt:prt",
+          "agencyName": "TriMet",
+          "agencyTimeZoneOffset": 0,
+          "agencyUrl": "http://trimet.org",
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 2804.1297859664874,
+          "endTime": "2009-10-21T23:55:32.000+00:00",
+          "from": {
+            "arrival": "2009-10-21T23:42:21.000+00:00",
+            "departure": "2009-10-21T23:42:21.000+00:00",
+            "lat": 45.529662,
+            "lon": -122.701423,
+            "name": "2400 Block NW Lovejoy",
+            "stopCode": "3589",
+            "stopId": "prt:3589",
+            "stopIndex": 6,
+            "stopSequence": 7,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
           "generalizedCost": 1391,
           "headsign": "Troutdale",
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "intermediateStops": [
             {
               "arrival": "2009-10-21T23:43:54.000+00:00",
               "departure": "2009-10-21T23:43:54.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.529746,
-                  "longitude": -122.69688
-                },
-                "name": "NW Lovejoy & 22nd",
-                "stop": {
-                  "code": "3596",
-                  "coordinate": {
-                    "latitude": 45.529746,
-                    "longitude": -122.69688
-                  },
-                  "description": "Eastbound stop in Portland (Stop ID 3596)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "3596"
-                  },
-                  "name": "NW Lovejoy & 22nd",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 7,
-                "stopSequence": 8,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.529746,
+              "lon": -122.69688,
+              "name": "NW Lovejoy & 22nd",
+              "stopCode": "3596",
+              "stopId": "prt:3596",
+              "stopIndex": 7,
+              "stopSequence": 8,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:44:39.000+00:00",
               "departure": "2009-10-21T23:44:39.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.529833,
-                  "longitude": -122.694676
-                },
-                "name": "NW Lovejoy & 21st",
-                "stop": {
-                  "code": "3595",
-                  "coordinate": {
-                    "latitude": 45.529833,
-                    "longitude": -122.694676
-                  },
-                  "description": "Eastbound stop in Portland (Stop ID 3595)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "3595"
-                  },
-                  "name": "NW Lovejoy & 21st",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 8,
-                "stopSequence": 9,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.529833,
+              "lon": -122.694676,
+              "name": "NW Lovejoy & 21st",
+              "stopCode": "3595",
+              "stopId": "prt:3595",
+              "stopIndex": 8,
+              "stopSequence": 9,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:46:23.000+00:00",
               "departure": "2009-10-21T23:46:23.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.529925,
-                  "longitude": -122.689587
-                },
-                "name": "NW Lovejoy & 18th",
-                "stop": {
-                  "code": "10751",
-                  "coordinate": {
-                    "latitude": 45.529925,
-                    "longitude": -122.689587
-                  },
-                  "description": "Eastbound stop in Portland (Stop ID 10751)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "10751"
-                  },
-                  "name": "NW Lovejoy & 18th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 9,
-                "stopSequence": 10,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.529925,
+              "lon": -122.689587,
+              "name": "NW Lovejoy & 18th",
+              "stopCode": "10751",
+              "stopId": "prt:10751",
+              "stopIndex": 9,
+              "stopSequence": 10,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:48:05.000+00:00",
               "departure": "2009-10-21T23:48:05.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.529997,
-                  "longitude": -122.684611
-                },
-                "name": "NW Lovejoy & 13th",
-                "stop": {
-                  "code": "10752",
-                  "coordinate": {
-                    "latitude": 45.529997,
-                    "longitude": -122.684611
-                  },
-                  "description": "Eastbound stop in Portland (Stop ID 10752)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "10752"
-                  },
-                  "name": "NW Lovejoy & 13th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 10,
-                "stopSequence": 11,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.529997,
+              "lon": -122.684611,
+              "name": "NW Lovejoy & 13th",
+              "stopCode": "10752",
+              "stopId": "prt:10752",
+              "stopIndex": 10,
+              "stopSequence": 11,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:49:07.000+00:00",
               "departure": "2009-10-21T23:49:07.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.530034,
-                  "longitude": -122.68155
-                },
-                "name": "NW Lovejoy & 10th",
-                "stop": {
-                  "code": "11000",
-                  "coordinate": {
-                    "latitude": 45.530034,
-                    "longitude": -122.68155
-                  },
-                  "description": "Eastbound stop in Portland (Stop ID 11000)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "11000"
-                  },
-                  "name": "NW Lovejoy & 10th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 11,
-                "stopSequence": 12,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.530034,
+              "lon": -122.68155,
+              "name": "NW Lovejoy & 10th",
+              "stopCode": "11000",
+              "stopId": "prt:11000",
+              "stopIndex": 11,
+              "stopSequence": 12,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:50:00.000+00:00",
               "departure": "2009-10-21T23:50:00.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.531086,
-                  "longitude": -122.680302
-                },
-                "name": "NW 9th & Marshall",
-                "stop": {
-                  "code": "12803",
-                  "coordinate": {
-                    "latitude": 45.531086,
-                    "longitude": -122.680302
-                  },
-                  "description": "Northbound stop in Portland (Stop ID 12803)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "12803"
-                  },
-                  "name": "NW 9th & Marshall",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 12,
-                "stopSequence": 13,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.531086,
+              "lon": -122.680302,
+              "name": "NW 9th & Marshall",
+              "stopCode": "12803",
+              "stopId": "prt:12803",
+              "stopIndex": 12,
+              "stopSequence": 13,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:52:50.000+00:00",
               "departure": "2009-10-21T23:52:50.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.528405,
-                  "longitude": -122.676979
-                },
-                "name": "NW Station Way & Union Station",
-                "stop": {
-                  "code": "12804",
-                  "coordinate": {
-                    "latitude": 45.528405,
-                    "longitude": -122.676979
-                  },
-                  "description": "Southbound stop in Portland (Stop ID 12804)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "12804"
-                  },
-                  "name": "NW Station Way & Union Station",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 13,
-                "stopSequence": 14,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.528405,
+              "lon": -122.676979,
+              "name": "NW Station Way & Union Station",
+              "stopCode": "12804",
+              "stopId": "prt:12804",
+              "stopIndex": 13,
+              "stopSequence": 14,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             }
           ],
           "legGeometry": {
@@ -4826,202 +2424,96 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "points": "yo{tG|b|kVC}CEuKGwI???}@G{J???YGsKEuKCuD???UCiECeEAgA?{@AkA?WAwDE{C???i@CiECkECcD??Ae@?mE{BDQ@q@@??{ADCsDbBiB`DaEt@_AVANIX?tBCLK`@c@\\c@l@w@??\\c@FKDCFEXCCgEvBEVAlCClCEnCECoD"
           },
           "mode": "BUS",
-          "onStreetNonTransit": false,
           "pathway": false,
           "realTime": false,
-          "scheduled": true,
-          "serviceDate": {
-            "day": 21,
-            "minMax": false,
-            "month": 10,
-            "sequenceNumber": 20091021,
-            "year": 2009
-          },
+          "route": "Broadway/Halsey",
+          "routeId": "prt:77",
+          "routeLongName": "Broadway/Halsey",
+          "routeShortName": "77",
+          "serviceDate": "2009-10-21",
           "startTime": "2009-10-21T23:42:21.000+00:00",
-          "streetNotes": [ ],
+          "steps": [ ],
           "to": {
-            "coordinate": {
-              "latitude": 45.525183,
-              "longitude": -122.674607
-            },
+            "arrival": "2009-10-21T23:55:32.000+00:00",
+            "departure": "2009-10-21T23:55:32.000+00:00",
+            "lat": 45.525183,
+            "lon": -122.674607,
             "name": "NW Everett & 4th",
-            "stop": {
-              "code": "9546",
-              "coordinate": {
-                "latitude": 45.525183,
-                "longitude": -122.674607
-              },
-              "description": "Eastbound stop in Portland (Stop ID 9546)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "0"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "9546"
-              },
-              "name": "NW Everett & 4th",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "9546",
+            "stopId": "prt:9546",
             "stopIndex": 14,
             "stopSequence": 15,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
           },
-          "transitAlerts": [ ],
           "transitLeg": true,
-          "trip": {
-            "alteration": "PLANNED",
-            "bikesAllowed": "UNKNOWN",
-            "blockId": "7703",
-            "direction": "OUTBOUND",
-            "id": {
-              "feedId": "prt",
-              "id": "770W1400"
-            },
-            "route": {
-              "agency": {
-                "fareUrl": "http://trimet.org/fares/index.htm",
-                "id": {
-                  "feedId": "prt",
-                  "id": "prt"
-                },
-                "lang": "en",
-                "name": "TriMet",
-                "phone": "503-238-7433",
-                "timezone": "America/Los_Angeles",
-                "url": "http://trimet.org"
-              },
-              "bikesAllowed": "UNKNOWN",
-              "gtfsType": 3,
-              "id": {
-                "feedId": "prt",
-                "id": "77"
-              },
-              "longName": "Broadway/Halsey",
-              "mode": "BUS",
-              "shortName": "77",
-              "sortOrder": -999,
-              "sortOrderSet": false,
-              "url": "http://trimet.org/schedules/r077.htm"
-            },
-            "serviceId": {
-              "feedId": "prt",
-              "id": "W"
-            },
-            "shapeId": {
-              "feedId": "prt",
-              "id": "77.0.2"
-            },
-            "wheelchairAccessible": 0
-          },
-          "walkSteps": [ ],
-          "walkingLeg": false
+          "tripBlockId": "7703",
+          "tripId": "prt:770W1400"
         },
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 49.938,
+          "distance": 49.938,
           "endTime": "2009-10-21T23:56:10.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.525183,
-              "longitude": -122.674607
-            },
+            "arrival": "2009-10-21T23:55:32.000+00:00",
+            "departure": "2009-10-21T23:55:32.000+00:00",
+            "lat": 45.525183,
+            "lon": -122.674607,
             "name": "NW Everett & 4th",
-            "stop": {
-              "code": "9546",
-              "coordinate": {
-                "latitude": 45.525183,
-                "longitude": -122.674607
-              },
-              "description": "Eastbound stop in Portland (Stop ID 9546)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "0"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "9546"
-              },
-              "name": "NW Everett & 4th",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "9546",
+            "stopId": "prt:9546",
             "stopIndex": 14,
             "stopSequence": 15,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
           },
           "generalizedCost": 77,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 3,
             "points": "ksztGh{vkVI?@~B"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-10-21T23:55:32.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.52523,
-              "longitude": -122.67525
-            },
-            "name": "NW Everett St. & NW 5th Ave. (P3)",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "WEST",
-              "angle": -1.5968688222706109,
               "area": false,
               "bogusName": false,
               "distance": 49.938,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.525239650875925,
+              "lon": -122.67460910872424,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.525239650875925,
-                "longitude": -122.67460910872424
-              },
               "stayOn": false,
-              "streetName": "Northwest Everett Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Everett Street"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
+          "to": {
+            "arrival": "2009-10-21T23:56:10.000+00:00",
+            "lat": 45.52523,
+            "lon": -122.67525,
+            "name": "NW Everett St. & NW 5th Ave. (P3)",
+            "vertexType": "NORMAL"
+          },
+          "transitLeg": false,
+          "walkingBike": false
         }
       ],
-      "nTransfers": 0,
-      "nonTransitDistanceMeters": 270.084,
-      "nonTransitTimeSeconds": 210,
-      "onStreetAllTheWay": false,
-      "streetOnly": false,
-      "systemNotices": [ ],
+      "startTime": "2009-10-21T23:39:29.000+00:00",
       "tooSloped": false,
-      "transferPriorityCost": 0,
-      "transitTimeSeconds": 791,
-      "waitTimeOptimizedCost": 0,
-      "waitingTimeSeconds": 0,
-      "walkOnly": false,
-      "walkingAllTheWay": false
+      "transfers": 0,
+      "transitTime": 791,
+      "waitingTime": 0,
+      "walkDistance": 270.084,
+      "walkLimitExceeded": false,
+      "walkTime": 210
     }
   ]
 ]
@@ -5030,493 +2522,280 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
 org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeRental=[
   [
     {
-      "arrivedAtDestinationWithRentedVehicle": false,
-      "durationSeconds": 477,
+      "arrivedAtDestinationWithRentedBicycle": false,
+      "duration": 477,
       "elevationGained": 0.0,
       "elevationLost": 0.0,
+      "endTime": "2009-10-21T23:17:57.000+00:00",
       "fare": {
         "details": { },
         "fare": { }
       },
-      "flaggedForDeletion": false,
       "generalizedCost": 915,
       "legs": [
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 106.589,
+          "distance": 106.589,
           "endTime": "2009-10-21T23:12:31.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.52832,
-              "longitude": -122.70059
-            },
+            "departure": "2009-10-21T23:10:00.000+00:00",
+            "lat": 45.52832,
+            "lon": -122.70059,
             "name": "SW Johnson St. & NW 24th Ave. (P1)",
             "vertexType": "NORMAL"
           },
           "generalizedCost": 288,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 4,
             "points": "}f{tGv}{kVjCA?e@WA"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-10-21T23:10:00.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.5277374,
-              "longitude": -122.7003879
-            },
-            "name": "-102309",
-            "vehicleRentalPlace": {
-              "allowDropoff": true,
-              "allowOverloading": false,
-              "allowPickup": true,
-              "carStation": false,
-              "floatingVehicle": false,
-              "id": {
-                "feedId": "test-network",
-                "id": "-102309"
-              },
-              "isInstalled": true,
-              "isKeepingVehicleRentalAtDestinationAllowed": true,
-              "isRenting": true,
-              "isReturning": true,
-              "isValetStation": false,
-              "isVirtualStation": false,
-              "keepingVehicleRentalAtDestinationAllowed": true,
-              "latitude": 45.5277374,
-              "longitude": -122.7003879,
-              "name": {
-                "name": "-102309"
-              },
-              "realTimeData": false,
-              "spacesAvailable": 0,
-              "spacesDisabled": 0,
-              "vehicleSpacesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehicleTypesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehiclesAvailable": 0,
-              "vehiclesDisabled": 0
-            },
-            "vertexType": "VEHICLERENTAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "SOUTH",
-              "angle": 3.1263917767722313,
               "area": false,
               "bogusName": false,
               "distance": 78.527,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.52831993266165,
+              "lon": -122.70059632295107,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.52831993266165,
-                "longitude": -122.70059632295107
-              },
               "stayOn": false,
-              "streetName": "Northwest 24th Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 24th Avenue"
             },
             {
               "absoluteDirection": "EAST",
-              "angle": 1.5443268101828453,
               "area": false,
               "bogusName": false,
               "distance": 14.704,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.527613800000005,
+              "lon": -122.70058100000001,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.527613800000005,
-                "longitude": -122.70058100000001
-              },
               "stayOn": false,
-              "streetName": "Northwest Irving Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Irving Street"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": 0.02566034822056683,
               "area": false,
               "bogusName": true,
               "distance": 13.358,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5276173,
+              "lon": -122.7003923,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.5276173,
-                "longitude": -122.7003923
-              },
               "stayOn": false,
-              "streetName": "way -102328 from 0",
-              "streetNotes": [ ],
-              "vehicleRentalOnStation": {
-                "id": "-102309",
-                "lat": 45.5277374,
-                "lon": -122.7003879,
-                "name": "-102309"
-              }
+              "streetName": "way -102328 from 0"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
+          "to": {
+            "arrival": "2009-10-21T23:12:31.000+00:00",
+            "bikeShareId": "-102309",
+            "departure": "2009-10-21T23:12:31.000+00:00",
+            "lat": 45.5277374,
+            "lon": -122.7003879,
+            "name": "-102309",
+            "vertexType": "BIKESHARE"
+          },
+          "transitLeg": false,
+          "walkingBike": false
         },
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 13.358,
+          "distance": 13.358,
           "endTime": "2009-10-21T23:12:42.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.5277374,
-              "longitude": -122.7003879
-            },
+            "arrival": "2009-10-21T23:12:31.000+00:00",
+            "bikeShareId": "-102309",
+            "departure": "2009-10-21T23:12:31.000+00:00",
+            "lat": 45.5277374,
+            "lon": -122.7003879,
             "name": "-102309",
-            "vehicleRentalPlace": {
-              "allowDropoff": true,
-              "allowOverloading": false,
-              "allowPickup": true,
-              "carStation": false,
-              "floatingVehicle": false,
-              "id": {
-                "feedId": "test-network",
-                "id": "-102309"
-              },
-              "isInstalled": true,
-              "isKeepingVehicleRentalAtDestinationAllowed": true,
-              "isRenting": true,
-              "isReturning": true,
-              "isValetStation": false,
-              "isVirtualStation": false,
-              "keepingVehicleRentalAtDestinationAllowed": true,
-              "latitude": 45.5277374,
-              "longitude": -122.7003879,
-              "name": {
-                "name": "-102309"
-              },
-              "realTimeData": false,
-              "spacesAvailable": 0,
-              "spacesDisabled": 0,
-              "vehicleSpacesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehicleTypesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehiclesAvailable": 0,
-              "vehiclesDisabled": 0
-            },
-            "vertexType": "VEHICLERENTAL"
+            "vertexType": "BIKESHARE"
           },
           "generalizedCost": 51,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 2,
             "points": "ic{tGl|{kVV@"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": true,
-          "scheduled": false,
+          "rentedBike": true,
+          "route": "",
           "startTime": "2009-10-21T23:12:31.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.5276173,
-              "longitude": -122.7003923
-            },
-            "name": "corner of way -102328 from 0 and Northwest Irving Street",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "vehicleRentalNetwork": "test-network",
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "SOUTH",
-              "angle": -3.1159323053692263,
               "area": false,
               "bogusName": true,
               "distance": 13.358,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5277374,
+              "lon": -122.70038790000001,
               "relativeDirection": "HARD_LEFT",
-              "startLocation": {
-                "latitude": 45.5277374,
-                "longitude": -122.70038790000001
-              },
               "stayOn": false,
-              "streetName": "way -102328 from 0",
-              "streetNotes": [ ]
+              "streetName": "way -102328 from 0"
             }
           ],
-          "walkingBike": true,
-          "walkingLeg": true
+          "to": {
+            "arrival": "2009-10-21T23:12:42.000+00:00",
+            "departure": "2009-10-21T23:12:42.000+00:00",
+            "lat": 45.5276173,
+            "lon": -122.7003923,
+            "name": "corner of way -102328 from 0 and Northwest Irving Street",
+            "vertexType": "NORMAL"
+          },
+          "transitLeg": false,
+          "walkingBike": true
         },
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 480.068,
+          "distance": 480.068,
           "endTime": "2009-10-21T23:15:03.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.5276173,
-              "longitude": -122.7003923
-            },
+            "arrival": "2009-10-21T23:12:42.000+00:00",
+            "departure": "2009-10-21T23:12:42.000+00:00",
+            "lat": 45.5276173,
+            "lon": -122.7003923,
             "name": "corner of way -102328 from 0 and Northwest Irving Street",
             "vertexType": "NORMAL"
           },
           "generalizedCost": 236,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 6,
             "points": "qb{tGn|{kVGsJEuKE}HAwAAo@"
           },
           "mode": "BICYCLE",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": true,
-          "scheduled": false,
+          "rentedBike": true,
+          "route": "",
           "startTime": "2009-10-21T23:12:42.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.5278491,
-              "longitude": -122.6942362
-            },
-            "name": "-102323",
-            "vehicleRentalPlace": {
-              "allowDropoff": true,
-              "allowOverloading": false,
-              "allowPickup": true,
-              "carStation": false,
-              "floatingVehicle": false,
-              "id": {
-                "feedId": "test-network",
-                "id": "-102323"
-              },
-              "isInstalled": true,
-              "isKeepingVehicleRentalAtDestinationAllowed": true,
-              "isRenting": true,
-              "isReturning": true,
-              "isValetStation": false,
-              "isVirtualStation": false,
-              "keepingVehicleRentalAtDestinationAllowed": true,
-              "latitude": 45.5278491,
-              "longitude": -122.6942362,
-              "name": {
-                "name": "-102323"
-              },
-              "realTimeData": false,
-              "spacesAvailable": 0,
-              "spacesDisabled": 0,
-              "vehicleSpacesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehicleTypesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehiclesAvailable": 0,
-              "vehiclesDisabled": 0
-            },
-            "vertexType": "VEHICLERENTAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "vehicleRentalNetwork": "test-network",
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "EAST",
-              "angle": 1.5441765471733384,
               "area": false,
               "bogusName": false,
               "distance": 480.068,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5276173,
+              "lon": -122.7003923,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.5276173,
-                "longitude": -122.7003923
-              },
               "stayOn": false,
-              "streetName": "Northwest Irving Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Irving Street"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": false
+          "to": {
+            "arrival": "2009-10-21T23:15:03.000+00:00",
+            "bikeShareId": "-102323",
+            "departure": "2009-10-21T23:15:03.000+00:00",
+            "lat": 45.5278491,
+            "lon": -122.6942362,
+            "name": "-102323",
+            "vertexType": "BIKESHARE"
+          },
+          "transitLeg": false,
+          "walkingBike": false
         },
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 219.063,
+          "distance": 219.063,
           "endTime": "2009-10-21T23:17:57.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.5278491,
-              "longitude": -122.6942362
-            },
+            "arrival": "2009-10-21T23:15:03.000+00:00",
+            "bikeShareId": "-102323",
+            "departure": "2009-10-21T23:15:03.000+00:00",
+            "lat": 45.5278491,
+            "lon": -122.6942362,
             "name": "-102323",
-            "vehicleRentalPlace": {
-              "allowDropoff": true,
-              "allowOverloading": false,
-              "allowPickup": true,
-              "carStation": false,
-              "floatingVehicle": false,
-              "id": {
-                "feedId": "test-network",
-                "id": "-102323"
-              },
-              "isInstalled": true,
-              "isKeepingVehicleRentalAtDestinationAllowed": true,
-              "isRenting": true,
-              "isReturning": true,
-              "isValetStation": false,
-              "isVirtualStation": false,
-              "keepingVehicleRentalAtDestinationAllowed": true,
-              "latitude": 45.5278491,
-              "longitude": -122.6942362,
-              "name": {
-                "name": "-102323"
-              },
-              "realTimeData": false,
-              "spacesAvailable": 0,
-              "spacesDisabled": 0,
-              "vehicleSpacesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehicleTypesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehiclesAvailable": 0,
-              "vehiclesDisabled": 0
-            },
-            "vertexType": "VEHICLERENTAL"
+            "vertexType": "BIKESHARE"
           },
           "generalizedCost": 338,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 4,
             "points": "ic{tG~uzkVEcJlCE?C"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-10-21T23:15:03.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.52704,
-              "longitude": -122.6924
-            },
-            "name": "NW Hoyt St. & NW 20th Ave. (P2)",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "EAST",
-              "angle": 1.5442642526352681,
               "area": false,
               "bogusName": false,
               "distance": 138.309,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.52773220198921,
+              "lon": -122.69423177172958,
               "relativeDirection": "CONTINUE",
-              "startLocation": {
-                "latitude": 45.52773220198921,
-                "longitude": -122.69423177172958
-              },
               "stayOn": false,
-              "streetName": "Northwest Irving Street",
-              "streetNotes": [ ],
-              "vehicleRentalOffStation": {
-                "id": "-102323",
-                "lat": 45.5278491,
-                "lon": -122.6942362,
-                "name": "-102323"
-              }
+              "streetName": "Northwest Irving Street"
             },
             {
               "absoluteDirection": "SOUTH",
-              "angle": 3.110936337978962,
               "area": false,
               "bogusName": false,
               "distance": 78.785,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.527765200000005,
+              "lon": -122.69245690000001,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.527765200000005,
-                "longitude": -122.69245690000001
-              },
               "stayOn": false,
-              "streetName": "Northwest 20th Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 20th Avenue"
             },
             {
               "absoluteDirection": "EAST",
-              "angle": 1.545875745502869,
               "area": false,
               "bogusName": false,
               "distance": 1.969,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.527057000000006,
+              "lon": -122.6924259,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.527057000000006,
-                "longitude": -122.6924259
-              },
               "stayOn": false,
-              "streetName": "Northwest Hoyt Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Hoyt Street"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
+          "to": {
+            "arrival": "2009-10-21T23:17:57.000+00:00",
+            "lat": 45.52704,
+            "lon": -122.6924,
+            "name": "NW Hoyt St. & NW 20th Ave. (P2)",
+            "vertexType": "NORMAL"
+          },
+          "transitLeg": false,
+          "walkingBike": false
         }
       ],
-      "nTransfers": 0,
-      "nonTransitDistanceMeters": 819.078,
-      "nonTransitTimeSeconds": 477,
-      "onStreetAllTheWay": true,
-      "streetOnly": true,
-      "systemNotices": [ ],
+      "startTime": "2009-10-21T23:10:00.000+00:00",
       "tooSloped": false,
-      "transferPriorityCost": -1,
-      "transitTimeSeconds": 0,
-      "waitTimeOptimizedCost": -1,
-      "waitingTimeSeconds": 0,
-      "walkOnly": false,
-      "walkingAllTheWay": false
+      "transfers": 0,
+      "transitTime": 0,
+      "waitingTime": 0,
+      "walkDistance": 819.078,
+      "walkLimitExceeded": false,
+      "walkTime": 477
     }
   ]
 ]
@@ -5525,358 +2804,227 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
 org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeRentalArrivingAtDestinationWithArriveBy=[
   [
     {
-      "arrivedAtDestinationWithRentedVehicle": true,
-      "durationSeconds": 338,
+      "arrivedAtDestinationWithRentedBicycle": true,
+      "duration": 338,
       "elevationGained": 0.0,
       "elevationLost": 0.0,
+      "endTime": "2009-10-21T23:10:00.000+00:00",
       "fare": {
         "details": { },
         "fare": { }
       },
-      "flaggedForDeletion": false,
       "generalizedCost": 652,
       "legs": [
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 106.589,
+          "distance": 106.589,
           "endTime": "2009-10-21T23:06:53.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.52832,
-              "longitude": -122.70059
-            },
+            "departure": "2009-10-21T23:04:22.000+00:00",
+            "lat": 45.52832,
+            "lon": -122.70059,
             "name": "SW Johnson St. & NW 24th Ave. (P1)",
             "vertexType": "NORMAL"
           },
           "generalizedCost": 288,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 4,
             "points": "}f{tGv}{kVjCA?e@WA"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-10-21T23:04:22.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.5277374,
-              "longitude": -122.7003879
-            },
-            "name": "-102309",
-            "vehicleRentalPlace": {
-              "allowDropoff": true,
-              "allowOverloading": false,
-              "allowPickup": true,
-              "carStation": false,
-              "floatingVehicle": false,
-              "id": {
-                "feedId": "test-network",
-                "id": "-102309"
-              },
-              "isInstalled": true,
-              "isKeepingVehicleRentalAtDestinationAllowed": true,
-              "isRenting": true,
-              "isReturning": true,
-              "isValetStation": false,
-              "isVirtualStation": false,
-              "keepingVehicleRentalAtDestinationAllowed": true,
-              "latitude": 45.5277374,
-              "longitude": -122.7003879,
-              "name": {
-                "name": "-102309"
-              },
-              "realTimeData": false,
-              "spacesAvailable": 0,
-              "spacesDisabled": 0,
-              "vehicleSpacesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehicleTypesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehiclesAvailable": 0,
-              "vehiclesDisabled": 0
-            },
-            "vertexType": "VEHICLERENTAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "SOUTH",
-              "angle": 3.1263917767722313,
               "area": false,
               "bogusName": false,
               "distance": 78.527,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.52831993266165,
+              "lon": -122.70059632295107,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.52831993266165,
-                "longitude": -122.70059632295107
-              },
               "stayOn": false,
-              "streetName": "Northwest 24th Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 24th Avenue"
             },
             {
               "absoluteDirection": "EAST",
-              "angle": 1.5443268101828453,
               "area": false,
               "bogusName": false,
               "distance": 14.704,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.527613800000005,
+              "lon": -122.70058100000001,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.527613800000005,
-                "longitude": -122.70058100000001
-              },
               "stayOn": false,
-              "streetName": "Northwest Irving Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Irving Street"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": 0.02566034822056683,
               "area": false,
               "bogusName": true,
               "distance": 13.358,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5276173,
+              "lon": -122.7003923,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.5276173,
-                "longitude": -122.7003923
-              },
               "stayOn": false,
-              "streetName": "way -102328 from 0",
-              "streetNotes": [ ],
-              "vehicleRentalOnStation": {
-                "id": "-102309",
-                "lat": 45.5277374,
-                "lon": -122.7003879,
-                "name": "-102309"
-              }
+              "streetName": "way -102328 from 0"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
+          "to": {
+            "arrival": "2009-10-21T23:06:53.000+00:00",
+            "bikeShareId": "-102309",
+            "departure": "2009-10-21T23:06:53.000+00:00",
+            "lat": 45.5277374,
+            "lon": -122.7003879,
+            "name": "-102309",
+            "vertexType": "BIKESHARE"
+          },
+          "transitLeg": false,
+          "walkingBike": false
         },
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 13.358,
+          "distance": 13.358,
           "endTime": "2009-10-21T23:07:18.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.5277374,
-              "longitude": -122.7003879
-            },
+            "arrival": "2009-10-21T23:06:53.000+00:00",
+            "bikeShareId": "-102309",
+            "departure": "2009-10-21T23:06:53.000+00:00",
+            "lat": 45.5277374,
+            "lon": -122.7003879,
             "name": "-102309",
-            "vehicleRentalPlace": {
-              "allowDropoff": true,
-              "allowOverloading": false,
-              "allowPickup": true,
-              "carStation": false,
-              "floatingVehicle": false,
-              "id": {
-                "feedId": "test-network",
-                "id": "-102309"
-              },
-              "isInstalled": true,
-              "isKeepingVehicleRentalAtDestinationAllowed": true,
-              "isRenting": true,
-              "isReturning": true,
-              "isValetStation": false,
-              "isVirtualStation": false,
-              "keepingVehicleRentalAtDestinationAllowed": true,
-              "latitude": 45.5277374,
-              "longitude": -122.7003879,
-              "name": {
-                "name": "-102309"
-              },
-              "realTimeData": false,
-              "spacesAvailable": 0,
-              "spacesDisabled": 0,
-              "vehicleSpacesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehicleTypesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehiclesAvailable": 0,
-              "vehiclesDisabled": 0
-            },
-            "vertexType": "VEHICLERENTAL"
+            "vertexType": "BIKESHARE"
           },
           "generalizedCost": 65,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 2,
             "points": "ic{tGl|{kVV@"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": true,
-          "scheduled": false,
+          "rentedBike": true,
+          "route": "",
           "startTime": "2009-10-21T23:06:53.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.5276173,
-              "longitude": -122.7003923
-            },
-            "name": "corner of way -102328 from 0 and Northwest Irving Street",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "vehicleRentalNetwork": "test-network",
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "SOUTH",
-              "angle": -3.1159323053692263,
               "area": false,
               "bogusName": true,
               "distance": 13.358,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5277374,
+              "lon": -122.70038790000001,
               "relativeDirection": "HARD_LEFT",
-              "startLocation": {
-                "latitude": 45.5277374,
-                "longitude": -122.70038790000001
-              },
               "stayOn": false,
-              "streetName": "way -102328 from 0",
-              "streetNotes": [ ]
+              "streetName": "way -102328 from 0"
             }
           ],
-          "walkingBike": true,
-          "walkingLeg": true
+          "to": {
+            "arrival": "2009-10-21T23:07:18.000+00:00",
+            "departure": "2009-10-21T23:07:18.000+00:00",
+            "lat": 45.5276173,
+            "lon": -122.7003923,
+            "name": "corner of way -102328 from 0 and Northwest Irving Street",
+            "vertexType": "NORMAL"
+          },
+          "transitLeg": false,
+          "walkingBike": true
         },
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 698.613,
+          "distance": 698.613,
           "endTime": "2009-10-21T23:10:00.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.5276173,
-              "longitude": -122.7003923
-            },
+            "arrival": "2009-10-21T23:07:18.000+00:00",
+            "departure": "2009-10-21T23:07:18.000+00:00",
+            "lat": 45.5276173,
+            "lon": -122.7003923,
             "name": "corner of way -102328 from 0 and Northwest Irving Street",
             "vertexType": "NORMAL"
           },
           "generalizedCost": 298,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 10,
             "points": "qb{tGn|{kVGsJL?F?tBCEuK?g@GmJEuK?C"
           },
           "mode": "BICYCLE",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": true,
-          "scheduled": false,
+          "rentedBike": true,
+          "route": "",
           "startTime": "2009-10-21T23:07:18.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.52704,
-              "longitude": -122.6924
-            },
-            "name": "NW Hoyt St. & NW 20th Ave. (P2)",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "vehicleRentalNetwork": "test-network",
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "EAST",
-              "angle": 1.5441765471733384,
               "area": false,
               "bogusName": false,
               "distance": 144.546,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5276173,
+              "lon": -122.7003923,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.5276173,
-                "longitude": -122.7003923
-              },
               "stayOn": false,
-              "streetName": "Northwest Irving Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Irving Street"
             },
             {
               "absoluteDirection": "SOUTH",
-              "angle": 3.114702563033784,
               "area": false,
               "bogusName": false,
               "distance": 77.976,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5276519,
+              "lon": -122.6985374,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5276519,
-                "longitude": -122.6985374
-              },
               "stayOn": false,
-              "streetName": "Northwest 23rd Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 23rd Avenue"
             },
             {
               "absoluteDirection": "EAST",
-              "angle": 1.545901243204427,
               "area": false,
               "bogusName": false,
               "distance": 476.091,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5269509,
+              "lon": -122.69851030000001,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.5269509,
-                "longitude": -122.69851030000001
-              },
               "stayOn": false,
-              "streetName": "Northwest Hoyt Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Hoyt Street"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": false
+          "to": {
+            "arrival": "2009-10-21T23:10:00.000+00:00",
+            "lat": 45.52704,
+            "lon": -122.6924,
+            "name": "NW Hoyt St. & NW 20th Ave. (P2)",
+            "vertexType": "NORMAL"
+          },
+          "transitLeg": false,
+          "walkingBike": false
         }
       ],
-      "nTransfers": 0,
-      "nonTransitDistanceMeters": 818.5600000000001,
-      "nonTransitTimeSeconds": 338,
-      "onStreetAllTheWay": true,
-      "streetOnly": true,
-      "systemNotices": [ ],
+      "startTime": "2009-10-21T23:04:22.000+00:00",
       "tooSloped": false,
-      "transferPriorityCost": -1,
-      "transitTimeSeconds": 0,
-      "waitTimeOptimizedCost": -1,
-      "waitingTimeSeconds": 0,
-      "walkOnly": false,
-      "walkingAllTheWay": false
+      "transfers": 0,
+      "transitTime": 0,
+      "waitingTime": 0,
+      "walkDistance": 818.5600000000001,
+      "walkLimitExceeded": false,
+      "walkTime": 338
     }
   ]
 ]
@@ -5885,358 +3033,227 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
 org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeRentalArrivingAtDestinationWithDepartAt=[
   [
     {
-      "arrivedAtDestinationWithRentedVehicle": true,
-      "durationSeconds": 337,
+      "arrivedAtDestinationWithRentedBicycle": true,
+      "duration": 337,
       "elevationGained": 0.0,
       "elevationLost": 0.0,
+      "endTime": "2009-10-21T23:15:37.000+00:00",
       "fare": {
         "details": { },
         "fare": { }
       },
-      "flaggedForDeletion": false,
       "generalizedCost": 652,
       "legs": [
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 106.589,
+          "distance": 106.589,
           "endTime": "2009-10-21T23:12:31.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.52832,
-              "longitude": -122.70059
-            },
+            "departure": "2009-10-21T23:10:00.000+00:00",
+            "lat": 45.52832,
+            "lon": -122.70059,
             "name": "SW Johnson St. & NW 24th Ave. (P1)",
             "vertexType": "NORMAL"
           },
           "generalizedCost": 288,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 4,
             "points": "}f{tGv}{kVjCA?e@WA"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-10-21T23:10:00.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.5277374,
-              "longitude": -122.7003879
-            },
-            "name": "-102309",
-            "vehicleRentalPlace": {
-              "allowDropoff": true,
-              "allowOverloading": false,
-              "allowPickup": true,
-              "carStation": false,
-              "floatingVehicle": false,
-              "id": {
-                "feedId": "test-network",
-                "id": "-102309"
-              },
-              "isInstalled": true,
-              "isKeepingVehicleRentalAtDestinationAllowed": true,
-              "isRenting": true,
-              "isReturning": true,
-              "isValetStation": false,
-              "isVirtualStation": false,
-              "keepingVehicleRentalAtDestinationAllowed": true,
-              "latitude": 45.5277374,
-              "longitude": -122.7003879,
-              "name": {
-                "name": "-102309"
-              },
-              "realTimeData": false,
-              "spacesAvailable": 0,
-              "spacesDisabled": 0,
-              "vehicleSpacesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehicleTypesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehiclesAvailable": 0,
-              "vehiclesDisabled": 0
-            },
-            "vertexType": "VEHICLERENTAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "SOUTH",
-              "angle": 3.1263917767722313,
               "area": false,
               "bogusName": false,
               "distance": 78.527,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.52831993266165,
+              "lon": -122.70059632295107,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.52831993266165,
-                "longitude": -122.70059632295107
-              },
               "stayOn": false,
-              "streetName": "Northwest 24th Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 24th Avenue"
             },
             {
               "absoluteDirection": "EAST",
-              "angle": 1.5443268101828453,
               "area": false,
               "bogusName": false,
               "distance": 14.704,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.527613800000005,
+              "lon": -122.70058100000001,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.527613800000005,
-                "longitude": -122.70058100000001
-              },
               "stayOn": false,
-              "streetName": "Northwest Irving Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Irving Street"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": 0.02566034822056683,
               "area": false,
               "bogusName": true,
               "distance": 13.358,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5276173,
+              "lon": -122.7003923,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.5276173,
-                "longitude": -122.7003923
-              },
               "stayOn": false,
-              "streetName": "way -102328 from 0",
-              "streetNotes": [ ],
-              "vehicleRentalOnStation": {
-                "id": "-102309",
-                "lat": 45.5277374,
-                "lon": -122.7003879,
-                "name": "-102309"
-              }
+              "streetName": "way -102328 from 0"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
+          "to": {
+            "arrival": "2009-10-21T23:12:31.000+00:00",
+            "bikeShareId": "-102309",
+            "departure": "2009-10-21T23:12:31.000+00:00",
+            "lat": 45.5277374,
+            "lon": -122.7003879,
+            "name": "-102309",
+            "vertexType": "BIKESHARE"
+          },
+          "transitLeg": false,
+          "walkingBike": false
         },
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 13.358,
+          "distance": 13.358,
           "endTime": "2009-10-21T23:12:42.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.5277374,
-              "longitude": -122.7003879
-            },
+            "arrival": "2009-10-21T23:12:31.000+00:00",
+            "bikeShareId": "-102309",
+            "departure": "2009-10-21T23:12:31.000+00:00",
+            "lat": 45.5277374,
+            "lon": -122.7003879,
             "name": "-102309",
-            "vehicleRentalPlace": {
-              "allowDropoff": true,
-              "allowOverloading": false,
-              "allowPickup": true,
-              "carStation": false,
-              "floatingVehicle": false,
-              "id": {
-                "feedId": "test-network",
-                "id": "-102309"
-              },
-              "isInstalled": true,
-              "isKeepingVehicleRentalAtDestinationAllowed": true,
-              "isRenting": true,
-              "isReturning": true,
-              "isValetStation": false,
-              "isVirtualStation": false,
-              "keepingVehicleRentalAtDestinationAllowed": true,
-              "latitude": 45.5277374,
-              "longitude": -122.7003879,
-              "name": {
-                "name": "-102309"
-              },
-              "realTimeData": false,
-              "spacesAvailable": 0,
-              "spacesDisabled": 0,
-              "vehicleSpacesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehicleTypesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehiclesAvailable": 0,
-              "vehiclesDisabled": 0
-            },
-            "vertexType": "VEHICLERENTAL"
+            "vertexType": "BIKESHARE"
           },
           "generalizedCost": 51,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 2,
             "points": "ic{tGl|{kVV@"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": true,
-          "scheduled": false,
+          "rentedBike": true,
+          "route": "",
           "startTime": "2009-10-21T23:12:31.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.5276173,
-              "longitude": -122.7003923
-            },
-            "name": "corner of way -102328 from 0 and Northwest Irving Street",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "vehicleRentalNetwork": "test-network",
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "SOUTH",
-              "angle": -3.1159323053692263,
               "area": false,
               "bogusName": true,
               "distance": 13.358,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5277374,
+              "lon": -122.70038790000001,
               "relativeDirection": "HARD_LEFT",
-              "startLocation": {
-                "latitude": 45.5277374,
-                "longitude": -122.70038790000001
-              },
               "stayOn": false,
-              "streetName": "way -102328 from 0",
-              "streetNotes": [ ]
+              "streetName": "way -102328 from 0"
             }
           ],
-          "walkingBike": true,
-          "walkingLeg": true
+          "to": {
+            "arrival": "2009-10-21T23:12:42.000+00:00",
+            "departure": "2009-10-21T23:12:42.000+00:00",
+            "lat": 45.5276173,
+            "lon": -122.7003923,
+            "name": "corner of way -102328 from 0 and Northwest Irving Street",
+            "vertexType": "NORMAL"
+          },
+          "transitLeg": false,
+          "walkingBike": true
         },
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 699.131,
+          "distance": 699.131,
           "endTime": "2009-10-21T23:15:37.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.5276173,
-              "longitude": -122.7003923
-            },
+            "arrival": "2009-10-21T23:12:42.000+00:00",
+            "departure": "2009-10-21T23:12:42.000+00:00",
+            "lat": 45.5276173,
+            "lon": -122.7003923,
             "name": "corner of way -102328 from 0 and Northwest Irving Street",
             "vertexType": "NORMAL"
           },
           "generalizedCost": 312,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 9,
             "points": "qb{tGn|{kVGsJEuKE}HAwAAo@EcJlCE?C"
           },
           "mode": "BICYCLE",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": true,
-          "scheduled": false,
+          "rentedBike": true,
+          "route": "",
           "startTime": "2009-10-21T23:12:42.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.52704,
-              "longitude": -122.6924
-            },
-            "name": "NW Hoyt St. & NW 20th Ave. (P2)",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "vehicleRentalNetwork": "test-network",
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "EAST",
-              "angle": 1.5441765471733384,
               "area": false,
               "bogusName": false,
               "distance": 618.377,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5276173,
+              "lon": -122.7003923,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.5276173,
-                "longitude": -122.7003923
-              },
               "stayOn": false,
-              "streetName": "Northwest Irving Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Irving Street"
             },
             {
               "absoluteDirection": "SOUTH",
-              "angle": 3.110936337978962,
               "area": false,
               "bogusName": false,
               "distance": 78.785,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.527765200000005,
+              "lon": -122.69245690000001,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.527765200000005,
-                "longitude": -122.69245690000001
-              },
               "stayOn": false,
-              "streetName": "Northwest 20th Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 20th Avenue"
             },
             {
               "absoluteDirection": "EAST",
-              "angle": 1.545875745502869,
               "area": false,
               "bogusName": false,
               "distance": 1.969,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.527057000000006,
+              "lon": -122.6924259,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.527057000000006,
-                "longitude": -122.6924259
-              },
               "stayOn": false,
-              "streetName": "Northwest Hoyt Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Hoyt Street"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": false
+          "to": {
+            "arrival": "2009-10-21T23:15:37.000+00:00",
+            "lat": 45.52704,
+            "lon": -122.6924,
+            "name": "NW Hoyt St. & NW 20th Ave. (P2)",
+            "vertexType": "NORMAL"
+          },
+          "transitLeg": false,
+          "walkingBike": false
         }
       ],
-      "nTransfers": 0,
-      "nonTransitDistanceMeters": 819.078,
-      "nonTransitTimeSeconds": 337,
-      "onStreetAllTheWay": true,
-      "streetOnly": true,
-      "systemNotices": [ ],
+      "startTime": "2009-10-21T23:10:00.000+00:00",
       "tooSloped": false,
-      "transferPriorityCost": -1,
-      "transitTimeSeconds": 0,
-      "waitTimeOptimizedCost": -1,
-      "waitingTimeSeconds": 0,
-      "walkOnly": false,
-      "walkingAllTheWay": false
+      "transfers": 0,
+      "transitTime": 0,
+      "waitingTime": 0,
+      "walkDistance": 819.078,
+      "walkLimitExceeded": false,
+      "walkTime": 337
     }
   ]
 ]
@@ -6245,10 +3262,11 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
 org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeRental=[
   [
     {
-      "arrivedAtDestinationWithRentedVehicle": false,
-      "durationSeconds": 977,
+      "arrivedAtDestinationWithRentedBicycle": false,
+      "duration": 977,
       "elevationGained": 0.0,
       "elevationLost": 0.0,
+      "endTime": "2009-10-21T23:28:51.000+00:00",
       "fare": {
         "details": {
           "regular": [
@@ -6281,468 +3299,216 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
           }
         }
       },
-      "flaggedForDeletion": false,
       "generalizedCost": 1998,
       "legs": [
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 167.86599999999999,
+          "distance": 167.86599999999999,
           "endTime": "2009-10-21T23:14:50.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.52523,
-              "longitude": -122.67525
-            },
+            "departure": "2009-10-21T23:12:34.000+00:00",
+            "lat": 45.52523,
+            "lon": -122.67525,
             "name": "NW Everett St. & NW 5th Ave. (P3)",
             "vertexType": "NORMAL"
           },
           "generalizedCost": 261,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 10,
             "points": "ssztGh_wkV?`@?LK?uBBK??F?JBbDN?"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-10-21T23:12:34.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.52583,
-              "longitude": -122.676422
-            },
-            "name": "NW 6th & Flanders",
-            "stop": {
-              "code": "9300",
-              "coordinate": {
-                "latitude": 45.52583,
-                "longitude": -122.676422
-              },
-              "description": "Northbound stop in Portland (Stop ID 9300)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "0"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "9300"
-              },
-              "name": "NW 6th & Flanders",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
-            "stopIndex": 66,
-            "stopSequence": 67,
-            "vertexType": "TRANSIT"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "WEST",
-              "angle": -1.596868818888735,
               "area": false,
               "bogusName": false,
               "distance": 17.975,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.52522794293369,
+              "lon": -122.67524992342938,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.52522794293369,
-                "longitude": -122.67524992342938
-              },
               "stayOn": false,
-              "streetName": "Northwest Everett Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Everett Street"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": -0.02939746732509391,
               "area": false,
               "bogusName": false,
               "distance": 78.514,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.525224200000004,
+              "lon": -122.67548060000001,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.525224200000004,
-                "longitude": -122.67548060000001
-              },
               "stayOn": false,
-              "streetName": "Northwest 5th Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 5th Avenue"
             },
             {
               "absoluteDirection": "WEST",
-              "angle": -1.5977129345986325,
               "area": false,
               "bogusName": false,
               "distance": 71.377,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.52593,
+              "lon": -122.6755097,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.52593,
-                "longitude": -122.6755097
-              },
               "stayOn": false,
-              "streetName": "Northwest Flanders Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Flanders Street"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
-        },
-        {
-          "agencyTimeZoneOffset": 0,
-          "arrivalDelay": 0,
-          "departureDelay": 0,
-          "distanceMeters": 1631.0313510234191,
-          "endTime": "2009-10-21T23:23:32.000+00:00",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.52583,
-              "longitude": -122.676422
-            },
+          "to": {
+            "arrival": "2009-10-21T23:14:50.000+00:00",
+            "departure": "2009-10-21T23:14:50.000+00:00",
+            "lat": 45.52583,
+            "lon": -122.676422,
             "name": "NW 6th & Flanders",
-            "stop": {
-              "code": "9300",
-              "coordinate": {
-                "latitude": 45.52583,
-                "longitude": -122.676422
-              },
-              "description": "Northbound stop in Portland (Stop ID 9300)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "0"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "9300"
-              },
-              "name": "NW 6th & Flanders",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "9300",
+            "stopId": "prt:9300",
             "stopIndex": 66,
             "stopSequence": 67,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
+          },
+          "transitLeg": false,
+          "walkingBike": false
+        },
+        {
+          "agencyId": "prt:prt",
+          "agencyName": "TriMet",
+          "agencyTimeZoneOffset": 0,
+          "agencyUrl": "http://trimet.org",
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 1631.0313510234191,
+          "endTime": "2009-10-21T23:23:32.000+00:00",
+          "from": {
+            "arrival": "2009-10-21T23:14:50.000+00:00",
+            "departure": "2009-10-21T23:14:50.000+00:00",
+            "lat": 45.52583,
+            "lon": -122.676422,
+            "name": "NW 6th & Flanders",
+            "stopCode": "9300",
+            "stopId": "prt:9300",
+            "stopIndex": 66,
+            "stopSequence": 67,
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
           },
           "generalizedCost": 1122,
           "headsign": "Sauvie Is. via St.Johns",
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "intermediateStops": [
             {
               "arrival": "2009-10-21T23:15:41.000+00:00",
               "departure": "2009-10-21T23:15:41.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.526678,
-                  "longitude": -122.677476
-                },
-                "name": "NW Glisan & Broadway",
-                "stop": {
-                  "code": "1997",
-                  "coordinate": {
-                    "latitude": 45.526678,
-                    "longitude": -122.677476
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 1997)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1997"
-                  },
-                  "name": "NW Glisan & Broadway",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 67,
-                "stopSequence": 68,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.526678,
+              "lon": -122.677476,
+              "name": "NW Glisan & Broadway",
+              "stopCode": "1997",
+              "stopId": "prt:1997",
+              "stopIndex": 67,
+              "stopSequence": 68,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-10-21T23:16:21.000+00:00",
               "departure": "2009-10-21T23:16:21.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.526643,
-                  "longitude": -122.679075
-                },
-                "name": "NW Glisan & Park",
-                "stop": {
-                  "code": "2007",
-                  "coordinate": {
-                    "latitude": 45.526643,
-                    "longitude": -122.679075
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 2007)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "2007"
-                  },
-                  "name": "NW Glisan & Park",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 68,
-                "stopSequence": 69,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.526643,
+              "lon": -122.679075,
+              "name": "NW Glisan & Park",
+              "stopCode": "2007",
+              "stopId": "prt:2007",
+              "stopIndex": 68,
+              "stopSequence": 69,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-10-21T23:17:11.000+00:00",
               "departure": "2009-10-21T23:17:11.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.526601,
-                  "longitude": -122.681091
-                },
-                "name": "NW Glisan & 10th",
-                "stop": {
-                  "code": "2011",
-                  "coordinate": {
-                    "latitude": 45.526601,
-                    "longitude": -122.681091
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 2011)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "2011"
-                  },
-                  "name": "NW Glisan & 10th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 69,
-                "stopSequence": 70,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.526601,
+              "lon": -122.681091,
+              "name": "NW Glisan & 10th",
+              "stopCode": "2011",
+              "stopId": "prt:2011",
+              "stopIndex": 69,
+              "stopSequence": 70,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-10-21T23:18:03.000+00:00",
               "departure": "2009-10-21T23:18:03.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.526578,
-                  "longitude": -122.683142
-                },
-                "name": "NW Glisan & 12th",
-                "stop": {
-                  "code": "2030",
-                  "coordinate": {
-                    "latitude": 45.526578,
-                    "longitude": -122.683142
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 2030)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "2030"
-                  },
-                  "name": "NW Glisan & 12th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 70,
-                "stopSequence": 71,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.526578,
+              "lon": -122.683142,
+              "name": "NW Glisan & 12th",
+              "stopCode": "2030",
+              "stopId": "prt:2030",
+              "stopIndex": 70,
+              "stopSequence": 71,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-10-21T23:18:53.000+00:00",
               "departure": "2009-10-21T23:18:53.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.526532,
-                  "longitude": -122.685164
-                },
-                "name": "NW Glisan & 14th",
-                "stop": {
-                  "code": "2046",
-                  "coordinate": {
-                    "latitude": 45.526532,
-                    "longitude": -122.685164
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 2046)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "2046"
-                  },
-                  "name": "NW Glisan & 14th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 71,
-                "stopSequence": 72,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.526532,
+              "lon": -122.685164,
+              "name": "NW Glisan & 14th",
+              "stopCode": "2046",
+              "stopId": "prt:2046",
+              "stopIndex": 71,
+              "stopSequence": 72,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-10-21T23:19:43.000+00:00",
               "departure": "2009-10-21T23:19:43.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.526503,
-                  "longitude": -122.687165
-                },
-                "name": "NW Glisan & 16th",
-                "stop": {
-                  "code": "2062",
-                  "coordinate": {
-                    "latitude": 45.526503,
-                    "longitude": -122.687165
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 2062)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "2062"
-                  },
-                  "name": "NW Glisan & 16th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 72,
-                "stopSequence": 73,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.526503,
+              "lon": -122.687165,
+              "name": "NW Glisan & 16th",
+              "stopCode": "2062",
+              "stopId": "prt:2062",
+              "stopIndex": 72,
+              "stopSequence": 73,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:20:59.000+00:00",
               "departure": "2009-10-21T23:20:59.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.526412,
-                  "longitude": -122.690196
-                },
-                "name": "NW Glisan & 19th",
-                "stop": {
-                  "code": "2086",
-                  "coordinate": {
-                    "latitude": 45.526412,
-                    "longitude": -122.690196
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 2086)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "2086"
-                  },
-                  "name": "NW Glisan & 19th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 73,
-                "stopSequence": 74,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.526412,
+              "lon": -122.690196,
+              "name": "NW Glisan & 19th",
+              "stopCode": "2086",
+              "stopId": "prt:2086",
+              "stopIndex": 73,
+              "stopSequence": 74,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:22:31.000+00:00",
               "departure": "2009-10-21T23:22:31.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.526387,
-                  "longitude": -122.693889
-                },
-                "name": "NW Glisan & 21st",
-                "stop": {
-                  "code": "2099",
-                  "coordinate": {
-                    "latitude": 45.526387,
-                    "longitude": -122.693889
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 2099)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "2099"
-                  },
-                  "name": "NW Glisan & 21st",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 74,
-                "stopSequence": 75,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.526387,
+              "lon": -122.693889,
+              "name": "NW Glisan & 21st",
+              "stopCode": "2099",
+              "stopId": "prt:2099",
+              "stopIndex": 74,
+              "stopSequence": 75,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             }
           ],
           "legGeometry": {
@@ -6750,592 +3516,296 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "points": "kwztGhgwkVQ?kC@@zD???PBjE?`B??@X@jEBjD???\\BhEBpD???XBhE@nD??@Z?hEBtA?h@@h@??@Z@nEBhEBhD???`@FtKDhH??@hBoCD}BB"
           },
           "mode": "BUS",
-          "onStreetNonTransit": false,
           "pathway": false,
           "realTime": false,
-          "scheduled": true,
-          "serviceDate": {
-            "day": 21,
-            "minMax": false,
-            "month": 10,
-            "sequenceNumber": 20091021,
-            "year": 2009
-          },
+          "route": "Holgate/NW 21st",
+          "routeId": "prt:17",
+          "routeLongName": "Holgate/NW 21st",
+          "routeShortName": "17",
+          "serviceDate": "2009-10-21",
           "startTime": "2009-10-21T23:14:50.000+00:00",
-          "streetNotes": [ ],
+          "steps": [ ],
           "to": {
-            "coordinate": {
-              "latitude": 45.527648,
-              "longitude": -122.694407
-            },
+            "arrival": "2009-10-21T23:23:32.000+00:00",
+            "departure": "2009-10-21T23:23:32.000+00:00",
+            "lat": 45.527648,
+            "lon": -122.694407,
             "name": "NW 21st & Irving",
-            "stop": {
-              "code": "7113",
-              "coordinate": {
-                "latitude": 45.527648,
-                "longitude": -122.694407
-              },
-              "description": "Northbound stop in Portland (Stop ID 7113)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "7113"
-              },
-              "name": "NW 21st & Irving",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "7113",
+            "stopId": "prt:7113",
             "stopIndex": 75,
             "stopSequence": 76,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
-          "transitAlerts": [ ],
           "transitLeg": true,
-          "trip": {
-            "alteration": "PLANNED",
-            "bikesAllowed": "UNKNOWN",
-            "blockId": "1707",
-            "direction": "INBOUND",
-            "id": {
-              "feedId": "prt",
-              "id": "171W1490"
-            },
-            "route": {
-              "agency": {
-                "fareUrl": "http://trimet.org/fares/index.htm",
-                "id": {
-                  "feedId": "prt",
-                  "id": "prt"
-                },
-                "lang": "en",
-                "name": "TriMet",
-                "phone": "503-238-7433",
-                "timezone": "America/Los_Angeles",
-                "url": "http://trimet.org"
-              },
-              "bikesAllowed": "UNKNOWN",
-              "gtfsType": 3,
-              "id": {
-                "feedId": "prt",
-                "id": "17"
-              },
-              "longName": "Holgate/NW 21st",
-              "mode": "BUS",
-              "shortName": "17",
-              "sortOrder": -999,
-              "sortOrderSet": false,
-              "url": "http://trimet.org/schedules/r017.htm"
-            },
-            "serviceId": {
-              "feedId": "prt",
-              "id": "W"
-            },
-            "shapeId": {
-              "feedId": "prt",
-              "id": "17.1.15"
-            },
-            "wheelchairAccessible": 0
-          },
-          "walkSteps": [ ],
-          "walkingLeg": false
+          "tripBlockId": "1707",
+          "tripId": "prt:171W1490"
         },
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 28.258000000000003,
+          "distance": 28.258000000000003,
           "endTime": "2009-10-21T23:24:58.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.527648,
-              "longitude": -122.694407
-            },
+            "arrival": "2009-10-21T23:23:32.000+00:00",
+            "departure": "2009-10-21T23:23:32.000+00:00",
+            "lat": 45.527648,
+            "lon": -122.694407,
             "name": "NW 21st & Irving",
-            "stop": {
-              "code": "7113",
-              "coordinate": {
-                "latitude": 45.527648,
-                "longitude": -122.694407
-              },
-              "description": "Northbound stop in Portland (Stop ID 7113)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "7113"
-              },
-              "name": "NW 21st & Irving",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "7113",
+            "stopId": "prt:7113",
             "stopIndex": 75,
             "stopSequence": 76,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
           "generalizedCost": 167,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 4,
             "points": "wb{tG`wzkV?LO?Ao@"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-10-21T23:23:32.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.5278491,
-              "longitude": -122.6942362
-            },
-            "name": "-102323",
-            "vehicleRentalPlace": {
-              "allowDropoff": true,
-              "allowOverloading": false,
-              "allowPickup": true,
-              "carStation": false,
-              "floatingVehicle": false,
-              "id": {
-                "feedId": "test-network",
-                "id": "-102323"
-              },
-              "isInstalled": true,
-              "isKeepingVehicleRentalAtDestinationAllowed": true,
-              "isRenting": true,
-              "isReturning": true,
-              "isValetStation": false,
-              "isVirtualStation": false,
-              "keepingVehicleRentalAtDestinationAllowed": true,
-              "latitude": 45.5278491,
-              "longitude": -122.6942362,
-              "name": {
-                "name": "-102323"
-              },
-              "realTimeData": false,
-              "spacesAvailable": 0,
-              "spacesDisabled": 0,
-              "vehicleSpacesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehicleTypesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehiclesAvailable": 0,
-              "vehiclesDisabled": 0
-            },
-            "vertexType": "VEHICLERENTAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "NORTH",
-              "angle": -0.021151532022270547,
               "area": false,
               "bogusName": false,
               "distance": 8.969,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.52764696458245,
+              "lon": -122.69447686508221,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.52764696458245,
-                "longitude": -122.69447686508221
-              },
               "stayOn": false,
-              "streetName": "Northwest 21st Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 21st Avenue"
             },
             {
               "absoluteDirection": "EAST",
-              "angle": 1.5442642615053612,
               "area": false,
               "bogusName": false,
               "distance": 19.289,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.527727600000006,
+              "lon": -122.69447930000001,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.527727600000006,
-                "longitude": -122.69447930000001
-              },
               "stayOn": false,
-              "streetName": "Northwest Irving Street",
-              "streetNotes": [ ],
-              "vehicleRentalOnStation": {
-                "id": "-102323",
-                "lat": 45.5278491,
-                "lon": -122.6942362,
-                "name": "-102323"
-              }
+              "streetName": "Northwest Irving Street"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
+          "to": {
+            "arrival": "2009-10-21T23:24:58.000+00:00",
+            "bikeShareId": "-102323",
+            "departure": "2009-10-21T23:24:58.000+00:00",
+            "lat": 45.5278491,
+            "lon": -122.6942362,
+            "name": "-102323",
+            "vertexType": "BIKESHARE"
+          },
+          "transitLeg": false,
+          "walkingBike": false
         },
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 480.068,
+          "distance": 480.068,
           "endTime": "2009-10-21T23:26:39.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.5278491,
-              "longitude": -122.6942362
-            },
+            "arrival": "2009-10-21T23:24:58.000+00:00",
+            "bikeShareId": "-102323",
+            "departure": "2009-10-21T23:24:58.000+00:00",
+            "lat": 45.5278491,
+            "lon": -122.6942362,
             "name": "-102323",
-            "vehicleRentalPlace": {
-              "allowDropoff": true,
-              "allowOverloading": false,
-              "allowPickup": true,
-              "carStation": false,
-              "floatingVehicle": false,
-              "id": {
-                "feedId": "test-network",
-                "id": "-102323"
-              },
-              "isInstalled": true,
-              "isKeepingVehicleRentalAtDestinationAllowed": true,
-              "isRenting": true,
-              "isReturning": true,
-              "isValetStation": false,
-              "isVirtualStation": false,
-              "keepingVehicleRentalAtDestinationAllowed": true,
-              "latitude": 45.5278491,
-              "longitude": -122.6942362,
-              "name": {
-                "name": "-102323"
-              },
-              "realTimeData": false,
-              "spacesAvailable": 0,
-              "spacesDisabled": 0,
-              "vehicleSpacesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehicleTypesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehiclesAvailable": 0,
-              "vehiclesDisabled": 0
-            },
-            "vertexType": "VEHICLERENTAL"
+            "vertexType": "BIKESHARE"
           },
           "generalizedCost": 196,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 6,
             "points": "ic{tG~uzkV@n@@vAD|HDtKFrJ"
           },
           "mode": "BICYCLE",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": true,
-          "scheduled": false,
+          "rentedBike": true,
+          "route": "",
           "startTime": "2009-10-21T23:24:58.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.5276173,
-              "longitude": -122.7003923
-            },
-            "name": "corner of way -102328 from 0 and Northwest Irving Street",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "vehicleRentalNetwork": "test-network",
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "WEST",
-              "angle": -1.5973283920844321,
               "area": false,
               "bogusName": false,
               "distance": 480.068,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.52773220198921,
+              "lon": -122.69423177172958,
               "relativeDirection": "HARD_LEFT",
-              "startLocation": {
-                "latitude": 45.52773220198921,
-                "longitude": -122.69423177172958
-              },
               "stayOn": false,
-              "streetName": "Northwest Irving Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Irving Street"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": false
+          "to": {
+            "arrival": "2009-10-21T23:26:39.000+00:00",
+            "departure": "2009-10-21T23:26:39.000+00:00",
+            "lat": 45.5276173,
+            "lon": -122.7003923,
+            "name": "corner of way -102328 from 0 and Northwest Irving Street",
+            "vertexType": "NORMAL"
+          },
+          "transitLeg": false,
+          "walkingBike": false
         },
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 13.358,
+          "distance": 13.358,
           "endTime": "2009-10-21T23:27:20.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.5276173,
-              "longitude": -122.7003923
-            },
+            "arrival": "2009-10-21T23:26:39.000+00:00",
+            "departure": "2009-10-21T23:26:39.000+00:00",
+            "lat": 45.5276173,
+            "lon": -122.7003923,
             "name": "corner of way -102328 from 0 and Northwest Irving Street",
             "vertexType": "NORMAL"
           },
           "generalizedCost": 81,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 2,
             "points": "qb{tGn|{kVWA"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": true,
-          "scheduled": false,
+          "rentedBike": true,
+          "route": "",
           "startTime": "2009-10-21T23:26:39.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.5277374,
-              "longitude": -122.7003879
-            },
-            "name": "-102309",
-            "vehicleRentalPlace": {
-              "allowDropoff": true,
-              "allowOverloading": false,
-              "allowPickup": true,
-              "carStation": false,
-              "floatingVehicle": false,
-              "id": {
-                "feedId": "test-network",
-                "id": "-102309"
-              },
-              "isInstalled": true,
-              "isKeepingVehicleRentalAtDestinationAllowed": true,
-              "isRenting": true,
-              "isReturning": true,
-              "isValetStation": false,
-              "isVirtualStation": false,
-              "keepingVehicleRentalAtDestinationAllowed": true,
-              "latitude": 45.5277374,
-              "longitude": -122.7003879,
-              "name": {
-                "name": "-102309"
-              },
-              "realTimeData": false,
-              "spacesAvailable": 0,
-              "spacesDisabled": 0,
-              "vehicleSpacesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehicleTypesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehiclesAvailable": 0,
-              "vehiclesDisabled": 0
-            },
-            "vertexType": "VEHICLERENTAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "vehicleRentalNetwork": "test-network",
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "NORTH",
-              "angle": 0.02566034822056683,
               "area": false,
               "bogusName": true,
               "distance": 13.358,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5276173,
+              "lon": -122.7003923,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5276173,
-                "longitude": -122.7003923
-              },
               "stayOn": false,
-              "streetName": "way -102328 from 0",
-              "streetNotes": [ ]
+              "streetName": "way -102328 from 0"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
+          "to": {
+            "arrival": "2009-10-21T23:27:20.000+00:00",
+            "bikeShareId": "-102309",
+            "departure": "2009-10-21T23:27:20.000+00:00",
+            "lat": 45.5277374,
+            "lon": -122.7003879,
+            "name": "-102309",
+            "vertexType": "BIKESHARE"
+          },
+          "transitLeg": false,
+          "walkingBike": false
         },
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 106.589,
+          "distance": 106.589,
           "endTime": "2009-10-21T23:28:51.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.5277374,
-              "longitude": -122.7003879
-            },
+            "arrival": "2009-10-21T23:27:20.000+00:00",
+            "bikeShareId": "-102309",
+            "departure": "2009-10-21T23:27:20.000+00:00",
+            "lat": 45.5277374,
+            "lon": -122.7003879,
             "name": "-102309",
-            "vehicleRentalPlace": {
-              "allowDropoff": true,
-              "allowOverloading": false,
-              "allowPickup": true,
-              "carStation": false,
-              "floatingVehicle": false,
-              "id": {
-                "feedId": "test-network",
-                "id": "-102309"
-              },
-              "isInstalled": true,
-              "isKeepingVehicleRentalAtDestinationAllowed": true,
-              "isRenting": true,
-              "isReturning": true,
-              "isValetStation": false,
-              "isVirtualStation": false,
-              "keepingVehicleRentalAtDestinationAllowed": true,
-              "latitude": 45.5277374,
-              "longitude": -122.7003879,
-              "name": {
-                "name": "-102309"
-              },
-              "realTimeData": false,
-              "spacesAvailable": 0,
-              "spacesDisabled": 0,
-              "vehicleSpacesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehicleTypesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehiclesAvailable": 0,
-              "vehiclesDisabled": 0
-            },
-            "vertexType": "VEHICLERENTAL"
+            "vertexType": "BIKESHARE"
           },
           "generalizedCost": 168,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 4,
             "points": "ic{tGl|{kVV@?d@kC@"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-10-21T23:27:20.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.52832,
-              "longitude": -122.70059
-            },
-            "name": "SW Johnson St. & NW 24th Ave. (P1)",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "SOUTH",
-              "angle": -3.1159323053692263,
               "area": false,
               "bogusName": true,
               "distance": 13.358,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5277374,
+              "lon": -122.70038790000001,
               "relativeDirection": "HARD_LEFT",
-              "startLocation": {
-                "latitude": 45.5277374,
-                "longitude": -122.70038790000001
-              },
               "stayOn": false,
-              "streetName": "way -102328 from 0",
-              "streetNotes": [ ],
-              "vehicleRentalOffStation": {
-                "id": "-102309",
-                "lat": 45.5277374,
-                "lon": -122.7003879,
-                "name": "-102309"
-              }
+              "streetName": "way -102328 from 0"
             },
             {
               "absoluteDirection": "WEST",
-              "angle": -1.5972658434069475,
               "area": false,
               "bogusName": false,
               "distance": 14.704,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5276173,
+              "lon": -122.7003923,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5276173,
-                "longitude": -122.7003923
-              },
               "stayOn": false,
-              "streetName": "Northwest Irving Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Irving Street"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": -0.015200876817562168,
               "area": false,
               "bogusName": false,
               "distance": 78.527,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.527613800000005,
+              "lon": -122.70058100000001,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.527613800000005,
-                "longitude": -122.70058100000001
-              },
               "stayOn": false,
-              "streetName": "Northwest 24th Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 24th Avenue"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
+          "to": {
+            "arrival": "2009-10-21T23:28:51.000+00:00",
+            "lat": 45.52832,
+            "lon": -122.70059,
+            "name": "SW Johnson St. & NW 24th Ave. (P1)",
+            "vertexType": "NORMAL"
+          },
+          "transitLeg": false,
+          "walkingBike": false
         }
       ],
-      "nTransfers": 0,
-      "nonTransitDistanceMeters": 796.1389999999999,
-      "nonTransitTimeSeconds": 455,
-      "onStreetAllTheWay": false,
-      "streetOnly": false,
-      "systemNotices": [ ],
+      "startTime": "2009-10-21T23:12:34.000+00:00",
       "tooSloped": false,
-      "transferPriorityCost": 0,
-      "transitTimeSeconds": 522,
-      "waitTimeOptimizedCost": 0,
-      "waitingTimeSeconds": 0,
-      "walkOnly": false,
-      "walkingAllTheWay": false
+      "transfers": 0,
+      "transitTime": 522,
+      "waitingTime": 0,
+      "walkDistance": 796.1389999999999,
+      "walkLimitExceeded": false,
+      "walkTime": 455
     },
     {
-      "arrivedAtDestinationWithRentedVehicle": false,
-      "durationSeconds": 1276,
+      "arrivedAtDestinationWithRentedBicycle": false,
+      "duration": 1276,
       "elevationGained": 0.0,
       "elevationLost": 0.0,
+      "endTime": "2009-10-21T23:35:24.000+00:00",
       "fare": {
         "details": {
           "regular": [
@@ -7368,505 +3838,229 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
           }
         }
       },
-      "flaggedForDeletion": false,
       "generalizedCost": 2503,
       "legs": [
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 287.815,
+          "distance": 287.815,
           "endTime": "2009-10-21T23:18:00.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.52523,
-              "longitude": -122.67525
-            },
+            "departure": "2009-10-21T23:14:08.000+00:00",
+            "lat": 45.52523,
+            "lon": -122.67525,
             "name": "NW Everett St. & NW 5th Ave. (P3)",
             "vertexType": "NORMAL"
           },
           "generalizedCost": 442,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 17,
             "points": "ssztGh_wkV?`@?LJAlBCH?J?H?vBCJ?H?jBCJA?D@L?lAE?"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-10-21T23:14:08.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.523169,
-              "longitude": -122.675893
-            },
-            "name": "W Burnside & NW 5th",
-            "stop": {
-              "code": "782",
-              "coordinate": {
-                "latitude": 45.523169,
-                "longitude": -122.675893
-              },
-              "description": "Westbound stop in Portland (Stop ID 782)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "0"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "782"
-              },
-              "name": "W Burnside & NW 5th",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
-            "stopIndex": 99,
-            "stopSequence": 100,
-            "vertexType": "TRANSIT"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "WEST",
-              "angle": -1.596868818888735,
               "area": false,
               "bogusName": false,
               "distance": 17.975,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.52522794293369,
+              "lon": -122.67524992342938,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.52522794293369,
-                "longitude": -122.67524992342938
-              },
               "stayOn": false,
-              "streetName": "Northwest Everett Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Everett Street"
             },
             {
               "absoluteDirection": "SOUTH",
-              "angle": 3.1122681276306428,
               "area": false,
               "bogusName": false,
               "distance": 231.76100000000002,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.525224200000004,
+              "lon": -122.67548060000001,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.525224200000004,
-                "longitude": -122.67548060000001
-              },
               "stayOn": false,
-              "streetName": "Northwest 5th Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 5th Avenue"
             },
             {
               "absoluteDirection": "WEST",
-              "angle": -1.5966159701088662,
               "area": false,
               "bogusName": false,
               "distance": 38.079,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.523141200000005,
+              "lon": -122.67540310000001,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.523141200000005,
-                "longitude": -122.67540310000001
-              },
               "stayOn": false,
-              "streetName": "West Burnside Street",
-              "streetNotes": [ ]
+              "streetName": "West Burnside Street"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
-        },
-        {
-          "agencyTimeZoneOffset": 0,
-          "arrivalDelay": 0,
-          "departureDelay": 0,
-          "distanceMeters": 1942.2498485359197,
-          "endTime": "2009-10-21T23:28:03.000+00:00",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.523169,
-              "longitude": -122.675893
-            },
+          "to": {
+            "arrival": "2009-10-21T23:18:00.000+00:00",
+            "departure": "2009-10-21T23:18:00.000+00:00",
+            "lat": 45.523169,
+            "lon": -122.675893,
             "name": "W Burnside & NW 5th",
-            "stop": {
-              "code": "782",
-              "coordinate": {
-                "latitude": 45.523169,
-                "longitude": -122.675893
-              },
-              "description": "Westbound stop in Portland (Stop ID 782)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "0"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "782"
-              },
-              "name": "W Burnside & NW 5th",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "782",
+            "stopId": "prt:782",
             "stopIndex": 99,
             "stopSequence": 100,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
+          },
+          "transitLeg": false,
+          "walkingBike": false
+        },
+        {
+          "agencyId": "prt:prt",
+          "agencyName": "TriMet",
+          "agencyTimeZoneOffset": 0,
+          "agencyUrl": "http://trimet.org",
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 1942.2498485359197,
+          "endTime": "2009-10-21T23:28:03.000+00:00",
+          "from": {
+            "arrival": "2009-10-21T23:18:00.000+00:00",
+            "departure": "2009-10-21T23:18:00.000+00:00",
+            "lat": 45.523169,
+            "lon": -122.675893,
+            "name": "W Burnside & NW 5th",
+            "stopCode": "782",
+            "stopId": "prt:782",
+            "stopIndex": 99,
+            "stopSequence": 100,
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
           },
           "generalizedCost": 1203,
           "headsign": "Beaverton TC",
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "intermediateStops": [
             {
               "arrival": "2009-10-21T23:19:43.000+00:00",
               "departure": "2009-10-21T23:19:43.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523115,
-                  "longitude": -122.678939
-                },
-                "name": "W Burnside & NW Park",
-                "stop": {
-                  "code": "716",
-                  "coordinate": {
-                    "latitude": 45.523115,
-                    "longitude": -122.678939
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 716)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "716"
-                  },
-                  "name": "W Burnside & NW Park",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 100,
-                "stopSequence": 101,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523115,
+              "lon": -122.678939,
+              "name": "W Burnside & NW Park",
+              "stopCode": "716",
+              "stopId": "prt:716",
+              "stopIndex": 100,
+              "stopSequence": 101,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-10-21T23:21:13.000+00:00",
               "departure": "2009-10-21T23:21:13.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523048,
-                  "longitude": -122.681606
-                },
-                "name": "W Burnside & NW 10th",
-                "stop": {
-                  "code": "10791",
-                  "coordinate": {
-                    "latitude": 45.523048,
-                    "longitude": -122.681606
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 10791)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "10791"
-                  },
-                  "name": "W Burnside & NW 10th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 101,
-                "stopSequence": 102,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523048,
+              "lon": -122.681606,
+              "name": "W Burnside & NW 10th",
+              "stopCode": "10791",
+              "stopId": "prt:10791",
+              "stopIndex": 101,
+              "stopSequence": 102,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-10-21T23:22:18.000+00:00",
               "departure": "2009-10-21T23:22:18.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523,
-                  "longitude": -122.683535
-                },
-                "name": "W Burnside & NW 12th",
-                "stop": {
-                  "code": "11032",
-                  "coordinate": {
-                    "latitude": 45.523,
-                    "longitude": -122.683535
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 11032)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "11032"
-                  },
-                  "name": "W Burnside & NW 12th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 102,
-                "stopSequence": 103,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523,
+              "lon": -122.683535,
+              "name": "W Burnside & NW 12th",
+              "stopCode": "11032",
+              "stopId": "prt:11032",
+              "stopIndex": 102,
+              "stopSequence": 103,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-10-21T23:24:52.000+00:00",
               "departure": "2009-10-21T23:24:52.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.522985,
-                  "longitude": -122.688091
-                },
-                "name": "W Burnside & NW 17th",
-                "stop": {
-                  "code": "10809",
-                  "coordinate": {
-                    "latitude": 45.522985,
-                    "longitude": -122.688091
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 10809)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "10809"
-                  },
-                  "name": "W Burnside & NW 17th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 103,
-                "stopSequence": 104,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.522985,
+              "lon": -122.688091,
+              "name": "W Burnside & NW 17th",
+              "stopCode": "10809",
+              "stopId": "prt:10809",
+              "stopIndex": 103,
+              "stopSequence": 104,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:26:00.000+00:00",
               "departure": "2009-10-21T23:26:00.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523097,
-                  "longitude": -122.690083
-                },
-                "name": "W Burnside & NW 19th",
-                "stop": {
-                  "code": "735",
-                  "coordinate": {
-                    "latitude": 45.523097,
-                    "longitude": -122.690083
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 735)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "735"
-                  },
-                  "name": "W Burnside & NW 19th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 104,
-                "stopSequence": 105,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523097,
+              "lon": -122.690083,
+              "name": "W Burnside & NW 19th",
+              "stopCode": "735",
+              "stopId": "prt:735",
+              "stopIndex": 104,
+              "stopSequence": 105,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:26:24.000+00:00",
               "departure": "2009-10-21T23:26:24.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523176,
-                  "longitude": -122.692139
-                },
-                "name": "W Burnside & NW 20th",
-                "stop": {
-                  "code": "741",
-                  "coordinate": {
-                    "latitude": 45.523176,
-                    "longitude": -122.692139
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 741)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "741"
-                  },
-                  "name": "W Burnside & NW 20th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 105,
-                "stopSequence": 106,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523176,
+              "lon": -122.692139,
+              "name": "W Burnside & NW 20th",
+              "stopCode": "741",
+              "stopId": "prt:741",
+              "stopIndex": 105,
+              "stopSequence": 106,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:26:35.000+00:00",
               "departure": "2009-10-21T23:26:35.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.52322,
-                  "longitude": -122.69313
-                },
-                "name": "W Burnside & NW 20th Pl",
-                "stop": {
-                  "code": "742",
-                  "coordinate": {
-                    "latitude": 45.52322,
-                    "longitude": -122.69313
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 742)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "742"
-                  },
-                  "name": "W Burnside & NW 20th Pl",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 106,
-                "stopSequence": 107,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.52322,
+              "lon": -122.69313,
+              "name": "W Burnside & NW 20th Pl",
+              "stopCode": "742",
+              "stopId": "prt:742",
+              "stopIndex": 106,
+              "stopSequence": 107,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:26:55.000+00:00",
               "departure": "2009-10-21T23:26:55.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523312,
-                  "longitude": -122.694901
-                },
-                "name": "W Burnside & NW King",
-                "stop": {
-                  "code": "747",
-                  "coordinate": {
-                    "latitude": 45.523312,
-                    "longitude": -122.694901
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 747)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "747"
-                  },
-                  "name": "W Burnside & NW King",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 107,
-                "stopSequence": 108,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523312,
+              "lon": -122.694901,
+              "name": "W Burnside & NW King",
+              "stopCode": "747",
+              "stopId": "prt:747",
+              "stopIndex": 107,
+              "stopSequence": 108,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:27:32.000+00:00",
               "departure": "2009-10-21T23:27:32.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523512,
-                  "longitude": -122.698081
-                },
-                "name": "W Burnside & NW 23rd",
-                "stop": {
-                  "code": "755",
-                  "coordinate": {
-                    "latitude": 45.523512,
-                    "longitude": -122.698081
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 755)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "755"
-                  },
-                  "name": "W Burnside & NW 23rd",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 108,
-                "stopSequence": 109,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523512,
+              "lon": -122.698081,
+              "name": "W Burnside & NW 23rd",
+              "stopCode": "755",
+              "stopId": "prt:755",
+              "stopIndex": 108,
+              "stopSequence": 109,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             }
           ],
           "legGeometry": {
@@ -7874,259 +4068,139 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "points": "efztGhcwkV@rBBzDBpE@~A???Z@tD@RBnEB|A???@BdB?lEBjA??BnBApF@dB?X?^@r@?f@@bCAx@EtB???VChAE|BGnD??AXKnEGnD???XGjD??AZEfCC`AEzB??AXCfAGxDE|AEtBIlC??APu@lJMhBI`@"
           },
           "mode": "BUS",
-          "onStreetNonTransit": false,
           "pathway": false,
           "realTime": false,
-          "scheduled": true,
-          "serviceDate": {
-            "day": 21,
-            "minMax": false,
-            "month": 10,
-            "sequenceNumber": 20091021,
-            "year": 2009
-          },
+          "route": "Burnside/Stark",
+          "routeId": "prt:20",
+          "routeLongName": "Burnside/Stark",
+          "routeShortName": "20",
+          "serviceDate": "2009-10-21",
           "startTime": "2009-10-21T23:18:00.000+00:00",
-          "streetNotes": [ ],
+          "steps": [ ],
           "to": {
-            "coordinate": {
-              "latitude": 45.523897,
-              "longitude": -122.700681
-            },
+            "arrival": "2009-10-21T23:28:03.000+00:00",
+            "departure": "2009-10-21T23:28:03.000+00:00",
+            "lat": 45.523897,
+            "lon": -122.700681,
             "name": "W Burnside & NW 23rd Pl",
-            "stop": {
-              "code": "9555",
-              "coordinate": {
-                "latitude": 45.523897,
-                "longitude": -122.700681
-              },
-              "description": "Westbound stop in Portland (Stop ID 9555)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "9555"
-              },
-              "name": "W Burnside & NW 23rd Pl",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "9555",
+            "stopId": "prt:9555",
             "stopIndex": 109,
             "stopSequence": 110,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
-          "transitAlerts": [ ],
           "transitLeg": true,
-          "trip": {
-            "alteration": "PLANNED",
-            "bikesAllowed": "UNKNOWN",
-            "blockId": "2069",
-            "direction": "OUTBOUND",
-            "id": {
-              "feedId": "prt",
-              "id": "200W1440"
-            },
-            "route": {
-              "agency": {
-                "fareUrl": "http://trimet.org/fares/index.htm",
-                "id": {
-                  "feedId": "prt",
-                  "id": "prt"
-                },
-                "lang": "en",
-                "name": "TriMet",
-                "phone": "503-238-7433",
-                "timezone": "America/Los_Angeles",
-                "url": "http://trimet.org"
-              },
-              "bikesAllowed": "UNKNOWN",
-              "gtfsType": 3,
-              "id": {
-                "feedId": "prt",
-                "id": "20"
-              },
-              "longName": "Burnside/Stark",
-              "mode": "BUS",
-              "shortName": "20",
-              "sortOrder": -999,
-              "sortOrderSet": false,
-              "url": "http://trimet.org/schedules/r020.htm"
-            },
-            "serviceId": {
-              "feedId": "prt",
-              "id": "W"
-            },
-            "shapeId": {
-              "feedId": "prt",
-              "id": "20.0.1"
-            },
-            "wheelchairAccessible": 0
-          },
-          "walkSteps": [ ],
-          "walkingLeg": false
+          "tripBlockId": "2069",
+          "tripId": "prt:200W1440"
         },
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 563.701,
+          "distance": 563.701,
           "endTime": "2009-10-21T23:35:24.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.523897,
-              "longitude": -122.700681
-            },
+            "arrival": "2009-10-21T23:28:03.000+00:00",
+            "departure": "2009-10-21T23:28:03.000+00:00",
+            "lat": 45.523897,
+            "lon": -122.700681,
             "name": "W Burnside & NW 23rd Pl",
-            "stop": {
-              "code": "9555",
-              "coordinate": {
-                "latitude": 45.523897,
-                "longitude": -122.700681
-              },
-              "description": "Westbound stop in Portland (Stop ID 9555)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "9555"
-              },
-              "name": "W Burnside & NW 23rd Pl",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "9555",
+            "stopId": "prt:9555",
             "stopIndex": 109,
             "stopSequence": 110,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
           "generalizedCost": 858,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 34,
             "points": "ikztGh~{kVNDEVUzACPOUQO_@Yc@[QMMEOKOIECGCIAMCGCGAECECECOOMOGKIFMLk@BsABGDGBoCBkCDkC@"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-10-21T23:28:03.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.52832,
-              "longitude": -122.70059
-            },
-            "name": "SW Johnson St. & NW 24th Ave. (P1)",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "WEST",
-              "angle": -1.247661800162498,
               "area": false,
               "bogusName": false,
               "distance": 54.628,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.523815597641374,
+              "lon": -122.70071990797962,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.523815597641374,
-                "longitude": -122.70071990797962
-              },
               "stayOn": false,
-              "streetName": "West Burnside Street",
-              "streetNotes": [ ]
+              "streetName": "West Burnside Street"
             },
             {
               "absoluteDirection": "NORTHEAST",
-              "angle": 0.7501559967245512,
               "area": false,
               "bogusName": false,
               "distance": 176.41,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5239733,
+              "lon": -122.701384,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5239733,
-                "longitude": -122.701384
-              },
               "stayOn": false,
-              "streetName": "Northwest 24th Place",
-              "streetNotes": [ ]
+              "streetName": "Northwest 24th Place"
             },
             {
               "absoluteDirection": "NORTHWEST",
-              "angle": -0.5889596407957216,
               "area": false,
               "bogusName": false,
               "distance": 15.262,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5253583,
+              "lon": -122.70033570000001,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.5253583,
-                "longitude": -122.70033570000001
-              },
               "stayOn": false,
-              "streetName": "Northwest Westover Road",
-              "streetNotes": [ ]
+              "streetName": "Northwest Westover Road"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": -0.05815952978341337,
               "area": false,
               "bogusName": false,
               "distance": 317.401,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.525472400000005,
+              "lon": -122.7004445,
               "relativeDirection": "SLIGHTLY_RIGHT",
-              "startLocation": {
-                "latitude": 45.525472400000005,
-                "longitude": -122.7004445
-              },
               "stayOn": false,
-              "streetName": "Northwest 24th Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 24th Avenue"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
+          "to": {
+            "arrival": "2009-10-21T23:35:24.000+00:00",
+            "lat": 45.52832,
+            "lon": -122.70059,
+            "name": "SW Johnson St. & NW 24th Ave. (P1)",
+            "vertexType": "NORMAL"
+          },
+          "transitLeg": false,
+          "walkingBike": false
         }
       ],
-      "nTransfers": 0,
-      "nonTransitDistanceMeters": 851.5160000000001,
-      "nonTransitTimeSeconds": 673,
-      "onStreetAllTheWay": false,
-      "streetOnly": false,
-      "systemNotices": [ ],
+      "startTime": "2009-10-21T23:14:08.000+00:00",
       "tooSloped": false,
-      "transferPriorityCost": 0,
-      "transitTimeSeconds": 603,
-      "waitTimeOptimizedCost": 0,
-      "waitingTimeSeconds": 0,
-      "walkOnly": false,
-      "walkingAllTheWay": false
+      "transfers": 0,
+      "transitTime": 603,
+      "waitingTime": 0,
+      "walkDistance": 851.5160000000001,
+      "walkLimitExceeded": false,
+      "walkTime": 673
     },
     {
-      "arrivedAtDestinationWithRentedVehicle": false,
-      "durationSeconds": 1134,
+      "arrivedAtDestinationWithRentedBicycle": false,
+      "duration": 1134,
       "elevationGained": 0.0,
       "elevationLost": 0.0,
+      "endTime": "2009-10-21T23:37:21.000+00:00",
       "fare": {
         "details": {
           "regular": [
@@ -8159,448 +4233,215 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
           }
         }
       },
-      "flaggedForDeletion": false,
       "generalizedCost": 2351,
       "legs": [
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 252.87499999999997,
+          "distance": 252.87499999999997,
           "endTime": "2009-10-21T23:21:53.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.52523,
-              "longitude": -122.67525
-            },
+            "departure": "2009-10-21T23:18:27.000+00:00",
+            "lat": 45.52523,
+            "lon": -122.67525,
             "name": "NW Everett St. & NW 5th Ave. (P3)",
             "vertexType": "NORMAL"
           },
           "generalizedCost": 392,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 15,
             "points": "ssztGh_wkV?`@?LK?uBBK?K@sBBM??D?L@\\?lCC??E"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-10-21T23:18:27.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.526655,
-              "longitude": -122.676462
-            },
-            "name": "NW Glisan & 6th",
-            "stop": {
-              "code": "10803",
-              "coordinate": {
-                "latitude": 45.526655,
-                "longitude": -122.676462
-              },
-              "description": "Westbound stop in Portland (Stop ID 10803)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "0"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "10803"
-              },
-              "name": "NW Glisan & 6th",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
-            "stopIndex": 85,
-            "stopSequence": 86,
-            "vertexType": "TRANSIT"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "WEST",
-              "angle": -1.596868818888735,
               "area": false,
               "bogusName": false,
               "distance": 17.975,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.52522794293369,
+              "lon": -122.67524992342938,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.52522794293369,
-                "longitude": -122.67524992342938
-              },
               "stayOn": false,
-              "streetName": "Northwest Everett Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Everett Street"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": -0.02939746732509391,
               "area": false,
               "bogusName": false,
               "distance": 158.018,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.525224200000004,
+              "lon": -122.67548060000001,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.525224200000004,
-                "longitude": -122.67548060000001
-              },
               "stayOn": false,
-              "streetName": "Northwest 5th Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 5th Avenue"
             },
             {
               "absoluteDirection": "WEST",
-              "angle": -1.6080284293804317,
               "area": false,
               "bogusName": false,
               "distance": 74.227,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.526644700000006,
+              "lon": -122.67553910000001,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.526644700000006,
-                "longitude": -122.67553910000001
-              },
               "stayOn": false,
-              "streetName": "Northwest Glisan Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Glisan Street"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": -0.03835551109631682,
               "area": false,
               "bogusName": true,
               "distance": 2.655,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5266303,
+              "lon": -122.67649170000001,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5266303,
-                "longitude": -122.67649170000001
-              },
               "stayOn": false,
-              "streetName": "way 156261070 from 2",
-              "streetNotes": [ ]
+              "streetName": "way 156261070 from 2"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
-        },
-        {
-          "agencyTimeZoneOffset": 0,
-          "arrivalDelay": 0,
-          "departureDelay": 0,
-          "distanceMeters": 2232.3107878360292,
-          "endTime": "2009-10-21T23:29:50.000+00:00",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.526655,
-              "longitude": -122.676462
-            },
+          "to": {
+            "arrival": "2009-10-21T23:21:53.000+00:00",
+            "departure": "2009-10-21T23:21:53.000+00:00",
+            "lat": 45.526655,
+            "lon": -122.676462,
             "name": "NW Glisan & 6th",
-            "stop": {
-              "code": "10803",
-              "coordinate": {
-                "latitude": 45.526655,
-                "longitude": -122.676462
-              },
-              "description": "Westbound stop in Portland (Stop ID 10803)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "0"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "10803"
-              },
-              "name": "NW Glisan & 6th",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "10803",
+            "stopId": "prt:10803",
             "stopIndex": 85,
             "stopSequence": 86,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
+          },
+          "transitLeg": false,
+          "walkingBike": false
+        },
+        {
+          "agencyId": "prt:prt",
+          "agencyName": "TriMet",
+          "agencyTimeZoneOffset": 0,
+          "agencyUrl": "http://trimet.org",
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 2232.3107878360292,
+          "endTime": "2009-10-21T23:29:50.000+00:00",
+          "from": {
+            "arrival": "2009-10-21T23:21:53.000+00:00",
+            "departure": "2009-10-21T23:21:53.000+00:00",
+            "lat": 45.526655,
+            "lon": -122.676462,
+            "name": "NW Glisan & 6th",
+            "stopCode": "10803",
+            "stopId": "prt:10803",
+            "stopIndex": 85,
+            "stopSequence": 86,
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
           },
           "generalizedCost": 1077,
           "headsign": "Montgomery Park",
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "intermediateStops": [
             {
               "arrival": "2009-10-21T23:22:57.000+00:00",
               "departure": "2009-10-21T23:22:57.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.528799,
-                  "longitude": -122.677238
-                },
-                "name": "NW Station Way & Union Station",
-                "stop": {
-                  "code": "12801",
-                  "coordinate": {
-                    "latitude": 45.528799,
-                    "longitude": -122.677238
-                  },
-                  "description": "Northbound stop in Portland (Stop ID 12801)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "12801"
-                  },
-                  "name": "NW Station Way & Union Station",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 86,
-                "stopSequence": 87,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.528799,
+              "lon": -122.677238,
+              "name": "NW Station Way & Union Station",
+              "stopCode": "12801",
+              "stopId": "prt:12801",
+              "stopIndex": 86,
+              "stopSequence": 87,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-10-21T23:25:00.000+00:00",
               "departure": "2009-10-21T23:25:00.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.531582,
-                  "longitude": -122.681193
-                },
-                "name": "NW Northrup & 10th",
-                "stop": {
-                  "code": "12802",
-                  "coordinate": {
-                    "latitude": 45.531582,
-                    "longitude": -122.681193
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 12802)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "12802"
-                  },
-                  "name": "NW Northrup & 10th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 87,
-                "stopSequence": 88,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.531582,
+              "lon": -122.681193,
+              "name": "NW Northrup & 10th",
+              "stopCode": "12802",
+              "stopId": "prt:12802",
+              "stopIndex": 87,
+              "stopSequence": 88,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:25:33.000+00:00",
               "departure": "2009-10-21T23:25:33.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.531534,
-                  "longitude": -122.683319
-                },
-                "name": "NW 12th & Northrup",
-                "stop": {
-                  "code": "12796",
-                  "coordinate": {
-                    "latitude": 45.531534,
-                    "longitude": -122.683319
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 12796)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "12796"
-                  },
-                  "name": "NW 12th & Northrup",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 88,
-                "stopSequence": 89,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.531534,
+              "lon": -122.683319,
+              "name": "NW 12th & Northrup",
+              "stopCode": "12796",
+              "stopId": "prt:12796",
+              "stopIndex": 88,
+              "stopSequence": 89,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:26:04.000+00:00",
               "departure": "2009-10-21T23:26:04.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.531503,
-                  "longitude": -122.685357
-                },
-                "name": "NW Northrup & 14th",
-                "stop": {
-                  "code": "10775",
-                  "coordinate": {
-                    "latitude": 45.531503,
-                    "longitude": -122.685357
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 10775)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "10775"
-                  },
-                  "name": "NW Northrup & 14th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 89,
-                "stopSequence": 90,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.531503,
+              "lon": -122.685357,
+              "name": "NW Northrup & 14th",
+              "stopCode": "10775",
+              "stopId": "prt:10775",
+              "stopIndex": 89,
+              "stopSequence": 90,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:27:07.000+00:00",
               "departure": "2009-10-21T23:27:07.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.531434,
-                  "longitude": -122.689417
-                },
-                "name": "NW Northrup & 18th",
-                "stop": {
-                  "code": "10776",
-                  "coordinate": {
-                    "latitude": 45.531434,
-                    "longitude": -122.689417
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 10776)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "10776"
-                  },
-                  "name": "NW Northrup & 18th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 90,
-                "stopSequence": 91,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.531434,
+              "lon": -122.689417,
+              "name": "NW Northrup & 18th",
+              "stopCode": "10776",
+              "stopId": "prt:10776",
+              "stopIndex": 90,
+              "stopSequence": 91,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:28:24.000+00:00",
               "departure": "2009-10-21T23:28:24.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.531346,
-                  "longitude": -122.694455
-                },
-                "name": "NW Northrup & 21st",
-                "stop": {
-                  "code": "10777",
-                  "coordinate": {
-                    "latitude": 45.531346,
-                    "longitude": -122.694455
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 10777)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "10777"
-                  },
-                  "name": "NW Northrup & 21st",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 91,
-                "stopSequence": 92,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.531346,
+              "lon": -122.694455,
+              "name": "NW Northrup & 21st",
+              "stopCode": "10777",
+              "stopId": "prt:10777",
+              "stopIndex": 91,
+              "stopSequence": 92,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:28:55.000+00:00",
               "departure": "2009-10-21T23:28:55.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.531308,
-                  "longitude": -122.696445
-                },
-                "name": "NW Northrup & 22nd",
-                "stop": {
-                  "code": "10778",
-                  "coordinate": {
-                    "latitude": 45.531308,
-                    "longitude": -122.696445
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 10778)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "10778"
-                  },
-                  "name": "NW Northrup & 22nd",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 92,
-                "stopSequence": 93,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.531308,
+              "lon": -122.696445,
+              "name": "NW Northrup & 22nd",
+              "stopCode": "10778",
+              "stopId": "prt:10778",
+              "stopIndex": 92,
+              "stopSequence": 93,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             }
           ],
           "legGeometry": {
@@ -8608,242 +4449,127 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "points": "i|ztG|fwkV?LqCFmCDYBGDEBGJkAzAQR??KNa@b@MJuBBY?OHW@u@~@aD`EcBhBBrD@xC??@l@BlE@lD???XBjEBpD???VBlE?dA@t@?b@?h@BfEBrD???VBhEFtKDvJ??@\\DnJ???d@FtKmCBo@@"
           },
           "mode": "BUS",
-          "onStreetNonTransit": false,
           "pathway": false,
           "realTime": false,
-          "scheduled": true,
-          "serviceDate": {
-            "day": 21,
-            "minMax": false,
-            "month": 10,
-            "sequenceNumber": 20091021,
-            "year": 2009
-          },
+          "route": "Broadway/Halsey",
+          "routeId": "prt:77",
+          "routeLongName": "Broadway/Halsey",
+          "routeShortName": "77",
+          "serviceDate": "2009-10-21",
           "startTime": "2009-10-21T23:21:53.000+00:00",
-          "streetNotes": [ ],
+          "steps": [ ],
           "to": {
-            "coordinate": {
-              "latitude": 45.532159,
-              "longitude": -122.698634
-            },
+            "arrival": "2009-10-21T23:29:50.000+00:00",
+            "departure": "2009-10-21T23:29:50.000+00:00",
+            "lat": 45.532159,
+            "lon": -122.698634,
             "name": "NW 23rd & Overton",
-            "stop": {
-              "code": "8981",
-              "coordinate": {
-                "latitude": 45.532159,
-                "longitude": -122.698634
-              },
-              "description": "Northbound stop in Portland (Stop ID 8981)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "8981"
-              },
-              "name": "NW 23rd & Overton",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "8981",
+            "stopId": "prt:8981",
             "stopIndex": 93,
             "stopSequence": 94,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
-          "transitAlerts": [ ],
           "transitLeg": true,
-          "trip": {
-            "alteration": "PLANNED",
-            "bikesAllowed": "UNKNOWN",
-            "blockId": "7710",
-            "direction": "INBOUND",
-            "id": {
-              "feedId": "prt",
-              "id": "771W1370"
-            },
-            "route": {
-              "agency": {
-                "fareUrl": "http://trimet.org/fares/index.htm",
-                "id": {
-                  "feedId": "prt",
-                  "id": "prt"
-                },
-                "lang": "en",
-                "name": "TriMet",
-                "phone": "503-238-7433",
-                "timezone": "America/Los_Angeles",
-                "url": "http://trimet.org"
-              },
-              "bikesAllowed": "UNKNOWN",
-              "gtfsType": 3,
-              "id": {
-                "feedId": "prt",
-                "id": "77"
-              },
-              "longName": "Broadway/Halsey",
-              "mode": "BUS",
-              "shortName": "77",
-              "sortOrder": -999,
-              "sortOrderSet": false,
-              "url": "http://trimet.org/schedules/r077.htm"
-            },
-            "serviceId": {
-              "feedId": "prt",
-              "id": "W"
-            },
-            "shapeId": {
-              "feedId": "prt",
-              "id": "77.1.3"
-            },
-            "wheelchairAccessible": 0
-          },
-          "walkSteps": [ ],
-          "walkingLeg": false
+          "tripBlockId": "7710",
+          "tripId": "prt:771W1370"
         },
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 580.63,
+          "distance": 580.63,
           "endTime": "2009-10-21T23:37:21.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.532159,
-              "longitude": -122.698634
-            },
+            "arrival": "2009-10-21T23:29:50.000+00:00",
+            "departure": "2009-10-21T23:29:50.000+00:00",
+            "lat": 45.532159,
+            "lon": -122.698634,
             "name": "NW 23rd & Overton",
-            "stop": {
-              "code": "8981",
-              "coordinate": {
-                "latitude": 45.532159,
-                "longitude": -122.698634
-              },
-              "description": "Northbound stop in Portland (Stop ID 8981)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "8981"
-              },
-              "name": "NW 23rd & Overton",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "8981",
+            "stopId": "prt:8981",
             "stopIndex": 93,
             "stopSequence": 94,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
           "generalizedCost": 881,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 12,
             "points": "}~{tGnq{kV?LVAF?J?FtKlCClCEnCElCElCCB?"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-10-21T23:29:50.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.52832,
-              "longitude": -122.70059
-            },
-            "name": "SW Johnson St. & NW 24th Ave. (P1)",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "SOUTH",
-              "angle": 3.117146926361324,
               "area": false,
               "bogusName": false,
               "distance": 24.895,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.53215782420268,
+              "lon": -122.69870264831422,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.53215782420268,
-                "longitude": -122.69870264831422
-              },
               "stayOn": false,
-              "streetName": "Northwest 23rd Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 23rd Avenue"
             },
             {
               "absoluteDirection": "WEST",
-              "angle": -1.6005554859058504,
               "area": false,
               "bogusName": false,
               "distance": 158.45,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.531934,
+              "lon": -122.698695,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.531934,
-                "longitude": -122.698695
-              },
               "stayOn": false,
-              "streetName": "Northwest Overton Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Overton Street"
             },
             {
               "absoluteDirection": "SOUTH",
-              "angle": 3.119908233299857,
               "area": false,
               "bogusName": false,
               "distance": 397.28499999999997,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5318916,
+              "lon": -122.70072830000001,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.5318916,
-                "longitude": -122.70072830000001
-              },
               "stayOn": false,
-              "streetName": "Northwest 24th Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 24th Avenue"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
+          "to": {
+            "arrival": "2009-10-21T23:37:21.000+00:00",
+            "lat": 45.52832,
+            "lon": -122.70059,
+            "name": "SW Johnson St. & NW 24th Ave. (P1)",
+            "vertexType": "NORMAL"
+          },
+          "transitLeg": false,
+          "walkingBike": false
         }
       ],
-      "nTransfers": 0,
-      "nonTransitDistanceMeters": 833.505,
-      "nonTransitTimeSeconds": 657,
-      "onStreetAllTheWay": false,
-      "streetOnly": false,
-      "systemNotices": [ ],
+      "startTime": "2009-10-21T23:18:27.000+00:00",
       "tooSloped": false,
-      "transferPriorityCost": 0,
-      "transitTimeSeconds": 477,
-      "waitTimeOptimizedCost": 0,
-      "waitingTimeSeconds": 0,
-      "walkOnly": false,
-      "walkingAllTheWay": false
+      "transfers": 0,
+      "transitTime": 477,
+      "waitingTime": 0,
+      "walkDistance": 833.505,
+      "walkLimitExceeded": false,
+      "walkTime": 657
     },
     {
-      "arrivedAtDestinationWithRentedVehicle": false,
-      "durationSeconds": 977,
+      "arrivedAtDestinationWithRentedBicycle": false,
+      "duration": 977,
       "elevationGained": 0.0,
       "elevationLost": 0.0,
+      "endTime": "2009-10-21T23:43:51.000+00:00",
       "fare": {
         "details": {
           "regular": [
@@ -8876,468 +4602,216 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
           }
         }
       },
-      "flaggedForDeletion": false,
       "generalizedCost": 1998,
       "legs": [
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 167.86599999999999,
+          "distance": 167.86599999999999,
           "endTime": "2009-10-21T23:29:50.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.52523,
-              "longitude": -122.67525
-            },
+            "departure": "2009-10-21T23:27:34.000+00:00",
+            "lat": 45.52523,
+            "lon": -122.67525,
             "name": "NW Everett St. & NW 5th Ave. (P3)",
             "vertexType": "NORMAL"
           },
           "generalizedCost": 261,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 10,
             "points": "ssztGh_wkV?`@?LK?uBBK??F?JBbDN?"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-10-21T23:27:34.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.52583,
-              "longitude": -122.676422
-            },
-            "name": "NW 6th & Flanders",
-            "stop": {
-              "code": "9300",
-              "coordinate": {
-                "latitude": 45.52583,
-                "longitude": -122.676422
-              },
-              "description": "Northbound stop in Portland (Stop ID 9300)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "0"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "9300"
-              },
-              "name": "NW 6th & Flanders",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
-            "stopIndex": 66,
-            "stopSequence": 67,
-            "vertexType": "TRANSIT"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "WEST",
-              "angle": -1.596868818888735,
               "area": false,
               "bogusName": false,
               "distance": 17.975,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.52522794293369,
+              "lon": -122.67524992342938,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.52522794293369,
-                "longitude": -122.67524992342938
-              },
               "stayOn": false,
-              "streetName": "Northwest Everett Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Everett Street"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": -0.02939746732509391,
               "area": false,
               "bogusName": false,
               "distance": 78.514,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.525224200000004,
+              "lon": -122.67548060000001,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.525224200000004,
-                "longitude": -122.67548060000001
-              },
               "stayOn": false,
-              "streetName": "Northwest 5th Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 5th Avenue"
             },
             {
               "absoluteDirection": "WEST",
-              "angle": -1.5977129345986325,
               "area": false,
               "bogusName": false,
               "distance": 71.377,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.52593,
+              "lon": -122.6755097,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.52593,
-                "longitude": -122.6755097
-              },
               "stayOn": false,
-              "streetName": "Northwest Flanders Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Flanders Street"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
-        },
-        {
-          "agencyTimeZoneOffset": 0,
-          "arrivalDelay": 0,
-          "departureDelay": 0,
-          "distanceMeters": 1631.0313510234191,
-          "endTime": "2009-10-21T23:38:32.000+00:00",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.52583,
-              "longitude": -122.676422
-            },
+          "to": {
+            "arrival": "2009-10-21T23:29:50.000+00:00",
+            "departure": "2009-10-21T23:29:50.000+00:00",
+            "lat": 45.52583,
+            "lon": -122.676422,
             "name": "NW 6th & Flanders",
-            "stop": {
-              "code": "9300",
-              "coordinate": {
-                "latitude": 45.52583,
-                "longitude": -122.676422
-              },
-              "description": "Northbound stop in Portland (Stop ID 9300)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "0"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "9300"
-              },
-              "name": "NW 6th & Flanders",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "9300",
+            "stopId": "prt:9300",
             "stopIndex": 66,
             "stopSequence": 67,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
+          },
+          "transitLeg": false,
+          "walkingBike": false
+        },
+        {
+          "agencyId": "prt:prt",
+          "agencyName": "TriMet",
+          "agencyTimeZoneOffset": 0,
+          "agencyUrl": "http://trimet.org",
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 1631.0313510234191,
+          "endTime": "2009-10-21T23:38:32.000+00:00",
+          "from": {
+            "arrival": "2009-10-21T23:29:50.000+00:00",
+            "departure": "2009-10-21T23:29:50.000+00:00",
+            "lat": 45.52583,
+            "lon": -122.676422,
+            "name": "NW 6th & Flanders",
+            "stopCode": "9300",
+            "stopId": "prt:9300",
+            "stopIndex": 66,
+            "stopSequence": 67,
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
           },
           "generalizedCost": 1122,
           "headsign": "31st & Industrial",
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "intermediateStops": [
             {
               "arrival": "2009-10-21T23:30:41.000+00:00",
               "departure": "2009-10-21T23:30:41.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.526678,
-                  "longitude": -122.677476
-                },
-                "name": "NW Glisan & Broadway",
-                "stop": {
-                  "code": "1997",
-                  "coordinate": {
-                    "latitude": 45.526678,
-                    "longitude": -122.677476
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 1997)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1997"
-                  },
-                  "name": "NW Glisan & Broadway",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 67,
-                "stopSequence": 68,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.526678,
+              "lon": -122.677476,
+              "name": "NW Glisan & Broadway",
+              "stopCode": "1997",
+              "stopId": "prt:1997",
+              "stopIndex": 67,
+              "stopSequence": 68,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-10-21T23:31:21.000+00:00",
               "departure": "2009-10-21T23:31:21.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.526643,
-                  "longitude": -122.679075
-                },
-                "name": "NW Glisan & Park",
-                "stop": {
-                  "code": "2007",
-                  "coordinate": {
-                    "latitude": 45.526643,
-                    "longitude": -122.679075
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 2007)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "2007"
-                  },
-                  "name": "NW Glisan & Park",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 68,
-                "stopSequence": 69,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.526643,
+              "lon": -122.679075,
+              "name": "NW Glisan & Park",
+              "stopCode": "2007",
+              "stopId": "prt:2007",
+              "stopIndex": 68,
+              "stopSequence": 69,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-10-21T23:32:11.000+00:00",
               "departure": "2009-10-21T23:32:11.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.526601,
-                  "longitude": -122.681091
-                },
-                "name": "NW Glisan & 10th",
-                "stop": {
-                  "code": "2011",
-                  "coordinate": {
-                    "latitude": 45.526601,
-                    "longitude": -122.681091
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 2011)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "2011"
-                  },
-                  "name": "NW Glisan & 10th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 69,
-                "stopSequence": 70,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.526601,
+              "lon": -122.681091,
+              "name": "NW Glisan & 10th",
+              "stopCode": "2011",
+              "stopId": "prt:2011",
+              "stopIndex": 69,
+              "stopSequence": 70,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-10-21T23:33:03.000+00:00",
               "departure": "2009-10-21T23:33:03.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.526578,
-                  "longitude": -122.683142
-                },
-                "name": "NW Glisan & 12th",
-                "stop": {
-                  "code": "2030",
-                  "coordinate": {
-                    "latitude": 45.526578,
-                    "longitude": -122.683142
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 2030)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "2030"
-                  },
-                  "name": "NW Glisan & 12th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 70,
-                "stopSequence": 71,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.526578,
+              "lon": -122.683142,
+              "name": "NW Glisan & 12th",
+              "stopCode": "2030",
+              "stopId": "prt:2030",
+              "stopIndex": 70,
+              "stopSequence": 71,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-10-21T23:33:53.000+00:00",
               "departure": "2009-10-21T23:33:53.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.526532,
-                  "longitude": -122.685164
-                },
-                "name": "NW Glisan & 14th",
-                "stop": {
-                  "code": "2046",
-                  "coordinate": {
-                    "latitude": 45.526532,
-                    "longitude": -122.685164
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 2046)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "2046"
-                  },
-                  "name": "NW Glisan & 14th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 71,
-                "stopSequence": 72,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.526532,
+              "lon": -122.685164,
+              "name": "NW Glisan & 14th",
+              "stopCode": "2046",
+              "stopId": "prt:2046",
+              "stopIndex": 71,
+              "stopSequence": 72,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-10-21T23:34:43.000+00:00",
               "departure": "2009-10-21T23:34:43.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.526503,
-                  "longitude": -122.687165
-                },
-                "name": "NW Glisan & 16th",
-                "stop": {
-                  "code": "2062",
-                  "coordinate": {
-                    "latitude": 45.526503,
-                    "longitude": -122.687165
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 2062)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "2062"
-                  },
-                  "name": "NW Glisan & 16th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 72,
-                "stopSequence": 73,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.526503,
+              "lon": -122.687165,
+              "name": "NW Glisan & 16th",
+              "stopCode": "2062",
+              "stopId": "prt:2062",
+              "stopIndex": 72,
+              "stopSequence": 73,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:35:59.000+00:00",
               "departure": "2009-10-21T23:35:59.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.526412,
-                  "longitude": -122.690196
-                },
-                "name": "NW Glisan & 19th",
-                "stop": {
-                  "code": "2086",
-                  "coordinate": {
-                    "latitude": 45.526412,
-                    "longitude": -122.690196
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 2086)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "2086"
-                  },
-                  "name": "NW Glisan & 19th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 73,
-                "stopSequence": 74,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.526412,
+              "lon": -122.690196,
+              "name": "NW Glisan & 19th",
+              "stopCode": "2086",
+              "stopId": "prt:2086",
+              "stopIndex": 73,
+              "stopSequence": 74,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:37:31.000+00:00",
               "departure": "2009-10-21T23:37:31.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.526387,
-                  "longitude": -122.693889
-                },
-                "name": "NW Glisan & 21st",
-                "stop": {
-                  "code": "2099",
-                  "coordinate": {
-                    "latitude": 45.526387,
-                    "longitude": -122.693889
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 2099)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "2099"
-                  },
-                  "name": "NW Glisan & 21st",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 74,
-                "stopSequence": 75,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.526387,
+              "lon": -122.693889,
+              "name": "NW Glisan & 21st",
+              "stopCode": "2099",
+              "stopId": "prt:2099",
+              "stopIndex": 74,
+              "stopSequence": 75,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             }
           ],
           "legGeometry": {
@@ -9345,592 +4819,296 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "points": "kwztGhgwkVQ?kC@@zD???PBjE?`B??@X@jEBjD???\\BhEBpD???XBhE@nD??@Z?hEBtA?h@@h@??@Z@nEBhEBhD???`@FtKDhH??@hBoCD}BB"
           },
           "mode": "BUS",
-          "onStreetNonTransit": false,
           "pathway": false,
           "realTime": false,
-          "scheduled": true,
-          "serviceDate": {
-            "day": 21,
-            "minMax": false,
-            "month": 10,
-            "sequenceNumber": 20091021,
-            "year": 2009
-          },
+          "route": "Holgate/NW 21st",
+          "routeId": "prt:17",
+          "routeLongName": "Holgate/NW 21st",
+          "routeShortName": "17",
+          "serviceDate": "2009-10-21",
           "startTime": "2009-10-21T23:29:50.000+00:00",
-          "streetNotes": [ ],
+          "steps": [ ],
           "to": {
-            "coordinate": {
-              "latitude": 45.527648,
-              "longitude": -122.694407
-            },
+            "arrival": "2009-10-21T23:38:32.000+00:00",
+            "departure": "2009-10-21T23:38:32.000+00:00",
+            "lat": 45.527648,
+            "lon": -122.694407,
             "name": "NW 21st & Irving",
-            "stop": {
-              "code": "7113",
-              "coordinate": {
-                "latitude": 45.527648,
-                "longitude": -122.694407
-              },
-              "description": "Northbound stop in Portland (Stop ID 7113)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "7113"
-              },
-              "name": "NW 21st & Irving",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "7113",
+            "stopId": "prt:7113",
             "stopIndex": 75,
             "stopSequence": 76,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
-          "transitAlerts": [ ],
           "transitLeg": true,
-          "trip": {
-            "alteration": "PLANNED",
-            "bikesAllowed": "UNKNOWN",
-            "blockId": "1701",
-            "direction": "INBOUND",
-            "id": {
-              "feedId": "prt",
-              "id": "171W1500"
-            },
-            "route": {
-              "agency": {
-                "fareUrl": "http://trimet.org/fares/index.htm",
-                "id": {
-                  "feedId": "prt",
-                  "id": "prt"
-                },
-                "lang": "en",
-                "name": "TriMet",
-                "phone": "503-238-7433",
-                "timezone": "America/Los_Angeles",
-                "url": "http://trimet.org"
-              },
-              "bikesAllowed": "UNKNOWN",
-              "gtfsType": 3,
-              "id": {
-                "feedId": "prt",
-                "id": "17"
-              },
-              "longName": "Holgate/NW 21st",
-              "mode": "BUS",
-              "shortName": "17",
-              "sortOrder": -999,
-              "sortOrderSet": false,
-              "url": "http://trimet.org/schedules/r017.htm"
-            },
-            "serviceId": {
-              "feedId": "prt",
-              "id": "W"
-            },
-            "shapeId": {
-              "feedId": "prt",
-              "id": "17.1.2"
-            },
-            "wheelchairAccessible": 0
-          },
-          "walkSteps": [ ],
-          "walkingLeg": false
+          "tripBlockId": "1701",
+          "tripId": "prt:171W1500"
         },
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 28.258000000000003,
+          "distance": 28.258000000000003,
           "endTime": "2009-10-21T23:39:58.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.527648,
-              "longitude": -122.694407
-            },
+            "arrival": "2009-10-21T23:38:32.000+00:00",
+            "departure": "2009-10-21T23:38:32.000+00:00",
+            "lat": 45.527648,
+            "lon": -122.694407,
             "name": "NW 21st & Irving",
-            "stop": {
-              "code": "7113",
-              "coordinate": {
-                "latitude": 45.527648,
-                "longitude": -122.694407
-              },
-              "description": "Northbound stop in Portland (Stop ID 7113)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "7113"
-              },
-              "name": "NW 21st & Irving",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "7113",
+            "stopId": "prt:7113",
             "stopIndex": 75,
             "stopSequence": 76,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
           "generalizedCost": 167,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 4,
             "points": "wb{tG`wzkV?LO?Ao@"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-10-21T23:38:32.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.5278491,
-              "longitude": -122.6942362
-            },
-            "name": "-102323",
-            "vehicleRentalPlace": {
-              "allowDropoff": true,
-              "allowOverloading": false,
-              "allowPickup": true,
-              "carStation": false,
-              "floatingVehicle": false,
-              "id": {
-                "feedId": "test-network",
-                "id": "-102323"
-              },
-              "isInstalled": true,
-              "isKeepingVehicleRentalAtDestinationAllowed": true,
-              "isRenting": true,
-              "isReturning": true,
-              "isValetStation": false,
-              "isVirtualStation": false,
-              "keepingVehicleRentalAtDestinationAllowed": true,
-              "latitude": 45.5278491,
-              "longitude": -122.6942362,
-              "name": {
-                "name": "-102323"
-              },
-              "realTimeData": false,
-              "spacesAvailable": 0,
-              "spacesDisabled": 0,
-              "vehicleSpacesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehicleTypesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehiclesAvailable": 0,
-              "vehiclesDisabled": 0
-            },
-            "vertexType": "VEHICLERENTAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "NORTH",
-              "angle": -0.021151532022270547,
               "area": false,
               "bogusName": false,
               "distance": 8.969,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.52764696458245,
+              "lon": -122.69447686508221,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.52764696458245,
-                "longitude": -122.69447686508221
-              },
               "stayOn": false,
-              "streetName": "Northwest 21st Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 21st Avenue"
             },
             {
               "absoluteDirection": "EAST",
-              "angle": 1.5442642615053612,
               "area": false,
               "bogusName": false,
               "distance": 19.289,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.527727600000006,
+              "lon": -122.69447930000001,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.527727600000006,
-                "longitude": -122.69447930000001
-              },
               "stayOn": false,
-              "streetName": "Northwest Irving Street",
-              "streetNotes": [ ],
-              "vehicleRentalOnStation": {
-                "id": "-102323",
-                "lat": 45.5278491,
-                "lon": -122.6942362,
-                "name": "-102323"
-              }
+              "streetName": "Northwest Irving Street"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
+          "to": {
+            "arrival": "2009-10-21T23:39:58.000+00:00",
+            "bikeShareId": "-102323",
+            "departure": "2009-10-21T23:39:58.000+00:00",
+            "lat": 45.5278491,
+            "lon": -122.6942362,
+            "name": "-102323",
+            "vertexType": "BIKESHARE"
+          },
+          "transitLeg": false,
+          "walkingBike": false
         },
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 480.068,
+          "distance": 480.068,
           "endTime": "2009-10-21T23:41:39.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.5278491,
-              "longitude": -122.6942362
-            },
+            "arrival": "2009-10-21T23:39:58.000+00:00",
+            "bikeShareId": "-102323",
+            "departure": "2009-10-21T23:39:58.000+00:00",
+            "lat": 45.5278491,
+            "lon": -122.6942362,
             "name": "-102323",
-            "vehicleRentalPlace": {
-              "allowDropoff": true,
-              "allowOverloading": false,
-              "allowPickup": true,
-              "carStation": false,
-              "floatingVehicle": false,
-              "id": {
-                "feedId": "test-network",
-                "id": "-102323"
-              },
-              "isInstalled": true,
-              "isKeepingVehicleRentalAtDestinationAllowed": true,
-              "isRenting": true,
-              "isReturning": true,
-              "isValetStation": false,
-              "isVirtualStation": false,
-              "keepingVehicleRentalAtDestinationAllowed": true,
-              "latitude": 45.5278491,
-              "longitude": -122.6942362,
-              "name": {
-                "name": "-102323"
-              },
-              "realTimeData": false,
-              "spacesAvailable": 0,
-              "spacesDisabled": 0,
-              "vehicleSpacesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehicleTypesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehiclesAvailable": 0,
-              "vehiclesDisabled": 0
-            },
-            "vertexType": "VEHICLERENTAL"
+            "vertexType": "BIKESHARE"
           },
           "generalizedCost": 196,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 6,
             "points": "ic{tG~uzkV@n@@vAD|HDtKFrJ"
           },
           "mode": "BICYCLE",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": true,
-          "scheduled": false,
+          "rentedBike": true,
+          "route": "",
           "startTime": "2009-10-21T23:39:58.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.5276173,
-              "longitude": -122.7003923
-            },
-            "name": "corner of way -102328 from 0 and Northwest Irving Street",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "vehicleRentalNetwork": "test-network",
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "WEST",
-              "angle": -1.5973283920844321,
               "area": false,
               "bogusName": false,
               "distance": 480.068,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.52773220198921,
+              "lon": -122.69423177172958,
               "relativeDirection": "HARD_LEFT",
-              "startLocation": {
-                "latitude": 45.52773220198921,
-                "longitude": -122.69423177172958
-              },
               "stayOn": false,
-              "streetName": "Northwest Irving Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Irving Street"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": false
+          "to": {
+            "arrival": "2009-10-21T23:41:39.000+00:00",
+            "departure": "2009-10-21T23:41:39.000+00:00",
+            "lat": 45.5276173,
+            "lon": -122.7003923,
+            "name": "corner of way -102328 from 0 and Northwest Irving Street",
+            "vertexType": "NORMAL"
+          },
+          "transitLeg": false,
+          "walkingBike": false
         },
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 13.358,
+          "distance": 13.358,
           "endTime": "2009-10-21T23:42:20.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.5276173,
-              "longitude": -122.7003923
-            },
+            "arrival": "2009-10-21T23:41:39.000+00:00",
+            "departure": "2009-10-21T23:41:39.000+00:00",
+            "lat": 45.5276173,
+            "lon": -122.7003923,
             "name": "corner of way -102328 from 0 and Northwest Irving Street",
             "vertexType": "NORMAL"
           },
           "generalizedCost": 81,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 2,
             "points": "qb{tGn|{kVWA"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": true,
-          "scheduled": false,
+          "rentedBike": true,
+          "route": "",
           "startTime": "2009-10-21T23:41:39.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.5277374,
-              "longitude": -122.7003879
-            },
-            "name": "-102309",
-            "vehicleRentalPlace": {
-              "allowDropoff": true,
-              "allowOverloading": false,
-              "allowPickup": true,
-              "carStation": false,
-              "floatingVehicle": false,
-              "id": {
-                "feedId": "test-network",
-                "id": "-102309"
-              },
-              "isInstalled": true,
-              "isKeepingVehicleRentalAtDestinationAllowed": true,
-              "isRenting": true,
-              "isReturning": true,
-              "isValetStation": false,
-              "isVirtualStation": false,
-              "keepingVehicleRentalAtDestinationAllowed": true,
-              "latitude": 45.5277374,
-              "longitude": -122.7003879,
-              "name": {
-                "name": "-102309"
-              },
-              "realTimeData": false,
-              "spacesAvailable": 0,
-              "spacesDisabled": 0,
-              "vehicleSpacesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehicleTypesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehiclesAvailable": 0,
-              "vehiclesDisabled": 0
-            },
-            "vertexType": "VEHICLERENTAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "vehicleRentalNetwork": "test-network",
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "NORTH",
-              "angle": 0.02566034822056683,
               "area": false,
               "bogusName": true,
               "distance": 13.358,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5276173,
+              "lon": -122.7003923,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5276173,
-                "longitude": -122.7003923
-              },
               "stayOn": false,
-              "streetName": "way -102328 from 0",
-              "streetNotes": [ ]
+              "streetName": "way -102328 from 0"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
+          "to": {
+            "arrival": "2009-10-21T23:42:20.000+00:00",
+            "bikeShareId": "-102309",
+            "departure": "2009-10-21T23:42:20.000+00:00",
+            "lat": 45.5277374,
+            "lon": -122.7003879,
+            "name": "-102309",
+            "vertexType": "BIKESHARE"
+          },
+          "transitLeg": false,
+          "walkingBike": false
         },
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 106.589,
+          "distance": 106.589,
           "endTime": "2009-10-21T23:43:51.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.5277374,
-              "longitude": -122.7003879
-            },
+            "arrival": "2009-10-21T23:42:20.000+00:00",
+            "bikeShareId": "-102309",
+            "departure": "2009-10-21T23:42:20.000+00:00",
+            "lat": 45.5277374,
+            "lon": -122.7003879,
             "name": "-102309",
-            "vehicleRentalPlace": {
-              "allowDropoff": true,
-              "allowOverloading": false,
-              "allowPickup": true,
-              "carStation": false,
-              "floatingVehicle": false,
-              "id": {
-                "feedId": "test-network",
-                "id": "-102309"
-              },
-              "isInstalled": true,
-              "isKeepingVehicleRentalAtDestinationAllowed": true,
-              "isRenting": true,
-              "isReturning": true,
-              "isValetStation": false,
-              "isVirtualStation": false,
-              "keepingVehicleRentalAtDestinationAllowed": true,
-              "latitude": 45.5277374,
-              "longitude": -122.7003879,
-              "name": {
-                "name": "-102309"
-              },
-              "realTimeData": false,
-              "spacesAvailable": 0,
-              "spacesDisabled": 0,
-              "vehicleSpacesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehicleTypesAvailable": {
-                "org.opentripplanner.routing.vehicle_rental.RentalVehicleType@51f0add2": 2
-              },
-              "vehiclesAvailable": 0,
-              "vehiclesDisabled": 0
-            },
-            "vertexType": "VEHICLERENTAL"
+            "vertexType": "BIKESHARE"
           },
           "generalizedCost": 168,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 4,
             "points": "ic{tGl|{kVV@?d@kC@"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-10-21T23:42:20.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.52832,
-              "longitude": -122.70059
-            },
-            "name": "SW Johnson St. & NW 24th Ave. (P1)",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "SOUTH",
-              "angle": -3.1159323053692263,
               "area": false,
               "bogusName": true,
               "distance": 13.358,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5277374,
+              "lon": -122.70038790000001,
               "relativeDirection": "HARD_LEFT",
-              "startLocation": {
-                "latitude": 45.5277374,
-                "longitude": -122.70038790000001
-              },
               "stayOn": false,
-              "streetName": "way -102328 from 0",
-              "streetNotes": [ ],
-              "vehicleRentalOffStation": {
-                "id": "-102309",
-                "lat": 45.5277374,
-                "lon": -122.7003879,
-                "name": "-102309"
-              }
+              "streetName": "way -102328 from 0"
             },
             {
               "absoluteDirection": "WEST",
-              "angle": -1.5972658434069475,
               "area": false,
               "bogusName": false,
               "distance": 14.704,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5276173,
+              "lon": -122.7003923,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5276173,
-                "longitude": -122.7003923
-              },
               "stayOn": false,
-              "streetName": "Northwest Irving Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Irving Street"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": -0.015200876817562168,
               "area": false,
               "bogusName": false,
               "distance": 78.527,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.527613800000005,
+              "lon": -122.70058100000001,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.527613800000005,
-                "longitude": -122.70058100000001
-              },
               "stayOn": false,
-              "streetName": "Northwest 24th Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 24th Avenue"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
+          "to": {
+            "arrival": "2009-10-21T23:43:51.000+00:00",
+            "lat": 45.52832,
+            "lon": -122.70059,
+            "name": "SW Johnson St. & NW 24th Ave. (P1)",
+            "vertexType": "NORMAL"
+          },
+          "transitLeg": false,
+          "walkingBike": false
         }
       ],
-      "nTransfers": 0,
-      "nonTransitDistanceMeters": 796.1389999999999,
-      "nonTransitTimeSeconds": 455,
-      "onStreetAllTheWay": false,
-      "streetOnly": false,
-      "systemNotices": [ ],
+      "startTime": "2009-10-21T23:27:34.000+00:00",
       "tooSloped": false,
-      "transferPriorityCost": 0,
-      "transitTimeSeconds": 522,
-      "waitTimeOptimizedCost": 0,
-      "waitingTimeSeconds": 0,
-      "walkOnly": false,
-      "walkingAllTheWay": false
+      "transfers": 0,
+      "transitTime": 522,
+      "waitingTime": 0,
+      "walkDistance": 796.1389999999999,
+      "walkLimitExceeded": false,
+      "walkTime": 455
     },
     {
-      "arrivedAtDestinationWithRentedVehicle": false,
-      "durationSeconds": 1336,
+      "arrivedAtDestinationWithRentedBicycle": false,
+      "duration": 1336,
       "elevationGained": 0.0,
       "elevationLost": 0.0,
+      "endTime": "2009-10-21T23:51:24.000+00:00",
       "fare": {
         "details": {
           "regular": [
@@ -9963,505 +5141,229 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
           }
         }
       },
-      "flaggedForDeletion": false,
       "generalizedCost": 2563,
       "legs": [
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 287.815,
+          "distance": 287.815,
           "endTime": "2009-10-21T23:33:00.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.52523,
-              "longitude": -122.67525
-            },
+            "departure": "2009-10-21T23:29:08.000+00:00",
+            "lat": 45.52523,
+            "lon": -122.67525,
             "name": "NW Everett St. & NW 5th Ave. (P3)",
             "vertexType": "NORMAL"
           },
           "generalizedCost": 442,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 17,
             "points": "ssztGh_wkV?`@?LJAlBCH?J?H?vBCJ?H?jBCJA?D@L?lAE?"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-10-21T23:29:08.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.523169,
-              "longitude": -122.675893
-            },
-            "name": "W Burnside & NW 5th",
-            "stop": {
-              "code": "782",
-              "coordinate": {
-                "latitude": 45.523169,
-                "longitude": -122.675893
-              },
-              "description": "Westbound stop in Portland (Stop ID 782)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "0"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "782"
-              },
-              "name": "W Burnside & NW 5th",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
-            "stopIndex": 99,
-            "stopSequence": 100,
-            "vertexType": "TRANSIT"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "WEST",
-              "angle": -1.596868818888735,
               "area": false,
               "bogusName": false,
               "distance": 17.975,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.52522794293369,
+              "lon": -122.67524992342938,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.52522794293369,
-                "longitude": -122.67524992342938
-              },
               "stayOn": false,
-              "streetName": "Northwest Everett Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Everett Street"
             },
             {
               "absoluteDirection": "SOUTH",
-              "angle": 3.1122681276306428,
               "area": false,
               "bogusName": false,
               "distance": 231.76100000000002,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.525224200000004,
+              "lon": -122.67548060000001,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.525224200000004,
-                "longitude": -122.67548060000001
-              },
               "stayOn": false,
-              "streetName": "Northwest 5th Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 5th Avenue"
             },
             {
               "absoluteDirection": "WEST",
-              "angle": -1.5966159701088662,
               "area": false,
               "bogusName": false,
               "distance": 38.079,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.523141200000005,
+              "lon": -122.67540310000001,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.523141200000005,
-                "longitude": -122.67540310000001
-              },
               "stayOn": false,
-              "streetName": "West Burnside Street",
-              "streetNotes": [ ]
+              "streetName": "West Burnside Street"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
-        },
-        {
-          "agencyTimeZoneOffset": 0,
-          "arrivalDelay": 0,
-          "departureDelay": 0,
-          "distanceMeters": 1942.2498485359197,
-          "endTime": "2009-10-21T23:44:03.000+00:00",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.523169,
-              "longitude": -122.675893
-            },
+          "to": {
+            "arrival": "2009-10-21T23:33:00.000+00:00",
+            "departure": "2009-10-21T23:33:00.000+00:00",
+            "lat": 45.523169,
+            "lon": -122.675893,
             "name": "W Burnside & NW 5th",
-            "stop": {
-              "code": "782",
-              "coordinate": {
-                "latitude": 45.523169,
-                "longitude": -122.675893
-              },
-              "description": "Westbound stop in Portland (Stop ID 782)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "0"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "782"
-              },
-              "name": "W Burnside & NW 5th",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "782",
+            "stopId": "prt:782",
             "stopIndex": 99,
             "stopSequence": 100,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
+          },
+          "transitLeg": false,
+          "walkingBike": false
+        },
+        {
+          "agencyId": "prt:prt",
+          "agencyName": "TriMet",
+          "agencyTimeZoneOffset": 0,
+          "agencyUrl": "http://trimet.org",
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 1942.2498485359197,
+          "endTime": "2009-10-21T23:44:03.000+00:00",
+          "from": {
+            "arrival": "2009-10-21T23:33:00.000+00:00",
+            "departure": "2009-10-21T23:33:00.000+00:00",
+            "lat": 45.523169,
+            "lon": -122.675893,
+            "name": "W Burnside & NW 5th",
+            "stopCode": "782",
+            "stopId": "prt:782",
+            "stopIndex": 99,
+            "stopSequence": 100,
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
           },
           "generalizedCost": 1263,
           "headsign": "Beaverton TC",
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "intermediateStops": [
             {
               "arrival": "2009-10-21T23:34:56.000+00:00",
               "departure": "2009-10-21T23:34:56.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523115,
-                  "longitude": -122.678939
-                },
-                "name": "W Burnside & NW Park",
-                "stop": {
-                  "code": "716",
-                  "coordinate": {
-                    "latitude": 45.523115,
-                    "longitude": -122.678939
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 716)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "716"
-                  },
-                  "name": "W Burnside & NW Park",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 100,
-                "stopSequence": 101,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523115,
+              "lon": -122.678939,
+              "name": "W Burnside & NW Park",
+              "stopCode": "716",
+              "stopId": "prt:716",
+              "stopIndex": 100,
+              "stopSequence": 101,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-10-21T23:36:37.000+00:00",
               "departure": "2009-10-21T23:36:37.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523048,
-                  "longitude": -122.681606
-                },
-                "name": "W Burnside & NW 10th",
-                "stop": {
-                  "code": "10791",
-                  "coordinate": {
-                    "latitude": 45.523048,
-                    "longitude": -122.681606
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 10791)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "10791"
-                  },
-                  "name": "W Burnside & NW 10th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 101,
-                "stopSequence": 102,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523048,
+              "lon": -122.681606,
+              "name": "W Burnside & NW 10th",
+              "stopCode": "10791",
+              "stopId": "prt:10791",
+              "stopIndex": 101,
+              "stopSequence": 102,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-10-21T23:37:50.000+00:00",
               "departure": "2009-10-21T23:37:50.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523,
-                  "longitude": -122.683535
-                },
-                "name": "W Burnside & NW 12th",
-                "stop": {
-                  "code": "11032",
-                  "coordinate": {
-                    "latitude": 45.523,
-                    "longitude": -122.683535
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 11032)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "11032"
-                  },
-                  "name": "W Burnside & NW 12th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 102,
-                "stopSequence": 103,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523,
+              "lon": -122.683535,
+              "name": "W Burnside & NW 12th",
+              "stopCode": "11032",
+              "stopId": "prt:11032",
+              "stopIndex": 102,
+              "stopSequence": 103,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-10-21T23:40:44.000+00:00",
               "departure": "2009-10-21T23:40:44.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.522985,
-                  "longitude": -122.688091
-                },
-                "name": "W Burnside & NW 17th",
-                "stop": {
-                  "code": "10809",
-                  "coordinate": {
-                    "latitude": 45.522985,
-                    "longitude": -122.688091
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 10809)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "10809"
-                  },
-                  "name": "W Burnside & NW 17th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 103,
-                "stopSequence": 104,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.522985,
+              "lon": -122.688091,
+              "name": "W Burnside & NW 17th",
+              "stopCode": "10809",
+              "stopId": "prt:10809",
+              "stopIndex": 103,
+              "stopSequence": 104,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:42:00.000+00:00",
               "departure": "2009-10-21T23:42:00.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523097,
-                  "longitude": -122.690083
-                },
-                "name": "W Burnside & NW 19th",
-                "stop": {
-                  "code": "735",
-                  "coordinate": {
-                    "latitude": 45.523097,
-                    "longitude": -122.690083
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 735)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "735"
-                  },
-                  "name": "W Burnside & NW 19th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 104,
-                "stopSequence": 105,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523097,
+              "lon": -122.690083,
+              "name": "W Burnside & NW 19th",
+              "stopCode": "735",
+              "stopId": "prt:735",
+              "stopIndex": 104,
+              "stopSequence": 105,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:42:24.000+00:00",
               "departure": "2009-10-21T23:42:24.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523176,
-                  "longitude": -122.692139
-                },
-                "name": "W Burnside & NW 20th",
-                "stop": {
-                  "code": "741",
-                  "coordinate": {
-                    "latitude": 45.523176,
-                    "longitude": -122.692139
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 741)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "741"
-                  },
-                  "name": "W Burnside & NW 20th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 105,
-                "stopSequence": 106,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523176,
+              "lon": -122.692139,
+              "name": "W Burnside & NW 20th",
+              "stopCode": "741",
+              "stopId": "prt:741",
+              "stopIndex": 105,
+              "stopSequence": 106,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:42:35.000+00:00",
               "departure": "2009-10-21T23:42:35.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.52322,
-                  "longitude": -122.69313
-                },
-                "name": "W Burnside & NW 20th Pl",
-                "stop": {
-                  "code": "742",
-                  "coordinate": {
-                    "latitude": 45.52322,
-                    "longitude": -122.69313
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 742)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "742"
-                  },
-                  "name": "W Burnside & NW 20th Pl",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 106,
-                "stopSequence": 107,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.52322,
+              "lon": -122.69313,
+              "name": "W Burnside & NW 20th Pl",
+              "stopCode": "742",
+              "stopId": "prt:742",
+              "stopIndex": 106,
+              "stopSequence": 107,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:42:55.000+00:00",
               "departure": "2009-10-21T23:42:55.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523312,
-                  "longitude": -122.694901
-                },
-                "name": "W Burnside & NW King",
-                "stop": {
-                  "code": "747",
-                  "coordinate": {
-                    "latitude": 45.523312,
-                    "longitude": -122.694901
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 747)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "747"
-                  },
-                  "name": "W Burnside & NW King",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 107,
-                "stopSequence": 108,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523312,
+              "lon": -122.694901,
+              "name": "W Burnside & NW King",
+              "stopCode": "747",
+              "stopId": "prt:747",
+              "stopIndex": 107,
+              "stopSequence": 108,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:43:32.000+00:00",
               "departure": "2009-10-21T23:43:32.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523512,
-                  "longitude": -122.698081
-                },
-                "name": "W Burnside & NW 23rd",
-                "stop": {
-                  "code": "755",
-                  "coordinate": {
-                    "latitude": 45.523512,
-                    "longitude": -122.698081
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 755)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "755"
-                  },
-                  "name": "W Burnside & NW 23rd",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 108,
-                "stopSequence": 109,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523512,
+              "lon": -122.698081,
+              "name": "W Burnside & NW 23rd",
+              "stopCode": "755",
+              "stopId": "prt:755",
+              "stopIndex": 108,
+              "stopSequence": 109,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             }
           ],
           "legGeometry": {
@@ -10469,259 +5371,139 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "points": "efztGhcwkV@rBBzDBpE@~A???Z@tD@RBnEB|A???@BdB?lEBjA??BnBApF@dB?X?^@r@?f@@bCAx@EtB???VChAE|BGnD??AXKnEGnD???XGjD??AZEfCC`AEzB??AXCfAGxDE|AEtBIlC??APu@lJMhBI`@"
           },
           "mode": "BUS",
-          "onStreetNonTransit": false,
           "pathway": false,
           "realTime": false,
-          "scheduled": true,
-          "serviceDate": {
-            "day": 21,
-            "minMax": false,
-            "month": 10,
-            "sequenceNumber": 20091021,
-            "year": 2009
-          },
+          "route": "Burnside/Stark",
+          "routeId": "prt:20",
+          "routeLongName": "Burnside/Stark",
+          "routeShortName": "20",
+          "serviceDate": "2009-10-21",
           "startTime": "2009-10-21T23:33:00.000+00:00",
-          "streetNotes": [ ],
+          "steps": [ ],
           "to": {
-            "coordinate": {
-              "latitude": 45.523897,
-              "longitude": -122.700681
-            },
+            "arrival": "2009-10-21T23:44:03.000+00:00",
+            "departure": "2009-10-21T23:44:03.000+00:00",
+            "lat": 45.523897,
+            "lon": -122.700681,
             "name": "W Burnside & NW 23rd Pl",
-            "stop": {
-              "code": "9555",
-              "coordinate": {
-                "latitude": 45.523897,
-                "longitude": -122.700681
-              },
-              "description": "Westbound stop in Portland (Stop ID 9555)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "9555"
-              },
-              "name": "W Burnside & NW 23rd Pl",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "9555",
+            "stopId": "prt:9555",
             "stopIndex": 109,
             "stopSequence": 110,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
-          "transitAlerts": [ ],
           "transitLeg": true,
-          "trip": {
-            "alteration": "PLANNED",
-            "bikesAllowed": "UNKNOWN",
-            "blockId": "2003",
-            "direction": "OUTBOUND",
-            "id": {
-              "feedId": "prt",
-              "id": "200W1450"
-            },
-            "route": {
-              "agency": {
-                "fareUrl": "http://trimet.org/fares/index.htm",
-                "id": {
-                  "feedId": "prt",
-                  "id": "prt"
-                },
-                "lang": "en",
-                "name": "TriMet",
-                "phone": "503-238-7433",
-                "timezone": "America/Los_Angeles",
-                "url": "http://trimet.org"
-              },
-              "bikesAllowed": "UNKNOWN",
-              "gtfsType": 3,
-              "id": {
-                "feedId": "prt",
-                "id": "20"
-              },
-              "longName": "Burnside/Stark",
-              "mode": "BUS",
-              "shortName": "20",
-              "sortOrder": -999,
-              "sortOrderSet": false,
-              "url": "http://trimet.org/schedules/r020.htm"
-            },
-            "serviceId": {
-              "feedId": "prt",
-              "id": "W"
-            },
-            "shapeId": {
-              "feedId": "prt",
-              "id": "20.0.1"
-            },
-            "wheelchairAccessible": 0
-          },
-          "walkSteps": [ ],
-          "walkingLeg": false
+          "tripBlockId": "2003",
+          "tripId": "prt:200W1450"
         },
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 563.701,
+          "distance": 563.701,
           "endTime": "2009-10-21T23:51:24.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.523897,
-              "longitude": -122.700681
-            },
+            "arrival": "2009-10-21T23:44:03.000+00:00",
+            "departure": "2009-10-21T23:44:03.000+00:00",
+            "lat": 45.523897,
+            "lon": -122.700681,
             "name": "W Burnside & NW 23rd Pl",
-            "stop": {
-              "code": "9555",
-              "coordinate": {
-                "latitude": 45.523897,
-                "longitude": -122.700681
-              },
-              "description": "Westbound stop in Portland (Stop ID 9555)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "9555"
-              },
-              "name": "W Burnside & NW 23rd Pl",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "9555",
+            "stopId": "prt:9555",
             "stopIndex": 109,
             "stopSequence": 110,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
           "generalizedCost": 858,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 34,
             "points": "ikztGh~{kVNDEVUzACPOUQO_@Yc@[QMMEOKOIECGCIAMCGCGAECECECOOMOGKIFMLk@BsABGDGBoCBkCDkC@"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-10-21T23:44:03.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.52832,
-              "longitude": -122.70059
-            },
-            "name": "SW Johnson St. & NW 24th Ave. (P1)",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "WEST",
-              "angle": -1.247661800162498,
               "area": false,
               "bogusName": false,
               "distance": 54.628,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.523815597641374,
+              "lon": -122.70071990797962,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.523815597641374,
-                "longitude": -122.70071990797962
-              },
               "stayOn": false,
-              "streetName": "West Burnside Street",
-              "streetNotes": [ ]
+              "streetName": "West Burnside Street"
             },
             {
               "absoluteDirection": "NORTHEAST",
-              "angle": 0.7501559967245512,
               "area": false,
               "bogusName": false,
               "distance": 176.41,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5239733,
+              "lon": -122.701384,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5239733,
-                "longitude": -122.701384
-              },
               "stayOn": false,
-              "streetName": "Northwest 24th Place",
-              "streetNotes": [ ]
+              "streetName": "Northwest 24th Place"
             },
             {
               "absoluteDirection": "NORTHWEST",
-              "angle": -0.5889596407957216,
               "area": false,
               "bogusName": false,
               "distance": 15.262,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5253583,
+              "lon": -122.70033570000001,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.5253583,
-                "longitude": -122.70033570000001
-              },
               "stayOn": false,
-              "streetName": "Northwest Westover Road",
-              "streetNotes": [ ]
+              "streetName": "Northwest Westover Road"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": -0.05815952978341337,
               "area": false,
               "bogusName": false,
               "distance": 317.401,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.525472400000005,
+              "lon": -122.7004445,
               "relativeDirection": "SLIGHTLY_RIGHT",
-              "startLocation": {
-                "latitude": 45.525472400000005,
-                "longitude": -122.7004445
-              },
               "stayOn": false,
-              "streetName": "Northwest 24th Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 24th Avenue"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
+          "to": {
+            "arrival": "2009-10-21T23:51:24.000+00:00",
+            "lat": 45.52832,
+            "lon": -122.70059,
+            "name": "SW Johnson St. & NW 24th Ave. (P1)",
+            "vertexType": "NORMAL"
+          },
+          "transitLeg": false,
+          "walkingBike": false
         }
       ],
-      "nTransfers": 0,
-      "nonTransitDistanceMeters": 851.5160000000001,
-      "nonTransitTimeSeconds": 673,
-      "onStreetAllTheWay": false,
-      "streetOnly": false,
-      "systemNotices": [ ],
+      "startTime": "2009-10-21T23:29:08.000+00:00",
       "tooSloped": false,
-      "transferPriorityCost": 0,
-      "transitTimeSeconds": 663,
-      "waitTimeOptimizedCost": 0,
-      "waitingTimeSeconds": 0,
-      "walkOnly": false,
-      "walkingAllTheWay": false
+      "transfers": 0,
+      "transitTime": 663,
+      "waitingTime": 0,
+      "walkDistance": 851.5160000000001,
+      "walkLimitExceeded": false,
+      "walkTime": 673
     },
     {
-      "arrivedAtDestinationWithRentedVehicle": false,
-      "durationSeconds": 1134,
+      "arrivedAtDestinationWithRentedBicycle": false,
+      "duration": 1134,
       "elevationGained": 0.0,
       "elevationLost": 0.0,
+      "endTime": "2009-10-21T23:56:21.000+00:00",
       "fare": {
         "details": {
           "regular": [
@@ -10754,448 +5536,215 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
           }
         }
       },
-      "flaggedForDeletion": false,
       "generalizedCost": 2351,
       "legs": [
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 252.87499999999997,
+          "distance": 252.87499999999997,
           "endTime": "2009-10-21T23:40:53.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.52523,
-              "longitude": -122.67525
-            },
+            "departure": "2009-10-21T23:37:27.000+00:00",
+            "lat": 45.52523,
+            "lon": -122.67525,
             "name": "NW Everett St. & NW 5th Ave. (P3)",
             "vertexType": "NORMAL"
           },
           "generalizedCost": 392,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 15,
             "points": "ssztGh_wkV?`@?LK?uBBK?K@sBBM??D?L@\\?lCC??E"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-10-21T23:37:27.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.526655,
-              "longitude": -122.676462
-            },
-            "name": "NW Glisan & 6th",
-            "stop": {
-              "code": "10803",
-              "coordinate": {
-                "latitude": 45.526655,
-                "longitude": -122.676462
-              },
-              "description": "Westbound stop in Portland (Stop ID 10803)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "0"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "10803"
-              },
-              "name": "NW Glisan & 6th",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
-            "stopIndex": 85,
-            "stopSequence": 86,
-            "vertexType": "TRANSIT"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "WEST",
-              "angle": -1.596868818888735,
               "area": false,
               "bogusName": false,
               "distance": 17.975,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.52522794293369,
+              "lon": -122.67524992342938,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.52522794293369,
-                "longitude": -122.67524992342938
-              },
               "stayOn": false,
-              "streetName": "Northwest Everett Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Everett Street"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": -0.02939746732509391,
               "area": false,
               "bogusName": false,
               "distance": 158.018,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.525224200000004,
+              "lon": -122.67548060000001,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.525224200000004,
-                "longitude": -122.67548060000001
-              },
               "stayOn": false,
-              "streetName": "Northwest 5th Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 5th Avenue"
             },
             {
               "absoluteDirection": "WEST",
-              "angle": -1.6080284293804317,
               "area": false,
               "bogusName": false,
               "distance": 74.227,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.526644700000006,
+              "lon": -122.67553910000001,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.526644700000006,
-                "longitude": -122.67553910000001
-              },
               "stayOn": false,
-              "streetName": "Northwest Glisan Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Glisan Street"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": -0.03835551109631682,
               "area": false,
               "bogusName": true,
               "distance": 2.655,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5266303,
+              "lon": -122.67649170000001,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5266303,
-                "longitude": -122.67649170000001
-              },
               "stayOn": false,
-              "streetName": "way 156261070 from 2",
-              "streetNotes": [ ]
+              "streetName": "way 156261070 from 2"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
-        },
-        {
-          "agencyTimeZoneOffset": 0,
-          "arrivalDelay": 0,
-          "departureDelay": 0,
-          "distanceMeters": 2232.3107878360292,
-          "endTime": "2009-10-21T23:48:50.000+00:00",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.526655,
-              "longitude": -122.676462
-            },
+          "to": {
+            "arrival": "2009-10-21T23:40:53.000+00:00",
+            "departure": "2009-10-21T23:40:53.000+00:00",
+            "lat": 45.526655,
+            "lon": -122.676462,
             "name": "NW Glisan & 6th",
-            "stop": {
-              "code": "10803",
-              "coordinate": {
-                "latitude": 45.526655,
-                "longitude": -122.676462
-              },
-              "description": "Westbound stop in Portland (Stop ID 10803)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "0"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "10803"
-              },
-              "name": "NW Glisan & 6th",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "10803",
+            "stopId": "prt:10803",
             "stopIndex": 85,
             "stopSequence": 86,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
+          },
+          "transitLeg": false,
+          "walkingBike": false
+        },
+        {
+          "agencyId": "prt:prt",
+          "agencyName": "TriMet",
+          "agencyTimeZoneOffset": 0,
+          "agencyUrl": "http://trimet.org",
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 2232.3107878360292,
+          "endTime": "2009-10-21T23:48:50.000+00:00",
+          "from": {
+            "arrival": "2009-10-21T23:40:53.000+00:00",
+            "departure": "2009-10-21T23:40:53.000+00:00",
+            "lat": 45.526655,
+            "lon": -122.676462,
+            "name": "NW Glisan & 6th",
+            "stopCode": "10803",
+            "stopId": "prt:10803",
+            "stopIndex": 85,
+            "stopSequence": 86,
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
           },
           "generalizedCost": 1077,
           "headsign": "Montgomery Park",
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "intermediateStops": [
             {
               "arrival": "2009-10-21T23:41:57.000+00:00",
               "departure": "2009-10-21T23:41:57.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.528799,
-                  "longitude": -122.677238
-                },
-                "name": "NW Station Way & Union Station",
-                "stop": {
-                  "code": "12801",
-                  "coordinate": {
-                    "latitude": 45.528799,
-                    "longitude": -122.677238
-                  },
-                  "description": "Northbound stop in Portland (Stop ID 12801)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "12801"
-                  },
-                  "name": "NW Station Way & Union Station",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 86,
-                "stopSequence": 87,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.528799,
+              "lon": -122.677238,
+              "name": "NW Station Way & Union Station",
+              "stopCode": "12801",
+              "stopId": "prt:12801",
+              "stopIndex": 86,
+              "stopSequence": 87,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-10-21T23:44:00.000+00:00",
               "departure": "2009-10-21T23:44:00.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.531582,
-                  "longitude": -122.681193
-                },
-                "name": "NW Northrup & 10th",
-                "stop": {
-                  "code": "12802",
-                  "coordinate": {
-                    "latitude": 45.531582,
-                    "longitude": -122.681193
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 12802)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "12802"
-                  },
-                  "name": "NW Northrup & 10th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 87,
-                "stopSequence": 88,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.531582,
+              "lon": -122.681193,
+              "name": "NW Northrup & 10th",
+              "stopCode": "12802",
+              "stopId": "prt:12802",
+              "stopIndex": 87,
+              "stopSequence": 88,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:44:33.000+00:00",
               "departure": "2009-10-21T23:44:33.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.531534,
-                  "longitude": -122.683319
-                },
-                "name": "NW 12th & Northrup",
-                "stop": {
-                  "code": "12796",
-                  "coordinate": {
-                    "latitude": 45.531534,
-                    "longitude": -122.683319
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 12796)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "12796"
-                  },
-                  "name": "NW 12th & Northrup",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 88,
-                "stopSequence": 89,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.531534,
+              "lon": -122.683319,
+              "name": "NW 12th & Northrup",
+              "stopCode": "12796",
+              "stopId": "prt:12796",
+              "stopIndex": 88,
+              "stopSequence": 89,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:45:04.000+00:00",
               "departure": "2009-10-21T23:45:04.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.531503,
-                  "longitude": -122.685357
-                },
-                "name": "NW Northrup & 14th",
-                "stop": {
-                  "code": "10775",
-                  "coordinate": {
-                    "latitude": 45.531503,
-                    "longitude": -122.685357
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 10775)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "10775"
-                  },
-                  "name": "NW Northrup & 14th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 89,
-                "stopSequence": 90,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.531503,
+              "lon": -122.685357,
+              "name": "NW Northrup & 14th",
+              "stopCode": "10775",
+              "stopId": "prt:10775",
+              "stopIndex": 89,
+              "stopSequence": 90,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:46:07.000+00:00",
               "departure": "2009-10-21T23:46:07.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.531434,
-                  "longitude": -122.689417
-                },
-                "name": "NW Northrup & 18th",
-                "stop": {
-                  "code": "10776",
-                  "coordinate": {
-                    "latitude": 45.531434,
-                    "longitude": -122.689417
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 10776)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "10776"
-                  },
-                  "name": "NW Northrup & 18th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 90,
-                "stopSequence": 91,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.531434,
+              "lon": -122.689417,
+              "name": "NW Northrup & 18th",
+              "stopCode": "10776",
+              "stopId": "prt:10776",
+              "stopIndex": 90,
+              "stopSequence": 91,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:47:24.000+00:00",
               "departure": "2009-10-21T23:47:24.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.531346,
-                  "longitude": -122.694455
-                },
-                "name": "NW Northrup & 21st",
-                "stop": {
-                  "code": "10777",
-                  "coordinate": {
-                    "latitude": 45.531346,
-                    "longitude": -122.694455
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 10777)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "10777"
-                  },
-                  "name": "NW Northrup & 21st",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 91,
-                "stopSequence": 92,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.531346,
+              "lon": -122.694455,
+              "name": "NW Northrup & 21st",
+              "stopCode": "10777",
+              "stopId": "prt:10777",
+              "stopIndex": 91,
+              "stopSequence": 92,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-10-21T23:47:55.000+00:00",
               "departure": "2009-10-21T23:47:55.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.531308,
-                  "longitude": -122.696445
-                },
-                "name": "NW Northrup & 22nd",
-                "stop": {
-                  "code": "10778",
-                  "coordinate": {
-                    "latitude": 45.531308,
-                    "longitude": -122.696445
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 10778)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "10778"
-                  },
-                  "name": "NW Northrup & 22nd",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 92,
-                "stopSequence": 93,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.531308,
+              "lon": -122.696445,
+              "name": "NW Northrup & 22nd",
+              "stopCode": "10778",
+              "stopId": "prt:10778",
+              "stopIndex": 92,
+              "stopSequence": 93,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             }
           ],
           "legGeometry": {
@@ -11203,236 +5752,120 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "points": "i|ztG|fwkV?LqCFmCDYBGDEBGJkAzAQR??KNa@b@MJuBBY?OHW@u@~@aD`EcBhBBrD@xC??@l@BlE@lD???XBjEBpD???VBlE?dA@t@?b@?h@BfEBrD???VBhEFtKDvJ??@\\DnJ???d@FtKmCBo@@"
           },
           "mode": "BUS",
-          "onStreetNonTransit": false,
           "pathway": false,
           "realTime": false,
-          "scheduled": true,
-          "serviceDate": {
-            "day": 21,
-            "minMax": false,
-            "month": 10,
-            "sequenceNumber": 20091021,
-            "year": 2009
-          },
+          "route": "Broadway/Halsey",
+          "routeId": "prt:77",
+          "routeLongName": "Broadway/Halsey",
+          "routeShortName": "77",
+          "serviceDate": "2009-10-21",
           "startTime": "2009-10-21T23:40:53.000+00:00",
-          "streetNotes": [ ],
+          "steps": [ ],
           "to": {
-            "coordinate": {
-              "latitude": 45.532159,
-              "longitude": -122.698634
-            },
+            "arrival": "2009-10-21T23:48:50.000+00:00",
+            "departure": "2009-10-21T23:48:50.000+00:00",
+            "lat": 45.532159,
+            "lon": -122.698634,
             "name": "NW 23rd & Overton",
-            "stop": {
-              "code": "8981",
-              "coordinate": {
-                "latitude": 45.532159,
-                "longitude": -122.698634
-              },
-              "description": "Northbound stop in Portland (Stop ID 8981)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "8981"
-              },
-              "name": "NW 23rd & Overton",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "8981",
+            "stopId": "prt:8981",
             "stopIndex": 93,
             "stopSequence": 94,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
-          "transitAlerts": [ ],
           "transitLeg": true,
-          "trip": {
-            "alteration": "PLANNED",
-            "bikesAllowed": "UNKNOWN",
-            "blockId": "7708",
-            "direction": "INBOUND",
-            "id": {
-              "feedId": "prt",
-              "id": "771W1380"
-            },
-            "route": {
-              "agency": {
-                "fareUrl": "http://trimet.org/fares/index.htm",
-                "id": {
-                  "feedId": "prt",
-                  "id": "prt"
-                },
-                "lang": "en",
-                "name": "TriMet",
-                "phone": "503-238-7433",
-                "timezone": "America/Los_Angeles",
-                "url": "http://trimet.org"
-              },
-              "bikesAllowed": "UNKNOWN",
-              "gtfsType": 3,
-              "id": {
-                "feedId": "prt",
-                "id": "77"
-              },
-              "longName": "Broadway/Halsey",
-              "mode": "BUS",
-              "shortName": "77",
-              "sortOrder": -999,
-              "sortOrderSet": false,
-              "url": "http://trimet.org/schedules/r077.htm"
-            },
-            "serviceId": {
-              "feedId": "prt",
-              "id": "W"
-            },
-            "shapeId": {
-              "feedId": "prt",
-              "id": "77.1.3"
-            },
-            "wheelchairAccessible": 0
-          },
-          "walkSteps": [ ],
-          "walkingLeg": false
+          "tripBlockId": "7708",
+          "tripId": "prt:771W1380"
         },
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 580.63,
+          "distance": 580.63,
           "endTime": "2009-10-21T23:56:21.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.532159,
-              "longitude": -122.698634
-            },
+            "arrival": "2009-10-21T23:48:50.000+00:00",
+            "departure": "2009-10-21T23:48:50.000+00:00",
+            "lat": 45.532159,
+            "lon": -122.698634,
             "name": "NW 23rd & Overton",
-            "stop": {
-              "code": "8981",
-              "coordinate": {
-                "latitude": 45.532159,
-                "longitude": -122.698634
-              },
-              "description": "Northbound stop in Portland (Stop ID 8981)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "8981"
-              },
-              "name": "NW 23rd & Overton",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "8981",
+            "stopId": "prt:8981",
             "stopIndex": 93,
             "stopSequence": 94,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
           "generalizedCost": 881,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 12,
             "points": "}~{tGnq{kV?LVAF?J?FtKlCClCEnCElCElCCB?"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-10-21T23:48:50.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.52832,
-              "longitude": -122.70059
-            },
-            "name": "SW Johnson St. & NW 24th Ave. (P1)",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "SOUTH",
-              "angle": 3.117146926361324,
               "area": false,
               "bogusName": false,
               "distance": 24.895,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.53215782420268,
+              "lon": -122.69870264831422,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.53215782420268,
-                "longitude": -122.69870264831422
-              },
               "stayOn": false,
-              "streetName": "Northwest 23rd Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 23rd Avenue"
             },
             {
               "absoluteDirection": "WEST",
-              "angle": -1.6005554859058504,
               "area": false,
               "bogusName": false,
               "distance": 158.45,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.531934,
+              "lon": -122.698695,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.531934,
-                "longitude": -122.698695
-              },
               "stayOn": false,
-              "streetName": "Northwest Overton Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Overton Street"
             },
             {
               "absoluteDirection": "SOUTH",
-              "angle": 3.119908233299857,
               "area": false,
               "bogusName": false,
               "distance": 397.28499999999997,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5318916,
+              "lon": -122.70072830000001,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.5318916,
-                "longitude": -122.70072830000001
-              },
               "stayOn": false,
-              "streetName": "Northwest 24th Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 24th Avenue"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
+          "to": {
+            "arrival": "2009-10-21T23:56:21.000+00:00",
+            "lat": 45.52832,
+            "lon": -122.70059,
+            "name": "SW Johnson St. & NW 24th Ave. (P1)",
+            "vertexType": "NORMAL"
+          },
+          "transitLeg": false,
+          "walkingBike": false
         }
       ],
-      "nTransfers": 0,
-      "nonTransitDistanceMeters": 833.505,
-      "nonTransitTimeSeconds": 657,
-      "onStreetAllTheWay": false,
-      "streetOnly": false,
-      "systemNotices": [ ],
+      "startTime": "2009-10-21T23:37:27.000+00:00",
       "tooSloped": false,
-      "transferPriorityCost": 0,
-      "transitTimeSeconds": 477,
-      "waitTimeOptimizedCost": 0,
-      "waitingTimeSeconds": 0,
-      "walkOnly": false,
-      "walkingAllTheWay": false
+      "transfers": 0,
+      "transitTime": 477,
+      "waitingTime": 0,
+      "walkDistance": 833.505,
+      "walkLimitExceeded": false,
+      "walkTime": 657
     }
   ]
 ]

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/TransitSnapshotTest.snap
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/TransitSnapshotTest.snap
@@ -1,302 +1,226 @@
 org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_planning_with_transit=[
   [
     {
-      "arrivedAtDestinationWithRentedVehicle": false,
-      "durationSeconds": 3821,
+      "arrivedAtDestinationWithRentedBicycle": false,
+      "duration": 3821,
       "elevationGained": 0.0,
       "elevationLost": 0.0,
+      "endTime": "2009-11-17T19:03:41.000+00:00",
       "fare": {
         "details": { },
         "fare": { }
       },
-      "flaggedForDeletion": false,
       "generalizedCost": 7447,
       "legs": [
         {
           "agencyTimeZoneOffset": -28800000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 4923.150999999999,
+          "distance": 4923.150999999999,
           "endTime": "2009-11-17T19:03:41.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.51726,
-              "longitude": -122.64847
-            },
+            "departure": "2009-11-17T18:00:00.000+00:00",
+            "lat": 45.51726,
+            "lon": -122.64847,
             "name": "SE Morrison St. & SE 17th Ave. (P1)",
             "vertexType": "NORMAL"
           },
           "generalizedCost": 7447,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 205,
             "points": "kaytG~wqkV?T?fCAl@?R?jE?rC?t@?hEAvD?R?R?|@?dBAP?PAxD?nD?X?jE?bA?t@?N?Z?ZAX?^@bBrA?DF?l@V?Z??xB?t@?F?NLNBH?vB?\\?JAFEP?NCpD?lECfE?H?`E@T`@@LBBCD?D?HHCJAF@ZAL?FAJGTCJGLQPKLWVSVMLILY`@c@v@INKRGNELEPENKb@iAvGkAxGETCRGd@If@Eb@Ip@APANAJ?J?H?H?L?DG@E?A@?@?@AB?HOhCIvAFBCRGPKRERg@xCETGXg@zCETGZg@vCCPADERADi@|CEXABCTi@vCCRGZm@fD[jBm@jDCJAFEVk@|CCVCFALk@|CEVETk@|CERG\\SjASnAGVCPAFg@tCCPCRm@lDw@fEi@bDCNETKf@EVEHMNATAh@ElCIlD?D?VARA`@EpB?N?TEjBCfAAP?RC`BATClAI|DK?G?mCBkCDoCDmCBoCDkCBoCB[?sBD]?Y@eA@K?C?K?W@{A@M@C@I?_CB?G"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-11-17T18:00:00.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.53122,
-              "longitude": -122.69659
-            },
-            "name": "NW Northrup St. & NW 22nd Ave. (P2)",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "WEST",
-              "angle": -1.5670436023962588,
               "area": false,
               "bogusName": false,
               "distance": 857.8739999999999,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.51718601153089,
+              "lon": -122.64847039626407,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.51718601153089,
-                "longitude": -122.64847039626407
-              },
               "stayOn": false,
-              "streetName": "Southeast Morrison Street",
-              "streetNotes": [ ]
+              "streetName": "Southeast Morrison Street"
             },
             {
               "absoluteDirection": "SOUTH",
-              "angle": 3.137499817662938,
               "area": false,
               "bogusName": true,
               "distance": 69.985,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.517229,
+              "lon": -122.6594795,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.517229,
-                "longitude": -122.6594795
-              },
               "stayOn": false,
-              "streetName": "way 261187797 from 2",
-              "streetNotes": [ ]
+              "streetName": "way 261187797 from 2"
             },
             {
               "absoluteDirection": "SOUTH",
-              "angle": -3.1372054652441514,
               "area": false,
               "bogusName": false,
               "distance": 28.343,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5167705,
+              "lon": -122.65974310000001,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.5167705,
-                "longitude": -122.65974310000001
-              },
               "stayOn": false,
-              "streetName": "Southeast 6th Avenue",
-              "streetNotes": [ ]
+              "streetName": "Southeast 6th Avenue"
             },
             {
               "absoluteDirection": "WEST",
-              "angle": -1.5665698853444308,
               "area": false,
               "bogusName": false,
               "distance": 78.102,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.516515600000005,
+              "lon": -122.6597447,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.516515600000005,
-                "longitude": -122.6597447
-              },
               "stayOn": false,
-              "streetName": "Southeast Belmont Street",
-              "streetNotes": [ ]
+              "streetName": "Southeast Belmont Street"
             },
             {
               "absoluteDirection": "SOUTHWEST",
-              "angle": -2.3788029750742075,
               "area": false,
               "bogusName": false,
               "distance": 401.95399999999995,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.516518500000004,
+              "lon": -122.66074710000001,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.516518500000004,
-                "longitude": -122.66074710000001
-              },
               "stayOn": true,
-              "streetName": "Southeast Belmont Street",
-              "streetNotes": [ ]
+              "streetName": "Southeast Belmont Street"
             },
             {
               "absoluteDirection": "WEST",
-              "angle": -1.574602005641645,
               "area": false,
               "bogusName": true,
               "distance": 8.765,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5165001,
+              "lon": -122.6658345,
               "relativeDirection": "CONTINUE",
-              "startLocation": {
-                "latitude": 45.5165001,
-                "longitude": -122.6658345
-              },
               "stayOn": false,
-              "streetName": "way 131623794 from 0",
-              "streetNotes": [ ]
+              "streetName": "way 131623794 from 0"
             },
             {
               "absoluteDirection": "SOUTH",
-              "angle": -3.1214370140909202,
               "area": false,
               "bogusName": false,
               "distance": 43.793000000000006,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.516499800000005,
+              "lon": -122.665947,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.516499800000005,
-                "longitude": -122.665947
-              },
               "stayOn": false,
-              "streetName": "Southeast Water Avenue",
-              "streetNotes": [ ]
+              "streetName": "Southeast Water Avenue"
             },
             {
               "absoluteDirection": "WEST",
-              "angle": -1.457818424454769,
               "area": false,
               "bogusName": false,
               "distance": 697.306,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.516128800000004,
+              "lon": -122.6660075,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.516128800000004,
-                "longitude": -122.6660075
-              },
               "stayOn": false,
-              "streetName": "Morrison Bridge",
-              "streetNotes": [ ]
+              "streetName": "Morrison Bridge"
             },
             {
               "absoluteDirection": "SOUTH",
-              "angle": -2.809645931686474,
               "area": false,
               "bogusName": true,
               "distance": 5.116,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5185836,
+              "lon": -122.6738909,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.5185836,
-                "longitude": -122.6738909
-              },
               "stayOn": false,
-              "streetName": "way 144373674 from 1",
-              "streetNotes": [ ]
+              "streetName": "way 144373674 from 1"
             },
             {
               "absoluteDirection": "NORTHWEST",
-              "angle": -1.1226708089494544,
               "area": false,
               "bogusName": false,
               "distance": 1368.8480000000002,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5185401,
+              "lon": -122.67391230000001,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5185401,
-                "longitude": -122.67391230000001
-              },
               "stayOn": false,
-              "streetName": "Southwest Alder Street",
-              "streetNotes": [ ]
+              "streetName": "Southwest Alder Street"
             },
             {
               "absoluteDirection": "WEST",
-              "angle": -1.5016768449698752,
               "area": false,
               "bogusName": false,
               "distance": 477.22899999999987,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.523017100000004,
+              "lon": -122.69024660000001,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.523017100000004,
-                "longitude": -122.69024660000001
-              },
               "stayOn": false,
-              "streetName": "West Burnside Street",
-              "streetNotes": [ ]
+              "streetName": "West Burnside Street"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": 0.04135150879789886,
               "area": false,
               "bogusName": false,
               "distance": 882.161,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5233204,
+              "lon": -122.696357,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5233204,
-                "longitude": -122.696357
-              },
               "stayOn": false,
-              "streetName": "Northwest 22nd Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 22nd Avenue"
             },
             {
               "absoluteDirection": "EAST",
-              "angle": 1.53914562034506,
               "area": false,
               "bogusName": false,
               "distance": 3.675,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5312508,
+              "lon": -122.69663860000001,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5312508,
-                "longitude": -122.69663860000001
-              },
               "stayOn": false,
-              "streetName": "Northwest Northrup Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Northrup Street"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
+          "to": {
+            "arrival": "2009-11-17T19:03:41.000+00:00",
+            "lat": 45.53122,
+            "lon": -122.69659,
+            "name": "NW Northrup St. & NW 22nd Ave. (P2)",
+            "vertexType": "NORMAL"
+          },
+          "transitLeg": false,
+          "walkingBike": false
         }
       ],
-      "nTransfers": 0,
-      "nonTransitDistanceMeters": 4923.150999999999,
-      "nonTransitTimeSeconds": 3821,
-      "onStreetAllTheWay": true,
-      "streetOnly": true,
-      "systemNotices": [ ],
+      "startTime": "2009-11-17T18:00:00.000+00:00",
       "tooSloped": false,
-      "transferPriorityCost": -1,
-      "transitTimeSeconds": 0,
-      "waitTimeOptimizedCost": -1,
-      "waitingTimeSeconds": 0,
-      "walkOnly": true,
-      "walkingAllTheWay": true
+      "transfers": 0,
+      "transitTime": 0,
+      "waitingTime": 0,
+      "walkDistance": 4923.150999999999,
+      "walkLimitExceeded": false,
+      "walkTime": 3821
     },
     {
-      "arrivedAtDestinationWithRentedVehicle": false,
-      "durationSeconds": 2261,
+      "arrivedAtDestinationWithRentedBicycle": false,
+      "duration": 2261,
       "elevationGained": 0.0,
       "elevationLost": 0.0,
+      "endTime": "2009-11-17T18:38:41.000+00:00",
       "fare": {
         "details": {
           "regular": [
@@ -329,707 +253,306 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           }
         }
       },
-      "flaggedForDeletion": false,
       "generalizedCost": 4281,
       "legs": [
         {
           "agencyTimeZoneOffset": -28800000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 920.3299999999999,
+          "distance": 920.3299999999999,
           "endTime": "2009-11-17T18:12:58.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.51726,
-              "longitude": -122.64847
-            },
+            "departure": "2009-11-17T18:01:00.000+00:00",
+            "lat": 45.51726,
+            "lon": -122.64847,
             "name": "SE Morrison St. & SE 17th Ave. (P1)",
             "vertexType": "NORMAL"
           },
           "generalizedCost": 1398,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 45,
             "points": "kaytG~wqkV?T?fCAl@?RmC?oCAmCAoC?_CAM?aC??A?A?A?A??AA?AAA??AAA???A?A?A???A@A??@A@?@??A@?@?BcC?mCAmCAmC?QBIYIWOH"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-11-17T18:01:00.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.524581,
-              "longitude": -122.649367
-            },
-            "name": "NE Sandy & 16th",
-            "stop": {
-              "code": "5060",
-              "coordinate": {
-                "latitude": 45.524581,
-                "longitude": -122.649367
-              },
-              "description": "Westbound stop in Portland (Stop ID 5060)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "5060"
-              },
-              "name": "NE Sandy & 16th",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
-            "stopIndex": 92,
-            "stopSequence": 93,
-            "vertexType": "TRANSIT"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "WEST",
-              "angle": -1.5670436023962588,
               "area": false,
               "bogusName": false,
               "distance": 87.669,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.51718601153089,
+              "lon": -122.64847039626407,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.51718601153089,
-                "longitude": -122.64847039626407
-              },
               "stayOn": false,
-              "streetName": "Southeast Morrison Street",
-              "streetNotes": [ ]
+              "streetName": "Southeast Morrison Street"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": 0.005200430917673284,
               "area": false,
               "bogusName": false,
               "distance": 641.033,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5171903,
+              "lon": -122.64959560000001,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5171903,
-                "longitude": -122.64959560000001
-              },
               "stayOn": false,
-              "streetName": "Southeast 16th Avenue",
-              "streetNotes": [ ]
+              "streetName": "Southeast 16th Avenue"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": 0.002739847065377106,
               "area": false,
               "bogusName": false,
               "distance": 168.885,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.522891200000004,
+              "lon": -122.64955280000001,
               "relativeDirection": "CONTINUE",
-              "startLocation": {
-                "latitude": 45.522891200000004,
-                "longitude": -122.64955280000001
-              },
               "stayOn": false,
-              "streetName": "Northeast 16th Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northeast 16th Avenue"
             },
             {
               "absoluteDirection": "NORTHEAST",
-              "angle": 1.0638286720243149,
               "area": false,
               "bogusName": false,
               "distance": 22.743,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.524409000000006,
+              "lon": -122.6495675,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.524409000000006,
-                "longitude": -122.6495675
-              },
               "stayOn": false,
-              "streetName": "Northeast Sandy Boulevard",
-              "streetNotes": [ ]
+              "streetName": "Northeast Sandy Boulevard"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
-        },
-        {
-          "agencyTimeZoneOffset": 0,
-          "arrivalDelay": 0,
-          "departureDelay": 0,
-          "distanceMeters": 3602.7301325109484,
-          "endTime": "2009-11-17T18:25:49.000+00:00",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.524581,
-              "longitude": -122.649367
-            },
+          "to": {
+            "arrival": "2009-11-17T18:12:58.000+00:00",
+            "departure": "2009-11-17T18:12:58.000+00:00",
+            "lat": 45.524581,
+            "lon": -122.649367,
             "name": "NE Sandy & 16th",
-            "stop": {
-              "code": "5060",
-              "coordinate": {
-                "latitude": 45.524581,
-                "longitude": -122.649367
-              },
-              "description": "Westbound stop in Portland (Stop ID 5060)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "5060"
-              },
-              "name": "NE Sandy & 16th",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "5060",
+            "stopId": "prt:5060",
             "stopIndex": 92,
             "stopSequence": 93,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "transitLeg": false,
+          "walkingBike": false
+        },
+        {
+          "agencyId": "prt:prt",
+          "agencyName": "TriMet",
+          "agencyTimeZoneOffset": 0,
+          "agencyUrl": "http://trimet.org",
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 3602.7301325109484,
+          "endTime": "2009-11-17T18:25:49.000+00:00",
+          "from": {
+            "arrival": "2009-11-17T18:12:58.000+00:00",
+            "departure": "2009-11-17T18:12:58.000+00:00",
+            "lat": 45.524581,
+            "lon": -122.649367,
+            "name": "NE Sandy & 16th",
+            "stopCode": "5060",
+            "stopId": "prt:5060",
+            "stopIndex": 92,
+            "stopSequence": 93,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
           "generalizedCost": 1371,
           "headsign": "Beaverton TC",
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "intermediateStops": [
             {
               "arrival": "2009-11-17T18:13:32.000+00:00",
               "departure": "2009-11-17T18:13:32.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523767,
-                  "longitude": -122.651428
-                },
-                "name": "NE Sandy & 14th",
-                "stop": {
-                  "code": "5058",
-                  "coordinate": {
-                    "latitude": 45.523767,
-                    "longitude": -122.651428
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 5058)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "5058"
-                  },
-                  "name": "NE Sandy & 14th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 93,
-                "stopSequence": 94,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523767,
+              "lon": -122.651428,
+              "name": "NE Sandy & 14th",
+              "stopCode": "5058",
+              "stopId": "prt:5058",
+              "stopIndex": 93,
+              "stopSequence": 94,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:14:00.000+00:00",
               "departure": "2009-11-17T18:14:00.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523103,
-                  "longitude": -122.653064
-                },
-                "name": "NE Sandy & 12th",
-                "stop": {
-                  "code": "5055",
-                  "coordinate": {
-                    "latitude": 45.523103,
-                    "longitude": -122.653064
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 5055)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "5055"
-                  },
-                  "name": "NE Sandy & 12th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 94,
-                "stopSequence": 95,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523103,
+              "lon": -122.653064,
+              "name": "NE Sandy & 12th",
+              "stopCode": "5055",
+              "stopId": "prt:5055",
+              "stopIndex": 94,
+              "stopSequence": 95,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:14:47.000+00:00",
               "departure": "2009-11-17T18:14:47.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523024,
-                  "longitude": -122.656526
-                },
-                "name": "E Burnside & NE 9th",
-                "stop": {
-                  "code": "819",
-                  "coordinate": {
-                    "latitude": 45.523024,
-                    "longitude": -122.656526
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 819)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "819"
-                  },
-                  "name": "E Burnside & NE 9th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 95,
-                "stopSequence": 96,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523024,
+              "lon": -122.656526,
+              "name": "E Burnside & NE 9th",
+              "stopCode": "819",
+              "stopId": "prt:819",
+              "stopIndex": 95,
+              "stopSequence": 96,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:15:24.000+00:00",
               "departure": "2009-11-17T18:15:24.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523012,
-                  "longitude": -122.659365
-                },
-                "name": "E Burnside & NE 6th",
-                "stop": {
-                  "code": "805",
-                  "coordinate": {
-                    "latitude": 45.523012,
-                    "longitude": -122.659365
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 805)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "805"
-                  },
-                  "name": "E Burnside & NE 6th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 96,
-                "stopSequence": 97,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523012,
+              "lon": -122.659365,
+              "name": "E Burnside & NE 6th",
+              "stopCode": "805",
+              "stopId": "prt:805",
+              "stopIndex": 96,
+              "stopSequence": 97,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:15:52.000+00:00",
               "departure": "2009-11-17T18:15:52.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523015,
-                  "longitude": -122.661534
-                },
-                "name": "E Burnside & NE M L King",
-                "stop": {
-                  "code": "705",
-                  "coordinate": {
-                    "latitude": 45.523015,
-                    "longitude": -122.661534
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 705)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "705"
-                  },
-                  "name": "E Burnside & NE M L King",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 97,
-                "stopSequence": 98,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523015,
+              "lon": -122.661534,
+              "name": "E Burnside & NE M L King",
+              "stopCode": "705",
+              "stopId": "prt:705",
+              "stopIndex": 97,
+              "stopSequence": 98,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:18:00.000+00:00",
               "departure": "2009-11-17T18:18:00.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523249,
-                  "longitude": -122.671269
-                },
-                "name": "W Burnside & Burnside Bridge",
-                "stop": {
-                  "code": "689",
-                  "coordinate": {
-                    "latitude": 45.523249,
-                    "longitude": -122.671269
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 689)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "689"
-                  },
-                  "name": "W Burnside & Burnside Bridge",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 98,
-                "stopSequence": 99,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523249,
+              "lon": -122.671269,
+              "name": "W Burnside & Burnside Bridge",
+              "stopCode": "689",
+              "stopId": "prt:689",
+              "stopIndex": 98,
+              "stopSequence": 99,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T18:19:00.000+00:00",
               "departure": "2009-11-17T18:19:00.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523169,
-                  "longitude": -122.675893
-                },
-                "name": "W Burnside & NW 5th",
-                "stop": {
-                  "code": "782",
-                  "coordinate": {
-                    "latitude": 45.523169,
-                    "longitude": -122.675893
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 782)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "782"
-                  },
-                  "name": "W Burnside & NW 5th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 99,
-                "stopSequence": 100,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523169,
+              "lon": -122.675893,
+              "name": "W Burnside & NW 5th",
+              "stopCode": "782",
+              "stopId": "prt:782",
+              "stopIndex": 99,
+              "stopSequence": 100,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T18:20:17.000+00:00",
               "departure": "2009-11-17T18:20:17.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523115,
-                  "longitude": -122.678939
-                },
-                "name": "W Burnside & NW Park",
-                "stop": {
-                  "code": "716",
-                  "coordinate": {
-                    "latitude": 45.523115,
-                    "longitude": -122.678939
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 716)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "716"
-                  },
-                  "name": "W Burnside & NW Park",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 100,
-                "stopSequence": 101,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523115,
+              "lon": -122.678939,
+              "name": "W Burnside & NW Park",
+              "stopCode": "716",
+              "stopId": "prt:716",
+              "stopIndex": 100,
+              "stopSequence": 101,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T18:21:25.000+00:00",
               "departure": "2009-11-17T18:21:25.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523048,
-                  "longitude": -122.681606
-                },
-                "name": "W Burnside & NW 10th",
-                "stop": {
-                  "code": "10791",
-                  "coordinate": {
-                    "latitude": 45.523048,
-                    "longitude": -122.681606
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 10791)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "10791"
-                  },
-                  "name": "W Burnside & NW 10th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 101,
-                "stopSequence": 102,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523048,
+              "lon": -122.681606,
+              "name": "W Burnside & NW 10th",
+              "stopCode": "10791",
+              "stopId": "prt:10791",
+              "stopIndex": 101,
+              "stopSequence": 102,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T18:22:14.000+00:00",
               "departure": "2009-11-17T18:22:14.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523,
-                  "longitude": -122.683535
-                },
-                "name": "W Burnside & NW 12th",
-                "stop": {
-                  "code": "11032",
-                  "coordinate": {
-                    "latitude": 45.523,
-                    "longitude": -122.683535
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 11032)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "11032"
-                  },
-                  "name": "W Burnside & NW 12th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 102,
-                "stopSequence": 103,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523,
+              "lon": -122.683535,
+              "name": "W Burnside & NW 12th",
+              "stopCode": "11032",
+              "stopId": "prt:11032",
+              "stopIndex": 102,
+              "stopSequence": 103,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T18:24:09.000+00:00",
               "departure": "2009-11-17T18:24:09.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.522985,
-                  "longitude": -122.688091
-                },
-                "name": "W Burnside & NW 17th",
-                "stop": {
-                  "code": "10809",
-                  "coordinate": {
-                    "latitude": 45.522985,
-                    "longitude": -122.688091
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 10809)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "10809"
-                  },
-                  "name": "W Burnside & NW 17th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 103,
-                "stopSequence": 104,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.522985,
+              "lon": -122.688091,
+              "name": "W Burnside & NW 17th",
+              "stopCode": "10809",
+              "stopId": "prt:10809",
+              "stopIndex": 103,
+              "stopSequence": 104,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:25:00.000+00:00",
               "departure": "2009-11-17T18:25:00.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523097,
-                  "longitude": -122.690083
-                },
-                "name": "W Burnside & NW 19th",
-                "stop": {
-                  "code": "735",
-                  "coordinate": {
-                    "latitude": 45.523097,
-                    "longitude": -122.690083
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 735)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "735"
-                  },
-                  "name": "W Burnside & NW 19th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 104,
-                "stopSequence": 105,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523097,
+              "lon": -122.690083,
+              "name": "W Burnside & NW 19th",
+              "stopCode": "735",
+              "stopId": "prt:735",
+              "stopIndex": 104,
+              "stopSequence": 105,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:25:21.000+00:00",
               "departure": "2009-11-17T18:25:21.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523176,
-                  "longitude": -122.692139
-                },
-                "name": "W Burnside & NW 20th",
-                "stop": {
-                  "code": "741",
-                  "coordinate": {
-                    "latitude": 45.523176,
-                    "longitude": -122.692139
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 741)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "741"
-                  },
-                  "name": "W Burnside & NW 20th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 105,
-                "stopSequence": 106,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523176,
+              "lon": -122.692139,
+              "name": "W Burnside & NW 20th",
+              "stopCode": "741",
+              "stopId": "prt:741",
+              "stopIndex": 105,
+              "stopSequence": 106,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:25:31.000+00:00",
               "departure": "2009-11-17T18:25:31.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.52322,
-                  "longitude": -122.69313
-                },
-                "name": "W Burnside & NW 20th Pl",
-                "stop": {
-                  "code": "742",
-                  "coordinate": {
-                    "latitude": 45.52322,
-                    "longitude": -122.69313
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 742)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "742"
-                  },
-                  "name": "W Burnside & NW 20th Pl",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 106,
-                "stopSequence": 107,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.52322,
+              "lon": -122.69313,
+              "name": "W Burnside & NW 20th Pl",
+              "stopCode": "742",
+              "stopId": "prt:742",
+              "stopIndex": 106,
+              "stopSequence": 107,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             }
           ],
           "legGeometry": {
@@ -1037,242 +560,127 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "points": "coztGd}qkVNl@r@`CZhA`A`D??Ph@l@tBb@rARh@Pd@???BPj@@jA?jEAhE?pD???VAjE?hE?dB?b@???`AAhE?dD???l@C`EAhEEhE?bAA|@?XAZ@\\AzACnGKbKAjC?bE???JEnE@fEDlE@hE@~A??@rBBzDBpE@~A???Z@tD@RBnEB|A???@BdB?lEBjA??BnBApF@dB?X?^@r@?f@@bCAx@EtB???VChAE|BGnD??AXKnEGnD???XGjD??AZEfCC`AEzB"
           },
           "mode": "BUS",
-          "onStreetNonTransit": false,
           "pathway": false,
           "realTime": false,
-          "scheduled": true,
-          "serviceDate": {
-            "day": 17,
-            "minMax": false,
-            "month": 11,
-            "sequenceNumber": 20091117,
-            "year": 2009
-          },
+          "route": "Burnside/Stark",
+          "routeId": "prt:20",
+          "routeLongName": "Burnside/Stark",
+          "routeShortName": "20",
+          "serviceDate": "2009-11-17",
           "startTime": "2009-11-17T18:12:58.000+00:00",
-          "streetNotes": [ ],
+          "steps": [ ],
           "to": {
-            "coordinate": {
-              "latitude": 45.523312,
-              "longitude": -122.694901
-            },
+            "arrival": "2009-11-17T18:25:49.000+00:00",
+            "departure": "2009-11-17T18:25:49.000+00:00",
+            "lat": 45.523312,
+            "lon": -122.694901,
             "name": "W Burnside & NW King",
-            "stop": {
-              "code": "747",
-              "coordinate": {
-                "latitude": 45.523312,
-                "longitude": -122.694901
-              },
-              "description": "Westbound stop in Portland (Stop ID 747)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "747"
-              },
-              "name": "W Burnside & NW King",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "747",
+            "stopId": "prt:747",
             "stopIndex": 107,
             "stopSequence": 108,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
-          "transitAlerts": [ ],
           "transitLeg": true,
-          "trip": {
-            "alteration": "PLANNED",
-            "bikesAllowed": "UNKNOWN",
-            "blockId": "2002",
-            "direction": "OUTBOUND",
-            "id": {
-              "feedId": "prt",
-              "id": "200W1200"
-            },
-            "route": {
-              "agency": {
-                "fareUrl": "http://trimet.org/fares/index.htm",
-                "id": {
-                  "feedId": "prt",
-                  "id": "prt"
-                },
-                "lang": "en",
-                "name": "TriMet",
-                "phone": "503-238-7433",
-                "timezone": "America/Los_Angeles",
-                "url": "http://trimet.org"
-              },
-              "bikesAllowed": "UNKNOWN",
-              "gtfsType": 3,
-              "id": {
-                "feedId": "prt",
-                "id": "20"
-              },
-              "longName": "Burnside/Stark",
-              "mode": "BUS",
-              "shortName": "20",
-              "sortOrder": -999,
-              "sortOrderSet": false,
-              "url": "http://trimet.org/schedules/r020.htm"
-            },
-            "serviceId": {
-              "feedId": "prt",
-              "id": "W"
-            },
-            "shapeId": {
-              "feedId": "prt",
-              "id": "20.0.1"
-            },
-            "wheelchairAccessible": 0
-          },
-          "walkSteps": [ ],
-          "walkingLeg": false
+          "tripBlockId": "2002",
+          "tripId": "prt:200W1200"
         },
         {
           "agencyTimeZoneOffset": -28800000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 999.0980000000001,
+          "distance": 999.0980000000001,
           "endTime": "2009-11-17T18:38:41.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.523312,
-              "longitude": -122.694901
-            },
+            "arrival": "2009-11-17T18:25:49.000+00:00",
+            "departure": "2009-11-17T18:25:49.000+00:00",
+            "lat": 45.523312,
+            "lon": -122.694901,
             "name": "W Burnside & NW King",
-            "stop": {
-              "code": "747",
-              "coordinate": {
-                "latitude": 45.523312,
-                "longitude": -122.694901
-              },
-              "description": "Westbound stop in Portland (Stop ID 747)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "747"
-              },
-              "name": "W Burnside & NW King",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "747",
+            "stopId": "prt:747",
             "stopIndex": 107,
             "stopSequence": 108,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
           "generalizedCost": 1511,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 29,
             "points": "ugztGdzzkVL?ATClAI|DK?G?mCBkCDoCDmCBoCDkCBoCB[?sBD]?Y@eA@K?C?K?W@{A@M@C@I?_CB?G"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-11-17T18:25:49.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.53122,
-              "longitude": -122.69659
-            },
-            "name": "NW Northrup St. & NW 22nd Ave. (P2)",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "WEST",
-              "angle": -1.5070160169213977,
               "area": false,
               "bogusName": false,
               "distance": 113.262,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.523249092859054,
+              "lon": -122.69490673448706,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.523249092859054,
-                "longitude": -122.69490673448706
-              },
               "stayOn": false,
-              "streetName": "West Burnside Street",
-              "streetNotes": [ ]
+              "streetName": "West Burnside Street"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": 0.04135150879789886,
               "area": false,
               "bogusName": false,
               "distance": 882.161,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5233204,
+              "lon": -122.696357,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5233204,
-                "longitude": -122.696357
-              },
               "stayOn": false,
-              "streetName": "Northwest 22nd Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 22nd Avenue"
             },
             {
               "absoluteDirection": "EAST",
-              "angle": 1.53914562034506,
               "area": false,
               "bogusName": false,
               "distance": 3.675,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5312508,
+              "lon": -122.69663860000001,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5312508,
-                "longitude": -122.69663860000001
-              },
               "stayOn": false,
-              "streetName": "Northwest Northrup Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Northrup Street"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
+          "to": {
+            "arrival": "2009-11-17T18:38:41.000+00:00",
+            "lat": 45.53122,
+            "lon": -122.69659,
+            "name": "NW Northrup St. & NW 22nd Ave. (P2)",
+            "vertexType": "NORMAL"
+          },
+          "transitLeg": false,
+          "walkingBike": false
         }
       ],
-      "nTransfers": 0,
-      "nonTransitDistanceMeters": 1919.4279999999999,
-      "nonTransitTimeSeconds": 1490,
-      "onStreetAllTheWay": false,
-      "streetOnly": false,
-      "systemNotices": [ ],
+      "startTime": "2009-11-17T18:01:00.000+00:00",
       "tooSloped": false,
-      "transferPriorityCost": 0,
-      "transitTimeSeconds": 771,
-      "waitTimeOptimizedCost": 0,
-      "waitingTimeSeconds": 0,
-      "walkOnly": false,
-      "walkingAllTheWay": false
+      "transfers": 0,
+      "transitTime": 771,
+      "waitingTime": 0,
+      "walkDistance": 1919.4279999999999,
+      "walkLimitExceeded": false,
+      "walkTime": 1490
     },
     {
-      "arrivedAtDestinationWithRentedVehicle": false,
-      "durationSeconds": 1467,
+      "arrivedAtDestinationWithRentedBicycle": false,
+      "duration": 1467,
       "elevationGained": 0.0,
       "elevationLost": 0.0,
+      "endTime": "2009-11-17T18:39:19.000+00:00",
       "fare": {
         "details": {
           "regular": [
@@ -1305,952 +713,374 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           }
         }
       },
-      "flaggedForDeletion": false,
       "generalizedCost": 2349,
       "legs": [
         {
           "agencyTimeZoneOffset": -28800000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 62.012,
+          "distance": 62.012,
           "endTime": "2009-11-17T18:15:40.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.51726,
-              "longitude": -122.64847
-            },
+            "departure": "2009-11-17T18:14:52.000+00:00",
+            "lat": 45.51726,
+            "lon": -122.64847,
             "name": "SE Morrison St. & SE 17th Ave. (P1)",
             "vertexType": "NORMAL"
           },
           "generalizedCost": 95,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 4,
             "points": "kaytG~wqkV?T?fCG?"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-11-17T18:14:52.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.517226,
-              "longitude": -122.649266
-            },
-            "name": "SE Morrison & 16th",
-            "stop": {
-              "code": "4019",
-              "coordinate": {
-                "latitude": 45.517226,
-                "longitude": -122.649266
-              },
-              "description": "Westbound stop in Portland (Stop ID 4019)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "4019"
-              },
-              "name": "SE Morrison & 16th",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
-            "stopIndex": 50,
-            "stopSequence": 51,
-            "vertexType": "TRANSIT"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "WEST",
-              "angle": -1.5670436023962588,
               "area": false,
               "bogusName": false,
               "distance": 62.012,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.51718601153089,
+              "lon": -122.64847039626407,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.51718601153089,
-                "longitude": -122.64847039626407
-              },
               "stayOn": false,
-              "streetName": "Southeast Morrison Street",
-              "streetNotes": [ ]
+              "streetName": "Southeast Morrison Street"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
-        },
-        {
-          "agencyTimeZoneOffset": 0,
-          "arrivalDelay": 0,
-          "departureDelay": 0,
-          "distanceMeters": 4943.103319311616,
-          "endTime": "2009-11-17T18:35:00.000+00:00",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.517226,
-              "longitude": -122.649266
-            },
+          "to": {
+            "arrival": "2009-11-17T18:15:40.000+00:00",
+            "departure": "2009-11-17T18:15:40.000+00:00",
+            "lat": 45.517226,
+            "lon": -122.649266,
             "name": "SE Morrison & 16th",
-            "stop": {
-              "code": "4019",
-              "coordinate": {
-                "latitude": 45.517226,
-                "longitude": -122.649266
-              },
-              "description": "Westbound stop in Portland (Stop ID 4019)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "4019"
-              },
-              "name": "SE Morrison & 16th",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "4019",
+            "stopId": "prt:4019",
             "stopIndex": 50,
             "stopSequence": 51,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "transitLeg": false,
+          "walkingBike": false
+        },
+        {
+          "agencyId": "prt:prt",
+          "agencyName": "TriMet",
+          "agencyTimeZoneOffset": 0,
+          "agencyUrl": "http://trimet.org",
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 4943.103319311616,
+          "endTime": "2009-11-17T18:35:00.000+00:00",
+          "from": {
+            "arrival": "2009-11-17T18:15:40.000+00:00",
+            "departure": "2009-11-17T18:15:40.000+00:00",
+            "lat": 45.517226,
+            "lon": -122.649266,
+            "name": "SE Morrison & 16th",
+            "stopCode": "4019",
+            "stopId": "prt:4019",
+            "stopIndex": 50,
+            "stopSequence": 51,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
           "generalizedCost": 1760,
           "headsign": "Montgomery Park",
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "intermediateStops": [
             {
               "arrival": "2009-11-17T18:16:15.000+00:00",
               "departure": "2009-11-17T18:16:15.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.517253,
-                  "longitude": -122.651354
-                },
-                "name": "SE Morrison & 14th",
-                "stop": {
-                  "code": "4016",
-                  "coordinate": {
-                    "latitude": 45.517253,
-                    "longitude": -122.651354
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 4016)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "4016"
-                  },
-                  "name": "SE Morrison & 14th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 51,
-                "stopSequence": 52,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.517253,
+              "lon": -122.651354,
+              "name": "SE Morrison & 14th",
+              "stopCode": "4016",
+              "stopId": "prt:4016",
+              "stopIndex": 51,
+              "stopSequence": 52,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:17:00.000+00:00",
               "departure": "2009-11-17T18:17:00.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.517299,
-                  "longitude": -122.654067
-                },
-                "name": "SE Morrison & 12th",
-                "stop": {
-                  "code": "4014",
-                  "coordinate": {
-                    "latitude": 45.517299,
-                    "longitude": -122.654067
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 4014)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "4014"
-                  },
-                  "name": "SE Morrison & 12th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 52,
-                "stopSequence": 53,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.517299,
+              "lon": -122.654067,
+              "name": "SE Morrison & 12th",
+              "stopCode": "4014",
+              "stopId": "prt:4014",
+              "stopIndex": 52,
+              "stopSequence": 53,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:17:38.000+00:00",
               "departure": "2009-11-17T18:17:38.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.517292,
-                  "longitude": -122.656563
-                },
-                "name": "SE Morrison & 9th",
-                "stop": {
-                  "code": "4026",
-                  "coordinate": {
-                    "latitude": 45.517292,
-                    "longitude": -122.656563
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 4026)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "4026"
-                  },
-                  "name": "SE Morrison & 9th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 53,
-                "stopSequence": 54,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.517292,
+              "lon": -122.656563,
+              "name": "SE Morrison & 9th",
+              "stopCode": "4026",
+              "stopId": "prt:4026",
+              "stopIndex": 53,
+              "stopSequence": 54,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:18:08.000+00:00",
               "departure": "2009-11-17T18:18:08.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.517322,
-                  "longitude": -122.65847
-                },
-                "name": "SE Morrison & 7th",
-                "stop": {
-                  "code": "4025",
-                  "coordinate": {
-                    "latitude": 45.517322,
-                    "longitude": -122.65847
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 4025)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "4025"
-                  },
-                  "name": "SE Morrison & 7th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 54,
-                "stopSequence": 55,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.517322,
+              "lon": -122.65847,
+              "name": "SE Morrison & 7th",
+              "stopCode": "4025",
+              "stopId": "prt:4025",
+              "stopIndex": 54,
+              "stopSequence": 55,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:18:39.000+00:00",
               "departure": "2009-11-17T18:18:39.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.517298,
-                  "longitude": -122.660523
-                },
-                "name": "SE Morrison & Grand",
-                "stop": {
-                  "code": "4013",
-                  "coordinate": {
-                    "latitude": 45.517298,
-                    "longitude": -122.660523
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 4013)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "4013"
-                  },
-                  "name": "SE Morrison & Grand",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 55,
-                "stopSequence": 56,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.517298,
+              "lon": -122.660523,
+              "name": "SE Morrison & Grand",
+              "stopCode": "4013",
+              "stopId": "prt:4013",
+              "stopIndex": 55,
+              "stopSequence": 56,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:20:03.000+00:00",
               "departure": "2009-11-17T18:20:03.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.517351,
-                  "longitude": -122.66601
-                },
-                "name": "Morrison Bridge",
-                "stop": {
-                  "code": "4029",
-                  "coordinate": {
-                    "latitude": 45.517351,
-                    "longitude": -122.66601
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 4029)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "4029"
-                  },
-                  "name": "Morrison Bridge",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 56,
-                "stopSequence": 57,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.517351,
+              "lon": -122.66601,
+              "name": "Morrison Bridge",
+              "stopCode": "4029",
+              "stopId": "prt:4029",
+              "stopIndex": 56,
+              "stopSequence": 57,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:22:27.000+00:00",
               "departure": "2009-11-17T18:22:27.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.51959,
-                  "longitude": -122.674599
-                },
-                "name": "SW Washington & 3rd",
-                "stop": {
-                  "code": "6158",
-                  "coordinate": {
-                    "latitude": 45.51959,
-                    "longitude": -122.674599
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 6158)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "6158"
-                  },
-                  "name": "SW Washington & 3rd",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 57,
-                "stopSequence": 58,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.51959,
+              "lon": -122.674599,
+              "name": "SW Washington & 3rd",
+              "stopCode": "6158",
+              "stopId": "prt:6158",
+              "stopIndex": 57,
+              "stopSequence": 58,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T18:23:00.000+00:00",
               "departure": "2009-11-17T18:23:00.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.520129,
-                  "longitude": -122.676635
-                },
-                "name": "SW Washington & 5th",
-                "stop": {
-                  "code": "6160",
-                  "coordinate": {
-                    "latitude": 45.520129,
-                    "longitude": -122.676635
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 6160)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "6160"
-                  },
-                  "name": "SW Washington & 5th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 58,
-                "stopSequence": 59,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.520129,
+              "lon": -122.676635,
+              "name": "SW Washington & 5th",
+              "stopCode": "6160",
+              "stopId": "prt:6160",
+              "stopIndex": 58,
+              "stopSequence": 59,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T18:23:52.000+00:00",
               "departure": "2009-11-17T18:23:52.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.520695,
-                  "longitude": -122.678657
-                },
-                "name": "SW Washington & Broadway",
-                "stop": {
-                  "code": "6137",
-                  "coordinate": {
-                    "latitude": 45.520695,
-                    "longitude": -122.678657
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 6137)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "6137"
-                  },
-                  "name": "SW Washington & Broadway",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 59,
-                "stopSequence": 60,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.520695,
+              "lon": -122.678657,
+              "name": "SW Washington & Broadway",
+              "stopCode": "6137",
+              "stopId": "prt:6137",
+              "stopIndex": 59,
+              "stopSequence": 60,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T18:24:34.000+00:00",
               "departure": "2009-11-17T18:24:34.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.521124,
-                  "longitude": -122.6803
-                },
-                "name": "SW Washington & 9th",
-                "stop": {
-                  "code": "6169",
-                  "coordinate": {
-                    "latitude": 45.521124,
-                    "longitude": -122.6803
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 6169)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "6169"
-                  },
-                  "name": "SW Washington & 9th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 60,
-                "stopSequence": 61,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.521124,
+              "lon": -122.6803,
+              "name": "SW Washington & 9th",
+              "stopCode": "6169",
+              "stopId": "prt:6169",
+              "stopIndex": 60,
+              "stopSequence": 61,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T18:25:47.000+00:00",
               "departure": "2009-11-17T18:25:47.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.521094,
-                  "longitude": -122.682819
-                },
-                "name": "SW 11th & Alder",
-                "stop": {
-                  "code": "9600",
-                  "coordinate": {
-                    "latitude": 45.521094,
-                    "longitude": -122.682819
-                  },
-                  "description": "Southbound stop in Portland (Stop ID 9600)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "9600"
-                  },
-                  "name": "SW 11th & Alder",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 61,
-                "stopSequence": 62,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.521094,
+              "lon": -122.682819,
+              "name": "SW 11th & Alder",
+              "stopCode": "9600",
+              "stopId": "prt:9600",
+              "stopIndex": 61,
+              "stopSequence": 62,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T18:26:36.000+00:00",
               "departure": "2009-11-17T18:26:36.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.52055,
-                  "longitude": -122.683933
-                },
-                "name": "SW Morrison & 12th",
-                "stop": {
-                  "code": "9598",
-                  "coordinate": {
-                    "latitude": 45.52055,
-                    "longitude": -122.683933
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 9598)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "9598"
-                  },
-                  "name": "SW Morrison & 12th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 62,
-                "stopSequence": 63,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.52055,
+              "lon": -122.683933,
+              "name": "SW Morrison & 12th",
+              "stopCode": "9598",
+              "stopId": "prt:9598",
+              "stopIndex": 62,
+              "stopSequence": 63,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T18:27:25.000+00:00",
               "departure": "2009-11-17T18:27:25.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.521063,
-                  "longitude": -122.685848
-                },
-                "name": "SW Morrison & 14th",
-                "stop": {
-                  "code": "9708",
-                  "coordinate": {
-                    "latitude": 45.521063,
-                    "longitude": -122.685848
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 9708)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "9708"
-                  },
-                  "name": "SW Morrison & 14th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 63,
-                "stopSequence": 64,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.521063,
+              "lon": -122.685848,
+              "name": "SW Morrison & 14th",
+              "stopCode": "9708",
+              "stopId": "prt:9708",
+              "stopIndex": 63,
+              "stopSequence": 64,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:28:18.000+00:00",
               "departure": "2009-11-17T18:28:18.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.521641,
-                  "longitude": -122.687932
-                },
-                "name": "SW Morrison & 16th",
-                "stop": {
-                  "code": "9613",
-                  "coordinate": {
-                    "latitude": 45.521641,
-                    "longitude": -122.687932
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 9613)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "9613"
-                  },
-                  "name": "SW Morrison & 16th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 64,
-                "stopSequence": 65,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.521641,
+              "lon": -122.687932,
+              "name": "SW Morrison & 16th",
+              "stopCode": "9613",
+              "stopId": "prt:9613",
+              "stopIndex": 64,
+              "stopSequence": 65,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:29:00.000+00:00",
               "departure": "2009-11-17T18:29:00.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.52206,
-                  "longitude": -122.689577
-                },
-                "name": "SW Morrison & 17th",
-                "stop": {
-                  "code": "9599",
-                  "coordinate": {
-                    "latitude": 45.52206,
-                    "longitude": -122.689577
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 9599)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "9599"
-                  },
-                  "name": "SW Morrison & 17th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 65,
-                "stopSequence": 66,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.52206,
+              "lon": -122.689577,
+              "name": "SW Morrison & 17th",
+              "stopCode": "9599",
+              "stopId": "prt:9599",
+              "stopIndex": 65,
+              "stopSequence": 66,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:29:54.000+00:00",
               "departure": "2009-11-17T18:29:54.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523097,
-                  "longitude": -122.690083
-                },
-                "name": "W Burnside & NW 19th",
-                "stop": {
-                  "code": "735",
-                  "coordinate": {
-                    "latitude": 45.523097,
-                    "longitude": -122.690083
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 735)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "735"
-                  },
-                  "name": "W Burnside & NW 19th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 66,
-                "stopSequence": 67,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523097,
+              "lon": -122.690083,
+              "name": "W Burnside & NW 19th",
+              "stopCode": "735",
+              "stopId": "prt:735",
+              "stopIndex": 66,
+              "stopSequence": 67,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:30:31.000+00:00",
               "departure": "2009-11-17T18:30:31.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523176,
-                  "longitude": -122.692139
-                },
-                "name": "W Burnside & NW 20th",
-                "stop": {
-                  "code": "741",
-                  "coordinate": {
-                    "latitude": 45.523176,
-                    "longitude": -122.692139
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 741)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "741"
-                  },
-                  "name": "W Burnside & NW 20th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 67,
-                "stopSequence": 68,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523176,
+              "lon": -122.692139,
+              "name": "W Burnside & NW 20th",
+              "stopCode": "741",
+              "stopId": "prt:741",
+              "stopIndex": 67,
+              "stopSequence": 68,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:30:48.000+00:00",
               "departure": "2009-11-17T18:30:48.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.52322,
-                  "longitude": -122.69313
-                },
-                "name": "W Burnside & NW 20th Pl",
-                "stop": {
-                  "code": "742",
-                  "coordinate": {
-                    "latitude": 45.52322,
-                    "longitude": -122.69313
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 742)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "742"
-                  },
-                  "name": "W Burnside & NW 20th Pl",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 68,
-                "stopSequence": 69,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.52322,
+              "lon": -122.69313,
+              "name": "W Burnside & NW 20th Pl",
+              "stopCode": "742",
+              "stopId": "prt:742",
+              "stopIndex": 68,
+              "stopSequence": 69,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:31:20.000+00:00",
               "departure": "2009-11-17T18:31:20.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523312,
-                  "longitude": -122.694901
-                },
-                "name": "W Burnside & NW King",
-                "stop": {
-                  "code": "747",
-                  "coordinate": {
-                    "latitude": 45.523312,
-                    "longitude": -122.694901
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 747)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "747"
-                  },
-                  "name": "W Burnside & NW King",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 69,
-                "stopSequence": 70,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523312,
+              "lon": -122.694901,
+              "name": "W Burnside & NW King",
+              "stopCode": "747",
+              "stopId": "prt:747",
+              "stopIndex": 69,
+              "stopSequence": 70,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:32:18.000+00:00",
               "departure": "2009-11-17T18:32:18.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523512,
-                  "longitude": -122.698081
-                },
-                "name": "W Burnside & NW 23rd",
-                "stop": {
-                  "code": "755",
-                  "coordinate": {
-                    "latitude": 45.523512,
-                    "longitude": -122.698081
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 755)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "755"
-                  },
-                  "name": "W Burnside & NW 23rd",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 70,
-                "stopSequence": 71,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523512,
+              "lon": -122.698081,
+              "name": "W Burnside & NW 23rd",
+              "stopCode": "755",
+              "stopId": "prt:755",
+              "stopIndex": 70,
+              "stopSequence": 71,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:33:11.000+00:00",
               "departure": "2009-11-17T18:33:11.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.525416,
-                  "longitude": -122.698381
-                },
-                "name": "NW 23rd & Flanders",
-                "stop": {
-                  "code": "7157",
-                  "coordinate": {
-                    "latitude": 45.525416,
-                    "longitude": -122.698381
-                  },
-                  "description": "Northbound stop in Portland (Stop ID 7157)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "7157"
-                  },
-                  "name": "NW 23rd & Flanders",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 71,
-                "stopSequence": 72,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.525416,
+              "lon": -122.698381,
+              "name": "NW 23rd & Flanders",
+              "stopCode": "7157",
+              "stopId": "prt:7157",
+              "stopIndex": 71,
+              "stopSequence": 72,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:34:05.000+00:00",
               "departure": "2009-11-17T18:34:05.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.527543,
-                  "longitude": -122.698473
-                },
-                "name": "NW 23rd & Irving",
-                "stop": {
-                  "code": "7161",
-                  "coordinate": {
-                    "latitude": 45.527543,
-                    "longitude": -122.698473
-                  },
-                  "description": "Northbound stop in Portland (Stop ID 7161)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "7161"
-                  },
-                  "name": "NW 23rd & Irving",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 72,
-                "stopSequence": 73,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.527543,
+              "lon": -122.698473,
+              "name": "NW 23rd & Irving",
+              "stopCode": "7161",
+              "stopId": "prt:7161",
+              "stopIndex": 72,
+              "stopSequence": 73,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             }
           ],
           "legGeometry": {
@@ -2258,276 +1088,151 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "points": "kaytG||qkVA~@?jE?tC???r@AhE?jE?rA???tBAjE?nD???X?hE?xC??Ah@?pE?~C???J?`@?vAAvBEbE?jEAlE?`BAbB@d@??@tAAj@Cx@Cb@Cp@_@dEcAtFoA`IS~@i@`BmAzDi@zAc@pAi@~C??Id@u@jEm@bD??If@u@jEk@bD??If@u@|DW`B??CPs@|Du@lElBz@??VJbCfAk@dD??Id@w@rEWvAId@AF??Q~@s@`Ei@~C??Ib@u@dEWzA??]jB]MQSe@WOKOKIIQe@GWE]GnD??AXKnEGnD???XGjD??AZEfCC`AEzB??AXCfAGxDE|AEtBIlC??APkAh@o@?sCB{BD??S?mCDmCDyBB??U?mCDmCDyBB"
           },
           "mode": "BUS",
-          "onStreetNonTransit": false,
           "pathway": false,
           "realTime": false,
-          "scheduled": true,
-          "serviceDate": {
-            "day": 17,
-            "minMax": false,
-            "month": 11,
-            "sequenceNumber": 20091117,
-            "year": 2009
-          },
+          "route": "Belmont/NW 23rd",
+          "routeId": "prt:15",
+          "routeLongName": "Belmont/NW 23rd",
+          "routeShortName": "15",
+          "serviceDate": "2009-11-17",
           "startTime": "2009-11-17T18:15:40.000+00:00",
-          "streetNotes": [ ],
+          "steps": [ ],
           "to": {
-            "coordinate": {
-              "latitude": 45.529681,
-              "longitude": -122.698529
-            },
+            "arrival": "2009-11-17T18:35:00.000+00:00",
+            "departure": "2009-11-17T18:35:00.000+00:00",
+            "lat": 45.529681,
+            "lon": -122.698529,
             "name": "NW 23rd & Lovejoy",
-            "stop": {
-              "code": "7163",
-              "coordinate": {
-                "latitude": 45.529681,
-                "longitude": -122.698529
-              },
-              "description": "Northbound stop in Portland (Stop ID 7163)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "7163"
-              },
-              "name": "NW 23rd & Lovejoy",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "7163",
+            "stopId": "prt:7163",
             "stopIndex": 73,
             "stopSequence": 74,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
-          "transitAlerts": [ ],
           "transitLeg": true,
-          "trip": {
-            "alteration": "PLANNED",
-            "bikesAllowed": "UNKNOWN",
-            "blockId": "1549",
-            "direction": "OUTBOUND",
-            "id": {
-              "feedId": "prt",
-              "id": "150W1400"
-            },
-            "route": {
-              "agency": {
-                "fareUrl": "http://trimet.org/fares/index.htm",
-                "id": {
-                  "feedId": "prt",
-                  "id": "prt"
-                },
-                "lang": "en",
-                "name": "TriMet",
-                "phone": "503-238-7433",
-                "timezone": "America/Los_Angeles",
-                "url": "http://trimet.org"
-              },
-              "bikesAllowed": "UNKNOWN",
-              "gtfsType": 3,
-              "id": {
-                "feedId": "prt",
-                "id": "15"
-              },
-              "longName": "Belmont/NW 23rd",
-              "mode": "BUS",
-              "shortName": "15",
-              "sortOrder": -999,
-              "sortOrderSet": false,
-              "url": "http://trimet.org/schedules/r015.htm"
-            },
-            "serviceId": {
-              "feedId": "prt",
-              "id": "W"
-            },
-            "shapeId": {
-              "feedId": "prt",
-              "id": "15.0.21"
-            },
-            "wheelchairAccessible": 0
-          },
-          "walkSteps": [ ],
-          "walkingLeg": false
+          "tripBlockId": "1549",
+          "tripId": "prt:150W1400"
         },
         {
           "agencyTimeZoneOffset": -28800000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 321.94500000000005,
+          "distance": 321.94500000000005,
           "endTime": "2009-11-17T18:39:19.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.529681,
-              "longitude": -122.698529
-            },
+            "arrival": "2009-11-17T18:35:00.000+00:00",
+            "departure": "2009-11-17T18:35:00.000+00:00",
+            "lat": 45.529681,
+            "lon": -122.698529,
             "name": "NW 23rd & Lovejoy",
-            "stop": {
-              "code": "7163",
-              "coordinate": {
-                "latitude": 45.529681,
-                "longitude": -122.698529
-              },
-              "description": "Northbound stop in Portland (Stop ID 7163)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "7163"
-              },
-              "name": "NW 23rd & Lovejoy",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "7163",
+            "stopId": "prt:7163",
             "stopIndex": 73,
             "stopSequence": 74,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
           "generalizedCost": 493,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 18,
             "points": "oo{tGxp{kVG@?GCwAAaF?G?i@?SK?C?K?W@{A@M@C@I?_CB?G"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-11-17T18:35:00.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.53122,
-              "longitude": -122.69659
-            },
-            "name": "NW Northrup St. & NW 22nd Ave. (P2)",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "EAST",
-              "angle": 1.5519664675850313,
               "area": false,
               "bogusName": true,
               "distance": 2.418,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.529726790620664,
+              "lon": -122.69853023095405,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.529726790620664,
-                "longitude": -122.69853023095405
-              },
               "stayOn": false,
-              "streetName": "way 158083864 from 0",
-              "streetNotes": [ ]
+              "streetName": "way 158083864 from 0"
             },
             {
               "absoluteDirection": "EAST",
-              "angle": 1.5293125423902536,
               "area": false,
               "bogusName": false,
               "distance": 142.155,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5297272,
+              "lon": -122.6984992,
               "relativeDirection": "CONTINUE",
-              "startLocation": {
-                "latitude": 45.5297272,
-                "longitude": -122.6984992
-              },
               "stayOn": false,
-              "streetName": "Northwest Lovejoy Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Lovejoy Street"
             },
             {
               "absoluteDirection": "EAST",
-              "angle": 1.5678920159151593,
               "area": false,
               "bogusName": true,
               "distance": 7.657,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.529758300000005,
+              "lon": -122.6966749,
               "relativeDirection": "CONTINUE",
-              "startLocation": {
-                "latitude": 45.529758300000005,
-                "longitude": -122.6966749
-              },
               "stayOn": false,
-              "streetName": "way 158083863 from 2",
-              "streetNotes": [ ]
+              "streetName": "way 158083863 from 2"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": -0.02805287330123452,
               "area": false,
               "bogusName": false,
               "distance": 166.04000000000002,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5297585,
+              "lon": -122.69657660000001,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.5297585,
-                "longitude": -122.69657660000001
-              },
               "stayOn": false,
-              "streetName": "Northwest 22nd Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 22nd Avenue"
             },
             {
               "absoluteDirection": "EAST",
-              "angle": 1.53914562034506,
               "area": false,
               "bogusName": false,
               "distance": 3.675,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5312508,
+              "lon": -122.69663860000001,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5312508,
-                "longitude": -122.69663860000001
-              },
               "stayOn": false,
-              "streetName": "Northwest Northrup Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Northrup Street"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
+          "to": {
+            "arrival": "2009-11-17T18:39:19.000+00:00",
+            "lat": 45.53122,
+            "lon": -122.69659,
+            "name": "NW Northrup St. & NW 22nd Ave. (P2)",
+            "vertexType": "NORMAL"
+          },
+          "transitLeg": false,
+          "walkingBike": false
         }
       ],
-      "nTransfers": 0,
-      "nonTransitDistanceMeters": 383.95700000000005,
-      "nonTransitTimeSeconds": 307,
-      "onStreetAllTheWay": false,
-      "streetOnly": false,
-      "systemNotices": [ ],
+      "startTime": "2009-11-17T18:14:52.000+00:00",
       "tooSloped": false,
-      "transferPriorityCost": 0,
-      "transitTimeSeconds": 1160,
-      "waitTimeOptimizedCost": 0,
-      "waitingTimeSeconds": 0,
-      "walkOnly": false,
-      "walkingAllTheWay": false
+      "transfers": 0,
+      "transitTime": 1160,
+      "waitingTime": 0,
+      "walkDistance": 383.95700000000005,
+      "walkLimitExceeded": false,
+      "walkTime": 307
     },
     {
-      "arrivedAtDestinationWithRentedVehicle": false,
-      "durationSeconds": 2275,
+      "arrivedAtDestinationWithRentedBicycle": false,
+      "duration": 2275,
       "elevationGained": 0.0,
       "elevationLost": 0.0,
+      "endTime": "2009-11-17T18:53:55.000+00:00",
       "fare": {
         "details": {
           "regular": [
@@ -2560,707 +1265,306 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           }
         }
       },
-      "flaggedForDeletion": false,
       "generalizedCost": 4295,
       "legs": [
         {
           "agencyTimeZoneOffset": -28800000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 920.3299999999999,
+          "distance": 920.3299999999999,
           "endTime": "2009-11-17T18:27:58.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.51726,
-              "longitude": -122.64847
-            },
+            "departure": "2009-11-17T18:16:00.000+00:00",
+            "lat": 45.51726,
+            "lon": -122.64847,
             "name": "SE Morrison St. & SE 17th Ave. (P1)",
             "vertexType": "NORMAL"
           },
           "generalizedCost": 1398,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 45,
             "points": "kaytG~wqkV?T?fCAl@?RmC?oCAmCAoC?_CAM?aC??A?A?A?A??AA?AAA??AAA???A?A?A???A@A??@A@?@??A@?@?BcC?mCAmCAmC?QBIYIWOH"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-11-17T18:16:00.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.524581,
-              "longitude": -122.649367
-            },
-            "name": "NE Sandy & 16th",
-            "stop": {
-              "code": "5060",
-              "coordinate": {
-                "latitude": 45.524581,
-                "longitude": -122.649367
-              },
-              "description": "Westbound stop in Portland (Stop ID 5060)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "5060"
-              },
-              "name": "NE Sandy & 16th",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
-            "stopIndex": 92,
-            "stopSequence": 93,
-            "vertexType": "TRANSIT"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "WEST",
-              "angle": -1.5670436023962588,
               "area": false,
               "bogusName": false,
               "distance": 87.669,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.51718601153089,
+              "lon": -122.64847039626407,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.51718601153089,
-                "longitude": -122.64847039626407
-              },
               "stayOn": false,
-              "streetName": "Southeast Morrison Street",
-              "streetNotes": [ ]
+              "streetName": "Southeast Morrison Street"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": 0.005200430917673284,
               "area": false,
               "bogusName": false,
               "distance": 641.033,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5171903,
+              "lon": -122.64959560000001,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5171903,
-                "longitude": -122.64959560000001
-              },
               "stayOn": false,
-              "streetName": "Southeast 16th Avenue",
-              "streetNotes": [ ]
+              "streetName": "Southeast 16th Avenue"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": 0.002739847065377106,
               "area": false,
               "bogusName": false,
               "distance": 168.885,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.522891200000004,
+              "lon": -122.64955280000001,
               "relativeDirection": "CONTINUE",
-              "startLocation": {
-                "latitude": 45.522891200000004,
-                "longitude": -122.64955280000001
-              },
               "stayOn": false,
-              "streetName": "Northeast 16th Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northeast 16th Avenue"
             },
             {
               "absoluteDirection": "NORTHEAST",
-              "angle": 1.0638286720243149,
               "area": false,
               "bogusName": false,
               "distance": 22.743,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.524409000000006,
+              "lon": -122.6495675,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.524409000000006,
-                "longitude": -122.6495675
-              },
               "stayOn": false,
-              "streetName": "Northeast Sandy Boulevard",
-              "streetNotes": [ ]
+              "streetName": "Northeast Sandy Boulevard"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
-        },
-        {
-          "agencyTimeZoneOffset": 0,
-          "arrivalDelay": 0,
-          "departureDelay": 0,
-          "distanceMeters": 3602.7301325109484,
-          "endTime": "2009-11-17T18:41:03.000+00:00",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.524581,
-              "longitude": -122.649367
-            },
+          "to": {
+            "arrival": "2009-11-17T18:27:58.000+00:00",
+            "departure": "2009-11-17T18:27:58.000+00:00",
+            "lat": 45.524581,
+            "lon": -122.649367,
             "name": "NE Sandy & 16th",
-            "stop": {
-              "code": "5060",
-              "coordinate": {
-                "latitude": 45.524581,
-                "longitude": -122.649367
-              },
-              "description": "Westbound stop in Portland (Stop ID 5060)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "5060"
-              },
-              "name": "NE Sandy & 16th",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "5060",
+            "stopId": "prt:5060",
             "stopIndex": 92,
             "stopSequence": 93,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "transitLeg": false,
+          "walkingBike": false
+        },
+        {
+          "agencyId": "prt:prt",
+          "agencyName": "TriMet",
+          "agencyTimeZoneOffset": 0,
+          "agencyUrl": "http://trimet.org",
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 3602.7301325109484,
+          "endTime": "2009-11-17T18:41:03.000+00:00",
+          "from": {
+            "arrival": "2009-11-17T18:27:58.000+00:00",
+            "departure": "2009-11-17T18:27:58.000+00:00",
+            "lat": 45.524581,
+            "lon": -122.649367,
+            "name": "NE Sandy & 16th",
+            "stopCode": "5060",
+            "stopId": "prt:5060",
+            "stopIndex": 92,
+            "stopSequence": 93,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
           "generalizedCost": 1385,
           "headsign": "23rd Ave to Tichner",
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "intermediateStops": [
             {
               "arrival": "2009-11-17T18:28:32.000+00:00",
               "departure": "2009-11-17T18:28:32.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523767,
-                  "longitude": -122.651428
-                },
-                "name": "NE Sandy & 14th",
-                "stop": {
-                  "code": "5058",
-                  "coordinate": {
-                    "latitude": 45.523767,
-                    "longitude": -122.651428
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 5058)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "5058"
-                  },
-                  "name": "NE Sandy & 14th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 93,
-                "stopSequence": 94,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523767,
+              "lon": -122.651428,
+              "name": "NE Sandy & 14th",
+              "stopCode": "5058",
+              "stopId": "prt:5058",
+              "stopIndex": 93,
+              "stopSequence": 94,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:29:00.000+00:00",
               "departure": "2009-11-17T18:29:00.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523103,
-                  "longitude": -122.653064
-                },
-                "name": "NE Sandy & 12th",
-                "stop": {
-                  "code": "5055",
-                  "coordinate": {
-                    "latitude": 45.523103,
-                    "longitude": -122.653064
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 5055)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "5055"
-                  },
-                  "name": "NE Sandy & 12th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 94,
-                "stopSequence": 95,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523103,
+              "lon": -122.653064,
+              "name": "NE Sandy & 12th",
+              "stopCode": "5055",
+              "stopId": "prt:5055",
+              "stopIndex": 94,
+              "stopSequence": 95,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:29:47.000+00:00",
               "departure": "2009-11-17T18:29:47.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523024,
-                  "longitude": -122.656526
-                },
-                "name": "E Burnside & NE 9th",
-                "stop": {
-                  "code": "819",
-                  "coordinate": {
-                    "latitude": 45.523024,
-                    "longitude": -122.656526
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 819)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "819"
-                  },
-                  "name": "E Burnside & NE 9th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 95,
-                "stopSequence": 96,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523024,
+              "lon": -122.656526,
+              "name": "E Burnside & NE 9th",
+              "stopCode": "819",
+              "stopId": "prt:819",
+              "stopIndex": 95,
+              "stopSequence": 96,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:30:24.000+00:00",
               "departure": "2009-11-17T18:30:24.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523012,
-                  "longitude": -122.659365
-                },
-                "name": "E Burnside & NE 6th",
-                "stop": {
-                  "code": "805",
-                  "coordinate": {
-                    "latitude": 45.523012,
-                    "longitude": -122.659365
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 805)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "805"
-                  },
-                  "name": "E Burnside & NE 6th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 96,
-                "stopSequence": 97,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523012,
+              "lon": -122.659365,
+              "name": "E Burnside & NE 6th",
+              "stopCode": "805",
+              "stopId": "prt:805",
+              "stopIndex": 96,
+              "stopSequence": 97,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:30:52.000+00:00",
               "departure": "2009-11-17T18:30:52.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523015,
-                  "longitude": -122.661534
-                },
-                "name": "E Burnside & NE M L King",
-                "stop": {
-                  "code": "705",
-                  "coordinate": {
-                    "latitude": 45.523015,
-                    "longitude": -122.661534
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 705)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "705"
-                  },
-                  "name": "E Burnside & NE M L King",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 97,
-                "stopSequence": 98,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523015,
+              "lon": -122.661534,
+              "name": "E Burnside & NE M L King",
+              "stopCode": "705",
+              "stopId": "prt:705",
+              "stopIndex": 97,
+              "stopSequence": 98,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:33:00.000+00:00",
               "departure": "2009-11-17T18:33:00.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523249,
-                  "longitude": -122.671269
-                },
-                "name": "W Burnside & Burnside Bridge",
-                "stop": {
-                  "code": "689",
-                  "coordinate": {
-                    "latitude": 45.523249,
-                    "longitude": -122.671269
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 689)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "689"
-                  },
-                  "name": "W Burnside & Burnside Bridge",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 98,
-                "stopSequence": 99,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523249,
+              "lon": -122.671269,
+              "name": "W Burnside & Burnside Bridge",
+              "stopCode": "689",
+              "stopId": "prt:689",
+              "stopIndex": 98,
+              "stopSequence": 99,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T18:34:00.000+00:00",
               "departure": "2009-11-17T18:34:00.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523169,
-                  "longitude": -122.675893
-                },
-                "name": "W Burnside & NW 5th",
-                "stop": {
-                  "code": "782",
-                  "coordinate": {
-                    "latitude": 45.523169,
-                    "longitude": -122.675893
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 782)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "782"
-                  },
-                  "name": "W Burnside & NW 5th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 99,
-                "stopSequence": 100,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523169,
+              "lon": -122.675893,
+              "name": "W Burnside & NW 5th",
+              "stopCode": "782",
+              "stopId": "prt:782",
+              "stopIndex": 99,
+              "stopSequence": 100,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T18:35:17.000+00:00",
               "departure": "2009-11-17T18:35:17.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523115,
-                  "longitude": -122.678939
-                },
-                "name": "W Burnside & NW Park",
-                "stop": {
-                  "code": "716",
-                  "coordinate": {
-                    "latitude": 45.523115,
-                    "longitude": -122.678939
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 716)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "716"
-                  },
-                  "name": "W Burnside & NW Park",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 100,
-                "stopSequence": 101,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523115,
+              "lon": -122.678939,
+              "name": "W Burnside & NW Park",
+              "stopCode": "716",
+              "stopId": "prt:716",
+              "stopIndex": 100,
+              "stopSequence": 101,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T18:36:25.000+00:00",
               "departure": "2009-11-17T18:36:25.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523048,
-                  "longitude": -122.681606
-                },
-                "name": "W Burnside & NW 10th",
-                "stop": {
-                  "code": "10791",
-                  "coordinate": {
-                    "latitude": 45.523048,
-                    "longitude": -122.681606
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 10791)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "10791"
-                  },
-                  "name": "W Burnside & NW 10th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 101,
-                "stopSequence": 102,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523048,
+              "lon": -122.681606,
+              "name": "W Burnside & NW 10th",
+              "stopCode": "10791",
+              "stopId": "prt:10791",
+              "stopIndex": 101,
+              "stopSequence": 102,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T18:37:14.000+00:00",
               "departure": "2009-11-17T18:37:14.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523,
-                  "longitude": -122.683535
-                },
-                "name": "W Burnside & NW 12th",
-                "stop": {
-                  "code": "11032",
-                  "coordinate": {
-                    "latitude": 45.523,
-                    "longitude": -122.683535
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 11032)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "11032"
-                  },
-                  "name": "W Burnside & NW 12th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 102,
-                "stopSequence": 103,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523,
+              "lon": -122.683535,
+              "name": "W Burnside & NW 12th",
+              "stopCode": "11032",
+              "stopId": "prt:11032",
+              "stopIndex": 102,
+              "stopSequence": 103,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T18:39:09.000+00:00",
               "departure": "2009-11-17T18:39:09.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.522985,
-                  "longitude": -122.688091
-                },
-                "name": "W Burnside & NW 17th",
-                "stop": {
-                  "code": "10809",
-                  "coordinate": {
-                    "latitude": 45.522985,
-                    "longitude": -122.688091
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 10809)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "10809"
-                  },
-                  "name": "W Burnside & NW 17th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 103,
-                "stopSequence": 104,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.522985,
+              "lon": -122.688091,
+              "name": "W Burnside & NW 17th",
+              "stopCode": "10809",
+              "stopId": "prt:10809",
+              "stopIndex": 103,
+              "stopSequence": 104,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:40:00.000+00:00",
               "departure": "2009-11-17T18:40:00.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523097,
-                  "longitude": -122.690083
-                },
-                "name": "W Burnside & NW 19th",
-                "stop": {
-                  "code": "735",
-                  "coordinate": {
-                    "latitude": 45.523097,
-                    "longitude": -122.690083
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 735)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "735"
-                  },
-                  "name": "W Burnside & NW 19th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 104,
-                "stopSequence": 105,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523097,
+              "lon": -122.690083,
+              "name": "W Burnside & NW 19th",
+              "stopCode": "735",
+              "stopId": "prt:735",
+              "stopIndex": 104,
+              "stopSequence": 105,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:40:27.000+00:00",
               "departure": "2009-11-17T18:40:27.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523176,
-                  "longitude": -122.692139
-                },
-                "name": "W Burnside & NW 20th",
-                "stop": {
-                  "code": "741",
-                  "coordinate": {
-                    "latitude": 45.523176,
-                    "longitude": -122.692139
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 741)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "741"
-                  },
-                  "name": "W Burnside & NW 20th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 105,
-                "stopSequence": 106,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523176,
+              "lon": -122.692139,
+              "name": "W Burnside & NW 20th",
+              "stopCode": "741",
+              "stopId": "prt:741",
+              "stopIndex": 105,
+              "stopSequence": 106,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:40:40.000+00:00",
               "departure": "2009-11-17T18:40:40.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.52322,
-                  "longitude": -122.69313
-                },
-                "name": "W Burnside & NW 20th Pl",
-                "stop": {
-                  "code": "742",
-                  "coordinate": {
-                    "latitude": 45.52322,
-                    "longitude": -122.69313
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 742)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "742"
-                  },
-                  "name": "W Burnside & NW 20th Pl",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 106,
-                "stopSequence": 107,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.52322,
+              "lon": -122.69313,
+              "name": "W Burnside & NW 20th Pl",
+              "stopCode": "742",
+              "stopId": "prt:742",
+              "stopIndex": 106,
+              "stopSequence": 107,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             }
           ],
           "legGeometry": {
@@ -3268,242 +1572,127 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "points": "coztGd}qkVNl@r@`CZhA`A`D??Ph@l@tBb@rARh@Pd@???BPj@@jA?jEAhE?pD???VAjE?hE?dB?b@???`AAhE?dD???l@C`EAhEEhE?bAA|@?XAZ@\\AzACnGKbKAjC?bE???JEnE@fEDlE@hE@~A??@rBBzDBpE@~A???Z@tD@RBnEB|A???@BdB?lEBjA??BnBApF@dB?X?^@r@?f@@bCAx@EtB???VChAE|BGnD??AXKnEGnD???XGjD??AZEfCC`AEzB"
           },
           "mode": "BUS",
-          "onStreetNonTransit": false,
           "pathway": false,
           "realTime": false,
-          "scheduled": true,
-          "serviceDate": {
-            "day": 17,
-            "minMax": false,
-            "month": 11,
-            "sequenceNumber": 20091117,
-            "year": 2009
-          },
+          "route": "Burnside/Stark",
+          "routeId": "prt:20",
+          "routeLongName": "Burnside/Stark",
+          "routeShortName": "20",
+          "serviceDate": "2009-11-17",
           "startTime": "2009-11-17T18:27:58.000+00:00",
-          "streetNotes": [ ],
+          "steps": [ ],
           "to": {
-            "coordinate": {
-              "latitude": 45.523312,
-              "longitude": -122.694901
-            },
+            "arrival": "2009-11-17T18:41:03.000+00:00",
+            "departure": "2009-11-17T18:41:03.000+00:00",
+            "lat": 45.523312,
+            "lon": -122.694901,
             "name": "W Burnside & NW King",
-            "stop": {
-              "code": "747",
-              "coordinate": {
-                "latitude": 45.523312,
-                "longitude": -122.694901
-              },
-              "description": "Westbound stop in Portland (Stop ID 747)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "747"
-              },
-              "name": "W Burnside & NW King",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "747",
+            "stopId": "prt:747",
             "stopIndex": 107,
             "stopSequence": 108,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
-          "transitAlerts": [ ],
           "transitLeg": true,
-          "trip": {
-            "alteration": "PLANNED",
-            "bikesAllowed": "UNKNOWN",
-            "blockId": "2071",
-            "direction": "OUTBOUND",
-            "id": {
-              "feedId": "prt",
-              "id": "200W1210"
-            },
-            "route": {
-              "agency": {
-                "fareUrl": "http://trimet.org/fares/index.htm",
-                "id": {
-                  "feedId": "prt",
-                  "id": "prt"
-                },
-                "lang": "en",
-                "name": "TriMet",
-                "phone": "503-238-7433",
-                "timezone": "America/Los_Angeles",
-                "url": "http://trimet.org"
-              },
-              "bikesAllowed": "UNKNOWN",
-              "gtfsType": 3,
-              "id": {
-                "feedId": "prt",
-                "id": "20"
-              },
-              "longName": "Burnside/Stark",
-              "mode": "BUS",
-              "shortName": "20",
-              "sortOrder": -999,
-              "sortOrderSet": false,
-              "url": "http://trimet.org/schedules/r020.htm"
-            },
-            "serviceId": {
-              "feedId": "prt",
-              "id": "W"
-            },
-            "shapeId": {
-              "feedId": "prt",
-              "id": "20.0.6"
-            },
-            "wheelchairAccessible": 0
-          },
-          "walkSteps": [ ],
-          "walkingLeg": false
+          "tripBlockId": "2071",
+          "tripId": "prt:200W1210"
         },
         {
           "agencyTimeZoneOffset": -28800000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 999.0980000000001,
+          "distance": 999.0980000000001,
           "endTime": "2009-11-17T18:53:55.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.523312,
-              "longitude": -122.694901
-            },
+            "arrival": "2009-11-17T18:41:03.000+00:00",
+            "departure": "2009-11-17T18:41:03.000+00:00",
+            "lat": 45.523312,
+            "lon": -122.694901,
             "name": "W Burnside & NW King",
-            "stop": {
-              "code": "747",
-              "coordinate": {
-                "latitude": 45.523312,
-                "longitude": -122.694901
-              },
-              "description": "Westbound stop in Portland (Stop ID 747)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "747"
-              },
-              "name": "W Burnside & NW King",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "747",
+            "stopId": "prt:747",
             "stopIndex": 107,
             "stopSequence": 108,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
           "generalizedCost": 1511,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 29,
             "points": "ugztGdzzkVL?ATClAI|DK?G?mCBkCDoCDmCBoCDkCBoCB[?sBD]?Y@eA@K?C?K?W@{A@M@C@I?_CB?G"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-11-17T18:41:03.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.53122,
-              "longitude": -122.69659
-            },
-            "name": "NW Northrup St. & NW 22nd Ave. (P2)",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "WEST",
-              "angle": -1.5070160169213977,
               "area": false,
               "bogusName": false,
               "distance": 113.262,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.523249092859054,
+              "lon": -122.69490673448706,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.523249092859054,
-                "longitude": -122.69490673448706
-              },
               "stayOn": false,
-              "streetName": "West Burnside Street",
-              "streetNotes": [ ]
+              "streetName": "West Burnside Street"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": 0.04135150879789886,
               "area": false,
               "bogusName": false,
               "distance": 882.161,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5233204,
+              "lon": -122.696357,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5233204,
-                "longitude": -122.696357
-              },
               "stayOn": false,
-              "streetName": "Northwest 22nd Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 22nd Avenue"
             },
             {
               "absoluteDirection": "EAST",
-              "angle": 1.53914562034506,
               "area": false,
               "bogusName": false,
               "distance": 3.675,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5312508,
+              "lon": -122.69663860000001,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5312508,
-                "longitude": -122.69663860000001
-              },
               "stayOn": false,
-              "streetName": "Northwest Northrup Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Northrup Street"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
+          "to": {
+            "arrival": "2009-11-17T18:53:55.000+00:00",
+            "lat": 45.53122,
+            "lon": -122.69659,
+            "name": "NW Northrup St. & NW 22nd Ave. (P2)",
+            "vertexType": "NORMAL"
+          },
+          "transitLeg": false,
+          "walkingBike": false
         }
       ],
-      "nTransfers": 0,
-      "nonTransitDistanceMeters": 1919.4279999999999,
-      "nonTransitTimeSeconds": 1490,
-      "onStreetAllTheWay": false,
-      "streetOnly": false,
-      "systemNotices": [ ],
+      "startTime": "2009-11-17T18:16:00.000+00:00",
       "tooSloped": false,
-      "transferPriorityCost": 0,
-      "transitTimeSeconds": 785,
-      "waitTimeOptimizedCost": 0,
-      "waitingTimeSeconds": 0,
-      "walkOnly": false,
-      "walkingAllTheWay": false
+      "transfers": 0,
+      "transitTime": 785,
+      "waitingTime": 0,
+      "walkDistance": 1919.4279999999999,
+      "walkLimitExceeded": false,
+      "walkTime": 1490
     },
     {
-      "arrivedAtDestinationWithRentedVehicle": false,
-      "durationSeconds": 1527,
+      "arrivedAtDestinationWithRentedBicycle": false,
+      "duration": 1527,
       "elevationGained": 0.0,
       "elevationLost": 0.0,
+      "endTime": "2009-11-17T18:55:19.000+00:00",
       "fare": {
         "details": {
           "regular": [
@@ -3536,952 +1725,374 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           }
         }
       },
-      "flaggedForDeletion": false,
       "generalizedCost": 2409,
       "legs": [
         {
           "agencyTimeZoneOffset": -28800000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 62.012,
+          "distance": 62.012,
           "endTime": "2009-11-17T18:30:40.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.51726,
-              "longitude": -122.64847
-            },
+            "departure": "2009-11-17T18:29:52.000+00:00",
+            "lat": 45.51726,
+            "lon": -122.64847,
             "name": "SE Morrison St. & SE 17th Ave. (P1)",
             "vertexType": "NORMAL"
           },
           "generalizedCost": 95,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 4,
             "points": "kaytG~wqkV?T?fCG?"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-11-17T18:29:52.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.517226,
-              "longitude": -122.649266
-            },
-            "name": "SE Morrison & 16th",
-            "stop": {
-              "code": "4019",
-              "coordinate": {
-                "latitude": 45.517226,
-                "longitude": -122.649266
-              },
-              "description": "Westbound stop in Portland (Stop ID 4019)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "4019"
-              },
-              "name": "SE Morrison & 16th",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
-            "stopIndex": 50,
-            "stopSequence": 51,
-            "vertexType": "TRANSIT"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "WEST",
-              "angle": -1.5670436023962588,
               "area": false,
               "bogusName": false,
               "distance": 62.012,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.51718601153089,
+              "lon": -122.64847039626407,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.51718601153089,
-                "longitude": -122.64847039626407
-              },
               "stayOn": false,
-              "streetName": "Southeast Morrison Street",
-              "streetNotes": [ ]
+              "streetName": "Southeast Morrison Street"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
-        },
-        {
-          "agencyTimeZoneOffset": 0,
-          "arrivalDelay": 0,
-          "departureDelay": 0,
-          "distanceMeters": 4943.103319311616,
-          "endTime": "2009-11-17T18:51:00.000+00:00",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.517226,
-              "longitude": -122.649266
-            },
+          "to": {
+            "arrival": "2009-11-17T18:30:40.000+00:00",
+            "departure": "2009-11-17T18:30:40.000+00:00",
+            "lat": 45.517226,
+            "lon": -122.649266,
             "name": "SE Morrison & 16th",
-            "stop": {
-              "code": "4019",
-              "coordinate": {
-                "latitude": 45.517226,
-                "longitude": -122.649266
-              },
-              "description": "Westbound stop in Portland (Stop ID 4019)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "4019"
-              },
-              "name": "SE Morrison & 16th",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "4019",
+            "stopId": "prt:4019",
             "stopIndex": 50,
             "stopSequence": 51,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "transitLeg": false,
+          "walkingBike": false
+        },
+        {
+          "agencyId": "prt:prt",
+          "agencyName": "TriMet",
+          "agencyTimeZoneOffset": 0,
+          "agencyUrl": "http://trimet.org",
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 4943.103319311616,
+          "endTime": "2009-11-17T18:51:00.000+00:00",
+          "from": {
+            "arrival": "2009-11-17T18:30:40.000+00:00",
+            "departure": "2009-11-17T18:30:40.000+00:00",
+            "lat": 45.517226,
+            "lon": -122.649266,
+            "name": "SE Morrison & 16th",
+            "stopCode": "4019",
+            "stopId": "prt:4019",
+            "stopIndex": 50,
+            "stopSequence": 51,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
           "generalizedCost": 1820,
           "headsign": "NW 27th & Thurman",
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "intermediateStops": [
             {
               "arrival": "2009-11-17T18:31:15.000+00:00",
               "departure": "2009-11-17T18:31:15.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.517253,
-                  "longitude": -122.651354
-                },
-                "name": "SE Morrison & 14th",
-                "stop": {
-                  "code": "4016",
-                  "coordinate": {
-                    "latitude": 45.517253,
-                    "longitude": -122.651354
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 4016)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "4016"
-                  },
-                  "name": "SE Morrison & 14th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 51,
-                "stopSequence": 52,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.517253,
+              "lon": -122.651354,
+              "name": "SE Morrison & 14th",
+              "stopCode": "4016",
+              "stopId": "prt:4016",
+              "stopIndex": 51,
+              "stopSequence": 52,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:32:00.000+00:00",
               "departure": "2009-11-17T18:32:00.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.517299,
-                  "longitude": -122.654067
-                },
-                "name": "SE Morrison & 12th",
-                "stop": {
-                  "code": "4014",
-                  "coordinate": {
-                    "latitude": 45.517299,
-                    "longitude": -122.654067
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 4014)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "4014"
-                  },
-                  "name": "SE Morrison & 12th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 52,
-                "stopSequence": 53,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.517299,
+              "lon": -122.654067,
+              "name": "SE Morrison & 12th",
+              "stopCode": "4014",
+              "stopId": "prt:4014",
+              "stopIndex": 52,
+              "stopSequence": 53,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:32:38.000+00:00",
               "departure": "2009-11-17T18:32:38.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.517292,
-                  "longitude": -122.656563
-                },
-                "name": "SE Morrison & 9th",
-                "stop": {
-                  "code": "4026",
-                  "coordinate": {
-                    "latitude": 45.517292,
-                    "longitude": -122.656563
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 4026)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "4026"
-                  },
-                  "name": "SE Morrison & 9th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 53,
-                "stopSequence": 54,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.517292,
+              "lon": -122.656563,
+              "name": "SE Morrison & 9th",
+              "stopCode": "4026",
+              "stopId": "prt:4026",
+              "stopIndex": 53,
+              "stopSequence": 54,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:33:08.000+00:00",
               "departure": "2009-11-17T18:33:08.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.517322,
-                  "longitude": -122.65847
-                },
-                "name": "SE Morrison & 7th",
-                "stop": {
-                  "code": "4025",
-                  "coordinate": {
-                    "latitude": 45.517322,
-                    "longitude": -122.65847
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 4025)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "4025"
-                  },
-                  "name": "SE Morrison & 7th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 54,
-                "stopSequence": 55,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.517322,
+              "lon": -122.65847,
+              "name": "SE Morrison & 7th",
+              "stopCode": "4025",
+              "stopId": "prt:4025",
+              "stopIndex": 54,
+              "stopSequence": 55,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:33:39.000+00:00",
               "departure": "2009-11-17T18:33:39.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.517298,
-                  "longitude": -122.660523
-                },
-                "name": "SE Morrison & Grand",
-                "stop": {
-                  "code": "4013",
-                  "coordinate": {
-                    "latitude": 45.517298,
-                    "longitude": -122.660523
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 4013)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "4013"
-                  },
-                  "name": "SE Morrison & Grand",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 55,
-                "stopSequence": 56,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.517298,
+              "lon": -122.660523,
+              "name": "SE Morrison & Grand",
+              "stopCode": "4013",
+              "stopId": "prt:4013",
+              "stopIndex": 55,
+              "stopSequence": 56,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:35:03.000+00:00",
               "departure": "2009-11-17T18:35:03.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.517351,
-                  "longitude": -122.66601
-                },
-                "name": "Morrison Bridge",
-                "stop": {
-                  "code": "4029",
-                  "coordinate": {
-                    "latitude": 45.517351,
-                    "longitude": -122.66601
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 4029)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "4029"
-                  },
-                  "name": "Morrison Bridge",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 56,
-                "stopSequence": 57,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.517351,
+              "lon": -122.66601,
+              "name": "Morrison Bridge",
+              "stopCode": "4029",
+              "stopId": "prt:4029",
+              "stopIndex": 56,
+              "stopSequence": 57,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:37:27.000+00:00",
               "departure": "2009-11-17T18:37:27.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.51959,
-                  "longitude": -122.674599
-                },
-                "name": "SW Washington & 3rd",
-                "stop": {
-                  "code": "6158",
-                  "coordinate": {
-                    "latitude": 45.51959,
-                    "longitude": -122.674599
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 6158)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "6158"
-                  },
-                  "name": "SW Washington & 3rd",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 57,
-                "stopSequence": 58,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.51959,
+              "lon": -122.674599,
+              "name": "SW Washington & 3rd",
+              "stopCode": "6158",
+              "stopId": "prt:6158",
+              "stopIndex": 57,
+              "stopSequence": 58,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T18:38:00.000+00:00",
               "departure": "2009-11-17T18:38:00.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.520129,
-                  "longitude": -122.676635
-                },
-                "name": "SW Washington & 5th",
-                "stop": {
-                  "code": "6160",
-                  "coordinate": {
-                    "latitude": 45.520129,
-                    "longitude": -122.676635
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 6160)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "6160"
-                  },
-                  "name": "SW Washington & 5th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 58,
-                "stopSequence": 59,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.520129,
+              "lon": -122.676635,
+              "name": "SW Washington & 5th",
+              "stopCode": "6160",
+              "stopId": "prt:6160",
+              "stopIndex": 58,
+              "stopSequence": 59,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T18:38:52.000+00:00",
               "departure": "2009-11-17T18:38:52.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.520695,
-                  "longitude": -122.678657
-                },
-                "name": "SW Washington & Broadway",
-                "stop": {
-                  "code": "6137",
-                  "coordinate": {
-                    "latitude": 45.520695,
-                    "longitude": -122.678657
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 6137)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "6137"
-                  },
-                  "name": "SW Washington & Broadway",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 59,
-                "stopSequence": 60,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.520695,
+              "lon": -122.678657,
+              "name": "SW Washington & Broadway",
+              "stopCode": "6137",
+              "stopId": "prt:6137",
+              "stopIndex": 59,
+              "stopSequence": 60,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T18:39:34.000+00:00",
               "departure": "2009-11-17T18:39:34.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.521124,
-                  "longitude": -122.6803
-                },
-                "name": "SW Washington & 9th",
-                "stop": {
-                  "code": "6169",
-                  "coordinate": {
-                    "latitude": 45.521124,
-                    "longitude": -122.6803
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 6169)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "6169"
-                  },
-                  "name": "SW Washington & 9th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 60,
-                "stopSequence": 61,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.521124,
+              "lon": -122.6803,
+              "name": "SW Washington & 9th",
+              "stopCode": "6169",
+              "stopId": "prt:6169",
+              "stopIndex": 60,
+              "stopSequence": 61,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T18:40:47.000+00:00",
               "departure": "2009-11-17T18:40:47.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.521094,
-                  "longitude": -122.682819
-                },
-                "name": "SW 11th & Alder",
-                "stop": {
-                  "code": "9600",
-                  "coordinate": {
-                    "latitude": 45.521094,
-                    "longitude": -122.682819
-                  },
-                  "description": "Southbound stop in Portland (Stop ID 9600)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "9600"
-                  },
-                  "name": "SW 11th & Alder",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 61,
-                "stopSequence": 62,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.521094,
+              "lon": -122.682819,
+              "name": "SW 11th & Alder",
+              "stopCode": "9600",
+              "stopId": "prt:9600",
+              "stopIndex": 61,
+              "stopSequence": 62,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T18:41:36.000+00:00",
               "departure": "2009-11-17T18:41:36.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.52055,
-                  "longitude": -122.683933
-                },
-                "name": "SW Morrison & 12th",
-                "stop": {
-                  "code": "9598",
-                  "coordinate": {
-                    "latitude": 45.52055,
-                    "longitude": -122.683933
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 9598)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "9598"
-                  },
-                  "name": "SW Morrison & 12th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 62,
-                "stopSequence": 63,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.52055,
+              "lon": -122.683933,
+              "name": "SW Morrison & 12th",
+              "stopCode": "9598",
+              "stopId": "prt:9598",
+              "stopIndex": 62,
+              "stopSequence": 63,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T18:42:25.000+00:00",
               "departure": "2009-11-17T18:42:25.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.521063,
-                  "longitude": -122.685848
-                },
-                "name": "SW Morrison & 14th",
-                "stop": {
-                  "code": "9708",
-                  "coordinate": {
-                    "latitude": 45.521063,
-                    "longitude": -122.685848
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 9708)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "9708"
-                  },
-                  "name": "SW Morrison & 14th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 63,
-                "stopSequence": 64,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.521063,
+              "lon": -122.685848,
+              "name": "SW Morrison & 14th",
+              "stopCode": "9708",
+              "stopId": "prt:9708",
+              "stopIndex": 63,
+              "stopSequence": 64,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:43:18.000+00:00",
               "departure": "2009-11-17T18:43:18.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.521641,
-                  "longitude": -122.687932
-                },
-                "name": "SW Morrison & 16th",
-                "stop": {
-                  "code": "9613",
-                  "coordinate": {
-                    "latitude": 45.521641,
-                    "longitude": -122.687932
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 9613)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "9613"
-                  },
-                  "name": "SW Morrison & 16th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 64,
-                "stopSequence": 65,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.521641,
+              "lon": -122.687932,
+              "name": "SW Morrison & 16th",
+              "stopCode": "9613",
+              "stopId": "prt:9613",
+              "stopIndex": 64,
+              "stopSequence": 65,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:44:00.000+00:00",
               "departure": "2009-11-17T18:44:00.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.52206,
-                  "longitude": -122.689577
-                },
-                "name": "SW Morrison & 17th",
-                "stop": {
-                  "code": "9599",
-                  "coordinate": {
-                    "latitude": 45.52206,
-                    "longitude": -122.689577
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 9599)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "9599"
-                  },
-                  "name": "SW Morrison & 17th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 65,
-                "stopSequence": 66,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.52206,
+              "lon": -122.689577,
+              "name": "SW Morrison & 17th",
+              "stopCode": "9599",
+              "stopId": "prt:9599",
+              "stopIndex": 65,
+              "stopSequence": 66,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:45:03.000+00:00",
               "departure": "2009-11-17T18:45:03.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523097,
-                  "longitude": -122.690083
-                },
-                "name": "W Burnside & NW 19th",
-                "stop": {
-                  "code": "735",
-                  "coordinate": {
-                    "latitude": 45.523097,
-                    "longitude": -122.690083
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 735)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "735"
-                  },
-                  "name": "W Burnside & NW 19th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 66,
-                "stopSequence": 67,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523097,
+              "lon": -122.690083,
+              "name": "W Burnside & NW 19th",
+              "stopCode": "735",
+              "stopId": "prt:735",
+              "stopIndex": 66,
+              "stopSequence": 67,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:45:46.000+00:00",
               "departure": "2009-11-17T18:45:46.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523176,
-                  "longitude": -122.692139
-                },
-                "name": "W Burnside & NW 20th",
-                "stop": {
-                  "code": "741",
-                  "coordinate": {
-                    "latitude": 45.523176,
-                    "longitude": -122.692139
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 741)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "741"
-                  },
-                  "name": "W Burnside & NW 20th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 67,
-                "stopSequence": 68,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523176,
+              "lon": -122.692139,
+              "name": "W Burnside & NW 20th",
+              "stopCode": "741",
+              "stopId": "prt:741",
+              "stopIndex": 67,
+              "stopSequence": 68,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:46:07.000+00:00",
               "departure": "2009-11-17T18:46:07.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.52322,
-                  "longitude": -122.69313
-                },
-                "name": "W Burnside & NW 20th Pl",
-                "stop": {
-                  "code": "742",
-                  "coordinate": {
-                    "latitude": 45.52322,
-                    "longitude": -122.69313
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 742)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "742"
-                  },
-                  "name": "W Burnside & NW 20th Pl",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 68,
-                "stopSequence": 69,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.52322,
+              "lon": -122.69313,
+              "name": "W Burnside & NW 20th Pl",
+              "stopCode": "742",
+              "stopId": "prt:742",
+              "stopIndex": 68,
+              "stopSequence": 69,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:46:44.000+00:00",
               "departure": "2009-11-17T18:46:44.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523312,
-                  "longitude": -122.694901
-                },
-                "name": "W Burnside & NW King",
-                "stop": {
-                  "code": "747",
-                  "coordinate": {
-                    "latitude": 45.523312,
-                    "longitude": -122.694901
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 747)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "747"
-                  },
-                  "name": "W Burnside & NW King",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 69,
-                "stopSequence": 70,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523312,
+              "lon": -122.694901,
+              "name": "W Burnside & NW King",
+              "stopCode": "747",
+              "stopId": "prt:747",
+              "stopIndex": 69,
+              "stopSequence": 70,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:47:51.000+00:00",
               "departure": "2009-11-17T18:47:51.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523512,
-                  "longitude": -122.698081
-                },
-                "name": "W Burnside & NW 23rd",
-                "stop": {
-                  "code": "755",
-                  "coordinate": {
-                    "latitude": 45.523512,
-                    "longitude": -122.698081
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 755)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "755"
-                  },
-                  "name": "W Burnside & NW 23rd",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 70,
-                "stopSequence": 71,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523512,
+              "lon": -122.698081,
+              "name": "W Burnside & NW 23rd",
+              "stopCode": "755",
+              "stopId": "prt:755",
+              "stopIndex": 70,
+              "stopSequence": 71,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:48:53.000+00:00",
               "departure": "2009-11-17T18:48:53.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.525416,
-                  "longitude": -122.698381
-                },
-                "name": "NW 23rd & Flanders",
-                "stop": {
-                  "code": "7157",
-                  "coordinate": {
-                    "latitude": 45.525416,
-                    "longitude": -122.698381
-                  },
-                  "description": "Northbound stop in Portland (Stop ID 7157)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "7157"
-                  },
-                  "name": "NW 23rd & Flanders",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 71,
-                "stopSequence": 72,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.525416,
+              "lon": -122.698381,
+              "name": "NW 23rd & Flanders",
+              "stopCode": "7157",
+              "stopId": "prt:7157",
+              "stopIndex": 71,
+              "stopSequence": 72,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:49:56.000+00:00",
               "departure": "2009-11-17T18:49:56.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.527543,
-                  "longitude": -122.698473
-                },
-                "name": "NW 23rd & Irving",
-                "stop": {
-                  "code": "7161",
-                  "coordinate": {
-                    "latitude": 45.527543,
-                    "longitude": -122.698473
-                  },
-                  "description": "Northbound stop in Portland (Stop ID 7161)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "7161"
-                  },
-                  "name": "NW 23rd & Irving",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 72,
-                "stopSequence": 73,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.527543,
+              "lon": -122.698473,
+              "name": "NW 23rd & Irving",
+              "stopCode": "7161",
+              "stopId": "prt:7161",
+              "stopIndex": 72,
+              "stopSequence": 73,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             }
           ],
           "legGeometry": {
@@ -4489,276 +2100,151 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "points": "kaytG||qkVA~@?jE?tC???r@AhE?jE?rA???tBAjE?nD???X?hE?xC??Ah@?pE?~C???J?`@?vAAvBEbE?jEAlE?`BAbB@d@??@tAAj@Cx@Cb@Cp@_@dEcAtFoA`IS~@i@`BmAzDi@zAc@pAi@~C??Id@u@jEm@bD??If@u@jEk@bD??If@u@|DW`B??CPs@|Du@lElBz@??VJbCfAk@dD??Id@w@rEWvAId@AF??Q~@s@`Ei@~C??Ib@u@dEWzA??]jB]MQSe@WOKOKIIQe@GWE]GnD??AXKnEGnD???XGjD??AZEfCC`AEzB??AXCfAGxDE|AEtBIlC??APkAh@o@?sCB{BD??S?mCDmCDyBB??U?mCDmCDyBB"
           },
           "mode": "BUS",
-          "onStreetNonTransit": false,
           "pathway": false,
           "realTime": false,
-          "scheduled": true,
-          "serviceDate": {
-            "day": 17,
-            "minMax": false,
-            "month": 11,
-            "sequenceNumber": 20091117,
-            "year": 2009
-          },
+          "route": "Belmont/NW 23rd",
+          "routeId": "prt:15",
+          "routeLongName": "Belmont/NW 23rd",
+          "routeShortName": "15",
+          "serviceDate": "2009-11-17",
           "startTime": "2009-11-17T18:30:40.000+00:00",
-          "streetNotes": [ ],
+          "steps": [ ],
           "to": {
-            "coordinate": {
-              "latitude": 45.529681,
-              "longitude": -122.698529
-            },
+            "arrival": "2009-11-17T18:51:00.000+00:00",
+            "departure": "2009-11-17T18:51:00.000+00:00",
+            "lat": 45.529681,
+            "lon": -122.698529,
             "name": "NW 23rd & Lovejoy",
-            "stop": {
-              "code": "7163",
-              "coordinate": {
-                "latitude": 45.529681,
-                "longitude": -122.698529
-              },
-              "description": "Northbound stop in Portland (Stop ID 7163)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "7163"
-              },
-              "name": "NW 23rd & Lovejoy",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "7163",
+            "stopId": "prt:7163",
             "stopIndex": 73,
             "stopSequence": 74,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
-          "transitAlerts": [ ],
           "transitLeg": true,
-          "trip": {
-            "alteration": "PLANNED",
-            "bikesAllowed": "UNKNOWN",
-            "blockId": "1541",
-            "direction": "OUTBOUND",
-            "id": {
-              "feedId": "prt",
-              "id": "150W1410"
-            },
-            "route": {
-              "agency": {
-                "fareUrl": "http://trimet.org/fares/index.htm",
-                "id": {
-                  "feedId": "prt",
-                  "id": "prt"
-                },
-                "lang": "en",
-                "name": "TriMet",
-                "phone": "503-238-7433",
-                "timezone": "America/Los_Angeles",
-                "url": "http://trimet.org"
-              },
-              "bikesAllowed": "UNKNOWN",
-              "gtfsType": 3,
-              "id": {
-                "feedId": "prt",
-                "id": "15"
-              },
-              "longName": "Belmont/NW 23rd",
-              "mode": "BUS",
-              "shortName": "15",
-              "sortOrder": -999,
-              "sortOrderSet": false,
-              "url": "http://trimet.org/schedules/r015.htm"
-            },
-            "serviceId": {
-              "feedId": "prt",
-              "id": "W"
-            },
-            "shapeId": {
-              "feedId": "prt",
-              "id": "15.0.23"
-            },
-            "wheelchairAccessible": 0
-          },
-          "walkSteps": [ ],
-          "walkingLeg": false
+          "tripBlockId": "1541",
+          "tripId": "prt:150W1410"
         },
         {
           "agencyTimeZoneOffset": -28800000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 321.94500000000005,
+          "distance": 321.94500000000005,
           "endTime": "2009-11-17T18:55:19.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.529681,
-              "longitude": -122.698529
-            },
+            "arrival": "2009-11-17T18:51:00.000+00:00",
+            "departure": "2009-11-17T18:51:00.000+00:00",
+            "lat": 45.529681,
+            "lon": -122.698529,
             "name": "NW 23rd & Lovejoy",
-            "stop": {
-              "code": "7163",
-              "coordinate": {
-                "latitude": 45.529681,
-                "longitude": -122.698529
-              },
-              "description": "Northbound stop in Portland (Stop ID 7163)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "7163"
-              },
-              "name": "NW 23rd & Lovejoy",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "7163",
+            "stopId": "prt:7163",
             "stopIndex": 73,
             "stopSequence": 74,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
           "generalizedCost": 493,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 18,
             "points": "oo{tGxp{kVG@?GCwAAaF?G?i@?SK?C?K?W@{A@M@C@I?_CB?G"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-11-17T18:51:00.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.53122,
-              "longitude": -122.69659
-            },
-            "name": "NW Northrup St. & NW 22nd Ave. (P2)",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "EAST",
-              "angle": 1.5519664675850313,
               "area": false,
               "bogusName": true,
               "distance": 2.418,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.529726790620664,
+              "lon": -122.69853023095405,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.529726790620664,
-                "longitude": -122.69853023095405
-              },
               "stayOn": false,
-              "streetName": "way 158083864 from 0",
-              "streetNotes": [ ]
+              "streetName": "way 158083864 from 0"
             },
             {
               "absoluteDirection": "EAST",
-              "angle": 1.5293125423902536,
               "area": false,
               "bogusName": false,
               "distance": 142.155,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5297272,
+              "lon": -122.6984992,
               "relativeDirection": "CONTINUE",
-              "startLocation": {
-                "latitude": 45.5297272,
-                "longitude": -122.6984992
-              },
               "stayOn": false,
-              "streetName": "Northwest Lovejoy Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Lovejoy Street"
             },
             {
               "absoluteDirection": "EAST",
-              "angle": 1.5678920159151593,
               "area": false,
               "bogusName": true,
               "distance": 7.657,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.529758300000005,
+              "lon": -122.6966749,
               "relativeDirection": "CONTINUE",
-              "startLocation": {
-                "latitude": 45.529758300000005,
-                "longitude": -122.6966749
-              },
               "stayOn": false,
-              "streetName": "way 158083863 from 2",
-              "streetNotes": [ ]
+              "streetName": "way 158083863 from 2"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": -0.02805287330123452,
               "area": false,
               "bogusName": false,
               "distance": 166.04000000000002,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5297585,
+              "lon": -122.69657660000001,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.5297585,
-                "longitude": -122.69657660000001
-              },
               "stayOn": false,
-              "streetName": "Northwest 22nd Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 22nd Avenue"
             },
             {
               "absoluteDirection": "EAST",
-              "angle": 1.53914562034506,
               "area": false,
               "bogusName": false,
               "distance": 3.675,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5312508,
+              "lon": -122.69663860000001,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5312508,
-                "longitude": -122.69663860000001
-              },
               "stayOn": false,
-              "streetName": "Northwest Northrup Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Northrup Street"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
+          "to": {
+            "arrival": "2009-11-17T18:55:19.000+00:00",
+            "lat": 45.53122,
+            "lon": -122.69659,
+            "name": "NW Northrup St. & NW 22nd Ave. (P2)",
+            "vertexType": "NORMAL"
+          },
+          "transitLeg": false,
+          "walkingBike": false
         }
       ],
-      "nTransfers": 0,
-      "nonTransitDistanceMeters": 383.95700000000005,
-      "nonTransitTimeSeconds": 307,
-      "onStreetAllTheWay": false,
-      "streetOnly": false,
-      "systemNotices": [ ],
+      "startTime": "2009-11-17T18:29:52.000+00:00",
       "tooSloped": false,
-      "transferPriorityCost": 0,
-      "transitTimeSeconds": 1220,
-      "waitTimeOptimizedCost": 0,
-      "waitingTimeSeconds": 0,
-      "walkOnly": false,
-      "walkingAllTheWay": false
+      "transfers": 0,
+      "transitTime": 1220,
+      "waitingTime": 0,
+      "walkDistance": 383.95700000000005,
+      "walkLimitExceeded": false,
+      "walkTime": 307
     },
     {
-      "arrivedAtDestinationWithRentedVehicle": false,
-      "durationSeconds": 1849,
+      "arrivedAtDestinationWithRentedBicycle": false,
+      "duration": 1849,
       "elevationGained": 0.0,
       "elevationLost": 0.0,
+      "endTime": "2009-11-17T19:08:19.000+00:00",
       "fare": {
         "details": {
           "regular": [
@@ -4795,488 +2281,217 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           }
         }
       },
-      "flaggedForDeletion": false,
       "generalizedCost": 3375,
       "legs": [
         {
           "agencyTimeZoneOffset": -28800000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 419.61499999999995,
+          "distance": 419.61499999999995,
           "endTime": "2009-11-17T18:42:54.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.51726,
-              "longitude": -122.64847
-            },
+            "departure": "2009-11-17T18:37:30.000+00:00",
+            "lat": 45.51726,
+            "lon": -122.64847,
             "name": "SE Morrison St. & SE 17th Ave. (P1)",
             "vertexType": "NORMAL"
           },
           "generalizedCost": 636,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 14,
             "points": "kaytG~wqkV?T?fCAl@?R?jE?rC?t@?hEAvD?RN?L??O"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-11-17T18:37:30.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.517059,
-              "longitude": -122.65358
-            },
-            "name": "SE 12th & Morrison",
-            "stop": {
-              "code": "6588",
-              "coordinate": {
-                "latitude": 45.517059,
-                "longitude": -122.65358
-              },
-              "description": "Northbound stop in Portland (Stop ID 6588)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "6588"
-              },
-              "name": "SE 12th & Morrison",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
-            "stopIndex": 31,
-            "stopSequence": 32,
-            "vertexType": "TRANSIT"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "WEST",
-              "angle": -1.5670436023962588,
               "area": false,
               "bogusName": false,
               "distance": 403.65599999999995,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.51718601153089,
+              "lon": -122.64847039626407,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.51718601153089,
-                "longitude": -122.64847039626407
-              },
               "stayOn": false,
-              "streetName": "Southeast Morrison Street",
-              "streetNotes": [ ]
+              "streetName": "Southeast Morrison Street"
             },
             {
               "absoluteDirection": "SOUTH",
-              "angle": -3.132186938587986,
               "area": false,
               "bogusName": false,
               "distance": 15.959,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5172031,
+              "lon": -122.6536511,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.5172031,
-                "longitude": -122.6536511
-              },
               "stayOn": false,
-              "streetName": "Southeast 12th Avenue",
-              "streetNotes": [ ]
+              "streetName": "Southeast 12th Avenue"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
-        },
-        {
-          "agencyTimeZoneOffset": 0,
-          "arrivalDelay": 0,
-          "departureDelay": 0,
-          "distanceMeters": 2347.5602438577907,
-          "endTime": "2009-11-17T18:52:12.000+00:00",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.517059,
-              "longitude": -122.65358
-            },
+          "to": {
+            "arrival": "2009-11-17T18:42:54.000+00:00",
+            "departure": "2009-11-17T18:42:54.000+00:00",
+            "lat": 45.517059,
+            "lon": -122.65358,
             "name": "SE 12th & Morrison",
-            "stop": {
-              "code": "6588",
-              "coordinate": {
-                "latitude": 45.517059,
-                "longitude": -122.65358
-              },
-              "description": "Northbound stop in Portland (Stop ID 6588)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "6588"
-              },
-              "name": "SE 12th & Morrison",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "6588",
+            "stopId": "prt:6588",
             "stopIndex": 31,
             "stopSequence": 32,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "transitLeg": false,
+          "walkingBike": false
+        },
+        {
+          "agencyId": "prt:prt",
+          "agencyName": "TriMet",
+          "agencyTimeZoneOffset": 0,
+          "agencyUrl": "http://trimet.org",
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 2347.5602438577907,
+          "endTime": "2009-11-17T18:52:12.000+00:00",
+          "from": {
+            "arrival": "2009-11-17T18:42:54.000+00:00",
+            "departure": "2009-11-17T18:42:54.000+00:00",
+            "lat": 45.517059,
+            "lon": -122.65358,
+            "name": "SE 12th & Morrison",
+            "stopCode": "6588",
+            "stopId": "prt:6588",
+            "stopIndex": 31,
+            "stopSequence": 32,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
           "generalizedCost": 1158,
           "headsign": "Rose Qtr TC",
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "intermediateStops": [
             {
               "arrival": "2009-11-17T18:44:00.000+00:00",
               "departure": "2009-11-17T18:44:00.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.519229,
-                  "longitude": -122.653546
-                },
-                "name": "SE 12th & Stark",
-                "stop": {
-                  "code": "6594",
-                  "coordinate": {
-                    "latitude": 45.519229,
-                    "longitude": -122.653546
-                  },
-                  "description": "Northbound stop in Portland (Stop ID 6594)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "6594"
-                  },
-                  "name": "SE 12th & Stark",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 32,
-                "stopSequence": 33,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.519229,
+              "lon": -122.653546,
+              "name": "SE 12th & Stark",
+              "stopCode": "6594",
+              "stopId": "prt:6594",
+              "stopIndex": 32,
+              "stopSequence": 33,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:44:44.000+00:00",
               "departure": "2009-11-17T18:44:44.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.520674,
-                  "longitude": -122.653544
-                },
-                "name": "SE 12th & Pine",
-                "stop": {
-                  "code": "6589",
-                  "coordinate": {
-                    "latitude": 45.520674,
-                    "longitude": -122.653544
-                  },
-                  "description": "Northbound stop in Portland (Stop ID 6589)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "6589"
-                  },
-                  "name": "SE 12th & Pine",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 33,
-                "stopSequence": 34,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.520674,
+              "lon": -122.653544,
+              "name": "SE 12th & Pine",
+              "stopCode": "6589",
+              "stopId": "prt:6589",
+              "stopIndex": 33,
+              "stopSequence": 34,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:46:00.000+00:00",
               "departure": "2009-11-17T18:46:00.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.52318,
-                  "longitude": -122.653507
-                },
-                "name": "NE 12th & Sandy",
-                "stop": {
-                  "code": "6592",
-                  "coordinate": {
-                    "latitude": 45.52318,
-                    "longitude": -122.653507
-                  },
-                  "description": "Northbound stop in Portland (Stop ID 6592)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "6592"
-                  },
-                  "name": "NE 12th & Sandy",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 34,
-                "stopSequence": 35,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.52318,
+              "lon": -122.653507,
+              "name": "NE 12th & Sandy",
+              "stopCode": "6592",
+              "stopId": "prt:6592",
+              "stopIndex": 34,
+              "stopSequence": 35,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:47:45.000+00:00",
               "departure": "2009-11-17T18:47:45.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.527449,
-                  "longitude": -122.653462
-                },
-                "name": "NE 12th & Irving",
-                "stop": {
-                  "code": "6582",
-                  "coordinate": {
-                    "latitude": 45.527449,
-                    "longitude": -122.653462
-                  },
-                  "description": "Northbound stop in Portland (Stop ID 6582)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "6582"
-                  },
-                  "name": "NE 12th & Irving",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 35,
-                "stopSequence": 36,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.527449,
+              "lon": -122.653462,
+              "name": "NE 12th & Irving",
+              "stopCode": "6582",
+              "stopId": "prt:6582",
+              "stopIndex": 35,
+              "stopSequence": 36,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:49:00.000+00:00",
               "departure": "2009-11-17T18:49:00.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.529793,
-                  "longitude": -122.654429
-                },
-                "name": "NE 11th & Holladay",
-                "stop": {
-                  "code": "8513",
-                  "coordinate": {
-                    "latitude": 45.529793,
-                    "longitude": -122.654429
-                  },
-                  "description": "Northbound stop in Portland (Stop ID 8513)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "8513"
-                  },
-                  "name": "NE 11th & Holladay",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 36,
-                "stopSequence": 37,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.529793,
+              "lon": -122.654429,
+              "name": "NE 11th & Holladay",
+              "stopCode": "8513",
+              "stopId": "prt:8513",
+              "stopIndex": 36,
+              "stopSequence": 37,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T18:49:39.000+00:00",
               "departure": "2009-11-17T18:49:39.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.53135,
-                  "longitude": -122.654497
-                },
-                "name": "NE 11th & Multnomah",
-                "stop": {
-                  "code": "8938",
-                  "coordinate": {
-                    "latitude": 45.53135,
-                    "longitude": -122.654497
-                  },
-                  "description": "Northbound stop in Portland (Stop ID 8938)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "8938"
-                  },
-                  "name": "NE 11th & Multnomah",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 37,
-                "stopSequence": 38,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.53135,
+              "lon": -122.654497,
+              "name": "NE 11th & Multnomah",
+              "stopCode": "8938",
+              "stopId": "prt:8938",
+              "stopIndex": 37,
+              "stopSequence": 38,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T18:50:15.000+00:00",
               "departure": "2009-11-17T18:50:15.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.531573,
-                  "longitude": -122.656408
-                },
-                "name": "NE Multnomah & 9th",
-                "stop": {
-                  "code": "4056",
-                  "coordinate": {
-                    "latitude": 45.531573,
-                    "longitude": -122.656408
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 4056)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "4056"
-                  },
-                  "name": "NE Multnomah & 9th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 38,
-                "stopSequence": 39,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.531573,
+              "lon": -122.656408,
+              "name": "NE Multnomah & 9th",
+              "stopCode": "4056",
+              "stopId": "prt:4056",
+              "stopIndex": 38,
+              "stopSequence": 39,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T18:51:01.000+00:00",
               "departure": "2009-11-17T18:51:01.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.531569,
-                  "longitude": -122.659045
-                },
-                "name": "NE Multnomah & 7th",
-                "stop": {
-                  "code": "4054",
-                  "coordinate": {
-                    "latitude": 45.531569,
-                    "longitude": -122.659045
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 4054)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "4054"
-                  },
-                  "name": "NE Multnomah & 7th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 39,
-                "stopSequence": 40,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.531569,
+              "lon": -122.659045,
+              "name": "NE Multnomah & 7th",
+              "stopCode": "4054",
+              "stopId": "prt:4054",
+              "stopIndex": 39,
+              "stopSequence": 40,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T18:51:27.000+00:00",
               "departure": "2009-11-17T18:51:27.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.531586,
-                  "longitude": -122.660482
-                },
-                "name": "NE Multnomah & Grand",
-                "stop": {
-                  "code": "4043",
-                  "coordinate": {
-                    "latitude": 45.531586,
-                    "longitude": -122.660482
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 4043)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "4043"
-                  },
-                  "name": "NE Multnomah & Grand",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 40,
-                "stopSequence": 41,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.531586,
+              "lon": -122.660482,
+              "name": "NE Multnomah & Grand",
+              "stopCode": "4043",
+              "stopId": "prt:4043",
+              "stopIndex": 40,
+              "stopSequence": 41,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             }
           ],
           "legGeometry": {
@@ -5284,564 +2499,161 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "points": "s`ytGhxrkV[?mCAmC?wBA??W?mC?{BA??Q?oC?mC?kBAa@?w@???wA?mCAmC?oCA}C?sDC??aBAm@@k@AY?uABU@I@IBQFb@fC}@d@OFO@q@???Q?]?gGA??[??nJ???b@?vK?rA???tBCfD???^?nE?V@Z?PH\\Nb@`@~@Rf@"
           },
           "mode": "BUS",
-          "onStreetNonTransit": false,
           "pathway": false,
           "realTime": false,
-          "scheduled": true,
-          "serviceDate": {
-            "day": 17,
-            "minMax": false,
-            "month": 11,
-            "sequenceNumber": 20091117,
-            "year": 2009
-          },
+          "route": "12th Ave",
+          "routeId": "prt:70",
+          "routeLongName": "12th Ave",
+          "routeShortName": "70",
+          "serviceDate": "2009-11-17",
           "startTime": "2009-11-17T18:42:54.000+00:00",
-          "streetNotes": [ ],
+          "steps": [ ],
           "to": {
-            "coordinate": {
-              "latitude": 45.531159,
-              "longitude": -122.66293
-            },
+            "arrival": "2009-11-17T18:52:12.000+00:00",
+            "departure": "2009-11-17T18:56:09.000+00:00",
+            "lat": 45.531159,
+            "lon": -122.66293,
             "name": "NE Multnomah & 3rd",
-            "stop": {
-              "code": "11492",
-              "coordinate": {
-                "latitude": 45.531159,
-                "longitude": -122.66293
-              },
-              "description": "Westbound stop in Portland (Stop ID 11492)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "0"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "11492"
-              },
-              "name": "NE Multnomah & 3rd",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "11492",
+            "stopId": "prt:11492",
             "stopIndex": 41,
             "stopSequence": 42,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
           },
-          "transitAlerts": [ ],
           "transitLeg": true,
-          "trip": {
-            "alteration": "PLANNED",
-            "bikesAllowed": "UNKNOWN",
-            "blockId": "7002",
-            "direction": "OUTBOUND",
-            "id": {
-              "feedId": "prt",
-              "id": "700W1170"
-            },
-            "route": {
-              "agency": {
-                "fareUrl": "http://trimet.org/fares/index.htm",
-                "id": {
-                  "feedId": "prt",
-                  "id": "prt"
-                },
-                "lang": "en",
-                "name": "TriMet",
-                "phone": "503-238-7433",
-                "timezone": "America/Los_Angeles",
-                "url": "http://trimet.org"
-              },
-              "bikesAllowed": "UNKNOWN",
-              "gtfsType": 3,
-              "id": {
-                "feedId": "prt",
-                "id": "70"
-              },
-              "longName": "12th Ave",
-              "mode": "BUS",
-              "shortName": "70",
-              "sortOrder": -999,
-              "sortOrderSet": false,
-              "url": "http://trimet.org/schedules/r070.htm"
-            },
-            "serviceId": {
-              "feedId": "prt",
-              "id": "W"
-            },
-            "shapeId": {
-              "feedId": "prt",
-              "id": "70.0.7"
-            },
-            "wheelchairAccessible": 0
-          },
-          "walkSteps": [ ],
-          "walkingLeg": false
+          "tripBlockId": "7002",
+          "tripId": "prt:700W1170"
         },
         {
+          "agencyId": "prt:prt",
+          "agencyName": "TriMet",
           "agencyTimeZoneOffset": 0,
+          "agencyUrl": "http://trimet.org",
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 3248.2996826174576,
+          "distance": 3248.2996826174576,
           "endTime": "2009-11-17T19:07:55.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.531159,
-              "longitude": -122.66293
-            },
+            "arrival": "2009-11-17T18:52:12.000+00:00",
+            "departure": "2009-11-17T18:56:09.000+00:00",
+            "lat": 45.531159,
+            "lon": -122.66293,
             "name": "NE Multnomah & 3rd",
-            "stop": {
-              "code": "11492",
-              "coordinate": {
-                "latitude": 45.531159,
-                "longitude": -122.66293
-              },
-              "description": "Westbound stop in Portland (Stop ID 11492)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "0"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "11492"
-              },
-              "name": "NE Multnomah & 3rd",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "11492",
+            "stopId": "prt:11492",
             "stopIndex": 83,
             "stopSequence": 84,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
           },
           "generalizedCost": 1543,
           "headsign": "Montgomery Park",
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "intermediateStops": [
             {
               "arrival": "2009-11-17T18:58:00.000+00:00",
               "departure": "2009-11-17T18:58:00.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.530005,
-                  "longitude": -122.666476
-                },
-                "name": "Rose Quarter Transit Center",
-                "stop": {
-                  "code": "2592",
-                  "coordinate": {
-                    "latitude": 45.530005,
-                    "longitude": -122.666476
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 2592)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "2592"
-                  },
-                  "name": "Rose Quarter Transit Center",
-                  "parentStation": {
-                    "code": "79-tc",
-                    "coordinate": {
-                      "latitude": 45.530205,
-                      "longitude": -122.666118
-                    },
-                    "geometry": {
-                      "SRID": 0,
-                      "empty": false,
-                      "factory": {
-                        "SRID": 0,
-                        "coordinateSequenceFactory": { },
-                        "precisionModel": {
-                          "floating": true,
-                          "modelType": {
-                            "name": "FLOATING"
-                          },
-                          "scale": 0.0
-                        }
-                      },
-                      "geometries": [
-                        {
-                          "SRID": 0,
-                          "coordinates": {
-                            "coords": [
-                              -122.666118,
-                              45.530205
-                            ],
-                            "dimension": 2
-                          },
-                          "empty": false,
-                          "factory": {
-                            "SRID": 0,
-                            "coordinateSequenceFactory": { },
-                            "precisionModel": {
-                              "floating": true,
-                              "modelType": {
-                                "name": "FLOATING"
-                              },
-                              "scale": 0.0
-                            }
-                          },
-                          "rectangle": false,
-                          "simple": true,
-                          "valid": true
-                        },
-                        {
-                          "SRID": 0,
-                          "empty": false,
-                          "factory": {
-                            "SRID": 0,
-                            "coordinateSequenceFactory": { },
-                            "precisionModel": {
-                              "floating": true,
-                              "modelType": {
-                                "name": "FLOATING"
-                              },
-                              "scale": 0.0
-                            }
-                          },
-                          "holes": [ ],
-                          "rectangle": false,
-                          "shell": {
-                            "SRID": 0,
-                            "closed": true,
-                            "empty": false,
-                            "envelope": {
-                              "maxx": -122.665648,
-                              "maxy": 45.530703,
-                              "minx": -122.667794,
-                              "miny": 45.529724,
-                              "null": false
-                            },
-                            "factory": {
-                              "SRID": 0,
-                              "coordinateSequenceFactory": { },
-                              "precisionModel": {
-                                "floating": true,
-                                "modelType": {
-                                  "name": "FLOATING"
-                                },
-                                "scale": 0.0
-                              }
-                            },
-                            "points": {
-                              "coords": [
-                                -122.666322,
-                                45.529724,
-                                -122.667591,
-                                45.529829,
-                                -122.667794,
-                                45.530244,
-                                -122.66599,
-                                45.530703,
-                                -122.665648,
-                                45.53069,
-                                -122.665697,
-                                45.529888,
-                                -122.666322,
-                                45.529724
-                              ],
-                              "dimension": 2
-                            },
-                            "rectangle": false,
-                            "ring": true,
-                            "simple": true,
-                            "valid": true
-                          },
-                          "simple": true,
-                          "valid": true
-                        }
-                      ],
-                      "rectangle": false,
-                      "simple": true,
-                      "valid": true
-                    },
-                    "id": {
-                      "feedId": "prt",
-                      "id": "79-tc"
-                    },
-                    "name": "Rose Quarter Transit Center",
-                    "priority": "ALLOWED"
-                  },
-                  "partOfStation": true,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 84,
-                "stopSequence": 85,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.530005,
+              "lon": -122.666476,
+              "name": "Rose Quarter Transit Center",
+              "stopCode": "2592",
+              "stopId": "prt:2592",
+              "stopIndex": 84,
+              "stopSequence": 85,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T19:01:20.000+00:00",
               "departure": "2009-11-17T19:01:20.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.526655,
-                  "longitude": -122.676462
-                },
-                "name": "NW Glisan & 6th",
-                "stop": {
-                  "code": "10803",
-                  "coordinate": {
-                    "latitude": 45.526655,
-                    "longitude": -122.676462
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 10803)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "10803"
-                  },
-                  "name": "NW Glisan & 6th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 85,
-                "stopSequence": 86,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.526655,
+              "lon": -122.676462,
+              "name": "NW Glisan & 6th",
+              "stopCode": "10803",
+              "stopId": "prt:10803",
+              "stopIndex": 85,
+              "stopSequence": 86,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T19:02:15.000+00:00",
               "departure": "2009-11-17T19:02:15.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.528799,
-                  "longitude": -122.677238
-                },
-                "name": "NW Station Way & Union Station",
-                "stop": {
-                  "code": "12801",
-                  "coordinate": {
-                    "latitude": 45.528799,
-                    "longitude": -122.677238
-                  },
-                  "description": "Northbound stop in Portland (Stop ID 12801)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "12801"
-                  },
-                  "name": "NW Station Way & Union Station",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 86,
-                "stopSequence": 87,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.528799,
+              "lon": -122.677238,
+              "name": "NW Station Way & Union Station",
+              "stopCode": "12801",
+              "stopId": "prt:12801",
+              "stopIndex": 86,
+              "stopSequence": 87,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T19:04:00.000+00:00",
               "departure": "2009-11-17T19:04:00.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.531582,
-                  "longitude": -122.681193
-                },
-                "name": "NW Northrup & 10th",
-                "stop": {
-                  "code": "12802",
-                  "coordinate": {
-                    "latitude": 45.531582,
-                    "longitude": -122.681193
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 12802)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "12802"
-                  },
-                  "name": "NW Northrup & 10th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 87,
-                "stopSequence": 88,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.531582,
+              "lon": -122.681193,
+              "name": "NW Northrup & 10th",
+              "stopCode": "12802",
+              "stopId": "prt:12802",
+              "stopIndex": 87,
+              "stopSequence": 88,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T19:04:33.000+00:00",
               "departure": "2009-11-17T19:04:33.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.531534,
-                  "longitude": -122.683319
-                },
-                "name": "NW 12th & Northrup",
-                "stop": {
-                  "code": "12796",
-                  "coordinate": {
-                    "latitude": 45.531534,
-                    "longitude": -122.683319
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 12796)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "12796"
-                  },
-                  "name": "NW 12th & Northrup",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 88,
-                "stopSequence": 89,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.531534,
+              "lon": -122.683319,
+              "name": "NW 12th & Northrup",
+              "stopCode": "12796",
+              "stopId": "prt:12796",
+              "stopIndex": 88,
+              "stopSequence": 89,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T19:05:04.000+00:00",
               "departure": "2009-11-17T19:05:04.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.531503,
-                  "longitude": -122.685357
-                },
-                "name": "NW Northrup & 14th",
-                "stop": {
-                  "code": "10775",
-                  "coordinate": {
-                    "latitude": 45.531503,
-                    "longitude": -122.685357
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 10775)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "10775"
-                  },
-                  "name": "NW Northrup & 14th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 89,
-                "stopSequence": 90,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.531503,
+              "lon": -122.685357,
+              "name": "NW Northrup & 14th",
+              "stopCode": "10775",
+              "stopId": "prt:10775",
+              "stopIndex": 89,
+              "stopSequence": 90,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T19:06:07.000+00:00",
               "departure": "2009-11-17T19:06:07.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.531434,
-                  "longitude": -122.689417
-                },
-                "name": "NW Northrup & 18th",
-                "stop": {
-                  "code": "10776",
-                  "coordinate": {
-                    "latitude": 45.531434,
-                    "longitude": -122.689417
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 10776)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "10776"
-                  },
-                  "name": "NW Northrup & 18th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 90,
-                "stopSequence": 91,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.531434,
+              "lon": -122.689417,
+              "name": "NW Northrup & 18th",
+              "stopCode": "10776",
+              "stopId": "prt:10776",
+              "stopIndex": 90,
+              "stopSequence": 91,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T19:07:24.000+00:00",
               "departure": "2009-11-17T19:07:24.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.531346,
-                  "longitude": -122.694455
-                },
-                "name": "NW Northrup & 21st",
-                "stop": {
-                  "code": "10777",
-                  "coordinate": {
-                    "latitude": 45.531346,
-                    "longitude": -122.694455
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 10777)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "10777"
-                  },
-                  "name": "NW Northrup & 21st",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 91,
-                "stopSequence": 92,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.531346,
+              "lon": -122.694455,
+              "name": "NW Northrup & 21st",
+              "stopCode": "10777",
+              "stopId": "prt:10777",
+              "stopIndex": 91,
+              "stopSequence": 92,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             }
           ],
           "legGeometry": {
@@ -5849,202 +2661,96 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "points": "kx{tG~qtkV`@bANb@FV@R?P?pE?jA@h@AnAbBl@LFJN\\f@LT??NXJPPVJFf@Vf@Pp@Nd@NRLB@RNXZR\\vAhC@BhAhD`AhClAbDBrDCnG@n@@^@d@HdAP`CBjEDvD???LqCFmCDYBGDEBGJkAzAQR??KNa@b@MJuBBY?OHW@u@~@aD`EcBhBBrD@xC??@l@BlE@lD???XBjEBpD???VBlE?dA@t@?b@?h@BfEBrD???VBhEFtKDvJ??@\\DnJ"
           },
           "mode": "BUS",
-          "onStreetNonTransit": false,
           "pathway": false,
           "realTime": false,
-          "scheduled": true,
-          "serviceDate": {
-            "day": 17,
-            "minMax": false,
-            "month": 11,
-            "sequenceNumber": 20091117,
-            "year": 2009
-          },
+          "route": "Broadway/Halsey",
+          "routeId": "prt:77",
+          "routeLongName": "Broadway/Halsey",
+          "routeShortName": "77",
+          "serviceDate": "2009-11-17",
           "startTime": "2009-11-17T18:56:09.000+00:00",
-          "streetNotes": [ ],
+          "steps": [ ],
           "to": {
-            "coordinate": {
-              "latitude": 45.531308,
-              "longitude": -122.696445
-            },
+            "arrival": "2009-11-17T19:07:55.000+00:00",
+            "departure": "2009-11-17T19:07:55.000+00:00",
+            "lat": 45.531308,
+            "lon": -122.696445,
             "name": "NW Northrup & 22nd",
-            "stop": {
-              "code": "10778",
-              "coordinate": {
-                "latitude": 45.531308,
-                "longitude": -122.696445
-              },
-              "description": "Westbound stop in Portland (Stop ID 10778)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "10778"
-              },
-              "name": "NW Northrup & 22nd",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "10778",
+            "stopId": "prt:10778",
             "stopIndex": 92,
             "stopSequence": 93,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
-          "transitAlerts": [ ],
           "transitLeg": true,
-          "trip": {
-            "alteration": "PLANNED",
-            "bikesAllowed": "UNKNOWN",
-            "blockId": "7702",
-            "direction": "INBOUND",
-            "id": {
-              "feedId": "prt",
-              "id": "771W1180"
-            },
-            "route": {
-              "agency": {
-                "fareUrl": "http://trimet.org/fares/index.htm",
-                "id": {
-                  "feedId": "prt",
-                  "id": "prt"
-                },
-                "lang": "en",
-                "name": "TriMet",
-                "phone": "503-238-7433",
-                "timezone": "America/Los_Angeles",
-                "url": "http://trimet.org"
-              },
-              "bikesAllowed": "UNKNOWN",
-              "gtfsType": 3,
-              "id": {
-                "feedId": "prt",
-                "id": "77"
-              },
-              "longName": "Broadway/Halsey",
-              "mode": "BUS",
-              "shortName": "77",
-              "sortOrder": -999,
-              "sortOrderSet": false,
-              "url": "http://trimet.org/schedules/r077.htm"
-            },
-            "serviceId": {
-              "feedId": "prt",
-              "id": "W"
-            },
-            "shapeId": {
-              "feedId": "prt",
-              "id": "77.1.3"
-            },
-            "wheelchairAccessible": 0
-          },
-          "walkSteps": [ ],
-          "walkingLeg": false
+          "tripBlockId": "7702",
+          "tripId": "prt:771W1180"
         },
         {
           "agencyTimeZoneOffset": -28800000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 18.806,
+          "distance": 18.806,
           "endTime": "2009-11-17T19:08:19.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.531308,
-              "longitude": -122.696445
-            },
+            "arrival": "2009-11-17T19:07:55.000+00:00",
+            "departure": "2009-11-17T19:07:55.000+00:00",
+            "lat": 45.531308,
+            "lon": -122.696445,
             "name": "NW Northrup & 22nd",
-            "stop": {
-              "code": "10778",
-              "coordinate": {
-                "latitude": 45.531308,
-                "longitude": -122.696445
-              },
-              "description": "Westbound stop in Portland (Stop ID 10778)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "10778"
-              },
-              "name": "NW Northrup & 22nd",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "10778",
+            "stopId": "prt:10778",
             "stopIndex": 92,
             "stopSequence": 93,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
           "generalizedCost": 37,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 7,
             "points": "sy{tGxc{kV???LABF?B??J"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-11-17T19:07:55.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.53122,
-              "longitude": -122.69659
-            },
-            "name": "NW Northrup St. & NW 22nd Ave. (P2)",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "WEST",
-              "angle": -1.3892041323260338,
               "area": false,
               "bogusName": false,
               "distance": 18.806,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.53130187189895,
+              "lon": -122.69644484256081,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.53130187189895,
-                "longitude": -122.69644484256081
-              },
               "stayOn": false,
-              "streetName": "Northwest Northrup Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Northrup Street"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
+          "to": {
+            "arrival": "2009-11-17T19:08:19.000+00:00",
+            "lat": 45.53122,
+            "lon": -122.69659,
+            "name": "NW Northrup St. & NW 22nd Ave. (P2)",
+            "vertexType": "NORMAL"
+          },
+          "transitLeg": false,
+          "walkingBike": false
         }
       ],
-      "nTransfers": 1,
-      "nonTransitDistanceMeters": 438.42099999999994,
-      "nonTransitTimeSeconds": 348,
-      "onStreetAllTheWay": false,
-      "streetOnly": false,
-      "systemNotices": [ ],
+      "startTime": "2009-11-17T18:37:30.000+00:00",
       "tooSloped": false,
-      "transferPriorityCost": 33,
-      "transitTimeSeconds": 1264,
-      "waitTimeOptimizedCost": -149,
-      "waitingTimeSeconds": 237,
-      "walkOnly": false,
-      "walkingAllTheWay": false
+      "transfers": 1,
+      "transitTime": 1264,
+      "waitingTime": 237,
+      "walkDistance": 438.42099999999994,
+      "walkLimitExceeded": false,
+      "walkTime": 348
     }
   ]
 ]
@@ -6053,274 +2759,193 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
 org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_planning_with_transit_stop=[
   [
     {
-      "arrivedAtDestinationWithRentedVehicle": false,
-      "durationSeconds": 3451,
+      "arrivedAtDestinationWithRentedBicycle": false,
+      "duration": 3451,
       "elevationGained": 0.0,
       "elevationLost": 0.0,
+      "endTime": "2009-11-17T18:57:31.000+00:00",
       "fare": {
         "details": { },
         "fare": { }
       },
-      "flaggedForDeletion": false,
       "generalizedCost": 6717,
       "legs": [
         {
           "agencyTimeZoneOffset": -28800000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 4442.913999999999,
+          "distance": 4442.913999999999,
           "endTime": "2009-11-17T18:57:31.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.52337,
-              "longitude": -122.653725
-            },
+            "departure": "2009-11-17T18:00:00.000+00:00",
+            "lat": 45.52337,
+            "lon": -122.653725,
             "name": "NE 12th & Couch",
-            "stop": {
-              "code": "6577",
-              "coordinate": {
-                "latitude": 45.52337,
-                "longitude": -122.653725
-              },
-              "description": "Southbound stop in Portland (Stop ID 6577)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "6577"
-              },
-              "name": "NE 12th & Couch",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
-            "vertexType": "TRANSIT"
+            "stopCode": "6577",
+            "stopId": "prt:6577",
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
           "generalizedCost": 6717,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 208,
             "points": "ahztGxxrkV@Sb@?`@@T??V?vCAT?R?`D?T?RA`D?R?R?t@?n@?z@?T?R?jB?@?r@?R?R?tA?\\?l@?R?T?VAd@?jA?N?N?J?Z?jA?z@?P?Z?J@N?hA@x@Ap@ATETGpJCjEA|CArAAxAAxAAdBEzHClF?@Ax@GTAjBAZ?R@hC@h@Q@cBBM?M?_CDsA@Y?Q@O?K?Q?mBB[?C?W@[?]@E?IDI@]DO@SBM?S@G@A?GDEJQ|@AL?L@nA?j@@L?V?d@@~@@NI?E?W@Q?Q?m@@Q@AF?DAJBzB?V?NANM@K?GBEDEHIJUX_@f@KNQRSVGFCBQPIHGDGBIBK@W@a@?mA@E?C@C@A?CBQTKJEHIJeC~CYZo@v@g@d@IJAFAD?L@vC@hB@p@?X?T@P?N@P@nA?j@AX?L@`B@dA?R?RBbD?T?NBbD?R?P@|D@jB?x@@J?N?B?P?LBjD@N@fD?T?LBdD?R?PF`K?RDlJ?R?PFlJ?RDbH@xA?D?P?RDpH"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-11-17T18:00:00.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.531,
-              "longitude": -122.70029
-            },
-            "name": "NW Northrup St. & NW 24th Ave. (P3)",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "SOUTH",
-              "angle": -3.1191187064694192,
               "area": false,
               "bogusName": false,
               "distance": 51.525,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.52336838632084,
+              "lon": -122.65362253301092,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.52336838632084,
-                "longitude": -122.65362253301092
-              },
               "stayOn": false,
-              "streetName": "Northeast 12th Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northeast 12th Avenue"
             },
             {
               "absoluteDirection": "WEST",
-              "angle": -1.5608232952160197,
               "area": false,
               "bogusName": false,
               "distance": 877.279,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5229051,
+              "lon": -122.6536312,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5229051,
-                "longitude": -122.6536312
-              },
               "stayOn": false,
-              "streetName": "East Burnside Street",
-              "streetNotes": [ ]
+              "streetName": "East Burnside Street"
             },
             {
               "absoluteDirection": "WEST",
-              "angle": -1.5429374364857065,
               "area": false,
               "bogusName": false,
               "distance": 407.384,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.523001,
+              "lon": -122.6648816,
               "relativeDirection": "CONTINUE",
-              "startLocation": {
-                "latitude": 45.523001,
-                "longitude": -122.6648816
-              },
               "stayOn": false,
-              "streetName": "Burnside Bridge",
-              "streetNotes": [ ]
+              "streetName": "Burnside Bridge"
             },
             {
               "absoluteDirection": "WEST",
-              "angle": -1.5423269695355575,
               "area": false,
               "bogusName": false,
               "distance": 256.851,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.523105400000006,
+              "lon": -122.67010870000001,
               "relativeDirection": "CONTINUE",
-              "startLocation": {
-                "latitude": 45.523105400000006,
-                "longitude": -122.67010870000001
-              },
               "stayOn": false,
-              "streetName": "West Burnside Street",
-              "streetNotes": [ ]
+              "streetName": "West Burnside Street"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": -0.028022114817565644,
               "area": false,
               "bogusName": false,
               "distance": 460.622,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.523177600000004,
+              "lon": -122.67338950000001,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.523177600000004,
-                "longitude": -122.67338950000001
-              },
               "stayOn": false,
-              "streetName": "Northwest 3rd Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 3rd Avenue"
             },
             {
               "absoluteDirection": "WEST",
-              "angle": -1.1944859782105497,
               "area": false,
               "bogusName": false,
               "distance": 145.81199999999998,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.527286600000004,
+              "lon": -122.67371650000001,
               "relativeDirection": "SLIGHTLY_LEFT",
-              "startLocation": {
-                "latitude": 45.527286600000004,
-                "longitude": -122.67371650000001
-              },
               "stayOn": false,
-              "streetName": "Northwest Hoyt Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Hoyt Street"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": -0.029032765206574367,
               "area": false,
               "bogusName": false,
               "distance": 77.353,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5273496,
+              "lon": -122.6755629,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5273496,
-                "longitude": -122.6755629
-              },
               "stayOn": false,
-              "streetName": "Northwest 5th Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 5th Avenue"
             },
             {
               "absoluteDirection": "WEST",
-              "angle": -1.4107231165936804,
               "area": false,
               "bogusName": false,
               "distance": 80.53,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.528044900000005,
+              "lon": -122.6755935,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.528044900000005,
-                "longitude": -122.6755935
-              },
               "stayOn": false,
-              "streetName": "Northwest Irving Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Irving Street"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": -0.07553970510661134,
               "area": false,
               "bogusName": false,
               "distance": 465.426,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.528051500000004,
+              "lon": -122.67662320000001,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.528051500000004,
-                "longitude": -122.67662320000001
-              },
               "stayOn": false,
-              "streetName": "Northwest Station Way",
-              "streetNotes": [ ]
+              "streetName": "Northwest Station Way"
             },
             {
               "absoluteDirection": "WEST",
-              "angle": -1.3840041579257698,
               "area": false,
               "bogusName": false,
               "distance": 1620.1320000000003,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.531545200000004,
+              "lon": -122.679511,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.531545200000004,
-                "longitude": -122.679511
-              },
               "stayOn": false,
-              "streetName": "Northwest Northrup Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Northrup Street"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
+          "to": {
+            "arrival": "2009-11-17T18:57:31.000+00:00",
+            "lat": 45.531,
+            "lon": -122.70029,
+            "name": "NW Northrup St. & NW 24th Ave. (P3)",
+            "vertexType": "NORMAL"
+          },
+          "transitLeg": false,
+          "walkingBike": false
         }
       ],
-      "nTransfers": 0,
-      "nonTransitDistanceMeters": 4442.913999999999,
-      "nonTransitTimeSeconds": 3451,
-      "onStreetAllTheWay": true,
-      "streetOnly": true,
-      "systemNotices": [ ],
+      "startTime": "2009-11-17T18:00:00.000+00:00",
       "tooSloped": false,
-      "transferPriorityCost": -1,
-      "transitTimeSeconds": 0,
-      "waitTimeOptimizedCost": -1,
-      "waitingTimeSeconds": 0,
-      "walkOnly": true,
-      "walkingAllTheWay": true
+      "transfers": 0,
+      "transitTime": 0,
+      "waitingTime": 0,
+      "walkDistance": 4442.913999999999,
+      "walkLimitExceeded": false,
+      "walkTime": 3451
     },
     {
-      "arrivedAtDestinationWithRentedVehicle": false,
-      "durationSeconds": 1553,
+      "arrivedAtDestinationWithRentedBicycle": false,
+      "duration": 1553,
       "elevationGained": 0.0,
       "elevationLost": 0.0,
+      "endTime": "2009-11-17T18:38:40.000+00:00",
       "fare": {
         "details": {
           "regular": [
@@ -6353,696 +2978,285 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           }
         }
       },
-      "flaggedForDeletion": false,
       "generalizedCost": 2895,
       "legs": [
         {
           "agencyTimeZoneOffset": -28800000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 87.019,
+          "distance": 87.019,
           "endTime": "2009-11-17T18:14:00.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.52337,
-              "longitude": -122.653725
-            },
+            "departure": "2009-11-17T18:12:47.000+00:00",
+            "lat": 45.52337,
+            "lon": -122.653725,
             "name": "NE 12th & Couch",
-            "stop": {
-              "code": "6577",
-              "coordinate": {
-                "latitude": 45.52337,
-                "longitude": -122.653725
-              },
-              "description": "Southbound stop in Portland (Stop ID 6577)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "6577"
-              },
-              "name": "NE 12th & Couch",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
-            "vertexType": "TRANSIT"
+            "stopCode": "6577",
+            "stopId": "prt:6577",
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
           "generalizedCost": 137,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 9,
             "points": "ahztGxxrkV@Sb@?`@@?a@?k@GGKY@A"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-11-17T18:12:47.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.523103,
-              "longitude": -122.653064
-            },
-            "name": "NE Sandy & 12th",
-            "stop": {
-              "code": "5055",
-              "coordinate": {
-                "latitude": 45.523103,
-                "longitude": -122.653064
-              },
-              "description": "Westbound stop in Portland (Stop ID 5055)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "5055"
-              },
-              "name": "NE Sandy & 12th",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
-            "stopIndex": 94,
-            "stopSequence": 95,
-            "vertexType": "TRANSIT"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "SOUTH",
-              "angle": -3.1191187064694192,
               "area": false,
               "bogusName": false,
               "distance": 39.059,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.52336838632084,
+              "lon": -122.65362253301092,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.52336838632084,
-                "longitude": -122.65362253301092
-              },
               "stayOn": false,
-              "streetName": "Northeast 12th Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northeast 12th Avenue"
             },
             {
               "absoluteDirection": "EAST",
-              "angle": 1.5906288403465376,
               "area": false,
               "bogusName": true,
               "distance": 47.959999999999994,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.523017200000005,
+              "lon": -122.65363380000001,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.523017200000005,
-                "longitude": -122.65363380000001
-              },
               "stayOn": false,
-              "streetName": "way 162042138 from 0",
-              "streetNotes": [ ]
+              "streetName": "way 162042138 from 0"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
-        },
-        {
-          "agencyTimeZoneOffset": 0,
-          "arrivalDelay": 0,
-          "departureDelay": 0,
-          "distanceMeters": 3729.9737283822847,
-          "endTime": "2009-11-17T18:26:49.000+00:00",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.523103,
-              "longitude": -122.653064
-            },
+          "to": {
+            "arrival": "2009-11-17T18:14:00.000+00:00",
+            "departure": "2009-11-17T18:14:00.000+00:00",
+            "lat": 45.523103,
+            "lon": -122.653064,
             "name": "NE Sandy & 12th",
-            "stop": {
-              "code": "5055",
-              "coordinate": {
-                "latitude": 45.523103,
-                "longitude": -122.653064
-              },
-              "description": "Westbound stop in Portland (Stop ID 5055)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "5055"
-              },
-              "name": "NE Sandy & 12th",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "5055",
+            "stopId": "prt:5055",
             "stopIndex": 94,
             "stopSequence": 95,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "transitLeg": false,
+          "walkingBike": false
+        },
+        {
+          "agencyId": "prt:prt",
+          "agencyName": "TriMet",
+          "agencyTimeZoneOffset": 0,
+          "agencyUrl": "http://trimet.org",
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 3729.9737283822847,
+          "endTime": "2009-11-17T18:26:49.000+00:00",
+          "from": {
+            "arrival": "2009-11-17T18:14:00.000+00:00",
+            "departure": "2009-11-17T18:14:00.000+00:00",
+            "lat": 45.523103,
+            "lon": -122.653064,
+            "name": "NE Sandy & 12th",
+            "stopCode": "5055",
+            "stopId": "prt:5055",
+            "stopIndex": 94,
+            "stopSequence": 95,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
           "generalizedCost": 1369,
           "headsign": "Beaverton TC",
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "intermediateStops": [
             {
               "arrival": "2009-11-17T18:14:47.000+00:00",
               "departure": "2009-11-17T18:14:47.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523024,
-                  "longitude": -122.656526
-                },
-                "name": "E Burnside & NE 9th",
-                "stop": {
-                  "code": "819",
-                  "coordinate": {
-                    "latitude": 45.523024,
-                    "longitude": -122.656526
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 819)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "819"
-                  },
-                  "name": "E Burnside & NE 9th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 95,
-                "stopSequence": 96,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523024,
+              "lon": -122.656526,
+              "name": "E Burnside & NE 9th",
+              "stopCode": "819",
+              "stopId": "prt:819",
+              "stopIndex": 95,
+              "stopSequence": 96,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:15:24.000+00:00",
               "departure": "2009-11-17T18:15:24.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523012,
-                  "longitude": -122.659365
-                },
-                "name": "E Burnside & NE 6th",
-                "stop": {
-                  "code": "805",
-                  "coordinate": {
-                    "latitude": 45.523012,
-                    "longitude": -122.659365
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 805)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "805"
-                  },
-                  "name": "E Burnside & NE 6th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 96,
-                "stopSequence": 97,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523012,
+              "lon": -122.659365,
+              "name": "E Burnside & NE 6th",
+              "stopCode": "805",
+              "stopId": "prt:805",
+              "stopIndex": 96,
+              "stopSequence": 97,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:15:52.000+00:00",
               "departure": "2009-11-17T18:15:52.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523015,
-                  "longitude": -122.661534
-                },
-                "name": "E Burnside & NE M L King",
-                "stop": {
-                  "code": "705",
-                  "coordinate": {
-                    "latitude": 45.523015,
-                    "longitude": -122.661534
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 705)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "705"
-                  },
-                  "name": "E Burnside & NE M L King",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 97,
-                "stopSequence": 98,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523015,
+              "lon": -122.661534,
+              "name": "E Burnside & NE M L King",
+              "stopCode": "705",
+              "stopId": "prt:705",
+              "stopIndex": 97,
+              "stopSequence": 98,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:18:00.000+00:00",
               "departure": "2009-11-17T18:18:00.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523249,
-                  "longitude": -122.671269
-                },
-                "name": "W Burnside & Burnside Bridge",
-                "stop": {
-                  "code": "689",
-                  "coordinate": {
-                    "latitude": 45.523249,
-                    "longitude": -122.671269
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 689)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "689"
-                  },
-                  "name": "W Burnside & Burnside Bridge",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 98,
-                "stopSequence": 99,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523249,
+              "lon": -122.671269,
+              "name": "W Burnside & Burnside Bridge",
+              "stopCode": "689",
+              "stopId": "prt:689",
+              "stopIndex": 98,
+              "stopSequence": 99,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T18:19:00.000+00:00",
               "departure": "2009-11-17T18:19:00.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523169,
-                  "longitude": -122.675893
-                },
-                "name": "W Burnside & NW 5th",
-                "stop": {
-                  "code": "782",
-                  "coordinate": {
-                    "latitude": 45.523169,
-                    "longitude": -122.675893
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 782)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "782"
-                  },
-                  "name": "W Burnside & NW 5th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 99,
-                "stopSequence": 100,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523169,
+              "lon": -122.675893,
+              "name": "W Burnside & NW 5th",
+              "stopCode": "782",
+              "stopId": "prt:782",
+              "stopIndex": 99,
+              "stopSequence": 100,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T18:20:17.000+00:00",
               "departure": "2009-11-17T18:20:17.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523115,
-                  "longitude": -122.678939
-                },
-                "name": "W Burnside & NW Park",
-                "stop": {
-                  "code": "716",
-                  "coordinate": {
-                    "latitude": 45.523115,
-                    "longitude": -122.678939
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 716)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "716"
-                  },
-                  "name": "W Burnside & NW Park",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 100,
-                "stopSequence": 101,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523115,
+              "lon": -122.678939,
+              "name": "W Burnside & NW Park",
+              "stopCode": "716",
+              "stopId": "prt:716",
+              "stopIndex": 100,
+              "stopSequence": 101,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T18:21:25.000+00:00",
               "departure": "2009-11-17T18:21:25.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523048,
-                  "longitude": -122.681606
-                },
-                "name": "W Burnside & NW 10th",
-                "stop": {
-                  "code": "10791",
-                  "coordinate": {
-                    "latitude": 45.523048,
-                    "longitude": -122.681606
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 10791)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "10791"
-                  },
-                  "name": "W Burnside & NW 10th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 101,
-                "stopSequence": 102,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523048,
+              "lon": -122.681606,
+              "name": "W Burnside & NW 10th",
+              "stopCode": "10791",
+              "stopId": "prt:10791",
+              "stopIndex": 101,
+              "stopSequence": 102,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T18:22:14.000+00:00",
               "departure": "2009-11-17T18:22:14.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523,
-                  "longitude": -122.683535
-                },
-                "name": "W Burnside & NW 12th",
-                "stop": {
-                  "code": "11032",
-                  "coordinate": {
-                    "latitude": 45.523,
-                    "longitude": -122.683535
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 11032)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "11032"
-                  },
-                  "name": "W Burnside & NW 12th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 102,
-                "stopSequence": 103,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523,
+              "lon": -122.683535,
+              "name": "W Burnside & NW 12th",
+              "stopCode": "11032",
+              "stopId": "prt:11032",
+              "stopIndex": 102,
+              "stopSequence": 103,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T18:24:09.000+00:00",
               "departure": "2009-11-17T18:24:09.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.522985,
-                  "longitude": -122.688091
-                },
-                "name": "W Burnside & NW 17th",
-                "stop": {
-                  "code": "10809",
-                  "coordinate": {
-                    "latitude": 45.522985,
-                    "longitude": -122.688091
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 10809)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "10809"
-                  },
-                  "name": "W Burnside & NW 17th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 103,
-                "stopSequence": 104,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.522985,
+              "lon": -122.688091,
+              "name": "W Burnside & NW 17th",
+              "stopCode": "10809",
+              "stopId": "prt:10809",
+              "stopIndex": 103,
+              "stopSequence": 104,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:25:00.000+00:00",
               "departure": "2009-11-17T18:25:00.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523097,
-                  "longitude": -122.690083
-                },
-                "name": "W Burnside & NW 19th",
-                "stop": {
-                  "code": "735",
-                  "coordinate": {
-                    "latitude": 45.523097,
-                    "longitude": -122.690083
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 735)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "735"
-                  },
-                  "name": "W Burnside & NW 19th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 104,
-                "stopSequence": 105,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523097,
+              "lon": -122.690083,
+              "name": "W Burnside & NW 19th",
+              "stopCode": "735",
+              "stopId": "prt:735",
+              "stopIndex": 104,
+              "stopSequence": 105,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:25:21.000+00:00",
               "departure": "2009-11-17T18:25:21.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523176,
-                  "longitude": -122.692139
-                },
-                "name": "W Burnside & NW 20th",
-                "stop": {
-                  "code": "741",
-                  "coordinate": {
-                    "latitude": 45.523176,
-                    "longitude": -122.692139
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 741)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "741"
-                  },
-                  "name": "W Burnside & NW 20th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 105,
-                "stopSequence": 106,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523176,
+              "lon": -122.692139,
+              "name": "W Burnside & NW 20th",
+              "stopCode": "741",
+              "stopId": "prt:741",
+              "stopIndex": 105,
+              "stopSequence": 106,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:25:31.000+00:00",
               "departure": "2009-11-17T18:25:31.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.52322,
-                  "longitude": -122.69313
-                },
-                "name": "W Burnside & NW 20th Pl",
-                "stop": {
-                  "code": "742",
-                  "coordinate": {
-                    "latitude": 45.52322,
-                    "longitude": -122.69313
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 742)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "742"
-                  },
-                  "name": "W Burnside & NW 20th Pl",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 106,
-                "stopSequence": 107,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.52322,
+              "lon": -122.69313,
+              "name": "W Burnside & NW 20th Pl",
+              "stopCode": "742",
+              "stopId": "prt:742",
+              "stopIndex": 106,
+              "stopSequence": 107,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:25:49.000+00:00",
               "departure": "2009-11-17T18:25:49.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523312,
-                  "longitude": -122.694901
-                },
-                "name": "W Burnside & NW King",
-                "stop": {
-                  "code": "747",
-                  "coordinate": {
-                    "latitude": 45.523312,
-                    "longitude": -122.694901
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 747)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "747"
-                  },
-                  "name": "W Burnside & NW King",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 107,
-                "stopSequence": 108,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523312,
+              "lon": -122.694901,
+              "name": "W Burnside & NW King",
+              "stopCode": "747",
+              "stopId": "prt:747",
+              "stopIndex": 107,
+              "stopSequence": 108,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:26:22.000+00:00",
               "departure": "2009-11-17T18:26:22.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523512,
-                  "longitude": -122.698081
-                },
-                "name": "W Burnside & NW 23rd",
-                "stop": {
-                  "code": "755",
-                  "coordinate": {
-                    "latitude": 45.523512,
-                    "longitude": -122.698081
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 755)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "755"
-                  },
-                  "name": "W Burnside & NW 23rd",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 108,
-                "stopSequence": 109,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523512,
+              "lon": -122.698081,
+              "name": "W Burnside & NW 23rd",
+              "stopCode": "755",
+              "stopId": "prt:755",
+              "stopIndex": 108,
+              "stopSequence": 109,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             }
           ],
           "legGeometry": {
@@ -7050,276 +3264,151 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "points": "weztGdtrkV?BPj@@jA?jEAhE?pD???VAjE?hE?dB?b@???`AAhE?dD???l@C`EAhEEhE?bAA|@?XAZ@\\AzACnGKbKAjC?bE???JEnE@fEDlE@hE@~A??@rBBzDBpE@~A???Z@tD@RBnEB|A???@BdB?lEBjA??BnBApF@dB?X?^@r@?f@@bCAx@EtB???VChAE|BGnD??AXKnEGnD???XGjD??AZEfCC`AEzB??AXCfAGxDE|AEtBIlC??APu@lJMhBI`@"
           },
           "mode": "BUS",
-          "onStreetNonTransit": false,
           "pathway": false,
           "realTime": false,
-          "scheduled": true,
-          "serviceDate": {
-            "day": 17,
-            "minMax": false,
-            "month": 11,
-            "sequenceNumber": 20091117,
-            "year": 2009
-          },
+          "route": "Burnside/Stark",
+          "routeId": "prt:20",
+          "routeLongName": "Burnside/Stark",
+          "routeShortName": "20",
+          "serviceDate": "2009-11-17",
           "startTime": "2009-11-17T18:14:00.000+00:00",
-          "streetNotes": [ ],
+          "steps": [ ],
           "to": {
-            "coordinate": {
-              "latitude": 45.523897,
-              "longitude": -122.700681
-            },
+            "arrival": "2009-11-17T18:26:49.000+00:00",
+            "departure": "2009-11-17T18:26:49.000+00:00",
+            "lat": 45.523897,
+            "lon": -122.700681,
             "name": "W Burnside & NW 23rd Pl",
-            "stop": {
-              "code": "9555",
-              "coordinate": {
-                "latitude": 45.523897,
-                "longitude": -122.700681
-              },
-              "description": "Westbound stop in Portland (Stop ID 9555)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "9555"
-              },
-              "name": "W Burnside & NW 23rd Pl",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "9555",
+            "stopId": "prt:9555",
             "stopIndex": 109,
             "stopSequence": 110,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
-          "transitAlerts": [ ],
           "transitLeg": true,
-          "trip": {
-            "alteration": "PLANNED",
-            "bikesAllowed": "UNKNOWN",
-            "blockId": "2002",
-            "direction": "OUTBOUND",
-            "id": {
-              "feedId": "prt",
-              "id": "200W1200"
-            },
-            "route": {
-              "agency": {
-                "fareUrl": "http://trimet.org/fares/index.htm",
-                "id": {
-                  "feedId": "prt",
-                  "id": "prt"
-                },
-                "lang": "en",
-                "name": "TriMet",
-                "phone": "503-238-7433",
-                "timezone": "America/Los_Angeles",
-                "url": "http://trimet.org"
-              },
-              "bikesAllowed": "UNKNOWN",
-              "gtfsType": 3,
-              "id": {
-                "feedId": "prt",
-                "id": "20"
-              },
-              "longName": "Burnside/Stark",
-              "mode": "BUS",
-              "shortName": "20",
-              "sortOrder": -999,
-              "sortOrderSet": false,
-              "url": "http://trimet.org/schedules/r020.htm"
-            },
-            "serviceId": {
-              "feedId": "prt",
-              "id": "W"
-            },
-            "shapeId": {
-              "feedId": "prt",
-              "id": "20.0.1"
-            },
-            "wheelchairAccessible": 0
-          },
-          "walkSteps": [ ],
-          "walkingLeg": false
+          "tripBlockId": "2002",
+          "tripId": "prt:200W1200"
         },
         {
           "agencyTimeZoneOffset": -28800000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 913.815,
+          "distance": 913.815,
           "endTime": "2009-11-17T18:38:40.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.523897,
-              "longitude": -122.700681
-            },
+            "arrival": "2009-11-17T18:26:49.000+00:00",
+            "departure": "2009-11-17T18:26:49.000+00:00",
+            "lat": 45.523897,
+            "lon": -122.700681,
             "name": "W Burnside & NW 23rd Pl",
-            "stop": {
-              "code": "9555",
-              "coordinate": {
-                "latitude": 45.523897,
-                "longitude": -122.700681
-              },
-              "description": "Westbound stop in Portland (Stop ID 9555)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "9555"
-              },
-              "name": "W Burnside & NW 23rd Pl",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "9555",
+            "stopId": "prt:9555",
             "stopIndex": 109,
             "stopSequence": 110,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
           "generalizedCost": 1388,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 39,
             "points": "ikztGh~{kVNDEVUzACPOUQO_@Yc@[QMMEOKOIECGCIAMCGCGAECECECOOMOGKIFMLk@BsABGDGBoCBkCDoC@mCBmCDoCDmCD?qA"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-11-17T18:26:49.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.531,
-              "longitude": -122.70029
-            },
-            "name": "NW Northrup St. & NW 24th Ave. (P3)",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "WEST",
-              "angle": -1.247661800162498,
               "area": false,
               "bogusName": false,
               "distance": 54.628,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.523815597641374,
+              "lon": -122.70071990797962,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.523815597641374,
-                "longitude": -122.70071990797962
-              },
               "stayOn": false,
-              "streetName": "West Burnside Street",
-              "streetNotes": [ ]
+              "streetName": "West Burnside Street"
             },
             {
               "absoluteDirection": "NORTHEAST",
-              "angle": 0.7501559967245512,
               "area": false,
               "bogusName": false,
               "distance": 176.41,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5239733,
+              "lon": -122.701384,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5239733,
-                "longitude": -122.701384
-              },
               "stayOn": false,
-              "streetName": "Northwest 24th Place",
-              "streetNotes": [ ]
+              "streetName": "Northwest 24th Place"
             },
             {
               "absoluteDirection": "NORTHWEST",
-              "angle": -0.5889596407957216,
               "area": false,
               "bogusName": false,
               "distance": 15.262,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5253583,
+              "lon": -122.70033570000001,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.5253583,
-                "longitude": -122.70033570000001
-              },
               "stayOn": false,
-              "streetName": "Northwest Westover Road",
-              "streetNotes": [ ]
+              "streetName": "Northwest Westover Road"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": -0.05815952978341337,
               "area": false,
               "bogusName": false,
               "distance": 635.654,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.525472400000005,
+              "lon": -122.7004445,
               "relativeDirection": "SLIGHTLY_RIGHT",
-              "startLocation": {
-                "latitude": 45.525472400000005,
-                "longitude": -122.7004445
-              },
               "stayOn": false,
-              "streetName": "Northwest 24th Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 24th Avenue"
             },
             {
               "absoluteDirection": "EAST",
-              "angle": 1.5432591328990624,
               "area": false,
               "bogusName": false,
               "distance": 31.861,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.531181000000004,
+              "lon": -122.70070630000001,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.531181000000004,
-                "longitude": -122.70070630000001
-              },
               "stayOn": false,
-              "streetName": "Northwest Northrup Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Northrup Street"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
+          "to": {
+            "arrival": "2009-11-17T18:38:40.000+00:00",
+            "lat": 45.531,
+            "lon": -122.70029,
+            "name": "NW Northrup St. & NW 24th Ave. (P3)",
+            "vertexType": "NORMAL"
+          },
+          "transitLeg": false,
+          "walkingBike": false
         }
       ],
-      "nTransfers": 0,
-      "nonTransitDistanceMeters": 1000.8340000000001,
-      "nonTransitTimeSeconds": 784,
-      "onStreetAllTheWay": false,
-      "streetOnly": false,
-      "systemNotices": [ ],
+      "startTime": "2009-11-17T18:12:47.000+00:00",
       "tooSloped": false,
-      "transferPriorityCost": 0,
-      "transitTimeSeconds": 769,
-      "waitTimeOptimizedCost": 0,
-      "waitingTimeSeconds": 0,
-      "walkOnly": false,
-      "walkingAllTheWay": false
+      "transfers": 0,
+      "transitTime": 769,
+      "waitingTime": 0,
+      "walkDistance": 1000.8340000000001,
+      "walkLimitExceeded": false,
+      "walkTime": 784
     },
     {
-      "arrivedAtDestinationWithRentedVehicle": false,
-      "durationSeconds": 1583,
+      "arrivedAtDestinationWithRentedBicycle": false,
+      "duration": 1583,
       "elevationGained": 0.0,
       "elevationLost": 0.0,
+      "endTime": "2009-11-17T18:54:10.000+00:00",
       "fare": {
         "details": {
           "regular": [
@@ -7352,696 +3441,285 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           }
         }
       },
-      "flaggedForDeletion": false,
       "generalizedCost": 2925,
       "legs": [
         {
           "agencyTimeZoneOffset": -28800000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 87.019,
+          "distance": 87.019,
           "endTime": "2009-11-17T18:29:00.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.52337,
-              "longitude": -122.653725
-            },
+            "departure": "2009-11-17T18:27:47.000+00:00",
+            "lat": 45.52337,
+            "lon": -122.653725,
             "name": "NE 12th & Couch",
-            "stop": {
-              "code": "6577",
-              "coordinate": {
-                "latitude": 45.52337,
-                "longitude": -122.653725
-              },
-              "description": "Southbound stop in Portland (Stop ID 6577)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "6577"
-              },
-              "name": "NE 12th & Couch",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
-            "vertexType": "TRANSIT"
+            "stopCode": "6577",
+            "stopId": "prt:6577",
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
           "generalizedCost": 137,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 9,
             "points": "ahztGxxrkV@Sb@?`@@?a@?k@GGKY@A"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-11-17T18:27:47.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.523103,
-              "longitude": -122.653064
-            },
-            "name": "NE Sandy & 12th",
-            "stop": {
-              "code": "5055",
-              "coordinate": {
-                "latitude": 45.523103,
-                "longitude": -122.653064
-              },
-              "description": "Westbound stop in Portland (Stop ID 5055)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "5055"
-              },
-              "name": "NE Sandy & 12th",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
-            "stopIndex": 94,
-            "stopSequence": 95,
-            "vertexType": "TRANSIT"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "SOUTH",
-              "angle": -3.1191187064694192,
               "area": false,
               "bogusName": false,
               "distance": 39.059,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.52336838632084,
+              "lon": -122.65362253301092,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.52336838632084,
-                "longitude": -122.65362253301092
-              },
               "stayOn": false,
-              "streetName": "Northeast 12th Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northeast 12th Avenue"
             },
             {
               "absoluteDirection": "EAST",
-              "angle": 1.5906288403465376,
               "area": false,
               "bogusName": true,
               "distance": 47.959999999999994,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.523017200000005,
+              "lon": -122.65363380000001,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.523017200000005,
-                "longitude": -122.65363380000001
-              },
               "stayOn": false,
-              "streetName": "way 162042138 from 0",
-              "streetNotes": [ ]
+              "streetName": "way 162042138 from 0"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
-        },
-        {
-          "agencyTimeZoneOffset": 0,
-          "arrivalDelay": 0,
-          "departureDelay": 0,
-          "distanceMeters": 3729.9737283822847,
-          "endTime": "2009-11-17T18:42:19.000+00:00",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.523103,
-              "longitude": -122.653064
-            },
+          "to": {
+            "arrival": "2009-11-17T18:29:00.000+00:00",
+            "departure": "2009-11-17T18:29:00.000+00:00",
+            "lat": 45.523103,
+            "lon": -122.653064,
             "name": "NE Sandy & 12th",
-            "stop": {
-              "code": "5055",
-              "coordinate": {
-                "latitude": 45.523103,
-                "longitude": -122.653064
-              },
-              "description": "Westbound stop in Portland (Stop ID 5055)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "5055"
-              },
-              "name": "NE Sandy & 12th",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "5055",
+            "stopId": "prt:5055",
             "stopIndex": 94,
             "stopSequence": 95,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "transitLeg": false,
+          "walkingBike": false
+        },
+        {
+          "agencyId": "prt:prt",
+          "agencyName": "TriMet",
+          "agencyTimeZoneOffset": 0,
+          "agencyUrl": "http://trimet.org",
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 3729.9737283822847,
+          "endTime": "2009-11-17T18:42:19.000+00:00",
+          "from": {
+            "arrival": "2009-11-17T18:29:00.000+00:00",
+            "departure": "2009-11-17T18:29:00.000+00:00",
+            "lat": 45.523103,
+            "lon": -122.653064,
+            "name": "NE Sandy & 12th",
+            "stopCode": "5055",
+            "stopId": "prt:5055",
+            "stopIndex": 94,
+            "stopSequence": 95,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
           "generalizedCost": 1399,
           "headsign": "23rd Ave to Tichner",
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "intermediateStops": [
             {
               "arrival": "2009-11-17T18:29:47.000+00:00",
               "departure": "2009-11-17T18:29:47.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523024,
-                  "longitude": -122.656526
-                },
-                "name": "E Burnside & NE 9th",
-                "stop": {
-                  "code": "819",
-                  "coordinate": {
-                    "latitude": 45.523024,
-                    "longitude": -122.656526
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 819)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "819"
-                  },
-                  "name": "E Burnside & NE 9th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 95,
-                "stopSequence": 96,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523024,
+              "lon": -122.656526,
+              "name": "E Burnside & NE 9th",
+              "stopCode": "819",
+              "stopId": "prt:819",
+              "stopIndex": 95,
+              "stopSequence": 96,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:30:24.000+00:00",
               "departure": "2009-11-17T18:30:24.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523012,
-                  "longitude": -122.659365
-                },
-                "name": "E Burnside & NE 6th",
-                "stop": {
-                  "code": "805",
-                  "coordinate": {
-                    "latitude": 45.523012,
-                    "longitude": -122.659365
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 805)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "805"
-                  },
-                  "name": "E Burnside & NE 6th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 96,
-                "stopSequence": 97,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523012,
+              "lon": -122.659365,
+              "name": "E Burnside & NE 6th",
+              "stopCode": "805",
+              "stopId": "prt:805",
+              "stopIndex": 96,
+              "stopSequence": 97,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:30:52.000+00:00",
               "departure": "2009-11-17T18:30:52.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523015,
-                  "longitude": -122.661534
-                },
-                "name": "E Burnside & NE M L King",
-                "stop": {
-                  "code": "705",
-                  "coordinate": {
-                    "latitude": 45.523015,
-                    "longitude": -122.661534
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 705)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "705"
-                  },
-                  "name": "E Burnside & NE M L King",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 97,
-                "stopSequence": 98,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523015,
+              "lon": -122.661534,
+              "name": "E Burnside & NE M L King",
+              "stopCode": "705",
+              "stopId": "prt:705",
+              "stopIndex": 97,
+              "stopSequence": 98,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:33:00.000+00:00",
               "departure": "2009-11-17T18:33:00.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523249,
-                  "longitude": -122.671269
-                },
-                "name": "W Burnside & Burnside Bridge",
-                "stop": {
-                  "code": "689",
-                  "coordinate": {
-                    "latitude": 45.523249,
-                    "longitude": -122.671269
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 689)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "689"
-                  },
-                  "name": "W Burnside & Burnside Bridge",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 98,
-                "stopSequence": 99,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523249,
+              "lon": -122.671269,
+              "name": "W Burnside & Burnside Bridge",
+              "stopCode": "689",
+              "stopId": "prt:689",
+              "stopIndex": 98,
+              "stopSequence": 99,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T18:34:00.000+00:00",
               "departure": "2009-11-17T18:34:00.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523169,
-                  "longitude": -122.675893
-                },
-                "name": "W Burnside & NW 5th",
-                "stop": {
-                  "code": "782",
-                  "coordinate": {
-                    "latitude": 45.523169,
-                    "longitude": -122.675893
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 782)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "782"
-                  },
-                  "name": "W Burnside & NW 5th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 99,
-                "stopSequence": 100,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523169,
+              "lon": -122.675893,
+              "name": "W Burnside & NW 5th",
+              "stopCode": "782",
+              "stopId": "prt:782",
+              "stopIndex": 99,
+              "stopSequence": 100,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T18:35:17.000+00:00",
               "departure": "2009-11-17T18:35:17.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523115,
-                  "longitude": -122.678939
-                },
-                "name": "W Burnside & NW Park",
-                "stop": {
-                  "code": "716",
-                  "coordinate": {
-                    "latitude": 45.523115,
-                    "longitude": -122.678939
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 716)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "716"
-                  },
-                  "name": "W Burnside & NW Park",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 100,
-                "stopSequence": 101,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523115,
+              "lon": -122.678939,
+              "name": "W Burnside & NW Park",
+              "stopCode": "716",
+              "stopId": "prt:716",
+              "stopIndex": 100,
+              "stopSequence": 101,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T18:36:25.000+00:00",
               "departure": "2009-11-17T18:36:25.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523048,
-                  "longitude": -122.681606
-                },
-                "name": "W Burnside & NW 10th",
-                "stop": {
-                  "code": "10791",
-                  "coordinate": {
-                    "latitude": 45.523048,
-                    "longitude": -122.681606
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 10791)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "10791"
-                  },
-                  "name": "W Burnside & NW 10th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 101,
-                "stopSequence": 102,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523048,
+              "lon": -122.681606,
+              "name": "W Burnside & NW 10th",
+              "stopCode": "10791",
+              "stopId": "prt:10791",
+              "stopIndex": 101,
+              "stopSequence": 102,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T18:37:14.000+00:00",
               "departure": "2009-11-17T18:37:14.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523,
-                  "longitude": -122.683535
-                },
-                "name": "W Burnside & NW 12th",
-                "stop": {
-                  "code": "11032",
-                  "coordinate": {
-                    "latitude": 45.523,
-                    "longitude": -122.683535
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 11032)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "11032"
-                  },
-                  "name": "W Burnside & NW 12th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 102,
-                "stopSequence": 103,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523,
+              "lon": -122.683535,
+              "name": "W Burnside & NW 12th",
+              "stopCode": "11032",
+              "stopId": "prt:11032",
+              "stopIndex": 102,
+              "stopSequence": 103,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T18:39:09.000+00:00",
               "departure": "2009-11-17T18:39:09.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.522985,
-                  "longitude": -122.688091
-                },
-                "name": "W Burnside & NW 17th",
-                "stop": {
-                  "code": "10809",
-                  "coordinate": {
-                    "latitude": 45.522985,
-                    "longitude": -122.688091
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 10809)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "10809"
-                  },
-                  "name": "W Burnside & NW 17th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 103,
-                "stopSequence": 104,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.522985,
+              "lon": -122.688091,
+              "name": "W Burnside & NW 17th",
+              "stopCode": "10809",
+              "stopId": "prt:10809",
+              "stopIndex": 103,
+              "stopSequence": 104,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:40:00.000+00:00",
               "departure": "2009-11-17T18:40:00.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523097,
-                  "longitude": -122.690083
-                },
-                "name": "W Burnside & NW 19th",
-                "stop": {
-                  "code": "735",
-                  "coordinate": {
-                    "latitude": 45.523097,
-                    "longitude": -122.690083
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 735)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "735"
-                  },
-                  "name": "W Burnside & NW 19th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 104,
-                "stopSequence": 105,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523097,
+              "lon": -122.690083,
+              "name": "W Burnside & NW 19th",
+              "stopCode": "735",
+              "stopId": "prt:735",
+              "stopIndex": 104,
+              "stopSequence": 105,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:40:27.000+00:00",
               "departure": "2009-11-17T18:40:27.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523176,
-                  "longitude": -122.692139
-                },
-                "name": "W Burnside & NW 20th",
-                "stop": {
-                  "code": "741",
-                  "coordinate": {
-                    "latitude": 45.523176,
-                    "longitude": -122.692139
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 741)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "741"
-                  },
-                  "name": "W Burnside & NW 20th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 105,
-                "stopSequence": 106,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523176,
+              "lon": -122.692139,
+              "name": "W Burnside & NW 20th",
+              "stopCode": "741",
+              "stopId": "prt:741",
+              "stopIndex": 105,
+              "stopSequence": 106,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:40:40.000+00:00",
               "departure": "2009-11-17T18:40:40.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.52322,
-                  "longitude": -122.69313
-                },
-                "name": "W Burnside & NW 20th Pl",
-                "stop": {
-                  "code": "742",
-                  "coordinate": {
-                    "latitude": 45.52322,
-                    "longitude": -122.69313
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 742)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "742"
-                  },
-                  "name": "W Burnside & NW 20th Pl",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 106,
-                "stopSequence": 107,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.52322,
+              "lon": -122.69313,
+              "name": "W Burnside & NW 20th Pl",
+              "stopCode": "742",
+              "stopId": "prt:742",
+              "stopIndex": 106,
+              "stopSequence": 107,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:41:03.000+00:00",
               "departure": "2009-11-17T18:41:03.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523312,
-                  "longitude": -122.694901
-                },
-                "name": "W Burnside & NW King",
-                "stop": {
-                  "code": "747",
-                  "coordinate": {
-                    "latitude": 45.523312,
-                    "longitude": -122.694901
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 747)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "747"
-                  },
-                  "name": "W Burnside & NW King",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 107,
-                "stopSequence": 108,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523312,
+              "lon": -122.694901,
+              "name": "W Burnside & NW King",
+              "stopCode": "747",
+              "stopId": "prt:747",
+              "stopIndex": 107,
+              "stopSequence": 108,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:41:44.000+00:00",
               "departure": "2009-11-17T18:41:44.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523512,
-                  "longitude": -122.698081
-                },
-                "name": "W Burnside & NW 23rd",
-                "stop": {
-                  "code": "755",
-                  "coordinate": {
-                    "latitude": 45.523512,
-                    "longitude": -122.698081
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 755)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "755"
-                  },
-                  "name": "W Burnside & NW 23rd",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 108,
-                "stopSequence": 109,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523512,
+              "lon": -122.698081,
+              "name": "W Burnside & NW 23rd",
+              "stopCode": "755",
+              "stopId": "prt:755",
+              "stopIndex": 108,
+              "stopSequence": 109,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             }
           ],
           "legGeometry": {
@@ -8049,276 +3727,151 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "points": "weztGdtrkV?BPj@@jA?jEAhE?pD???VAjE?hE?dB?b@???`AAhE?dD???l@C`EAhEEhE?bAA|@?XAZ@\\AzACnGKbKAjC?bE???JEnE@fEDlE@hE@~A??@rBBzDBpE@~A???Z@tD@RBnEB|A???@BdB?lEBjA??BnBApF@dB?X?^@r@?f@@bCAx@EtB???VChAE|BGnD??AXKnEGnD???XGjD??AZEfCC`AEzB??AXCfAGxDE|AEtBIlC??APu@lJMhBI`@"
           },
           "mode": "BUS",
-          "onStreetNonTransit": false,
           "pathway": false,
           "realTime": false,
-          "scheduled": true,
-          "serviceDate": {
-            "day": 17,
-            "minMax": false,
-            "month": 11,
-            "sequenceNumber": 20091117,
-            "year": 2009
-          },
+          "route": "Burnside/Stark",
+          "routeId": "prt:20",
+          "routeLongName": "Burnside/Stark",
+          "routeShortName": "20",
+          "serviceDate": "2009-11-17",
           "startTime": "2009-11-17T18:29:00.000+00:00",
-          "streetNotes": [ ],
+          "steps": [ ],
           "to": {
-            "coordinate": {
-              "latitude": 45.523897,
-              "longitude": -122.700681
-            },
+            "arrival": "2009-11-17T18:42:19.000+00:00",
+            "departure": "2009-11-17T18:42:19.000+00:00",
+            "lat": 45.523897,
+            "lon": -122.700681,
             "name": "W Burnside & NW 23rd Pl",
-            "stop": {
-              "code": "9555",
-              "coordinate": {
-                "latitude": 45.523897,
-                "longitude": -122.700681
-              },
-              "description": "Westbound stop in Portland (Stop ID 9555)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "9555"
-              },
-              "name": "W Burnside & NW 23rd Pl",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "9555",
+            "stopId": "prt:9555",
             "stopIndex": 109,
             "stopSequence": 110,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
-          "transitAlerts": [ ],
           "transitLeg": true,
-          "trip": {
-            "alteration": "PLANNED",
-            "bikesAllowed": "UNKNOWN",
-            "blockId": "2071",
-            "direction": "OUTBOUND",
-            "id": {
-              "feedId": "prt",
-              "id": "200W1210"
-            },
-            "route": {
-              "agency": {
-                "fareUrl": "http://trimet.org/fares/index.htm",
-                "id": {
-                  "feedId": "prt",
-                  "id": "prt"
-                },
-                "lang": "en",
-                "name": "TriMet",
-                "phone": "503-238-7433",
-                "timezone": "America/Los_Angeles",
-                "url": "http://trimet.org"
-              },
-              "bikesAllowed": "UNKNOWN",
-              "gtfsType": 3,
-              "id": {
-                "feedId": "prt",
-                "id": "20"
-              },
-              "longName": "Burnside/Stark",
-              "mode": "BUS",
-              "shortName": "20",
-              "sortOrder": -999,
-              "sortOrderSet": false,
-              "url": "http://trimet.org/schedules/r020.htm"
-            },
-            "serviceId": {
-              "feedId": "prt",
-              "id": "W"
-            },
-            "shapeId": {
-              "feedId": "prt",
-              "id": "20.0.6"
-            },
-            "wheelchairAccessible": 0
-          },
-          "walkSteps": [ ],
-          "walkingLeg": false
+          "tripBlockId": "2071",
+          "tripId": "prt:200W1210"
         },
         {
           "agencyTimeZoneOffset": -28800000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 913.815,
+          "distance": 913.815,
           "endTime": "2009-11-17T18:54:10.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.523897,
-              "longitude": -122.700681
-            },
+            "arrival": "2009-11-17T18:42:19.000+00:00",
+            "departure": "2009-11-17T18:42:19.000+00:00",
+            "lat": 45.523897,
+            "lon": -122.700681,
             "name": "W Burnside & NW 23rd Pl",
-            "stop": {
-              "code": "9555",
-              "coordinate": {
-                "latitude": 45.523897,
-                "longitude": -122.700681
-              },
-              "description": "Westbound stop in Portland (Stop ID 9555)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "9555"
-              },
-              "name": "W Burnside & NW 23rd Pl",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "9555",
+            "stopId": "prt:9555",
             "stopIndex": 109,
             "stopSequence": 110,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
           "generalizedCost": 1388,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 39,
             "points": "ikztGh~{kVNDEVUzACPOUQO_@Yc@[QMMEOKOIECGCIAMCGCGAECECECOOMOGKIFMLk@BsABGDGBoCBkCDoC@mCBmCDoCDmCD?qA"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-11-17T18:42:19.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.531,
-              "longitude": -122.70029
-            },
-            "name": "NW Northrup St. & NW 24th Ave. (P3)",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "WEST",
-              "angle": -1.247661800162498,
               "area": false,
               "bogusName": false,
               "distance": 54.628,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.523815597641374,
+              "lon": -122.70071990797962,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.523815597641374,
-                "longitude": -122.70071990797962
-              },
               "stayOn": false,
-              "streetName": "West Burnside Street",
-              "streetNotes": [ ]
+              "streetName": "West Burnside Street"
             },
             {
               "absoluteDirection": "NORTHEAST",
-              "angle": 0.7501559967245512,
               "area": false,
               "bogusName": false,
               "distance": 176.41,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5239733,
+              "lon": -122.701384,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5239733,
-                "longitude": -122.701384
-              },
               "stayOn": false,
-              "streetName": "Northwest 24th Place",
-              "streetNotes": [ ]
+              "streetName": "Northwest 24th Place"
             },
             {
               "absoluteDirection": "NORTHWEST",
-              "angle": -0.5889596407957216,
               "area": false,
               "bogusName": false,
               "distance": 15.262,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5253583,
+              "lon": -122.70033570000001,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.5253583,
-                "longitude": -122.70033570000001
-              },
               "stayOn": false,
-              "streetName": "Northwest Westover Road",
-              "streetNotes": [ ]
+              "streetName": "Northwest Westover Road"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": -0.05815952978341337,
               "area": false,
               "bogusName": false,
               "distance": 635.654,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.525472400000005,
+              "lon": -122.7004445,
               "relativeDirection": "SLIGHTLY_RIGHT",
-              "startLocation": {
-                "latitude": 45.525472400000005,
-                "longitude": -122.7004445
-              },
               "stayOn": false,
-              "streetName": "Northwest 24th Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 24th Avenue"
             },
             {
               "absoluteDirection": "EAST",
-              "angle": 1.5432591328990624,
               "area": false,
               "bogusName": false,
               "distance": 31.861,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.531181000000004,
+              "lon": -122.70070630000001,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.531181000000004,
-                "longitude": -122.70070630000001
-              },
               "stayOn": false,
-              "streetName": "Northwest Northrup Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Northrup Street"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
+          "to": {
+            "arrival": "2009-11-17T18:54:10.000+00:00",
+            "lat": 45.531,
+            "lon": -122.70029,
+            "name": "NW Northrup St. & NW 24th Ave. (P3)",
+            "vertexType": "NORMAL"
+          },
+          "transitLeg": false,
+          "walkingBike": false
         }
       ],
-      "nTransfers": 0,
-      "nonTransitDistanceMeters": 1000.8340000000001,
-      "nonTransitTimeSeconds": 784,
-      "onStreetAllTheWay": false,
-      "streetOnly": false,
-      "systemNotices": [ ],
+      "startTime": "2009-11-17T18:27:47.000+00:00",
       "tooSloped": false,
-      "transferPriorityCost": 0,
-      "transitTimeSeconds": 799,
-      "waitTimeOptimizedCost": 0,
-      "waitingTimeSeconds": 0,
-      "walkOnly": false,
-      "walkingAllTheWay": false
+      "transfers": 0,
+      "transitTime": 799,
+      "waitingTime": 0,
+      "walkDistance": 1000.8340000000001,
+      "walkLimitExceeded": false,
+      "walkTime": 784
     },
     {
-      "arrivedAtDestinationWithRentedVehicle": false,
-      "durationSeconds": 1553,
+      "arrivedAtDestinationWithRentedBicycle": false,
+      "duration": 1553,
       "elevationGained": 0.0,
       "elevationLost": 0.0,
+      "endTime": "2009-11-17T19:09:40.000+00:00",
       "fare": {
         "details": {
           "regular": [
@@ -8351,696 +3904,285 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           }
         }
       },
-      "flaggedForDeletion": false,
       "generalizedCost": 2895,
       "legs": [
         {
           "agencyTimeZoneOffset": -28800000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 87.019,
+          "distance": 87.019,
           "endTime": "2009-11-17T18:45:00.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.52337,
-              "longitude": -122.653725
-            },
+            "departure": "2009-11-17T18:43:47.000+00:00",
+            "lat": 45.52337,
+            "lon": -122.653725,
             "name": "NE 12th & Couch",
-            "stop": {
-              "code": "6577",
-              "coordinate": {
-                "latitude": 45.52337,
-                "longitude": -122.653725
-              },
-              "description": "Southbound stop in Portland (Stop ID 6577)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "6577"
-              },
-              "name": "NE 12th & Couch",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
-            "vertexType": "TRANSIT"
+            "stopCode": "6577",
+            "stopId": "prt:6577",
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
           "generalizedCost": 137,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 9,
             "points": "ahztGxxrkV@Sb@?`@@?a@?k@GGKY@A"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-11-17T18:43:47.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.523103,
-              "longitude": -122.653064
-            },
-            "name": "NE Sandy & 12th",
-            "stop": {
-              "code": "5055",
-              "coordinate": {
-                "latitude": 45.523103,
-                "longitude": -122.653064
-              },
-              "description": "Westbound stop in Portland (Stop ID 5055)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "5055"
-              },
-              "name": "NE Sandy & 12th",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
-            "stopIndex": 94,
-            "stopSequence": 95,
-            "vertexType": "TRANSIT"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "SOUTH",
-              "angle": -3.1191187064694192,
               "area": false,
               "bogusName": false,
               "distance": 39.059,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.52336838632084,
+              "lon": -122.65362253301092,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.52336838632084,
-                "longitude": -122.65362253301092
-              },
               "stayOn": false,
-              "streetName": "Northeast 12th Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northeast 12th Avenue"
             },
             {
               "absoluteDirection": "EAST",
-              "angle": 1.5906288403465376,
               "area": false,
               "bogusName": true,
               "distance": 47.959999999999994,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.523017200000005,
+              "lon": -122.65363380000001,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.523017200000005,
-                "longitude": -122.65363380000001
-              },
               "stayOn": false,
-              "streetName": "way 162042138 from 0",
-              "streetNotes": [ ]
+              "streetName": "way 162042138 from 0"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
-        },
-        {
-          "agencyTimeZoneOffset": 0,
-          "arrivalDelay": 0,
-          "departureDelay": 0,
-          "distanceMeters": 3729.9737283822847,
-          "endTime": "2009-11-17T18:57:49.000+00:00",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.523103,
-              "longitude": -122.653064
-            },
+          "to": {
+            "arrival": "2009-11-17T18:45:00.000+00:00",
+            "departure": "2009-11-17T18:45:00.000+00:00",
+            "lat": 45.523103,
+            "lon": -122.653064,
             "name": "NE Sandy & 12th",
-            "stop": {
-              "code": "5055",
-              "coordinate": {
-                "latitude": 45.523103,
-                "longitude": -122.653064
-              },
-              "description": "Westbound stop in Portland (Stop ID 5055)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "5055"
-              },
-              "name": "NE Sandy & 12th",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "5055",
+            "stopId": "prt:5055",
             "stopIndex": 94,
             "stopSequence": 95,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "transitLeg": false,
+          "walkingBike": false
+        },
+        {
+          "agencyId": "prt:prt",
+          "agencyName": "TriMet",
+          "agencyTimeZoneOffset": 0,
+          "agencyUrl": "http://trimet.org",
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 3729.9737283822847,
+          "endTime": "2009-11-17T18:57:49.000+00:00",
+          "from": {
+            "arrival": "2009-11-17T18:45:00.000+00:00",
+            "departure": "2009-11-17T18:45:00.000+00:00",
+            "lat": 45.523103,
+            "lon": -122.653064,
+            "name": "NE Sandy & 12th",
+            "stopCode": "5055",
+            "stopId": "prt:5055",
+            "stopIndex": 94,
+            "stopSequence": 95,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
           "generalizedCost": 1369,
           "headsign": "Beaverton TC",
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "intermediateStops": [
             {
               "arrival": "2009-11-17T18:45:47.000+00:00",
               "departure": "2009-11-17T18:45:47.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523024,
-                  "longitude": -122.656526
-                },
-                "name": "E Burnside & NE 9th",
-                "stop": {
-                  "code": "819",
-                  "coordinate": {
-                    "latitude": 45.523024,
-                    "longitude": -122.656526
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 819)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "819"
-                  },
-                  "name": "E Burnside & NE 9th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 95,
-                "stopSequence": 96,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523024,
+              "lon": -122.656526,
+              "name": "E Burnside & NE 9th",
+              "stopCode": "819",
+              "stopId": "prt:819",
+              "stopIndex": 95,
+              "stopSequence": 96,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:46:24.000+00:00",
               "departure": "2009-11-17T18:46:24.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523012,
-                  "longitude": -122.659365
-                },
-                "name": "E Burnside & NE 6th",
-                "stop": {
-                  "code": "805",
-                  "coordinate": {
-                    "latitude": 45.523012,
-                    "longitude": -122.659365
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 805)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "805"
-                  },
-                  "name": "E Burnside & NE 6th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 96,
-                "stopSequence": 97,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523012,
+              "lon": -122.659365,
+              "name": "E Burnside & NE 6th",
+              "stopCode": "805",
+              "stopId": "prt:805",
+              "stopIndex": 96,
+              "stopSequence": 97,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:46:52.000+00:00",
               "departure": "2009-11-17T18:46:52.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523015,
-                  "longitude": -122.661534
-                },
-                "name": "E Burnside & NE M L King",
-                "stop": {
-                  "code": "705",
-                  "coordinate": {
-                    "latitude": 45.523015,
-                    "longitude": -122.661534
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 705)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "705"
-                  },
-                  "name": "E Burnside & NE M L King",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 97,
-                "stopSequence": 98,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523015,
+              "lon": -122.661534,
+              "name": "E Burnside & NE M L King",
+              "stopCode": "705",
+              "stopId": "prt:705",
+              "stopIndex": 97,
+              "stopSequence": 98,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:49:00.000+00:00",
               "departure": "2009-11-17T18:49:00.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523249,
-                  "longitude": -122.671269
-                },
-                "name": "W Burnside & Burnside Bridge",
-                "stop": {
-                  "code": "689",
-                  "coordinate": {
-                    "latitude": 45.523249,
-                    "longitude": -122.671269
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 689)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "689"
-                  },
-                  "name": "W Burnside & Burnside Bridge",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 98,
-                "stopSequence": 99,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523249,
+              "lon": -122.671269,
+              "name": "W Burnside & Burnside Bridge",
+              "stopCode": "689",
+              "stopId": "prt:689",
+              "stopIndex": 98,
+              "stopSequence": 99,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T18:50:00.000+00:00",
               "departure": "2009-11-17T18:50:00.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523169,
-                  "longitude": -122.675893
-                },
-                "name": "W Burnside & NW 5th",
-                "stop": {
-                  "code": "782",
-                  "coordinate": {
-                    "latitude": 45.523169,
-                    "longitude": -122.675893
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 782)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "782"
-                  },
-                  "name": "W Burnside & NW 5th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 99,
-                "stopSequence": 100,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523169,
+              "lon": -122.675893,
+              "name": "W Burnside & NW 5th",
+              "stopCode": "782",
+              "stopId": "prt:782",
+              "stopIndex": 99,
+              "stopSequence": 100,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T18:51:17.000+00:00",
               "departure": "2009-11-17T18:51:17.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523115,
-                  "longitude": -122.678939
-                },
-                "name": "W Burnside & NW Park",
-                "stop": {
-                  "code": "716",
-                  "coordinate": {
-                    "latitude": 45.523115,
-                    "longitude": -122.678939
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 716)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "716"
-                  },
-                  "name": "W Burnside & NW Park",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 100,
-                "stopSequence": 101,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523115,
+              "lon": -122.678939,
+              "name": "W Burnside & NW Park",
+              "stopCode": "716",
+              "stopId": "prt:716",
+              "stopIndex": 100,
+              "stopSequence": 101,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T18:52:25.000+00:00",
               "departure": "2009-11-17T18:52:25.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523048,
-                  "longitude": -122.681606
-                },
-                "name": "W Burnside & NW 10th",
-                "stop": {
-                  "code": "10791",
-                  "coordinate": {
-                    "latitude": 45.523048,
-                    "longitude": -122.681606
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 10791)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "10791"
-                  },
-                  "name": "W Burnside & NW 10th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 101,
-                "stopSequence": 102,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523048,
+              "lon": -122.681606,
+              "name": "W Burnside & NW 10th",
+              "stopCode": "10791",
+              "stopId": "prt:10791",
+              "stopIndex": 101,
+              "stopSequence": 102,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T18:53:14.000+00:00",
               "departure": "2009-11-17T18:53:14.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523,
-                  "longitude": -122.683535
-                },
-                "name": "W Burnside & NW 12th",
-                "stop": {
-                  "code": "11032",
-                  "coordinate": {
-                    "latitude": 45.523,
-                    "longitude": -122.683535
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 11032)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "11032"
-                  },
-                  "name": "W Burnside & NW 12th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 102,
-                "stopSequence": 103,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523,
+              "lon": -122.683535,
+              "name": "W Burnside & NW 12th",
+              "stopCode": "11032",
+              "stopId": "prt:11032",
+              "stopIndex": 102,
+              "stopSequence": 103,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T18:55:09.000+00:00",
               "departure": "2009-11-17T18:55:09.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.522985,
-                  "longitude": -122.688091
-                },
-                "name": "W Burnside & NW 17th",
-                "stop": {
-                  "code": "10809",
-                  "coordinate": {
-                    "latitude": 45.522985,
-                    "longitude": -122.688091
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 10809)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "10809"
-                  },
-                  "name": "W Burnside & NW 17th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 103,
-                "stopSequence": 104,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.522985,
+              "lon": -122.688091,
+              "name": "W Burnside & NW 17th",
+              "stopCode": "10809",
+              "stopId": "prt:10809",
+              "stopIndex": 103,
+              "stopSequence": 104,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:56:00.000+00:00",
               "departure": "2009-11-17T18:56:00.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523097,
-                  "longitude": -122.690083
-                },
-                "name": "W Burnside & NW 19th",
-                "stop": {
-                  "code": "735",
-                  "coordinate": {
-                    "latitude": 45.523097,
-                    "longitude": -122.690083
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 735)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "735"
-                  },
-                  "name": "W Burnside & NW 19th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 104,
-                "stopSequence": 105,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523097,
+              "lon": -122.690083,
+              "name": "W Burnside & NW 19th",
+              "stopCode": "735",
+              "stopId": "prt:735",
+              "stopIndex": 104,
+              "stopSequence": 105,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:56:21.000+00:00",
               "departure": "2009-11-17T18:56:21.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523176,
-                  "longitude": -122.692139
-                },
-                "name": "W Burnside & NW 20th",
-                "stop": {
-                  "code": "741",
-                  "coordinate": {
-                    "latitude": 45.523176,
-                    "longitude": -122.692139
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 741)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "741"
-                  },
-                  "name": "W Burnside & NW 20th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 105,
-                "stopSequence": 106,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523176,
+              "lon": -122.692139,
+              "name": "W Burnside & NW 20th",
+              "stopCode": "741",
+              "stopId": "prt:741",
+              "stopIndex": 105,
+              "stopSequence": 106,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:56:31.000+00:00",
               "departure": "2009-11-17T18:56:31.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.52322,
-                  "longitude": -122.69313
-                },
-                "name": "W Burnside & NW 20th Pl",
-                "stop": {
-                  "code": "742",
-                  "coordinate": {
-                    "latitude": 45.52322,
-                    "longitude": -122.69313
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 742)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "742"
-                  },
-                  "name": "W Burnside & NW 20th Pl",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 106,
-                "stopSequence": 107,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.52322,
+              "lon": -122.69313,
+              "name": "W Burnside & NW 20th Pl",
+              "stopCode": "742",
+              "stopId": "prt:742",
+              "stopIndex": 106,
+              "stopSequence": 107,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:56:49.000+00:00",
               "departure": "2009-11-17T18:56:49.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523312,
-                  "longitude": -122.694901
-                },
-                "name": "W Burnside & NW King",
-                "stop": {
-                  "code": "747",
-                  "coordinate": {
-                    "latitude": 45.523312,
-                    "longitude": -122.694901
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 747)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "747"
-                  },
-                  "name": "W Burnside & NW King",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 107,
-                "stopSequence": 108,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523312,
+              "lon": -122.694901,
+              "name": "W Burnside & NW King",
+              "stopCode": "747",
+              "stopId": "prt:747",
+              "stopIndex": 107,
+              "stopSequence": 108,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:57:22.000+00:00",
               "departure": "2009-11-17T18:57:22.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523512,
-                  "longitude": -122.698081
-                },
-                "name": "W Burnside & NW 23rd",
-                "stop": {
-                  "code": "755",
-                  "coordinate": {
-                    "latitude": 45.523512,
-                    "longitude": -122.698081
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 755)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "755"
-                  },
-                  "name": "W Burnside & NW 23rd",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 108,
-                "stopSequence": 109,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523512,
+              "lon": -122.698081,
+              "name": "W Burnside & NW 23rd",
+              "stopCode": "755",
+              "stopId": "prt:755",
+              "stopIndex": 108,
+              "stopSequence": 109,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             }
           ],
           "legGeometry": {
@@ -9048,276 +4190,151 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "points": "weztGdtrkV?BPj@@jA?jEAhE?pD???VAjE?hE?dB?b@???`AAhE?dD???l@C`EAhEEhE?bAA|@?XAZ@\\AzACnGKbKAjC?bE???JEnE@fEDlE@hE@~A??@rBBzDBpE@~A???Z@tD@RBnEB|A???@BdB?lEBjA??BnBApF@dB?X?^@r@?f@@bCAx@EtB???VChAE|BGnD??AXKnEGnD???XGjD??AZEfCC`AEzB??AXCfAGxDE|AEtBIlC??APu@lJMhBI`@"
           },
           "mode": "BUS",
-          "onStreetNonTransit": false,
           "pathway": false,
           "realTime": false,
-          "scheduled": true,
-          "serviceDate": {
-            "day": 17,
-            "minMax": false,
-            "month": 11,
-            "sequenceNumber": 20091117,
-            "year": 2009
-          },
+          "route": "Burnside/Stark",
+          "routeId": "prt:20",
+          "routeLongName": "Burnside/Stark",
+          "routeShortName": "20",
+          "serviceDate": "2009-11-17",
           "startTime": "2009-11-17T18:45:00.000+00:00",
-          "streetNotes": [ ],
+          "steps": [ ],
           "to": {
-            "coordinate": {
-              "latitude": 45.523897,
-              "longitude": -122.700681
-            },
+            "arrival": "2009-11-17T18:57:49.000+00:00",
+            "departure": "2009-11-17T18:57:49.000+00:00",
+            "lat": 45.523897,
+            "lon": -122.700681,
             "name": "W Burnside & NW 23rd Pl",
-            "stop": {
-              "code": "9555",
-              "coordinate": {
-                "latitude": 45.523897,
-                "longitude": -122.700681
-              },
-              "description": "Westbound stop in Portland (Stop ID 9555)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "9555"
-              },
-              "name": "W Burnside & NW 23rd Pl",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "9555",
+            "stopId": "prt:9555",
             "stopIndex": 109,
             "stopSequence": 110,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
-          "transitAlerts": [ ],
           "transitLeg": true,
-          "trip": {
-            "alteration": "PLANNED",
-            "bikesAllowed": "UNKNOWN",
-            "blockId": "2037",
-            "direction": "OUTBOUND",
-            "id": {
-              "feedId": "prt",
-              "id": "200W1220"
-            },
-            "route": {
-              "agency": {
-                "fareUrl": "http://trimet.org/fares/index.htm",
-                "id": {
-                  "feedId": "prt",
-                  "id": "prt"
-                },
-                "lang": "en",
-                "name": "TriMet",
-                "phone": "503-238-7433",
-                "timezone": "America/Los_Angeles",
-                "url": "http://trimet.org"
-              },
-              "bikesAllowed": "UNKNOWN",
-              "gtfsType": 3,
-              "id": {
-                "feedId": "prt",
-                "id": "20"
-              },
-              "longName": "Burnside/Stark",
-              "mode": "BUS",
-              "shortName": "20",
-              "sortOrder": -999,
-              "sortOrderSet": false,
-              "url": "http://trimet.org/schedules/r020.htm"
-            },
-            "serviceId": {
-              "feedId": "prt",
-              "id": "W"
-            },
-            "shapeId": {
-              "feedId": "prt",
-              "id": "20.0.1"
-            },
-            "wheelchairAccessible": 0
-          },
-          "walkSteps": [ ],
-          "walkingLeg": false
+          "tripBlockId": "2037",
+          "tripId": "prt:200W1220"
         },
         {
           "agencyTimeZoneOffset": -28800000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 913.815,
+          "distance": 913.815,
           "endTime": "2009-11-17T19:09:40.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.523897,
-              "longitude": -122.700681
-            },
+            "arrival": "2009-11-17T18:57:49.000+00:00",
+            "departure": "2009-11-17T18:57:49.000+00:00",
+            "lat": 45.523897,
+            "lon": -122.700681,
             "name": "W Burnside & NW 23rd Pl",
-            "stop": {
-              "code": "9555",
-              "coordinate": {
-                "latitude": 45.523897,
-                "longitude": -122.700681
-              },
-              "description": "Westbound stop in Portland (Stop ID 9555)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "9555"
-              },
-              "name": "W Burnside & NW 23rd Pl",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "9555",
+            "stopId": "prt:9555",
             "stopIndex": 109,
             "stopSequence": 110,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
           "generalizedCost": 1388,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 39,
             "points": "ikztGh~{kVNDEVUzACPOUQO_@Yc@[QMMEOKOIECGCIAMCGCGAECECECOOMOGKIFMLk@BsABGDGBoCBkCDoC@mCBmCDoCDmCD?qA"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-11-17T18:57:49.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.531,
-              "longitude": -122.70029
-            },
-            "name": "NW Northrup St. & NW 24th Ave. (P3)",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "WEST",
-              "angle": -1.247661800162498,
               "area": false,
               "bogusName": false,
               "distance": 54.628,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.523815597641374,
+              "lon": -122.70071990797962,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.523815597641374,
-                "longitude": -122.70071990797962
-              },
               "stayOn": false,
-              "streetName": "West Burnside Street",
-              "streetNotes": [ ]
+              "streetName": "West Burnside Street"
             },
             {
               "absoluteDirection": "NORTHEAST",
-              "angle": 0.7501559967245512,
               "area": false,
               "bogusName": false,
               "distance": 176.41,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5239733,
+              "lon": -122.701384,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5239733,
-                "longitude": -122.701384
-              },
               "stayOn": false,
-              "streetName": "Northwest 24th Place",
-              "streetNotes": [ ]
+              "streetName": "Northwest 24th Place"
             },
             {
               "absoluteDirection": "NORTHWEST",
-              "angle": -0.5889596407957216,
               "area": false,
               "bogusName": false,
               "distance": 15.262,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5253583,
+              "lon": -122.70033570000001,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.5253583,
-                "longitude": -122.70033570000001
-              },
               "stayOn": false,
-              "streetName": "Northwest Westover Road",
-              "streetNotes": [ ]
+              "streetName": "Northwest Westover Road"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": -0.05815952978341337,
               "area": false,
               "bogusName": false,
               "distance": 635.654,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.525472400000005,
+              "lon": -122.7004445,
               "relativeDirection": "SLIGHTLY_RIGHT",
-              "startLocation": {
-                "latitude": 45.525472400000005,
-                "longitude": -122.7004445
-              },
               "stayOn": false,
-              "streetName": "Northwest 24th Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 24th Avenue"
             },
             {
               "absoluteDirection": "EAST",
-              "angle": 1.5432591328990624,
               "area": false,
               "bogusName": false,
               "distance": 31.861,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.531181000000004,
+              "lon": -122.70070630000001,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.531181000000004,
-                "longitude": -122.70070630000001
-              },
               "stayOn": false,
-              "streetName": "Northwest Northrup Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Northrup Street"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
+          "to": {
+            "arrival": "2009-11-17T19:09:40.000+00:00",
+            "lat": 45.531,
+            "lon": -122.70029,
+            "name": "NW Northrup St. & NW 24th Ave. (P3)",
+            "vertexType": "NORMAL"
+          },
+          "transitLeg": false,
+          "walkingBike": false
         }
       ],
-      "nTransfers": 0,
-      "nonTransitDistanceMeters": 1000.8340000000001,
-      "nonTransitTimeSeconds": 784,
-      "onStreetAllTheWay": false,
-      "streetOnly": false,
-      "systemNotices": [ ],
+      "startTime": "2009-11-17T18:43:47.000+00:00",
       "tooSloped": false,
-      "transferPriorityCost": 0,
-      "transitTimeSeconds": 769,
-      "waitTimeOptimizedCost": 0,
-      "waitingTimeSeconds": 0,
-      "walkOnly": false,
-      "walkingAllTheWay": false
+      "transfers": 0,
+      "transitTime": 769,
+      "waitingTime": 0,
+      "walkDistance": 1000.8340000000001,
+      "walkLimitExceeded": false,
+      "walkTime": 784
     },
     {
-      "arrivedAtDestinationWithRentedVehicle": false,
-      "durationSeconds": 1567,
+      "arrivedAtDestinationWithRentedBicycle": false,
+      "duration": 1567,
       "elevationGained": 0.0,
       "elevationLost": 0.0,
+      "endTime": "2009-11-17T19:11:51.000+00:00",
       "fare": {
         "details": {
           "regular": [
@@ -9354,383 +4371,169 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           }
         }
       },
-      "flaggedForDeletion": false,
       "generalizedCost": 2957,
       "legs": [
         {
           "agencyTimeZoneOffset": -28800000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 20.74,
+          "distance": 20.74,
           "endTime": "2009-11-17T18:46:00.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.52337,
-              "longitude": -122.653725
-            },
+            "departure": "2009-11-17T18:45:44.000+00:00",
+            "lat": 45.52337,
+            "lon": -122.653725,
             "name": "NE 12th & Couch",
-            "stop": {
-              "code": "6577",
-              "coordinate": {
-                "latitude": 45.52337,
-                "longitude": -122.653725
-              },
-              "description": "Southbound stop in Portland (Stop ID 6577)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "6577"
-              },
-              "name": "NE 12th & Couch",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
-            "vertexType": "TRANSIT"
+            "stopCode": "6577",
+            "stopId": "prt:6577",
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
           "generalizedCost": 33,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 4,
             "points": "ahztGxxrkV@Sb@??W"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-11-17T18:45:44.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.52318,
-              "longitude": -122.653507
-            },
-            "name": "NE 12th & Sandy",
-            "stop": {
-              "code": "6592",
-              "coordinate": {
-                "latitude": 45.52318,
-                "longitude": -122.653507
-              },
-              "description": "Northbound stop in Portland (Stop ID 6592)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "6592"
-              },
-              "name": "NE 12th & Sandy",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
-            "stopIndex": 34,
-            "stopSequence": 35,
-            "vertexType": "TRANSIT"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "SOUTH",
-              "angle": -3.1191187064694192,
               "area": false,
               "bogusName": false,
               "distance": 20.74,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.52336838632084,
+              "lon": -122.65362253301092,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.52336838632084,
-                "longitude": -122.65362253301092
-              },
               "stayOn": false,
-              "streetName": "Northeast 12th Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northeast 12th Avenue"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
-        },
-        {
-          "agencyTimeZoneOffset": 0,
-          "arrivalDelay": 0,
-          "departureDelay": 0,
-          "distanceMeters": 1667.1475209896525,
-          "endTime": "2009-11-17T18:52:12.000+00:00",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.52318,
-              "longitude": -122.653507
-            },
+          "to": {
+            "arrival": "2009-11-17T18:46:00.000+00:00",
+            "departure": "2009-11-17T18:46:00.000+00:00",
+            "lat": 45.52318,
+            "lon": -122.653507,
             "name": "NE 12th & Sandy",
-            "stop": {
-              "code": "6592",
-              "coordinate": {
-                "latitude": 45.52318,
-                "longitude": -122.653507
-              },
-              "description": "Northbound stop in Portland (Stop ID 6592)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "6592"
-              },
-              "name": "NE 12th & Sandy",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "6592",
+            "stopId": "prt:6592",
             "stopIndex": 34,
             "stopSequence": 35,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "transitLeg": false,
+          "walkingBike": false
+        },
+        {
+          "agencyId": "prt:prt",
+          "agencyName": "TriMet",
+          "agencyTimeZoneOffset": 0,
+          "agencyUrl": "http://trimet.org",
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 1667.1475209896525,
+          "endTime": "2009-11-17T18:52:12.000+00:00",
+          "from": {
+            "arrival": "2009-11-17T18:46:00.000+00:00",
+            "departure": "2009-11-17T18:46:00.000+00:00",
+            "lat": 45.52318,
+            "lon": -122.653507,
+            "name": "NE 12th & Sandy",
+            "stopCode": "6592",
+            "stopId": "prt:6592",
+            "stopIndex": 34,
+            "stopSequence": 35,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
           "generalizedCost": 972,
           "headsign": "Rose Qtr TC",
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "intermediateStops": [
             {
               "arrival": "2009-11-17T18:47:45.000+00:00",
               "departure": "2009-11-17T18:47:45.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.527449,
-                  "longitude": -122.653462
-                },
-                "name": "NE 12th & Irving",
-                "stop": {
-                  "code": "6582",
-                  "coordinate": {
-                    "latitude": 45.527449,
-                    "longitude": -122.653462
-                  },
-                  "description": "Northbound stop in Portland (Stop ID 6582)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "6582"
-                  },
-                  "name": "NE 12th & Irving",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 35,
-                "stopSequence": 36,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.527449,
+              "lon": -122.653462,
+              "name": "NE 12th & Irving",
+              "stopCode": "6582",
+              "stopId": "prt:6582",
+              "stopIndex": 35,
+              "stopSequence": 36,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T18:49:00.000+00:00",
               "departure": "2009-11-17T18:49:00.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.529793,
-                  "longitude": -122.654429
-                },
-                "name": "NE 11th & Holladay",
-                "stop": {
-                  "code": "8513",
-                  "coordinate": {
-                    "latitude": 45.529793,
-                    "longitude": -122.654429
-                  },
-                  "description": "Northbound stop in Portland (Stop ID 8513)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "8513"
-                  },
-                  "name": "NE 11th & Holladay",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 36,
-                "stopSequence": 37,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.529793,
+              "lon": -122.654429,
+              "name": "NE 11th & Holladay",
+              "stopCode": "8513",
+              "stopId": "prt:8513",
+              "stopIndex": 36,
+              "stopSequence": 37,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T18:49:39.000+00:00",
               "departure": "2009-11-17T18:49:39.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.53135,
-                  "longitude": -122.654497
-                },
-                "name": "NE 11th & Multnomah",
-                "stop": {
-                  "code": "8938",
-                  "coordinate": {
-                    "latitude": 45.53135,
-                    "longitude": -122.654497
-                  },
-                  "description": "Northbound stop in Portland (Stop ID 8938)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "8938"
-                  },
-                  "name": "NE 11th & Multnomah",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 37,
-                "stopSequence": 38,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.53135,
+              "lon": -122.654497,
+              "name": "NE 11th & Multnomah",
+              "stopCode": "8938",
+              "stopId": "prt:8938",
+              "stopIndex": 37,
+              "stopSequence": 38,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T18:50:15.000+00:00",
               "departure": "2009-11-17T18:50:15.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.531573,
-                  "longitude": -122.656408
-                },
-                "name": "NE Multnomah & 9th",
-                "stop": {
-                  "code": "4056",
-                  "coordinate": {
-                    "latitude": 45.531573,
-                    "longitude": -122.656408
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 4056)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "4056"
-                  },
-                  "name": "NE Multnomah & 9th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 38,
-                "stopSequence": 39,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.531573,
+              "lon": -122.656408,
+              "name": "NE Multnomah & 9th",
+              "stopCode": "4056",
+              "stopId": "prt:4056",
+              "stopIndex": 38,
+              "stopSequence": 39,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T18:51:01.000+00:00",
               "departure": "2009-11-17T18:51:01.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.531569,
-                  "longitude": -122.659045
-                },
-                "name": "NE Multnomah & 7th",
-                "stop": {
-                  "code": "4054",
-                  "coordinate": {
-                    "latitude": 45.531569,
-                    "longitude": -122.659045
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 4054)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "4054"
-                  },
-                  "name": "NE Multnomah & 7th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 39,
-                "stopSequence": 40,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.531569,
+              "lon": -122.659045,
+              "name": "NE Multnomah & 7th",
+              "stopCode": "4054",
+              "stopId": "prt:4054",
+              "stopIndex": 39,
+              "stopSequence": 40,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T18:51:27.000+00:00",
               "departure": "2009-11-17T18:51:27.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.531586,
-                  "longitude": -122.660482
-                },
-                "name": "NE Multnomah & Grand",
-                "stop": {
-                  "code": "4043",
-                  "coordinate": {
-                    "latitude": 45.531586,
-                    "longitude": -122.660482
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 4043)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "4043"
-                  },
-                  "name": "NE Multnomah & Grand",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 40,
-                "stopSequence": 41,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.531586,
+              "lon": -122.660482,
+              "name": "NE Multnomah & Grand",
+              "stopCode": "4043",
+              "stopId": "prt:4043",
+              "stopIndex": 40,
+              "stopSequence": 41,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             }
           ],
           "legGeometry": {
@@ -9738,601 +4541,174 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "points": "{fztG`xrkVwA?mCAmC?oCA}C?sDC??aBAm@@k@AY?uABU@I@IBQFb@fC}@d@OFO@q@???Q?]?gGA??[??nJ???b@?vK?rA???tBCfD???^?nE?V@Z?PH\\Nb@`@~@Rf@"
           },
           "mode": "BUS",
-          "onStreetNonTransit": false,
           "pathway": false,
           "realTime": false,
-          "scheduled": true,
-          "serviceDate": {
-            "day": 17,
-            "minMax": false,
-            "month": 11,
-            "sequenceNumber": 20091117,
-            "year": 2009
-          },
+          "route": "12th Ave",
+          "routeId": "prt:70",
+          "routeLongName": "12th Ave",
+          "routeShortName": "70",
+          "serviceDate": "2009-11-17",
           "startTime": "2009-11-17T18:46:00.000+00:00",
-          "streetNotes": [ ],
+          "steps": [ ],
           "to": {
-            "coordinate": {
-              "latitude": 45.531159,
-              "longitude": -122.66293
-            },
+            "arrival": "2009-11-17T18:52:12.000+00:00",
+            "departure": "2009-11-17T18:56:09.000+00:00",
+            "lat": 45.531159,
+            "lon": -122.66293,
             "name": "NE Multnomah & 3rd",
-            "stop": {
-              "code": "11492",
-              "coordinate": {
-                "latitude": 45.531159,
-                "longitude": -122.66293
-              },
-              "description": "Westbound stop in Portland (Stop ID 11492)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "0"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "11492"
-              },
-              "name": "NE Multnomah & 3rd",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "11492",
+            "stopId": "prt:11492",
             "stopIndex": 41,
             "stopSequence": 42,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
           },
-          "transitAlerts": [ ],
           "transitLeg": true,
-          "trip": {
-            "alteration": "PLANNED",
-            "bikesAllowed": "UNKNOWN",
-            "blockId": "7002",
-            "direction": "OUTBOUND",
-            "id": {
-              "feedId": "prt",
-              "id": "700W1170"
-            },
-            "route": {
-              "agency": {
-                "fareUrl": "http://trimet.org/fares/index.htm",
-                "id": {
-                  "feedId": "prt",
-                  "id": "prt"
-                },
-                "lang": "en",
-                "name": "TriMet",
-                "phone": "503-238-7433",
-                "timezone": "America/Los_Angeles",
-                "url": "http://trimet.org"
-              },
-              "bikesAllowed": "UNKNOWN",
-              "gtfsType": 3,
-              "id": {
-                "feedId": "prt",
-                "id": "70"
-              },
-              "longName": "12th Ave",
-              "mode": "BUS",
-              "shortName": "70",
-              "sortOrder": -999,
-              "sortOrderSet": false,
-              "url": "http://trimet.org/schedules/r070.htm"
-            },
-            "serviceId": {
-              "feedId": "prt",
-              "id": "W"
-            },
-            "shapeId": {
-              "feedId": "prt",
-              "id": "70.0.7"
-            },
-            "wheelchairAccessible": 0
-          },
-          "walkSteps": [ ],
-          "walkingLeg": false
+          "tripBlockId": "7002",
+          "tripId": "prt:700W1170"
         },
         {
+          "agencyId": "prt:prt",
+          "agencyName": "TriMet",
           "agencyTimeZoneOffset": 0,
+          "agencyUrl": "http://trimet.org",
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 3526.7741793792093,
+          "distance": 3526.7741793792093,
           "endTime": "2009-11-17T19:08:50.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.531159,
-              "longitude": -122.66293
-            },
+            "arrival": "2009-11-17T18:52:12.000+00:00",
+            "departure": "2009-11-17T18:56:09.000+00:00",
+            "lat": 45.531159,
+            "lon": -122.66293,
             "name": "NE Multnomah & 3rd",
-            "stop": {
-              "code": "11492",
-              "coordinate": {
-                "latitude": 45.531159,
-                "longitude": -122.66293
-              },
-              "description": "Westbound stop in Portland (Stop ID 11492)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "0"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "11492"
-              },
-              "name": "NE Multnomah & 3rd",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "11492",
+            "stopId": "prt:11492",
             "stopIndex": 83,
             "stopSequence": 84,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
           },
           "generalizedCost": 1598,
           "headsign": "Montgomery Park",
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "intermediateStops": [
             {
               "arrival": "2009-11-17T18:58:00.000+00:00",
               "departure": "2009-11-17T18:58:00.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.530005,
-                  "longitude": -122.666476
-                },
-                "name": "Rose Quarter Transit Center",
-                "stop": {
-                  "code": "2592",
-                  "coordinate": {
-                    "latitude": 45.530005,
-                    "longitude": -122.666476
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 2592)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "2592"
-                  },
-                  "name": "Rose Quarter Transit Center",
-                  "parentStation": {
-                    "code": "79-tc",
-                    "coordinate": {
-                      "latitude": 45.530205,
-                      "longitude": -122.666118
-                    },
-                    "geometry": {
-                      "SRID": 0,
-                      "empty": false,
-                      "factory": {
-                        "SRID": 0,
-                        "coordinateSequenceFactory": { },
-                        "precisionModel": {
-                          "floating": true,
-                          "modelType": {
-                            "name": "FLOATING"
-                          },
-                          "scale": 0.0
-                        }
-                      },
-                      "geometries": [
-                        {
-                          "SRID": 0,
-                          "coordinates": {
-                            "coords": [
-                              -122.666118,
-                              45.530205
-                            ],
-                            "dimension": 2
-                          },
-                          "empty": false,
-                          "factory": {
-                            "SRID": 0,
-                            "coordinateSequenceFactory": { },
-                            "precisionModel": {
-                              "floating": true,
-                              "modelType": {
-                                "name": "FLOATING"
-                              },
-                              "scale": 0.0
-                            }
-                          },
-                          "rectangle": false,
-                          "simple": true,
-                          "valid": true
-                        },
-                        {
-                          "SRID": 0,
-                          "empty": false,
-                          "factory": {
-                            "SRID": 0,
-                            "coordinateSequenceFactory": { },
-                            "precisionModel": {
-                              "floating": true,
-                              "modelType": {
-                                "name": "FLOATING"
-                              },
-                              "scale": 0.0
-                            }
-                          },
-                          "holes": [ ],
-                          "rectangle": false,
-                          "shell": {
-                            "SRID": 0,
-                            "closed": true,
-                            "empty": false,
-                            "envelope": {
-                              "maxx": -122.665648,
-                              "maxy": 45.530703,
-                              "minx": -122.667794,
-                              "miny": 45.529724,
-                              "null": false
-                            },
-                            "factory": {
-                              "SRID": 0,
-                              "coordinateSequenceFactory": { },
-                              "precisionModel": {
-                                "floating": true,
-                                "modelType": {
-                                  "name": "FLOATING"
-                                },
-                                "scale": 0.0
-                              }
-                            },
-                            "points": {
-                              "coords": [
-                                -122.666322,
-                                45.529724,
-                                -122.667591,
-                                45.529829,
-                                -122.667794,
-                                45.530244,
-                                -122.66599,
-                                45.530703,
-                                -122.665648,
-                                45.53069,
-                                -122.665697,
-                                45.529888,
-                                -122.666322,
-                                45.529724
-                              ],
-                              "dimension": 2
-                            },
-                            "rectangle": false,
-                            "ring": true,
-                            "simple": true,
-                            "valid": true
-                          },
-                          "simple": true,
-                          "valid": true
-                        }
-                      ],
-                      "rectangle": false,
-                      "simple": true,
-                      "valid": true
-                    },
-                    "id": {
-                      "feedId": "prt",
-                      "id": "79-tc"
-                    },
-                    "name": "Rose Quarter Transit Center",
-                    "priority": "ALLOWED"
-                  },
-                  "partOfStation": true,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 84,
-                "stopSequence": 85,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.530005,
+              "lon": -122.666476,
+              "name": "Rose Quarter Transit Center",
+              "stopCode": "2592",
+              "stopId": "prt:2592",
+              "stopIndex": 84,
+              "stopSequence": 85,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T19:01:20.000+00:00",
               "departure": "2009-11-17T19:01:20.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.526655,
-                  "longitude": -122.676462
-                },
-                "name": "NW Glisan & 6th",
-                "stop": {
-                  "code": "10803",
-                  "coordinate": {
-                    "latitude": 45.526655,
-                    "longitude": -122.676462
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 10803)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "10803"
-                  },
-                  "name": "NW Glisan & 6th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 85,
-                "stopSequence": 86,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.526655,
+              "lon": -122.676462,
+              "name": "NW Glisan & 6th",
+              "stopCode": "10803",
+              "stopId": "prt:10803",
+              "stopIndex": 85,
+              "stopSequence": 86,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T19:02:15.000+00:00",
               "departure": "2009-11-17T19:02:15.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.528799,
-                  "longitude": -122.677238
-                },
-                "name": "NW Station Way & Union Station",
-                "stop": {
-                  "code": "12801",
-                  "coordinate": {
-                    "latitude": 45.528799,
-                    "longitude": -122.677238
-                  },
-                  "description": "Northbound stop in Portland (Stop ID 12801)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "12801"
-                  },
-                  "name": "NW Station Way & Union Station",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 86,
-                "stopSequence": 87,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.528799,
+              "lon": -122.677238,
+              "name": "NW Station Way & Union Station",
+              "stopCode": "12801",
+              "stopId": "prt:12801",
+              "stopIndex": 86,
+              "stopSequence": 87,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T19:04:00.000+00:00",
               "departure": "2009-11-17T19:04:00.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.531582,
-                  "longitude": -122.681193
-                },
-                "name": "NW Northrup & 10th",
-                "stop": {
-                  "code": "12802",
-                  "coordinate": {
-                    "latitude": 45.531582,
-                    "longitude": -122.681193
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 12802)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "12802"
-                  },
-                  "name": "NW Northrup & 10th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 87,
-                "stopSequence": 88,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.531582,
+              "lon": -122.681193,
+              "name": "NW Northrup & 10th",
+              "stopCode": "12802",
+              "stopId": "prt:12802",
+              "stopIndex": 87,
+              "stopSequence": 88,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T19:04:33.000+00:00",
               "departure": "2009-11-17T19:04:33.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.531534,
-                  "longitude": -122.683319
-                },
-                "name": "NW 12th & Northrup",
-                "stop": {
-                  "code": "12796",
-                  "coordinate": {
-                    "latitude": 45.531534,
-                    "longitude": -122.683319
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 12796)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "12796"
-                  },
-                  "name": "NW 12th & Northrup",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 88,
-                "stopSequence": 89,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.531534,
+              "lon": -122.683319,
+              "name": "NW 12th & Northrup",
+              "stopCode": "12796",
+              "stopId": "prt:12796",
+              "stopIndex": 88,
+              "stopSequence": 89,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T19:05:04.000+00:00",
               "departure": "2009-11-17T19:05:04.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.531503,
-                  "longitude": -122.685357
-                },
-                "name": "NW Northrup & 14th",
-                "stop": {
-                  "code": "10775",
-                  "coordinate": {
-                    "latitude": 45.531503,
-                    "longitude": -122.685357
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 10775)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "10775"
-                  },
-                  "name": "NW Northrup & 14th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 89,
-                "stopSequence": 90,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.531503,
+              "lon": -122.685357,
+              "name": "NW Northrup & 14th",
+              "stopCode": "10775",
+              "stopId": "prt:10775",
+              "stopIndex": 89,
+              "stopSequence": 90,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T19:06:07.000+00:00",
               "departure": "2009-11-17T19:06:07.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.531434,
-                  "longitude": -122.689417
-                },
-                "name": "NW Northrup & 18th",
-                "stop": {
-                  "code": "10776",
-                  "coordinate": {
-                    "latitude": 45.531434,
-                    "longitude": -122.689417
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 10776)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "10776"
-                  },
-                  "name": "NW Northrup & 18th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 90,
-                "stopSequence": 91,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.531434,
+              "lon": -122.689417,
+              "name": "NW Northrup & 18th",
+              "stopCode": "10776",
+              "stopId": "prt:10776",
+              "stopIndex": 90,
+              "stopSequence": 91,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T19:07:24.000+00:00",
               "departure": "2009-11-17T19:07:24.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.531346,
-                  "longitude": -122.694455
-                },
-                "name": "NW Northrup & 21st",
-                "stop": {
-                  "code": "10777",
-                  "coordinate": {
-                    "latitude": 45.531346,
-                    "longitude": -122.694455
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 10777)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "10777"
-                  },
-                  "name": "NW Northrup & 21st",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 91,
-                "stopSequence": 92,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.531346,
+              "lon": -122.694455,
+              "name": "NW Northrup & 21st",
+              "stopCode": "10777",
+              "stopId": "prt:10777",
+              "stopIndex": 91,
+              "stopSequence": 92,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T19:07:55.000+00:00",
               "departure": "2009-11-17T19:07:55.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.531308,
-                  "longitude": -122.696445
-                },
-                "name": "NW Northrup & 22nd",
-                "stop": {
-                  "code": "10778",
-                  "coordinate": {
-                    "latitude": 45.531308,
-                    "longitude": -122.696445
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 10778)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "10778"
-                  },
-                  "name": "NW Northrup & 22nd",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 92,
-                "stopSequence": 93,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.531308,
+              "lon": -122.696445,
+              "name": "NW Northrup & 22nd",
+              "stopCode": "10778",
+              "stopId": "prt:10778",
+              "stopIndex": 92,
+              "stopSequence": 93,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             }
           ],
           "legGeometry": {
@@ -10340,225 +4716,115 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "points": "kx{tG~qtkV`@bANb@FV@R?P?pE?jA@h@AnAbBl@LFJN\\f@LT??NXJPPVJFf@Vf@Pp@Nd@NRLB@RNXZR\\vAhC@BhAhD`AhClAbDBrDCnG@n@@^@d@HdAP`CBjEDvD???LqCFmCDYBGDEBGJkAzAQR??KNa@b@MJuBBY?OHW@u@~@aD`EcBhBBrD@xC??@l@BlE@lD???XBjEBpD???VBlE?dA@t@?b@?h@BfEBrD???VBhEFtKDvJ??@\\DnJ???d@FtKmCBo@@"
           },
           "mode": "BUS",
-          "onStreetNonTransit": false,
           "pathway": false,
           "realTime": false,
-          "scheduled": true,
-          "serviceDate": {
-            "day": 17,
-            "minMax": false,
-            "month": 11,
-            "sequenceNumber": 20091117,
-            "year": 2009
-          },
+          "route": "Broadway/Halsey",
+          "routeId": "prt:77",
+          "routeLongName": "Broadway/Halsey",
+          "routeShortName": "77",
+          "serviceDate": "2009-11-17",
           "startTime": "2009-11-17T18:56:09.000+00:00",
-          "streetNotes": [ ],
+          "steps": [ ],
           "to": {
-            "coordinate": {
-              "latitude": 45.532159,
-              "longitude": -122.698634
-            },
+            "arrival": "2009-11-17T19:08:50.000+00:00",
+            "departure": "2009-11-17T19:08:50.000+00:00",
+            "lat": 45.532159,
+            "lon": -122.698634,
             "name": "NW 23rd & Overton",
-            "stop": {
-              "code": "8981",
-              "coordinate": {
-                "latitude": 45.532159,
-                "longitude": -122.698634
-              },
-              "description": "Northbound stop in Portland (Stop ID 8981)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "8981"
-              },
-              "name": "NW 23rd & Overton",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "8981",
+            "stopId": "prt:8981",
             "stopIndex": 93,
             "stopSequence": 94,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
-          "transitAlerts": [ ],
           "transitLeg": true,
-          "trip": {
-            "alteration": "PLANNED",
-            "bikesAllowed": "UNKNOWN",
-            "blockId": "7702",
-            "direction": "INBOUND",
-            "id": {
-              "feedId": "prt",
-              "id": "771W1180"
-            },
-            "route": {
-              "agency": {
-                "fareUrl": "http://trimet.org/fares/index.htm",
-                "id": {
-                  "feedId": "prt",
-                  "id": "prt"
-                },
-                "lang": "en",
-                "name": "TriMet",
-                "phone": "503-238-7433",
-                "timezone": "America/Los_Angeles",
-                "url": "http://trimet.org"
-              },
-              "bikesAllowed": "UNKNOWN",
-              "gtfsType": 3,
-              "id": {
-                "feedId": "prt",
-                "id": "77"
-              },
-              "longName": "Broadway/Halsey",
-              "mode": "BUS",
-              "shortName": "77",
-              "sortOrder": -999,
-              "sortOrderSet": false,
-              "url": "http://trimet.org/schedules/r077.htm"
-            },
-            "serviceId": {
-              "feedId": "prt",
-              "id": "W"
-            },
-            "shapeId": {
-              "feedId": "prt",
-              "id": "77.1.3"
-            },
-            "wheelchairAccessible": 0
-          },
-          "walkSteps": [ ],
-          "walkingLeg": false
+          "tripBlockId": "7702",
+          "tripId": "prt:771W1180"
         },
         {
           "agencyTimeZoneOffset": -28800000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 231.459,
+          "distance": 231.459,
           "endTime": "2009-11-17T19:11:51.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.532159,
-              "longitude": -122.698634
-            },
+            "arrival": "2009-11-17T19:08:50.000+00:00",
+            "departure": "2009-11-17T19:08:50.000+00:00",
+            "lat": 45.532159,
+            "lon": -122.698634,
             "name": "NW 23rd & Overton",
-            "stop": {
-              "code": "8981",
-              "coordinate": {
-                "latitude": 45.532159,
-                "longitude": -122.698634
-              },
-              "description": "Northbound stop in Portland (Stop ID 8981)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "8981"
-              },
-              "name": "NW 23rd & Overton",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "8981",
+            "stopId": "prt:8981",
             "stopIndex": 93,
             "stopSequence": 94,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
           "generalizedCost": 353,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 10,
             "points": "}~{tGnq{kV?LVAF?J?L?rBCLA?RDpH"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-11-17T19:08:50.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.531,
-              "longitude": -122.70029
-            },
-            "name": "NW Northrup St. & NW 24th Ave. (P3)",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "SOUTH",
-              "angle": 3.117146926361324,
               "area": false,
               "bogusName": false,
               "distance": 104.452,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.53215782420268,
+              "lon": -122.69870264831422,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.53215782420268,
-                "longitude": -122.69870264831422
-              },
               "stayOn": false,
-              "streetName": "Northwest 23rd Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 23rd Avenue"
             },
             {
               "absoluteDirection": "WEST",
-              "angle": -1.576477897189337,
               "area": false,
               "bogusName": false,
               "distance": 127.007,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.531218800000005,
+              "lon": -122.69866750000001,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.531218800000005,
-                "longitude": -122.69866750000001
-              },
               "stayOn": false,
-              "streetName": "Northwest Northrup Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Northrup Street"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
+          "to": {
+            "arrival": "2009-11-17T19:11:51.000+00:00",
+            "lat": 45.531,
+            "lon": -122.70029,
+            "name": "NW Northrup St. & NW 24th Ave. (P3)",
+            "vertexType": "NORMAL"
+          },
+          "transitLeg": false,
+          "walkingBike": false
         }
       ],
-      "nTransfers": 1,
-      "nonTransitDistanceMeters": 252.199,
-      "nonTransitTimeSeconds": 197,
-      "onStreetAllTheWay": false,
-      "streetOnly": false,
-      "systemNotices": [ ],
+      "startTime": "2009-11-17T18:45:44.000+00:00",
       "tooSloped": false,
-      "transferPriorityCost": 33,
-      "transitTimeSeconds": 1133,
-      "waitTimeOptimizedCost": -149,
-      "waitingTimeSeconds": 237,
-      "walkOnly": false,
-      "walkingAllTheWay": false
+      "transfers": 1,
+      "transitTime": 1133,
+      "waitingTime": 237,
+      "walkDistance": 252.199,
+      "walkLimitExceeded": false,
+      "walkTime": 197
     },
     {
-      "arrivedAtDestinationWithRentedVehicle": false,
-      "durationSeconds": 1577,
+      "arrivedAtDestinationWithRentedBicycle": false,
+      "duration": 1577,
       "elevationGained": 0.0,
       "elevationLost": 0.0,
+      "endTime": "2009-11-17T19:25:04.000+00:00",
       "fare": {
         "details": {
           "regular": [
@@ -10595,659 +4861,272 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           }
         }
       },
-      "flaggedForDeletion": false,
       "generalizedCost": 3060,
       "legs": [
         {
           "agencyTimeZoneOffset": -28800000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 87.019,
+          "distance": 87.019,
           "endTime": "2009-11-17T19:00:00.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.52337,
-              "longitude": -122.653725
-            },
+            "departure": "2009-11-17T18:58:47.000+00:00",
+            "lat": 45.52337,
+            "lon": -122.653725,
             "name": "NE 12th & Couch",
-            "stop": {
-              "code": "6577",
-              "coordinate": {
-                "latitude": 45.52337,
-                "longitude": -122.653725
-              },
-              "description": "Southbound stop in Portland (Stop ID 6577)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "6577"
-              },
-              "name": "NE 12th & Couch",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
-            "vertexType": "TRANSIT"
+            "stopCode": "6577",
+            "stopId": "prt:6577",
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
           "generalizedCost": 137,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 9,
             "points": "ahztGxxrkV@Sb@?`@@?a@?k@GGKY@A"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-11-17T18:58:47.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.523103,
-              "longitude": -122.653064
-            },
-            "name": "NE Sandy & 12th",
-            "stop": {
-              "code": "5055",
-              "coordinate": {
-                "latitude": 45.523103,
-                "longitude": -122.653064
-              },
-              "description": "Westbound stop in Portland (Stop ID 5055)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "5055"
-              },
-              "name": "NE Sandy & 12th",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
-            "stopIndex": 94,
-            "stopSequence": 95,
-            "vertexType": "TRANSIT"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "SOUTH",
-              "angle": -3.1191187064694192,
               "area": false,
               "bogusName": false,
               "distance": 39.059,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.52336838632084,
+              "lon": -122.65362253301092,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.52336838632084,
-                "longitude": -122.65362253301092
-              },
               "stayOn": false,
-              "streetName": "Northeast 12th Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northeast 12th Avenue"
             },
             {
               "absoluteDirection": "EAST",
-              "angle": 1.5906288403465376,
               "area": false,
               "bogusName": true,
               "distance": 47.959999999999994,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.523017200000005,
+              "lon": -122.65363380000001,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.523017200000005,
-                "longitude": -122.65363380000001
-              },
               "stayOn": false,
-              "streetName": "way 162042138 from 0",
-              "streetNotes": [ ]
+              "streetName": "way 162042138 from 0"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
-        },
-        {
-          "agencyTimeZoneOffset": 0,
-          "arrivalDelay": 0,
-          "departureDelay": 0,
-          "distanceMeters": 3520.3249159419115,
-          "endTime": "2009-11-17T19:12:44.000+00:00",
-          "flexibleTrip": false,
-          "from": {
-            "coordinate": {
-              "latitude": 45.523103,
-              "longitude": -122.653064
-            },
+          "to": {
+            "arrival": "2009-11-17T19:00:00.000+00:00",
+            "departure": "2009-11-17T19:00:00.000+00:00",
+            "lat": 45.523103,
+            "lon": -122.653064,
             "name": "NE Sandy & 12th",
-            "stop": {
-              "code": "5055",
-              "coordinate": {
-                "latitude": 45.523103,
-                "longitude": -122.653064
-              },
-              "description": "Westbound stop in Portland (Stop ID 5055)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "5055"
-              },
-              "name": "NE Sandy & 12th",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "5055",
+            "stopId": "prt:5055",
             "stopIndex": 94,
             "stopSequence": 95,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "transitLeg": false,
+          "walkingBike": false
+        },
+        {
+          "agencyId": "prt:prt",
+          "agencyName": "TriMet",
+          "agencyTimeZoneOffset": 0,
+          "agencyUrl": "http://trimet.org",
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 3520.3249159419115,
+          "endTime": "2009-11-17T19:12:44.000+00:00",
+          "from": {
+            "arrival": "2009-11-17T19:00:00.000+00:00",
+            "departure": "2009-11-17T19:00:00.000+00:00",
+            "lat": 45.523103,
+            "lon": -122.653064,
+            "name": "NE Sandy & 12th",
+            "stopCode": "5055",
+            "stopId": "prt:5055",
+            "stopIndex": 94,
+            "stopSequence": 95,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
           "generalizedCost": 1364,
           "headsign": "23rd Ave to Tichner",
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "intermediateStops": [
             {
               "arrival": "2009-11-17T19:00:47.000+00:00",
               "departure": "2009-11-17T19:00:47.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523024,
-                  "longitude": -122.656526
-                },
-                "name": "E Burnside & NE 9th",
-                "stop": {
-                  "code": "819",
-                  "coordinate": {
-                    "latitude": 45.523024,
-                    "longitude": -122.656526
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 819)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "819"
-                  },
-                  "name": "E Burnside & NE 9th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 95,
-                "stopSequence": 96,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523024,
+              "lon": -122.656526,
+              "name": "E Burnside & NE 9th",
+              "stopCode": "819",
+              "stopId": "prt:819",
+              "stopIndex": 95,
+              "stopSequence": 96,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T19:01:24.000+00:00",
               "departure": "2009-11-17T19:01:24.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523012,
-                  "longitude": -122.659365
-                },
-                "name": "E Burnside & NE 6th",
-                "stop": {
-                  "code": "805",
-                  "coordinate": {
-                    "latitude": 45.523012,
-                    "longitude": -122.659365
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 805)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "805"
-                  },
-                  "name": "E Burnside & NE 6th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 96,
-                "stopSequence": 97,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523012,
+              "lon": -122.659365,
+              "name": "E Burnside & NE 6th",
+              "stopCode": "805",
+              "stopId": "prt:805",
+              "stopIndex": 96,
+              "stopSequence": 97,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T19:01:52.000+00:00",
               "departure": "2009-11-17T19:01:52.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523015,
-                  "longitude": -122.661534
-                },
-                "name": "E Burnside & NE M L King",
-                "stop": {
-                  "code": "705",
-                  "coordinate": {
-                    "latitude": 45.523015,
-                    "longitude": -122.661534
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 705)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "705"
-                  },
-                  "name": "E Burnside & NE M L King",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 97,
-                "stopSequence": 98,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523015,
+              "lon": -122.661534,
+              "name": "E Burnside & NE M L King",
+              "stopCode": "705",
+              "stopId": "prt:705",
+              "stopIndex": 97,
+              "stopSequence": 98,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T19:04:00.000+00:00",
               "departure": "2009-11-17T19:04:00.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523249,
-                  "longitude": -122.671269
-                },
-                "name": "W Burnside & Burnside Bridge",
-                "stop": {
-                  "code": "689",
-                  "coordinate": {
-                    "latitude": 45.523249,
-                    "longitude": -122.671269
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 689)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "689"
-                  },
-                  "name": "W Burnside & Burnside Bridge",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 98,
-                "stopSequence": 99,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523249,
+              "lon": -122.671269,
+              "name": "W Burnside & Burnside Bridge",
+              "stopCode": "689",
+              "stopId": "prt:689",
+              "stopIndex": 98,
+              "stopSequence": 99,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T19:05:00.000+00:00",
               "departure": "2009-11-17T19:05:00.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523169,
-                  "longitude": -122.675893
-                },
-                "name": "W Burnside & NW 5th",
-                "stop": {
-                  "code": "782",
-                  "coordinate": {
-                    "latitude": 45.523169,
-                    "longitude": -122.675893
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 782)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "782"
-                  },
-                  "name": "W Burnside & NW 5th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 99,
-                "stopSequence": 100,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523169,
+              "lon": -122.675893,
+              "name": "W Burnside & NW 5th",
+              "stopCode": "782",
+              "stopId": "prt:782",
+              "stopIndex": 99,
+              "stopSequence": 100,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T19:06:17.000+00:00",
               "departure": "2009-11-17T19:06:17.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523115,
-                  "longitude": -122.678939
-                },
-                "name": "W Burnside & NW Park",
-                "stop": {
-                  "code": "716",
-                  "coordinate": {
-                    "latitude": 45.523115,
-                    "longitude": -122.678939
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 716)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "716"
-                  },
-                  "name": "W Burnside & NW Park",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 100,
-                "stopSequence": 101,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523115,
+              "lon": -122.678939,
+              "name": "W Burnside & NW Park",
+              "stopCode": "716",
+              "stopId": "prt:716",
+              "stopIndex": 100,
+              "stopSequence": 101,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T19:07:25.000+00:00",
               "departure": "2009-11-17T19:07:25.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523048,
-                  "longitude": -122.681606
-                },
-                "name": "W Burnside & NW 10th",
-                "stop": {
-                  "code": "10791",
-                  "coordinate": {
-                    "latitude": 45.523048,
-                    "longitude": -122.681606
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 10791)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "10791"
-                  },
-                  "name": "W Burnside & NW 10th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 101,
-                "stopSequence": 102,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523048,
+              "lon": -122.681606,
+              "name": "W Burnside & NW 10th",
+              "stopCode": "10791",
+              "stopId": "prt:10791",
+              "stopIndex": 101,
+              "stopSequence": 102,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T19:08:14.000+00:00",
               "departure": "2009-11-17T19:08:14.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523,
-                  "longitude": -122.683535
-                },
-                "name": "W Burnside & NW 12th",
-                "stop": {
-                  "code": "11032",
-                  "coordinate": {
-                    "latitude": 45.523,
-                    "longitude": -122.683535
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 11032)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "0"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "11032"
-                  },
-                  "name": "W Burnside & NW 12th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 102,
-                "stopSequence": 103,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523,
+              "lon": -122.683535,
+              "name": "W Burnside & NW 12th",
+              "stopCode": "11032",
+              "stopId": "prt:11032",
+              "stopIndex": 102,
+              "stopSequence": 103,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
             },
             {
               "arrival": "2009-11-17T19:10:09.000+00:00",
               "departure": "2009-11-17T19:10:09.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.522985,
-                  "longitude": -122.688091
-                },
-                "name": "W Burnside & NW 17th",
-                "stop": {
-                  "code": "10809",
-                  "coordinate": {
-                    "latitude": 45.522985,
-                    "longitude": -122.688091
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 10809)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "10809"
-                  },
-                  "name": "W Burnside & NW 17th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 103,
-                "stopSequence": 104,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.522985,
+              "lon": -122.688091,
+              "name": "W Burnside & NW 17th",
+              "stopCode": "10809",
+              "stopId": "prt:10809",
+              "stopIndex": 103,
+              "stopSequence": 104,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T19:11:00.000+00:00",
               "departure": "2009-11-17T19:11:00.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523097,
-                  "longitude": -122.690083
-                },
-                "name": "W Burnside & NW 19th",
-                "stop": {
-                  "code": "735",
-                  "coordinate": {
-                    "latitude": 45.523097,
-                    "longitude": -122.690083
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 735)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "735"
-                  },
-                  "name": "W Burnside & NW 19th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 104,
-                "stopSequence": 105,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523097,
+              "lon": -122.690083,
+              "name": "W Burnside & NW 19th",
+              "stopCode": "735",
+              "stopId": "prt:735",
+              "stopIndex": 104,
+              "stopSequence": 105,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T19:11:27.000+00:00",
               "departure": "2009-11-17T19:11:27.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523176,
-                  "longitude": -122.692139
-                },
-                "name": "W Burnside & NW 20th",
-                "stop": {
-                  "code": "741",
-                  "coordinate": {
-                    "latitude": 45.523176,
-                    "longitude": -122.692139
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 741)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "741"
-                  },
-                  "name": "W Burnside & NW 20th",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 105,
-                "stopSequence": 106,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523176,
+              "lon": -122.692139,
+              "name": "W Burnside & NW 20th",
+              "stopCode": "741",
+              "stopId": "prt:741",
+              "stopIndex": 105,
+              "stopSequence": 106,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T19:11:40.000+00:00",
               "departure": "2009-11-17T19:11:40.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.52322,
-                  "longitude": -122.69313
-                },
-                "name": "W Burnside & NW 20th Pl",
-                "stop": {
-                  "code": "742",
-                  "coordinate": {
-                    "latitude": 45.52322,
-                    "longitude": -122.69313
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 742)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "742"
-                  },
-                  "name": "W Burnside & NW 20th Pl",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 106,
-                "stopSequence": 107,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.52322,
+              "lon": -122.69313,
+              "name": "W Burnside & NW 20th Pl",
+              "stopCode": "742",
+              "stopId": "prt:742",
+              "stopIndex": 106,
+              "stopSequence": 107,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T19:12:03.000+00:00",
               "departure": "2009-11-17T19:12:03.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.523312,
-                  "longitude": -122.694901
-                },
-                "name": "W Burnside & NW King",
-                "stop": {
-                  "code": "747",
-                  "coordinate": {
-                    "latitude": 45.523312,
-                    "longitude": -122.694901
-                  },
-                  "description": "Westbound stop in Portland (Stop ID 747)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "747"
-                  },
-                  "name": "W Burnside & NW King",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 107,
-                "stopSequence": 108,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.523312,
+              "lon": -122.694901,
+              "name": "W Burnside & NW King",
+              "stopCode": "747",
+              "stopId": "prt:747",
+              "stopIndex": 107,
+              "stopSequence": 108,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             }
           ],
           "legGeometry": {
@@ -11255,219 +5134,83 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "points": "weztGdtrkV?BPj@@jA?jEAhE?pD???VAjE?hE?dB?b@???`AAhE?dD???l@C`EAhEEhE?bAA|@?XAZ@\\AzACnGKbKAjC?bE???JEnE@fEDlE@hE@~A??@rBBzDBpE@~A???Z@tD@RBnEB|A???@BdB?lEBjA??BnBApF@dB?X?^@r@?f@@bCAx@EtB???VChAE|BGnD??AXKnEGnD???XGjD??AZEfCC`AEzB??AXCfAGxDE|AEtBIlC"
           },
           "mode": "BUS",
-          "onStreetNonTransit": false,
           "pathway": false,
           "realTime": false,
-          "scheduled": true,
-          "serviceDate": {
-            "day": 17,
-            "minMax": false,
-            "month": 11,
-            "sequenceNumber": 20091117,
-            "year": 2009
-          },
+          "route": "Burnside/Stark",
+          "routeId": "prt:20",
+          "routeLongName": "Burnside/Stark",
+          "routeShortName": "20",
+          "serviceDate": "2009-11-17",
           "startTime": "2009-11-17T19:00:00.000+00:00",
-          "streetNotes": [ ],
+          "steps": [ ],
           "to": {
-            "coordinate": {
-              "latitude": 45.523512,
-              "longitude": -122.698081
-            },
+            "arrival": "2009-11-17T19:12:44.000+00:00",
+            "departure": "2009-11-17T19:17:51.000+00:00",
+            "lat": 45.523512,
+            "lon": -122.698081,
             "name": "W Burnside & NW 23rd",
-            "stop": {
-              "code": "755",
-              "coordinate": {
-                "latitude": 45.523512,
-                "longitude": -122.698081
-              },
-              "description": "Westbound stop in Portland (Stop ID 755)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "755"
-              },
-              "name": "W Burnside & NW 23rd",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "755",
+            "stopId": "prt:755",
             "stopIndex": 108,
             "stopSequence": 109,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
-          "transitAlerts": [ ],
           "transitLeg": true,
-          "trip": {
-            "alteration": "PLANNED",
-            "bikesAllowed": "UNKNOWN",
-            "blockId": "2038",
-            "direction": "OUTBOUND",
-            "id": {
-              "feedId": "prt",
-              "id": "200W1230"
-            },
-            "route": {
-              "agency": {
-                "fareUrl": "http://trimet.org/fares/index.htm",
-                "id": {
-                  "feedId": "prt",
-                  "id": "prt"
-                },
-                "lang": "en",
-                "name": "TriMet",
-                "phone": "503-238-7433",
-                "timezone": "America/Los_Angeles",
-                "url": "http://trimet.org"
-              },
-              "bikesAllowed": "UNKNOWN",
-              "gtfsType": 3,
-              "id": {
-                "feedId": "prt",
-                "id": "20"
-              },
-              "longName": "Burnside/Stark",
-              "mode": "BUS",
-              "shortName": "20",
-              "sortOrder": -999,
-              "sortOrderSet": false,
-              "url": "http://trimet.org/schedules/r020.htm"
-            },
-            "serviceId": {
-              "feedId": "prt",
-              "id": "W"
-            },
-            "shapeId": {
-              "feedId": "prt",
-              "id": "20.0.6"
-            },
-            "wheelchairAccessible": 0
-          },
-          "walkSteps": [ ],
-          "walkingLeg": false
+          "tripBlockId": "2038",
+          "tripId": "prt:200W1230"
         },
         {
+          "agencyId": "prt:prt",
+          "agencyName": "TriMet",
           "agencyTimeZoneOffset": 0,
+          "agencyUrl": "http://trimet.org",
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 706.1004833986134,
+          "distance": 706.1004833986134,
           "endTime": "2009-11-17T19:21:00.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.523512,
-              "longitude": -122.698081
-            },
+            "arrival": "2009-11-17T19:12:44.000+00:00",
+            "departure": "2009-11-17T19:17:51.000+00:00",
+            "lat": 45.523512,
+            "lon": -122.698081,
             "name": "W Burnside & NW 23rd",
-            "stop": {
-              "code": "755",
-              "coordinate": {
-                "latitude": 45.523512,
-                "longitude": -122.698081
-              },
-              "description": "Westbound stop in Portland (Stop ID 755)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "755"
-              },
-              "name": "W Burnside & NW 23rd",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "755",
+            "stopId": "prt:755",
             "stopIndex": 70,
             "stopSequence": 71,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
           "generalizedCost": 1096,
           "headsign": "27th & Thurman",
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "intermediateStops": [
             {
               "arrival": "2009-11-17T19:18:53.000+00:00",
               "departure": "2009-11-17T19:18:53.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.525416,
-                  "longitude": -122.698381
-                },
-                "name": "NW 23rd & Flanders",
-                "stop": {
-                  "code": "7157",
-                  "coordinate": {
-                    "latitude": 45.525416,
-                    "longitude": -122.698381
-                  },
-                  "description": "Northbound stop in Portland (Stop ID 7157)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "7157"
-                  },
-                  "name": "NW 23rd & Flanders",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 71,
-                "stopSequence": 72,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.525416,
+              "lon": -122.698381,
+              "name": "NW 23rd & Flanders",
+              "stopCode": "7157",
+              "stopId": "prt:7157",
+              "stopIndex": 71,
+              "stopSequence": 72,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             },
             {
               "arrival": "2009-11-17T19:19:56.000+00:00",
               "departure": "2009-11-17T19:19:56.000+00:00",
-              "place": {
-                "coordinate": {
-                  "latitude": 45.527543,
-                  "longitude": -122.698473
-                },
-                "name": "NW 23rd & Irving",
-                "stop": {
-                  "code": "7161",
-                  "coordinate": {
-                    "latitude": 45.527543,
-                    "longitude": -122.698473
-                  },
-                  "description": "Northbound stop in Portland (Stop ID 7161)",
-                  "fareZones": [
-                    {
-                      "id": {
-                        "feedId": "prt",
-                        "id": "1"
-                      }
-                    }
-                  ],
-                  "id": {
-                    "feedId": "prt",
-                    "id": "7161"
-                  },
-                  "name": "NW 23rd & Irving",
-                  "partOfStation": false,
-                  "wheelchairBoarding": "NO_INFORMATION"
-                },
-                "stopIndex": 72,
-                "stopSequence": 73,
-                "vertexType": "TRANSIT"
-              }
+              "lat": 45.527543,
+              "lon": -122.698473,
+              "name": "NW 23rd & Irving",
+              "stopCode": "7161",
+              "stopId": "prt:7161",
+              "stopIndex": 72,
+              "stopSequence": 73,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             }
           ],
           "legGeometry": {
@@ -11475,304 +5218,168 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "points": "khztGbn{kVAPkAh@o@?sCB{BD??S?mCDmCDyBB??U?mCDmCDyBB"
           },
           "mode": "BUS",
-          "onStreetNonTransit": false,
           "pathway": false,
           "realTime": false,
-          "scheduled": true,
-          "serviceDate": {
-            "day": 17,
-            "minMax": false,
-            "month": 11,
-            "sequenceNumber": 20091117,
-            "year": 2009
-          },
+          "route": "Belmont/NW 23rd",
+          "routeId": "prt:15",
+          "routeLongName": "Belmont/NW 23rd",
+          "routeShortName": "15",
+          "serviceDate": "2009-11-17",
           "startTime": "2009-11-17T19:17:51.000+00:00",
-          "streetNotes": [ ],
+          "steps": [ ],
           "to": {
-            "coordinate": {
-              "latitude": 45.529681,
-              "longitude": -122.698529
-            },
+            "arrival": "2009-11-17T19:21:00.000+00:00",
+            "departure": "2009-11-17T19:21:00.000+00:00",
+            "lat": 45.529681,
+            "lon": -122.698529,
             "name": "NW 23rd & Lovejoy",
-            "stop": {
-              "code": "7163",
-              "coordinate": {
-                "latitude": 45.529681,
-                "longitude": -122.698529
-              },
-              "description": "Northbound stop in Portland (Stop ID 7163)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "7163"
-              },
-              "name": "NW 23rd & Lovejoy",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "7163",
+            "stopId": "prt:7163",
             "stopIndex": 73,
             "stopSequence": 74,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
-          "transitAlerts": [ ],
           "transitLeg": true,
-          "trip": {
-            "alteration": "PLANNED",
-            "bikesAllowed": "UNKNOWN",
-            "blockId": "1550",
-            "direction": "OUTBOUND",
-            "id": {
-              "feedId": "prt",
-              "id": "150W1430"
-            },
-            "route": {
-              "agency": {
-                "fareUrl": "http://trimet.org/fares/index.htm",
-                "id": {
-                  "feedId": "prt",
-                  "id": "prt"
-                },
-                "lang": "en",
-                "name": "TriMet",
-                "phone": "503-238-7433",
-                "timezone": "America/Los_Angeles",
-                "url": "http://trimet.org"
-              },
-              "bikesAllowed": "UNKNOWN",
-              "gtfsType": 3,
-              "id": {
-                "feedId": "prt",
-                "id": "15"
-              },
-              "longName": "Belmont/NW 23rd",
-              "mode": "BUS",
-              "shortName": "15",
-              "sortOrder": -999,
-              "sortOrderSet": false,
-              "url": "http://trimet.org/schedules/r015.htm"
-            },
-            "serviceId": {
-              "feedId": "prt",
-              "id": "W"
-            },
-            "shapeId": {
-              "feedId": "prt",
-              "id": "15.0.23"
-            },
-            "wheelchairAccessible": 0
-          },
-          "walkSteps": [ ],
-          "walkingLeg": false
+          "tripBlockId": "1550",
+          "tripId": "prt:150W1430"
         },
         {
           "agencyTimeZoneOffset": -28800000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 297.11,
+          "distance": 297.11,
           "endTime": "2009-11-17T19:25:04.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.529681,
-              "longitude": -122.698529
-            },
+            "arrival": "2009-11-17T19:21:00.000+00:00",
+            "departure": "2009-11-17T19:21:00.000+00:00",
+            "lat": 45.529681,
+            "lon": -122.698529,
             "name": "NW 23rd & Lovejoy",
-            "stop": {
-              "code": "7163",
-              "coordinate": {
-                "latitude": 45.529681,
-                "longitude": -122.698529
-              },
-              "description": "Northbound stop in Portland (Stop ID 7163)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "7163"
-              },
-              "name": "NW 23rd & Lovejoy",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
+            "stopCode": "7163",
+            "stopId": "prt:7163",
             "stopIndex": 73,
             "stopSequence": 74,
-            "vertexType": "TRANSIT"
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
           "generalizedCost": 462,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 15,
             "points": "oo{tGxp{kVG@?NM?M?_CD?B?FM?G@K?GBwADK?DpH"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-11-17T19:21:00.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.531,
-              "longitude": -122.70029
-            },
-            "name": "NW Northrup St. & NW 24th Ave. (P3)",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "WEST",
-              "angle": -1.5896261859144973,
               "area": false,
               "bogusName": true,
               "distance": 6.44,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.529726790620664,
+              "lon": -122.69853023095405,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.529726790620664,
-                "longitude": -122.69853023095405
-              },
               "stayOn": false,
-              "streetName": "way 158083864 from 0",
-              "streetNotes": [ ]
+              "streetName": "way 158083864 from 0"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": -0.02639098155686617,
               "area": false,
               "bogusName": false,
               "distance": 87.181,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5297257,
+              "lon": -122.69861290000001,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5297257,
-                "longitude": -122.69861290000001
-              },
               "stayOn": false,
-              "streetName": "Northwest 23rd Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 23rd Avenue"
             },
             {
               "absoluteDirection": "WEST",
-              "angle": -1.5917857716676513,
               "area": false,
               "bogusName": false,
               "distance": 4.768,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5305094,
+              "lon": -122.69864600000001,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.5305094,
-                "longitude": -122.69864600000001
-              },
               "stayOn": false,
-              "streetName": "Northwest Marshall Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Marshall Street"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": -0.023560834241705943,
               "area": false,
               "bogusName": true,
               "distance": 7.274,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5305085,
+              "lon": -122.6987072,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5305085,
-                "longitude": -122.6987072
-              },
               "stayOn": false,
-              "streetName": "way 158083033 from 0",
-              "streetNotes": [ ]
+              "streetName": "way 158083033 from 0"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": -0.014157951861867555,
               "area": false,
               "bogusName": false,
               "distance": 64.974,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5305739,
+              "lon": -122.69870940000001,
               "relativeDirection": "CONTINUE",
-              "startLocation": {
-                "latitude": 45.5305739,
-                "longitude": -122.69870940000001
-              },
               "stayOn": false,
-              "streetName": "Northwest 23rd Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 23rd Avenue"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": -0.07909846198417768,
               "area": false,
               "bogusName": true,
               "distance": 7.294,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.531153,
+              "lon": -122.69876060000001,
               "relativeDirection": "CONTINUE",
-              "startLocation": {
-                "latitude": 45.531153,
-                "longitude": -122.69876060000001
-              },
               "stayOn": false,
-              "streetName": "way 158083032 from 0",
-              "streetNotes": [ ]
+              "streetName": "way 158083032 from 0"
             },
             {
               "absoluteDirection": "WEST",
-              "angle": -1.598333529851037,
               "area": false,
               "bogusName": false,
               "distance": 119.179,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5312184,
+              "lon": -122.698768,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.5312184,
-                "longitude": -122.698768
-              },
               "stayOn": false,
-              "streetName": "Northwest Northrup Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Northrup Street"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
+          "to": {
+            "arrival": "2009-11-17T19:25:04.000+00:00",
+            "lat": 45.531,
+            "lon": -122.70029,
+            "name": "NW Northrup St. & NW 24th Ave. (P3)",
+            "vertexType": "NORMAL"
+          },
+          "transitLeg": false,
+          "walkingBike": false
         }
       ],
-      "nTransfers": 1,
-      "nonTransitDistanceMeters": 384.129,
-      "nonTransitTimeSeconds": 317,
-      "onStreetAllTheWay": false,
-      "streetOnly": false,
-      "systemNotices": [ ],
+      "startTime": "2009-11-17T18:58:47.000+00:00",
       "tooSloped": false,
-      "transferPriorityCost": 33,
-      "transitTimeSeconds": 953,
-      "waitTimeOptimizedCost": -229,
-      "waitingTimeSeconds": 307,
-      "walkOnly": false,
-      "walkingAllTheWay": false
+      "transfers": 1,
+      "transitTime": 953,
+      "waitingTime": 307,
+      "walkDistance": 384.129,
+      "walkLimitExceeded": false,
+      "walkTime": 317
     }
   ]
 ]
@@ -11781,364 +5388,267 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
 org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_planning_with_walk_only=[
   [
     {
-      "arrivedAtDestinationWithRentedVehicle": false,
-      "durationSeconds": 3804,
+      "arrivedAtDestinationWithRentedBicycle": false,
+      "duration": 3804,
       "elevationGained": 0.0,
       "elevationLost": 0.0,
+      "endTime": "2009-11-17T19:03:24.000+00:00",
       "fare": {
         "details": { },
         "fare": { }
       },
-      "flaggedForDeletion": false,
       "generalizedCost": 7384,
       "legs": [
         {
           "agencyTimeZoneOffset": -28800000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 4875.788999999999,
+          "distance": 4875.788999999999,
           "endTime": "2009-11-17T19:03:24.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.51932,
-              "longitude": -122.648567
-            },
+            "departure": "2009-11-17T18:00:00.000+00:00",
+            "lat": 45.51932,
+            "lon": -122.648567,
             "name": "SE Stark    St. & SE 17th Ave. (P0)",
             "vertexType": "NORMAL"
           },
           "generalizedCost": 7384,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 252,
             "points": "unytGpxqkVA??dACpB@P?f@?p@?j@?dAAhE?jE?vD?P?RK?GFCDCFADABADADAF?D?FADCF?B?B?@?D@DADABCBC?A?C?AA??GICAAAA?A?A?AACAC?A@ABABC@CDCBCBC@CBABABCJ?J?@?@MR?hE?fEAdB?dB?lE?`A?T?pBA|D?J?x@?r@y@??bBuA?y@AU?{@?O?}@?E?y@?_@Aa@?u@?W??J@N?hA@x@Ap@ATETGpJCjEA|CArAAxAAxAAdBEzHClF?@Ax@GTAjBAZ?R@hC@h@Q@cBBM?M?_CDsA@Y?Q@O?K?Q?mBB[?C?W@[?]@E?IDI@]DO@SBM?S@G@A?GDEJQ|@AL?L@nA?j@@L?V?d@@~@@NI?E?W@Q?Q?m@@Q@AF?DAJBzB?V?NANM@K?GBEDEHIJUX_@f@KNQRSVGFCBQPIHGDGBIBK@W@a@?mA@E?C@C@A?CBQTKJEHIJeC~CYZo@v@g@d@IJAFAD?L@vC@hB@p@?X?T@P?N@P@nA?j@AX?L@`B@dA?R?RBbD?T?NBbD?R?P@|D@jB?x@@J?N?B?P?LBjD@N@fD?T?LBdD?R?PF`K?RDlJ?R?PFlJ?J"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-11-17T18:00:00.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.53122,
-              "longitude": -122.69659
-            },
-            "name": "NW Northrup St. & NW 22nd Ave. (P2)",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "NORTH",
-              "angle": 0.005027264987678128,
               "area": false,
               "bogusName": false,
               "distance": 0.69,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.51931999240744,
+              "lon": -122.64856484453956,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.51931999240744,
-                "longitude": -122.64856484453956
-              },
               "stayOn": false,
-              "streetName": "Southeast 17th Avenue",
-              "streetNotes": [ ]
+              "streetName": "Southeast 17th Avenue"
             },
             {
               "absoluteDirection": "WEST",
-              "angle": -1.563502376862697,
               "area": false,
               "bogusName": false,
               "distance": 402.49899999999997,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5193262,
+              "lon": -122.6485648,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.5193262,
-                "longitude": -122.6485648
-              },
               "stayOn": false,
-              "streetName": "Southeast Stark Street",
-              "streetNotes": [ ]
+              "streetName": "Southeast Stark Street"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": -0.021995448871088733,
               "area": false,
               "bogusName": true,
               "distance": 7.084,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5193421,
+              "lon": -122.65373050000001,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5193421,
-                "longitude": -122.65373050000001
-              },
               "stayOn": false,
-              "streetName": "way 226431264 from 0",
-              "streetNotes": [ ]
+              "streetName": "way 226431264 from 0"
             },
             {
               "absoluteDirection": "NORTHWEST",
-              "angle": -0.815473399597555,
               "area": false,
               "bogusName": true,
               "distance": 55.955,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5194058,
+              "lon": -122.6537325,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.5194058,
-                "longitude": -122.6537325
-              },
               "stayOn": true,
-              "streetName": "way 226431263 from 21",
-              "streetNotes": [ ]
+              "streetName": "way 226431263 from 21"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": 0.24897432162446365,
               "area": false,
               "bogusName": true,
               "distance": 68.713,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5196271,
+              "lon": -122.65431720000001,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5196271,
-                "longitude": -122.65431720000001
-              },
               "stayOn": true,
-              "streetName": "way 226431263 from 23",
-              "streetNotes": [ ]
+              "streetName": "way 226431263 from 23"
             },
             {
               "absoluteDirection": "WEST",
-              "angle": -1.5660263134574557,
               "area": false,
               "bogusName": false,
               "distance": 516.483,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5200623,
+              "lon": -122.6546522,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.5200623,
-                "longitude": -122.6546522
-              },
               "stayOn": false,
-              "streetName": "Southeast Oak Street",
-              "streetNotes": [ ]
+              "streetName": "Southeast Oak Street"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": -0.006329690506327446,
               "area": false,
               "bogusName": true,
               "distance": 70.838,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5200842,
+              "lon": -122.66128140000001,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5200842,
-                "longitude": -122.66128140000001
-              },
               "stayOn": false,
-              "streetName": "way 257064467 from 1",
-              "streetNotes": [ ]
+              "streetName": "way 257064467 from 1"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": 0.00450681094739917,
               "area": false,
               "bogusName": false,
               "distance": 284.735,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.520373600000006,
+              "lon": -122.66178300000001,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.520373600000006,
-                "longitude": -122.66178300000001
-              },
               "stayOn": false,
-              "streetName": "Southeast Martin Luther King, Junior Boulevard",
-              "streetNotes": [ ]
+              "streetName": "Southeast Martin Luther King, Junior Boulevard"
             },
             {
               "absoluteDirection": "WEST",
-              "angle": -1.623532134494845,
               "area": false,
               "bogusName": false,
               "distance": 243.448,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5229343,
+              "lon": -122.66176650000001,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.5229343,
-                "longitude": -122.66176650000001
-              },
               "stayOn": false,
-              "streetName": "East Burnside Street",
-              "streetNotes": [ ]
+              "streetName": "East Burnside Street"
             },
             {
               "absoluteDirection": "WEST",
-              "angle": -1.5429374364857065,
               "area": false,
               "bogusName": false,
               "distance": 407.384,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.523001,
+              "lon": -122.6648816,
               "relativeDirection": "CONTINUE",
-              "startLocation": {
-                "latitude": 45.523001,
-                "longitude": -122.6648816
-              },
               "stayOn": false,
-              "streetName": "Burnside Bridge",
-              "streetNotes": [ ]
+              "streetName": "Burnside Bridge"
             },
             {
               "absoluteDirection": "WEST",
-              "angle": -1.5423269695355575,
               "area": false,
               "bogusName": false,
               "distance": 256.851,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.523105400000006,
+              "lon": -122.67010870000001,
               "relativeDirection": "CONTINUE",
-              "startLocation": {
-                "latitude": 45.523105400000006,
-                "longitude": -122.67010870000001
-              },
               "stayOn": false,
-              "streetName": "West Burnside Street",
-              "streetNotes": [ ]
+              "streetName": "West Burnside Street"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": -0.028022114817565644,
               "area": false,
               "bogusName": false,
               "distance": 460.622,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.523177600000004,
+              "lon": -122.67338950000001,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.523177600000004,
-                "longitude": -122.67338950000001
-              },
               "stayOn": false,
-              "streetName": "Northwest 3rd Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 3rd Avenue"
             },
             {
               "absoluteDirection": "WEST",
-              "angle": -1.1944859782105497,
               "area": false,
               "bogusName": false,
               "distance": 145.81199999999998,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.527286600000004,
+              "lon": -122.67371650000001,
               "relativeDirection": "SLIGHTLY_LEFT",
-              "startLocation": {
-                "latitude": 45.527286600000004,
-                "longitude": -122.67371650000001
-              },
               "stayOn": false,
-              "streetName": "Northwest Hoyt Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Hoyt Street"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": -0.029032765206574367,
               "area": false,
               "bogusName": false,
               "distance": 77.353,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5273496,
+              "lon": -122.6755629,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5273496,
-                "longitude": -122.6755629
-              },
               "stayOn": false,
-              "streetName": "Northwest 5th Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 5th Avenue"
             },
             {
               "absoluteDirection": "WEST",
-              "angle": -1.4107231165936804,
               "area": false,
               "bogusName": false,
               "distance": 80.53,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.528044900000005,
+              "lon": -122.6755935,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.528044900000005,
-                "longitude": -122.6755935
-              },
               "stayOn": false,
-              "streetName": "Northwest Irving Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Irving Street"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": -0.07553970510661134,
               "area": false,
               "bogusName": false,
               "distance": 465.426,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.528051500000004,
+              "lon": -122.67662320000001,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.528051500000004,
-                "longitude": -122.67662320000001
-              },
               "stayOn": false,
-              "streetName": "Northwest Station Way",
-              "streetNotes": [ ]
+              "streetName": "Northwest Station Way"
             },
             {
               "absoluteDirection": "WEST",
-              "angle": -1.3840041579257698,
               "area": false,
               "bogusName": false,
               "distance": 1331.3660000000002,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.531545200000004,
+              "lon": -122.679511,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.531545200000004,
-                "longitude": -122.679511
-              },
               "stayOn": false,
-              "streetName": "Northwest Northrup Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Northrup Street"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
+          "to": {
+            "arrival": "2009-11-17T19:03:24.000+00:00",
+            "lat": 45.53122,
+            "lon": -122.69659,
+            "name": "NW Northrup St. & NW 22nd Ave. (P2)",
+            "vertexType": "NORMAL"
+          },
+          "transitLeg": false,
+          "walkingBike": false
         }
       ],
-      "nTransfers": 0,
-      "nonTransitDistanceMeters": 4875.788999999999,
-      "nonTransitTimeSeconds": 3804,
-      "onStreetAllTheWay": true,
-      "streetOnly": true,
-      "systemNotices": [ ],
+      "startTime": "2009-11-17T18:00:00.000+00:00",
       "tooSloped": false,
-      "transferPriorityCost": -1,
-      "transitTimeSeconds": 0,
-      "waitTimeOptimizedCost": -1,
-      "waitingTimeSeconds": 0,
-      "walkOnly": true,
-      "walkingAllTheWay": true
+      "transfers": 0,
+      "transitTime": 0,
+      "waitingTime": 0,
+      "walkDistance": 4875.788999999999,
+      "walkLimitExceeded": false,
+      "walkTime": 3804
     }
   ]
 ]
@@ -12147,268 +5657,186 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
 org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_planning_with_walk_only_stop=[
   [
     {
-      "arrivedAtDestinationWithRentedVehicle": false,
-      "durationSeconds": 3230,
+      "arrivedAtDestinationWithRentedBicycle": false,
+      "duration": 3230,
       "elevationGained": 0.0,
       "elevationLost": 0.0,
+      "endTime": "2009-11-17T18:53:50.000+00:00",
       "fare": {
         "details": { },
         "fare": { }
       },
-      "flaggedForDeletion": false,
       "generalizedCost": 6283,
       "legs": [
         {
           "agencyTimeZoneOffset": -28800000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 4154.147999999998,
+          "distance": 4154.147999999998,
           "endTime": "2009-11-17T18:53:50.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.52337,
-              "longitude": -122.653725
-            },
+            "departure": "2009-11-17T18:00:00.000+00:00",
+            "lat": 45.52337,
+            "lon": -122.653725,
             "name": "NE 12th & Couch",
-            "stop": {
-              "code": "6577",
-              "coordinate": {
-                "latitude": 45.52337,
-                "longitude": -122.653725
-              },
-              "description": "Southbound stop in Portland (Stop ID 6577)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "1"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "6577"
-              },
-              "name": "NE 12th & Couch",
-              "partOfStation": false,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
-            "vertexType": "TRANSIT"
+            "stopCode": "6577",
+            "stopId": "prt:6577",
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
           },
           "generalizedCost": 6283,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 202,
             "points": "ahztGxxrkV@Sb@?`@@T??V?vCAT?R?`D?T?RA`D?R?R?t@?n@?z@?T?R?jB?@?r@?R?R?tA?\\?l@?R?T?VAd@?jA?N?N?J?Z?jA?z@?P?Z?J@N?hA@x@Ap@ATETGpJCjEA|CArAAxAAxAAdBEzHClF?@Ax@GTAjBAZ?R@hC@h@Q@cBBM?M?_CDsA@Y?Q@O?K?Q?mBB[?C?W@[?]@E?IDI@]DO@SBM?S@G@A?GDEJQ|@AL?L@nA?j@@L?V?d@@~@@NI?E?W@Q?Q?m@@Q@AF?DAJBzB?V?NANM@K?GBEDEHIJUX_@f@KNQRSVGFCBQPIHGDGBIBK@W@a@?mA@E?C@C@A?CBQTKJEHIJeC~CYZo@v@g@d@IJAFAD?L@vC@hB@p@?X?T@P?N@P@nA?j@AX?L@`B@dA?R?RBbD?T?NBbD?R?P@|D@jB?x@@J?N?B?P?LBjD@N@fD?T?LBdD?R?PF`K?RDlJ?R?PFlJ?J"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-11-17T18:00:00.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.53122,
-              "longitude": -122.69659
-            },
-            "name": "NW Northrup St. & NW 22nd Ave. (P2)",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "SOUTH",
-              "angle": -3.1191187064694192,
               "area": false,
               "bogusName": false,
               "distance": 51.525,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.52336838632084,
+              "lon": -122.65362253301092,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.52336838632084,
-                "longitude": -122.65362253301092
-              },
               "stayOn": false,
-              "streetName": "Northeast 12th Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northeast 12th Avenue"
             },
             {
               "absoluteDirection": "WEST",
-              "angle": -1.5608232952160197,
               "area": false,
               "bogusName": false,
               "distance": 877.279,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5229051,
+              "lon": -122.6536312,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5229051,
-                "longitude": -122.6536312
-              },
               "stayOn": false,
-              "streetName": "East Burnside Street",
-              "streetNotes": [ ]
+              "streetName": "East Burnside Street"
             },
             {
               "absoluteDirection": "WEST",
-              "angle": -1.5429374364857065,
               "area": false,
               "bogusName": false,
               "distance": 407.384,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.523001,
+              "lon": -122.6648816,
               "relativeDirection": "CONTINUE",
-              "startLocation": {
-                "latitude": 45.523001,
-                "longitude": -122.6648816
-              },
               "stayOn": false,
-              "streetName": "Burnside Bridge",
-              "streetNotes": [ ]
+              "streetName": "Burnside Bridge"
             },
             {
               "absoluteDirection": "WEST",
-              "angle": -1.5423269695355575,
               "area": false,
               "bogusName": false,
               "distance": 256.851,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.523105400000006,
+              "lon": -122.67010870000001,
               "relativeDirection": "CONTINUE",
-              "startLocation": {
-                "latitude": 45.523105400000006,
-                "longitude": -122.67010870000001
-              },
               "stayOn": false,
-              "streetName": "West Burnside Street",
-              "streetNotes": [ ]
+              "streetName": "West Burnside Street"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": -0.028022114817565644,
               "area": false,
               "bogusName": false,
               "distance": 460.622,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.523177600000004,
+              "lon": -122.67338950000001,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.523177600000004,
-                "longitude": -122.67338950000001
-              },
               "stayOn": false,
-              "streetName": "Northwest 3rd Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 3rd Avenue"
             },
             {
               "absoluteDirection": "WEST",
-              "angle": -1.1944859782105497,
               "area": false,
               "bogusName": false,
               "distance": 145.81199999999998,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.527286600000004,
+              "lon": -122.67371650000001,
               "relativeDirection": "SLIGHTLY_LEFT",
-              "startLocation": {
-                "latitude": 45.527286600000004,
-                "longitude": -122.67371650000001
-              },
               "stayOn": false,
-              "streetName": "Northwest Hoyt Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Hoyt Street"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": -0.029032765206574367,
               "area": false,
               "bogusName": false,
               "distance": 77.353,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5273496,
+              "lon": -122.6755629,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5273496,
-                "longitude": -122.6755629
-              },
               "stayOn": false,
-              "streetName": "Northwest 5th Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 5th Avenue"
             },
             {
               "absoluteDirection": "WEST",
-              "angle": -1.4107231165936804,
               "area": false,
               "bogusName": false,
               "distance": 80.53,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.528044900000005,
+              "lon": -122.6755935,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.528044900000005,
-                "longitude": -122.6755935
-              },
               "stayOn": false,
-              "streetName": "Northwest Irving Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Irving Street"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": -0.07553970510661134,
               "area": false,
               "bogusName": false,
               "distance": 465.426,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.528051500000004,
+              "lon": -122.67662320000001,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.528051500000004,
-                "longitude": -122.67662320000001
-              },
               "stayOn": false,
-              "streetName": "Northwest Station Way",
-              "streetNotes": [ ]
+              "streetName": "Northwest Station Way"
             },
             {
               "absoluteDirection": "WEST",
-              "angle": -1.3840041579257698,
               "area": false,
               "bogusName": false,
               "distance": 1331.3660000000002,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.531545200000004,
+              "lon": -122.679511,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.531545200000004,
-                "longitude": -122.679511
-              },
               "stayOn": false,
-              "streetName": "Northwest Northrup Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Northrup Street"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
+          "to": {
+            "arrival": "2009-11-17T18:53:50.000+00:00",
+            "lat": 45.53122,
+            "lon": -122.69659,
+            "name": "NW Northrup St. & NW 22nd Ave. (P2)",
+            "vertexType": "NORMAL"
+          },
+          "transitLeg": false,
+          "walkingBike": false
         }
       ],
-      "nTransfers": 0,
-      "nonTransitDistanceMeters": 4154.147999999998,
-      "nonTransitTimeSeconds": 3230,
-      "onStreetAllTheWay": true,
-      "streetOnly": true,
-      "systemNotices": [ ],
+      "startTime": "2009-11-17T18:00:00.000+00:00",
       "tooSloped": false,
-      "transferPriorityCost": -1,
-      "transitTimeSeconds": 0,
-      "waitTimeOptimizedCost": -1,
-      "waitingTimeSeconds": 0,
-      "walkOnly": true,
-      "walkingAllTheWay": true
+      "transfers": 0,
+      "transitTime": 0,
+      "waitingTime": 0,
+      "walkDistance": 4154.147999999998,
+      "walkLimitExceeded": false,
+      "walkTime": 3230
     }
   ]
 ]
@@ -12417,469 +5845,246 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
 org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_planning_with_walk_only_stop_collection=[
   [
     {
-      "arrivedAtDestinationWithRentedVehicle": false,
-      "durationSeconds": 2361,
+      "arrivedAtDestinationWithRentedBicycle": false,
+      "duration": 2361,
       "elevationGained": 0.0,
       "elevationLost": 0.0,
+      "endTime": "2009-11-17T18:39:21.000+00:00",
       "fare": {
         "details": { },
         "fare": { }
       },
-      "flaggedForDeletion": false,
       "generalizedCost": 4557,
       "legs": [
         {
           "agencyTimeZoneOffset": -28800000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distanceMeters": 2989.7960000000003,
+          "distance": 2989.7960000000003,
           "endTime": "2009-11-17T18:39:21.000+00:00",
-          "flexibleTrip": false,
           "from": {
-            "coordinate": {
-              "latitude": 45.530244,
-              "longitude": -122.667794
-            },
+            "departure": "2009-11-17T18:00:00.000+00:00",
+            "lat": 45.530244,
+            "lon": -122.667794,
             "name": "Interstate/Rose Quarter MAX Station",
-            "stop": {
-              "code": "11508",
-              "coordinate": {
-                "latitude": 45.530244,
-                "longitude": -122.667794
-              },
-              "description": "Northbound stop in Portland (Stop ID 11508)",
-              "fareZones": [
-                {
-                  "id": {
-                    "feedId": "prt",
-                    "id": "0"
-                  }
-                }
-              ],
-              "id": {
-                "feedId": "prt",
-                "id": "11508"
-              },
-              "name": "Interstate/Rose Quarter MAX Station",
-              "parentStation": {
-                "code": "79-tc",
-                "coordinate": {
-                  "latitude": 45.530205,
-                  "longitude": -122.666118
-                },
-                "geometry": {
-                  "SRID": 0,
-                  "empty": false,
-                  "factory": {
-                    "SRID": 0,
-                    "coordinateSequenceFactory": { },
-                    "precisionModel": {
-                      "floating": true,
-                      "modelType": {
-                        "name": "FLOATING"
-                      },
-                      "scale": 0.0
-                    }
-                  },
-                  "geometries": [
-                    {
-                      "SRID": 0,
-                      "coordinates": {
-                        "coords": [
-                          -122.666118,
-                          45.530205
-                        ],
-                        "dimension": 2
-                      },
-                      "empty": false,
-                      "factory": {
-                        "SRID": 0,
-                        "coordinateSequenceFactory": { },
-                        "precisionModel": {
-                          "floating": true,
-                          "modelType": {
-                            "name": "FLOATING"
-                          },
-                          "scale": 0.0
-                        }
-                      },
-                      "rectangle": false,
-                      "simple": true,
-                      "valid": true
-                    },
-                    {
-                      "SRID": 0,
-                      "empty": false,
-                      "factory": {
-                        "SRID": 0,
-                        "coordinateSequenceFactory": { },
-                        "precisionModel": {
-                          "floating": true,
-                          "modelType": {
-                            "name": "FLOATING"
-                          },
-                          "scale": 0.0
-                        }
-                      },
-                      "holes": [ ],
-                      "rectangle": false,
-                      "shell": {
-                        "SRID": 0,
-                        "closed": true,
-                        "empty": false,
-                        "factory": {
-                          "SRID": 0,
-                          "coordinateSequenceFactory": { },
-                          "precisionModel": {
-                            "floating": true,
-                            "modelType": {
-                              "name": "FLOATING"
-                            },
-                            "scale": 0.0
-                          }
-                        },
-                        "points": {
-                          "coords": [
-                            -122.666322,
-                            45.529724,
-                            -122.667591,
-                            45.529829,
-                            -122.667794,
-                            45.530244,
-                            -122.66599,
-                            45.530703,
-                            -122.665648,
-                            45.53069,
-                            -122.665697,
-                            45.529888,
-                            -122.666322,
-                            45.529724
-                          ],
-                          "dimension": 2
-                        },
-                        "rectangle": false,
-                        "ring": true,
-                        "simple": true,
-                        "valid": true
-                      },
-                      "simple": true,
-                      "valid": true
-                    }
-                  ],
-                  "rectangle": false,
-                  "simple": true,
-                  "valid": true
-                },
-                "id": {
-                  "feedId": "prt",
-                  "id": "79-tc"
-                },
-                "name": "Rose Quarter Transit Center",
-                "priority": "ALLOWED"
-              },
-              "partOfStation": true,
-              "wheelchairBoarding": "NO_INFORMATION"
-            },
-            "vertexType": "TRANSIT"
+            "stopCode": "11508",
+            "stopId": "prt:11508",
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
           },
           "generalizedCost": 4557,
-          "interlinedWithPreviousLeg": false,
+          "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 173,
             "points": "_s{tGvpukV??c@tADDFDDDHHYx@Wt@{@lBS^MROZ]h@Y`@[`@k@r@kAtASVEDa@f@EDm@l@s@p@JVA@GOCBzEfKxF`M|AfDJRLPVb@DBBBBBDBB@CRE\\C?A@A@ABAB?DAHATC\\AXAVCZATAPAPATG`AATAPAL?J?F?F?D?F@x@AJ@D@B@DAB?RK@I??TBlBCJ?D?BAFAB?DADABEFCDA@CDC?c@@{@@O?K??LCDC??LC?G?E@GBE?KCI?EFC@?N?F?D?BABA@AD?D?B?D@B@BABAB?D?DADABABABC@A@I@IZCFIJ?L@`B@dA?R?RBbD?T?NBbD?R?P@|D@jB?x@@J?N?B?P?LBjD@N@fD?T?LBdD?R?PF`K?RDlJ?R?PFlJ?RDbH@xA?D?P?RDpH"
           },
           "mode": "WALK",
-          "onStreetNonTransit": true,
           "pathway": false,
           "realTime": false,
-          "rentedVehicle": false,
-          "scheduled": false,
+          "rentedBike": false,
+          "route": "",
           "startTime": "2009-11-17T18:00:00.000+00:00",
-          "streetNotes": [ ],
-          "to": {
-            "coordinate": {
-              "latitude": 45.531,
-              "longitude": -122.70029
-            },
-            "name": "NW Northrup St. & NW 24th Ave. (P3)",
-            "vertexType": "NORMAL"
-          },
-          "transitAlerts": [ ],
-          "transitLeg": false,
-          "walkSteps": [
+          "steps": [
             {
               "absoluteDirection": "NORTHWEST",
-              "angle": -1.0117505068799668,
               "area": false,
               "bogusName": false,
               "distance": 39.035,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.53024090735772,
+              "lon": -122.66779676192563,
               "relativeDirection": "DEPART",
-              "startLocation": {
-                "latitude": 45.53024090735772,
-                "longitude": -122.66779676192563
-              },
               "stayOn": false,
-              "streetName": "Interstate/Rose Quarter Northbound Yellow Line MAX Platform",
-              "streetNotes": [ ]
+              "streetName": "Interstate/Rose Quarter Northbound Yellow Line MAX Platform"
             },
             {
               "absoluteDirection": "SOUTHWEST",
-              "angle": -2.5578844637953133,
               "area": false,
               "bogusName": true,
               "distance": 20.608,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.530427100000004,
+              "lon": -122.66822160000001,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.530427100000004,
-                "longitude": -122.66822160000001
-              },
               "stayOn": false,
-              "streetName": "way 125785939 from 4",
-              "streetNotes": [ ]
+              "streetName": "way 125785939 from 4"
             },
             {
               "absoluteDirection": "NORTHWEST",
-              "angle": -1.0040390128191803,
               "area": false,
               "bogusName": false,
               "distance": 410.023,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5302724,
+              "lon": -122.66836730000001,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5302724,
-                "longitude": -122.66836730000001
-              },
               "stayOn": false,
-              "streetName": "North Interstate Avenue",
-              "streetNotes": [ ]
+              "streetName": "North Interstate Avenue"
             },
             {
               "absoluteDirection": "SOUTHWEST",
-              "angle": -2.1939957467118765,
               "area": false,
               "bogusName": true,
               "distance": 40.36,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.532912800000005,
+              "lon": -122.67197920000001,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.532912800000005,
-                "longitude": -122.67197920000001
-              },
               "stayOn": false,
-              "streetName": "way 117315127 from 2",
-              "streetNotes": [ ]
+              "streetName": "way 117315127 from 2"
             },
             {
               "absoluteDirection": "NORTHWEST",
-              "angle": -0.5513565900563633,
               "area": false,
               "bogusName": true,
               "distance": 2.245,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.532907900000005,
+              "lon": -122.67202800000001,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.532907900000005,
-                "longitude": -122.67202800000001
-              },
               "stayOn": true,
-              "streetName": "way 117315115 from 0",
-              "streetNotes": [ ]
+              "streetName": "way 117315115 from 0"
             },
             {
               "absoluteDirection": "SOUTHWEST",
-              "angle": -2.244625586005241,
               "area": false,
               "bogusName": false,
               "distance": 543.668,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5329251,
+              "lon": -122.67204310000001,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.5329251,
-                "longitude": -122.67204310000001
-              },
               "stayOn": false,
-              "streetName": "Broadway Bridge",
-              "streetNotes": [ ]
+              "streetName": "Broadway Bridge"
             },
             {
               "absoluteDirection": "SOUTHWEST",
-              "angle": -2.6328128620177256,
               "area": false,
               "bogusName": false,
               "distance": 14.158,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5298506,
+              "lon": -122.67746670000001,
               "relativeDirection": "CONTINUE",
-              "startLocation": {
-                "latitude": 45.5298506,
-                "longitude": -122.67746670000001
-              },
               "stayOn": false,
-              "streetName": "Northwest Broadway",
-              "streetNotes": [ ]
+              "streetName": "Northwest Broadway"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": -0.3605525651149334,
               "area": false,
               "bogusName": false,
               "distance": 23.666,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5297871,
+              "lon": -122.67780010000001,
               "relativeDirection": "UTURN_RIGHT",
-              "startLocation": {
-                "latitude": 45.5297871,
-                "longitude": -122.67780010000001
-              },
               "stayOn": true,
-              "streetName": "Northwest Broadway",
-              "streetNotes": [ ]
+              "streetName": "Northwest Broadway"
             },
             {
               "absoluteDirection": "NORTHWEST",
-              "angle": -0.824039902719837,
               "area": false,
               "bogusName": false,
               "distance": 298.376,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.529817200000004,
+              "lon": -122.6778163,
               "relativeDirection": "SLIGHTLY_LEFT",
-              "startLocation": {
-                "latitude": 45.529817200000004,
-                "longitude": -122.6778163
-              },
               "stayOn": false,
-              "streetName": "Northwest Lovejoy Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Lovejoy Street"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": -0.02530676616508235,
               "area": false,
               "bogusName": false,
               "distance": 71.22,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5302432,
+              "lon": -122.6813836,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.5302432,
-                "longitude": -122.6813836
-              },
               "stayOn": false,
-              "streetName": "Northwest 10th Avenue",
-              "streetNotes": [ ]
+              "streetName": "Northwest 10th Avenue"
             },
             {
               "absoluteDirection": "WEST",
-              "angle": -1.6009032896942996,
               "area": false,
               "bogusName": false,
               "distance": 5.54,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5308835,
+              "lon": -122.68140700000001,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.5308835,
-                "longitude": -122.68140700000001
-              },
               "stayOn": false,
-              "streetName": "Northwest Marshall Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Marshall Street"
             },
             {
               "absoluteDirection": "NORTHWEST",
-              "angle": -0.43945025938890175,
               "area": false,
               "bogusName": true,
               "distance": 5.888,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.530882000000005,
+              "lon": -122.6814781,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.530882000000005,
-                "longitude": -122.6814781
-              },
               "stayOn": false,
-              "streetName": "way 117751890 from 1",
-              "streetNotes": [ ]
+              "streetName": "way 117751890 from 1"
             },
             {
               "absoluteDirection": "WEST",
-              "angle": -1.2367914711217416,
               "area": false,
               "bogusName": false,
               "distance": 7.364,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5309273,
+              "lon": -122.6815085,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.5309273,
-                "longitude": -122.6815085
-              },
               "stayOn": false,
-              "streetName": "Tanner Springs Park",
-              "streetNotes": [ ]
+              "streetName": "Tanner Springs Park"
             },
             {
               "absoluteDirection": "NORTH",
-              "angle": -0.023281899787656588,
               "area": false,
               "bogusName": false,
               "distance": 116.77899999999998,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.530944000000005,
+              "lon": -122.6815772,
               "relativeDirection": "RIGHT",
-              "startLocation": {
-                "latitude": 45.530944000000005,
-                "longitude": -122.6815772
-              },
               "stayOn": false,
-              "streetName": "Tanner Springs Park Trail",
-              "streetNotes": [ ]
+              "streetName": "Tanner Springs Park Trail"
             },
             {
               "absoluteDirection": "WEST",
-              "angle": -1.5979804349450852,
               "area": false,
               "bogusName": false,
               "distance": 1390.866,
-              "edges": [ ],
-              "elevation": [ ],
+              "elevation": "",
+              "lat": 45.5315117,
+              "lon": -122.68244770000001,
               "relativeDirection": "LEFT",
-              "startLocation": {
-                "latitude": 45.5315117,
-                "longitude": -122.68244770000001
-              },
               "stayOn": false,
-              "streetName": "Northwest Northrup Street",
-              "streetNotes": [ ]
+              "streetName": "Northwest Northrup Street"
             }
           ],
-          "walkingBike": false,
-          "walkingLeg": true
+          "to": {
+            "arrival": "2009-11-17T18:39:21.000+00:00",
+            "lat": 45.531,
+            "lon": -122.70029,
+            "name": "NW Northrup St. & NW 24th Ave. (P3)",
+            "vertexType": "NORMAL"
+          },
+          "transitLeg": false,
+          "walkingBike": false
         }
       ],
-      "nTransfers": 0,
-      "nonTransitDistanceMeters": 2989.7960000000003,
-      "nonTransitTimeSeconds": 2361,
-      "onStreetAllTheWay": true,
-      "streetOnly": true,
-      "systemNotices": [ ],
+      "startTime": "2009-11-17T18:00:00.000+00:00",
       "tooSloped": false,
-      "transferPriorityCost": -1,
-      "transitTimeSeconds": 0,
-      "waitTimeOptimizedCost": -1,
-      "waitingTimeSeconds": 0,
-      "walkOnly": true,
-      "walkingAllTheWay": true
+      "transfers": 0,
+      "transitTime": 0,
+      "waitingTime": 0,
+      "walkDistance": 2989.7960000000003,
+      "walkLimitExceeded": false,
+      "walkTime": 2361
     }
   ]
 ]


### PR DESCRIPTION
### Summary

Currently we use the internal object for the snapshot tests. This changes the tests to utilize the REST API models instead.

### Unit tests
Updated

### Code style
✅ 

### Documentation
None needed

### Changelog
The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md) 
is generated from the pull-request title, make sure the title describe the feature or issue fixed. 
To exclude the PR from the changelog add `[changelog skip]` in the title.
