### PR TITLE
Allow for null values in vector tiles mapper [changelog skip]

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/DigitransitStopPropertyMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/DigitransitStopPropertyMapper.java
@@ -3,7 +3,6 @@ package org.opentripplanner.ext.vectortiles.layers.stops;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.json.simple.JSONArray;
@@ -44,11 +43,11 @@ public class DigitransitStopPropertyMapper extends PropertyMapper<TransitStopVer
       int stopPos = tripPattern.findStopPosition(stop);
       var headsign  = stopPos < 0 ? "Not Available" :
               tripPattern.getScheduledTimetable().getTripTimes().get(0).getHeadsign(stopPos);
-      return new JSONObject(Map.of(
-              "headsign", Optional.ofNullable(headsign).orElse(""),
-              "type", tripPattern.getRoute().getMode().name(),
-              "shortName", Optional.ofNullable(tripPattern.getRoute().getShortName()).orElse("")
-      ));
+      JSONObject pattern = new JSONObject();
+      pattern.put("headsign", headsign);
+      pattern.put("type", tripPattern.getRoute().getMode().name());
+      pattern.put("shortName", tripPattern.getRoute().getShortName());
+      return pattern;
     }).collect(Collectors.toList()));
 
     return List.of(

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/DigitransitStopPropertyMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/DigitransitStopPropertyMapper.java
@@ -3,6 +3,7 @@ package org.opentripplanner.ext.vectortiles.layers.stops;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.json.simple.JSONArray;
@@ -44,9 +45,9 @@ public class DigitransitStopPropertyMapper extends PropertyMapper<TransitStopVer
       var headsign  = stopPos < 0 ? "Not Available" :
               tripPattern.getScheduledTimetable().getTripTimes().get(0).getHeadsign(stopPos);
       return new JSONObject(Map.of(
-              "headsign", headsign,
+              "headsign", Optional.ofNullable(headsign).orElse(""),
               "type", tripPattern.getRoute().getMode().name(),
-              "shortName", tripPattern.getRoute().getShortName()
+              "shortName", Optional.ofNullable(tripPattern.getRoute().getShortName()).orElse("")
       ));
     }).collect(Collectors.toList()));
 


### PR DESCRIPTION
### Summary

I merged upstream OTP into one of my downstream forks and we saw the following stack trace when generating vector tiles with null values:

```
Feb 02 15:00:26 dev da267ea3c15b[17630]: 14:00:26.046 ERROR (OTPExceptionMapper.java:39) Unhandled exception
Feb 02 15:00:26 dev da267ea3c15b[17630]: java.lang.NullPointerException: null
Feb 02 15:00:26 dev da267ea3c15b[17630]:         at java.base/java.util.Objects.requireNonNull(Objects.java:221)
Feb 02 15:00:26 dev da267ea3c15b[17630]:         at java.base/java.util.ImmutableCollections$MapN.<init>(ImmutableCollections.java:827)
Feb 02 15:00:26 dev da267ea3c15b[17630]:         at java.base/java.util.Map.of(Map.java:1349)
Feb 02 15:00:26 dev da267ea3c15b[17630]:         at org.opentripplanner.ext.vectortiles.layers.stops.DigitransitStopPropertyMapper.lambda$map$0(DigitransitStopPropertyMapper.java:46)
Feb 02 15:00:26 dev da267ea3c15b[17630]:         at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
Feb 02 15:00:26 dev da267ea3c15b[17630]:         at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1655)
Feb 02 15:00:26 dev da267ea3c15b[17630]:         at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
Feb 02 15:00:26 dev da267ea3c15b[17630]:         at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
Feb 02 15:00:26 dev da267ea3c15b[17630]:         at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
Feb 02 15:00:26 dev da267ea3c15b[17630]:         at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
Feb 02 15:00:26 dev da267ea3c15b[17630]:         at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)
Feb 02 15:00:26 dev da267ea3c15b[17630]:         at org.opentripplanner.ext.vectortiles.layers.stops.DigitransitStopPropertyMapper.map(DigitransitStopPropertyMapper.java:51)
Feb 02 15:00:26 dev da267ea3c15b[17630]:         at org.opentripplanner.ext.vectortiles.layers.stops.DigitransitStopPropertyMapper.map(DigitransitStopPropertyMapper.java:17)
Feb 02 15:00:26 dev da267ea3c15b[17630]:         at org.opentripplanner.ext.vectortiles.PropertyMapper.addTags(PropertyMapper.java:30)
Feb 02 15:00:26 dev da267ea3c15b[17630]:         at com.wdtinc.mapbox_vector_tile.adapt.jts.JtsAdapter.toFeature(JtsAdapter.java:414)
Feb 02 15:00:26 dev da267ea3c15b[17630]:         at com.wdtinc.mapbox_vector_tile.adapt.jts.JtsAdapter.toFeatures(JtsAdapter.java:300)
Feb 02 15:00:26 dev da267ea3c15b[17630]:         at org.opentripplanner.ext.vectortiles.LayerBuilder.build(LayerBuilder.java:43)
Feb 02 15:00:26 dev da267ea3c15b[17630]:         at org.opentripplanner.ext.vectortiles.VectorTilesResource.tileGet(VectorTilesResource.java:93)
Feb 02 15:00:26 dev da267ea3c15b[17630]:         at jdk.internal.reflect.GeneratedMethodAccessor127.invoke(Unknown Source)
Feb 02 15:00:26 dev da267ea3c15b[17630]:         at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
Feb 02 15:00:26 dev da267ea3c15b[17630]:         at java.base/java.lang.reflect.Method.invoke(Method.java:566)
```

This handling has recently been changed in https://github.com/opentripplanner/OpenTripPlanner/commit/594f8f4b4825bfc1e8513df756fbc20f499c9e26#diff-a356f2a8eec550c24077cd0ce989ae35bb5a129e8035377731950e678b558ff1 and using `Map.of` requires values to be non-null, which isn't the case here.

This PR converts the `null` values to empty strings.

### Issue
n/a

### Unit tests
n/a

### Code style
yes

### Documentation
n/a