### PR TITLE
Implement trip banning

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/BannedInputType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/BannedInputType.java
@@ -19,22 +19,14 @@ public class BannedInputType {
           "authorities",
           "Set of ids for authorities that should not be used"
       ))
-      // TODO trip ids (serviceJourneys) are expected on format AgencyId:trip-id[:stop ordinal:stop ordinal..]
-      //  and thus will not work with serviceJourney ids containing ':'.
-      // Need to subclass GraphQLPlanner if this field is to be supported
-      //  .field(GraphQLInputObjectField.newInputObjectField()
-      //     .name("serviceJourneys")
-      //     .description("Do not use certain named serviceJourneys")
-      //     .type(new GraphQLList(Scalars.GraphQLString))
-      //     .build())
       .field(GqlUtil.newIdListInputField(
           "quays",
-          "Set of ids of quays that should not be allowed for boarding or alighting. Trip patterns "
+          "NOT IMPLEMENTED. Set of ids of quays that should not be allowed for boarding or alighting. Trip patterns "
           + "that travel through the quay will still be permitted."
       ))
       .field(GqlUtil.newIdListInputField(
           "quaysHard",
-          "Set of ids of quays that should not be allowed for boarding, alighting or traveling "
+          "NOT IMPLEMENTED. Set of ids of quays that should not be allowed for boarding, alighting or traveling "
           + "thorugh."
       ))
       .field(GqlUtil.newIdListInputField(

--- a/src/main/java/org/opentripplanner/api/common/RoutingResource.java
+++ b/src/main/java/org/opentripplanner/api/common/RoutingResource.java
@@ -342,16 +342,12 @@ public abstract class RoutingResource {
 
     /**
      * The comma-separated list of banned agencies.
-     *
-     * @deprecated TODO OTP2 Regression. Not currently working in OTP2.
      */
     @QueryParam("bannedAgencies")
     protected String bannedAgencies;
 
     /**
      * Functions the same as banned agencies, except only the listed agencies are allowed.
-     *
-     * @deprecated TODO OTP2 Regression. Not currently working in OTP2.
      */
     @QueryParam("whiteListedAgencies")
     protected String whiteListedAgencies;
@@ -422,8 +418,6 @@ public abstract class RoutingResource {
      * The comma-separated list of banned routes. The format is agency_[routename][_routeid], so
      * TriMet_100 (100 is route short name) or Trimet__42 (two underscores, 42 is the route
      * internal ID).
-     *
-     * @deprecated TODO OTP2 Regression. Not currently working in OTP2.
      */
     @Deprecated
     @QueryParam("bannedRoutes")
@@ -431,8 +425,6 @@ public abstract class RoutingResource {
 
     /**
      * Functions the same as bannnedRoutes, except only the listed routes are allowed.
-     *
-     * @deprecated TODO OTP2 Regression. Not currently working in OTP2.
      */
     @QueryParam("whiteListedRoutes")
     @Deprecated
@@ -469,12 +461,8 @@ public abstract class RoutingResource {
     protected Integer otherThanPreferredRoutesPenalty;
 
     /**
-     * The comma-separated list of banned trips.  The format is agency_trip[:stop*], so:
-     * TriMet_24601 or TriMet_24601:0:1:2:17:18:19
-     *
-     * @deprecated TODO OTP2 Regression. Not currently working in OTP2.
+     * The comma-separated list of banned trips.  The format is feedId:tripId
      */
-    @Deprecated
     @QueryParam("bannedTrips")
     protected String bannedTrips;
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RoutingRequestTransitDataProviderFilter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RoutingRequestTransitDataProviderFilter.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.routing.algorithm.raptoradapter.transit.request;
 
 import java.util.EnumSet;
+import java.util.Map.Entry;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.opentripplanner.model.BikeAccess;
@@ -9,6 +10,7 @@ import org.opentripplanner.model.TransitMode;
 import org.opentripplanner.model.modes.AllowedTransitMode;
 import org.opentripplanner.model.Trip;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripPatternForDate;
+import org.opentripplanner.routing.api.request.BannedStopSet;
 import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.routing.graph.GraphIndex;
@@ -28,17 +30,21 @@ public class RoutingRequestTransitDataProviderFilter implements TransitDataProvi
 
   private final Set<FeedScopedId> bannedRoutes;
 
+  private final Set<FeedScopedId> bannedTrips;
+
   public RoutingRequestTransitDataProviderFilter(
       boolean requireBikesAllowed,
       boolean requireWheelchairAccessible,
       boolean includePlannedCancellations,
       Set<AllowedTransitMode> allowedTransitModes,
-      Set<FeedScopedId> bannedRoutes
+      Set<FeedScopedId> bannedRoutes,
+      Set<FeedScopedId> bannedTrips
   ) {
     this.requireBikesAllowed = requireBikesAllowed;
     this.requireWheelchairAccessible = requireWheelchairAccessible;
     this.includePlannedCancellations = includePlannedCancellations;
     this.bannedRoutes = bannedRoutes;
+    this.bannedTrips = bannedTrips;
     boolean hasOnlyMainModeFilters = allowedTransitModes.stream()
             .noneMatch(AllowedTransitMode::hasSubMode);
 
@@ -67,7 +73,11 @@ public class RoutingRequestTransitDataProviderFilter implements TransitDataProvi
         request.wheelchairAccessible,
         request.includePlannedCancellations,
         request.modes.transitModes,
-        request.getBannedRoutes(graphIndex.getAllRoutes())
+        request.getBannedRoutes(graphIndex.getAllRoutes()),
+        request.bannedTrips.entrySet().stream()
+                .filter(e -> e.getValue().equals(BannedStopSet.ALL))
+                .map(Entry::getKey)
+                .collect(Collectors.toSet())
     );
   }
 
@@ -78,20 +88,25 @@ public class RoutingRequestTransitDataProviderFilter implements TransitDataProvi
 
   @Override
   public boolean tripTimesPredicate(TripTimes tripTimes) {
-    if (!transitModeIsAllowed.test(tripTimes.getTrip())) {
+    final Trip trip = tripTimes.getTrip();
+    if (!transitModeIsAllowed.test(trip)) {
+      return false;
+    }
+
+    if (bannedTrips.contains(trip.getId()) ) {
       return false;
     }
 
     if (requireBikesAllowed) {
-      return bikeAccessForTrip(tripTimes.getTrip()) == BikeAccess.ALLOWED;
+      return bikeAccessForTrip(trip) == BikeAccess.ALLOWED;
     }
 
     if (requireWheelchairAccessible) {
-      return tripTimes.getTrip().getWheelchairAccessible() == 1;
+      return trip.getWheelchairAccessible() == 1;
     }
 
     if (!includePlannedCancellations) {
-      return !tripTimes.getTrip().getTripAlteration().isCanceledOrReplaced();
+      return !trip.getTripAlteration().isCanceledOrReplaced();
     }
 
     return true;

--- a/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
@@ -543,9 +543,8 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
     /**
      * Do not use certain trips
      *
-     * @deprecated TODO OTP2: Needs to be implemented
+     * Currently, only trips, which are completely banned are filtered out.
      */
-    @Deprecated
     public HashMap<FeedScopedId, BannedStopSet> bannedTrips = new HashMap<FeedScopedId, BannedStopSet>();
 
     /**

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RoutingRequestTransitDataProviderFilterTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RoutingRequestTransitDataProviderFilterTest.java
@@ -30,6 +30,8 @@ public class RoutingRequestTransitDataProviderFilterTest {
 
   private static final FeedScopedId TEST_ROUTE_ID = new FeedScopedId("TEST", "ROUTE");
 
+  private static final FeedScopedId TEST_TRIP_ID = new FeedScopedId("TEST", "TRIP");
+
   private static final Stop STOP_FOR_TEST = Stop.stopForTest("TEST:STOP", 0, 0);
 
   @Test
@@ -64,6 +66,24 @@ public class RoutingRequestTransitDataProviderFilterTest {
     );
 
     boolean valid = filter.tripPatternPredicate(tripPatternForDate);
+
+    assertFalse(valid);
+  }
+
+  @Test
+  public void bannedTripFilteringTest() {
+    TripTimes tripTimes = createTestTripTimes();
+
+    var filter = new RoutingRequestTransitDataProviderFilter(
+            false,
+            false,
+            false,
+            Set.of(AllowedTransitMode.fromMainModeEnum(TransitMode.BUS)),
+            Set.of(),
+            Set.of(TEST_TRIP_ID)
+    );
+
+    boolean valid = filter.tripTimesPredicate(tripTimes);
 
     assertFalse(valid);
   }
@@ -170,9 +190,9 @@ public class RoutingRequestTransitDataProviderFilterTest {
   }
 
   private TripTimes createTestTripTimes() {
-    Trip trip = new Trip(new FeedScopedId("TEST", "TRIP"));
+    Trip trip = new Trip(TEST_TRIP_ID);
     trip.setBikesAllowed(BikeAccess.NOT_ALLOWED);
-    trip.setRoute(new Route(new FeedScopedId("TEST", "ROUTE")));
+    trip.setRoute(new Route(TEST_ROUTE_ID));
     trip.setMode(TransitMode.BUS);
     trip.setNetexSubmode(TransmodelTransportSubmode.LOCAL_BUS.getValue());
 

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RoutingRequestTransitDataProviderFilterTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RoutingRequestTransitDataProviderFilterTest.java
@@ -41,6 +41,7 @@ public class RoutingRequestTransitDataProviderFilterTest {
         false,
         false,
         Set.of(AllowedTransitMode.fromMainModeEnum(TransitMode.BUS)),
+        Set.of(),
         Set.of()
     );
 
@@ -58,7 +59,8 @@ public class RoutingRequestTransitDataProviderFilterTest {
         false,
         false,
         Set.of(AllowedTransitMode.fromMainModeEnum(TransitMode.BUS)),
-        Set.of(TEST_ROUTE_ID)
+        Set.of(TEST_ROUTE_ID),
+        Set.of()
     );
 
     boolean valid = filter.tripPatternPredicate(tripPatternForDate);
@@ -88,6 +90,7 @@ public class RoutingRequestTransitDataProviderFilterTest {
             false,
             false,
             allowedModes,
+            Set.of(),
             Set.of()
     );
 
@@ -103,6 +106,7 @@ public class RoutingRequestTransitDataProviderFilterTest {
         false,
         false,
         Set.of(AllowedTransitMode.fromMainModeEnum(TransitMode.BUS)),
+        Set.of(),
         Set.of()
     );
 
@@ -120,6 +124,7 @@ public class RoutingRequestTransitDataProviderFilterTest {
         false,
         false,
         Set.of(),
+        Set.of(),
         Set.of()
     );
 
@@ -136,6 +141,7 @@ public class RoutingRequestTransitDataProviderFilterTest {
         false,
         true,
         false,
+        Set.of(),
         Set.of(),
         Set.of()
     );
@@ -191,6 +197,7 @@ public class RoutingRequestTransitDataProviderFilterTest {
         false,
         true,
         Set.of(AllowedTransitMode.fromMainModeEnum(TransitMode.BUS)),
+        Set.of(),
         Set.of()
     );
 
@@ -209,6 +216,7 @@ public class RoutingRequestTransitDataProviderFilterTest {
         false,
         false,
         false,
+        Set.of(),
         Set.of(),
         Set.of()
     );

--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTest.java
@@ -455,6 +455,7 @@ public class SpeedTest {
                 false,
                 false,
                 request.getTransitModes(),
+                Set.of(),
                 Set.of()
         );
 


### PR DESCRIPTION
### Summary

Trip banning was not implemented when moving from OTP1 to OTP2. This implements it, and fixes the descriptions in the Transmodel API for the unimplemented banned types.

### Changelog
The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md)
is generated from the pull-request title, make sure the title describe the feature or issue fixed.
To exclude the PR from the changelog add `[changelog skip]` in the title.
