### PR TITLE
The createETServiceRequestAsXml method is not used

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriHelper.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriHelper.java
@@ -48,11 +48,6 @@ public class SiriHelper {
         return SiriXml.toXml(request);
     }
 
-    public static String createETServiceRequestAsXml(String requestorRef) throws JAXBException {
-        Siri request = createETServiceRequest(requestorRef, -1);
-        return SiriXml.toXml(request);
-    }
-
     public static String createETServiceRequestAsXml(String requestorRef, int previewIntervalMillis) throws JAXBException {
         Siri request = createETServiceRequest(requestorRef, previewIntervalMillis);
         return SiriXml.toXml(request);


### PR DESCRIPTION
### Summary
The createETServiceRequestAsXml method with 1 argument has been removed since its counterpart with 2 arguments is always used. In this method, the second argument was set to -1 by default.
