### PR TITLE
Sandbox vector tiles stop name translation fix [changelog skip]

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/vectortiles/StopsLayerTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/vectortiles/StopsLayerTest.java
@@ -1,16 +1,12 @@
 package org.opentripplanner.ext.vectortiles;
 
-import ch.poole.openinghoursparser.OpeningHoursParseException;
 import org.junit.Before;
 import org.junit.Test;
 import org.opentripplanner.ext.vectortiles.layers.stops.DigitransitStopPropertyMapper;
-import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.model.Stop;
-import org.opentripplanner.model.WgsCoordinate;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.GraphIndex;
 import org.opentripplanner.routing.vertextype.TransitStopVertex;
-import org.opentripplanner.util.NonLocalizedString;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -22,39 +18,22 @@ public class StopsLayerTest {
     private Stop stop;
 
     @Before
-    public void setUp() throws OpeningHoursParseException {
-        stop =  new Stop(
-                new FeedScopedId("F", "id"),
-                new NonLocalizedString("name"),
-                "code",
-                "desc",
-                new WgsCoordinate(50, 10),
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-        );
+    public void setUp() {
+        stop = Stop.stopForTest("name", "desc", 50, 10);
     }
 
     @Test
     public void digitransitVehicleParkingPropertyMapperTest() {
         Graph graph = mock(Graph.class);
-        graph.index=mock(GraphIndex.class);
+        graph.index = mock(GraphIndex.class);
 
         DigitransitStopPropertyMapper mapper = DigitransitStopPropertyMapper.create(graph);
         Map<String, Object> map = new HashMap<>();
-        mapper.map(new TransitStopVertex(graph, stop, null)).forEach(o -> map.put(o.first, o.second));
+        mapper.map(new TransitStopVertex(graph, stop, null))
+                .forEach(o -> map.put(o.first, o.second));
 
-        assertEquals("F:id", map.get("gtfsId"));
+        assertEquals("F:name", map.get("gtfsId"));
         assertEquals("name", map.get("name"));
         assertEquals("desc", map.get("desc"));
-
-
-
-
     }
 }

--- a/src/ext-test/java/org/opentripplanner/ext/vectortiles/StopsLayerTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/vectortiles/StopsLayerTest.java
@@ -1,0 +1,60 @@
+package org.opentripplanner.ext.vectortiles;
+
+import ch.poole.openinghoursparser.OpeningHoursParseException;
+import org.junit.Before;
+import org.junit.Test;
+import org.opentripplanner.ext.vectortiles.layers.stops.DigitransitStopPropertyMapper;
+import org.opentripplanner.model.FeedScopedId;
+import org.opentripplanner.model.Stop;
+import org.opentripplanner.model.WgsCoordinate;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.routing.graph.GraphIndex;
+import org.opentripplanner.routing.vertextype.TransitStopVertex;
+import org.opentripplanner.util.NonLocalizedString;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+public class StopsLayerTest {
+
+    private Stop stop;
+
+    @Before
+    public void setUp() throws OpeningHoursParseException {
+        stop =  new Stop(
+                new FeedScopedId("F", "id"),
+                new NonLocalizedString("name"),
+                "code",
+                "desc",
+                new WgsCoordinate(50, 10),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+    }
+
+    @Test
+    public void digitransitVehicleParkingPropertyMapperTest() {
+        Graph graph = mock(Graph.class);
+        graph.index=mock(GraphIndex.class);
+
+        DigitransitStopPropertyMapper mapper = DigitransitStopPropertyMapper.create(graph);
+        Map<String, Object> map = new HashMap<>();
+        mapper.map(new TransitStopVertex(graph, stop, null)).forEach(o -> map.put(o.first, o.second));
+
+        assertEquals("F:id", map.get("gtfsId"));
+        assertEquals("name", map.get("name"));
+        assertEquals("desc", map.get("desc"));
+
+
+
+
+    }
+}

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stations/DigitransitStationPropertyMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stations/DigitransitStationPropertyMapper.java
@@ -28,7 +28,8 @@ public class DigitransitStationPropertyMapper extends PropertyMapper<Station> {
 
     return List.of(
       new T2<>("gtfsId", station.getId().toString()),
-      new T2<>("name", station.getName()),
+      // Name is I18NString now, we return default name
+      new T2<>("name", station.getName().toString()),
       new T2<>("type", childStops
         .stream()
         .flatMap(stop -> graph.index.getPatternsForStop(stop).stream())

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/DigitransitStopPropertyMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/DigitransitStopPropertyMapper.java
@@ -52,7 +52,8 @@ public class DigitransitStopPropertyMapper extends PropertyMapper<TransitStopVer
 
     return List.of(
       new T2<>("gtfsId", stop.getId().toString()),
-      new T2<>("name", stop.getName()),
+      // Name is I18NString now, we return default name
+      new T2<>("name", stop.getName().toString()),
       new T2<>("code", stop.getCode()),
       new T2<>("platform", stop.getPlatformCode()),
       new T2<>("desc", stop.getDescription()),

--- a/src/main/java/org/opentripplanner/model/Stop.java
+++ b/src/main/java/org/opentripplanner/model/Stop.java
@@ -70,19 +70,38 @@ public final class Stop extends StationElement implements StopLocation {
 
   /** @see #stopForTest(String, double, double, Station) */
   public static Stop stopForTest(String idAndName, double lat, double lon) {
-    return stopForTest(idAndName, lat, lon, null);
+    return stopForTest(idAndName, null, lat, lon, null);
   }
 
-    /**
-     * Create a minimal Stop object for unit-test use, where the test only care about id, name and
-     * coordinate. The feedId is static set to "F"
-     */
+  /** @see #stopForTest(String, double, double, Station) */
+  public static Stop stopForTest(String idAndName, String desc, double lat, double lon) {
+    return stopForTest(idAndName, desc, lat, lon, null);
+  }
+
+  /**
+   * Create a minimal Stop object for unit-test use, where the test only care about id, name and
+   * coordinate. The feedId is static set to "F"
+   */
   public static Stop stopForTest(String idAndName, double lat, double lon, Station parent) {
+    return stopForTest(idAndName, null, lat, lon, parent);
+  }
+
+  /**
+   * Create a minimal Stop object for unit-test use, where the test only care about id, name,
+   * description and coordinate. The feedId is static set to "F"
+   */
+  public static Stop stopForTest(
+          String idAndName,
+          String desc,
+          double lat,
+          double lon,
+          Station parent
+  ) {
     var stop = new Stop(
         new FeedScopedId("F", idAndName),
         new NonLocalizedString(idAndName),
         idAndName,
-        null,
+        desc,
         new WgsCoordinate(lat, lon),
         null,
         null,


### PR DESCRIPTION
### Summary
Fixes a translation issue in vector tiles sandbox stops layer.

### Issue
Minor sandbox problem so don't need an issue

### Unit tests
Added

### Code style
Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Codestyle.md)?
Yes

### Documentation
Not needed

### Changelog
Not needed
