### PR TITLE
Turn ParallelRouting off

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -207,7 +207,7 @@ Feature | Description | Enabled by default | Sandbox
 `APIUpdaterStatus` | Enable endpoint for graph updaters status | yes | no
 `OptimizeTransfers` | OTP will inspect all itineraries found and optimize where (which stops) the transfer will happen. Waiting time, priority and guaranteed transfers are taken into account. | yes | no
 `MinimumTransferTimeIsDefinitive` | If the minimum transfer time is a lower bound (default) or the definitive time for the transfer. Set this to true if you want to set a transfer time lower than what OTP derives from OSM data. | no | no
-`ParallelRouting` | Enable performing parts of the trip planning in parallel | yes | no
+`ParallelRouting` | Enable performing parts of the trip planning in parallel | no | no
 `TransferConstraints` | Enforce transfers to happen according to the _transfers.txt_(GTFS) and Interchanges(NeTEx). Turing this _off_ will increase the routing performance a little. | yes | no
 `ActuatorAPI` | Enpoint for actuators (service health status) | no | yes
 `GoogleCloudStorage` | Enable Google Cloud Storage integration | no | yes

--- a/src/main/java/org/opentripplanner/util/OTPFeature.java
+++ b/src/main/java/org/opentripplanner/util/OTPFeature.java
@@ -21,7 +21,7 @@ public enum OTPFeature {
     APIUpdaterStatus(true),
     MinimumTransferTimeIsDefinitive(false),
     OptimizeTransfers(true),
-    ParallelRouting(true),
+    ParallelRouting(false),
     TransferConstraints(true),
 
     // Sandbox extension features - Must be turned OFF by default


### PR DESCRIPTION
### Summary

Under high load the parallel routing may lead to an entire cluster of OTP servers to go down.
We believe this happens because new connections are accepted, but the request threads block
each other, waiting for available threads to fork out. The number of accepting threads in
the Grizzly Server is 1.25x as many as cores. This is previously tested to perform well
and give the best throughput for a synchronous request handler. When switching to a
ParallelRouting strategy we need to retest this.


### Issue
See #3920

### Code style
NOT APPLICABLE

### Documentation
Updated
