### PR TITLE
Expose Raptor debug functionality in the debug client / rest api [changelog skip]

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
@@ -881,15 +881,15 @@ public class LegacyGraphQLQueryTypeImpl
       callWith.argument("arriveBy", request::setArriveBy);
       request.showIntermediateStops = true;
       callWith.argument("intermediatePlaces", (List<Map<String, Object>> v) -> request.intermediatePlaces = v.stream().map(LegacyGraphQLQueryTypeImpl::toGenericLocation).collect(Collectors.toList()));
-      callWith.argument("preferred.routes", request::setPreferredRoutesFromSting);
+      callWith.argument("preferred.routes", request::setPreferredRoutesFromString);
       callWith.argument("preferred.otherThanPreferredRoutesPenalty", request::setOtherThanPreferredRoutesPenalty);
       callWith.argument("preferred.agencies", request::setPreferredAgenciesFromString);
-      callWith.argument("unpreferred.routes", request::setUnpreferredRoutesFromSting);
+      callWith.argument("unpreferred.routes", request::setUnpreferredRoutesFromString);
       callWith.argument("unpreferred.agencies", request::setUnpreferredAgenciesFromString);
       // callWith.argument("unpreferred.useUnpreferredRoutesPenalty", request::setUseUnpreferredRoutesPenalty);
       callWith.argument("walkBoardCost", request::setWalkBoardCost);
       callWith.argument("bikeBoardCost", request::setBikeBoardCost);
-      callWith.argument("banned.routes", request::setBannedRoutesFromSting);
+      callWith.argument("banned.routes", request::setBannedRoutesFromString);
       callWith.argument("banned.agencies", request::setBannedAgenciesFromSting);
       callWith.argument("banned.trips", request::setBannedTripsFromString);
       // callWith.argument("banned.stops", request::setBannedStops);

