### PR TITLE
Update link to code style in PR template [changelog skip]

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,10 +2,10 @@
 When creating a pull request, please follow the format below. For each section, *replace* the guidance text with your own text, keeping the section heading. If you have nothing to say in a particular section, you can completely delete the section including its heading to indicate that you have taken the requested steps. None of these instructions or the guidance text (non-heading text) should be present in the submitted PR. These sections serve as a checklist: when you have replaced or deleted all of them, the PR is considered complete. As of 2021, most regular OTP contributors participate in our twice-weekly conference calls. For all but the simplest and smallest PRs, participation in these discussions is necessary to facilitate the review and merge process. Other developers can ask questions and provide immediate feedback on technical design and code style, and resolve any concerns about long term maintenance and comprehension of new code.
 
 ### Summary
-Explain in one or two sentences what this PR achieves. 
+Explain in one or two sentences what this PR achieves.
 
 ### Issue
-Link to or create an [issue](https://github.com/opentripplanner/OpenTripPlanner/issues) that describes the relevant feature or bug. 
+Link to or create an [issue](https://github.com/opentripplanner/OpenTripPlanner/issues) that describes the relevant feature or bug.
 You need not create an issue for small bugfixes and code cleanups, but in that case do describe the problem clearly and completely in the "summary" section above.
 In the linked issue (or summary section for smaller PRs) please describe:
 - Motivation (problem or need encountered)
@@ -19,7 +19,7 @@ Add [GitHub keywords](https://help.github.com/articles/closing-issues-using-keyw
 `closes #45`
 
 ### Unit tests
-Write a few words on how the new code is tested. 
+Write a few words on how the new code is tested.
 - Were unit tests added/updated?
 - Was any manual verification done?
 - Any observations on changes to performance?
@@ -28,7 +28,7 @@ Write a few words on how the new code is tested.
 - Do all tests pass [the continuous integration service](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Developers-Guide.md#continuous-integration)?
 
 ### Code style
-Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Developers-Guide.md#code-style)? 
+Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Developers-Guide.md#code-style)?
 
 ### Documentation
 - Have you added documentation in code covering design and rationale behind the code?
@@ -36,6 +36,6 @@ Have you followed the [suggested code style](https://github.com/opentripplanner/
 - Were any new configuration options added? If so were the tables in the [configuration documentation](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Configuration.md) updated?
 
 ### Changelog
-The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md) 
-is generated from the pull-request title, make sure the title describe the feature or issue fixed. 
+The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md)
+is generated from the pull-request title, make sure the title describe the feature or issue fixed.
 To exclude the PR from the changelog add `[changelog skip]` in the title.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,7 +28,7 @@ Write a few words on how the new code is tested.
 - Do all tests pass [the continuous integration service](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Developers-Guide.md#continuous-integration)?
 
 ### Code style
-Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Developers-Guide.md#code-style)?
+Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Codestyle.md)?
 
 ### Documentation
 - Have you added documentation in code covering design and rationale behind the code?


### PR DESCRIPTION
### Summary
Update the link to Code Style article.

Trim whitespace on line endings (Automatically done by editor. Has no effect on rendered markdown.)
