### PR TITLE
Do not override already set flex window [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/netex/mapping/StopTimesMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/StopTimesMapper.java
@@ -366,10 +366,14 @@ class StopTimesMapper {
             int arrivalTime = stopTimes.get(1).getArrivalTime();
 
             for (StopTime stopTime : stopTimes) {
-                stopTime.clearArrivalTime();
-                stopTime.clearDepartureTime();
-                stopTime.setFlexWindowStart(departureTime);
-                stopTime.setFlexWindowEnd(arrivalTime);
+                if (stopTime.getFlexWindowStart() == StopTime.MISSING_VALUE) {
+                    stopTime.clearDepartureTime();
+                    stopTime.setFlexWindowStart(departureTime);
+                }
+                if (stopTime.getFlexWindowEnd() == StopTime.MISSING_VALUE) {
+                    stopTime.clearArrivalTime();
+                    stopTime.setFlexWindowEnd(arrivalTime);
+                }
             }
         }
     }


### PR DESCRIPTION
### Summary

In #3800, we enabled reading flex opening hours from the correct fields. However those could later be overridden by the previous hack. This disables the hack, if times have been set.

### Changelog
The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md)
is generated from the pull-request title, make sure the title describe the feature or issue fixed.
To exclude the PR from the changelog add `[changelog skip]` in the title.
