### PR TITLE
Remove optimize=TRANSFERS

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
@@ -930,11 +930,6 @@ public class LegacyGraphQLQueryTypeImpl
           request.setTriangleNormalized(args[0], args[1], args[2]);
         }
 
-        if (optimize == BicycleOptimizeType.TRANSFERS) {
-          optimize = BicycleOptimizeType.QUICK;
-          request.transferCost += 1800;
-        }
-
         if (optimize != null) {
           request.bicycleOptimizeType = optimize;
         }

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLPlanner.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLPlanner.java
@@ -148,11 +148,6 @@ public class TransmodelGraphQLPlanner {
             request.setTriangleNormalized(args[0], args[1], args[2]);
         }
 
-        if (bicycleOptimizeType == BicycleOptimizeType.TRANSFERS) {
-            bicycleOptimizeType = BicycleOptimizeType.QUICK;
-            request.transferCost += 1800;
-        }
-
         if (bicycleOptimizeType != null) {
             request.bicycleOptimizeType = bicycleOptimizeType;
         }

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/EnumTypes.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/EnumTypes.java
@@ -246,7 +246,6 @@ public class EnumTypes {
             .value("flat", BicycleOptimizeType.FLAT)
             .value("greenways", BicycleOptimizeType.GREENWAYS)
             .value("triangle", BicycleOptimizeType.TRIANGLE)
-            .value("transfers", BicycleOptimizeType.TRANSFERS)
             .build();
 
     public static GraphQLEnumType DIRECTION_TYPE = GraphQLEnumType.newEnum()

--- a/src/main/java/org/opentripplanner/api/common/RoutingResource.java
+++ b/src/main/java/org/opentripplanner/api/common/RoutingResource.java
@@ -877,10 +877,6 @@ public abstract class RoutingResource {
         // The "Least transfers" optimization is accomplished via an increased transfer penalty.
         // See comment on RoutingRequest.transferPentalty.
         if (transferPenalty != null) { request.transferCost = transferPenalty; }
-        if (optimize == BicycleOptimizeType.TRANSFERS) {
-            optimize = BicycleOptimizeType.QUICK;
-            request.transferCost += 1800;
-        }
 
         if (optimize != null) {
             request.setBicycleOptimizeType(optimize);

--- a/src/main/java/org/opentripplanner/routing/core/BicycleOptimizeType.java
+++ b/src/main/java/org/opentripplanner/routing/core/BicycleOptimizeType.java
@@ -1,15 +1,12 @@
 package org.opentripplanner.routing.core;
 
 /**
- * TODO: apparently, other than TRANSFERS all of these only affect BICYCLE traversal of street edges.
- * If so this should be very clearly stated in documentation and even in the Enum name, which could be
- * BicycleOptimizeType, since TRANSFERS is vestigial and should probably be removed.
+ * When planning a bicycle route what should be optimized for.
  */
 public enum BicycleOptimizeType {
     QUICK, /* the fastest trip */
     SAFE,
     FLAT, /* needs a rewrite */
     GREENWAYS,
-    TRIANGLE,
-    TRANSFERS /* obsolete, replaced by the transferPenalty option in Traverse options */
+    TRIANGLE
 }


### PR DESCRIPTION
### Summary
This has not worked as expected for a very long time. You should use `transferCost` instead.

It is a breaking change for the Transmodel API. If you want I can make it backwards-compatible.

### Issue

None

### Unit tests

None

### Code style

Yes

### Documentation

None

### Changelog

Skip