### PR TITLE
Request dateTime set to now(), if missing in input

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     </scm>
 
     <properties>
-        <otp.serialization.version.id>18</otp.serialization.version.id>
+        <otp.serialization.version.id>19</otp.serialization.version.id>
         <!-- Lib versions - keep list sorted on property name -->
         <geotools.version>26.2</geotools.version>
         <jackson.version>2.13.1</jackson.version>

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/LegacyGraphQLAPI.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/LegacyGraphQLAPI.java
@@ -70,12 +70,13 @@ public class LegacyGraphQLAPI {
 
     Locale locale = headers.getAcceptableLanguages().size() > 0
         ? headers.getAcceptableLanguages().get(0)
-        : router.defaultRoutingRequest.locale;
+        : router.getDefaultLocale();
 
     String query = (String) queryParameters.get("query");
     Object queryVariables = queryParameters.getOrDefault("variables", null);
     String operationName = (String) queryParameters.getOrDefault("operationName", null);
     Map<String, Object> variables;
+
     if (queryVariables instanceof Map) {
       variables = (Map) queryVariables;
     }
@@ -115,7 +116,7 @@ public class LegacyGraphQLAPI {
   ) {
     Locale locale = headers.getAcceptableLanguages().size() > 0
         ? headers.getAcceptableLanguages().get(0)
-        : router.defaultRoutingRequest.locale;
+        : router.getDefaultLocale();
     return LegacyGraphQLIndex.getGraphQLResponse(
         query,
         router,
@@ -138,7 +139,7 @@ public class LegacyGraphQLAPI {
     List<Callable<ExecutionResult>> futures = new ArrayList<>();
     Locale locale = headers.getAcceptableLanguages().size() > 0
         ? headers.getAcceptableLanguages().get(0)
-        : router.defaultRoutingRequest.locale;
+        : router.getDefaultLocale();
 
     for (HashMap<String, Object> query : queries) {
       Map<String, Object> variables;

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
@@ -848,7 +848,7 @@ public class LegacyGraphQLQueryTypeImpl
   public DataFetcher<DataFetcherResult<RoutingResponse>> plan() {
     return environment -> {
       LegacyGraphQLRequestContext context = environment.<LegacyGraphQLRequestContext>getContext();
-      RoutingRequest request = context.getRouter().defaultRoutingRequest.clone();
+      RoutingRequest request = context.getRouter().copyDefaultRoutingRequest();
 
       CallerWithEnvironment callWith = new CallerWithEnvironment(environment);
 

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLPlanner.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLPlanner.java
@@ -51,11 +51,9 @@ public class TransmodelGraphQLPlanner {
         PlanResponse response = new PlanResponse();
         TransmodelRequestContext ctx = environment.getContext();
         Router router = ctx.getRouter();
-        Locale locale = router.defaultRoutingRequest.locale;
         RoutingRequest request = null;
         try {
             request = createRequest(environment);
-            locale = request.locale;
 
             RoutingResponse res = ctx.getRoutingService().route(request, router);
 
@@ -75,6 +73,7 @@ public class TransmodelGraphQLPlanner {
             response.plan = TripPlanMapper.mapTripPlan(request, List.of());
             response.messages.add(new RoutingError(RoutingErrorCode.SYSTEM_ERROR, null));
         }
+        Locale locale = request == null ? router.getDefaultLocale() : request.locale;
         return DataFetcherResult.<PlanResponse>newResult()
                 .data(response)
                 .localContext(Map.of("locale", locale))
@@ -99,10 +98,11 @@ public class TransmodelGraphQLPlanner {
     }
 
     private RoutingRequest createRequest(DataFetchingEnvironment environment)
-    throws ParameterException {
+            throws ParameterException
+    {
         TransmodelRequestContext context = environment.getContext();
         Router router = context.getRouter();
-        RoutingRequest request = router.defaultRoutingRequest.clone();
+        RoutingRequest request = router.copyDefaultRoutingRequest();
 
         DataFetcherDecorator callWith = new DataFetcherDecorator(environment);
 

--- a/src/main/java/org/opentripplanner/api/common/RoutingResource.java
+++ b/src/main/java/org/opentripplanner/api/common/RoutingResource.java
@@ -709,7 +709,7 @@ public abstract class RoutingResource {
      */
     protected RoutingRequest buildRequest(MultivaluedMap<String, String> queryParameters) throws ParameterException {
         Router router = otpServer.getRouter();
-        RoutingRequest request = router.defaultRoutingRequest.clone();
+        RoutingRequest request = router.copyDefaultRoutingRequest();
 
         // The routing request should already contain defaults, which are set when it is initialized or in the JSON
         // router configuration and cloned. We check whether each parameter was supplied before overwriting the default.

--- a/src/main/java/org/opentripplanner/standalone/server/Router.java
+++ b/src/main/java/org/opentripplanner/standalone/server/Router.java
@@ -6,6 +6,8 @@ import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.FileAppender;
 import io.micrometer.core.instrument.Metrics;
+import java.time.Instant;
+import java.util.Locale;
 import org.opentripplanner.ext.transmodelapi.TransmodelAPI;
 import org.opentripplanner.inspector.TileRendererManager;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TransitLayer;
@@ -30,6 +32,7 @@ import org.slf4j.LoggerFactory;
 public class Router {
 
     private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(Router.class);
+    private final RoutingRequest defaultRoutingRequest;
     public final Graph graph;
     public final RouterConfig routerConfig;
     public final RaptorConfig<TripSchedule> raptorConfig;
@@ -46,18 +49,13 @@ public class Router {
     /** Inspector/debug services */
     public TileRendererManager tileRendererManager;
 
-    /**
-     * A RoutingRequest containing default parameters that will be cloned when handling each
-     * request.
-     */
-    public RoutingRequest defaultRoutingRequest;
-
     /** A graphical window that is used for visualizing search progress (debugging). */
     public GraphVisualizer graphVisualizer = null;
 
     public Router(Graph graph, RouterConfig routerConfig) {
         this.graph = graph;
         this.routerConfig = routerConfig;
+        this.defaultRoutingRequest = routerConfig.routingRequestDefaults();
         this.raptorConfig = new RaptorConfig<>(
             routerConfig.raptorTuningParameters(),
             Metrics.globalRegistry
@@ -75,7 +73,6 @@ public class Router {
      */
     public void startup() {
         this.tileRendererManager = new TileRendererManager(this.graph);
-        this.defaultRoutingRequest = routerConfig.routingRequestDefaults();
 
         if (routerConfig.requestLogFile() != null) {
             this.requestLogger = createLogger(routerConfig.requestLogFile());
@@ -122,6 +119,23 @@ public class Router {
                 defaultRoutingRequest
             );
         }
+    }
+
+    /**
+     * A RoutingRequest containing default parameters that will be cloned when handling each
+     * request.
+     */
+    public RoutingRequest copyDefaultRoutingRequest() {
+        var copy = this.defaultRoutingRequest.clone();
+        copy.setDateTime(Instant.now());
+        return copy;
+    }
+
+    /**
+     * Return the default routing request locale(without cloning the request).
+     */
+    public Locale getDefaultLocale() {
+        return this.defaultRoutingRequest.locale;
     }
 
     /** Shut down this router when evicted or (auto-)reloaded. Stop any real-time updater threads. */

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/SnapshotTestBase.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/SnapshotTestBase.java
@@ -87,7 +87,7 @@ public abstract class SnapshotTestBase {
     protected RoutingRequest createTestRequest(int year, int month, int day, int hour, int minute, int second) {
         Router router = getRouter();
 
-        RoutingRequest request = router.defaultRoutingRequest.clone();
+        RoutingRequest request = router.copyDefaultRoutingRequest();
         request.setDateTime(TestUtils.dateInstant(router.graph.getTimeZone().getID(), year, month, day, hour, minute, second));
         request.maxTransfers = 6;
         request.numItineraries = 6;


### PR DESCRIPTION
### Summary

The default request where initiated at start up and the `dateTime` where set at that time. When a request was made without the `dateTime` parameter the startup-time was used for the request, and not `now()`.


### Issue

closes #3713

### Unit tests
No tests added.

### Code style
✅ 

### Documentation
No do added.

