### PR TITLE
OTP support for NeTEx Line keyvalues

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
@@ -47,6 +47,7 @@ import org.opentripplanner.ext.transmodelapi.model.TransmodelPlaceType;
 import org.opentripplanner.ext.transmodelapi.model.framework.AuthorityType;
 import org.opentripplanner.ext.transmodelapi.model.framework.BrandingType;
 import org.opentripplanner.ext.transmodelapi.model.framework.InfoLinkType;
+import org.opentripplanner.ext.transmodelapi.model.framework.KeyValueType;
 import org.opentripplanner.ext.transmodelapi.model.framework.MultilingualStringType;
 import org.opentripplanner.ext.transmodelapi.model.framework.NoticeType;
 import org.opentripplanner.ext.transmodelapi.model.framework.OperatorType;
@@ -188,7 +189,8 @@ public class TransmodelGraphQLSchema {
           JourneyPatternType.REF,
           ServiceJourneyType.REF,
           PtSituationElementType.REF,
-          brandingType
+          brandingType,
+          KeyValueType.TYPE
       );
       GraphQLOutputType interchangeType = InterchangeType.create(lineType, ServiceJourneyType.REF);
 

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/framework/KeyValueType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/framework/KeyValueType.java
@@ -3,6 +3,7 @@ package org.opentripplanner.ext.transmodelapi.model.framework;
 import graphql.Scalars;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLObjectType;
+import org.opentripplanner.model.KeyValue;
 
 public class KeyValueType {
   public static final GraphQLObjectType TYPE = GraphQLObjectType.newObject()
@@ -11,19 +12,19 @@ public class KeyValueType {
           .name("key")
           .description("Identifier of value.")
           .type(Scalars.GraphQLString)
-          .dataFetcher(environment -> null)
+          .dataFetcher(environment -> ((KeyValue) environment.getSource()).getKey())
           .build())
       .field(GraphQLFieldDefinition.newFieldDefinition()
           .name("value")
           .description("The actual value")
           .type(Scalars.GraphQLString)
-          .dataFetcher(environment -> null)
+          .dataFetcher(environment -> ((KeyValue) environment.getSource()).getValue())
           .build())
       .field(GraphQLFieldDefinition.newFieldDefinition()
           .name("typeOfKey")
           .description("Identifier of type of key")
           .type(Scalars.GraphQLString)
-          .dataFetcher(environment -> null)
+          .dataFetcher(environment -> ((KeyValue) environment.getSource()).getTypeOfKey())
           .build())
       .build();
 

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/network/LineType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/network/LineType.java
@@ -38,7 +38,8 @@ public class LineType {
       GraphQLOutputType journeyPatternType,
       GraphQLOutputType serviceJourneyType,
       GraphQLOutputType ptSituationElementType,
-      GraphQLOutputType brandingType
+      GraphQLOutputType brandingType,
+      GraphQLOutputType keyValuesType
   ) {
     return GraphQLObjectType.newObject()
             .name(NAME)
@@ -180,6 +181,12 @@ public class LineType {
                 .deprecate("BookingArrangements are defined per stop, and can be found under `passingTimes` or `estimatedCalls`")
                 .dataFetcher(environment -> null)
                 .build())
+            .field(GraphQLFieldDefinition.newFieldDefinition()
+                    .name("keyValues")
+                    .description("List of keyValue pairs for the line.")
+                    .type(new GraphQLNonNull(new GraphQLList(keyValuesType)))
+                    .dataFetcher(environment -> ((Route) environment.getSource()).getKeyValues())
+                    .build())
             .build();
   }
 }

