### PR TITLE
Make language nullable in MultilingualString, as it is not set in NonLocalizedString [changelog skip]

### DIFF
--- a/docs/sandbox/TransmodelApi.md
+++ b/docs/sandbox/TransmodelApi.md
@@ -39,6 +39,8 @@
   EstimatedCall [#3846](https://github.com/opentripplanner/OpenTripPlanner/pull/3846)
 - Allow selecting first or last quays in a
   ServiceJourney [#3846](https://github.com/opentripplanner/OpenTripPlanner/pull/3846)
+- Make language nullable in MultilingualString, as it is not set in NonLocalizedString
+  [#4074](https://github.com/opentripplanner/OpenTripPlanner/pull/4074)
 
 ## Documentation
 

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/framework/MultilingualStringType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/framework/MultilingualStringType.java
@@ -27,7 +27,7 @@ public class MultilingualStringType {
         GraphQLFieldDefinition
           .newFieldDefinition()
           .name("language")
-          .type(new GraphQLNonNull(Scalars.GraphQLString))
+          .type(Scalars.GraphQLString)
           .dataFetcher(environment -> ((Map.Entry<String, String>) environment.getSource()).getKey()
           )
           .build()


### PR DESCRIPTION
### Summary
Make language nullable in MultilingualString, in the Transmodel API.
