### PR TITLE
Include generalizedCost in the optimized transfers wait-time cost

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
@@ -125,7 +125,7 @@ public class RaptorPathToItineraryMapper {
         itinerary.arrivedAtDestinationWithRentedVehicle = mapped != null && mapped.arrivedAtDestinationWithRentedVehicle;
 
         if(optimizedPath != null) {
-            itinerary.waitTimeOptimizedCost = toOtpDomainCost(optimizedPath.waitTimeOptimizedCost());
+            itinerary.waitTimeOptimizedCost = toOtpDomainCost(optimizedPath.generalizedCostWaitTimeOptimized());
             itinerary.transferPriorityCost = toOtpDomainCost(optimizedPath.transferPriorityCost());
         }
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/api/OptimizedPath.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/api/OptimizedPath.java
@@ -70,8 +70,8 @@ public class OptimizedPath<T extends RaptorTripSchedule> extends Path<T>
     }
 
     @Override
-    public int waitTimeOptimizedCost() {
-        return waitTimeOptimizedCost;
+    public int generalizedCostWaitTimeOptimized() {
+        return generalizedCost() + waitTimeOptimizedCost;
     }
 
     @Override
@@ -95,8 +95,8 @@ public class OptimizedPath<T extends RaptorTripSchedule> extends Path<T>
     }
 
     private void appendSummary(PathStringBuilder buf) {
-        buf.costCentiSec(transferPriorityCost, "pri");
-        buf.costCentiSec(waitTimeOptimizedCost, "wtc");
+        buf.costCentiSec(transferPriorityCost, TransferConstraint.ZERO_COST, "pri");
+        buf.costCentiSec(generalizedCostWaitTimeOptimized(), generalizedCost(), "wtc");
     }
 
     private static int priorityCost(Path<?> path) {

--- a/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/api/TransferOptimized.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/api/TransferOptimized.java
@@ -53,7 +53,7 @@ public interface TransferOptimized {
      *
      * @see TransferWaitTimeCostCalculator
      */
-    int waitTimeOptimizedCost();
+    int generalizedCostWaitTimeOptimized();
 
     /**
      * Optimize so that the transfers happens as early as possible. This is normally the case when

--- a/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/services/TransferOptimizedFilterFactory.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/services/TransferOptimizedFilterFactory.java
@@ -26,7 +26,7 @@ public class TransferOptimizedFilterFactory<T extends RaptorTripSchedule> {
         }
 
         if(optimizeWaitTime) {
-            filters.add(OptimizedPathTail::waitTimeOptimizedCost);
+            filters.add(OptimizedPathTail::generalizedCostWaitTimeOptimized);
         }
         else {
             filters.add(OptimizedPathTail::generalizedCost);

--- a/src/main/java/org/opentripplanner/transit/raptor/util/PathStringBuilder.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/util/PathStringBuilder.java
@@ -4,6 +4,7 @@ import java.util.Calendar;
 import javax.annotation.Nullable;
 import org.opentripplanner.model.base.OtpNumberFormat;
 import org.opentripplanner.routing.core.TraverseMode;
+import org.opentripplanner.transit.raptor.api.transit.CostCalculator;
 import org.opentripplanner.transit.raptor.api.transit.RaptorStopNameResolver;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
 import org.opentripplanner.util.time.DurationUtils;
@@ -92,9 +93,9 @@ public class PathStringBuilder {
         return space().time(fromTime, toTime).generalizedCostSentiSec(generalizedCost);
     }
 
-    /** Add generalizedCostCentiSec {@link #costCentiSec(int, String)} */
+    /** Add generalizedCostCentiSec {@link #costCentiSec(int, int, String)} */
     public PathStringBuilder generalizedCostSentiSec(int cost) {
-        return costCentiSec(cost, null);
+        return costCentiSec(cost, CostCalculator.ZERO_COST, null);
     }
 
     /**
@@ -106,8 +107,8 @@ public class PathStringBuilder {
      *     <li>{@code "pri"} - Transfer priority cost</li>
      * </ul>
      */
-    public PathStringBuilder costCentiSec(int cost, String unit) {
-        if(cost == 0) { return this; }
+    public PathStringBuilder costCentiSec(int cost, int defaultValue, String unit) {
+        if(cost == defaultValue) { return this; }
         space().append(OtpNumberFormat.formatCost(cost));
         if(unit != null) {
             append(unit);

--- a/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/api/OptimizedPathTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/api/OptimizedPathTest.java
@@ -17,7 +17,7 @@ class OptimizedPathTest implements RaptorTestConstants {
         // Verify all costs
         assertEquals(BasicPathTestCase.TOTAL_COST, path.generalizedCost());
         assertEquals(0, path.breakTieCost());
-        assertEquals(0, path.waitTimeOptimizedCost());
+        assertEquals(BasicPathTestCase.TOTAL_COST, path.generalizedCostWaitTimeOptimized());
         assertEquals(66_00, path.transferPriorityCost());
 
         // And toString is the same (transfer priority cost added)
@@ -46,6 +46,7 @@ class OptimizedPathTest implements RaptorTestConstants {
         final int generalizedCost = 881100;
         final int transferPriorityCost = 120100;
         final int waitTimeOptimizedCost = 130200;
+        final int generalizedCostWaitTimeOptimized = generalizedCost + waitTimeOptimizedCost;
         final int breakTieCost = 140300;
 
         var path = new OptimizedPath<>(
@@ -59,12 +60,14 @@ class OptimizedPathTest implements RaptorTestConstants {
 
         assertEquals(generalizedCost, path.generalizedCost());
         assertEquals(breakTieCost, path.breakTieCost());
-        assertEquals(waitTimeOptimizedCost, path.waitTimeOptimizedCost());
+        assertEquals(generalizedCostWaitTimeOptimized, path.generalizedCostWaitTimeOptimized());
         assertEquals(transferPriorityCost, path.transferPriorityCost());
 
         var exp = BasicPathTestCase.BASIC_PATH_AS_STRING
-                .replace("$8184]", "$8811 $1201pri $1302wtc]");
+                .replace("$8184]", "$8811 $1201pri "
+                        + "$" + (generalizedCostWaitTimeOptimized/100) + "wtc]");
 
         assertEquals(exp, path.toString(this::stopIndexToName));
     }
 }
+// 881 100 + 130 200 = 1 011 300

--- a/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/model/OptimizedPathTailTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/model/OptimizedPathTailTest.java
@@ -75,7 +75,7 @@ class OptimizedPathTailTest implements RaptorTestConstants {
                 + "~ BUS L21 11:00 11:23 ~ D "
                 + "~ BUS L31 11:40 11:52 ~ E "
                 + "~ Walk 7m45s "
-                + "[$8019 $46pri $-101126wtc]";
+                + "[$8019 $46pri $-93107wtc]";
 
         assertEquals(exp, subject.toString());
     }
@@ -88,7 +88,7 @@ class OptimizedPathTailTest implements RaptorTestConstants {
         var exp = "Walk 3m15s ~ A "
                 + "~ BUS L11 10:04 10:35 ~ B "
                 + "~ Walk 7m45s "
-                + "[$3318 $0pri $60wtc]";
+                + "[$3318 $0pri $3378wtc]";
 
         assertEquals(exp, subject.toString());
     }
@@ -136,7 +136,7 @@ class OptimizedPathTailTest implements RaptorTestConstants {
                 + "~ BUS L21 11:00 11:23 23m $2724 ~ D 17m {staySeated} "
                 + "~ BUS L31 11:40 11:52 12m $1737 ~ E 15s "
                 + "~ Walk 7m45s 11:52:15 12:00 $930 "
-                + "[10:00 12:00 2h $8019 $46pri $-101126wtc]";
+                + "[10:00 12:00 2h $8019 $46pri $-93107wtc]";
 
         assertEquals(expPath, path.toStringDetailed(this::stopIndexToName));
     }

--- a/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/services/OptimizePathDomainServiceTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/services/OptimizePathDomainServiceTest.java
@@ -124,7 +124,7 @@ public class OptimizePathDomainServiceTest implements RaptorTestConstants {
 
         // Insert wait-time cost summary info
         var expected = original.toStringDetailed(this::stopIndexToName)
-                .replace("$3250]", "$3250 $33pri $333.81wtc]");
+                .replace("$3250]", "$3250 $33pri $3583.81wtc]");
 
         assertEquals(
                 expected,
@@ -201,7 +201,7 @@ public class OptimizePathDomainServiceTest implements RaptorTestConstants {
 
         assertEquals(
                 "A ~ BUS T1 10:02 10:10 ~ B ~ Walk 30s ~ C ~ BUS T2 10:15 10:35 ~ F "
-                        + "~ BUS T3 10:37 10:49 ~ G [10:00:20 10:49:20 49m $3040 $66pri $314.05wtc]",
+                        + "~ BUS T3 10:37 10:49 ~ G [10:00:20 10:49:20 49m $3040 $66pri $3354.05wtc]",
                 PathUtils.pathsToString(result)
         );
     }


### PR DESCRIPTION
### Summary
The Optimized transfer calculate a wait-time-optimized-cost for each possible combination of transfers for a given path. It does so to find the pest places to do the transfer, avoiding back travel and short transfer times. The existing implementation did not take into account the walking cost for the different transfers. In most cases this is ok, because long walking transfers leave less time to do the transfer, but not in all cases - see issue. This fixes this be just adding the generalized cost to the wait-time-optimized-cost (both have the same cost unit/scale - seconds). 


NOTE! The optimized transfer service is configured and needs to be tuned again, after this PR is merged.

### Issue

closes #3834

### Unit tests
Updated


### Code style
✅ 

### Documentation
✅ 

