### PR TITLE
Update enunciate and site plugin in order to build API docs [changelog skip]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
             <plugin>
                 <groupId>com.webcohesion.enunciate</groupId>
                 <artifactId>enunciate-maven-plugin</artifactId>
-                <version>2.12.0</version>
+                <version>2.13.3</version>
                 <executions>
                     <execution>
                         <!-- override default binding to process-sources phase (enunciate generates web services). -->
@@ -220,6 +220,13 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+                <version>3.11.0</version>
+            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
### Summary

This updates the maven plugins needed for building the REST API docs.

The background for this is that IBI has decided to become the maintainer of the REST API.

closes #2161

/cc @demory @t2gran @abyrd 