### PR TITLE
Fix number format exception for elevator duration parsing OSM data

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModule.java
@@ -12,7 +12,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.OptionalInt;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -1454,35 +1453,4 @@ public class OpenStreetMapModule implements GraphBuilderModule {
         }
     }
 
-    static class VertexAndName {
-
-        private final I18NString name;
-        private final OsmVertex vertex;
-
-        VertexAndName(I18NString name, OsmVertex vertex) {
-            this.name = name;
-            this.vertex = vertex;
-        }
-
-        public I18NString getName() {
-            return this.name;
-        }
-
-        public OsmVertex getVertex() {
-            return this.vertex;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) {return true;}
-            if (o == null || getClass() != o.getClass()) {return false;}
-            final VertexAndName that = (VertexAndName) o;
-            return Objects.equals(name, that.name) && vertex.equals(that.vertex);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(name, vertex);
-        }
-    }
 }

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModule.java
@@ -85,7 +85,7 @@ import org.slf4j.LoggerFactory;
  */
 public class OpenStreetMapModule implements GraphBuilderModule {
 
-    private static Logger LOG = LoggerFactory.getLogger(OpenStreetMapModule.class);
+    private static final Logger LOG = LoggerFactory.getLogger(OpenStreetMapModule.class);
 
     private static final String VEHICLE_PARKING_OSM_FEED_ID = "OSM";
 
@@ -93,9 +93,7 @@ public class OpenStreetMapModule implements GraphBuilderModule {
 
     // Private members that are only read or written internally.
 
-    private Set<Object> _uniques = new HashSet<Object>();
-
-    private HashMap<Vertex, Double> elevationData = new HashMap<Vertex, Double>();
+    private final HashMap<Vertex, Double> elevationData = new HashMap<>();
 
     public boolean skipVisibility = false;
 
@@ -111,7 +109,7 @@ public class OpenStreetMapModule implements GraphBuilderModule {
     /**
      * Providers of OSM data.
      */
-    private List<BinaryOpenStreetMapProvider> _providers = new ArrayList<BinaryOpenStreetMapProvider>();
+    private final List<BinaryOpenStreetMapProvider> providers = new ArrayList<>();
 
     /**
      * Allows for arbitrary custom naming of edges.
@@ -157,14 +155,14 @@ public class OpenStreetMapModule implements GraphBuilderModule {
      * The source for OSM map data
      */
     public void setProvider(BinaryOpenStreetMapProvider provider) {
-        _providers.add(provider);
+        providers.add(provider);
     }
 
     /**
      * Multiple sources for OSM map data
      */
     public void setProviders(List<BinaryOpenStreetMapProvider> providers) {
-        _providers.addAll(providers);
+        this.providers.addAll(providers);
     }
 
     /**
@@ -203,7 +201,7 @@ public class OpenStreetMapModule implements GraphBuilderModule {
         this.issueStore = issueStore;
         OSMDatabase osmdb = new OSMDatabase(issueStore);
         Handler handler = new Handler(graph, osmdb);
-        for (BinaryOpenStreetMapProvider provider : _providers) {
+        for (BinaryOpenStreetMapProvider provider : providers) {
             LOG.info("Gathering OSM from provider: " + provider);
             provider.readOSM(osmdb);
         }
@@ -221,25 +219,15 @@ public class OpenStreetMapModule implements GraphBuilderModule {
         graph.calculateEnvelope();
     }
 
-    /*
-     * TODO: What this function is supposed to do? Please comment or remove.
-     */
-    private <T> T unique(T value) {
-        if (!_uniques.contains(value)) {
-            _uniques.add(value);
-        }
-        return (T) value;
-    }
-
     protected class Handler {
 
         private static final String nodeLabelFormat = "osm:node:%d";
 
         private static final String levelnodeLabelFormat = nodeLabelFormat + ":level:%s";
 
-        private Graph graph;
+        private final Graph graph;
 
-        private OSMDatabase osmdb;
+        private final OSMDatabase osmdb;
 
         /**
          * The bike safety factor of the safest street
@@ -248,16 +236,10 @@ public class OpenStreetMapModule implements GraphBuilderModule {
 
         // track OSM nodes which are decomposed into multiple graph vertices because they are
         // elevators. later they will be iterated over to build ElevatorEdges between them.
-        private HashMap<Long, HashMap<OSMLevel, OsmVertex>> multiLevelNodes = new HashMap<Long, HashMap<OSMLevel, OsmVertex>>();
+        private final HashMap<Long, HashMap<OSMLevel, OsmVertex>> multiLevelNodes = new HashMap<>();
 
         // track OSM nodes that will become graph vertices because they appear in multiple OSM ways
-        private Map<Long, OsmVertex> intersectionNodes = new HashMap<Long, OsmVertex>();
-
-        // track vertices to be removed in the turn-graph conversion.
-        // this is a superset of intersectionNodes.values, which contains
-        // a null vertex reference for multilevel nodes. the individual vertices
-        // for each level of a multilevel node are includeed in endpoints.
-        private ArrayList<OsmVertex> endpoints = new ArrayList<OsmVertex>();
+        private final Map<Long, OsmVertex> intersectionNodes = new HashMap<>();
 
         public Handler(Graph graph, OSMDatabase osmdb) {
             this.graph = graph;
@@ -389,7 +371,8 @@ public class OpenStreetMapModule implements GraphBuilderModule {
                 );
                 for (AreaGroup group : areaGroups) {
                     walkableAreaBuilder.buildWithVisibility(group);
-                    //Keep lambda! A method-ref would causes incorrect class and line number to be logged
+                    //Keep lambda! A method-ref would log incorrect class and line number
+                    //noinspection Convert2MethodRef
                     progress.step(m -> LOG.info(m));
                 }
                 LOG.info(progress.completeMessage());
@@ -687,7 +670,7 @@ public class OpenStreetMapModule implements GraphBuilderModule {
 
                 // handle duplicate nodes in OSM ways
                 // this is a workaround for crappy OSM data quality
-                ArrayList<Long> nodes = new ArrayList<Long>(way.getNodeRefs().size());
+                ArrayList<Long> nodes = new ArrayList<>(way.getNodeRefs().size());
                 long last = -1;
                 double lastLat = -1, lastLon = -1;
                 String lastLevel = null;
@@ -719,7 +702,7 @@ public class OpenStreetMapModule implements GraphBuilderModule {
                 OsmVertex startEndpoint = null;
                 OsmVertex endEndpoint = null;
 
-                ArrayList<Coordinate> segmentCoordinates = new ArrayList<Coordinate>();
+                ArrayList<Coordinate> segmentCoordinates = new ArrayList<>();
 
                 /*
                  * Traverse through all the nodes of this edge. For nodes which are not shared with any other edge, do not create endpoints -- just
@@ -733,19 +716,19 @@ public class OpenStreetMapModule implements GraphBuilderModule {
 
                 for (int i = 0; i < nodes.size() - 1; i++) {
                     OSMNode segmentStartOSMNode = osmdb.getNode(nodes.get(i));
+
                     if (segmentStartOSMNode == null) {
                         continue;
                     }
+
                     Long endNode = nodes.get(i + 1);
+
                     if (osmStartNode == null) {
                         startNode = nodes.get(i);
                         osmStartNode = segmentStartOSMNode;
                     }
                     // where the current edge might end
                     OSMNode osmEndNode = osmdb.getNode(endNode);
-
-                    if (osmStartNode == null || osmEndNode == null)
-                        continue;
 
                     LineString geometry;
 
@@ -808,7 +791,8 @@ public class OpenStreetMapModule implements GraphBuilderModule {
                     osmStartNode = osmdb.getNode(startNode);
                 }
 
-                //Keep lambda! A method-ref would causes incorrect class and line number to be logged
+                //Keep lambda! A method-ref would log incorrect class and line number
+                //noinspection Convert2MethodRef
                 progress.step(m -> LOG.info(m));
             } // END loop over OSM ways
 
@@ -890,7 +874,7 @@ public class OpenStreetMapModule implements GraphBuilderModule {
                  */
                 OSMLevel[] levels = vertices.keySet().toArray(new OSMLevel[0]);
                 Arrays.sort(levels);
-                ArrayList<Vertex> onboardVertices = new ArrayList<Vertex>();
+                ArrayList<Vertex> onboardVertices = new ArrayList<>();
                 for (OSMLevel level : levels) {
                     // get the node to build the elevator out from
                     OsmVertex sourceVertex = vertices.get(level);
@@ -918,11 +902,11 @@ public class OpenStreetMapModule implements GraphBuilderModule {
 
             // Add highway=elevators to graph as elevators
             Iterator<OSMWay> elevators = osmdb.getWays().stream()
-                    .filter(way -> isElevatorWay(way))
+                    .filter(this::isElevatorWay)
                     .iterator();
 
-            for (Iterator<OSMWay> it = elevators; it.hasNext(); ) {
-                OSMWay elevatorWay = it.next();
+            while (elevators.hasNext()) {
+                OSMWay elevatorWay = elevators.next();
 
                 List<Long> nodes = Arrays.stream(elevatorWay.getNodeRefs().toArray())
                         .filter(nodeRef -> intersectionNodes.containsKey(nodeRef)
@@ -930,7 +914,7 @@ public class OpenStreetMapModule implements GraphBuilderModule {
                         .boxed()
                         .collect(Collectors.toList());
 
-                ArrayList<Vertex> onboardVertices = new ArrayList<Vertex>();
+                ArrayList<Vertex> onboardVertices = new ArrayList<>();
                 for (int i = 0; i < nodes.size(); i++) {
                     Long node = nodes.get(i);
                     OsmVertex sourceVertex = intersectionNodes.get(node);
@@ -945,10 +929,8 @@ public class OpenStreetMapModule implements GraphBuilderModule {
                         Integer.parseInt(elevatorWay.getTag("duration")) :
                         -1;
                 int levels = nodes.size();
-                boolean wheelchairAccessible = true;
-                if (elevatorWay.isTagFalse("wheelchair")) {
-                    wheelchairAccessible = false;
-                }
+                boolean wheelchairAccessible = !elevatorWay.isTagFalse("wheelchair");
+
                 createElevatorHopEdges(
                         onboardVertices,
                         wheelchairAccessible,
@@ -1007,7 +989,7 @@ public class OpenStreetMapModule implements GraphBuilderModule {
                 int travelTime
         ) {
             // -1 because we loop over onboardVertices two at a time
-            for (Integer i = 0, vSize = onboardVertices.size() - 1; i < vSize; i++) {
+            for (int i = 0, vSize = onboardVertices.size() - 1; i < vSize; i++) {
                 Vertex from = onboardVertices.get(i);
                 Vertex to = onboardVertices.get(i + 1);
 
@@ -1056,7 +1038,7 @@ public class OpenStreetMapModule implements GraphBuilderModule {
                             continue;
                         }
                         for (StreetEdge to : restrictionTag.possibleTo) {
-                            if (from == null || to == null) {
+                            if (to == null) {
                                 issueStore.add(
                                     new TurnRestrictionBad(restrictionTag.relationOSMID,
                                         "to-edge is null"));
@@ -1141,7 +1123,7 @@ public class OpenStreetMapModule implements GraphBuilderModule {
         }
 
         private void initIntersectionNodes() {
-            Set<Long> possibleIntersectionNodes = new HashSet<Long>();
+            Set<Long> possibleIntersectionNodes = new HashSet<>();
             for (OSMWay way : osmdb.getWays()) {
                 TLongList nodes = way.getNodeRefs();
                 nodes.forEach(node -> {
@@ -1179,14 +1161,12 @@ public class OpenStreetMapModule implements GraphBuilderModule {
          * the length ratio of the safest street, ensuring this property.
          *
          * TODO Move this away, this is common to all street builders.
-         *
-         * @param graph
          */
         private void applyBikeSafetyFactor(Graph graph) {
             issueStore.add(new Graphwide(
                     "Multiplying all bike safety values by " + (1 / bestBikeSafety)));
-            HashSet<Edge> seenEdges = new HashSet<Edge>();
-            HashSet<AreaEdgeList> seenAreas = new HashSet<AreaEdgeList>();
+            HashSet<Edge> seenEdges = new HashSet<>();
+            HashSet<AreaEdgeList> seenAreas = new HashSet<>();
             for (Vertex vertex : graph.getVertices()) {
                 for (Edge e : vertex.getOutgoing()) {
                     if (e instanceof AreaEdge) {
@@ -1237,9 +1217,6 @@ public class OpenStreetMapModule implements GraphBuilderModule {
 
         /**
          * Returns the length of the geometry in meters.
-         *
-         * @param geometry
-         * @return
          */
         private double getGeometryLengthMeters(Geometry geometry) {
             Coordinate[] coordinates = geometry.getCoordinates();
@@ -1253,19 +1230,16 @@ public class OpenStreetMapModule implements GraphBuilderModule {
         /**
          * Handle oneway streets, cycleways, and other per-mode and universal access controls. See http://wiki.openstreetmap.org/wiki/Bicycle for
          * various scenarios, along with http://wiki.openstreetmap.org/wiki/OSM_tags_for_routing#Oneway.
-         *
-         * @param endEndpoint
-         * @param startEndpoint
          */
         private P2<StreetEdge> getEdgesForStreet(OsmVertex startEndpoint,
                                                       OsmVertex endEndpoint, OSMWay way, int index, long startNode, long endNode,
                                                       StreetTraversalPermission permissions, LineString geometry) {
             // No point in returning edges that can't be traversed by anyone.
             if (permissions.allowsNothing()) {
-                return new P2<StreetEdge>(null, null);
+                return new P2<>(null, null);
             }
 
-            LineString backGeometry = (LineString) geometry.reverse();
+            LineString backGeometry = geometry.reverse();
             StreetEdge street = null, backStreet = null;
             double length = this.getGeometryLengthMeters(geometry);
 
@@ -1294,7 +1268,7 @@ public class OpenStreetMapModule implements GraphBuilderModule {
                     backStreet.setRoundabout(true);
             }
 
-            return new P2<StreetEdge>(street, backStreet);
+            return new P2<>(street, backStreet);
         }
 
         private StreetEdge getEdgeForStreet(OsmVertex startEndpoint, OsmVertex endEndpoint,
@@ -1302,7 +1276,7 @@ public class OpenStreetMapModule implements GraphBuilderModule {
                                                  StreetTraversalPermission permissions, LineString geometry, boolean back) {
 
             String label = "way " + way.getId() + " from " + index;
-            label = unique(label);
+            label = label.intern();
             I18NString name = getNameForWay(way, label);
 
             // consider the elevation gain of stairs, roughly
@@ -1392,7 +1366,7 @@ public class OpenStreetMapModule implements GraphBuilderModule {
             if (multiLevelNodes.containsKey(nodeId)) {
                 vertices = multiLevelNodes.get(nodeId);
             } else {
-                vertices = new HashMap<OSMLevel, OsmVertex>();
+                vertices = new HashMap<>();
                 multiLevelNodes.put(nodeId, vertices);
             }
             if (!vertices.containsKey(level)) {
@@ -1401,8 +1375,7 @@ public class OpenStreetMapModule implements GraphBuilderModule {
                 OsmVertex vertex = new OsmVertex(graph, label, coordinate.x,
                          coordinate.y, node.getId(), new NonLocalizedString(label));
                 vertices.put(level, vertex);
-                // multilevel nodes should also undergo turn-conversion
-                endpoints.add(vertex);
+
                 return vertex;
             }
             return vertices.get(level);
@@ -1447,8 +1420,7 @@ public class OpenStreetMapModule implements GraphBuilderModule {
                     String ref = node.getTag("ref");
                     String name = node.getTag("name");
                     if (ref != null) {
-                        TransitStopStreetVertex tsv = new TransitStopStreetVertex(graph, label, coordinate.x, coordinate.y, nid, name, ref);
-                        iv = tsv;
+                        iv = new TransitStopStreetVertex(graph, label, coordinate.x, coordinate.y, nid, name, ref);
                     }
                 }
 
@@ -1466,15 +1438,15 @@ public class OpenStreetMapModule implements GraphBuilderModule {
                 }
 
                 intersectionNodes.put(nid, iv);
-                endpoints.add(iv);
             }
+
             return iv;
         }
     }
 
     @Override
     public void checkInputs() {
-        for (BinaryOpenStreetMapProvider provider : _providers) {
+        for (BinaryOpenStreetMapProvider provider : providers) {
             provider.checkInputs();
         }
     }

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/VertexAndName.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/VertexAndName.java
@@ -1,0 +1,37 @@
+package org.opentripplanner.graph_builder.module.osm;
+
+import java.util.Objects;
+import org.opentripplanner.routing.vertextype.OsmVertex;
+import org.opentripplanner.util.I18NString;
+
+class VertexAndName {
+
+    private final I18NString name;
+    private final OsmVertex vertex;
+
+    VertexAndName(I18NString name, OsmVertex vertex) {
+        this.name = name;
+        this.vertex = vertex;
+    }
+
+    public I18NString getName() {
+        return this.name;
+    }
+
+    public OsmVertex getVertex() {
+        return this.vertex;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {return true;}
+        if (o == null || getClass() != o.getClass()) {return false;}
+        final VertexAndName that = (VertexAndName) o;
+        return Objects.equals(name, that.name) && vertex.equals(that.vertex);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, vertex);
+    }
+}

--- a/src/main/java/org/opentripplanner/openstreetmap/model/OSMWithTags.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/model/OSMWithTags.java
@@ -3,6 +3,10 @@ package org.opentripplanner.openstreetmap.model;
 import java.util.HashMap;
 import java.util.Map;
 
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.function.Consumer;
+import org.opentripplanner.graph_builder.DataImportIssueStore;
 import org.opentripplanner.graph_builder.module.osm.TemplateLibrary;
 import org.opentripplanner.util.I18NString;
 import org.opentripplanner.util.NonLocalizedString;
@@ -118,6 +122,24 @@ public class OSMWithTags {
         }
         return null;
     }
+
+    /**
+     * Get tag and convert it to an integer. If the tag exist, but can not be parsed into a
+     * number, then the error handler is called with the value witch failed to parse.
+     */
+    public OptionalInt getTagAsInt(String tag, Consumer<String> errorHandler) {
+        String value = getTag(tag);
+        if (value != null) {
+            try {
+                return OptionalInt.of(Integer.parseInt(value));
+            }
+            catch (NumberFormatException e) {
+                errorHandler.accept(value);
+            }
+        }
+        return OptionalInt.empty();
+    }
+
 
     /**
      * Checks is a tag contains the specified value.


### PR DESCRIPTION
### Summary
The OSM parser fails if the duration for elevators contain something else then a number. It might be that this should contain number of seconds, but OTP need to handle other values without crashing. 

### Issue
No issue

### Unit tests
No unit tests added.


### Code style
✅ 

### Documentation
No doc added, bug fix.

### Changelog
