### PR TITLE
Remove ET realtime override code

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/siri/TimetableHelper.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/TimetableHelper.java
@@ -181,9 +181,7 @@ public class TimetableHelper {
                     } else if (recordedCall.getAimedDepartureTime() != null) {
                         realtimeDepartureTime = DateMapper.secondsSinceStartOfService(departureDate, recordedCall.getAimedDepartureTime(), zoneId);
                     }
-                    if (realtimeDepartureTime < realtimeArrivalTime) {
-                        realtimeDepartureTime = realtimeArrivalTime;
-                    }
+
                     int departureDelay = realtimeDepartureTime - departureTime;
 
                     newTimes.updateDepartureDelay(callCounter, departureDelay);
@@ -260,9 +258,6 @@ public class TimetableHelper {
 
                         if (realtimeArrivalTime == -1) {
                             realtimeArrivalTime = realtimeDepartureTime;
-                        }
-                        if (realtimeDepartureTime < realtimeArrivalTime) {
-                            realtimeDepartureTime = realtimeArrivalTime;
                         }
 
                         int arrivalDelay = realtimeArrivalTime - arrivalTime;


### PR DESCRIPTION
### Summary
Ensure that OTP does not override times from SIRI ET messages.

### Issue
[#3909](https://github.com/opentripplanner/OpenTripPlanner/issues/3909)

### Unit tests
This is a minor fix. No unit tests needed.

### Code style
Following code style.

### Documentation
This is a minor fix. No documentation needed.
