### PR TITLE
Add invalid GTFS transfers to the issue store [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/issues/IgnoredGtfsTransfer.java
+++ b/src/main/java/org/opentripplanner/graph_builder/issues/IgnoredGtfsTransfer.java
@@ -1,0 +1,21 @@
+package org.opentripplanner.graph_builder.issues;
+
+import org.onebusaway.gtfs.model.Transfer;
+import org.opentripplanner.graph_builder.DataImportIssue;
+
+public class IgnoredGtfsTransfer implements DataImportIssue {
+
+    public static final String FMT =
+            "GTFS Transfer was ignored, since it doesn't provide any routing advantages: %s";
+
+    private final Transfer transfer;
+
+    public IgnoredGtfsTransfer(Transfer transfer) {
+        this.transfer = transfer;
+    }
+
+    @Override
+    public String getMessage() {
+        return String.format(FMT, transfer);
+    }
+}

--- a/src/main/java/org/opentripplanner/graph_builder/issues/InvalidGtfsTransfer.java
+++ b/src/main/java/org/opentripplanner/graph_builder/issues/InvalidGtfsTransfer.java
@@ -1,0 +1,23 @@
+package org.opentripplanner.graph_builder.issues;
+
+import org.onebusaway.gtfs.model.Transfer;
+import org.opentripplanner.graph_builder.DataImportIssue;
+
+public class InvalidGtfsTransfer implements DataImportIssue {
+
+    public static final String FMT = "GTFS Transfer was invalid (%s): %s";
+
+    private final String reason;
+
+    private final Transfer transfer;
+
+    public InvalidGtfsTransfer(String reason, Transfer transfer) {
+        this.reason = reason;
+        this.transfer = transfer;
+    }
+
+    @Override
+    public String getMessage() {
+        return String.format(FMT, reason, transfer);
+    }
+}

--- a/src/main/java/org/opentripplanner/gtfs/mapping/GTFSToOtpTransitServiceMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/GTFSToOtpTransitServiceMapper.java
@@ -128,7 +128,8 @@ public class GTFSToOtpTransitServiceMapper {
                 stationMapper,
                 stopMapper,
                 tripMapper,
-                builder.getStopTimesSortedByTrip()
+                builder.getStopTimesSortedByTrip(),
+                issueStore
         );
         builder.getTransfers().addAll(transferMapper.map(data.getAllTransfers()));
     }

--- a/src/main/java/org/opentripplanner/gtfs/mapping/TransferMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/TransferMapper.java
@@ -8,6 +8,9 @@ import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.onebusaway.gtfs.model.Transfer;
+import org.opentripplanner.graph_builder.DataImportIssueStore;
+import org.opentripplanner.graph_builder.issues.IgnoredGtfsTransfer;
+import org.opentripplanner.graph_builder.issues.InvalidGtfsTransfer;
 import org.opentripplanner.model.Route;
 import org.opentripplanner.model.Station;
 import org.opentripplanner.model.Stop;
