### PR TITLE
Extract StatesToWalkStepsMapper from GraphPathToItineraryMapper [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/api/mapping/WalkStepMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/WalkStepMapper.java
@@ -43,6 +43,7 @@ public class WalkStepMapper {
             api.lat = domain.startLocation.latitude();
         }
         api.elevation = mapElevation(domain.elevation);
+        api.walkingBike = domain.walkingBike;
         api.alerts = alertsMapper.mapToApi(domain.streetNotes);
 
         return api;

--- a/src/main/java/org/opentripplanner/api/model/ApiWalkStep.java
+++ b/src/main/java/org/opentripplanner/api/model/ApiWalkStep.java
@@ -88,6 +88,11 @@ public class ApiWalkStep {
      */
     public String elevation;
 
+    /**
+     * Is this step walking with a bike?
+     */
+    public Boolean walkingBike;
+
     public List<ApiAlert> alerts;
 
     public String toString() {

--- a/src/main/java/org/opentripplanner/model/plan/WalkStep.java
+++ b/src/main/java/org/opentripplanner/model/plan/WalkStep.java
@@ -99,6 +99,11 @@ public class WalkStep {
     public double angle;
 
     /**
+     * Is this step walking with a bike?
+     */
+    public boolean walkingBike;
+
+    /**
      * The street edges that make up this walkStep.
      * Used only in generating the streetEdges array in StreetSegment; not serialized. 
      */

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/StatesToWalkStepsMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/StatesToWalkStepsMapper.java
@@ -414,6 +414,7 @@ public class StatesToWalkStepsMapper {
         step.bogusName = en.hasBogusName();
         step.addStreetNotes(graph.streetNotesService.getNotes(forwardState));
         step.angle = DirectionUtils.getFirstAngle(forwardState.getBackEdge().getGeometry());
+        step.walkingBike = forwardState.isBackWalkingBike();
         if (forwardState.getBackEdge() instanceof AreaEdge) {
             step.area = true;
         }

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/StatesToWalkStepsMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/StatesToWalkStepsMapper.java
@@ -1,0 +1,465 @@
+package org.opentripplanner.routing.algorithm.mapping;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+import org.opentripplanner.common.geometry.DirectionUtils;
+import org.opentripplanner.common.model.P2;
+import org.opentripplanner.model.VehicleRentalStationInfo;
+import org.opentripplanner.model.WgsCoordinate;
+import org.opentripplanner.model.plan.RelativeDirection;
+import org.opentripplanner.model.plan.WalkStep;
+import org.opentripplanner.routing.core.State;
+import org.opentripplanner.routing.edgetype.AreaEdge;
+import org.opentripplanner.routing.edgetype.ElevatorAlightEdge;
+import org.opentripplanner.routing.edgetype.FreeEdge;
+import org.opentripplanner.routing.edgetype.StreetEdge;
+import org.opentripplanner.routing.graph.Edge;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.routing.graph.Vertex;
+import org.opentripplanner.routing.vertextype.ExitVertex;
+import org.opentripplanner.routing.vertextype.VehicleRentalStationVertex;
+
+/**
+ * Process a list of states into a list of walking/driving instructions for a street leg.
+ */
+public class StatesToWalkStepsMapper {
+
+    /**
+     * Tolerance for how many meters can be between two consecutive turns will be merged into a
+     * singe walk step. See {@link StatesToWalkStepsMapper#removeZag(WalkStep, WalkStep)}
+     */
+    private static final double MAX_ZAG_DISTANCE = 30;
+
+    private final Graph graph;
+    private final List<State> states;
+    private final WalkStep previous;
+    private final List<WalkStep> steps = new ArrayList<>();
+
+    private WalkStep current = null;
+    private double lastAngle = 0;
+
+    /**
+     * Distance used for appending elevation profiles
+     */
+    private double distance = 0;
+
+    /**
+     * Track whether we are in a roundabout, and if so the exit number
+     */
+    private int roundaboutExit = 0;
+    private String roundaboutPreviousStreet = null;
+
+    /**
+     * Converts a list of street edges to a list of turn-by-turn directions.
+     *
+     * @param previousStep the last walking step of a non-transit leg that immediately precedes this
+       one or null, if first leg
+     */
+    public StatesToWalkStepsMapper(Graph graph, List<State> states, WalkStep previousStep) {
+        this.graph = graph;
+        this.states = states;
+        this.previous = previousStep;
+    }
+
+    public List<WalkStep> generateWalkSteps() {
+        for (int i = 0; i < states.size() - 1; i++) {
+            processState(states.get(i), states.get(i + 1));
+        }
+
+        if (steps.isEmpty()) {
+            return steps;
+        }
+
+        // add vehicle rental information if applicable
+        if (GraphPathToItineraryMapper.isRentalPickUp(states.get(states.size() - 1))) {
+            VehicleRentalStationVertex vertex =
+                    (VehicleRentalStationVertex) (states.get(states.size() - 1)).getVertex();
+            steps.get(steps.size() - 1).vehicleRentalOnStation =
+                    new VehicleRentalStationInfo(vertex);
+        }
+        if (GraphPathToItineraryMapper.isRentalDropOff(states.get(0))) {
+            VehicleRentalStationVertex vertex =
+                    (VehicleRentalStationVertex) (states.get(0)).getVertex();
+            steps.get(0).vehicleRentalOffStation = new VehicleRentalStationInfo(vertex);
+        }
+
+        return steps;
+    }
+
+    private void processState(State backState, State forwardState) {
+        Edge edge = forwardState.getBackEdge();
+
+        boolean createdNewStep = false;
+        if (edge instanceof FreeEdge) {
+            return;
+        }
+        if (forwardState.getBackMode() == null) {
+            return;
+        }
+        Geometry geom = edge.getGeometry();
+        if (geom == null) {
+            return;
+        }
+
+        // generate a step for getting off an elevator (all elevator narrative generation occurs
+        // when alighting). We don't need to know what came before or will come after
+        if (edge instanceof ElevatorAlightEdge) {
+            createElevatorWalkStep(backState, forwardState, edge);
+            return;
+        }
+
+        String streetName = edge.getName().toString();
+        String streetNameNoParens = getNormalizedName(streetName);
+
+        boolean modeTransition = forwardState.getBackMode() != backState.getBackMode();
+
+        if (current == null) {
+            createFirstStep(backState, forwardState);
+            createdNewStep = true;
+        }
+        else if (modeTransition || !continueOnSameStreet(edge, streetNameNoParens) ||
+                // went on to or off of a roundabout
+                edge.isRoundabout() != (roundaboutExit > 0) || isLink(edge) && !isLink(
+                backState.getBackEdge())) {
+            // Street name has changed, or we've gone on to or off of a roundabout.
+
+            // if we were just on a roundabout, make note of which exit was taken in the existing step
+            if (roundaboutExit > 0) {
+                current.exit = Integer.toString(roundaboutExit); // ordinal numbers from
+                if (streetNameNoParens.equals(roundaboutPreviousStreet)) {
+                    current.stayOn = true;
+                }
+                roundaboutExit = 0;
+            }
+
+            // start a new step
+            current = createWalkStep(graph, forwardState, backState);
+            createdNewStep = true;
+            steps.add(current);
+
+            // indicate that we are now on a roundabout and use one-based exit numbering
+            if (edge.isRoundabout()) {
+                roundaboutExit = 1;
+                roundaboutPreviousStreet =
+                        getNormalizedName(backState.getBackEdge().getName().toString());
+            }
+
+            double thisAngle = DirectionUtils.getFirstAngle(geom);
+            current.setDirections(lastAngle, thisAngle, edge.isRoundabout());
+            // new step, set distance to length of first edge
+            distance = edge.getDistanceMeters();
+        }
+        else {
+            // street name has not changed
+            double thisAngle = DirectionUtils.getFirstAngle(geom);
+            RelativeDirection direction =
+                    WalkStep.getRelativeDirection(lastAngle, thisAngle, edge.isRoundabout());
+            boolean optionsBefore = backState.multipleOptionsBefore();
+            if (edge.isRoundabout()) {
+                // we are on a roundabout, and have already traversed at least one edge of it.
+                if (optionsBefore) {
+                    // increment exit count if we passed one.
+                    roundaboutExit += 1;
+                }
+            }
+            else if (direction != RelativeDirection.CONTINUE) {
+                // we are not on a roundabout, and not continuing straight through.
+                // figure out if there were other plausible turn options at the last intersection
+                // to see if we should generate a "left to continue" instruction.
+                if (isPossibleToTurnToOtherStreet(backState, edge, streetName, thisAngle)) {
+                    // turn to stay on same-named street
+                    current = createWalkStep(graph, forwardState, backState);
+                    createdNewStep = true;
+                    steps.add(current);
+                    current.setDirections(lastAngle, thisAngle, false);
+                    current.stayOn = true;
+                    // new step, set distance to length of first edge
+                    distance = edge.getDistanceMeters();
+                }
+            }
+        }
+
+        setMotorwayExit(backState);
+
+        if (createdNewStep && !modeTransition) {
+            // check last three steps for zag
+            int lastIndex = steps.size() - 1;
+            if (lastIndex >= 2) {
+                WalkStep threeBack = steps.get(lastIndex - 2);
+                WalkStep twoBack = steps.get(lastIndex - 1);
+                WalkStep lastStep = steps.get(lastIndex);
+                boolean isOnSameStreet =
+                        lastStep.streetNameNoParens().equals(threeBack.streetNameNoParens());
+                if (twoBack.distance < MAX_ZAG_DISTANCE && isOnSameStreet) {
+                    if (isUTurn(twoBack, lastStep)) {
+                        steps.remove(lastIndex - 1);
+                        processUTurn(lastStep, twoBack);
+                    }
+                    else {
+                        // total hack to remove zags.
+                        steps.remove(lastIndex);
+                        steps.remove(lastIndex - 1);
+                        removeZag(threeBack, twoBack);
+                    }
+                }
+            }
+        }
+        else {
+            if (!createdNewStep && current.elevation != null) {
+                updateElevationProfile(backState, edge);
+            }
+            distance += edge.getDistanceMeters();
+
+        }
+
+        // increment the total length for this step
+        current.distance += edge.getDistanceMeters();
+        current.addStreetNotes(graph.streetNotesService.getNotes(forwardState));
+        lastAngle = DirectionUtils.getLastAngle(geom);
+
+        current.edges.add(edge);
+    }
+
+    private void updateElevationProfile(State backState, Edge edge) {
+        List<P2<Double>> s = encodeElevationProfile(edge, distance,
+                backState.getOptions().geoidElevation ? -graph.ellipsoidToGeoidDifference : 0
+        );
+        if (current.elevation != null && current.elevation.size() > 0) {
+            current.elevation.addAll(s);
+        }
+        else {
+            current.elevation = s;
+        }
+    }
+
+    /**
+     * Merge two consecutive turns will be into a singe walk step.
+     * <p>
+     *      | a
+     *      | 
+     *  ____/ 
+     * / ^ this is a zag between walk steps a and b. If it is less than 30 meters, a and b will be 
+     * |   in the same walk step. 
+     * | b
+     */
+    private void removeZag(WalkStep threeBack, WalkStep twoBack) {
+        current = threeBack;
+        current.distance += twoBack.distance;
+        distance += current.distance;
+        if (twoBack.elevation != null) {
+            if (current.elevation == null) {
+                current.elevation = twoBack.elevation;
+            }
+            else {
+                for (P2<Double> d : twoBack.elevation) {
+                    current.elevation.add(new P2<>(d.first + current.distance, d.second));
+                }
+            }
+        }
+    }
+
+    /**
+     * Have we done a U-Turn with the previous two states
+     */
+    private static boolean isUTurn(WalkStep twoBack, WalkStep lastStep) {
+        RelativeDirection d1 = lastStep.relativeDirection;
+        RelativeDirection d2 = twoBack.relativeDirection;
+        return (
+                (d1 == RelativeDirection.RIGHT || d1 == RelativeDirection.HARD_RIGHT) && (
+                        d2 == RelativeDirection.RIGHT || d2 == RelativeDirection.HARD_RIGHT
+                )
+        ) || (
+                (d1 == RelativeDirection.LEFT || d1 == RelativeDirection.HARD_LEFT) && (
+                        d2 == RelativeDirection.LEFT || d2 == RelativeDirection.HARD_LEFT
+                )
+        );
+    }
+
+    private void processUTurn(WalkStep lastStep, WalkStep twoBack) {
+        // in this case, we have two left turns or two right turns in quick
+        // succession; this is probably a U-turn.
+
+        lastStep.distance += twoBack.distance;
+
+        // A U-turn to the left, typical in the US.
+        if (lastStep.relativeDirection == RelativeDirection.LEFT
+                || lastStep.relativeDirection == RelativeDirection.HARD_LEFT) {
+            lastStep.relativeDirection = RelativeDirection.UTURN_LEFT;
+        }
+        else {
+            lastStep.relativeDirection = RelativeDirection.UTURN_RIGHT;
+        }
+
+        // in this case, we're definitely staying on the same street
+        // (since it's zag removal, the street names are the same)
+        lastStep.stayOn = true;
+    }
+
+    /**
+     * Update the walk step with the name of the motorway junction if set from OSM
+     */
+    private void setMotorwayExit(State backState) {
+        State exitState = backState;
+        Edge exitEdge = exitState.getBackEdge();
+        while (exitEdge instanceof FreeEdge) {
+            exitState = exitState.getBackState();
+            exitEdge = exitState.getBackEdge();
+        }
+        if (exitState.getVertex() instanceof ExitVertex) {
+            current.exit = ((ExitVertex) exitState.getVertex()).getExitName();
+        }
+    }
+
+    /**
+     * Is it possible to turn to another street from this previous state
+     */
+    private boolean isPossibleToTurnToOtherStreet(
+            State backState, Edge edge, String streetName, double thisAngle
+    ) {
+        if (edge instanceof StreetEdge) {
+            // the next edges will be PlainStreetEdges, we hope
+            double angleDiff = getAbsoluteAngleDiff(thisAngle, lastAngle);
+            for (Edge alternative : backState.getVertex().getOutgoingStreetEdges()) {
+                if (isTurnToOtherStreet(streetName, angleDiff, alternative)) {
+                    return true;
+                }
+            }
+        }
+        else {
+            double angleDiff = getAbsoluteAngleDiff(lastAngle, thisAngle);
+            // FIXME: this code might be wrong with the removal of the edge-based graph
+            State twoStatesBack = backState.getBackState();
+            Vertex backVertex = twoStatesBack.getVertex();
+            for (Edge alternative : backVertex.getOutgoingStreetEdges()) {
+                for (Edge innerAlternative : alternative.getToVertex().getOutgoingStreetEdges()) {
+                    if (isTurnToOtherStreet(streetName, angleDiff, innerAlternative)) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Is it possible to turn to another street from this alternative edge
+     */
+    private boolean isTurnToOtherStreet(String streetName, double angleDiff, Edge alternative) {
+        if (alternative.getName().toString().equals(streetName)) {
+            // alternatives that have the same name
+            // are usually caused by street splits
+            return false;
+        }
+
+        double altAngle = DirectionUtils.getFirstAngle(alternative.getGeometry());
+        double altAngleDiff = getAbsoluteAngleDiff(altAngle, lastAngle);
+        return angleDiff > Math.PI / 4 || altAngleDiff - angleDiff < Math.PI / 16;
+    }
+
+    private boolean continueOnSameStreet(Edge edge, String streetNameNoParens) {
+        return !(
+                (
+                        current.streetName != null && !current.streetNameNoParens()
+                                .equals(streetNameNoParens)
+                ) && (!current.bogusName || !edge.hasBogusName())
+        );
+    }
+
+    private void createFirstStep(State backState, State forwardState) {
+        current = createWalkStep(graph, forwardState, backState);
+        steps.add(current);
+
+        Edge edge = forwardState.getBackEdge();
+        double thisAngle = DirectionUtils.getFirstAngle(edge.getGeometry());
+        if (previous == null) {
+            current.setAbsoluteDirection(thisAngle);
+            current.relativeDirection = RelativeDirection.DEPART;
+        }
+        else {
+            current.setDirections(previous.angle, thisAngle, false);
+        }
+        // new step, set distance to length of first edge
+        distance = edge.getDistanceMeters();
+    }
+
+    private void createElevatorWalkStep(State backState, State forwardState, Edge edge) {
+        // don't care what came before or comes after
+        current = createWalkStep(graph, forwardState, backState);
+
+        // tell the user where to get off the elevator using the exit notation, so the
+        // i18n interface will say 'Elevator to <exit>'
+        // what happens is that the webapp sees name == null and ignores that, and it sees
+        // exit != null and uses to <exit>
+        // the floor name is the AlightEdge name
+        // reset to avoid confusion with 'Elevator on floor 1 to floor 1'
+        current.streetName = edge.getName();
+
+        current.relativeDirection = RelativeDirection.ELEVATOR;
+
+        steps.add(current);
+    }
+
+    private static WalkStep createWalkStep(Graph graph, State forwardState, State backState) {
+        Edge en = forwardState.getBackEdge();
+        WalkStep step;
+        step = new WalkStep();
+        step.streetName = en.getName();
+        step.startLocation =
+                new WgsCoordinate(backState.getVertex().getLat(), backState.getVertex().getLon());
+        step.elevation = encodeElevationProfile(forwardState.getBackEdge(), 0,
+                forwardState.getOptions().geoidElevation ? -graph.ellipsoidToGeoidDifference : 0
+        );
+        step.bogusName = en.hasBogusName();
+        step.addStreetNotes(graph.streetNotesService.getNotes(forwardState));
+        step.angle = DirectionUtils.getFirstAngle(forwardState.getBackEdge().getGeometry());
+        if (forwardState.getBackEdge() instanceof AreaEdge) {
+            step.area = true;
+        }
+        return step;
+    }
+
+    private static String getNormalizedName(String streetName) {
+        int idx = streetName.indexOf('(');
+        if (idx > 0) {
+            return streetName.substring(0, idx - 1);
+        }
+        return streetName;
+    }
+
+    private static double getAbsoluteAngleDiff(double thisAngle, double lastAngle) {
+        double angleDiff = thisAngle - lastAngle;
+        if (angleDiff < 0) {
+            angleDiff += Math.PI * 2;
+        }
+        double ccwAngleDiff = Math.PI * 2 - angleDiff;
+        if (ccwAngleDiff < angleDiff) {
+            angleDiff = ccwAngleDiff;
+        }
+        return angleDiff;
+    }
+
+    private static boolean isLink(Edge edge) {
+        return edge instanceof StreetEdge
+                && (((StreetEdge) edge).getStreetClass() & StreetEdge.CLASS_LINK)
+                == StreetEdge.CLASS_LINK;
+    }
+
+    private static List<P2<Double>> encodeElevationProfile(
+            Edge edge, double distanceOffset, double heightOffset
+    ) {
+        if (!(edge instanceof StreetEdge)) {
+            return new ArrayList<>();
+        }
+        StreetEdge elevEdge = (StreetEdge) edge;
+        if (elevEdge.getElevationProfile() == null) {
+            return new ArrayList<>();
+        }
+        ArrayList<P2<Double>> out = new ArrayList<>();
+        for (Coordinate coordinate : elevEdge.getElevationProfile().toCoordinateArray()) {
+            out.add(new P2<>(coordinate.x + distanceOffset, coordinate.y + heightOffset));
+        }
+        return out;
+    }
+}

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/BikeRentalSnapshotTest.snap
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/BikeRentalSnapshotTest.snap
@@ -76,7 +76,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.70059632295107,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "Northwest 24th Avenue"
+              "streetName": "Northwest 24th Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "EAST",
@@ -88,7 +89,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.70058100000001,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "Northwest Irving Street"
+              "streetName": "Northwest Irving Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -100,7 +102,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.7003923,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "way -102328 from 0"
+              "streetName": "way -102328 from 0",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -153,7 +156,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.70038790000001,
               "relativeDirection": "HARD_LEFT",
               "stayOn": false,
-              "streetName": "way -102328 from 0"
+              "streetName": "way -102328 from 0",
+              "walkingBike": true
             }
           ],
           "to": {
@@ -204,7 +208,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.7003923,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "Northwest Irving Street"
+              "streetName": "Northwest Irving Street",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -257,7 +262,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.69423177172958,
               "relativeDirection": "HARD_LEFT",
               "stayOn": false,
-              "streetName": "Northwest Irving Street"
+              "streetName": "Northwest Irving Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -269,7 +275,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.69447930000001,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest 21st Avenue"
+              "streetName": "Northwest 21st Avenue",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -462,7 +469,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.6776666369647,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "Northwest Everett Street"
+              "streetName": "Northwest Everett Street",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -561,7 +569,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.70059632295107,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "Northwest 24th Avenue"
+              "streetName": "Northwest 24th Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "SOUTHEAST",
@@ -573,7 +582,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.7004445,
               "relativeDirection": "SLIGHTLY_LEFT",
               "stayOn": false,
-              "streetName": "Northwest Westover Road"
+              "streetName": "Northwest Westover Road",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "SOUTHWEST",
@@ -585,7 +595,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.70033570000001,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest 24th Place"
+              "streetName": "Northwest 24th Place",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "EAST",
@@ -597,7 +608,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.701384,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "West Burnside Street"
+              "streetName": "West Burnside Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "SOUTHWEST",
@@ -609,7 +621,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.70083500000001,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "way 113897002 from 7"
+              "streetName": "way 113897002 from 7",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -828,7 +841,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.67692504190299,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "West Burnside Street"
+              "streetName": "West Burnside Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -840,7 +854,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.6764861,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "Southwest 6th Avenue"
+              "streetName": "Southwest 6th Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -852,7 +867,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.67645900000001,
               "relativeDirection": "CONTINUE",
               "stayOn": false,
-              "streetName": "Northwest 6th Avenue"
+              "streetName": "Northwest 6th Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "EAST",
@@ -864,7 +880,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.6765342,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest Everett Street"
+              "streetName": "Northwest Everett Street",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -963,7 +980,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.70059632295107,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "Northwest 24th Avenue"
+              "streetName": "Northwest 24th Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "SOUTHEAST",
@@ -975,7 +993,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.7004445,
               "relativeDirection": "SLIGHTLY_LEFT",
               "stayOn": false,
-              "streetName": "Northwest Westover Road"
+              "streetName": "Northwest Westover Road",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "SOUTHWEST",
@@ -987,7 +1006,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.70033570000001,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest 24th Place"
+              "streetName": "Northwest 24th Place",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "EAST",
@@ -999,7 +1019,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.701384,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "West Burnside Street"
+              "streetName": "West Burnside Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "SOUTHWEST",
@@ -1011,7 +1032,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.70083500000001,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "way 113897002 from 7"
+              "streetName": "way 113897002 from 7",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -1243,7 +1265,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.6748017088418,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "West Burnside Street"
+              "streetName": "West Burnside Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -1255,7 +1278,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.67538630000001,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Southwest 5th Avenue"
+              "streetName": "Southwest 5th Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -1267,7 +1291,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.67540310000001,
               "relativeDirection": "CONTINUE",
               "stayOn": false,
-              "streetName": "Northwest 5th Avenue"
+              "streetName": "Northwest 5th Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "EAST",
@@ -1279,7 +1304,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.67548060000001,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest Everett Street"
+              "streetName": "Northwest Everett Street",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -1378,7 +1404,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.70059632295107,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "Northwest 24th Avenue"
+              "streetName": "Northwest 24th Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "WEST",
@@ -1390,7 +1417,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.70064880000001,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "Northwest Lovejoy Street"
+              "streetName": "Northwest Lovejoy Street",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -1596,7 +1624,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.67460910872424,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "Northwest Everett Street"
+              "streetName": "Northwest Everett Street",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -1695,7 +1724,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.70059632295107,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "Northwest 24th Avenue"
+              "streetName": "Northwest 24th Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "EAST",
@@ -1707,7 +1737,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.70058100000001,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "Northwest Irving Street"
+              "streetName": "Northwest Irving Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -1719,7 +1750,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.7003923,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "way -102328 from 0"
+              "streetName": "way -102328 from 0",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -1772,7 +1804,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.70038790000001,
               "relativeDirection": "HARD_LEFT",
               "stayOn": false,
-              "streetName": "way -102328 from 0"
+              "streetName": "way -102328 from 0",
+              "walkingBike": true
             }
           ],
           "to": {
@@ -1823,7 +1856,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.7003923,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "Northwest Irving Street"
+              "streetName": "Northwest Irving Street",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -1876,7 +1910,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.69423177172958,
               "relativeDirection": "HARD_LEFT",
               "stayOn": false,
-              "streetName": "Northwest Irving Street"
+              "streetName": "Northwest Irving Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -1888,7 +1923,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.69447930000001,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest 21st Avenue"
+              "streetName": "Northwest 21st Avenue",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -2081,7 +2117,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.6776666369647,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "Northwest Everett Street"
+              "streetName": "Northwest Everett Street",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -2180,7 +2217,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.70059632295107,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "Northwest 24th Avenue"
+              "streetName": "Northwest 24th Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "EAST",
@@ -2192,7 +2230,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.70058100000001,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "Northwest Irving Street"
+              "streetName": "Northwest Irving Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -2204,7 +2243,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.7003923,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "way -102328 from 0"
+              "streetName": "way -102328 from 0",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -2257,7 +2297,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.70038790000001,
               "relativeDirection": "HARD_LEFT",
               "stayOn": false,
-              "streetName": "way -102328 from 0"
+              "streetName": "way -102328 from 0",
+              "walkingBike": true
             }
           ],
           "to": {
@@ -2308,7 +2349,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.7003923,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "Northwest Irving Street"
+              "streetName": "Northwest Irving Street",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -2361,7 +2403,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.69423177172958,
               "relativeDirection": "HARD_LEFT",
               "stayOn": false,
-              "streetName": "Northwest Irving Street"
+              "streetName": "Northwest Irving Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -2373,7 +2416,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.69447930000001,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest 21st Avenue"
+              "streetName": "Northwest 21st Avenue",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -2566,7 +2610,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.6776666369647,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "Northwest Everett Street"
+              "streetName": "Northwest Everett Street",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -2643,7 +2688,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
               "lon": -122.70059632295107,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "Northwest 24th Avenue"
+              "streetName": "Northwest 24th Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "EAST",
@@ -2655,7 +2701,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
               "lon": -122.70058100000001,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "Northwest Irving Street"
+              "streetName": "Northwest Irving Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -2667,7 +2714,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
               "lon": -122.7003923,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "way -102328 from 0"
+              "streetName": "way -102328 from 0",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -2720,7 +2768,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
               "lon": -122.70038790000001,
               "relativeDirection": "HARD_LEFT",
               "stayOn": false,
-              "streetName": "way -102328 from 0"
+              "streetName": "way -102328 from 0",
+              "walkingBike": true
             }
           ],
           "to": {
@@ -2771,7 +2820,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
               "lon": -122.7003923,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "Northwest Irving Street"
+              "streetName": "Northwest Irving Street",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -2824,7 +2874,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
               "lon": -122.69423177172958,
               "relativeDirection": "CONTINUE",
               "stayOn": false,
-              "streetName": "Northwest Irving Street"
+              "streetName": "Northwest Irving Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "SOUTH",
@@ -2836,7 +2887,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
               "lon": -122.69245690000001,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest 20th Avenue"
+              "streetName": "Northwest 20th Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "EAST",
@@ -2848,7 +2900,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
               "lon": -122.6924259,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "Northwest Hoyt Street"
+              "streetName": "Northwest Hoyt Street",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -2925,7 +2978,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
               "lon": -122.70059632295107,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "Northwest 24th Avenue"
+              "streetName": "Northwest 24th Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "EAST",
@@ -2937,7 +2991,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
               "lon": -122.70058100000001,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "Northwest Irving Street"
+              "streetName": "Northwest Irving Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -2949,7 +3004,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
               "lon": -122.7003923,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "way -102328 from 0"
+              "streetName": "way -102328 from 0",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -3002,7 +3058,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
               "lon": -122.70038790000001,
               "relativeDirection": "HARD_LEFT",
               "stayOn": false,
-              "streetName": "way -102328 from 0"
+              "streetName": "way -102328 from 0",
+              "walkingBike": true
             }
           ],
           "to": {
@@ -3053,7 +3110,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
               "lon": -122.7003923,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "Northwest Irving Street"
+              "streetName": "Northwest Irving Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "SOUTH",
@@ -3065,7 +3123,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
               "lon": -122.6985374,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest 23rd Avenue"
+              "streetName": "Northwest 23rd Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "EAST",
@@ -3077,7 +3136,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
               "lon": -122.69851030000001,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "Northwest Hoyt Street"
+              "streetName": "Northwest Hoyt Street",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -3154,7 +3214,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
               "lon": -122.70059632295107,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "Northwest 24th Avenue"
+              "streetName": "Northwest 24th Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "EAST",
@@ -3166,7 +3227,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
               "lon": -122.70058100000001,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "Northwest Irving Street"
+              "streetName": "Northwest Irving Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -3178,7 +3240,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
               "lon": -122.7003923,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "way -102328 from 0"
+              "streetName": "way -102328 from 0",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -3231,7 +3294,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
               "lon": -122.70038790000001,
               "relativeDirection": "HARD_LEFT",
               "stayOn": false,
-              "streetName": "way -102328 from 0"
+              "streetName": "way -102328 from 0",
+              "walkingBike": true
             }
           ],
           "to": {
@@ -3282,7 +3346,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
               "lon": -122.7003923,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "Northwest Irving Street"
+              "streetName": "Northwest Irving Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "SOUTH",
@@ -3294,7 +3359,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
               "lon": -122.69245690000001,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest 20th Avenue"
+              "streetName": "Northwest 20th Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "EAST",
@@ -3306,7 +3372,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
               "lon": -122.6924259,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "Northwest Hoyt Street"
+              "streetName": "Northwest Hoyt Street",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -3411,7 +3478,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.67524992342938,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "Northwest Everett Street"
+              "streetName": "Northwest Everett Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -3423,7 +3491,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.67548060000001,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest 5th Avenue"
+              "streetName": "Northwest 5th Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "WEST",
@@ -3435,7 +3504,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.6755097,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "Northwest Flanders Street"
+              "streetName": "Northwest Flanders Street",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -3654,7 +3724,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.69447686508221,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "Northwest 21st Avenue"
+              "streetName": "Northwest 21st Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "EAST",
@@ -3666,7 +3737,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.69447930000001,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest Irving Street"
+              "streetName": "Northwest Irving Street",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -3719,7 +3791,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.69423177172958,
               "relativeDirection": "HARD_LEFT",
               "stayOn": false,
-              "streetName": "Northwest Irving Street"
+              "streetName": "Northwest Irving Street",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -3770,7 +3843,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.7003923,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "way -102328 from 0"
+              "streetName": "way -102328 from 0",
+              "walkingBike": true
             }
           ],
           "to": {
@@ -3823,7 +3897,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.70038790000001,
               "relativeDirection": "HARD_LEFT",
               "stayOn": false,
-              "streetName": "way -102328 from 0"
+              "streetName": "way -102328 from 0",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "WEST",
@@ -3835,7 +3910,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.7003923,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest Irving Street"
+              "streetName": "Northwest Irving Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -3847,7 +3923,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.70058100000001,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest 24th Avenue"
+              "streetName": "Northwest 24th Avenue",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -3946,7 +4023,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.67524992342938,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "Northwest Everett Street"
+              "streetName": "Northwest Everett Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "SOUTH",
@@ -3958,7 +4036,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.67548060000001,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "Northwest 5th Avenue"
+              "streetName": "Northwest 5th Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "WEST",
@@ -3970,7 +4049,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.67540310000001,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "West Burnside Street"
+              "streetName": "West Burnside Street",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -4202,7 +4282,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.70071990797962,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "West Burnside Street"
+              "streetName": "West Burnside Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTHEAST",
@@ -4214,7 +4295,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.701384,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest 24th Place"
+              "streetName": "Northwest 24th Place",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTHWEST",
@@ -4226,7 +4308,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.70033570000001,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "Northwest Westover Road"
+              "streetName": "Northwest Westover Road",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -4238,7 +4321,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.7004445,
               "relativeDirection": "SLIGHTLY_RIGHT",
               "stayOn": false,
-              "streetName": "Northwest 24th Avenue"
+              "streetName": "Northwest 24th Avenue",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -4337,7 +4421,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.67524992342938,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "Northwest Everett Street"
+              "streetName": "Northwest Everett Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -4349,7 +4434,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.67548060000001,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest 5th Avenue"
+              "streetName": "Northwest 5th Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "WEST",
@@ -4361,7 +4447,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.67553910000001,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "Northwest Glisan Street"
+              "streetName": "Northwest Glisan Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -4373,7 +4460,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.67649170000001,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "way 156261070 from 2"
+              "streetName": "way 156261070 from 2",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -4579,7 +4667,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.69870264831422,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "Northwest 23rd Avenue"
+              "streetName": "Northwest 23rd Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "WEST",
@@ -4591,7 +4680,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.698695,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest Overton Street"
+              "streetName": "Northwest Overton Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "SOUTH",
@@ -4603,7 +4693,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.70072830000001,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "Northwest 24th Avenue"
+              "streetName": "Northwest 24th Avenue",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -4702,7 +4793,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.67524992342938,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "Northwest Everett Street"
+              "streetName": "Northwest Everett Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -4714,7 +4806,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.67548060000001,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest 5th Avenue"
+              "streetName": "Northwest 5th Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "WEST",
@@ -4726,7 +4819,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.6755097,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "Northwest Flanders Street"
+              "streetName": "Northwest Flanders Street",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -4945,7 +5039,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.69447686508221,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "Northwest 21st Avenue"
+              "streetName": "Northwest 21st Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "EAST",
@@ -4957,7 +5052,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.69447930000001,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest Irving Street"
+              "streetName": "Northwest Irving Street",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -5010,7 +5106,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.69423177172958,
               "relativeDirection": "HARD_LEFT",
               "stayOn": false,
-              "streetName": "Northwest Irving Street"
+              "streetName": "Northwest Irving Street",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -5061,7 +5158,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.7003923,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "way -102328 from 0"
+              "streetName": "way -102328 from 0",
+              "walkingBike": true
             }
           ],
           "to": {
@@ -5114,7 +5212,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.70038790000001,
               "relativeDirection": "HARD_LEFT",
               "stayOn": false,
-              "streetName": "way -102328 from 0"
+              "streetName": "way -102328 from 0",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "WEST",
@@ -5126,7 +5225,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.7003923,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest Irving Street"
+              "streetName": "Northwest Irving Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -5138,7 +5238,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.70058100000001,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest 24th Avenue"
+              "streetName": "Northwest 24th Avenue",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -5237,7 +5338,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.67524992342938,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "Northwest Everett Street"
+              "streetName": "Northwest Everett Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "SOUTH",
@@ -5249,7 +5351,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.67548060000001,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "Northwest 5th Avenue"
+              "streetName": "Northwest 5th Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "WEST",
@@ -5261,7 +5364,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.67540310000001,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "West Burnside Street"
+              "streetName": "West Burnside Street",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -5493,7 +5597,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.70071990797962,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "West Burnside Street"
+              "streetName": "West Burnside Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTHEAST",
@@ -5505,7 +5610,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.701384,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest 24th Place"
+              "streetName": "Northwest 24th Place",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTHWEST",
@@ -5517,7 +5623,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.70033570000001,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "Northwest Westover Road"
+              "streetName": "Northwest Westover Road",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -5529,7 +5636,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.7004445,
               "relativeDirection": "SLIGHTLY_RIGHT",
               "stayOn": false,
-              "streetName": "Northwest 24th Avenue"
+              "streetName": "Northwest 24th Avenue",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -5628,7 +5736,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.67524992342938,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "Northwest Everett Street"
+              "streetName": "Northwest Everett Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -5640,7 +5749,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.67548060000001,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest 5th Avenue"
+              "streetName": "Northwest 5th Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "WEST",
@@ -5652,7 +5762,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.67553910000001,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "Northwest Glisan Street"
+              "streetName": "Northwest Glisan Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -5664,7 +5775,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.67649170000001,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "way 156261070 from 2"
+              "streetName": "way 156261070 from 2",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -5870,7 +5982,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.69870264831422,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "Northwest 23rd Avenue"
+              "streetName": "Northwest 23rd Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "WEST",
@@ -5882,7 +5995,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.698695,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest Overton Street"
+              "streetName": "Northwest Overton Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "SOUTH",
@@ -5894,7 +6008,8 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.70072830000001,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "Northwest 24th Avenue"
+              "streetName": "Northwest 24th Avenue",
+              "walkingBike": false
             }
           ],
           "to": {

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/TransitSnapshotTest.snap
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/TransitSnapshotTest.snap
@@ -48,7 +48,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.64847039626407,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "Southeast Morrison Street"
+              "streetName": "Southeast Morrison Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "SOUTH",
@@ -60,7 +61,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.6594795,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "way 261187797 from 2"
+              "streetName": "way 261187797 from 2",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "SOUTH",
@@ -72,7 +74,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.65974310000001,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "Southeast 6th Avenue"
+              "streetName": "Southeast 6th Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "WEST",
@@ -84,7 +87,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.6597447,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Southeast Belmont Street"
+              "streetName": "Southeast Belmont Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "SOUTHWEST",
@@ -96,7 +100,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.66074710000001,
               "relativeDirection": "LEFT",
               "stayOn": true,
-              "streetName": "Southeast Belmont Street"
+              "streetName": "Southeast Belmont Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "WEST",
@@ -108,7 +113,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.6658345,
               "relativeDirection": "CONTINUE",
               "stayOn": false,
-              "streetName": "way 131623794 from 0"
+              "streetName": "way 131623794 from 0",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "SOUTH",
@@ -120,7 +126,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.665947,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "Southeast Water Avenue"
+              "streetName": "Southeast Water Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "WEST",
@@ -132,7 +139,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.6660075,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Morrison Bridge"
+              "streetName": "Morrison Bridge",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "SOUTH",
@@ -144,7 +152,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.6738909,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "way 144373674 from 1"
+              "streetName": "way 144373674 from 1",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTHWEST",
@@ -156,7 +165,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.67391230000001,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Southwest Alder Street"
+              "streetName": "Southwest Alder Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "WEST",
@@ -168,7 +178,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.69024660000001,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "West Burnside Street"
+              "streetName": "West Burnside Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -180,7 +191,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.696357,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest 22nd Avenue"
+              "streetName": "Northwest 22nd Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "EAST",
@@ -192,7 +204,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.69663860000001,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest Northrup Street"
+              "streetName": "Northwest Northrup Street",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -291,7 +304,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.64847039626407,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "Southeast Morrison Street"
+              "streetName": "Southeast Morrison Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -303,7 +317,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.64959560000001,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Southeast 16th Avenue"
+              "streetName": "Southeast 16th Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -315,7 +330,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.64955280000001,
               "relativeDirection": "CONTINUE",
               "stayOn": false,
-              "streetName": "Northeast 16th Avenue"
+              "streetName": "Northeast 16th Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTHEAST",
@@ -327,7 +343,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.6495675,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northeast Sandy Boulevard"
+              "streetName": "Northeast Sandy Boulevard",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -624,7 +641,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.69490673448706,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "West Burnside Street"
+              "streetName": "West Burnside Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -636,7 +654,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.696357,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest 22nd Avenue"
+              "streetName": "Northwest 22nd Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "EAST",
@@ -648,7 +667,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.69663860000001,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest Northrup Street"
+              "streetName": "Northwest Northrup Street",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -747,7 +767,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.64847039626407,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "Southeast Morrison Street"
+              "streetName": "Southeast Morrison Street",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -1161,7 +1182,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.69870264831422,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "Northwest 23rd Avenue"
+              "streetName": "Northwest 23rd Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "EAST",
@@ -1173,7 +1195,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.69866750000001,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "Northwest Northrup Street"
+              "streetName": "Northwest Northrup Street",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -1272,7 +1295,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.64847039626407,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "Southeast Morrison Street"
+              "streetName": "Southeast Morrison Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -1284,7 +1308,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.64959560000001,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Southeast 16th Avenue"
+              "streetName": "Southeast 16th Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -1296,7 +1321,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.64955280000001,
               "relativeDirection": "CONTINUE",
               "stayOn": false,
-              "streetName": "Northeast 16th Avenue"
+              "streetName": "Northeast 16th Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTHEAST",
@@ -1308,7 +1334,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.6495675,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northeast Sandy Boulevard"
+              "streetName": "Northeast Sandy Boulevard",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -1605,7 +1632,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.69490673448706,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "West Burnside Street"
+              "streetName": "West Burnside Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -1617,7 +1645,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.696357,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest 22nd Avenue"
+              "streetName": "Northwest 22nd Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "EAST",
@@ -1629,7 +1658,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.69663860000001,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest Northrup Street"
+              "streetName": "Northwest Northrup Street",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -1728,7 +1758,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.64847039626407,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "Southeast Morrison Street"
+              "streetName": "Southeast Morrison Street",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -2142,7 +2173,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.69870264831422,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "Northwest 23rd Avenue"
+              "streetName": "Northwest 23rd Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "EAST",
@@ -2154,7 +2186,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.69866750000001,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "Northwest Northrup Street"
+              "streetName": "Northwest Northrup Street",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -2257,7 +2290,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.64847039626407,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "Southeast Morrison Street"
+              "streetName": "Southeast Morrison Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "SOUTH",
@@ -2269,7 +2303,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.6536511,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "Southeast 12th Avenue"
+              "streetName": "Southeast 12th Avenue",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -2663,7 +2698,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.69644484256081,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "Northwest Northrup Street"
+              "streetName": "Northwest Northrup Street",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -2743,7 +2779,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.65362253301092,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "Northeast 12th Avenue"
+              "streetName": "Northeast 12th Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "WEST",
@@ -2755,7 +2792,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.6536312,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "East Burnside Street"
+              "streetName": "East Burnside Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "WEST",
@@ -2767,7 +2805,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.6648816,
               "relativeDirection": "CONTINUE",
               "stayOn": false,
-              "streetName": "Burnside Bridge"
+              "streetName": "Burnside Bridge",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "WEST",
@@ -2779,7 +2818,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.67010870000001,
               "relativeDirection": "CONTINUE",
               "stayOn": false,
-              "streetName": "West Burnside Street"
+              "streetName": "West Burnside Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -2791,7 +2831,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.67338950000001,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest 3rd Avenue"
+              "streetName": "Northwest 3rd Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "WEST",
@@ -2803,7 +2844,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.67371650000001,
               "relativeDirection": "SLIGHTLY_LEFT",
               "stayOn": false,
-              "streetName": "Northwest Hoyt Street"
+              "streetName": "Northwest Hoyt Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -2815,7 +2857,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.6755629,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest 5th Avenue"
+              "streetName": "Northwest 5th Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "WEST",
@@ -2827,7 +2870,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.6755935,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "Northwest Irving Street"
+              "streetName": "Northwest Irving Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -2839,7 +2883,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.67662320000001,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest Station Way"
+              "streetName": "Northwest Station Way",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "WEST",
@@ -2851,7 +2896,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.679511,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "Northwest Northrup Street"
+              "streetName": "Northwest Northrup Street",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -2953,7 +2999,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.65362253301092,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "Northeast 12th Avenue"
+              "streetName": "Northeast 12th Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "EAST",
@@ -2965,7 +3012,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.65363380000001,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "way 162042138 from 0"
+              "streetName": "way 162042138 from 0",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -3262,7 +3310,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.70071990797962,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "West Burnside Street"
+              "streetName": "West Burnside Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTHEAST",
@@ -3274,7 +3323,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.701384,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest 24th Place"
+              "streetName": "Northwest 24th Place",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTHWEST",
@@ -3286,7 +3336,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.70033570000001,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "Northwest Westover Road"
+              "streetName": "Northwest Westover Road",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -3298,7 +3349,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.7004445,
               "relativeDirection": "SLIGHTLY_RIGHT",
               "stayOn": false,
-              "streetName": "Northwest 24th Avenue"
+              "streetName": "Northwest 24th Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "EAST",
@@ -3310,7 +3362,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.70070630000001,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest Northrup Street"
+              "streetName": "Northwest Northrup Street",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -3412,7 +3465,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.65362253301092,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "Northeast 12th Avenue"
+              "streetName": "Northeast 12th Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "EAST",
@@ -3424,7 +3478,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.65363380000001,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "way 162042138 from 0"
+              "streetName": "way 162042138 from 0",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -3721,7 +3776,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.70071990797962,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "West Burnside Street"
+              "streetName": "West Burnside Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTHEAST",
@@ -3733,7 +3789,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.701384,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest 24th Place"
+              "streetName": "Northwest 24th Place",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTHWEST",
@@ -3745,7 +3802,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.70033570000001,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "Northwest Westover Road"
+              "streetName": "Northwest Westover Road",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -3757,7 +3815,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.7004445,
               "relativeDirection": "SLIGHTLY_RIGHT",
               "stayOn": false,
-              "streetName": "Northwest 24th Avenue"
+              "streetName": "Northwest 24th Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "EAST",
@@ -3769,7 +3828,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.70070630000001,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest Northrup Street"
+              "streetName": "Northwest Northrup Street",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -3871,7 +3931,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.65362253301092,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "Northeast 12th Avenue"
+              "streetName": "Northeast 12th Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "EAST",
@@ -3883,7 +3944,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.65363380000001,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "way 162042138 from 0"
+              "streetName": "way 162042138 from 0",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -4180,7 +4242,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.70071990797962,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "West Burnside Street"
+              "streetName": "West Burnside Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTHEAST",
@@ -4192,7 +4255,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.701384,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest 24th Place"
+              "streetName": "Northwest 24th Place",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTHWEST",
@@ -4204,7 +4268,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.70033570000001,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "Northwest Westover Road"
+              "streetName": "Northwest Westover Road",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -4216,7 +4281,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.7004445,
               "relativeDirection": "SLIGHTLY_RIGHT",
               "stayOn": false,
-              "streetName": "Northwest 24th Avenue"
+              "streetName": "Northwest 24th Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "EAST",
@@ -4228,7 +4294,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.70070630000001,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest Northrup Street"
+              "streetName": "Northwest Northrup Street",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -4334,7 +4401,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.65362253301092,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "Northeast 12th Avenue"
+              "streetName": "Northeast 12th Avenue",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -4702,7 +4770,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.69870264831422,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "Northwest 23rd Avenue"
+              "streetName": "Northwest 23rd Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "WEST",
@@ -4714,7 +4783,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.69866750000001,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest Northrup Street"
+              "streetName": "Northwest Northrup Street",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -4816,7 +4886,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.65362253301092,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "Northeast 12th Avenue"
+              "streetName": "Northeast 12th Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "SOUTH",
@@ -4828,7 +4899,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.6536312,
               "relativeDirection": "CONTINUE",
               "stayOn": false,
-              "streetName": "Southeast 12th Avenue"
+              "streetName": "Southeast 12th Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "WEST",
@@ -4840,7 +4912,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.6536511,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Southeast Morrison Street"
+              "streetName": "Southeast Morrison Street",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -5215,7 +5288,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.69853023095405,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "way 158083864 from 0"
+              "streetName": "way 158083864 from 0",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -5227,7 +5301,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.69861290000001,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest 23rd Avenue"
+              "streetName": "Northwest 23rd Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "WEST",
@@ -5239,7 +5314,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.69864600000001,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "Northwest Marshall Street"
+              "streetName": "Northwest Marshall Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -5251,7 +5327,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.6987072,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "way 158083033 from 0"
+              "streetName": "way 158083033 from 0",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -5263,7 +5340,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.69870940000001,
               "relativeDirection": "CONTINUE",
               "stayOn": false,
-              "streetName": "Northwest 23rd Avenue"
+              "streetName": "Northwest 23rd Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -5275,7 +5353,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.69876060000001,
               "relativeDirection": "CONTINUE",
               "stayOn": false,
-              "streetName": "way 158083032 from 0"
+              "streetName": "way 158083032 from 0",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "WEST",
@@ -5287,7 +5366,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.698768,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "Northwest Northrup Street"
+              "streetName": "Northwest Northrup Street",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -5364,7 +5444,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.64856484453956,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "Southeast 17th Avenue"
+              "streetName": "Southeast 17th Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "WEST",
@@ -5376,7 +5457,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.6485648,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "Southeast Stark Street"
+              "streetName": "Southeast Stark Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -5388,7 +5470,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.65373050000001,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "way 226431264 from 0"
+              "streetName": "way 226431264 from 0",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTHWEST",
@@ -5400,7 +5483,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.6537325,
               "relativeDirection": "LEFT",
               "stayOn": true,
-              "streetName": "way 226431263 from 21"
+              "streetName": "way 226431263 from 21",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -5412,7 +5496,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.65431720000001,
               "relativeDirection": "RIGHT",
               "stayOn": true,
-              "streetName": "way 226431263 from 23"
+              "streetName": "way 226431263 from 23",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "WEST",
@@ -5424,7 +5509,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.6546522,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "Southeast Oak Street"
+              "streetName": "Southeast Oak Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -5436,7 +5522,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.66128140000001,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "way 257064467 from 1"
+              "streetName": "way 257064467 from 1",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -5448,7 +5535,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.66178300000001,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Southeast Martin Luther King, Junior Boulevard"
+              "streetName": "Southeast Martin Luther King, Junior Boulevard",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "WEST",
@@ -5460,7 +5548,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.66176650000001,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "East Burnside Street"
+              "streetName": "East Burnside Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "WEST",
@@ -5472,7 +5561,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.6648816,
               "relativeDirection": "CONTINUE",
               "stayOn": false,
-              "streetName": "Burnside Bridge"
+              "streetName": "Burnside Bridge",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "WEST",
@@ -5484,7 +5574,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.67010870000001,
               "relativeDirection": "CONTINUE",
               "stayOn": false,
-              "streetName": "West Burnside Street"
+              "streetName": "West Burnside Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -5496,7 +5587,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.67338950000001,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest 3rd Avenue"
+              "streetName": "Northwest 3rd Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "WEST",
@@ -5508,7 +5600,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.67371650000001,
               "relativeDirection": "SLIGHTLY_LEFT",
               "stayOn": false,
-              "streetName": "Northwest Hoyt Street"
+              "streetName": "Northwest Hoyt Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -5520,7 +5613,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.6755629,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest 5th Avenue"
+              "streetName": "Northwest 5th Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "WEST",
@@ -5532,7 +5626,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.6755935,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "Northwest Irving Street"
+              "streetName": "Northwest Irving Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -5544,7 +5639,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.67662320000001,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest Station Way"
+              "streetName": "Northwest Station Way",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "WEST",
@@ -5556,7 +5652,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.679511,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "Northwest Northrup Street"
+              "streetName": "Northwest Northrup Street",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -5636,7 +5733,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.65362253301092,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "Northeast 12th Avenue"
+              "streetName": "Northeast 12th Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "WEST",
@@ -5648,7 +5746,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.6536312,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "East Burnside Street"
+              "streetName": "East Burnside Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "WEST",
@@ -5660,7 +5759,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.6648816,
               "relativeDirection": "CONTINUE",
               "stayOn": false,
-              "streetName": "Burnside Bridge"
+              "streetName": "Burnside Bridge",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "WEST",
@@ -5672,7 +5772,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.67010870000001,
               "relativeDirection": "CONTINUE",
               "stayOn": false,
-              "streetName": "West Burnside Street"
+              "streetName": "West Burnside Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -5684,7 +5785,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.67338950000001,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest 3rd Avenue"
+              "streetName": "Northwest 3rd Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "WEST",
@@ -5696,7 +5798,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.67371650000001,
               "relativeDirection": "SLIGHTLY_LEFT",
               "stayOn": false,
-              "streetName": "Northwest Hoyt Street"
+              "streetName": "Northwest Hoyt Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -5708,7 +5811,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.6755629,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest 5th Avenue"
+              "streetName": "Northwest 5th Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "WEST",
@@ -5720,7 +5824,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.6755935,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "Northwest Irving Street"
+              "streetName": "Northwest Irving Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -5732,7 +5837,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.67662320000001,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest Station Way"
+              "streetName": "Northwest Station Way",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "WEST",
@@ -5744,7 +5850,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.679511,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "Northwest Northrup Street"
+              "streetName": "Northwest Northrup Street",
+              "walkingBike": false
             }
           ],
           "to": {
@@ -5824,7 +5931,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.66779676192563,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "Interstate/Rose Quarter Northbound Yellow Line MAX Platform"
+              "streetName": "Interstate/Rose Quarter Northbound Yellow Line MAX Platform",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "SOUTHWEST",
@@ -5836,7 +5944,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.66822160000001,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "way 125785939 from 4"
+              "streetName": "way 125785939 from 4",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTHWEST",
@@ -5848,7 +5957,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.66836730000001,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "North Interstate Avenue"
+              "streetName": "North Interstate Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "SOUTHWEST",
@@ -5860,7 +5970,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.67197920000001,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "way 117315127 from 2"
+              "streetName": "way 117315127 from 2",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTHWEST",
@@ -5872,7 +5983,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.67202800000001,
               "relativeDirection": "RIGHT",
               "stayOn": true,
-              "streetName": "way 117315115 from 0"
+              "streetName": "way 117315115 from 0",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "SOUTHWEST",
@@ -5884,7 +5996,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.67204310000001,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "Broadway Bridge"
+              "streetName": "Broadway Bridge",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "SOUTHWEST",
@@ -5896,7 +6009,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.67746670000001,
               "relativeDirection": "CONTINUE",
               "stayOn": false,
-              "streetName": "Northwest Broadway"
+              "streetName": "Northwest Broadway",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -5908,7 +6022,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.67780010000001,
               "relativeDirection": "UTURN_RIGHT",
               "stayOn": true,
-              "streetName": "Northwest Broadway"
+              "streetName": "Northwest Broadway",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTHWEST",
@@ -5920,7 +6035,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.6778163,
               "relativeDirection": "SLIGHTLY_LEFT",
               "stayOn": false,
-              "streetName": "Northwest Lovejoy Street"
+              "streetName": "Northwest Lovejoy Street",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
@@ -5932,7 +6048,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.6813836,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest 10th Avenue"
+              "streetName": "Northwest 10th Avenue",
+              "walkingBike": false
             },
             {
               "absoluteDirection": "WEST",
@@ -5944,7 +6061,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.6814307,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "Northwest Northrup Street"
+              "streetName": "Northwest Northrup Street",
+              "walkingBike": false
             }
           ],
           "to": {


### PR DESCRIPTION
### Summary

This extracts the `StatesToWalkStepsMapper` from `GraphPathToItineraryMapper`, in order to make it easier to reason about. Also the various parts of the mapping process are separated into functions, which make the process easier to understand.

We also add information whether a walk step requires the bike to be walked. For now, it is exactly the same on the leg, but in a future PR, we will change the behaviour, so that a leg can require walking the bike only for some steps.

### Unit tests
No changes needed

### Code style
✅ 

### Documentation
No public facing changes

### Changelog
The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md)
is generated from the pull-request title, make sure the title describe the feature or issue fixed.
To exclude the PR from the changelog add `[changelog skip]` in the title.
