### PR TITLE
Make PtSituation related fields non-nullable [changelog skip]

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/framework/InfoLinkType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/framework/InfoLinkType.java
@@ -2,6 +2,7 @@ package org.opentripplanner.ext.transmodelapi.model.framework;
 
 import graphql.Scalars;
 import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLNonNull;
 import graphql.schema.GraphQLObjectType;
 import org.opentripplanner.routing.alertpatch.AlertUrl;
 
@@ -12,7 +13,7 @@ public class InfoLinkType {
         .name("infoLink")
         .field(GraphQLFieldDefinition.newFieldDefinition()
                 .name("uri")
-                .type(Scalars.GraphQLString)
+                .type(new GraphQLNonNull(new GraphScalars.GraphQLString))
                 .description("URI")
                 .dataFetcher(environment -> {
                     AlertUrl source = environment.getSource();

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/framework/MultilingualStringType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/framework/MultilingualStringType.java
@@ -2,6 +2,7 @@ package org.opentripplanner.ext.transmodelapi.model.framework;
 
 import graphql.Scalars;
 import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLNonNull;
 import graphql.schema.GraphQLObjectType;
 
 import java.util.Map;
@@ -16,13 +17,13 @@ public class MultilingualStringType {
         .field(GraphQLFieldDefinition
             .newFieldDefinition()
             .name("value")
-            .type(Scalars.GraphQLString)
+            .type(new GraphQLNonNull(Scalars.GraphQLString))
             .dataFetcher(environment -> ((Map.Entry<String, String>) environment.getSource()).getValue())
             .build())
         .field(GraphQLFieldDefinition
             .newFieldDefinition()
             .name("language")
-            .type(Scalars.GraphQLString)
+            .type(new GraphQLNonNull(Scalars.GraphQLString))
             .dataFetcher(environment -> ((Map.Entry<String, String>) environment.getSource()).getKey())
             .build())
         .build();

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/sx/PtSituationElementType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/sx/PtSituationElementType.java
@@ -166,7 +166,7 @@ public class PtSituationElementType {
                     .build())
             .field(GraphQLFieldDefinition.newFieldDefinition()
                     .name("infoLinks")
-                    .type(new GraphQLList(infoLinkType))
+                    .type(new GraphQLList(new GraphQLNonNull(infoLinkType)))
                     .description("Optional links to more information.")
                     .dataFetcher(environment -> {
                         TransitAlert alert = environment.getSource();


### PR DESCRIPTION
### Summary
This makes the following PtSituation-related fields non-nullable in the schema:

* Entries of `PtSituation.infoLinks`: `[InfoLink]` -> `[InfoLinks!]`
* `language` and `value` of `MultilingualString`
* `uri` of `InfoLink`

I also wonder if `InfoLink.label` is non-nullable?

