### PR TITLE
Store a proper Geometry on the leg, not an encoded version [changelog skip]

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/flex/ScheduledDeviatedTripTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/flex/ScheduledDeviatedTripTest.java
@@ -36,7 +36,9 @@ import org.opentripplanner.routing.location.StreetLocation;
 import org.opentripplanner.standalone.config.RouterConfig;
 import org.opentripplanner.standalone.server.Router;
 import org.opentripplanner.util.OTPFeature;
+import org.opentripplanner.util.PolylineEncoder;
 import org.opentripplanner.util.TestUtils;
+import org.opentripplanner.util.model.EncodedPolylineBean;
 
 /**
  * This tests that the feed for the Cobb County Flex service is processed correctly. This service
@@ -184,8 +186,9 @@ public class ScheduledDeviatedTripTest extends FlexTest {
         assertEquals(1, intermediateStops.size());
         assertEquals("zone_1", intermediateStops.get(0).place.stop.getId().getId());
 
+        EncodedPolylineBean legGeometry = PolylineEncoder.createEncodings(leg.getLegGeometry());
         assertThatPolylinesAreEqual(
-                leg.getLegGeometry().getPoints(),
+                legGeometry.getPoints(),
                 "kfsmEjojcOa@eBRKfBfHR|ALjBBhVArMG|OCrEGx@OhAKj@a@tAe@hA]l@MPgAnAgw@nr@cDxCm@t@c@t@c@x@_@~@]pAyAdIoAhG}@lE{AzHWhAtt@t~Aj@tAb@~AXdBHn@FlBC`CKnA_@nC{CjOa@dCOlAEz@E|BRtUCbCQ~CWjD??qBvXBl@kBvWOzAc@dDOx@sHv]aIG?q@@c@ZaB\\mA"
         );
 

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLGeometryImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLGeometryImpl.java
@@ -2,7 +2,9 @@ package org.opentripplanner.ext.legacygraphqlapi.datafetchers;
 
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
+import org.locationtech.jts.geom.Geometry;
 import org.opentripplanner.ext.legacygraphqlapi.generated.LegacyGraphQLDataFetchers;
+import org.opentripplanner.util.PolylineEncoder;
 import org.opentripplanner.util.model.EncodedPolylineBean;
 
 public class LegacyGraphQLGeometryImpl implements LegacyGraphQLDataFetchers.LegacyGraphQLGeometry {
@@ -18,6 +20,6 @@ public class LegacyGraphQLGeometryImpl implements LegacyGraphQLDataFetchers.Lega
   }
 
   private EncodedPolylineBean getSource(DataFetchingEnvironment environment) {
-    return environment.getSource();
+    return PolylineEncoder.createEncodings((Geometry) environment.getSource());
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLLegImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLLegImpl.java
@@ -5,6 +5,7 @@ import graphql.schema.DataFetchingEnvironment;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import org.locationtech.jts.geom.Geometry;
 import org.opentripplanner.api.mapping.ServiceDateMapper;
 import org.opentripplanner.ext.legacygraphqlapi.LegacyGraphQLRequestContext;
 import org.opentripplanner.ext.legacygraphqlapi.generated.LegacyGraphQLDataFetchers;
@@ -56,7 +57,7 @@ public class LegacyGraphQLLegImpl implements LegacyGraphQLDataFetchers.LegacyGra
   }
 
   @Override
-  public DataFetcher<EncodedPolylineBean> legGeometry() {
+  public DataFetcher<Geometry> legGeometry() {
     return environment -> getSource(environment).getLegGeometry();
   }
 

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLPatternImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLPatternImpl.java
@@ -6,6 +6,7 @@ import graphql.schema.DataFetchingEnvironment;
 import java.util.ArrayList;
 import java.util.Collection;
 import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.ext.legacygraphqlapi.LegacyGraphQLRequestContext;
 import org.opentripplanner.ext.legacygraphqlapi.generated.LegacyGraphQLDataFetchers;
@@ -106,15 +107,8 @@ public class LegacyGraphQLPatternImpl implements LegacyGraphQLDataFetchers.Legac
   }
 
   @Override
-  public DataFetcher<EncodedPolylineBean> patternGeometry() {
-    return environment -> {
-      LineString geometry = getSource(environment).getGeometry();
-      if (geometry == null) {
-        return null;
-      }
-
-      return PolylineEncoder.createEncodings(Arrays.asList(geometry.getCoordinates()));
-    };
+  public DataFetcher<Geometry> patternGeometry() {
+    return environment -> getSource(environment).getGeometry();
   }
 
   @Override

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLStopGeometriesImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLStopGeometriesImpl.java
@@ -17,17 +17,15 @@ public class LegacyGraphQLStopGeometriesImpl implements LegacyGraphQLStopGeometr
     }
 
     @Override
-    public DataFetcher<Iterable<EncodedPolylineBean>> googleEncoded() {
+    public DataFetcher<Iterable<Geometry>> googleEncoded() {
         return env -> {
-            var geometries = getSource(env);
-            var polylines = new ArrayList<EncodedPolylineBean>();
+            Geometry geometries = getSource(env);
+            ArrayList<Geometry> output = new ArrayList<>();
 
-            for(int i = 0; i < geometries.getNumGeometries(); i++) {
-               var geom = geometries.getGeometryN(i);
-               var polyline = PolylineEncoder.createEncodings(geom);
-               polylines.add(polyline);
+            for (int i = 0; i < geometries.getNumGeometries(); i++) {
+                output.add(geometries.getGeometryN(i));
             }
-            return polylines;
+            return output;
         };
     }
 

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLTripImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLTripImpl.java
@@ -3,8 +3,13 @@ package org.opentripplanner.ext.legacygraphqlapi.datafetchers;
 import graphql.relay.Relay;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
+import java.text.ParseException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.ext.legacygraphqlapi.LegacyGraphQLRequestContext;
 import org.opentripplanner.ext.legacygraphqlapi.generated.LegacyGraphQLDataFetchers;
@@ -24,13 +29,6 @@ import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.routing.core.ServiceDay;
 import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.routing.trippattern.TripTimes;
-import org.opentripplanner.util.PolylineEncoder;
-import org.opentripplanner.util.model.EncodedPolylineBean;
-
-import java.text.ParseException;
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
 
 public class LegacyGraphQLTripImpl implements LegacyGraphQLDataFetchers.LegacyGraphQLTrip {
 
@@ -258,13 +256,11 @@ public class LegacyGraphQLTripImpl implements LegacyGraphQLDataFetchers.LegacyGr
   }
 
   @Override
-  public DataFetcher<EncodedPolylineBean> tripGeometry() {
+  public DataFetcher<Geometry> tripGeometry() {
     return environment -> {
       TripPattern tripPattern = getTripPattern(environment);
       if (tripPattern == null) { return null; }
-      LineString geometry = tripPattern.getGeometry();
-      if (geometry == null) { return null; }
-      return PolylineEncoder.createEncodings(Arrays.asList(geometry.getCoordinates()));
+      return tripPattern.getGeometry();
     };
   }
 

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/LegacyGraphQLDataFetchers.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/LegacyGraphQLDataFetchers.java
@@ -17,7 +17,7 @@ import org.opentripplanner.routing.graphfinder.PatternAtStop;
 import org.opentripplanner.common.model.P2;
 import java.util.Map;
 import org.opentripplanner.routing.core.FareComponent;
-import org.opentripplanner.util.model.EncodedPolylineBean;
+import org.locationtech.jts.geom.Geometry;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.model.TripPattern;
@@ -393,7 +393,7 @@ public class LegacyGraphQLDataFetchers {
 
         public DataFetcher<Iterable<Object>> intermediateStops();
 
-        public DataFetcher<EncodedPolylineBean> legGeometry();
+        public DataFetcher<Geometry> legGeometry();
 
         public DataFetcher<String> mode();
 
@@ -486,7 +486,7 @@ public class LegacyGraphQLDataFetchers {
 
         public DataFetcher<String> name();
 
-        public DataFetcher<EncodedPolylineBean> patternGeometry();
+        public DataFetcher<Geometry> patternGeometry();
 
         public DataFetcher<Route> route();
 
@@ -793,7 +793,7 @@ public class LegacyGraphQLDataFetchers {
 
         public DataFetcher<org.locationtech.jts.geom.Geometry> geoJson();
 
-        public DataFetcher<Iterable<EncodedPolylineBean>> googleEncoded();
+        public DataFetcher<Iterable<Geometry>> googleEncoded();
     }
 
     /**
@@ -947,7 +947,7 @@ public class LegacyGraphQLDataFetchers {
 
         public DataFetcher<Iterable<TripTimeOnDate>> stoptimesForDate();
 
-        public DataFetcher<EncodedPolylineBean> tripGeometry();
+        public DataFetcher<Geometry> tripGeometry();
 
         public DataFetcher<String> tripHeadsign();
 

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/graphql-codegen.yml
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/graphql-codegen.yml
@@ -50,7 +50,7 @@ config:
     fare: java.util.Map#Map<String, Object>
     fareComponent: org.opentripplanner.routing.core.FareComponent#FareComponent
     Feed: String
-    Geometry: org.opentripplanner.util.model.EncodedPolylineBean#EncodedPolylineBean
+    Geometry: org.locationtech.jts.geom.Geometry#Geometry
     Itinerary: org.opentripplanner.model.plan.Itinerary#Itinerary
     Leg: org.opentripplanner.model.plan.Leg#Leg
     Mode: String

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/LegType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/LegType.java
@@ -19,6 +19,7 @@ import org.opentripplanner.ext.transmodelapi.model.TripTimeShortHelper;
 import org.opentripplanner.ext.transmodelapi.support.GqlUtil;
 import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.model.plan.StopArrival;
+import org.opentripplanner.util.PolylineEncoder;
 
 public class LegType {
   public static GraphQLObjectType create(
@@ -114,9 +115,9 @@ public class LegType {
         .field(GraphQLFieldDefinition
             .newFieldDefinition()
             .name("pointsOnLink")
-            .description("The legs's geometry.")
+            .description("The leg's geometry.")
             .type(linkGeometryType)
-            .dataFetcher(env -> leg(env).getLegGeometry())
+            .dataFetcher(env -> PolylineEncoder.createEncodings(leg(env).getLegGeometry()))
             .build())
         .field(GraphQLFieldDefinition
             .newFieldDefinition()

--- a/src/main/java/org/opentripplanner/api/mapping/LegMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/LegMapper.java
@@ -7,6 +7,7 @@ import java.util.Locale;
 import org.opentripplanner.api.model.ApiAlert;
 import org.opentripplanner.api.model.ApiLeg;
 import org.opentripplanner.model.plan.Leg;
+import org.opentripplanner.util.PolylineEncoder;
 
 public class LegMapper {
     private final WalkStepMapper walkStepMapper;
@@ -111,7 +112,7 @@ public class LegMapper {
         if(addIntermediateStops) {
             api.intermediateStops = placeMapper.mapStopArrivals(domain.getIntermediateStops());
         }
-        api.legGeometry = domain.getLegGeometry();
+        api.legGeometry = PolylineEncoder.createEncodings(domain.getLegGeometry());
         api.steps = walkStepMapper.mapWalkSteps(domain.getWalkSteps());
         api.alerts = concatenateAlerts(
             streetNoteMaperMapper.mapToApi(domain.getStreetNotes()),

--- a/src/main/java/org/opentripplanner/common/geometry/GeometryUtils.java
+++ b/src/main/java/org/opentripplanner/common/geometry/GeometryUtils.java
@@ -50,6 +50,11 @@ public class GeometryUtils {
         return factory.createLineString(coordinates);
     }
 
+    public static LineString makeLineString(List<Coordinate> coordinates) {
+        GeometryFactory factory = getGeometryFactory();
+        return factory.createLineString(coordinates.toArray(new Coordinate[]{}));
+    }
+
     public static LineString makeLineString(Coordinate[] coordinates) {
         GeometryFactory factory = getGeometryFactory();
         return factory.createLineString(coordinates);

--- a/src/main/java/org/opentripplanner/model/plan/Leg.java
+++ b/src/main/java/org/opentripplanner/model/plan/Leg.java
@@ -4,6 +4,8 @@ import java.util.Calendar;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.model.Agency;
 import org.opentripplanner.model.BookingInfo;
 import org.opentripplanner.model.FeedScopedId;
@@ -16,7 +18,6 @@ import org.opentripplanner.model.calendar.ServiceDate;
 import org.opentripplanner.model.transfer.ConstrainedTransfer;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.routing.core.TraverseMode;
-import org.opentripplanner.util.model.EncodedPolylineBean;
 
 /**
 * One leg of a trip -- that is, a temporally continuous piece of the journey that takes place on a
@@ -66,7 +67,7 @@ public class Leg {
 
     private List<StopArrival> intermediateStops;
 
-    private EncodedPolylineBean legGeometry;
+    private LineString legGeometry;
 
     private List<WalkStep> walkSteps;
 
@@ -497,11 +498,11 @@ public class Leg {
     /**
      * The leg's geometry.
      */
