### PR TITLE
Make SiriETGooglePubsubUpdater wait for runnable completition [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/updater/GraphUpdaterManager.java
+++ b/src/main/java/org/opentripplanner/updater/GraphUpdaterManager.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
@@ -129,8 +130,8 @@ public class GraphUpdaterManager implements WriteToGraphCallback {
     }
 
     @Override
-    public void execute(GraphWriterRunnable runnable) {
-        scheduler.submit(() -> {
+    public Future<?> execute(GraphWriterRunnable runnable) {
+        return scheduler.submit(() -> {
             try {
                 runnable.run(graph);
             } catch (Exception e) {

--- a/src/main/java/org/opentripplanner/updater/WriteToGraphCallback.java
+++ b/src/main/java/org/opentripplanner/updater/WriteToGraphCallback.java
@@ -1,5 +1,7 @@
 package org.opentripplanner.updater;
 
+import java.util.concurrent.Future;
+
 public interface WriteToGraphCallback {
 
     /**
@@ -11,5 +13,5 @@ public interface WriteToGraphCallback {
      *
      * @param runnable is a graph writer runnable
      */
-    void execute(GraphWriterRunnable runnable);
+    Future<?> execute(GraphWriterRunnable runnable);
 }

--- a/src/test/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingUpdaterTest.java
+++ b/src/test/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingUpdaterTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.concurrent.Future;
+import com.google.common.util.concurrent.Futures;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -98,8 +100,9 @@ class VehicleParkingUpdaterTest {
       }
 
       @Override
-      public void execute(GraphWriterRunnable runnable) {
+      public Future<?> execute(GraphWriterRunnable runnable) {
         runnable.run(graph);
+        return Futures.immediateVoidFuture();
       }
     }
 


### PR DESCRIPTION
### Summary

Currently the updater is marked ready before the initial updates are applied. This fixes that

### Changelog
The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md)
is generated from the pull-request title, make sure the title describe the feature or issue fixed.
To exclude the PR from the changelog add `[changelog skip]` in the title.
