### PR TITLE
Pull down localization to APIs from itinerary creation [changelog skip]

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/flex/FlexLegMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/FlexLegMapper.java
@@ -29,7 +29,7 @@ public class FlexLegMapper {
               flexTripEdge.getFlexTrip().getPickupBookingInfo(leg.getAlightStopPosInPattern()));
   }
 
-    public static void addFlexPlaces(Leg leg, FlexTripEdge flexEdge, Locale requestedLocale) {
+    public static void addFlexPlaces(Leg leg, FlexTripEdge flexEdge) {
         leg.setFrom(Place.forFlexStop(flexEdge.s1, flexEdge.getFromVertex()));
         leg.setTo(Place.forFlexStop(flexEdge.s2, flexEdge.getToVertex()));
     }

--- a/src/ext/java/org/opentripplanner/ext/flex/edgetype/FlexTripEdge.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/edgetype/FlexTripEdge.java
@@ -12,10 +12,9 @@ import org.opentripplanner.routing.core.StateEditor;
 import org.opentripplanner.routing.core.TraverseMode;
 import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Vertex;
+import org.opentripplanner.util.I18NString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Locale;
 
 public class FlexTripEdge extends Edge {
 
@@ -77,13 +76,8 @@ public class FlexTripEdge extends Edge {
   }
 
   @Override
-  public String getName() {
+  public I18NString getName() {
     return null;
-  }
-
-  @Override
-  public String getName(Locale locale) {
-    return this.getName();
   }
 
   @Override

--- a/src/ext/java/org/opentripplanner/ext/flex/template/FlexAccessTemplate.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/template/FlexAccessTemplate.java
@@ -88,10 +88,7 @@ public class FlexAccessTemplate extends FlexAccessEgressTemplate {
       timeShift = secondsFromStartOfTime + earliestDepartureTime - preFlexTime;
     }
 
-    Itinerary itinerary = GraphPathToItineraryMapper.generateItinerary(
-        new GraphPath(state),
-        Locale.ENGLISH
-    );
+    Itinerary itinerary = GraphPathToItineraryMapper.generateItinerary(new GraphPath(state));
 
     ZonedDateTime zdt = startOfTime.plusSeconds(timeShift);
     Calendar c = Calendar.getInstance(TimeZone.getTimeZone(zdt.getZone()));

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/LegacyGraphQLUtils.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/LegacyGraphQLUtils.java
@@ -1,0 +1,22 @@
+package org.opentripplanner.ext.legacygraphqlapi;
+
+import graphql.schema.DataFetchingEnvironment;
+import java.util.Locale;
+import java.util.Map;
+
+public class LegacyGraphQLUtils {
+
+    public static Locale getLocale(DataFetchingEnvironment environment) {
+      String argLang = environment.getArgument("language");
+      if (argLang != null) {
+        return Locale.forLanguageTag(argLang);
+      }
+
+      Map<String, ?> localContext = environment.getLocalContext();
+      if (localContext != null && localContext.get("locale") != null) {
+        return (Locale) localContext.get("locale");
+      }
+
+      return environment.getLocale();
+    }
+}

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLPlaceImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLPlaceImpl.java
@@ -2,7 +2,9 @@ package org.opentripplanner.ext.legacygraphqlapi.datafetchers;
 
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
+import java.util.Locale;
 import org.opentripplanner.ext.legacygraphqlapi.LegacyGraphQLRequestContext;
+import org.opentripplanner.ext.legacygraphqlapi.LegacyGraphQLUtils;
 import org.opentripplanner.ext.legacygraphqlapi.generated.LegacyGraphQLDataFetchers;
 import org.opentripplanner.ext.legacygraphqlapi.generated.LegacyGraphQLTypes.LegacyGraphQLVertexType;
 import org.opentripplanner.model.plan.Place;
@@ -18,7 +20,10 @@ public class LegacyGraphQLPlaceImpl implements LegacyGraphQLDataFetchers.LegacyG
 
   @Override
   public DataFetcher<String> name() {
-    return environment -> getSource(environment).place.name;
+    return environment -> {
+      Locale locale = LegacyGraphQLUtils.getLocale(environment);
+      return getSource(environment).place.name.toString(locale);
+    };
   }
 
   @Override

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
@@ -7,6 +7,7 @@ import static org.opentripplanner.ext.legacygraphqlapi.mapping.LegacyGraphQLSeve
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimaps;
+import graphql.execution.DataFetcherResult;
 import graphql.relay.Connection;
 import graphql.relay.Relay;
 import graphql.relay.SimpleListConnection;
@@ -844,7 +845,7 @@ public class LegacyGraphQLQueryTypeImpl
   }
 
   @Override
-  public DataFetcher<RoutingResponse> plan() {
+  public DataFetcher<DataFetcherResult<RoutingResponse>> plan() {
     return environment -> {
       LegacyGraphQLRequestContext context = environment.<LegacyGraphQLRequestContext>getContext();
       RoutingRequest request = context.getRouter().defaultRoutingRequest.clone();
@@ -983,7 +984,8 @@ public class LegacyGraphQLQueryTypeImpl
       callWith.argument("disableRemainingWeightHeuristic", (Boolean v) -> request.disableRemainingWeightHeuristic = v);
 
       callWith.argument("locale", (String v) -> request.locale = ResourceBundleSingleton.INSTANCE.getLocale(v));
-      return context.getRoutingService().route(request, context.getRouter());
+      RoutingResponse res = context.getRoutingService().route(request, context.getRouter());
+      return DataFetcherResult.<RoutingResponse>newResult().data(res).localContext(Map.of("locale", request.locale)).build();
     };
   }
 

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/LegacyGraphQLDataFetchers.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/LegacyGraphQLDataFetchers.java
@@ -25,7 +25,6 @@ import org.opentripplanner.model.plan.StopArrival;
 import org.opentripplanner.routing.graphfinder.PlaceAtDistance;
 import graphql.relay.Connection;
 import graphql.relay.Edge;
-import org.opentripplanner.routing.api.response.RoutingResponse;
 import org.opentripplanner.model.Route;
 import org.opentripplanner.model.plan.WalkStep;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
@@ -608,7 +607,7 @@ public class LegacyGraphQLDataFetchers {
 
         public DataFetcher<Iterable<TripPattern>> patterns();
 
-        public DataFetcher<RoutingResponse> plan();
+        public DataFetcher<graphql.execution.DataFetcherResult<org.opentripplanner.routing.api.response.RoutingResponse>> plan();
 
         public DataFetcher<VehicleRentalVehicle> rentalVehicle();
 

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/graphql-codegen.yml
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/graphql-codegen.yml
@@ -61,7 +61,7 @@ config:
     placeAtDistance: org.opentripplanner.routing.graphfinder.PlaceAtDistance#PlaceAtDistance
     placeAtDistanceConnection: graphql.relay.Connection#Connection<PlaceAtDistance>
     placeAtDistanceEdge: graphql.relay.Edge#Edge<PlaceAtDistance>
-    Plan: org.opentripplanner.routing.api.response.RoutingResponse#RoutingResponse
+    Plan: graphql.execution.DataFetcherResult<org.opentripplanner.routing.api.response.RoutingResponse>
     RealtimeState: String
     Route: org.opentripplanner.model.Route#Route
     serviceTimeRange: Object

--- a/src/ext/java/org/opentripplanner/ext/parkAndRideApi/ParkAndRideResource.java
+++ b/src/ext/java/org/opentripplanner/ext/parkAndRideApi/ParkAndRideResource.java
@@ -96,7 +96,7 @@ public class ParkAndRideResource {
         public Double x, y;
 
         public ParkAndRideInfo(VehicleParkingEntranceVertex vertex) {
-            this.name = vertex.getName();
+            this.name = vertex.getDefaultName();
             this.x = vertex.getX();
             this.y = vertex.getY();
         }

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLUtils.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLUtils.java
@@ -1,0 +1,22 @@
+package org.opentripplanner.ext.transmodelapi;
+
+import graphql.schema.DataFetchingEnvironment;
+import java.util.Locale;
+import java.util.Map;
+
+public class TransmodelGraphQLUtils {
+
+    public static Locale getLocale(DataFetchingEnvironment environment) {
+      String argLang = environment.getArgument("language");
+      if (argLang != null) {
+        return Locale.forLanguageTag(argLang);
+      }
+
+      Map<String, ?> localContext = environment.getLocalContext();
+      if (localContext != null && localContext.get("locale") != null) {
+        return (Locale) localContext.get("locale");
+      }
+
+      return environment.getLocale();
+    }
+}

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/PathGuidanceType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/PathGuidanceType.java
@@ -3,7 +3,10 @@ package org.opentripplanner.ext.transmodelapi.model.plan;
 import graphql.Scalars;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLObjectType;
+import java.util.Locale;
+import org.opentripplanner.ext.transmodelapi.TransmodelGraphQLUtils;
 import org.opentripplanner.ext.transmodelapi.model.EnumTypes;
+import org.opentripplanner.model.plan.Place;
 import org.opentripplanner.model.plan.WalkStep;
 
 public class PathGuidanceType {
@@ -32,7 +35,10 @@ public class PathGuidanceType {
             .name("streetName")
             .description("The name of the street.")
             .type(Scalars.GraphQLString)
-            .dataFetcher(environment -> ((WalkStep) environment.getSource()).streetName)
+            .dataFetcher(environment -> {
+                Locale locale = TransmodelGraphQLUtils.getLocale(environment);
+                return ((WalkStep) environment.getSource()).streetName.toString(locale);
+            })
             .build())
         .field(GraphQLFieldDefinition
             .newFieldDefinition()

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/PlanPlaceType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/PlanPlaceType.java
@@ -5,6 +5,8 @@ import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLNonNull;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLOutputType;
+import java.util.Locale;
+import org.opentripplanner.ext.transmodelapi.TransmodelGraphQLUtils;
 import org.opentripplanner.ext.transmodelapi.model.EnumTypes;
 import org.opentripplanner.ext.transmodelapi.model.scalars.GeoJSONCoordinatesScalar;
 import org.opentripplanner.model.FlexStopLocation;
@@ -32,7 +34,10 @@ public class PlanPlaceType {
             .description(
                 "For transit quays, the name of the quay. For points of interest, the name of the POI.")
             .type(Scalars.GraphQLString)
-            .dataFetcher(environment -> ((Place) environment.getSource()).name)
+            .dataFetcher(environment -> {
+                Locale locale = TransmodelGraphQLUtils.getLocale(environment);
+                return ((Place) environment.getSource()).name.toString(locale);
+            })
             .build())
         .field(GraphQLFieldDefinition
             .newFieldDefinition()

--- a/src/main/java/org/opentripplanner/api/mapping/PlaceMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/PlaceMapper.java
@@ -50,7 +50,7 @@ public class PlaceMapper {
 
         ApiPlace api = new ApiPlace();
 
-        api.name = domain.name;
+        api.name = domain.name.toString(locale);
 
         if (domain.stop != null) {
             api.stopId = FeedScopedIdMapper.mapToApi(domain.stop.getId());

--- a/src/main/java/org/opentripplanner/api/mapping/WalkStepMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/WalkStepMapper.java
@@ -14,8 +14,10 @@ import static org.opentripplanner.api.mapping.RelativeDirectionMapper.mapRelativ
 
 public class WalkStepMapper {
     private final StreetNoteMaperMapper alertsMapper;
+    private final Locale locale;
 
     public WalkStepMapper(Locale locale) {
+        this.locale = locale;
         this.alertsMapper = new StreetNoteMaperMapper(locale);
     }
 
@@ -30,7 +32,7 @@ public class WalkStepMapper {
 
         api.distance = domain.distance;
         api.relativeDirection = mapRelativeDirection(domain.relativeDirection);
-        api.streetName = domain.streetName;
+        api.streetName = domain.streetName.toString(locale);
         api.absoluteDirection = mapAbsoluteDirection(domain.absoluteDirection);
         api.exit = domain.exit;
         api.stayOn = domain.stayOn;

--- a/src/main/java/org/opentripplanner/graph_builder/GraphStats.java
+++ b/src/main/java/org/opentripplanner/graph_builder/GraphStats.java
@@ -173,7 +173,7 @@ public class GraphStats {
                     gc.setStartingGeographicPoint(c.x, c.y);
                     gc.setDirection(azimuth, distance);
                     Point2D dest = gc.getDestinationGeographicPoint();
-                    String name = v.getName();
+                    String name = v.getDefaultName();
                     String[] entries = new String[]{
                             Integer.toString(i),
                             name,

--- a/src/main/java/org/opentripplanner/graph_builder/issues/ParkAndRideEntranceRemoved.java
+++ b/src/main/java/org/opentripplanner/graph_builder/issues/ParkAndRideEntranceRemoved.java
@@ -12,7 +12,7 @@ public class ParkAndRideEntranceRemoved implements DataImportIssue {
 
   public ParkAndRideEntranceRemoved(VehicleParkingEntrance vehicleParkingEntrance){
     this.entranceId = vehicleParkingEntrance.getEntranceId().toString();
-    this.streetVertexName = vehicleParkingEntrance.getVertex().getName();
+    this.streetVertexName = vehicleParkingEntrance.getVertex().getDefaultName();
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/graph_builder/issues/StopLinkedTooFar.java
+++ b/src/main/java/org/opentripplanner/graph_builder/issues/StopLinkedTooFar.java
@@ -24,7 +24,7 @@ public class StopLinkedTooFar implements DataImportIssue {
 
     @Override
     public String getHTMLMessage() {
-        return String.format(HTMLFMT, stop.getStop().getLat(), stop.getStop().getLon(), stop.getName(), stop.getStop().getId(), Integer.toString(distance));
+        return String.format(HTMLFMT, stop.getStop().getLat(), stop.getStop().getLon(), stop.getDefaultName(), stop.getStop().getId(), Integer.toString(distance));
     }
 
     @Override

--- a/src/main/java/org/opentripplanner/graph_builder/issues/StopNotLinkedForTransfers.java
+++ b/src/main/java/org/opentripplanner/graph_builder/issues/StopNotLinkedForTransfers.java
@@ -18,7 +18,7 @@ public class StopNotLinkedForTransfers implements DataImportIssue {
 
     @Override
     public String getHTMLMessage() {
-        return String.format(HTMLFMT, stop.getLat(), stop.getLon(), stop.getName(), stop.getStop().getId());
+        return String.format(HTMLFMT, stop.getLat(), stop.getLon(), stop.getDefaultName(), stop.getStop().getId());
     }
 
     @Override

--- a/src/main/java/org/opentripplanner/graph_builder/issues/StopUnlinked.java
+++ b/src/main/java/org/opentripplanner/graph_builder/issues/StopUnlinked.java
@@ -22,7 +22,7 @@ public class StopUnlinked implements DataImportIssue {
 
     @Override
     public String getHTMLMessage() {
-        return String.format(HTMLFMT, stop.getStop().getLat(), stop.getStop().getLon(), stop.getName(), stop.getStop().getId());
+        return String.format(HTMLFMT, stop.getStop().getLat(), stop.getStop().getLon(), stop.getDefaultName(), stop.getStop().getId());
     }
 
     @Override

--- a/src/main/java/org/opentripplanner/graph_builder/module/AddTransitModelEntitiesToGraph.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/AddTransitModelEntitiesToGraph.java
@@ -36,6 +36,8 @@ import org.opentripplanner.routing.vertextype.TransitBoardingAreaVertex;
 import org.opentripplanner.routing.vertextype.TransitEntranceVertex;
 import org.opentripplanner.routing.vertextype.TransitPathwayNodeVertex;
 import org.opentripplanner.routing.vertextype.TransitStopVertex;
+import org.opentripplanner.util.I18NString;
+import org.opentripplanner.util.NonLocalizedString;
 import org.opentripplanner.util.OTPFeature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -171,13 +173,13 @@ public class AddTransitModelEntitiesToGraph {
                 new PathwayEdge(
                     boardingAreaVertex,
                     stationElementNodes.get(boardingArea.getParentStop()),
-                    boardingArea.getName()
+                    new NonLocalizedString(boardingArea.getName())
                 );
 
                 new PathwayEdge(
                     stationElementNodes.get(boardingArea.getParentStop()),
                     boardingAreaVertex,
-                    boardingArea.getName()
+                    new NonLocalizedString(boardingArea.getName())
                 );
             }
         }
@@ -198,7 +200,7 @@ public class AddTransitModelEntitiesToGraph {
                         fromVertex,
                         toVertex,
                         pathway.getId(),
-                        pathway.getName(),
+                        new NonLocalizedString(pathway.getName()),
                         pathway.getTraversalTime(),
                         pathway.getLength(),
                         pathway.getStairCount(),
@@ -210,7 +212,7 @@ public class AddTransitModelEntitiesToGraph {
                             toVertex,
                             fromVertex,
                             pathway.getId(),
-                            pathway.getReversedName(),
+                            new NonLocalizedString(pathway.getReversedName()),
                             pathway.getTraversalTime(),
                             pathway.getLength(),
                             -1 * pathway.getStairCount(),
@@ -243,15 +245,15 @@ public class AddTransitModelEntitiesToGraph {
         Vertex toVertex
     ) {
         StationElement fromStation = fromVertex.getStationElement();
-        String fromVertexLevelName = fromStation == null || fromStation.getLevelName() == null
+        I18NString fromVertexLevelName = fromStation == null || fromStation.getLevelName() == null
             ? fromVertex.getName()
-            : fromStation.getLevelName();
+            : new NonLocalizedString(fromStation.getLevelName());
         Double fromVertexLevelIndex = fromStation == null ? null : fromStation.getLevelIndex();
 
         StationElement toStation = toVertex.getStationElement();
-        String toVertexLevelName = toStation == null || toStation.getLevelName() == null
+        I18NString toVertexLevelName = toStation == null || toStation.getLevelName() == null
             ? toVertex.getName()
-            : toStation.getLevelName();
+            : new NonLocalizedString(toStation.getLevelName());
         Double toVertexLevelIndex = toStation == null ? null : toStation.getLevelIndex();
 
         double levels = 1;

--- a/src/main/java/org/opentripplanner/graph_builder/module/GraphStatisticsModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/GraphStatisticsModule.java
@@ -59,8 +59,8 @@ public class GraphStatisticsModule implements GraphBuilderModule {
 
         for (Edge e : graph.getEdges()) {
             edgeTypeDistribution.add(new ConstantQuantifiable<String>(e.getClass().toString()));
-            edgeNameDistribution.add(new NumberQuantifiable<Integer>(e.getName() == null ? 0 : e
-                    .getName().length()), e.getName());
+            edgeNameDistribution.add(new NumberQuantifiable<Integer>(e.getDefaultName() == null ? 0 : e
+                    .getDefaultName().length()), e.getDefaultName());
             if (e.getGeometry() != null) {
                 LineString geometry = e.getGeometry();
                 geomSizeDistribution.add(new NumberQuantifiable<Integer>(geometry.getNumPoints()));
@@ -70,8 +70,8 @@ public class GraphStatisticsModule implements GraphBuilderModule {
         }
         for (Vertex v : graph.getVertices()) {
             vertexTypeDistribution.add(new ConstantQuantifiable<String>(v.getClass().toString()));
-            vertexNameDistribution.add(new NumberQuantifiable<Integer>(v.getName() == null ? 0 : v
-                    .getName().length()), v.getName());
+            vertexNameDistribution.add(new NumberQuantifiable<Integer>(v.getDefaultName() == null ? 0 : v
+                    .getDefaultName().length()), v.getDefaultName());
             vertexLabelDistribution.add(new NumberQuantifiable<Integer>(v.getLabel().length()),
                     v.getLabel());
         }

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModule.java
@@ -981,7 +981,7 @@ public class OpenStreetMapModule implements GraphBuilderModule {
         ) {
             ElevatorOffboardVertex offboardVertex = new ElevatorOffboardVertex(graph,
                     sourceVertexLabel + "_offboard", sourceVertex.getX(),
-                    sourceVertex.getY(), levelName
+                    sourceVertex.getY(), new NonLocalizedString(levelName)
             );
 
             new FreeEdge(sourceVertex, offboardVertex);
@@ -989,11 +989,11 @@ public class OpenStreetMapModule implements GraphBuilderModule {
 
             ElevatorOnboardVertex onboardVertex = new ElevatorOnboardVertex(graph,
                     sourceVertexLabel + "_onboard", sourceVertex.getX(),
-                    sourceVertex.getY(), levelName
+                    sourceVertex.getY(), new NonLocalizedString(levelName)
             );
 
             new ElevatorBoardEdge(offboardVertex, onboardVertex);
-            new ElevatorAlightEdge(onboardVertex, offboardVertex, levelName);
+            new ElevatorAlightEdge(onboardVertex, offboardVertex, new NonLocalizedString(levelName));
 
             // accumulate onboard vertices to so they can be connected by hop edges later
             onboardVertices.add(onboardVertex);

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/PortlandCustomNamer.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/PortlandCustomNamer.java
@@ -148,7 +148,7 @@ public class PortlandCustomNamer implements CustomNamer {
                 e.setName(new NonLocalizedString(name));
                 return name;
             } else {
-                String name = out.getName();
+                String name = out.getDefaultName();
                 e.setName(new NonLocalizedString(name));
                 return name;
             }
@@ -170,7 +170,7 @@ public class PortlandCustomNamer implements CustomNamer {
                 e.setName(new NonLocalizedString(name));
                 return name;
             } else {
-                String name = in.getName();
+                String name = in.getDefaultName();
                 e.setName(new NonLocalizedString(name));
                 return name;
             }

--- a/src/main/java/org/opentripplanner/inspector/BikeSafetyEdgeRenderer.java
+++ b/src/main/java/org/opentripplanner/inspector/BikeSafetyEdgeRenderer.java
@@ -53,7 +53,7 @@ public class BikeSafetyEdgeRenderer implements EdgeVertexRenderer {
     public boolean renderVertex(Vertex v, VertexVisualAttributes attrs) {
         if (v instanceof VehicleRentalStationVertex) {
             attrs.color = VEHICLE_RENTAL_COLOR_VERTEX;
-            attrs.label = v.getName();
+            attrs.label = v.getDefaultName();
         } else if (v instanceof IntersectionVertex) {
             attrs.color = Color.DARK_GRAY;
         } else {

--- a/src/main/java/org/opentripplanner/inspector/TraversalPermissionsEdgeRenderer.java
+++ b/src/main/java/org/opentripplanner/inspector/TraversalPermissionsEdgeRenderer.java
@@ -85,13 +85,13 @@ public class TraversalPermissionsEdgeRenderer implements EdgeVertexRenderer {
             }
         } else if (v instanceof TransitStopVertex || v instanceof TransitEntranceVertex || v instanceof TransitPathwayNodeVertex || v instanceof TransitBoardingAreaVertex) {
             attrs.color = TRANSIT_STOP_COLOR_VERTEX;
-            attrs.label = v.getName();
+            attrs.label = v.getDefaultName();
         } else if (v instanceof VehicleRentalStationVertex) {
             attrs.color = VEHICLE_RENTAL_COLOR_VERTEX;
-            attrs.label = v.getName();
+            attrs.label = v.getDefaultName();
         } else if (v instanceof VehicleParkingEntranceVertex) {
             attrs.color = PARK_AND_RIDE_COLOR_VERTEX;
-            attrs.label = v.getName();
+            attrs.label = v.getDefaultName();
         } else {
             return false;
         }

--- a/src/main/java/org/opentripplanner/inspector/WheelchairEdgeRenderer.java
+++ b/src/main/java/org/opentripplanner/inspector/WheelchairEdgeRenderer.java
@@ -67,7 +67,7 @@ public class WheelchairEdgeRenderer implements EdgeVertexRenderer {
             if(((TransitStopVertex) v).getStop().getWheelchairBoarding()
                     == WheelChairBoarding.NOT_POSSIBLE)
                 attrs.color = NO_WHEELCHAIR_COLOR;
-            attrs.label = v.getName();
+            attrs.label = v.getDefaultName();
         } else  {
             return false;
         }

--- a/src/main/java/org/opentripplanner/model/VehicleRentalStationInfo.java
+++ b/src/main/java/org/opentripplanner/model/VehicleRentalStationInfo.java
@@ -14,7 +14,7 @@ public class VehicleRentalStationInfo {
     
     public VehicleRentalStationInfo(VehicleRentalStationVertex vertex) {
         id = vertex.getStation().getStationId();
-        name = vertex.getName();
+        name = vertex.getDefaultName();
         lat = vertex.getLat();
         lon = vertex.getLon();
     }

--- a/src/main/java/org/opentripplanner/model/plan/Itinerary.java
+++ b/src/main/java/org/opentripplanner/model/plan/Itinerary.java
@@ -320,7 +320,7 @@ public class Itinerary {
     public String toStr() {
         // No translater needed, stop indexes are never passed to the builder
         PathStringBuilder buf = new PathStringBuilder(null);
-        buf.stop(firstLeg().getFrom().name);
+        buf.stop(firstLeg().getFrom().name.toString());
 
         for (Leg leg : legs) {
             buf.sep();
@@ -336,7 +336,7 @@ public class Itinerary {
             }
 
             buf.sep();
-            buf.stop(leg.getTo().name);
+            buf.stop(leg.getTo().name.toString());
         }
 
         buf.space().append(String.format(ROOT, "[ $%d ]", generalizedCost));

--- a/src/main/java/org/opentripplanner/model/plan/Place.java
+++ b/src/main/java/org/opentripplanner/model/plan/Place.java
@@ -9,6 +9,8 @@ import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalPlace;
 import org.opentripplanner.routing.vertextype.VehicleParkingEntranceVertex;
 import org.opentripplanner.routing.vertextype.VehicleRentalStationVertex;
+import org.opentripplanner.util.I18NString;
+import org.opentripplanner.util.NonLocalizedString;
 
 /** 
 * A Place is where a journey starts or ends, or a transit stop along the way.
@@ -18,7 +20,7 @@ public class Place {
     /** 
      * For transit stops, the name of the stop.  For points of interest, the name of the POI.
      */
-    public final String name;
+    public final I18NString name;
 
     /**
      * The coordinate of the place.
@@ -47,7 +49,7 @@ public class Place {
     public final VehicleParkingWithEntrance vehicleParkingWithEntrance;
 
     private Place(
-            String name,
+            I18NString name,
             WgsCoordinate coordinate,
             VertexType vertexType,
             StopLocation stop,
@@ -79,7 +81,7 @@ public class Place {
      * just the necessary information for a human to identify the place in a given the context.
      */
     public String toStringShort() {
-        StringBuilder buf = new StringBuilder(name);
+        StringBuilder buf = new StringBuilder(name.toString());
         if(stop != null) {
             buf.append(" (").append(stop.getId()).append(")");
         } else {
@@ -92,7 +94,7 @@ public class Place {
     @Override
     public String toString() {
         return ToStringBuilder.of(Place.class)
-                .addStr("name", name)
+                .addStr("name", name.toString())
                 .addObj("stop", stop)
                 .addObj("coordinate", coordinate)
                 .addEnum("vertexType", vertexType)
@@ -103,14 +105,14 @@ public class Place {
 
     public static Place normal(Double lat, Double lon, String name) {
         return new Place(
-                name,
+                new NonLocalizedString(name),
                 WgsCoordinate.creatOptionalCoordinate(lat, lon),
                 VertexType.NORMAL,
                 null, null, null
         );
     }
 
-    public static Place normal(Vertex vertex, String name) {
+    public static Place normal(Vertex vertex, I18NString name) {
         return new Place(
                 name,
                 WgsCoordinate.creatOptionalCoordinate(vertex.getLat(), vertex.getLon()),
@@ -121,7 +123,7 @@ public class Place {
 
     public static Place forStop(StopLocation stop) {
         return new Place(
-                stop.getName(),
+                new NonLocalizedString(stop.getName()),
                 stop.getCoordinate(),
                 VertexType.TRANSIT,
                 stop,
@@ -134,7 +136,7 @@ public class Place {
         // The actual vertex is used because the StopLocation coordinates may not be equal to the vertex's
         // coordinates.
         return new Place(
-                stop.getName(),
+                new NonLocalizedString(stop.getName()),
                 WgsCoordinate.creatOptionalCoordinate(vertex.getLat(), vertex.getLon()),
                 VertexType.TRANSIT,
                 stop,
@@ -143,9 +145,9 @@ public class Place {
         );
     }
 
-    public static Place forVehicleRentalPlace(VehicleRentalStationVertex vertex, String name) {
+    public static Place forVehicleRentalPlace(VehicleRentalStationVertex vertex) {
         return new Place(
-                name,
+                vertex.getName(),
                 WgsCoordinate.creatOptionalCoordinate(vertex.getLat(), vertex.getLon()),
                 VertexType.VEHICLERENTAL,
                 null,
@@ -154,7 +156,7 @@ public class Place {
         );
     }
 
-    public static Place forVehicleParkingEntrance(VehicleParkingEntranceVertex vertex, String name, RoutingRequest request) {
+    public static Place forVehicleParkingEntrance(VehicleParkingEntranceVertex vertex, RoutingRequest request) {
         TraverseMode traverseMode = null;
         if (request.streetSubRequestModes.getCar()) {
             traverseMode = TraverseMode.CAR;
@@ -165,7 +167,7 @@ public class Place {
         boolean realTime = request.useVehicleParkingAvailabilityInformation
                 && vertex.getVehicleParking().hasRealTimeDataForMode(traverseMode, request.wheelchairAccessible);
         return new Place(
-                name,
+                vertex.getName(),
                 WgsCoordinate.creatOptionalCoordinate(vertex.getLat(), vertex.getLon()),
                 VertexType.VEHICLEPARKING,
                 null,

--- a/src/main/java/org/opentripplanner/model/plan/WalkStep.java
+++ b/src/main/java/org/opentripplanner/model/plan/WalkStep.java
@@ -11,6 +11,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import org.opentripplanner.util.I18NString;
 
 /**
  * Represents one instruction in walking directions. Three examples from New York City:
@@ -54,7 +55,7 @@ public class WalkStep {
     /**
      * The name of the street.
      */
-    public String streetName;
+    public I18NString streetName;
 
     /**
      * The absolute direction of this step.
@@ -167,11 +168,11 @@ public class WalkStep {
     }
 
     public String streetNameNoParens() {
-        int idx = streetName.indexOf('(');
+        int idx = streetName.toString().indexOf('(');
         if (idx <= 0) {
-            return streetName;
+            return streetName.toString();
         }
-        return streetName.substring(0, idx - 1);
+        return streetName.toString().substring(0, idx - 1);
     }
 
     @Override

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/AlertToLegMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/AlertToLegMapper.java
@@ -20,7 +20,7 @@ import java.util.Set;
 
 public class AlertToLegMapper {
 
-    public static void addTransitAlertPatchesToLeg(Graph graph, Leg leg, boolean isFirstLeg, Locale requestedLocale) {
+    public static void addTransitAlertPatchesToLeg(Graph graph, Leg leg, boolean isFirstLeg) {
 
         // Alert patches are only relevant for transit legs
         if (!leg.isTransitLeg()) { return; }
@@ -42,7 +42,7 @@ public class AlertToLegMapper {
                     leg.getServiceDate()
             ));
             alerts.addAll(getAlertsForStop(graph, (Stop) fromStop));
-            addTransitAlertPatchesToLeg(leg, departingStopConditions, alerts, requestedLocale, legStartTime, legEndTime);
+            addTransitAlertPatchesToLeg(leg, departingStopConditions, alerts, legStartTime, legEndTime);
         }
         if (toStop instanceof Stop) {
             Collection<TransitAlert> alerts = getAlertsForStopAndRoute(graph, (Stop) toStop, routeId);
@@ -50,7 +50,7 @@ public class AlertToLegMapper {
                     leg.getServiceDate()
             ));
             alerts.addAll(getAlertsForStop(graph, (Stop) toStop));
-            addTransitAlertPatchesToLeg(leg, StopCondition.ARRIVING, alerts, requestedLocale, legStartTime, legEndTime);
+            addTransitAlertPatchesToLeg(leg, StopCondition.ARRIVING, alerts, legStartTime, legEndTime);
         }
 
         if (leg.getIntermediateStops() != null) {
@@ -64,7 +64,7 @@ public class AlertToLegMapper {
                     Date stopArrival = visit.arrival.getTime();
                     Date stopDepature = visit.departure.getTime();
 
-                    addTransitAlertPatchesToLeg(leg, StopCondition.PASSING, alerts, requestedLocale, stopArrival, stopDepature);
+                    addTransitAlertPatchesToLeg(leg, StopCondition.PASSING, alerts, stopArrival, stopDepature);
                 }
             }
         }
@@ -74,19 +74,19 @@ public class AlertToLegMapper {
         // trips - alerts tagged on ServiceDate
         patches = alertPatchService(graph)
                 .getTripAlerts(leg.getTrip().getId(), leg.getServiceDate());
-        addTransitAlertPatchesToLeg(leg, patches, requestedLocale, legStartTime, legEndTime);
+        addTransitAlertPatchesToLeg(leg, patches, legStartTime, legEndTime);
 
         // trips - alerts tagged on any date
         patches = alertPatchService(graph).getTripAlerts(leg.getTrip().getId(), null);
-        addTransitAlertPatchesToLeg(leg, patches, requestedLocale, legStartTime, legEndTime);
+        addTransitAlertPatchesToLeg(leg, patches, legStartTime, legEndTime);
 
         // route
         patches = alertPatchService(graph).getRouteAlerts(leg.getRoute().getId());
-        addTransitAlertPatchesToLeg(leg, patches, requestedLocale, legStartTime, legEndTime);
+        addTransitAlertPatchesToLeg(leg, patches, legStartTime, legEndTime);
 
         // agency
         patches = alertPatchService(graph).getAgencyAlerts(leg.getAgency().getId());
-        addTransitAlertPatchesToLeg(leg, patches, requestedLocale, legStartTime, legEndTime);
+        addTransitAlertPatchesToLeg(leg, patches, legStartTime, legEndTime);
 
         // Filter alerts when there are multiple timePeriods for each alert
         leg.getTransitAlerts().removeIf(alertPatch ->  
@@ -261,7 +261,7 @@ public class AlertToLegMapper {
     }
 
 
-    private static void addTransitAlertPatchesToLeg(Leg leg, Collection<StopCondition> stopConditions, Collection<TransitAlert> alertPatches, Locale requestedLocale, Date fromTime, Date toTime) {
+    private static void addTransitAlertPatchesToLeg(Leg leg, Collection<StopCondition> stopConditions, Collection<TransitAlert> alertPatches, Date fromTime, Date toTime) {
         if (alertPatches != null) {
             for (TransitAlert alert : alertPatches) {
                 if (alert.displayDuring(fromTime.getTime() / 1000, toTime.getTime() / 1000)) {
@@ -281,7 +281,7 @@ public class AlertToLegMapper {
         }
     }
 
-    private static void addTransitAlertPatchesToLeg(Leg leg, Collection<TransitAlert> alertPatches, Locale requestedLocale, Date fromTime, Date toTime) {
-        addTransitAlertPatchesToLeg(leg, null, alertPatches, requestedLocale, fromTime, toTime);
+    private static void addTransitAlertPatchesToLeg(Leg leg, Collection<TransitAlert> alertPatches, Date fromTime, Date toTime) {
+        addTransitAlertPatchesToLeg(leg, null, alertPatches, fromTime, toTime);
     }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/GraphPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/GraphPathToItineraryMapper.java
@@ -47,6 +47,7 @@ import org.opentripplanner.routing.vertextype.StreetVertex;
 import org.opentripplanner.routing.vertextype.TransitStopVertex;
 import org.opentripplanner.routing.vertextype.VehicleParkingEntranceVertex;
 import org.opentripplanner.routing.vertextype.VehicleRentalStationVertex;
+import org.opentripplanner.util.I18NString;
 import org.opentripplanner.util.OTPFeature;
 import org.opentripplanner.util.PolylineEncoder;
 import org.slf4j.Logger;
@@ -490,13 +491,13 @@ public abstract class GraphPathToItineraryMapper {
      */
     private static Place makePlace(State state, Locale requestedLocale) {
         Vertex vertex = state.getVertex();
-        String name = vertex.getName(requestedLocale);
+        String name = vertex.getName().toString(requestedLocale);
 
         //This gets nicer names instead of osm:node:id when changing mode of transport
         //Names are generated from all the streets in a corner, same as names in origin and destination
         //We use name in TemporaryStreetLocation since this name generation already happened when temporary location was generated
         if (vertex instanceof StreetVertex && !(vertex instanceof TemporaryStreetLocation)) {
-            name = ((StreetVertex) vertex).getIntersectionName(requestedLocale).toString(requestedLocale);
+            name = ((StreetVertex) vertex).getIntersectionName().toString(requestedLocale);
         }
 
         if (vertex instanceof TransitStopVertex) {
@@ -563,7 +564,7 @@ public abstract class GraphPathToItineraryMapper {
                 // exit != null and uses to <exit>
                 // the floor name is the AlightEdge name
                 // reset to avoid confusion with 'Elevator on floor 1 to floor 1'
-                step.streetName = ((ElevatorAlightEdge) edge).getName(requestedLocale);
+                step.streetName = edge.getName().toString(requestedLocale);
 
                 step.relativeDirection = RelativeDirection.ELEVATOR;
 
@@ -571,7 +572,7 @@ public abstract class GraphPathToItineraryMapper {
                 continue;
             }
 
-            String streetName = edge.getName(requestedLocale);
+            String streetName = edge.getName().toString(requestedLocale);
             int idx = streetName.indexOf('(');
             String streetNameNoParens;
             if (idx > 0)
@@ -617,7 +618,7 @@ public abstract class GraphPathToItineraryMapper {
                     // indicate that we are now on a roundabout
                     // and use one-based exit numbering
                     roundaboutExit = 1;
-                    roundaboutPreviousStreet = backState.getBackEdge().getName(requestedLocale);
+                    roundaboutPreviousStreet = backState.getBackEdge().getName().toString(requestedLocale);
                     idx = roundaboutPreviousStreet.indexOf('(');
                     if (idx > 0)
                         roundaboutPreviousStreet = roundaboutPreviousStreet.substring(0, idx - 1);
@@ -654,7 +655,7 @@ public abstract class GraphPathToItineraryMapper {
                         // the next edges will be PlainStreetEdges, we hope
                         double angleDiff = getAbsoluteAngleDiff(thisAngle, lastAngle);
                         for (Edge alternative : backState.getVertex().getOutgoingStreetEdges()) {
-                            if (alternative.getName(requestedLocale).equals(streetName)) {
+                            if (alternative.getName().toString(requestedLocale).equals(streetName)) {
                                 // alternatives that have the same name
                                 // are usually caused by street splits
                                 continue;
@@ -679,7 +680,7 @@ public abstract class GraphPathToItineraryMapper {
                                 continue; // this is not an alternative
                             }
                             alternative = alternatives.get(0);
-                            if (alternative.getName(requestedLocale).equals(streetName)) {
+                            if (alternative.getName().equals(streetName)) {
                                 // alternatives that have the same name
                                 // are usually caused by street splits
                                 continue;
@@ -841,7 +842,7 @@ public abstract class GraphPathToItineraryMapper {
         Edge en = forwardState.getBackEdge();
         WalkStep step;
         step = new WalkStep();
-        step.streetName = en.getName(wantedLocale);
+        step.streetName = en.getName().toString(wantedLocale);
         step.startLocation = new WgsCoordinate(
                 backState.getVertex().getLat(),
                 backState.getVertex().getLon()

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/GraphPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/GraphPathToItineraryMapper.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Locale;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.stream.Stream;
@@ -26,7 +25,6 @@ import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.model.plan.Place;
 import org.opentripplanner.model.plan.RelativeDirection;
 import org.opentripplanner.model.plan.WalkStep;
-import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.core.RoutingContext;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.core.TraverseMode;
@@ -70,11 +68,11 @@ public abstract class GraphPathToItineraryMapper {
     /**
      * Generates a TripPlan from a set of paths
      */
-    public static List<Itinerary> mapItineraries(List<GraphPath> paths, RoutingRequest request) {
+    public static List<Itinerary> mapItineraries(List<GraphPath> paths) {
 
         List<Itinerary> itineraries = new LinkedList<>();
         for (GraphPath path : paths) {
-            Itinerary itinerary = generateItinerary(path, request.locale);
+            Itinerary itinerary = generateItinerary(path);
             if (itinerary.legs.isEmpty()) { continue; }
             itineraries.add(itinerary);
         }
@@ -90,7 +88,7 @@ public abstract class GraphPathToItineraryMapper {
      * @param path The graph path to base the itinerary on
      * @return The generated itinerary
      */
-    public static Itinerary generateItinerary(GraphPath path, Locale requestedLocale) {
+    public static Itinerary generateItinerary(GraphPath path) {
 
         State[] states = new State[path.states.size()];
         State lastState = path.states.getLast();
@@ -105,15 +103,15 @@ public abstract class GraphPathToItineraryMapper {
 
         List<Leg> legs = new ArrayList<>();
         for (State[] legStates : legsStates) {
-            legs.add(generateLeg(graph, legStates, requestedLocale));
+            legs.add(generateLeg(graph, legStates));
         }
 
-        addWalkSteps(graph, legs, legsStates, requestedLocale);
+        addWalkSteps(graph, legs, legsStates);
 
 
         boolean first = true;
         for (Leg leg : legs) {
-            AlertToLegMapper.addTransitAlertPatchesToLeg(graph, leg, first, requestedLocale);
+            AlertToLegMapper.addTransitAlertPatchesToLeg(graph, leg, first);
             first = false;
         }
 
@@ -249,7 +247,7 @@ public abstract class GraphPathToItineraryMapper {
      * @param states The array of states to base the leg on
      * @return The generated leg
      */
-    private static Leg generateLeg(Graph graph, State[] states, Locale requestedLocale) {
+    private static Leg generateLeg(Graph graph, State[] states) {
         Leg leg = null;
         FlexTripEdge flexEdge = null;
 
@@ -287,9 +285,9 @@ public abstract class GraphPathToItineraryMapper {
         leg.setAgencyTimeZoneOffset(timeZone.getOffset(leg.getStartTime().getTimeInMillis()));
 
         if (flexEdge != null) {
-            FlexLegMapper.addFlexPlaces(leg, flexEdge, requestedLocale);
+            FlexLegMapper.addFlexPlaces(leg, flexEdge);
         } else {
-            addPlaces(leg, states, requestedLocale);
+            addPlaces(leg, states);
         }
 
         CoordinateArrayListSequence coordinates = makeCoordinates(edges);
@@ -338,13 +336,13 @@ public abstract class GraphPathToItineraryMapper {
      * @param legs The legs of the itinerary
      * @param legsStates The states that go with the legs
      */
-    private static void addWalkSteps(Graph graph, List<Leg> legs, State[][] legsStates, Locale requestedLocale) {
+    private static void addWalkSteps(Graph graph, List<Leg> legs, State[][] legsStates) {
         WalkStep previousStep = null;
 
         TraverseMode lastMode = null;
 
         for (int i = 0; i < legsStates.length; i++) {
-            List<WalkStep> walkSteps = generateWalkSteps(graph, legsStates[i], previousStep, requestedLocale);
+            List<WalkStep> walkSteps = generateWalkSteps(graph, legsStates[i], previousStep);
             TraverseMode legMode = legs.get(i).getMode();
             if(legMode != lastMode && !walkSteps.isEmpty()) {
                 lastMode = legMode;
@@ -477,35 +475,34 @@ public abstract class GraphPathToItineraryMapper {
      * @param leg The leg to add the places to
      * @param states The states that go with the leg
      */
-    private static void addPlaces(Leg leg, State[] states, Locale requestedLocale) {
-        leg.setFrom(makePlace(states[0], requestedLocale));
-        leg.setTo(makePlace(states[states.length - 1], requestedLocale));
+    private static void addPlaces(Leg leg, State[] states) {
+        leg.setFrom(makePlace(states[0]));
+        leg.setTo(makePlace(states[states.length - 1]));
     }
 
     /**
      * Make a {@link Place} to add to a {@link Leg}.
      *
      * @param state The {@link State}.
-     * @param requestedLocale The locale to use for all text attributes.
      * @return The resulting {@link Place} object.
      */
-    private static Place makePlace(State state, Locale requestedLocale) {
+    private static Place makePlace(State state) {
         Vertex vertex = state.getVertex();
-        String name = vertex.getName().toString(requestedLocale);
+        I18NString name = vertex.getName();
 
         //This gets nicer names instead of osm:node:id when changing mode of transport
         //Names are generated from all the streets in a corner, same as names in origin and destination
         //We use name in TemporaryStreetLocation since this name generation already happened when temporary location was generated
         if (vertex instanceof StreetVertex && !(vertex instanceof TemporaryStreetLocation)) {
-            name = ((StreetVertex) vertex).getIntersectionName().toString(requestedLocale);
+            name = ((StreetVertex) vertex).getIntersectionName();
         }
 
         if (vertex instanceof TransitStopVertex) {
             return Place.forStop(((TransitStopVertex) vertex).getStop());
         } else if(vertex instanceof VehicleRentalStationVertex) {
-            return Place.forVehicleRentalPlace((VehicleRentalStationVertex) vertex, name);
+            return Place.forVehicleRentalPlace((VehicleRentalStationVertex) vertex);
         } else if (vertex instanceof VehicleParkingEntranceVertex) {
-            return Place.forVehicleParkingEntrance((VehicleParkingEntranceVertex) vertex, name, state.getOptions());
+            return Place.forVehicleParkingEntrance((VehicleParkingEntranceVertex) vertex, state.getOptions());
         } else {
             return Place.normal(vertex, name);
         }
@@ -516,7 +513,7 @@ public abstract class GraphPathToItineraryMapper {
      * 
      * @param previous a non-transit leg that immediately precedes this one (bike-walking, say), or null
      */
-    public static List<WalkStep> generateWalkSteps(Graph graph, State[] states, WalkStep previous, Locale requestedLocale) {
+    public static List<WalkStep> generateWalkSteps(Graph graph, State[] states, WalkStep previous) {
         List<WalkStep> steps = new ArrayList<>();
         WalkStep step = null;
         double lastAngle = 0, distance = 0; // distance used for appending elevation profiles
@@ -554,7 +551,7 @@ public abstract class GraphPathToItineraryMapper {
             // before or will come after
             if (edge instanceof ElevatorAlightEdge) {
                 // don't care what came before or comes after
-                step = createWalkStep(graph, forwardState, backState, requestedLocale);
+                step = createWalkStep(graph, forwardState, backState);
                 createdNewStep = true;
                 disableZagRemovalForThisStep = true;
 
@@ -564,7 +561,7 @@ public abstract class GraphPathToItineraryMapper {
                 // exit != null and uses to <exit>
                 // the floor name is the AlightEdge name
                 // reset to avoid confusion with 'Elevator on floor 1 to floor 1'
-                step.streetName = edge.getName().toString(requestedLocale);
+                step.streetName = edge.getName();
 
                 step.relativeDirection = RelativeDirection.ELEVATOR;
 
@@ -572,7 +569,7 @@ public abstract class GraphPathToItineraryMapper {
                 continue;
             }
 
-            String streetName = edge.getName().toString(requestedLocale);
+            String streetName = edge.getName().toString();
             int idx = streetName.indexOf('(');
             String streetNameNoParens;
             if (idx > 0)
@@ -582,7 +579,7 @@ public abstract class GraphPathToItineraryMapper {
 
             if (step == null) {
                 // first step
-                step = createWalkStep(graph, forwardState, backState, requestedLocale);
+                step = createWalkStep(graph, forwardState, backState);
                 createdNewStep = true;
 
                 steps.add(step);
@@ -610,7 +607,7 @@ public abstract class GraphPathToItineraryMapper {
                     roundaboutExit = 0;
                 }
                 /* start a new step */
-                step = createWalkStep(graph, forwardState, backState, requestedLocale);
+                step = createWalkStep(graph, forwardState, backState);
                 createdNewStep = true;
 
                 steps.add(step);
@@ -618,7 +615,7 @@ public abstract class GraphPathToItineraryMapper {
                     // indicate that we are now on a roundabout
                     // and use one-based exit numbering
                     roundaboutExit = 1;
-                    roundaboutPreviousStreet = backState.getBackEdge().getName().toString(requestedLocale);
+                    roundaboutPreviousStreet = backState.getBackEdge().getName().toString();
                     idx = roundaboutPreviousStreet.indexOf('(');
                     if (idx > 0)
                         roundaboutPreviousStreet = roundaboutPreviousStreet.substring(0, idx - 1);
@@ -655,7 +652,7 @@ public abstract class GraphPathToItineraryMapper {
                         // the next edges will be PlainStreetEdges, we hope
                         double angleDiff = getAbsoluteAngleDiff(thisAngle, lastAngle);
                         for (Edge alternative : backState.getVertex().getOutgoingStreetEdges()) {
-                            if (alternative.getName().toString(requestedLocale).equals(streetName)) {
+                            if (alternative.getName().toString().equals(streetName)) {
                                 // alternatives that have the same name
                                 // are usually caused by street splits
                                 continue;
@@ -680,7 +677,7 @@ public abstract class GraphPathToItineraryMapper {
                                 continue; // this is not an alternative
                             }
                             alternative = alternatives.get(0);
-                            if (alternative.getName().equals(streetName)) {
+                            if (alternative.getName().toString().equals(streetName)) {
                                 // alternatives that have the same name
                                 // are usually caused by street splits
                                 continue;
@@ -697,7 +694,7 @@ public abstract class GraphPathToItineraryMapper {
 
                     if (shouldGenerateContinue) {
                         // turn to stay on same-named street
-                        step = createWalkStep(graph, forwardState, backState, requestedLocale);
+                        step = createWalkStep(graph, forwardState, backState);
                         createdNewStep = true;
                         steps.add(step);
                         step.setDirections(lastAngle, thisAngle, false);
@@ -838,11 +835,11 @@ public abstract class GraphPathToItineraryMapper {
         return angleDiff;
     }
 
-    private static WalkStep createWalkStep(Graph graph, State forwardState, State backState, Locale wantedLocale) {
+    private static WalkStep createWalkStep(Graph graph, State forwardState, State backState) {
         Edge en = forwardState.getBackEdge();
         WalkStep step;
         step = new WalkStep();
-        step.streetName = en.getName().toString(wantedLocale);
+        step.streetName = en.getName();
         step.startLocation = new WgsCoordinate(
                 backState.getVertex().getLat(),
                 backState.getVertex().getLon()

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
@@ -95,9 +95,7 @@ public class RaptorPathToItineraryMapper {
         while (!pathLeg.isEgressLeg()) {
             // Map transit leg
             if (pathLeg.isTransitLeg()) {
-                transitLeg = mapTransitLeg(
-                        request, transitLeg, pathLeg.asTransitLeg(), firstLeg
-                );
+                transitLeg = mapTransitLeg(transitLeg, pathLeg.asTransitLeg(), firstLeg);
                 firstLeg = false;
                 legs.add(transitLeg);
             }
@@ -139,8 +137,7 @@ public class RaptorPathToItineraryMapper {
 
         GraphPath graphPath = new GraphPath(accessPath.getLastState());
 
-        Itinerary subItinerary = GraphPathToItineraryMapper
-            .generateItinerary(graphPath, request.locale);
+        Itinerary subItinerary = GraphPathToItineraryMapper.generateItinerary(graphPath);
 
         if (subItinerary.legs.isEmpty()) { return List.of(); }
 
@@ -150,7 +147,6 @@ public class RaptorPathToItineraryMapper {
     }
 
     private Leg mapTransitLeg(
-            RoutingRequest request,
             Leg prevTransitLeg,
             TransitPathLeg<TripSchedule> pathLeg,
             boolean firstLeg
@@ -227,8 +223,7 @@ public class RaptorPathToItineraryMapper {
         AlertToLegMapper.addTransitAlertPatchesToLeg(
             graph,
             leg,
-            firstLeg,
-            request.locale
+            firstLeg
         );
 
         return leg;
@@ -251,8 +246,7 @@ public class RaptorPathToItineraryMapper {
 
         GraphPath graphPath = new GraphPath(egressPath.getLastState());
 
-        Itinerary subItinerary = GraphPathToItineraryMapper
-            .generateItinerary(graphPath, request.locale);
+        Itinerary subItinerary = GraphPathToItineraryMapper.generateItinerary(graphPath);
 
         if (subItinerary.legs.isEmpty()) { return null; }
 
@@ -302,8 +296,7 @@ public class RaptorPathToItineraryMapper {
                 State[] states = transferStates.toArray(new State[0]);
                 GraphPath graphPath = new GraphPath(states[states.length - 1]);
 
-                Itinerary subItinerary = GraphPathToItineraryMapper
-                        .generateItinerary(graphPath, request.locale);
+                Itinerary subItinerary = GraphPathToItineraryMapper.generateItinerary(graphPath);
 
                 if (subItinerary.legs.isEmpty()) {
                     return List.of();

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/router/street/DirectStreetRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/router/street/DirectStreetRouter.java
@@ -35,7 +35,7 @@ public class DirectStreetRouter {
       List<GraphPath> paths = gpFinder.graphPathFinderEntryPoint(directRequest);
 
       // Convert the internal GraphPaths to itineraries
-      List<Itinerary> response = GraphPathToItineraryMapper.mapItineraries(paths, directRequest);
+      List<Itinerary> response = GraphPathToItineraryMapper.mapItineraries(paths);
       ItinerariesHelper.decorateItinerariesWithRequestData(response, directRequest);
       return response;
     }

--- a/src/main/java/org/opentripplanner/routing/edgetype/AreaEdgeList.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/AreaEdgeList.java
@@ -106,10 +106,10 @@ public class AreaEdgeList implements Serializable {
 
             double length = SphericalDistanceLibrary.distance(to.getCoordinate(), from.getCoordinate());
 
-            AreaEdge forward = new AreaEdge(from, to, line, area.getRawName(), length,
+            AreaEdge forward = new AreaEdge(from, to, line, area.getName(), length,
                     area.getPermission(), false, this);
             forward.setStreetClass(area.getStreetClass());
-            AreaEdge backward = new AreaEdge(to, from, (LineString) line.reverse(), area.getRawName(),
+            AreaEdge backward = new AreaEdge(to, from, (LineString) line.reverse(), area.getName(),
                     length, area.getPermission(), true, this);
             backward.setStreetClass(area.getStreetClass());
         }

--- a/src/main/java/org/opentripplanner/routing/edgetype/ElevatorAlightEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/ElevatorAlightEdge.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.routing.edgetype;
 
-import java.util.Locale;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.common.geometry.GeometryUtils;
@@ -9,6 +8,7 @@ import org.opentripplanner.routing.core.StateEditor;
 import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.vertextype.ElevatorOffboardVertex;
 import org.opentripplanner.routing.vertextype.ElevatorOnboardVertex;
+import org.opentripplanner.util.I18NString;
 
 /**
  * A relatively low cost edge for alighting from an elevator.
@@ -24,7 +24,7 @@ public class ElevatorAlightEdge extends Edge implements BikeWalkableEdge, Elevat
     /**
      * This is the level of this elevator exit, used in narrative generation.
      */
-    private String level;
+    private I18NString level;
 
     /**
      * The polyline geometry of this edge.
@@ -36,7 +36,7 @@ public class ElevatorAlightEdge extends Edge implements BikeWalkableEdge, Elevat
     /**
      * @param level It's a float for future expansion.
      */
-    public ElevatorAlightEdge(ElevatorOnboardVertex from, ElevatorOffboardVertex to, String level) {
+    public ElevatorAlightEdge(ElevatorOnboardVertex from, ElevatorOffboardVertex to, I18NString level) {
         super(from, to);
         this.level = level;
 
@@ -64,11 +64,11 @@ public class ElevatorAlightEdge extends Edge implements BikeWalkableEdge, Elevat
         return the_geom;
     }
 
-    /** 
+    /**
      * The level from OSM is the name
      */
     @Override
-    public String getName() {
+    public I18NString getName() {
         return level;
     }
 
@@ -85,9 +85,4 @@ public class ElevatorAlightEdge extends Edge implements BikeWalkableEdge, Elevat
         return "ElevatorAlightEdge(" + fromv + " -> " + tov + ")";
     }
 
-    @Override
-    public String getName(Locale locale) {
-        //FIXME: no localization currently
-        return level;
-    }
 }

--- a/src/main/java/org/opentripplanner/routing/edgetype/ElevatorBoardEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/ElevatorBoardEdge.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.routing.edgetype;
 
-import java.util.Locale;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.common.geometry.GeometryUtils;
@@ -10,6 +9,8 @@ import org.opentripplanner.routing.core.StateEditor;
 import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.vertextype.ElevatorOffboardVertex;
 import org.opentripplanner.routing.vertextype.ElevatorOnboardVertex;
+import org.opentripplanner.util.I18NString;
+import org.opentripplanner.util.NonLocalizedString;
 
 
 /**
@@ -63,9 +64,9 @@ public class ElevatorBoardEdge extends Edge implements BikeWalkableEdge, Elevato
     }
 
     @Override
-    public String getName() {
+    public I18NString getName() {
         // TODO: i18n
-        return "Elevator";
+        return new NonLocalizedString( "Elevator");
     }
 
     /** 
@@ -80,11 +81,5 @@ public class ElevatorBoardEdge extends Edge implements BikeWalkableEdge, Elevato
     
     public String toString() {
         return "ElevatorBoardEdge(" + fromv + " -> " + tov + ")";
-    }
-
-    @Override
-    public String getName(Locale locale) {
-        //TODO: localize
-        return this.getName();
     }
 }

--- a/src/main/java/org/opentripplanner/routing/edgetype/ElevatorHopEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/ElevatorHopEdge.java
@@ -8,7 +8,7 @@ import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Vertex;
 
 import org.locationtech.jts.geom.LineString;
-import java.util.Locale;
+import org.opentripplanner.util.I18NString;
 
 /**
  * A relatively low cost edge for travelling one level in an elevator.
@@ -85,7 +85,7 @@ public class ElevatorHopEdge extends Edge implements ElevatorEdge {
     }
 
     @Override
-    public String getName() {
+    public I18NString getName() {
         return null;
     }
 
@@ -95,10 +95,5 @@ public class ElevatorHopEdge extends Edge implements ElevatorEdge {
 
     public String toString() {
         return "ElevatorHopEdge(" + fromv + " -> " + tov + ")";
-    }
-
-    @Override
-    public String getName(Locale locale) {
-        return this.getName();
     }
 }

--- a/src/main/java/org/opentripplanner/routing/edgetype/FreeEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/FreeEdge.java
@@ -6,7 +6,7 @@ import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Vertex;
 
 import org.locationtech.jts.geom.LineString;
-import java.util.Locale;
+import org.opentripplanner.util.I18NString;
 
 /**
  * An edge that costs nothing to traverse. Used for connecting intersection vertices to the main
@@ -42,13 +42,8 @@ public class FreeEdge extends Edge {
     }
 
     @Override
-    public String getName() {
+    public I18NString getName() {
         return null;
-    }
-
-    @Override
-    public String getName(Locale locale) {
-        return this.getName();
     }
 
     public String toString() {

--- a/src/main/java/org/opentripplanner/routing/edgetype/NamedArea.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/NamedArea.java
@@ -25,11 +25,7 @@ public class NamedArea implements Serializable {
 
     private StreetTraversalPermission permission;
 
-    public String getName() {
-        return name.toString();
-    }
-
-    public I18NString getRawName() {
+    public I18NString getName() {
         return name;
     }
 

--- a/src/main/java/org/opentripplanner/routing/edgetype/PathwayEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/PathwayEdge.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.routing.edgetype;
 
+import java.util.Objects;
 import org.opentripplanner.common.geometry.GeometryUtils;
 import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.routing.core.State;
@@ -10,7 +11,8 @@ import org.opentripplanner.routing.graph.Vertex;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.routing.core.TraverseMode;
-import java.util.Locale;
+import org.opentripplanner.util.I18NString;
+import org.opentripplanner.util.NonLocalizedString;
 
 /**
  * A walking pathway as described in GTFS
@@ -18,44 +20,40 @@ import java.util.Locale;
 public class PathwayEdge extends Edge implements BikeWalkableEdge {
 
     private static final long serialVersionUID = -3311099256178798982L;
+    public static final I18NString DEFAULT_NAME = new NonLocalizedString("pathway");
 
+    private final I18NString name;
     private int traversalTime;
     private double distance;
     private int steps;
     private double angle;
-    private String name = "pathway";
 
     private boolean wheelchairAccessible = true;
     private FeedScopedId id;
 
-    public PathwayEdge(Vertex fromv, Vertex tov, String name) {
+    public PathwayEdge(Vertex fromv, Vertex tov, I18NString name) {
         super(fromv, tov);
-        if (name != null) this.name = name;
+        this.name = Objects.requireNonNullElse(name, DEFAULT_NAME);
     }
 
     public PathwayEdge(
         Vertex fromv,
         Vertex tov,
         FeedScopedId id,
-        String name,
+        I18NString name,
         int traversalTime,
         double distance,
         int steps,
         double angle,
         boolean wheelchairAccessible
     ) {
-        super(fromv, tov);
+        this(fromv, tov, name != null ? name : tov.getName());
         this.id = id;
         this.traversalTime = traversalTime;
         this.distance = distance;
         this.steps = steps;
         this.angle = angle;
         this.wheelchairAccessible = wheelchairAccessible;
-        if (name != null) {
-            this.name = name;
-        } else if (tov.getName() != null) {
-            this.name = tov.getName();
-        }
     }
 
     public String getDirection() {
@@ -86,14 +84,9 @@ public class PathwayEdge extends Edge implements BikeWalkableEdge {
         return GeometryUtils.getGeometryFactory().createLineString(coordinates);
     }
 
-    public String getName() {
-        return name;
-    }
-
     @Override
-    public String getName(Locale locale) {
-        //TODO: localize
-        return this.getName();
+    public I18NString getName() {
+        return name;
     }
 
     public void setWheelchairAccessible(boolean wheelchairAccessible) {

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
@@ -5,7 +5,6 @@ import java.io.ObjectOutputStream;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.Locale;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.common.TurnRestriction;
@@ -612,21 +611,12 @@ public class StreetEdge extends Edge implements BikeWalkableEdge, Cloneable, Car
         return true;
     }
 
-	@Override
-	public String getName() {
-		return this.name.toString();
-	}
-
 	/**
 	* Gets non-localized I18NString (Used when splitting edges)
 	* @return non-localized Name
 	*/
-	public I18NString getRawName() {
+	public I18NString getName() {
 		return this.name;
-	}
-
-	public String getName(Locale locale) {
-		return this.name.toString(locale);
 	}
 
 	public void setName(I18NString name) {

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetTransitEntityLink.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetTransitEntityLink.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.routing.edgetype;
 
-import java.util.Locale;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.common.geometry.GeometryUtils;
@@ -11,6 +10,7 @@ import org.opentripplanner.routing.core.StateEditor;
 import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.routing.vertextype.StreetVertex;
+import org.opentripplanner.util.I18NString;
 
 /**
  * This represents the connection between a street vertex and a transit vertex.
@@ -55,13 +55,8 @@ public abstract class StreetTransitEntityLink<T extends Vertex> extends Edge imp
         return GeometryUtils.getGeometryFactory().createLineString(coordinates);
     }
 
-    public String getName() {
+    public I18NString getName() {
         return this.transitEntityVertex.getName();
-    }
-
-    public String getName(Locale locale) {
-        //TODO: localize
-        return getName();
     }
 
 

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetVehicleParkingLink.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetVehicleParkingLink.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.routing.edgetype;
 
-import java.util.Locale;
 import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.core.State;
@@ -10,6 +9,7 @@ import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.vehicle_parking.VehicleParking;
 import org.opentripplanner.routing.vertextype.StreetVertex;
 import org.opentripplanner.routing.vertextype.VehicleParkingEntranceVertex;
+import org.opentripplanner.util.I18NString;
 
 /**
  * This represents the connection between a street vertex and a vehicle parking vertex.
@@ -40,12 +40,8 @@ public class StreetVehicleParkingLink extends Edge {
         return null;
     }
 
-    public String getName() {
+    public I18NString getName() {
         return vehicleParkingEntranceVertex.getName();
-    }
-
-    public String getName(Locale locale) {
-        return vehicleParkingEntranceVertex.getName(locale);
     }
 
     public State traverse(State s0) {

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetVehicleRentalLink.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetVehicleRentalLink.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.routing.edgetype;
 
-import java.util.Locale;
 import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.core.StateEditor;
@@ -8,6 +7,7 @@ import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.routing.vertextype.StreetVertex;
 import org.opentripplanner.routing.vertextype.VehicleRentalStationVertex;
+import org.opentripplanner.util.I18NString;
 
 /**
  * This represents the connection between a street vertex and a bike rental station vertex.
@@ -41,13 +41,9 @@ public class StreetVehicleRentalLink extends Edge {
         return null;
     }
 
-    public String getName() {
-        return vehicleRentalStationVertex.getName();
-    }
-
     @Override
-    public String getName(Locale locale) {
-        return vehicleRentalStationVertex.getName(locale);
+    public I18NString getName() {
+        return vehicleRentalStationVertex.getName();
     }
 
     public State traverse(State s0) {

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetWithElevationEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetWithElevationEdge.java
@@ -114,7 +114,7 @@ public class StreetWithElevationEdge extends StreetEdge {
 
     @Override
     public String toString() {
-        return "StreetWithElevationEdge(" + getName() + ", " + fromv + " -> "
+        return "StreetWithElevationEdge(" + getDefaultName() + ", " + fromv + " -> "
                 + tov + " length=" + this.getDistanceMeters() + " carSpeed=" + this.getCarSpeed()
                 + " permission=" + this.getPermission() + ")";
     }

--- a/src/main/java/org/opentripplanner/routing/edgetype/TemporaryPartialStreetEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/TemporaryPartialStreetEdge.java
@@ -131,7 +131,7 @@ final public class TemporaryPartialStreetEdge extends StreetWithElevationEdge im
 
     @Override
     public String toString() {
-        return "TemporaryPartialStreetEdge(" + this.getName() + ", " + this.getFromVertex() + " -> "
+        return "TemporaryPartialStreetEdge(" + this.getDefaultName() + ", " + this.getFromVertex() + " -> "
                 + this.getToVertex() + " length=" + this.getDistanceMeters() + " carSpeed="
                 + this.getCarSpeed() + " parentEdge=" + parentEdge + ")";
     }

--- a/src/main/java/org/opentripplanner/routing/edgetype/VehicleParkingEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/VehicleParkingEdge.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.routing.edgetype;
 
-import java.util.Locale;
 import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.core.State;
@@ -9,6 +8,7 @@ import org.opentripplanner.routing.core.TraverseMode;
 import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.vehicle_parking.VehicleParking;
 import org.opentripplanner.routing.vertextype.VehicleParkingEntranceVertex;
+import org.opentripplanner.util.I18NString;
 
 /**
  * Parking a vehicle edge.
@@ -122,13 +122,8 @@ public class VehicleParkingEdge extends Edge {
     }
 
     @Override
-    public String getName() {
+    public I18NString getName() {
         return getToVertex().getName();
-    }
-
-    @Override
-    public String getName(Locale locale) {
-        return getToVertex().getName(locale);
     }
 
     @Override

--- a/src/main/java/org/opentripplanner/routing/edgetype/VehicleRentalEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/VehicleRentalEdge.java
@@ -1,15 +1,14 @@
 package org.opentripplanner.routing.edgetype;
 
-import java.util.Locale;
 import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.core.StateEditor;
-import org.opentripplanner.routing.core.TraverseMode;
 import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.vehicle_rental.RentalVehicleType.FormFactor;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalPlace;
 import org.opentripplanner.routing.vertextype.VehicleRentalStationVertex;
+import org.opentripplanner.util.I18NString;
 
 /**
  * Renting or dropping off a rented vehicle edge.
@@ -154,13 +153,8 @@ public class VehicleRentalEdge extends Edge {
     }
 
     @Override
-    public String getName() {
+    public I18NString getName() {
         return getToVertex().getName();
-    }
-
-    @Override
-    public String getName(Locale locale) {
-        return getToVertex().getName(locale);
     }
 
     @Override

--- a/src/main/java/org/opentripplanner/routing/graph/Edge.java
+++ b/src/main/java/org/opentripplanner/routing/graph/Edge.java
@@ -9,7 +9,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
-import java.util.Locale;
+import org.opentripplanner.util.I18NString;
 
 /**
  * This is the standard implementation of an edge with fixed from and to Vertex instances;
@@ -107,17 +107,17 @@ public abstract class Edge implements Serializable {
     public abstract State traverse(State s0);
 
     /**
-     * Gets english localized name
-     * @return english localized name
+     * Returns the default name of the edge
      */
-    public abstract String getName();
+    public String getDefaultName() {
+        I18NString name = getName();
+        return name != null ? name.toString() : null;
+    }
 
     /**
-     * Gets wanted localization
-     * @param locale wanted locale
-     * @return Localized in specified locale name
+     * Returns the name of the edge
      */
-    public abstract String getName(Locale locale);
+    public abstract I18NString getName();
 
     // TODO Add comments about what a "bogus name" is.
     public boolean hasBogusName() {

--- a/src/main/java/org/opentripplanner/routing/graph/Vertex.java
+++ b/src/main/java/org/opentripplanner/routing/graph/Vertex.java
@@ -201,18 +201,15 @@ public abstract class Vertex implements Serializable, Cloneable {
         return y;
     }
 
-
-    /** If this vertex is located on only one street, get that street's name
-     * in english localization */
-    public String getName() {
-        return this.name.toString();
+    /** If this vertex is located on only one street, get that street's name */
+    public I18NString getName() {
+        return this.name;
     }
 
-    /** If this vertex is located on only one street, get that street's name
-     * in provided localization
-     * @param locale wanted localization */
-    public String getName(Locale locale) {
-        return this.name.toString(locale);
+    /** If this vertex is located on only one street, get that street's name in default localization
+     */
+    public String getDefaultName() {
+        return this.name.toString();
     }
 
     /** Get the corresponding StationElement if this is a transit vertex */

--- a/src/main/java/org/opentripplanner/routing/impl/LoggingTraverseVisitor.java
+++ b/src/main/java/org/opentripplanner/routing/impl/LoggingTraverseVisitor.java
@@ -11,7 +11,7 @@ public class LoggingTraverseVisitor implements TraverseVisitor {
 
     @Override
     public void visitEdge(Edge edge, State state) {
-        String nextName = edge.getName();
+        String nextName = edge.getDefaultName();
         LOG.info("Traversing edge {}", nextName);
     }
 

--- a/src/main/java/org/opentripplanner/routing/vertextype/ElevatorOffboardVertex.java
+++ b/src/main/java/org/opentripplanner/routing/vertextype/ElevatorOffboardVertex.java
@@ -1,14 +1,14 @@
 package org.opentripplanner.routing.vertextype;
 
 import org.opentripplanner.routing.graph.Graph;
-import org.opentripplanner.util.NonLocalizedString;
+import org.opentripplanner.util.I18NString;
 
 public class ElevatorOffboardVertex extends StreetVertex {
 
     private static final long serialVersionUID = 20120209L;
 
-    public ElevatorOffboardVertex(Graph g, String label, double x, double y, String name) {
-        super(g, label, x, y, new NonLocalizedString(name));
+    public ElevatorOffboardVertex(Graph g, String label, double x, double y, I18NString name) {
+        super(g, label, x, y, name);
     }
 
 }

--- a/src/main/java/org/opentripplanner/routing/vertextype/ElevatorOnboardVertex.java
+++ b/src/main/java/org/opentripplanner/routing/vertextype/ElevatorOnboardVertex.java
@@ -1,14 +1,14 @@
 package org.opentripplanner.routing.vertextype;
 
 import org.opentripplanner.routing.graph.Graph;
-import org.opentripplanner.util.NonLocalizedString;
+import org.opentripplanner.util.I18NString;
 
 public class ElevatorOnboardVertex extends StreetVertex {
 
     private static final long serialVersionUID = 20120209L;
 
-    public ElevatorOnboardVertex(Graph g, String label, double x, double y, String name) {
-        super(g, label, x, y, new NonLocalizedString(name));
+    public ElevatorOnboardVertex(Graph g, String label, double x, double y, I18NString name) {
+        super(g, label, x, y, name);
     }
 
 }

--- a/src/main/java/org/opentripplanner/routing/vertextype/StreetVertex.java
+++ b/src/main/java/org/opentripplanner/routing/vertextype/StreetVertex.java
@@ -42,25 +42,26 @@ public abstract class StreetVertex extends Vertex {
      *  - unnamedStreed (localized in requested language) if it doesn't have a name
      *  - corner of 0 and 1 (localized corner of zero and first street in the corner)
      *
-     * @param locale Wanted locale
      * @return already localized street names and non-localized corner of x and unnamedStreet
      */
-    public I18NString getIntersectionName(Locale locale) {
+    public I18NString getIntersectionName() {
         I18NString calculatedName = null;
         // generate names for corners when no name was given
-        Set<String> uniqueNameSet = new HashSet<String>();
+        Set<I18NString> uniqueNameSet = new HashSet<>();
         for (Edge e : getOutgoing()) {
             if (e instanceof StreetEdge) {
-                uniqueNameSet.add(e.getName(locale));
+                uniqueNameSet.add(e.getName());
             }
         }
-        List<String> uniqueNames = new ArrayList<String>(uniqueNameSet);
+        List<I18NString> uniqueNames = new ArrayList<>(uniqueNameSet);
 
         if (uniqueNames.size() > 1) {
-            calculatedName = new LocalizedString("corner", new String[]{uniqueNames.get(0),
-                uniqueNames.get(1)});
+            calculatedName = locale -> new LocalizedString("corner", new String[]{
+                    uniqueNames.get(0).toString(locale),
+                    uniqueNames.get(1).toString(locale)
+            }).toString(locale);
         } else if (uniqueNames.size() == 1) {
-            calculatedName = new NonLocalizedString(uniqueNames.get(0));
+            calculatedName = uniqueNames.get(0);
         } else {
             calculatedName = new LocalizedString("unnamedStreet", (String[]) null);
         }

--- a/src/main/java/org/opentripplanner/routing/vertextype/TransitBoardingAreaVertex.java
+++ b/src/main/java/org/opentripplanner/routing/vertextype/TransitBoardingAreaVertex.java
@@ -5,6 +5,7 @@ import org.opentripplanner.model.StationElement;
 import org.opentripplanner.model.WheelChairBoarding;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
+import org.opentripplanner.util.NonLocalizedString;
 
 public class TransitBoardingAreaVertex extends Vertex {
   private static final long serialVersionUID = 1L;
@@ -21,17 +22,13 @@ public class TransitBoardingAreaVertex extends Vertex {
         graph,
         boardingArea.getId().toString(),
         boardingArea.getCoordinate().longitude(),
-        boardingArea.getCoordinate().latitude()
+        boardingArea.getCoordinate().latitude(),
+        new NonLocalizedString(boardingArea.getName())
     );
     this.boardingArea = boardingArea;
     this.wheelchairAccessible = boardingArea.getWheelchairBoarding() != WheelChairBoarding.NOT_POSSIBLE;
     //Adds this vertex into graph envelope so that we don't need to loop over all vertices
     graph.expandToInclude(boardingArea.getCoordinate().longitude(), boardingArea.getCoordinate().latitude());
-  }
-
-  @Override
-  public String getName() {
-    return boardingArea.getName();
   }
 
   public boolean isWheelchairAccessible() {

--- a/src/main/java/org/opentripplanner/routing/vertextype/TransitEntranceVertex.java
+++ b/src/main/java/org/opentripplanner/routing/vertextype/TransitEntranceVertex.java
@@ -5,6 +5,7 @@ import org.opentripplanner.model.StationElement;
 import org.opentripplanner.model.WheelChairBoarding;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
+import org.opentripplanner.util.NonLocalizedString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,17 +27,13 @@ public class TransitEntranceVertex extends Vertex {
         graph,
         entrance.getId().toString(),
         entrance.getCoordinate().longitude(),
-        entrance.getCoordinate().latitude()
+        entrance.getCoordinate().latitude(),
+        new NonLocalizedString(entrance.getName())
     );
     this.entrance = entrance;
     this.wheelchairEntrance = entrance.getWheelchairBoarding() != WheelChairBoarding.NOT_POSSIBLE;
     //Adds this vertex into graph envelope so that we don't need to loop over all vertices
     graph.expandToInclude(entrance.getCoordinate().longitude(), entrance.getCoordinate().latitude());
-  }
-
-  @Override
-  public String getName() {
-    return entrance.getName();
   }
 
   public boolean isWheelchairEntrance() {

--- a/src/main/java/org/opentripplanner/routing/vertextype/TransitPathwayNodeVertex.java
+++ b/src/main/java/org/opentripplanner/routing/vertextype/TransitPathwayNodeVertex.java
@@ -5,6 +5,7 @@ import org.opentripplanner.model.StationElement;
 import org.opentripplanner.model.WheelChairBoarding;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
+import org.opentripplanner.util.NonLocalizedString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,17 +27,13 @@ public class TransitPathwayNodeVertex extends Vertex {
         graph,
         node.getId().toString(),
         node.getCoordinate().longitude(),
-        node.getCoordinate().latitude()
+        node.getCoordinate().latitude(),
+        new NonLocalizedString(node.getName())
     );
     this.node = node;
     this.wheelchairEntrance = node.getWheelchairBoarding() != WheelChairBoarding.NOT_POSSIBLE;
     //Adds this vertex into graph envelope so that we don't need to loop over all vertices
     graph.expandToInclude(node.getCoordinate().longitude(), node.getCoordinate().latitude());
-  }
-
-  @Override
-  public String getName() {
-    return node.getName();
   }
 
   public boolean isWheelchairEntrance() {

--- a/src/main/java/org/opentripplanner/routing/vertextype/TransitStopVertex.java
+++ b/src/main/java/org/opentripplanner/routing/vertextype/TransitStopVertex.java
@@ -9,6 +9,7 @@ import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.model.TransitMode;
+import org.opentripplanner.util.NonLocalizedString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,7 +45,13 @@ public class TransitStopVertex extends Vertex {
      * @param modes Set of modes for all Routes using this stop. If {@code null} an empty set is used.
      */
     public TransitStopVertex (Graph graph, Stop stop, Set<TransitMode> modes) {
-        super(graph, stop.getId().toString(), stop.getLon(), stop.getLat());
+        super(
+                graph,
+                stop.getId().toString(),
+                stop.getLon(),
+                stop.getLat(),
+                new NonLocalizedString(stop.getName())
+        );
         this.stop = stop;
         this.modes = modes != null ? modes : new HashSet<>();
         this.wheelchairEntrance = stop.getWheelchairBoarding() != WheelChairBoarding.NOT_POSSIBLE;
@@ -89,16 +96,6 @@ public class TransitStopVertex extends Vertex {
 
     public Stop getStop() {
             return this.stop;
-    }
-
-    @Override
-    public String getName() {
-        return stop.getName();
-    }
-
-    @Override
-    public String getName(Locale locale) {
-        return stop.getName();
     }
 
     @Override

--- a/src/main/java/org/opentripplanner/visualizer/GraphVisualizer.java
+++ b/src/main/java/org/opentripplanner/visualizer/GraphVisualizer.java
@@ -96,7 +96,7 @@ class DisplayVertex {
     public String toString() {
         String label = vertex.getLabel();
         if (label.contains("osm node")) {
-            label = vertex.getName();
+            label = vertex.getDefaultName();
         }
         return label;
     }
@@ -931,7 +931,7 @@ public class GraphVisualizer extends JFrame implements VertexSelectionListener {
                         JOptionPane.PLAIN_MESSAGE);
                 for (Vertex gv : getGraph().getVertices()) {
                     for (Edge edge : gv.getOutgoing()) {
-                        if (edge.getName() != null && edge.getName().contains(edgeName)) {
+                        if (edge.getDefaultName() != null && edge.getDefaultName().contains(edgeName)) {
                             showGraph.highlightVertex(gv);
                             ArrayList<Vertex> l = new ArrayList<Vertex>();
                             l.add(gv);

--- a/src/test/java/org/opentripplanner/GtfsTest.java
+++ b/src/test/java/org/opentripplanner/GtfsTest.java
@@ -137,9 +137,7 @@ public abstract class GtfsTest extends TestCase {
         routingRequest.setWalkBoardCost(30);
 
         List<GraphPath> paths = new GraphPathFinder(router).getPaths(routingRequest);
-        List<Itinerary> itineraries = GraphPathToItineraryMapper.mapItineraries(
-                paths, routingRequest
-        );
+        List<Itinerary> itineraries = GraphPathToItineraryMapper.mapItineraries(paths);
         // Stored in instance field for use in individual tests
         itinerary = itineraries.get(0);
 

--- a/src/test/java/org/opentripplanner/graph_builder/module/map/TestStreetMatcher.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/map/TestStreetMatcher.java
@@ -173,17 +173,7 @@ public class TestStreetMatcher {
         }
 
         @Override
-        public String getName() {
-            return null;
-        }
-
-        @Override
-        public I18NString getRawName() {
-            return null;
-        }
-
-        @Override
-        public String getName(Locale locale) {
+        public I18NString getName() {
             return null;
         }
 

--- a/src/test/java/org/opentripplanner/graph_builder/module/osm/TestIntermediatePlaces.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/osm/TestIntermediatePlaces.java
@@ -142,7 +142,7 @@ public class TestIntermediatePlaces {
         assertNotNull(paths);
         assertFalse(paths.isEmpty());
 
-        List<Itinerary> itineraries = GraphPathToItineraryMapper.mapItineraries(paths, request);
+        List<Itinerary> itineraries = GraphPathToItineraryMapper.mapItineraries(paths);
         TripPlan plan = TripPlanMapper.mapTripPlan(request, itineraries);
         assertLocationIsVeryCloseToPlace(from, plan.from);
         assertLocationIsVeryCloseToPlace(to, plan.to);

--- a/src/test/java/org/opentripplanner/graph_builder/module/osm/TestOpenStreetMapGraphBuilder.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/osm/TestOpenStreetMapGraphBuilder.java
@@ -16,7 +16,6 @@ import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.routing.impl.GraphPathFinder;
-import org.opentripplanner.routing.impl.StreetVertexIndex;
 import org.opentripplanner.routing.spt.GraphPath;
 import org.opentripplanner.routing.vertextype.IntersectionVertex;
 import org.opentripplanner.standalone.config.RouterConfig;
@@ -88,10 +87,10 @@ public class TestOpenStreetMapGraphBuilder extends TestCase {
         assertNotNull(e2);
         assertNotNull(e3);
 
-        assertTrue("name of e1 must be like \"Kamiennog\u00F3rska\"; was " + e1.getName(), e1
-                .getName().contains("Kamiennog\u00F3rska"));
-        assertTrue("name of e2 must be like \"Mariana Smoluchowskiego\"; was " + e2.getName(), e2
-                .getName().contains("Mariana Smoluchowskiego"));
+        assertTrue("name of e1 must be like \"Kamiennog\u00F3rska\"; was " + e1.getDefaultName(), e1
+                .getDefaultName().contains("Kamiennog\u00F3rska"));
+        assertTrue("name of e2 must be like \"Mariana Smoluchowskiego\"; was " + e2.getDefaultName(), e2
+                .getDefaultName().contains("Mariana Smoluchowskiego"));
     }
 
     /**

--- a/src/test/java/org/opentripplanner/graph_builder/module/osm/TestUnroutable.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/osm/TestUnroutable.java
@@ -61,7 +61,7 @@ public class TestUnroutable extends TestCase {
         if (path != null) {
             for (Edge edge : path.edges) {
                 assertFalse("Path should not use the as-yet unbuilt Tilikum Crossing bridge.",
-                        "Tilikum Crossing".equals(edge.getName()));
+                        "Tilikum Crossing".equals(edge.getDefaultName()));
             }
         }
     }

--- a/src/test/java/org/opentripplanner/graph_builder/module/shapefile/TestShapefileStreetGraphBuilderImpl.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/shapefile/TestShapefileStreetGraphBuilderImpl.java
@@ -106,10 +106,10 @@ public class TestShapefileStreetGraphBuilderImpl extends TestCase {
                 int numParks = 0;
                 int numCarltons = 0;
                 for (Edge e: v.getOutgoing()) {
-                    if (e.getToVertex().getName().contains("PARK")) {
+                    if (e.getToVertex().getDefaultName().contains("PARK")) {
                         numParks ++;
                     }
-                    if (e.getToVertex().getName().contains("CARLTON")) {
+                    if (e.getToVertex().getDefaultName().contains("CARLTON")) {
                         numCarltons ++;
                     }
                 }
@@ -127,10 +127,10 @@ public class TestShapefileStreetGraphBuilderImpl extends TestCase {
                 int numParks = 0;
 
                 for (Edge e: v.getOutgoing()) {
-                    if (e.getToVertex().getName().contains("FLATBUSH")) {
+                    if (e.getToVertex().getDefaultName().contains("FLATBUSH")) {
                         numFlatbushes ++;
                     }
-                    if (e.getToVertex().getName().contains("PARK")) {
+                    if (e.getToVertex().getDefaultName().contains("PARK")) {
                         numParks ++;
                     }
                 }

--- a/src/test/java/org/opentripplanner/routing/algorithm/BikeRentalTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/BikeRentalTest.java
@@ -560,7 +560,7 @@ public class BikeRentalTest extends GraphRoutingTest {
                         s.getBackMode(),
                         s.getVehicleRentalState(),
                         s.mayKeepRentedVehicleAtDestination() ? " (may keep)" : "",
-                        s.getBackEdge() != null ? s.getBackEdge().getName() : null,
+                        s.getBackEdge() != null ? s.getBackEdge().getDefaultName() : null,
                         s.getWeight(),
                         s.getElapsedTimeSeconds()
                 ))

--- a/src/test/java/org/opentripplanner/routing/algorithm/BikeWalkingTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/BikeWalkingTest.java
@@ -369,7 +369,7 @@ public class BikeWalkingTest extends GraphRoutingTest {
                                 ? ((double) Math.round(s.getWeightDelta() * 10)) / 10
                                 : 0.0,
                         s.getBackEdge() != null
-                                ? s.getBackEdge().getName()
+                                ? s.getBackEdge().getDefaultName()
                                 : null
                 ))
                 .collect(Collectors.toList());

--- a/src/test/java/org/opentripplanner/routing/algorithm/CarPickupTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/CarPickupTest.java
@@ -187,7 +187,7 @@ public class CarPickupTest extends GraphRoutingTest {
                 "%s - %s - %s",
                 s.getBackMode(),
                 s.getCarPickupState(),
-                s.getBackEdge() != null ? s.getBackEdge().getName() : null
+                s.getBackEdge() != null ? s.getBackEdge().getDefaultName() : null
         )).collect(Collectors.joining(", ")) : "path not found";
     }
 }

--- a/src/test/java/org/opentripplanner/routing/algorithm/GraphRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/GraphRoutingTest.java
@@ -103,7 +103,7 @@ public abstract class GraphRoutingTest {
             return new StreetEdge(from, to,
                     GeometryUtils.makeLineString(
                             from.getLat(), from.getLon(), to.getLat(), to.getLon()),
-                    String.format("%s%s street", from.getName(), to.getName()),
+                    String.format("%s%s street", from.getDefaultName(), to.getDefaultName()),
                     length,
                     permissions,
                     false
@@ -121,7 +121,7 @@ public abstract class GraphRoutingTest {
                     new StreetEdge(from, to,
                             GeometryUtils.makeLineString(
                                     from.getLat(), from.getLon(), to.getLat(), to.getLon()),
-                            String.format("%s%s street", from.getName(), to.getName()),
+                            String.format("%s%s street", from.getDefaultName(), to.getDefaultName()),
                             length,
                             forwardPermissions,
                             false
@@ -129,7 +129,7 @@ public abstract class GraphRoutingTest {
                     new StreetEdge(to, from,
                             GeometryUtils.makeLineString(
                                     to.getLat(), to.getLon(), from.getLat(), from.getLon()),
-                            String.format("%s%s street", from.getName(), to.getName()),
+                            String.format("%s%s street", from.getDefaultName(), to.getDefaultName()),
                             length,
                             reversePermissions,
                             true
@@ -170,22 +170,22 @@ public abstract class GraphRoutingTest {
             List<ElevatorOnboardVertex> onboardVertices = new ArrayList<>();
 
             for (Vertex v : vertices) {
-                var level = String.format("L-%s", v.getName());
+                var level = String.format("L-%s", v.getDefaultName());
                 var boardLabel = String.format("%s-onboard", level);
                 var alightLabel = String.format("%s-offboard", level);
 
                 var onboard = new ElevatorOnboardVertex(
-                        graph, boardLabel, v.getX(), v.getY(), boardLabel
+                        graph, boardLabel, v.getX(), v.getY(), new NonLocalizedString(boardLabel)
                 );
                 var offboard = new ElevatorOffboardVertex(
-                        graph, alightLabel, v.getX(), v.getY(), alightLabel
+                        graph, alightLabel, v.getX(), v.getY(), new NonLocalizedString(alightLabel)
                 );
 
                 new FreeEdge(v, offboard);
                 new FreeEdge(offboard, v);
 
                 edges.add(new ElevatorBoardEdge(offboard, onboard));
-                edges.add(new ElevatorAlightEdge(onboard, offboard, level));
+                edges.add(new ElevatorAlightEdge(onboard, offboard, new NonLocalizedString(level)));
 
                 onboardVertices.add(onboard);
             }
@@ -272,7 +272,7 @@ public abstract class GraphRoutingTest {
         public PathwayEdge pathway(Vertex from, Vertex to, int time, int length) {
             return new PathwayEdge(
                     from, to, null,
-                    String.format("%s%s pathway", from.getName(), to.getName()),
+                    new NonLocalizedString(String.format("%s%s pathway", from.getDefaultName(), to.getDefaultName())),
                     time, length, 0, 0, false
             );
         }
@@ -428,8 +428,8 @@ public abstract class GraphRoutingTest {
     public static String graphPathToString(GraphPath graphPath) {
         return graphPath.states.stream()
             .flatMap(s -> Stream.of(
-                s.getBackEdge() != null ? s.getBackEdge().getName() : null,
-                s.getVertex().getName()
+                s.getBackEdge() != null ? s.getBackEdge().getDefaultName() : null,
+                s.getVertex().getDefaultName()
             ))
             .filter(Objects::nonNull)
             .collect(Collectors.joining(" - "));

--- a/src/test/java/org/opentripplanner/routing/algorithm/ParkAndRideTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/ParkAndRideTest.java
@@ -24,7 +24,7 @@ public abstract class ParkAndRideTest extends GraphRoutingTest {
                 .map(s -> String.format("%s%s - %s (%,.2f, %d)",
                         s.getBackMode(),
                         s.isVehicleParked() ? " (parked)" : "",
-                        s.getBackEdge() != null ? s.getBackEdge().getName() : null,
+                        s.getBackEdge() != null ? s.getBackEdge().getDefaultName() : null,
                         s.getWeight(),
                         s.getElapsedTimeSeconds()
                 ))
@@ -129,7 +129,7 @@ public abstract class ParkAndRideTest extends GraphRoutingTest {
                         "%s%s - %s (%,.2f, %d)",
                         s.getBackMode(),
                         s.isVehicleParked() ? " (parked)" : "",
-                        s.getBackEdge() != null ? s.getBackEdge().getName() : null,
+                        s.getBackEdge() != null ? s.getBackEdge().getDefaultName() : null,
                         s.getWeight(),
                         s.getElapsedTimeSeconds()
                 ))

--- a/src/test/java/org/opentripplanner/routing/algorithm/StreetModeLinkingTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/StreetModeLinkingTest.java
@@ -181,7 +181,7 @@ public class StreetModeLinkingTest extends GraphRoutingTest {
                 .next();
         assertEquals(
                 streetName,
-                outgoing.getName(),
+                outgoing.getDefaultName(),
                 String.format("%s should be linked to %s", streetMode, streetName)
         );
     }
@@ -202,7 +202,7 @@ public class StreetModeLinkingTest extends GraphRoutingTest {
 
         assertEquals(
                 streetName,
-                outgoing.getName(),
+                outgoing.getDefaultName(),
                 streetMode + " should be linked to " + streetName
         );
     }

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/BikeRentalSnapshotTest.snap
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/BikeRentalSnapshotTest.snap
@@ -161,7 +161,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "departure": "2009-10-21T23:17:37.000+00:00",
             "lat": 45.5276173,
             "lon": -122.7003923,
-            "name": "corner of way -102328 from 0 and Northwest Irving Street",
+            "name": "corner of Northwest Irving Street and way -102328 from 0",
             "vertexType": "NORMAL"
           },
           "transitLeg": false,
@@ -178,7 +178,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "departure": "2009-10-21T23:17:37.000+00:00",
             "lat": 45.5276173,
             "lon": -122.7003923,
-            "name": "corner of way -102328 from 0 and Northwest Irving Street",
+            "name": "corner of Northwest Irving Street and way -102328 from 0",
             "vertexType": "NORMAL"
           },
           "generalizedCost": 236,
@@ -1780,7 +1780,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "departure": "2009-10-21T23:30:37.000+00:00",
             "lat": 45.5276173,
             "lon": -122.7003923,
-            "name": "corner of way -102328 from 0 and Northwest Irving Street",
+            "name": "corner of Northwest Irving Street and way -102328 from 0",
             "vertexType": "NORMAL"
           },
           "transitLeg": false,
@@ -1797,7 +1797,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "departure": "2009-10-21T23:30:37.000+00:00",
             "lat": 45.5276173,
             "lon": -122.7003923,
-            "name": "corner of way -102328 from 0 and Northwest Irving Street",
+            "name": "corner of Northwest Irving Street and way -102328 from 0",
             "vertexType": "NORMAL"
           },
           "generalizedCost": 236,
@@ -2265,7 +2265,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "departure": "2009-10-21T23:39:37.000+00:00",
             "lat": 45.5276173,
             "lon": -122.7003923,
-            "name": "corner of way -102328 from 0 and Northwest Irving Street",
+            "name": "corner of Northwest Irving Street and way -102328 from 0",
             "vertexType": "NORMAL"
           },
           "transitLeg": false,
@@ -2282,7 +2282,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "departure": "2009-10-21T23:39:37.000+00:00",
             "lat": 45.5276173,
             "lon": -122.7003923,
-            "name": "corner of way -102328 from 0 and Northwest Irving Street",
+            "name": "corner of Northwest Irving Street and way -102328 from 0",
             "vertexType": "NORMAL"
           },
           "generalizedCost": 236,
@@ -2728,7 +2728,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
             "departure": "2009-10-21T23:12:42.000+00:00",
             "lat": 45.5276173,
             "lon": -122.7003923,
-            "name": "corner of way -102328 from 0 and Northwest Irving Street",
+            "name": "corner of Northwest Irving Street and way -102328 from 0",
             "vertexType": "NORMAL"
           },
           "transitLeg": false,
@@ -2745,7 +2745,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
             "departure": "2009-10-21T23:12:42.000+00:00",
             "lat": 45.5276173,
             "lon": -122.7003923,
-            "name": "corner of way -102328 from 0 and Northwest Irving Street",
+            "name": "corner of Northwest Irving Street and way -102328 from 0",
             "vertexType": "NORMAL"
           },
           "generalizedCost": 236,
@@ -3010,7 +3010,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
             "departure": "2009-10-21T23:07:18.000+00:00",
             "lat": 45.5276173,
             "lon": -122.7003923,
-            "name": "corner of way -102328 from 0 and Northwest Irving Street",
+            "name": "corner of Northwest Irving Street and way -102328 from 0",
             "vertexType": "NORMAL"
           },
           "transitLeg": false,
@@ -3027,7 +3027,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
             "departure": "2009-10-21T23:07:18.000+00:00",
             "lat": 45.5276173,
             "lon": -122.7003923,
-            "name": "corner of way -102328 from 0 and Northwest Irving Street",
+            "name": "corner of Northwest Irving Street and way -102328 from 0",
             "vertexType": "NORMAL"
           },
           "generalizedCost": 298,
@@ -3239,7 +3239,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
             "departure": "2009-10-21T23:12:42.000+00:00",
             "lat": 45.5276173,
             "lon": -122.7003923,
-            "name": "corner of way -102328 from 0 and Northwest Irving Street",
+            "name": "corner of Northwest Irving Street and way -102328 from 0",
             "vertexType": "NORMAL"
           },
           "transitLeg": false,
@@ -3256,7 +3256,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
             "departure": "2009-10-21T23:12:42.000+00:00",
             "lat": 45.5276173,
             "lon": -122.7003923,
-            "name": "corner of way -102328 from 0 and Northwest Irving Street",
+            "name": "corner of Northwest Irving Street and way -102328 from 0",
             "vertexType": "NORMAL"
           },
           "generalizedCost": 312,
@@ -3727,7 +3727,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "departure": "2009-10-21T23:26:39.000+00:00",
             "lat": 45.5276173,
             "lon": -122.7003923,
-            "name": "corner of way -102328 from 0 and Northwest Irving Street",
+            "name": "corner of Northwest Irving Street and way -102328 from 0",
             "vertexType": "NORMAL"
           },
           "transitLeg": false,
@@ -3744,7 +3744,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "departure": "2009-10-21T23:26:39.000+00:00",
             "lat": 45.5276173,
             "lon": -122.7003923,
-            "name": "corner of way -102328 from 0 and Northwest Irving Street",
+            "name": "corner of Northwest Irving Street and way -102328 from 0",
             "vertexType": "NORMAL"
           },
           "generalizedCost": 81,
@@ -5018,7 +5018,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "departure": "2009-10-21T23:41:39.000+00:00",
             "lat": 45.5276173,
             "lon": -122.7003923,
-            "name": "corner of way -102328 from 0 and Northwest Irving Street",
+            "name": "corner of Northwest Irving Street and way -102328 from 0",
             "vertexType": "NORMAL"
           },
           "transitLeg": false,
@@ -5035,7 +5035,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "departure": "2009-10-21T23:41:39.000+00:00",
             "lat": 45.5276173,
             "lon": -122.7003923,
-            "name": "corner of way -102328 from 0 and Northwest Irving Street",
+            "name": "corner of Northwest Irving Street and way -102328 from 0",
             "vertexType": "NORMAL"
           },
           "generalizedCost": 81,

--- a/src/test/java/org/opentripplanner/routing/core/RoutingContextDestroyTest.java
+++ b/src/test/java/org/opentripplanner/routing/core/RoutingContextDestroyTest.java
@@ -91,8 +91,8 @@ public class RoutingContextDestroyTest {
 
     private void originAndDestinationInsertedCorrect() {
         // Then - the origin and destination is
-        assertEquals("Origin", subject.fromVertices.iterator().next().getName());
-        assertEquals("Destination", subject.toVertices.iterator().next().getName());
+        assertEquals("Origin", subject.fromVertices.iterator().next().getDefaultName());
+        assertEquals("Destination", subject.toVertices.iterator().next().getDefaultName());
 
         // And - from the origin
         Collection<String> vertexesReachableFromOrigin = findAllReachableVertexes(
@@ -128,11 +128,11 @@ public class RoutingContextDestroyTest {
 
     private static <T extends Collection<String>> T findAllReachableVertexes(Vertex vertex,
             boolean forward, T list) {
-        if (list.contains(vertex.getName())) {
+        if (list.contains(vertex.getDefaultName())) {
             return list;
         }
 
-        list.add(vertex.getName());
+        list.add(vertex.getDefaultName());
         if (forward) {
             vertex.getOutgoing()
                     .forEach(it -> findAllReachableVertexes(it.getToVertex(), forward, list));
@@ -144,8 +144,8 @@ public class RoutingContextDestroyTest {
     }
 
     private void assertVertexEdgeIsNotReferencingTemporaryElements(Vertex src, Edge e, Vertex v) {
-        String sourceName = src.getName();
-        assertFalse(sourceName + " -> " + e.getName(), e instanceof TemporaryEdge);
-        assertFalse(sourceName + " -> " + v.getName(), v instanceof TemporaryVertex);
+        String sourceName = src.getDefaultName();
+        assertFalse(sourceName + " -> " + e.getDefaultName(), e instanceof TemporaryEdge);
+        assertFalse(sourceName + " -> " + v.getDefaultName(), v instanceof TemporaryVertex);
     }
 }

--- a/src/test/java/org/opentripplanner/routing/graph/SimpleConcreteEdge.java
+++ b/src/test/java/org/opentripplanner/routing/graph/SimpleConcreteEdge.java
@@ -6,7 +6,7 @@ import org.opentripplanner.routing.core.StateEditor;
 import org.opentripplanner.routing.core.TraverseMode;
 
 import org.locationtech.jts.geom.LineString;
-import java.util.Locale;
+import org.opentripplanner.util.I18NString;
 
 public class SimpleConcreteEdge extends Edge {
     private static final long serialVersionUID = 1L;
@@ -33,12 +33,7 @@ public class SimpleConcreteEdge extends Edge {
     }
 
     @Override
-    public String getName() {
-        return null;
-    }
-
-    @Override
-    public String getName(Locale locale) {
+    public I18NString getName() {
         return null;
     }
 

--- a/src/test/java/org/opentripplanner/routing/graph/TemporaryConcreteEdge.java
+++ b/src/test/java/org/opentripplanner/routing/graph/TemporaryConcreteEdge.java
@@ -6,9 +6,9 @@ import org.opentripplanner.routing.core.StateEditor;
 import org.opentripplanner.routing.core.TraverseMode;
 
 import org.locationtech.jts.geom.LineString;
-import java.util.Locale;
 import org.opentripplanner.routing.edgetype.TemporaryEdge;
 import org.opentripplanner.routing.vertextype.TemporaryVertex;
+import org.opentripplanner.util.I18NString;
 
 public class TemporaryConcreteEdge extends Edge implements TemporaryEdge {
 
@@ -40,12 +40,7 @@ public class TemporaryConcreteEdge extends Edge implements TemporaryEdge {
     }
 
     @Override
-    public String getName() {
-        return null;
-    }
-
-    @Override
-    public String getName(Locale locale) {
+    public I18NString getName() {
         return null;
     }
 

--- a/src/test/java/org/opentripplanner/routing/street/BarrierRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/street/BarrierRoutingTest.java
@@ -146,7 +146,7 @@ public class BarrierRoutingTest {
         var gpf = new GraphPathFinder(new Router(graph, RouterConfig.DEFAULT));
         var paths = gpf.graphPathFinderEntryPoint(request);
 
-        var itineraries = GraphPathToItineraryMapper.mapItineraries(paths, request);
+        var itineraries = GraphPathToItineraryMapper.mapItineraries(paths);
 
         assertAll(assertions.apply(itineraries));
 

--- a/src/test/java/org/opentripplanner/routing/street/BicycleRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/street/BicycleRoutingTest.java
@@ -68,7 +68,7 @@ public class BicycleRoutingTest {
         var gpf = new GraphPathFinder(new Router(graph, RouterConfig.DEFAULT));
         var paths = gpf.graphPathFinderEntryPoint(request);
 
-        var itineraries = GraphPathToItineraryMapper.mapItineraries(paths, request);
+        var itineraries = GraphPathToItineraryMapper.mapItineraries(paths);
         // make sure that we only get BICYLE legs
         itineraries.forEach(i -> i.legs.forEach(l -> Assertions.assertEquals(l.getMode(), TraverseMode.BICYCLE)));
         return itineraries.get(0).legs.get(0).getLegGeometry().getPoints();

--- a/src/test/java/org/opentripplanner/routing/street/CarRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/street/CarRoutingTest.java
@@ -122,7 +122,7 @@ public class CarRoutingTest {
         var gpf = new GraphPathFinder(new Router(graph, RouterConfig.DEFAULT));
         var paths = gpf.graphPathFinderEntryPoint(request);
 
-        var itineraries = GraphPathToItineraryMapper.mapItineraries(paths, request);
+        var itineraries = GraphPathToItineraryMapper.mapItineraries(paths);
         // make sure that we only get CAR legs
         itineraries.forEach(
                 i -> i.legs.forEach(l -> Assertions.assertEquals(l.getMode(), TraverseMode.CAR)));

--- a/src/test/java/org/opentripplanner/routing/street/SplitEdgeTurnRestrictionsTest.java
+++ b/src/test/java/org/opentripplanner/routing/street/SplitEdgeTurnRestrictionsTest.java
@@ -152,7 +152,7 @@ public class SplitEdgeTurnRestrictionsTest {
         var gpf = new GraphPathFinder(new Router(graph, RouterConfig.DEFAULT));
         var paths = gpf.graphPathFinderEntryPoint(request);
 
-        var itineraries = GraphPathToItineraryMapper.mapItineraries(paths, request);
+        var itineraries = GraphPathToItineraryMapper.mapItineraries(paths);
         // make sure that we only get CAR legs
         itineraries.forEach(
                 i -> i.legs.forEach(l -> Assertions.assertEquals(l.getMode(), TraverseMode.CAR)));

--- a/src/test/java/org/opentripplanner/routing/vehicle_parking/VehicleParkingTestUtil.java
+++ b/src/test/java/org/opentripplanner/routing/vehicle_parking/VehicleParkingTestUtil.java
@@ -46,7 +46,7 @@ public class VehicleParkingTestUtil {
         new StreetEdge(from, to,
                 GeometryUtils.makeLineString(
                         from.getLat(), from.getLon(), to.getLat(), to.getLon()),
-                String.format("%s%s street", from.getName(), to.getName()),
+                String.format("%s%s street", from.getDefaultName(), to.getDefaultName()),
                 1,
                 permissions,
                 false


### PR DESCRIPTION
This is a pure refactoring for following things:
- Make `Vertex` and `Edge` names return localizable strings.
- Move localization from itinerary creation to the API layer

These are required for two upcoming PRs, regarding transit model localization, and leg creation simplification

### Unit tests
Updated to match new API

### Code style
✅ 

### Documentation
None updated

### Changelog
The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md)
is generated from the pull-request title, make sure the title describe the feature or issue fixed.
To exclude the PR from the changelog add `[changelog skip]` in the title.
