### PR TITLE
Optimize routeIterator by adding a pattern index and pre-calculating allowed stops [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TripPatternWithRaptorStopIndexes.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TripPatternWithRaptorStopIndexes.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.routing.algorithm.raptoradapter.transit;
 
+import java.util.BitSet;
 import java.util.Objects;
 import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.model.TransitMode;
@@ -14,6 +15,10 @@ public class TripPatternWithRaptorStopIndexes {
 
     private final TripPattern pattern;
     private final int[] stopIndexes;
+
+    private final BitSet boardingPossible;
+
+    private final BitSet alightingPossible;
 
     /**
      * List of transfers TO this pattern for each stop position in pattern used by Raptor during the
@@ -43,6 +48,15 @@ public class TripPatternWithRaptorStopIndexes {
     ) {
         this.pattern = pattern;
         this.stopIndexes = stopIndexes;
+
+        final int nStops = stopIndexes.length;
+        boardingPossible = new BitSet(nStops);
+        alightingPossible = new BitSet(nStops);
+
+        for (int s = 0; s < nStops; s++) {
+            boardingPossible.set(s, pattern.canBoard(s));
+            alightingPossible.set(s, pattern.canAlight(s));
+        }
     }
 
     public FeedScopedId getId() {return pattern.getId();}
@@ -76,6 +90,14 @@ public class TripPatternWithRaptorStopIndexes {
 
     public RaptorConstrainedTripScheduleBoardingSearch<TripSchedule> constrainedTransferReverseSearch() {
         return new ConstrainedBoardingSearch(false, constrainedTransfersReverseSearch);
+    }
+
+    public boolean boardingPossibleAt(int stopPositionInPattern) {
+        return boardingPossible.get(stopPositionInPattern);
+    }
+
+    public boolean alightingPossibleAt(int stopPositionInPattern) {
+        return alightingPossible.get(stopPositionInPattern);
     }
 
     @Override

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RaptorRoutingRequestTransitData.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RaptorRoutingRequestTransitData.java
@@ -37,12 +37,12 @@ public class RaptorRoutingRequestTransitData implements RaptorTransitDataProvide
   private final TransferService transferService;
 
   /**
-   * Active trip pattern indices by stop index
+   * Active route indices by stop index
    */
   private final List<int[]> activeTripPatternsPerStop;
 
   /**
-   * Trip patterns by trip pattern index
+   * Trip patterns by route index
    */
   private final List<TripPatternForDates> patternIndex;
 
@@ -126,7 +126,7 @@ public class RaptorRoutingRequestTransitData implements RaptorTransitDataProvide
   }
 
   @Override
-  public RaptorRoute<TripSchedule> getPatternForIndex(int routeIndex) {
+  public RaptorRoute<TripSchedule> getRouteForIndex(int routeIndex) {
     return patternIndex.get(routeIndex);
   }
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RaptorRoutingRequestTransitData.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RaptorRoutingRequestTransitData.java
@@ -1,10 +1,9 @@
 package org.opentripplanner.routing.algorithm.raptoradapter.transit.request;
 
 import java.time.ZonedDateTime;
+import java.util.BitSet;
 import java.util.Iterator;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 import javax.annotation.Nullable;
 import org.opentripplanner.model.transfer.TransferService;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.RaptorTransferIndex;
@@ -22,6 +21,7 @@ import org.opentripplanner.transit.raptor.api.transit.RaptorRoute;
 import org.opentripplanner.transit.raptor.api.transit.RaptorStopNameResolver;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTransitDataProvider;
+import org.opentripplanner.transit.raptor.util.BitSetIterator;
 import org.opentripplanner.util.OTPFeature;
 
 
@@ -37,9 +37,14 @@ public class RaptorRoutingRequestTransitData implements RaptorTransitDataProvide
   private final TransferService transferService;
 
   /**
-   * Active trip patterns by stop index
+   * Active trip pattern indices by stop index
    */
-  private final List<List<TripPatternForDates>> activeTripPatternsPerStop;
+  private final List<int[]> activeTripPatternsPerStop;
+
+  /**
+   * Trip patterns by trip pattern index
+   */
+  private final List<TripPatternForDates> patternIndex;
 
   /**
    * Transfers by stop index
@@ -74,11 +79,12 @@ public class RaptorRoutingRequestTransitData implements RaptorTransitDataProvide
     var transitDataCreator = new RaptorRoutingRequestTransitDataCreator(
             transitLayer, transitSearchTimeZero
     );
-    this.activeTripPatternsPerStop = transitDataCreator.createTripPatternsPerStop(
+    this.patternIndex = transitDataCreator.createTripPatterns(
         additionalPastSearchDays,
         additionalFutureSearchDays,
         filter
     );
+    this.activeTripPatternsPerStop = transitDataCreator.createTripPatternsPerStop(patternIndex);
     this.transfers = transitLayer.getRaptorTransfersForRequest(routingRequest);
     this.generalizedCostCalculator = new DefaultCostCalculator(
             McCostParamsMapper.map(routingRequest),
@@ -106,13 +112,22 @@ public class RaptorRoutingRequestTransitData implements RaptorTransitDataProvide
   }
 
   @Override
-  public Iterator<? extends RaptorRoute<TripSchedule>> routeIterator(IntIterator stops) {
-    // A LinkedHashSet is used so that the iteration order is deterministic.
-    Set<TripPatternForDates> activeTripPatternsForGivenStops = new LinkedHashSet<>();
+  public IntIterator routeIndexIterator(IntIterator stops) {
+    BitSet activeTripPatternsForGivenStops = new BitSet(patternIndex.size());
+
     while (stops.hasNext()) {
-      activeTripPatternsForGivenStops.addAll(activeTripPatternsPerStop.get(stops.next()));
+      int[] patterns = activeTripPatternsPerStop.get(stops.next());
+      for (int i : patterns) {
+        activeTripPatternsForGivenStops.set(i);
+      }
     }
-    return activeTripPatternsForGivenStops.iterator();
+
+    return new BitSetIterator(activeTripPatternsForGivenStops);
+  }
+
+  @Override
+  public RaptorRoute<TripSchedule> getPatternForIndex(int routeIndex) {
+    return patternIndex.get(routeIndex);
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripPatternForDates.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripPatternForDates.java
@@ -1,8 +1,9 @@
 package org.opentripplanner.routing.algorithm.raptoradapter.transit.request;
 
-import java.util.Arrays;
+import java.util.BitSet;
 import java.util.List;
 import java.util.function.IntUnaryOperator;
+import org.opentripplanner.model.TripPattern;
 import org.opentripplanner.model.base.ToStringBuilder;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripPatternForDate;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripPatternWithRaptorStopIndexes;
@@ -143,12 +144,12 @@ public class TripPatternForDates
 
     @Override
     public boolean boardingPossibleAt(int stopPositionInPattern) {
-        return tripPattern.getPattern().canBoard(stopPositionInPattern);
+        return tripPattern.boardingPossibleAt(stopPositionInPattern);
     }
 
     @Override
     public boolean alightingPossibleAt(int stopPositionInPattern) {
-        return tripPattern.getPattern().canAlight(stopPositionInPattern);
+        return tripPattern.alightingPossibleAt(stopPositionInPattern);
     }
 
     @Override public int numberOfStopsInPattern() {

--- a/src/main/java/org/opentripplanner/transit/raptor/api/transit/RaptorTransitDataProvider.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/transit/RaptorTransitDataProvider.java
@@ -63,14 +63,19 @@ public interface RaptorTransitDataProvider<T extends RaptorTripSchedule> {
     Iterator<? extends RaptorTransfer> getTransfersToStop(int toStop);
 
     /**
-     * Return a set of all patterns visiting the given set of stops.
+     * Return an iterator of trip pattern indices for all patterns visiting the given set of stops.
      * <p/>
      * The implementation may implement a lightweight {@link RaptorTripPattern} representation.
      * See {@link #getTransfersFromStop(int)} for detail on how to implement this.
      *
      * @param stops set of stops for find all patterns for.
      */
-    Iterator<? extends RaptorRoute<T>> routeIterator(IntIterator stops);
+    IntIterator routeIndexIterator(IntIterator stops);
+
+    /**
+     * Returns the trip pattern for a specific trip pattern index
+     */
+    RaptorRoute<T> getPatternForIndex(int routeIndex);
 
     /**
      * This is the total number of stops, it should be possible to retrieve transfers and pattern

--- a/src/main/java/org/opentripplanner/transit/raptor/api/transit/RaptorTransitDataProvider.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/transit/RaptorTransitDataProvider.java
@@ -63,19 +63,19 @@ public interface RaptorTransitDataProvider<T extends RaptorTripSchedule> {
     Iterator<? extends RaptorTransfer> getTransfersToStop(int toStop);
 
     /**
-     * Return an iterator of trip pattern indices for all patterns visiting the given set of stops.
-     * <p/>
-     * The implementation may implement a lightweight {@link RaptorTripPattern} representation.
-     * See {@link #getTransfersFromStop(int)} for detail on how to implement this.
+     * Return an iterator of route indices for all routes visiting the given set of stops.
      *
-     * @param stops set of stops for find all patterns for.
+     * @param stops set of stops for find all routes for.
      */
     IntIterator routeIndexIterator(IntIterator stops);
 
     /**
-     * Returns the trip pattern for a specific trip pattern index
+     * Returns the raptor route for a specific route index
+     * <p/>
+     * The implementation may implement a lightweight {@link RaptorTripPattern} representation.
+     * See {@link #getTransfersFromStop(int)} for detail on how to implement this.
      */
-    RaptorRoute<T> getPatternForIndex(int routeIndex);
+    RaptorRoute<T> getRouteForIndex(int routeIndex);
 
     /**
      * This is the total number of stops, it should be possible to retrieve transfers and pattern

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/RangeRaptorWorker.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/RangeRaptorWorker.java
@@ -3,15 +3,14 @@ package org.opentripplanner.transit.raptor.rangeraptor;
 
 import io.micrometer.core.instrument.Timer;
 import java.util.Collection;
-import java.util.Iterator;
 import org.opentripplanner.transit.raptor.api.path.Path;
 import org.opentripplanner.transit.raptor.api.transit.IntIterator;
 import org.opentripplanner.transit.raptor.api.transit.RaptorConstrainedTripScheduleBoardingSearch;
-import org.opentripplanner.transit.raptor.api.transit.RaptorRoute;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTimeTable;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTransitDataProvider;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
+import org.opentripplanner.transit.raptor.api.transit.RaptorTripScheduleSearch;
 import org.opentripplanner.transit.raptor.api.transit.TransitArrival;
 import org.opentripplanner.transit.raptor.api.view.Worker;
 import org.opentripplanner.transit.raptor.rangeraptor.debug.WorkerPerformanceTimers;
@@ -19,7 +18,6 @@ import org.opentripplanner.transit.raptor.rangeraptor.transit.AccessPaths;
 import org.opentripplanner.transit.raptor.rangeraptor.transit.RoundTracker;
 import org.opentripplanner.transit.raptor.rangeraptor.transit.TransitCalculator;
 import org.opentripplanner.transit.raptor.rangeraptor.transit.TripScheduleBoardSearch;
-import org.opentripplanner.transit.raptor.api.transit.RaptorTripScheduleSearch;
 import org.opentripplanner.transit.raptor.rangeraptor.workerlifecycle.LifeCycleEventPublisher;
 
 
@@ -199,10 +197,11 @@ public final class RangeRaptorWorker<T extends RaptorTripSchedule> implements Wo
     private void findTransitForRound() {
         timerByMinuteScheduleSearch().record(() -> {
             IntIterator stops = state.stopsTouchedPreviousRound();
-            Iterator<? extends RaptorRoute<T>> routeIterator = transitData.routeIterator(stops);
+            IntIterator routeIndexIterator = transitData.routeIndexIterator(stops);
 
-            while (routeIterator.hasNext()) {
-                var route = routeIterator.next();
+            while (routeIndexIterator.hasNext()) {
+                var routeIndex = routeIndexIterator.next();
+                var route = transitData.getPatternForIndex(routeIndex);
                 var pattern = route.pattern();
                 var tripSearch = createTripSearch(route.timetable());
                 var txSearch = enableTransferConstraints

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/RangeRaptorWorker.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/RangeRaptorWorker.java
@@ -201,7 +201,7 @@ public final class RangeRaptorWorker<T extends RaptorTripSchedule> implements Wo
 
             while (routeIndexIterator.hasNext()) {
                 var routeIndex = routeIndexIterator.next();
-                var route = transitData.getPatternForIndex(routeIndex);
+                var route = transitData.getRouteForIndex(routeIndex);
                 var pattern = route.pattern();
                 var tripSearch = createTripSearch(route.timetable());
                 var txSearch = enableTransferConstraints

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RaptorRoutingRequestTransitDataCreatorTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RaptorRoutingRequestTransitDataCreatorTest.java
@@ -32,7 +32,7 @@ public class RaptorRoutingRequestTransitDataCreatorTest {
   private static final TripPattern TP = new TripPattern(
           new FeedScopedId("F", "P1"),
           new Route(new FeedScopedId("F", "L1")),
-          new StopPattern(List.of())
+          new StopPattern(List.of(new StopTime(), new StopTime()))
   );
 
   @BeforeEach

--- a/src/test/java/org/opentripplanner/transit/raptor/_data/transit/TestTransitData.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/_data/transit/TestTransitData.java
@@ -42,7 +42,7 @@ public class TestTransitData implements RaptorTransitDataProvider<TestTripSchedu
 
   private final List<List<RaptorTransfer>> transfersFromStop = new ArrayList<>();
   private final List<List<RaptorTransfer>> transfersToStop = new ArrayList<>();
-  private final List<Set<Integer>> routesByStop = new ArrayList<>();
+  private final List<Set<Integer>> routeIndexesByStopIndex = new ArrayList<>();
   private final List<TestRoute> routes = new ArrayList<>();
   private final List<ConstrainedTransfer> constrainedTransfers = new ArrayList<>();
   private final McCostParamsBuilder costParamsBuilder = new McCostParamsBuilder();
@@ -62,7 +62,7 @@ public class TestTransitData implements RaptorTransitDataProvider<TestTripSchedu
     BitSet routes = new BitSet();
     while (stops.hasNext()) {
       int stop = stops.next();
-      for (int i : routesByStop.get(stop)) {
+      for (int i : routeIndexesByStopIndex.get(stop)) {
         routes.set(i);
       }
     }
@@ -70,13 +70,13 @@ public class TestTransitData implements RaptorTransitDataProvider<TestTripSchedu
   }
 
   @Override
-  public RaptorRoute<TestTripSchedule> getPatternForIndex(int routeIndex) {
+  public RaptorRoute<TestTripSchedule> getRouteForIndex(int routeIndex) {
     return this.routes.get(routeIndex);
   }
 
   @Override
   public int numberOfStops() {
-    return routesByStop.size();
+    return routeIndexesByStopIndex.size();
   }
 
   @Override
@@ -166,7 +166,7 @@ public class TestTransitData implements RaptorTransitDataProvider<TestTripSchedu
     for(int i=0; i< pattern.numberOfStopsInPattern(); ++i) {
       int stopIndex = pattern.stopIndex(i);
       expandNumOfStops(stopIndex);
-      routesByStop.get(stopIndex).add(routeIndex);
+      routeIndexesByStopIndex.get(stopIndex).add(routeIndex);
     }
     return this;
   }
@@ -264,14 +264,14 @@ public class TestTransitData implements RaptorTransitDataProvider<TestTripSchedu
     for (int i=numberOfStops(); i<=stopIndex; ++i) {
       transfersFromStop.add(new ArrayList<>());
       transfersToStop.add(new ArrayList<>());
-      routesByStop.add(new HashSet<>());
+      routeIndexesByStopIndex.add(new HashSet<>());
     }
   }
 
   private List<Integer> stopsVisited() {
     final List<Integer> stops = new ArrayList<>();
-    for (int i = 0; i < routesByStop.size(); i++) {
-       if(!routesByStop.get(i).isEmpty()) {
+    for (int i = 0; i < routeIndexesByStopIndex.size(); i++) {
+       if(!routeIndexesByStopIndex.get(i).isEmpty()) {
          stops.add(i);
        }
     }


### PR DESCRIPTION
### Summary

This is an optimization, with approximately 12% routing performance improvement in the SpeedTest.

The first commit optimizes the routeIterator, by calculating an index for each pattern, and using those indexes rather than references when combining all patterns from reached stops.

The second commit adds two bisets, which contain information whether boarding and alighting is allowed at each stop along the pattern.

### Changelog
The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md)
is generated from the pull-request title, make sure the title describe the feature or issue fixed.
To exclude the PR from the changelog add `[changelog skip]` in the title.
