### PR TITLE
Fix data fetcher for destinationDisplay in TimetabledPassingTime [changelog skip]

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/TimetabledPassingTimeType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/TimetabledPassingTimeType.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.ext.transmodelapi.model.timetable;
 
 import graphql.Scalars;
+import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLList;
 import graphql.schema.GraphQLNonNull;
@@ -107,7 +108,7 @@ public class TimetabledPassingTimeType {
             .newFieldDefinition()
             .name("destinationDisplay")
             .type(destinationDisplayType)
-            .dataFetcher(environment -> ((TripTimeOnDate) environment.getSource()).getHeadsign())
+            .dataFetcher(DataFetchingEnvironment::getSource)
             .build())
         .field(GraphQLFieldDefinition
             .newFieldDefinition()


### PR DESCRIPTION
### Summary
It seems like #3883 missed the usage of `DestinationDisplay` in `TimetabledPassingTime`. This fixes the usage of that class.

### Changelog
The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md)
is generated from the pull-request title, make sure the title describe the feature or issue fixed.
To exclude the PR from the changelog add `[changelog skip]` in the title.
