### PR TITLE
Make all situations & notices entries non-null [changelog skip]

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
@@ -1083,7 +1083,7 @@ public class TransmodelGraphQLSchema {
             .name("situations")
             .description("Get all active situations.")
             .withDirective(gqlUtil.timingData)
-            .type(new GraphQLNonNull(new GraphQLList(ptSituationElementType)))
+            .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(ptSituationElementType))))
             .argument(GraphQLArgument
                 .newArgument()
                 .name("authorities")

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/framework/AuthorityType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/framework/AuthorityType.java
@@ -62,7 +62,7 @@ public class AuthorityType {
                 .name("situations")
                 .withDirective(gqlUtil.timingData)
                 .description("Get all situations active for the authority.")
-                .type(new GraphQLNonNull(new GraphQLList(ptSituationElementType)))
+                .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(ptSituationElementType))))
                 .dataFetcher(environment -> getRoutingService(environment)
                     .getTransitAlertService()
                     .getAgencyAlerts(((Agency)environment.getSource()).getId()))

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/network/JourneyPatternType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/network/JourneyPatternType.java
@@ -100,7 +100,7 @@ public class JourneyPatternType {
         .field(GraphQLFieldDefinition.newFieldDefinition()
             .name("situations")
             .description("Get all situations active for the journey pattern.")
-            .type(new GraphQLNonNull(new GraphQLList(ptSituationElementType)))
+            .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(ptSituationElementType))))
             .dataFetcher(environment -> {
                 TripPattern tripPattern = environment.getSource();
                 return GqlUtil.getRoutingService(environment)
@@ -113,7 +113,7 @@ public class JourneyPatternType {
             .build())
         .field(GraphQLFieldDefinition.newFieldDefinition()
             .name("notices")
-            .type(new GraphQLNonNull(new GraphQLList(noticeType)))
+            .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(noticeType))))
             .dataFetcher(environment -> {
               TripPattern tripPattern = environment.getSource();
               return GqlUtil.getRoutingService(environment).getNoticesByEntity(tripPattern);

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/network/LineType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/network/LineType.java
@@ -153,7 +153,7 @@ public class LineType {
                     .build())
             .field(GraphQLFieldDefinition.newFieldDefinition()
                     .name("notices")
-                    .type(new GraphQLNonNull(new GraphQLList(noticeType)))
+                    .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(noticeType))))
                     .dataFetcher(environment -> {
                         Route route = environment.getSource();
                       return GqlUtil.getRoutingService(environment).getNoticesByEntity(route);
@@ -162,7 +162,7 @@ public class LineType {
             .field(GraphQLFieldDefinition.newFieldDefinition()
                     .name("situations")
                     .description("Get all situations active for the line.")
-                    .type(new GraphQLNonNull(new GraphQLList(ptSituationElementType)))
+                    .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(ptSituationElementType))))
                 .dataFetcher(environment -> GqlUtil.getRoutingService(environment)
                         .getTransitAlertService()
                         .getRouteAlerts(((Route) environment.getSource()).getId()))

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/QuayType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/QuayType.java
@@ -239,7 +239,7 @@ public class QuayType {
             .field(GraphQLFieldDefinition.newFieldDefinition()
                     .name("situations")
                     .description("Get all situations active for the quay.")
-                    .type(new GraphQLNonNull(new GraphQLList(ptSituationElementType)))
+                    .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(ptSituationElementType))))
                     .dataFetcher(env -> {
                         return GqlUtil.getRoutingService(env).getTransitAlertService()
                                 .getStopAlerts(((StopLocation) env.getSource()).getId());

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/ServiceJourneyType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/ServiceJourneyType.java
@@ -233,7 +233,7 @@ public class ServiceJourneyType {
                     .build())
             .field(GraphQLFieldDefinition.newFieldDefinition()
                     .name("notices")
-                    .type(new GraphQLNonNull(new GraphQLList(noticeType)))
+                    .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(noticeType))))
                     .dataFetcher(env ->
                         GqlUtil.getRoutingService(env).getNoticesByEntity(trip(env))
                     )
@@ -241,7 +241,7 @@ public class ServiceJourneyType {
             .field(GraphQLFieldDefinition.newFieldDefinition()
                     .name("situations")
                     .description("Get all situations active for the service journey.")
-                    .type(new GraphQLNonNull(new GraphQLList(ptSituationElementType)))
+                    .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(ptSituationElementType))))
                     .dataFetcher(environment ->
                         GqlUtil.getRoutingService(environment)
                             .getTransitAlertService()

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/TimetabledPassingTimeType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/TimetabledPassingTimeType.java
@@ -113,7 +113,7 @@ public class TimetabledPassingTimeType {
         .field(GraphQLFieldDefinition
             .newFieldDefinition()
             .name("notices")
-            .type(new GraphQLNonNull(new GraphQLList(noticeType)))
+            .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(noticeType))))
             .dataFetcher(environment -> {
               TripTimeOnDate tripTimeOnDate = environment.getSource();
               return GqlUtil.getRoutingService(environment).getNoticesByEntity(tripTimeOnDate.getStopTimeKey());


### PR DESCRIPTION
### Summary

I suspect that these lists of `situations` and `notices` cannot have `null` as entries. Therefore the schema should reflect this.

Schema diff:
```diff
-[Notice]!
+[Notice!]!
```
```diff
-[PtSituationElement]!
+[PtSituationElement!]!
```