### PR TITLE
fix: Avoid mixed path separators on Windows in Park API test

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/vehicleparking/parkapi/ParkAPIUpdaterTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/vehicleparking/parkapi/ParkAPIUpdaterTest.java
@@ -13,8 +13,7 @@ public class ParkAPIUpdaterTest {
     void parseCars() {
 
         var cwd = System.getProperty("user.dir");
-        var url = "file://" + cwd
-                + "/src/ext-test/resources/vehicleparking/parkapi/parkapi-reutlingen.json";
+        var url = "file:src/ext-test/resources/vehicleparking/parkapi/parkapi-reutlingen.json";
 
         var parameters =
                 new ParkAPIUpdaterParameters("", url, "park-api", 30, null, List.of(), null);

--- a/src/ext-test/java/org/opentripplanner/ext/vehicleparking/parkapi/ParkAPIUpdaterTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/vehicleparking/parkapi/ParkAPIUpdaterTest.java
@@ -11,8 +11,6 @@ public class ParkAPIUpdaterTest {
 
     @Test
     void parseCars() {
-
-        var cwd = System.getProperty("user.dir");
         var url = "file:src/ext-test/resources/vehicleparking/parkapi/parkapi-reutlingen.json";
 
         var parameters =


### PR DESCRIPTION
### Summary

When concatenating "user.dir" with the "file://" pattern on Windows, you get mixed path separators like:

```
file://C:\git-projects\OpenTripPlanner/src/ext-test/resources/vehicleparking/parkapi/parkapi-reutlingen.json
```

...which causes the file not to be found and the test to fail.

This patch simplifies the string used to load the test file for the Park API test to avoid mixed path separators on Windows.

Based on https://github.com/leonardehrenfried/OpenTripPlanner/commit/012c0b7ea7ee7947db29bf47a70d264fce08cb1a.

Closes https://github.com/opentripplanner/OpenTripPlanner/issues/3839