### PR TITLE
Remove unused field GtfsBundle#url [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/model/GtfsBundle.java
+++ b/src/main/java/org/opentripplanner/graph_builder/model/GtfsBundle.java
@@ -1,27 +1,21 @@
 package org.opentripplanner.graph_builder.model;
 
-import org.apache.http.client.ClientProtocolException;
-import org.onebusaway.csv_entities.CsvInputSource;
-import org.opentripplanner.graph_builder.module.GtfsFeedId;
-import org.opentripplanner.datastore.CompositeDataSource;
-import org.opentripplanner.datastore.FileType;
-import org.opentripplanner.datastore.configure.DataStoreFactory;
-import org.opentripplanner.util.HttpUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URL;
+import org.onebusaway.csv_entities.CsvInputSource;
+import org.opentripplanner.datastore.CompositeDataSource;
+import org.opentripplanner.datastore.FileType;
+import org.opentripplanner.datastore.configure.DataStoreFactory;
+import org.opentripplanner.graph_builder.module.GtfsFeedId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class GtfsBundle {
 
     private static final Logger LOG = LoggerFactory.getLogger(GtfsBundle.class);
 
     private final CompositeDataSource dataSource;
-
-    private URL url;
 
     private GtfsFeedId feedId;
 
@@ -33,9 +27,9 @@ public class GtfsBundle {
      */
     public boolean parentStationTransfers = false;
 
-    /** 
-     * Connect parent station vertices to their constituent stops to allow beginning and 
-     * ending paths (itineraries) at them. 
+    /**
+     * Connect parent station vertices to their constituent stops to allow beginning and
+     * ending paths (itineraries) at them.
      */
     public boolean linkStopsToParentStations = false;
 
@@ -52,10 +46,6 @@ public class GtfsBundle {
 
     public GtfsBundle(CompositeDataSource dataSource) {
         this.dataSource = dataSource;
-    }
-
-    public void setUrl(URL url) {
-        this.url = url;
     }
 
     public CsvInputSource getCsvInputSource() {
@@ -94,7 +84,7 @@ public class GtfsBundle {
         }
         return "GTFS bundle at " + src;
     }
-    
+
     /**
      * So that we can load multiple gtfs feeds into the same database.
      */
@@ -119,14 +109,6 @@ public class GtfsBundle {
                         "GTFS Path " + dataSource.path() + " does not exist or "
                                 + "cannot be read."
                 );
-        } else if (url != null) {
-            try {
-                HttpUtils.testUrl(url.toExternalForm());
-            } catch (ClientProtocolException e) {
-                throw new RuntimeException("Error connecting to " + url.toExternalForm() + "\n" + e);
-            } catch (IOException e) {
-                throw new RuntimeException("GTFS url " + url.toExternalForm() + " cannot be read.\n" + e);
-            }
         }
     }
 

--- a/src/main/java/org/opentripplanner/util/HttpUtils.java
+++ b/src/main/java/org/opentripplanner/util/HttpUtils.java
@@ -1,26 +1,21 @@
 package org.opentripplanner.util;
 
-import java.net.URL;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.StatusLine;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpHead;
-import org.apache.http.config.SocketConfig;
-import org.apache.http.impl.client.HttpClientBuilder;
-
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.net.URL;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.config.SocketConfig;
+import org.apache.http.impl.client.HttpClientBuilder;
 
 public class HttpUtils {
     
     private static final long TIMEOUT_CONNECTION = 5000;
-    private static final int TIMEOUT_SOCKET = 5000;
 
     public static InputStream getData(URI uri) throws IOException {
         return getData(uri, null);
@@ -58,26 +53,6 @@ public class HttpUtils {
 
     public static InputStream getData(URI uri, Map<String, String> requestHeaderValues) throws IOException {
         return getData(uri, TIMEOUT_CONNECTION, requestHeaderValues);
-    }
-
-    public static void testUrl(String url) throws IOException {
-        HttpHead head = new HttpHead(url);
-        HttpClient httpclient = getClient();
-        HttpResponse response = httpclient.execute(head);
-
-        StatusLine status = response.getStatusLine();
-        if (status.getStatusCode() == 404) {
-            throw new FileNotFoundException();
-        }
-
-        if (status.getStatusCode() != 200) {
-            throw new RuntimeException("Could not get URL: " + status.getStatusCode() + ": "
-                    + status.getReasonPhrase());
-        }
-    }
-    
-    private static HttpClient getClient() {
-        return getClient(TIMEOUT_CONNECTION, TIMEOUT_SOCKET);
     }
 
     private static HttpClient getClient(long timeoutConnection, long timeoutSocket) {


### PR DESCRIPTION
### Summary

While investigating an issue with HTTP timeouts for graph updaters I noticed a completely unused field in GtfsBundle: presumably it was used to download GTFS feeds via HTTP. It doesn't work anymore so I removed it and some code that only this feature used.

### Issue

n/a

### Code style
Yes

### Documentation

n/a

### Changelog
skip