### PR TITLE
Narrow down non-null types to improve schema and docs

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/LegType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/LegType.java
@@ -165,14 +165,14 @@ public class LegType {
             .newFieldDefinition()
             .name("walkingBike")
             .description("Whether this leg is walking with a bike.")
-            .type(new GraphQLNonNull(Scalars.GraphQLBoolean))
+            .type(Scalars.GraphQLBoolean)
             .dataFetcher(env -> leg(env).getWalkingBike())
             .build())
         .field(GraphQLFieldDefinition
             .newFieldDefinition()
             .name("rentedBike")
             .description("Whether this leg is with a rented bike.")
-            .type(new GraphQLNonNull(Scalars.GraphQLBoolean))
+            .type(Scalars.GraphQLBoolean)
             .dataFetcher(env -> leg(env).getRentedVehicle())
             .build())
         .field(GraphQLFieldDefinition

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/LegType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/LegType.java
@@ -137,7 +137,7 @@ public class LegType {
             .newFieldDefinition()
             .name("realtime")
             .description("Whether there is real-time data about this leg")
-            .type(Scalars.GraphQLBoolean)
+            .type(new GraphQLNonNull(Scalars.GraphQLBoolean))
             .dataFetcher(env -> leg(env).getRealTime())
             .build())
         .field(GraphQLFieldDefinition
@@ -158,21 +158,21 @@ public class LegType {
             .newFieldDefinition()
             .name("ride")
             .description("Whether this leg is a ride leg or not.")
-            .type(Scalars.GraphQLBoolean)
+            .type(new GraphQLNonNull(Scalars.GraphQLBoolean))
             .dataFetcher(env -> leg(env).isTransitLeg())
             .build())
         .field(GraphQLFieldDefinition
             .newFieldDefinition()
             .name("walkingBike")
             .description("Whether this leg is walking with a bike.")
-            .type(Scalars.GraphQLBoolean)
+            .type(new GraphQLNonNull(Scalars.GraphQLBoolean))
             .dataFetcher(env -> leg(env).getWalkingBike())
             .build())
         .field(GraphQLFieldDefinition
             .newFieldDefinition()
             .name("rentedBike")
             .description("Whether this leg is with a rented bike.")
-            .type(Scalars.GraphQLBoolean)
+            .type(new GraphQLNonNull(Scalars.GraphQLBoolean))
             .dataFetcher(env -> leg(env).getRentedVehicle())
             .build())
         .field(GraphQLFieldDefinition

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/LegType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/LegType.java
@@ -46,7 +46,7 @@ public class LegType {
             .newFieldDefinition()
             .name("aimedStartTime")
             .description("The aimed date and time this leg starts.")
-            .type(gqlUtil.dateTimeScalar)
+            .type(new GraphQLNonNull(gqlUtil.dateTimeScalar))
             .dataFetcher(
                 // startTime is already adjusted for realtime - need to subtract delay to get aimed time
                 env -> leg(env).getStartTime().getTimeInMillis() - (1000L * leg(
@@ -57,14 +57,14 @@ public class LegType {
             .newFieldDefinition()
             .name("expectedStartTime")
             .description("The expected, realtime adjusted date and time this leg starts.")
-            .type(gqlUtil.dateTimeScalar)
+            .type(new GraphQLNonNull(gqlUtil.dateTimeScalar))
             .dataFetcher(env -> leg(env).getStartTime().getTimeInMillis())
             .build())
         .field(GraphQLFieldDefinition
             .newFieldDefinition()
             .name("aimedEndTime")
             .description("The aimed date and time this leg ends.")
-            .type(gqlUtil.dateTimeScalar)
+            .type(new GraphQLNonNull(gqlUtil.dateTimeScalar))
             .dataFetcher(
                 // endTime is already adjusted for realtime - need to subtract delay to get aimed time
                 env -> leg(env).getEndTime().getTimeInMillis() - 1000L * leg(env).getArrivalDelay())
@@ -73,7 +73,7 @@ public class LegType {
             .newFieldDefinition()
             .name("expectedEndTime")
             .description("The expected, realtime adjusted date and time this leg ends.")
-            .type(gqlUtil.dateTimeScalar)
+            .type(new GraphQLNonNull(gqlUtil.dateTimeScalar))
             .dataFetcher(env -> leg(env).getEndTime().getTimeInMillis())
             .build())
         .field(GraphQLFieldDefinition
@@ -81,7 +81,7 @@ public class LegType {
             .name("mode")
             .description(
                 "The mode of transport or access (e.g., foot) used when traversing this leg.")
-            .type(MODE)
+            .type(new GraphQLNonNull(MODE))
             .dataFetcher(env -> leg(env).getMode())
             .build())
         .field(GraphQLFieldDefinition
@@ -228,7 +228,7 @@ public class LegType {
             .name("intermediateQuays")
             .description(
                 "For ride legs, intermediate quays between the Place where the leg originates and the Place where the leg ends. For non-ride legs, empty list.")
-            .type(new GraphQLNonNull(new GraphQLList(quayType)))
+            .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(quayType))))
             .dataFetcher(env -> {
               List<StopArrival> stops = ((Leg) env.getSource()).getIntermediateStops();
               if (stops == null || stops.isEmpty()) {
@@ -277,7 +277,7 @@ public class LegType {
             .newFieldDefinition()
             .name("situations")
             .description("All relevant situations for this leg")
-            .type(new GraphQLNonNull(new GraphQLList(ptSituationElementType)))
+            .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(ptSituationElementType))))
             .dataFetcher(env -> leg(env).getTransitAlerts())
             .build())
         .field(GraphQLFieldDefinition
@@ -316,7 +316,7 @@ public class LegType {
             .build())
         .build();
   }
-  
+
   private static Leg leg(DataFetchingEnvironment environment) {
       return environment.getSource();
   }

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/TripPatternType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/TripPatternType.java
@@ -42,7 +42,7 @@ public class TripPatternType {
                 .field(GraphQLFieldDefinition.newFieldDefinition()
                         .name("aimedStartTime")
                         .description("The aimed date and time the trip starts.")
-                        .type(gqlUtil.dateTimeScalar)
+                        .type(new GraphQLNonNull(gqlUtil.dateTimeScalar))
                         .dataFetcher(
                                 // startTime is already adjusted for realtime - need to subtract delay to get aimed time
                                 env -> itinerary(env).startTime().getTime().getTime()
@@ -52,23 +52,23 @@ public class TripPatternType {
                         .name("expectedStartTime")
                         .description(
                                 "The expected, realtime adjusted date and time the trip starts.")
-                        .type(gqlUtil.dateTimeScalar)
+                        .type(new GraphQLNonNull(gqlUtil.dateTimeScalar))
                         .dataFetcher(env -> itinerary(env).startTime().getTime().getTime())
                         .build())
                 .field(GraphQLFieldDefinition.newFieldDefinition()
                         .name("aimedEndTime")
                         .description("The aimed date and time the trip ends.")
-                        .type(gqlUtil.dateTimeScalar)
+                        .type(new GraphQLNonNull(gqlUtil.dateTimeScalar))
                         .dataFetcher(
                                 // endTime is already adjusted for realtime - need to subtract delay to get aimed time
-                                env -> itinerary(env).endTime().getTime().getTime() 
+                                env -> itinerary(env).endTime().getTime().getTime()
                                         - 1000L * itinerary(env).arrivalDelay()
                         )
                         .build())
                 .field(GraphQLFieldDefinition.newFieldDefinition()
                         .name("expectedEndTime")
                         .description("The expected, realtime adjusted date and time the trip ends.")
-                        .type(gqlUtil.dateTimeScalar)
+                        .type(new GraphQLNonNull(gqlUtil.dateTimeScalar))
                         .dataFetcher(env -> itinerary(env).endTime().getTime().getTime())
                         .build())
                 .field(GraphQLFieldDefinition
@@ -119,9 +119,9 @@ public class TripPatternType {
                         .newFieldDefinition()
                         .name("legs")
                         .description(
-                                "A list of legs. Each leg is either a walking (cycling, car) " 
-                                + "portion of the trip, or a ride leg on a particular vehicle. So " 
-                                + "a trip where the use walks to the Q train, transfers to the 6, " 
+                                "A list of legs. Each leg is either a walking (cycling, car) "
+                                + "portion of the trip, or a ride leg on a particular vehicle. So "
+                                + "a trip where the use walks to the Q train, transfers to the 6, "
                                 + "then walks to their destination, has four legs."
                         )
                         .type(new GraphQLNonNull(new GraphQLList(legType)))
@@ -131,7 +131,7 @@ public class TripPatternType {
                         .newFieldDefinition()
                         .name("systemNotices")
                         .description("Get all system notices.")
-                        .type(new GraphQLNonNull(new GraphQLList(systemNoticeType)))
+                        .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(systemNoticeType))))
                         .dataFetcher(env -> itinerary(env).systemNotices)
                         .build())
                 .field(GraphQLFieldDefinition

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/et/EstimatedCallType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/et/EstimatedCallType.java
@@ -56,7 +56,7 @@ public class EstimatedCallType {
             .field(GraphQLFieldDefinition.newFieldDefinition()
                            .name("aimedArrivalTime")
                            .description("Scheduled time of arrival at quay. Not affected by read time updated")
-                           .type(gqlUtil.dateTimeScalar)
+                           .type(new GraphQLNonNull(gqlUtil.dateTimeScalar))
                            .dataFetcher(
                                    environment -> 1000 * (
                                        ((TripTimeOnDate) environment.getSource()).getServiceDay()
@@ -65,7 +65,7 @@ public class EstimatedCallType {
                            .build())
             .field(GraphQLFieldDefinition.newFieldDefinition()
                            .name("expectedArrivalTime")
-                           .type(gqlUtil.dateTimeScalar)
+                           .type(new GraphQLNonNull(gqlUtil.dateTimeScalar))
                            .description("Expected time of arrival at quay. Updated with real time information if available. Will be null if an actualArrivalTime exists")
                            .dataFetcher(
                                    environment -> {
@@ -92,7 +92,7 @@ public class EstimatedCallType {
             .field(GraphQLFieldDefinition.newFieldDefinition()
                            .name("aimedDepartureTime")
                            .description("Scheduled time of departure from quay. Not affected by read time updated")
-                           .type(gqlUtil.dateTimeScalar)
+                           .type(new GraphQLNonNull(gqlUtil.dateTimeScalar))
                            .dataFetcher(
                                    environment -> 1000 * (
                                        ((TripTimeOnDate) environment.getSource()).getServiceDay()
@@ -101,7 +101,7 @@ public class EstimatedCallType {
                            .build())
             .field(GraphQLFieldDefinition.newFieldDefinition()
                            .name("expectedDepartureTime")
-                           .type(gqlUtil.dateTimeScalar)
+                           .type(new GraphQLNonNull(gqlUtil.dateTimeScalar))
                            .description("Expected time of departure from quay. Updated with real time information if available. Will be null if an actualDepartureTime exists")
                            .dataFetcher(
                                    environment -> {
@@ -127,30 +127,30 @@ public class EstimatedCallType {
                            .build())
             .field(GraphQLFieldDefinition.newFieldDefinition()
                     .name("timingPoint")
-                    .type(Scalars.GraphQLBoolean)
+                    .type(new GraphQLNonNull(Scalars.GraphQLBoolean))
                     .description("Whether this is a timing point or not. Boarding and alighting is not allowed at timing points.")
                     .dataFetcher(environment -> ((TripTimeOnDate) environment.getSource()).isTimepoint())
                     .build())
             .field(GraphQLFieldDefinition.newFieldDefinition()
                     .name("realtime")
-                    .type(Scalars.GraphQLBoolean)
+                    .type(new GraphQLNonNull(Scalars.GraphQLBoolean))
                     .description("Whether this call has been updated with real time information.")
                     .dataFetcher(environment -> ((TripTimeOnDate) environment.getSource()).isRealtime())
                     .build())
             .field(GraphQLFieldDefinition.newFieldDefinition()
                     .name("predictionInaccurate")
-                    .type(Scalars.GraphQLBoolean)
+                    .type(new GraphQLNonNull(Scalars.GraphQLBoolean))
                     .description("Whether the updated estimates are expected to be inaccurate. NOT IMPLEMENTED")
                     .dataFetcher(environment -> false)
                     .build())
             .field(GraphQLFieldDefinition.newFieldDefinition()
                     .name("realtimeState")
-                    .type(EnumTypes.REALTIME_STATE)
+                    .type(new GraphQLNonNull(EnumTypes.REALTIME_STATE))
                     .dataFetcher(environment -> ((TripTimeOnDate) environment.getSource()).getRealtimeState())
                     .build())
             .field(GraphQLFieldDefinition.newFieldDefinition()
                 .name("forBoarding")
-                .type(Scalars.GraphQLBoolean)
+                .type(new GraphQLNonNull(Scalars.GraphQLBoolean))
                 .description("Whether vehicle may be boarded at quay according to the planned data. "
                     + "If the cancellation flag is set, boarding is not possible, even if this field "
                     + "is set to true.")
@@ -159,7 +159,7 @@ public class EstimatedCallType {
                 ).build())
             .field(GraphQLFieldDefinition.newFieldDefinition()
                 .name("forAlighting")
-                .type(Scalars.GraphQLBoolean)
+                .type(new GraphQLNonNull(Scalars.GraphQLBoolean))
                 .description("Whether vehicle may be alighted at quay according to the planned data. "
                     + "If the cancellation flag is set, alighting is not possible, even if this field "
                     + "is set to true.")
@@ -168,7 +168,7 @@ public class EstimatedCallType {
                 ).build())
             .field(GraphQLFieldDefinition.newFieldDefinition()
                     .name("requestStop")
-                    .type(Scalars.GraphQLBoolean)
+                    .type(new GraphQLNonNull(Scalars.GraphQLBoolean))
                     .description("Whether vehicle will only stop on request.")
                     .dataFetcher(environment ->
                         GqlUtil.getRoutingService(environment).getPatternForTrip()
@@ -179,7 +179,7 @@ public class EstimatedCallType {
             .field(GraphQLFieldDefinition
                     .newFieldDefinition()
                     .name("cancellation")
-                    .type(Scalars.GraphQLBoolean)
+                    .type(new GraphQLNonNull(Scalars.GraphQLBoolean))
                     .description("Whether stop is cancelled. This means that either the "
                         + "ServiceJourney has a planned cancellation, the ServiceJourney has been "
                         + "cancelled by realtime data, or this particular StopPoint has been "
@@ -205,7 +205,7 @@ public class EstimatedCallType {
                     .build())
             .field(GraphQLFieldDefinition.newFieldDefinition()
                     .name("notices")
-                    .type(new GraphQLNonNull(new GraphQLList(noticeType)))
+                    .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(noticeType))))
                     .dataFetcher(environment -> {
                         TripTimeOnDate tripTimeOnDate = environment.getSource();
                         return GqlUtil.getRoutingService(environment).getNoticesByEntity(
@@ -215,7 +215,7 @@ public class EstimatedCallType {
             .field(GraphQLFieldDefinition.newFieldDefinition()
                     .name("situations")
                     .withDirective(gqlUtil.timingData)
-                    .type(new GraphQLNonNull(new GraphQLList(ptSituationElementType)))
+                    .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(ptSituationElementType))))
                     .description("Get all relevant situations for this EstimatedCall.")
                     .dataFetcher(environment -> {
                       return getAllRelevantAlerts(environment.getSource(),


### PR DESCRIPTION
<!--
When creating a pull request, please follow the format below. For each section, *replace* the guidance text with your own text, keeping the section heading. If you have nothing to say in a particular section, you can completely delete the section including its heading to indicate that you have taken the requested steps. None of these instructions or the guidance text (non-heading text) should be present in the submitted PR. These sections serve as a checklist: when you have replaced or deleted all of them, the PR is considered complete. As of 2021, most regular OTP contributors participate in our twice-weekly conference calls. For all but the simplest and smallest PRs, participation in these discussions is necessary to facilitate the review and merge process. Other developers can ask questions and provide immediate feedback on technical design and code style, and resolve any concerns about long term maintenance and comprehension of new code.
-->
### Summary
Narrow down non-null types to improve schema and docs. 
Correct usage of GraphQLNonNull makes the life easier for consumers who generate their clients based on introspection.

### Unit tests
<!--
Write a few words on how the new code is tested. 
- Were unit tests added/updated?
- Was any manual verification done?
- Any observations on changes to performance?
- Was the code designed so it is unit testable?
- Were any tests applied to the smallest appropriate unit?
- Do all tests pass [the continuous integration service](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Developers-Guide.md#continuous-integration)?
-->
No tests done whatsoever!

### Code style
Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Developers-Guide.md#code-style)? 
Yes. 
Some dangling whitespaces have been removed by my IDE. I don't see anything mentioned about this in the Codestyle Guide, so I guess that's OK?
