### PR TITLE
Consider Wheelchair boarding/alightning when routing from or to directly to a stop

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -548,6 +548,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
             <version>${junit.version}</version>

--- a/src/main/java/org/opentripplanner/model/Stop.java
+++ b/src/main/java/org/opentripplanner/model/Stop.java
@@ -68,12 +68,25 @@ public final class Stop extends StationElement implements StopLocation {
     this.netexSubmode = netexSubmode;
   }
 
-  /** @see #stopForTest(String, double, double, Station) */
+  public static Stop stopForTest(
+    String idAndName,
+    WheelChairBoarding wheelChairBoarding,
+    double lat,
+    double lon
+  ) {
+    return stopForTest(idAndName, null, lat, lon, null, wheelChairBoarding);
+  }
+
+  /**
+   * @see #stopForTest(String, double, double, Station)
+   */
   public static Stop stopForTest(String idAndName, double lat, double lon) {
     return stopForTest(idAndName, null, lat, lon, null);
   }
 
-  /** @see #stopForTest(String, double, double, Station) */
+  /**
+   * @see #stopForTest(String, double, double, Station)
+   */
   public static Stop stopForTest(String idAndName, String desc, double lat, double lon) {
     return stopForTest(idAndName, desc, lat, lon, null);
   }
@@ -86,6 +99,16 @@ public final class Stop extends StationElement implements StopLocation {
     return stopForTest(idAndName, null, lat, lon, parent);
   }
 
+  public static Stop stopForTest(
+    String idAndName,
+    String desc,
+    double lat,
+    double lon,
+    Station parent
+  ) {
+    return stopForTest(idAndName, desc, lat, lon, parent, null);
+  }
+
   /**
    * Create a minimal Stop object for unit-test use, where the test only care about id, name,
    * description and coordinate. The feedId is static set to "F"
@@ -95,7 +118,8 @@ public final class Stop extends StationElement implements StopLocation {
     String desc,
     double lat,
     double lon,
-    Station parent
+    Station parent,
+    WheelChairBoarding wheelChairBoarding
   ) {
     var stop = new Stop(
       new FeedScopedId("F", idAndName),
@@ -103,7 +127,7 @@ public final class Stop extends StationElement implements StopLocation {
       idAndName,
       desc,
       new WgsCoordinate(lat, lon),
-      null,
+      wheelChairBoarding,
       null,
       null,
       null,

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TripPatternWithRaptorStopIndexes.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TripPatternWithRaptorStopIndexes.java
@@ -15,10 +15,9 @@ public class TripPatternWithRaptorStopIndexes {
 
   private final TripPattern pattern;
   private final int[] stopIndexes;
-
   private final BitSet boardingPossible;
-
   private final BitSet alightingPossible;
+  private final BitSet wheelchairAccessible;
 
   /**
    * List of transfers TO this pattern for each stop position in pattern used by Raptor during the
@@ -46,10 +45,12 @@ public class TripPatternWithRaptorStopIndexes {
     final int nStops = stopIndexes.length;
     boardingPossible = new BitSet(nStops);
     alightingPossible = new BitSet(nStops);
+    wheelchairAccessible = new BitSet(nStops);
 
     for (int s = 0; s < nStops; s++) {
       boardingPossible.set(s, pattern.canBoard(s));
       alightingPossible.set(s, pattern.canAlight(s));
+      wheelchairAccessible.set(s, pattern.wheelchairAccessible(s));
     }
   }
 
@@ -71,6 +72,18 @@ public class TripPatternWithRaptorStopIndexes {
 
   public final TripPattern getPattern() {
     return this.pattern;
+  }
+
+  public BitSet getBoardingPossible() {
+    return boardingPossible;
+  }
+
+  public BitSet getAlightingPossible() {
+    return alightingPossible;
+  }
+
+  public BitSet getWheelchairAccessible() {
+    return wheelchairAccessible;
   }
 
   /**

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RaptorRoutingRequestTransitDataCreator.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RaptorRoutingRequestTransitDataCreator.java
@@ -71,7 +71,8 @@ class RaptorRoutingRequestTransitDataCreator {
    */
   static List<TripPatternForDates> merge(
     ZonedDateTime transitSearchTimeZero,
-    List<TripPatternForDate> patternForDateList
+    List<TripPatternForDate> patternForDateList,
+    TransitDataProviderFilter filter
   ) {
     // Group TripPatternForDate objects by TripPattern.
     // This is done in a loop to increase performance.
@@ -100,7 +101,17 @@ class RaptorRoutingRequestTransitDataCreator {
       }
 
       // Combine TripPatternForDate objects
-      combinedList.add(new TripPatternForDates(patternEntry.getKey(), patternsSorted, offsets));
+      final TripPatternWithRaptorStopIndexes tripPattern = patternEntry.getKey();
+
+      combinedList.add(
+        new TripPatternForDates(
+          tripPattern,
+          patternsSorted,
+          offsets,
+          filter.filterAvailableStops(tripPattern, tripPattern.getBoardingPossible()),
+          filter.filterAvailableStops(tripPattern, tripPattern.getAlightingPossible())
+        )
+      );
     }
 
     return combinedList;
@@ -117,7 +128,7 @@ class RaptorRoutingRequestTransitDataCreator {
       filter
     );
 
