### PR TITLE
Fix HTTP client timeout [changelog skip]

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETGooglePubsubUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETGooglePubsubUpdater.java
@@ -273,7 +273,7 @@ public class SiriETGooglePubsubUpdater implements GraphUpdater {
             final long t1 = System.currentTimeMillis();
 
             final InputStream data = HttpUtils.getData(
-                dataInitializationUrl, 30000, Map.of("Content-Type", "application/x-protobuf"));
+                dataInitializationUrl, java.time.Duration.ofSeconds(30), Map.of("Content-Type", "application/x-protobuf"));
             ByteString value = ByteString.readFrom(data);
 
             final long t2 = System.currentTimeMillis();


### PR DESCRIPTION
### Summary

The current timeout doesn't actually work and this fixes that.

If you want to test this you can use the following config: https://github.com/leonardehrenfried/otp2-setup/blob/main/atlanta/router-config.json#L22-L28

The vehicle positions feed https://bustime.cobbcounty.org/gtfsrt/vehicles actually never sends any data so it's a good test case.

Now that the timeout actually works we can debate if 5 seconds is actually too short a value.

Any opinions?

### Issue
none

### Unit tests
none

### Code style
yes