### PR TITLE
Fix mapping of URL in REST API [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/api/mapping/StopMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/StopMapper.java
@@ -2,12 +2,14 @@ package org.opentripplanner.api.mapping;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.opentripplanner.api.model.ApiStop;
 import org.opentripplanner.api.model.ApiStopShort;
 import org.opentripplanner.model.Stop;
 import org.opentripplanner.model.StopLocation;
+import org.opentripplanner.util.I18NString;
 
 public class StopMapper {
 
@@ -32,7 +34,7 @@ public class StopMapper {
         if (extended) {
             api.desc = domain.getDescription();
             api.zoneId = domain.getFirstZoneAsString();
-            api.url = domain.getUrl().toString();
+            api.url = Optional.ofNullable(domain.getUrl()).map(I18NString::toString).orElse(null);
             api.locationType = 0;
             api.stationId = FeedScopedIdMapper.mapIdToApi(domain.getParentStation());
             api.parentStation = mapToParentStationOldId(domain);
@@ -54,7 +56,7 @@ public class StopMapper {
         api.name = domain.getName().toString();
         api.lat = domain.getLat();
         api.lon = domain.getLon();
-        api.url = domain.getUrl().toString();
+        api.url = Optional.ofNullable(domain.getUrl()).map(I18NString::toString).orElse(null);
         api.stationId = FeedScopedIdMapper.mapIdToApi(domain.getParentStation());
         // parentStation may be missing on the stop returning null.
         // TODO harmonize these names, maybe use "station" everywhere

--- a/src/main/java/org/opentripplanner/api/mapping/StopMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/StopMapper.java
@@ -2,14 +2,11 @@ package org.opentripplanner.api.mapping;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
-
 import org.opentripplanner.api.model.ApiStop;
 import org.opentripplanner.api.model.ApiStopShort;
 import org.opentripplanner.model.Stop;
 import org.opentripplanner.model.StopLocation;
-import org.opentripplanner.util.I18NString;
 
 public class StopMapper {
 
@@ -56,7 +53,7 @@ public class StopMapper {
         api.name = domain.getName().toString();
         api.lat = domain.getLat();
         api.lon = domain.getLon();
-        api.url = Optional.ofNullable(domain.getUrl()).map(I18NString::toString).orElse(null);
+        api.url = I18NStringMapper.mapToApi(domain.getUrl(), null);
         api.stationId = FeedScopedIdMapper.mapIdToApi(domain.getParentStation());
         // parentStation may be missing on the stop returning null.
         // TODO harmonize these names, maybe use "station" everywhere

--- a/src/main/java/org/opentripplanner/api/mapping/StopMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/StopMapper.java
@@ -34,7 +34,7 @@ public class StopMapper {
         if (extended) {
             api.desc = domain.getDescription();
             api.zoneId = domain.getFirstZoneAsString();
-            api.url = Optional.ofNullable(domain.getUrl()).map(I18NString::toString).orElse(null);
+            api.url = I18NStringMapper.mapToApi(domain.getUrl(), null);
             api.locationType = 0;
             api.stationId = FeedScopedIdMapper.mapIdToApi(domain.getParentStation());
             api.parentStation = mapToParentStationOldId(domain);

--- a/src/main/java/org/opentripplanner/model/StopLocation.java
+++ b/src/main/java/org/opentripplanner/model/StopLocation.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.model;
 
+import javax.annotation.Nullable;
 import org.locationtech.jts.geom.Geometry;
 import org.opentripplanner.util.I18NString;
 
@@ -22,6 +23,7 @@ public interface StopLocation {
 
   String getDescription();
 
+  @Nullable
   I18NString getUrl();
 
   /**


### PR DESCRIPTION
### Summary

Calling toString could lead to a NPE since it's now an I18NString.

Alternative approaches:

- return `Optional<I18NString>`
- add method `defaultUrl`

### Issue
none

### Unit tests
none

### Code style
yes

### Documentation
n/a

### Changelog
skip