### PR TITLE
Filter out elevator ways that are also implicit areas

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModule.java
@@ -966,7 +966,9 @@ public class OpenStreetMapModule implements GraphBuilderModule {
             if (osmdb.isAreaWay(way.getId())) { return false; }
 
             TLongList nodeRefs = way.getNodeRefs();
-            // A way whose first and last nore are the same is probably an area, skip that.
+            // A way whose first and last node are the same is probably an area, skip that.
+            // https://www.openstreetmap.org/way/503412863
+            // https://www.openstreetmap.org/way/187719215
             return nodeRefs.get(0) != nodeRefs.get(nodeRefs.size() - 1);
         }
 

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModule.java
@@ -918,8 +918,7 @@ public class OpenStreetMapModule implements GraphBuilderModule {
 
             // Add highway=elevators to graph as elevators
             Iterator<OSMWay> elevators = osmdb.getWays().stream()
-                    .filter(way -> way.hasTag("highway") && "elevator".equals(way.getTag("highway"))
-                            && !osmdb.isAreaWay(way.getId()))
+                    .filter(way -> isElevatorWay(way))
                     .iterator();
 
             for (Iterator<OSMWay> it = elevators; it.hasNext(); ) {
@@ -959,6 +958,16 @@ public class OpenStreetMapModule implements GraphBuilderModule {
                 );
                 LOG.debug("Created elevatorHopEdges for way {}", elevatorWay.getId());
             }
+        }
+
+        private boolean isElevatorWay(OSMWay way) {
+            if (!way.hasTag("highway")) { return false; }
+            if (!"elevator".equals(way.getTag("highway"))) { return false; }
+            if (osmdb.isAreaWay(way.getId())) { return false; }
+
+            TLongList nodeRefs = way.getNodeRefs();
+            // A way whose first and last nore are the same is probably an area, skip that.
+            return nodeRefs.get(0) != nodeRefs.get(nodeRefs.size() - 1);
         }
 
         private void createElevatorVertices(


### PR DESCRIPTION
### Summary

The PR #3750 did not consider elevator which are modeled as areas, without explicitly being defined as such. This adds filtering for these kind of elevators, eg. https://www.openstreetmap.org/way/503412863 or https://www.openstreetmap.org/way/187719215

### Issue
Closes #3847

### Unit tests
None changed

### Code style
✅ 

### Documentation
None changed

### Changelog
The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md)
is generated from the pull-request title, make sure the title describe the feature or issue fixed.
To exclude the PR from the changelog add `[changelog skip]` in the title.
