### PR TITLE
Use array for iterating over transfers in raptor for better performance [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/RaptorTransferIndex.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/RaptorTransferIndex.java
@@ -23,11 +23,11 @@ public class RaptorTransferIndex {
         // Create arrays of the lists for each stop to make them faster to iterate
         this.forwardTransfers = forwardTransfers.stream()
                 .map(l -> l.toArray(new RaptorTransfer[0]))
-                .collect(Collectors.toList());
+                .toList();
 
         this.reversedTransfers = reversedTransfers.stream()
                 .map(l -> l.toArray(new RaptorTransfer[0]))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public List<RaptorTransfer[]> getForwardTransfers() {

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/RaptorTransferIndex.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/RaptorTransferIndex.java
@@ -12,29 +12,29 @@ import org.opentripplanner.transit.raptor.util.ReversedRaptorTransfer;
 
 public class RaptorTransferIndex {
 
-    private final List<List<RaptorTransfer>> forwardTransfers;
+    private final List<RaptorTransfer[]> forwardTransfers;
 
-    private final List<List<RaptorTransfer>> reversedTransfers;
+    private final List<RaptorTransfer[]> reversedTransfers;
 
     public RaptorTransferIndex(
             List<List<RaptorTransfer>> forwardTransfers,
             List<List<RaptorTransfer>> reversedTransfers
     ) {
-        // Create immutable copies of the lists for each stop to make them immutable and faster to iterate
+        // Create arrays of the lists for each stop to make them faster to iterate
         this.forwardTransfers = forwardTransfers.stream()
-                .map(List::copyOf)
+                .map(l -> l.toArray(new RaptorTransfer[0]))
                 .collect(Collectors.toList());
 
         this.reversedTransfers = reversedTransfers.stream()
-                .map(List::copyOf)
+                .map(l -> l.toArray(new RaptorTransfer[0]))
                 .collect(Collectors.toList());
     }
 
-    public List<List<RaptorTransfer>> getForwardTransfers() {
+    public List<RaptorTransfer[]> getForwardTransfers() {
         return forwardTransfers;
     }
 
-    public List<List<RaptorTransfer>> getReversedTransfers() {
+    public List<RaptorTransfer[]> getReversedTransfers() {
         return reversedTransfers;
     }
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RaptorRoutingRequestTransitData.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RaptorRoutingRequestTransitData.java
@@ -102,13 +102,13 @@ public class RaptorRoutingRequestTransitData implements RaptorTransitDataProvide
   }
 
   @Override
-  public Iterator<RaptorTransfer> getTransfersFromStop(int stopIndex) {
-    return transfers.getForwardTransfers().get(stopIndex).iterator();
+  public RaptorTransfer[] getTransfersFromStop(int stopIndex) {
+    return transfers.getForwardTransfers().get(stopIndex);
   }
 
   @Override
-  public Iterator<? extends RaptorTransfer> getTransfersToStop(int stopIndex) {
-    return transfers.getReversedTransfers().get(stopIndex).iterator();
+  public RaptorTransfer[] getTransfersToStop(int stopIndex) {
+    return transfers.getReversedTransfers().get(stopIndex);
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/services/TransferGenerator.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/services/TransferGenerator.java
@@ -152,10 +152,7 @@ public class TransferGenerator<T extends RaptorTripSchedule> {
 
   private Collection<? extends TripToTripTransfer<T>> findStandardTransfers(TripStopTime<T> from) {
     final List<TripToTripTransfer<T>> result = new ArrayList<>();
-    Iterator<? extends RaptorTransfer> transfers = stdTransfers.getTransfersFromStop(from.stop());
-
-    while (transfers.hasNext()) {
-      var it = transfers.next();
+    for (var it : stdTransfers.getTransfersFromStop(from.stop())) {
       int toStop = it.stop();
 
       ConstrainedTransfer tx = transferServiceAdaptor.findTransfer(from, toTrip, toStop);

--- a/src/main/java/org/opentripplanner/transit/raptor/api/transit/RaptorTransitDataProvider.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/transit/RaptorTransitDataProvider.java
@@ -26,41 +26,17 @@ public interface RaptorTransitDataProvider<T extends RaptorTripSchedule> {
     /**
      * This method is responsible for providing all transfers from a given stop to all
      * possible stops around that stop.
-     * <p/>
-     * The implementation may implement a lightweight {@link RaptorTransfer} representation.
-     * The iterator element only needs to be valid for the duration og a single iterator step.
-     * Hence; It is safe to use a cursor/flyweight pattern to represent both the Transfer
-     * and the Iterator<Transfer> - this will most likely be the best performing implementation.
-     * <p/>
-     * Example:
-     * <pre>
-     *class LightweightTransferIterator implements Iterator&lt;RaptorTransfer&gt;, RaptorTransfer {
-     *     private static final int[] EMPTY_ARRAY = new int[0];
-     *     private final int[] a;
-     *     private int index;
-     *
-     *     LightweightTransferIterator(int[] a) {
-     *         this.a = a == null ? EMPTY_ARRAY : a;
-     *         this.index = this.a.length == 0 ? 0 : -2;
-     *     }
-     *
-     *     public int stop()              { return a[index]; }
-     *     public int durationInSeconds() { return a[index+1]; }
-     *     public boolean hasNext()       { index += 2; return index < a.length; }
-     *     public RaptorTransfer next()   { return this; }
-     * }
-     * </pre>
-     * @return a map of distances from the given input stop to all other stops.
+     * @return an array of {@link RaptorTransfer} from the given input stop to all other stops.
      */
-    Iterator<? extends RaptorTransfer> getTransfersFromStop(int fromStop);
+    RaptorTransfer[] getTransfersFromStop(int fromStop);
 
     /**
      * This method is responsible for providing all transfers to a given stop from all
      * possible stops around that stop.
      * See {@link #getTransfersFromStop(int)} for detail on how to implement this.
-     * @return a map of distances to the given input stop from all other stops.
+     * @return an array of {@link RaptorTransfer} to the given input stop from all other stops.
      */
-    Iterator<? extends RaptorTransfer> getTransfersToStop(int toStop);
+    RaptorTransfer[] getTransfersToStop(int toStop);
 
     /**
      * Return an iterator of route indices for all routes visiting the given set of stops.

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/WorkerState.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/WorkerState.java
@@ -48,7 +48,7 @@ public interface WorkerState<T extends RaptorTripSchedule> {
     /**
      *  Update state with a new transfer.
      */
-    void transferToStops(int fromStop, Iterator<? extends RaptorTransfer> transfers);
+    void transferToStops(int fromStop, RaptorTransfer[] transfers);
 
     /**
      * Extract paths after the search is complete. This method is optional,

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/McRangeRaptorWorkerState.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/McRangeRaptorWorkerState.java
@@ -95,11 +95,11 @@ final public class McRangeRaptorWorkerState<T extends RaptorTripSchedule> implem
      * Set the time at a transit stops iff it is optimal.
      */
     @Override
-    public void transferToStops(int fromStop, Iterator<? extends RaptorTransfer> transfers) {
+    public void transferToStops(int fromStop, RaptorTransfer[] transfers) {
         Iterable<? extends AbstractStopArrival<T>> fromArrivals = arrivals.listArrivalsAfterMarker(fromStop);
 
-        while (transfers.hasNext()) {
-            transferToStop(fromArrivals, transfers.next());
+        for (var transfer : transfers) {
+            transferToStop(fromArrivals, transfer);
         }
     }
 

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/StdRangeRaptorWorkerState.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/StdRangeRaptorWorkerState.java
@@ -162,10 +162,10 @@ public final class StdRangeRaptorWorkerState<T extends RaptorTripSchedule>
      * Set the arrival time at all transit stop if time is optimal for the given list of transfers.
      */
     @Override
-    public void transferToStops(int fromStop, Iterator<? extends RaptorTransfer> transfers) {
+    public void transferToStops(int fromStop, RaptorTransfer[] transfers) {
         int arrivalTimeTransit = bestTimes.onBoardTime(fromStop);
-        while (transfers.hasNext()) {
-            transferToStop(arrivalTimeTransit, fromStop, transfers.next());
+        for (var transfer: transfers) {
+            transferToStop(arrivalTimeTransit, fromStop, transfer);
         }
     }
 

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/transit/ForwardTransitCalculator.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/transit/ForwardTransitCalculator.java
@@ -109,7 +109,7 @@ final class ForwardTransitCalculator<T extends RaptorTripSchedule>
     }
 
     @Override
-    public Iterator<? extends RaptorTransfer> getTransfers(RaptorTransitDataProvider<T> transitDataProvider, int fromStop) {
+    public RaptorTransfer[] getTransfers(RaptorTransitDataProvider<T> transitDataProvider, int fromStop) {
         return transitDataProvider.getTransfersFromStop(fromStop);
     }
 

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/transit/ReverseTransitCalculator.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/transit/ReverseTransitCalculator.java
@@ -115,7 +115,7 @@ final class ReverseTransitCalculator<T extends RaptorTripSchedule>
     }
 
     @Override
-    public Iterator<? extends RaptorTransfer> getTransfers(RaptorTransitDataProvider<T> transitDataProvider, int fromStop) {
+    public RaptorTransfer[] getTransfers(RaptorTransitDataProvider<T> transitDataProvider, int fromStop) {
         return transitDataProvider.getTransfersToStop(fromStop);
     }
 

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/transit/TransitCalculator.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/transit/TransitCalculator.java
@@ -164,10 +164,10 @@ public interface TransitCalculator<T extends RaptorTripSchedule> extends TimeCal
     boolean alightingPossibleAt(RaptorTripPattern pattern, int stopPos);
 
     /**
-     * Returns an iterator over all transfers "from" (or "to" for reverse searches) a stopIndex.
+     * Returns an array of all transfers "from" (or "to" for reverse searches) a stopIndex.
      *
      * @see RaptorTransitDataProvider#getTransfersFromStop(int)
      * @see RaptorTransitDataProvider#getTransfersToStop(int)
      */
-    Iterator<? extends RaptorTransfer> getTransfers(RaptorTransitDataProvider<T> transitDataProvider, int fromStop);
+    RaptorTransfer[] getTransfers(RaptorTransitDataProvider<T> transitDataProvider, int fromStop);
 }

--- a/src/main/java/org/opentripplanner/transit/raptor/util/ReversedRaptorTransfer.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/util/ReversedRaptorTransfer.java
@@ -2,20 +2,7 @@ package org.opentripplanner.transit.raptor.util;
 
 import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
 
-public class ReversedRaptorTransfer implements RaptorTransfer {
-
-    private final int stopIndex;
-    private final RaptorTransfer transfer;
-
-    public ReversedRaptorTransfer(int fromStopIndex, RaptorTransfer transfer) {
-        this.stopIndex = fromStopIndex;
-        this.transfer = transfer;
-    }
-
-    @Override
-    public int stop() {
-        return stopIndex;
-    }
+public record ReversedRaptorTransfer(int stop, RaptorTransfer transfer) implements RaptorTransfer {
 
     @Override
     public int generalizedCost() {

--- a/src/test/java/org/opentripplanner/transit/raptor/_data/transit/TestTransitData.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/_data/transit/TestTransitData.java
@@ -48,13 +48,13 @@ public class TestTransitData implements RaptorTransitDataProvider<TestTripSchedu
   private final McCostParamsBuilder costParamsBuilder = new McCostParamsBuilder();
 
   @Override
-  public Iterator<? extends RaptorTransfer> getTransfersFromStop(int fromStop) {
-    return transfersFromStop.get(fromStop).iterator();
+  public RaptorTransfer[] getTransfersFromStop(int fromStop) {
+    return transfersFromStop.get(fromStop).toArray(new RaptorTransfer[0]);
   }
 
   @Override
-  public Iterator<? extends RaptorTransfer> getTransfersToStop(int toStop) {
-    return transfersToStop.get(toStop).iterator();
+  public RaptorTransfer[] getTransfersToStop(int toStop) {
+    return transfersToStop.get(toStop).toArray(new RaptorTransfer[0]);
   }
 
   @Override

--- a/src/test/java/org/opentripplanner/transit/raptor/rangeraptor/transit/ForwardTransitCalculatorTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/rangeraptor/transit/ForwardTransitCalculatorTest.java
@@ -95,11 +95,11 @@ public class ForwardTransitCalculatorTest {
 
         // Expect transfer from stop A to stop B
         var transfersFromStopA = subject.getTransfers(transitData, STOP_A);
-        assertTrue(transfersFromStopA.hasNext());
-        assertEquals(STOP_B, transfersFromStopA.next().stop());
+        assertEquals(1, transfersFromStopA.length);
+        assertEquals(STOP_B, transfersFromStopA[0].stop());
 
         // No transfer for stop B expected
-        assertFalse(subject.getTransfers(transitData, STOP_B).hasNext());
+        assertEquals(0, subject.getTransfers(transitData, STOP_B).length);
     }
 
     private void assertIntIterator(IntIterator it, int ... values) {

--- a/src/test/java/org/opentripplanner/transit/raptor/rangeraptor/transit/ReverseTransitCalculatorTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/rangeraptor/transit/ReverseTransitCalculatorTest.java
@@ -97,11 +97,11 @@ public class ReverseTransitCalculatorTest {
 
         // Expect transfer from stop A to stop B (reversed)
         var transfersFromStopB = subject.getTransfers(transitData, STOP_B);
-        assertTrue(transfersFromStopB.hasNext());
-        assertEquals(STOP_A, transfersFromStopB.next().stop());
+        assertEquals(1, transfersFromStopB.length);
+        assertEquals(STOP_A, transfersFromStopB[0].stop());
 
         // No transfer form stop A expected
-        assertFalse(subject.getTransfers(transitData, STOP_A).hasNext());
+        assertEquals(0, subject.getTransfers(transitData, STOP_A).length);
     }
 
     private void assertIntIterator(IntIterator it, int ... values) {


### PR DESCRIPTION
### Summary

When profiling the new SpeedTest, I noticed that quite a lot of time was spent creating iterator objects for raptor transfers. This replaces the iterator by an array, which is much faster to iterate, as internally it is rolled to a regular for-loop. The is approximately a 5% improvement on the total time and 8% for the time spent in the Raptor search.

See https://github.com/opentripplanner/OpenTripPlanner/issues/3814#issuecomment-1082862994

![image](https://user-images.githubusercontent.com/698100/161061157-6f35eaff-ec36-4251-b333-a3bb356c1dbb.png)
