### PR TITLE
Handle unsupported modes gracefully by logging to issue store. [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/netex/mapping/NetexMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/NetexMapper.java
@@ -391,11 +391,15 @@ public class NetexMapper {
         );
         for (Line line : currentNetexIndex.getLineById().localValues()) {
             Route route = routeMapper.mapRoute(line);
-            transitBuilder.getRoutes().add(route);
+            if(route != null) {
+                transitBuilder.getRoutes().add(route);
+            }
         }
         for (FlexibleLine line : currentNetexIndex.getFlexibleLineById().localValues()) {
             Route route = routeMapper.mapRoute(line);
-            transitBuilder.getRoutes().add(route);
+            if(route != null) {
+                transitBuilder.getRoutes().add(route);
+            }
         }
     }
 

--- a/src/main/java/org/opentripplanner/netex/mapping/TransportModeMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/TransportModeMapper.java
@@ -14,37 +14,30 @@ class TransportModeMapper {
     public T2<TransitMode, String> map(
         AllVehicleModesOfTransportEnumeration netexMode,
         TransportSubmodeStructure submode
-    ) {
+    ) throws UnsupportedModeException {
         if (submode != null) {
             return getSubmodeAsString(submode);
         }
         return new T2<>(mapAllVehicleModesOfTransport(netexMode), null);
     }
 
-    private TransitMode mapAllVehicleModesOfTransport(AllVehicleModesOfTransportEnumeration mode) {
-        switch (mode) {
-            case AIR:
-                return TransitMode.AIRPLANE;
-            case BUS:
-            case TAXI:
-                return TransitMode.BUS;
-            case CABLEWAY:
-                return TransitMode.CABLE_CAR;
-            case COACH:
-                return TransitMode.COACH;
-            case FUNICULAR:
-                return TransitMode.FUNICULAR;
-            case METRO:
-                return TransitMode.SUBWAY;
-            case RAIL:
-                return TransitMode.RAIL;
-            case TRAM:
-                return TransitMode.TRAM;
-            case WATER:
-                return TransitMode.FERRY;
-            default:
-                throw new IllegalArgumentException(mode.toString());
+    private TransitMode mapAllVehicleModesOfTransport(AllVehicleModesOfTransportEnumeration mode)
+            throws UnsupportedModeException {
+        if(mode == null) {
+            throw new UnsupportedModeException(null);
         }
+        return switch (mode) {
+            case AIR -> TransitMode.AIRPLANE;
+            case BUS, TAXI -> TransitMode.BUS;
+            case CABLEWAY -> TransitMode.CABLE_CAR;
+            case COACH -> TransitMode.COACH;
+            case FUNICULAR -> TransitMode.FUNICULAR;
+            case METRO -> TransitMode.SUBWAY;
+            case RAIL -> TransitMode.RAIL;
+            case TRAM -> TransitMode.TRAM;
+            case WATER -> TransitMode.FERRY;
+            default -> throw new UnsupportedModeException(mode);
+        };
     }
 
     private T2<TransitMode, String> getSubmodeAsString(TransportSubmodeStructure submode) {
@@ -68,5 +61,13 @@ class TransportModeMapper {
             return new T2<>(TransitMode.FERRY, submode.getWaterSubmode().value());
         }
         throw new IllegalArgumentException();
+    }
+
+    static class UnsupportedModeException extends Exception {
+        final AllVehicleModesOfTransportEnumeration mode;
+
+        public UnsupportedModeException(AllVehicleModesOfTransportEnumeration mode) {
+            this.mode = mode;
+        }
     }
 }

--- a/src/main/java/org/opentripplanner/netex/mapping/TripMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/TripMapper.java
@@ -1,6 +1,11 @@
 package org.opentripplanner.netex.mapping;
 
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+import javax.xml.bind.JAXBElement;
 import org.opentripplanner.common.model.T2;
+import org.opentripplanner.graph_builder.DataImportIssueStore;
 import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.model.Operator;
 import org.opentripplanner.model.TransitMode;
@@ -16,11 +21,6 @@ import org.rutebanken.netex.model.ServiceJourney;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
-import javax.xml.bind.JAXBElement;
-import java.util.Map;
-import java.util.Set;
-
 /**
  * This maps a NeTEx ServiceJourney to an OTP Trip. A ServiceJourney can be connected to a Line (OTP
  * Route) in two ways. Either directly from the ServiceJourney or through JourneyPattern → Route.
@@ -30,6 +30,7 @@ class TripMapper {
     private static final Logger LOG = LoggerFactory.getLogger(TripMapper.class);
 
     private final FeedScopedIdFactory idFactory;
+    private final DataImportIssueStore issueStore;
     private final EntityById<org.opentripplanner.model.Route> otpRouteById;
     private final ReadOnlyHierarchicalMap<String, Route> routeById;
     private final ReadOnlyHierarchicalMap<String, JourneyPattern> journeyPatternsById;
@@ -40,6 +41,7 @@ class TripMapper {
 
   TripMapper(
             FeedScopedIdFactory idFactory,
+            DataImportIssueStore issueStore,
             EntityById<Operator> operatorsById,
             EntityById<org.opentripplanner.model.Route> otpRouteById,
             ReadOnlyHierarchicalMap<String, Route> routeById,
@@ -48,6 +50,7 @@ class TripMapper {
             Set<FeedScopedId> shapePointIds
     ) {
         this.idFactory = idFactory;
+        this.issueStore = issueStore;
         this.otpRouteById = otpRouteById;
         this.routeById = routeById;
         this.journeyPatternsById = journeyPatternsById;
@@ -91,10 +94,21 @@ class TripMapper {
         trip.setTripOperator(findOperator(serviceJourney));
 
         if (serviceJourney.getTransportMode() != null) {
-            T2<TransitMode, String> transitMode = transportModeMapper.map(
-                serviceJourney.getTransportMode(),
-                serviceJourney.getTransportSubmode()
-            );
+            T2<TransitMode, String> transitMode = null;
+            try {
+                transitMode = transportModeMapper.map(
+                    serviceJourney.getTransportMode(),
+                    serviceJourney.getTransportSubmode()
+                );
+            } catch (TransportModeMapper.UnsupportedModeException e) {
+                issueStore.add(
+                        "UnsupportedModeInServiceJourney",
+                        "Unsupported mode in ServiceJourney. Mode: %s, sj: %s",
+                        e.mode,
+                        serviceJourney.getId()
+                );
+                return null;
+            }
             trip.setMode(transitMode.first);
             trip.setNetexSubmode(transitMode.second);
         }

--- a/src/main/java/org/opentripplanner/netex/mapping/TripPatternMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/TripPatternMapper.java
@@ -84,6 +84,7 @@ class TripPatternMapper {
         this.otpRouteById = otpRouteById;
         this.tripMapper = new TripMapper(
             idFactory,
+            issueStore,
             operatorById,
             otpRouteById,
             routeById,
@@ -116,7 +117,7 @@ class TripPatternMapper {
         result = new TripPatternMapperResult();
         Collection<ServiceJourney> serviceJourneys = serviceJourniesByPatternId.get(journeyPattern.getId());
 
-        if (serviceJourneys == null || serviceJourneys.isEmpty()) {
+        if (serviceJourneys.isEmpty()) {
             issueStore.add(
                     "ServiceJourneyPatternIsEmpty",
                     "ServiceJourneyPattern %s does not contain any serviceJourneys.",

--- a/src/test/java/org/opentripplanner/netex/mapping/TransportModeMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/TransportModeMapperTest.java
@@ -1,21 +1,25 @@
 package org.opentripplanner.netex.mapping;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.opentripplanner.common.model.T2;
 import org.opentripplanner.model.TransitMode;
+import org.opentripplanner.netex.mapping.TransportModeMapper.UnsupportedModeException;
 import org.rutebanken.netex.model.AllVehicleModesOfTransportEnumeration;
 import org.rutebanken.netex.model.RailSubmodeEnumeration;
 import org.rutebanken.netex.model.TransportSubmodeStructure;
 import org.rutebanken.netex.model.WaterSubmodeEnumeration;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+
 public class TransportModeMapperTest {
+  public static final TransportSubmodeStructure VALID_SUBMODE_STRCUTURE = new TransportSubmodeStructure().withRailSubmode(RailSubmodeEnumeration.LONG_DISTANCE);
   private final TransportModeMapper transportModeMapper = new TransportModeMapper();
 
   @Test
-  public void mapWithTransportModeOnly() {
+  public void mapWithTransportModeOnly() throws UnsupportedModeException {
     final T2<TransitMode, String> transitMode =
             transportModeMapper.map(AllVehicleModesOfTransportEnumeration.BUS, null);
     assertEquals(TransitMode.BUS, transitMode.first);
@@ -23,17 +27,17 @@ public class TransportModeMapperTest {
   }
 
   @Test
-  public void mapWithSubMode() {
+  public void mapWithSubMode() throws UnsupportedModeException {
     final T2<TransitMode, String> transitMode = transportModeMapper.map(
             AllVehicleModesOfTransportEnumeration.RAIL,
-            new TransportSubmodeStructure().withRailSubmode(RailSubmodeEnumeration.LONG_DISTANCE)
+            VALID_SUBMODE_STRCUTURE
     );
     assertEquals(TransitMode.RAIL, transitMode.first);
     assertEquals("longDistance", transitMode.second);
   }
 
   @Test
-  public void checkSubModePrecedensOverMainMode() {
+  public void checkSubModePrecedensOverMainMode() throws UnsupportedModeException {
     final T2<TransitMode, String> transitMode = transportModeMapper.map(
             AllVehicleModesOfTransportEnumeration.BUS,
             new TransportSubmodeStructure().withWaterSubmode(
@@ -41,5 +45,15 @@ public class TransportModeMapperTest {
     );
     assertEquals(TransitMode.FERRY, transitMode.first);
     assertEquals("internationalPassengerFerry", transitMode.second);
+  }
+
+  @Test
+  public void unsupportedMode() {
+    Assertions.assertThrows(UnsupportedModeException.class, () ->
+            transportModeMapper.map(AllVehicleModesOfTransportEnumeration.UNKNOWN, null)
+    );
+    Assertions.assertThrows(UnsupportedModeException.class, () ->
+            transportModeMapper.map(null, null)
+    );
   }
 }

--- a/src/test/java/org/opentripplanner/netex/mapping/TripMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/TripMapperTest.java
@@ -1,6 +1,10 @@
 package org.opentripplanner.netex.mapping;
 
+import java.util.Collections;
+import java.util.Map;
+import javax.xml.bind.JAXBElement;
 import org.junit.Test;
+import org.opentripplanner.graph_builder.DataImportIssueStore;
 import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.model.Route;
 import org.opentripplanner.model.Trip;
@@ -13,11 +17,6 @@ import org.rutebanken.netex.model.LineRefStructure;
 import org.rutebanken.netex.model.RouteRefStructure;
 import org.rutebanken.netex.model.ServiceJourney;
 
-import javax.xml.bind.JAXBElement;
-
-import java.util.Collections;
-import java.util.Map;
-
 import static org.junit.Assert.assertEquals;
 import static org.opentripplanner.netex.mapping.MappingSupport.ID_FACTORY;
 import static org.opentripplanner.netex.mapping.MappingSupport.createWrappedRef;
@@ -28,6 +27,7 @@ public class TripMapperTest {
     private static final String SERVICE_JOURNEY_ID = NetexTestDataSample.SERVICE_JOURNEY_ID;
     private static final String JOURNEY_PATTERN_ID = "RUT:JourneyPattern:1";
     private static final FeedScopedId SERVICE_ID = new FeedScopedId("F", "S001");
+    private static final DataImportIssueStore issueStore = new DataImportIssueStore(false);
 
     private static final JAXBElement<LineRefStructure> LINE_REF = MappingSupport.createWrappedRef(
             ROUTE_ID, LineRefStructure.class
@@ -41,6 +41,7 @@ public class TripMapperTest {
 
         TripMapper tripMapper = new TripMapper(
             ID_FACTORY,
+            issueStore,
             transitBuilder.getOperatorsById(),
             transitBuilder.getRoutes(),
             new HierarchicalMapById<>(),
@@ -83,6 +84,7 @@ public class TripMapperTest {
 
         TripMapper tripMapper = new TripMapper(
                 ID_FACTORY,
+                issueStore,
                 transitBuilder.getOperatorsById(),
                 transitBuilder.getRoutes(),
                 routeById,


### PR DESCRIPTION
### Summary
This just make the NeTEx mod mapping a bit more robust, dropping Lines and ServiceJournyes with unknown main mode. An issue is written to the issue report. Earlier the entire import crashed. 


### Issue
No issue.


### Unit tests
✅ 
I had this problem with an old data set, which now works fine.


### Code style
✅ 

### Documentation
No
