### PR TITLE
ci: Add Windows to GitHub Action builds

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -16,7 +16,10 @@ on:
       - dev-2.x
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest ]
     steps:
       # Starting in v2.2 checkout action fetches all tags when fetch-depth=0, for auto-versioning.
       - uses: actions/checkout@v2.3.2


### PR DESCRIPTION
### Summary
This PR adds a Windows GitHub Action build via a matrix, so each commit will now be run on Windows and Ubuntu to quickly detect potential cross-platform failures.

### Issue
There have been several Windows-specific bugs in the past related to paths and loading test files that weren't caught until another developer tried to build the project on Windows, specifically:
* https://github.com/opentripplanner/OpenTripPlanner/issues/3839
* https://github.com/opentripplanner/OpenTripPlanner/issues/2950
* https://github.com/opentripplanner/OpenTripPlanner/issues/2339

This change to the GitHub Action will help detect those failures before merging PRs.