-    public EncodedPolylineBean getLegGeometry() {
+    public LineString getLegGeometry() {
         return legGeometry;
     }
 
-    public void setLegGeometry(EncodedPolylineBean legGeometry) {
+    public void setLegGeometry(LineString legGeometry) {
         this.legGeometry = legGeometry;
     }
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/GraphPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/GraphPathToItineraryMapper.java
@@ -40,7 +40,6 @@ import org.opentripplanner.routing.vertextype.VehicleParkingEntranceVertex;
 import org.opentripplanner.routing.vertextype.VehicleRentalStationVertex;
 import org.opentripplanner.util.I18NString;
 import org.opentripplanner.util.OTPFeature;
-import org.opentripplanner.util.PolylineEncoder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -293,9 +292,9 @@ public abstract class GraphPathToItineraryMapper {
         }
 
         CoordinateArrayListSequence coordinates = makeCoordinates(edges);
-        Geometry geometry = GeometryUtils.getGeometryFactory().createLineString(coordinates);
+        LineString geometry = GeometryUtils.getGeometryFactory().createLineString(coordinates);
 
-        leg.setLegGeometry(PolylineEncoder.createEncodings(geometry));
+        leg.setLegGeometry(geometry);
 
         leg.setGeneralizedCost(
                 (int) (states[states.length - 1].getWeight() - states[0].getWeight()));

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
@@ -13,6 +13,7 @@ import org.locationtech.jts.geom.Coordinate;
 import org.opentripplanner.common.geometry.SphericalDistanceLibrary;
 import org.opentripplanner.model.TripPattern;
 import org.opentripplanner.model.calendar.ServiceDate;
+import org.opentripplanner.common.geometry.GeometryUtils;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.model.plan.Place;
@@ -40,7 +41,6 @@ import org.opentripplanner.transit.raptor.api.path.Path;
 import org.opentripplanner.transit.raptor.api.path.PathLeg;
 import org.opentripplanner.transit.raptor.api.path.TransferPathLeg;
 import org.opentripplanner.transit.raptor.api.path.TransitPathLeg;
-import org.opentripplanner.util.PolylineEncoder;
 
 /**
  * This maps the paths found by the Raptor search algorithm to the itinerary structure currently used by OTP. The paths,
@@ -182,7 +182,7 @@ public class RaptorPathToItineraryMapper {
         leg.setFrom(Place.forStop(boardStop));
         leg.setTo(Place.forStop(alightStop));
         List<Coordinate> transitLegCoordinates = extractTransitLegCoordinates(pathLeg, boardStopIndexInPattern, alightStopIndexInPattern);
-        leg.setLegGeometry(PolylineEncoder.createEncodings(transitLegCoordinates));
+        leg.setLegGeometry(GeometryUtils.makeLineString(transitLegCoordinates));
         leg.setDistanceMeters(getDistanceFromCoordinates(transitLegCoordinates));
 
         // intermediate stops are required for fare calculation that's why we always add them here
@@ -269,7 +269,7 @@ public class RaptorPathToItineraryMapper {
             leg.setTo(to);
             leg.setStartTime(createCalendar(pathLeg.fromTime()));
             leg.setEndTime(createCalendar(pathLeg.toTime()));
-            leg.setLegGeometry(PolylineEncoder.createEncodings(transfer.getCoordinates()));
+            leg.setLegGeometry(GeometryUtils.makeLineString(transfer.getCoordinates()));
             leg.setDistanceMeters((double) transfer.getDistanceMeters());
             leg.setWalkSteps(Collections.emptyList());
             leg.setGeneralizedCost(toOtpDomainCost(pathLeg.generalizedCost()));

--- a/src/test/java/org/opentripplanner/routing/street/BarrierRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/street/BarrierRoutingTest.java
@@ -16,6 +16,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
+import org.locationtech.jts.geom.Geometry;
 import org.opentripplanner.ConstantsForTests;
 import org.opentripplanner.model.GenericLocation;
 import org.opentripplanner.model.plan.Itinerary;
@@ -27,6 +28,7 @@ import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.impl.GraphPathFinder;
 import org.opentripplanner.standalone.config.RouterConfig;
 import org.opentripplanner.standalone.server.Router;
+import org.opentripplanner.util.PolylineEncoder;
 
 
 public class BarrierRoutingTest {
@@ -150,6 +152,7 @@ public class BarrierRoutingTest {
 
         assertAll(assertions.apply(itineraries));
 
-        return itineraries.get(0).legs.get(0).getLegGeometry().getPoints();
+        Geometry legGeometry = itineraries.get(0).legs.get(0).getLegGeometry();
+        return PolylineEncoder.createEncodings(legGeometry).getPoints();
     }
 }

--- a/src/test/java/org/opentripplanner/routing/street/BicycleRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/street/BicycleRoutingTest.java
@@ -5,6 +5,7 @@ import static org.opentripplanner.PolylineAssert.assertThatPolylinesAreEqual;
 import java.time.Instant;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Geometry;
 import org.opentripplanner.ConstantsForTests;
 import org.opentripplanner.model.GenericLocation;
 import org.opentripplanner.routing.algorithm.mapping.GraphPathToItineraryMapper;
@@ -16,6 +17,7 @@ import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.impl.GraphPathFinder;
 import org.opentripplanner.standalone.config.RouterConfig;
 import org.opentripplanner.standalone.server.Router;
+import org.opentripplanner.util.PolylineEncoder;
 
 
 public class BicycleRoutingTest {
@@ -71,6 +73,7 @@ public class BicycleRoutingTest {
         var itineraries = GraphPathToItineraryMapper.mapItineraries(paths);
         // make sure that we only get BICYLE legs
         itineraries.forEach(i -> i.legs.forEach(l -> Assertions.assertEquals(l.getMode(), TraverseMode.BICYCLE)));
-        return itineraries.get(0).legs.get(0).getLegGeometry().getPoints();
+        Geometry legGeometry = itineraries.get(0).legs.get(0).getLegGeometry();
+        return PolylineEncoder.createEncodings(legGeometry).getPoints();
     }
 }

--- a/src/test/java/org/opentripplanner/routing/street/CarRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/street/CarRoutingTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Geometry;
 import org.opentripplanner.ConstantsForTests;
 import org.opentripplanner.model.GenericLocation;
 import org.opentripplanner.routing.algorithm.mapping.GraphPathToItineraryMapper;
@@ -17,6 +18,7 @@ import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.impl.GraphPathFinder;
 import org.opentripplanner.standalone.config.RouterConfig;
 import org.opentripplanner.standalone.server.Router;
+import org.opentripplanner.util.PolylineEncoder;
 
 
 public class CarRoutingTest {
@@ -126,6 +128,7 @@ public class CarRoutingTest {
         // make sure that we only get CAR legs
         itineraries.forEach(
                 i -> i.legs.forEach(l -> Assertions.assertEquals(l.getMode(), TraverseMode.CAR)));
-        return itineraries.get(0).legs.get(0).getLegGeometry().getPoints();
+        Geometry legGeometry = itineraries.get(0).legs.get(0).getLegGeometry();
+        return PolylineEncoder.createEncodings(legGeometry).getPoints();
     }
 }

--- a/src/test/java/org/opentripplanner/routing/street/SplitEdgeTurnRestrictionsTest.java
+++ b/src/test/java/org/opentripplanner/routing/street/SplitEdgeTurnRestrictionsTest.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.time.Instant;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Geometry;
 import org.opentripplanner.ConstantsForTests;
 import org.opentripplanner.model.GenericLocation;
 import org.opentripplanner.routing.algorithm.mapping.GraphPathToItineraryMapper;
@@ -16,6 +17,7 @@ import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.impl.GraphPathFinder;
 import org.opentripplanner.standalone.config.RouterConfig;
 import org.opentripplanner.standalone.server.Router;
+import org.opentripplanner.util.PolylineEncoder;
 import org.opentripplanner.util.TestUtils;
 
 /*
@@ -156,6 +158,7 @@ public class SplitEdgeTurnRestrictionsTest {
         // make sure that we only get CAR legs
         itineraries.forEach(
                 i -> i.legs.forEach(l -> Assertions.assertEquals(l.getMode(), TraverseMode.CAR)));
-        return itineraries.get(0).legs.get(0).getLegGeometry().getPoints();
+        Geometry geometry = itineraries.get(0).legs.get(0).getLegGeometry();
+        return PolylineEncoder.createEncodings(geometry).getPoints();
     }
 }


### PR DESCRIPTION
### Summary

Currently the internal model for the leg stores the geometry in an encoded format, which needs to be decoded and encoded again for the GraphQL APIs. Instead we should store a jts geometry, and do the required mapping in the API layer.

### Unit tests
Updated to match the new internal API

### Code style
✅ 

### Documentation
None needed

### Changelog
The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md)
is generated from the pull-request title, make sure the title describe the feature or issue fixed.
To exclude the PR from the changelog add `[changelog skip]` in the title.
