### PR TITLE
Optimize transit data creation when only main modes are in specified request [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/model/modes/AllowedTransitMode.java
+++ b/src/main/java/org/opentripplanner/model/modes/AllowedTransitMode.java
@@ -35,6 +35,17 @@ public class AllowedTransitMode {
     );
   }
 
+  public TransitMode getMainMode() {
+    return mainMode;
+  }
+
+  /**
+   * Is the sub-mode set for this main mode
+   */
+  public boolean hasSubMode() {
+    return subMode != null;
+  }
+
   /**
    * Returns a set of AllowedModes that will cover all available TransitModes.
    */


### PR DESCRIPTION
### Summary
After merging #3844, we noticed a slowdown in the transit data creation. When profiling, I noticed that the reason is the creation of extremely many streams, when most of the times, no submode filters are used, and a simple Set lookup would suffice. This implements that.

This brings transit data creation down from 96 ms to 75 ms, which is a total reduction of 5% in the SpeedTest.

### Unit tests
None, required, pure optimization.

### Code style
✅ 

### Documentation
None needed

### Changelog
The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md)
is generated from the pull-request title, make sure the title describe the feature or issue fixed.
To exclude the PR from the changelog add `[changelog skip]` in the title.
