### PR TITLE
Deduce enum for bookWhen in Transmodel API [changelog skip]

### DIFF
--- a/docs/sandbox/TransmodelApi.md
+++ b/docs/sandbox/TransmodelApi.md
@@ -22,6 +22,7 @@
 - Narrow down non-null types type [#3803](https://github.com/opentripplanner/OpenTripPlanner/pull/3803)
 - Fix issue with fetching parent StopPlaces in nearest query in Transmodel API [#3807](https://github.com/opentripplanner/OpenTripPlanner/pull/3807)
 - Fix invalid cast in situations resolver for line type [#3810](https://github.com/opentripplanner/OpenTripPlanner/pull/3810)
+- Deduce enum for bookWhen in Transmodel API [#3854](https://github.com/opentripplanner/OpenTripPlanner/pull/3854)
 
 ## Documentation
 

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/EnumTypes.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/EnumTypes.java
@@ -302,6 +302,15 @@ public class EnumTypes {
         .value("to", InputField.TO_PLACE)
         .build();
 
+    public static GraphQLEnumType PURCHASE_WHEN = GraphQLEnumType.newEnum()
+        .name("PurchaseWhen")
+        .value("timeOfTravelOnly", "timeOfTravelOnly")
+        .value("dayOfTravelOnly", "dayOfTravelOnly")
+        .value("untilPreviousDay", "untilPreviousDay")
+        .value("advanceAndDayOfTravel", "advanceAndDayOfTravel")
+        .value("other", "other")
+        .build();
+
     public static Object enumToString(GraphQLEnumType type, Enum<?> value) {
         return type.serialize(value);
     }

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/BookingArrangementType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/BookingArrangementType.java
@@ -83,6 +83,34 @@ public class BookingArrangementType {
                 })
             .build())
         .field(GraphQLFieldDefinition.newFieldDefinition()
+            .name("bookWhen")
+            .description("Time constraints for booking")
+            .type(EnumTypes.PURCHASE_WHEN)
+            .dataFetcher(environment -> {
+                BookingInfo bookingInfo = bookingInfo(environment);
+                if (bookingInfo.getMinimumBookingNotice() != null) { return null; }
+                BookingTime latestBookingTime = bookingInfo.getLatestBookingTime();
+                BookingTime earliestBookingTime = bookingInfo.getEarliestBookingTime();
+
+                // Try to deduce the original enum from stored values
+                if (earliestBookingTime == null) {
+                    if (latestBookingTime == null) {
+                        return "timeOfTravelOnly";
+                    } else if (latestBookingTime.getDaysPrior() == 1) {
+                        return "untilPreviousDay";
+                    } else if (latestBookingTime.getDaysPrior() == 0) {
+                        return "advanceAndDayOfTravel";
+                    } else {
+                        return "other";
+                    }
+                } else if (earliestBookingTime.getDaysPrior() == 0 && latestBookingTime.getDaysPrior() == 0) {
+                    return "dayOfTravelOnly";
+                } else {
+                    return "other";
+                }
+            })
+            .build())
+        .field(GraphQLFieldDefinition.newFieldDefinition()
             .name("minimumBookingPeriod")
             .description("Minimum period in advance service can be booked as a ISO 8601 duration")
             .type(Scalars.GraphQLString)


### PR DESCRIPTION
### Summary
Currently we can't get the `bookWhen` enum from the api, which is used in Netex data, and which the consumers expect to get when fetching booking information. This PR adds logic for trying to deduce correct enum for bookWhen based on the reverse mapping of the different possibilities of how it is mapped.

### Unit tests
Non changed

### Code style
✅ 

### Documentation
None updated

### Changelog
The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md)
is generated from the pull-request title, make sure the title describe the feature or issue fixed.
To exclude the PR from the changelog add `[changelog skip]` in the title.