--- a/src/main/java/org/opentripplanner/model/KeyValue.java
+++ b/src/main/java/org/opentripplanner/model/KeyValue.java
@@ -1,0 +1,30 @@
+package org.opentripplanner.model;
+
+import java.io.Serializable;
+
+public class KeyValue implements Serializable {
+
+    private final String typeOfKey;
+
+    private final String key;
+
+    private final String value;
+
+    public KeyValue(String typeOfKey, String key, String value) {
+        this.typeOfKey = typeOfKey;
+        this.key = key;
+        this.value = value;
+    }
+
+    public String getTypeOfKey() {
+        return typeOfKey;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/org/opentripplanner/model/Route.java
+++ b/src/main/java/org/opentripplanner/model/Route.java
@@ -1,6 +1,8 @@
 /* This file is based on code copied from project OneBusAway, see the LICENSE file for further information. */
 package org.opentripplanner.model;
 
+import java.util.List;
+
 public final class Route extends TransitEntity {
 
     private static final long serialVersionUID = 1L;
@@ -30,6 +32,8 @@ public final class Route extends TransitEntity {
     private String color;
 
     private String textColor;
+
+    private List<KeyValue> keyValues;
 
     private BikeAccess bikesAllowed = BikeAccess.UNKNOWN;
 
@@ -135,6 +139,14 @@ public final class Route extends TransitEntity {
 
     public void setTextColor(String textColor) {
         this.textColor = textColor;
+    }
+
+    public List<KeyValue> getKeyValues() {
+        return keyValues != null ? keyValues : List.of();
+    }
+
+    public void setKeyValues(List<KeyValue> keyValues) {
+        this.keyValues = keyValues;
     }
 
     public BikeAccess getBikesAllowed() {

--- a/src/main/java/org/opentripplanner/netex/mapping/KeyValueMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/KeyValueMapper.java
@@ -1,0 +1,24 @@
+package org.opentripplanner.netex.mapping;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.opentripplanner.model.KeyValue;
+import org.rutebanken.netex.model.KeyListStructure;
+import org.rutebanken.netex.model.KeyValueStructure;
+
+/** Responsible for mapping NeTEx key value structure into OTP model */
+public class KeyValueMapper {
+
+    public List<KeyValue> mapKeyValues(KeyListStructure keyListStructure) {
+        if (keyListStructure == null || keyListStructure.getKeyValue() == null) {
+            return null;
+        }
+
+        return keyListStructure.getKeyValue().stream().map(this::mapKeyValue).collect(
+                Collectors.toList());
+    }
+
+    private KeyValue mapKeyValue(KeyValueStructure netexKeyValue) {
+        return new KeyValue(netexKeyValue.getTypeOfKey(), netexKeyValue.getKey(), netexKeyValue.getValue());
+    }
+}

--- a/src/main/java/org/opentripplanner/netex/mapping/RouteMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/RouteMapper.java
@@ -36,6 +36,7 @@ class RouteMapper {
     private final EntityById<Branding> brandingsById;
     private final NetexEntityIndexReadOnlyView netexIndex;
     private final AuthorityToAgencyMapper authorityMapper;
+    private final KeyValueMapper keyValueMapper;
     private final Set<String> ferryIdsNotAllowedForBicycle;
 
     RouteMapper(
@@ -55,6 +56,7 @@ class RouteMapper {
         this.brandingsById = brandingsById;
         this.netexIndex = netexIndex;
         this.authorityMapper = new AuthorityToAgencyMapper(idFactory, timeZone);
+        this.keyValueMapper = new KeyValueMapper();
         this.ferryIdsNotAllowedForBicycle = ferryIdsNotAllowedForBicycle;
     }
 
@@ -67,6 +69,7 @@ class RouteMapper {
         otpRoute.setBranding(findBranding(line));
         otpRoute.setLongName(line.getName().getValue());
         otpRoute.setShortName(line.getPublicCode());
+        otpRoute.setKeyValues(keyValueMapper.mapKeyValues(line.getKeyList()));
         T2<TransitMode, String> mode = transportModeMapper.map(
                 line.getTransportMode(),
                 line.getTransportSubmode()

--- a/src/test/java/org/opentripplanner/netex/mapping/KeyValueMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/KeyValueMapperTest.java
@@ -1,0 +1,38 @@
+package org.opentripplanner.netex.mapping;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import org.junit.Test;
+import org.opentripplanner.model.KeyValue;
+import org.rutebanken.netex.model.KeyListStructure;
+import org.rutebanken.netex.model.KeyValueStructure;
+
+public class KeyValueMapperTest {
+
+    private final String TYPE_OF_KEY = "TEST_TYPE";
+    private final String KEY = "TEST_KEY";
+    private final String VALUE = "TEST_VALUE";
+
+    @Test
+    public void mapKeyValues() {
+       KeyValueMapper keyValueMapper = new KeyValueMapper();
+
+       KeyListStructure keyListStructure = createKeyListStructure();
+       List<KeyValue> result = keyValueMapper.mapKeyValues(keyListStructure);
+
+       assertEquals(1, result.size());
+       KeyValue keyValue = result.get(0);
+       assertEquals(TYPE_OF_KEY, keyValue.getTypeOfKey());
+       assertEquals(KEY, keyValue.getKey());
+       assertEquals(VALUE, keyValue.getValue());
+    }
+
+    public KeyListStructure createKeyListStructure() {
+        return new KeyListStructure()
+                .withKeyValue(new KeyValueStructure()
+                        .withTypeOfKey(TYPE_OF_KEY)
+                        .withKey(KEY)
+                        .withValue(VALUE));
+    }
+}


### PR DESCRIPTION
### Summary
Support for mapping key-values present in Line in NeTEx + exposing those fields in transmodel GraphQL. 

### Issue
n/a

### Unit tests
- added unit tests for _src/main/java/org/opentripplanner/netex/mapping/KeyValueMapper.java_

### Code style
Following code style

### Documentation
- Java Docs for _src/main/java/org/opentripplanner/netex/mapping/KeyValueMapper.java_