### PR TITLE
Add support for NeTex DatedServiceJourneys

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
@@ -866,7 +866,7 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
      *
      * @return true if successful
      */
-    private boolean addTripToGraphAndBuffer(final Graph graph, final Trip trip,
+    private boolean addTripToGraphAndBuffer(final String feedId, final Graph graph, final Trip trip,
                                             final List<StopTime> stopTimes, final List<StopLocation> stops, TripTimes updatedTripTimes,
                                             final ServiceDate serviceDate, EstimatedVehicleJourney estimatedVehicleJourney) {
 

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
@@ -14,6 +14,8 @@ import org.opentripplanner.model.TimetableSnapshot;
 import org.opentripplanner.model.TimetableSnapshotProvider;
 import org.opentripplanner.model.TransitMode;
 import org.opentripplanner.model.Trip;
+import org.opentripplanner.model.TripAlteration;
+import org.opentripplanner.model.TripOnServiceDate;
 import org.opentripplanner.model.TripPattern;
 import org.opentripplanner.model.calendar.ServiceDate;
 import org.opentripplanner.routing.RoutingService;
@@ -656,7 +658,7 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
 
         Preconditions.checkState(tripTimes.timesIncreasing(), "Non-increasing triptimes for added trip");
 
-        return addTripToGraphAndBuffer(graph, trip, aimedStopTimes, addedStops, tripTimes, serviceDate);
+        return addTripToGraphAndBuffer(feedId, graph, trip, aimedStopTimes, addedStops, tripTimes, serviceDate, estimatedVehicleJourney);
     }
 
     /**
@@ -813,7 +815,7 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
                             tripTimes.cancelTrip();
                         } else {
                             // Add new trip
-                            result = result | addTripToGraphAndBuffer(graph, trip, modifiedStopTimes, modifiedStops, tripTimes, serviceDate);
+                            result = result | addTripToGraphAndBuffer(feedId, graph, trip, modifiedStopTimes, modifiedStops, tripTimes, serviceDate, estimatedVehicleJourney);
                         }
                     } else {
                         result = result | buffer.update(pattern, tripTimes, serviceDate);
@@ -862,7 +864,7 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
      */
     private boolean addTripToGraphAndBuffer(final Graph graph, final Trip trip,
                                             final List<StopTime> stopTimes, final List<StopLocation> stops, TripTimes updatedTripTimes,
-                                            final ServiceDate serviceDate) {
+                                            final ServiceDate serviceDate, EstimatedVehicleJourney estimatedVehicleJourney) {
 
         // Preconditions
         Preconditions.checkNotNull(stops);
@@ -896,7 +898,24 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
         pattern.getScheduledTimetable().getTripTimes().clear();
 
         // Add to buffer as-is to include it in the 'lastAddedTripPattern'
+        //TODO - Should this update be done twice?
         buffer.update(pattern, updatedTripTimes, serviceDate);
+
+        // Add TripOnServiceDate to buffer if a dated service journey id is supplied in the SIRI message
+        if(estimatedVehicleJourney.getDatedVehicleJourneyRef() != null || estimatedVehicleJourney.getFramedVehicleJourneyRef().getDatedVehicleJourneyRef() != null) {
+            TripAlteration tripAlteration;
+            var dsjId = estimatedVehicleJourney.getDatedVehicleJourneyRef() == null ? estimatedVehicleJourney.getFramedVehicleJourneyRef().getDatedVehicleJourneyRef(): estimatedVehicleJourney.getDatedVehicleJourneyRef().getValue();
+
+            FeedScopedId datedServiceJourneyId = new FeedScopedId(feedId,
+                    dsjId
+            );
+            var tripOnServiceDate = new TripOnServiceDate(datedServiceJourneyId,
+                            trip,
+                            serviceDate,
+                    null);
+
+            buffer.addLastAddedTripOnServiceDate(trip, serviceDate,datedServiceJourneyId, tripOnServiceDate);
+        }
 
         //TODO - SIRI: Add pattern to index?
 

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
@@ -80,6 +80,8 @@ import org.opentripplanner.ext.transmodelapi.model.stop.RentalVehicleType;
 import org.opentripplanner.ext.transmodelapi.model.stop.StopPlaceType;
 import org.opentripplanner.ext.transmodelapi.model.stop.TariffZoneType;
 import org.opentripplanner.ext.transmodelapi.model.timetable.BookingArrangementType;
+import org.opentripplanner.ext.transmodelapi.model.timetable.DatedServiceJourneyQuery;
+import org.opentripplanner.ext.transmodelapi.model.timetable.DatedServiceJourneyType;
 import org.opentripplanner.ext.transmodelapi.model.timetable.InterchangeType;
 import org.opentripplanner.ext.transmodelapi.model.timetable.ServiceJourneyType;
 import org.opentripplanner.ext.transmodelapi.model.timetable.TimetabledPassingTimeType;
@@ -219,6 +221,10 @@ public class TransmodelGraphQLSchema {
           gqlUtil
       );
 
+
+      GraphQLOutputType datedServiceJourneyType =
+              DatedServiceJourneyType.create(serviceJourneyType);
+
       GraphQLOutputType timetabledPassingTime  = TimetabledPassingTimeType.create(
           bookingArrangementType,
           noticeType,
@@ -241,8 +247,8 @@ public class TransmodelGraphQLSchema {
             estimatedCallType,
             lineType,
             serviceJourneyType,
-            ptSituationElementType
-
+            ptSituationElementType,
+            datedServiceJourneyType
         );
 
         GraphQLFieldDefinition tripQuery = TripQuery.create(routing, tripType, gqlUtil);
@@ -1143,6 +1149,7 @@ public class TransmodelGraphQLSchema {
             .type(new GraphQLNonNull(serverInfoType))
             .dataFetcher(e -> projectInfo())
             .build())
+        .field(DatedServiceJourneyQuery.createGetById(datedServiceJourneyType))
         .build();
 
         Set<GraphQLType> dictionary = new HashSet<>();
@@ -1178,7 +1185,8 @@ public class TransmodelGraphQLSchema {
         GraphQLOutputType estimatedCallType,
         GraphQLOutputType lineType,
         GraphQLOutputType serviceJourneyType,
-        GraphQLOutputType ptSituationElementType
+        GraphQLOutputType ptSituationElementType,
+        GraphQLOutputType datedServiceJourneyType
     ) {
       GraphQLObjectType tripMetadataType = TripMetadataType.create(gqlUtil);
       GraphQLObjectType placeType = PlanPlaceType.create(bikeRentalStationType, rentalVehicleType, quayType);
@@ -1193,6 +1201,7 @@ public class TransmodelGraphQLSchema {
           estimatedCallType,
           lineType,
           serviceJourneyType,
+          datedServiceJourneyType,
           ptSituationElementType,
           placeType,
           pathGuidanceType,

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/LegType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/LegType.java
@@ -32,6 +32,7 @@ public class LegType {
       GraphQLOutputType estimatedCallType,
       GraphQLOutputType lineType,
       GraphQLOutputType serviceJourneyType,
+      GraphQLOutputType datedServiceJourneyType,
       GraphQLOutputType ptSituationElementType,
       GraphQLObjectType placeType,
       GraphQLObjectType pathGuidanceType,
@@ -220,6 +221,22 @@ public class LegType {
             .type(serviceJourneyType)
             .dataFetcher(env -> leg(env).getTrip())
             .build())
+            .field(GraphQLFieldDefinition
+            .newFieldDefinition()
+            .name("datedServiceJourney")
+            .description("Trip On Day")
+            .type(datedServiceJourneyType)
+            .dataFetcher(env -> {
+                var trip = leg(env).getTrip();
+                if(trip == null) {
+                    return null;
+                }
+                var tripId = leg(env).getTrip().getId();
+                var serviceDate = leg(env).getServiceDate();
+
+                return GqlUtil.getRoutingService(env)
+                        .getTripOnServiceDateForTripAndDay(tripId, serviceDate);
+            }).build())
         .field(GraphQLFieldDefinition
             .newFieldDefinition()
             .name("intermediateQuays")

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/LegType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/LegType.java
@@ -224,7 +224,7 @@ public class LegType {
             .field(GraphQLFieldDefinition
             .newFieldDefinition()
             .name("datedServiceJourney")
-            .description("Trip On Day")
+            .description("The dated service journey used for this leg.")
             .type(datedServiceJourneyType)
             .dataFetcher(env -> {
                 var trip = leg(env).getTrip();

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/LegType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/LegType.java
@@ -221,7 +221,7 @@ public class LegType {
             .type(serviceJourneyType)
             .dataFetcher(env -> leg(env).getTrip())
             .build())
-            .field(GraphQLFieldDefinition
+        .field(GraphQLFieldDefinition
             .newFieldDefinition()
             .name("datedServiceJourney")
             .description("The dated service journey used for this leg.")

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/DatedServiceJourneyQuery.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/DatedServiceJourneyQuery.java
@@ -4,6 +4,7 @@ import graphql.Scalars;
 import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLOutputType;
+import org.opentripplanner.ext.transmodelapi.mapping.TransitIdMapper;
 import org.opentripplanner.ext.transmodelapi.support.GqlUtil;
 import org.opentripplanner.model.FeedScopedId;
 
@@ -24,7 +25,7 @@ public class DatedServiceJourneyQuery {
                         .type(Scalars.GraphQLString))
                 .dataFetcher(environment -> {
                     FeedScopedId id =
-                            FeedScopedId.parseId(environment.getArgument("datedServiceJourneyId"));
+                            TransitIdMapper.mapIDToDomain(environment.getArgument("id"));
 
                     return GqlUtil.getRoutingService(environment)
                             .getTripOnServiceDateById(id);

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/DatedServiceJourneyQuery.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/DatedServiceJourneyQuery.java
@@ -20,7 +20,7 @@ public class DatedServiceJourneyQuery {
                 .type(datedServiceJourneyType)
                 .description("Get a single dated service journey based on its id")
                 .argument(GraphQLArgument.newArgument()
-                        .name("datedServiceJourneyId")
+                        .name("id")
                         .type(Scalars.GraphQLString))
                 .dataFetcher(environment -> {
                     FeedScopedId id =

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/DatedServiceJourneyQuery.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/DatedServiceJourneyQuery.java
@@ -1,0 +1,36 @@
+package org.opentripplanner.ext.transmodelapi.model.timetable;
+
+import graphql.Scalars;
+import graphql.schema.GraphQLArgument;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLOutputType;
+import org.opentripplanner.ext.transmodelapi.support.GqlUtil;
+import org.opentripplanner.model.FeedScopedId;
+
+/**
+ * A GraphQL query for retrieving data on DatedServiceJourneys
+ */
+public class DatedServiceJourneyQuery {
+
+    public static GraphQLFieldDefinition createGetById(
+            GraphQLOutputType datedServiceJourneyType
+    ) {
+        return GraphQLFieldDefinition.newFieldDefinition()
+                .name("datedServiceJourney")
+                .type(datedServiceJourneyType)
+                .description("Get a single dated service journey based on its id")
+                .argument(GraphQLArgument.newArgument()
+                        .name("datedServiceJourneyId")
+                        .type(Scalars.GraphQLString))
+                .dataFetcher(environment -> {
+                    FeedScopedId id =
+                            FeedScopedId.parseId(environment.getArgument("datedServiceJourneyId"));
+
+                    return GqlUtil.getRoutingService(environment)
+                            .getTripOnServiceDateById(id);
+                })
+                .build();
+    }
+
+}
+

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/DatedServiceJourneyType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/DatedServiceJourneyType.java
@@ -27,6 +27,7 @@ public class DatedServiceJourneyType {
                 .field(GqlUtil.newTransitIdField())
                 .field(GraphQLFieldDefinition.newFieldDefinition()
                         .name("OperatingDayDate")
+                        .description("The date this service runs. The date used is based on the service date as opposed to calendar date.")
                         .type(Scalars.GraphQLString)
                         .dataFetcher(environment -> (
                                 tripOnServiceDate(environment).getServiceDate().toString()
@@ -34,6 +35,7 @@ public class DatedServiceJourneyType {
                 )
                 .field(GraphQLFieldDefinition.newFieldDefinition()
                         .name("ServiceJourney")
+                        .description("The service journey this Dated Service Journey is based on")
                         .type(new GraphQLNonNull(serviceJourneyType))
                         .dataFetcher(environment -> (
                                         tripOnServiceDate(environment).getTrip()
@@ -41,6 +43,7 @@ public class DatedServiceJourneyType {
                         ))
                 .field(GraphQLFieldDefinition.newFieldDefinition()
                         .name("TripAlteration")
+                        .description("Alterations specified on the Trip in the planned data")
                         .type(SERVICE_ALTERATION)
                         .dataFetcher(environment -> tripOnServiceDate(environment).getTripAlteration())
                 )

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/DatedServiceJourneyType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/DatedServiceJourneyType.java
@@ -26,7 +26,7 @@ public class DatedServiceJourneyType {
                 .description("A planned journey on a specific day")
                 .field(GqlUtil.newTransitIdField())
                 .field(GraphQLFieldDefinition.newFieldDefinition()
-                        .name("OperatingDayDate")
+                        .name("operatingDay")
                         .description("The date this service runs. The date used is based on the service date as opposed to calendar date.")
                         .type(Scalars.GraphQLString)
                         .dataFetcher(environment -> (
@@ -34,7 +34,7 @@ public class DatedServiceJourneyType {
                         ))
                 )
                 .field(GraphQLFieldDefinition.newFieldDefinition()
-                        .name("ServiceJourney")
+                        .name("serviceJourney")
                         .description("The service journey this Dated Service Journey is based on")
                         .type(new GraphQLNonNull(serviceJourneyType))
                         .dataFetcher(environment -> (
@@ -42,7 +42,7 @@ public class DatedServiceJourneyType {
                                 )
                         ))
                 .field(GraphQLFieldDefinition.newFieldDefinition()
-                        .name("TripAlteration")
+                        .name("tripAlteration")
                         .description("Alterations specified on the Trip in the planned data")
                         .type(SERVICE_ALTERATION)
                         .dataFetcher(environment -> tripOnServiceDate(environment).getTripAlteration())

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/DatedServiceJourneyType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/DatedServiceJourneyType.java
@@ -1,0 +1,53 @@
+package org.opentripplanner.ext.transmodelapi.model.timetable;
+
+import static org.opentripplanner.ext.transmodelapi.model.EnumTypes.SERVICE_ALTERATION;
+
+import graphql.Scalars;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLNonNull;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLOutputType;
+import graphql.schema.GraphQLTypeReference;
+import org.opentripplanner.ext.transmodelapi.support.GqlUtil;
+import org.opentripplanner.model.TripOnServiceDate;
+
+/**
+ * A DatedServiceJourney GraphQL Type for use in endpoints fetching DatedServiceJourney data
+ */
+public class DatedServiceJourneyType {
+
+    private static final String NAME = "DatedServiceJourney";
+    public static final GraphQLTypeReference REF = new GraphQLTypeReference(NAME);
+
+    public static GraphQLObjectType create(GraphQLOutputType serviceJourneyType) {
+        return GraphQLObjectType.newObject()
+                .name(NAME)
+                .description("A planned journey on a specific day")
+                .field(GqlUtil.newTransitIdField())
+                .field(GraphQLFieldDefinition.newFieldDefinition()
+                        .name("OperatingDayDate")
+                        .type(Scalars.GraphQLString)
+                        .dataFetcher(environment -> (
+                                tripOnServiceDate(environment).getServiceDate().toString()
+                        ))
+                )
+                .field(GraphQLFieldDefinition.newFieldDefinition()
+                        .name("ServiceJourney")
+                        .type(new GraphQLNonNull(serviceJourneyType))
+                        .dataFetcher(environment -> (
+                                        tripOnServiceDate(environment).getTrip()
+                                )
+                        ))
+                .field(GraphQLFieldDefinition.newFieldDefinition()
+                        .name("TripAlteration")
+                        .type(SERVICE_ALTERATION)
+                        .dataFetcher(environment -> tripOnServiceDate(environment).getTripAlteration())
+                )
+                .build();
+    }
+
+    private static TripOnServiceDate tripOnServiceDate(DataFetchingEnvironment environment) {
+        return environment.getSource();
+    }
+}

--- a/src/main/java/org/opentripplanner/model/TimetableSnapshot.java
+++ b/src/main/java/org/opentripplanner/model/TimetableSnapshot.java
@@ -3,6 +3,7 @@ package org.opentripplanner.model;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.SetMultimap;
+import org.opentripplanner.common.model.T2;
 import org.opentripplanner.model.calendar.ServiceDate;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.mappers.TransitLayerUpdater;
 import org.opentripplanner.routing.trippattern.TripTimes;
@@ -111,6 +112,9 @@ public class TimetableSnapshot {
      * TODO clarify what it means to say "last" added trip pattern. There can be more than one? What happens to the older ones?
      */
     private HashMap<TripIdAndServiceDate, TripPattern> lastAddedTripPattern = new HashMap<>();
+
+    private HashMap<FeedScopedId, TripOnServiceDate> lastAddedTripOnServiceDate = new HashMap<>();
+    private HashMap<T2<FeedScopedId, ServiceDate>, TripOnServiceDate> lastAddedTripOnServiceDateByTripIdAndServiceDate = new HashMap<>();
 
     /**
      * This maps contains all of the new or updated TripPatterns added by realtime data indexed on
@@ -261,7 +265,7 @@ public class TimetableSnapshot {
 
         // To make these trip patterns visible for departureRow searches.
         addPatternToIndex(pattern);
-        
+
         // The time tables are finished during the commit
         
         return true;
@@ -300,6 +304,10 @@ public class TimetableSnapshot {
             transitLayerUpdater.update(dirtyTimetables);
         }
 
+        ret.lastAddedTripOnServiceDate =
+                (HashMap<FeedScopedId, TripOnServiceDate>) this.lastAddedTripOnServiceDate.clone();
+        ret.lastAddedTripOnServiceDateByTripIdAndServiceDate =
+                (HashMap<T2<FeedScopedId, ServiceDate>, TripOnServiceDate>) this.lastAddedTripOnServiceDateByTripIdAndServiceDate.clone();
         this.dirtyTimetables.clear();
         this.dirty = false;
 
@@ -429,5 +437,19 @@ public class TimetableSnapshot {
 
     public void setPatternsForStop(SetMultimap<StopLocation, TripPattern> patternsForStop) {
         this.patternsForStop = patternsForStop;
+    }
+
+    public void addLastAddedTripOnServiceDate(Trip trip, ServiceDate serviceDate, FeedScopedId datedServiceJourneyId, TripOnServiceDate tripOnServiceDate) {
+        lastAddedTripOnServiceDate.put(datedServiceJourneyId, tripOnServiceDate);
+        lastAddedTripOnServiceDateByTripIdAndServiceDate.put(
+                new T2(trip.getId(), serviceDate), tripOnServiceDate);
+    }
+
+    public HashMap<FeedScopedId, TripOnServiceDate> getLastAddedTripOnServiceDate() {
+        return lastAddedTripOnServiceDate;
+    }
+
+    public HashMap<T2<FeedScopedId, ServiceDate>, TripOnServiceDate> getLastAddedTripOnServiceDateByTripIdAndServiceDate() {
+        return lastAddedTripOnServiceDateByTripIdAndServiceDate;
     }
 }

--- a/src/main/java/org/opentripplanner/model/TimetableSnapshot.java
+++ b/src/main/java/org/opentripplanner/model/TimetableSnapshot.java
@@ -114,7 +114,7 @@ public class TimetableSnapshot {
     private HashMap<TripIdAndServiceDate, TripPattern> lastAddedTripPattern = new HashMap<>();
 
     private HashMap<FeedScopedId, TripOnServiceDate> lastAddedTripOnServiceDate = new HashMap<>();
-    private HashMap<T2<FeedScopedId, ServiceDate>, TripOnServiceDate> lastAddedTripOnServiceDateByTripIdAndServiceDate = new HashMap<>();
+    private HashMap<TripIdAndServiceDate, TripOnServiceDate> lastAddedTripOnServiceDateByTripIdAndServiceDate = new HashMap<>();
 
     /**
      * This maps contains all of the new or updated TripPatterns added by realtime data indexed on
@@ -307,7 +307,7 @@ public class TimetableSnapshot {
         ret.lastAddedTripOnServiceDate =
                 (HashMap<FeedScopedId, TripOnServiceDate>) this.lastAddedTripOnServiceDate.clone();
         ret.lastAddedTripOnServiceDateByTripIdAndServiceDate =
-                (HashMap<T2<FeedScopedId, ServiceDate>, TripOnServiceDate>) this.lastAddedTripOnServiceDateByTripIdAndServiceDate.clone();
+                (HashMap<TripIdAndServiceDate, TripOnServiceDate>) this.lastAddedTripOnServiceDateByTripIdAndServiceDate.clone();
         this.dirtyTimetables.clear();
         this.dirty = false;
 
@@ -442,14 +442,14 @@ public class TimetableSnapshot {
     public void addLastAddedTripOnServiceDate(Trip trip, ServiceDate serviceDate, FeedScopedId datedServiceJourneyId, TripOnServiceDate tripOnServiceDate) {
         lastAddedTripOnServiceDate.put(datedServiceJourneyId, tripOnServiceDate);
         lastAddedTripOnServiceDateByTripIdAndServiceDate.put(
-                new T2(trip.getId(), serviceDate), tripOnServiceDate);
+                new TripIdAndServiceDate(trip.getId(), serviceDate), tripOnServiceDate);
     }
 
     public HashMap<FeedScopedId, TripOnServiceDate> getLastAddedTripOnServiceDate() {
         return lastAddedTripOnServiceDate;
     }
 
-    public HashMap<T2<FeedScopedId, ServiceDate>, TripOnServiceDate> getLastAddedTripOnServiceDateByTripIdAndServiceDate() {
+    public HashMap<TripIdAndServiceDate, TripOnServiceDate> getLastAddedTripOnServiceDateByTripIdAndServiceDate() {
         return lastAddedTripOnServiceDateByTripIdAndServiceDate;
     }
 }

--- a/src/main/java/org/opentripplanner/model/TripOnServiceDate.java
+++ b/src/main/java/org/opentripplanner/model/TripOnServiceDate.java
@@ -7,9 +7,9 @@ import org.opentripplanner.model.calendar.ServiceDate;
  */
 public class TripOnServiceDate extends TransitEntity {
 
-    private Trip trip;
-    private ServiceDate serviceDate;
-    private TripAlteration tripAlteration;
+    private final Trip trip;
+    private final ServiceDate serviceDate;
+    private final TripAlteration tripAlteration;
 
     public TripOnServiceDate(FeedScopedId id, Trip trip, ServiceDate serviceDate, TripAlteration tripAlteration) {
         super(id);
@@ -30,7 +30,4 @@ public class TripOnServiceDate extends TransitEntity {
         return tripAlteration;
     }
 
-    public void setTripAlteration(TripAlteration tripAlteration) {
-        this.tripAlteration = tripAlteration;
-    }
 }

--- a/src/main/java/org/opentripplanner/model/TripOnServiceDate.java
+++ b/src/main/java/org/opentripplanner/model/TripOnServiceDate.java
@@ -1,0 +1,36 @@
+package org.opentripplanner.model;
+
+import org.opentripplanner.model.calendar.ServiceDate;
+
+/**
+ * Class for holding data about a certain trip on a certain day. Essentially a DatedServiceJourney.
+ */
+public class TripOnServiceDate extends TransitEntity {
+
+    private Trip trip;
+    private ServiceDate serviceDate;
+    private TripAlteration tripAlteration;
+
+    public TripOnServiceDate(FeedScopedId id, Trip trip, ServiceDate serviceDate, TripAlteration tripAlteration) {
+        super(id);
+        this.trip = trip;
+        this.serviceDate = serviceDate;
+        this.tripAlteration = tripAlteration;
+    }
+
+    public Trip getTrip() {
+        return trip;
+    }
+
+    public ServiceDate getServiceDate() {
+        return serviceDate;
+    }
+
+    public TripAlteration getTripAlteration() {
+        return tripAlteration;
+    }
+
+    public void setTripAlteration(TripAlteration tripAlteration) {
+        this.tripAlteration = tripAlteration;
+    }
+}

--- a/src/main/java/org/opentripplanner/model/impl/OtpTransitServiceBuilder.java
+++ b/src/main/java/org/opentripplanner/model/impl/OtpTransitServiceBuilder.java
@@ -37,6 +37,7 @@ import org.opentripplanner.model.Stop;
 import org.opentripplanner.model.StopPattern;
 import org.opentripplanner.model.TransitEntity;
 import org.opentripplanner.model.Trip;
+import org.opentripplanner.model.TripOnServiceDate;
 import org.opentripplanner.model.TripPattern;
 import org.opentripplanner.model.TripStopTimes;
 import org.opentripplanner.model.calendar.CalendarServiceData;
@@ -115,6 +116,8 @@ public class OtpTransitServiceBuilder {
     private final EntityById<Branding> brandingsById = new EntityById<>();
 
     private final Multimap<FeedScopedId, GroupOfRoutes> groupsOfRoutesByRouteId = ArrayListMultimap.create();
+    
+    private final EntityById<TripOnServiceDate> tripOnServiceDates = new EntityById<>();
 
     private final EntityById<GroupOfRoutes> groupOfRouteById = new EntityById<>();
 
@@ -245,6 +248,10 @@ public class OtpTransitServiceBuilder {
         return groupOfRouteById;
     }
 
+    public EntityById<TripOnServiceDate> getTripOnServiceDates() {
+        return tripOnServiceDates;
+    }
+
     /**
      * Find all serviceIds in both CalendarServices and CalendarServiceDates.
      */
@@ -331,6 +338,7 @@ public class OtpTransitServiceBuilder {
         removeStopTimesForNoneExistingTrips();
         fixOrRemovePatternsWhichReferenceNoneExistingTrips();
         removeTransfersForNoneExistingTrips();
+        removeTripOnServiceDateForNonExistingTrip();
     }
 
     private void removeInvalidShapeIds(DataImportIssueStore issues) {
@@ -385,6 +393,21 @@ public class OtpTransitServiceBuilder {
         int orgSize = transfers.size();
         transfers.removeIf(this::transferTripReferencesDoNotExist);
         logRemove("Trip", orgSize, transfers.size(), "Transfer to/from trip does not exist.");
+    }
+
+    /**
+     * Remove TripOnServiceDates if there are no trips using them
+     */
+    private void removeTripOnServiceDateForNonExistingTrip() {
+        int orgSize = tripOnServiceDates.size();
+        for(TripOnServiceDate tripOnServiceDate : tripOnServiceDates.values()) {
+            if(!tripsById.containsKey(tripOnServiceDate.getTrip().getId())) {
+                logRemove(
+                        "TripOnServiceDate", orgSize, tripOnServiceDates.size(),
+                        "Trip for TripOnServiceDate does not exist."
+                );
+            }
+        }
     }
 
     /** Return {@code true} if the from/to trip reference is none null, but do not exist. */

--- a/src/main/java/org/opentripplanner/netex/NetexModule.java
+++ b/src/main/java/org/opentripplanner/netex/NetexModule.java
@@ -7,6 +7,7 @@ import org.opentripplanner.graph_builder.module.GtfsFeedId;
 import org.opentripplanner.graph_builder.module.geometry.GeometryAndBlockProcessor;
 import org.opentripplanner.graph_builder.services.GraphBuilderModule;
 import org.opentripplanner.model.OtpTransitService;
+import org.opentripplanner.model.TripOnServiceDate;
 import org.opentripplanner.model.calendar.CalendarServiceData;
 import org.opentripplanner.model.calendar.ServiceDateInterval;
 import org.opentripplanner.model.impl.OtpTransitServiceBuilder;
@@ -79,7 +80,9 @@ public class NetexModule implements GraphBuilderModule {
                         issueStore
                 );
                 transitBuilder.limitServiceDays(transitPeriodLimit, issueStore);
-                graph.getTripOnServiceDates().addAll(transitBuilder.getTripOnServiceDates().values());
+                for(TripOnServiceDate tripOnServiceDate : transitBuilder.getTripOnServiceDates().values()) {
+                    graph.getTripOnServiceDates().put(tripOnServiceDate.getId(), tripOnServiceDate);
+                }
                 calendarServiceData.add(transitBuilder.buildCalendarServiceData());
 
                 if (OTPFeature.FlexRouting.isOn()) {

--- a/src/main/java/org/opentripplanner/netex/NetexModule.java
+++ b/src/main/java/org/opentripplanner/netex/NetexModule.java
@@ -79,7 +79,7 @@ public class NetexModule implements GraphBuilderModule {
                         issueStore
                 );
                 transitBuilder.limitServiceDays(transitPeriodLimit, issueStore);
-
+                graph.getTripOnServiceDates().addAll(transitBuilder.getTripOnServiceDates().values());
                 calendarServiceData.add(transitBuilder.buildCalendarServiceData());
 
                 if (OTPFeature.FlexRouting.isOn()) {

--- a/src/main/java/org/opentripplanner/netex/mapping/NetexMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/NetexMapper.java
@@ -83,7 +83,7 @@ public class NetexMapper {
      */
     private final Map<String, StopTime> stopTimesByNetexId = new HashMap<>();
 
-    private final ArrayListMultimap<String, DatedServiceJourney> datedServiceJourneysBySjId = ArrayListMultimap.create();
+    private final Multimap<String, DatedServiceJourney> datedServiceJourneysBySjId = ArrayListMultimap.create();
 
 
     public NetexMapper(
@@ -361,7 +361,7 @@ public class NetexMapper {
         ));
         tripCalendarBuilder.addDatedServiceJourneys(
             currentNetexIndex.getOperatingDayById(),
-                datedServiceJourneysBySjId
+            datedServiceJourneysBySjId
         );
     }
 

--- a/src/main/java/org/opentripplanner/netex/mapping/NetexMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/NetexMapper.java
@@ -83,7 +83,7 @@ public class NetexMapper {
      */
     private final Map<String, StopTime> stopTimesByNetexId = new HashMap<>();
 
-    private final Map<String, List<DatedServiceJourney>> datedServiceJourneysBySjId = new HashMap<>();
+    private final ArrayListMultimap<String, DatedServiceJourney> datedServiceJourneysBySjId = ArrayListMultimap.create();
 
 
     public NetexMapper(

--- a/src/main/java/org/opentripplanner/netex/mapping/NetexMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/NetexMapper.java
@@ -34,6 +34,7 @@ import org.opentripplanner.netex.mapping.support.FeedScopedIdFactory;
 import org.opentripplanner.routing.trippattern.Deduplicator;
 import org.rutebanken.netex.model.Authority;
 import org.rutebanken.netex.model.Branding;
+import org.rutebanken.netex.model.DatedServiceJourney;
 import org.rutebanken.netex.model.FlexibleLine;
 import org.rutebanken.netex.model.FlexibleStopPlace;
 import org.rutebanken.netex.model.GroupOfStopPlaces;
@@ -81,6 +82,8 @@ public class NetexMapper {
      * OTPTransitService, so we need to temporally cash this here.
      */
     private final Map<String, StopTime> stopTimesByNetexId = new HashMap<>();
+
+    private final Map<String, List<DatedServiceJourney>> datedServiceJourneysBySjId = new HashMap<>();
 
 
     public NetexMapper(
@@ -353,11 +356,12 @@ public class NetexMapper {
     }
 
     private void mapDatedServiceJourneys() {
+        datedServiceJourneysBySjId.putAll(DatedServiceJourneyMapper.indexDSJBySJId(
+                currentNetexIndex.getDatedServiceJourneys()
+        ));
         tripCalendarBuilder.addDatedServiceJourneys(
             currentNetexIndex.getOperatingDayById(),
-            DatedServiceJourneyMapper.indexDSJBySJId(
-                currentNetexIndex.getDatedServiceJourneys()
-            )
+                datedServiceJourneysBySjId
         );
     }
 
@@ -420,6 +424,8 @@ public class NetexMapper {
                 currentNetexIndex.getDestinationDisplayById(),
                 currentNetexIndex.getServiceJourneyById(),
                 currentNetexIndex.getFlexibleLineById(),
+                currentNetexIndex.getOperatingDayById(),
+                datedServiceJourneysBySjId,
                 serviceIds,
                 deduplicator
         );
@@ -436,6 +442,7 @@ public class NetexMapper {
             }
             stopTimesByNetexId.putAll(result.stopTimeByNetexId);
             groupMapper.scheduledStopPointsIndex.putAll(result.scheduledStopPointsIndex);
+            transitBuilder.getTripOnServiceDates().addAll(result.tripOnServiceDates);
         }
     }
 

--- a/src/main/java/org/opentripplanner/netex/mapping/TripCalendarBuilder.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/TripCalendarBuilder.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.netex.mapping;
 
+import com.google.common.collect.ArrayListMultimap;
 import org.opentripplanner.graph_builder.DataImportIssueStore;
 import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.model.calendar.ServiceDate;
@@ -75,7 +76,7 @@ public class TripCalendarBuilder {
 
   void addDatedServiceJourneys(
       ReadOnlyHierarchicalMapById<OperatingDay> operatingDayById,
-      Map<String, List<DatedServiceJourney>> datedServiceJourneyBySJId
+      ArrayListMultimap<String, DatedServiceJourney> datedServiceJourneyBySJId
   ) {
     for (String sjId : datedServiceJourneyBySJId.keySet()) {
 

--- a/src/main/java/org/opentripplanner/netex/mapping/TripCalendarBuilder.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/TripCalendarBuilder.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.netex.mapping;
 
 import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
 import org.opentripplanner.graph_builder.DataImportIssueStore;
 import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.model.calendar.ServiceDate;
@@ -76,7 +77,7 @@ public class TripCalendarBuilder {
 
   void addDatedServiceJourneys(
       ReadOnlyHierarchicalMapById<OperatingDay> operatingDayById,
-      ArrayListMultimap<String, DatedServiceJourney> datedServiceJourneyBySJId
+      Multimap<String, DatedServiceJourney> datedServiceJourneyBySJId
   ) {
     for (String sjId : datedServiceJourneyBySJId.keySet()) {
 

--- a/src/main/java/org/opentripplanner/netex/mapping/TripPatternMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/TripPatternMapper.java
@@ -56,7 +56,7 @@ class TripPatternMapper {
     private final Multimap<String, ServiceJourney> serviceJourniesByPatternId = ArrayListMultimap.create();
 
     private ReadOnlyHierarchicalMapById<OperatingDay> operatingDayById;
-    private final Map<String, List<DatedServiceJourney>> datedServiceJourneys;
+    private final ArrayListMultimap<String, DatedServiceJourney> datedServiceJourneys;
 
     private final TripMapper tripMapper;
 
@@ -83,7 +83,7 @@ class TripPatternMapper {
             ReadOnlyHierarchicalMap<String, ServiceJourney> serviceJourneyById,
             ReadOnlyHierarchicalMapById<FlexibleLine> flexibleLinesById,
             ReadOnlyHierarchicalMapById<OperatingDay> operatingDayById,
-            Map<String, List<DatedServiceJourney>> datedServiceJourneys,
+            ArrayListMultimap<String, DatedServiceJourney> datedServiceJourneys,
             Map<String, FeedScopedId> serviceIds,
             Deduplicator deduplicator
     ) {
@@ -145,7 +145,8 @@ class TripPatternMapper {
 
             if(datedServiceJourneys.containsKey(serviceJourney.getId())) {
                 for (DatedServiceJourney datedServiceJourney : datedServiceJourneys.get(
-                        serviceJourney.getId())) {
+                        serviceJourney.getId())
+                ) {
                     var opDay = operatingDayById.lookup(
                             datedServiceJourney.getOperatingDayRef().getRef());
                     if (opDay == null) {
@@ -159,7 +160,8 @@ class TripPatternMapper {
                                     trip, serviceDate,
                                     TripServiceAlterationMapper.mapAlteration(
                                             datedServiceJourney.getServiceAlteration())
-                            ));
+                            )
+                    );
                 }
             }
             // Unable to map ServiceJourney, problem logged by the mapper above

--- a/src/main/java/org/opentripplanner/netex/mapping/TripPatternMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/TripPatternMapper.java
@@ -56,7 +56,7 @@ class TripPatternMapper {
     private final Multimap<String, ServiceJourney> serviceJourniesByPatternId = ArrayListMultimap.create();
 
     private ReadOnlyHierarchicalMapById<OperatingDay> operatingDayById;
-    private final ArrayListMultimap<String, DatedServiceJourney> datedServiceJourneys;
+    private final Multimap<String, DatedServiceJourney> datedServiceJourneys;
 
     private final TripMapper tripMapper;
 
@@ -83,7 +83,7 @@ class TripPatternMapper {
             ReadOnlyHierarchicalMap<String, ServiceJourney> serviceJourneyById,
             ReadOnlyHierarchicalMapById<FlexibleLine> flexibleLinesById,
             ReadOnlyHierarchicalMapById<OperatingDay> operatingDayById,
-            ArrayListMultimap<String, DatedServiceJourney> datedServiceJourneys,
+            Multimap<String, DatedServiceJourney> datedServiceJourneys,
             Map<String, FeedScopedId> serviceIds,
             Deduplicator deduplicator
     ) {
@@ -148,7 +148,8 @@ class TripPatternMapper {
                         serviceJourney.getId())
                 ) {
                     var opDay = operatingDayById.lookup(
-                            datedServiceJourney.getOperatingDayRef().getRef());
+                            datedServiceJourney.getOperatingDayRef().getRef()
+                    );
                     if (opDay == null) {
                         continue;
                     }

--- a/src/main/java/org/opentripplanner/netex/mapping/TripPatternMapperResult.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/TripPatternMapperResult.java
@@ -2,12 +2,14 @@ package org.opentripplanner.netex.mapping;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.opentripplanner.model.StopPattern;
 import org.opentripplanner.model.StopTime;
 import org.opentripplanner.model.Trip;
+import org.opentripplanner.model.TripOnServiceDate;
 import org.opentripplanner.model.TripPattern;
 
 /**
@@ -29,4 +31,6 @@ class TripPatternMapperResult {
      * stopTimes by the timetabled-passing-time id
      */
     final Map<String, StopTime> stopTimeByNetexId = new HashMap<>();
+
+    final ArrayList<TripOnServiceDate> tripOnServiceDates = new ArrayList<>();
 }

--- a/src/main/java/org/opentripplanner/netex/mapping/calendar/DatedServiceJourneyMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/calendar/DatedServiceJourneyMapper.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.netex.mapping.calendar;
 
 import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
 import org.opentripplanner.model.calendar.ServiceDate;
 import org.opentripplanner.netex.index.api.ReadOnlyHierarchicalMapById;
 import org.rutebanken.netex.model.DatedServiceJourney;
@@ -22,10 +23,10 @@ import static org.opentripplanner.netex.mapping.support.ServiceAlterationFilter.
  */
 public class DatedServiceJourneyMapper {
 
-  public static ArrayListMultimap<String, DatedServiceJourney> indexDSJBySJId(
+  public static Multimap<String, DatedServiceJourney> indexDSJBySJId(
       ReadOnlyHierarchicalMapById<DatedServiceJourney> datedServiceJourneys
   ) {
-    ArrayListMultimap<String, DatedServiceJourney> dsjBySJId = ArrayListMultimap.create();
+    Multimap<String, DatedServiceJourney> dsjBySJId = ArrayListMultimap.create();
     for (DatedServiceJourney dsj : datedServiceJourneys.localValues()) {
       dsjBySJId.put(dsj.getJourneyRef().get(0).getValue().getRef(), dsj);
     }

--- a/src/main/java/org/opentripplanner/netex/mapping/calendar/DatedServiceJourneyMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/calendar/DatedServiceJourneyMapper.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.netex.mapping.calendar;
 
+import com.google.common.collect.ArrayListMultimap;
 import org.opentripplanner.model.calendar.ServiceDate;
 import org.opentripplanner.netex.index.api.ReadOnlyHierarchicalMapById;
 import org.rutebanken.netex.model.DatedServiceJourney;
@@ -21,16 +22,12 @@ import static org.opentripplanner.netex.mapping.support.ServiceAlterationFilter.
  */
 public class DatedServiceJourneyMapper {
 
-  public static Map<String, List<DatedServiceJourney>> indexDSJBySJId(
+  public static ArrayListMultimap<String, DatedServiceJourney> indexDSJBySJId(
       ReadOnlyHierarchicalMapById<DatedServiceJourney> datedServiceJourneys
   ) {
-    Map<String, List<DatedServiceJourney>> dsjBySJId = new HashMap<>();
+    ArrayListMultimap<String, DatedServiceJourney> dsjBySJId = ArrayListMultimap.create();
     for (DatedServiceJourney dsj : datedServiceJourneys.localValues()) {
-      dsjBySJId.computeIfAbsent(
-          // The validation step ensure no NPE occurs here
-          dsj.getJourneyRef().get(0).getValue().getRef(),
-          it -> new ArrayList<>()
-      ).add(dsj);
+      dsjBySJId.put(dsj.getJourneyRef().get(0).getValue().getRef(), dsj);
     }
     return dsjBySJId;
   }

--- a/src/main/java/org/opentripplanner/routing/DatedServiceJourneyHelper.java
+++ b/src/main/java/org/opentripplanner/routing/DatedServiceJourneyHelper.java
@@ -8,21 +8,27 @@ import org.opentripplanner.model.calendar.ServiceDate;
 public class DatedServiceJourneyHelper {
 
     /**
-     * Gets a TripOnServiceDate from a timetable snapshot if it has realtime updates
-     * otherwise from the graph index
+     * Gets a TripOnServiceDate from a timetable snapshot if it has realtime updates otherwise from
+     * the graph index
+     *
      * @param routingService
      * @param tripId
      * @param serviceDate
      * @return
      */
-    public static TripOnServiceDate getTripOnServiceDate(RoutingService routingService, FeedScopedId tripId, ServiceDate serviceDate) {
+    public static TripOnServiceDate getTripOnServiceDate(
+            RoutingService routingService,
+            FeedScopedId tripId,
+            ServiceDate serviceDate
+    ) {
 
         var tuple = new T2<>(tripId, serviceDate);
         if (routingService.getTimetableSnapshot() != null) {
             if (routingService
                     .getTimetableSnapshot()
                     .getLastAddedTripOnServiceDateByTripIdAndServiceDate()
-                    .containsKey(tuple)) {
+                    .containsKey(tuple)
+            ) {
 
                 return routingService
                         .getTimetableSnapshot()
@@ -34,17 +40,22 @@ public class DatedServiceJourneyHelper {
     }
 
     /**
-     * Gets a TripOnServiceDate from a timetable snapshot if it has realtime updates
-     * otherwise from the graph index
+     * Gets a TripOnServiceDate from a timetable snapshot if it has realtime updates otherwise from
+     * the graph index
+     *
      * @param routingService
      * @param datedServiceJourneyId
      * @return
      */
-    public static TripOnServiceDate getTripOnServiceDate(RoutingService routingService, FeedScopedId datedServiceJourneyId) {
+    public static TripOnServiceDate getTripOnServiceDate(
+            RoutingService routingService,
+            FeedScopedId datedServiceJourneyId
+    ) {
         if (routingService
                 .getTimetableSnapshot()
                 .getLastAddedTripOnServiceDate()
-                .containsKey(datedServiceJourneyId)) {
+                .containsKey(datedServiceJourneyId)
+        ) {
 
             return routingService
                     .getTimetableSnapshot()

--- a/src/main/java/org/opentripplanner/routing/DatedServiceJourneyHelper.java
+++ b/src/main/java/org/opentripplanner/routing/DatedServiceJourneyHelper.java
@@ -1,0 +1,58 @@
+package org.opentripplanner.routing;
+
+import org.opentripplanner.common.model.T2;
+import org.opentripplanner.model.FeedScopedId;
+import org.opentripplanner.model.TripOnServiceDate;
+import org.opentripplanner.model.calendar.ServiceDate;
+
+public class DatedServiceJourneyHelper {
+
+    /**
+     * Gets a TripOnServiceDate from a timetable snapshot if it has realtime updates
+     * otherwise from the graph index
+     * @param routingService
+     * @param tripId
+     * @param serviceDate
+     * @return
+     */
+    public static TripOnServiceDate getTripOnServiceDate(RoutingService routingService, FeedScopedId tripId, ServiceDate serviceDate) {
+
+        var tuple = new T2<>(tripId, serviceDate);
+        if (routingService.getTimetableSnapshot() != null) {
+            if (routingService
+                    .getTimetableSnapshot()
+                    .getLastAddedTripOnServiceDateByTripIdAndServiceDate()
+                    .containsKey(tuple)) {
+
+                return routingService
+                        .getTimetableSnapshot()
+                        .getLastAddedTripOnServiceDateByTripIdAndServiceDate()
+                        .get(tuple);
+            }
+        }
+        return routingService.getTripOnServiceDateForTripAndDay().get(tuple);
+    }
+
+    /**
+     * Gets a TripOnServiceDate from a timetable snapshot if it has realtime updates
+     * otherwise from the graph index
+     * @param routingService
+     * @param datedServiceJourneyId
+     * @return
+     */
+    public static TripOnServiceDate getTripOnServiceDate(RoutingService routingService, FeedScopedId datedServiceJourneyId) {
+        if (routingService
+                .getTimetableSnapshot()
+                .getLastAddedTripOnServiceDate()
+                .containsKey(datedServiceJourneyId)) {
+
+            return routingService
+                    .getTimetableSnapshot()
+                    .getLastAddedTripOnServiceDate().get(datedServiceJourneyId);
+        }
+
+        return routingService
+                .getTripOnServiceDateById()
+                .get(datedServiceJourneyId);
+    }
+}

--- a/src/main/java/org/opentripplanner/routing/RoutingService.java
+++ b/src/main/java/org/opentripplanner/routing/RoutingService.java
@@ -31,6 +31,7 @@ import org.opentripplanner.model.TimetableSnapshotProvider;
 import org.opentripplanner.model.TransitEntity;
 import org.opentripplanner.model.TransitMode;
 import org.opentripplanner.model.Trip;
+import org.opentripplanner.model.TripOnServiceDate;
 import org.opentripplanner.model.TripPattern;
 import org.opentripplanner.model.TripTimeOnDate;
 import org.opentripplanner.model.WgsCoordinate;
@@ -629,4 +630,21 @@ public class RoutingService {
         }
         return this.timetableSnapshot;
     }
+    
+    public TripOnServiceDate getTripOnServiceDateForTripAndDay(FeedScopedId tripId, ServiceDate serviceDate) {
+        return DatedServiceJourneyHelper.getTripOnServiceDate(this, tripId, serviceDate);
+    }
+    
+    public TripOnServiceDate getTripOnServiceDateById(FeedScopedId datedServiceJourneyId) {
+        return DatedServiceJourneyHelper.getTripOnServiceDate(this, datedServiceJourneyId);
+    }
+
+    public Map<T2<FeedScopedId, ServiceDate>, TripOnServiceDate> getTripOnServiceDateForTripAndDay() {
+        return graphIndex.getTripOnServiceDateForTripAndDay();
+    }
+
+    public Map<FeedScopedId, TripOnServiceDate> getTripOnServiceDateById() {
+        return graphIndex.getTripOnServiceDateById();
+    }
+
 }

--- a/src/main/java/org/opentripplanner/routing/graph/Graph.java
+++ b/src/main/java/org/opentripplanner/routing/graph/Graph.java
@@ -63,6 +63,7 @@ import org.opentripplanner.model.TimetableSnapshot;
 import org.opentripplanner.model.TimetableSnapshotProvider;
 import org.opentripplanner.model.TransitEntity;
 import org.opentripplanner.model.TransitMode;
+import org.opentripplanner.model.TripOnServiceDate;
 import org.opentripplanner.model.TripPattern;
 import org.opentripplanner.model.WgsCoordinate;
 import org.opentripplanner.model.calendar.CalendarService;
@@ -237,6 +238,8 @@ public class Graph implements Serializable {
      * vertices/edges anymore.
      */
     public Map<FeedScopedId, TripPattern> tripPatternForId = Maps.newHashMap();
+
+    public Collection<TripOnServiceDate> tripOnServiceDates = new ArrayList();
 
     /** Pre-generated transfers between all stops. */
     public final Multimap<StopLocation, PathTransfer> transfersByStop = HashMultimap.create();
@@ -953,6 +956,10 @@ public class Graph implements Serializable {
 
     public Collection<TripPattern> getTripPatterns() {
         return tripPatternForId.values();
+    }
+
+    public Collection<TripOnServiceDate> getTripOnServiceDates() {
+        return tripOnServiceDates;
     }
 
     public Collection<Notice> getNotices() {

--- a/src/main/java/org/opentripplanner/routing/graph/Graph.java
+++ b/src/main/java/org/opentripplanner/routing/graph/Graph.java
@@ -239,7 +239,7 @@ public class Graph implements Serializable {
      */
     public Map<FeedScopedId, TripPattern> tripPatternForId = Maps.newHashMap();
 
-    public Collection<TripOnServiceDate> tripOnServiceDates = new ArrayList();
+    public Map<FeedScopedId, TripOnServiceDate> tripOnServiceDates = Maps.newHashMap();
 
     /** Pre-generated transfers between all stops. */
     public final Multimap<StopLocation, PathTransfer> transfersByStop = HashMultimap.create();
@@ -958,7 +958,7 @@ public class Graph implements Serializable {
         return tripPatternForId.values();
     }
 
-    public Collection<TripOnServiceDate> getTripOnServiceDates() {
+    public Map<FeedScopedId, TripOnServiceDate> getTripOnServiceDates() {
         return tripOnServiceDates;
     }
 

--- a/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
+++ b/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
@@ -107,7 +107,7 @@ public class GraphIndex {
             }
         }
 
-        for(TripOnServiceDate tripOnServiceDate : graph.tripOnServiceDates) {
+        for(TripOnServiceDate tripOnServiceDate : graph.tripOnServiceDates.values()) {
             tripOnServiceDateById.put(tripOnServiceDate.getId(), tripOnServiceDate);
             tripOnServiceDateForTripAndDay.put(
                     new T2<>(tripOnServiceDate.getTrip().getId(), tripOnServiceDate.getServiceDate()), tripOnServiceDate);

--- a/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
+++ b/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
@@ -17,6 +17,7 @@ import java.util.stream.Collectors;
 import org.locationtech.jts.geom.Envelope;
 import org.opentripplanner.common.geometry.CompactElevationProfile;
 import org.opentripplanner.common.geometry.HashGridSpatialIndex;
+import org.opentripplanner.common.model.T2;
 import org.opentripplanner.ext.flex.FlexIndex;
 import org.opentripplanner.ext.flex.trip.FlexTrip;
 import org.opentripplanner.model.Agency;
@@ -29,6 +30,7 @@ import org.opentripplanner.model.Stop;
 import org.opentripplanner.model.StopLocation;
 import org.opentripplanner.model.TimetableSnapshot;
 import org.opentripplanner.model.Trip;
+import org.opentripplanner.model.TripOnServiceDate;
 import org.opentripplanner.model.TripPattern;
 import org.opentripplanner.model.calendar.CalendarService;
 import org.opentripplanner.model.calendar.ServiceDate;
@@ -55,6 +57,8 @@ public class GraphIndex {
     private final Map<Station, MultiModalStation> multiModalStationForStations = Maps.newHashMap();
     private final HashGridSpatialIndex<TransitStopVertex> stopSpatialIndex = new HashGridSpatialIndex<>();
     private final Map<ServiceDate, TIntSet> serviceCodesRunningForDate = new HashMap<>();
+    private final Map<FeedScopedId, TripOnServiceDate> tripOnServiceDateById = new HashMap<>();
+    private final Map<T2<FeedScopedId, ServiceDate>, TripOnServiceDate> tripOnServiceDateForTripAndDay = new HashMap<>();
     private FlexIndex flexIndex = null;
 
     public GraphIndex(Graph graph) {
@@ -101,6 +105,12 @@ public class GraphIndex {
             for (Station childStation : multiModalStation.getChildStations()) {
                 multiModalStationForStations.put(childStation, multiModalStation);
             }
+        }
+
+        for(TripOnServiceDate tripOnServiceDate : graph.tripOnServiceDates) {
+            tripOnServiceDateById.put(tripOnServiceDate.getId(), tripOnServiceDate);
+            tripOnServiceDateForTripAndDay.put(
+                    new T2<>(tripOnServiceDate.getTrip().getId(), tripOnServiceDate.getServiceDate()), tripOnServiceDate);
         }
 
         initalizeServiceCodesForDate(graph);
@@ -230,6 +240,14 @@ public class GraphIndex {
 
     public Map<FeedScopedId, Trip> getTripForId() {
         return tripForId;
+    }
+
+    public Map<FeedScopedId, TripOnServiceDate> getTripOnServiceDateById() {
+        return tripOnServiceDateById;
+    }
+
+    public Map<T2<FeedScopedId, ServiceDate>, TripOnServiceDate> getTripOnServiceDateForTripAndDay() {
+        return tripOnServiceDateForTripAndDay;
     }
 
     public Collection<Route> getAllRoutes() {

--- a/src/test/java/org/opentripplanner/netex/mapping/NetexTestDataSample.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/NetexTestDataSample.java
@@ -4,6 +4,7 @@ import static org.opentripplanner.netex.mapping.MappingSupport.ID_FACTORY;
 import static org.opentripplanner.netex.mapping.MappingSupport.createJaxbElement;
 import static org.opentripplanner.netex.mapping.MappingSupport.createWrappedRef;
 
+import com.google.common.collect.ArrayListMultimap;
 import java.math.BigInteger;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -63,7 +64,7 @@ class NetexTestDataSample {
     private final HierarchicalMapById<ServiceJourney> serviceJourneyById = new HierarchicalMapById<>();
     private final HierarchicalMapById<Route> routesById = new HierarchicalMapById<>();
     private final HierarchicalMapById<OperatingDay> operatingDaysById = new HierarchicalMapById<>();
-    private final Map<String, List<DatedServiceJourney>> datedServiceJourneyBySjId = new HashMap<>();
+    private final ArrayListMultimap<String, DatedServiceJourney> datedServiceJourneyBySjId = ArrayListMultimap.create();
 
     private final EntityById<org.opentripplanner.model.Route> otpRouteByid = new EntityById<>();
 
@@ -152,7 +153,6 @@ class NetexTestDataSample {
                     );
             serviceJourneyById.add(serviceJourney);
 
-            datedServiceJourneyBySjId.put(SERVICE_JOURNEY_ID, new ArrayList());
             for(int i=0; i<DATED_SERVICE_JOURNEY_ID.size(); i++) {
                 OperatingDay operatingDay = new OperatingDay()
                         .withId(OPERATING_DAYS.get(i))
@@ -166,7 +166,7 @@ class NetexTestDataSample {
                         .withOperatingDayRef(
                                 new OperatingDayRefStructure().withRef(operatingDay.getId()));
 
-                datedServiceJourneyBySjId.get(SERVICE_JOURNEY_ID).add(datedServiceJourney);
+                datedServiceJourneyBySjId.put(SERVICE_JOURNEY_ID, datedServiceJourney);
 
             }
         }
@@ -229,7 +229,7 @@ class NetexTestDataSample {
         return operatingDaysById;
     }
 
-    Map<String, List<DatedServiceJourney>> getDatedServiceJourneyBySjId() {
+    ArrayListMultimap<String, DatedServiceJourney> getDatedServiceJourneyBySjId() {
         return datedServiceJourneyBySjId;
     }
 

--- a/src/test/java/org/opentripplanner/netex/mapping/NetexTestDataSample.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/NetexTestDataSample.java
@@ -5,16 +5,21 @@ import static org.opentripplanner.netex.mapping.MappingSupport.createJaxbElement
 import static org.opentripplanner.netex.mapping.MappingSupport.createWrappedRef;
 
 import java.math.BigInteger;
+import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import javax.xml.bind.JAXBElement;
 import org.opentripplanner.model.Stop;
 import org.opentripplanner.model.impl.EntityById;
 import org.opentripplanner.netex.index.hierarchy.HierarchicalMap;
 import org.opentripplanner.netex.index.hierarchy.HierarchicalMapById;
 import org.rutebanken.netex.model.AllVehicleModesOfTransportEnumeration;
+import org.rutebanken.netex.model.DatedServiceJourney;
 import org.rutebanken.netex.model.DayType;
 import org.rutebanken.netex.model.DayTypeRefStructure;
 import org.rutebanken.netex.model.DayTypeRefs_RelStructure;
@@ -25,11 +30,14 @@ import org.rutebanken.netex.model.JourneyPatternRefStructure;
 import org.rutebanken.netex.model.Line;
 import org.rutebanken.netex.model.LineRefStructure;
 import org.rutebanken.netex.model.MultilingualString;
+import org.rutebanken.netex.model.OperatingDay;
+import org.rutebanken.netex.model.OperatingDayRefStructure;
 import org.rutebanken.netex.model.PointInLinkSequence_VersionedChildStructure;
 import org.rutebanken.netex.model.PointsInJourneyPattern_RelStructure;
 import org.rutebanken.netex.model.Route;
 import org.rutebanken.netex.model.RouteRefStructure;
 import org.rutebanken.netex.model.ScheduledStopPointRefStructure;
+import org.rutebanken.netex.model.ServiceAlterationEnumeration;
 import org.rutebanken.netex.model.ServiceJourney;
 import org.rutebanken.netex.model.StopPointInJourneyPattern;
 import org.rutebanken.netex.model.StopPointInJourneyPatternRefStructure;
@@ -40,6 +48,8 @@ import org.rutebanken.netex.model.Vias_RelStructure;
 
 class NetexTestDataSample {
     public static final String SERVICE_JOURNEY_ID = "RUT:ServiceJourney:1";
+    public static final List<String> DATED_SERVICE_JOURNEY_ID = List.of("RUT:DatedServiceJourney:1", "RUT:DatedServiceJourney:2");
+    public static final List<String> OPERATING_DAYS = List.of("2022-02-28", "2022-02-29");
     private static final DayType EVERYDAY = new DayType()
             .withId("EVERYDAY")
             .withName(new MultilingualString().withValue("everyday"));
@@ -52,6 +62,8 @@ class NetexTestDataSample {
     private final List<TimetabledPassingTime> timetabledPassingTimes = new ArrayList<>();
     private final HierarchicalMapById<ServiceJourney> serviceJourneyById = new HierarchicalMapById<>();
     private final HierarchicalMapById<Route> routesById = new HierarchicalMapById<>();
+    private final HierarchicalMapById<OperatingDay> operatingDaysById = new HierarchicalMapById<>();
+    private final Map<String, List<DatedServiceJourney>> datedServiceJourneyBySjId = new HashMap<>();
 
     private final EntityById<org.opentripplanner.model.Route> otpRouteByid = new EntityById<>();
 
@@ -139,6 +151,24 @@ class NetexTestDataSample {
                             new TimetabledPassingTimes_RelStructure().withTimetabledPassingTime(timetabledPassingTimes)
                     );
             serviceJourneyById.add(serviceJourney);
+
+            datedServiceJourneyBySjId.put(SERVICE_JOURNEY_ID, new ArrayList());
+            for(int i=0; i<DATED_SERVICE_JOURNEY_ID.size(); i++) {
+                OperatingDay operatingDay = new OperatingDay()
+                        .withId(OPERATING_DAYS.get(i))
+                                .withCalendarDate(
+                                        LocalDate.parse(OPERATING_DAYS.get(i), DateTimeFormatter.ofPattern("yyyy-MM-dd")).atStartOfDay());
+                operatingDaysById.add(operatingDay);
+
+                DatedServiceJourney datedServiceJourney = new DatedServiceJourney()
+                        .withId(DATED_SERVICE_JOURNEY_ID.get(i))
+                        .withServiceAlteration(ServiceAlterationEnumeration.PLANNED)
+                        .withOperatingDayRef(
+                                new OperatingDayRefStructure().withRef(operatingDay.getId()));
+
+                datedServiceJourneyBySjId.get(SERVICE_JOURNEY_ID).add(datedServiceJourney);
+
+            }
         }
 
         // Setup stops
@@ -193,6 +223,14 @@ class NetexTestDataSample {
 
     EntityById<org.opentripplanner.model.Route> getOtpRouteByid() {
         return otpRouteByid;
+    }
+
+    HierarchicalMapById<OperatingDay> getOperatingDaysById() {
+        return operatingDaysById;
+    }
+
+    Map<String, List<DatedServiceJourney>> getDatedServiceJourneyBySjId() {
+        return datedServiceJourneyBySjId;
     }
 
 

--- a/src/test/java/org/opentripplanner/netex/mapping/TripCalendarBuilderTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/TripCalendarBuilderTest.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.netex.mapping;
 
+import com.google.common.collect.ArrayListMultimap;
 import org.junit.Test;
 import org.opentripplanner.graph_builder.DataImportIssueStore;
 import org.opentripplanner.model.FeedScopedId;
@@ -127,11 +128,13 @@ public class TripCalendarBuilderTest {
         .toString();
   }
 
-  private Map<String, List<DatedServiceJourney>> dsj_2020_11_02(String sjId) {
+  private ArrayListMultimap<String, DatedServiceJourney> dsj_2020_11_02(String sjId) {
     var dsj = new DatedServiceJourney();
     dsj.withOperatingDayRef(new OperatingDayRefStructure().withRef(OD_1));
     dsj.getJourneyRef().add(jaxbElement(new JourneyRefStructure().withRef(sjId), JourneyRefStructure.class));
-    return Map.of(sjId, List.of(dsj));
+    ArrayListMultimap<String, DatedServiceJourney> map = ArrayListMultimap.create();
+    map.put(sjId, dsj);
+    return map;
   }
 
   private static HierarchicalMapById<OperatingDay> operatingDays_2020_11_02() {

--- a/src/test/java/org/opentripplanner/netex/mapping/TripPatternMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/TripPatternMapperTest.java
@@ -2,6 +2,7 @@ package org.opentripplanner.netex.mapping;
 
 import static org.junit.Assert.assertEquals;
 
+import com.google.common.collect.ArrayListMultimap;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -47,7 +48,7 @@ public class TripPatternMapperTest {
                 sample.getServiceJourneyById(),
                 new HierarchicalMapById<>(),
                 new HierarchicalMapById<>(),
-                new HashMap<>(),
+                ArrayListMultimap.create(),
                 Map.of(NetexTestDataSample.SERVICE_JOURNEY_ID, SERVICE_ID),
                 new Deduplicator()
         );

--- a/src/test/java/org/opentripplanner/netex/mapping/TripPatternMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/TripPatternMapperTest.java
@@ -3,17 +3,21 @@ package org.opentripplanner.netex.mapping;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import org.junit.Test;
 import org.opentripplanner.graph_builder.DataImportIssueStore;
 import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.model.Trip;
+import org.opentripplanner.model.TripAlteration;
+import org.opentripplanner.model.TripOnServiceDate;
 import org.opentripplanner.model.TripPattern;
 import org.opentripplanner.model.impl.EntityById;
 import org.opentripplanner.netex.index.hierarchy.HierarchicalMap;
 import org.opentripplanner.netex.index.hierarchy.HierarchicalMapById;
 import org.opentripplanner.routing.trippattern.Deduplicator;
 import org.opentripplanner.routing.trippattern.TripTimes;
+import org.rutebanken.netex.model.OperatingDay;
 
 /**
  * @author Thomas Gran (Capra) - tgr@capraconsulting.no (29.11.2017)
@@ -42,6 +46,8 @@ public class TripPatternMapperTest {
                 new HierarchicalMapById<>(),
                 sample.getServiceJourneyById(),
                 new HierarchicalMapById<>(),
+                new HierarchicalMapById<>(),
+                new HashMap<>(),
                 Map.of(NetexTestDataSample.SERVICE_JOURNEY_ID, SERVICE_ID),
                 new Deduplicator()
         );
@@ -73,5 +79,49 @@ public class TripPatternMapperTest {
         assertEquals(18240, tripTimes.getDepartureTime(1));
         assertEquals(18600, tripTimes.getDepartureTime(2));
         assertEquals(18900, tripTimes.getDepartureTime(3));
+    }
+
+    @Test
+    public void testMapTripPattern_datedServiceJourney() {
+        NetexTestDataSample sample = new NetexTestDataSample();
+
+        TripPatternMapper tripPatternMapper = new TripPatternMapper(
+                new DataImportIssueStore(false),
+                MappingSupport.ID_FACTORY,
+                new EntityById<>(),
+                sample.getStopsById(),
+                new EntityById<>(),
+                new EntityById<>(),
+                sample.getOtpRouteByid(),
+                Collections.emptySet(),
+                sample.getRouteById(),
+                sample.getJourneyPatternById(),
+                sample.getQuayIdByStopPointRef(),
+                new HierarchicalMap<>(),
+                new HierarchicalMapById<>(),
+                sample.getServiceJourneyById(),
+                new HierarchicalMapById<>(),
+                sample.getOperatingDaysById(),
+                sample.getDatedServiceJourneyBySjId(),
+                Map.of(NetexTestDataSample.SERVICE_JOURNEY_ID, SERVICE_ID),
+                new Deduplicator()
+        );
+
+        TripPatternMapperResult r = tripPatternMapper.mapTripPattern(sample.getJourneyPattern());
+
+        assertEquals(1, r.tripPatterns.size());
+        assertEquals(2, r.tripOnServiceDates.size());
+
+        TripPattern tripPattern = r.tripPatterns.values().stream().findFirst().orElseThrow();
+        Trip trip = tripPattern.scheduledTripsAsStream().findFirst().get();
+
+
+        for(TripOnServiceDate tripOnServiceDate : r.tripOnServiceDates) {
+            assertEquals(trip, tripOnServiceDate.getTrip());
+            assertEquals(TripAlteration.PLANNED, tripOnServiceDate.getTripAlteration());
+            assertEquals(1, sample.getOperatingDaysById().localValues().stream()
+                    .map(OperatingDay::getId)
+                    .filter(id -> id.equals(tripOnServiceDate.getServiceDate().toString())).count());
+        }
     }
 }

--- a/src/test/java/org/opentripplanner/netex/mapping/calendar/DatedServiceJourneyMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/calendar/DatedServiceJourneyMapperTest.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.netex.mapping.calendar;
 
 import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
 import org.junit.Test;
 import org.opentripplanner.model.calendar.ServiceDate;
 import org.opentripplanner.netex.index.hierarchy.HierarchicalMapById;
@@ -52,7 +53,7 @@ public class DatedServiceJourneyMapperTest {
     HierarchicalMapById<DatedServiceJourney> input = new HierarchicalMapById<>();
     input.addAll(List.of(dsj1, dsj2, dsj3));
 
-    ArrayListMultimap<String, DatedServiceJourney> result = DatedServiceJourneyMapper.indexDSJBySJId(input);
+    Multimap<String, DatedServiceJourney> result = DatedServiceJourneyMapper.indexDSJBySJId(input);
 
     assertEquals("DSJ-1, DSJ-3", listIdsSortedAsStr(result.get(SJ_1)));
     assertEquals("DSJ-2", listIdsSortedAsStr(result.get(SJ_2)));
@@ -94,7 +95,7 @@ public class DatedServiceJourneyMapperTest {
     assertEquals(List.of(SD1, SD2), sort(result));
   }
 
-  private static String listIdsSortedAsStr(List<DatedServiceJourney> list) {
+  private static String listIdsSortedAsStr(Collection<DatedServiceJourney> list) {
     return list.stream()
         .map(EntityStructure::getId)
         .sorted()

--- a/src/test/java/org/opentripplanner/netex/mapping/calendar/DatedServiceJourneyMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/calendar/DatedServiceJourneyMapperTest.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.netex.mapping.calendar;
 
+import com.google.common.collect.ArrayListMultimap;
 import org.junit.Test;
 import org.opentripplanner.model.calendar.ServiceDate;
 import org.opentripplanner.netex.index.hierarchy.HierarchicalMapById;
@@ -39,7 +40,7 @@ public class DatedServiceJourneyMapperTest {
 
   @Test
   public void indexDSJBySJIdWithEmptyInput() {
-    assertEquals(Map.of(), DatedServiceJourneyMapper.indexDSJBySJId(new HierarchicalMapById<>()));
+    assertEquals(ArrayListMultimap.create(), DatedServiceJourneyMapper.indexDSJBySJId(new HierarchicalMapById<>()));
   }
 
   @Test
@@ -51,7 +52,7 @@ public class DatedServiceJourneyMapperTest {
     HierarchicalMapById<DatedServiceJourney> input = new HierarchicalMapById<>();
     input.addAll(List.of(dsj1, dsj2, dsj3));
 
-    Map<String, List<DatedServiceJourney>> result = DatedServiceJourneyMapper.indexDSJBySJId(input);
+    ArrayListMultimap<String, DatedServiceJourney> result = DatedServiceJourneyMapper.indexDSJBySJId(input);
 
     assertEquals("DSJ-1, DSJ-3", listIdsSortedAsStr(result.get(SJ_1)));
     assertEquals("DSJ-2", listIdsSortedAsStr(result.get(SJ_2)));


### PR DESCRIPTION
### Summary
Created a new object `TripOnServiceDate` to represent a DatedServiceJourney and adds these to the graph index by creating two new maps. 
One is indexed using datedServiceJourneyId and the other using a tuple of tripId and serviceDate. Both return a single TripOnServiceDate.
TripOnServiceDates are also indexed in TimetableSnapshots for when there are realtime updates.

A new GraphQL endpoint is added called datedServiceJourney with which you can retrieve a datedServiceJourney from the graph index (or TimetableSnapshot if there are realtime updates) using a datedServiceJourneyId.
Additionally a field is added to the LegType where you can now retrieve the datedServiceJourney used in that leg aswell following the same logic as above.

### Unit tests
A new unit test was added asserting that TripOnServiceDate objects are correctly created during NeTEx mapping.

### Code style
Followed the code style included in the repo

Related issue #3150 