### PR TITLE
Remove unused field `orig` from `Place` [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/api/mapping/PlaceMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/PlaceMapper.java
@@ -66,7 +66,6 @@ public class PlaceMapper {
 
         api.arrival = arrival;
         api.departure = departure;
-        api.orig = domain.orig;
         api.stopIndex = stopIndex;
         api.stopSequence = gtfsStopSequence;
         api.vertexType = VertexTypeMapper.mapVertexType(domain.vertexType);

--- a/src/main/java/org/opentripplanner/api/model/ApiPlace.java
+++ b/src/main/java/org/opentripplanner/api/model/ApiPlace.java
@@ -49,8 +49,6 @@ public class ApiPlace {
      */
     public Calendar departure = null;
 
-    public String orig;
-
     public String zoneId;
 
     /**

--- a/src/main/java/org/opentripplanner/model/plan/Place.java
+++ b/src/main/java/org/opentripplanner/model/plan/Place.java
@@ -7,7 +7,6 @@ import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.core.TraverseMode;
 import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalPlace;
-import org.opentripplanner.routing.vertextype.TransitStopVertex;
 import org.opentripplanner.routing.vertextype.VehicleParkingEntranceVertex;
 import org.opentripplanner.routing.vertextype.VehicleRentalStationVertex;
 
@@ -20,8 +19,6 @@ public class Place {
      * For transit stops, the name of the stop.  For points of interest, the name of the POI.
      */
     public final String name;
-
-    public final String orig;
 
     /**
      * The coordinate of the place.
@@ -51,7 +48,6 @@ public class Place {
 
     private Place(
             String name,
-            String orig,
             WgsCoordinate coordinate,
             VertexType vertexType,
             StopLocation stop,
@@ -59,7 +55,6 @@ public class Place {
             VehicleParkingWithEntrance vehicleParkingWithEntrance
     ) {
         this.name = name;
-        this.orig = orig;
         this.coordinate = coordinate;
         this.vertexType = vertexType;
         this.stop = stop;
@@ -100,7 +95,6 @@ public class Place {
                 .addStr("name", name)
                 .addObj("stop", stop)
                 .addObj("coordinate", coordinate)
-                .addStr("orig", orig)
                 .addEnum("vertexType", vertexType)
                 .addObj("vehicleRentalPlace", vehicleRentalPlace)
                 .addObj("vehicleParkingEntrance", vehicleParkingWithEntrance)
@@ -110,7 +104,6 @@ public class Place {
     public static Place normal(Double lat, Double lon, String name) {
         return new Place(
                 name,
-                null,
                 WgsCoordinate.creatOptionalCoordinate(lat, lon),
                 VertexType.NORMAL,
                 null, null, null
@@ -120,7 +113,6 @@ public class Place {
     public static Place normal(Vertex vertex, String name) {
         return new Place(
                 name,
-                null,
                 WgsCoordinate.creatOptionalCoordinate(vertex.getLat(), vertex.getLon()),
                 VertexType.NORMAL,
                 null, null, null
@@ -130,7 +122,6 @@ public class Place {
     public static Place forStop(StopLocation stop) {
         return new Place(
                 stop.getName(),
-                null,
                 stop.getCoordinate(),
                 VertexType.TRANSIT,
                 stop,
@@ -144,7 +135,6 @@ public class Place {
         // coordinates.
         return new Place(
                 stop.getName(),
-                null,
                 WgsCoordinate.creatOptionalCoordinate(vertex.getLat(), vertex.getLon()),
                 VertexType.TRANSIT,
                 stop,
@@ -156,7 +146,6 @@ public class Place {
     public static Place forVehicleRentalPlace(VehicleRentalStationVertex vertex, String name) {
         return new Place(
                 name,
-                null,
                 WgsCoordinate.creatOptionalCoordinate(vertex.getLat(), vertex.getLon()),
                 VertexType.VEHICLERENTAL,
                 null,
@@ -177,7 +166,6 @@ public class Place {
                 && vertex.getVehicleParking().hasRealTimeDataForMode(traverseMode, request.wheelchairAccessible);
         return new Place(
                 name,
-                null,
                 WgsCoordinate.creatOptionalCoordinate(vertex.getLat(), vertex.getLon()),
                 VertexType.VEHICLEPARKING,
                 null,


### PR DESCRIPTION
### Summary

Remove unused field `orig` from `Place`. As the field is always null, and null is not serialized in the Rest API, it is never used anywhere.

### Unit tests
None changed

### Code style
✅ 

### Documentation
None needed

### Changelog
The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md)
is generated from the pull-request title, make sure the title describe the feature or issue fixed.
To exclude the PR from the changelog add `[changelog skip]` in the title.
