### PR TITLE
fix NPE with node used for two elevators [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/module/AddTransitModelEntitiesToGraph.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/AddTransitModelEntitiesToGraph.java
@@ -283,16 +283,18 @@ public class AddTransitModelEntitiesToGraph {
             levels = Math.abs(fromVertexLevelIndex - toVertexLevelIndex);
         }
 
+        String elevatorLabel = fromVertex.getLabel() + "-" + toVertex.getLabel();
+
         ElevatorOffboardVertex fromOffboardVertex = new ElevatorOffboardVertex(
             graph,
-            fromVertex.getLabel() + "_" + pathway.getId() + "_offboard",
+            fromVertex.getLabel() + "(" + elevatorLabel +")" + "_" + pathway.getId() + "_offboard",
             fromVertex.getX(),
             fromVertex.getY(),
             fromVertexLevelName
         );
         ElevatorOffboardVertex toOffboardVertex = new ElevatorOffboardVertex(
             graph,
-            toVertex.getLabel() + "_" + pathway.getId() + "_offboard",
+            toVertex.getLabel() + "(" + elevatorLabel +")"  + "_" + pathway.getId() + "_offboard",
             toVertex.getX(),
             toVertex.getY(),
             toVertexLevelName
@@ -303,14 +305,14 @@ public class AddTransitModelEntitiesToGraph {
 
         ElevatorOnboardVertex fromOnboardVertex = new ElevatorOnboardVertex(
             graph,
-            fromVertex.getLabel() + "_" + pathway.getId() + "_onboard",
+            fromVertex.getLabel() + "(" + elevatorLabel +")"  + "_" + pathway.getId() + "_onboard",
             fromVertex.getX(),
             fromVertex.getY(),
             fromVertexLevelName
         );
         ElevatorOnboardVertex toOnboardVertex = new ElevatorOnboardVertex(
             graph,
-            toVertex.getLabel() + "_" + pathway.getId() + "_onboard",
+            toVertex.getLabel() + "(" + elevatorLabel +")"  + "_" + pathway.getId() + "_onboard",
             toVertex.getX(),
             toVertex.getY(),
             toVertexLevelName

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModule.java
@@ -846,6 +846,11 @@ public class OpenStreetMapModule implements GraphBuilderModule {
             /* build elevator edges */
             for (Long nodeId : multiLevelNodes.keySet()) {
                 OSMNode node = osmdb.getNode(nodeId);
+
+                // Use the first elevator node as the elevator label suffix
+                // Prevent duplicated vertex for elevator using the sames stops (chained elevator)
+                String elevatorLabelSuffix = getNodeLabel(node);
+
                 // this allows skipping levels, e.g., an elevator that stops
                 // at floor 0, 2, 3, and 5.
                 // Converting to an Array allows us to
@@ -875,7 +880,7 @@ public class OpenStreetMapModule implements GraphBuilderModule {
                     String levelName = level.longName;
 
                     createElevatorVertices(
-                            graph, onboardVertices, sourceVertex, sourceVertexLabel,
+                            graph, onboardVertices, sourceVertex, elevatorLabelSuffix + "_" + sourceVertexLabel,
                             levelName
                     );
                 }
@@ -903,14 +908,21 @@ public class OpenStreetMapModule implements GraphBuilderModule {
                         .boxed()
                         .collect(Collectors.toList());
 
+                if(nodes.isEmpty()) {
+                    continue;
+                }
+
+
+                String elevatorLabelSuffix = getNodeLabel(osmdb.getNode(nodes.get(0)));
                 ArrayList<Vertex> onboardVertices = new ArrayList<>();
                 for (int i = 0; i < nodes.size(); i++) {
                     Long node = nodes.get(i);
                     OsmVertex sourceVertex = intersectionNodes.get(node);
+
                     String sourceVertexLabel = sourceVertex.getLabel();
                     String levelName = elevatorWay.getId() + " / " + i;
                     createElevatorVertices(
-                            graph, onboardVertices, sourceVertex, sourceVertexLabel, levelName
+                            graph, onboardVertices, sourceVertex, elevatorLabelSuffix + "_" + sourceVertexLabel, levelName
                     );
                 }
 


### PR DESCRIPTION
### Summary
OSM nodes that are included in two different elevator way (think chained-elevator) can cause a duplicate vertex at build time.
As a result the graph throw a NPE at load time/subsequent build step.

### Issue

closes #3966 
closes #4059 

