### PR TITLE
Make IndexApi fields non-final again [changlelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/index/IndexAPI.java
+++ b/src/main/java/org/opentripplanner/index/IndexAPI.java
@@ -71,11 +71,11 @@ public class IndexAPI {
 
     /** Choose short or long form of results. */
     @QueryParam("detail")
-    private final boolean detail = false;
+    private boolean detail = false;
 
     /** Include GTFS entities referenced by ID in the result. */
     @QueryParam("refs")
-    private final boolean refs = false;
+    private boolean refs = false;
 
     private final OTPServer otpServer;
 


### PR DESCRIPTION
@t2gran's PR #4010 made some fields in `IndexApi` final. Apparently Jersey doesn't like that:

```
MultiException stack 1 of 3
java.lang.IllegalArgumentException: The field field(boolean detail in org.opentripplanner.index.IndexAPI) may not be static, final or have an Annotation type
	at org.jvnet.hk2.internal.Utilities.findInitializerFields(Utilities.java:1484)
	at org.jvnet.hk2.internal.DefaultClassAnalyzer.getFields(DefaultClassAnalyzer.java:94)
	at org.glassfish.jersey.inject.hk2.JerseyClassAnalyzer.getFields(JerseyClassAnalyzer.java:223)
	at org.jvnet.hk2.internal.Utilities.getInitFields(Utilities.java:227)
	at org.jvnet.hk2.internal.ClazzCreator.initialize(ClazzCreator.java:133)
	at org.jvnet.hk2.internal.ClazzCreator.initialize(ClazzCreator.java:156)
	at org.jvnet.hk2.internal.SystemDescriptor.internalReify(SystemDescriptor.java:716)
	at org.jvnet.hk2.internal.SystemDescriptor.reify(SystemDescriptor.java:670)
	at org.jvnet.hk2.internal.ServiceLocatorImpl.reifyDescriptor(ServiceLocatorImpl.java:442)
	at org.jvnet.hk2.internal.ServiceLocatorImpl.narrow(ServiceLocatorImpl.java:2300)
	at org.jvnet.hk2.internal.ServiceLocatorImpl.igdCacheCompute(ServiceLocatorImpl.java:1176)
	at org.jvnet.hk2.internal.ServiceLocatorImpl.access$400(ServiceLocatorImpl.java:106)
	at org.jvnet.hk2.internal.ServiceLocatorImpl$8.compute(ServiceLocatorImpl.java:1170)
	at org.jvnet.hk2.internal.ServiceLocatorImpl$8.compute(ServiceLocatorImpl.java:1167)
	at org.glassfish.hk2.utilities.cache.internal.WeakCARCacheImpl.compute(WeakCARCacheImpl.java:105)
	at org.jvnet.hk2.internal.ServiceLocatorImpl.internalGetDescriptor(ServiceLocatorImpl.java:1250)
	at org.jvnet.hk2.internal.ServiceLocatorImpl.internalGetService(ServiceLocatorImpl.java:754)
	at org.jvnet.hk2.internal.ServiceLocatorImpl.internalGetService(ServiceLocatorImpl.java:721)
	at org.jvnet.hk2.internal.ServiceLocatorImpl.getService(ServiceLocatorImpl.java:691)
	at org.glassfish.jersey.inject.hk2.AbstractHk2InjectionManager.getInstance(AbstractHk2InjectionManager.java:160)
	at org.glassfish.jersey.inject.hk2.ImmediateHk2InjectionManager.getInstance(ImmediateHk2InjectionManager.java:30)
	at org.glassfish.jersey.internal.inject.Injections.getOrCreate(Injections.java:105)
	at org.glassfish.jersey.server.model.MethodHandler$ClassBasedMethodHandler.getInstance(MethodHandler.java:260)
	at org.glassfish.jersey.server.internal.routing.PushMethodHandlerRouter.apply(PushMethodHandlerRouter.java:51)
	at org.glassfish.jersey.server.internal.routing.RoutingStage._apply(RoutingStage.java:86)
	at org.glassfish.jersey.server.internal.routing.RoutingStage._apply(RoutingStage.java:89)
	at org.glassfish.jersey.server.internal.routing.RoutingStage._apply(RoutingStage.java:89)
	at org.glassfish.jersey.server.internal.routing.RoutingStage._apply(RoutingStage.java:89)
	at org.glassfish.jersey.server.internal.routing.RoutingStage._apply(RoutingStage.java:89)
	at org.glassfish.jersey.server.internal.routing.RoutingStage.apply(RoutingStage.java:69)
	at org.glassfish.jersey.server.internal.routing.RoutingStage.apply(RoutingStage.java:38)
	at org.glassfish.jersey.process.internal.Stages.process(Stages.java:173)
	at org.glassfish.jersey.server.ServerRuntime$1.run(ServerRuntime.java:247)
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:248)
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:244)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:292)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:274)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:244)
	at org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:265)
	at org.glassfish.jersey.server.ServerRuntime.process(ServerRuntime.java:234)
	at org.glassfish.jersey.server.ApplicationHandler.handle(ApplicationHandler.java:680)
	at org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpContainer.service(GrizzlyHttpContainer.java:356)
	at org.glassfish.grizzly.http.server.HttpHandler$1.run(HttpHandler.java:200)
	at org.glassfish.grizzly.threadpool.AbstractThreadPool$Worker.doWork(AbstractThreadPool.java:569)
	at org.glassfish.grizzly.threadpool.AbstractThreadPool$Worker.run(AbstractThreadPool.java:549)
	at java.base/java.lang.Thread.run(Thread.java:833)
```
I frankly don't know why that is but making those fields non-final makes the problem go away.