### PR TITLE
Shortcut in ParetoCheck add/check for performance [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/transit/raptor/util/paretoset/ParetoSet.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/util/paretoset/ParetoSet.java
@@ -33,6 +33,8 @@ public class ParetoSet<T> extends AbstractCollection<T> {
 
   private int size = 0;
 
+  private T goodElement = null;
+
   /**
    * Create a new ParetoSet with a comparator and a drop event listener.
    *
@@ -81,6 +83,12 @@ public class ParetoSet<T> extends AbstractCollection<T> {
       return true;
     }
 
+    // Quick shortcut, one element probably dominate most of the new elements
+    if (goodElement != null && leftVectorDominatesRightVector(goodElement, newValue)) {
+      notifyElementRejected(newValue, goodElement);
+      return false;
+    }
+
     boolean mutualDominanceExist = false;
     boolean equivalentVectorExist = false;
 
@@ -96,6 +104,7 @@ public class ParetoSet<T> extends AbstractCollection<T> {
         removeDominatedElementsFromRestOfSetAndAddNewElement(newValue, i);
         return true;
       } else if (rightDominance) {
+        goodElement = elements[i];
         notifyElementRejected(newValue, it);
         return false;
       } else {
@@ -122,6 +131,7 @@ public class ParetoSet<T> extends AbstractCollection<T> {
   @Override
   public void clear() {
     size = 0;
+    goodElement = null;
   }
 
   @Override
@@ -140,10 +150,16 @@ public class ParetoSet<T> extends AbstractCollection<T> {
       return true;
     }
 
+    // Quick shortcut, one element probably dominate most of the new elements
+    if (goodElement != null && leftVectorDominatesRightVector(goodElement, newValue)) {
+      notifyElementRejected(newValue, goodElement);
+      return false;
+    }
+
     boolean mutualDominanceExist = false;
     boolean equivalentVectorExist = false;
 
-    for (int i = 0; i < size; ++i) {
+    for (int i = size - 1; i >= 0; --i) {
       boolean leftDominance = leftDominanceExist(newValue, elements[i]);
       boolean rightDominance = rightDominanceExist(newValue, elements[i]);
 
@@ -155,6 +171,7 @@ public class ParetoSet<T> extends AbstractCollection<T> {
       } else if (leftDominance) {
         return true;
       } else if (rightDominance) {
+        goodElement = elements[i];
         return false;
       } else {
         if (mutualDominanceExist) {


### PR DESCRIPTION
### Summary
When looking for HotSpot in long searches, I've seen that the ParetoCheck for Heuristics and Arrival takes a lot of time, most of the time the result is to reject the test (qualify/add). I've seen that in order to reject a path, it would in general do between 10 or 20 times more 'leftDominanceExist' call, so they go through the list and test several elements not-dominating before finding one that dominate the result.

I quickly tried to keep a reference to the last element that fully dominated an input, in hope that this element will also dominate the next input.

This brings a general small improvements in perf-test with sometimes huge improvement on long searches (see test case 34 going from 3.7s to 2.9s).

I think that this is probably due to one of the criteria (i.e. probably `l.endTime()` tend to decrease as solutions are found (lower raptor iteration minute) and that every new 'potential path' might dominate an arrival path of a previous iteration minute while the dominating paths will be found lower in the list - my change allow a shortcut to prevent testing results from earlier iterations by picking one of the later one).

I've quickly tried keeping track of the N best elements, randomly replacing them, but that didn't bring any improvement, as soon as a good destination is detected and selected as bestElement, it will trim most of the path for that round.

Potentially a more general fix would be to store or iterate over the set list backward when checking for a dominating path.

```
Before
Test case ids       : [  1   2   3   4  5   6   7   8   9  10  11  12 13  14  15  16 17  18  19  20  21  22   23  24  25   26  27  28  29  30  31   32  33   34   35   36  101  102 103 104  105  106  107]
Number of paths     : [  2   2   3   2  1   1   3   1   3   3   3   3  2   2   3   2  3   2   1   3   2   2    3   1   1    3   2   3   1   3   3    3   3    3    3    3    3    3   3   3    3    3    2]
Transit times(ms)   : [282 258 224 290 93 169 428 306 143 409 193 105 86 266 162 104 87 353 269 104 161 357 1476 363 857 1271 341 409 150 562 645 1046 765 3720 1069 2335 1310 1009 754 634  843 1361 1644]
Total times(ms)     : [284 258 272 308 94 169 562 306 152 410 193 113 94 268 172 104 89 354 270 105 162 358 1476 363 857 1272 341 417 150 563 647 1052 768 3721 1070 2336 1733 1126 795 730 1316 1779 3185]
Successful searches : 41 / 43
Sample              : 4 / 4
Time total          : 31 seconds

Worker: 
 ==> mc_destination : [  536,  520,  522,  520 ] Avg: 524.5

Total:  
 ==> mc_destination : [  744,  713,  718,  716 ] Avg: 722.8

After
Test case ids       : [  1   2   3   4  5   6   7   8   9  10  11  12 13  14  15  16 17  18  19  20  21  22   23  24  25   26  27  28  29  30  31   32  33   34   35   36  101  102 103 104  105  106  107]
Number of paths     : [  2   2   3   2  1   1   3   1   3   3   3   3  2   2   3   2  3   2   1   3   2   2    3   1   1    3   2   3   1   3   3    3   3    3    3    3    3    3   3   3    3    3    2]
Transit times(ms)   : [281 262 222 297 93 170 433 313 146 432 196 107 87 281 166 107 88 375 289 107 171 377 1464 364 892 1318 364 412 153 604 676 1056 780 2908 1114 2296 1232  953 754 659  867 1102 1643]
Total times(ms)     : [284 262 269 315 94 170 565 313 155 432 197 115 95 284 176 107 89 376 289 108 171 377 1465 365 892 1319 364 421 153 605 677 1062 783 2909 1115 2297 1641 1068 794 753 1335 1509 3029]
Successful searches : 41 / 43
Sample              : 4 / 4
Time total          : 30 seconds

Worker: 
 ==> mc_destination : [  538,  505,  508,  503 ] Avg: 513.5

Total:  
 ==> mc_destination : [  746,  697,  700,  693 ] Avg: 709.0
```
