### PR TITLE
Minor Transmodel GraphQL API improvements [changelog skip]

### DIFF
--- a/docs/sandbox/TransmodelApi.md
+++ b/docs/sandbox/TransmodelApi.md
@@ -23,6 +23,9 @@
 - Fix issue with fetching parent StopPlaces in nearest query in Transmodel API [#3807](https://github.com/opentripplanner/OpenTripPlanner/pull/3807)
 - Fix invalid cast in situations resolver for line type [#3810](https://github.com/opentripplanner/OpenTripPlanner/pull/3810)
 - Deduce enum for bookWhen in Transmodel API [#3854](https://github.com/opentripplanner/OpenTripPlanner/pull/3854)
+- Fix coercion of default parameter for maximumDistance in nearest [#3846](https://github.com/opentripplanner/OpenTripPlanner/pull/3846)
+- Expose stopPositionInPattern on EstimatedCall [#3846](https://github.com/opentripplanner/OpenTripPlanner/pull/3846)
+- Allow selecting first or last quays in a ServiceJourney [#3846](https://github.com/opentripplanner/OpenTripPlanner/pull/3846)
 
 ## Documentation
 

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
@@ -601,7 +601,7 @@ public class TransmodelGraphQLSchema {
           .argument(GraphQLArgument.newArgument()
               .name("maximumDistance")
               .description("Maximum distance (in meters) to search for from the specified location. Default is 2000m.")
-              .defaultValue(2000)
+              .defaultValueProgrammatic(2000)
               .type(new GraphQLNonNull(Scalars.GraphQLFloat))
               .build())
           .argument(GraphQLArgument.newArgument()

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/et/EstimatedCallType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/et/EstimatedCallType.java
@@ -149,6 +149,11 @@ public class EstimatedCallType {
                     .dataFetcher(environment -> ((TripTimeOnDate) environment.getSource()).getRealtimeState())
                     .build())
             .field(GraphQLFieldDefinition.newFieldDefinition()
+                    .name("stopPositionInPattern")
+                    .type(Scalars.GraphQLInt)
+                    .dataFetcher(environment -> ((TripTimeOnDate) environment.getSource()).getStopIndex())
+                    .build())
+            .field(GraphQLFieldDefinition.newFieldDefinition()
                 .name("forBoarding")
                 .type(new GraphQLNonNull(Scalars.GraphQLBoolean))
                 .description("Whether vehicle may be boarded at quay according to the planned data. "

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/ServiceJourneyType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/ServiceJourneyType.java
@@ -1,30 +1,35 @@
 package org.opentripplanner.ext.transmodelapi.model.timetable;
 
+import static org.opentripplanner.ext.transmodelapi.model.EnumTypes.TRANSPORT_MODE;
+import static org.opentripplanner.ext.transmodelapi.model.EnumTypes.TRANSPORT_SUBMODE;
+
+import com.google.common.collect.Lists;
+import graphql.AssertException;
 import graphql.Scalars;
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.GraphQLArgument;
-import graphql.schema.GraphQLEnumType;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLList;
 import graphql.schema.GraphQLNonNull;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLOutputType;
 import graphql.schema.GraphQLTypeReference;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
 import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.ext.transmodelapi.model.EnumTypes;
 import org.opentripplanner.ext.transmodelapi.model.TransmodelTransportSubmode;
 import org.opentripplanner.ext.transmodelapi.support.GqlUtil;
-import org.opentripplanner.model.Route;
+import org.opentripplanner.model.StopLocation;
 import org.opentripplanner.model.Trip;
 import org.opentripplanner.model.TripPattern;
 import org.opentripplanner.model.TripTimeOnDate;
 import org.opentripplanner.model.calendar.ServiceDate;
 import org.opentripplanner.util.PolylineEncoder;
-
-import java.util.stream.Collectors;
-
-import static org.opentripplanner.ext.transmodelapi.model.EnumTypes.TRANSPORT_MODE;
-import static org.opentripplanner.ext.transmodelapi.model.EnumTypes.TRANSPORT_SUBMODE;
 
 public class ServiceJourneyType {
   private static final String NAME = "ServiceJourney";
@@ -139,9 +144,40 @@ public class ServiceJourneyType {
                     .name("quays")
                     .description("Quays visited by service journey")
                     .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(quayType))))
-                    .dataFetcher(environment ->
-                        GqlUtil.getRoutingService(environment).getPatternForTrip().get(trip(environment)).getStops()
-                    )
+                    .argument(GraphQLArgument.newArgument()
+                            .name("first")
+                            .description("Only fetch the first n quays on the service journey")
+                            .type(Scalars.GraphQLInt)
+                            .build())
+                    .argument(GraphQLArgument.newArgument()
+                            .name("last")
+                            .description("Only fetch the last n quays on the service journey")
+                            .type(Scalars.GraphQLInt)
+                            .build())
+                    .dataFetcher(environment -> {
+                        Integer first = environment.getArgument("first");
+                        Integer last = environment.getArgument("last");
+
+                        List<StopLocation> stops = GqlUtil.getRoutingService(environment)
+                                .getPatternForTrip()
+                                .get(trip(environment))
+                                .getStops();
+
+                        if (first != null && last != null) {
+                            throw new AssertException("Both first and last can't be defined simultaneously.");
+                        } else if (first != null) {
+                            stops = stops.stream()
+                                    .limit(Long.valueOf(first))
+                                    .collect(Collectors.toList());
+                        } else if (last != null) {
+                            List<StopLocation> reversedStops = Lists.reverse(stops).stream()
+                                    .limit(Long.valueOf(last))
+                                    .collect(Collectors.toList());
+                            stops = Lists.reverse(reversedStops);
+                        }
+
+                        return stops;
+                    })
                     .build())
             .field(GraphQLFieldDefinition.newFieldDefinition()
                     .name("passingTimes")


### PR DESCRIPTION
### Summary

This PR contains three separate fixes/new features for the Transmodel GraphQL API.
- Fix coercion of default parameter
- Expose stopPositionInPattern on EstimatedCall
- Allow selecting first or last quays in a ServiceJourney

### Unit tests
None changed

### Code style
✅ 

### Documentation
Inline documentation updated

### Changelog
The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md)
is generated from the pull-request title, make sure the title describe the feature or issue fixed.
To exclude the PR from the changelog add `[changelog skip]` in the title.
