### PR TITLE
Make raptor transfer lists immutable for faster iteration [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/RaptorTransferIndex.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/RaptorTransferIndex.java
@@ -5,6 +5,7 @@ import static java.util.stream.Collectors.toMap;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
 import org.opentripplanner.transit.raptor.util.ReversedRaptorTransfer;
@@ -19,8 +20,14 @@ public class RaptorTransferIndex {
             List<List<RaptorTransfer>> forwardTransfers,
             List<List<RaptorTransfer>> reversedTransfers
     ) {
-        this.forwardTransfers = forwardTransfers;
-        this.reversedTransfers = reversedTransfers;
+        // Create immutable copies of the lists for each stop to make them immutable and faster to iterate
+        this.forwardTransfers = forwardTransfers.stream()
+                .map(List::copyOf)
+                .collect(Collectors.toList());
+
+        this.reversedTransfers = reversedTransfers.stream()
+                .map(List::copyOf)
+                .collect(Collectors.toList());
     }
 
     public List<List<RaptorTransfer>> getForwardTransfers() {


### PR DESCRIPTION
### Summary
Quite a bit of time is spent on iterating the transfers for each stop, especially in the reverse heuristic. This improves the reverse heuristic by around 5% and the total search by around 2%

### Changelog
The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md)
is generated from the pull-request title, make sure the title describe the feature or issue fixed.
To exclude the PR from the changelog add `[changelog skip]` in the title.
