### PR TITLE
Make walking lines more visible in debug client [changelog skip]

### DIFF
--- a/src/client/index.html
+++ b/src/client/index.html
@@ -14,7 +14,7 @@
 
 <link rel="stylesheet" href="js/lib/jquery-ui/css/smoothness/jquery-ui-1.9.1.custom.css" />
 <link rel="stylesheet" href="js/lib/jquery-ui/addons/jquery-ui-timepicker.css" />
-<link rel="stylesheet" href="//cdn.jsdelivr.net/leaflet/0.7.3/leaflet.css" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.7.1/dist/leaflet.css" />
 <link rel="stylesheet" href="js/otp/widgets/widget-style.css?v=1" />
 <link rel="stylesheet" href="js/otp/modules/planner/planner-style.css?v=1" />
 <link rel="stylesheet" href="js/otp/modules/bikeshare/bikeshare-style.css?v=1" />
@@ -26,7 +26,7 @@
 <!--Loads jquery, underscore, json2, momentjs and raphael makes 7 requests less-->
 <script src="//cdn.jsdelivr.net/g/jquery@1.9.1,underscorejs@1.4.2,json2@0.1,momentjs@1.7.2,raphael@2.1.2"></script>
 
-<script src="//cdn.jsdelivr.net/leaflet/0.7.3/leaflet.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/leaflet@1.7.1/dist/leaflet.js"></script>
 
 <!-- jquery-ui -->
 <script src="js/lib/jquery-ui/js/jquery-ui-1.9.1.custom.min.js"></script>

--- a/src/client/js/otp/modules/planner/PlannerModule.js
+++ b/src/client/js/otp/modules/planner/PlannerModule.js
@@ -516,7 +516,10 @@ otp.modules.planner.PlannerModule =
             var weight = 8;
             var legColor = otp.util.Itin.getLegBackgroundColor(leg);
 
-            polyline.setStyle({ color : legColor, weight: weight});
+            var style = otp.util.Itin.getLineStyle(leg);
+            style.color = legColor;
+            polyline.setStyle(style);
+
             this.pathLayer.addLayer(polyline);
             polyline.leg = leg;
             polyline.bindPopup("("+leg.routeShortName+") "+leg.routeLongName);
@@ -629,19 +632,6 @@ otp.modules.planner.PlannerModule =
                 this.drawStartBubble(leg, false);
             }
         }
-    },
-
-    getModeColor : function(mode) {
-        if(mode === "WALK") return '#444';
-        if(mode === "BICYCLE") return '#0073e5';
-        if(mode === "SCOOTER") return '#88f';
-        if(mode === "SUBWAY") return '#f00';
-        if(mode === "RAIL") return '#b00';
-        if(mode === "BUS") return '#080';
-        if(mode === "TRAM") return '#800';
-        if(mode === "CAR") return '#444';
-        if(mode === "AIRPLANE") return '#f0f';
-        return '#aaa';
     },
 
     clearTrip : function() {

--- a/src/client/js/otp/util/Itin.js
+++ b/src/client/js/otp/util/Itin.js
@@ -340,7 +340,7 @@ otp.util.Itin = {
     },
 
     getModeColor : function(mode) {
-        if(mode === "WALK") return '#bbb';
+        if(mode === "WALK") return '#444';
         if(mode === "BICYCLE") return '#44f';
         if(mode === "SCOOTER") return '#88f';
         if(mode === "CAR") return '#444';
@@ -367,16 +367,28 @@ otp.util.Itin = {
     getLegTextColor : function (leg) {
         if (leg.routeTextColor) {
             return '#' + leg.routeTextColor;
-        } else {
+        }
+        else if(leg.mode === "WALK") {
+            return '#fff';
+        }
+        else {
             return '#000000';
         }
     },
 
-    getLegBackgroundColor : function (leg) {
+    getLegBackgroundColor: function (leg) {
         if (leg.routeColor) {
             return '#' + leg.routeColor;
         } else {
             return this.getModeColor(leg.mode);
+        }
+    },
+
+    getLineStyle: function (leg) {
+        if (leg.mode === "WALK") {
+            return { weight: 4, opacity: 0.8}
+        } else {
+            return { weight: 8, opacity: 0.6}
         }
     },
 }


### PR DESCRIPTION
### Summary
This makes the walking polylines in the debug client more visible after they changed colour in #3908.

#### Before
![Screenshot from 2022-03-25 14-47-23](https://user-images.githubusercontent.com/151346/160133075-231b4c21-d90e-4855-929f-df4af5fdb07a.png)

#### After
![Screenshot from 2022-03-25 14-42-28](https://user-images.githubusercontent.com/151346/160133115-af8a5653-e62a-4563-ad71-3313c2c5b01a.png)

I also upgraded the ancient leaflet version to the latest one.

### Issue
none

### Unit tests
none

### Code style
none

### Documentation
none

### Changelog
skip