### PR TITLE
fix: Log more for Unexpected leg type before TransferLeg [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/transit/raptor/api/path/PathBuilderLeg.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/path/PathBuilderLeg.java
@@ -389,7 +389,7 @@ public class PathBuilderLeg<T extends RaptorTripSchedule> {
             newFromTime = prev.toTime();
         }
         else {
-            throw new IllegalStateException();
+            throw new IllegalStateException("Unexpected leg type before TransferLeg: " + this);
         }
         setTime(newFromTime, newFromTime + asTransferLeg().streetPath.durationInSeconds());
     }


### PR DESCRIPTION
### Summary
There is no issue for this `one-liner`.  We(Entur) got this error witch should never happen when doing a system test of the latest release. We played back 100.000 requests so it is difficult to find out witch of these requests witch caused the error. So this PR improves the logging for the singe case. 

<details>
  <summary>Stacktrace</summary>
<pre>
Caused by: java.lang.IllegalStateException: null
	at org.opentripplanner.transit.raptor.api.path.PathBuilderLeg.timeShiftTransferTime(PathBuilderLeg.java:391)
	at org.opentripplanner.transit.raptor.api.path.PathBuilderLeg.timeShiftThisAndNextLeg(PathBuilderLeg.java:228)
	at org.opentripplanner.transit.raptor.api.path.PathBuilder.lambda$timeShiftAllStreetLegs$1(PathBuilder.java:203)
	at java.base/java.util.stream.Stream$2.forEachRemaining(Stream.java:1314)
	at java.base/java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:658)
	at org.opentripplanner.transit.raptor.api.path.PathBuilder.timeShiftAllStreetLegs(PathBuilder.java:203)
	at org.opentripplanner.transit.raptor.api.path.PathBuilder.updateAggregatedFields(PathBuilder.java:173)
	at org.opentripplanner.transit.raptor.api.path.PathBuilder.build(PathBuilder.java:145)
	at org.opentripplanner.transit.raptor.rangeraptor.path.ReversePathMapper.mapToPath(ReversePathMapper.java:67)
	at org.opentripplanner.transit.raptor.rangeraptor.path.DestinationArrivalPaths.add(DestinationArrivalPaths.java:115)
	at org.opentripplanner.transit.raptor.rangeraptor.standard.stoparrivals.path.EgressArrivalToPathAdapter.addToPath(EgressArrivalToPathAdapter.java:96)
	at org.opentripplanner.transit.raptor.rangeraptor.standard.stoparrivals.path.EgressArrivalToPathAdapter.roundComplete(EgressArrivalToPathAdapter.java:81)
	at org.opentripplanner.transit.raptor.rangeraptor.standard.stoparrivals.path.EgressArrivalToPathAdapter.lambda$new$1(EgressArrivalToPathAdapter.java:50)
	at org.opentripplanner.transit.raptor.rangeraptor.workerlifecycle.LifeCycleEventPublisher.roundComplete(LifeCycleEventPublisher.java:65)
	at org.opentripplanner.transit.raptor.rangeraptor.RangeRaptorWorker.runRaptorForMinute(RangeRaptorWorker.java:186)
	at org.opentripplanner.transit.raptor.rangeraptor.RangeRaptorWorker.lambda$route$0(RangeRaptorWorker.java:162)
	at io.micrometer.core.instrument.composite.CompositeTimer.record(CompositeTimer.java:79)
	at org.opentripplanner.transit.raptor.rangeraptor.RangeRaptorWorker.route(RangeRaptorWorker.java:149)
	at org.opentripplanner.transit.raptor.rangeraptor.standard.heuristics.HeuristicSearch.route(HeuristicSearch.java:31)
	at org.opentripplanner.transit.raptor.service.HeuristicSearchTask.run(HeuristicSearchTask.java:125)
	at org.opentripplanner.transit.raptor.service.RangeRaptorDynamicSearch.runHeuristicsSequentially(RangeRaptorDynamicSearch.java:207)
	at org.opentripplanner.transit.raptor.service.RangeRaptorDynamicSearch.runHeuristics(RangeRaptorDynamicSearch.java:116)
	at org.opentripplanner.transit.raptor.service.RangeRaptorDynamicSearch.route(RangeRaptorDynamicSearch.java:72)
	at org.opentripplanner.transit.raptor.RaptorService.route(RaptorService.java:34)
	at org.opentripplanner.routing.algorithm.raptor.router.TransitRouter.route(TransitRouter.java:104)
	at org.opentripplanner.routing.algorithm.raptor.router.TransitRouter.route(TransitRouter.java:297)
	at org.opentripplanner.routing.algorithm.RoutingWorker.routeTransit(RoutingWorker.java:202)
	at org.opentripplanner.routing.algorithm.RoutingWorker.lambda$route$2(RoutingWorker.java:87)
</pre>
</details>

### Unit tests
No


### Code style
✅ 

### Documentation
Not relevant


