### PR TITLE
Make sure NonLocalizedString is correctly initialized [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/util/NonLocalizedString.java
+++ b/src/main/java/org/opentripplanner/util/NonLocalizedString.java
@@ -3,6 +3,7 @@ package org.opentripplanner.util;
 import java.io.Serializable;
 import java.util.Locale;
 import java.util.Objects;
+import javax.annotation.Nonnull;
 
 /**
  * This is to support strings which can't be localized.
@@ -14,7 +15,10 @@ import java.util.Objects;
 public class NonLocalizedString implements I18NString, Serializable {
     private final String name;
 
-    public NonLocalizedString(String name) {
+    public NonLocalizedString(@Nonnull String name) {
+        if (name == null) {
+            throw new IllegalArgumentException();
+        }
         this.name = name;
     }
 

--- a/src/test/java/org/opentripplanner/model/plan/PlaceTest.java
+++ b/src/test/java/org/opentripplanner/model/plan/PlaceTest.java
@@ -53,7 +53,7 @@ public class PlaceTest {
     private static Stop stop(String stopId, double lat, double lon) {
        return new Stop(
                 new FeedScopedId("S", stopId),
-                null,
+                stopId,
                 null,
                 null,
                 WgsCoordinate.creatOptionalCoordinate(lat, lon),


### PR DESCRIPTION
### Summary
As previously discussed, we never want the `NonLocalizedString` to be initialized with a null value. This adds a check, and trows a runtime error, which can be used to fix the implementation.

### Changelog
The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md)
is generated from the pull-request title, make sure the title describe the feature or issue fixed.
To exclude the PR from the changelog add `[changelog skip]` in the title.
