### PR TITLE
Link platforms also against railway=platform

### DIFF
--- a/src/main/java/org/opentripplanner/openstreetmap/model/OSMNode.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/model/OSMNode.java
@@ -54,7 +54,8 @@ public class OSMNode extends OSMWithTags {
       "tram_stop".equals(getTag("railway")) ||
       "station".equals(getTag("railway")) ||
       "halt".equals(getTag("railway")) ||
-      "bus_station".equals(getTag("amenity"))
+      "bus_station".equals(getTag("amenity")) ||
+      "platform".equals(getTag("public_transport"))
     );
   }
 


### PR DESCRIPTION
OpenStreetmap strictly guides modeling of train stations in such a way, that station geometry does not have a natural counterpart node for a train stop. A train stop therefore gets linked to the closest edge of the street network. This is often a very bad choice because the stop  might link with a highway intended for motor vehicles instead of the actual railway platform. 

In this pull request, an existing graph build time parameter 'extra', which is passed between build modules, is extended to contain information about public transit platforms. An existing stop code - OSM ref tag matching rule is extended to guide the stop linking to primarily use dedicated platform geometry. This PR also changes the whole stop code - OSM ref linking to be a configurable option. 

The actual low level  transit stop - street linking module gets a general purpose ability to select the target edges from a subset of the street graph. Selective linking adds some complexity to the linker,  but this option might be useful in other situations, too.

In picture below, guided linking connects two overlapping railway stops to the middle parts of the platforms, which in average, results to somewhat expected walk connection length. Without guided linking, traveler would be instructed to jump down 5 meters to a highway. 

![tolsa_railway_station](https://user-images.githubusercontent.com/13776096/161742334-b74f4ee7-bd12-4abe-93e1-b90bed5daa9b.png)

The second picture below shows an actual walking route along safe platforms and their connections.
 
![walk_from_tolsa](https://user-images.githubusercontent.com/13776096/161743132-def8ae3d-3e44-4661-a206-eadae9521ba9.png)
