### PR TITLE
Optimise TripPatternForDates.getTripSchedule(int) - TripScheduleWithOffset [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripPatternForDates.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripPatternForDates.java
@@ -162,18 +162,8 @@ public class TripPatternForDates
 
 
     // Implementing RaptorTimeTable
-
     @Override public TripSchedule getTripSchedule(int index) {
-        for (int i = 0; i < tripPatternForDates.length; i++) {
-            TripPatternForDate tripPatternForDate = tripPatternForDates[i];
-
-            if (index < tripPatternForDate.numberOfTripSchedules()) {
-                return new TripScheduleWithOffset(this, tripPatternForDate.getLocalDate(),
-                        tripPatternForDate.getTripTimes(index), offsets[i]);
-            }
-            index -= tripPatternForDate.numberOfTripSchedules();
-        }
-        throw new IndexOutOfBoundsException("Index out of bound: " + index);
+        return new TripScheduleWithOffset(this, index);
     }
 
     @Override

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripPatternForDates.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripPatternForDates.java
@@ -169,13 +169,21 @@ public class TripPatternForDates
     @Override
     public IntUnaryOperator getArrivalTimes(int stopPositionInPattern) {
         final int base = stopPositionInPattern * numberOfTripSchedules;
-        return (int i) -> arrivalTimes[base + i];
+        return (int index) -> arrivalTimes[base + index];
     }
 
     @Override
     public IntUnaryOperator getDepartureTimes(int stopPositionInPattern) {
         final int base = stopPositionInPattern * numberOfTripSchedules;
-        return (int i) -> departureTimes[base + i];
+        return (int index) -> departureTimes[base + index];
+    }
+
+    public IntUnaryOperator getArrivalTimesForTrip(int index) {
+        return (int stopPositionInPattern) -> arrivalTimes[stopPositionInPattern * numberOfTripSchedules + index];
+    }
+
+    public IntUnaryOperator getDepartureTimesForTrip(int index) {
+        return (int stopPositionInPattern) -> departureTimes[stopPositionInPattern * numberOfTripSchedules + index];
     }
 
     @Override public int numberOfTripSchedules() {

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TestRouteData.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TestRouteData.java
@@ -66,10 +66,12 @@ public class TestRouteData {
         var patternForDates = new TripPatternForDates(
                 raptorTripPattern, listOfTripPatternForDates, List.of(OFFSET)
         );
+        int id = 0;
         for (Trip trip : trips) {
             var tripSchedule = new TripScheduleWithOffset(
-                    patternForDates, DATE, tripTimesByTrip.get(trip), OFFSET
+                    patternForDates, id
             );
+            id += 1;
             tripSchedulesByTrip.put(trip, tripSchedule);
         }
 


### PR DESCRIPTION
### Summary
Optimise `TripScheduleWithOffset` creating from `TripPatternForDates.getTripSchedule(int)`. re-using data from TripPatternForDates instead of finding the actual `TripTimes`.

The  `TripTimes` is selected only when needed later for the `RaptorPathToItineraryMapper` and only on relevant trips.

### Issue
c.f.  https://github.com/opentripplanner/OpenTripPlanner/issues/3814#issuecomment-1082862994

### Perf-Tests

```
Before:
Worker: 
 ==> mc_destination : [  552,  525,  526,  530 ] Avg: 533.3

Total:  
 ==> mc_destination : [  755,  712,  715,  718 ] Avg: 725.0


After:
Worker: 
 ==> mc_destination : [  523,  511,  509,  507 ] Avg: 512.5

Total:  
 ==> mc_destination : [  729,  703,  700,  697 ] Avg: 707.3
```
