### PR TITLE
Fix vehicle parking updater for ParkAPI [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/standalone/config/updaters/VehicleParkingUpdaterConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/updaters/VehicleParkingUpdaterConfig.java
@@ -3,6 +3,7 @@ package org.opentripplanner.standalone.config.updaters;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import org.opentripplanner.ext.vehicleparking.hslpark.HslParkUpdaterParameters;
 import org.opentripplanner.ext.vehicleparking.kml.KmlUpdaterParameters;
 import org.opentripplanner.ext.vehicleparking.parkapi.ParkAPIUpdaterParameters;
@@ -62,7 +63,7 @@ public class VehicleParkingUpdaterConfig {
                 feedId,
                 c.asInt("frequencySec", 60),
                 c.asMap("headers", NodeAdapter::asText),
-                new ArrayList<>(c.asTextSet("tags", null)),
+                new ArrayList<>(c.asTextSet("tags", Set.of())),
                 sourceType
         );
       default:


### PR DESCRIPTION
### Summary

Today we merged in the vehicle parking updater that @optionsome has upstreamed in #3796 - thanks for this!

I encountered a exception when trying out the ParkAPI support:

```
Feb 02 13:24:33 dev build-graph[3636]: java.lang.NullPointerException: null
Feb 02 13:24:33 dev build-graph[3636]:         at java.base/java.util.ArrayList.<init>(ArrayList.java:179)
Feb 02 13:24:33 dev build-graph[3636]:         at org.opentripplanner.standalone.config.updaters.VehicleParkingUpdaterConfig.create(VehicleParkingUpdaterConfig.java:65)
Feb 02 13:24:33 dev build-graph[3636]:         at org.opentripplanner.standalone.config.UpdatersConfig.<init>(UpdatersConfig.java:101)
Feb 02 13:24:33 dev build-graph[3636]:         at org.opentripplanner.standalone.config.RouterConfig.<init>(RouterConfig.java:58)
Feb 02 13:24:33 dev build-graph[3636]:         at org.opentripplanner.standalone.config.ConfigLoader.loadRouterConfig(ConfigLoader.java:126)
Feb 02 13:24:33 dev build-graph[3636]:         at org.opentripplanner.standalone.configure.OTPConfiguration.<init>(OTPConfiguration.java:62)
Feb 02 13:24:33 dev build-graph[3636]:         at org.opentripplanner.standalone.configure.OTPConfiguration.<init>(OTPConfiguration.java:70)
Feb 02 13:24:33 dev build-graph[3636]:         at org.opentripplanner.standalone.configure.OTPAppConstruction.<init>(OTPAppConstruction.java:53)
Feb 02 13:24:33 dev build-graph[3636]:         at org.opentripplanner.standalone.OTPMain.startOTPServer(OTPMain.java:111)
```

it was easy to fix though.

### Issue
no issue

### Unit tests
n/a

### Code style
n/a

### Documentation
n/a
