### PR TITLE
debug-client: add 🚶 to walkingBike steps [changelog skip]

### DIFF
--- a/src/client/js/otp/util/Itin.js
+++ b/src/client/js/otp/util/Itin.js
@@ -310,6 +310,9 @@ otp.util.Itin = {
                             step.streetName + (asHtml ? "</b>" : "");
             }
         }
+        if (step.walkingBike) {
+            text += ' 🚶';
+        }
         return text;
     },
 


### PR DESCRIPTION
### Summary

The `walkingBike` flag was moved from `Leg` to `WalkStep`, but there is no indication in the debug client of its value. This adds a🚶 to steps which have `walkingBike` set.

![image](https://user-images.githubusercontent.com/58879/159859112-02da0c3f-6c64-456d-a4b4-df3655eb3cf2.png)
