### PR TITLE
Make some list entries non-null in schema/docs

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/LegType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/LegType.java
@@ -260,7 +260,7 @@ public class LegType {
             .withDirective(gqlUtil.timingData)
             .description(
                 "For ride legs, all estimated calls for the service journey. For non-ride legs, empty list.")
-            .type(new GraphQLNonNull(new GraphQLList(estimatedCallType)))
+            .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(estimatedCallType))))
             .dataFetcher(env ->
                 TripTimeShortHelper.getAllTripTimeShortsForLegsTrip(
                     env.getSource(),

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/LegType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/LegType.java
@@ -249,7 +249,7 @@ public class LegType {
             .description(
                 "For ride legs, estimated calls for quays between the Place where the leg originates and the Place where the leg ends. For non-ride legs, empty list."
             )
-            .type(new GraphQLNonNull(new GraphQLList(estimatedCallType)))
+            .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(estimatedCallType))))
             .dataFetcher(env -> TripTimeShortHelper.getIntermediateTripTimeShortsForLeg((
                 env.getSource()
             ), GqlUtil.getRoutingService(env)))

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/TripPatternType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/TripPatternType.java
@@ -124,7 +124,7 @@ public class TripPatternType {
                                 + "a trip where the use walks to the Q train, transfers to the 6, "
                                 + "then walks to their destination, has four legs."
                         )
-                        .type(new GraphQLNonNull(new GraphQLList(legType)))
+                        .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(legType))))
                         .dataFetcher(env -> itinerary(env).legs)
                         .build())
                 .field(GraphQLFieldDefinition


### PR DESCRIPTION
### Summary

This makes the _entries_ of the following three lists non-nullable:
* `TripPattern.legs`
* `Leg.intermediateEstimatedCalls`
* `Leg.serviceJourneyEstimatedCalls`
