### PR TITLE
Use PickDrop enum in Leg and FlexTrip [changelog skip]

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/flex/FlexLegMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/FlexLegMapper.java
@@ -3,6 +3,9 @@ package org.opentripplanner.ext.flex;
 import java.util.ArrayList;
 import java.util.Locale;
 import org.opentripplanner.ext.flex.edgetype.FlexTripEdge;
+import org.opentripplanner.ext.flex.template.FlexAccessEgressTemplate;
+import org.opentripplanner.ext.flex.trip.FlexTrip;
+import org.opentripplanner.model.Trip;
 import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.model.plan.Place;
 import org.opentripplanner.routing.algorithm.mapping.GraphPathToItineraryMapper;
@@ -10,23 +13,24 @@ import org.opentripplanner.routing.algorithm.mapping.GraphPathToItineraryMapper;
 public class FlexLegMapper {
 
   static public void fixFlexTripLeg(Leg leg, FlexTripEdge flexTripEdge) {
+      FlexTrip flexTrip = flexTripEdge.getFlexTrip();
+      FlexAccessEgressTemplate flexTemplate = flexTripEdge.flexTemplate;
+
       leg.setIntermediateStops(new ArrayList<>());
       leg.setDistanceMeters(flexTripEdge.getDistanceMeters());
 
-      leg.setServiceDate(flexTripEdge.flexTemplate.serviceDate);
-      leg.setHeadsign(flexTripEdge.getTrip().getTripHeadsign());
+      leg.setServiceDate(flexTemplate.serviceDate);
+      leg.setHeadsign(flexTrip.getTrip().getTripHeadsign());
       leg.setWalkSteps(new ArrayList<>());
 
-      leg.setBoardRule(GraphPathToItineraryMapper.getBoardAlightMessage(2));
-      leg.setAlightRule(GraphPathToItineraryMapper.getBoardAlightMessage(3));
+      leg.setBoardRule(flexTrip.getBoardRule(flexTemplate.fromStopIndex));
+      leg.setAlightRule(flexTrip.getAlightRule(flexTemplate.toStopIndex));
 
-      leg.setBoardStopPosInPattern(flexTripEdge.flexTemplate.fromStopIndex);
-      leg.setAlightStopPosInPattern(flexTripEdge.flexTemplate.toStopIndex);
+      leg.setBoardStopPosInPattern(flexTemplate.fromStopIndex);
+      leg.setAlightStopPosInPattern(flexTemplate.toStopIndex);
 
-      leg.setDropOffBookingInfo(
-              flexTripEdge.getFlexTrip().getDropOffBookingInfo(leg.getBoardStopPosInPattern()));
-      leg.setPickupBookingInfo(
-              flexTripEdge.getFlexTrip().getPickupBookingInfo(leg.getAlightStopPosInPattern()));
+      leg.setDropOffBookingInfo(flexTrip.getDropOffBookingInfo(leg.getBoardStopPosInPattern()));
+      leg.setPickupBookingInfo(flexTrip.getPickupBookingInfo(leg.getAlightStopPosInPattern()));
   }
 
     public static void addFlexPlaces(Leg leg, FlexTripEdge flexEdge) {

--- a/src/ext/java/org/opentripplanner/ext/flex/trip/FlexTrip.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/trip/FlexTrip.java
@@ -12,6 +12,7 @@ import org.opentripplanner.ext.flex.template.FlexEgressTemplate;
 import org.opentripplanner.model.BookingInfo;
 import org.opentripplanner.model.FlexLocationGroup;
 import org.opentripplanner.model.FlexStopLocation;
+import org.opentripplanner.model.PickDrop;
 import org.opentripplanner.model.StopLocation;
 import org.opentripplanner.model.StopTime;
 import org.opentripplanner.model.TransitEntity;
@@ -62,6 +63,10 @@ public abstract class FlexTrip extends TransitEntity {
 
   public abstract BookingInfo getPickupBookingInfo(int i);
 
+  public abstract PickDrop getBoardRule(int i);
+
+  public abstract PickDrop getAlightRule(int i);
+
   public abstract boolean isBoardingPossible(NearbyStop stop);
 
   public abstract boolean isAlightingPossible(NearbyStop stop);
@@ -73,4 +78,5 @@ public abstract class FlexTrip extends TransitEntity {
   public static boolean isFlexStop(StopLocation stop) {
     return stop instanceof FlexLocationGroup || stop instanceof FlexStopLocation;
   }
+
 }

--- a/src/ext/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTrip.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTrip.java
@@ -79,7 +79,7 @@ public class ScheduledDeviatedTrip extends FlexTrip {
     ArrayList<FlexAccessTemplate> res = new ArrayList<>();
 
     for (int toIndex = fromIndex; toIndex < stopTimes.length; toIndex++) {
-      if (!stopTimes[toIndex].dropOffType.isRoutable()) continue;
+      if (getDropOffType(toIndex).isNotRoutable()) continue;
       for (StopLocation stop : expandStops(stopTimes[toIndex].stop)) {
         res.add(new FlexAccessTemplate(
                 access,
@@ -110,7 +110,7 @@ public class ScheduledDeviatedTrip extends FlexTrip {
     ArrayList<FlexEgressTemplate> res = new ArrayList<>();
 
     for (int fromIndex = toIndex; fromIndex >= 0; fromIndex--) {
-      if (!stopTimes[fromIndex].pickupType.isRoutable()) continue;
+      if (getPickupType(fromIndex).isNotRoutable()) continue;
       for (StopLocation stop : expandStops(stopTimes[fromIndex].stop)) {
         res.add(new FlexEgressTemplate(
                 egress,
@@ -186,6 +186,14 @@ public class ScheduledDeviatedTrip extends FlexTrip {
     return getToIndex(stop) != -1;
   }
 
+  public PickDrop getPickupType(int i) {
+    return stopTimes[i].pickupType;
+  }
+
+  public PickDrop getDropOffType(int i) {
+    return stopTimes[i].dropOffType;
+  }
+
   private Collection<StopLocation> expandStops(StopLocation stop) {
     return stop instanceof FlexLocationGroup
         ? ((FlexLocationGroup) stop).getLocations()
@@ -194,7 +202,7 @@ public class ScheduledDeviatedTrip extends FlexTrip {
 
   private int getFromIndex(NearbyStop accessEgress) {
     for (int i = 0; i < stopTimes.length; i++) {
-      if (!stopTimes[i].pickupType.isRoutable()) continue; // No pickup allowed here
+      if (getPickupType(i).isNotRoutable()) continue;
       StopLocation stop = stopTimes[i].stop;
       if (stop instanceof FlexLocationGroup) {
         if (((FlexLocationGroup) stop).getLocations().contains(accessEgress.stop)) {
@@ -212,7 +220,7 @@ public class ScheduledDeviatedTrip extends FlexTrip {
 
   private int getToIndex(NearbyStop accessEgress) {
     for (int i = stopTimes.length - 1; i >= 0; i--) {
-      if (!stopTimes[i].dropOffType.isRoutable()) continue; // No drop off allowed here
+      if (getDropOffType(i).isNotRoutable()) continue;
       StopLocation stop = stopTimes[i].stop;
       if (stop instanceof FlexLocationGroup) {
         if (((FlexLocationGroup) stop).getLocations().contains(accessEgress.stop)) {

--- a/src/ext/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTrip.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTrip.java
@@ -79,7 +79,7 @@ public class ScheduledDeviatedTrip extends FlexTrip {
     ArrayList<FlexAccessTemplate> res = new ArrayList<>();
 
     for (int toIndex = fromIndex; toIndex < stopTimes.length; toIndex++) {
-      if (getDropOffType(toIndex).isNotRoutable()) continue;
+      if (getDropOffType(toIndex).isNotRoutable()) { continue; }
       for (StopLocation stop : expandStops(stopTimes[toIndex].stop)) {
         res.add(new FlexAccessTemplate(
                 access,
@@ -110,7 +110,7 @@ public class ScheduledDeviatedTrip extends FlexTrip {
     ArrayList<FlexEgressTemplate> res = new ArrayList<>();
 
     for (int fromIndex = toIndex; fromIndex >= 0; fromIndex--) {
-      if (getPickupType(fromIndex).isNotRoutable()) continue;
+      if (getPickupType(fromIndex).isNotRoutable()) { continue; }
       for (StopLocation stop : expandStops(stopTimes[fromIndex].stop)) {
         res.add(new FlexEgressTemplate(
                 egress,
@@ -202,7 +202,7 @@ public class ScheduledDeviatedTrip extends FlexTrip {
 
   private int getFromIndex(NearbyStop accessEgress) {
     for (int i = 0; i < stopTimes.length; i++) {
-      if (getPickupType(i).isNotRoutable()) continue;
+      if (getPickupType(i).isNotRoutable()) { continue; }
       StopLocation stop = stopTimes[i].stop;
       if (stop instanceof FlexLocationGroup) {
         if (((FlexLocationGroup) stop).getLocations().contains(accessEgress.stop)) {
@@ -220,7 +220,7 @@ public class ScheduledDeviatedTrip extends FlexTrip {
 
   private int getToIndex(NearbyStop accessEgress) {
     for (int i = stopTimes.length - 1; i >= 0; i--) {
-      if (getDropOffType(i).isNotRoutable()) continue;
+      if (getDropOffType(i).isNotRoutable()) { continue; }
       StopLocation stop = stopTimes[i].stop;
       if (stop instanceof FlexLocationGroup) {
         if (((FlexLocationGroup) stop).getLocations().contains(accessEgress.stop)) {

--- a/src/ext/java/org/opentripplanner/ext/flex/trip/UnscheduledTrip.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/trip/UnscheduledTrip.java
@@ -82,7 +82,7 @@ public class UnscheduledTrip extends FlexTrip {
     // Check if trip is possible
     if (fromIndex == -1 ||
         fromIndex > toIndex ||
-        !stopTimes[toIndex].dropOffType.isRoutable()
+        getDropOffType(toIndex).isNotRoutable()
     ) {
       return Stream.empty();
     }
@@ -109,7 +109,7 @@ public class UnscheduledTrip extends FlexTrip {
     // Check if trip is possible
     if (toIndex == -1 ||
         fromIndex > toIndex ||
-        !stopTimes[fromIndex].pickupType.isRoutable()
+        getPickupType(fromIndex).isNotRoutable()
     ) {
       return Stream.empty();
     }
@@ -190,6 +190,14 @@ public class UnscheduledTrip extends FlexTrip {
     return getToIndex(stop) != -1;
   }
 
+  public PickDrop getPickupType(int i) {
+    return stopTimes[i].pickupType;
+  }
+
+  public PickDrop getDropOffType(int i) {
+    return stopTimes[i].dropOffType;
+  }
+
   private Collection<StopLocation> expandStops(StopLocation stop) {
     return stop instanceof FlexLocationGroup
         ? ((FlexLocationGroup) stop).getLocations()
@@ -198,7 +206,7 @@ public class UnscheduledTrip extends FlexTrip {
 
   private int getFromIndex(NearbyStop accessEgress) {
     for (int i = 0; i < stopTimes.length; i++) {
-      if (!stopTimes[i].pickupType.isRoutable()) continue;
+      if (getPickupType(i).isNotRoutable()) continue;
       StopLocation stop = stopTimes[i].stop;
       if (stop instanceof FlexLocationGroup) {
         if (((FlexLocationGroup) stop).getLocations().contains(accessEgress.stop)) {
@@ -216,7 +224,7 @@ public class UnscheduledTrip extends FlexTrip {
 
   private int getToIndex(NearbyStop accessEgress) {
     for (int i = stopTimes.length - 1; i >= 0; i--) {
-      if (!stopTimes[i].dropOffType.isRoutable()) continue;
+      if (getDropOffType(i).isNotRoutable()) continue;
       StopLocation stop = stopTimes[i].stop;
       if (stop instanceof FlexLocationGroup) {
         if (((FlexLocationGroup) stop).getLocations().contains(accessEgress.stop)) {

--- a/src/ext/java/org/opentripplanner/ext/flex/trip/UnscheduledTrip.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/trip/UnscheduledTrip.java
@@ -206,7 +206,7 @@ public class UnscheduledTrip extends FlexTrip {
 
   private int getFromIndex(NearbyStop accessEgress) {
     for (int i = 0; i < stopTimes.length; i++) {
-      if (getPickupType(i).isNotRoutable()) continue;
+      if (getPickupType(i).isNotRoutable()) { continue; }
       StopLocation stop = stopTimes[i].stop;
       if (stop instanceof FlexLocationGroup) {
         if (((FlexLocationGroup) stop).getLocations().contains(accessEgress.stop)) {
@@ -224,7 +224,7 @@ public class UnscheduledTrip extends FlexTrip {
 
   private int getToIndex(NearbyStop accessEgress) {
     for (int i = stopTimes.length - 1; i >= 0; i--) {
-      if (getDropOffType(i).isNotRoutable()) continue;
+      if (getDropOffType(i).isNotRoutable()) { continue; }
       StopLocation stop = stopTimes[i].stop;
       if (stop instanceof FlexLocationGroup) {
         if (((FlexLocationGroup) stop).getLocations().contains(accessEgress.stop)) {

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLLegImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLLegImpl.java
@@ -11,6 +11,7 @@ import org.opentripplanner.ext.legacygraphqlapi.LegacyGraphQLRequestContext;
 import org.opentripplanner.ext.legacygraphqlapi.generated.LegacyGraphQLDataFetchers;
 import org.opentripplanner.model.Agency;
 import org.opentripplanner.model.BookingInfo;
+import org.opentripplanner.model.PickDrop;
 import org.opentripplanner.model.Route;
 import org.opentripplanner.model.Trip;
 import org.opentripplanner.model.plan.Leg;
@@ -171,26 +172,16 @@ public class LegacyGraphQLLegImpl implements LegacyGraphQLDataFetchers.LegacyGra
   @Override
   public DataFetcher<String> pickupType() {
     return environment -> {
-      if (getSource(environment).getBoardRule() == null) { return "SCHEDULED"; }
-      switch (getSource(environment).getBoardRule()) {
-        case "impossible": return "NONE";
-        case "mustPhone": return "CALL_AGENCY";
-        case "coordinateWithDriver": return "COORDINATE_WITH_DRIVER";
-        default: return "SCHEDULED";
-      }
+      if (getSource(environment).getBoardRule() == null) { return PickDrop.SCHEDULED.name(); }
+      return getSource(environment).getBoardRule().name();
     };
   }
 
   @Override
   public DataFetcher<String> dropoffType() {
     return environment -> {
-      if (getSource(environment).getAlightRule() == null) { return "SCHEDULED"; }
-      switch (getSource(environment).getAlightRule()) {
-        case "impossible": return "NONE";
-        case "mustPhone": return "CALL_AGENCY";
-        case "coordinateWithDriver": return "COORDINATE_WITH_DRIVER";
-        default: return "SCHEDULED";
-      }
+      if (getSource(environment).getAlightRule() == null) { return PickDrop.SCHEDULED.name(); }
+      return getSource(environment).getAlightRule().name();
     };
   }
 

--- a/src/main/java/org/opentripplanner/api/mapping/LegMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/LegMapper.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Locale;
 import org.opentripplanner.api.model.ApiAlert;
 import org.opentripplanner.api.model.ApiLeg;
+import org.opentripplanner.model.PickDrop;
 import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.util.PolylineEncoder;
 
@@ -118,8 +119,8 @@ public class LegMapper {
             streetNoteMaperMapper.mapToApi(domain.getStreetNotes()),
             alertMapper.mapToApi(domain.getTransitAlerts())
         );
-        api.boardRule = domain.getBoardRule();
-        api.alightRule = domain.getAlightRule();
+        api.boardRule = getBoardAlightMessage(domain.getBoardRule());
+        api.alightRule = getBoardAlightMessage(domain.getAlightRule());
 
         api.pickupBookingInfo = BookingInfoMapper.mapBookingInfo(domain.getPickupBookingInfo(), true);
         api.dropOffBookingInfo = BookingInfoMapper.mapBookingInfo(domain.getDropOffBookingInfo(), false);
@@ -128,6 +129,20 @@ public class LegMapper {
         api.walkingBike = domain.getWalkingBike();
 
         return api;
+    }
+
+    private static String getBoardAlightMessage (PickDrop boardAlightType) {
+        if (boardAlightType == null) { return null; }
+        switch (boardAlightType) {
+            case NONE:
+                return "impossible";
+            case CALL_AGENCY:
+                return "mustPhone";
+            case COORDINATE_WITH_DRIVER:
+                return "coordinateWithDriver";
+            default:
+                return null;
+        }
     }
 
     private static List<ApiAlert> concatenateAlerts(List<ApiAlert> a, List<ApiAlert> b) {

--- a/src/main/java/org/opentripplanner/gtfs/mapping/TransferMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/TransferMapper.java
@@ -240,8 +240,8 @@ class TransferMapper {
 
     for (int i = firstStopPos; i < lastStopPos; i++) {
       StopTime stopTime = stopTimes.get(i);
-      if(boardTrip && !stopTime.getPickupType().isRoutable()) { continue; }
-      if(!boardTrip && !stopTime.getDropOffType().isRoutable()) { continue; }
+      if(boardTrip && stopTime.getPickupType().isNotRoutable()) { continue; }
+      if(!boardTrip && stopTime.getDropOffType().isNotRoutable()) { continue; }
 
       if(stopMatches.test(stopTime.getStop())) {
         return i;

--- a/src/main/java/org/opentripplanner/model/PickDrop.java
+++ b/src/main/java/org/opentripplanner/model/PickDrop.java
@@ -24,6 +24,10 @@ public enum PickDrop {
     return routable;
   }
 
+  public boolean isNotRoutable() {
+    return !routable;
+  }
+
   public int getGtfsCode() {
     return gtfsCode;
   }

--- a/src/main/java/org/opentripplanner/model/plan/Leg.java
+++ b/src/main/java/org/opentripplanner/model/plan/Leg.java
@@ -10,6 +10,7 @@ import org.opentripplanner.model.Agency;
 import org.opentripplanner.model.BookingInfo;
 import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.model.Operator;
+import org.opentripplanner.model.PickDrop;
 import org.opentripplanner.model.Route;
 import org.opentripplanner.model.StreetNote;
 import org.opentripplanner.model.Trip;
@@ -75,9 +76,9 @@ public class Leg {
 
     private Set<TransitAlert> transitAlerts = new HashSet<>();
 
-    private String boardRule;
+    private PickDrop boardRule;
 
-    private String alightRule;
+    private PickDrop alightRule;
 
     private BookingInfo dropOffBookingInfo = null;
 
@@ -254,8 +255,8 @@ public class Leg {
                 .addCol("walkSteps", walkSteps)
                 .addCol("streetNotes", streetNotes)
                 .addCol("transitAlerts", transitAlerts)
-                .addStr("boardRule", boardRule)
-                .addStr("alightRule", alightRule)
+                .addEnum("boardRule", boardRule)
+                .addEnum("alightRule", alightRule)
                 .addBool("walkingBike", walkingBike)
                 .addBool("rentedVehicle", rentedVehicle)
                 .addStr("bikeRentalNetwork", vehicleRentalNetwork)
@@ -533,19 +534,19 @@ public class Leg {
         this.transitAlerts = transitAlerts;
     }
 
-    public String getBoardRule() {
+    public PickDrop getBoardRule() {
         return boardRule;
     }
 
-    public void setBoardRule(String boardRule) {
+    public void setBoardRule(PickDrop boardRule) {
         this.boardRule = boardRule;
     }
 
-    public String getAlightRule() {
+    public PickDrop getAlightRule() {
         return alightRule;
     }
 
-    public void setAlightRule(String alightRule) {
+    public void setAlightRule(PickDrop alightRule) {
         this.alightRule = alightRule;
     }
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/GraphPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/GraphPathToItineraryMapper.java
@@ -336,23 +336,6 @@ public abstract class GraphPathToItineraryMapper {
         return leg;
     }
 
-    /**
-     * This was originally in TransitUtils.handleBoardAlightType.
-     * Edges that always block traversal (forbidden pickups/dropoffs) are simply not ever created.
-     */
-    public static String getBoardAlightMessage (int boardAlightType) {
-        switch (boardAlightType) {
-        case 1:
-            return "impossible";
-        case 2:
-            return "mustPhone";
-        case 3:
-            return "coordinateWithDriver";
-        default:
-            return null;
-        }
-    }
-
     private static void setPathwayInfo(List<Leg> legs, State[][] legsStates) {
         OUTER:
         for (int i = 0; i < legsStates.length; i++) {


### PR DESCRIPTION
### Summary

Currently the pickup/drop off information is stored as a string in the Leg, and needs to be mapped multiple times. This changes it to use the correct Enum until the API level, where correct mapping is done.

Also expose the information from the FlexTrip interface in the correct enum type.

### Unit tests
Pure refactoring, none needed

### Code style
✅ 

### Documentation
None needed

### Changelog
The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md)
is generated from the pull-request title, make sure the title describe the feature or issue fixed.
To exclude the PR from the changelog add `[changelog skip]` in the title.
