### PR TITLE
Use native type for distance, as it is always defined[changelog skip]

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/flex/FlexibleTransitLeg.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/FlexibleTransitLeg.java
@@ -34,7 +34,7 @@ public class FlexibleTransitLeg implements Leg {
 
     private final Calendar endTime;
 
-    private final Double distanceMeters;
+    private final double distanceMeters;
 
     private final ServiceDate serviceDate;
 
@@ -144,7 +144,7 @@ public class FlexibleTransitLeg implements Leg {
     }
 
     @Override
-    public Double getDistanceMeters() {
+    public double getDistanceMeters() {
         return distanceMeters;
     }
 

--- a/src/main/java/org/opentripplanner/model/plan/Itinerary.java
+++ b/src/main/java/org/opentripplanner/model/plan/Itinerary.java
@@ -189,7 +189,7 @@ public class Itinerary {
      * Total distance in meters.
      */
     public double distanceMeters() {
-        return legs.stream().mapToDouble(it -> it.getDistanceMeters()).sum();
+        return legs.stream().mapToDouble(Leg::getDistanceMeters).sum();
     }
 
     /**

--- a/src/main/java/org/opentripplanner/model/plan/Leg.java
+++ b/src/main/java/org/opentripplanner/model/plan/Leg.java
@@ -181,7 +181,7 @@ public interface Leg {
     /**
      * The distance traveled while traversing the leg in meters.
      */
-    Double getDistanceMeters();
+    double getDistanceMeters();
 
     /**
      * The GTFS pathway id

--- a/src/main/java/org/opentripplanner/model/plan/ScheduledTransitLeg.java
+++ b/src/main/java/org/opentripplanner/model/plan/ScheduledTransitLeg.java
@@ -41,7 +41,7 @@ public class ScheduledTransitLeg implements Leg {
     private final Calendar startTime;
     private final Calendar endTime;
 
-    private Double distanceMeters;
+    private double distanceMeters;
     private final LineString legGeometry;
 
     private final Set<TransitAlert> transitAlerts = new HashSet<>();
@@ -196,12 +196,12 @@ public class ScheduledTransitLeg implements Leg {
     }
 
     @Override
-    public Double getDistanceMeters() {
+    public double getDistanceMeters() {
         return distanceMeters;
     }
 
     /** Only for testing purposes */
-    protected void setDistanceMeters(Double distanceMeters) {
+    protected void setDistanceMeters(double distanceMeters) {
         this.distanceMeters = distanceMeters;
     }
 

--- a/src/main/java/org/opentripplanner/model/plan/StreetLeg.java
+++ b/src/main/java/org/opentripplanner/model/plan/StreetLeg.java
@@ -22,7 +22,7 @@ public class StreetLeg implements Leg {
 
     private final Calendar endTime;
 
-    private final Double distanceMeters;
+    private final double distanceMeters;
 
     private final Place from;
 
@@ -50,7 +50,7 @@ public class StreetLeg implements Leg {
             Calendar endTime,
             Place from,
             Place to,
-            Double distanceMeters,
+            double distanceMeters,
             int generalizedCost,
             LineString geometry,
             List<WalkStep> walkSteps
@@ -110,7 +110,7 @@ public class StreetLeg implements Leg {
     }
 
     @Override
-    public Double getDistanceMeters() {
+    public double getDistanceMeters() {
         return distanceMeters;
     }
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/filterchain/deletionflagger/RemoveBikerentalWithMostlyWalkingFilter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/filterchain/deletionflagger/RemoveBikerentalWithMostlyWalkingFilter.java
@@ -2,6 +2,7 @@ package org.opentripplanner.routing.algorithm.filterchain.deletionflagger;
 
 import java.util.function.Predicate;
 import org.opentripplanner.model.plan.Itinerary;
+import org.opentripplanner.model.plan.Leg;
 
 /**
  * This is used to filter out bike rental itineraries that contain mostly walking. The value
@@ -32,7 +33,7 @@ public class RemoveBikerentalWithMostlyWalkingFilter implements ItineraryDeletio
             double bikeRentalDistance = itinerary.legs
                     .stream()
                     .filter(l -> l.getRentedVehicle() != null && l.getRentedVehicle())
-                    .mapToDouble(l -> l.getDistanceMeters())
+                    .mapToDouble(Leg::getDistanceMeters)
                     .sum();
             double totalDistance = itinerary.distanceMeters();
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/filterchain/groupids/GroupByTripIdAndDistance.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/filterchain/groupids/GroupByTripIdAndDistance.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.routing.algorithm.filterchain.groupids;
 
+import java.util.Comparator;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.Leg;
 
@@ -61,14 +62,14 @@ public class GroupByTripIdAndDistance implements GroupId<GroupByTripIdAndDistanc
 
     /** package local to be unit-testable */
     static double calculateTotalDistance(List<Leg> transitLegs) {
-        return transitLegs.stream().mapToDouble(it -> it.getDistanceMeters()).sum();
+        return transitLegs.stream().mapToDouble(Leg::getDistanceMeters).sum();
     }
 
     /** package local to be unit-testable */
     static List<Leg> getKeySetOfLegsByLimit(List<Leg> legs, double distanceLimitMeters) {
         // Sort legs descending on distance
         legs = legs.stream()
-                .sorted((l,r) -> r.getDistanceMeters().compareTo(l.getDistanceMeters()))
+                .sorted(Comparator.comparingDouble(Leg::getDistanceMeters).reversed())
                 .collect(Collectors.toList());
         double sum = 0.0;
         int i=0;

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
@@ -239,7 +239,7 @@ public class RaptorPathToItineraryMapper {
                     createCalendar(pathLeg.toTime()),
                     from,
                     to,
-                    (double) transfer.getDistanceMeters(),
+                    transfer.getDistanceMeters(),
                     toOtpDomainCost(pathLeg.generalizedCost()),
                     GeometryUtils.makeLineString(transfer.getCoordinates()),
                     List.of()

--- a/src/test/java/org/opentripplanner/routing/algorithm/filterchain/groupids/GroupByTripIdAndDistanceTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/filterchain/groupids/GroupByTripIdAndDistanceTest.java
@@ -56,8 +56,8 @@ public class GroupByTripIdAndDistanceTest implements PlanTestConstants {
         Leg l2 = i.legs.get(1);
         Leg l3 = i.legs.get(2);
 
-        Double d1 = l1.getDistanceMeters();
-        Double d3 = l3.getDistanceMeters();
+        double d1 = l1.getDistanceMeters();
+        double d3 = l3.getDistanceMeters();
 
         // These test relay on the internal sort by distance, which make the implementation
         // a bit simpler, but strictly is not something the method grantees


### PR DESCRIPTION
### Summary

Distance It is always non-null, so it is nicer to use a native, rather than the boxed type.

### Issue

Relates to #3982

### Changelog
The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md)
is generated from the pull-request title, make sure the title describe the feature or issue fixed.
To exclude the PR from the changelog add `[changelog skip]` in the title.
