### PR TITLE
Make sure we keep the itinerary with the least number of transfers when grouping the itineraries

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/filterchain/ItineraryListFilterChainBuilder.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/filterchain/ItineraryListFilterChainBuilder.java
@@ -23,6 +23,7 @@ import org.opentripplanner.routing.algorithm.filterchain.deletionflagger.RemoveW
 import org.opentripplanner.routing.algorithm.filterchain.deletionflagger.TransitGeneralizedCostFilter;
 import org.opentripplanner.routing.algorithm.filterchain.filter.DeletionFlaggingFilter;
 import org.opentripplanner.routing.algorithm.filterchain.filter.GroupByFilter;
+import org.opentripplanner.routing.algorithm.filterchain.filter.RemoveDeletionFlagForLeastTransfersItinerary;
 import org.opentripplanner.routing.algorithm.filterchain.filter.SortingFilter;
 import org.opentripplanner.routing.algorithm.filterchain.groupids.GroupByAllSameStations;
 import org.opentripplanner.routing.algorithm.filterchain.groupids.GroupByTripIdAndDistance;
@@ -321,6 +322,8 @@ public class ItineraryListFilterChainBuilder {
                 name,
                 it.maxNumOfItinerariesPerGroup
             )));
+
+            nested.add(new RemoveDeletionFlagForLeastTransfersItinerary());
 
             groupByFilters.add(
                 new GroupByFilter<>(

--- a/src/main/java/org/opentripplanner/routing/algorithm/filterchain/comparator/SortOrderComparator.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/filterchain/comparator/SortOrderComparator.java
@@ -54,6 +54,11 @@ public class SortOrderComparator extends CompositeComparator<Itinerary> {
           NUM_OF_TRANSFERS_COMP
   );
 
+  private static final SortOrderComparator NUM_TRANSFERS = new SortOrderComparator(
+          NUM_OF_TRANSFERS_COMP,
+          GENERALIZED_COST_COMP
+  );
+
   /** Return the default comparator for a depart-after search. */
   public static SortOrderComparator defaultComparatorDepartAfter() {
     return STREET_AND_ARRIVAL_TIME;
@@ -70,6 +75,14 @@ public class SortOrderComparator extends CompositeComparator<Itinerary> {
    */
   public static SortOrderComparator generalizedCostComparator() {
     return GENERALIZED_COST;
+  }
+
+  /**
+   * This comparator sorts itineraries based on the fewest number-of-transfers. If the number is the
+   * same then the filter pick the itinerary with the lowest generalized-cost.
+   */
+    public static SortOrderComparator numberOfTransfersComparator() {
+    return NUM_TRANSFERS;
   }
 
   public static SortOrderComparator comparator(SortOrder sortOrder) {

--- a/src/main/java/org/opentripplanner/routing/algorithm/filterchain/filter/RemoveDeletionFlagForLeastTransfersItinerary.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/filterchain/filter/RemoveDeletionFlagForLeastTransfersItinerary.java
@@ -1,0 +1,23 @@
+package org.opentripplanner.routing.algorithm.filterchain.filter;
+
+import static org.opentripplanner.routing.algorithm.filterchain.comparator.SortOrderComparator.numberOfTransfersComparator;
+
+import java.util.List;
+import org.opentripplanner.model.plan.Itinerary;
+import org.opentripplanner.routing.algorithm.filterchain.ItineraryListFilter;
+
+/**
+ * This filter makes sure that the itinerary with the least amount of transfers is not marked for
+ * deletion
+ */
+public class RemoveDeletionFlagForLeastTransfersItinerary implements ItineraryListFilter {
+
+    @Override
+    public List<Itinerary> filter(List<Itinerary> itineraries) {
+        itineraries.stream()
+                .min(numberOfTransfersComparator())
+                .ifPresent(itinerary -> itinerary.systemNotices.clear());
+
+        return itineraries;
+    }
+}

--- a/src/test/java/org/opentripplanner/routing/algorithm/filterchain/comparator/SortOnNumberOfTransfersTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/filterchain/comparator/SortOnNumberOfTransfersTest.java
@@ -1,0 +1,44 @@
+package org.opentripplanner.routing.algorithm.filterchain.comparator;
+
+import static org.junit.Assert.assertEquals;
+import static org.opentripplanner.model.plan.Itinerary.toStr;
+import static org.opentripplanner.model.plan.TestItineraryBuilder.newItinerary;
+import static org.opentripplanner.routing.algorithm.filterchain.comparator.SortOrderComparator.numberOfTransfersComparator;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.Test;
+import org.opentripplanner.model.plan.Itinerary;
+import org.opentripplanner.model.plan.PlanTestConstants;
+
+public class SortOnNumberOfTransfersTest implements PlanTestConstants {
+
+    @Test
+    public void sortOnNumberOfTransfers() {
+        List<Itinerary> result;
+
+        // Given: alternatives with zero one and two transfers
+        Itinerary zeroTransfers = newItinerary(A)
+                .bus(1, 0, 200, C)
+                .build();
+
+        Itinerary oneTransfer = newItinerary(A)
+                .bus(1, 0, 50, B)
+                .bus(11, 50, 100, C)
+                .build();
+        Itinerary twoTransfers = newItinerary(A)
+                .bus(1, 0, 50, A)
+                .bus(11, 50, 70, B)
+                .bus(21, 70, 90, C)
+                .build();
+
+        // When: sorting
+        result = Stream.of(twoTransfers, oneTransfer, zeroTransfers)
+                .sorted(numberOfTransfersComparator())
+                .collect(Collectors.toList());
+
+        // Then: expect the results to be in order according to number of transfers
+        assertEquals(toStr(List.of(zeroTransfers, oneTransfer, twoTransfers)), toStr(result));
+    }
+}


### PR DESCRIPTION
### Summary
We want to make sure we always keep the itinerary with the least number of transfers when doing a group by filter, as the cost is not always the most important factor when filtering relatively similar itineraries.

![image](https://user-images.githubusercontent.com/698100/151351389-90063e7d-af5a-4468-b6ad-aaa121f1c7b6.png)

Here the direct itinerary was filtered away previously.

This is built on some commits from #3828, in order to avoid merge conflicts.

### Issue

closes #3801

### Unit tests
Added test for the new comparator

### Code style
✅ 

### Documentation
None required

### Changelog
The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md) 
is generated from the pull-request title, make sure the title describe the feature or issue fixed. 
To exclude the PR from the changelog add `[changelog skip]` in the title.
