### PR TITLE
Account for from/to splitting when copying turnRestrictions [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/common/TurnRestriction.java
+++ b/src/main/java/org/opentripplanner/common/TurnRestriction.java
@@ -1,10 +1,8 @@
 package org.opentripplanner.common;
 
 import java.io.Serializable;
-
 import org.opentripplanner.routing.core.TraverseModeSet;
 import org.opentripplanner.routing.edgetype.StreetEdge;
-import org.opentripplanner.routing.graph.Edge;
 
 public class TurnRestriction implements Serializable {
     private static final long serialVersionUID = 6072427988268244536L;
@@ -14,17 +12,6 @@ public class TurnRestriction implements Serializable {
     public final RepeatingTimePeriod time;
     public final TraverseModeSet modes;
 
-    public String toString() {
-        return type.name() + " from " + from + " to " + to + "(" + modes + ")";
-    }
-    
-    /**
-     * Convenience constructor.
-     * 
-     * @param from
-     * @param to
-     * @param type
-     */
     public TurnRestriction(StreetEdge from, StreetEdge to, TurnRestrictionType type,
             TraverseModeSet modes, RepeatingTimePeriod time) {
         this.from = from;
@@ -37,12 +24,16 @@ public class TurnRestriction implements Serializable {
     /**
      * Return true if the turn restriction is in force at the time described by the long.
      * @param time
-     * @return
      */
     public boolean active(long time) {
         if (this.time != null) {
             return this.time.active(time);
         }
         return true;
+    }
+
+    @Override
+    public String toString() {
+        return type.name() + " from " + from + " to " + to + " (modes: " + modes + ")";
     }
 }

--- a/src/main/java/org/opentripplanner/graph_builder/linking/VertexLinker.java
+++ b/src/main/java/org/opentripplanner/graph_builder/linking/VertexLinker.java
@@ -454,14 +454,13 @@ public class VertexLinker {
       }
 
       if (scope == Scope.PERMANENT) {
-        // remove original edge from the graph
-        originalEdge.getToVertex().removeIncoming(originalEdge);
-        originalEdge.getFromVertex().removeOutgoing(originalEdge);
         // remove original edges from the spatial index
         // This iterates over the entire rectangular envelope of the edge rather than the segments making it up.
         // It will be inefficient for very long edges, but creating a new remove method mirroring the more efficient
         // insert logic is not trivial and would require additional testing of the spatial index.
         removeEdgeFromIndex(originalEdge, scope);
+        // remove original edge from the graph
+        graph.removeEdge(originalEdge);
       }
     }
 

--- a/src/main/java/org/opentripplanner/routing/edgetype/TemporaryPartialStreetEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/TemporaryPartialStreetEdge.java
@@ -1,10 +1,7 @@
 package org.opentripplanner.routing.edgetype;
 
-import java.util.Collection;
-import javax.annotation.Nonnull;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.LineString;
-import org.opentripplanner.common.TurnRestriction;
 import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.util.ElevationUtils;
 import org.opentripplanner.routing.vertextype.StreetVertex;
@@ -81,12 +78,6 @@ final public class TemporaryPartialStreetEdge extends StreetWithElevationEdge im
     @Override
     public int getOutAngle() {
         return parentEdge.getInAngle();
-    }
-
-    @Nonnull
-    @Override
-    public Collection<TurnRestriction> getTurnRestrictions() {
-        return parentEdge.getTurnRestrictions();
     }
 
     /**

--- a/src/main/java/org/opentripplanner/routing/graph/Graph.java
+++ b/src/main/java/org/opentripplanner/routing/graph/Graph.java
@@ -348,9 +348,11 @@ public class Graph implements Serializable {
         if (e != null) {
             streetNotesService.removeStaticNotes(e);
 
-            if (e.fromv != null) {
-                e.fromv.removeOutgoing(e);
+            if (e instanceof StreetEdge) {
+                ((StreetEdge) e).removeAllTurnRestrictions();
+            }
 
+            if (e.fromv != null) {
                 e.fromv.getIncoming()
                         .stream()
                         .filter(StreetEdge.class::isInstance)
@@ -363,6 +365,7 @@ public class Graph implements Serializable {
                             }
                         });
 
+                e.fromv.removeOutgoing(e);
                 e.fromv = null;
             }
 

--- a/src/test/java/org/opentripplanner/routing/edgetype/StreetEdgeTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/StreetEdgeTest.java
@@ -1,0 +1,212 @@
+package org.opentripplanner.routing.edgetype;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.common.TurnRestriction;
+import org.opentripplanner.common.TurnRestrictionType;
+import org.opentripplanner.graph_builder.linking.DisposableEdgeCollection;
+import org.opentripplanner.graph_builder.linking.LinkingDirection;
+import org.opentripplanner.routing.algorithm.GraphRoutingTest;
+import org.opentripplanner.routing.core.TraverseMode;
+import org.opentripplanner.routing.core.TraverseModeSet;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.routing.vertextype.SplitterVertex;
+import org.opentripplanner.routing.vertextype.StreetVertex;
+import org.opentripplanner.routing.vertextype.TemporarySplitterVertex;
+
+class StreetEdgeTest extends GraphRoutingTest {
+
+  private StreetVertex V1, V2;
+
+  private StreetEdge streetEdge1, streetEdge2;
+
+  private final Graph graph;
+
+  private TurnRestriction originalTurnRestriction;
+
+  public StreetEdgeTest() {
+    graph = graph();
+  }
+
+  private Graph graph() {
+    return graphOf(new Builder() {
+      @Override
+      public void build() {
+        V1 = intersection("V1", 0.0, 0.0);
+        V2 = intersection("V2", 2.0, 0.0);
+
+        streetEdge1 = street(V2, V1, 100, StreetTraversalPermission.ALL);
+        streetEdge2 = street(V1, V2, 100, StreetTraversalPermission.ALL);
+
+        originalTurnRestriction = disallowTurn(streetEdge1, streetEdge2);
+      }
+    });
+  }
+
+  @Test
+  public void turnRestrictionFromEdgeSplit() {
+    var splitVtx = new SplitterVertex(graph, "Split_Vertex", 1.0, 0.0, streetEdge1);
+
+    var splitResult = streetEdge1.splitDestructively(splitVtx);
+    assertTrue(splitResult.first.getTurnRestrictions().isEmpty());
+    assertFalse(splitResult.second.getTurnRestrictions().isEmpty());
+    assertEquals(streetEdge2, addedRestriction(splitResult.second).to);
+    // The turn restriction is removed when the edge is removed
+    assertOriginalRestrictionExists();
+
+    graph.removeEdge(streetEdge1);
+    assertOriginalRestrictionMissing();
+
+    assertTrue(splitResult.first.getTurnRestrictions().isEmpty());
+    assertFalse(splitResult.second.getTurnRestrictions().isEmpty());
+    assertEquals(streetEdge2, addedRestriction(splitResult.second).to);
+  }
+
+  @Test
+  public void turnRestrictionToEdgeSplit() {
+    var splitVtx = new SplitterVertex(graph, "Split_Vertex", 1.0, 1.0, streetEdge2);
+
+    var splitResult = streetEdge2.splitDestructively(splitVtx);
+    assertEquals(splitResult.first, addedRestriction(streetEdge1).to);
+    // The turn restriction is removed when the edge is removed
+    assertOriginalRestrictionExists();
+
+    graph.removeEdge(streetEdge2);
+    assertOriginalRestrictionMissing();
+
+    assertTrue(splitResult.first.getTurnRestrictions().isEmpty());
+    assertTrue(splitResult.second.getTurnRestrictions().isEmpty());
+    assertEquals(splitResult.first, addedRestriction(streetEdge1).to);
+  }
+
+  @Test
+  public void turnRestrictionFromEdgeSplitWithTemporary() {
+    var splitVtx = new TemporarySplitterVertex("Split_Vertex", 1.0, 0.0, streetEdge1, true);
+    var disposableEdgeCollection = new DisposableEdgeCollection(graph);
+
+    var splitResult = streetEdge1.splitNonDestructively(splitVtx, disposableEdgeCollection, LinkingDirection.BOTH_WAYS);
+    assertTrue(splitResult.first.getTurnRestrictions().isEmpty());
+    assertFalse(splitResult.second.getTurnRestrictions().isEmpty());
+    assertEquals(streetEdge2, addedRestriction(splitResult.second).to);
+    assertOriginalRestrictionExists();
+
+    disposableEdgeCollection.disposeEdges();
+    assertTrue(splitResult.first.getTurnRestrictions().isEmpty());
+    assertTrue(splitResult.second.getTurnRestrictions().isEmpty());
+    assertOnlyOriginalRestrictionExists();
+  }
+
+  @Test
+  public void turnRestrictionToEdgeSplitTemporary() {
+    var splitVtx = new TemporarySplitterVertex("Split_Vertex", 1.0, 1.0, streetEdge2, false);
+    var disposableEdgeCollection = new DisposableEdgeCollection(graph);
+
+    var splitResult = streetEdge2.splitNonDestructively(splitVtx, disposableEdgeCollection, LinkingDirection.BOTH_WAYS);
+    assertEquals(splitResult.first, addedRestriction(streetEdge1).to);
+    assertOriginalRestrictionExists();
+
+    disposableEdgeCollection.disposeEdges();
+    assertTrue(splitResult.first.getTurnRestrictions().isEmpty());
+    assertTrue(splitResult.second.getTurnRestrictions().isEmpty());
+    assertOnlyOriginalRestrictionExists();
+  }
+
+  @Test
+  public void turnRestrictionFromEdgeSplitWithToVertex() {
+    var splitVtx = new TemporarySplitterVertex("Split_Vertex", 1.0, 0.0, streetEdge1, true);
+    var disposableEdgeCollection = new DisposableEdgeCollection(graph);
+
+    var splitResult = streetEdge1.splitNonDestructively(splitVtx, disposableEdgeCollection, LinkingDirection.OUTGOING);
+
+    assertOnlyOriginalRestrictionExists();
+    assertTrue(splitResult.first.getTurnRestrictions().isEmpty());
+    assertNull(splitResult.second);
+
+    disposableEdgeCollection.disposeEdges();
+    assertOnlyOriginalRestrictionExists();
+  }
+
+  @Test
+  public void turnRestrictionToEdgeSplitWithToVertex() {
+    var splitVtx = new TemporarySplitterVertex("Split_Vertex", 1.0, 1.0, streetEdge2, true);
+    var disposableEdgeCollection = new DisposableEdgeCollection(graph);
+
+    var splitResult = streetEdge2.splitNonDestructively(splitVtx, disposableEdgeCollection, LinkingDirection.OUTGOING);
+
+    var turnRestrictions = streetEdge1.getTurnRestrictions();
+    assertEquals(2, turnRestrictions.size());
+
+    assertOriginalRestrictionExists();
+    assertEquals(splitResult.first, addedRestriction(streetEdge1).to);
+
+    disposableEdgeCollection.disposeEdges();
+    assertOnlyOriginalRestrictionExists();
+  }
+
+  @Test
+  public void turnRestrictionFromEdgeSplitWithFromVertex() {
+    var splitVtx = new TemporarySplitterVertex("Split_Vertex", 1.0, 0.0, streetEdge1, false);
+    var disposableEdgeCollection = new DisposableEdgeCollection(graph);
+
+    var splitResult = streetEdge1.splitNonDestructively(splitVtx, disposableEdgeCollection, LinkingDirection.INCOMING);
+
+    assertOnlyOriginalRestrictionExists();
+
+    assertEquals(streetEdge2, addedRestriction(splitResult.second).to);
+
+    disposableEdgeCollection.disposeEdges();
+
+    assertOnlyOriginalRestrictionExists();
+    assertTrue(splitResult.second.getTurnRestrictions().isEmpty());
+  }
+
+  @Test
+  public void turnRestrictionToEdgeSplitWithFromVertex() {
+    var splitVtx = new TemporarySplitterVertex("Split_Vertex", 1.0, 1.0, streetEdge2, false);
+    var disposableEdgeCollection = new DisposableEdgeCollection(graph);
+
+    var splitResult = streetEdge2.splitNonDestructively(splitVtx, disposableEdgeCollection, LinkingDirection.INCOMING);
+
+    assertOnlyOriginalRestrictionExists();
+    assertTrue(splitResult.second.getTurnRestrictions().isEmpty());
+
+    disposableEdgeCollection.disposeEdges();
+    assertOnlyOriginalRestrictionExists();
+  }
+
+  private void assertOriginalRestrictionExists() {
+    var turnRestrictions = streetEdge1.getTurnRestrictions();
+    assertTrue(turnRestrictions.contains(originalTurnRestriction));
+  }
+
+  private void assertOnlyOriginalRestrictionExists() {
+    var turnRestrictions = streetEdge1.getTurnRestrictions();
+    assertEquals(1, turnRestrictions.size());
+    assertEquals(originalTurnRestriction, turnRestrictions.get(0));
+  }
+
+  private void assertOriginalRestrictionMissing() {
+    var turnRestrictions = streetEdge1.getTurnRestrictions();
+    assertFalse(turnRestrictions.contains(originalTurnRestriction));
+  }
+
+  private TurnRestriction addedRestriction(StreetEdge streetEdge) {
+    return streetEdge.getTurnRestrictions()
+            .stream()
+            .filter(tr -> tr != originalTurnRestriction)
+            .findFirst()
+            .orElseThrow();
+  }
+
+  private TurnRestriction disallowTurn(StreetEdge from, StreetEdge to) {
+    TurnRestrictionType restrictionType = TurnRestrictionType.NO_TURN;
+    TraverseModeSet restrictedModes = new TraverseModeSet(TraverseMode.CAR);
+    TurnRestriction restrict = new TurnRestriction(from, to, restrictionType, restrictedModes, null);
+    from.addTurnRestriction(restrict);
+    return restrict;
+  }
+}


### PR DESCRIPTION
### Summary

When splitting edges and the related turn restrictions, the `from` / `to` directions weren't fully accounted for. This updates the code to correctly copy the turn restrictions with added tests.

When splitting edges:
 * there are permanent and temporary splits. The original turn restrictions don't need to be removed for temporary splits.
 * splitting edges doesn't always result in two edges, and so the `first` and `second` edges may be missing.
 * the `first` and `second` split parts need to have turn restriction copied differently.

### Issue

may be related to #3947

### Unit tests

Test are added for edge splitting + turn restrictions in `StreetEdgeTest`

### Code style

:ballot_box_with_check: 
