### PR TITLE
Don't expect every pattern in a route to have the specified stop with constrained transfers

### DIFF
--- a/src/main/java/org/opentripplanner/model/StopPattern.java
+++ b/src/main/java/org/opentripplanner/model/StopPattern.java
@@ -79,19 +79,19 @@ public final class StopPattern implements Serializable {
     }
 
     int findBoardingPosition(StopLocation stop) {
-        return findStopPosition(0, stops.length-1, (s) -> s == stop, stop);
+        return findStopPosition(0, stops.length - 1, (s) -> s == stop);
     }
 
     int findAlightPosition(StopLocation stop) {
-        return findStopPosition(1, stops.length, (s) -> s == stop, stop);
+        return findStopPosition(1, stops.length, (s) -> s == stop);
     }
 
     int findBoardingPosition(Station station) {
-        return findStopPosition(0, stops.length-1, station::includes, station);
+        return findStopPosition(0, stops.length - 1, station::includes);
     }
 
     int findAlightPosition(Station station) {
-        return findStopPosition(1, stops.length, station::includes, station);
+        return findStopPosition(1, stops.length, station::includes);
     }
 
     public boolean equals(Object other) {
@@ -198,15 +198,18 @@ public final class StopPattern implements Serializable {
         else { return pickDrop; }
     }
 
+    /**
+     * Find the given stop position in the sequence according to match Predicate, return -1 if not
+     * found.
+     */
     private int findStopPosition(
             final int start,
             final int end,
-            final Predicate<StopLocation> match,
-            final Object entity
+            final Predicate<StopLocation> match
     ) {
-        for (int i=start; i<end; ++i) {
-            if(match.test(stops[i])) { return i; }
+        for (int i = start; i < end; ++i) {
+            if (match.test(stops[i])) { return i; }
         }
-        throw new IllegalArgumentException("Stop/Station not found: " + entity);
+        return -1;
     }
 }

--- a/src/main/java/org/opentripplanner/model/TripPattern.java
+++ b/src/main/java/org/opentripplanner/model/TripPattern.java
@@ -215,22 +215,46 @@ public final class TripPattern extends TransitEntity implements Cloneable, Seria
         return stopPattern.getStops();
     }
 
+    /**
+     * Find the first stop position in pattern matching the given {@code stop}. The search start at
+     * position {@code 0}. Return a negative number if not found. Use {@link
+     * #findAlightStopPositionInPattern(StopLocation)} or {@link #findBoardingStopPositionInPattern(StopLocation)}
+     * if possible.
+     */
     public int findStopPosition(StopLocation stop) {
         return stopPattern.findStopPosition(stop);
     }
 
+    /**
+     * Find the first stop position in pattern matching the given {@code station} where it is
+     * allowed to board. The search start at position {@code 0}. Return a negative number if not
+     * found.
+     */
     public int findBoardingStopPositionInPattern(Station station) {
         return stopPattern.findBoardingPosition(station);
     }
 
+    /**
+     * Find the first stop position in pattern matching the given {@code station} where it is
+     * allowed to alight. The search start at position {@code 1}. Return a negative number if not
+     * found.
+     */
     public int findAlightStopPositionInPattern(Station station) {
         return stopPattern.findAlightPosition(station);
     }
 
+    /**
+     * Find the first stop position in pattern matching the given {@code stop} where it is allowed
+     * to board. The search start at position {@code 0}. Return a negative number if not found.
+     */
     public int findBoardingStopPositionInPattern(StopLocation stop) {
         return stopPattern.findBoardingPosition(stop);
     }
 
+    /**
+     * Find the first stop position in pattern matching the given {@code stop} where it is allowed
+     * to alight. The search start at position {@code 1}. Return a negative number if not found.
+     */
     public int findAlightStopPositionInPattern(StopLocation stop) {
         return stopPattern.findAlightPosition(stop);
     }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/constrainedtransfer/TransferIndexGenerator.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/transit/constrainedtransfer/TransferIndexGenerator.java
@@ -184,9 +184,12 @@ public class TransferIndexGenerator {
 
         for (var pattern : patterns) {
             int stopPosInPattern = resolveStopPosInPattern.applyAsInt(pattern.getPattern());
-            int stopIndex = pattern.stopIndex(stopPosInPattern);
-            var sourcePoint = createTransferPointForPattern(route, stopIndex);
-            points.add(new TPoint(pattern, sourcePoint, null, stopPosInPattern));
+            // stopPosInPattern == -1 means stop is not on pattern
+            if (stopPosInPattern >= 0) {
+                int stopIndex = pattern.stopIndex(stopPosInPattern);
+                var sourcePoint = createTransferPointForPattern(route, stopIndex);
+                points.add(new TPoint(pattern, sourcePoint, null, stopPosInPattern));
+            }
         }
         return points;
     }


### PR DESCRIPTION
### Summary
Adds validation for indexing constrained transfers so that it can handle situations where a route doesn't have a stop specified in a transfer in every pattern.

### Issue
closes #3867

### Unit tests
Should they be added?

### Code style
Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Codestyle.md)?
Yes

### Documentation
not needed

### Changelog
From title
