### PR TITLE
Fix default value for transit alerts

### DIFF
--- a/src/main/java/org/opentripplanner/model/plan/Leg.java
+++ b/src/main/java/org/opentripplanner/model/plan/Leg.java
@@ -266,7 +266,7 @@ public interface Leg {
     }
 
     default Set<TransitAlert> getTransitAlerts() {
-        return null;
+        return Set.of();
     }
 
     default PickDrop getBoardRule() {


### PR DESCRIPTION
### Summary
In #3837 The type of alerts for a leg was narrowed to be always non-null. This conflicted with #3896, where the default value was set to null. This fixes the issue, by always returning an empty set.

### Issue
Fixes #3933

### Changelog
The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md)
is generated from the pull-request title, make sure the title describe the feature or issue fixed.
To exclude the PR from the changelog add `[changelog skip]` in the title.
