### PR TITLE
Expose maxStopToShapeSnapDistance as build-config.json parameter

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -259,6 +259,7 @@ config key | description | value type | value default | notes
 `transitServiceEnd` | Limit the import of transit services to the given *end* date. *Inclusive*. Use an absolute date or a period relative to the day the graph is build. | date or period | P3Y | _2022&#8209;12&#8209;31, P1Y6M10D, P12W_
 `writeCachedElevations` | If true, writes the calculated elevation data. | boolean | false | see [Elevation Data Calculation Optimizations](#elevation-data-calculation-optimizations)
 `maxAreaNodes` | Visibility calculations for an area will not be done if there are more nodes than this limit | integer | 500 |
+`maxStopToShapeSnapDistance` | This field is used for mapping route's geometry shapes. It determines max distance between shape points and their stop sequence. If the mapper can not find any stops within this radius it will default to simple stop-to-stop geometry instead. | double | 150 | units: meters
 
 This list of parameters in defined in the [BuildConfig.java](https://github.com/opentripplanner/OpenTripPlanner/blob/v2.0.0/src/main/java/org/opentripplanner/standalone/config/BuildConfig.java).
 

--- a/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
@@ -141,6 +141,7 @@ public class GraphBuilder implements Runnable {
                 gtfsBundle.parentStationTransfers = config.stationTransfers;
                 gtfsBundle.subwayAccessTime = config.getSubwayAccessTimeSeconds();
                 gtfsBundle.maxInterlineDistance = config.maxInterlineDistance;
+                gtfsBundle.setMaxStopToShapeSnapDistance(config.maxStopToShapeSnapDistance);
                 gtfsBundles.add(gtfsBundle);
             }
             GtfsModule gtfsModule = new GtfsModule(gtfsBundles, config.getTransitServicePeriod());

--- a/src/main/java/org/opentripplanner/netex/NetexModule.java
+++ b/src/main/java/org/opentripplanner/netex/NetexModule.java
@@ -29,8 +29,8 @@ import java.util.List;
  * but it is intended to be updated later to support other profiles.
  */
 public class NetexModule implements GraphBuilderModule {
-    private final static double MAX_STOP_TO_SHAPE_SNAP_DISTANCE = 150;
 
+    private final double maxStopToShapeSnapDistance;
     private final int subwayAccessTime;
     private final int maxInterlineDistance;
     private final String netexFeedId;
@@ -49,6 +49,7 @@ public class NetexModule implements GraphBuilderModule {
             String netexFeedId,
             int subwayAccessTime,
             int maxInterlineDistance,
+            double maxStopToShapeSnapDistance,
             ServiceDateInterval transitPeriodLimit,
             List<NetexBundle> netexBundles
     ) {
@@ -57,6 +58,7 @@ public class NetexModule implements GraphBuilderModule {
         this.maxInterlineDistance = maxInterlineDistance;
         this.transitPeriodLimit = transitPeriodLimit;
         this.netexBundles = netexBundles;
+        this.maxStopToShapeSnapDistance = maxStopToShapeSnapDistance;
     }
 
     @Override
@@ -104,7 +106,7 @@ public class NetexModule implements GraphBuilderModule {
                 new GeometryAndBlockProcessor(
                         otpService,
                         fareServiceFactory,
-                        MAX_STOP_TO_SHAPE_SNAP_DISTANCE,
+                        maxStopToShapeSnapDistance,
                         maxInterlineDistance
                 ).run(graph, issueStore);
             }

--- a/src/main/java/org/opentripplanner/netex/configure/NetexConfig.java
+++ b/src/main/java/org/opentripplanner/netex/configure/NetexConfig.java
@@ -57,6 +57,7 @@ public class NetexConfig {
                 buildParams.netex.netexFeedId,
                 buildParams.getSubwayAccessTimeSeconds(),
                 buildParams.maxInterlineDistance,
+                buildParams.maxStopToShapeSnapDistance,
                 buildParams.getTransitServicePeriod(),
                 netexBundles
         );

--- a/src/main/java/org/opentripplanner/standalone/config/BuildConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/BuildConfig.java
@@ -310,6 +310,13 @@ public class BuildConfig {
     public final DataOverlayConfig dataOverlay;
 
     /**
+     * This field is used for mapping routes geometry shapes.
+     * It determines max distance between shape points and their stop sequence.
+     * If mapper can not find any stops within this radius it will default to simple stop-to-stop geometry instead.
+     */
+    public final double maxStopToShapeSnapDistance;
+
+    /**
      * Set all parameters from the given Jackson JSON tree, applying defaults.
      * Supplying MissingNode.getInstance() will cause all the defaults to be applied.
      * This could be done automatically with the "reflective query scraper" but it's less type safe and less clear.
@@ -339,6 +346,7 @@ public class BuildConfig {
         maxDataImportIssuesPerFile = c.asInt("maxDataImportIssuesPerFile", 1000);
         maxInterlineDistance = c.asInt("maxInterlineDistance", 200);
         maxTransferDurationSeconds = c.asDouble("maxTransferDurationSeconds", Duration.ofMinutes(30).toSeconds());
+        maxStopToShapeSnapDistance = c.asDouble("maxStopToShapeSnapDistance", 150);
         multiThreadElevationCalculations = c.asBoolean("multiThreadElevationCalculations", false);
         osmCacheDataInMem = c.asBoolean("osmCacheDataInMem", false);
         osmWayPropertySet = WayPropertySetSource.fromConfig(c.asText("osmWayPropertySet", "default"));


### PR DESCRIPTION
### Summary
Expose maxStopToShapeSnapDistance as build-config.json parameter so that it is no longer hard-coded.

### Unit tests
No new tests included.

### Code style
Follows code style.

### Documentation
Documented new parameter in Java docs and Configuration.md
