### PR TITLE
Add stairsTimeFactor to StreetEdge

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModule.java
@@ -1216,12 +1216,6 @@ public class OpenStreetMapModule implements GraphBuilderModule {
             label = unique(label);
             I18NString name = getNameForWay(way, label);
 
-            // consider the elevation gain of stairs, roughly
-            boolean steps = way.isSteps();
-            if (steps) {
-                length *= 2;
-            }
-
             float carSpeed = wayPropertySet.getCarSpeedForWay(way, back);
 
             StreetEdge street = edgeFactory.createEdge(startEndpoint, endEndpoint, geometry, name, length,
@@ -1250,6 +1244,8 @@ public class OpenStreetMapModule implements GraphBuilderModule {
             if (!way.hasTag("name") && !way.hasTag("ref")) {
                 street.setHasBogusName(true);
             }
+
+            boolean steps = way.isSteps();
             street.setStairs(steps);
 
             /* TODO: This should probably generalized somehow? */

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/Transfer.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/Transfer.java
@@ -104,6 +104,7 @@ public class Transfer {
 
         transferRoutingRequest.walkReluctance = roundTo(request.walkReluctance, 1);
         transferRoutingRequest.stairsReluctance = roundTo(request.stairsReluctance, 1);
+        transferRoutingRequest.stairsTimeFactor = roundTo(request.stairsTimeFactor, 1);
         transferRoutingRequest.turnReluctance = roundTo(request.turnReluctance, 1);
 
         transferRoutingRequest.elevatorBoardCost = roundTo100(request.elevatorBoardCost);

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/request/RaptorRequestTransferCache.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/request/RaptorRequestTransferCache.java
@@ -105,6 +105,7 @@ public class RaptorRequestTransferCache {
         private final double bikeSpeed;
         private final double walkReluctance;
         private final double stairsReluctance;
+        private final double stairsTimeFactor;
         private final double turnReluctance;
         private final int elevatorBoardCost;
         private final int elevatorBoardTime;
@@ -131,6 +132,7 @@ public class RaptorRequestTransferCache {
 
             this.walkReluctance = routingRequest.walkReluctance;
             this.stairsReluctance = routingRequest.stairsReluctance;
+            this.stairsTimeFactor = routingRequest.stairsTimeFactor;
             this.turnReluctance = routingRequest.turnReluctance;
 
             this.elevatorBoardCost = routingRequest.elevatorBoardCost;
@@ -152,6 +154,7 @@ public class RaptorRequestTransferCache {
                     && Double.compare(that.bikeSpeed, bikeSpeed) == 0
                     && Double.compare(that.walkReluctance, walkReluctance) == 0
                     && Double.compare(that.stairsReluctance, stairsReluctance) == 0
+                    && Double.compare(that.stairsTimeFactor, stairsTimeFactor) == 0
                     && Double.compare(that.turnReluctance, turnReluctance) == 0
                     && wheelchairAccessible == that.wheelchairAccessible
                     && elevatorBoardCost == that.elevatorBoardCost
@@ -171,7 +174,7 @@ public class RaptorRequestTransferCache {
                     bikeTriangleTimeFactor, wheelchairAccessible, maxWheelchairSlope, walkSpeed,
                     bikeSpeed, walkReluctance, stairsReluctance, turnReluctance, elevatorBoardCost,
                     elevatorBoardTime, elevatorHopCost, elevatorHopTime, bikeSwitchCost,
-                    bikeSwitchTime
+                    bikeSwitchTime, stairsTimeFactor
             );
         }
     }

--- a/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
@@ -328,6 +328,20 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
 
     public double carReluctance = 2.0;
 
+    /** Zero means turned off. HACK SØRLANDSBANEN */
+    public double extraSearchCoachReluctance = 0.0;
+
+    /**
+     * How much more time does it take to walk a flight of stairs compared to walking a similar
+     * horizontal length
+     *
+     * Default value is based on:
+     * Fujiyama, T., & Tyler, N. (2010).
+     * Predicting the walking speed of pedestrians on stairs.
+     * Transportation Planning and Technology, 33(2), 177–202.
+     */
+    public double stairsTimeFactor = 3.0;
+
     /** Used instead of walk reluctance for stairs */
     public double stairsReluctance = 2.0;
 

--- a/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
@@ -328,8 +328,6 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
 
     public double carReluctance = 2.0;
 
-    /** Zero means turned off. HACK SØRLANDSBANEN */
-    public double extraSearchCoachReluctance = 0.0;
 
     /**
      * How much more time does it take to walk a flight of stairs compared to walking a similar

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
@@ -383,7 +383,6 @@ public class StreetEdge extends Edge implements BikeWalkableEdge, Cloneable, Car
                     time = weight = getEffectiveBikeDistance() / speed;
                 } else {
                     // take slopes into account when walking
-                    // FIXME: this causes steep stairs to be avoided. see #1297.
                     time = weight = getEffectiveWalkDistance() / speed;
                 }
                 break;

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
@@ -539,7 +539,8 @@ public class StreetEdge extends Edge implements BikeWalkableEdge, Cloneable, Car
             // NOTE: Automobiles have variable speeds depending on the edge type
             return calculateCarSpeed(options);
         }
-        return options.getSpeed(traverseMode, walkingBike);
+        final double speed = options.getSpeed(traverseMode, walkingBike);
+        return isStairs() ? (speed / options.stairsTimeFactor) : speed;
     }
 
     /**

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
@@ -852,6 +852,7 @@ public class StreetEdge extends Edge implements BikeWalkableEdge, Cloneable, Car
             e1.setBicycleNoThruTraffic(this.isBicycleNoThruTraffic());
             e1.setWalkNoThruTraffic(this.isWalkNoThruTraffic());
             e1.setStreetClass(this.getStreetClass());
+            e1.setStairs(this.isStairs());
             tempEdges.addEdge(e1);
         }
         if (direction == LinkingDirection.INCOMING || direction == LinkingDirection.BOTH_WAYS) {
@@ -860,6 +861,7 @@ public class StreetEdge extends Edge implements BikeWalkableEdge, Cloneable, Car
             e2.setBicycleNoThruTraffic(this.isBicycleNoThruTraffic());
             e2.setWalkNoThruTraffic(this.isWalkNoThruTraffic());
             e2.setStreetClass(this.getStreetClass());
+            e2.setStairs(this.isStairs());
             tempEdges.addEdge(e2);
         }
 

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetWithElevationEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetWithElevationEdge.java
@@ -99,7 +99,7 @@ public class StreetWithElevationEdge extends StreetEdge {
 
     @Override
     public double getEffectiveBikeDistance() {
-        return effectiveBikeDistanceFactor * getDistanceMeters();
+        return (isStairs() ? 1 : effectiveWalkDistanceFactor) * getDistanceMeters();
     }
 
     @Override
@@ -109,7 +109,7 @@ public class StreetWithElevationEdge extends StreetEdge {
 
     @Override
     public double getEffectiveWalkDistance() {
-        return effectiveWalkDistanceFactor * getDistanceMeters();
+        return (isStairs() ? 1 : effectiveWalkDistanceFactor) * getDistanceMeters();
     }
 
     @Override

--- a/src/main/java/org/opentripplanner/standalone/config/RoutingRequestMapper.java
+++ b/src/main/java/org/opentripplanner/standalone/config/RoutingRequestMapper.java
@@ -84,6 +84,7 @@ public class RoutingRequestMapper {
         request.requiredVehicleParkingTags = c.asTextSet("requiredVehicleParkingTags", dft.requiredVehicleParkingTags);
         request.showIntermediateStops = c.asBoolean("showIntermediateStops", dft.showIntermediateStops);
         request.stairsReluctance = c.asDouble("stairsReluctance", dft.stairsReluctance);
+        request.stairsTimeFactor = c.asDouble("stairsTimeFactor", dft.stairsTimeFactor);
         request.startingTransitTripId = c.asFeedScopedId("startingTransitTripId", dft.startingTransitTripId);
         request.transferCost = c.asInt("transferPenalty", dft.transferCost);
         request.transferSlack = c.asInt("transferSlack", dft.transferSlack);

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/TransitSnapshotTest.snap
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/TransitSnapshotTest.snap
@@ -5846,22 +5846,22 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
   [
     {
       "arrivedAtDestinationWithRentedBicycle": false,
-      "duration": 2361,
+      "duration": 2370,
       "elevationGained": 0.0,
       "elevationLost": 0.0,
-      "endTime": "2009-11-17T18:39:21.000+00:00",
+      "endTime": "2009-11-17T18:39:30.000+00:00",
       "fare": {
         "details": { },
         "fare": { }
       },
-      "generalizedCost": 4557,
+      "generalizedCost": 4621,
       "legs": [
         {
           "agencyTimeZoneOffset": -28800000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distance": 2989.7960000000003,
-          "endTime": "2009-11-17T18:39:21.000+00:00",
+          "distance": 3052.902,
+          "endTime": "2009-11-17T18:39:30.000+00:00",
           "from": {
             "departure": "2009-11-17T18:00:00.000+00:00",
             "lat": 45.530244,
@@ -5872,11 +5872,11 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "vertexType": "TRANSIT",
             "zoneId": "0"
           },
-          "generalizedCost": 4557,
+          "generalizedCost": 4621,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
-            "length": 173,
-            "points": "_s{tGvpukV??c@tADDFDDDHHYx@Wt@{@lBS^MROZ]h@Y`@[`@k@r@kAtASVEDa@f@EDm@l@s@p@JVA@GOCBzEfKxF`M|AfDJRLPVb@DBBBBBDBB@CRE\\C?A@A@ABAB?DAHATC\\AXAVCZATAPAPATG`AATAPAL?J?F?F?D?F@x@AJ@D@B@DAB?RK@I??TBlBCJ?D?BAFAB?DADABEFCDA@CDC?c@@{@@O?K??LCDC??LC?G?E@GBE?KCI?EFC@?N?F?D?BABA@AD?D?B?D@B@BABAB?D?DADABABABC@A@I@IZCFIJ?L@`B@dA?R?RBbD?T?NBbD?R?P@|D@jB?x@@J?N?B?P?LBjD@N@fD?T?LBdD?R?PF`K?RDlJ?R?PFlJ?RDbH@xA?D?P?RDpH"
+            "length": 137,
+            "points": "_s{tGvpukV??c@tAIIMb@ADIZM\\KZWr@Ud@Ud@IRSb@k@x@_@h@a@f@_AfAYXKQMUIKGGIGKEOCI?I?KBKBQHqAxAONL\\j@rA@R?FVh@~EpKxFzLdA|B^x@BD@@BDHLHJBFBDBF@DBF?J?HAF?HGbAK~AGz@IlAEd@?TAP?L?L@Z?`@?R?T?TBlBCJ?D?BAFAB?DADABEFCDA@CDC?c@@{@@O?K?eBBM?M@@P?N@P@nA?j@AX?L@`B@dA?R?RBbD?T?NBbD?R?P@|D@jB?x@@J?N?B?P?LBjD@N@fD?T?LBdD?R?PF`K?RDlJ?R?PFlJ?RDbH@xA?D?P?RDpH"
           },
           "mode": "WALK",
           "pathway": false,
@@ -5898,98 +5898,74 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "streetName": "Interstate/Rose Quarter Northbound Yellow Line MAX Platform"
             },
             {
-              "absoluteDirection": "SOUTHWEST",
+              "absoluteDirection": "NORTHEAST",
               "area": false,
               "bogusName": true,
-              "distance": 20.608,
+              "distance": 5.991,
               "elevation": "",
               "lat": 45.530427100000004,
               "lon": -122.66822160000001,
-              "relativeDirection": "LEFT",
+              "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "way 125785939 from 4"
+              "streetName": "way 125785939 from 1"
             },
             {
               "absoluteDirection": "NORTHWEST",
               "area": false,
               "bogusName": false,
-              "distance": 410.023,
+              "distance": 292.244,
               "elevation": "",
-              "lat": 45.5302724,
-              "lon": -122.66836730000001,
-              "relativeDirection": "RIGHT",
+              "lat": 45.530472100000004,
+              "lon": -122.6681793,
+              "relativeDirection": "LEFT",
               "stayOn": false,
               "streetName": "North Interstate Avenue"
             },
             {
-              "absoluteDirection": "SOUTHWEST",
+              "absoluteDirection": "NORTHEAST",
               "area": false,
-              "bogusName": true,
-              "distance": 40.36,
+              "bogusName": false,
+              "distance": 160.69199999999998,
               "elevation": "",
-              "lat": 45.532912800000005,
-              "lon": -122.67197920000001,
-              "relativeDirection": "LEFT",
-              "stayOn": false,
-              "streetName": "way 117315127 from 2"
-            },
-            {
-              "absoluteDirection": "NORTHWEST",
-              "area": false,
-              "bogusName": true,
-              "distance": 2.245,
-              "elevation": "",
-              "lat": 45.532907900000005,
-              "lon": -122.67202800000001,
+              "lat": 45.5322204,
+              "lon": -122.670929,
               "relativeDirection": "RIGHT",
-              "stayOn": true,
-              "streetName": "way 117315115 from 0"
+              "stayOn": false,
+              "streetName": "North Larrabee Avenue"
             },
             {
               "absoluteDirection": "SOUTHWEST",
               "area": false,
               "bogusName": false,
-              "distance": 543.668,
+              "distance": 55.036,
               "elevation": "",
-              "lat": 45.5329251,
-              "lon": -122.67204310000001,
+              "lat": 45.5334329,
+              "lon": -122.67115310000001,
               "relativeDirection": "LEFT",
+              "stayOn": false,
+              "streetName": "North Broadway"
+            },
+            {
+              "absoluteDirection": "WEST",
+              "area": false,
+              "bogusName": false,
+              "distance": 584.674,
+              "elevation": "",
+              "lat": 45.533143,
+              "lon": -122.67172570000001,
+              "relativeDirection": "SLIGHTLY_RIGHT",
               "stayOn": false,
               "streetName": "Broadway Bridge"
             },
             {
-              "absoluteDirection": "SOUTHWEST",
+              "absoluteDirection": "WEST",
               "area": false,
               "bogusName": false,
-              "distance": 14.158,
+              "distance": 301.763,
               "elevation": "",
-              "lat": 45.5298506,
-              "lon": -122.67746670000001,
-              "relativeDirection": "CONTINUE",
-              "stayOn": false,
-              "streetName": "Northwest Broadway"
-            },
-            {
-              "absoluteDirection": "NORTH",
-              "area": false,
-              "bogusName": false,
-              "distance": 23.666,
-              "elevation": "",
-              "lat": 45.5297871,
-              "lon": -122.67780010000001,
-              "relativeDirection": "UTURN_RIGHT",
-              "stayOn": true,
-              "streetName": "Northwest Broadway"
-            },
-            {
-              "absoluteDirection": "NORTHWEST",
-              "area": false,
-              "bogusName": false,
-              "distance": 298.376,
-              "elevation": "",
-              "lat": 45.529817200000004,
-              "lon": -122.6778163,
-              "relativeDirection": "SLIGHTLY_LEFT",
+              "lat": 45.5298997,
+              "lon": -122.67760050000001,
+              "relativeDirection": "SLIGHTLY_RIGHT",
               "stayOn": false,
               "streetName": "Northwest Lovejoy Street"
             },
@@ -5997,7 +5973,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "absoluteDirection": "NORTH",
               "area": false,
               "bogusName": false,
-              "distance": 71.22,
+              "distance": 143.231,
               "elevation": "",
               "lat": 45.5302432,
               "lon": -122.6813836,
@@ -6009,65 +5985,17 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "absoluteDirection": "WEST",
               "area": false,
               "bogusName": false,
-              "distance": 5.54,
+              "distance": 1470.2359999999999,
               "elevation": "",
-              "lat": 45.5308835,
-              "lon": -122.68140700000001,
-              "relativeDirection": "LEFT",
-              "stayOn": false,
-              "streetName": "Northwest Marshall Street"
-            },
-            {
-              "absoluteDirection": "NORTHWEST",
-              "area": false,
-              "bogusName": true,
-              "distance": 5.888,
-              "elevation": "",
-              "lat": 45.530882000000005,
-              "lon": -122.6814781,
-              "relativeDirection": "RIGHT",
-              "stayOn": false,
-              "streetName": "way 117751890 from 1"
-            },
-            {
-              "absoluteDirection": "WEST",
-              "area": false,
-              "bogusName": false,
-              "distance": 7.364,
-              "elevation": "",
-              "lat": 45.5309273,
-              "lon": -122.6815085,
-              "relativeDirection": "LEFT",
-              "stayOn": false,
-              "streetName": "Tanner Springs Park"
-            },
-            {
-              "absoluteDirection": "NORTH",
-              "area": false,
-              "bogusName": false,
-              "distance": 116.77899999999998,
-              "elevation": "",
-              "lat": 45.530944000000005,
-              "lon": -122.6815772,
-              "relativeDirection": "RIGHT",
-              "stayOn": false,
-              "streetName": "Tanner Springs Park Trail"
-            },
-            {
-              "absoluteDirection": "WEST",
-              "area": false,
-              "bogusName": false,
-              "distance": 1390.866,
-              "elevation": "",
-              "lat": 45.5315117,
-              "lon": -122.68244770000001,
+              "lat": 45.5315309,
+              "lon": -122.6814307,
               "relativeDirection": "LEFT",
               "stayOn": false,
               "streetName": "Northwest Northrup Street"
             }
           ],
           "to": {
-            "arrival": "2009-11-17T18:39:21.000+00:00",
+            "arrival": "2009-11-17T18:39:30.000+00:00",
             "lat": 45.531,
             "lon": -122.70029,
             "name": "NW Northrup St. & NW 24th Ave. (P3)",
@@ -6082,9 +6010,9 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
       "transfers": 0,
       "transitTime": 0,
       "waitingTime": 0,
-      "walkDistance": 2989.7960000000003,
+      "walkDistance": 3052.902,
       "walkLimitExceeded": false,
-      "walkTime": 2361
+      "walkTime": 2370
     }
   ]
 ]

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/TransitSnapshotTest.snap
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/TransitSnapshotTest.snap
@@ -5846,22 +5846,22 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
   [
     {
       "arrivedAtDestinationWithRentedBicycle": false,
-      "duration": 2370,
+      "duration": 2366,
       "elevationGained": 0.0,
       "elevationLost": 0.0,
-      "endTime": "2009-11-17T18:39:30.000+00:00",
+      "endTime": "2009-11-17T18:39:26.000+00:00",
       "fare": {
         "details": { },
         "fare": { }
       },
-      "generalizedCost": 4621,
+      "generalizedCost": 4597,
       "legs": [
         {
           "agencyTimeZoneOffset": -28800000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distance": 3052.902,
-          "endTime": "2009-11-17T18:39:30.000+00:00",
+          "distance": 2985.4260000000004,
+          "endTime": "2009-11-17T18:39:26.000+00:00",
           "from": {
             "departure": "2009-11-17T18:00:00.000+00:00",
             "lat": 45.530244,
@@ -5872,11 +5872,11 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "vertexType": "TRANSIT",
             "zoneId": "0"
           },
-          "generalizedCost": 4621,
+          "generalizedCost": 4597,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
-            "length": 137,
-            "points": "_s{tGvpukV??c@tAIIMb@ADIZM\\KZWr@Ud@Ud@IRSb@k@x@_@h@a@f@_AfAYXKQMUIKGGIGKEOCI?I?KBKBQHqAxAONL\\j@rA@R?FVh@~EpKxFzLdA|B^x@BD@@BDHLHJBFBDBF@DBF?J?HAF?HGbAK~AGz@IlAEd@?TAP?L?L@Z?`@?R?T?TBlBCJ?D?BAFAB?DADABEFCDA@CDC?c@@{@@O?K?eBBM?M@@P?N@P@nA?j@AX?L@`B@dA?R?RBbD?T?NBbD?R?P@|D@jB?x@@J?N?B?P?LBjD@N@fD?T?LBdD?R?PF`K?RDlJ?R?PFlJ?RDbH@xA?D?P?RDpH"
+            "length": 143,
+            "points": "_s{tGvpukV??c@tADDFDDDHHYx@Wt@{@lBS^MROZ]h@Y`@[`@k@r@kAtASVEDa@f@EDm@l@s@p@JVA@GOCBzEfKxF`M|AfDJRLPVb@DBBBBBDBB@CRE\\C?A@A@ABAB?DAHATC\\AXAVCZATAPAPATG`AATAPAL?J?F?F?D?F@x@AJ@D@B@DAB?RK@I??TBlBCJ?D?BAFAB?DADABEFCDA@CDC?c@@{@@O?K?eBBM?M@@P?N@P@nA?j@AX?L@`B@dA?R?RBbD?T?NBbD?R?P@|D@jB?x@@J?N?B?P?LBjD@N@fD?T?LBdD?R?PF`K?RDlJ?R?PFlJ?RDbH@xA?D?P?RDpH"
           },
           "mode": "WALK",
           "pathway": false,
@@ -5898,74 +5898,98 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "streetName": "Interstate/Rose Quarter Northbound Yellow Line MAX Platform"
             },
             {
-              "absoluteDirection": "NORTHEAST",
+              "absoluteDirection": "SOUTHWEST",
               "area": false,
               "bogusName": true,
-              "distance": 5.991,
+              "distance": 20.608,
               "elevation": "",
               "lat": 45.530427100000004,
               "lon": -122.66822160000001,
-              "relativeDirection": "RIGHT",
+              "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "way 125785939 from 1"
+              "streetName": "way 125785939 from 4"
             },
             {
               "absoluteDirection": "NORTHWEST",
               "area": false,
               "bogusName": false,
-              "distance": 292.244,
+              "distance": 410.023,
               "elevation": "",
-              "lat": 45.530472100000004,
-              "lon": -122.6681793,
-              "relativeDirection": "LEFT",
+              "lat": 45.5302724,
+              "lon": -122.66836730000001,
+              "relativeDirection": "RIGHT",
               "stayOn": false,
               "streetName": "North Interstate Avenue"
             },
             {
-              "absoluteDirection": "NORTHEAST",
+              "absoluteDirection": "SOUTHWEST",
               "area": false,
-              "bogusName": false,
-              "distance": 160.69199999999998,
+              "bogusName": true,
+              "distance": 20.18,
               "elevation": "",
-              "lat": 45.5322204,
-              "lon": -122.670929,
-              "relativeDirection": "RIGHT",
+              "lat": 45.532912800000005,
+              "lon": -122.67197920000001,
+              "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "North Larrabee Avenue"
+              "streetName": "way 117315127 from 2"
+            },
+            {
+              "absoluteDirection": "NORTHWEST",
+              "area": false,
+              "bogusName": true,
+              "distance": 2.245,
+              "elevation": "",
+              "lat": 45.532907900000005,
+              "lon": -122.67202800000001,
+              "relativeDirection": "RIGHT",
+              "stayOn": true,
+              "streetName": "way 117315115 from 0"
             },
             {
               "absoluteDirection": "SOUTHWEST",
               "area": false,
               "bogusName": false,
-              "distance": 55.036,
+              "distance": 543.668,
               "elevation": "",
-              "lat": 45.5334329,
-              "lon": -122.67115310000001,
+              "lat": 45.5329251,
+              "lon": -122.67204310000001,
               "relativeDirection": "LEFT",
-              "stayOn": false,
-              "streetName": "North Broadway"
-            },
-            {
-              "absoluteDirection": "WEST",
-              "area": false,
-              "bogusName": false,
-              "distance": 584.674,
-              "elevation": "",
-              "lat": 45.533143,
-              "lon": -122.67172570000001,
-              "relativeDirection": "SLIGHTLY_RIGHT",
               "stayOn": false,
               "streetName": "Broadway Bridge"
             },
             {
-              "absoluteDirection": "WEST",
+              "absoluteDirection": "SOUTHWEST",
               "area": false,
               "bogusName": false,
-              "distance": 301.763,
+              "distance": 14.158,
               "elevation": "",
-              "lat": 45.5298997,
-              "lon": -122.67760050000001,
-              "relativeDirection": "SLIGHTLY_RIGHT",
+              "lat": 45.5298506,
+              "lon": -122.67746670000001,
+              "relativeDirection": "CONTINUE",
+              "stayOn": false,
+              "streetName": "Northwest Broadway"
+            },
+            {
+              "absoluteDirection": "NORTH",
+              "area": false,
+              "bogusName": false,
+              "distance": 23.666,
+              "elevation": "",
+              "lat": 45.5297871,
+              "lon": -122.67780010000001,
+              "relativeDirection": "UTURN_RIGHT",
+              "stayOn": true,
+              "streetName": "Northwest Broadway"
+            },
+            {
+              "absoluteDirection": "NORTHWEST",
+              "area": false,
+              "bogusName": false,
+              "distance": 298.376,
+              "elevation": "",
+              "lat": 45.529817200000004,
+              "lon": -122.6778163,
+              "relativeDirection": "SLIGHTLY_LEFT",
               "stayOn": false,
               "streetName": "Northwest Lovejoy Street"
             },
@@ -5995,7 +6019,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             }
           ],
           "to": {
-            "arrival": "2009-11-17T18:39:30.000+00:00",
+            "arrival": "2009-11-17T18:39:26.000+00:00",
             "lat": 45.531,
             "lon": -122.70029,
             "name": "NW Northrup St. & NW 24th Ave. (P3)",
@@ -6010,9 +6034,9 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
       "transfers": 0,
       "transitTime": 0,
       "waitingTime": 0,
-      "walkDistance": 3052.902,
+      "walkDistance": 2985.4260000000004,
       "walkLimitExceeded": false,
-      "walkTime": 2370
+      "walkTime": 2366
     }
   ]
 ]


### PR DESCRIPTION
### Summary
Currently stairs are traversed using the same speed as regular horizontal ways. This adds a specific factor which slows down  stair traversal by a configurable factor

### Issue
Currently traversal between two platforms in Oslo S takes less than two minutes, which is unrealistic. Much of this is due to the stairs being too quick to traverse.

![image](https://user-images.githubusercontent.com/698100/151256729-0963708e-cbb3-41b2-afc6-6c2f9ca2918c.png)

### Unit tests
None added (yet)

### Code style
✅ 

### Documentation
None required

### Changelog
The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md) 
is generated from the pull-request title, make sure the title describe the feature or issue fixed. 
To exclude the PR from the changelog add `[changelog skip]` in the title.
