### PR TITLE
Remove self-referring DatedServiceJourneyRefs [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/netex/mapping/TripPatternMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/TripPatternMapper.java
@@ -274,11 +274,22 @@ class TripPatternMapper {
       .filter(Objects::nonNull)
       .map(replacement -> {
         if (datedServiceJourney.equals(replacement)) {
+          issueStore.add(
+            "InvalidDatedServiceJourneyRef",
+            "DatedServiceJourney %s has reference to itself, skipping",
+            datedServiceJourney.getId()
+          );
           return null;
         }
         String serviceJourneyRef = replacement.getJourneyRef().get(0).getValue().getRef();
         ServiceJourney serviceJourney = serviceJourneyById.lookup(serviceJourneyRef);
         if (serviceJourney == null) {
+          issueStore.add(
+            "InvalidDatedServiceJourneyRef",
+            "DatedServiceJourney %s has reference to %s, which is not found, skipping",
+            datedServiceJourney.getId(),
+            serviceJourneyRef
+          );
           return null;
         }
         return mapDatedServiceJourney(tripMapper.mapServiceJourney(serviceJourney), replacement);

--- a/src/main/java/org/opentripplanner/netex/mapping/TripPatternMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/TripPatternMapper.java
@@ -273,6 +273,9 @@ class TripPatternMapper {
       .map(datedServiceJourneyById::lookup)
       .filter(Objects::nonNull)
       .map(replacement -> {
+        if (datedServiceJourney.equals(replacement)) {
+          return null;
+        }
         String serviceJourneyRef = replacement.getJourneyRef().get(0).getValue().getRef();
         ServiceJourney serviceJourney = serviceJourneyById.lookup(serviceJourneyRef);
         if (serviceJourney == null) {


### PR DESCRIPTION
### Summary
Currently some of our datasets have invalid DatedServiceJourneyRefs referencing back to themselves. This filters out these cases.
