### PR TITLE
Fixes NPE in Netex ServiceLinkMapper [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/netex/mapping/ServiceLinkMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/ServiceLinkMapper.java
@@ -71,21 +71,25 @@ class ServiceLinkMapper {
             .getServiceLinkRef()
             .getRef();
         ServiceLink serviceLink = serviceLinkById.lookup(serviceLinkRef);
+        
         if(serviceLink !=null) {
-          shapePoints.addAll(mapServiceLink(
-                  serviceLink,
-                  journeyPattern,
-                  sequenceCounter,
-                  distance,
-                  quayIdByStopPointRef,
-                  quayById
-          ));
+          shapePoints.addAll(
+                  mapServiceLink(
+                          serviceLink,
+                          journeyPattern,
+                          sequenceCounter,
+                          distance,
+                          quayIdByStopPointRef,
+                          quayById
+                  )
+          );
         }
         else {
           issueStore.add(
                   "MissingServiceLink",
                   "ServiceLink not found in journey pattern %s",
-                  journeyPattern.getId());
+                  journeyPattern.getId()
+          );
         }
       }
     }

--- a/src/main/java/org/opentripplanner/netex/mapping/ServiceLinkMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/ServiceLinkMapper.java
@@ -70,14 +70,23 @@ class ServiceLinkMapper {
             linkInLinkSequence_versionedChildStructure)
             .getServiceLinkRef()
             .getRef();
-        shapePoints.addAll(mapServiceLink(
-            serviceLinkById.lookup(serviceLinkRef),
-            journeyPattern,
-            sequenceCounter,
-            distance,
-            quayIdByStopPointRef,
-            quayById
-        ));
+        ServiceLink serviceLink = serviceLinkById.lookup(serviceLinkRef);
+        if(serviceLink !=null) {
+          shapePoints.addAll(mapServiceLink(
+                  serviceLink,
+                  journeyPattern,
+                  sequenceCounter,
+                  distance,
+                  quayIdByStopPointRef,
+                  quayById
+          ));
+        }
+        else {
+          issueStore.add(
+                  "MissingServiceLink",
+                  "ServiceLink not found in journey pattern %s",
+                  journeyPattern.getId());
+        }
       }
     }
     return shapePoints;


### PR DESCRIPTION
### Summary
Checks null pointer if service link by serviceLinkRef not found netex ServiceLinkMapper .

### Issue
Not relevant

### Unit tests
- Not relevant

### Code style
yes

### Documentation
- Not relevant