@@ -89,22 +92,25 @@ class TransferMapper {
   private final TripMapper tripMapper;
 
   private final TripStopTimes stopTimesByTrip;
+  private final DataImportIssueStore issueStore;
 
   private final Multimap<Route, Trip> tripsByRoute = ArrayListMultimap.create();
 
 
   TransferMapper(
-      RouteMapper routeMapper,
-      StationMapper stationMapper,
-      StopMapper stopMapper,
-      TripMapper tripMapper,
-      TripStopTimes stopTimesByTrip
+          RouteMapper routeMapper,
+          StationMapper stationMapper,
+          StopMapper stopMapper,
+          TripMapper tripMapper,
+          TripStopTimes stopTimesByTrip,
+          DataImportIssueStore issueStore
   ) {
     this.routeMapper = routeMapper;
     this.stationMapper = stationMapper;
     this.stopMapper = stopMapper;
     this.tripMapper = tripMapper;
     this.stopTimesByTrip = stopTimesByTrip;
+    this.issueStore = issueStore;
   }
 
   static TransferPriority mapTypeToPriority(int type) {
@@ -138,12 +144,12 @@ class TransferMapper {
 
     // If this transfer do not give any advantages in the routing, then drop it
     if(constraint.isRegularTransfer()) {
-      LOG.warn("Transfer skipped - no effect on routing: {}", rhs);
+      issueStore.add(new IgnoredGtfsTransfer(rhs));
       return null;
     }
 
     if (constraint.isStaySeated() && (fromTrip == null || toTrip == null)) {
-      LOG.warn("Transfer skipped - from_trip_id and to_trip_id must exist for in-seat transfer: {}", rhs);
+      issueStore.add(new InvalidGtfsTransfer("from_trip_id and to_trip_id must exist for in-seat transfer", rhs));
       return null;
     }
 
@@ -151,7 +157,7 @@ class TransferMapper {
     TransferPoint toPoint = mapTransferPoint(rhs.getToStop(), rhs.getToRoute(), toTrip, true);
 
     if (fromPoint == null || toPoint == null) {
-      LOG.warn("Transfer skipped - from_stop or to_stop not found on from_trip / to_trip: {}", rhs);
+      issueStore.add(new InvalidGtfsTransfer("fromPoint / toPoint doesn't exist", rhs));
       return null;
     }
 

--- a/src/main/java/org/opentripplanner/gtfs/mapping/TransferMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/TransferMapper.java
@@ -138,12 +138,12 @@ class TransferMapper {
 
     // If this transfer do not give any advantages in the routing, then drop it
     if(constraint.isRegularTransfer()) {
-      LOG.warn("Transfer skipped - no effect on routing: " + rhs);
+      LOG.warn("Transfer skipped - no effect on routing: {}", rhs);
       return null;
     }
 
     if (constraint.isStaySeated() && (fromTrip == null || toTrip == null)) {
-      LOG.warn("Transfer skipped - from_trip_id and to_trip_id must exist for in-seat transfer");
+      LOG.warn("Transfer skipped - from_trip_id and to_trip_id must exist for in-seat transfer: {}", rhs);
       return null;
     }
 
@@ -151,7 +151,7 @@ class TransferMapper {
     TransferPoint toPoint = mapTransferPoint(rhs.getToStop(), rhs.getToRoute(), toTrip, true);
 
     if (fromPoint == null || toPoint == null) {
-      LOG.warn("Transfer '{}' skipped - from_stop or to_stop not found on from_trip / to_trip", rhs.getId());
+      LOG.warn("Transfer skipped - from_stop or to_stop not found on from_trip / to_trip: {}", rhs);
       return null;
     }
 

--- a/src/main/java/org/opentripplanner/gtfs/mapping/TransferMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/TransferMapper.java
@@ -150,6 +150,11 @@ class TransferMapper {
     TransferPoint fromPoint = mapTransferPoint(rhs.getFromStop(), rhs.getFromRoute(), fromTrip, false);
     TransferPoint toPoint = mapTransferPoint(rhs.getToStop(), rhs.getToRoute(), toTrip, true);
 
+    if (fromPoint == null || toPoint == null) {
+      LOG.warn("Transfer '{}' skipped - from_stop or to_stop not found on from_trip / to_trip", rhs.getId());
+      return null;
+    }
+
     return new ConstrainedTransfer(null, fromPoint, toPoint, constraint);
   }
 

--- a/src/test/java/org/opentripplanner/gtfs/mapping/TransferMapperTest.java
+++ b/src/test/java/org/opentripplanner/gtfs/mapping/TransferMapperTest.java
@@ -42,6 +42,8 @@ public class TransferMapperTest {
 
     private static final Transfer TRANSFER = new Transfer();
 
+    private static final DataImportIssueStore issueStore = new DataImportIssueStore(true);
+
     static {
         FROM_ROUTE.setId(AGENCY_AND_ID);
         FROM_STOP.setId(AGENCY_AND_ID);
@@ -66,7 +68,8 @@ public class TransferMapperTest {
             STATION_MAPPER,
             STOP_MAPPER,
             TRIP_MAPPER,
-            new TripStopTimes()
+            new TripStopTimes(),
+            issueStore
     );
 
     /*


### PR DESCRIPTION
### Summary

Currently having an invalid GTFS `transfers.txt` can stop the graph build. This makes two minor changes:
 * avoids an NPE if the `Transfer` couldn't be processed
 * adds elements to the `DataImportIssueStore` when a `Transfer` couldn't be processed

### Issue

Closes #3937 

### Unit tests

No changes.

### Code style

:ballot_box_with_check: 

### Documentation

No changes.