### PR TITLE
Fallback to recorded/expected arrival/departure time if other one is missing in SIRI-ET

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/siri/TimetableHelper.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/TimetableHelper.java
@@ -177,11 +177,27 @@ public class TimetableHelper {
               );
             //Flag as recorded
             newTimes.setRecorded(callCounter, true);
+          } else if (recordedCall.getActualDepartureTime() != null) {
+            realtimeArrivalTime =
+              DateMapper.secondsSinceStartOfService(
+                departureDate,
+                recordedCall.getActualDepartureTime(),
+                zoneId
+              );
+            //Flag as recorded
+            newTimes.setRecorded(callCounter, true);
           } else if (recordedCall.getExpectedArrivalTime() != null) {
             realtimeArrivalTime =
               DateMapper.secondsSinceStartOfService(
                 departureDate,
                 recordedCall.getExpectedArrivalTime(),
+                zoneId
+              );
+          } else if (recordedCall.getExpectedDepartureTime() != null) {
+            realtimeArrivalTime =
+              DateMapper.secondsSinceStartOfService(
+                departureDate,
+                recordedCall.getExpectedDepartureTime(),
                 zoneId
               );
           } else if (recordedCall.getAimedArrivalTime() != null) {
@@ -207,11 +223,20 @@ public class TimetableHelper {
               );
             //Flag as recorded
             newTimes.setRecorded(callCounter, true);
-          } else if (recordedCall.getExpectedDepartureTime() != null) {
+          }
+          // Do not use actual arrival time for departure time, as the vehicle can be currently at the stop
+          else if (recordedCall.getExpectedDepartureTime() != null) {
             realtimeDepartureTime =
               DateMapper.secondsSinceStartOfService(
                 departureDate,
                 recordedCall.getExpectedDepartureTime(),
+                zoneId
+              );
+          } else if (recordedCall.getExpectedArrivalTime() != null) {
+            realtimeDepartureTime =
+              DateMapper.secondsSinceStartOfService(
+                departureDate,
+                recordedCall.getExpectedArrivalTime(),
                 zoneId
               );
           } else if (recordedCall.getAimedDepartureTime() != null) {
@@ -294,6 +319,13 @@ public class TimetableHelper {
                   estimatedCall.getExpectedArrivalTime(),
                   zoneId
                 );
+            } else if (estimatedCall.getExpectedDepartureTime() != null) {
+              realtimeArrivalTime =
+                DateMapper.secondsSinceStartOfService(
+                  departureDate,
+                  estimatedCall.getExpectedDepartureTime(),
+                  zoneId
+                );
             } else if (estimatedCall.getAimedArrivalTime() != null) {
               realtimeArrivalTime =
                 DateMapper.secondsSinceStartOfService(
@@ -310,6 +342,13 @@ public class TimetableHelper {
                 DateMapper.secondsSinceStartOfService(
                   departureDate,
                   estimatedCall.getExpectedDepartureTime(),
+                  zoneId
+                );
+            } else if (estimatedCall.getExpectedArrivalTime() != null) {
+              realtimeDepartureTime =
+                DateMapper.secondsSinceStartOfService(
+                  departureDate,
+                  estimatedCall.getExpectedArrivalTime(),
                   zoneId
                 );
             } else if (estimatedCall.getAimedDepartureTime() != null) {

--- a/src/ext/java/org/opentripplanner/ext/siri/TimetableHelper.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/TimetableHelper.java
@@ -186,7 +186,8 @@ public class TimetableHelper {
             callCounter == 0 ? recordedCall::getActualDepartureTime : () -> null,
             recordedCall::getExpectedArrivalTime,
             callCounter == 0 ? recordedCall::getExpectedDepartureTime : () -> null,
-            recordedCall::getAimedArrivalTime
+            recordedCall::getAimedArrivalTime,
+            callCounter == 0 ? recordedCall::getAimedDepartureTime : () -> null
           );
 
           if (realtimeArrivalTime == null) {
@@ -207,7 +208,8 @@ public class TimetableHelper {
             // Do not use actual arrival time for departure time, as the vehicle can be currently at the stop
             recordedCall::getExpectedDepartureTime,
             isLastStop ? recordedCall::getExpectedArrivalTime : () -> null,
-            recordedCall::getAimedDepartureTime
+            recordedCall::getAimedDepartureTime,
+            isLastStop ? recordedCall::getAimedArrivalTime : () -> null
           );
 
           if (realtimeDepartureTime == null) {
@@ -293,7 +295,8 @@ public class TimetableHelper {
               startOfService,
               estimatedCall::getExpectedArrivalTime,
               callCounter == 0 ? estimatedCall::getExpectedDepartureTime : () -> null,
-              estimatedCall::getAimedArrivalTime
+              estimatedCall::getAimedArrivalTime,
+              callCounter == 0 ? estimatedCall::getAimedDepartureTime : () -> null
             );
 
             int departureTime = newTimes.getDepartureTime(callCounter);
@@ -304,7 +307,8 @@ public class TimetableHelper {
               startOfService,
               estimatedCall::getExpectedDepartureTime,
               isLastStop ? estimatedCall::getExpectedArrivalTime : () -> null,
-              estimatedCall::getAimedDepartureTime
+              estimatedCall::getAimedDepartureTime,
+              isLastStop ? estimatedCall::getAimedArrivalTime : () -> null
             );
 
             if (realtimeDepartureTime == null) {

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/DateMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/DateMapper.java
@@ -8,6 +8,7 @@ import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.function.Supplier;
 
 public class DateMapper {
 
@@ -46,6 +47,13 @@ public class DateMapper {
     ZoneId zoneId
   ) {
     ZonedDateTime startOfService = asStartOfService(departureDate.toLocalDate(), zoneId);
+    return (int) Duration.between(startOfService, dateTime).toSeconds();
+  }
+
+  public static int secondsSinceStartOfService(
+    ZonedDateTime startOfService,
+    ZonedDateTime dateTime
+  ) {
     return (int) Duration.between(startOfService, dateTime).toSeconds();
   }
 }


### PR DESCRIPTION
### Summary

Currently we get a lot of non-increasing times due to either the bus leaving before it's assigned time or being expected to arrive late at the final stop. This is due to either recorded or expected arrival or departure time being missing, so that the scheduled time is used instead. Instead we should use the actual or expected departure or arrival time to fill in the missing time.