### PR TITLE
Fix date handling for estimated calls for service journey on specific date in Transmodel API

### DIFF
--- a/src/main/java/org/opentripplanner/model/TripTimeOnDate.java
+++ b/src/main/java/org/opentripplanner/model/TripTimeOnDate.java
@@ -20,20 +20,20 @@ public class TripTimeOnDate {
     private final int stopIndex;
     // This is only needed because TripTimes has no reference to TripPattern
     private final TripPattern tripPattern;
-    private final Integer midnight;
+    private final long midnight;
 
     public TripTimeOnDate(TripTimes tripTimes, int stopIndex, TripPattern tripPattern, ServiceDay serviceDay) {
         this.tripTimes = tripTimes;
         this.stopIndex = stopIndex;
         this.tripPattern = tripPattern;
-        this.midnight = serviceDay != null ? serviceDay.secondsSinceMidnight(0) : UNDEFINED;
+        this.midnight = serviceDay != null ? serviceDay.time(0) : UNDEFINED;
     }
 
     public TripTimeOnDate(TripTimes tripTimes, int stopIndex, TripPattern tripPattern, Instant midnight) {
         this.tripTimes = tripTimes;
         this.stopIndex = stopIndex;
         this.tripPattern = tripPattern;
-        this.midnight = (int) midnight.getEpochSecond();
+        this.midnight = midnight.getEpochSecond();
     }
 
     /** Must pass in both Timetable and Trip, because TripTimes do not have a reference to StopPatterns. */


### PR DESCRIPTION
### Summary
In #3897 a bug was introduced, where the midnight of the service day was calculated wrong. This fixes the issue.

### Changelog
The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md)
is generated from the pull-request title, make sure the title describe the feature or issue fixed.
To exclude the PR from the changelog add `[changelog skip]` in the title.
