### PR TITLE
Otp2 remove lombok [changelog skip]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -729,13 +729,6 @@
             <artifactId>javacsv</artifactId>
             <version>2.0</version>
         </dependency>
-        <!-- Lombok -->
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>1.18.20</version>
-            <scope>provided</scope>
-        </dependency>
         <dependency>
             <groupId>org.eclipse.paho</groupId>
             <artifactId>org.eclipse.paho.client.mqttv3</artifactId>

--- a/src/ext/java/org/opentripplanner/ext/siri/TimetableHelper.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/TimetableHelper.java
@@ -12,7 +12,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.TimeZone;
 import javax.xml.datatype.Duration;
-import lombok.val;
 import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.model.StopLocation;
 import org.opentripplanner.model.StopTime;
@@ -368,7 +367,7 @@ public class TimetableHelper {
         }
 
         //Get all scheduled stops
-        val pattern = timetable.getPattern();
+        var pattern = timetable.getPattern();
 
         // Keeping track of visited stop-objects to allow multiple visits to a stop.
         List<Object> alreadyVisited = new ArrayList<>();
@@ -610,7 +609,7 @@ public class TimetableHelper {
 
                 int arrivalDelay = 0;
                 int departureDelay = 0;
-                val pattern = timetable.getPattern();
+                var pattern = timetable.getPattern();
 
                 for (int index = 0; index < newTimes.getNumStops(); ++index) {
                     if (!matchFound) {

--- a/src/main/java/org/opentripplanner/index/IndexAPI.java
+++ b/src/main/java/org/opentripplanner/index/IndexAPI.java
@@ -227,7 +227,7 @@ public class IndexAPI {
         return routingService
                 .getPatternsForStop(stop)
                 .stream()
-                .map(it -> it.getRoute())
+                .map(TripPattern::getRoute)
                 .map(RouteMapper::mapToApiShort)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/org/opentripplanner/routing/RoutingService.java
+++ b/src/main/java/org/opentripplanner/routing/RoutingService.java
@@ -1,27 +1,79 @@
 package org.opentripplanner.routing;
 
+import com.google.common.collect.Multimap;
+import gnu.trove.set.TIntSet;
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.BitSet;
 import java.util.Calendar;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
-import lombok.experimental.Delegate;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TimeZone;
+import java.util.function.Function;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Envelope;
+import org.locationtech.jts.geom.Geometry;
+import org.opentripplanner.common.TurnRestriction;
+import org.opentripplanner.common.geometry.HashGridSpatialIndex;
+import org.opentripplanner.common.model.T2;
+import org.opentripplanner.ext.flex.FlexIndex;
+import org.opentripplanner.graph_builder.DataImportIssueStore;
+import org.opentripplanner.graph_builder.linking.VertexLinker;
+import org.opentripplanner.graph_builder.module.osm.WayPropertySetSource.DrivingDirection;
+import org.opentripplanner.model.Agency;
+import org.opentripplanner.model.FeedInfo;
+import org.opentripplanner.model.FeedScopedId;
+import org.opentripplanner.model.FlexStopLocation;
+import org.opentripplanner.model.GraphBundle;
+import org.opentripplanner.model.MultiModalStation;
+import org.opentripplanner.model.Notice;
+import org.opentripplanner.model.Operator;
+import org.opentripplanner.model.PathTransfer;
+import org.opentripplanner.model.Route;
+import org.opentripplanner.model.Station;
 import org.opentripplanner.model.Stop;
 import org.opentripplanner.model.StopLocation;
 import org.opentripplanner.model.StopTimesInPattern;
 import org.opentripplanner.model.Timetable;
 import org.opentripplanner.model.TimetableSnapshot;
+import org.opentripplanner.model.TimetableSnapshotProvider;
+import org.opentripplanner.model.TransitEntity;
+import org.opentripplanner.model.TransitMode;
 import org.opentripplanner.model.Trip;
 import org.opentripplanner.model.TripPattern;
 import org.opentripplanner.model.TripTimeOnDate;
+import org.opentripplanner.model.WgsCoordinate;
+import org.opentripplanner.model.calendar.CalendarService;
+import org.opentripplanner.model.calendar.CalendarServiceData;
 import org.opentripplanner.model.calendar.ServiceDate;
+import org.opentripplanner.model.transfer.TransferService;
 import org.opentripplanner.routing.algorithm.RoutingWorker;
+import org.opentripplanner.routing.algorithm.raptor.transit.TransitLayer;
 import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.api.response.RoutingResponse;
+import org.opentripplanner.routing.core.intersection_model.IntersectionTraversalCostModel;
+import org.opentripplanner.routing.edgetype.StreetEdge;
+import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.GraphIndex;
+import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.routing.graphfinder.GraphFinder;
+import org.opentripplanner.routing.graphfinder.NearbyStop;
+import org.opentripplanner.routing.graphfinder.PlaceAtDistance;
+import org.opentripplanner.routing.graphfinder.PlaceType;
+import org.opentripplanner.routing.impl.StreetVertexIndex;
+import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.routing.stoptimes.ArrivalDeparture;
 import org.opentripplanner.routing.stoptimes.StopTimesHelper;
+import org.opentripplanner.routing.vehicle_parking.VehicleParkingService;
+import org.opentripplanner.routing.vehicle_rental.VehicleRentalStationService;
+import org.opentripplanner.routing.vertextype.TransitStopVertex;
 import org.opentripplanner.standalone.server.Router;
+import org.opentripplanner.util.WorldEnvelope;
 
 /**
  * This is the entry point of all API requests towards the OTP graph. A new instance of this class
@@ -30,13 +82,10 @@ import org.opentripplanner.standalone.server.Router;
  */
 public class RoutingService {
 
-    @Delegate(types = Graph.class)
     private final Graph graph;
 
-    @Delegate(types = GraphIndex.class)
     private final GraphIndex graphIndex;
 
-    @Delegate(types = GraphFinder.class)
     private final GraphFinder graphFinder;
 
     /**
@@ -163,6 +212,420 @@ public class RoutingService {
 
     public List<TripTimeOnDate> getTripTimesShort(Trip trip, ServiceDate serviceDate) {
         return TripTimesShortHelper.getTripTimesShort(this, trip, serviceDate);
+    }
+
+    /** {@link Graph#getTimetableSnapshot()} */
+    public TimetableSnapshot getTimetableSnapshot() {return this.graph.getTimetableSnapshot();}
+
+    /** {@link Graph#getOrSetupTimetableSnapshotProvider(Function)} */
+    public <T extends TimetableSnapshotProvider> T getOrSetupTimetableSnapshotProvider(Function<Graph, T> creator) {
+        return this.graph.getOrSetupTimetableSnapshotProvider(creator);
+    }
+
+    /** {@link Graph#addVertex(Vertex)} */
+    public void addVertex(Vertex v) {this.graph.addVertex(v);}
+
+    /** {@link Graph#removeEdge(Edge)} */
+    public void removeEdge(Edge e) {this.graph.removeEdge(e);}
+
+    /** {@link Graph#getVertex(String)} */
+    public Vertex getVertex(String label) {return this.graph.getVertex(label);}
+
+    /** {@link Graph#getVertices()} */
+    public Collection<Vertex> getVertices() {return this.graph.getVertices();}
+
+    /** {@link Graph#getVerticesOfType(Class)} */
+    public <T extends Vertex> List<T> getVerticesOfType(Class<T> cls) {
+        return this.graph.getVerticesOfType(cls);
+    }
+
+    /** {@link Graph#getEdges()} */
+    public Collection<Edge> getEdges() {return this.graph.getEdges();}
+
+    /** {@link Graph#getEdgesOfType(Class)} */
+    public <T extends Edge> List<T> getEdgesOfType(Class<T> cls) {
+        return this.graph.getEdgesOfType(cls);
+    }
+
+    /** {@link Graph#addTurnRestriction(Edge, TurnRestriction)} */
+    public void addTurnRestriction(Edge edge, TurnRestriction turnRestriction) {
+        this.graph.addTurnRestriction(edge, turnRestriction);
+    }
+
+    /** {@link Graph#removeTurnRestriction(Edge, TurnRestriction)} */
+    public void removeTurnRestriction(Edge edge, TurnRestriction turnRestriction) {
+        this.graph.removeTurnRestriction(edge, turnRestriction);
+    }
+
+    /** {@link Graph#getTurnRestrictions(Edge)} */
+    public List<TurnRestriction> getTurnRestrictions(Edge edge) {
+        return this.graph.getTurnRestrictions(edge);
+    }
+
+    /** {@link Graph#getStreetEdges()} */
+    public Collection<StreetEdge> getStreetEdges() {return this.graph.getStreetEdges();}
+
+    /** {@link Graph#getTransitLayer()} */
+    public TransitLayer getTransitLayer() {return this.graph.getTransitLayer();}
+
+    /** {@link Graph#setTransitLayer(TransitLayer)} */
+    public void setTransitLayer(TransitLayer transitLayer) {
+        this.graph.setTransitLayer(transitLayer);
+    }
+
+    /** {@link Graph#getRealtimeTransitLayer()} */
+    public TransitLayer getRealtimeTransitLayer() {return this.graph.getRealtimeTransitLayer();}
+
+    /** {@link Graph#hasRealtimeTransitLayer()} */
+    public boolean hasRealtimeTransitLayer() {return this.graph.hasRealtimeTransitLayer();}
+
+    /** {@link Graph#setRealtimeTransitLayer(TransitLayer)} */
+    public void setRealtimeTransitLayer(TransitLayer realtimeTransitLayer) {
+        this.graph.setRealtimeTransitLayer(realtimeTransitLayer);
+    }
+
+    /** {@link Graph#containsVertex(Vertex)} */
+    public boolean containsVertex(Vertex v) {return this.graph.containsVertex(v);}
+
+    /** {@link Graph#putService(Class, Serializable)} */
+    public <T extends Serializable> T putService(
+            Class<T> serviceType,
+            T service
+    ) {return this.graph.putService(serviceType, service);}
+
+    /** {@link Graph#hasService(Class)} */
+    public boolean hasService(Class<? extends Serializable> serviceType) {
+        return this.graph.hasService(serviceType);
+    }
+
+    /** {@link Graph#getService(Class)} */
+    public <T extends Serializable> T getService(Class<T> serviceType) {
+        return this.graph.getService(serviceType);
+    }
+
+    /** {@link Graph#getService(Class, boolean)} */
+    public <T extends Serializable> T getService(
+            Class<T> serviceType,
+            boolean autoCreate
+    ) {return this.graph.getService(serviceType, autoCreate);}
+
+    /** {@link Graph#remove(Vertex)} */
+    public void remove(Vertex vertex) {this.graph.remove(vertex);}
+
+    /** {@link Graph#removeIfUnconnected(Vertex)} */
+    public void removeIfUnconnected(Vertex v) {this.graph.removeIfUnconnected(v);}
+
+    /** {@link Graph#getExtent()} */
+    public Envelope getExtent() {return this.graph.getExtent();}
+
+    /** {@link Graph#getTransferService()} */
+    public TransferService getTransferService() {return this.graph.getTransferService();}
+
+    /** {@link Graph#updateTransitFeedValidity(CalendarServiceData, DataImportIssueStore)} */
+    public void updateTransitFeedValidity(
+            CalendarServiceData data,
+            DataImportIssueStore issueStore
+    ) {this.graph.updateTransitFeedValidity(data, issueStore);}
+
+    /** {@link Graph#transitFeedCovers(Instant)} */
+    public boolean transitFeedCovers(Instant time) {return this.graph.transitFeedCovers(time);}
+
+    /** {@link Graph#getBundle()} */
+    public GraphBundle getBundle() {return this.graph.getBundle();}
+
+    /** {@link Graph#setBundle(GraphBundle)} */
+    public void setBundle(GraphBundle bundle) {this.graph.setBundle(bundle);}
+
+    /** {@link Graph#countVertices()} */
+    public int countVertices() {return this.graph.countVertices();}
+
+    /** {@link Graph#countEdges()} */
+    public int countEdges() {return this.graph.countEdges();}
+
+    /** {@link Graph#addTransitMode(TransitMode)} */
+    public void addTransitMode(TransitMode mode) {this.graph.addTransitMode(mode);}
+
+    /** {@link Graph#getTransitModes()} */
+    public HashSet<TransitMode> getTransitModes() {return this.graph.getTransitModes();}
+
+    /** {@link Graph#index()} */
+    //public void index() {this.graph.index();}
+
+    /** {@link Graph#getCalendarService()} */
+    public CalendarService getCalendarService() {return this.graph.getCalendarService();}
+
+    /** {@link Graph#getCalendarDataService()} */
+    public CalendarServiceData getCalendarDataService() {return this.graph.getCalendarDataService();}
+
+    /** {@link Graph#clearCachedCalenderService()} */
+    public void clearCachedCalenderService() {this.graph.clearCachedCalenderService();}
+
+    /** {@link Graph#getStreetIndex()} */
+    public StreetVertexIndex getStreetIndex() {return this.graph.getStreetIndex();}
+
+    /** {@link Graph#getLinker()} */
+    public VertexLinker getLinker() {return this.graph.getLinker();}
+
+    /** {@link Graph#getOrCreateServiceIdForDate(ServiceDate)} */
+    public FeedScopedId getOrCreateServiceIdForDate(ServiceDate serviceDate) {
+        return this.graph.getOrCreateServiceIdForDate(serviceDate);
+    }
+
+    /** {@link Graph#removeEdgelessVertices()} */
+    public int removeEdgelessVertices() {return this.graph.removeEdgelessVertices();}
+
+    /** {@link Graph#getFeedIds()} */
+    public Collection<String> getFeedIds() {return this.graph.getFeedIds();}
+
+    /** {@link Graph#getAgencies()} */
+    public Collection<Agency> getAgencies() {return this.graph.getAgencies();}
+
+    /** {@link Graph#getFeedInfo(String)} ()} */
+    public FeedInfo getFeedInfo(String feedId) {return this.graph.getFeedInfo(feedId);}
+
+    /** {@link Graph#addAgency(String, Agency)} */
+    public void addAgency(String feedId, Agency agency) {this.graph.addAgency(feedId, agency);}
+
+    /** {@link Graph#addFeedInfo(FeedInfo)} */
+    public void addFeedInfo(FeedInfo info) {this.graph.addFeedInfo(info);}
+
+    /** {@link Graph#getTimeZone()} */
+    public TimeZone getTimeZone() {return this.graph.getTimeZone();}
+
+    /** {@link Graph#getOperators()} */
+    public Collection<Operator> getOperators() {return this.graph.getOperators();}
+
+    /** {@link Graph#clearTimeZone()} */
+    public void clearTimeZone() {this.graph.clearTimeZone();}
+
+    /** {@link Graph#calculateEnvelope()} */
+    public void calculateEnvelope() {this.graph.calculateEnvelope();}
+
+    /** {@link Graph#calculateConvexHull()} */
+    public void calculateConvexHull() {this.graph.calculateConvexHull();}
+
+    /** {@link Graph#getConvexHull()} */
+    public Geometry getConvexHull() {return this.graph.getConvexHull();}
+
+    /** {@link Graph#expandToInclude(double, double)} ()} */
+    public void expandToInclude(double x, double y) {this.graph.expandToInclude(x, y);}
+
+    /** {@link Graph#getEnvelope()} */
+    public WorldEnvelope getEnvelope() {return this.graph.getEnvelope();}
+
+    /** {@link Graph#calculateTransitCenter()} */
+    public void calculateTransitCenter() {this.graph.calculateTransitCenter();}
+
+    /** {@link Graph#getCenter()} */
+    public Optional<Coordinate> getCenter() {return this.graph.getCenter();}
+
+    /** {@link Graph#getTransitServiceStarts()} */
+    public long getTransitServiceStarts() {return this.graph.getTransitServiceStarts();}
+
+    /** {@link Graph#getTransitServiceEnds()} */
+    public long getTransitServiceEnds() {return this.graph.getTransitServiceEnds();}
+
+    /** {@link Graph#getNoticesByElement()} */
+    public Multimap<TransitEntity, Notice> getNoticesByElement() {return this.graph.getNoticesByElement();}
+
+    /** {@link Graph#addNoticeAssignments(Multimap)} */
+    public void addNoticeAssignments(Multimap<TransitEntity, Notice> noticesByElement) {
+        this.graph.addNoticeAssignments(noticesByElement);
+    }
+
+    /** {@link Graph#getDistanceBetweenElevationSamples()} */
+    public double getDistanceBetweenElevationSamples() {return this.graph.getDistanceBetweenElevationSamples();}
+
+    /** {@link Graph#setDistanceBetweenElevationSamples(double)} */
+    public void setDistanceBetweenElevationSamples(double distanceBetweenElevationSamples) {
+        this.graph.setDistanceBetweenElevationSamples(distanceBetweenElevationSamples);
+    }
+
+    /** {@link Graph#getTransitAlertService()} */
+    public TransitAlertService getTransitAlertService() {return this.graph.getTransitAlertService();}
+
+    /** {@link Graph#getStopVerticesById(FeedScopedId)} */
+    public Set<Vertex> getStopVerticesById(FeedScopedId id) {
+        return this.graph.getStopVerticesById(id);
+    }
+
+    /** {@link Graph#getServicesRunningForDate(ServiceDate)} */
+    public BitSet getServicesRunningForDate(ServiceDate date) {
+        return this.graph.getServicesRunningForDate(date);
+    }
+
+    /** {@link Graph#getVehicleRentalStationService()} */
+    public VehicleRentalStationService getVehicleRentalStationService() {return this.graph.getVehicleRentalStationService();}
+
+    /** {@link Graph#getVehicleParkingService()} */
+    public VehicleParkingService getVehicleParkingService() {return this.graph.getVehicleParkingService();}
+
+    /** {@link Graph#getNoticesByEntity(TransitEntity)} */
+    public Collection<Notice> getNoticesByEntity(TransitEntity entity) {
+        return this.graph.getNoticesByEntity(entity);
+    }
+
+    /** {@link Graph#getTripPatternForId(FeedScopedId)} */
+    public TripPattern getTripPatternForId(FeedScopedId id) {
+        return this.graph.getTripPatternForId(id);
+    }
+
+    /** {@link Graph#getTripPatterns()} */
+    public Collection<TripPattern> getTripPatterns() {return this.graph.getTripPatterns();}
+
+    /** {@link Graph#getNotices()} */
+    public Collection<Notice> getNotices() {return this.graph.getNotices();}
+
+    /** {@link Graph#getStopsByBoundingBox(double, double, double, double)} */
+    public Collection<StopLocation> getStopsByBoundingBox(
+            double minLat,
+            double minLon,
+            double maxLat,
+            double maxLon
+    ) {return this.graph.getStopsByBoundingBox(minLat, minLon, maxLat, maxLon);}
+
+    /** {@link Graph#getStopsInRadius(WgsCoordinate, double)} */
+    public List<T2<Stop, Double>> getStopsInRadius(
+            WgsCoordinate center,
+            double radius
+    ) {return this.graph.getStopsInRadius(center, radius);}
+
+    /** {@link Graph#getStationById(FeedScopedId)} */
+    public Station getStationById(FeedScopedId id) {return this.graph.getStationById(id);}
+
+    /** {@link Graph#getMultiModalStation(FeedScopedId)} */
+    public MultiModalStation getMultiModalStation(FeedScopedId id) {
+        return this.graph.getMultiModalStation(id);
+    }
+
+    /** {@link Graph#getStations()} */
+    public Collection<Station> getStations() {return this.graph.getStations();}
+
+    /** {@link Graph#getServiceCodes()} */
+    public Map<FeedScopedId, Integer> getServiceCodes() {return this.graph.getServiceCodes();}
+
+    /** {@link Graph#getTransfersByStop(StopLocation)} */
+    public Collection<PathTransfer> getTransfersByStop(StopLocation stop) {
+        return this.graph.getTransfersByStop(stop);
+    }
+
+    /** {@link Graph#getDrivingDirection()} */
+    public DrivingDirection getDrivingDirection() {return this.graph.getDrivingDirection();}
+
+    /** {@link Graph#setDrivingDirection(DrivingDirection)} */
+    public void setDrivingDirection(DrivingDirection drivingDirection) {
+        this.graph.setDrivingDirection(drivingDirection);
+    }
+
+    /** {@link Graph#getIntersectionTraversalModel()} */
+    public IntersectionTraversalCostModel getIntersectionTraversalModel() {return this.graph.getIntersectionTraversalModel();}
+
+    /** {@link Graph#setIntersectionTraversalCostModel(IntersectionTraversalCostModel)} */
+    public void setIntersectionTraversalCostModel(IntersectionTraversalCostModel intersectionTraversalCostModel) {
+        this.graph.setIntersectionTraversalCostModel(intersectionTraversalCostModel);
+    }
+
+    /** {@link Graph#getLocationById(FeedScopedId)} */
+    public FlexStopLocation getLocationById(FeedScopedId id) {
+        return this.graph.getLocationById(id);
+    }
+
+    /** {@link Graph#getAllFlexStopsFlat()} */
+    public Set<StopLocation> getAllFlexStopsFlat() {return this.graph.getAllFlexStopsFlat();}
+
+    /** {@link GraphIndex#getAgencyForId(FeedScopedId)} */
+    public Agency getAgencyForId(FeedScopedId id) {return this.graphIndex.getAgencyForId(id);}
+
+    /** {@link GraphIndex#getStopForId(FeedScopedId)} */
+    public StopLocation getStopForId(FeedScopedId id) {return this.graphIndex.getStopForId(id);}
+
+    /** {@link GraphIndex#getRouteForId(FeedScopedId)} */
+    public Route getRouteForId(FeedScopedId id) {return this.graphIndex.getRouteForId(id);}
+
+    /** {@link GraphIndex#addRoutes(Route)} */
+    public void addRoutes(Route route) {this.graphIndex.addRoutes(route);}
+
+    /** {@link GraphIndex#getRoutesForStop(StopLocation)} */
+    public Set<Route> getRoutesForStop(StopLocation stop) {
+        return this.graphIndex.getRoutesForStop(stop);
+    }
+
+    /** {@link GraphIndex#getPatternsForStop(StopLocation)} */
+    public Collection<TripPattern> getPatternsForStop(StopLocation stop) {
+        return this.graphIndex.getPatternsForStop(stop);
+    }
+
+    /** {@link GraphIndex#getPatternsForStop(StopLocation, TimetableSnapshot)} */
+    public Collection<TripPattern> getPatternsForStop(
+            StopLocation stop,
+            TimetableSnapshot timetableSnapshot
+    ) {return this.graphIndex.getPatternsForStop(stop, timetableSnapshot);}
+
+    /** {@link GraphIndex#getAllOperators()} */
+    public Collection<Operator> getAllOperators() {return this.graphIndex.getAllOperators();}
+
+    /** {@link GraphIndex#getOperatorForId()} */
+    public Map<FeedScopedId, Operator> getOperatorForId() {return this.graphIndex.getOperatorForId();}
+
+    /** {@link GraphIndex#getAllStops()} */
+    public Collection<StopLocation> getAllStops() {return this.graphIndex.getAllStops();}
+
+    /** {@link GraphIndex#getTripForId()} */
+    public Map<FeedScopedId, Trip> getTripForId() {return this.graphIndex.getTripForId();}
+
+    /** {@link GraphIndex#getAllRoutes()} */
+    public Collection<Route> getAllRoutes() {return this.graphIndex.getAllRoutes();}
+
+    /** {@link GraphIndex#getStopVertexForStop()} */
+    public Map<Stop, TransitStopVertex> getStopVertexForStop() {return this.graphIndex.getStopVertexForStop();}
+
+    /** {@link GraphIndex#getPatternForTrip()} */
+    public Map<Trip, TripPattern> getPatternForTrip() {return this.graphIndex.getPatternForTrip();}
+
+    /** {@link GraphIndex#getPatternsForFeedId()} */
+    public Multimap<String, TripPattern> getPatternsForFeedId() {return this.graphIndex.getPatternsForFeedId();}
+
+    /** {@link GraphIndex#getPatternsForRoute()} */
+    public Multimap<Route, TripPattern> getPatternsForRoute() {return this.graphIndex.getPatternsForRoute();}
+
+    /** {@link GraphIndex#getMultiModalStationForStations()} */
+    public Map<Station, MultiModalStation> getMultiModalStationForStations() {return this.graphIndex.getMultiModalStationForStations();}
+
+    /** {@link GraphIndex#getStopSpatialIndex()} */
+    public HashGridSpatialIndex<TransitStopVertex> getStopSpatialIndex() {return this.graphIndex.getStopSpatialIndex();}
+
+    /** {@link GraphIndex#getServiceCodesRunningForDate()} */
+    public Map<ServiceDate, TIntSet> getServiceCodesRunningForDate() {return this.graphIndex.getServiceCodesRunningForDate();}
+
+    /** {@link GraphIndex#getFlexIndex()} */
+    public FlexIndex getFlexIndex() {return this.graphIndex.getFlexIndex();}
+
+    /** {@link GraphFinder#findClosestStops(double, double, double)} */
+    public List<NearbyStop> findClosestStops(
+            double lat,
+            double lon,
+            double radiusMeters
+    ) {return this.graphFinder.findClosestStops(lat, lon, radiusMeters);}
+
+    /** {@link GraphFinder#findClosestPlaces(double, double, double, int, List, List, List, List, List, List, List, RoutingService)} */
+    public List<PlaceAtDistance> findClosestPlaces(
+            double lat,
+            double lon,
+            double radiusMeters,
+            int maxResults,
+            List<TransitMode> filterByModes,
+            List<PlaceType> filterByPlaceTypes,
+            List<FeedScopedId> filterByStops,
+            List<FeedScopedId> filterByRoutes,
+            List<String> filterByBikeRentalStations,
+            List<String> filterByBikeParks,
+            List<String> filterByCarParks,
+            RoutingService routingService
+    ) {
+        return this.graphFinder.findClosestPlaces(lat, lon, radiusMeters, maxResults, filterByModes,
+                filterByPlaceTypes, filterByStops, filterByRoutes, filterByBikeRentalStations,
+                filterByBikeParks, filterByCarParks, routingService
+        );
     }
 
     /**

--- a/src/main/java/org/opentripplanner/standalone/config/IncludeFileDirective.java
+++ b/src/main/java/org/opentripplanner/standalone/config/IncludeFileDirective.java
@@ -10,7 +10,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import lombok.val;
 import org.apache.commons.io.IOUtils;
 import org.opentripplanner.util.OtpAppException;
 

--- a/src/main/java/org/opentripplanner/standalone/config/NodeAdapter.java
+++ b/src/main/java/org/opentripplanner/standalone/config/NodeAdapter.java
@@ -24,7 +24,6 @@ import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import javax.validation.constraints.NotNull;
-import lombok.val;
 import org.opentripplanner.api.parameter.QualifiedModeSet;
 import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.routing.api.request.RequestFunctions;

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptor/transit/mappers/StopIndexForRaptorTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptor/transit/mappers/StopIndexForRaptorTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
-import lombok.val;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.model.Station;
@@ -39,7 +38,7 @@ public class StopIndexForRaptorTest {
 
     @Test public void listStopIndexesForEmptyTripPattern() {
         StopIndexForRaptor stopIndex = new StopIndexForRaptor(STOPS, TransitTuningParameters.FOR_TEST);
-        val p = new TripPattern(ANY_ID, null, new StopPattern(List.of()));
+        var p = new TripPattern(ANY_ID, null, new StopPattern(List.of()));
 
         int[] result = stopIndex.listStopIndexesForPattern(p);
 
@@ -85,7 +84,7 @@ public class StopIndexForRaptorTest {
     }
 
     private static StopTime stopTime(Stop stop) {
-        val st = new StopTime();
+        var st = new StopTime();
         st.setStop(stop);
         return st;
     }


### PR DESCRIPTION
### Summary
Lombok was introduced because of the `@Delegate` pattern, but the library do not work with Dagger DI, witch we also want to use. The usage is limited to one class.

THIS IS A PURE REFACORING


### Issue
No

### Unit tests
No

### Code style
Yes

### Documentation
No