-    return merge(transitSearchTimeZero, tripPatternForDates);
+    return merge(transitSearchTimeZero, tripPatternForDates, filter);
   }
 
   private static List<TripPatternForDate> filterActiveTripPatterns(

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RoutingRequestTransitDataProviderFilter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RoutingRequestTransitDataProviderFilter.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.routing.algorithm.raptoradapter.transit.request;
 
+import java.util.BitSet;
 import java.util.EnumSet;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -11,6 +12,7 @@ import org.opentripplanner.model.Trip;
 import org.opentripplanner.model.WheelChairBoarding;
 import org.opentripplanner.model.modes.AllowedTransitMode;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripPatternForDate;
+import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripPatternWithRaptorStopIndexes;
 import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.routing.graph.GraphIndex;
@@ -116,6 +118,23 @@ public class RoutingRequestTransitDataProviderFilter implements TransitDataProvi
     }
 
     return true;
+  }
+
+  @Override
+  public BitSet filterAvailableStops(
+    TripPatternWithRaptorStopIndexes tripPattern,
+    BitSet boardingPossible
+  ) {
+    // Currently the function only checks wheelchair accessibility if requested, if not just return default (input) values
+    if (!requireWheelchairAccessible) {
+      return boardingPossible;
+    }
+
+    var copy = (BitSet) boardingPossible.clone();
+    // Use the and bitwise operator to add false flag to all stops that are not accessible by wheelchair
+    copy.and(tripPattern.getWheelchairAccessible());
+
+    return copy;
   }
 
   private boolean routeIsNotBanned(TripPatternForDate tripPatternForDate) {

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TransitDataProviderFilter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TransitDataProviderFilter.java
@@ -1,6 +1,8 @@
 package org.opentripplanner.routing.algorithm.raptoradapter.transit.request;
 
+import java.util.BitSet;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripPatternForDate;
+import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripPatternWithRaptorStopIndexes;
 import org.opentripplanner.routing.trippattern.TripTimes;
 
 /**
@@ -17,4 +19,18 @@ public interface TransitDataProviderFilter {
   boolean tripPatternPredicate(TripPatternForDate tripPatternForDate);
 
   boolean tripTimesPredicate(TripTimes tripTimes);
+
+  /**
+   * Check if boarding/alighting is possible at each stop. If the values differ from the default
+   * input values, create a clone of the bitset and subtract the unavailable stops.
+   *
+   * @param tripPattern      Trip pattern that should contain boarding/alighting information, e.g.
+   *                         wheelchair accessibility for each stop.
+   * @param boardingPossible Initial information regarding boarding/alighting possible
+   * @return Information if stops are available for boarding or alighting
+   */
+  BitSet filterAvailableStops(
+    TripPatternWithRaptorStopIndexes tripPattern,
+    BitSet boardingPossible
+  );
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripPatternForDates.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripPatternForDates.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.routing.algorithm.raptoradapter.transit.request;
 
+import java.util.BitSet;
 import java.util.List;
 import java.util.function.IntUnaryOperator;
 import org.opentripplanner.model.base.ToStringBuilder;
@@ -46,15 +47,22 @@ public class TripPatternForDates
    * arrivalTimes.
    */
   private final int[] departureTimes;
+  // bit arrays with boarding/alighting information for all stops on trip pattern
+  private final BitSet boardingPossible;
+  private final BitSet alightingPossible;
 
   TripPatternForDates(
     TripPatternWithRaptorStopIndexes tripPattern,
     List<TripPatternForDate> tripPatternForDates,
-    List<Integer> offsets
+    List<Integer> offsets,
+    BitSet boardingPossible,
+    BitSet alightningPossible
   ) {
     this.tripPattern = tripPattern;
     this.tripPatternForDates = tripPatternForDates.toArray(new TripPatternForDate[] {});
     this.offsets = offsets.stream().mapToInt(i -> i).toArray();
+    this.boardingPossible = boardingPossible;
+    this.alightingPossible = alightningPossible;
 
     int numberOfTripSchedules = 0;
     boolean hasFrequencies = false;
@@ -138,12 +146,12 @@ public class TripPatternForDates
 
   @Override
   public boolean boardingPossibleAt(int stopPositionInPattern) {
-    return tripPattern.boardingPossibleAt(stopPositionInPattern);
+    return boardingPossible.get(stopPositionInPattern);
   }
 
   @Override
   public boolean alightingPossibleAt(int stopPositionInPattern) {
-    return tripPattern.alightingPossibleAt(stopPositionInPattern);
+    return alightingPossible.get(stopPositionInPattern);
   }
 
   @Override

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TestRouteData.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TestRouteData.java
@@ -70,7 +70,9 @@ public class TestRouteData {
     var patternForDates = new TripPatternForDates(
       raptorTripPattern,
       listOfTripPatternForDates,
-      List.of(OFFSET)
+      List.of(OFFSET),
+      null,
+      null
     );
     int id = 0;
     for (Trip trip : trips) {

--- a/src/test/resources/mmri/2b/stops.txt
+++ b/src/test/resources/mmri/2b/stops.txt
@@ -1,3 +1,3 @@
-stop_id,stop_name,stop_lat,stop_lon
-2b1,Stop 2b1,2.201,2.2
-2b2,Stop 2b2,2.202,2.2
+stop_id,stop_name,stop_lat,stop_lon,wheelchair_boarding
+2b1,Stop 2b1,2.201,2.2,1
+2b2,Stop 2b2,2.202,2.2,1


### PR DESCRIPTION
	- If requested wheelchair trip, check on boarding/alightning if possible on stop
	- Unit test Raptor wheelchair accessibility

# Summary
If a trip search is done from a StopPoint to another and in GraphQl the parameter wheelhairAccessible is true then we find trips that should not be found because the stop is not considered accessible for wheelchair.

# Issue
closes #4044 

# Unit tests
Unit test in Raptor module, new class following instructions in markup document. Test going between stops where one stop has no access for wheelchair.
