### PR TITLE
Add an implementation for fetching alternative legs

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLStopImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLStopImpl.java
@@ -361,7 +361,7 @@ public class LegacyGraphQLStopImpl implements LegacyGraphQLDataFetchers.LegacyGr
 
       return stream
         .flatMap(stoptimesWithPattern -> stoptimesWithPattern.times.stream())
-        .sorted(Comparator.comparing(t -> t.getServiceDay() + t.getRealtimeDeparture()))
+        .sorted(Comparator.comparing(t -> t.getServiceDayMidnight() + t.getRealtimeDeparture()))
         .limit(args.getLegacyGraphQLNumberOfDepartures())
         .collect(Collectors.toList());
     };

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLStoptimeImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLStoptimeImpl.java
@@ -98,7 +98,7 @@ public class LegacyGraphQLStoptimeImpl implements LegacyGraphQLDataFetchers.Lega
 
   @Override
   public DataFetcher<Long> serviceDay() {
-    return environment -> getSource(environment).getServiceDay();
+    return environment -> getSource(environment).getServiceDayMidnight();
   }
 
   @Override

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
@@ -89,6 +89,8 @@ import org.opentripplanner.ext.transmodelapi.support.GqlUtil;
 import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.model.Route;
 import org.opentripplanner.model.TransitMode;
+import org.opentripplanner.model.plan.legreference.LegReference;
+import org.opentripplanner.model.plan.legreference.LegReferenceSerializer;
 import org.opentripplanner.routing.RoutingService;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.routing.api.request.RoutingRequest;
@@ -1473,6 +1475,33 @@ public class TransmodelGraphQLSchema {
               .getRoutingService(environment)
               .getTransitAlertService()
               .getAlertById(environment.getArgument("situationNumber"));
+          })
+          .build()
+      )
+      .field(
+        GraphQLFieldDefinition
+          .newFieldDefinition()
+          .name("leg")
+          .description("Refetch a single leg based on its id")
+          .withDirective(gqlUtil.timingData)
+          .type(LegType.REF)
+          .argument(
+            GraphQLArgument
+              .newArgument()
+              .name("id")
+              .type(new GraphQLNonNull(Scalars.GraphQLID))
+              .build()
+          )
+          .dataFetcher(environment -> {
+            final String id = environment.getArgument("id");
+            if (id.isBlank()) {
+              return null;
+            }
+            LegReference ref = LegReferenceSerializer.decode(id);
+            if (ref == null) {
+              return null;
+            }
+            return ref.getLeg(GqlUtil.getRoutingService(environment));
           })
           .build()
       )

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/EnumTypes.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/EnumTypes.java
@@ -13,6 +13,7 @@ import org.opentripplanner.model.plan.RelativeDirection;
 import org.opentripplanner.model.plan.VertexType;
 import org.opentripplanner.model.transfer.TransferPriority;
 import org.opentripplanner.routing.alertpatch.StopCondition;
+import org.opentripplanner.routing.alternativelegs.AlternativeLegsFilter;
 import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.routing.api.response.InputField;
 import org.opentripplanner.routing.api.response.RoutingErrorCode;
