### PR TITLE
Add support for NeTEx VIA's

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/network/DestinationDisplayType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/network/DestinationDisplayType.java
@@ -1,9 +1,10 @@
 package org.opentripplanner.ext.transmodelapi.model.network;
 
 import graphql.Scalars;
-import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLList;
 import graphql.schema.GraphQLObjectType;
+import org.opentripplanner.model.TripTimeOnDate;
 
 public class DestinationDisplayType {
 
@@ -15,7 +16,13 @@ public class DestinationDisplayType {
                     .name("frontText")
                     .description("Name of destination to show on front of vehicle.")
                     .type(Scalars.GraphQLString)
-                    .dataFetcher(DataFetchingEnvironment::getSource)
+                    .dataFetcher(e -> ((TripTimeOnDate) e.getSource()).getHeadsign())
+                    .build())
+            .field(GraphQLFieldDefinition.newFieldDefinition()
+                    .name("via")
+                    .description("Intermediary destinations which the vehicle will pass before reaching its final destination.")
+                    .type(new GraphQLList(Scalars.GraphQLString))
+                    .dataFetcher(e -> ((TripTimeOnDate) e.getSource()).getHeadsignVias())
                     .build())
             .build();
   }

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/et/EstimatedCallType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/et/EstimatedCallType.java
@@ -4,6 +4,7 @@ import static org.opentripplanner.model.PickDrop.COORDINATE_WITH_DRIVER;
 import static org.opentripplanner.model.PickDrop.NONE;
 
 import graphql.Scalars;
+import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLList;
 import graphql.schema.GraphQLNonNull;
