### PR TITLE
Make distance, duration, directDuration non-null [changelog skip]

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/LegType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/LegType.java
@@ -101,14 +101,14 @@ public class LegType {
         .field(GraphQLFieldDefinition
             .newFieldDefinition()
             .name("duration")
-            .description("The legs's duration in seconds")
-            .type(ExtendedScalars.GraphQLLong)
+            .description("The leg's duration in seconds")
+            .type(new GraphQLNonNull(ExtendedScalars.GraphQLLong))
             .dataFetcher(env -> leg(env).getDuration())
             .build())
         .field(GraphQLFieldDefinition
             .newFieldDefinition()
             .name("directDuration")
-            .type(ExtendedScalars.GraphQLLong)
+            .type(new GraphQLNonNull(ExtendedScalars.GraphQLLong))
             .description("NOT IMPLEMENTED")
             .dataFetcher(env -> leg(env).getDuration())
             .build())
@@ -145,7 +145,7 @@ public class LegType {
             .newFieldDefinition()
             .name("distance")
             .description("The distance traveled while traversing the leg in meters.")
-            .type(Scalars.GraphQLFloat)
+            .type(new GraphQLNonNull(Scalars.GraphQLFloat))
             .dataFetcher(env -> leg(env).getDistanceMeters())
             .build())
         .field(GraphQLFieldDefinition


### PR DESCRIPTION
### Summary
These `Leg` types should not be nullable. This PR updates the GrahphQL schema types. And fixes a typo!