### PR TITLE
NeTEx mapping for WheelChairBoarding

### DIFF
--- a/src/main/java/org/opentripplanner/netex/mapping/NetexMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/NetexMapper.java
@@ -258,7 +258,8 @@ public class NetexMapper {
                 idFactory,
                 currentNetexIndex.getQuayById(),
                 tariffZoneMapper,
-                issueStore
+                issueStore,
+                currentNetexIndex.getStopPlaceById()
         );
         for (String stopPlaceId : currentNetexIndex.getStopPlaceById().localKeys()) {
             Collection<StopPlace> stopPlaceAllVersions = currentNetexIndex.getStopPlaceById().lookup(stopPlaceId);

--- a/src/main/java/org/opentripplanner/netex/mapping/StopAndStationMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/StopAndStationMapper.java
@@ -63,10 +63,11 @@ class StopAndStationMapper {
             FeedScopedIdFactory idFactory,
             ReadOnlyHierarchicalVersionMapById<Quay> quayIndex,
             TariffZoneMapper tariffZoneMapper,
-            DataImportIssueStore issueStore
+            DataImportIssueStore issueStore,
+            ReadOnlyHierarchicalVersionMapById<StopPlace> stopPlaceIndex
     ) {
         this.stationMapper = new StationMapper(issueStore, idFactory);
-        this.stopMapper = new StopMapper(idFactory, issueStore);
+        this.stopMapper = new StopMapper(idFactory, issueStore, stopPlaceIndex);
         this.tariffZoneMapper = tariffZoneMapper;
         this.quayIndex = quayIndex;
         this.issueStore = issueStore;

--- a/src/main/java/org/opentripplanner/netex/mapping/StopMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/StopMapper.java
@@ -9,9 +9,13 @@ import org.opentripplanner.model.Station;
 import org.opentripplanner.model.Stop;
 import org.opentripplanner.model.TransitMode;
 import org.opentripplanner.model.WgsCoordinate;
+import org.opentripplanner.model.WheelChairBoarding;
+import org.opentripplanner.netex.index.api.ReadOnlyHierarchicalVersionMapById;
 import org.opentripplanner.netex.issues.QuayWithoutCoordinates;
 import org.opentripplanner.netex.mapping.support.FeedScopedIdFactory;
+import org.rutebanken.netex.model.AccessibilityAssessment;
 import org.rutebanken.netex.model.Quay;
+import org.rutebanken.netex.model.StopPlace;
 
 class StopMapper {
 
@@ -19,12 +23,16 @@ class StopMapper {
 
   private final FeedScopedIdFactory idFactory;
 
+  private final ReadOnlyHierarchicalVersionMapById<StopPlace> stopPlaceIndex;
+
   StopMapper(
-      FeedScopedIdFactory idFactory,
-      DataImportIssueStore issueStore
+          FeedScopedIdFactory idFactory,
+          DataImportIssueStore issueStore,
+          ReadOnlyHierarchicalVersionMapById<StopPlace> stopPlaceIndex
   ) {
     this.idFactory = idFactory;
     this.issueStore = issueStore;
+    this.stopPlaceIndex = stopPlaceIndex;
   }
 
   /**
@@ -44,23 +52,98 @@ class StopMapper {
       return null;
     }
 
+    var wheelchairBoarding = wheelChairBoardingFromQuay(quay, parentStation);
+
     Stop stop = new Stop(
-        idFactory.createId(quay.getId()),
-        parentStation.getName(),
-        quay.getPublicCode(),
-        quay.getDescription() != null ? quay.getDescription().getValue() : null,
-        WgsCoordinateMapper.mapToDomain(quay.getCentroid()),
-        null,
-        null,
-        null,
-        fareZones,
-        null,
-        null,
-        transitMode.first,
-        transitMode.second
+            idFactory.createId(quay.getId()),
+            parentStation.getName(),
+            quay.getPublicCode(),
+            quay.getDescription() != null ? quay.getDescription().getValue() : null,
+            WgsCoordinateMapper.mapToDomain(quay.getCentroid()),
+            wheelchairBoarding,
+            null,
+            null,
+            fareZones,
+            null,
+            null,
+            transitMode.first,
+            transitMode.second
     );
+
     stop.setParentStation(parentStation);
 
     return stop;
   }
+
+  /**
+   * Get WheelChairBoarding from Quay and parent Station.
+   *
+   * @param quay          NeTEx quay could contain information about accessability
+   * @param parentStation Used to get a default WheelChairBoarding if not found from Quay.
+   * @return not null value with default NO_INFORMATION if nothing defined in quay or
+   * parentStation.
+   */
+  private WheelChairBoarding wheelChairBoardingFromQuay(Quay quay, Station parentStation) {
+
+    var defaultWheelChairBoarding = WheelChairBoarding.NO_INFORMATION;
+    var stopPlaceId = parentStation.getId();
+    var stopPlace = stopPlaceIndex.lookupLastVersionById(stopPlaceId.getId());
+
+    if (stopPlace != null) {
+      defaultWheelChairBoarding = wheelChairBoarding(
+              stopPlace.getAccessibilityAssessment(),
+              WheelChairBoarding.NO_INFORMATION
+      );
+    }
+
+    return wheelChairBoarding(quay.getAccessibilityAssessment(), defaultWheelChairBoarding);
+  }
+
+  /**
+   * If input and containing objects are not null, get the LimitationStatusEnumeration and map to
+   * internal {@link WheelChairBoarding} enumeration.
+   *
+   * @param accessibilityAssessment NeTEx object wrapping information regarding
+   *                                WheelChairBoarding
+   * @param defaultValue            If no {@link AccessibilityAssessment} is defined, default to
+   *                                this value
+   * @return Mapped enumerator, {@link WheelChairBoarding#NO_INFORMATION} if no value is found
+   */
+  private WheelChairBoarding wheelChairBoarding(
+          AccessibilityAssessment accessibilityAssessment,
+          WheelChairBoarding defaultValue
+  ) {
+    if (defaultValue == null) {
+      defaultValue = WheelChairBoarding.NO_INFORMATION;
+    }
+
+    if (accessibilityAssessment == null || accessibilityAssessment.getLimitations() == null
+            || accessibilityAssessment.getLimitations().getAccessibilityLimitation() == null ||
+            accessibilityAssessment.getLimitations()
+                    .getAccessibilityLimitation()
+                    .getWheelchairAccess() == null || accessibilityAssessment.getLimitations()
+            .getAccessibilityLimitation()
+            .getWheelchairAccess()
+            .value() == null) {
+
+      return defaultValue;
+
+    }
+
+    var wheelchairAccessValue = accessibilityAssessment.getLimitations()
+            .getAccessibilityLimitation()
+            .getWheelchairAccess()
+            .value();
+
+    switch (wheelchairAccessValue) {
+      case "true":
+        return WheelChairBoarding.POSSIBLE;
+      case "false":
+        return WheelChairBoarding.NOT_POSSIBLE;
+      default:
+        return WheelChairBoarding.NO_INFORMATION;
+    }
+
+  }
+
 }

--- a/src/main/java/org/opentripplanner/netex/mapping/StopMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/StopMapper.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.netex.mapping;
 
 import java.util.Collection;
+import java.util.Optional;
 import javax.annotation.Nullable;
 import org.opentripplanner.common.model.T2;
 import org.opentripplanner.graph_builder.DataImportIssueStore;
@@ -14,6 +15,9 @@ import org.opentripplanner.netex.index.api.ReadOnlyHierarchicalVersionMapById;
 import org.opentripplanner.netex.issues.QuayWithoutCoordinates;
 import org.opentripplanner.netex.mapping.support.FeedScopedIdFactory;
 import org.rutebanken.netex.model.AccessibilityAssessment;
+import org.rutebanken.netex.model.AccessibilityLimitation;
+import org.rutebanken.netex.model.AccessibilityLimitations_RelStructure;
+import org.rutebanken.netex.model.LimitationStatusEnumeration;
 import org.rutebanken.netex.model.Quay;
 import org.rutebanken.netex.model.StopPlace;
 
@@ -117,25 +121,20 @@ class StopMapper {
       defaultValue = WheelChairBoarding.NO_INFORMATION;
     }
 
-    if (accessibilityAssessment == null || accessibilityAssessment.getLimitations() == null
-            || accessibilityAssessment.getLimitations().getAccessibilityLimitation() == null ||
-            accessibilityAssessment.getLimitations()
-                    .getAccessibilityLimitation()
-                    .getWheelchairAccess() == null || accessibilityAssessment.getLimitations()
-            .getAccessibilityLimitation()
-            .getWheelchairAccess()
-            .value() == null) {
+    return Optional.ofNullable(accessibilityAssessment)
+            .map(AccessibilityAssessment::getLimitations)
+            .map(AccessibilityLimitations_RelStructure::getAccessibilityLimitation)
+            .map(AccessibilityLimitation::getWheelchairAccess)
+            .map(this::fromLimitationStatusEnumeration)
+            .orElse(defaultValue);
+  }
 
-      return defaultValue;
-
+  private WheelChairBoarding fromLimitationStatusEnumeration(LimitationStatusEnumeration wheelChairLimitation) {
+    if (wheelChairLimitation == null) {
+      return WheelChairBoarding.NO_INFORMATION;
     }
 
-    var wheelchairAccessValue = accessibilityAssessment.getLimitations()
-            .getAccessibilityLimitation()
-            .getWheelchairAccess()
-            .value();
-
-    switch (wheelchairAccessValue) {
+    switch (wheelChairLimitation.value()) {
       case "true":
         return WheelChairBoarding.POSSIBLE;
       case "false":
@@ -143,7 +142,6 @@ class StopMapper {
       default:
         return WheelChairBoarding.NO_INFORMATION;
     }
-
   }
 
 }

--- a/src/main/java/org/opentripplanner/netex/mapping/StopMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/StopMapper.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.netex.mapping;
 
 import java.util.Collection;
-import java.util.Optional;
 import javax.annotation.Nullable;
 import org.opentripplanner.common.model.T2;
 import org.opentripplanner.graph_builder.DataImportIssueStore;
@@ -14,10 +13,6 @@ import org.opentripplanner.model.WheelChairBoarding;
 import org.opentripplanner.netex.index.api.ReadOnlyHierarchicalVersionMapById;
 import org.opentripplanner.netex.issues.QuayWithoutCoordinates;
 import org.opentripplanner.netex.mapping.support.FeedScopedIdFactory;
-import org.rutebanken.netex.model.AccessibilityAssessment;
-import org.rutebanken.netex.model.AccessibilityLimitation;
-import org.rutebanken.netex.model.AccessibilityLimitations_RelStructure;
-import org.rutebanken.netex.model.LimitationStatusEnumeration;
 import org.rutebanken.netex.model.Quay;
 import org.rutebanken.netex.model.StopPlace;
 
@@ -94,54 +89,14 @@ class StopMapper {
     var stopPlace = stopPlaceIndex.lookupLastVersionById(stopPlaceId.getId());
 
     if (stopPlace != null) {
-      defaultWheelChairBoarding = wheelChairBoarding(
+      defaultWheelChairBoarding = WheelChairMapper.wheelChairBoarding(
               stopPlace.getAccessibilityAssessment(),
               WheelChairBoarding.NO_INFORMATION
       );
     }
 
-    return wheelChairBoarding(quay.getAccessibilityAssessment(), defaultWheelChairBoarding);
-  }
-
-  /**
-   * If input and containing objects are not null, get the LimitationStatusEnumeration and map to
-   * internal {@link WheelChairBoarding} enumeration.
-   *
-   * @param accessibilityAssessment NeTEx object wrapping information regarding
-   *                                WheelChairBoarding
-   * @param defaultValue            If no {@link AccessibilityAssessment} is defined, default to
-   *                                this value
-   * @return Mapped enumerator, {@link WheelChairBoarding#NO_INFORMATION} if no value is found
-   */
-  private WheelChairBoarding wheelChairBoarding(
-          AccessibilityAssessment accessibilityAssessment,
-          WheelChairBoarding defaultValue
-  ) {
-    if (defaultValue == null) {
-      defaultValue = WheelChairBoarding.NO_INFORMATION;
-    }
-
-    return Optional.ofNullable(accessibilityAssessment)
-            .map(AccessibilityAssessment::getLimitations)
-            .map(AccessibilityLimitations_RelStructure::getAccessibilityLimitation)
-            .map(AccessibilityLimitation::getWheelchairAccess)
-            .map(this::fromLimitationStatusEnumeration)
-            .orElse(defaultValue);
-  }
-
-  private WheelChairBoarding fromLimitationStatusEnumeration(LimitationStatusEnumeration wheelChairLimitation) {
-    if (wheelChairLimitation == null) {
-      return WheelChairBoarding.NO_INFORMATION;
-    }
-
-    switch (wheelChairLimitation.value()) {
-      case "true":
-        return WheelChairBoarding.POSSIBLE;
-      case "false":
-        return WheelChairBoarding.NOT_POSSIBLE;
-      default:
-        return WheelChairBoarding.NO_INFORMATION;
-    }
+    return WheelChairMapper.wheelChairBoarding(
+            quay.getAccessibilityAssessment(), defaultWheelChairBoarding);
   }
 
 }

--- a/src/main/java/org/opentripplanner/netex/mapping/WheelChairMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/WheelChairMapper.java
@@ -1,0 +1,54 @@
+package org.opentripplanner.netex.mapping;
+
+import java.util.Optional;
+import org.opentripplanner.model.WheelChairBoarding;
+import org.rutebanken.netex.model.AccessibilityAssessment;
+import org.rutebanken.netex.model.AccessibilityLimitation;
+import org.rutebanken.netex.model.AccessibilityLimitations_RelStructure;
+import org.rutebanken.netex.model.LimitationStatusEnumeration;
+
+public class WheelChairMapper {
+
+    /**
+     * If input and containing objects are not null, get the LimitationStatusEnumeration and map to
+     * internal {@link WheelChairBoarding} enumeration.
+     *
+     * @param accessibilityAssessment NeTEx object wrapping information regarding
+     *                                WheelChairBoarding
+     * @param defaultValue            If no {@link AccessibilityAssessment} is defined, default to
+     *                                this value
+     * @return Mapped enumerator, {@link WheelChairBoarding#NO_INFORMATION} if no value is found
+     */
+    public static WheelChairBoarding wheelChairBoarding(
+            AccessibilityAssessment accessibilityAssessment,
+            WheelChairBoarding defaultValue
+    ) {
+        if (defaultValue == null) {
+            defaultValue = WheelChairBoarding.NO_INFORMATION;
+        }
+
+        return Optional.ofNullable(accessibilityAssessment)
+                .map(AccessibilityAssessment::getLimitations)
+                .map(AccessibilityLimitations_RelStructure::getAccessibilityLimitation)
+                .map(AccessibilityLimitation::getWheelchairAccess)
+                .map(WheelChairMapper::fromLimitationStatusEnumeration)
+                .orElse(defaultValue);
+    }
+
+    public static WheelChairBoarding fromLimitationStatusEnumeration(LimitationStatusEnumeration wheelChairLimitation) {
+        if (wheelChairLimitation == null) {
+            return WheelChairBoarding.NO_INFORMATION;
+        }
+
+        switch (wheelChairLimitation.value()) {
+            case "true":
+                return WheelChairBoarding.POSSIBLE;
+            case "false":
+                return WheelChairBoarding.NOT_POSSIBLE;
+            default:
+                return WheelChairBoarding.NO_INFORMATION;
+        }
+    }
+
+
+}


### PR DESCRIPTION
	- NeTEx mapping to internal model
	- Fix GraphQl to return integer on WheelChairBoarding
	- Unit test



### Summary
Maps NeTEx `WheelChairAccess` to internal `Stop.wheelChairBoarding`.

### Issue

closes #3926 
### Unit tests
One unit test with different values added to cover all cases of mapping.


