### PR TITLE
Use WALK mode after park [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/GraphPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/GraphPathToItineraryMapper.java
@@ -335,7 +335,11 @@ public abstract class GraphPathToItineraryMapper {
                         case CAR:
                             return TraverseMode.CAR;
                     }
-                } else {
+                }
+                else if (state.isVehicleParked()) {
+                    return TraverseMode.WALK;
+                }
+                else {
                     return mode;
                 }
             }


### PR DESCRIPTION
### Summary
WALK mode is used after park instead of the mode that was used before parking on itineraries without transit.
### Issue
closes #3958

### Unit tests
TODO

### Code style
Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Codestyle.md)?
Yes
### Documentation
Not needed
### Changelog
From title