@@ -206,7 +207,7 @@ public class EstimatedCallType {
             .field(GraphQLFieldDefinition.newFieldDefinition()
                     .name("destinationDisplay")
                     .type(destinationDisplayType)
-                    .dataFetcher(environment -> ((TripTimeOnDate) environment.getSource()).getHeadsign())
+                    .dataFetcher(DataFetchingEnvironment::getSource)
                     .build())
             .field(GraphQLFieldDefinition.newFieldDefinition()
                     .name("notices")

--- a/src/main/java/org/opentripplanner/model/StopTime.java
+++ b/src/main/java/org/opentripplanner/model/StopTime.java
@@ -1,6 +1,7 @@
 /* This file is based on code copied from project OneBusAway, see the LICENSE file for further information. */
 package org.opentripplanner.model;
 
+import java.util.List;
 import org.opentripplanner.util.time.TimeUtils;
 
 
@@ -28,6 +29,8 @@ public final class StopTime implements Comparable<StopTime> {
     private int stopSequence;
 
     private String stopHeadsign;
+
+    private List<String> headsignVias;
 
     private String routeShortName;
 
@@ -75,6 +78,7 @@ public final class StopTime implements Comparable<StopTime> {
         this.flexContinuousDropOff = st.flexContinuousDropOff;
         this.dropOffBookingInfo = st.dropOffBookingInfo;
         this.pickupBookingInfo = st.pickupBookingInfo;
+        this.headsignVias = st.headsignVias;
     }
 
     /**
@@ -273,6 +277,14 @@ public final class StopTime implements Comparable<StopTime> {
 
     public void setPickupBookingInfo(BookingInfo pickupBookingInfo) {
         this.pickupBookingInfo = pickupBookingInfo;
+    }
+
+    public List<String> getHeadsignVias() {
+        return headsignVias;
+    }
+
+    public void setHeadsignVias(List<String> headsignVias) {
+        this.headsignVias = headsignVias;
     }
 
     public int compareTo(StopTime o) {

--- a/src/main/java/org/opentripplanner/model/TripTimeOnDate.java
+++ b/src/main/java/org/opentripplanner/model/TripTimeOnDate.java
@@ -148,6 +148,10 @@ public class TripTimeOnDate {
         return tripTimes.getHeadsign(stopIndex);
     }
 
+    public List<String> getHeadsignVias() {
+        return tripTimes.getVia(stopIndex);
+    }
+
     public PickDrop getPickupType() {
         return tripTimes.isCanceled() || tripTimes.isCancelledStop(stopIndex)
             ? PickDrop.CANCELLED

--- a/src/main/java/org/opentripplanner/netex/mapping/StopTimesMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/StopTimesMapper.java
@@ -8,6 +8,8 @@ import java.math.BigInteger;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.xml.bind.JAXBElement;
 import org.opentripplanner.graph_builder.DataImportIssueStore;
@@ -24,14 +26,19 @@ import org.opentripplanner.netex.index.api.ReadOnlyHierarchicalMapById;
 import org.opentripplanner.netex.mapping.support.FeedScopedIdFactory;
 import org.opentripplanner.util.OTPFeature;
 import org.rutebanken.netex.model.DestinationDisplay;
+import org.rutebanken.netex.model.DestinationDisplay_VersionStructure;
 import org.rutebanken.netex.model.FlexibleLine;
 import org.rutebanken.netex.model.JourneyPattern;
 import org.rutebanken.netex.model.LineRefStructure;
+import org.rutebanken.netex.model.MultilingualString;
 import org.rutebanken.netex.model.PointInLinkSequence_VersionedChildStructure;
 import org.rutebanken.netex.model.Route;
 import org.rutebanken.netex.model.ServiceJourney;
 import org.rutebanken.netex.model.StopPointInJourneyPattern;
 import org.rutebanken.netex.model.TimetabledPassingTime;
+import org.rutebanken.netex.model.VersionOfObjectRefStructure;
+import org.rutebanken.netex.model.Via_VersionedChildStructure;
+import org.rutebanken.netex.model.Vias_RelStructure;
 
 /**
  * This maps a list of TimetabledPassingTimes to a list of StopTimes. It also makes sure the StopTime has a reference
@@ -196,6 +203,8 @@ class StopTimesMapper {
             return null;
         }
 
+        List<String> vias = null;
+
         if (stopPoint != null) {
             if (isFalse(stopPoint.isForAlighting())) {
                 stopTime.setDropOffType(NONE);
@@ -216,8 +225,30 @@ class StopTimesMapper {
             if (stopPoint.getDestinationDisplayRef() != null) {
                 DestinationDisplay destinationDisplay =
                         destinationDisplayById.lookup(stopPoint.getDestinationDisplayRef().getRef());
+
+                Vias_RelStructure viaValues = null;
+
                 if (destinationDisplay != null) {
                     currentHeadSign = destinationDisplay.getFrontText().getValue();
+                    viaValues = destinationDisplay.getVias();
+                }
+
+                if (viaValues != null && viaValues.getVia() != null) {
+                    vias = viaValues.getVia().stream()
+                            .map(Via_VersionedChildStructure::getDestinationDisplayRef)
+                            .filter(Objects::nonNull)
+                            .map(VersionOfObjectRefStructure::getRef)
+                            .filter(Objects::nonNull)
+                            .map(destinationDisplayById::lookup)
+                            .filter(Objects::nonNull)
+                            .map(DestinationDisplay_VersionStructure::getFrontText)
+                            .filter(Objects::nonNull)
+                            .map(MultilingualString::getValue)
+                            .collect(Collectors.toList());
+
+                    if (vias.isEmpty()) {
+                        vias = null;
+                    }
                 }
             }
         }
@@ -231,6 +262,7 @@ class StopTimesMapper {
         if (currentHeadSign != null) {
             stopTime.setStopHeadsign(currentHeadSign);
         }
+        stopTime.setHeadsignVias(vias);
         return stopTime;
     }
 

--- a/src/test/java/org/opentripplanner/netex/mapping/NetexTestDataSample.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/NetexTestDataSample.java
@@ -35,6 +35,8 @@ import org.rutebanken.netex.model.StopPointInJourneyPattern;
 import org.rutebanken.netex.model.StopPointInJourneyPatternRefStructure;
 import org.rutebanken.netex.model.TimetabledPassingTime;
 import org.rutebanken.netex.model.TimetabledPassingTimes_RelStructure;
+import org.rutebanken.netex.model.Via_VersionedChildStructure;
+import org.rutebanken.netex.model.Vias_RelStructure;
 
 class NetexTestDataSample {
     public static final String SERVICE_JOURNEY_ID = "RUT:ServiceJourney:1";
@@ -83,13 +85,17 @@ class NetexTestDataSample {
             timetabledPassingTimes.add(createTimetablePassingTime("TTPT-" + (i+1), 5, stopTimes[i]));
         }
 
+        final String DESTINATION_DISPLAY_ID_1 = "NSR:DestinationDisplay:1";
+        final String DESTINATION_DISPLAY_ID_2 = "NSR:DestinationDisplay:2";
 
         DestinationDisplay destinationBergen = new DestinationDisplay()
-                .withId("NSR:DestinationDisplay:1")
+                .withId(DESTINATION_DISPLAY_ID_1)
+                .withVias(new Vias_RelStructure().withVia(List.of(this.createViaDestinationDisplayRef(DESTINATION_DISPLAY_ID_2))))
                 .withFrontText(new MultilingualString().withValue("Bergen"));
 
         DestinationDisplay destinationStavanger = new DestinationDisplay()
-                .withId("NSR:DestinationDisplay:2")
+                .withId(DESTINATION_DISPLAY_ID_2)
+                .withVias(new Vias_RelStructure().withVia(List.of(this.createViaDestinationDisplayRef(DESTINATION_DISPLAY_ID_1))))
                 .withFrontText(new MultilingualString().withValue("Stavanger"));
 
         destinationDisplayById.add(destinationBergen);
@@ -141,6 +147,12 @@ class NetexTestDataSample {
             stopsById.add(Stop.stopForTest(stopId, 60.0, 10.0));
             quayIdByStopPointRef.add(pointsInLink.get(i).getId(), stopId);
         }
+    }
+
+    private Via_VersionedChildStructure createViaDestinationDisplayRef(String destinationDisplayId) {
+        return new Via_VersionedChildStructure()
+                .withDestinationDisplayRef(new DestinationDisplayRefStructure()
+                        .withRef(destinationDisplayId));
     }
 
     static DayTypeRefs_RelStructure createEveryDayRefs() {

--- a/src/test/java/org/opentripplanner/netex/mapping/StopTimesMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/StopTimesMapperTest.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.netex.mapping;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.math.BigInteger;
 import java.time.LocalTime;
@@ -60,10 +61,10 @@ public class StopTimesMapperTest {
 
         assertEquals(4, stopTimes.size());
 
-        assertStop(stopTimes.get(0),"NSR:Quay:1", 18000, "Bergen");
-        assertStop(stopTimes.get(1),"NSR:Quay:2", 18240, "Bergen");
-        assertStop(stopTimes.get(2),"NSR:Quay:3", 18600, "Stavanger");
-        assertStop(stopTimes.get(3),"NSR:Quay:4", 18900, "Stavanger");
+        assertStop(stopTimes.get(0),"NSR:Quay:1", 18000, "Bergen", List.of("Stavanger"));
+        assertStop(stopTimes.get(1),"NSR:Quay:2", 18240, "Bergen", null);
+        assertStop(stopTimes.get(2),"NSR:Quay:3", 18600, "Stavanger", List.of("Bergen"));
+        assertStop(stopTimes.get(3),"NSR:Quay:4", 18900, "Stavanger", null);
 
         Map<String, StopTime> map = result.stopTimeByNetexId;
 
@@ -73,9 +74,12 @@ public class StopTimesMapperTest {
         assertEquals(stopTimes.get(3), map.get("TTPT-4"));
     }
 
-    private void assertStop(StopTime stopTime, String stopId, long departureTime, String headsign) {
+    private void assertStop(StopTime stopTime, String stopId, long departureTime, String headsign, List<String> via) {
         assertEquals(stopId, stopTime.getStop().getId().getId());
         assertEquals(departureTime, stopTime.getDepartureTime());
         assertEquals(headsign, stopTime.getStopHeadsign());
+
+        List<String> stopTimeVia = stopTime.getHeadsignVias();
+        assertEquals(via, stopTimeVia);
     }
 }

--- a/src/test/java/org/opentripplanner/routing/trippattern/DeduplicatorTest.java
+++ b/src/test/java/org/opentripplanner/routing/trippattern/DeduplicatorTest.java
@@ -23,6 +23,8 @@ public class DeduplicatorTest {
   private static final String STRING_2 = new String("Abba");
   private static final String[] STRING_ARRAY = {"Alf"};
   private static final String[] STRING_ARRAY_2 = {"Alf"};
+  private static final String[][] STRING_2D_ARRAY = new String[][] {{"test_1", "test_2"}, {"test_3", "test_4"}};
+  private static final String[][] STRING_2D_ARRAY_2 = new String[][] {{"test_1", "test_2"}, {"test_3", "test_4"}};
   private static final LocalDate DATE = LocalDate.of(2021, 1, 15);
   private static final LocalDate DATE_2 = LocalDate.of(2021, 1, 15);
   private static final LocalTime TIME = LocalTime.of(12, 45);
@@ -62,7 +64,7 @@ public class DeduplicatorTest {
     subject.reset();
 
     assertEquals(
-        "Deduplicator{BitSet: 0(0), IntArray: 0(0), String: 0(0), StringArray: 0(0)}",
+        "Deduplicator{BitSet: 0(0), IntArray: 0(0), String: 0(0), StringArray: 0(0), String2DArray: 0(0)}",
         subject.toString()
     );
   }
@@ -74,7 +76,7 @@ public class DeduplicatorTest {
     assertSame(INT_ARRAY, subject.deduplicateIntArray(INT_ARRAY_2));
 
     assertEquals(
-        "Deduplicator{BitSet: 0(0), IntArray: 1(2), String: 0(0), StringArray: 0(0)}",
+        "Deduplicator{BitSet: 0(0), IntArray: 1(2), String: 0(0), StringArray: 0(0), String2DArray: 0(0)}",
         subject.toString()
     );
 
@@ -90,7 +92,7 @@ public class DeduplicatorTest {
     assertSame(STRING, subject.deduplicateString(STRING_2));
 
     assertEquals(
-        "Deduplicator{BitSet: 0(0), IntArray: 0(0), String: 1(2), StringArray: 0(0)}",
+        "Deduplicator{BitSet: 0(0), IntArray: 0(0), String: 1(2), StringArray: 0(0), String2DArray: 0(0)}",
         subject.toString()
     );
 
@@ -106,7 +108,7 @@ public class DeduplicatorTest {
     assertSame(BIT_SET, subject.deduplicateBitSet(BIT_SET_2));
 
     assertEquals(
-        "Deduplicator{BitSet: 1(2), IntArray: 0(0), String: 0(0), StringArray: 0(0)}",
+        "Deduplicator{BitSet: 1(2), IntArray: 0(0), String: 0(0), StringArray: 0(0), String2DArray: 0(0)}",
         subject.toString()
     );
 
@@ -122,13 +124,28 @@ public class DeduplicatorTest {
     assertSame(deduplicatedArray, subject.deduplicateStringArray(STRING_ARRAY_2));
 
     assertEquals(
-        "Deduplicator{BitSet: 0(0), IntArray: 0(0), String: 1(1), StringArray: 1(2)}",
+        "Deduplicator{BitSet: 0(0), IntArray: 0(0), String: 1(1), StringArray: 1(2), String2DArray: 0(0)}",
         subject.toString()
     );
 
     subject.reset();
     // After reset the "new" value is used
     assertNotSame(deduplicatedArray, subject.deduplicateStringArray(STRING_ARRAY_2));
+  }
+
+  @Test
+  public void deduplicateString2DArray() {
+    var deduplicatedArray = subject.deduplicateString2DArray(STRING_2D_ARRAY);
+
+    assertSame(deduplicatedArray, subject.deduplicateString2DArray(STRING_2D_ARRAY_2));
+
+    assertEquals(
+            "Deduplicator{BitSet: 0(0), IntArray: 0(0), String: 4(4), StringArray: 2(2), String2DArray: 1(2)}",
+            subject.toString());
+
+    subject.reset();
+    // After reset the "new" value is used
+    assertNotSame(deduplicatedArray, subject.deduplicateString2DArray(STRING_2D_ARRAY_2));
   }
 
   @Test
@@ -172,7 +189,7 @@ public class DeduplicatorTest {
   @Test
   public void testToStringForEmptyDeduplicator() {
     assertEquals(
-        "Deduplicator{BitSet: 0(0), IntArray: 0(0), String: 0(0), StringArray: 0(0)}",
+        "Deduplicator{BitSet: 0(0), IntArray: 0(0), String: 0(0), StringArray: 0(0), String2DArray: 0(0)}",
         subject.toString()
     );
   }
@@ -188,13 +205,14 @@ public class DeduplicatorTest {
 
     assertEquals(
         "Deduplicator{"
-            + "BitSet: 1(1), "
-            + "IntArray: 1(1), "
-            + "String: 2(2), "
-            + "StringArray: 1(1), "
-            + "LocalDate: 1(2), "
-            + "List<LocalDate>: 1(1)"
-            + "}",
+                + "BitSet: 1(1), "
+                + "IntArray: 1(1), "
+                + "String: 2(2), "
+                + "StringArray: 1(1), "
+                + "String2DArray: 0(0), "
+                + "LocalDate: 1(2), "
+                + "List<LocalDate>: 1(1)"
+                + "}",
         subject.toString()
     );
   }


### PR DESCRIPTION
### Summary
Support for NeTEx via's (with transmodel GraphQL API). According to [Transmodel Documentation](https://enturas.atlassian.net/wiki/spaces/PUBLIC/pages/728563886/network#DestinationDisplay).

### Issue
[#3886](https://github.com/opentripplanner/OpenTripPlanner/issues/3886)

### Unit tests
- New unit tests inside _src/test/java/org/opentripplanner/routing/trippattern/DeduplicatorTest.java_
- New unit tests inside _src/test/java/org/opentripplanner/netex/mapping/StopTimesMapperTest.java_

### Code style
Follows recommended code style.

### Documentation
- Added Java docs for new methods. 