--- a/src/main/java/org/opentripplanner/api/common/RoutingResource.java
+++ b/src/main/java/org/opentripplanner/api/common/RoutingResource.java
@@ -844,7 +844,7 @@ public abstract class RoutingResource {
             request.setIntermediatePlacesFromStrings(intermediatePlaces);
         }
         if (preferredRoutes != null) {
-            request.setPreferredRoutesFromSting(preferredRoutes);
+            request.setPreferredRoutesFromString(preferredRoutes);
         }
         if (otherThanPreferredRoutesPenalty != null) {
             request.setOtherThanPreferredRoutesPenalty(otherThanPreferredRoutesPenalty);
@@ -853,7 +853,7 @@ public abstract class RoutingResource {
             request.setPreferredAgenciesFromString(preferredAgencies);
         }
         if (unpreferredRoutes != null) {
-            request.setUnpreferredRoutesFromSting(unpreferredRoutes);
+            request.setUnpreferredRoutesFromString(unpreferredRoutes);
         }
         if (unpreferredAgencies != null) {
             request.setUnpreferredAgenciesFromString(unpreferredAgencies);
@@ -865,10 +865,10 @@ public abstract class RoutingResource {
             request.setBikeBoardCost(bikeBoardCost);
         }
         if (bannedRoutes != null) {
-            request.setBannedRoutesFromSting(bannedRoutes);
+            request.setBannedRoutesFromString(bannedRoutes);
         }
         if (whiteListedRoutes != null) {
-            request.setWhiteListedRoutesFromSting(whiteListedRoutes);
+            request.setWhiteListedRoutesFromString(whiteListedRoutes);
         }
         if (bannedAgencies != null) {
             request.setBannedAgenciesFromSting(bannedAgencies);

--- a/src/main/java/org/opentripplanner/model/FeedScopedId.java
+++ b/src/main/java/org/opentripplanner/model/FeedScopedId.java
@@ -4,6 +4,7 @@ package org.opentripplanner.model;
 import javax.validation.constraints.NotNull;
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -105,10 +106,20 @@ public final class FeedScopedId implements Serializable, Comparable<FeedScopedId
     /**
      * Parses a string consisting of concatenated FeedScopedIds to a Set
      */
-    public static Set<FeedScopedId> parseListOfIds(String s) {
+    public static Set<FeedScopedId> parseSetOfIds(String s) {
         return Arrays
             .stream(s.split(","))
             .map(FeedScopedId::parseId)
             .collect(Collectors.toSet());
+    }
+
+    /**
+     * Parses a string consisting of concatenated FeedScopedIds to a List
+     */
+    public static List<FeedScopedId> parseListOfIds(String s) {
+        return Arrays
+                .stream(s.split(","))
+                .map(FeedScopedId::parseId)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
@@ -918,7 +918,7 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
         preferredRoutes = RouteMatcher.idMatcher(routeIds);
     }
 
-    public void setPreferredRoutesFromSting(String s) {
+    public void setPreferredRoutesFromString(String s) {
         if (!s.isEmpty()) {
             preferredRoutes = RouteMatcher.parse(s);
         }
@@ -931,7 +931,7 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
         unpreferredRoutes = RouteMatcher.idMatcher(routeIds);
     }
 
-    public void setUnpreferredRoutesFromSting(String s) {
+    public void setUnpreferredRoutesFromString(String s) {
         if (!s.isEmpty()) {
             unpreferredRoutes = RouteMatcher.parse(s);
         }
@@ -944,7 +944,7 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
         bannedRoutes = RouteMatcher.idMatcher(routeIds);
     }
 
-    public void setBannedRoutesFromSting(String s) {
+    public void setBannedRoutesFromString(String s) {
         if (!s.isEmpty()) {
             bannedRoutes = RouteMatcher.parse(s);
         }
@@ -953,7 +953,7 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
         }
     }
 
-    public void setWhiteListedRoutesFromSting(String s) {
+    public void setWhiteListedRoutesFromString(String s) {
         if (!s.isEmpty()) {
             whiteListedRoutes = RouteMatcher.parse(s);
         }

--- a/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
@@ -869,7 +869,7 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
 
     public void setPreferredAgenciesFromString(String s) {
         if (!s.isEmpty()) {
-            preferredAgencies = FeedScopedId.parseListOfIds(s);
+            preferredAgencies = FeedScopedId.parseSetOfIds(s);
         }
     }
 
@@ -881,7 +881,7 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
 
     public void setUnpreferredAgenciesFromString(String s) {
         if (!s.isEmpty()) {
-            unpreferredAgencies = FeedScopedId.parseListOfIds(s);
+            unpreferredAgencies = FeedScopedId.parseSetOfIds(s);
         }
     }
 
@@ -893,7 +893,7 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
 
     public void setBannedAgenciesFromSting(String s) {
         if (!s.isEmpty()) {
-            bannedAgencies = FeedScopedId.parseListOfIds(s);
+            bannedAgencies = FeedScopedId.parseSetOfIds(s);
         }
     }
 
@@ -905,7 +905,7 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
 
     public void setWhiteListedAgenciesFromSting(String s) {
         if (!s.isEmpty()) {
-            whiteListedAgencies = FeedScopedId.parseListOfIds(s);
+            whiteListedAgencies = FeedScopedId.parseSetOfIds(s);
         }
     }
 
@@ -974,7 +974,7 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
 
     public void setBannedTripsFromString(String ids) {
         if (!ids.isEmpty()) {
-            bannedTrips = FeedScopedId.parseListOfIds(ids);
+            bannedTrips = FeedScopedId.parseSetOfIds(ids);
         }
     }
 

--- a/src/main/java/org/opentripplanner/transit/raptor/api/view/ArrivalView.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/view/ArrivalView.java
@@ -80,15 +80,15 @@ public interface ArrivalView<T extends RaptorTripSchedule> {
     ArrivalView<T> previous();
 
     /**
-     * If it exist, return the most resent transit arrival visited. For a transit-stop-arrival
-     * this is it self, for a transfer-stop-arrival it is the previous stop-arrival.
+     * If it exists, return the most recent transit arrival visited. For a transit-stop-arrival
+     * this is itself, for a transfer-stop-arrival it is the previous stop-arrival.
      * <p>
      * For access- and egress-arrivals, including flex this method return {@code null}.
      * <p>
      * The method should be as light as possible, since it is used during routing.
      */
     @Nullable
-    default TransitArrival<T> mostResentTransitArrival() {
+    default TransitArrival<T> mostRecentTransitArrival() {
         return null;
     }
 

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/MultiCriteriaRoutingStrategy.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/MultiCriteriaRoutingStrategy.java
@@ -83,7 +83,7 @@ public final class MultiCriteriaRoutingStrategy<T extends RaptorTripSchedule>
 
     @Override
     public TransitArrival<T> previousTransit(int boardStopIndex) {
-        return prevArrival.mostResentTransitArrival();
+        return prevArrival.mostRecentTransitArrival();
     }
 
     @Override

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/arrivals/TransferStopArrival.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/arrivals/TransferStopArrival.java
@@ -39,7 +39,7 @@ public final class TransferStopArrival<T extends RaptorTripSchedule> extends Abs
     }
 
     @Override
-    public TransitArrival<T> mostResentTransitArrival() {
-        return previous().mostResentTransitArrival();
+    public TransitArrival<T> mostRecentTransitArrival() {
+        return previous().mostRecentTransitArrival();
     }
 }

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/arrivals/TransitStopArrival.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/arrivals/TransitStopArrival.java
@@ -53,7 +53,7 @@ public final class TransitStopArrival<T extends RaptorTripSchedule>
     }
 
     @Override
-    public TransitArrival<T> mostResentTransitArrival() {
+    public TransitArrival<T> mostRecentTransitArrival() {
         return this;
     }
 }

--- a/src/test/java/org/opentripplanner/GtfsTest.java
+++ b/src/test/java/org/opentripplanner/GtfsTest.java
@@ -124,7 +124,7 @@ public abstract class GtfsTest extends TestCase {
         routingRequest.setStreetSubRequestModes(new TraverseModeSet(TraverseMode.WALK, mode));
         // TODO route matcher still using underscores because it's quite nonstandard and should be eliminated from the 1.0 release rather than reworked
         if (excludedRoute != null && !excludedRoute.isEmpty()) {
-            routingRequest.setBannedRoutesFromSting(feedId.getId() + "__" + excludedRoute);
+            routingRequest.setBannedRoutesFromString(feedId.getId() + "__" + excludedRoute);
         }
         if (excludedStop != null && !excludedStop.isEmpty()) {
             throw new UnsupportedOperationException("Stop banning is not yet implemented in OTP2");

--- a/src/test/java/org/opentripplanner/routing/algorithm/TestBanning.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/TestBanning.java
@@ -22,7 +22,7 @@ public class TestBanning {
 
         RoutingRequest routingRequest = new RoutingRequest();
 
-        routingRequest.setBannedRoutesFromSting("RB__RUT:Route:1");
+        routingRequest.setBannedRoutesFromString("RB__RUT:Route:1");
         routingRequest.setBannedAgenciesFromSting("RB:RUT:Agency:2");
 
         Collection<FeedScopedId> bannedRoutes =
@@ -39,7 +39,7 @@ public class TestBanning {
 
         RoutingRequest routingRequest = new RoutingRequest();
 
-        routingRequest.setWhiteListedRoutesFromSting("RB__RUT:Route:1");
+        routingRequest.setWhiteListedRoutesFromString("RB__RUT:Route:1");
         routingRequest.setWhiteListedAgenciesFromSting("RB:RUT:Agency:2");
 
         Collection<FeedScopedId> bannedRoutes =


### PR DESCRIPTION
### Summary

The raptor implementation has fields in `RoutingResource` to enable debug logging to stderr, but the implementation required knowing the raptor integer ids.

This modifies the implementation to included mapping from `stopId`s to the raptor integer ids on a per-request basis. This allows using the debugging functionality from the debug client.

 * `debugRaptorStops` - expects a list of `FeedScopedId`s separated by commas (`,`)
    ```
    debugRaptorStops=BKK:F00379
    ```

* `debugRaptorPath` and `debugRaptorPathFromStopIndex` -- expects a list (path) of `FeedScopedId`s separated by commas (`,`), along with an index in the path from which to enable debugging
    ```
    debugRaptorPath=BKK:F00373,BKK:F003015
    debugRaptorPathFromStopIndex=1
    ```

A few related typo fixes are also included.

:question: Should these fields be hidden behind a feature flag, so that they may not be used in all deployments?