### PR TITLE
Modifiy timesIncreasing check in TripTimes

### DIFF
--- a/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
+++ b/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
@@ -365,20 +365,29 @@ public class TripTimes implements Serializable, Comparable<TripTimes> {
      */
     public boolean timesIncreasing() {
         final int nStops = scheduledArrivalTimes.length;
-        int prevDep = -1;
+        int prevDep = Integer.MIN_VALUE;
+        int prevIndex = -1;
         for (int s = 0; s < nStops; s++) {
+            // Do not validate for cancelled stops
+            if (isCancelledStop(s)) {
+                continue;
+            }
+            boolean isFirstStop = s == 0;
+            boolean isLastStop = s + 1 == nStops;
             final int arr = getArrivalTime(s);
             final int dep = getDepartureTime(s);
 
-            if (dep < arr) {
+            // Do not validate for first and last stop
+            if (!isFirstStop && !isLastStop && dep < arr) {
                 LOG.warn("Negative dwell time in TripTimes at stop index {}.", s);
                 return false;
             }
             if (prevDep > arr) {
-                LOG.warn("Negative running time in TripTimes after stop index {}.", s);
+                LOG.warn("Negative running time in TripTimes between stop index {} and index {}.", prevIndex, s);
                 return false;
             }
             prevDep = dep;
+            prevIndex = s;
         }
         return true;
     }

--- a/src/test/java/org/opentripplanner/routing/trippattern/TripTimesTest.java
+++ b/src/test/java/org/opentripplanner/routing/trippattern/TripTimesTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class TripTimesTest {
     private static final FeedScopedId TRIP_ID = new FeedScopedId("agency", "testTripId");
@@ -89,6 +90,43 @@ public class TripTimesTest {
         updatedTripTimesB.updateArrivalTime(7, 420);
 
         assertFalse(updatedTripTimesB.timesIncreasing());
+    }
+
+
+    @Test
+    public void testNonIncreasingUpdateWithCancellation() {
+        TripTimes updatedTripTimesA = new TripTimes(originalTripTimes);
+
+        updatedTripTimesA.updateArrivalTime(1, 60);
+        updatedTripTimesA.updateDepartureTime(1, 59);
+        updatedTripTimesA.setCancelled(1);
+
+        assertTrue(updatedTripTimesA.timesIncreasing());
+
+        TripTimes updatedTripTimesB = new TripTimes(originalTripTimes);
+        updatedTripTimesB.updateDepartureTime(6, 421);
+        updatedTripTimesB.updateArrivalTime(7, 420);
+        updatedTripTimesB.setCancelled(6);
+
+        assertTrue(updatedTripTimesA.timesIncreasing());
+    }
+
+    @Test
+    public void testNonIncreasingUpdateOnFirstAndLastStop() {
+        TripTimes updatedTripTimesA = new TripTimes(originalTripTimes);
+
+        updatedTripTimesA.updateArrivalTime(0, 1);
+        updatedTripTimesA.updateDepartureTime(0, 0);
+
+        assertTrue(updatedTripTimesA.timesIncreasing());
+
+
+        TripTimes updatedTripTimesB = new TripTimes(originalTripTimes);
+
+        updatedTripTimesB.updateArrivalTime(7,421);
+        updatedTripTimesB.updateDepartureTime(7, 420);
+
+        assertTrue(updatedTripTimesB.timesIncreasing());
     }
 
     @Test


### PR DESCRIPTION
### Summary
Ensure that negative running time error is not triggered on cancelled stops and negative dwell time is not triggered on first or last stops or cancelled stop

### Issue
closes #3714 

### Unit tests
- New unit tests for modified logic in timesIncreasing method

### Code style
Follows code style guidelines.

### Documentation
- No new documentation needed.
