### PR TITLE
Always parse Netex flexible lines

### DIFF
--- a/src/main/java/org/opentripplanner/netex/loader/parser/ServiceFrameParser.java
+++ b/src/main/java/org/opentripplanner/netex/loader/parser/ServiceFrameParser.java
@@ -244,9 +244,7 @@ class ServiceFrameParser extends NetexParser<Service_VersionFrameStructure> {
             if (element.getValue() instanceof Line) {
                 this.lines.add((Line) element.getValue());
             } else if (element.getValue() instanceof FlexibleLine) {
-                if(OTPFeature.FlexRouting.isOn()) {
-                    this.flexibleLines.add((FlexibleLine) element.getValue());
-                }
+                this.flexibleLines.add((FlexibleLine) element.getValue());
             }
             else {
                 warnOnMissingMapping(LOG, element.getValue());


### PR DESCRIPTION
### Summary
Previously, we parsed flexible lines to routes, only when the `FlexRouting` feature was turned on. However, these routes may include scheduled trips, which should be included. The actual creation of flexible trips is still guarded in [NetexModule](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/src/main/java/org/opentripplanner/netex/NetexModule.java#L88-L92), so no additional flexible trips are generated, when the feature is off.

### Changelog
The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md)
is generated from the pull-request title, make sure the title describe the feature or issue fixed.
To exclude the PR from the changelog add `[changelog skip]` in the title.
