### PR TITLE
Implement in-seat transfers per GTFS draft

### DIFF
--- a/src/main/java/org/opentripplanner/gtfs/mapping/TransferMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/TransferMapper.java
@@ -77,7 +77,7 @@ class TransferMapper {
    *
    * @see <a href="https://github.com/google/transit/pull/303">GTFS proposal</a>
    */
-  private static final int NO_STAY_SEATED = 5;
+  private static final int STAY_SEATED_NOT_ALLOWED = 5;
 
 
   private final RouteMapper routeMapper;
@@ -113,12 +113,11 @@ class TransferMapper {
         return TransferPriority.NOT_ALLOWED;
       case GUARANTEED:
       case MIN_TIME:
-      case NO_STAY_SEATED:
+      case STAY_SEATED:
+      case STAY_SEATED_NOT_ALLOWED:
         return TransferPriority.ALLOWED;
       case RECOMMENDED:
         return TransferPriority.RECOMMENDED;
-      case STAY_SEATED:
-        return TransferPriority.PREFERRED;
     }
     throw new IllegalArgumentException("Mapping missing for type: " + type);
   }
@@ -171,7 +170,7 @@ class TransferMapper {
     // and not explicitly disallowed.
     builder.staySeated(
             rhs.getTransferType() == STAY_SEATED ||
-            (rhs.getTransferType() != NO_STAY_SEATED && sameBlockId(fromTrip, toTrip))
+            (rhs.getTransferType() != STAY_SEATED_NOT_ALLOWED && sameBlockId(fromTrip, toTrip))
 
     );
 

--- a/src/main/java/org/opentripplanner/gtfs/mapping/TransferMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/TransferMapper.java
@@ -66,12 +66,16 @@ class TransferMapper {
 
   /**
    * Passengers can transfer from one trip to another by staying onboard the same vehicle.
+   *
+   * @see <a href="https://github.com/google/transit/pull/303">GTFS proposal</a>
    */
   private static final int STAY_SEATED = 4;
 
   /**
    * In-seat transfers are not allowed between sequential trips. The passenger must alight from the
    * vehicle and re-board.
+   *
+   * @see <a href="https://github.com/google/transit/pull/303">GTFS proposal</a>
    */
   private static final int NO_STAY_SEATED = 5;
 


### PR DESCRIPTION
### Summary
This PR adds functionality for reading in-seat transfers from GTFS files per the draft specification.

### Issue
Relates to https://github.com/google/transit/pull/303

### Unit tests
None added

### Code style
✅ 

### Documentation
None required

### Changelog
The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md) 
is generated from the pull-request title, make sure the title describe the feature or issue fixed. 
To exclude the PR from the changelog add `[changelog skip]` in the title.