@@ -447,6 +448,15 @@ public class EnumTypes {
     .value("untilPreviousDay", "untilPreviousDay")
     .value("advanceAndDayOfTravel", "advanceAndDayOfTravel")
     .value("other", "other")
+    .build();
+
+  public static GraphQLEnumType ALTERNATIVE_LEGS_FILTER = GraphQLEnumType
+    .newEnum()
+    .name("AlternativeLegsFilter")
+    .value("noFilter", AlternativeLegsFilter.NO_FILTER)
+    .value("sameAuthority", AlternativeLegsFilter.SAME_AGENCY)
+    .value("sameMode", AlternativeLegsFilter.SAME_MODE)
+    .value("sameLine", AlternativeLegsFilter.SAME_ROUTE)
     .build();
 
   private static <T extends Enum> GraphQLEnumType createEnum(

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/TripTimeShortHelper.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/TripTimeShortHelper.java
@@ -88,14 +88,7 @@ public class TripTimeShortHelper {
     ServiceDate serviceDate = transitLeg.getServiceDate();
     return IntStream
       .range(0, tripPattern.numberOfStops())
-      .mapToObj(i ->
-        new TripTimeOnDate(
-          tripTimes,
-          i,
-          tripPattern,
-          serviceDate,
-          serviceDateMidnight
-        )
+      .mapToObj(i -> new TripTimeOnDate(tripTimes, i, tripPattern, serviceDate, serviceDateMidnight)
       )
       .collect(Collectors.toList());
   }
@@ -114,14 +107,7 @@ public class TripTimeShortHelper {
     ServiceDate serviceDate = transitLeg.getServiceDate();
     return IntStream
       .range(leg.getBoardStopPosInPattern() + 1, leg.getAlightStopPosInPattern())
-      .mapToObj(i ->
-        new TripTimeOnDate(
-          tripTimes,
-          i,
-          tripPattern,
-          serviceDate,
-          serviceDateMidnight
-        )
+      .mapToObj(i -> new TripTimeOnDate(tripTimes, i, tripPattern, serviceDate, serviceDateMidnight)
       )
       .collect(Collectors.toList());
   }

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/TripTimeShortHelper.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/TripTimeShortHelper.java
@@ -7,6 +7,7 @@ import java.util.stream.IntStream;
 import javax.annotation.Nullable;
 import org.opentripplanner.model.TripPattern;
 import org.opentripplanner.model.TripTimeOnDate;
+import org.opentripplanner.model.calendar.ServiceDate;
 import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.model.plan.ScheduledTransitLeg;
 import org.opentripplanner.routing.trippattern.TripTimes;
@@ -29,6 +30,7 @@ public class TripTimeShortHelper {
       transitLeg.getTripTimes(),
       transitLeg.getBoardStopPosInPattern(),
       transitLeg.getTripPattern(),
+      transitLeg.getServiceDate(),
       transitLeg.getServiceDateMidnight()
     );
     /* TODO OTP2 This method is only used for EstimatedCalls for from place. We have to decide
@@ -56,6 +58,7 @@ public class TripTimeShortHelper {
       transitLeg.getTripTimes(),
       transitLeg.getAlightStopPosInPattern(),
       transitLeg.getTripPattern(),
+      transitLeg.getServiceDate(),
       transitLeg.getServiceDateMidnight()
     );
     /* TODO OTP2 This method is only used for EstimatedCalls for to place. We have to decide
@@ -82,9 +85,18 @@ public class TripTimeShortHelper {
     TripTimes tripTimes = transitLeg.getTripTimes();
     TripPattern tripPattern = transitLeg.getTripPattern();
     Instant serviceDateMidnight = transitLeg.getServiceDateMidnight();
+    ServiceDate serviceDate = transitLeg.getServiceDate();
     return IntStream
       .range(0, tripPattern.numberOfStops())
-      .mapToObj(i -> new TripTimeOnDate(tripTimes, i, tripPattern, serviceDateMidnight))
+      .mapToObj(i ->
+        new TripTimeOnDate(
+          tripTimes,
+          i,
+          tripPattern,
+          serviceDate,
+          serviceDateMidnight
+        )
+      )
       .collect(Collectors.toList());
   }
 
@@ -99,9 +111,18 @@ public class TripTimeShortHelper {
     TripTimes tripTimes = transitLeg.getTripTimes();
     TripPattern tripPattern = transitLeg.getTripPattern();
     Instant serviceDateMidnight = transitLeg.getServiceDateMidnight();
+    ServiceDate serviceDate = transitLeg.getServiceDate();
     return IntStream
       .range(leg.getBoardStopPosInPattern() + 1, leg.getAlightStopPosInPattern())
-      .mapToObj(i -> new TripTimeOnDate(tripTimes, i, tripPattern, serviceDateMidnight))
+      .mapToObj(i ->
+        new TripTimeOnDate(
+          tripTimes,
+          i,
+          tripPattern,
+          serviceDate,
+          serviceDateMidnight
+        )
+      )
       .collect(Collectors.toList());
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/LegType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/LegType.java
@@ -10,6 +10,7 @@ import graphql.schema.GraphQLList;
 import graphql.schema.GraphQLNonNull;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLOutputType;
+import graphql.schema.GraphQLTypeReference;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -19,9 +20,14 @@ import org.opentripplanner.ext.transmodelapi.model.TripTimeShortHelper;
 import org.opentripplanner.ext.transmodelapi.support.GqlUtil;
 import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.model.plan.StopArrival;
+import org.opentripplanner.model.plan.legreference.LegReference;
+import org.opentripplanner.model.plan.legreference.LegReferenceSerializer;
 import org.opentripplanner.util.PolylineEncoder;
 
 public class LegType {
+
+  private static final String NAME = "Leg";
+  public static final GraphQLTypeReference REF = new GraphQLTypeReference(NAME);
 
   public static GraphQLObjectType create(
     GraphQLOutputType bookingArrangementType,
@@ -44,6 +50,15 @@ public class LegType {
       .name("Leg")
       .description(
         "Part of a trip pattern. Either a ride on a public transport vehicle or access or path link to/from/between places"
+      )
+      .field(
+        GraphQLFieldDefinition
+          .newFieldDefinition()
+          .name("id")
+          .description("An identifier for the leg, which can be used to re-fetch the information.")
+          .type(Scalars.GraphQLID)
+          .dataFetcher(env -> LegReferenceSerializer.encode(leg(env).getLegReference()))
+          .build()
       )
       .field(
         GraphQLFieldDefinition

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/LegType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/LegType.java
@@ -1,6 +1,8 @@
 package org.opentripplanner.ext.transmodelapi.model.plan;
 
+import static org.opentripplanner.ext.transmodelapi.model.EnumTypes.ALTERNATIVE_LEGS_FILTER;
 import static org.opentripplanner.ext.transmodelapi.model.EnumTypes.MODE;
+import static org.opentripplanner.routing.alternativelegs.AlternativeLegsFilter.NO_FILTER;
 
 import graphql.Scalars;
 import graphql.scalars.ExtendedScalars;
@@ -23,7 +25,7 @@ import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.model.plan.StopArrival;
 import org.opentripplanner.model.plan.legreference.LegReferenceSerializer;
 import org.opentripplanner.routing.RoutingService;
-import org.opentripplanner.routing.stoptimes.AlternativeLegs;
+import org.opentripplanner.routing.alternativelegs.AlternativeLegs;
 import org.opentripplanner.util.PolylineEncoder;
 
 public class LegType {
@@ -434,6 +436,15 @@ public class LegType {
               .defaultValueProgrammatic(1)
               .type(Scalars.GraphQLInt)
           )
+          .argument(
+            GraphQLArgument
+              .newArgument()
+              .name("filter")
+              .description("Whether the leg should be similar to this leg in some way.")
+              .defaultValueProgrammatic("noFilter")
+              .type(ALTERNATIVE_LEGS_FILTER)
+              .build()
+          )
           .dataFetcher(env -> {
             Leg leg = leg(env);
             if (!leg.isScheduledTransitLeg()) {
@@ -441,7 +452,13 @@ public class LegType {
             }
             int previous = env.getArgument("previous");
             RoutingService routingService = GqlUtil.getRoutingService(env);
-            return AlternativeLegs.getAlternativeLegs(leg, previous, routingService, true);
+            return AlternativeLegs.getAlternativeLegs(
+              leg,
+              previous,
+              routingService,
+              true,
+              env.getArgument("filter")
+            );
           })
           .build()
       )
@@ -461,6 +478,15 @@ public class LegType {
               .defaultValueProgrammatic(1)
               .type(Scalars.GraphQLInt)
           )
+          .argument(
+            GraphQLArgument
+              .newArgument()
+              .name("filter")
+              .description("Whether the leg should be similar to this leg in some way.")
+              .defaultValueProgrammatic("noFilter")
+              .type(ALTERNATIVE_LEGS_FILTER)
+              .build()
+          )
           .dataFetcher(env -> {
             Leg leg = leg(env);
             if (!leg.isScheduledTransitLeg()) {
@@ -468,7 +494,13 @@ public class LegType {
             }
             int next = env.getArgument("next");
             RoutingService routingService = GqlUtil.getRoutingService(env);
-            return AlternativeLegs.getAlternativeLegs(leg, next, routingService, false);
+            return AlternativeLegs.getAlternativeLegs(
+              leg,
+              next,
+              routingService,
+              false,
+              env.getArgument("filter")
+            );
           })
           .build()
       )

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/LegType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/LegType.java
@@ -5,6 +5,7 @@ import static org.opentripplanner.ext.transmodelapi.model.EnumTypes.MODE;
 import graphql.Scalars;
 import graphql.scalars.ExtendedScalars;
 import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLList;
 import graphql.schema.GraphQLNonNull;
@@ -20,8 +21,9 @@ import org.opentripplanner.ext.transmodelapi.model.TripTimeShortHelper;
 import org.opentripplanner.ext.transmodelapi.support.GqlUtil;
 import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.model.plan.StopArrival;
-import org.opentripplanner.model.plan.legreference.LegReference;
 import org.opentripplanner.model.plan.legreference.LegReferenceSerializer;
+import org.opentripplanner.routing.RoutingService;
+import org.opentripplanner.routing.stoptimes.AlternativeLegs;
 import org.opentripplanner.util.PolylineEncoder;
 
 public class LegType {
@@ -414,6 +416,60 @@ public class LegType {
               ? List.of()
               : List.of(leg(env).getVehicleRentalNetwork())
           )
+          .build()
+      )
+      .field(
+        GraphQLFieldDefinition
+          .newFieldDefinition()
+          .name("previousLegs")
+          .description(
+            "Fetch the previous legs, which can be used to replace this leg. The replacement legs do arrive/depart from/to the same stop places. It might be necessary to change other legs in an itinerary in order to be able to ride the returned legs."
+          )
+          .type(new GraphQLList(new GraphQLNonNull(REF)))
+          .argument(
+            GraphQLArgument
+              .newArgument()
+              .name("previous")
+              .description("Number of earlier legs to return.")
+              .defaultValueProgrammatic(1)
+              .type(Scalars.GraphQLInt)
+          )
+          .dataFetcher(env -> {
+            Leg leg = leg(env);
+            if (!leg.isScheduledTransitLeg()) {
+              return null;
+            }
+            int previous = env.getArgument("previous");
+            RoutingService routingService = GqlUtil.getRoutingService(env);
+            return AlternativeLegs.getAlternativeLegs(leg, previous, routingService, true);
+          })
+          .build()
+      )
+      .field(
+        GraphQLFieldDefinition
+          .newFieldDefinition()
+          .name("nextLegs")
+          .description(
+            "Fetch the next legs, which can be used to replace this leg. The replacement legs do arrive/depart from/to the same stop places. It might be necessary to change other legs in an itinerary in order to be able to ride the returned legs."
+          )
+          .type(new GraphQLList(new GraphQLNonNull(REF)))
+          .argument(
+            GraphQLArgument
+              .newArgument()
+              .name("next")
+              .description("Number of later legs to return.")
+              .defaultValueProgrammatic(1)
+              .type(Scalars.GraphQLInt)
+          )
+          .dataFetcher(env -> {
+            Leg leg = leg(env);
+            if (!leg.isScheduledTransitLeg()) {
+              return null;
+            }
+            int next = env.getArgument("next");
+            RoutingService routingService = GqlUtil.getRoutingService(env);
+            return AlternativeLegs.getAlternativeLegs(leg, next, routingService, false);
+          })
           .build()
       )
       .build();

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/et/EstimatedCallType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/et/EstimatedCallType.java
@@ -66,7 +66,7 @@ public class EstimatedCallType {
           .dataFetcher(environment ->
             1000 *
             (
-              ((TripTimeOnDate) environment.getSource()).getServiceDay() +
+              ((TripTimeOnDate) environment.getSource()).getServiceDayMidnight() +
               ((TripTimeOnDate) environment.getSource()).getScheduledArrival()
             )
           )
@@ -82,7 +82,9 @@ public class EstimatedCallType {
           )
           .dataFetcher(environment -> {
             TripTimeOnDate tripTimeOnDate = environment.getSource();
-            return 1000 * (tripTimeOnDate.getServiceDay() + tripTimeOnDate.getRealtimeArrival());
+            return (
+              1000 * (tripTimeOnDate.getServiceDayMidnight() + tripTimeOnDate.getRealtimeArrival())
+            );
           })
           .build()
       )
@@ -99,7 +101,9 @@ public class EstimatedCallType {
             if (tripTimeOnDate.getActualArrival() == -1) {
               return null;
             }
-            return 1000 * (tripTimeOnDate.getServiceDay() + tripTimeOnDate.getActualArrival());
+            return (
+              1000 * (tripTimeOnDate.getServiceDayMidnight() + tripTimeOnDate.getActualArrival())
+            );
           })
           .build()
       )
@@ -112,7 +116,7 @@ public class EstimatedCallType {
           .dataFetcher(environment ->
             1000 *
             (
-              ((TripTimeOnDate) environment.getSource()).getServiceDay() +
+              ((TripTimeOnDate) environment.getSource()).getServiceDayMidnight() +
               ((TripTimeOnDate) environment.getSource()).getScheduledDeparture()
             )
           )
@@ -128,7 +132,10 @@ public class EstimatedCallType {
           )
           .dataFetcher(environment -> {
             TripTimeOnDate tripTimeOnDate = environment.getSource();
-            return 1000 * (tripTimeOnDate.getServiceDay() + tripTimeOnDate.getRealtimeDeparture());
+            return (
+              1000 *
+              (tripTimeOnDate.getServiceDayMidnight() + tripTimeOnDate.getRealtimeDeparture())
+            );
           })
           .build()
       )
@@ -145,7 +152,9 @@ public class EstimatedCallType {
             if (tripTimeOnDate.getActualDeparture() == -1) {
               return null;
             }
-            return 1000 * (tripTimeOnDate.getServiceDay() + tripTimeOnDate.getActualDeparture());
+            return (
+              1000 * (tripTimeOnDate.getServiceDayMidnight() + tripTimeOnDate.getActualDeparture())
+            );
           })
           .build()
       )
@@ -344,9 +353,7 @@ public class EstimatedCallType {
 
     TransitAlertService alertPatchService = routingService.getTransitAlertService();
 
-    final ServiceDate serviceDate = new ServiceDate(
-      LocalDate.ofEpochDay(1 + tripTimeOnDate.getServiceDay() / (24 * 3600))
-    );
+    final ServiceDate serviceDate = tripTimeOnDate.getServiceDay();
 
     // Quay
     allAlerts.addAll(alertPatchService.getStopAlerts(stopId));
@@ -368,7 +375,7 @@ public class EstimatedCallType {
       alertPatchService.getDirectionAndRouteAlerts(trip.getDirection().gtfsCode, routeId)
     );
 
-    long serviceDayMillis = 1000L * tripTimeOnDate.getServiceDay();
+    long serviceDayMillis = 1000L * tripTimeOnDate.getServiceDayMidnight();
     long arrivalMillis = 1000L * tripTimeOnDate.getRealtimeArrival();
     long departureMillis = 1000L * tripTimeOnDate.getRealtimeDeparture();
 

--- a/src/main/java/org/opentripplanner/api/mapping/TripTimeMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/TripTimeMapper.java
@@ -38,7 +38,7 @@ public class TripTimeMapper {
     api.blockId = domain.getBlockId();
     api.headsign = domain.getHeadsign();
     api.tripId = FeedScopedIdMapper.mapToApi(domain.getTrip().getId());
-    api.serviceDay = domain.getServiceDay();
+    api.serviceDay = domain.getServiceDayMidnight();
 
     return api;
   }

--- a/src/main/java/org/opentripplanner/model/TripTimeOnDate.java
+++ b/src/main/java/org/opentripplanner/model/TripTimeOnDate.java
@@ -95,6 +95,10 @@ public class TripTimeOnDate {
     return stopIndex;
   }
 
+  public TripTimes getTripTimes() {
+    return tripTimes;
+  }
+
   public int getStopCount() {
     return tripTimes.getNumStops();
   }

--- a/src/main/java/org/opentripplanner/model/TripTimeOnDate.java
+++ b/src/main/java/org/opentripplanner/model/TripTimeOnDate.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import org.opentripplanner.model.calendar.ServiceDate;
 import org.opentripplanner.routing.core.ServiceDay;
 import org.opentripplanner.routing.trippattern.RealTimeState;
 import org.opentripplanner.routing.trippattern.TripTimes;
@@ -20,6 +21,7 @@ public class TripTimeOnDate {
   private final int stopIndex;
   // This is only needed because TripTimes has no reference to TripPattern
   private final TripPattern tripPattern;
+  private final ServiceDate serviceDate;
   private final long midnight;
 
   public TripTimeOnDate(
@@ -31,6 +33,7 @@ public class TripTimeOnDate {
     this.tripTimes = tripTimes;
     this.stopIndex = stopIndex;
     this.tripPattern = tripPattern;
+    this.serviceDate = serviceDay != null ? serviceDay.getServiceDate() : null;
     this.midnight = serviceDay != null ? serviceDay.time(0) : UNDEFINED;
   }
 
@@ -38,11 +41,13 @@ public class TripTimeOnDate {
     TripTimes tripTimes,
     int stopIndex,
     TripPattern tripPattern,
+    ServiceDate serviceDate,
     Instant midnight
   ) {
     this.tripTimes = tripTimes;
     this.stopIndex = stopIndex;
     this.tripPattern = tripPattern;
+    this.serviceDate = serviceDate;
     this.midnight = midnight.getEpochSecond();
   }
 
@@ -79,7 +84,7 @@ public class TripTimeOnDate {
   }
 
   public static Comparator<TripTimeOnDate> compareByDeparture() {
-    return Comparator.comparing(t -> t.getServiceDay() + t.getRealtimeDeparture());
+    return Comparator.comparing(t -> t.getServiceDayMidnight() + t.getRealtimeDeparture());
   }
 
   public StopLocation getStop() {
@@ -164,8 +169,12 @@ public class TripTimeOnDate {
     return tripTimes.getRealTimeState();
   }
 
-  public long getServiceDay() {
+  public long getServiceDayMidnight() {
     return midnight;
+  }
+
+  public ServiceDate getServiceDay() {
+    return serviceDate;
   }
 
   public Trip getTrip() {

--- a/src/main/java/org/opentripplanner/model/plan/Leg.java
+++ b/src/main/java/org/opentripplanner/model/plan/Leg.java
@@ -15,6 +15,7 @@ import org.opentripplanner.model.Route;
 import org.opentripplanner.model.StreetNote;
 import org.opentripplanner.model.Trip;
 import org.opentripplanner.model.calendar.ServiceDate;
+import org.opentripplanner.model.plan.legreference.LegReference;
 import org.opentripplanner.model.transfer.ConstrainedTransfer;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.routing.core.TraverseMode;
@@ -364,6 +365,10 @@ public interface Leg {
    * -1 indicate that the cost is not set/computed.
    */
   int getGeneralizedCost();
+
+  default LegReference getLegReference() {
+    return null;
+  }
 
   default void addAlert(TransitAlert alert) {
     throw new UnsupportedOperationException();

--- a/src/main/java/org/opentripplanner/model/plan/ScheduledTransitLeg.java
+++ b/src/main/java/org/opentripplanner/model/plan/ScheduledTransitLeg.java
@@ -24,6 +24,8 @@ import org.opentripplanner.model.Trip;
 import org.opentripplanner.model.TripPattern;
 import org.opentripplanner.model.base.ToStringBuilder;
 import org.opentripplanner.model.calendar.ServiceDate;
+import org.opentripplanner.model.plan.legreference.LegReference;
+import org.opentripplanner.model.plan.legreference.ScheduledTransitLegReference;
 import org.opentripplanner.model.transfer.ConstrainedTransfer;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.routing.core.TraverseMode;
@@ -296,6 +298,16 @@ public class ScheduledTransitLeg implements Leg {
   @Override
   public int getGeneralizedCost() {
     return generalizedCost;
+  }
+
+  @Override
+  public LegReference getLegReference() {
+    return new ScheduledTransitLegReference(
+      tripTimes.getTrip().getId(),
+      serviceDate,
+      boardStopPosInPattern,
+      alightStopPosInPattern
+    );
   }
 
   public void addAlert(TransitAlert alert) {

--- a/src/main/java/org/opentripplanner/model/plan/legreference/LegReference.java
+++ b/src/main/java/org/opentripplanner/model/plan/legreference/LegReference.java
@@ -1,6 +1,11 @@
 package org.opentripplanner.model.plan.legreference;
 
+import org.opentripplanner.model.plan.Leg;
+import org.opentripplanner.routing.RoutingService;
+
 /**
  * Marker interface for various types of leg references
  */
-public interface LegReference {}
+public interface LegReference {
+  Leg getLeg(RoutingService routingService);
+}

--- a/src/main/java/org/opentripplanner/model/plan/legreference/LegReference.java
+++ b/src/main/java/org/opentripplanner/model/plan/legreference/LegReference.java
@@ -1,0 +1,6 @@
+package org.opentripplanner.model.plan.legreference;
+
+/**
+ * Marker interface for various types of leg references
+ */
+public interface LegReference {}

--- a/src/main/java/org/opentripplanner/model/plan/legreference/LegReferenceSerializer.java
+++ b/src/main/java/org/opentripplanner/model/plan/legreference/LegReferenceSerializer.java
@@ -1,0 +1,103 @@
+package org.opentripplanner.model.plan.legreference;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.text.ParseException;
+import java.util.Base64;
+import javax.annotation.Nullable;
+import org.opentripplanner.model.FeedScopedId;
+import org.opentripplanner.model.calendar.ServiceDate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Serializer for LegReferences
+ */
+public class LegReferenceSerializer {
+
+  private static final Logger LOG = LoggerFactory.getLogger(LegReferenceSerializer.class);
+
+  /** private constructor to prevent instantiating this utility class */
+  private LegReferenceSerializer() {}
+
+  @Nullable
+  public static String encode(LegReference legReference) {
+    if (legReference == null) {
+      return null;
+    }
+    LegReferenceType typeEnum = LegReferenceType.forClass(legReference.getClass());
+
+    if (typeEnum == null) {
+      throw new IllegalArgumentException("Unknown LegReference type");
+    }
+
+    var buf = new ByteArrayOutputStream();
+    try (var out = new ObjectOutputStream(buf)) {
+      // The order must be the same in the encode and decode function
+      writeEnum(typeEnum, out);
+      typeEnum.getSerializer().write(legReference, out);
+      out.flush();
+      return Base64.getUrlEncoder().encodeToString(buf.toByteArray());
+    } catch (IOException e) {
+      LOG.error("Failed to encode leg reference", e);
+      return null;
+    }
+  }
+
+  @Nullable
+  public static LegReference decode(String legReference) {
+    if (legReference == null) {
+      return null;
+    }
+
+    var buf = Base64.getUrlDecoder().decode(legReference);
+    var input = new ByteArrayInputStream(buf);
+
+    try (var in = new ObjectInputStream(input)) {
+      // The order must be the same in the encode and decode function
+
+      var type = readEnum(in, LegReferenceType.class);
+      return type.getDeserializer().read(in);
+    } catch (IOException | ParseException e) {
+      LOG.error("Unable to decode leg reference: '" + legReference + "'", e);
+      return null;
+    }
+  }
+
+  static void writeScheduledTransitLeg(LegReference ref, ObjectOutputStream out)
+    throws IOException {
+    if (ref instanceof ScheduledTransitLegReference s) {
+      out.writeUTF(s.trip().toString());
+      out.writeUTF(s.serviceDate().asCompactString());
+      out.writeInt(s.fromStopPositionInPattern());
+      out.writeInt(s.toStopPositionInPattern());
+    } else {
+      throw new IllegalArgumentException("Invalid LegReference type");
+    }
+  }
+
+  static LegReference readScheduledTransitLeg(ObjectInputStream objectInputStream)
+    throws IOException, ParseException {
+    return new ScheduledTransitLegReference(
+      FeedScopedId.parseId(objectInputStream.readUTF()),
+      ServiceDate.parseString(objectInputStream.readUTF()),
+      objectInputStream.readInt(),
+      objectInputStream.readInt()
+    );
+  }
+
+  private static <T extends Enum<T>> void writeEnum(T value, ObjectOutputStream out)
+    throws IOException {
+    out.writeUTF(value.name());
+  }
+
+  @SuppressWarnings("SameParameterValue")
+  private static <T extends Enum<T>> T readEnum(ObjectInputStream in, Class<T> enumType)
+    throws IOException {
+    String value = in.readUTF();
+    return Enum.valueOf(enumType, value);
+  }
+}

--- a/src/main/java/org/opentripplanner/model/plan/legreference/LegReferenceSerializer.java
+++ b/src/main/java/org/opentripplanner/model/plan/legreference/LegReferenceSerializer.java
@@ -70,7 +70,7 @@ public class LegReferenceSerializer {
   static void writeScheduledTransitLeg(LegReference ref, ObjectOutputStream out)
     throws IOException {
     if (ref instanceof ScheduledTransitLegReference s) {
-      out.writeUTF(s.trip().toString());
+      out.writeUTF(s.tripId().toString());
       out.writeUTF(s.serviceDate().asCompactString());
       out.writeInt(s.fromStopPositionInPattern());
       out.writeInt(s.toStopPositionInPattern());

--- a/src/main/java/org/opentripplanner/model/plan/legreference/LegReferenceType.java
+++ b/src/main/java/org/opentripplanner/model/plan/legreference/LegReferenceType.java
@@ -1,0 +1,59 @@
+package org.opentripplanner.model.plan.legreference;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.text.ParseException;
+
+/**
+ * Enum for different types of LegReferences
+ */
+enum LegReferenceType {
+  SCHEDULED_TRANSIT_LEG_V1(
+    ScheduledTransitLegReference.class,
+    LegReferenceSerializer::writeScheduledTransitLeg,
+    LegReferenceSerializer::readScheduledTransitLeg
+  );
+
+  private final Class<? extends LegReference> legReferenceClass;
+
+  private final Writer<LegReference> serializer;
+  private final Reader<? extends LegReference> deserializer;
+
+  LegReferenceType(
+    Class<? extends LegReference> legReferenceClass,
+    Writer<LegReference> serializer,
+    Reader<? extends LegReference> deserializer
+  ) {
+    this.legReferenceClass = legReferenceClass;
+    this.serializer = serializer;
+    this.deserializer = deserializer;
+  }
+
+  static LegReferenceType forClass(Class<? extends LegReference> legReferenceClass) {
+    for (var type : LegReferenceType.values()) {
+      if (type.legReferenceClass.equals(legReferenceClass)) {
+        return type;
+      }
+    }
+    return null;
+  }
+
+  Writer<LegReference> getSerializer() {
+    return serializer;
+  }
+
+  Reader<? extends LegReference> getDeserializer() {
+    return deserializer;
+  }
+
+  @FunctionalInterface
+  interface Writer<T> {
+    void write(T t, ObjectOutputStream out) throws IOException;
+  }
+
+  @FunctionalInterface
+  interface Reader<T> {
+    T read(ObjectInputStream in) throws IOException, ParseException;
+  }
+}

--- a/src/main/java/org/opentripplanner/model/plan/legreference/ScheduledTransitLegReference.java
+++ b/src/main/java/org/opentripplanner/model/plan/legreference/ScheduledTransitLegReference.java
@@ -41,7 +41,7 @@ public record ScheduledTransitLegReference(
 
     // Otherwise use scheduled pattern
     if (tripPattern == null) {
-      tripPattern = routingService.getTripPatternForId(tripId);
+      tripPattern = routingService.getPatternForTrip().get(trip);
     }
 
     // no matching pattern found anywhere

--- a/src/main/java/org/opentripplanner/model/plan/legreference/ScheduledTransitLegReference.java
+++ b/src/main/java/org/opentripplanner/model/plan/legreference/ScheduledTransitLegReference.java
@@ -1,17 +1,76 @@
 package org.opentripplanner.model.plan.legreference;
 
+import java.time.ZoneId;
+import java.util.GregorianCalendar;
 import org.opentripplanner.model.FeedScopedId;
+import org.opentripplanner.model.Timetable;
+import org.opentripplanner.model.TimetableSnapshot;
+import org.opentripplanner.model.Trip;
+import org.opentripplanner.model.TripPattern;
 import org.opentripplanner.model.calendar.ServiceDate;
 import org.opentripplanner.model.plan.ScheduledTransitLeg;
+import org.opentripplanner.routing.RoutingService;
+import org.opentripplanner.routing.trippattern.TripTimes;
 
 /**
  * A reference which can be used to rebuild an exact copy of a {@link ScheduledTransitLeg} using the
  * {@Link RoutingService}
  */
 public record ScheduledTransitLegReference(
-  FeedScopedId trip,
+  FeedScopedId tripId,
   ServiceDate serviceDate,
   int fromStopPositionInPattern,
   int toStopPositionInPattern
 )
-  implements LegReference {}
+  implements LegReference {
+  @Override
+  public ScheduledTransitLeg getLeg(RoutingService routingService) {
+    Trip trip = routingService.getTripForId().get(tripId);
+
+    if (trip == null) {
+      return null;
+    }
+
+    TripPattern tripPattern = null;
+    TimetableSnapshot timetableSnapshot = routingService.getTimetableSnapshot();
+
+    // Check if pattern is changed by real-time updater
+    if (timetableSnapshot != null) {
+      tripPattern = timetableSnapshot.getLastAddedTripPattern(tripId, serviceDate);
+    }
+
+    // Otherwise use scheduled pattern
+    if (tripPattern == null) {
+      tripPattern = routingService.getTripPatternForId(tripId);
+    }
+
+    // no matching pattern found anywhere
+    if (tripPattern == null) {
+      return null;
+    }
+
+    Timetable timetable = routingService.getTimetableForTripPattern(tripPattern, serviceDate);
+
+    TripTimes tripTimes = timetable.getTripTimes(trip);
+
+    // TODO: What should we have here
+    ZoneId timeZone = routingService.getTimeZone().toZoneId();
+
+    int boardingTime = tripTimes.getDepartureTime(fromStopPositionInPattern);
+    int alightingTime = tripTimes.getArrivalTime(toStopPositionInPattern);
+
+    return new ScheduledTransitLeg(
+      tripTimes,
+      tripPattern,
+      fromStopPositionInPattern,
+      toStopPositionInPattern,
+      GregorianCalendar.from(serviceDate.toZonedDateTime(timeZone, boardingTime)),
+      GregorianCalendar.from(serviceDate.toZonedDateTime(timeZone, alightingTime)),
+      serviceDate.toLocalDate(),
+      timeZone,
+      null,
+      null,
+      0 // TODO: What should we have here
+    );
+  }
+}

--- a/src/main/java/org/opentripplanner/model/plan/legreference/ScheduledTransitLegReference.java
+++ b/src/main/java/org/opentripplanner/model/plan/legreference/ScheduledTransitLegReference.java
@@ -1,0 +1,17 @@
+package org.opentripplanner.model.plan.legreference;
+
+import org.opentripplanner.model.FeedScopedId;
+import org.opentripplanner.model.calendar.ServiceDate;
+import org.opentripplanner.model.plan.ScheduledTransitLeg;
+
+/**
+ * A reference which can be used to rebuild an exact copy of a {@link ScheduledTransitLeg} using the
+ * {@Link RoutingService}
+ */
+public record ScheduledTransitLegReference(
+  FeedScopedId trip,
+  ServiceDate serviceDate,
+  int fromStopPositionInPattern,
+  int toStopPositionInPattern
+)
+  implements LegReference {}

--- a/src/main/java/org/opentripplanner/routing/alternativelegs/AlternativeLegsFilter.java
+++ b/src/main/java/org/opentripplanner/routing/alternativelegs/AlternativeLegsFilter.java
@@ -1,0 +1,28 @@
+package org.opentripplanner.routing.alternativelegs;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+import org.opentripplanner.model.TripPattern;
+import org.opentripplanner.model.plan.Leg;
+
+public enum AlternativeLegsFilter {
+  NO_FILTER((Leg leg) -> (TripPattern tripPattern) -> true),
+  SAME_AGENCY((Leg leg) ->
+    (TripPattern tripPattern) -> leg.getAgency().equals(tripPattern.getRoute().getAgency())
+  ),
+  SAME_ROUTE((Leg leg) -> (TripPattern tripPattern) -> leg.getRoute().equals(tripPattern.getRoute())
+  ),
+  SAME_MODE((Leg leg) ->
+    (TripPattern tripPattern) -> leg.getTrip().getMode().equals(tripPattern.getMode())
+  );
+
+  public final Function<Leg, Predicate<TripPattern>> predicateGenerator;
+
+  AlternativeLegsFilter(Function<Leg, Predicate<TripPattern>> predicateGenerator) {
+    this.predicateGenerator = predicateGenerator;
+  }
+
+  public Predicate<TripPattern> getFilter(Leg leg) {
+    return predicateGenerator.apply(leg);
+  }
+}

--- a/src/main/java/org/opentripplanner/routing/stoptimes/AlternativeLegs.java
+++ b/src/main/java/org/opentripplanner/routing/stoptimes/AlternativeLegs.java
@@ -108,9 +108,9 @@ public class AlternativeLegs {
     ServiceDate originalDate,
     boolean searchBackward
   ) {
-    var pattern = patternWithBoardAlightPositions.first;
-    var boardingPosition = patternWithBoardAlightPositions.second.first;
-    var alightingPosition = patternWithBoardAlightPositions.second.second;
+    TripPattern pattern = patternWithBoardAlightPositions.first;
+    int boardingPosition = patternWithBoardAlightPositions.second.first;
+    int alightingPosition = patternWithBoardAlightPositions.second.second;
 
     // TODO: What should we have here
     ZoneId timeZone = routingService.getTimeZone().toZoneId();
@@ -178,8 +178,8 @@ public class AlternativeLegs {
   private static ScheduledTransitLeg mapToLeg(
     ZoneId timeZone,
     TripPattern pattern,
-    Integer boardingPosition,
-    Integer alightingPosition,
+    int boardingPosition,
+    int alightingPosition,
     TripTimeOnDate tripTimeOnDate
   ) {
     ServiceDate serviceDay = tripTimeOnDate.getServiceDay();

--- a/src/main/java/org/opentripplanner/routing/stoptimes/AlternativeLegs.java
+++ b/src/main/java/org/opentripplanner/routing/stoptimes/AlternativeLegs.java
@@ -1,0 +1,242 @@
+package org.opentripplanner.routing.stoptimes;
+
+import static org.opentripplanner.routing.stoptimes.StopTimesHelper.skipByTripCancellation;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.GregorianCalendar;
+import java.util.List;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import javax.annotation.Nonnull;
+import org.opentripplanner.common.model.P2;
+import org.opentripplanner.common.model.T2;
+import org.opentripplanner.model.Station;
+import org.opentripplanner.model.StopLocation;
+import org.opentripplanner.model.Timetable;
+import org.opentripplanner.model.TimetableSnapshot;
+import org.opentripplanner.model.TripPattern;
+import org.opentripplanner.model.TripTimeOnDate;
+import org.opentripplanner.model.calendar.ServiceDate;
+import org.opentripplanner.model.plan.Leg;
+import org.opentripplanner.model.plan.ScheduledTransitLeg;
+import org.opentripplanner.routing.RoutingService;
+import org.opentripplanner.routing.core.ServiceDay;
+import org.opentripplanner.routing.trippattern.TripTimes;
+
+/**
+ * A helper class to fetch previous/next alternative legs for a scheduled transit leg.
+ * The replacement legs arrive/depart from/to the same station as the original leg, but uses other
+ * trips for the leg.
+ *
+ * Generalized cost and constrained transfers are not included in the alternative legs.
+ */
+public class AlternativeLegs {
+
+  public static final int ZERO_COST = 0;
+
+  public static List<ScheduledTransitLeg> getAlternativeLegs(
+    Leg leg,
+    Integer numberLegs,
+    RoutingService routingService,
+    boolean searchBackward
+  ) {
+    StopLocation fromStop = leg.getFrom().stop;
+    StopLocation toStop = leg.getTo().stop;
+
+    Station fromStation = fromStop.getParentStation();
+    Station toStation = toStop.getParentStation();
+
+    Collection<StopLocation> origins = fromStation == null
+      ? List.of(fromStop)
+      : fromStation.getChildStops();
+
+    Collection<StopLocation> destinations = toStation == null
+      ? List.of(toStop)
+      : toStation.getChildStops();
+
+    TimetableSnapshot timetableSnapshot = routingService.getTimetableSnapshot();
+
+    Comparator<ScheduledTransitLeg> legComparator = Comparator.comparing(
+      ScheduledTransitLeg::getStartTime
+    );
+
+    if (searchBackward) {
+      legComparator = legComparator.reversed();
+    }
+
+    return origins
+      .stream()
+      .flatMap(stop -> routingService.getPatternsForStop(stop, timetableSnapshot).stream())
+      .filter(tripPattern -> tripPattern.getStops().stream().anyMatch(destinations::contains))
+      .flatMap(tripPattern -> withBoardingAlightingPositions(origins, destinations, tripPattern))
+      .flatMap(t ->
+        generateLegs(
+          routingService,
+          timetableSnapshot,
+          t,
+          leg.getStartTime(),
+          leg.getServiceDate(),
+          searchBackward
+        )
+      )
+      .filter(Predicate.not(leg::isPartiallySameTransitLeg))
+      .sorted(legComparator)
+      .limit(numberLegs)
+      .collect(Collectors.toList());
+  }
+
+  /**
+   * This has been copied and slightly modified from StopTimesHelper.
+   * TODO: Adapt after new transit model is in place
+   */
+  @Nonnull
+  private static Stream<ScheduledTransitLeg> generateLegs(
+    RoutingService routingService,
+    TimetableSnapshot timetableSnapshot,
+    T2<TripPattern, P2<Integer>> patternWithBoardAlightPositions,
+    Calendar departureTime,
+    ServiceDate originalDate,
+    boolean searchBackward
+  ) {
+    var pattern = patternWithBoardAlightPositions.first;
+    var boardingPosition = patternWithBoardAlightPositions.second.first;
+    var alightingPosition = patternWithBoardAlightPositions.second.second;
+
+    // TODO: What should we have here
+    ZoneId timeZone = routingService.getTimeZone().toZoneId();
+
+    Comparator<TripTimeOnDate> comparator = Comparator.comparing((TripTimeOnDate tts) ->
+      tts.getServiceDayMidnight() + tts.getRealtimeDeparture()
+    );
+
+    if (searchBackward) {
+      comparator = comparator.reversed();
+    }
+
+    Queue<TripTimeOnDate> pq = new PriorityQueue<>(comparator);
+
+    long startTime = departureTime.getTimeInMillis() / 1000;
+
+    // Loop through all possible days
+    ServiceDate[] serviceDates = { originalDate.previous(), originalDate, originalDate.next() };
+
+    for (ServiceDate serviceDate : serviceDates) {
+      ServiceDay sd = new ServiceDay(
+        routingService.getServiceCodes(),
+        serviceDate,
+        routingService.getCalendarService(),
+        pattern.getRoute().getAgency().getId()
+      );
+
+      Timetable timetable;
+      if (timetableSnapshot != null) {
+        timetable = timetableSnapshot.resolve(pattern, serviceDate);
+      } else {
+        timetable = pattern.getScheduledTimetable();
+      }
+
+      int secondsSinceMidnight = sd.secondsSinceMidnight(startTime);
+      for (TripTimes tripTimes : timetable.getTripTimes()) {
+        if (!sd.serviceRunning(tripTimes.getServiceCode())) {
+          continue;
+        }
+        if (skipByTripCancellation(tripTimes, false)) {
+          continue;
+        }
+
+        boolean departureTimeInRange = searchBackward
+          ? tripTimes.getDepartureTime(boardingPosition) <= secondsSinceMidnight
+          : tripTimes.getDepartureTime(boardingPosition) >= secondsSinceMidnight;
+
+        if (departureTimeInRange) {
+          pq.add(new TripTimeOnDate(tripTimes, boardingPosition, pattern, sd));
+        }
+      }
+    }
+
+    List<ScheduledTransitLeg> res = new ArrayList<>();
+
+    while (!pq.isEmpty()) {
+      TripTimeOnDate tripTimeOnDate = pq.poll();
+      res.add(mapToLeg(timeZone, pattern, boardingPosition, alightingPosition, tripTimeOnDate));
+    }
+
+    return res.stream();
+  }
+
+  @Nonnull
+  private static ScheduledTransitLeg mapToLeg(
+    ZoneId timeZone,
+    TripPattern pattern,
+    Integer boardingPosition,
+    Integer alightingPosition,
+    TripTimeOnDate tripTimeOnDate
+  ) {
+    ServiceDate serviceDay = tripTimeOnDate.getServiceDay();
+
+    TripTimes tripTimes = tripTimeOnDate.getTripTimes();
+    ZonedDateTime boardingTime = serviceDay.toZonedDateTime(
+      timeZone,
+      tripTimeOnDate.getRealtimeDeparture()
+    );
+    ZonedDateTime alightingTime = serviceDay.toZonedDateTime(
+      timeZone,
+      tripTimes.getArrivalTime(alightingPosition)
+    );
+
+    return new ScheduledTransitLeg(
+      tripTimes,
+      pattern,
+      boardingPosition,
+      alightingPosition,
+      GregorianCalendar.from(boardingTime),
+      GregorianCalendar.from(alightingTime),
+      serviceDay.toLocalDate(),
+      timeZone,
+      null,
+      null,
+      ZERO_COST
+    );
+  }
+
+  @Nonnull
+  private static Stream<T2<TripPattern, P2<Integer>>> withBoardingAlightingPositions(
+    Collection<StopLocation> origins,
+    Collection<StopLocation> destinations,
+    TripPattern tripPattern
+  ) {
+    List<StopLocation> stops = tripPattern.getStops();
+
+    // Find out all alighting positions
+    var alightingPositions = IntStream
+      .iterate(stops.size() - 1, i -> i - 1)
+      .limit(stops.size())
+      .filter(i -> destinations.contains(stops.get(i)) && tripPattern.canAlight(i))
+      .toArray();
+
+    // Find out all boarding positions
+    return IntStream
+      .range(0, stops.size())
+      .filter(i -> origins.contains(stops.get(i)) && tripPattern.canBoard(i))
+      .boxed()
+      // Create a cartesian product of the pairs
+      .flatMap(boardingPosition ->
+        Arrays
+          .stream(alightingPositions)
+          // Filter out the impossible combinations
+          .filter(alightingPosition -> boardingPosition < alightingPosition)
+          .mapToObj(alightingPosition -> new P2<>(boardingPosition, alightingPosition))
+      )
+      .map(pair -> new T2<>(tripPattern, pair));
+  }
+}

--- a/src/main/java/org/opentripplanner/routing/stoptimes/StopTimesHelper.java
+++ b/src/main/java/org/opentripplanner/routing/stoptimes/StopTimesHelper.java
@@ -330,7 +330,7 @@ public class StopTimesHelper {
     return replacement != null && !replacement.equals(pattern);
   }
 
-  private static boolean skipByTripCancellation(TripTimes tripTimes, boolean includeCancellations) {
+  static boolean skipByTripCancellation(TripTimes tripTimes, boolean includeCancellations) {
     return (
       (tripTimes.isCanceled() || tripTimes.getTrip().getTripAlteration().isCanceledOrReplaced()) &&
       !includeCancellations

--- a/src/main/java/org/opentripplanner/routing/stoptimes/StopTimesHelper.java
+++ b/src/main/java/org/opentripplanner/routing/stoptimes/StopTimesHelper.java
@@ -240,7 +240,7 @@ public class StopTimesHelper {
     MinMaxPriorityQueue<TripTimeOnDate> pq = MinMaxPriorityQueue
       .orderedBy(
         Comparator.comparing((TripTimeOnDate tts) ->
-          tts.getServiceDay() + tts.getRealtimeDeparture()
+          tts.getServiceDayMidnight() + tts.getRealtimeDeparture()
         )
       )
       .maximumSize(numberOfDepartures)

--- a/src/main/java/org/opentripplanner/routing/stoptimes/StopTimesHelper.java
+++ b/src/main/java/org/opentripplanner/routing/stoptimes/StopTimesHelper.java
@@ -330,7 +330,7 @@ public class StopTimesHelper {
     return replacement != null && !replacement.equals(pattern);
   }
 
-  static boolean skipByTripCancellation(TripTimes tripTimes, boolean includeCancellations) {
+  public static boolean skipByTripCancellation(TripTimes tripTimes, boolean includeCancellations) {
     return (
       (tripTimes.isCanceled() || tripTimes.getTrip().getTripAlteration().isCanceledOrReplaced()) &&
       !includeCancellations

--- a/src/test/java/org/opentripplanner/GtfsTest.java
+++ b/src/test/java/org/opentripplanner/GtfsTest.java
@@ -48,7 +48,7 @@ public abstract class GtfsTest {
   TimetableSnapshotSource timetableSnapshotSource;
   TransitAlertServiceImpl alertPatchServiceImpl;
   public Router router;
-  private GtfsFeedId feedId;
+  public GtfsFeedId feedId;
 
   public abstract String getFeedName();
 

--- a/src/test/java/org/opentripplanner/model/plan/legreference/LegReferenceSerializerTest.java
+++ b/src/test/java/org/opentripplanner/model/plan/legreference/LegReferenceSerializerTest.java
@@ -1,0 +1,26 @@
+package org.opentripplanner.model.plan.legreference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.model.FeedScopedId;
+import org.opentripplanner.model.calendar.ServiceDate;
+
+class LegReferenceSerializerTest {
+
+  @Test
+  void testScheduledTransitLegReferenceRoundTrip() {
+    var ref = new ScheduledTransitLegReference(
+      new FeedScopedId("Feed", "Trip"),
+      new ServiceDate(2022, 1, 31),
+      1,
+      3
+    );
+
+    var out = LegReferenceSerializer.encode(ref);
+
+    var ref2 = LegReferenceSerializer.decode(out);
+
+    assertEquals(ref, ref2);
+  }
+}

--- a/src/test/java/org/opentripplanner/model/plan/legreference/LegReferenceSerializerTest.java
+++ b/src/test/java/org/opentripplanner/model/plan/legreference/LegReferenceSerializerTest.java
@@ -23,4 +23,16 @@ class LegReferenceSerializerTest {
 
     assertEquals(ref, ref2);
   }
+
+  @Test
+  void testScheduledTransitLegReferenceDeserialize() {
+    var in = "rO0ABXc3ABhTQ0hFRFVMRURfVFJBTlNJVF9MRUdfVjEACUZlZWQ6VHJpcAAIMjAyMjAxMzEAAAABAAAAAw==";
+
+    var ref = (ScheduledTransitLegReference) LegReferenceSerializer.decode(in);
+
+    assertEquals(new FeedScopedId("Feed", "Trip"), ref.tripId());
+    assertEquals(new ServiceDate(2022, 1, 31), ref.serviceDate());
+    assertEquals(1, ref.fromStopPositionInPattern());
+    assertEquals(3, ref.toStopPositionInPattern());
+  }
 }

--- a/src/test/java/org/opentripplanner/routing/stoptimes/AlternativeLegsTest.java
+++ b/src/test/java/org/opentripplanner/routing/stoptimes/AlternativeLegsTest.java
@@ -1,0 +1,96 @@
+package org.opentripplanner.routing.stoptimes;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.GtfsTest;
+import org.opentripplanner.model.FeedScopedId;
+import org.opentripplanner.model.calendar.ServiceDate;
+import org.opentripplanner.model.plan.Itinerary;
+import org.opentripplanner.model.plan.Leg;
+import org.opentripplanner.model.plan.ScheduledTransitLeg;
+import org.opentripplanner.model.plan.legreference.ScheduledTransitLegReference;
+import org.opentripplanner.routing.RoutingService;
+
+/**
+ * Check that the correct alternative legs are found, and that the search traverses the date
+ * boundary correctly
+ */
+class AlternativeLegsTest extends GtfsTest {
+
+  @Override
+  public String getFeedName() {
+    return "testagency";
+  }
+
+  @Test
+  void testPreviousLegs() throws Exception {
+    var routingService = new RoutingService(graph);
+
+    var originalLeg = new ScheduledTransitLegReference(
+      new FeedScopedId(this.feedId.getId(), "1.2"),
+      ServiceDate.parseString("2022-04-02"),
+      1,
+      2
+    )
+      .getLeg(routingService);
+
+    final List<ScheduledTransitLeg> alternativeLegs = AlternativeLegs.getAlternativeLegs(
+      originalLeg,
+      3,
+      routingService,
+      true
+    );
+
+    var legs = Itinerary.toStr(
+      alternativeLegs.stream().map(Leg.class::cast).map(List::of).map(Itinerary::new).toList()
+    );
+
+    var expectd = String.join(
+      ", ",
+      List.of(
+        "B ~ BUS 2 0:20 0:30 ~ C [ $-1 ]",
+        "B ~ BUS 1 0:10 0:20 ~ C [ $-1 ]",
+        "B ~ BUS 1 8:20 8:30 ~ C [ $-1 ]" // Previous day
+      )
+    );
+
+    assertEquals(expectd, legs);
+  }
+
+  @Test
+  void testNextLegs() throws Exception {
+    var routingService = new RoutingService(graph);
+
+    var originalLeg = new ScheduledTransitLegReference(
+      new FeedScopedId(this.feedId.getId(), "2.2"),
+      ServiceDate.parseString("2022-04-02"),
+      0,
+      1
+    )
+      .getLeg(routingService);
+
+    final List<ScheduledTransitLeg> alternativeLegs = AlternativeLegs.getAlternativeLegs(
+      originalLeg,
+      3,
+      routingService,
+      false
+    );
+
+    var legs = Itinerary.toStr(
+      alternativeLegs.stream().map(Leg.class::cast).map(List::of).map(Itinerary::new).toList()
+    );
+
+    var expectd = String.join(
+      ", ",
+      List.of(
+        "B ~ BUS 3 1:00 1:10 ~ C [ $-1 ]",
+        "B ~ BUS 1 8:20 8:30 ~ C [ $-1 ]",
+        "B ~ BUS 1 0:10 0:20 ~ C [ $-1 ]" // Next day
+      )
+    );
+
+    assertEquals(expectd, legs);
+  }
+}

--- a/src/test/java/org/opentripplanner/routing/stoptimes/AlternativeLegsTest.java
+++ b/src/test/java/org/opentripplanner/routing/stoptimes/AlternativeLegsTest.java
@@ -12,6 +12,8 @@ import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.model.plan.ScheduledTransitLeg;
 import org.opentripplanner.model.plan.legreference.ScheduledTransitLegReference;
 import org.opentripplanner.routing.RoutingService;
+import org.opentripplanner.routing.alternativelegs.AlternativeLegs;
+import org.opentripplanner.routing.alternativelegs.AlternativeLegsFilter;
 
 /**
  * Check that the correct alternative legs are found, and that the search traverses the date
@@ -40,7 +42,8 @@ class AlternativeLegsTest extends GtfsTest {
       originalLeg,
       3,
       routingService,
-      true
+      true,
+      AlternativeLegsFilter.NO_FILTER
     );
 
     var legs = Itinerary.toStr(
@@ -75,7 +78,8 @@ class AlternativeLegsTest extends GtfsTest {
       originalLeg,
       3,
       routingService,
-      false
+      false,
+      AlternativeLegsFilter.NO_FILTER
     );
 
     var legs = Itinerary.toStr(


### PR DESCRIPTION
### Summary
This PR adds an implementation for re-fetching legs, and fetching "alternative legs", i.e. trips which use the same origin/destination station and depart prior/after the current leg.
 
### Unit tests
Module test added for the new functions.

### Code style
✅ 

### Documentation
Added documentation to the GraphQL schema.

