### PR TITLE
Remove disableRemainingWeightHeuristics, move parameters from RoutingRequest into AStar

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/flex/FlexIntegrationTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/flex/FlexIntegrationTest.java
@@ -169,7 +169,7 @@ public class FlexIntegrationTest {
         var req = new RoutingRequest();
 
         // we don't have a complete coverage of the entire area so use straight lines for transfers
-        var transfers = new DirectTransferGenerator(600, List.of(req));
+        var transfers = new DirectTransferGenerator(Duration.ofMinutes(10), List.of(req));
         transfers.buildGraph(graph, extra);
 
         graph.index();

--- a/src/ext/java/org/opentripplanner/ext/flex/flexpathcalculator/StreetFlexPathCalculator.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/flexpathcalculator/StreetFlexPathCalculator.java
@@ -2,7 +2,6 @@ package org.opentripplanner.ext.flex.flexpathcalculator;
 
 import org.opentripplanner.routing.algorithm.astar.AStar;
 import org.opentripplanner.routing.algorithm.astar.strategies.DurationSkipEdgeStrategy;
-import org.opentripplanner.routing.algorithm.astar.strategies.TrivialRemainingWeightHeuristic;
 import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.core.TraverseMode;
 import org.opentripplanner.routing.graph.Graph;
@@ -31,7 +30,7 @@ import java.util.Map;
  */
 public class StreetFlexPathCalculator implements FlexPathCalculator {
 
-  private static final long MAX_FLEX_TRIP_DURATION_SECONDS = Duration.ofMinutes(45).toSeconds();
+  private static final Duration MAX_FLEX_TRIP_DURATION = Duration.ofMinutes(45);
 
   private final Graph graph;
   private final Map<Vertex, ShortestPathTree> cache = new HashMap<>();
@@ -80,12 +79,8 @@ public class StreetFlexPathCalculator implements FlexPathCalculator {
     } else {
       routingRequest.setRoutingContext(graph, vertex, null);
     }
-    routingRequest.disableRemainingWeightHeuristic = true;
-    routingRequest.rctx.remainingWeightHeuristic = new TrivialRemainingWeightHeuristic();
     routingRequest.dominanceFunction = new DominanceFunction.EarliestArrival();
-    routingRequest.oneToMany = true;
-    AStar search = new AStar();
-    search.setSkipEdgeStrategy(new DurationSkipEdgeStrategy(MAX_FLEX_TRIP_DURATION_SECONDS));
+    AStar search = AStar.allDirectionsMaxDuration(MAX_FLEX_TRIP_DURATION);
     ShortestPathTree spt = search.getShortestPathTree(routingRequest);
     routingRequest.cleanup();
     return spt;

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
@@ -960,7 +960,6 @@ public class LegacyGraphQLQueryTypeImpl
       //callWith.argument("reverseOptimizeOnTheFly", (Boolean v) -> request.reverseOptimizeOnTheFly = v);
       //callWith.argument("omitCanceled", (Boolean v) -> request.omitCanceled = v);
       callWith.argument("ignoreRealtimeUpdates", (Boolean v) -> request.ignoreRealtimeUpdates = v);
-      callWith.argument("disableRemainingWeightHeuristic", (Boolean v) -> request.disableRemainingWeightHeuristic = v);
 
       callWith.argument("locale", (String v) -> request.locale = ResourceBundleSingleton.INSTANCE.getLocale(v));
       RoutingResponse res = context.getRoutingService().route(request, context.getRouter());

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/DefaultRoutingRequestType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/DefaultRoutingRequestType.java
@@ -316,7 +316,7 @@ public class DefaultRoutingRequestType {
                         .name("disableRemainingWeightHeuristic")
                         .description("If true, the remaining weight heuristic is disabled.")
                         .type(Scalars.GraphQLBoolean)
-                        .dataFetcher(env -> request.disableRemainingWeightHeuristic)
+                        .dataFetcher(env -> false)
                         .build())
                 .field(GraphQLFieldDefinition
                         .newFieldDefinition()

--- a/src/ext/resources/legacygraphqlapi/schema.graphqls
+++ b/src/ext/resources/legacygraphqlapi/schema.graphqls
@@ -2520,7 +2520,7 @@ type QueryType {
         ~~If true, the remaining weight heuristic is disabled. Currently only
         implemented for the long distance path service. Default value: false.~~
         """
-        disableRemainingWeightHeuristic: Boolean
+        disableRemainingWeightHeuristic: Boolean @deprecated(reason: "Removed in OTP 2.2")
 
         """
         Two-letter language code (ISO 639-1) used for returned text.

--- a/src/main/java/org/opentripplanner/api/common/RoutingResource.java
+++ b/src/main/java/org/opentripplanner/api/common/RoutingResource.java
@@ -930,9 +930,6 @@ public abstract class RoutingResource {
         if (ignoreRealtimeUpdates != null)
             request.ignoreRealtimeUpdates = ignoreRealtimeUpdates;
 
-        if (disableRemainingWeightHeuristic != null)
-            request.disableRemainingWeightHeuristic = disableRemainingWeightHeuristic;
-
         if (disableAlertFiltering != null)
             request.disableAlertFiltering = disableAlertFiltering;
 

--- a/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.graph_builder;
 
 import com.google.common.collect.Lists;
+import java.time.Duration;
 import org.opentripplanner.datastore.CompositeDataSource;
 import org.opentripplanner.datastore.DataSource;
 import org.opentripplanner.ext.dataoverlay.configure.DataOverlayFactory;
@@ -221,7 +222,8 @@ public class GraphBuilder implements Runnable {
             }
 
             // This module will use streets or straight line distance depending on whether OSM data is found in the graph.
-            graphBuilder.addModule(new DirectTransferGenerator(config.maxTransferDurationSeconds, config.transferRequests));
+            graphBuilder.addModule(new DirectTransferGenerator(Duration.ofSeconds(
+                    (long) config.maxTransferDurationSeconds), config.transferRequests));
 
             // Analyze routing between stops to generate report
             if (OTPFeature.TransferAnalyzer.isOn()) {

--- a/src/main/java/org/opentripplanner/graph_builder/module/DirectTransferGenerator.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/DirectTransferGenerator.java
@@ -2,6 +2,7 @@ package org.opentripplanner.graph_builder.module;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimaps;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -36,7 +37,7 @@ public class DirectTransferGenerator implements GraphBuilderModule {
 
     private static final Logger LOG = LoggerFactory.getLogger(DirectTransferGenerator.class);
 
-    final double radiusByDurationInSeconds;
+    private final Duration radiusByDuration;
 
     private final List<RoutingRequest> transferRequests;
 
@@ -48,8 +49,8 @@ public class DirectTransferGenerator implements GraphBuilderModule {
         return List.of("street to transit");
     }
 
-    public DirectTransferGenerator (double radiusByDurationInSeconds, List<RoutingRequest> transferRequests) {
-        this.radiusByDurationInSeconds = radiusByDurationInSeconds;
+    public DirectTransferGenerator (Duration radiusByDuration, List<RoutingRequest> transferRequests) {
+        this.radiusByDuration = radiusByDuration;
         this.transferRequests = transferRequests;
     }
 
@@ -65,7 +66,7 @@ public class DirectTransferGenerator implements GraphBuilderModule {
         }
 
         /* The linker will use streets if they are available, or straight-line distance otherwise. */
-        NearbyStopFinder nearbyStopFinder = new NearbyStopFinder(graph, radiusByDurationInSeconds);
+        NearbyStopFinder nearbyStopFinder = new NearbyStopFinder(graph, radiusByDuration);
         if (nearbyStopFinder.useStreets) {
             LOG.info("Creating direct transfer edges between stops using the street network from OSM...");
         } else {

--- a/src/main/java/org/opentripplanner/graph_builder/module/NearbyStopFinder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/NearbyStopFinder.java
@@ -185,13 +185,10 @@ public class NearbyStopFinder {
         } else {
             routingRequest.setRoutingContext(graph, null, originVertices);
         }
-        routingRequest.disableRemainingWeightHeuristic = true;
-        routingRequest.rctx.remainingWeightHeuristic = new TrivialRemainingWeightHeuristic();
         routingRequest.dominanceFunction = new DominanceFunction.MinimumWeight();
 
-        var astar = new AStar();
         var skipEdgeStrategy = getSkipEdgeStrategy(reverseDirection, routingRequest);
-        astar.setSkipEdgeStrategy(skipEdgeStrategy);
+        var astar = AStar.allDirections(skipEdgeStrategy);
 
         ShortestPathTree spt = astar.getShortestPathTree(routingRequest);
 

--- a/src/main/java/org/opentripplanner/graph_builder/module/NearbyStopFinder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/NearbyStopFinder.java
@@ -4,6 +4,7 @@ import com.beust.jcommander.internal.Lists;
 import com.beust.jcommander.internal.Sets;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
+import java.time.Duration;
 import org.locationtech.jts.geom.Coordinate;
 import org.opentripplanner.common.MinMap;
 import org.opentripplanner.ext.flex.trip.FlexTrip;
@@ -17,7 +18,6 @@ import org.opentripplanner.routing.algorithm.astar.AStar;
 import org.opentripplanner.routing.algorithm.astar.strategies.ComposingSkipEdgeStrategy;
 import org.opentripplanner.routing.algorithm.astar.strategies.DurationSkipEdgeStrategy;
 import org.opentripplanner.routing.algorithm.astar.strategies.SkipEdgeStrategy;
-import org.opentripplanner.routing.algorithm.astar.strategies.TrivialRemainingWeightHeuristic;
 import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.routing.core.State;
@@ -54,7 +54,7 @@ public class NearbyStopFinder {
 
     public  final boolean useStreets;
     private final Graph graph;
-    private final double durationLimitInSeconds;
+    private final Duration durationLimit;
 
     private DirectGraphFinder directGraphFinder;
 
@@ -63,18 +63,18 @@ public class NearbyStopFinder {
      * Construct a NearbyStopFinder for the given graph and search radius, choosing whether to search via the street
      * network or straight line distance based on the presence of OSM street data in the graph.
      */
-    public NearbyStopFinder(Graph graph, double durationLimitInSeconds) {
-        this (graph, durationLimitInSeconds, graph.hasStreets);
+    public NearbyStopFinder(Graph graph, Duration durationLimit) {
+        this (graph, durationLimit, graph.hasStreets);
     }
 
     /**
      * Construct a NearbyStopFinder for the given graph and search radius.
      * @param useStreets if true, search via the street network instead of using straight-line distance.
      */
-    public NearbyStopFinder(Graph graph, double durationLimitInSeconds, boolean useStreets) {
+    public NearbyStopFinder(Graph graph, Duration durationLimit, boolean useStreets) {
         this.graph = graph;
         this.useStreets = useStreets;
-        this.durationLimitInSeconds = durationLimitInSeconds;
+        this.durationLimit = durationLimit;
 
         if (!useStreets) {
             // We need to accommodate straight line distance (in meters) but when streets are present we use an
@@ -136,7 +136,7 @@ public class NearbyStopFinder {
             return findNearbyStopsViaStreets(Set.of(vertex), reverseDirection, true, routingRequest);
         }
         // It make sense for the directGraphFinder to use meters as a limit, so we convert first
-        double limitMeters = durationLimitInSeconds * new RoutingRequest(TraverseMode.WALK).walkSpeed;
+        double limitMeters = durationLimit.toSeconds() * new RoutingRequest(TraverseMode.WALK).walkSpeed;
         Coordinate c0 = vertex.getCoordinate();
         return directGraphFinder.findClosestStops(c0.y, c0.x, limitMeters);
     }
@@ -246,7 +246,7 @@ public class NearbyStopFinder {
             boolean reverseDirection,
             RoutingRequest routingRequest
     ) {
-        var durationSkipEdgeStrategy = new DurationSkipEdgeStrategy(durationLimitInSeconds);
+        var durationSkipEdgeStrategy = new DurationSkipEdgeStrategy(durationLimit);
 
         // if we compute the accesses for Park+Ride, Bike+Ride and Bike+Transit we don't want to
         // search the full durationLimit as this returns way too many stops.

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilder.java
@@ -382,12 +382,10 @@ public class WalkableAreaBuilder {
         RoutingRequest options = new RoutingRequest(mode);
         options.dominanceFunction = new DominanceFunction.EarliestArrival();
         options.setDummyRoutingContext(graph);
-        AStar search = new AStar();
-        search.setSkipEdgeStrategy(new ListedEdgesOnly(edges));
+        AStar search = AStar.allDirections(new ListedEdgesOnly(edges));
         Set<Edge> usedEdges = new HashSet<>();
         for (Vertex vertex : startingVertices) {
             options.setRoutingContext(graph, vertex, null);
-            options.rctx.remainingWeightHeuristic = new TrivialRemainingWeightHeuristic();
             ShortestPathTree spt = search.getShortestPathTree(options);
             for (Vertex endVertex : startingVertices) {
                 GraphPath path = spt.getPath(endVertex);

--- a/src/main/java/org/opentripplanner/routing/algorithm/astar/AStar.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/astar/AStar.java
@@ -53,11 +53,11 @@ public class AStar {
     }
 
     public static AStar oneToOne(Duration maxDuration) {
-        return new AStar(new EuclideanRemainingWeightHeuristic(), new DurationSkipEdgeStrategy(maxDuration.toSeconds()));
+        return new AStar(new EuclideanRemainingWeightHeuristic(), new DurationSkipEdgeStrategy(maxDuration));
     }
 
     public static AStar allDirectionsMaxDuration(Duration maxDuration) {
-        return allDirections(new DurationSkipEdgeStrategy(maxDuration.toSeconds()));
+        return allDirections(new DurationSkipEdgeStrategy(maxDuration));
     }
 
     public static AStar allDirections(SkipEdgeStrategy strategy) {

--- a/src/main/java/org/opentripplanner/routing/algorithm/astar/AStar.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/astar/AStar.java
@@ -1,10 +1,14 @@
 package org.opentripplanner.routing.algorithm.astar;
 
 import com.beust.jcommander.internal.Lists;
+import java.time.Duration;
 import org.opentripplanner.common.pqueue.BinHeap;
+import org.opentripplanner.routing.algorithm.astar.strategies.DurationSkipEdgeStrategy;
+import org.opentripplanner.routing.algorithm.astar.strategies.EuclideanRemainingWeightHeuristic;
 import org.opentripplanner.routing.algorithm.astar.strategies.RemainingWeightHeuristic;
 import org.opentripplanner.routing.algorithm.astar.strategies.SearchTerminationStrategy;
 import org.opentripplanner.routing.algorithm.astar.strategies.SkipEdgeStrategy;
+import org.opentripplanner.routing.algorithm.astar.strategies.TrivialRemainingWeightHeuristic;
 import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.core.RoutingContext;
 import org.opentripplanner.routing.core.State;
@@ -36,11 +40,34 @@ public class AStar {
 
     private TraverseVisitor traverseVisitor;
 
+    private final SkipEdgeStrategy skipEdgeStrategy;
+    private final RemainingWeightHeuristic heuristic;
+
+    private AStar(RemainingWeightHeuristic heuristic, SkipEdgeStrategy skipEdgeStrategy) {
+        this.heuristic = heuristic;
+        this.skipEdgeStrategy = skipEdgeStrategy;
+    }
+
+    public static AStar oneToOne() {
+        return new AStar(new EuclideanRemainingWeightHeuristic(), null);
+    }
+
+    public static AStar oneToOne(Duration maxDuration) {
+        return new AStar(new EuclideanRemainingWeightHeuristic(), new DurationSkipEdgeStrategy(maxDuration.toSeconds()));
+    }
+
+    public static AStar allDirectionsMaxDuration(Duration maxDuration) {
+        return allDirections(new DurationSkipEdgeStrategy(maxDuration.toSeconds()));
+    }
+
+    public static AStar allDirections(SkipEdgeStrategy strategy) {
+        return new AStar(new TrivialRemainingWeightHeuristic(), strategy);
+    }
+
     enum RunStatus {
         RUNNING, STOPPED
     }
 
-    private SkipEdgeStrategy skipEdgeStrategy;
 
     /* TODO instead of having a separate class for search state, we should just make one GenericAStar per request. */
     static class RunState {
@@ -94,9 +121,7 @@ public class AStar {
         runState.rctx = options.getRoutingContext();
         runState.spt = options.getNewShortestPathTree();
 
-        // We want to reuse the heuristic instance in a series of requests for the same target to avoid repeated work.
-        runState.heuristic = runState.rctx.remainingWeightHeuristic;
-
+        runState.heuristic = heuristic;
         // Since initial states can be multiple, heuristic cannot depend on the initial state.
         // Initializing the bidirectional heuristic is a pretty complicated operation that involves searching through
         // the streets around the origin and destination.
@@ -320,9 +345,5 @@ public class AStar {
             }
         }
         return ret;
-    }
-
-    public void setSkipEdgeStrategy(SkipEdgeStrategy skipEdgeStrategy) {
-        this.skipEdgeStrategy = skipEdgeStrategy;
     }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/astar/strategies/DurationSkipEdgeStrategy.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/astar/strategies/DurationSkipEdgeStrategy.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.routing.algorithm.astar.strategies;
 
+import java.time.Duration;
 import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.graph.Edge;
@@ -17,8 +18,8 @@ public class DurationSkipEdgeStrategy implements SkipEdgeStrategy {
 
   private final double durationInSeconds;
 
-  public DurationSkipEdgeStrategy(double durationInSeconds) {
-    this.durationInSeconds = durationInSeconds;
+  public DurationSkipEdgeStrategy(Duration duration) {
+    this.durationInSeconds = duration.toSeconds();
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/AccessEgressRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/AccessEgressRouter.java
@@ -43,7 +43,7 @@ public class AccessEgressRouter {
 
         NearbyStopFinder nearbyStopFinder = new NearbyStopFinder(
             rr.rctx.graph,
-            rr.getMaxAccessEgressDurationSecondsForMode(streetMode),
+            rr.getMaxAccessEgressDuration(streetMode),
             true
         );
         List<NearbyStop> nearbyStopList = nearbyStopFinder.findNearbyStopsViaStreets(

--- a/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
@@ -3,7 +3,6 @@ package org.opentripplanner.routing.api.request;
 import org.geotools.geojson.geom.GeometryJSON;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Envelope;
-import org.locationtech.jts.geom.GeometryFactory;
 import org.opentripplanner.api.common.LocationStringParser;
 import org.opentripplanner.common.geometry.GeometryUtils;
 import org.opentripplanner.common.geometry.SphericalDistanceLibrary;
@@ -1405,11 +1404,12 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
         return bannedRoutes;
     }
 
-    public double getMaxAccessEgressDurationSecondsForMode(StreetMode mode) {
-        return maxAccessEgressDurationSecondsForMode.getOrDefault(
+    public Duration getMaxAccessEgressDuration(StreetMode mode) {
+        Double seconds = maxAccessEgressDurationSecondsForMode.getOrDefault(
             mode,
             maxAccessEgressDurationSeconds
         );
+        return Duration.ofSeconds(seconds.longValue());
     }
 
     /**

--- a/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
@@ -99,17 +99,6 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
     public GenericLocation to;
 
     /**
-     * If true, the tree will be allowed to grow in all directions, rather than being directed
-     * toward a single target. This parameter only apply to access/egress AStar searches,
-     * not transit searches in Raptor.
-     *
-     * @deprecated TODO OTP2 - This looks like an A Star implementation detail. Should be moved to
-     *                       - an A Star specific request class
-     */
-    @Deprecated
-    public boolean oneToMany = false;
-
-    /**
      * An ordered list of intermediate locations to be visited.
      *
      * @deprecated TODO OTP2 - Regression. Not currently working in OTP2. Must be re-implemented
@@ -664,16 +653,6 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
      * When true, trips cancelled in scheduled data are included in this search.
      */
     public boolean includePlannedCancellations = false;
-
-    /**
-     * If true, the remaining weight heuristic is disabled. Currently only implemented for the long
-     * distance path service.
-     *
-     * This is used by the Street search only.
-     *
-     * TODO OTP2 Can we merge this with the 'oneToMany' option?
-     */
-    public boolean disableRemainingWeightHeuristic = false;
 
     /**
      * The routing context used to actually carry out this search. It is important to build States from TraverseOptions

--- a/src/main/java/org/opentripplanner/routing/core/RoutingContext.java
+++ b/src/main/java/org/opentripplanner/routing/core/RoutingContext.java
@@ -61,8 +61,6 @@ public class RoutingContext implements Cloneable {
     // TODO(flamholz): figure out a better way.
     public Edge originBackEdge;
 
-    public RemainingWeightHeuristic remainingWeightHeuristic;
-
     /** Indicates that the search timed out or was otherwise aborted. */
     public boolean aborted;
 
@@ -158,9 +156,8 @@ public class RoutingContext implements Cloneable {
                 }
             }
         }
-
-        remainingWeightHeuristic = new EuclideanRemainingWeightHeuristic();
     }
+
     private RoutingContext(
             RoutingRequest routingRequest,
             Graph graph,

--- a/src/main/java/org/opentripplanner/routing/graphfinder/StreetGraphFinder.java
+++ b/src/main/java/org/opentripplanner/routing/graphfinder/StreetGraphFinder.java
@@ -68,17 +68,15 @@ public class StreetGraphFinder implements GraphFinder {
     // TODO make a function that builds normal routing requests from profile requests
     try (RoutingRequest rr = new RoutingRequest(TraverseMode.WALK)) {
       rr.from = new GenericLocation(null, null, lat, lon);
-      rr.oneToMany = true;
       rr.setRoutingContext(graph);
       rr.walkSpeed = 1;
       rr.dominanceFunction = new DominanceFunction.LeastWalk();
-      rr.rctx.remainingWeightHeuristic = new TrivialRemainingWeightHeuristic();
       // RR dateTime defaults to currentTime.
       // If elapsed time is not capped, searches are very slow.
-      AStar astar = new AStar();
+
+      AStar astar = AStar.allDirections(skipEdgeStrategy);
       rr.setNumItineraries(1);
       astar.setTraverseVisitor(visitor);
-      astar.setSkipEdgeStrategy(skipEdgeStrategy);
       astar.getShortestPathTree(rr);
       // Destroy the routing context, to clean up the temporary edges & vertices
       rr.rctx.destroy();

--- a/src/main/java/org/opentripplanner/standalone/config/RoutingRequestMapper.java
+++ b/src/main/java/org/opentripplanner/standalone/config/RoutingRequestMapper.java
@@ -61,7 +61,6 @@ public class RoutingRequestMapper {
         request.carSpeed = c.asDouble("carSpeed", dft.carSpeed);
         request.itineraryFilters = ItineraryFiltersMapper.map(c.path("itineraryFilters"));
         request.disableAlertFiltering = c.asBoolean("disableAlertFiltering", dft.disableAlertFiltering);
-        request.disableRemainingWeightHeuristic = c.asBoolean("disableRemainingWeightHeuristic", dft.disableRemainingWeightHeuristic);
         request.elevatorBoardCost = c.asInt("elevatorBoardCost", dft.elevatorBoardCost);
         request.elevatorBoardTime = c.asInt("elevatorBoardTime", dft.elevatorBoardTime);
         request.elevatorHopCost = c.asInt("elevatorHopCost", dft.elevatorHopCost);

--- a/src/test/java/org/opentripplanner/graph_builder/module/DirectTransferGeneratorTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/DirectTransferGeneratorTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.collect.Multimap;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -38,7 +39,7 @@ import org.opentripplanner.routing.vertextype.TransitStopVertex;
  */
 class DirectTransferGeneratorTest extends GraphRoutingTest {
 
-    private static final double MAX_TRANSFER_DURATION = 3600;
+    private static final Duration MAX_TRANSFER_DURATION = Duration.ofSeconds(3600);
     private TransitStopVertex S0, S11, S12, S21, S22;
     private StreetVertex V0, V11, V12, V21, V22;
 

--- a/src/test/java/org/opentripplanner/graph_builder/module/osm/TestUnroutable.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/osm/TestUnroutable.java
@@ -32,7 +32,7 @@ public class TestUnroutable {
 
     private final Graph graph = new Graph();
 
-    private final AStar aStar = new AStar();
+    private final AStar aStar = AStar.oneToOne();
 
     @BeforeEach
     public void setUp() throws Exception {

--- a/src/test/java/org/opentripplanner/graph_builder/module/osm/TriangleInequalityTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/osm/TriangleInequalityTest.java
@@ -104,7 +104,7 @@ public class TriangleInequalityTest {
         RoutingRequest options = prototypeOptions.clone();
         options.setRoutingContext(graph, start, end);
         
-        AStar aStar = new AStar();
+        AStar aStar = AStar.oneToOne();
         
         ShortestPathTree tree = aStar.getShortestPathTree(options);
         GraphPath path = tree.getPath(end);

--- a/src/test/java/org/opentripplanner/model/TimetableTest.java
+++ b/src/test/java/org/opentripplanner/model/TimetableTest.java
@@ -41,7 +41,7 @@ import static org.opentripplanner.util.TestUtils.AUGUST;
 public class TimetableTest {
     
     private static Graph graph;
-    private final AStar aStar = new AStar();
+    private final AStar aStar = AStar.oneToOne();
     private static Map<FeedScopedId, TripPattern> patternIndex;
     private static TripPattern pattern;
     private static Timetable timetable;

--- a/src/test/java/org/opentripplanner/routing/TestHalfEdges.java
+++ b/src/test/java/org/opentripplanner/routing/TestHalfEdges.java
@@ -51,7 +51,7 @@ public class TestHalfEdges {
 
     Graph graph;
 
-    private final AStar aStar = new AStar();
+    private final AStar aStar = AStar.oneToOne();
 
     private StreetEdge top, bottom, left, right, leftBack, rightBack;
 

--- a/src/test/java/org/opentripplanner/routing/algorithm/AStarTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/AStarTest.java
@@ -85,7 +85,7 @@ public class AStarTest {
         RoutingRequest options = new RoutingRequest();
         options.walkSpeed = 1.0;
         options.setRoutingContext(graph, graph.getVertex("56th_24th"), graph.getVertex("leary_20th"));
-        ShortestPathTree tree = new AStar().getShortestPathTree(options);
+        ShortestPathTree tree = AStar.oneToOne().getShortestPathTree(options);
 
         GraphPath path = tree.getPath(graph.getVertex("leary_20th"));
 
@@ -110,7 +110,7 @@ public class AStarTest {
         options.setArriveBy(true);
         options.setRoutingContext(graph, graph.getVertex("56th_24th"),
                 graph.getVertex("leary_20th"));
-        ShortestPathTree tree = new AStar().getShortestPathTree(options);
+        ShortestPathTree tree = AStar.oneToOne().getShortestPathTree(options);
 
         GraphPath path = tree.getPath(graph.getVertex("56th_24th"));
 
@@ -152,7 +152,7 @@ public class AStarTest {
         new TemporaryConcreteEdge(graph.getVertex("56th_20th"), to);
 
         options.setRoutingContext(graph, from, to);
-        ShortestPathTree tree = new AStar().getShortestPathTree(options);
+        ShortestPathTree tree = AStar.oneToOne().getShortestPathTree(options);
         options.cleanup();
 
         GraphPath path = tree.getPath(to);
@@ -188,7 +188,7 @@ public class AStarTest {
         new TemporaryConcreteEdge(graph.getVertex("56th_20th"), to);
 
         options.setRoutingContext(graph, from, to);
-        ShortestPathTree tree = new AStar().getShortestPathTree(options);
+        ShortestPathTree tree = AStar.oneToOne().getShortestPathTree(options);
         options.cleanup();
 
         GraphPath path = tree.getPath(from);
@@ -221,7 +221,7 @@ public class AStarTest {
         targets.add(graph.getVertex("leary_20th"));
 
         SearchTerminationStrategy strategy = new MultiTargetTerminationStrategy(targets);
-        ShortestPathTree tree = new AStar().getShortestPathTree(options, -1, strategy);
+        ShortestPathTree tree = AStar.oneToOne().getShortestPathTree(options, -1, strategy);
 
         for (Vertex v : targets) {
             GraphPath path = tree.getPath(v);

--- a/src/test/java/org/opentripplanner/routing/algorithm/BikeRentalTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/BikeRentalTest.java
@@ -542,7 +542,7 @@ public class BikeRentalTest extends GraphRoutingTest {
         var bikeRentalOptions = options.getStreetSearchRequest(streetMode);
         bikeRentalOptions.setRoutingContext(graph, fromVertex, toVertex);
 
-        var tree = new AStar().getShortestPathTree(bikeRentalOptions);
+        var tree = AStar.oneToOne().getShortestPathTree(bikeRentalOptions);
         var path = tree.getPath(
                 arriveBy ? fromVertex : toVertex
         );

--- a/src/test/java/org/opentripplanner/routing/algorithm/BikeWalkingTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/BikeWalkingTest.java
@@ -350,7 +350,7 @@ public class BikeWalkingTest extends GraphRoutingTest {
         var bikeOptions = options.getStreetSearchRequest(streetMode);
         bikeOptions.setRoutingContext(graph, fromVertex, toVertex);
 
-        var tree = new AStar().getShortestPathTree(bikeOptions);
+        var tree = AStar.oneToOne().getShortestPathTree(bikeOptions);
         var path = tree.getPath(
                 arriveBy ? fromVertex : toVertex
         );

--- a/src/test/java/org/opentripplanner/routing/algorithm/CarPickupTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/CarPickupTest.java
@@ -178,7 +178,7 @@ public class CarPickupTest extends GraphRoutingTest {
 
         var carPickupOptions = options.getStreetSearchRequest(StreetMode.CAR_PICKUP);
         carPickupOptions.setRoutingContext(graph, fromVertex, toVertex);
-        var tree = new AStar().getShortestPathTree(carPickupOptions);
+        var tree = AStar.oneToOne().getShortestPathTree(carPickupOptions);
         var path = tree.getPath(
                 arriveBy ? fromVertex : toVertex
         );

--- a/src/test/java/org/opentripplanner/routing/algorithm/GraphRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/GraphRoutingTest.java
@@ -409,7 +409,7 @@ public abstract class GraphRoutingTest {
         request.setRoutingContext(graph, from, to);
         request.parkAndRide = true;
 
-        AStar aStar = new AStar();
+        AStar aStar = AStar.oneToOne();
         ShortestPathTree tree = aStar.getShortestPathTree(request);
         return tree.getPath(to);
     }

--- a/src/test/java/org/opentripplanner/routing/algorithm/ParkAndRideTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/ParkAndRideTest.java
@@ -113,7 +113,7 @@ public abstract class ParkAndRideTest extends GraphRoutingTest {
         options.arriveBy = arriveBy;
         options.setRoutingContext(graph, fromVertex, toVertex);
 
-        var tree = new AStar().getShortestPathTree(options);
+        var tree = AStar.oneToOne().getShortestPathTree(options);
         var path = tree.getPath(
                 arriveBy ? fromVertex : toVertex
         );

--- a/src/test/java/org/opentripplanner/routing/algorithm/TestAStar.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/TestAStar.java
@@ -24,7 +24,7 @@ import static org.opentripplanner.gtfs.GtfsContextBuilder.contextBuilder;
 @Ignore
 public class TestAStar extends TestCase {
     
-    private final AStar aStar = new AStar();
+    private final AStar aStar = AStar.oneToOne();
 
     public void testBasic() throws Exception {
 

--- a/src/test/java/org/opentripplanner/routing/algorithm/TestGraphPath.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/TestGraphPath.java
@@ -29,7 +29,7 @@ public class TestGraphPath extends TestCase {
     
     private Graph graph;
 
-    private final AStar aStar = new AStar();
+    private final AStar aStar = AStar.oneToOne();
 
     public void setUp() throws Exception {
         GtfsContext context = contextBuilder(ConstantsForTests.FAKE_GTFS).build();

--- a/src/test/java/org/opentripplanner/routing/algorithm/TurnCostTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/TurnCostTest.java
@@ -102,7 +102,7 @@ public class TurnCostTest {
     }
     
     private GraphPath checkForwardRouteDuration(RoutingRequest options, int expectedDuration) {
-        ShortestPathTree tree = new AStar().getShortestPathTree(options);
+        ShortestPathTree tree = AStar.oneToOne().getShortestPathTree(options);
         GraphPath path = tree.getPath(bottomLeft);
         assertNotNull(path);
         

--- a/src/test/java/org/opentripplanner/routing/algorithm/TurnRestrictionTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/TurnRestrictionTest.java
@@ -101,7 +101,7 @@ public class TurnRestrictionTest {
         options.walkSpeed = 1.0;
 
         options.setRoutingContext(graph, topRight, bottomLeft);
-        ShortestPathTree tree = new AStar().getShortestPathTree(options);
+        ShortestPathTree tree = AStar.oneToOne().getShortestPathTree(options);
 
         GraphPath path = tree.getPath(bottomLeft);
         assertNotNull(path);
@@ -126,7 +126,7 @@ public class TurnRestrictionTest {
         options.walkSpeed = 1.0;
         
         options.setRoutingContext(graph, topRight, bottomLeft);
-        ShortestPathTree tree = new AStar().getShortestPathTree(options);
+        ShortestPathTree tree = AStar.oneToOne().getShortestPathTree(options);
 
         GraphPath path = tree.getPath(bottomLeft);
         assertNotNull(path);
@@ -151,7 +151,7 @@ public class TurnRestrictionTest {
         options.carSpeed = 1.0;
 
         options.setRoutingContext(graph, topRight, bottomLeft);
-        ShortestPathTree tree = new AStar().getShortestPathTree(options);
+        ShortestPathTree tree = AStar.oneToOne().getShortestPathTree(options);
 
         GraphPath path = tree.getPath(bottomLeft);
         assertNotNull(path);

--- a/src/test/java/org/opentripplanner/routing/edgetype/loader/TestGeometryAndBlockProcessor.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/loader/TestGeometryAndBlockProcessor.java
@@ -46,7 +46,7 @@ import static org.opentripplanner.gtfs.GtfsContextBuilder.contextBuilder;
 public class TestGeometryAndBlockProcessor extends TestCase {
 
     private Graph graph;
-    private final AStar aStar = new AStar();
+    private final AStar aStar = AStar.oneToOne();
     private GtfsContext context;
     private String feedId;
     private DataImportIssueStore issueStore;

--- a/src/test/java/org/opentripplanner/routing/edgetype/loader/TestHopFactory.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/loader/TestHopFactory.java
@@ -30,7 +30,7 @@ import static org.opentripplanner.gtfs.GtfsContextBuilder.contextBuilder;
 public class TestHopFactory extends TestCase {
     private final ZoneId zoneId = ZoneId.of("America/New_York");
 
-    private final AStar aStar = new AStar();
+    private final AStar aStar = AStar.oneToOne();
 
     private Graph graph;
 

--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTestRequest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTestRequest.java
@@ -6,6 +6,7 @@ import static org.opentripplanner.transit.raptor.api.request.RaptorProfile.MIN_T
 
 import gnu.trove.iterator.TIntIntIterator;
 import gnu.trove.map.TIntIntMap;
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZoneId;
@@ -80,8 +81,8 @@ public class SpeedTestRequest {
         return config.walkSpeedMeterPrSecond;
     }
 
-    public double getAccessEgressMaxWalkDurationSeconds() {
-        return config.maxWalkDurationSeconds;
+    public Duration getAccessEgressMaxWalkDuration() {
+        return Duration.ofSeconds(config.maxWalkDurationSeconds);
     }
 
 

--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/transit/EgressAccessRouter.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/transit/EgressAccessRouter.java
@@ -31,7 +31,7 @@ public class EgressAccessRouter {
         routeTimer.record(() -> {
             // Search for access to / egress from transit on streets.
             NearbyStopFinder nearbyStopFinder = new NearbyStopFinder(
-                    graph, request.getAccessEgressMaxWalkDurationSeconds(), true
+                    graph, request.getAccessEgressMaxWalkDuration(), true
             );
             accessSearch = new StreetSearch(transitLayer, graph, linker, nearbyStopFinder);
             egressSearch = new StreetSearch(transitLayer, graph, linker, nearbyStopFinder);


### PR DESCRIPTION
### Summary
Removes the parameters `oneToMany` and `disableRemainingWeightHeuristics` from the RoutingRequest and moves them into the constructor of the AStar class. This resolves the long standing Javadoc comment about those fields.

Instead of the routing request configuring the AStar you now have to explicitly decide which usecase you have when instantiating/

### Issue
none

### Unit tests
existing tests adjusted

### Code style
yes

### Documentation
none

### Changelog
yes
