### PR TITLE
Avoid reading Graph/RoutingContext from GraphPath [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/GraphPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/GraphPathToItineraryMapper.java
@@ -40,11 +40,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * A library class with only static methods used in converting internal GraphPaths to TripPlans, which are
- * returned by the OTP "planner" web service. TripPlans are made up of Itineraries, so the functions to produce them
- * are also bundled together here. This only produces itineraries for non-transit searches, as well as
- * the non-transit parts of itineraries containing transit, while the whole transit itinerary is produced
- * by {@link RaptorPathToItineraryMapper}.
+ * A mapper class used in converting internal GraphPaths to Itineraries, which are returned by the
+ * OTP APIs. This only produces itineraries for non-transit searches, as well as the non-transit
+ * parts of itineraries containing transit, while the whole transit itinerary is produced by
+ * {@link RaptorPathToItineraryMapper}.
  */
 public class GraphPathToItineraryMapper {
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/GraphPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/GraphPathToItineraryMapper.java
@@ -19,7 +19,6 @@ import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.model.plan.Place;
 import org.opentripplanner.model.plan.StreetLeg;
 import org.opentripplanner.model.plan.WalkStep;
-import org.opentripplanner.routing.core.RoutingContext;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.core.TraverseMode;
 import org.opentripplanner.routing.edgetype.PathwayEdge;
@@ -27,9 +26,9 @@ import org.opentripplanner.routing.edgetype.StreetEdge;
 import org.opentripplanner.routing.edgetype.VehicleParkingEdge;
 import org.opentripplanner.routing.edgetype.VehicleRentalEdge;
 import org.opentripplanner.routing.graph.Edge;
-import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.routing.location.TemporaryStreetLocation;
+import org.opentripplanner.routing.services.notes.StreetNotesService;
 import org.opentripplanner.routing.spt.GraphPath;
 import org.opentripplanner.routing.vertextype.StreetVertex;
 import org.opentripplanner.routing.vertextype.TransitStopVertex;
@@ -47,14 +46,31 @@ import org.slf4j.LoggerFactory;
  * the non-transit parts of itineraries containing transit, while the whole transit itinerary is produced
  * by {@link RaptorPathToItineraryMapper}.
  */
-public abstract class GraphPathToItineraryMapper {
+public class GraphPathToItineraryMapper {
 
     private static final Logger LOG = LoggerFactory.getLogger(GraphPathToItineraryMapper.class);
+
+    private final TimeZone timeZone;
+    private final AlertToLegMapper alertToLegMapper;
+    private final StreetNotesService streetNotesService;
+    private final double ellipsoidToGeoidDifference;
+
+    public GraphPathToItineraryMapper(
+            TimeZone timeZone,
+            AlertToLegMapper alertToLegMapper,
+            StreetNotesService streetNotesService,
+            double ellipsoidToGeoidDifference
+    ) {
+        this.timeZone = timeZone;
+        this.alertToLegMapper = alertToLegMapper;
+        this.streetNotesService = streetNotesService;
+        this.ellipsoidToGeoidDifference = ellipsoidToGeoidDifference;
+    }
 
     /**
      * Generates a TripPlan from a set of paths
      */
-    public static List<Itinerary> mapItineraries(List<GraphPath> paths) {
+    public List<Itinerary> mapItineraries(List<GraphPath> paths) {
 
         List<Itinerary> itineraries = new LinkedList<>();
         for (GraphPath path : paths) {
@@ -73,18 +89,16 @@ public abstract class GraphPathToItineraryMapper {
      * @param path The graph path to base the itinerary on
      * @return The generated itinerary
      */
-    public static Itinerary generateItinerary(GraphPath path) {
-        Graph graph = path.getRoutingContext().graph;
-
+    public Itinerary generateItinerary(GraphPath path) {
         List<Leg> legs = new ArrayList<>();
         WalkStep previousStep = null;
         for (List<State> legStates : sliceStates(path.states)) {
             if (OTPFeature.FlexRouting.isOn() && legStates.get(1).backEdge instanceof FlexTripEdge) {
-                legs.add(generateFlexLeg(graph, legStates));
+                legs.add(generateFlexLeg(legStates));
                 previousStep = null;
                 continue;
             }
-            StreetLeg leg = generateLeg(graph, legStates, previousStep);
+            StreetLeg leg = generateLeg(legStates, previousStep);
             legs.add(leg);
 
             List<WalkStep> walkSteps = leg.getWalkSteps();
@@ -107,9 +121,7 @@ public abstract class GraphPathToItineraryMapper {
         return itinerary;
     }
 
-    private static Calendar makeCalendar(State state) {
-        RoutingContext rctx = state.getContext();
-        TimeZone timeZone = rctx.graph.getTimeZone();
+    private Calendar makeCalendar(State state) {
         Calendar calendar = Calendar.getInstance(timeZone);
         calendar.setTimeInMillis(state.getTimeInMillis());
         return calendar;
@@ -192,7 +204,7 @@ public abstract class GraphPathToItineraryMapper {
     /**
      * Generate a flex leg from the states belonging to the flex leg
      */
-    private static Leg generateFlexLeg(Graph graph, List<State> states) {
+    private Leg generateFlexLeg(List<State> states) {
         State fromState = states.get(0);
         State toState = states.get(1);
         FlexTripEdge flexEdge = (FlexTripEdge) toState.backEdge;
@@ -202,7 +214,7 @@ public abstract class GraphPathToItineraryMapper {
 
         Leg leg = new FlexibleTransitLeg(flexEdge, startTime, endTime, generalizedCost);
 
-        AlertToLegMapper.addTransitAlertPatchesToLeg(graph, leg, true);
+        alertToLegMapper.addTransitAlertPatchesToLeg(leg, true);
         return leg;
     }
 
@@ -214,7 +226,7 @@ public abstract class GraphPathToItineraryMapper {
      *                     calculated correctly
      * @return The generated leg
      */
-    private static StreetLeg generateLeg(Graph graph, List<State> states, WalkStep previousStep) {
+    private StreetLeg generateLeg(List<State> states, WalkStep previousStep) {
         List<Edge> edges = states.stream()
                 // The first back edge is part of the previous leg, skip it
                 .skip(1)
@@ -229,7 +241,8 @@ public abstract class GraphPathToItineraryMapper {
         CoordinateArrayListSequence coordinates = makeCoordinates(edges);
         LineString geometry = GeometryUtils.getGeometryFactory().createLineString(coordinates);
 
-        List<WalkStep> walkSteps = new StatesToWalkStepsMapper(graph, states, previousStep).generateWalkSteps();
+        var statesToWalkStepsMapper = new StatesToWalkStepsMapper(states, previousStep, streetNotesService, ellipsoidToGeoidDifference);
+        List<WalkStep> walkSteps = statesToWalkStepsMapper.generateWalkSteps();
 
         /* For the from/to vertices to be in the correct place for vehicle parking
          * the state for actually parking (traversing the VehicleParkEdge) is excluded
@@ -265,7 +278,7 @@ public abstract class GraphPathToItineraryMapper {
             }
         }
 
-        addStreetNotes(graph, leg, states);
+        addStreetNotes(leg, states);
 
         setPathwayInfo(leg, states);
 
@@ -277,8 +290,7 @@ public abstract class GraphPathToItineraryMapper {
      */
     private static void setPathwayInfo(StreetLeg leg, List<State> legStates) {
         for (State legsState : legStates) {
-            if (legsState.getBackEdge() instanceof PathwayEdge) {
-                PathwayEdge pe = (PathwayEdge) legsState.getBackEdge();
+            if (legsState.getBackEdge() instanceof PathwayEdge pe) {
                 leg.setPathwayId(pe.getId());
                 return;
             }
@@ -293,9 +305,7 @@ public abstract class GraphPathToItineraryMapper {
      */
     private static void calculateElevations(Itinerary itinerary, List<Edge> edges) {
         for (Edge edge : edges) {
-            if (!(edge instanceof StreetEdge)) continue;
-
-            StreetEdge edgeWithElevation = (StreetEdge) edge;
+            if (!(edge instanceof StreetEdge edgeWithElevation)) { continue; }
             PackedCoordinateSequence coordinates = edgeWithElevation.getElevationProfile();
 
             if (coordinates == null) continue;
@@ -325,16 +335,11 @@ public abstract class GraphPathToItineraryMapper {
             if (mode != null) {
                 // Resolve correct mode if renting vehicle
                 if (state.isRentingVehicle()) {
-                    switch (state.stateData.rentalVehicleFormFactor) {
-                        case BICYCLE:
-                        case OTHER:
-                            return TraverseMode.BICYCLE;
-                        case SCOOTER:
-                        case MOPED:
-                            return TraverseMode.SCOOTER;
-                        case CAR:
-                            return TraverseMode.CAR;
-                    }
+                    return switch (state.stateData.rentalVehicleFormFactor) {
+                        case BICYCLE, OTHER -> TraverseMode.BICYCLE;
+                        case SCOOTER, MOPED -> TraverseMode.SCOOTER;
+                        case CAR -> TraverseMode.CAR;
+                    };
                 } else {
                     return mode;
                 }
@@ -351,9 +356,9 @@ public abstract class GraphPathToItineraryMapper {
      * @param leg The leg to add the mode and alerts to
      * @param states The states that go with the leg
      */
-    private static void addStreetNotes(Graph graph, StreetLeg leg, List<State> states) {
+    private void addStreetNotes(StreetLeg leg, List<State> states) {
         for (State state : states) {
-            Set<StreetNote> streetNotes = graph.streetNotesService.getNotes(state);
+            Set<StreetNote> streetNotes = streetNotesService.getNotes(state);
 
             if (streetNotes != null) {
                 for (StreetNote streetNote : streetNotes) {

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/DirectStreetRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/DirectStreetRouter.java
@@ -2,6 +2,7 @@ package org.opentripplanner.routing.algorithm.raptoradapter.router.street;
 
 import org.opentripplanner.common.geometry.SphericalDistanceLibrary;
 import org.opentripplanner.model.plan.Itinerary;
+import org.opentripplanner.routing.algorithm.mapping.AlertToLegMapper;
 import org.opentripplanner.routing.algorithm.mapping.GraphPathToItineraryMapper;
 import org.opentripplanner.routing.algorithm.mapping.ItinerariesHelper;
 import org.opentripplanner.routing.api.request.StreetMode;
@@ -35,7 +36,13 @@ public class DirectStreetRouter {
       List<GraphPath> paths = gpFinder.graphPathFinderEntryPoint(directRequest);
 
       // Convert the internal GraphPaths to itineraries
-      List<Itinerary> response = GraphPathToItineraryMapper.mapItineraries(paths);
+      final GraphPathToItineraryMapper graphPathToItineraryMapper = new GraphPathToItineraryMapper(
+              router.graph.getTimeZone(),
+              new AlertToLegMapper(router.graph.getTransitAlertService()),
+              router.graph.streetNotesService,
+              router.graph.ellipsoidToGeoidDifference
+      );
+      List<Itinerary> response = graphPathToItineraryMapper.mapItineraries(paths);
       ItinerariesHelper.decorateItinerariesWithRequestData(response, directRequest);
       return response;
     }

--- a/src/main/java/org/opentripplanner/routing/core/State.java
+++ b/src/main/java/org/opentripplanner/routing/core/State.java
@@ -475,6 +475,10 @@ public class State implements Cloneable {
         return time;
     }
 
+    public void timeshiftBySeconds(int timeShift) {
+        time += (timeShift * 1000L);
+    }
+
     public boolean multipleOptionsBefore() {
         boolean foundAlternatePaths = false;
         TraverseMode requestedMode = getNonTransitMode();

--- a/src/main/java/org/opentripplanner/routing/spt/GraphPath.java
+++ b/src/main/java/org/opentripplanner/routing/spt/GraphPath.java
@@ -18,13 +18,7 @@ public class GraphPath {
 
     public LinkedList<Edge> edges;
 
-    // needed to track repeat invocations of path-reversing methods
-    private final boolean back;
-
     private double walkDistance = 0;
-
-    // don't really need to save this (available through State) but why not
-    private final RoutingContext rctx;
 
     /**
      * Construct a GraphPath based on the given state by following back-edge fields all the way back
@@ -39,13 +33,12 @@ public class GraphPath {
      *
      */
     public GraphPath(State s) {
-        this.rctx = s.getContext();
-        this.back = s.getOptions().arriveBy;
+        walkDistance = s.getWalkDistance();
 
         /* Put path in chronological order */
         State lastState;
-        walkDistance = s.getWalkDistance();
-        if (back) {
+        // needed to track repeat invocations of path-reversing methods
+        if (s.getOptions().arriveBy) {
             lastState = s.reverse();
         } else {
             lastState = s;
@@ -160,10 +153,6 @@ public class GraphPath {
 
     public double getWalkDistance() {
         return walkDistance;
-    }
-    
-    public RoutingContext getRoutingContext() {
-        return rctx;
     }
 
 }

--- a/src/test/java/org/opentripplanner/GtfsTest.java
+++ b/src/test/java/org/opentripplanner/GtfsTest.java
@@ -12,6 +12,7 @@ import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.model.calendar.ServiceDateInterval;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.Leg;
+import org.opentripplanner.routing.algorithm.mapping.AlertToLegMapper;
 import org.opentripplanner.routing.algorithm.mapping.GraphPathToItineraryMapper;
 import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.core.TraverseMode;
@@ -138,7 +139,13 @@ public abstract class GtfsTest extends TestCase {
         routingRequest.setWalkBoardCost(30);
 
         List<GraphPath> paths = new GraphPathFinder(router).getPaths(routingRequest);
-        List<Itinerary> itineraries = GraphPathToItineraryMapper.mapItineraries(paths);
+        GraphPathToItineraryMapper graphPathToItineraryMapper = new GraphPathToItineraryMapper(
+                graph.getTimeZone(),
+                new AlertToLegMapper(graph.getTransitAlertService()),
+                graph.streetNotesService,
+                graph.ellipsoidToGeoidDifference
+        );
+        List<Itinerary> itineraries = graphPathToItineraryMapper.mapItineraries(paths);
         // Stored in instance field for use in individual tests
         itinerary = itineraries.get(0);
 

--- a/src/test/java/org/opentripplanner/routing/street/BarrierRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/street/BarrierRoutingTest.java
@@ -19,6 +19,7 @@ import org.locationtech.jts.geom.Geometry;
 import org.opentripplanner.ConstantsForTests;
 import org.opentripplanner.model.GenericLocation;
 import org.opentripplanner.model.plan.Itinerary;
+import org.opentripplanner.routing.algorithm.mapping.AlertToLegMapper;
 import org.opentripplanner.routing.algorithm.mapping.GraphPathToItineraryMapper;
 import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.core.TraverseMode;
@@ -143,7 +144,14 @@ public class BarrierRoutingTest {
         var gpf = new GraphPathFinder(new Router(graph, RouterConfig.DEFAULT));
         var paths = gpf.graphPathFinderEntryPoint(request);
 
-        var itineraries = GraphPathToItineraryMapper.mapItineraries(paths);
+        GraphPathToItineraryMapper graphPathToItineraryMapper = new GraphPathToItineraryMapper(
+                graph.getTimeZone(),
+                new AlertToLegMapper(graph.getTransitAlertService()),
+                graph.streetNotesService,
+                graph.ellipsoidToGeoidDifference
+        );
+
+        var itineraries = graphPathToItineraryMapper.mapItineraries(paths);
 
         assertAll(assertions.apply(itineraries));
 

--- a/src/test/java/org/opentripplanner/routing/street/BicycleRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/street/BicycleRoutingTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Geometry;
 import org.opentripplanner.ConstantsForTests;
 import org.opentripplanner.model.GenericLocation;
+import org.opentripplanner.routing.algorithm.mapping.AlertToLegMapper;
 import org.opentripplanner.routing.algorithm.mapping.GraphPathToItineraryMapper;
 import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.core.BicycleOptimizeType;
@@ -70,7 +71,14 @@ public class BicycleRoutingTest {
         var gpf = new GraphPathFinder(new Router(graph, RouterConfig.DEFAULT));
         var paths = gpf.graphPathFinderEntryPoint(request);
 
-        var itineraries = GraphPathToItineraryMapper.mapItineraries(paths);
+        GraphPathToItineraryMapper graphPathToItineraryMapper = new GraphPathToItineraryMapper(
+                graph.getTimeZone(),
+                new AlertToLegMapper(graph.getTransitAlertService()),
+                graph.streetNotesService,
+                graph.ellipsoidToGeoidDifference
+        );
+
+        var itineraries = graphPathToItineraryMapper.mapItineraries(paths);
         // make sure that we only get BICYLE legs
         itineraries.forEach(i -> i.legs.forEach(l -> Assertions.assertEquals(l.getMode(), TraverseMode.BICYCLE)));
         Geometry legGeometry = itineraries.get(0).legs.get(0).getLegGeometry();

--- a/src/test/java/org/opentripplanner/routing/street/CarRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/street/CarRoutingTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Geometry;
 import org.opentripplanner.ConstantsForTests;
 import org.opentripplanner.model.GenericLocation;
+import org.opentripplanner.routing.algorithm.mapping.AlertToLegMapper;
 import org.opentripplanner.routing.algorithm.mapping.GraphPathToItineraryMapper;
 import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.core.TraverseMode;
@@ -124,7 +125,14 @@ public class CarRoutingTest {
         var gpf = new GraphPathFinder(new Router(graph, RouterConfig.DEFAULT));
         var paths = gpf.graphPathFinderEntryPoint(request);
 
-        var itineraries = GraphPathToItineraryMapper.mapItineraries(paths);
+        GraphPathToItineraryMapper graphPathToItineraryMapper = new GraphPathToItineraryMapper(
+                graph.getTimeZone(),
+                new AlertToLegMapper(graph.getTransitAlertService()),
+                graph.streetNotesService,
+                graph.ellipsoidToGeoidDifference
+        );
+
+        var itineraries = graphPathToItineraryMapper.mapItineraries(paths);
         // make sure that we only get CAR legs
         itineraries.forEach(
                 i -> i.legs.forEach(l -> Assertions.assertEquals(l.getMode(), TraverseMode.CAR)));

--- a/src/test/java/org/opentripplanner/routing/street/SplitEdgeTurnRestrictionsTest.java
+++ b/src/test/java/org/opentripplanner/routing/street/SplitEdgeTurnRestrictionsTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Geometry;
 import org.opentripplanner.ConstantsForTests;
 import org.opentripplanner.model.GenericLocation;
+import org.opentripplanner.routing.algorithm.mapping.AlertToLegMapper;
 import org.opentripplanner.routing.algorithm.mapping.GraphPathToItineraryMapper;
 import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.core.TraverseMode;
@@ -154,7 +155,14 @@ public class SplitEdgeTurnRestrictionsTest {
         var gpf = new GraphPathFinder(new Router(graph, RouterConfig.DEFAULT));
         var paths = gpf.graphPathFinderEntryPoint(request);
 
-        var itineraries = GraphPathToItineraryMapper.mapItineraries(paths);
+        GraphPathToItineraryMapper graphPathToItineraryMapper = new GraphPathToItineraryMapper(
+                graph.getTimeZone(),
+                new AlertToLegMapper(graph.getTransitAlertService()),
+                graph.streetNotesService,
+                graph.ellipsoidToGeoidDifference
+        );
+
+        var itineraries = graphPathToItineraryMapper.mapItineraries(paths);
         // make sure that we only get CAR legs
         itineraries.forEach(
                 i -> i.legs.forEach(l -> Assertions.assertEquals(l.getMode(), TraverseMode.CAR)));


### PR DESCRIPTION
### Summary
In preparation for the inversion of `RoutingRequest` and `RoutingContext`, I want to remove any unnecessary access to the `Graph` and `RoutingContext` from `GraphPath`. Fortunately it is only used in the itinerary mappers, and it is easy enough to convert these to instead be instantiated in the router using the pieces of the graph they require. None of the mappers require actual access to the graph, but only to some services bound to it, which can be acquired through dependency injection in the future.
