### PR TITLE
Encapsulate fields in the `Leg` and remove stop indices from `Place` [changelog skip]

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/flex/FlexIntegrationTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/flex/FlexIntegrationTest.java
@@ -83,19 +83,19 @@ public class FlexIntegrationTest {
         assertEquals(4, itin.legs.size());
 
         var walkToBus = itin.legs.get(0);
-        assertEquals(TraverseMode.WALK, walkToBus.mode);
+        assertEquals(TraverseMode.WALK, walkToBus.getMode());
 
         var bus = itin.legs.get(1);
-        assertEquals(BUS, bus.mode);
+        assertEquals(BUS, bus.getMode());
         assertEquals("30", bus.getRoute().getShortName());
 
         var transfer = itin.legs.get(2);
-        assertEquals(TraverseMode.WALK, transfer.mode);
+        assertEquals(TraverseMode.WALK, transfer.getMode());
 
         var flex = itin.legs.get(3);
-        assertEquals(BUS, flex.mode);
+        assertEquals(BUS, flex.getMode());
         assertEquals("Zone 2", flex.getRoute().getShortName());
-        assertTrue(flex.flexibleTrip);
+        assertTrue(flex.isFlexibleTrip());
     }
 
     @Test
@@ -108,23 +108,23 @@ public class FlexIntegrationTest {
         assertEquals(5, itin.legs.size());
 
         var firstBus = itin.legs.get(0);
-        assertEquals(BUS, firstBus.mode);
+        assertEquals(BUS, firstBus.getMode());
         assertEquals("856", firstBus.getRoute().getShortName());
 
         var transferToSecondBus = itin.legs.get(1);
-        assertEquals(WALK, transferToSecondBus.mode);
+        assertEquals(WALK, transferToSecondBus.getMode());
 
         var secondBus = itin.legs.get(2);
-        assertEquals(BUS, secondBus.mode);
+        assertEquals(BUS, secondBus.getMode());
         assertEquals("30", secondBus.getRoute().getShortName());
 
         var transferToFlex = itin.legs.get(3);
-        assertEquals(WALK, transferToFlex.mode);
+        assertEquals(WALK, transferToFlex.getMode());
 
         var finalFlex = itin.legs.get(4);
-        assertEquals(BUS, finalFlex.mode);
+        assertEquals(BUS, finalFlex.getMode());
         assertEquals("Zone 2", finalFlex.getRoute().getShortName());
-        assertTrue(finalFlex.flexibleTrip);
+        assertTrue(finalFlex.isFlexibleTrip());
     }
 
     private Itinerary getItinerary(GenericLocation from, GenericLocation to, int index) {

--- a/src/ext-test/java/org/opentripplanner/ext/flex/ScheduledDeviatedTripTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/flex/ScheduledDeviatedTripTest.java
@@ -176,15 +176,15 @@ public class ScheduledDeviatedTripTest extends FlexTest {
         var itin = itineraries.get(0);
         var leg = itin.legs.get(0);
 
-        assertEquals("cujv", leg.from.stop.getId().getId());
-        assertEquals("yz85", leg.to.stop.getId().getId());
+        assertEquals("cujv", leg.getFrom().stop.getId().getId());
+        assertEquals("yz85", leg.getTo().stop.getId().getId());
 
-        var intermediateStops = leg.intermediateStops;
+        var intermediateStops = leg.getIntermediateStops();
         assertEquals(1, intermediateStops.size());
         assertEquals("zone_1", intermediateStops.get(0).place.stop.getId().getId());
 
         assertThatPolylinesAreEqual(
-                leg.legGeometry.getPoints(),
+                leg.getLegGeometry().getPoints(),
                 "kfsmEjojcOa@eBRKfBfHR|ALjBBhVArMG|OCrEGx@OhAKj@a@tAe@hA]l@MPgAnAgw@nr@cDxCm@t@c@t@c@x@_@~@]pAyAdIoAhG}@lE{AzHWhAtt@t~Aj@tAb@~AXdBHn@FlBC`CKnA_@nC{CjOa@dCOlAEz@E|BRtUCbCQ~CWjD??qBvXBl@kBvWOzAc@dDOx@sHv]aIG?q@@c@ZaB\\mA"
         );
 

--- a/src/ext/java/org/opentripplanner/ext/flex/FlexLegMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/FlexLegMapper.java
@@ -10,25 +10,27 @@ import org.opentripplanner.routing.algorithm.mapping.GraphPathToItineraryMapper;
 public class FlexLegMapper {
 
   static public void fixFlexTripLeg(Leg leg, FlexTripEdge flexTripEdge) {
-      leg.intermediateStops = new ArrayList<>();
-      leg.distanceMeters = flexTripEdge.getDistanceMeters();
+      leg.setIntermediateStops(new ArrayList<>());
+      leg.setDistanceMeters(flexTripEdge.getDistanceMeters());
 
-      leg.serviceDate = flexTripEdge.flexTemplate.serviceDate;
-      leg.headsign = flexTripEdge.getTrip().getTripHeadsign();
-      leg.walkSteps = new ArrayList<>();
+      leg.setServiceDate(flexTripEdge.flexTemplate.serviceDate);
+      leg.setHeadsign(flexTripEdge.getTrip().getTripHeadsign());
+      leg.setWalkSteps(new ArrayList<>());
 
-      leg.boardRule = GraphPathToItineraryMapper.getBoardAlightMessage(2);
-      leg.alightRule = GraphPathToItineraryMapper.getBoardAlightMessage(3);
+      leg.setBoardRule(GraphPathToItineraryMapper.getBoardAlightMessage(2));
+      leg.setAlightRule(GraphPathToItineraryMapper.getBoardAlightMessage(3));
 
-      leg.boardStopPosInPattern = flexTripEdge.flexTemplate.fromStopIndex;
-      leg.alightStopPosInPattern = flexTripEdge.flexTemplate.toStopIndex;
+      leg.setBoardStopPosInPattern(flexTripEdge.flexTemplate.fromStopIndex);
+      leg.setAlightStopPosInPattern(flexTripEdge.flexTemplate.toStopIndex);
 
-      leg.dropOffBookingInfo = flexTripEdge.getFlexTrip().getDropOffBookingInfo(leg.boardStopPosInPattern);
-      leg.pickupBookingInfo = flexTripEdge.getFlexTrip().getPickupBookingInfo(leg.alightStopPosInPattern);
+      leg.setDropOffBookingInfo(
+              flexTripEdge.getFlexTrip().getDropOffBookingInfo(leg.getBoardStopPosInPattern()));
+      leg.setPickupBookingInfo(
+              flexTripEdge.getFlexTrip().getPickupBookingInfo(leg.getAlightStopPosInPattern()));
   }
 
     public static void addFlexPlaces(Leg leg, FlexTripEdge flexEdge, Locale requestedLocale) {
-        leg.from = Place.forFlexStop(flexEdge.s1, flexEdge.getFromVertex());
-        leg.to = Place.forFlexStop(flexEdge.s2, flexEdge.getToVertex());
+        leg.setFrom(Place.forFlexStop(flexEdge.s1, flexEdge.getFromVertex()));
+        leg.setTo(Place.forFlexStop(flexEdge.s2, flexEdge.getToVertex()));
     }
 }

--- a/src/ext/java/org/opentripplanner/ext/flex/FlexLegMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/FlexLegMapper.java
@@ -20,22 +20,15 @@ public class FlexLegMapper {
       leg.boardRule = GraphPathToItineraryMapper.getBoardAlightMessage(2);
       leg.alightRule = GraphPathToItineraryMapper.getBoardAlightMessage(3);
 
-      leg.dropOffBookingInfo = flexTripEdge.getFlexTrip().getDropOffBookingInfo(leg.from.stopIndex);
-      leg.pickupBookingInfo = flexTripEdge.getFlexTrip().getPickupBookingInfo(leg.from.stopIndex);
+      leg.boardStopPosInPattern = flexTripEdge.flexTemplate.fromStopIndex;
+      leg.alightStopPosInPattern = flexTripEdge.flexTemplate.toStopIndex;
+
+      leg.dropOffBookingInfo = flexTripEdge.getFlexTrip().getDropOffBookingInfo(leg.boardStopPosInPattern);
+      leg.pickupBookingInfo = flexTripEdge.getFlexTrip().getPickupBookingInfo(leg.alightStopPosInPattern);
   }
 
     public static void addFlexPlaces(Leg leg, FlexTripEdge flexEdge, Locale requestedLocale) {
-        leg.from = Place.forFlexStop(
-                flexEdge.s1,
-                flexEdge.getFromVertex(),
-                flexEdge.flexTemplate.fromStopIndex,
-                null
-        );
-        leg.to = Place.forFlexStop(
-                flexEdge.s2,
-                flexEdge.getToVertex(),
-                flexEdge.flexTemplate.toStopIndex,
-                null
-        );
+        leg.from = Place.forFlexStop(flexEdge.s1, flexEdge.getFromVertex());
+        leg.to = Place.forFlexStop(flexEdge.s2, flexEdge.getToVertex());
     }
 }

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLLegImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLLegImpl.java
@@ -100,7 +100,13 @@ public class LegacyGraphQLLegImpl implements LegacyGraphQLDataFetchers.LegacyGra
   public DataFetcher<StopArrival> from() {
     return environment -> {
       Leg source = getSource(environment);
-      return new StopArrival(source.from, source.startTime, source.startTime);
+      return new StopArrival(
+              source.from,
+              source.startTime,
+              source.startTime,
+              source.boardStopPosInPattern,
+              source.boardingStopSequence
+      );
     };
   }
 
@@ -108,7 +114,13 @@ public class LegacyGraphQLLegImpl implements LegacyGraphQLDataFetchers.LegacyGra
   public DataFetcher<StopArrival> to() {
     return environment -> {
       Leg source = getSource(environment);
-      return new StopArrival(source.to, source.endTime, source.endTime);
+      return new StopArrival(
+              source.to,
+              source.endTime,
+              source.endTime,
+              source.alightStopPosInPattern,
+              source.alightStopSequence
+      );
     };
   }
 

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLLegImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLLegImpl.java
@@ -105,7 +105,7 @@ public class LegacyGraphQLLegImpl implements LegacyGraphQLDataFetchers.LegacyGra
               source.getStartTime(),
               source.getStartTime(),
               source.getBoardStopPosInPattern(),
-              source.getBoardingStopSequence()
+              source.getBoardingGtfsStopSequence()
       );
     };
   }
@@ -119,7 +119,7 @@ public class LegacyGraphQLLegImpl implements LegacyGraphQLDataFetchers.LegacyGra
               source.getEndTime(),
               source.getEndTime(),
               source.getAlightStopPosInPattern(),
-              source.getAlightStopSequence()
+              source.getAlightGtfsStopSequence()
       );
     };
   }

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLLegImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLLegImpl.java
@@ -22,27 +22,27 @@ public class LegacyGraphQLLegImpl implements LegacyGraphQLDataFetchers.LegacyGra
 
   @Override
   public DataFetcher<Long> startTime() {
-    return environment -> getSource(environment).startTime.getTime().getTime();
+    return environment -> getSource(environment).getStartTime().getTime().getTime();
   }
 
   @Override
   public DataFetcher<Long> endTime() {
-    return environment -> getSource(environment).endTime.getTime().getTime();
+    return environment -> getSource(environment).getEndTime().getTime().getTime();
   }
 
   @Override
   public DataFetcher<Integer> departureDelay() {
-    return environment -> getSource(environment).departureDelay;
+    return environment -> getSource(environment).getDepartureDelay();
   }
 
   @Override
   public DataFetcher<Integer> arrivalDelay() {
-    return environment -> getSource(environment).arrivalDelay;
+    return environment -> getSource(environment).getArrivalDelay();
   }
 
   @Override
   public DataFetcher<String> mode() {
-    return environment -> getSource(environment).mode.name();
+    return environment -> getSource(environment).getMode().name();
   }
 
   @Override
@@ -52,12 +52,12 @@ public class LegacyGraphQLLegImpl implements LegacyGraphQLDataFetchers.LegacyGra
 
   @Override
   public DataFetcher<Integer> generalizedCost() {
-    return environment -> getSource(environment).generalizedCost;
+    return environment -> getSource(environment).getGeneralizedCost();
   }
 
   @Override
   public DataFetcher<EncodedPolylineBean> legGeometry() {
-    return environment -> getSource(environment).legGeometry;
+    return environment -> getSource(environment).getLegGeometry();
   }
 
   @Override
@@ -67,7 +67,7 @@ public class LegacyGraphQLLegImpl implements LegacyGraphQLDataFetchers.LegacyGra
 
   @Override
   public DataFetcher<Boolean> realTime() {
-    return environment -> getSource(environment).realTime;
+    return environment -> getSource(environment).getRealTime();
   }
 
   // TODO
@@ -78,7 +78,7 @@ public class LegacyGraphQLLegImpl implements LegacyGraphQLDataFetchers.LegacyGra
 
   @Override
   public DataFetcher<Double> distance() {
-    return environment -> getSource(environment).distanceMeters;
+    return environment -> getSource(environment).getDistanceMeters();
   }
 
   @Override
@@ -88,12 +88,12 @@ public class LegacyGraphQLLegImpl implements LegacyGraphQLDataFetchers.LegacyGra
 
   @Override
   public DataFetcher<Boolean> walkingBike() {
-    return environment -> getSource(environment).walkingBike;
+    return environment -> getSource(environment).getWalkingBike();
   }
 
   @Override
   public DataFetcher<Boolean> rentedBike() {
-    return environment -> getSource(environment).rentedVehicle;
+    return environment -> getSource(environment).getRentedVehicle();
   }
 
   @Override
@@ -101,11 +101,11 @@ public class LegacyGraphQLLegImpl implements LegacyGraphQLDataFetchers.LegacyGra
     return environment -> {
       Leg source = getSource(environment);
       return new StopArrival(
-              source.from,
-              source.startTime,
-              source.startTime,
-              source.boardStopPosInPattern,
-              source.boardingStopSequence
+              source.getFrom(),
+              source.getStartTime(),
+              source.getStartTime(),
+              source.getBoardStopPosInPattern(),
+              source.getBoardingStopSequence()
       );
     };
   }
@@ -115,11 +115,11 @@ public class LegacyGraphQLLegImpl implements LegacyGraphQLDataFetchers.LegacyGra
     return environment -> {
       Leg source = getSource(environment);
       return new StopArrival(
-              source.to,
-              source.endTime,
-              source.endTime,
-              source.alightStopPosInPattern,
-              source.alightStopSequence
+              source.getTo(),
+              source.getEndTime(),
+              source.getEndTime(),
+              source.getAlightStopPosInPattern(),
+              source.getAlightStopSequence()
       );
     };
   }
