### PR TITLE
Refactor trip search [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TripSchedule.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TripSchedule.java
@@ -10,6 +10,8 @@ import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
  * original trip from the path when creating itineraries.
  */
 public interface TripSchedule extends RaptorTripSchedule {
+  LocalDate getServiceDate();
+
   /**
    * TODO OTP2 - Add JavaDoc
    */
@@ -19,8 +21,6 @@ public interface TripSchedule extends RaptorTripSchedule {
    * TODO OTP2 - Add JavaDoc
    */
   TripPattern getOriginalTripPattern();
-
-  LocalDate getServiceDate();
 
   /**
    * Return {@code true} if this trip is not based on a fixed schedule, but instead a frequency

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/constrainedtransfer/ConstrainedBoardingSearch.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/constrainedtransfer/ConstrainedBoardingSearch.java
@@ -102,6 +102,23 @@ public final class ConstrainedBoardingSearch
     );
   }
 
+  private Iterable<TransferForPattern> findMatchingTransfers(
+    TripSchedule tripSchedule,
+    int stopIndex
+  ) {
+    final Trip trip = tripSchedule.getOriginalTripTimes().getTrip();
+    // for performance reasons we use a for loop here as streams are much slower.
+    // I experimented with LinkedList and ArrayList and LinkedList was faster, presumably
+    // because insertion is quick and we don't need index-based access, only iteration.
+    var result = new LinkedList<TransferForPattern>();
+    for (var t : currentTransfers) {
+      if (t.matchesSourcePoint(stopIndex, trip)) {
+        result.add(t);
+      }
+    }
+    return result;
+  }
+
   /**
    * Find the trip to board (trip index) and the transfer constraint.
    * <p>
@@ -114,7 +131,7 @@ public final class ConstrainedBoardingSearch
    *
    * @return {@code true} if a matching trip is found
    */
-  public boolean findTimetableTripInfo(
+  private boolean findTimetableTripInfo(
     RaptorTimeTable<TripSchedule> timetable,
     Iterable<TransferForPattern> transfers,
     int stopPos,
@@ -199,22 +216,5 @@ public final class ConstrainedBoardingSearch
       }
     }
     return false;
-  }
-
-  private Iterable<TransferForPattern> findMatchingTransfers(
-    TripSchedule tripSchedule,
-    int stopIndex
-  ) {
-    final Trip trip = tripSchedule.getOriginalTripTimes().getTrip();
-    // for performance reasons we use a for loop here as streams are much slower.
-    // I experimented with LinkedList and ArrayList and LinkedList was faster, presumably
-    // because insertion is quick and we don't need index-based access, only iteration.
-    var result = new LinkedList<TransferForPattern>();
-    for (var t : currentTransfers) {
-      if (t.matchesSourcePoint(stopIndex, trip)) {
-        result.add(t);
-      }
-    }
-    return result;
   }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripPatternForDates.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripPatternForDates.java
@@ -22,7 +22,11 @@ import org.opentripplanner.transit.raptor.util.IntIterators;
  * tripSchedulesByDay refers to days in order.
  */
 public class TripPatternForDates
-  implements RaptorRoute<TripSchedule>, RaptorTimeTable<TripSchedule>, RaptorTripPattern {
+  implements
+    RaptorRoute<TripSchedule>,
+    RaptorTimeTable<TripSchedule>,
+    RaptorTripPattern,
+    TripSearchTimetable<TripSchedule> {
 
   private final TripPatternWithRaptorStopIndexes tripPattern;
 
@@ -101,7 +105,7 @@ public class TripPatternForDates
 
   /**
    * @deprecated This is exposed because it is needed in the TripFrequencyNnnSearch classes, but is
-   * realy an implementation detail that should not leak outside the class.
+   * an implementation detail that should not leak outside the class.
    */
   @Deprecated
   public int tripPatternForDateOffsets(int index) {
@@ -129,7 +133,7 @@ public class TripPatternForDates
     return getTripPattern().constrainedTransferReverseSearch();
   }
 
-  // Implementing RaptorTripPattern
+  /* Implementing RaptorStopPattern */
 
   @Override
   public int stopIndex(int stopPositionInPattern) {
@@ -158,7 +162,16 @@ public class TripPatternForDates
     );
   }
 
-  // Implementing RaptorTimeTable
+  /*  Implementing RaptorTimeTable */
+
+  @Override
+  public RaptorTripScheduleSearch<TripSchedule> tripSearch(SearchDirection direction) {
+    if (useCustomizedTripSearch()) {
+      return createCustomizedTripSearch(direction);
+    }
+    return TripScheduleSearchFactory.create(direction, this);
+  }
+
   @Override
   public TripSchedule getTripSchedule(int index) {
     return new TripScheduleWithOffset(this, index);
@@ -176,25 +189,6 @@ public class TripPatternForDates
     return (int index) -> departureTimes[base + index];
   }
 
-  @Override
-  public int numberOfTripSchedules() {
-    return numberOfTripSchedules;
-  }
-
-  @Override
-  public boolean useCustomizedTripSearch() {
-    return isFrequencyBased;
-  }
-
-  @Override
-  public RaptorTripScheduleSearch<TripSchedule> createCustomizedTripSearch(
-    SearchDirection direction
-  ) {
-    return direction.isForward()
-      ? new TripFrequencyBoardSearch<>(this)
-      : new TripFrequencyAlightSearch<>(this);
-  }
-
   public IntUnaryOperator getArrivalTimesForTrip(int index) {
     return (int stopPositionInPattern) ->
       arrivalTimes[stopPositionInPattern * numberOfTripSchedules + index];
@@ -203,6 +197,36 @@ public class TripPatternForDates
   public IntUnaryOperator getDepartureTimesForTrip(int index) {
     return (int stopPositionInPattern) ->
       departureTimes[stopPositionInPattern * numberOfTripSchedules + index];
+  }
+
+  @Override
+  public int numberOfTripSchedules() {
+    return numberOfTripSchedules;
+  }
+
+  /**
+   * Raptor provides a trips search for regular trip schedules, but in some cases it makes
+   * sense to be able to override this - for example for frequency based trips.
+   *
+   * @return {@code true} If you do not want to use the built-in trip search and instead
+   *         will provide your own. Make sure to implement the
+   *         {@link #createCustomizedTripSearch(SearchDirection)} for both forward and reverse
+   *         searches.
+   */
+  public boolean useCustomizedTripSearch() {
+    return isFrequencyBased;
+  }
+
+  /**
+   * Factory method to provide an alternative trip search in Raptor.
+   * @see #useCustomizedTripSearch()
+   */
+  public RaptorTripScheduleSearch<TripSchedule> createCustomizedTripSearch(
+    SearchDirection direction
+  ) {
+    return direction.isForward()
+      ? new TripFrequencyBoardSearch<>(this)
+      : new TripFrequencyAlightSearch<>(this);
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripScheduleSearchFactory.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripScheduleSearchFactory.java
@@ -1,0 +1,37 @@
+package org.opentripplanner.routing.algorithm.raptoradapter.transit.request;
+
+import org.opentripplanner.transit.raptor.api.request.SearchDirection;
+import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
+import org.opentripplanner.transit.raptor.api.transit.RaptorTripScheduleSearch;
+
+/**
+ * The purpose of this class is to create a new trip search.
+ */
+public class TripScheduleSearchFactory {
+
+  /**
+   * This threshold is used to determine when to perform a binary trip schedule search
+   * to reduce the number of trips departure time lookups and comparisons. When testing
+   * with data from Entur and all of Norway as a Graph, the optimal value was about 50.
+   * <p/>
+   * If you calculate the departure time every time or want to fine tune the performance,
+   * changing this may improve the performance a few percent.
+   */
+  private static final int BINARY_SEARCH_THRESHOLD = 50;
+
+  /**
+   * Create a new search based on the given direction:
+   * <ou>
+   *   <li>FORWARD -> Board search</li>
+   *   <li>REVERSE -> Alight search</li>
+   * </ou>
+   */
+  public static <T extends RaptorTripSchedule> RaptorTripScheduleSearch<T> create(
+    SearchDirection searchDirection,
+    TripSearchTimetable<T> timetable
+  ) {
+    return searchDirection.isForward()
+      ? new TripScheduleBoardSearch<>(timetable, BINARY_SEARCH_THRESHOLD)
+      : new TripScheduleAlightSearch<>(timetable, BINARY_SEARCH_THRESHOLD);
+  }
+}

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripSearchTimetable.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripSearchTimetable.java
@@ -1,0 +1,29 @@
+package org.opentripplanner.routing.algorithm.raptoradapter.transit.request;
+
+import java.util.function.IntUnaryOperator;
+import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripSchedule;
+import org.opentripplanner.transit.raptor.api.transit.RaptorTimeTable;
+import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
+
+/**
+ * This interface add two methods the the {@link RaptorTimeTable} to optimize the terip search
+ * inside the transit model. They were previously in Raptor, but the trip Search is moded outside
+ * of Raptor; We have keep these methods in an interface to be able to reuse the complex TripSearch
+ * in tests, witch do not use the transit model {@link TripSchedule}; Hence also the generic type
+ * on this interface.
+ */
+public interface TripSearchTimetable<T extends RaptorTripSchedule> extends RaptorTimeTable<T> {
+  /**
+   * Get the arrival times of all trips at a specific stop index, sorted by time. The returned
+   * function takes the trip index in the TimeTable as input and returns the arrival time as
+   * seconds from midnight on the search date.
+   */
+  IntUnaryOperator getArrivalTimes(int stopPositionInPattern);
+
+  /**
+   * Get the departure times of all trips at a specific stop index, sorted by time. The returned
+   * function takes the trip index in the TimeTable as input and returns the departure time as
+   * seconds from midnight on the search date.
+   */
+  IntUnaryOperator getDepartureTimes(int stopPositionInPattern);
+}

--- a/src/main/java/org/opentripplanner/transit/raptor/api/transit/RaptorTimeTable.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/transit/RaptorTimeTable.java
@@ -9,7 +9,6 @@ import org.opentripplanner.transit.raptor.api.request.SearchDirection;
  * the implementation of this interface. Raptor uses a binary search to find the right
  * trip-schedule, so even for long time-tables the Raptor search perform quite well.
  * <p>
- *
  * @param <T> The TripSchedule type defined by the user of the raptor API.
  */
 public interface RaptorTimeTable<T extends RaptorTripSchedule> {
@@ -24,38 +23,12 @@ public interface RaptorTimeTable<T extends RaptorTripSchedule> {
   T getTripSchedule(int index);
 
   /**
-   * Get the arrival times of all trips at a specific stop index, sorted by time. The returned
-   * function takes the trip index in the TimeTable as input and returns the arrival time as seconds
-   * from midnight on the search date.
-   */
-  IntUnaryOperator getArrivalTimes(int stopPositionInPattern);
-
-  /**
-   * Get the departure times of all trips at a specific stop index, sorted by time. The returned
-   * function takes the trip index in the TimeTable as input and returns the departure time as
-   * seconds from midnight on the search date.
-   */
-  IntUnaryOperator getDepartureTimes(int stopPositionInPattern);
-
-  /**
    * Number of trips in time-table.
    */
   int numberOfTripSchedules();
 
   /**
-   * Raptor provides a trips search for regular trip schedules, but in some cases it makes sense to
-   * be able to override this - for example for frequency based trips.
-   *
-   * @return {@code true} If you do not want to use the built-in trip search and instead will
-   * provide your own. Make sure to implement the {@link #createCustomizedTripSearch(SearchDirection)}
-   * for both forward and reverse searches.
+   * Factory method to create the trip search
    */
-  boolean useCustomizedTripSearch();
-
-  /**
-   * Factory method to provide an alternative trip search in Raptor.
-   *
-   * @see #useCustomizedTripSearch()
-   */
-  RaptorTripScheduleSearch<T> createCustomizedTripSearch(SearchDirection direction);
+  RaptorTripScheduleSearch<T> tripSearch(SearchDirection direction);
 }

--- a/src/main/java/org/opentripplanner/transit/raptor/api/transit/RaptorTripScheduleBoardOrAlightEvent.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/transit/RaptorTripScheduleBoardOrAlightEvent.java
@@ -17,8 +17,13 @@ import javax.validation.constraints.NotNull;
  * @param <T> The TripSchedule type defined by the user of the raptor API.
  */
 public interface RaptorTripScheduleBoardOrAlightEvent<T extends RaptorTripSchedule> {
+  /** Used to indicate that no trip is found. */
+  static final int NOT_FOUND = -1;
+
   /**
    * The trip timetable index for the trip  found.
+   * <p>
+   * If not found {@link #NOT_FOUND} is returned.
    */
   int getTripIndex();
 

--- a/src/main/java/org/opentripplanner/transit/raptor/api/transit/RaptorTripScheduleSearch.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/transit/RaptorTripScheduleSearch.java
@@ -3,19 +3,15 @@ package org.opentripplanner.transit.raptor.api.transit;
 import javax.annotation.Nullable;
 
 /**
- * The purpose of the TripScheduleSearch is to optimize the search for a trip schedule for a given
- * pattern. Normally the search scan trips sequentially, aborting when a valid trip is found, it can
- * do so because the trips are ordered after the FIRST stop alight/board times. We also assume that
- * trips do not pass each other; Hence trips in service on a given day will be in order for all
- * other stops too.
+ * The purpose of the TripScheduleSearch is to search for a trip schedule for a given pattern.
+ * The search need to be optimized for speed, this is one of the most frequently called
+ * operations in Raptor and accessing objects in memory should be avoided.
  * <p/>
- * The search use a binary search if the number of trip schedules is above a given threshold. A
- * linear search is slow when the number of schedules is very large, let say more than 300 trip
- * schedules.
- * <p/>
- * The implementation of this interface take care the search direction (forward/reverse). For a
- * reverse search (searching backward in time) the trip found departure/arrival times are swapped.
- * This is one of the things that allows for the algorithm to be generic, used in both cases.
+ * There should be two implementations of this interface, one for board-times and one for
+ * alight-times. When Raptor search in reverse direction the alight-time search should be used. For
+ * a reverse search (searching backward in time) the trip found departure/arrival times are swapped.
+ * This is one of the things that allows for the Raptor implementation to be generic, used in both
+ * cases.
  *
  * @param <T> The TripSchedule type defined by the user of the raptor API.
  */

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/RangeRaptorWorker.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/RangeRaptorWorker.java
@@ -2,6 +2,7 @@ package org.opentripplanner.transit.raptor.rangeraptor;
 
 import io.micrometer.core.instrument.Timer;
 import java.util.Collection;
+import org.opentripplanner.routing.algorithm.raptoradapter.transit.request.TripScheduleBoardSearch;
 import org.opentripplanner.transit.raptor.api.path.Path;
 import org.opentripplanner.transit.raptor.api.transit.IntIterator;
 import org.opentripplanner.transit.raptor.api.transit.RaptorConstrainedTripScheduleBoardingSearch;
@@ -16,7 +17,6 @@ import org.opentripplanner.transit.raptor.rangeraptor.debug.WorkerPerformanceTim
 import org.opentripplanner.transit.raptor.rangeraptor.transit.AccessPaths;
 import org.opentripplanner.transit.raptor.rangeraptor.transit.RoundTracker;
 import org.opentripplanner.transit.raptor.rangeraptor.transit.TransitCalculator;
-import org.opentripplanner.transit.raptor.rangeraptor.transit.TripScheduleBoardSearch;
 import org.opentripplanner.transit.raptor.rangeraptor.workerlifecycle.LifeCycleEventPublisher;
 
 /**
@@ -26,8 +26,8 @@ import org.opentripplanner.transit.raptor.rangeraptor.workerlifecycle.LifeCycleE
  * Land Use Sketch Planning Using Interactive Accessibility Methods on Combined Schedule and
  * Headway-Based Networks.” Transportation Research Record 2653 (2017). doi:10.3141/2653-06.
  * <p>
- * Delling, Daniel, Thomas Pajor, and Renato Werneck. “Round-Based Public Transit Routing,” January
- * 1, 2012. http://research.microsoft.com/pubs/156567/raptor_alenex.pdf.
+ * Delling, Daniel, Thomas Pajor, and Renato Werneck. “Round-Based Public Transit Routing,”
+ * January 1, 2012. http://research.microsoft.com/pubs/156567/raptor_alenex.pdf.
  * <p>
  * This version do support the following features:
  * <ul>
@@ -52,7 +52,7 @@ public final class RangeRaptorWorker<T extends RaptorTripSchedule> implements Wo
   private final RoutingStrategy<T> transitWorker;
 
   /**
-   * The RangeRaptor state - we delegate keeping track of state to the state object, this allow the
+   * The RangeRaptor state - we delegate keeping track of state to the state object, this allows the
    * worker implementation to focus on the algorithm, while the state keep track of the result.
    * <p/>
    * This also allow us to try out different strategies for storing the result in memory. For a long
@@ -125,7 +125,8 @@ public final class RangeRaptorWorker<T extends RaptorTripSchedule> implements Wo
    * Run the scheduled search, round 0 is the street search
    * <p/>
    * We are using the Range-RAPTOR extension described in Delling, Daniel, Thomas Pajor, and Renato
-   * Werneck. “Round-Based Public Transit Routing,” January 1, 2012. http://research.microsoft.com/pubs/156567/raptor_alenex.pdf.
+   * Werneck. “Round-Based Public Transit Routing,” January 1, 2012.
+   * http://research.microsoft.com/pubs/156567/raptor_alenex.pdf.
    *
    * @return a unique set of paths
    */

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/transit/ForwardTransitCalculator.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/transit/ForwardTransitCalculator.java
@@ -100,28 +100,10 @@ final class ForwardTransitCalculator<T extends RaptorTripSchedule>
   }
 
   @Override
-  public RaptorTripScheduleSearch<T> createTripSearch(RaptorTimeTable<T> timeTable) {
-    if (timeTable.useCustomizedTripSearch()) {
-      return timeTable.createCustomizedTripSearch(SearchDirection.FORWARD);
-    }
-    return new TripScheduleBoardSearch<>(tripSearchBinarySearchThreshold, timeTable);
-  }
-
-  @Override
-  public RaptorTripScheduleSearch<T> createExactTripSearch(RaptorTimeTable<T> pattern) {
-    return new TripScheduleExactMatchSearch<>(createTripSearch(pattern), this, iterationStep);
-  }
-
-  @Override
   public RaptorConstrainedTripScheduleBoardingSearch<T> transferConstraintsSearch(
     RaptorRoute<T> route
   ) {
     return route.transferConstraintsForwardSearch();
-  }
-
-  @Override
-  public boolean boardingPossibleAt(RaptorTripPattern pattern, int stopPos) {
-    return pattern.boardingPossibleAt(stopPos);
   }
 
   @Override
@@ -135,5 +117,20 @@ final class ForwardTransitCalculator<T extends RaptorTripSchedule>
     int fromStop
   ) {
     return transitDataProvider.getTransfersFromStop(fromStop);
+  }
+
+  @Override
+  public boolean boardingPossibleAt(RaptorTripPattern pattern, int stopPos) {
+    return pattern.boardingPossibleAt(stopPos);
+  }
+
+  @Override
+  public RaptorTripScheduleSearch<T> createTripSearch(RaptorTimeTable<T> timeTable) {
+    return timeTable.tripSearch(SearchDirection.FORWARD);
+  }
+
+  @Override
+  public RaptorTripScheduleSearch<T> createExactTripSearch(RaptorTimeTable<T> pattern) {
+    return new TripScheduleExactMatchSearch<>(createTripSearch(pattern), this, iterationStep);
   }
 }

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/transit/ReverseTransitCalculator.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/transit/ReverseTransitCalculator.java
@@ -105,29 +105,10 @@ final class ReverseTransitCalculator<T extends RaptorTripSchedule>
   }
 
   @Override
-  public RaptorTripScheduleSearch<T> createTripSearch(RaptorTimeTable<T> timeTable) {
-    if (timeTable.useCustomizedTripSearch()) {
-      return timeTable.createCustomizedTripSearch(SearchDirection.REVERSE);
-    }
-
-    return new TripScheduleAlightSearch<>(tripSearchBinarySearchThreshold, timeTable);
-  }
-
-  @Override
-  public RaptorTripScheduleSearch<T> createExactTripSearch(RaptorTimeTable<T> timeTable) {
-    return new TripScheduleExactMatchSearch<>(createTripSearch(timeTable), this, -iterationStep);
-  }
-
-  @Override
   public RaptorConstrainedTripScheduleBoardingSearch<T> transferConstraintsSearch(
     RaptorRoute<T> route
   ) {
     return route.transferConstraintsReverseSearch();
-  }
-
-  @Override
-  public boolean boardingPossibleAt(RaptorTripPattern pattern, int stopPos) {
-    return pattern.alightingPossibleAt(stopPos);
   }
 
   @Override
@@ -141,5 +122,20 @@ final class ReverseTransitCalculator<T extends RaptorTripSchedule>
     int fromStop
   ) {
     return transitDataProvider.getTransfersToStop(fromStop);
+  }
+
+  @Override
+  public boolean boardingPossibleAt(RaptorTripPattern pattern, int stopPos) {
+    return pattern.alightingPossibleAt(stopPos);
+  }
+
+  @Override
+  public RaptorTripScheduleSearch<T> createTripSearch(RaptorTimeTable<T> timeTable) {
+    return timeTable.tripSearch(SearchDirection.REVERSE);
+  }
+
+  @Override
+  public RaptorTripScheduleSearch<T> createExactTripSearch(RaptorTimeTable<T> timeTable) {
+    return new TripScheduleExactMatchSearch<>(createTripSearch(timeTable), this, -iterationStep);
   }
 }

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripAssert.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripAssert.java
@@ -1,4 +1,4 @@
-package org.opentripplanner.transit.raptor.rangeraptor.transit;
+package org.opentripplanner.routing.algorithm.raptoradapter.transit.request;
 
 import org.junit.Assert;
 import org.opentripplanner.transit.raptor._data.transit.TestTripSchedule;

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripScheduleAlightSearchTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripScheduleAlightSearchTest.java
@@ -1,4 +1,4 @@
-package org.opentripplanner.transit.raptor.rangeraptor.transit;
+package org.opentripplanner.routing.algorithm.raptoradapter.transit.request;
 
 import static org.opentripplanner.transit.raptor._data.transit.TestTripPattern.pattern;
 import static org.opentripplanner.transit.raptor._data.transit.TestTripSchedule.schedule;
@@ -11,7 +11,9 @@ import org.opentripplanner.transit.raptor._data.RaptorTestConstants;
 import org.opentripplanner.transit.raptor._data.transit.TestRoute;
 import org.opentripplanner.transit.raptor._data.transit.TestTripPattern;
 import org.opentripplanner.transit.raptor._data.transit.TestTripSchedule;
+import org.opentripplanner.transit.raptor.api.request.SearchDirection;
 import org.opentripplanner.transit.raptor.api.transit.RaptorRoute;
+import org.opentripplanner.transit.raptor.api.transit.RaptorTripScheduleSearch;
 
 public class TripScheduleAlightSearchTest implements RaptorTestConstants {
 
@@ -52,7 +54,7 @@ public class TripScheduleAlightSearchTest implements RaptorTestConstants {
 
   private final TestTripPattern pattern = pattern("R1", STOP_A, STOP_B);
 
-  private RaptorRoute<TestTripSchedule> route = TestRoute
+  private TestRoute route = TestRoute
     .route(pattern)
     .withTimetable(
       // Trips in service
@@ -66,9 +68,8 @@ public class TripScheduleAlightSearchTest implements RaptorTestConstants {
   private final TestTripSchedule tripC = route.timetable().getTripSchedule(TRIP_C);
 
   // The service under test - the subject
-  private TripScheduleAlightSearch<TestTripSchedule> subject = new TripScheduleAlightSearch<>(
-    TRIPS_BINARY_SEARCH_THRESHOLD,
-    route.timetable()
+  private RaptorTripScheduleSearch<TestTripSchedule> subject = route.tripSearch(
+    SearchDirection.REVERSE
   );
 
   @Test
@@ -196,12 +197,6 @@ public class TripScheduleAlightSearchTest implements RaptorTestConstants {
     searchForTrip(TIME_A2, STOP_POS_1).assertTripFound().withIndex(indexA).withAlightTime(TIME_A2);
   }
 
-  private static void addNTimes(List<TestTripSchedule> trips, TestTripSchedule tripS, int n) {
-    for (int i = 0; i < n; i++) {
-      trips.add(tripS);
-    }
-  }
-
   private void withTrips(TestTripSchedule... schedules) {
     useRoute(TestRoute.route(pattern).withTimetable(schedules));
   }
@@ -212,8 +207,13 @@ public class TripScheduleAlightSearchTest implements RaptorTestConstants {
 
   private void useRoute(TestRoute route) {
     this.route = route;
-    this.subject =
-      new TripScheduleAlightSearch<>(TRIPS_BINARY_SEARCH_THRESHOLD, this.route.timetable());
+    this.subject = route.tripSearch(SearchDirection.REVERSE);
+  }
+
+  private static void addNTimes(List<TestTripSchedule> trips, TestTripSchedule tripS, int n) {
+    for (int i = 0; i < n; i++) {
+      trips.add(tripS);
+    }
   }
 
   private TripAssert searchForTrip(int arrivalTime, int stopPosition) {

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripScheduleBoardSearchTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripScheduleBoardSearchTest.java
@@ -1,4 +1,4 @@
-package org.opentripplanner.transit.raptor.rangeraptor.transit;
+package org.opentripplanner.routing.algorithm.raptoradapter.transit.request;
 
 import static org.opentripplanner.transit.raptor._data.transit.TestTripSchedule.schedule;
 
@@ -10,6 +10,8 @@ import org.opentripplanner.transit.raptor._data.RaptorTestConstants;
 import org.opentripplanner.transit.raptor._data.transit.TestRoute;
 import org.opentripplanner.transit.raptor._data.transit.TestTripPattern;
 import org.opentripplanner.transit.raptor._data.transit.TestTripSchedule;
+import org.opentripplanner.transit.raptor.api.request.SearchDirection;
+import org.opentripplanner.transit.raptor.api.transit.RaptorTripScheduleSearch;
 
 public class TripScheduleBoardSearchTest implements RaptorTestConstants {
 
@@ -43,10 +45,13 @@ public class TripScheduleBoardSearchTest implements RaptorTestConstants {
 
   private static final int TIME_C1 = 2000;
   private static final int TIME_C2 = 2500;
+
+  private final TestTripPattern pattern = TestTripPattern.pattern("R1", STOP_A, STOP_B);
+
   private static final int TRIP_A = 0;
   private static final int TRIP_B = 1;
   private static final int TRIP_C = 2;
-  private final TestTripPattern pattern = TestTripPattern.pattern("R1", STOP_A, STOP_B);
+
   // Route with trip A, B, C.
   private TestRoute route = TestRoute
     .route(pattern)
@@ -61,9 +66,8 @@ public class TripScheduleBoardSearchTest implements RaptorTestConstants {
   private final TestTripSchedule tripB = route.timetable().getTripSchedule(TRIP_B);
 
   // The service under test - the subject
-  private TripScheduleBoardSearch<TestTripSchedule> subject = new TripScheduleBoardSearch<>(
-    TRIPS_BINARY_SEARCH_THRESHOLD,
-    route.timetable()
+  private RaptorTripScheduleSearch<TestTripSchedule> subject = route.tripSearch(
+    SearchDirection.FORWARD
   );
 
   @Test
@@ -173,8 +177,7 @@ public class TripScheduleBoardSearchTest implements RaptorTestConstants {
 
   private void useTripPattern(TestRoute route) {
     this.route = route;
-    this.subject =
-      new TripScheduleBoardSearch<>(TRIPS_BINARY_SEARCH_THRESHOLD, this.route.timetable());
+    this.subject = route.tripSearch(SearchDirection.FORWARD);
   }
 
   private TripAssert searchForTrip(int arrivalTime, int stopPosition) {

--- a/src/test/java/org/opentripplanner/transit/raptor/_data/transit/TestRoute.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/_data/transit/TestRoute.java
@@ -3,9 +3,9 @@ package org.opentripplanner.transit.raptor._data.transit;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.function.IntUnaryOperator;
 import org.opentripplanner.model.base.ToStringBuilder;
 import org.opentripplanner.model.transfer.TransferConstraint;
+import org.opentripplanner.routing.algorithm.raptoradapter.transit.request.TripScheduleSearchFactory;
 import org.opentripplanner.transit.raptor.api.request.SearchDirection;
 import org.opentripplanner.transit.raptor.api.transit.RaptorConstrainedTripScheduleBoardingSearch;
 import org.opentripplanner.transit.raptor.api.transit.RaptorRoute;
@@ -36,48 +36,7 @@ public class TestRoute implements RaptorRoute<TestTripSchedule>, RaptorTimeTable
     return route(TestTripPattern.pattern(name, stopIndexes));
   }
 
-  @Override
-  public TestTripSchedule getTripSchedule(int index) {
-    return schedules.get(index);
-  }
-
-  @Override
-  public IntUnaryOperator getArrivalTimes(int stopPositionInPattern) {
-    final int[] arrivalTimes = schedules
-      .stream()
-      .mapToInt(schedule -> schedule.arrival(stopPositionInPattern))
-      .toArray();
-    return (int i) -> arrivalTimes[i];
-  }
-
-  @Override
-  public IntUnaryOperator getDepartureTimes(int stopPositionInPattern) {
-    final int[] departureTimes = schedules
-      .stream()
-      .mapToInt(schedule -> schedule.departure(stopPositionInPattern))
-      .toArray();
-    return (int i) -> departureTimes[i];
-  }
-
-  @Override
-  public int numberOfTripSchedules() {
-    return schedules.size();
-  }
-
-  @Override
-  public boolean useCustomizedTripSearch() {
-    return false;
-  }
-
-  @Override
-  public RaptorTripScheduleSearch<TestTripSchedule> createCustomizedTripSearch(
-    SearchDirection direction
-  ) {
-    throw new IllegalStateException(
-      "Support for frequency based trips are not implemented here. " +
-      "This is outside the scope of the Raptor unit tests."
-    );
-  }
+  /* RaptorRoute */
 
   @Override
   public RaptorTimeTable<TestTripSchedule> timetable() {
@@ -97,6 +56,23 @@ public class TestRoute implements RaptorRoute<TestTripSchedule>, RaptorTimeTable
   @Override
   public RaptorConstrainedTripScheduleBoardingSearch<TestTripSchedule> transferConstraintsReverseSearch() {
     return transferConstraintsReverseSearch;
+  }
+
+  /* RaptorTimeTable */
+
+  @Override
+  public TestTripSchedule getTripSchedule(int index) {
+    return schedules.get(index);
+  }
+
+  @Override
+  public int numberOfTripSchedules() {
+    return schedules.size();
+  }
+
+  @Override
+  public RaptorTripScheduleSearch<TestTripSchedule> tripSearch(SearchDirection direction) {
+    return TripScheduleSearchFactory.create(direction, new TestTripSearchTimetable(this));
   }
 
   public List<TestConstrainedTransfer> listTransferConstraintsForwardSearch() {

--- a/src/test/java/org/opentripplanner/transit/raptor/_data/transit/TestTripSearchTimetable.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/_data/transit/TestTripSearchTimetable.java
@@ -1,0 +1,46 @@
+package org.opentripplanner.transit.raptor._data.transit;
+
+import java.util.function.IntUnaryOperator;
+import org.opentripplanner.routing.algorithm.raptoradapter.transit.request.TripScheduleSearchFactory;
+import org.opentripplanner.routing.algorithm.raptoradapter.transit.request.TripSearchTimetable;
+import org.opentripplanner.transit.raptor.api.request.SearchDirection;
+import org.opentripplanner.transit.raptor.api.transit.RaptorTripScheduleSearch;
+
+public class TestTripSearchTimetable implements TripSearchTimetable<TestTripSchedule> {
+
+  private final TestTripSchedule[] trips;
+
+  public TestTripSearchTimetable(TestRoute route) {
+    int nTrips = route.timetable().numberOfTripSchedules();
+    this.trips = new TestTripSchedule[nTrips];
+
+    for (int i = 0; i < nTrips; ++i) {
+      trips[i] = route.getTripSchedule(i);
+    }
+  }
+
+  @Override
+  public TestTripSchedule getTripSchedule(int index) {
+    return trips[index];
+  }
+
+  @Override
+  public int numberOfTripSchedules() {
+    return trips.length;
+  }
+
+  @Override
+  public IntUnaryOperator getArrivalTimes(int stopPositionInPattern) {
+    return (int tripIndex) -> trips[tripIndex].arrival(stopPositionInPattern);
+  }
+
+  @Override
+  public IntUnaryOperator getDepartureTimes(int stopPositionInPattern) {
+    return (int tripIndex) -> trips[tripIndex].departure(stopPositionInPattern);
+  }
+
+  @Override
+  public RaptorTripScheduleSearch<TestTripSchedule> tripSearch(SearchDirection direction) {
+    return TripScheduleSearchFactory.create(direction, this);
+  }
+}


### PR DESCRIPTION
### Summary
Searching for a trip to board at a particular stop is Transit Model dependent, it could possible take request parameters into account as well as being adapted to an optimized data structure; This PR move the trip search and all interfaces out of Raptor and into the Transit Raptor Adaptor layer. 

### Issue
part of  #4002

### Unit tests
Unit tests are moved as well, no new tests added. But, some test now reuse the TripSearch instead of mocking this, the search is made generic enough so it can be reused in the Raptor tests - operating on a different model. 
 
### Code style
✅ 

### Documentation
✅  I have tried to update all relevant Java documentation.

