### PR TITLE
Turn off SandboxAPITransmodelApi in OTPFeature

### DIFF
--- a/src/main/java/org/opentripplanner/util/OTPFeature.java
+++ b/src/main/java/org/opentripplanner/util/OTPFeature.java
@@ -33,7 +33,7 @@ public enum OTPFeature {
     ReportApi(false),
     SandboxAPILegacyGraphQLApi(false),
     SandboxAPIMapboxVectorTilesApi(false),
-    SandboxAPITransmodelApi(true),
+    SandboxAPITransmodelApi(false),
     SandboxExampleAPIGraphStatistics(false),
     SandboxAPIParkAndRideApi(false),
     TransferAnalyzer(false);


### PR DESCRIPTION
### Summary
Turn off SandboxAPITransmodelApi in OTPFeature
