### PR TITLE
Add the visualizer to the interactive launcher

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/interactivelauncher/InteractiveOtpMain.java
+++ b/src/ext/java/org/opentripplanner/ext/interactivelauncher/InteractiveOtpMain.java
@@ -26,7 +26,7 @@ public class InteractiveOtpMain {
 
   private void run() {
     this.model = Model.load();
-    MainView frame = new MainView(this::startOtp, model);
+    MainView frame = new MainView(new Thread(this::startOtp)::start, model);
     frame.start();
   }
 

--- a/src/ext/java/org/opentripplanner/ext/interactivelauncher/Model.java
+++ b/src/ext/java/org/opentripplanner/ext/interactivelauncher/Model.java
@@ -31,6 +31,7 @@ public class Model implements Serializable {
     private boolean buildTransit = true;
     private boolean saveGraph = false;
     private boolean serveGraph = true;
+    private boolean visualizer = false;
 
 
     public Model() {
@@ -140,6 +141,15 @@ public class Model implements Serializable {
         notifyChangeListener();
     }
 
+    public boolean isVisualizer() {
+        return visualizer;
+    }
+
+    public void setVisualizer(boolean visualizer) {
+        this.visualizer = visualizer;
+        notifyChangeListener();
+    }
+
     public Map<String, Boolean> getDebugLogging() {
         return debugLogging;
     }
@@ -161,6 +171,7 @@ public class Model implements Serializable {
                 + (buildTransit ? ", buildTransit" : "")
                 + (saveGraph ? ", saveGraph" : "")
                 + (serveGraph ? ", serveGraph" : "")
+                + (visualizer ? ", visualizer" : "")
                 + ')';
     }
 
@@ -203,6 +214,7 @@ public class Model implements Serializable {
 
         if (saveGraph && (buildTransit || buildStreet)) { args.add("--save"); }
         if (serveGraph && !buildStreetOnly()) { args.add("--serve"); }
+        if (serveGraph && !buildStreetOnly() && visualizer) { args.add("--visualize"); }
 
         args.add(getDataSourceDirectory());
 

--- a/src/ext/java/org/opentripplanner/ext/interactivelauncher/views/MainView.java
+++ b/src/ext/java/org/opentripplanner/ext/interactivelauncher/views/MainView.java
@@ -103,6 +103,8 @@ public class MainView extends JFrame {
             statusBarTxt
     );
     model.subscribeCmdLineUpdates(statusBarTxt::setText);
+
+    statusBarTxt.setText(model.toCliString());
   }
 
   public void onRootDirChanged(String newRootDir) {

--- a/src/ext/java/org/opentripplanner/ext/interactivelauncher/views/OptionsView.java
+++ b/src/ext/java/org/opentripplanner/ext/interactivelauncher/views/OptionsView.java
@@ -5,7 +5,6 @@ import static org.opentripplanner.ext.interactivelauncher.views.ViewUtils.addSec
 import static org.opentripplanner.ext.interactivelauncher.views.ViewUtils.addSectionSpace;
 
 import java.awt.event.ActionEvent;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -20,6 +19,7 @@ class OptionsView {
   private final JCheckBox buildTransitGraphChk;
   private final JCheckBox saveGraphChk;
   private final JCheckBox startOptServerChk;
+  private final JCheckBox startOptVisualizerChk;
   private final Model model;
 
   OptionsView(Model model) {
@@ -28,6 +28,7 @@ class OptionsView {
     this.buildTransitGraphChk = new JCheckBox("Transit graph", model.isBuildTransit());
     this.saveGraphChk = new JCheckBox("Save graph", model.isSaveGraph());
     this.startOptServerChk = new JCheckBox("Serve graph", model.isServeGraph());
+    this.startOptVisualizerChk = new JCheckBox("Visualizer", model.isVisualizer());
 
     addComp(new JLabel("Build graph"), panel);
     addSectionSpace(panel);
@@ -38,11 +39,13 @@ class OptionsView {
     // Toggle [ ] save on/off
     buildStreetGraphChk.addActionListener(this::onBuildGraphChkChanged);
     buildTransitGraphChk.addActionListener(this::onBuildGraphChkChanged);
+    startOptServerChk.addActionListener(this::onStartOptServerChkChanged);
 
     addComp(new JLabel("Actions"), panel);
     addSectionSpace(panel);
     addComp(saveGraphChk, panel);
     addComp(startOptServerChk, panel);
+    addComp(startOptVisualizerChk, panel);
 
     addDebugCheckBoxes(model);
     addSectionDoubleSpace(panel);
@@ -75,6 +78,7 @@ class OptionsView {
     bind(buildTransitGraphChk, model::setBuildTransit);
     bind(saveGraphChk, model::setSaveGraph);
     bind(startOptServerChk, model::setServeGraph);
+    bind(startOptVisualizerChk, model::setVisualizer);
   }
 
   void bind(JCheckBox box, Consumer<Boolean> modelUpdate) {
@@ -92,5 +96,10 @@ class OptionsView {
   private void onBuildGraphChkChanged(ActionEvent e) {
     saveGraphChk.setEnabled(buildStreet() || buildTransit());
     startOptServerChk.setEnabled(buildTransit() || !buildStreet());
+    startOptVisualizerChk.setEnabled(buildTransit() || !buildStreet());
+  }
+
+  private void onStartOptServerChkChanged(ActionEvent actionEvent) {
+    startOptVisualizerChk.setEnabled(startOptServerChk.isEnabled() && startOptServerChk.isSelected());
   }
 }

--- a/src/main/java/org/opentripplanner/visualizer/GraphVisualizer.java
+++ b/src/main/java/org/opentripplanner/visualizer/GraphVisualizer.java
@@ -437,6 +437,7 @@ public class GraphVisualizer extends JFrame implements VertexSelectionListener {
         super();
         LOG.info("Starting up graph visualizer...");
         setTitle("GraphVisualizer");
+        setExtendedState(JFrame.MAXIMIZED_BOTH);
         this.router = router;
         this.graph = router.graph;
         init();

--- a/src/main/java/org/opentripplanner/visualizer/ShowGraph.java
+++ b/src/main/java/org/opentripplanner/visualizer/ShowGraph.java
@@ -350,7 +350,7 @@ public class ShowGraph extends PApplet implements MouseWheelListener {
      * Setup Processing applet
      */
     public void setup() {
-        size(getSize().width, getSize().height, P2D);
+        size(getSize().width, getSize().height, JAVA2D);
 
         /* Build spatial index of vertices and edges */
         buildSpatialIndex();


### PR DESCRIPTION
### Summary

The sandbox interactive laucher is extended with a checkbox for the visualizer:
![image](https://user-images.githubusercontent.com/58879/155576725-c3699849-4883-4411-b399-59cface69c67.png)

A few related minor bugs are fixed:
 * the interactive launcher had an empty status bar (with the OTP CLI commands) on start
 * the rendered edges / vertices is extended to contain the currently used set

Some of the functionality doesn't work, but it can be used to check the graph connectivity:
![image](https://user-images.githubusercontent.com/58879/155577062-732501bf-8947-46f4-bccc-a68ac2d6aa80.png)