@@ -136,13 +136,13 @@ public class LegacyGraphQLLegImpl implements LegacyGraphQLDataFetchers.LegacyGra
 
   @Override
   public DataFetcher<String> serviceDate() {
-    return environment -> ServiceDateMapper.mapToApi(getSource(environment).serviceDate);
+    return environment -> ServiceDateMapper.mapToApi(getSource(environment).getServiceDate());
   }
 
   @Override
   public DataFetcher<Iterable<Object>> intermediateStops() {
     return environment -> {
-      List<StopArrival> intermediateStops = getSource(environment).intermediateStops;
+      List<StopArrival> intermediateStops = getSource(environment).getIntermediateStops();
       if (intermediateStops == null) { return null; }
       return intermediateStops.stream()
           .map(intermediateStop -> intermediateStop.place.stop)
@@ -153,7 +153,7 @@ public class LegacyGraphQLLegImpl implements LegacyGraphQLDataFetchers.LegacyGra
 
   @Override
   public DataFetcher<Iterable<StopArrival>> intermediatePlaces() {
-    return environment -> getSource(environment).intermediateStops;
+    return environment -> getSource(environment).getIntermediateStops();
   }
 
   // TODO
@@ -164,14 +164,14 @@ public class LegacyGraphQLLegImpl implements LegacyGraphQLDataFetchers.LegacyGra
 
   @Override
   public DataFetcher<Iterable<WalkStep>> steps() {
-    return environment -> getSource(environment).walkSteps;
+    return environment -> getSource(environment).getWalkSteps();
   }
 
   @Override
   public DataFetcher<String> pickupType() {
     return environment -> {
-      if (getSource(environment).boardRule == null) { return "SCHEDULED"; }
-      switch (getSource(environment).boardRule) {
+      if (getSource(environment).getBoardRule() == null) { return "SCHEDULED"; }
+      switch (getSource(environment).getBoardRule()) {
         case "impossible": return "NONE";
         case "mustPhone": return "CALL_AGENCY";
         case "coordinateWithDriver": return "COORDINATE_WITH_DRIVER";
@@ -183,8 +183,8 @@ public class LegacyGraphQLLegImpl implements LegacyGraphQLDataFetchers.LegacyGra
   @Override
   public DataFetcher<String> dropoffType() {
     return environment -> {
-      if (getSource(environment).alightRule == null) { return "SCHEDULED"; }
-      switch (getSource(environment).alightRule) {
+      if (getSource(environment).getAlightRule() == null) { return "SCHEDULED"; }
+      switch (getSource(environment).getAlightRule()) {
         case "impossible": return "NONE";
         case "mustPhone": return "CALL_AGENCY";
         case "coordinateWithDriver": return "COORDINATE_WITH_DRIVER";
@@ -200,12 +200,12 @@ public class LegacyGraphQLLegImpl implements LegacyGraphQLDataFetchers.LegacyGra
 
   @Override
   public DataFetcher<BookingInfo> dropOffBookingInfo() {
-    return environment -> getSource(environment).dropOffBookingInfo;
+    return environment -> getSource(environment).getDropOffBookingInfo();
   }
 
   @Override
   public DataFetcher<BookingInfo> pickupBookingInfo() {
-    return environment -> getSource(environment).pickupBookingInfo;
+    return environment -> getSource(environment).getPickupBookingInfo();
   }
 
   private RoutingService getRoutingService(DataFetchingEnvironment environment) {

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLPlanImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLPlanImpl.java
@@ -21,12 +21,23 @@ public class LegacyGraphQLPlanImpl implements LegacyGraphQLDataFetchers.LegacyGr
 
   @Override
   public DataFetcher<StopArrival> from() {
-    return environment -> new StopArrival(getSource(environment).getTripPlan().from, null, null);
+    return environment -> new StopArrival(getSource(environment).getTripPlan().from,
+            null,
+            null,
+            null,
+            null
+    );
   }
 
   @Override
   public DataFetcher<StopArrival> to() {
-    return environment -> new StopArrival(getSource(environment).getTripPlan().to, null, null);
+    return environment -> new StopArrival(
+            getSource(environment).getTripPlan().to,
+            null,
+            null,
+            null,
+            null
+    );
   }
 
   @Override

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLPlanImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLPlanImpl.java
@@ -21,7 +21,8 @@ public class LegacyGraphQLPlanImpl implements LegacyGraphQLDataFetchers.LegacyGr
 
   @Override
   public DataFetcher<StopArrival> from() {
-    return environment -> new StopArrival(getSource(environment).getTripPlan().from,
+    return environment -> new StopArrival(
+            getSource(environment).getTripPlan().from,
             null,
             null,
             null,

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/TripTimeShortHelper.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/TripTimeShortHelper.java
@@ -18,9 +18,9 @@ public class TripTimeShortHelper {
     @Nullable
     public static TripTimeOnDate getTripTimeShortForFromPlace(Leg leg, RoutingService routingService) {
         if (!leg.isTransitLeg()) { return null; }
-        if (leg.flexibleTrip) { return null; }
+        if (leg.isFlexibleTrip()) { return null; }
 
-        ServiceDate serviceDate = leg.serviceDate;
+        ServiceDate serviceDate = leg.getServiceDate();
         List<TripTimeOnDate> tripTimes = routingService.getTripTimesShort(leg.getTrip(), serviceDate);
 
         /* TODO OTP2 This method is only used for EstimatedCalls for from place. We have to decide
@@ -34,7 +34,7 @@ public class TripTimeShortHelper {
         }
          */
 
-        return tripTimes.get(leg.boardStopPosInPattern);
+        return tripTimes.get(leg.getBoardStopPosInPattern());
     }
 
     /**
@@ -43,9 +43,9 @@ public class TripTimeShortHelper {
     @Nullable
     public static TripTimeOnDate getTripTimeShortForToPlace(Leg leg, RoutingService routingService) {
         if (!leg.isTransitLeg()) { return null; }
-        if (leg.flexibleTrip) { return null; }
+        if (leg.isFlexibleTrip()) { return null; }
 
-        ServiceDate serviceDate = leg.serviceDate;
+        ServiceDate serviceDate = leg.getServiceDate();
         List<TripTimeOnDate> tripTimes = routingService.getTripTimesShort(leg.getTrip(), serviceDate);
 
         /* TODO OTP2 This method is only used for EstimatedCalls for to place. We have to decide
@@ -59,7 +59,7 @@ public class TripTimeShortHelper {
         }
         */
 
-        return tripTimes.get(leg.alightStopPosInPattern);
+        return tripTimes.get(leg.getAlightStopPosInPattern());
     }
 
 
@@ -68,9 +68,9 @@ public class TripTimeShortHelper {
      */
     public static List<TripTimeOnDate> getAllTripTimeShortsForLegsTrip(Leg leg, RoutingService routingService) {
         if (!leg.isTransitLeg()) { return List.of(); }
-        if (leg.flexibleTrip) { return List.of(); }
+        if (leg.isFlexibleTrip()) { return List.of(); }
 
-        ServiceDate serviceDate = leg.serviceDate;
+        ServiceDate serviceDate = leg.getServiceDate();
         return routingService.getTripTimesShort(leg.getTrip(), serviceDate);
     }
 
@@ -79,11 +79,11 @@ public class TripTimeShortHelper {
      */
     public static List<TripTimeOnDate> getIntermediateTripTimeShortsForLeg(Leg leg, RoutingService routingService) {
         if (!leg.isTransitLeg()) { return List.of(); }
-        if (leg.flexibleTrip) { return List.of(); }
+        if (leg.isFlexibleTrip()) { return List.of(); }
 
-        ServiceDate serviceDate = leg.serviceDate;
+        ServiceDate serviceDate = leg.getServiceDate();
 
         List<TripTimeOnDate> tripTimes = routingService.getTripTimesShort(leg.getTrip(), serviceDate);
-        return tripTimes.subList(leg.boardStopPosInPattern + 1, leg.alightStopPosInPattern);
+        return tripTimes.subList(leg.getBoardStopPosInPattern() + 1, leg.getAlightStopPosInPattern());
     }
 }

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/LegType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/LegType.java
@@ -49,14 +49,16 @@ public class LegType {
             .type(gqlUtil.dateTimeScalar)
             .dataFetcher(
                 // startTime is already adjusted for realtime - need to subtract delay to get aimed time
-                env -> leg(env).startTime.getTimeInMillis() - (1000L * leg(env).departureDelay))
+                env -> leg(env).getStartTime().getTimeInMillis() - (1000L * leg(
+                        env).getDepartureDelay()
+                ))
             .build())
         .field(GraphQLFieldDefinition
             .newFieldDefinition()
             .name("expectedStartTime")
             .description("The expected, realtime adjusted date and time this leg starts.")
             .type(gqlUtil.dateTimeScalar)
-            .dataFetcher(env -> leg(env).startTime.getTimeInMillis())
+            .dataFetcher(env -> leg(env).getStartTime().getTimeInMillis())
             .build())
         .field(GraphQLFieldDefinition
             .newFieldDefinition()
@@ -65,14 +67,14 @@ public class LegType {
             .type(gqlUtil.dateTimeScalar)
             .dataFetcher(
                 // endTime is already adjusted for realtime - need to subtract delay to get aimed time
-                env -> leg(env).endTime.getTimeInMillis() - 1000L * leg(env).arrivalDelay)
+                env -> leg(env).getEndTime().getTimeInMillis() - 1000L * leg(env).getArrivalDelay())
             .build())
         .field(GraphQLFieldDefinition
             .newFieldDefinition()
             .name("expectedEndTime")
             .description("The expected, realtime adjusted date and time this leg ends.")
             .type(gqlUtil.dateTimeScalar)
-            .dataFetcher(env -> leg(env).endTime.getTimeInMillis())
+            .dataFetcher(env -> leg(env).getEndTime().getTimeInMillis())
             .build())
         .field(GraphQLFieldDefinition
             .newFieldDefinition()
@@ -80,7 +82,7 @@ public class LegType {
             .description(
                 "The mode of transport or access (e.g., foot) used when traversing this leg.")
             .type(MODE)
-            .dataFetcher(env -> leg(env).mode)
+            .dataFetcher(env -> leg(env).getMode())
             .build())
         .field(GraphQLFieldDefinition
             .newFieldDefinition()
@@ -114,7 +116,7 @@ public class LegType {
             .name("pointsOnLink")
             .description("The legs's geometry.")
             .type(linkGeometryType)
-            .dataFetcher(env -> leg(env).legGeometry)
+            .dataFetcher(env -> leg(env).getLegGeometry())
             .build())
         .field(GraphQLFieldDefinition
             .newFieldDefinition()
@@ -136,21 +138,21 @@ public class LegType {
             .name("realtime")
             .description("Whether there is real-time data about this leg")
             .type(Scalars.GraphQLBoolean)
-            .dataFetcher(env -> leg(env).realTime)
+            .dataFetcher(env -> leg(env).getRealTime())
             .build())
         .field(GraphQLFieldDefinition
             .newFieldDefinition()
             .name("distance")
             .description("The distance traveled while traversing the leg in meters.")
             .type(Scalars.GraphQLFloat)
-            .dataFetcher(env -> leg(env).distanceMeters)
+            .dataFetcher(env -> leg(env).getDistanceMeters())
             .build())
         .field(GraphQLFieldDefinition
             .newFieldDefinition()
             .name("generalizedCost")
             .description("Generalized cost or weight of the leg. Used for debugging.")
             .type(Scalars.GraphQLInt)
-            .dataFetcher(env -> leg(env).generalizedCost)
+            .dataFetcher(env -> leg(env).getGeneralizedCost())
             .build())
         .field(GraphQLFieldDefinition
             .newFieldDefinition()
@@ -164,28 +166,28 @@ public class LegType {
             .name("walkingBike")
             .description("Whether this leg is walking with a bike.")
             .type(Scalars.GraphQLBoolean)
-            .dataFetcher(env -> leg(env).walkingBike)
+            .dataFetcher(env -> leg(env).getWalkingBike())
             .build())
         .field(GraphQLFieldDefinition
             .newFieldDefinition()
             .name("rentedBike")
             .description("Whether this leg is with a rented bike.")
             .type(Scalars.GraphQLBoolean)
-            .dataFetcher(env -> leg(env).rentedVehicle)
+            .dataFetcher(env -> leg(env).getRentedVehicle())
             .build())
         .field(GraphQLFieldDefinition
             .newFieldDefinition()
             .name("fromPlace")
             .description("The Place where the leg originates.")
             .type(new GraphQLNonNull(placeType))
-            .dataFetcher(env -> leg(env).from)
+            .dataFetcher(env -> leg(env).getFrom())
             .build())
         .field(GraphQLFieldDefinition
             .newFieldDefinition()
             .name("toPlace")
             .description("The Place where the leg ends.")
             .type(new GraphQLNonNull(placeType))
-            .dataFetcher(env -> leg(env).to)
+            .dataFetcher(env -> leg(env).getTo())
             .build())
         .field(GraphQLFieldDefinition
             .newFieldDefinition()
@@ -228,7 +230,7 @@ public class LegType {
                 "For ride legs, intermediate quays between the Place where the leg originates and the Place where the leg ends. For non-ride legs, empty list.")
             .type(new GraphQLNonNull(new GraphQLList(quayType)))
             .dataFetcher(env -> {
-              List<StopArrival> stops = ((Leg) env.getSource()).intermediateStops;
+              List<StopArrival> stops = ((Leg) env.getSource()).getIntermediateStops();
               if (stops == null || stops.isEmpty()) {
                 return List.of();
               }
@@ -276,39 +278,40 @@ public class LegType {
             .name("situations")
             .description("All relevant situations for this leg")
             .type(new GraphQLNonNull(new GraphQLList(ptSituationElementType)))
-            .dataFetcher(env -> leg(env).transitAlerts)
+            .dataFetcher(env -> leg(env).getTransitAlerts())
             .build())
         .field(GraphQLFieldDefinition
             .newFieldDefinition()
             .name("steps")
             .description("Do we continue from a specified via place")
             .type(new GraphQLNonNull(new GraphQLList(pathGuidanceType)))
-            .dataFetcher(env -> leg(env).walkSteps)
+            .dataFetcher(env -> leg(env).getWalkSteps())
             .build())
         .field(GraphQLFieldDefinition
             .newFieldDefinition()
             .name("interchangeFrom")
             .type(interchangeType)
-            .dataFetcher(env -> leg(env).transferFromPrevLeg)
+            .dataFetcher(env -> leg(env).getTransferFromPrevLeg())
             .build())
         .field(GraphQLFieldDefinition
             .newFieldDefinition()
             .name("interchangeTo")
             .type(interchangeType)
-            .dataFetcher(env -> leg(env).transferToNextLeg)
+            .dataFetcher(env -> leg(env).getTransferToNextLeg())
             .build())
         .field(GraphQLFieldDefinition
             .newFieldDefinition()
             .name("bookingArrangements")
             .type(bookingArrangementType)
-            .dataFetcher(env -> leg(env).pickupBookingInfo)
+            .dataFetcher(env -> leg(env).getPickupBookingInfo())
             .build())
         .field(GraphQLFieldDefinition
             .newFieldDefinition()
             .name("bikeRentalNetworks")
             .type(new GraphQLNonNull(new GraphQLList(Scalars.GraphQLString)))
             .dataFetcher(env ->
-                    leg(env).vehicleRentalNetwork == null ? List.of() : List.of(leg(env).vehicleRentalNetwork)
+                    leg(env).getVehicleRentalNetwork() == null ? List.of() : List.of(
+                            leg(env).getVehicleRentalNetwork())
             )
             .build())
         .build();

--- a/src/main/java/org/opentripplanner/api/mapping/LegMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/LegMapper.java
@@ -32,8 +32,9 @@ public class LegMapper {
         final int lastIdx = size-1;
 
         for (int i=0; i < size; ++i) {
-            Calendar arrivalTimeFromPlace = (i == 0) ? null : domain.get(i-1).endTime;
-            Calendar departureTimeToPlace = (i == lastIdx) ? null : domain.get(i+1).startTime;
+            Calendar arrivalTimeFromPlace = (i == 0) ? null : domain.get(i - 1).getEndTime();
+            Calendar departureTimeToPlace = (i == lastIdx) ? null : domain.get(i + 1)
+                    .getStartTime();
 
             apiLegs.add(mapLeg(domain.get(i), arrivalTimeFromPlace, departureTimeToPlace));
         }
@@ -43,35 +44,35 @@ public class LegMapper {
     public ApiLeg mapLeg(Leg domain, Calendar arrivalTimeFromPlace, Calendar departureTimeToPlace) {
         if(domain == null) { return null; }
         ApiLeg api = new ApiLeg();
-        api.startTime = domain.startTime;
-        api.endTime = domain.endTime;
+        api.startTime = domain.getStartTime();
+        api.endTime = domain.getEndTime();
 
         // Set the arrival and departure times, even if this is redundant information
         api.from = placeMapper.mapPlace(
-                domain.from,
+                domain.getFrom(),
                 arrivalTimeFromPlace,
                 api.startTime,
-                domain.boardStopPosInPattern,
-                domain.boardingStopSequence
+                domain.getBoardStopPosInPattern(),
+                domain.getBoardingStopSequence()
         );
         api.to = placeMapper.mapPlace(
-                domain.to,
+                domain.getTo(),
                 api.endTime,
                 departureTimeToPlace,
-                domain.alightStopPosInPattern,
-                domain.alightStopSequence
+                domain.getAlightStopPosInPattern(),
+                domain.getAlightStopSequence()
         );
 
-        api.departureDelay = domain.departureDelay;
-        api.arrivalDelay = domain.arrivalDelay;
-        api.realTime = domain.realTime;
-        api.isNonExactFrequency = domain.isNonExactFrequency;
-        api.headway = domain.headway;
-        api.distance = domain.distanceMeters;
-        api.generalizedCost = domain.generalizedCost;
-        api.pathway = domain.pathway;
-        api.mode = TraverseModeMapper.mapToApi(domain.mode);
-        api.agencyTimeZoneOffset = domain.agencyTimeZoneOffset;
+        api.departureDelay = domain.getDepartureDelay();
+        api.arrivalDelay = domain.getArrivalDelay();
+        api.realTime = domain.getRealTime();
+        api.isNonExactFrequency = domain.getNonExactFrequency();
+        api.headway = domain.getHeadway();
+        api.distance = domain.getDistanceMeters();
+        api.generalizedCost = domain.getGeneralizedCost();
+        api.pathway = domain.getPathway();
+        api.mode = TraverseModeMapper.mapToApi(domain.getMode());
+        api.agencyTimeZoneOffset = domain.getAgencyTimeZoneOffset();
         api.transitLeg = domain.isTransitLeg();
 
         if(domain.isTransitLeg()) {
@@ -84,7 +85,7 @@ public class LegMapper {
             var route = domain.getRoute();
             api.route = route.getLongName();
             api.routeColor = route.getColor();
-            api.routeType = domain.routeType;
+            api.routeType = domain.getRouteType();
             api.routeId = FeedScopedIdMapper.mapToApi(route.getId());
             api.routeShortName = route.getShortName();
             api.routeLongName = route.getLongName();
@@ -95,8 +96,8 @@ public class LegMapper {
             api.tripShortName = trip.getTripShortName();
             api.tripBlockId = trip.getBlockId();
         }
-        else if (domain.pathway) {
-            api.route = FeedScopedIdMapper.mapToApi(domain.pathwayId);
+        else if (domain.getPathway()) {
+            api.route = FeedScopedIdMapper.mapToApi(domain.getPathwayId());
         }
         else {
             // TODO OTP2 - This should be set to the street name according to the JavaDoc
@@ -104,26 +105,26 @@ public class LegMapper {
         }
 
         api.interlineWithPreviousLeg = domain.isInterlinedWithPreviousLeg();
-        api.headsign = domain.headsign;
-        api.serviceDate = ServiceDateMapper.mapToApi(domain.serviceDate);
-        api.routeBrandingUrl = domain.routeBrandingUrl;
+        api.headsign = domain.getHeadsign();
+        api.serviceDate = ServiceDateMapper.mapToApi(domain.getServiceDate());
+        api.routeBrandingUrl = domain.getRouteBrandingUrl();
         if(addIntermediateStops) {
-            api.intermediateStops = placeMapper.mapStopArrivals(domain.intermediateStops);
+            api.intermediateStops = placeMapper.mapStopArrivals(domain.getIntermediateStops());
         }
-        api.legGeometry = domain.legGeometry;
-        api.steps = walkStepMapper.mapWalkSteps(domain.walkSteps);
+        api.legGeometry = domain.getLegGeometry();
+        api.steps = walkStepMapper.mapWalkSteps(domain.getWalkSteps());
         api.alerts = concatenateAlerts(
-            streetNoteMaperMapper.mapToApi(domain.streetNotes),
-            alertMapper.mapToApi(domain.transitAlerts)
+            streetNoteMaperMapper.mapToApi(domain.getStreetNotes()),
+            alertMapper.mapToApi(domain.getTransitAlerts())
         );
-        api.boardRule = domain.boardRule;
-        api.alightRule = domain.alightRule;
+        api.boardRule = domain.getBoardRule();
+        api.alightRule = domain.getAlightRule();
 
-        api.pickupBookingInfo = BookingInfoMapper.mapBookingInfo(domain.pickupBookingInfo, true);
-        api.dropOffBookingInfo = BookingInfoMapper.mapBookingInfo(domain.dropOffBookingInfo, false);
+        api.pickupBookingInfo = BookingInfoMapper.mapBookingInfo(domain.getPickupBookingInfo(), true);
+        api.dropOffBookingInfo = BookingInfoMapper.mapBookingInfo(domain.getDropOffBookingInfo(), false);
 
-        api.rentedBike = domain.rentedVehicle;
-        api.walkingBike = domain.walkingBike;
+        api.rentedBike = domain.getRentedVehicle();
+        api.walkingBike = domain.getWalkingBike();
 
         return api;
     }

--- a/src/main/java/org/opentripplanner/api/mapping/LegMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/LegMapper.java
@@ -53,14 +53,14 @@ public class LegMapper {
                 arrivalTimeFromPlace,
                 api.startTime,
                 domain.getBoardStopPosInPattern(),
-                domain.getBoardingStopSequence()
+                domain.getBoardingGtfsStopSequence()
         );
         api.to = placeMapper.mapPlace(
                 domain.getTo(),
                 api.endTime,
                 departureTimeToPlace,
                 domain.getAlightStopPosInPattern(),
-                domain.getAlightStopSequence()
+                domain.getAlightGtfsStopSequence()
         );
 
         api.departureDelay = domain.getDepartureDelay();

--- a/src/main/java/org/opentripplanner/api/mapping/LegMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/LegMapper.java
@@ -47,8 +47,20 @@ public class LegMapper {
         api.endTime = domain.endTime;
 
         // Set the arrival and departure times, even if this is redundant information
-        api.from = placeMapper.mapPlace(domain.from, arrivalTimeFromPlace, api.startTime);
-        api.to = placeMapper.mapPlace(domain.to, api.endTime, departureTimeToPlace);
+        api.from = placeMapper.mapPlace(
+                domain.from,
+                arrivalTimeFromPlace,
+                api.startTime,
+                domain.boardStopPosInPattern,
+                domain.boardingStopSequence
+        );
+        api.to = placeMapper.mapPlace(
+                domain.to,
+                api.endTime,
+                departureTimeToPlace,
+                domain.alightStopPosInPattern,
+                domain.alightStopSequence
+        );
 
         api.departureDelay = domain.departureDelay;
         api.arrivalDelay = domain.arrivalDelay;

--- a/src/main/java/org/opentripplanner/api/mapping/PlaceMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/PlaceMapper.java
@@ -34,8 +34,8 @@ public class PlaceMapper {
                 domain.place,
                 domain.arrival,
                 domain.departure,
-                domain.stopIndex,
-                domain.stopSequence
+                domain.stopPosInPattern,
+                domain.gtfsStopSequence
         );
     }
 
@@ -44,7 +44,7 @@ public class PlaceMapper {
             Calendar arrival,
             Calendar departure,
             Integer stopIndex,
-            Integer stopSequence
+            Integer gtfsStopSequence
     ) {
         if(domain == null) { return null; }
 
@@ -68,7 +68,7 @@ public class PlaceMapper {
         api.departure = departure;
         api.orig = domain.orig;
         api.stopIndex = stopIndex;
-        api.stopSequence = stopSequence;
+        api.stopSequence = gtfsStopSequence;
         api.vertexType = VertexTypeMapper.mapVertexType(domain.vertexType);
         if (domain.vehicleRentalPlace != null) {
             api.bikeShareId = domain.vehicleRentalPlace.getStationId();

--- a/src/main/java/org/opentripplanner/api/mapping/PlaceMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/PlaceMapper.java
@@ -30,10 +30,22 @@ public class PlaceMapper {
     }
 
     public ApiPlace mapStopArrival(StopArrival domain) {
-        return mapPlace(domain.place, domain.arrival, domain.departure);
+        return mapPlace(
+                domain.place,
+                domain.arrival,
+                domain.departure,
+                domain.stopIndex,
+                domain.stopSequence
+        );
     }
 
-    public ApiPlace mapPlace(Place domain, Calendar arrival, Calendar departure) {
+    public ApiPlace mapPlace(
+            Place domain,
+            Calendar arrival,
+            Calendar departure,
+            Integer stopIndex,
+            Integer stopSequence
+    ) {
         if(domain == null) { return null; }
 
         ApiPlace api = new ApiPlace();
@@ -55,8 +67,8 @@ public class PlaceMapper {
         api.arrival = arrival;
         api.departure = departure;
         api.orig = domain.orig;
-        api.stopIndex = domain.stopIndex;
-        api.stopSequence = domain.stopSequence;
+        api.stopIndex = stopIndex;
+        api.stopSequence = stopSequence;
         api.vertexType = VertexTypeMapper.mapVertexType(domain.vertexType);
         if (domain.vehicleRentalPlace != null) {
             api.bikeShareId = domain.vehicleRentalPlace.getStationId();

--- a/src/main/java/org/opentripplanner/api/mapping/TripPlanMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/TripPlanMapper.java
@@ -19,8 +19,8 @@ public class TripPlanMapper {
         ApiTripPlan api = new ApiTripPlan();
         api.date = domain.date;
         // The origin/destination do not have arrival/depature times; Hence {@code null} is used.
-        api.from = placeMapper.mapPlace(domain.from, null, null);
-        api.to = placeMapper.mapPlace(domain.to, null, null);
+        api.from = placeMapper.mapPlace(domain.from, null, null, null, null);
+        api.to = placeMapper.mapPlace(domain.to, null, null, null, null);
         api.itineraries = itineraryMapper.mapItineraries(domain.itineraries);
         return api;
     }

--- a/src/main/java/org/opentripplanner/model/plan/ItinerariesCalculateLegTotals.java
+++ b/src/main/java/org/opentripplanner/model/plan/ItinerariesCalculateLegTotals.java
@@ -1,7 +1,5 @@
 package org.opentripplanner.model.plan;
 
-import org.opentripplanner.routing.core.TraverseMode;
-
 import java.util.List;
 
 
@@ -25,8 +23,8 @@ class ItinerariesCalculateLegTotals {
     }
 
     private void calculate(List<Leg> legs) {
-        long startTimeMs = legs.get(0).startTime.getTimeInMillis();
-        long endTimeMs = legs.get(legs.size()-1).endTime.getTimeInMillis();
+        long startTimeMs = legs.get(0).getStartTime().getTimeInMillis();
+        long endTimeMs = legs.get(legs.size() - 1).getEndTime().getTimeInMillis();
 
         totalDurationSeconds = (int) Math.round((endTimeMs - startTimeMs) / 1000.0);
 
@@ -39,7 +37,7 @@ class ItinerariesCalculateLegTotals {
             }
             else if(leg.isOnStreetNonTransit()) {
                 nonTransitTimeSeconds += dt;
-                nonTransitDistanceMeters += leg.distanceMeters;
+                nonTransitDistanceMeters += leg.getDistanceMeters();
             }
             if (!leg.isWalkingLeg()) {
                 walkOnly = false;

--- a/src/main/java/org/opentripplanner/model/plan/Itinerary.java
+++ b/src/main/java/org/opentripplanner/model/plan/Itinerary.java
@@ -151,14 +151,14 @@ public class Itinerary {
      * Time that the trip departs.
      */
     public Calendar startTime() {
-        return firstLeg().startTime;
+        return firstLeg().getStartTime();
     }
 
     /**
      * Time that the trip arrives.
      */
     public Calendar endTime() {
-        return lastLeg().endTime;
+        return lastLeg().getEndTime();
     }
 
     /**
@@ -166,14 +166,14 @@ public class Itinerary {
      * Unit: seconds.
      */
     public int departureDelay() {
-        return firstLeg().departureDelay;
+        return firstLeg().getDepartureDelay();
     }
     /**
      * Reflects the arrivalDelay on the last Leg
      * Unit: seconds.
      */
     public int arrivalDelay() {
-        return lastLeg().arrivalDelay;
+        return lastLeg().getArrivalDelay();
     }
 
 
@@ -189,7 +189,7 @@ public class Itinerary {
      * Total distance in meters.
      */
     public double distanceMeters() {
-        return legs.stream().mapToDouble(it -> it.distanceMeters).sum();
+        return legs.stream().mapToDouble(it -> it.getDistanceMeters()).sum();
     }
 
     /**
@@ -242,7 +242,7 @@ public class Itinerary {
     }
 
     public void timeShiftToStartAt(Calendar afterTime) {
-        Calendar startTimeFirstLeg = firstLeg().startTime;
+        Calendar startTimeFirstLeg = firstLeg().getStartTime();
         long adjustmentMilliSeconds =
             afterTime.getTimeInMillis() - startTimeFirstLeg.getTimeInMillis();
         timeShift(adjustmentMilliSeconds);
@@ -250,8 +250,8 @@ public class Itinerary {
 
     private void timeShift(long adjustmentMilliSeconds) {
         for (Leg leg : this.legs) {
-            leg.startTime.setTimeInMillis(leg.startTime.getTimeInMillis() + adjustmentMilliSeconds);
-            leg.endTime.setTimeInMillis(leg.endTime.getTimeInMillis() + adjustmentMilliSeconds);
+            leg.getStartTime().setTimeInMillis(leg.getStartTime().getTimeInMillis() + adjustmentMilliSeconds);
+            leg.getEndTime().setTimeInMillis(leg.getEndTime().getTimeInMillis() + adjustmentMilliSeconds);
         }
     }
 
@@ -274,10 +274,10 @@ public class Itinerary {
     @Override
     public String toString() {
         return ToStringBuilder.of(Itinerary.class)
-                .addStr("from", firstLeg().from.toStringShort())
-                .addStr("to", lastLeg().to.toStringShort())
-                .addTimeCal("start", firstLeg().startTime)
-                .addTimeCal("end", lastLeg().endTime)
+                .addStr("from", firstLeg().getFrom().toStringShort())
+                .addStr("to", lastLeg().getTo().toStringShort())
+                .addTimeCal("start", firstLeg().getStartTime())
+                .addTimeCal("end", lastLeg().getEndTime())
                 .addNum("nTransfers", nTransfers, -1)
                 .addDurationSec("duration", durationSeconds)
                 .addNum("generalizedCost", generalizedCost)
@@ -320,7 +320,7 @@ public class Itinerary {
     public String toStr() {
         // No translater needed, stop indexes are never passed to the builder
         PathStringBuilder buf = new PathStringBuilder(null);
-        buf.stop(firstLeg().from.name);
+        buf.stop(firstLeg().getFrom().name);
 
         for (Leg leg : legs) {
             buf.sep();
@@ -328,14 +328,15 @@ public class Itinerary {
                 buf.walk((int)leg.getDuration());
             }
             else if(leg.isTransitLeg()) {
-              buf.transit(leg.mode, leg.getTrip().logInfo(), leg.startTime, leg.endTime);
+              buf.transit(
+                      leg.getMode(), leg.getTrip().logInfo(), leg.getStartTime(), leg.getEndTime());
             }
             else {
-                buf.other(leg.mode, leg.startTime, leg.endTime);
+                buf.other(leg.getMode(), leg.getStartTime(), leg.getEndTime());
             }
 
             buf.sep();
-            buf.stop(leg.to.name);
+            buf.stop(leg.getTo().name);
         }
 
         buf.space().append(String.format(ROOT, "[ $%d ]", generalizedCost));

--- a/src/main/java/org/opentripplanner/model/plan/Leg.java
+++ b/src/main/java/org/opentripplanner/model/plan/Leg.java
@@ -24,220 +24,128 @@ import org.opentripplanner.util.model.EncodedPolylineBean;
 */
 public class Leg {
 
-  /**
-   * The mode (e.g., <code>Walk</code>) used when traversing this leg.
-   */
-  public final TraverseMode mode;
+    private final TraverseMode mode;
 
-  private final Trip trip;
+    private final Trip trip;
 
-  /**
-   * The date and time this leg begins.
-   */
-  public Calendar startTime = null;
+    private Calendar startTime = null;
 
-  /**
-   * The date and time this leg ends.
-   */
-  public Calendar endTime = null;
+    private Calendar endTime = null;
 
-  /**
-   * For transit leg, the offset from the scheduled departure-time of the boarding stop in this leg.
-   * "scheduled time of departure at boarding stop" = startTime - departureDelay
-   * Unit: seconds.
-   */
-  public int departureDelay = 0;
+    private int departureDelay = 0;
 
-  /**
-   * For transit leg, the offset from the scheduled arrival-time of the alighting stop in this leg.
-   * "scheduled time of arrival at alighting stop" = endTime - arrivalDelay
-   * Unit: seconds.
-   */
-  public int arrivalDelay = 0;
+    private int arrivalDelay = 0;
 
-  /**
-   * Whether there is real-time data about this Leg
-   */
-  public Boolean realTime = false;
+    private Boolean realTime = false;
 
-  /**
-   * Whether this Leg describes a flexible trip. The reason we need this is that FlexTrip does
-   * not inherit from Trip, so that the information that the Trip is flexible would be lost when
-   * creating this object.
-   */
-  public boolean flexibleTrip = false;
+    private boolean flexibleTrip = false;
 
-  /**
-   * Is this a frequency-based trip with non-strict departure times?
-   */
-  public Boolean isNonExactFrequency = null;
+    private Boolean isNonExactFrequency = null;
 
-  /**
-   * The best estimate of the time between two arriving vehicles. This is particularly important
-   * for non-strict frequency trips, but could become important for real-time trips, strict
-   * frequency trips, and scheduled trips with empirical headways.
-   */
-  public Integer headway = null;
+    private Integer headway = null;
 
-  /**
-   * The distance traveled while traversing the leg in meters.
-   */
-  public Double distanceMeters = null;
+    private Double distanceMeters = null;
 
-  /**
-   * Is this leg a traversing pathways?
-   */
-  public Boolean pathway = false;
+    private Boolean pathway = false;
 
-  /**
-   * The GTFS pathway id
-   */
-  public FeedScopedId pathwayId;
+    private FeedScopedId pathwayId;
 
-  public int agencyTimeZoneOffset;
+    private int agencyTimeZoneOffset;
 
-   /**
-    * For transit legs, the type of the route. Non transit -1
-    * When 0-7: 0 Tram, 1 Subway, 2 Train, 3 Bus, 4 Ferry, 5 Cable Car, 6 Gondola, 7 Funicular
-    * When equal or highter than 100, it is coded using the Hierarchical Vehicle Type (HVT) codes from the European TPEG standard
-    * Also see http://groups.google.com/group/gtfs-changes/msg/ed917a69cf8c5bef
-    */
-   public Integer routeType = null;
+    private Integer routeType = null;
 
-   /**
-    * For transit legs, the headsign of the bus or train being used. For non-transit legs, null.
-    */
-   public String headsign = null;
+    private String headsign = null;
 
-   /**
-    * For transit legs, the service date of the trip.
-    * For non-transit legs, null.
-    * <p>
-    * The trip service date should be used to identify the correct trip schedule and
-    * can not be trusted to display the date for any departures or arrivals. For example,
-    * the first departure for a given trip may happen at service date March 25th and
-    * service time 25:00, which in local time would be Mach 26th 01:00.
-    */
-   public ServiceDate serviceDate = null;
+    private ServiceDate serviceDate = null;
 
-    /**
-     * For transit leg, the route's branding URL (if one exists). For non-transit legs, null.
-     */
-    public String routeBrandingUrl = null;
+    private String routeBrandingUrl = null;
 
-    /**
-    * The Place where the leg originates.
-    */
-   public Place from = null;
+    private Place from = null;
 
-   /**
-    * The Place where the leg begins.
-    */
-   public Place to = null;
+    private Place to = null;
 
-    /**
-     * For transit legs, intermediate stops between the Place where the leg originates and the Place
-     * where the leg ends. For non-transit legs, {@code null}. This field is optional i.e. it is
-     * always {@code null} unless {@code showIntermediateStops} parameter is set to "true" in the
-     * planner request.
-     */
-    public List<StopArrival> intermediateStops;
+    private List<StopArrival> intermediateStops;
 
-   /**
-    * The leg's geometry.
-    */
-   public EncodedPolylineBean legGeometry;
+    private EncodedPolylineBean legGeometry;
 
-   /**
-    * A series of turn by turn instructions used for walking, biking and driving.
-    */
-   public List<WalkStep> walkSteps;
+    private List<WalkStep> walkSteps;
 
-   public Set<StreetNote> streetNotes = new HashSet<>();
+    private Set<StreetNote> streetNotes = new HashSet<>();
 
-   public Set<TransitAlert> transitAlerts = new HashSet<>();
+    private Set<TransitAlert> transitAlerts = new HashSet<>();
 
-   public String boardRule;
+    private String boardRule;
 
-   public String alightRule;
+    private String alightRule;
 
-   public BookingInfo dropOffBookingInfo = null;
+    private BookingInfo dropOffBookingInfo = null;
 
-   public BookingInfo pickupBookingInfo = null;
+    private BookingInfo pickupBookingInfo = null;
 
-    public ConstrainedTransfer transferFromPrevLeg = null;
+    private ConstrainedTransfer transferFromPrevLeg = null;
 
-    public ConstrainedTransfer transferToNextLeg = null;
+    private ConstrainedTransfer transferToNextLeg = null;
 
     public Integer boardStopPosInPattern = null;
 
     public Integer alightStopPosInPattern = null;
 
-    public Integer boardingStopSequence = null;
+    private Integer boardingStopSequence = null;
 
-    public Integer alightStopSequence = null;
+    private Integer alightStopSequence = null;
 
-    /**
-     * Is this leg walking with a bike?
-     */
-    public Boolean walkingBike;
+    private Boolean walkingBike;
 
-    public Boolean rentedVehicle;
+    private Boolean rentedVehicle;
 
-    public String vehicleRentalNetwork;
+    private String vehicleRentalNetwork;
 
-  /**
-   * If a generalized cost is used in the routing algorithm, this should be the "delta" cost
-   * computed by the algorithm for the section this leg account for. This is relevant for anyone
-   * who want to debug an search and tuning the system. The unit should be equivalent to the cost
-   * of "one second of transit".
-   * <p>
-   * -1 indicate that the cost is not set/computed.
-   */
-  public int generalizedCost = -1;
+    private int generalizedCost = -1;
 
-  public Leg(TraverseMode mode) {
-    if(mode.isTransit()) {
-      throw new IllegalArgumentException("To create a transit leg use the other constructor.");
+    public Leg(TraverseMode mode) {
+        if (mode.isTransit()) {
+            throw new IllegalArgumentException(
+                    "To create a transit leg use the other constructor.");
+        }
+        this.mode = mode;
+        this.trip = null;
     }
-    this.mode = mode;
-    this.trip = null;
-  }
 
-  public Leg(Trip trip) {
-    this.mode = TraverseMode.fromTransitMode(trip.getMode());
-    this.trip = trip;
-  }
-
-  /**
-    * Whether this leg is a transit leg or not.
-    * @return Boolean true if the leg is a transit leg
-    */
-  public boolean isTransitLeg() {
-       return mode.isTransit();
-   }
+    public Leg(Trip trip) {
+        this.mode = TraverseMode.fromTransitMode(trip.getMode());
+        this.trip = trip;
+    }
 
     /**
-     * For transit legs, if the rider should stay on the vehicle as it changes route names.
-     * This is the same as a stay-seated transfer.
+     * Whether this leg is a transit leg or not.
+     *
+     * @return Boolean true if the leg is a transit leg
+     */
+    public boolean isTransitLeg() {
+        return mode.isTransit();
+    }
+
+    /**
+     * For transit legs, if the rider should stay on the vehicle as it changes route names. This is
+     * the same as a stay-seated transfer.
      */
     public Boolean isInterlinedWithPreviousLeg() {
-        if(transferFromPrevLeg == null) { return false; }
+        if (transferFromPrevLeg == null) {return false;}
         return transferFromPrevLeg.getTransferConstraint().isStaySeated();
     }
 
-  /**
-   * A scheduled leg is a leg riding a public scheduled transport including frequency based
-   * transport, or flex service. If the ride is not likely to wait for the passenger, even if the
-   * passenger call in and say hen is late, then this method should return {@code true}.
-   * <p>
-   * For example, this method can be used to add extra "cost" if the transfer time is tight.
-   */
-  public boolean isScheduled() {
-    return isTransitLeg() || flexibleTrip;
-  }
+    /**
+     * A scheduled leg is a leg riding a public scheduled transport including frequency based
+     * transport, or flex service. If the ride is not likely to wait for the passenger, even if the
+     * passenger call in and say hen is late, then this method should return {@code true}.
+     * <p>
+     * For example, this method can be used to add extra "cost" if the transfer time is tight.
+     */
+    public boolean isScheduled() {
+        return isTransitLeg() || flexibleTrip;
+    }
 
-  public boolean isWalkingLeg() {
+    public boolean isWalkingLeg() {
         return mode.isWalking();
     }
 
@@ -246,8 +154,8 @@ public class Leg {
     }
 
     /**
-    * The leg's duration in seconds
-    */
+     * The leg's duration in seconds
+     */
     public long getDuration() {
         // Round to closest second; Hence subtract 500 ms before dividing by 1000
         return (500 + endTime.getTimeInMillis() - startTime.getTimeInMillis()) / 1000;
@@ -258,57 +166,66 @@ public class Leg {
     }
 
     public void addAlert(TransitAlert alert) {
-      transitAlerts.add(alert);
+        transitAlerts.add(alert);
     }
 
     public void setVehicleRentalNetwork(String network) {
-      vehicleRentalNetwork = network;
+        vehicleRentalNetwork = network;
     }
 
     /**
-     * Return {@code true} if to legs ride the same trip(same tripId) and at least part of the
-     * rides overlap. Two legs overlap is they have at least one segment(from one stop to the next)
-     * in common.
+     * Return {@code true} if to legs ride the same trip(same tripId) and at least part of the rides
+     * overlap. Two legs overlap is they have at least one segment(from one stop to the next) in
+     * common.
      */
     public boolean isPartiallySameTransitLeg(Leg other) {
-      // Assert both legs are transit legs
-      if(!isTransitLeg() || !other.isTransitLeg()) { throw new IllegalStateException(); }
+        // Assert both legs are transit legs
+        if (!isTransitLeg() || !other.isTransitLeg()) {throw new IllegalStateException();}
 
-      // Must be on the same service date
-      if(!serviceDate.equals(other.serviceDate)) { return false; }
+        // Must be on the same service date
+        if (!serviceDate.equals(other.serviceDate)) {return false;}
 
-      // If NOT the same trip, return false
-      if(!trip.getId().equals(other.trip.getId())) { return false; }
+        // If NOT the same trip, return false
+        if (!trip.getId().equals(other.trip.getId())) {return false;}
 
-      // Return true if legs overlap
-      return boardStopPosInPattern < other.alightStopPosInPattern &&
-             alightStopPosInPattern > other.boardStopPosInPattern;
+        // Return true if legs overlap
+        return boardStopPosInPattern < other.alightStopPosInPattern &&
+               alightStopPosInPattern > other.boardStopPosInPattern;
     }
 
-  /** For transit legs, the route agency. For non-transit legs {@code null}. */
-  public Agency getAgency() {
-    return isTransitLeg() ? getRoute().getAgency() : null;
-  }
+    /**
+     * For transit legs, the route agency. For non-transit legs {@code null}.
+     */
+    public Agency getAgency() {
+        return isTransitLeg() ? getRoute().getAgency() : null;
+    }
 
-  /**
-   * For transit legs, the trip operator, fallback to route operator.
-   * For non-transit legs {@code null}.
-   * @see Trip#getOperator()
-   */
-  public Operator getOperator() {
-    return isTransitLeg() ? trip.getOperator() : null;
-  }
+    /**
+     * For transit legs, the trip operator, fallback to route operator. For non-transit legs {@code
+     * null}.
+     *
+     * @see Trip#getOperator()
+     */
+    public Operator getOperator() {
+        return isTransitLeg() ? trip.getOperator() : null;
+    }
 
-  /** For transit legs, the route. For non-transit legs, null. */
-  public Route getRoute() { return isTransitLeg() ? trip.getRoute() : null; }
+    /**
+     * For transit legs, the route. For non-transit legs, null.
+     */
+    public Route getRoute() {return isTransitLeg() ? trip.getRoute() : null;}
 
-  /** For transit legs, the trip. For non-transit legs, null. */
-  public Trip getTrip() {  return trip; }
+    /**
+     * For transit legs, the trip. For non-transit legs, null.
+     */
+    public Trip getTrip() {return trip;}
 
-  /** Should be used for debug logging only */
+    /**
+     * Should be used for debug logging only
+     */
     @Override
     public String toString() {
-      return ToStringBuilder.of(Leg.class)
+        return ToStringBuilder.of(Leg.class)
                 .addObj("from", from)
                 .addObj("to", to)
                 .addTimeCal("startTime", startTime)
@@ -344,5 +261,393 @@ public class Leg {
                 .addObj("transferFromPrevLeg", transferFromPrevLeg)
                 .addObj("transferToNextLeg", transferToNextLeg)
                 .toString();
+    }
+
+    /**
+     * The mode (e.g., <code>Walk</code>) used when traversing this leg.
+     */
+    public TraverseMode getMode() {
+        return mode;
+    }
+
+    /**
+     * The date and time this leg begins.
+     */
+    public Calendar getStartTime() {
+        return startTime;
+    }
+
+    public void setStartTime(Calendar startTime) {
+        this.startTime = startTime;
+    }
+
+    /**
+     * The date and time this leg ends.
+     */
+    public Calendar getEndTime() {
+        return endTime;
+    }
+
+    public void setEndTime(Calendar endTime) {
+        this.endTime = endTime;
+    }
+
+    /**
+     * For transit leg, the offset from the scheduled departure-time of the boarding stop in this
+     * leg. "scheduled time of departure at boarding stop" = startTime - departureDelay Unit:
+     * seconds.
+     */
+    public int getDepartureDelay() {
+        return departureDelay;
+    }
+
+    public void setDepartureDelay(int departureDelay) {
+        this.departureDelay = departureDelay;
+    }
+
+    /**
+     * For transit leg, the offset from the scheduled arrival-time of the alighting stop in this
+     * leg. "scheduled time of arrival at alighting stop" = endTime - arrivalDelay Unit: seconds.
+     */
+    public int getArrivalDelay() {
+        return arrivalDelay;
+    }
+
+    public void setArrivalDelay(int arrivalDelay) {
+        this.arrivalDelay = arrivalDelay;
+    }
+
+    /**
+     * Whether there is real-time data about this Leg
+     */
+    public Boolean getRealTime() {
+        return realTime;
+    }
+
+    public void setRealTime(Boolean realTime) {
+        this.realTime = realTime;
+    }
+
+    /**
+     * Whether this Leg describes a flexible trip. The reason we need this is that FlexTrip does not
+     * inherit from Trip, so that the information that the Trip is flexible would be lost when
+     * creating this object.
+     */
+    public boolean isFlexibleTrip() {
+        return flexibleTrip;
+    }
+
+    public void setFlexibleTrip(boolean flexibleTrip) {
+        this.flexibleTrip = flexibleTrip;
+    }
+
+    /**
+     * Is this a frequency-based trip with non-strict departure times?
+     */
+    public Boolean getNonExactFrequency() {
+        return isNonExactFrequency;
+    }
+
+    public void setNonExactFrequency(Boolean nonExactFrequency) {
+        isNonExactFrequency = nonExactFrequency;
+    }
+
+    /**
+     * The best estimate of the time between two arriving vehicles. This is particularly important
+     * for non-strict frequency trips, but could become important for real-time trips, strict
+     * frequency trips, and scheduled trips with empirical headways.
+     */
+    public Integer getHeadway() {
+        return headway;
+    }
+
+    public void setHeadway(Integer headway) {
+        this.headway = headway;
+    }
+
+    /**
+     * The distance traveled while traversing the leg in meters.
+     */
+    public Double getDistanceMeters() {
+        return distanceMeters;
+    }
+
+    public void setDistanceMeters(Double distanceMeters) {
+        this.distanceMeters = distanceMeters;
+    }
+
+    /**
+     * Is this leg a traversing pathways?
+     */
+    public Boolean getPathway() {
+        return pathway;
+    }
+
+    public void setPathway(Boolean pathway) {
+        this.pathway = pathway;
+    }
+
+    /**
+     * The GTFS pathway id
+     */
+    public FeedScopedId getPathwayId() {
+        return pathwayId;
+    }
+
+    public void setPathwayId(FeedScopedId pathwayId) {
+        this.pathwayId = pathwayId;
+    }
+
+    public int getAgencyTimeZoneOffset() {
+        return agencyTimeZoneOffset;
+    }
+
+    public void setAgencyTimeZoneOffset(int agencyTimeZoneOffset) {
+        this.agencyTimeZoneOffset = agencyTimeZoneOffset;
+    }
+
+    /**
+     * For transit legs, the type of the route. Non transit -1 When 0-7: 0 Tram, 1 Subway, 2 Train,
+     * 3 Bus, 4 Ferry, 5 Cable Car, 6 Gondola, 7 Funicular When equal or highter than 100, it is
+     * coded using the Hierarchical Vehicle Type (HVT) codes from the European TPEG standard Also
+     * see http://groups.google.com/group/gtfs-changes/msg/ed917a69cf8c5bef
+     */
+    public Integer getRouteType() {
+        return routeType;
+    }
+
+    public void setRouteType(Integer routeType) {
+        this.routeType = routeType;
+    }
+
+    /**
+     * For transit legs, the headsign of the bus or train being used. For non-transit legs, null.
+     */
+    public String getHeadsign() {
+        return headsign;
+    }
+
+    public void setHeadsign(String headsign) {
+        this.headsign = headsign;
+    }
+
+    /**
+     * For transit legs, the service date of the trip. For non-transit legs, null.
+     * <p>
+     * The trip service date should be used to identify the correct trip schedule and can not be
+     * trusted to display the date for any departures or arrivals. For example, the first departure
+     * for a given trip may happen at service date March 25th and service time 25:00, which in local
+     * time would be Mach 26th 01:00.
+     */
+    public ServiceDate getServiceDate() {
+        return serviceDate;
+    }
+
+    public void setServiceDate(ServiceDate serviceDate) {
+        this.serviceDate = serviceDate;
+    }
+
+    /**
+     * For transit leg, the route's branding URL (if one exists). For non-transit legs, null.
+     */
+    public String getRouteBrandingUrl() {
+        return routeBrandingUrl;
+    }
+
+    public void setRouteBrandingUrl(String routeBrandingUrl) {
+        this.routeBrandingUrl = routeBrandingUrl;
+    }
+
+    /**
+     * The Place where the leg originates.
+     */
+    public Place getFrom() {
+        return from;
+    }
+
+    public void setFrom(Place from) {
+        this.from = from;
+    }
+
+    /**
+     * The Place where the leg begins.
+     */
+    public Place getTo() {
+        return to;
+    }
+
+    public void setTo(Place to) {
+        this.to = to;
+    }
+
+    /**
+     * For transit legs, intermediate stops between the Place where the leg originates and the Place
+     * where the leg ends. For non-transit legs, {@code null}. This field is optional i.e. it is
+     * always {@code null} unless {@code showIntermediateStops} parameter is set to "true" in the
+     * planner request.
+     */
+    public List<StopArrival> getIntermediateStops() {
+        return intermediateStops;
+    }
+
+    public void setIntermediateStops(List<StopArrival> intermediateStops) {
+        this.intermediateStops = intermediateStops;
+    }
+
+    /**
+     * The leg's geometry.
+     */
+    public EncodedPolylineBean getLegGeometry() {
+        return legGeometry;
+    }
+
+    public void setLegGeometry(EncodedPolylineBean legGeometry) {
+        this.legGeometry = legGeometry;
+    }
+
+    /**
+     * A series of turn by turn instructions used for walking, biking and driving.
+     */
+    public List<WalkStep> getWalkSteps() {
+        return walkSteps;
+    }
+
+    public void setWalkSteps(List<WalkStep> walkSteps) {
+        this.walkSteps = walkSteps;
+    }
+
+    public Set<StreetNote> getStreetNotes() {
+        return streetNotes;
+    }
+
+    public void setStreetNotes(Set<StreetNote> streetNotes) {
+        this.streetNotes = streetNotes;
+    }
+
+    public Set<TransitAlert> getTransitAlerts() {
+        return transitAlerts;
+    }
+
+    public void setTransitAlerts(Set<TransitAlert> transitAlerts) {
+        this.transitAlerts = transitAlerts;
+    }
+
+    public String getBoardRule() {
+        return boardRule;
+    }
+
+    public void setBoardRule(String boardRule) {
+        this.boardRule = boardRule;
+    }
+
+    public String getAlightRule() {
+        return alightRule;
+    }
+
+    public void setAlightRule(String alightRule) {
+        this.alightRule = alightRule;
+    }
+
+    public BookingInfo getDropOffBookingInfo() {
+        return dropOffBookingInfo;
+    }
+
+    public void setDropOffBookingInfo(BookingInfo dropOffBookingInfo) {
+        this.dropOffBookingInfo = dropOffBookingInfo;
+    }
+
+    public BookingInfo getPickupBookingInfo() {
+        return pickupBookingInfo;
+    }
+
+    public void setPickupBookingInfo(BookingInfo pickupBookingInfo) {
+        this.pickupBookingInfo = pickupBookingInfo;
+    }
+
+    public ConstrainedTransfer getTransferFromPrevLeg() {
+        return transferFromPrevLeg;
+    }
+
+    public void setTransferFromPrevLeg(ConstrainedTransfer transferFromPrevLeg) {
+        this.transferFromPrevLeg = transferFromPrevLeg;
+    }
+
+    public ConstrainedTransfer getTransferToNextLeg() {
+        return transferToNextLeg;
+    }
+
+    public void setTransferToNextLeg(ConstrainedTransfer transferToNextLeg) {
+        this.transferToNextLeg = transferToNextLeg;
+    }
+
+    public Integer getBoardStopPosInPattern() {
+        return boardStopPosInPattern;
+    }
+
+    public void setBoardStopPosInPattern(Integer boardStopPosInPattern) {
+        this.boardStopPosInPattern = boardStopPosInPattern;
+    }
+
+    public Integer getAlightStopPosInPattern() {
+        return alightStopPosInPattern;
+    }
+
+    public void setAlightStopPosInPattern(Integer alightStopPosInPattern) {
+        this.alightStopPosInPattern = alightStopPosInPattern;
+    }
+
+    public Integer getBoardingStopSequence() {
+        return boardingStopSequence;
+    }
+
+    public void setBoardingStopSequence(Integer boardingStopSequence) {
+        this.boardingStopSequence = boardingStopSequence;
+    }
+
+    public Integer getAlightStopSequence() {
+        return alightStopSequence;
+    }
+
+    public void setAlightStopSequence(Integer alightStopSequence) {
+        this.alightStopSequence = alightStopSequence;
+    }
+
+    /**
+     * Is this leg walking with a bike?
+     */
+    public Boolean getWalkingBike() {
+        return walkingBike;
+    }
+
+    public void setWalkingBike(Boolean walkingBike) {
+        this.walkingBike = walkingBike;
+    }
+
+    public Boolean getRentedVehicle() {
+        return rentedVehicle;
+    }
+
+    public void setRentedVehicle(Boolean rentedVehicle) {
+        this.rentedVehicle = rentedVehicle;
+    }
+
+    public String getVehicleRentalNetwork() {
+        return vehicleRentalNetwork;
+    }
+
+    /**
+     * If a generalized cost is used in the routing algorithm, this should be the "delta" cost
+     * computed by the algorithm for the section this leg account for. This is relevant for anyone
+     * who want to debug an search and tuning the system. The unit should be equivalent to the cost
+     * of "one second of transit".
+     * <p>
+     * -1 indicate that the cost is not set/computed.
+     */
+    public int getGeneralizedCost() {
+        return generalizedCost;
+    }
+
+    public void setGeneralizedCost(int generalizedCost) {
+        this.generalizedCost = generalizedCost;
     }
 }

--- a/src/main/java/org/opentripplanner/model/plan/Leg.java
+++ b/src/main/java/org/opentripplanner/model/plan/Leg.java
@@ -173,6 +173,10 @@ public class Leg {
 
     public Integer alightStopPosInPattern = null;
 
+    public Integer boardingStopSequence = null;
+
+    public Integer alightStopSequence = null;
+
     /**
      * Is this leg walking with a bike?
      */
@@ -277,7 +281,8 @@ public class Leg {
       if(!trip.getId().equals(other.trip.getId())) { return false; }
 
       // Return true if legs overlap
-      return this.from.stopIndex < other.to.stopIndex && to.stopIndex > other.from.stopIndex;
+      return boardStopPosInPattern < other.alightStopPosInPattern &&
+             alightStopPosInPattern > other.boardStopPosInPattern;
     }
 
   /** For transit legs, the route agency. For non-transit legs {@code null}. */

--- a/src/main/java/org/opentripplanner/model/plan/Leg.java
+++ b/src/main/java/org/opentripplanner/model/plan/Leg.java
@@ -90,9 +90,9 @@ public class Leg {
 
     public Integer alightStopPosInPattern = null;
 
-    private Integer boardingStopSequence = null;
+    private Integer boardingGtfsStopSequence = null;
 
-    private Integer alightStopSequence = null;
+    private Integer alightGtfsStopSequence = null;
 
     private Boolean walkingBike;
 
@@ -596,20 +596,20 @@ public class Leg {
         this.alightStopPosInPattern = alightStopPosInPattern;
     }
 
-    public Integer getBoardingStopSequence() {
-        return boardingStopSequence;
+    public Integer getBoardingGtfsStopSequence() {
+        return boardingGtfsStopSequence;
     }
 
-    public void setBoardingStopSequence(Integer boardingStopSequence) {
-        this.boardingStopSequence = boardingStopSequence;
+    public void setBoardingGtfsStopSequence(Integer boardingGtfsStopSequence) {
+        this.boardingGtfsStopSequence = boardingGtfsStopSequence;
     }
 
-    public Integer getAlightStopSequence() {
-        return alightStopSequence;
+    public Integer getAlightGtfsStopSequence() {
+        return alightGtfsStopSequence;
     }
 
-    public void setAlightStopSequence(Integer alightStopSequence) {
-        this.alightStopSequence = alightStopSequence;
+    public void setAlightGtfsStopSequence(Integer alightGtfsStopSequence) {
+        this.alightGtfsStopSequence = alightGtfsStopSequence;
     }
 
     /**

--- a/src/main/java/org/opentripplanner/model/plan/Place.java
+++ b/src/main/java/org/opentripplanner/model/plan/Place.java
@@ -40,16 +40,6 @@ public class Place {
     public final StopLocation stop;
 
     /**
-     * For transit trips, the stop index (numbered from zero from the start of the trip).
-     */
-    public final Integer stopIndex;
-
-    /**
-     * For transit trips, the sequence number of the stop. Per GTFS, these numbers are increasing.
-     */
-    public final Integer stopSequence;
-
-    /**
      * The vehicle rental place if the type is {@link VertexType#VEHICLERENTAL}.
      */
     public final VehicleRentalPlace vehicleRentalPlace;
@@ -65,8 +55,6 @@ public class Place {
             WgsCoordinate coordinate,
             VertexType vertexType,
             StopLocation stop,
-            Integer stopIndex,
-            Integer stopSequence,
             VehicleRentalPlace vehicleRentalPlace,
             VehicleParkingWithEntrance vehicleParkingWithEntrance
     ) {
@@ -75,8 +63,6 @@ public class Place {
         this.coordinate = coordinate;
         this.vertexType = vertexType;
         this.stop = stop;
-        this.stopIndex = stopIndex;
-        this.stopSequence = stopSequence;
         this.vehicleRentalPlace = vehicleRentalPlace;
         this.vehicleParkingWithEntrance = vehicleParkingWithEntrance;
     }
@@ -115,8 +101,6 @@ public class Place {
                 .addObj("stop", stop)
                 .addObj("coordinate", coordinate)
                 .addStr("orig", orig)
-                .addNum("stopIndex", stopIndex)
-                .addNum("stopSequence", stopSequence)
                 .addEnum("vertexType", vertexType)
                 .addObj("vehicleRentalPlace", vehicleRentalPlace)
                 .addObj("vehicleParkingEntrance", vehicleParkingWithEntrance)
@@ -129,7 +113,7 @@ public class Place {
                 null,
                 WgsCoordinate.creatOptionalCoordinate(lat, lon),
                 VertexType.NORMAL,
-                null, null, null, null, null
+                null, null, null
         );
     }
 
@@ -139,30 +123,23 @@ public class Place {
                 null,
                 WgsCoordinate.creatOptionalCoordinate(vertex.getLat(), vertex.getLon()),
                 VertexType.NORMAL,
-                null, null, null, null, null
+                null, null, null
         );
     }
 
-    public static Place forStop(StopLocation stop, Integer stopIndex, Integer stopSequence) {
+    public static Place forStop(StopLocation stop) {
         return new Place(
                 stop.getName(),
                 null,
                 stop.getCoordinate(),
                 VertexType.TRANSIT,
                 stop,
-                stopIndex,
-                stopSequence,
                 null,
                 null
         );
     }
 
-    public static Place forFlexStop(
-            StopLocation stop,
-            Vertex vertex,
-            Integer stopIndex,
-            Integer stopSequence
-    ) {
+    public static Place forFlexStop(StopLocation stop, Vertex vertex) {
         // The actual vertex is used because the StopLocation coordinates may not be equal to the vertex's
         // coordinates.
         return new Place(
@@ -171,22 +148,6 @@ public class Place {
                 WgsCoordinate.creatOptionalCoordinate(vertex.getLat(), vertex.getLon()),
                 VertexType.TRANSIT,
                 stop,
-                stopIndex,
-                stopSequence,
-                null,
-                null
-        );
-    }
-
-    public static Place forStop(TransitStopVertex vertex, String name) {
-        return new Place(
-                name,
-                null,
-                WgsCoordinate.creatOptionalCoordinate(vertex.getLat(), vertex.getLon()),
-                VertexType.TRANSIT,
-                vertex.getStop(),
-                null,
-                null,
                 null,
                 null
         );
@@ -198,8 +159,6 @@ public class Place {
                 null,
                 WgsCoordinate.creatOptionalCoordinate(vertex.getLat(), vertex.getLon()),
                 VertexType.VEHICLERENTAL,
-                null,
-                null,
                 null,
                 vertex.getStation(),
                 null
@@ -221,8 +180,6 @@ public class Place {
                 null,
                 WgsCoordinate.creatOptionalCoordinate(vertex.getLat(), vertex.getLon()),
                 VertexType.VEHICLEPARKING,
-                null,
-                null,
                 null,
                 null,
                 VehicleParkingWithEntrance.builder()

--- a/src/main/java/org/opentripplanner/model/plan/StopArrival.java
+++ b/src/main/java/org/opentripplanner/model/plan/StopArrival.java
@@ -23,25 +23,25 @@ public class StopArrival {
     /**
      * For transit trips, the stop index (numbered from zero from the start of the trip).
      */
-    public final Integer stopIndex;
+    public final Integer stopPosInPattern;
 
     /**
      * For transit trips, the sequence number of the stop. Per GTFS, these numbers are increasing.
      */
-    public final Integer stopSequence;
+    public final Integer gtfsStopSequence;
 
     public StopArrival(
             Place place,
             Calendar arrival,
             Calendar departure,
-            Integer stopIndex,
-            Integer stopSequence
+            Integer stopPosInPattern,
+            Integer gtfsStopSequence
     ) {
         this.place = place;
         this.arrival = arrival;
         this.departure = departure;
-        this.stopIndex = stopIndex;
-        this.stopSequence = stopSequence;
+        this.stopPosInPattern = stopPosInPattern;
+        this.gtfsStopSequence = gtfsStopSequence;
     }
 
     @Override

--- a/src/main/java/org/opentripplanner/model/plan/StopArrival.java
+++ b/src/main/java/org/opentripplanner/model/plan/StopArrival.java
@@ -20,11 +20,28 @@ public class StopArrival {
      */
     public final Calendar departure;
 
+    /**
+     * For transit trips, the stop index (numbered from zero from the start of the trip).
+     */
+    public final Integer stopIndex;
 
-    public StopArrival(Place place, Calendar arrival, Calendar departure) {
+    /**
+     * For transit trips, the sequence number of the stop. Per GTFS, these numbers are increasing.
+     */
+    public final Integer stopSequence;
+
+    public StopArrival(
+            Place place,
+            Calendar arrival,
+            Calendar departure,
+            Integer stopIndex,
+            Integer stopSequence
+    ) {
         this.place = place;
         this.arrival = arrival;
         this.departure = departure;
+        this.stopIndex = stopIndex;
+        this.stopSequence = stopSequence;
     }
 
     @Override

--- a/src/main/java/org/opentripplanner/routing/algorithm/filterchain/deletionflagger/OtherThanSameLegsMaxGeneralizedCostFilter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/filterchain/deletionflagger/OtherThanSameLegsMaxGeneralizedCostFilter.java
@@ -60,7 +60,7 @@ public class OtherThanSameLegsMaxGeneralizedCostFilter implements ItineraryDelet
             itinerary -> itinerary.legs.stream()
                 .filter(Leg::isTransitLeg)
                 .filter(leg -> commonTrips.contains(leg.getTrip()))
-                .mapToInt(leg -> leg.generalizedCost)
+                .mapToInt(leg -> leg.getGeneralizedCost())
                 .sum()
         ).min();
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/filterchain/deletionflagger/RemoveBikerentalWithMostlyWalkingFilter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/filterchain/deletionflagger/RemoveBikerentalWithMostlyWalkingFilter.java
@@ -27,12 +27,12 @@ public class RemoveBikerentalWithMostlyWalkingFilter implements ItineraryDeletio
     public Predicate<Itinerary> predicate() {
         return itinerary -> {
             var containsTransit =
-                    itinerary.legs.stream().anyMatch(l -> l != null && l.mode.isTransit());
+                    itinerary.legs.stream().anyMatch(l -> l != null && l.getMode().isTransit());
 
             double bikeRentalDistance = itinerary.legs
                     .stream()
-                    .filter(l -> l.rentedVehicle != null && l.rentedVehicle)
-                    .mapToDouble(l -> l.distanceMeters)
+                    .filter(l -> l.getRentedVehicle() != null && l.getRentedVehicle())
+                    .mapToDouble(l -> l.getDistanceMeters())
                     .sum();
             double totalDistance = itinerary.distanceMeters();
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/filterchain/deletionflagger/RemoveParkAndRideWithMostlyWalkingFilter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/filterchain/deletionflagger/RemoveParkAndRideWithMostlyWalkingFilter.java
@@ -31,11 +31,11 @@ public class RemoveParkAndRideWithMostlyWalkingFilter implements ItineraryDeleti
     public Predicate<Itinerary> predicate() {
         return itinerary -> {
             var containsTransit =
-                    itinerary.legs.stream().anyMatch(l -> l != null && l.mode.isTransit());
+                    itinerary.legs.stream().anyMatch(l -> l != null && l.getMode().isTransit());
 
             double carDuration = itinerary.legs
                     .stream()
-                    .filter(l -> l.mode == TraverseMode.CAR)
+                    .filter(l -> l.getMode() == TraverseMode.CAR)
                     .mapToDouble(Leg::getDuration)
                     .sum();
             double totalDuration = itinerary.durationSeconds;

--- a/src/main/java/org/opentripplanner/routing/algorithm/filterchain/groupids/GroupByAllSameStations.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/filterchain/groupids/GroupByAllSameStations.java
@@ -24,7 +24,8 @@ public class GroupByAllSameStations implements GroupId<GroupByAllSameStations> {
     public GroupByAllSameStations(Itinerary itinerary) {
         keySet = itinerary.legs.stream()
                 .filter(Leg::isTransitLeg)
-                .map(leg -> new P2<>(getStopOrStationId(leg.from.stop), getStopOrStationId(leg.to.stop)))
+                .map(leg -> new P2<>(getStopOrStationId(leg.getFrom().stop), getStopOrStationId(
+                        leg.getTo().stop)))
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/filterchain/groupids/GroupByTripIdAndDistance.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/filterchain/groupids/GroupByTripIdAndDistance.java
@@ -61,21 +61,21 @@ public class GroupByTripIdAndDistance implements GroupId<GroupByTripIdAndDistanc
 
     /** package local to be unit-testable */
     static double calculateTotalDistance(List<Leg> transitLegs) {
-        return transitLegs.stream().mapToDouble(it -> it.distanceMeters).sum();
+        return transitLegs.stream().mapToDouble(it -> it.getDistanceMeters()).sum();
     }
 
     /** package local to be unit-testable */
     static List<Leg> getKeySetOfLegsByLimit(List<Leg> legs, double distanceLimitMeters) {
         // Sort legs descending on distance
         legs = legs.stream()
-                .sorted((l,r) -> r.distanceMeters.compareTo(l.distanceMeters))
+                .sorted((l,r) -> r.getDistanceMeters().compareTo(l.getDistanceMeters()))
                 .collect(Collectors.toList());
         double sum = 0.0;
         int i=0;
         while (sum < distanceLimitMeters) {
             // If the transit legs is not long enough, threat the itinerary as non-transit
             if(i == legs.size()) { return List.of(); }
-            sum += legs.get(i).distanceMeters;
+            sum += legs.get(i).getDistanceMeters();
             ++i;
         }
         return legs.stream()

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/AlertToLegMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/AlertToLegMapper.java
@@ -72,9 +72,8 @@ public class AlertToLegMapper {
         Collection<TransitAlert> patches;
 
         // trips - alerts tagged on ServiceDate
-        patches = alertPatchService(graph).getTripAlerts(leg.getTrip().getId(),
-                leg.getServiceDate()
-        );
+        patches = alertPatchService(graph)
+                .getTripAlerts(leg.getTrip().getId(), leg.getServiceDate());
         addTransitAlertPatchesToLeg(leg, patches, requestedLocale, legStartTime, legEndTime);
 
         // trips - alerts tagged on any date
@@ -90,9 +89,12 @@ public class AlertToLegMapper {
         addTransitAlertPatchesToLeg(leg, patches, requestedLocale, legStartTime, legEndTime);
 
         // Filter alerts when there are multiple timePeriods for each alert
-        leg.getTransitAlerts()
-                .removeIf(alertPatch ->  !alertPatch.displayDuring(
-                        leg.getStartTime().getTimeInMillis()/1000, leg.getEndTime().getTimeInMillis()/1000));
+        leg.getTransitAlerts().removeIf(alertPatch ->  
+                !alertPatch.displayDuring(
+                        leg.getStartTime().getTimeInMillis()/1000,
+                        leg.getEndTime().getTimeInMillis()/1000
+                )
+        );
     }
 
     private static TransitAlertService alertPatchService(Graph g) {

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/AlertToLegMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/AlertToLegMapper.java
@@ -5,7 +5,6 @@ import org.opentripplanner.model.Stop;
 import org.opentripplanner.model.StopLocation;
 import org.opentripplanner.model.calendar.ServiceDate;
 import org.opentripplanner.model.plan.Leg;
-import org.opentripplanner.model.plan.Place;
 import org.opentripplanner.model.plan.StopArrival;
 import org.opentripplanner.routing.alertpatch.StopCondition;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
@@ -30,32 +29,36 @@ public class AlertToLegMapper {
                 ? StopCondition.DEPARTURE
                 : StopCondition.FIRST_DEPARTURE;
 
-        Date legStartTime = leg.startTime.getTime();
-        Date legEndTime = leg.endTime.getTime();
-        StopLocation fromStop = leg.from == null ? null : leg.from.stop;
-        StopLocation toStop = leg.to == null ? null : leg.to.stop;
+        Date legStartTime = leg.getStartTime().getTime();
+        Date legEndTime = leg.getEndTime().getTime();
+        StopLocation fromStop = leg.getFrom() == null ? null : leg.getFrom().stop;
+        StopLocation toStop = leg.getTo() == null ? null : leg.getTo().stop;
 
         FeedScopedId routeId = leg.getRoute().getId();
         FeedScopedId tripId = leg.getTrip().getId();
         if (fromStop instanceof Stop) {
             Collection<TransitAlert> alerts = getAlertsForStopAndRoute(graph, (Stop) fromStop, routeId);
-            alerts.addAll(getAlertsForStopAndTrip(graph, (Stop) fromStop, tripId, leg.serviceDate));
+            alerts.addAll(getAlertsForStopAndTrip(graph, (Stop) fromStop, tripId,
+                    leg.getServiceDate()
+            ));
             alerts.addAll(getAlertsForStop(graph, (Stop) fromStop));
             addTransitAlertPatchesToLeg(leg, departingStopConditions, alerts, requestedLocale, legStartTime, legEndTime);
         }
         if (toStop instanceof Stop) {
             Collection<TransitAlert> alerts = getAlertsForStopAndRoute(graph, (Stop) toStop, routeId);
-            alerts.addAll(getAlertsForStopAndTrip(graph, (Stop) toStop, tripId, leg.serviceDate));
+            alerts.addAll(getAlertsForStopAndTrip(graph, (Stop) toStop, tripId,
+                    leg.getServiceDate()
+            ));
             alerts.addAll(getAlertsForStop(graph, (Stop) toStop));
             addTransitAlertPatchesToLeg(leg, StopCondition.ARRIVING, alerts, requestedLocale, legStartTime, legEndTime);
         }
 
-        if (leg.intermediateStops != null) {
-            for (StopArrival visit : leg.intermediateStops) {
+        if (leg.getIntermediateStops() != null) {
+            for (StopArrival visit : leg.getIntermediateStops()) {
                 if (visit.place.stop instanceof Stop) {
                     Stop stop = (Stop) visit.place.stop;
                     Collection<TransitAlert> alerts = getAlertsForStopAndRoute(graph, stop, routeId);
-                    alerts.addAll(getAlertsForStopAndTrip(graph, stop, tripId, leg.serviceDate));
+                    alerts.addAll(getAlertsForStopAndTrip(graph, stop, tripId, leg.getServiceDate()));
                     alerts.addAll(getAlertsForStop(graph, stop));
 
                     Date stopArrival = visit.arrival.getTime();
@@ -69,7 +72,9 @@ public class AlertToLegMapper {
         Collection<TransitAlert> patches;
 
         // trips - alerts tagged on ServiceDate
-        patches = alertPatchService(graph).getTripAlerts(leg.getTrip().getId(), leg.serviceDate);
+        patches = alertPatchService(graph).getTripAlerts(leg.getTrip().getId(),
+                leg.getServiceDate()
+        );
         addTransitAlertPatchesToLeg(leg, patches, requestedLocale, legStartTime, legEndTime);
 
         // trips - alerts tagged on any date
@@ -85,7 +90,9 @@ public class AlertToLegMapper {
         addTransitAlertPatchesToLeg(leg, patches, requestedLocale, legStartTime, legEndTime);
 
         // Filter alerts when there are multiple timePeriods for each alert
-        leg.transitAlerts.removeIf(alertPatch ->  !alertPatch.displayDuring(leg.startTime.getTimeInMillis()/1000, leg.endTime.getTimeInMillis()/1000));
+        leg.getTransitAlerts()
+                .removeIf(alertPatch ->  !alertPatch.displayDuring(
+                        leg.getStartTime().getTimeInMillis()/1000, leg.getEndTime().getTimeInMillis()/1000));
     }
 
     private static TransitAlertService alertPatchService(Graph g) {

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/GraphPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/GraphPathToItineraryMapper.java
@@ -499,7 +499,7 @@ public abstract class GraphPathToItineraryMapper {
         }
 
         if (vertex instanceof TransitStopVertex) {
-            return Place.forStop((TransitStopVertex) vertex, name);
+            return Place.forStop(((TransitStopVertex) vertex).getStop());
         } else if(vertex instanceof VehicleRentalStationVertex) {
             return Place.forVehicleRentalPlace((VehicleRentalStationVertex) vertex, name);
         } else if (vertex instanceof VehicleParkingEntranceVertex) {

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/GraphPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/GraphPathToItineraryMapper.java
@@ -262,7 +262,7 @@ public abstract class GraphPathToItineraryMapper {
                 .orElse(null);
             if (flexEdge != null) {
                 leg = new Leg(flexEdge.getTrip());
-                leg.flexibleTrip = true;
+                leg.setFlexibleTrip(true);
             }
         }
 
@@ -272,18 +272,18 @@ public abstract class GraphPathToItineraryMapper {
 
         Edge[] edges = new Edge[states.length - 1];
 
-        leg.startTime = makeCalendar(states[0]);
-        leg.endTime = makeCalendar(states[states.length - 1]);
+        leg.setStartTime(makeCalendar(states[0]));
+        leg.setEndTime(makeCalendar(states[states.length - 1]));
 
         // Calculate leg distance and fill array of edges
-        leg.distanceMeters = 0.0;
+        leg.setDistanceMeters(0.0);
         for (int i = 0; i < edges.length; i++) {
             edges[i] = states[i + 1].getBackEdge();
-            leg.distanceMeters += edges[i].getDistanceMeters();
+            leg.setDistanceMeters(leg.getDistanceMeters() + edges[i].getDistanceMeters());
         }
 
-        TimeZone timeZone = leg.startTime.getTimeZone();
-        leg.agencyTimeZoneOffset = timeZone.getOffset(leg.startTime.getTimeInMillis());
+        TimeZone timeZone = leg.getStartTime().getTimeZone();
+        leg.setAgencyTimeZoneOffset(timeZone.getOffset(leg.getStartTime().getTimeInMillis()));
 
         if (flexEdge != null) {
             FlexLegMapper.addFlexPlaces(leg, flexEdge, requestedLocale);
@@ -294,15 +294,16 @@ public abstract class GraphPathToItineraryMapper {
         CoordinateArrayListSequence coordinates = makeCoordinates(edges);
         Geometry geometry = GeometryUtils.getGeometryFactory().createLineString(coordinates);
 
-        leg.legGeometry = PolylineEncoder.createEncodings(geometry);
+        leg.setLegGeometry(PolylineEncoder.createEncodings(geometry));
 
-        leg.generalizedCost = (int) (states[states.length - 1].getWeight() - states[0].getWeight());
+        leg.setGeneralizedCost(
+                (int) (states[states.length - 1].getWeight() - states[0].getWeight()));
 
-        leg.walkingBike = states[states.length - 1].isBackWalkingBike();
+        leg.setWalkingBike(states[states.length - 1].isBackWalkingBike());
 
-        leg.rentedVehicle = states[0].isRentingVehicle();
+        leg.setRentedVehicle(states[0].isRentingVehicle());
 
-        if (leg.rentedVehicle) {
+        if (leg.getRentedVehicle()) {
             String vehicleRentalNetwork = states[0].getVehicleRentalNetwork();
             if (vehicleRentalNetwork != null) {
                 leg.setVehicleRentalNetwork(vehicleRentalNetwork);
@@ -323,7 +324,7 @@ public abstract class GraphPathToItineraryMapper {
         var previousStateIsVehicleParking = states[0].getBackState() != null
                 && states[0].getBackEdge() instanceof VehicleParkingEdge;
         if (previousStateIsVehicleParking) {
-            leg.startTime = makeCalendar(states[0].getBackState());
+            leg.setStartTime(makeCalendar(states[0].getBackState()));
         }
 
         return leg;
@@ -343,12 +344,12 @@ public abstract class GraphPathToItineraryMapper {
 
         for (int i = 0; i < legsStates.length; i++) {
             List<WalkStep> walkSteps = generateWalkSteps(graph, legsStates[i], previousStep, requestedLocale);
-            TraverseMode legMode = legs.get(i).mode;
+            TraverseMode legMode = legs.get(i).getMode();
             if(legMode != lastMode && !walkSteps.isEmpty()) {
                 lastMode = legMode;
             }
 
-            legs.get(i).walkSteps = walkSteps;
+            legs.get(i).setWalkSteps(walkSteps);
 
             if (walkSteps.size() > 0) {
                 previousStep = walkSteps.get(walkSteps.size() - 1);
@@ -381,8 +382,8 @@ public abstract class GraphPathToItineraryMapper {
             for (int j = 1; j < legsStates[i].length; j++) {
                 if (legsStates[i][j].getBackEdge() instanceof PathwayEdge) {
                     PathwayEdge pe = (PathwayEdge) legsStates[i][j].getBackEdge();
-                    legs.get(i).pathwayId = pe.getId();
-                    legs.get(i).pathway = true;
+                    legs.get(i).setPathwayId(pe.getId());
+                    legs.get(i).setPathway(true);
                     break OUTER;
                 }
             }
@@ -476,8 +477,8 @@ public abstract class GraphPathToItineraryMapper {
      * @param states The states that go with the leg
      */
     private static void addPlaces(Leg leg, State[] states, Locale requestedLocale) {
-        leg.from = makePlace(states[0], requestedLocale);
-        leg.to = makePlace(states[states.length - 1], requestedLocale);
+        leg.setFrom(makePlace(states[0], requestedLocale));
+        leg.setTo(makePlace(states[states.length - 1], requestedLocale));
     }
 
     /**

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
@@ -208,8 +208,8 @@ public class RaptorPathToItineraryMapper {
         leg.setBoardStopPosInPattern(boardStopIndexInPattern);
         leg.setAlightStopPosInPattern(alightStopIndexInPattern);
 
-        leg.setBoardingStopSequence(tripTimes.getOriginalGtfsStopSequence(boardStopIndexInPattern));
-        leg.setAlightStopSequence(tripTimes.getOriginalGtfsStopSequence(alightStopIndexInPattern));
+        leg.setBoardingGtfsStopSequence(tripTimes.getOriginalGtfsStopSequence(boardStopIndexInPattern));
+        leg.setAlightGtfsStopSequence(tripTimes.getOriginalGtfsStopSequence(alightStopIndexInPattern));
 
         // TODO OTP2 - alightRule and boardRule needs mapping
         //    Under Raptor, for transit trips, ItineraryMapper converts Path<TripSchedule> directly to Itinerary

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
@@ -175,39 +175,41 @@ public class RaptorPathToItineraryMapper {
 
         // Include real-time information in the Leg.
         if (!tripTimes.isScheduled()) {
-            leg.realTime = true;
-            leg.departureDelay = tripTimes.getDepartureDelay(boardStopIndexInPattern);
-            leg.arrivalDelay = tripTimes.getArrivalDelay(alightStopIndexInPattern);
+            leg.setRealTime(true);
+            leg.setDepartureDelay(tripTimes.getDepartureDelay(boardStopIndexInPattern));
+            leg.setArrivalDelay(tripTimes.getArrivalDelay(alightStopIndexInPattern));
         }
 
-        leg.serviceDate = new ServiceDate(tripSchedule.getServiceDate());
-        leg.startTime = createCalendar(pathLeg.fromTime());
-        leg.endTime = createCalendar(pathLeg.toTime());
-        leg.from = Place.forStop(boardStop);
-        leg.to = Place.forStop(alightStop);
+        leg.setServiceDate(new ServiceDate(tripSchedule.getServiceDate()));
+        leg.setStartTime(createCalendar(pathLeg.fromTime()));
+        leg.setEndTime(createCalendar(pathLeg.toTime()));
+        leg.setFrom(Place.forStop(boardStop));
+        leg.setTo(Place.forStop(alightStop));
         List<Coordinate> transitLegCoordinates = extractTransitLegCoordinates(pathLeg, boardStopIndexInPattern, alightStopIndexInPattern);
-        leg.legGeometry = PolylineEncoder.createEncodings(transitLegCoordinates);
-        leg.distanceMeters = getDistanceFromCoordinates(transitLegCoordinates);
+        leg.setLegGeometry(PolylineEncoder.createEncodings(transitLegCoordinates));
+        leg.setDistanceMeters(getDistanceFromCoordinates(transitLegCoordinates));
 
         // intermediate stops are required for fare calculation that's why we always add them here
         // and remove them in the API layers after the fare calculation if they were not requested.
-        leg.intermediateStops = extractIntermediateStops(pathLeg, boardStopIndexInPattern, alightStopIndexInPattern);
+        leg.setIntermediateStops(
+                extractIntermediateStops(pathLeg, boardStopIndexInPattern, alightStopIndexInPattern));
 
-        leg.headsign = tripTimes.getHeadsign(boardStopIndexInPattern);
-        leg.walkSteps = new ArrayList<>();
-        leg.generalizedCost = toOtpDomainCost(pathLeg.generalizedCost());
+        leg.setHeadsign(tripTimes.getHeadsign(boardStopIndexInPattern));
+        leg.setWalkSteps(new ArrayList<>());
+        leg.setGeneralizedCost(toOtpDomainCost(pathLeg.generalizedCost()));
 
-        leg.dropOffBookingInfo = tripTimes.getDropOffBookingInfo(boardStopIndexInPattern);
-        leg.pickupBookingInfo = tripTimes.getPickupBookingInfo(boardStopIndexInPattern);
+        leg.setDropOffBookingInfo(tripTimes.getDropOffBookingInfo(boardStopIndexInPattern));
+        leg.setPickupBookingInfo(tripTimes.getPickupBookingInfo(boardStopIndexInPattern));
 
-        leg.transferToNextLeg = (ConstrainedTransfer) pathLeg.getConstrainedTransferAfterLeg();
-        leg.transferFromPrevLeg = prevTransitLeg == null ? null : prevTransitLeg.transferToNextLeg;
+        leg.setTransferToNextLeg((ConstrainedTransfer) pathLeg.getConstrainedTransferAfterLeg());
+        leg.setTransferFromPrevLeg(
+                prevTransitLeg == null ? null : prevTransitLeg.getTransferToNextLeg());
 
-        leg.boardStopPosInPattern = boardStopIndexInPattern;
-        leg.alightStopPosInPattern = alightStopIndexInPattern;
+        leg.setBoardStopPosInPattern(boardStopIndexInPattern);
+        leg.setAlightStopPosInPattern(alightStopIndexInPattern);
 
-        leg.boardingStopSequence = tripTimes.getOriginalGtfsStopSequence(boardStopIndexInPattern);
-        leg.alightStopSequence = tripTimes.getOriginalGtfsStopSequence(alightStopIndexInPattern);
+        leg.setBoardingStopSequence(tripTimes.getOriginalGtfsStopSequence(boardStopIndexInPattern));
+        leg.setAlightStopSequence(tripTimes.getOriginalGtfsStopSequence(alightStopIndexInPattern));
 
         // TODO OTP2 - alightRule and boardRule needs mapping
         //    Under Raptor, for transit trips, ItineraryMapper converts Path<TripSchedule> directly to Itinerary
@@ -269,14 +271,14 @@ public class RaptorPathToItineraryMapper {
         List<Edge> edges = transfer.getEdges();
         if (edges == null || edges.isEmpty()) {
             Leg leg = new Leg(transferMode);
-            leg.from = from;
-            leg.to = to;
-            leg.startTime = createCalendar(pathLeg.fromTime());
-            leg.endTime = createCalendar(pathLeg.toTime());
-            leg.legGeometry = PolylineEncoder.createEncodings(transfer.getCoordinates());
-            leg.distanceMeters = (double) transfer.getDistanceMeters();
-            leg.walkSteps = Collections.emptyList();
-            leg.generalizedCost = toOtpDomainCost(pathLeg.generalizedCost());
+            leg.setFrom(from);
+            leg.setTo(to);
+            leg.setStartTime(createCalendar(pathLeg.fromTime()));
+            leg.setEndTime(createCalendar(pathLeg.toTime()));
+            leg.setLegGeometry(PolylineEncoder.createEncodings(transfer.getCoordinates()));
+            leg.setDistanceMeters((double) transfer.getDistanceMeters());
+            leg.setWalkSteps(Collections.emptyList());
+            leg.setGeneralizedCost(toOtpDomainCost(pathLeg.generalizedCost()));
 
             return List.of(leg);
         } else {
@@ -323,11 +325,11 @@ public class RaptorPathToItineraryMapper {
             Leg nextLeg = legs.get(i + 1);
 
             if (currLeg.isTransitLeg() && !nextLeg.isTransitLeg()) {
-                nextLeg.from = currLeg.to;
+                nextLeg.setFrom(currLeg.getTo());
             }
 
             if (!currLeg.isTransitLeg() && nextLeg.isTransitLeg()) {
-                currLeg.to = nextLeg.from;
+                currLeg.setTo(nextLeg.getFrom());
             }
         }
     }

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/TripPlanMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/TripPlanMapper.java
@@ -28,8 +28,8 @@ public class TripPlanMapper {
         }
         else {
             List<Leg> legs = itineraries.get(0).legs;
-            from = legs.get(0).from;
-            to = legs.get(legs.size() - 1).to;
+            from = legs.get(0).getFrom();
+            to = legs.get(legs.size() - 1).getTo();
         }
         return new TripPlan(from, to, Date.from(request.getDateTimeOriginalSearch()), itineraries);
     }

--- a/src/main/java/org/opentripplanner/routing/fares/impl/RideMapper.java
+++ b/src/main/java/org/opentripplanner/routing/fares/impl/RideMapper.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.routing.fares.impl;
 
-import java.time.LocalTime;
 import java.time.ZonedDateTime;
 import java.util.Calendar;
 import java.util.List;
@@ -26,20 +25,20 @@ public class RideMapper {
      */
     public static List<Ride> ridesForItinerary(Itinerary itinerary) {
         return itinerary.legs.stream()
-                .filter(leg -> leg.isTransitLeg() || leg.flexibleTrip)
+                .filter(leg -> leg.isTransitLeg() || leg.isFlexibleTrip())
                 .map(RideMapper::rideForTransitPathLeg)
                 .collect(Collectors.toList());
     }
 
     public static Ride rideForTransitPathLeg(Leg leg) {
         Ride ride = new Ride();
-        ride.firstStop = leg.from.stop;
-        ride.lastStop = leg.to.stop;
+        ride.firstStop = leg.getFrom().stop;
+        ride.lastStop = leg.getTo().stop;
 
         ride.startZone = ride.firstStop.getFirstZoneAsString();
         ride.endZone = ride.lastStop.getFirstZoneAsString();
 
-        var zones = leg.intermediateStops.stream()
+        var zones = leg.getIntermediateStops().stream()
                 .map(stopArrival -> stopArrival.place.stop.getFirstZoneAsString())
                 .collect(Collectors.toSet());
 
@@ -52,11 +51,11 @@ public class RideMapper {
         ride.route = leg.getRoute().getId();
         ride.trip = leg.getTrip().getId();
 
-        ride.startTime = toZonedDateTime(leg.startTime);
-        ride.endTime = toZonedDateTime(leg.endTime);
+        ride.startTime = toZonedDateTime(leg.getStartTime());
+        ride.endTime = toZonedDateTime(leg.getEndTime());
 
         // In the default fare service, we classify rides by mode.
-        ride.classifier = leg.mode;
+        ride.classifier = leg.getMode();
         return ride;
     }
 

--- a/src/main/java/org/opentripplanner/routing/fares/impl/TimeBasedVehicleRentalFareService.java
+++ b/src/main/java/org/opentripplanner/routing/fares/impl/TimeBasedVehicleRentalFareService.java
@@ -47,7 +47,7 @@ public class TimeBasedVehicleRentalFareService implements FareService, Serializa
     public Fare getCost(Itinerary itinerary) {
 
         var totalCost = itinerary.legs.stream()
-                .filter(l -> l.rentedVehicle)
+                .filter(l -> l.getRentedVehicle())
                 .mapToInt(this::getLegCost).sum();
 
         Fare fare = new Fare();

--- a/src/test/java/org/opentripplanner/GtfsTest.java
+++ b/src/test/java/org/opentripplanner/GtfsTest.java
@@ -156,22 +156,22 @@ public abstract class GtfsTest extends TestCase {
             String fromStopId,
             String alert
     ) {
-        assertEquals(startTime, leg.startTime.getTimeInMillis());
-        assertEquals(endTime, leg.endTime.getTimeInMillis());
-        assertEquals(toStopId, leg.to.stop.getId().getId());
-        assertEquals(feedId.getId(), leg.to.stop.getId().getFeedId());
+        assertEquals(startTime, leg.getStartTime().getTimeInMillis());
+        assertEquals(endTime, leg.getEndTime().getTimeInMillis());
+        assertEquals(toStopId, leg.getTo().stop.getId().getId());
+        assertEquals(feedId.getId(), leg.getTo().stop.getId().getFeedId());
         if (fromStopId != null) {
-            assertEquals(feedId.getId(), leg.from.stop.getId().getFeedId());
-            assertEquals(fromStopId, leg.from.stop.getId().getId());
+            assertEquals(feedId.getId(), leg.getFrom().stop.getId().getFeedId());
+            assertEquals(fromStopId, leg.getFrom().stop.getId().getId());
         } else {
-            assertNull(leg.from.stop.getId());
+            assertNull(leg.getFrom().stop.getId());
         }
         if (alert != null) {
-            assertNotNull(leg.streetNotes);
-            assertEquals(1, leg.streetNotes.size());
-            assertEquals(alert, leg.streetNotes.iterator().next().note.toString());
+            assertNotNull(leg.getStreetNotes());
+            assertEquals(1, leg.getStreetNotes().size());
+            assertEquals(alert, leg.getStreetNotes().iterator().next().note.toString());
         } else {
-            assertNull(leg.streetNotes);
+            assertNull(leg.getStreetNotes());
         }
     }
 }

--- a/src/test/java/org/opentripplanner/graph_builder/module/osm/TestIntermediatePlaces.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/osm/TestIntermediatePlaces.java
@@ -169,8 +169,8 @@ public class TestIntermediatePlaces {
                     legIndex < itinerary.legs.size());
                 leg = itinerary.legs.get(legIndex);
                 legIndex++;
-            } while (Math.abs(leg.to.coordinate.latitude() - location.lat) > DELTA
-                || Math.abs(leg.to.coordinate.longitude() - location.lng) > DELTA);
+            } while (Math.abs(leg.getTo().coordinate.latitude() - location.lat) > DELTA
+                || Math.abs(leg.getTo().coordinate.longitude() - location.lng) > DELTA);
         }
     }
 
@@ -178,8 +178,8 @@ public class TestIntermediatePlaces {
     private void validateLegsSpatially(TripPlan plan, Itinerary itinerary) {
         Place place = plan.from;
         for (Leg leg : itinerary.legs) {
-            assertEquals(place.coordinate, leg.from.coordinate);
-            place = leg.to;
+            assertEquals(place.coordinate, leg.getFrom().coordinate);
+            place = leg.getTo();
         }
         assertEquals(place.coordinate, plan.to.coordinate);
     }
@@ -189,18 +189,18 @@ public class TestIntermediatePlaces {
         Calendar departTime = Calendar.getInstance(timeZone);
         Calendar arriveTime = Calendar.getInstance(timeZone);
         if (request.arriveBy) {
-            departTime = itinerary.legs.get(0).startTime;
+            departTime = itinerary.legs.get(0).getStartTime();
             arriveTime.setTimeInMillis(request.getDateTimeOriginalSearch().toEpochMilli());
         } else {
             departTime.setTimeInMillis(request.getDateTimeCurrentPage().toEpochMilli());
-            arriveTime = itinerary.legs.get(itinerary.legs.size() - 1).endTime;
+            arriveTime = itinerary.legs.get(itinerary.legs.size() - 1).getEndTime();
         }
         long sumOfDuration = 0;
         for (Leg leg : itinerary.legs) {
-            assertFalse(departTime.after(leg.startTime));
-            assertFalse(leg.startTime.after(leg.endTime));
+            assertFalse(departTime.after(leg.getStartTime()));
+            assertFalse(leg.getStartTime().after(leg.getEndTime()));
 
-            departTime = leg.endTime;
+            departTime = leg.getEndTime();
             sumOfDuration += leg.getDuration();
         }
         sumOfDuration += itinerary.waitingTimeSeconds;

--- a/src/test/java/org/opentripplanner/model/plan/ItineraryTest.java
+++ b/src/test/java/org/opentripplanner/model/plan/ItineraryTest.java
@@ -27,12 +27,12 @@ public class ItineraryTest implements PlanTestConstants {
         assertTrue(result.walkOnly);
 
         // Expected fields on walking leg set
-        assertSameLocation(A, result.firstLeg().from);
-        assertEquals(GregorianCalendar.from(newTime(T11_00)), result.firstLeg().startTime);
-        assertEquals(GregorianCalendar.from(newTime(T11_05)), result.firstLeg().endTime);
-        assertEquals(TraverseMode.WALK, result.firstLeg().mode);
-        assertEquals(420.0d, result.firstLeg().distanceMeters, 1E-3);
-        assertSameLocation(B, result.lastLeg().to);
+        assertSameLocation(A, result.firstLeg().getFrom());
+        assertEquals(GregorianCalendar.from(newTime(T11_00)), result.firstLeg().getStartTime());
+        assertEquals(GregorianCalendar.from(newTime(T11_05)), result.firstLeg().getEndTime());
+        assertEquals(TraverseMode.WALK, result.firstLeg().getMode());
+        assertEquals(420.0d, result.firstLeg().getDistanceMeters(), 1E-3);
+        assertSameLocation(B, result.lastLeg().getTo());
 
         assertEquals("A ~ Walk 5m ~ B [ $600 ]", result.toStr());
     }
@@ -50,13 +50,13 @@ public class ItineraryTest implements PlanTestConstants {
         assertFalse(result.walkOnly);
 
         // Expected fields on bus leg set
-        assertSameLocation(A, result.firstLeg().from);
-        assertSameLocation(B, result.firstLeg().to);
-        assertEquals(GregorianCalendar.from(newTime(T11_00)), result.firstLeg().startTime);
-        assertEquals(GregorianCalendar.from(newTime(T11_10)), result.firstLeg().endTime);
-        assertEquals(TraverseMode.BUS, result.firstLeg().mode);
+        assertSameLocation(A, result.firstLeg().getFrom());
+        assertSameLocation(B, result.firstLeg().getTo());
+        assertEquals(GregorianCalendar.from(newTime(T11_00)), result.firstLeg().getStartTime());
+        assertEquals(GregorianCalendar.from(newTime(T11_10)), result.firstLeg().getEndTime());
+        assertEquals(TraverseMode.BUS, result.firstLeg().getMode());
       assertEquals(new FeedScopedId("F", "55"), result.firstLeg().getTrip().getId());
-        assertEquals(7500, result.firstLeg().distanceMeters, 1E-3);
+        assertEquals(7500, result.firstLeg().getDistanceMeters(), 1E-3);
 
         assertEquals("A ~ BUS 55 11:00 11:10 ~ B [ $720 ]", result.toStr());
     }
@@ -74,13 +74,13 @@ public class ItineraryTest implements PlanTestConstants {
         assertFalse(result.walkOnly);
 
         // Expected fields on bus leg set
-        assertSameLocation(A, result.firstLeg().from);
-        assertSameLocation(B, result.firstLeg().to);
-        assertEquals(GregorianCalendar.from(newTime(T11_05)), result.firstLeg().startTime);
-        assertEquals(GregorianCalendar.from(newTime(T11_15)), result.firstLeg().endTime);
-        assertEquals(TraverseMode.RAIL, result.firstLeg().mode);
+        assertSameLocation(A, result.firstLeg().getFrom());
+        assertSameLocation(B, result.firstLeg().getTo());
+        assertEquals(GregorianCalendar.from(newTime(T11_05)), result.firstLeg().getStartTime());
+        assertEquals(GregorianCalendar.from(newTime(T11_15)), result.firstLeg().getEndTime());
+        assertEquals(TraverseMode.RAIL, result.firstLeg().getMode());
         assertEquals(new FeedScopedId("F", "20"), result.firstLeg().getTrip().getId());
-        assertEquals(15_000, result.firstLeg().distanceMeters, 1E-3);
+        assertEquals(15_000, result.firstLeg().getDistanceMeters(), 1E-3);
 
         assertEquals("A ~ RAIL 20 11:05 11:15 ~ B [ $720 ]", result.toStr());
     }
@@ -147,8 +147,8 @@ public class ItineraryTest implements PlanTestConstants {
         assertEquals(660, result.waitingTimeSeconds);
         assertEquals(720 + 528 + 360 + 2040, result.generalizedCost);
         assertFalse(result.walkOnly);
-        assertSameLocation(A, result.firstLeg().from);
-        assertSameLocation(G, result.lastLeg().to);
+        assertSameLocation(A, result.firstLeg().getFrom());
+        assertSameLocation(G, result.lastLeg().getTo());
 
         assertEquals(
             "A ~ Walk 2m ~ B ~ BUS 55 11:04 11:14 ~ C ~ BUS 21 11:16 11:20 ~ D "

--- a/src/test/java/org/opentripplanner/model/plan/LegTest.java
+++ b/src/test/java/org/opentripplanner/model/plan/LegTest.java
@@ -92,7 +92,7 @@ public class LegTest implements PlanTestConstants {
 
   private static Leg createLegIgnoreTime(int tripId, int fromStopIndex, int toStopIndex, ServiceDate service) {
     Leg leg = TestItineraryBuilder.newItinerary(A, 99).bus(tripId, 99, 99, fromStopIndex, toStopIndex, B).build().firstLeg();
-    leg.serviceDate = service;
+    leg.setServiceDate(service);
     return leg;
   }
 }

--- a/src/test/java/org/opentripplanner/model/plan/PlaceTest.java
+++ b/src/test/java/org/opentripplanner/model/plan/PlaceTest.java
@@ -69,8 +69,6 @@ public class PlaceTest {
     }
 
     private static Place place(Stop stop) {
-        return Place.forStop(
-                stop, null, null
-        );
+        return Place.forStop(stop);
     }
 }

--- a/src/test/java/org/opentripplanner/model/plan/PlanTestConstants.java
+++ b/src/test/java/org/opentripplanner/model/plan/PlanTestConstants.java
@@ -88,8 +88,6 @@ public interface PlanTestConstants {
             null,
             null
     );
-    return Place.forStop(
-            stop, null, null
-    );
+    return Place.forStop(stop);
   }
 }

--- a/src/test/java/org/opentripplanner/model/plan/TestItineraryBuilder.java
+++ b/src/test/java/org/opentripplanner/model/plan/TestItineraryBuilder.java
@@ -98,7 +98,7 @@ public class TestItineraryBuilder implements PlanTestConstants {
   public TestItineraryBuilder rentedBicycle(int startTime, int endTime, Place to) {
     int legCost = cost(BICYCLE_RELUCTANCE_FACTOR, endTime - startTime);
     streetLeg(BICYCLE, startTime, endTime, to, legCost);
-    this.legs.get(0).rentedVehicle = true;
+    this.legs.get(0).setRentedVehicle(true);
     return this;
   }
 
@@ -150,7 +150,7 @@ public class TestItineraryBuilder implements PlanTestConstants {
     legCost += cost(WAIT_RELUCTANCE_FACTOR, waitTime);
     legCost += cost(1.0f, end - start) + BOARD_COST;
     Leg leg = leg(new Leg(trip(tripId, route)), start, end, to, fromStopIndex, toStopIndex, legCost);
-    leg.serviceDate = SERVICE_DATE;
+    leg.setServiceDate(SERVICE_DATE);
     return this;
   }
 
@@ -159,16 +159,22 @@ public class TestItineraryBuilder implements PlanTestConstants {
   }
 
   private Leg leg(
-          Leg leg, int startTime, int endTime, Place to, Integer fromStopIndex, Integer toStopIndex, int legCost
+          Leg leg,
+          int startTime,
+          int endTime,
+          Place to,
+          Integer boardStopPosInPattern,
+          Integer alightStopPosInPattern,
+          int legCost
   ) {
-    leg.from = stop(lastPlace);
-    leg.startTime = GregorianCalendar.from(newTime(startTime));
-    leg.to = stop(to);
-    leg.endTime = GregorianCalendar.from(newTime(endTime));
-    leg.boardStopPosInPattern = fromStopIndex;
-    leg.alightStopPosInPattern = toStopIndex;
-    leg.distanceMeters = speed(leg.mode) * (endTime - startTime);
-    leg.generalizedCost = legCost;
+    leg.setFrom(stop(lastPlace));
+    leg.setStartTime(GregorianCalendar.from(newTime(startTime)));
+    leg.setTo(stop(to));
+    leg.setEndTime(GregorianCalendar.from(newTime(endTime)));
+    leg.setBoardStopPosInPattern(boardStopPosInPattern);
+    leg.setAlightStopPosInPattern(alightStopPosInPattern);
+    leg.setDistanceMeters(speed(leg.getMode()) * (endTime - startTime));
+    leg.setGeneralizedCost(legCost);
     legs.add(leg);
     cost += legCost;
 

--- a/src/test/java/org/opentripplanner/model/plan/TestItineraryBuilder.java
+++ b/src/test/java/org/opentripplanner/model/plan/TestItineraryBuilder.java
@@ -161,10 +161,12 @@ public class TestItineraryBuilder implements PlanTestConstants {
   private Leg leg(
           Leg leg, int startTime, int endTime, Place to, Integer fromStopIndex, Integer toStopIndex, int legCost
   ) {
-    leg.from = stop(lastPlace, fromStopIndex);
+    leg.from = stop(lastPlace);
     leg.startTime = GregorianCalendar.from(newTime(startTime));
-    leg.to = stop(to, toStopIndex);
+    leg.to = stop(to);
     leg.endTime = GregorianCalendar.from(newTime(endTime));
+    leg.boardStopPosInPattern = fromStopIndex;
+    leg.alightStopPosInPattern = toStopIndex;
     leg.distanceMeters = speed(leg.mode) * (endTime - startTime);
     leg.generalizedCost = legCost;
     legs.add(leg);
@@ -210,11 +212,7 @@ public class TestItineraryBuilder implements PlanTestConstants {
     return route;
   }
 
-  private static Place stop(Place source, Integer stopIndex) {
-    return Place.forStop(
-            source.stop,
-            stopIndex,
-            null
-    );
+  private static Place stop(Place source) {
+    return Place.forStop(source.stop);
   }
 }

--- a/src/test/java/org/opentripplanner/routing/algorithm/FaresTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/FaresTest.java
@@ -123,8 +123,8 @@ public class FaresTest {
         var onPeakStartTime = TestUtils.dateInstant("America/Los_Angeles", 2016, 5, 24, 8, 0, 0);
         var peakItinerary = getItineraries(from, to, onPeakStartTime, router).get(1);
         var leg = peakItinerary.legs.get(0);
-        assertTrue(toLocalTime(leg.startTime).isAfter(LocalTime.parse("08:00")));
-        assertTrue(toLocalTime(leg.startTime).isBefore(LocalTime.parse("09:00")));
+        assertTrue(toLocalTime(leg.getStartTime()).isAfter(LocalTime.parse("08:00")));
+        assertTrue(toLocalTime(leg.getStartTime()).isBefore(LocalTime.parse("09:00")));
 
         assertEquals(new Money(USD, 275), peakItinerary.fare.getFare(FareType.regular));
 

--- a/src/test/java/org/opentripplanner/routing/algorithm/filterchain/deletionflagger/LatestDepartureTimeFilterTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/filterchain/deletionflagger/LatestDepartureTimeFilterTest.java
@@ -17,7 +17,7 @@ public class LatestDepartureTimeFilterTest implements PlanTestConstants {
     public void filterOnLatestDepartureTime() {
         // Given:
         Itinerary it = newItinerary(A).bus(32, 0, 60, E).build();
-        Instant time = it.firstLeg().startTime.toInstant();
+        Instant time = it.firstLeg().getStartTime().toInstant();
 
         // When:
         assertTrue(DeletionFlaggerTestHelper.process(List.of(it), new LatestDepartureTimeFilter(time.minusSeconds(1))).isEmpty());

--- a/src/test/java/org/opentripplanner/routing/algorithm/filterchain/groupids/GroupByTripIdAndDistanceTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/filterchain/groupids/GroupByTripIdAndDistanceTest.java
@@ -56,8 +56,8 @@ public class GroupByTripIdAndDistanceTest implements PlanTestConstants {
         Leg l2 = i.legs.get(1);
         Leg l3 = i.legs.get(2);
 
-        Double d1 = l1.distanceMeters;
-        Double d3 = l3.distanceMeters;
+        Double d1 = l1.getDistanceMeters();
+        Double d3 = l3.getDistanceMeters();
 
         // These test relay on the internal sort by distance, witch make the implementation
         // a bit simpler, but strictly is not something the method grantees

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/BikeRentalSnapshotTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/BikeRentalSnapshotTest.java
@@ -56,8 +56,8 @@ public class BikeRentalSnapshotTest
             /* The cost for switching between walking/biking is added the edge where switching occurs,
              * because of this the times for departAt / arriveBy itineraries differ.
              */
-            arriveBy.legs.get(1).endTime = departAt.legs.get(1).endTime;
-            arriveBy.legs.get(2).startTime = departAt.legs.get(2).startTime;
+            arriveBy.legs.get(1).setEndTime(departAt.legs.get(1).getEndTime());
+            arriveBy.legs.get(2).setStartTime(departAt.legs.get(2).getStartTime());
 
             handleGeneralizedCost(departAt, arriveBy);
         });

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/SnapshotTestBase.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/SnapshotTestBase.java
@@ -41,7 +41,6 @@ import org.opentripplanner.model.GenericLocation;
 import org.opentripplanner.model.modes.AllowedTransitMode;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.Leg;
-import org.opentripplanner.model.plan.WalkStep;
 import org.opentripplanner.routing.RoutingService;
 import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
@@ -115,10 +114,11 @@ public abstract class SnapshotTestBase {
 
             for (int j = 0; j < itinerary.legs.size(); j++) {
                 Leg leg = itinerary.legs.get(j);
-                String mode = leg.mode.name().substring(0, 1);
-                System.out.printf(" - leg %2d - %52.52s %9s --%s-> %-9s %-52.52s\n", j, leg.from.toStringShort(),
-                        dtf.format(leg.startTime.toInstant().atZone(zoneId)), mode,
-                        dtf.format(leg.endTime.toInstant().atZone(zoneId)), leg.to.toStringShort());
+                String mode = leg.getMode().name().substring(0, 1);
+                System.out.printf(" - leg %2d - %52.52s %9s --%s-> %-9s %-52.52s\n", j, leg.getFrom()
+                                .toStringShort(),
+                        dtf.format(leg.getStartTime().toInstant().atZone(zoneId)), mode,
+                        dtf.format(leg.getEndTime().toInstant().atZone(zoneId)), leg.getTo().toStringShort());
             }
 
             System.out.println();
@@ -175,7 +175,7 @@ public abstract class SnapshotTestBase {
 
         RoutingRequest arriveBy = request.clone();
         arriveBy.setArriveBy(true);
-        arriveBy.setDateTime(departByItineraries.get(0).lastLeg().endTime.toInstant());
+        arriveBy.setDateTime(departByItineraries.get(0).lastLeg().getEndTime().toInstant());
 
         List<Itinerary> arriveByItineraries = retrieveItineraries(arriveBy, router);
 
@@ -364,10 +364,10 @@ public abstract class SnapshotTestBase {
      */
     public static void handleGeneralizedCost(Itinerary departAt, Itinerary arriveBy) {
         departAt.legs.stream()
-                .filter(l -> !l.mode.isTransit())
-                .forEach(l -> l.generalizedCost = 0);
+                .filter(l -> !l.getMode().isTransit())
+                .forEach(l -> l.setGeneralizedCost(0));
         arriveBy.legs.stream()
-                .filter(l -> !l.mode.isTransit())
-                .forEach(l -> l.generalizedCost = 0);
+                .filter(l -> !l.getMode().isTransit())
+                .forEach(l -> l.setGeneralizedCost(0));
     }
 }

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/BikeRentalSnapshotTest.snap
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/BikeRentalSnapshotTest.snap
@@ -280,8 +280,6 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "name": "NW 21st & Irving",
             "stopCode": "7114",
             "stopId": "prt:7114",
-            "stopIndex": 15,
-            "stopSequence": 16,
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
@@ -438,8 +436,6 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "name": "NW Everett & Broadway",
             "stopCode": "1606",
             "stopId": "prt:1606",
-            "stopIndex": 22,
-            "stopSequence": 23,
             "vertexType": "TRANSIT",
             "zoneId": "0"
           },
@@ -624,8 +620,6 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "name": "W Burnside & SW Osage",
             "stopCode": "9354",
             "stopId": "prt:9354",
-            "stopIndex": 36,
-            "stopSequence": 37,
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
@@ -808,8 +802,6 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "name": "W Burnside & SW 6th",
             "stopCode": "792",
             "stopId": "prt:792",
-            "stopIndex": 45,
-            "stopSequence": 46,
             "vertexType": "TRANSIT",
             "zoneId": "0"
           },
@@ -994,8 +986,6 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "name": "2400 Block NW Lovejoy",
             "stopCode": "3589",
             "stopId": "prt:3589",
-            "stopIndex": 6,
-            "stopSequence": 7,
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
@@ -1165,8 +1155,6 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "name": "NW Everett & 4th",
             "stopCode": "9546",
             "stopId": "prt:9546",
-            "stopIndex": 14,
-            "stopSequence": 15,
             "vertexType": "TRANSIT",
             "zoneId": "0"
           },
@@ -1496,8 +1484,6 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "name": "NW 21st & Irving",
             "stopCode": "7114",
             "stopId": "prt:7114",
-            "stopIndex": 15,
-            "stopSequence": 16,
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
@@ -1654,8 +1640,6 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "name": "NW Everett & Broadway",
             "stopCode": "1606",
             "stopId": "prt:1606",
-            "stopIndex": 22,
-            "stopSequence": 23,
             "vertexType": "TRANSIT",
             "zoneId": "0"
           },
@@ -1985,8 +1969,6 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "name": "NW 21st & Irving",
             "stopCode": "7114",
             "stopId": "prt:7114",
-            "stopIndex": 50,
-            "stopSequence": 51,
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
@@ -2143,8 +2125,6 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "name": "NW Everett & Broadway",
             "stopCode": "1606",
             "stopId": "prt:1606",
-            "stopIndex": 57,
-            "stopSequence": 58,
             "vertexType": "TRANSIT",
             "zoneId": "0"
           },
@@ -2293,8 +2273,6 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "name": "2400 Block NW Lovejoy",
             "stopCode": "3589",
             "stopId": "prt:3589",
-            "stopIndex": 6,
-            "stopSequence": 7,
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
@@ -2464,8 +2442,6 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "name": "NW Everett & 4th",
             "stopCode": "9546",
             "stopId": "prt:9546",
-            "stopIndex": 14,
-            "stopSequence": 15,
             "vertexType": "TRANSIT",
             "zoneId": "0"
           },
@@ -3372,8 +3348,6 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "name": "NW 6th & Flanders",
             "stopCode": "9300",
             "stopId": "prt:9300",
-            "stopIndex": 66,
-            "stopSequence": 67,
             "vertexType": "TRANSIT",
             "zoneId": "0"
           },
@@ -3556,8 +3530,6 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "name": "NW 21st & Irving",
             "stopCode": "7113",
             "stopId": "prt:7113",
-            "stopIndex": 75,
-            "stopSequence": 76,
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
@@ -3911,8 +3883,6 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "name": "W Burnside & NW 5th",
             "stopCode": "782",
             "stopId": "prt:782",
-            "stopIndex": 99,
-            "stopSequence": 100,
             "vertexType": "TRANSIT",
             "zoneId": "0"
           },
@@ -4108,8 +4078,6 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "name": "W Burnside & NW 23rd Pl",
             "stopCode": "9555",
             "stopId": "prt:9555",
-            "stopIndex": 109,
-            "stopSequence": 110,
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
@@ -4318,8 +4286,6 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "name": "NW Glisan & 6th",
             "stopCode": "10803",
             "stopId": "prt:10803",
-            "stopIndex": 85,
-            "stopSequence": 86,
             "vertexType": "TRANSIT",
             "zoneId": "0"
           },
@@ -4489,8 +4455,6 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "name": "NW 23rd & Overton",
             "stopCode": "8981",
             "stopId": "prt:8981",
-            "stopIndex": 93,
-            "stopSequence": 94,
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
@@ -4675,8 +4639,6 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "name": "NW 6th & Flanders",
             "stopCode": "9300",
             "stopId": "prt:9300",
-            "stopIndex": 66,
-            "stopSequence": 67,
             "vertexType": "TRANSIT",
             "zoneId": "0"
           },
@@ -4859,8 +4821,6 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "name": "NW 21st & Irving",
             "stopCode": "7113",
             "stopId": "prt:7113",
-            "stopIndex": 75,
-            "stopSequence": 76,
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
@@ -5214,8 +5174,6 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "name": "W Burnside & NW 5th",
             "stopCode": "782",
             "stopId": "prt:782",
-            "stopIndex": 99,
-            "stopSequence": 100,
             "vertexType": "TRANSIT",
             "zoneId": "0"
           },
@@ -5411,8 +5369,6 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "name": "W Burnside & NW 23rd Pl",
             "stopCode": "9555",
             "stopId": "prt:9555",
-            "stopIndex": 109,
-            "stopSequence": 110,
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
@@ -5621,8 +5577,6 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "name": "NW Glisan & 6th",
             "stopCode": "10803",
             "stopId": "prt:10803",
-            "stopIndex": 85,
-            "stopSequence": 86,
             "vertexType": "TRANSIT",
             "zoneId": "0"
           },
@@ -5792,8 +5746,6 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "name": "NW 23rd & Overton",
             "stopCode": "8981",
             "stopId": "prt:8981",
-            "stopIndex": 93,
-            "stopSequence": 94,
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/TransitSnapshotTest.snap
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/TransitSnapshotTest.snap
@@ -338,8 +338,6 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "name": "NE Sandy & 16th",
             "stopCode": "5060",
             "stopId": "prt:5060",
-            "stopIndex": 92,
-            "stopSequence": 93,
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
@@ -600,8 +598,6 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "name": "W Burnside & NW King",
             "stopCode": "747",
             "stopId": "prt:747",
-            "stopIndex": 107,
-            "stopSequence": 108,
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
@@ -762,8 +758,6 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "name": "SE Morrison & 16th",
             "stopCode": "4019",
             "stopId": "prt:4019",
-            "stopIndex": 50,
-            "stopSequence": 51,
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
@@ -1128,8 +1122,6 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "name": "NW 23rd & Lovejoy",
             "stopCode": "7163",
             "stopId": "prt:7163",
-            "stopIndex": 73,
-            "stopSequence": 74,
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
@@ -1350,8 +1342,6 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "name": "NE Sandy & 16th",
             "stopCode": "5060",
             "stopId": "prt:5060",
-            "stopIndex": 92,
-            "stopSequence": 93,
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
@@ -1612,8 +1602,6 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "name": "W Burnside & NW King",
             "stopCode": "747",
             "stopId": "prt:747",
-            "stopIndex": 107,
-            "stopSequence": 108,
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
@@ -1774,8 +1762,6 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "name": "SE Morrison & 16th",
             "stopCode": "4019",
             "stopId": "prt:4019",
-            "stopIndex": 50,
-            "stopSequence": 51,
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
@@ -2140,8 +2126,6 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "name": "NW 23rd & Lovejoy",
             "stopCode": "7163",
             "stopId": "prt:7163",
-            "stopIndex": 73,
-            "stopSequence": 74,
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
@@ -2342,8 +2326,6 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "name": "SE 12th & Morrison",
             "stopCode": "6588",
             "stopId": "prt:6588",
-            "stopIndex": 31,
-            "stopSequence": 32,
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
@@ -2701,8 +2683,6 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "name": "NW Northrup & 22nd",
             "stopCode": "10778",
             "stopId": "prt:10778",
-            "stopIndex": 92,
-            "stopSequence": 93,
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
@@ -3042,8 +3022,6 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "name": "NE Sandy & 12th",
             "stopCode": "5055",
             "stopId": "prt:5055",
-            "stopIndex": 94,
-            "stopSequence": 95,
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
@@ -3304,8 +3282,6 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "name": "W Burnside & NW 23rd Pl",
             "stopCode": "9555",
             "stopId": "prt:9555",
-            "stopIndex": 109,
-            "stopSequence": 110,
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
@@ -3505,8 +3481,6 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "name": "NE Sandy & 12th",
             "stopCode": "5055",
             "stopId": "prt:5055",
-            "stopIndex": 94,
-            "stopSequence": 95,
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
@@ -3767,8 +3741,6 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "name": "W Burnside & NW 23rd Pl",
             "stopCode": "9555",
             "stopId": "prt:9555",
-            "stopIndex": 109,
-            "stopSequence": 110,
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
@@ -3968,8 +3940,6 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "name": "NE Sandy & 12th",
             "stopCode": "5055",
             "stopId": "prt:5055",
-            "stopIndex": 94,
-            "stopSequence": 95,
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
@@ -4230,8 +4200,6 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "name": "W Burnside & NW 23rd Pl",
             "stopCode": "9555",
             "stopId": "prt:9555",
-            "stopIndex": 109,
-            "stopSequence": 110,
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
@@ -4423,8 +4391,6 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "name": "NE 12th & Sandy",
             "stopCode": "6592",
             "stopId": "prt:6592",
-            "stopIndex": 34,
-            "stopSequence": 35,
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
@@ -4756,8 +4722,6 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "name": "NW 23rd & Overton",
             "stopCode": "8981",
             "stopId": "prt:8981",
-            "stopIndex": 93,
-            "stopSequence": 94,
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
@@ -4925,8 +4889,6 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "name": "NE Sandy & 12th",
             "stopCode": "5055",
             "stopId": "prt:5055",
-            "stopIndex": 94,
-            "stopSequence": 95,
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
@@ -5258,8 +5220,6 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "name": "NW 23rd & Lovejoy",
             "stopCode": "7163",
             "stopId": "prt:7163",
-            "stopIndex": 73,
-            "stopSequence": 74,
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },

--- a/src/test/java/org/opentripplanner/routing/street/BarrierRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/street/BarrierRoutingTest.java
@@ -61,13 +61,13 @@ public class BarrierRoutingTest {
                                 () -> assertEquals(
                                         List.of(BICYCLE, WALK, BICYCLE, WALK, BICYCLE),
                                         i.legs.stream()
-                                                .map(leg -> leg.mode)
+                                                .map(leg -> leg.getMode())
                                                 .collect(Collectors.toList())
                                 ),
                                 () -> assertEquals(
                                         List.of(false, true, false, true, false),
                                         i.legs.stream()
-                                                .map(leg -> leg.walkingBike)
+                                                .map(leg -> leg.getWalkingBike())
                                                 .collect(Collectors.toList())
                                 )
                         ))
@@ -120,7 +120,7 @@ public class BarrierRoutingTest {
                 (itineraries) -> itineraries.stream()
                         .flatMap(i -> i.legs.stream())
                         .map(l -> () -> assertEquals(
-                                traverseMode, l.mode, "Allow only " + traverseMode + " legs"
+                                traverseMode, l.getMode(), "Allow only " + traverseMode + " legs"
                         ))
         );
     }
@@ -150,6 +150,6 @@ public class BarrierRoutingTest {
 
         assertAll(assertions.apply(itineraries));
 
-        return itineraries.get(0).legs.get(0).legGeometry.getPoints();
+        return itineraries.get(0).legs.get(0).getLegGeometry().getPoints();
     }
 }

--- a/src/test/java/org/opentripplanner/routing/street/BicycleRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/street/BicycleRoutingTest.java
@@ -70,7 +70,7 @@ public class BicycleRoutingTest {
 
         var itineraries = GraphPathToItineraryMapper.mapItineraries(paths, request);
         // make sure that we only get BICYLE legs
-        itineraries.forEach(i -> i.legs.forEach(l -> Assertions.assertEquals(l.mode, TraverseMode.BICYCLE)));
-        return itineraries.get(0).legs.get(0).legGeometry.getPoints();
+        itineraries.forEach(i -> i.legs.forEach(l -> Assertions.assertEquals(l.getMode(), TraverseMode.BICYCLE)));
+        return itineraries.get(0).legs.get(0).getLegGeometry().getPoints();
     }
 }

--- a/src/test/java/org/opentripplanner/routing/street/CarRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/street/CarRoutingTest.java
@@ -125,7 +125,7 @@ public class CarRoutingTest {
         var itineraries = GraphPathToItineraryMapper.mapItineraries(paths, request);
         // make sure that we only get CAR legs
         itineraries.forEach(
-                i -> i.legs.forEach(l -> Assertions.assertEquals(l.mode, TraverseMode.CAR)));
-        return itineraries.get(0).legs.get(0).legGeometry.getPoints();
+                i -> i.legs.forEach(l -> Assertions.assertEquals(l.getMode(), TraverseMode.CAR)));
+        return itineraries.get(0).legs.get(0).getLegGeometry().getPoints();
     }
 }

--- a/src/test/java/org/opentripplanner/routing/street/SplitEdgeTurnRestrictionsTest.java
+++ b/src/test/java/org/opentripplanner/routing/street/SplitEdgeTurnRestrictionsTest.java
@@ -155,7 +155,7 @@ public class SplitEdgeTurnRestrictionsTest {
         var itineraries = GraphPathToItineraryMapper.mapItineraries(paths, request);
         // make sure that we only get CAR legs
         itineraries.forEach(
-                i -> i.legs.forEach(l -> Assertions.assertEquals(l.mode, TraverseMode.CAR)));
-        return itineraries.get(0).legs.get(0).legGeometry.getPoints();
+                i -> i.legs.forEach(l -> Assertions.assertEquals(l.getMode(), TraverseMode.CAR)));
+        return itineraries.get(0).legs.get(0).getLegGeometry().getPoints();
     }
 }


### PR DESCRIPTION
### Summary

This PR is a pure refactoring, where we do the two following things:
- After merging #3820 we now store the stop position in pattern for each leg, so they can be removed from the `Place` objects, and read from the `Leg` where needed.
- Before splitting the `Leg` into separate classes, we want to encapsulate the field access, so that other parts of the code don't have to be changed when doing that change.

### Unit tests
Pure refactoring, no changes.

### Code style
✅ 

### Documentation
Non needed

### Changelog
No need to add to changelog
