### PR TITLE
Convert stream to list for constrained boarding search [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/constrainedtransfer/ConstrainedBoardingSearch.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/constrainedtransfer/ConstrainedBoardingSearch.java
@@ -105,7 +105,8 @@ public final class ConstrainedBoardingSearch
             int stopIndex
     ) {
         final Trip trip = tripSchedule.getOriginalTripTimes().getTrip();
-        // for performance reasons we use a for loop here as streams are much slower
+        // for performance reasons we use a for loop here as streams are much slower.
+        // I experimented with LinkedList and ArrayList and LinkedList was faster.
         var result = new LinkedList<TransferForPattern>();
         for (var t : currentTransfers) {
             if (t.matchesSourcePoint(stopIndex, trip)) {

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/constrainedtransfer/ConstrainedBoardingSearch.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/constrainedtransfer/ConstrainedBoardingSearch.java
@@ -1,7 +1,7 @@
 package org.opentripplanner.routing.algorithm.raptoradapter.transit.constrainedtransfer;
 
+import java.util.LinkedList;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.opentripplanner.model.Trip;
 import org.opentripplanner.model.transfer.TransferConstraint;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripSchedule;
@@ -105,9 +105,15 @@ public final class ConstrainedBoardingSearch
             int stopIndex
     ) {
         final Trip trip = tripSchedule.getOriginalTripTimes().getTrip();
-        return currentTransfers.stream()
-                .filter(t -> t.matchesSourcePoint(stopIndex, trip))
-                .collect(Collectors.toList());
+        // for performance reasons we use a for loop here as streams are much slower.
+        // i experimented with LinkedList and ArrayList and LinkedList was faster.
+        var result = new LinkedList<TransferForPattern>();
+        for (var t : currentTransfers) {
+            if (t.matchesSourcePoint(stopIndex, trip)) {
+                result.add(t);
+            }
+        }
+        return result;
     }
 
     /**

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/constrainedtransfer/ConstrainedBoardingSearch.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/constrainedtransfer/ConstrainedBoardingSearch.java
@@ -75,7 +75,7 @@ public final class ConstrainedBoardingSearch
     ) {
         var transfers = findMatchingTransfers(sourceTripSchedule, sourceStopIndex);
 
-        if(transfers.isEmpty()) { return null; }
+        if(!transfers.iterator().hasNext()) { return null; }
 
         boolean found = findTimetableTripInfo(
                 timetable,
@@ -100,13 +100,12 @@ public final class ConstrainedBoardingSearch
         );
     }
 
-    private List<TransferForPattern> findMatchingTransfers(
+    private Iterable<TransferForPattern> findMatchingTransfers(
             TripSchedule tripSchedule,
             int stopIndex
     ) {
         final Trip trip = tripSchedule.getOriginalTripTimes().getTrip();
-        // for performance reasons we use a for loop here as streams are much slower.
-        // i experimented with LinkedList and ArrayList and LinkedList was faster.
+        // for performance reasons we use a for loop here as streams are much slower
         var result = new LinkedList<TransferForPattern>();
         for (var t : currentTransfers) {
             if (t.matchesSourcePoint(stopIndex, trip)) {
@@ -130,7 +129,7 @@ public final class ConstrainedBoardingSearch
      */
     public boolean findTimetableTripInfo(
             RaptorTimeTable<TripSchedule> timetable,
-            List<TransferForPattern> transfers,
+            Iterable<TransferForPattern> transfers,
             int stopPos,
             int sourceTransitArrivalTime,
             int earliestBoardTime

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/constrainedtransfer/ConstrainedBoardingSearch.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/constrainedtransfer/ConstrainedBoardingSearch.java
@@ -106,7 +106,8 @@ public final class ConstrainedBoardingSearch
     ) {
         final Trip trip = tripSchedule.getOriginalTripTimes().getTrip();
         // for performance reasons we use a for loop here as streams are much slower.
-        // I experimented with LinkedList and ArrayList and LinkedList was faster.
+        // I experimented with LinkedList and ArrayList and LinkedList was faster, presumably
+        // because insertion is quick and we don't need index-based access, only iteration.
         var result = new LinkedList<TransferForPattern>();
         for (var t : currentTransfers) {
             if (t.matchesSourcePoint(stopIndex, trip)) {


### PR DESCRIPTION
### Summary

For data sets which have a huge number of constrained transfers (see #3950), the `Stream` in `ConstrainedBoarding` search is actually a bottleneck.

# Before
```
10:20:59.409 DEBUG (DebugTimingAggregator.java:232) ┌  Routing initialization           :     0 ms
10:20:59.409 DEBUG (DebugTimingAggregator.java:232) ├  Direct street routing            :     2 ms
10:20:59.409 DEBUG (DebugTimingAggregator.java:232) ├  Direct flex routing              :     0 ms
10:20:59.409 DEBUG (DebugTimingAggregator.java:232) │┌ Creating raptor data model       :    88 ms
10:20:59.409 DEBUG (DebugTimingAggregator.java:232) │├ Access routing (325 accesses)    :    31 ms
10:20:59.409 DEBUG (DebugTimingAggregator.java:232) │├ Egress routing (91 egresses)     :     7 ms
10:20:59.409 DEBUG (DebugTimingAggregator.java:232) ││ Access/Egress routing            :    31 ms
10:20:59.409 DEBUG (DebugTimingAggregator.java:232) │├ Main routing                     :  5357 ms
10:20:59.409 DEBUG (DebugTimingAggregator.java:232) │├ Creating itineraries             :    13 ms
10:20:59.409 DEBUG (DebugTimingAggregator.java:232) ├┴ Transit routing total            :  5490 ms
10:20:59.409 DEBUG (DebugTimingAggregator.java:232) │  Routing total:                   :  5491 ms
10:20:59.410 DEBUG (DebugTimingAggregator.java:232) ├  Filtering itineraries            :     0 ms
10:20:59.410 DEBUG (DebugTimingAggregator.java:232) ├  Converting model objects         :     2 ms
10:20:59.410 DEBUG (DebugTimingAggregator.java:232) ┴  Request total                    :  5493 ms
```

# After

```
10:04:42.305 DEBUG (DebugTimingAggregator.java:232) ┌  Routing initialization           :     0 ms
10:04:42.305 DEBUG (DebugTimingAggregator.java:232) ├  Direct street routing            :     2 ms
10:04:42.306 DEBUG (DebugTimingAggregator.java:232) ├  Direct flex routing              :     0 ms
10:04:42.306 DEBUG (DebugTimingAggregator.java:232) │┌ Creating raptor data model       :    81 ms
10:04:42.306 DEBUG (DebugTimingAggregator.java:232) │├ Access routing (325 accesses)    :    23 ms
10:04:42.306 DEBUG (DebugTimingAggregator.java:232) │├ Egress routing (91 egresses)     :     7 ms
10:04:42.306 DEBUG (DebugTimingAggregator.java:232) ││ Access/Egress routing            :    23 ms
10:04:42.306 DEBUG (DebugTimingAggregator.java:232) │├ Main routing                     :  3670 ms
10:04:42.306 DEBUG (DebugTimingAggregator.java:232) │├ Creating itineraries             :    17 ms
10:04:42.306 DEBUG (DebugTimingAggregator.java:232) ├┴ Transit routing total            :  3793 ms
10:04:42.306 DEBUG (DebugTimingAggregator.java:232) │  Routing total:                   :  3793 ms
10:04:42.306 DEBUG (DebugTimingAggregator.java:232) ├  Filtering itineraries            :     0 ms
10:04:42.306 DEBUG (DebugTimingAggregator.java:232) ├  Converting model objects         :     2 ms
10:04:42.306 DEBUG (DebugTimingAggregator.java:232) ┴  Request total                    :  3796 ms
```

### Issue

Relates to #3950 but I feel that in order to solve the problem we need to tackle it algorithmically.

### Unit tests

None, since it's a performance improvement.

### Code style
yes

### Documentation
no