### PR TITLE
Use board/aligh cost only for transits

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/StopIndexForRaptor.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/StopIndexForRaptor.java
@@ -38,7 +38,7 @@ public final class StopIndexForRaptor {
   ) {
     this.stopsByIndex = List.copyOf(stops);
     initializeIndexByStop();
-    this.stopBoardAlightCosts = createStopBoardAlightCosts(stopsByIndex, tuningParameters);
+    this.stopBoardAlightCosts = createStopTransferCosts(stopsByIndex, tuningParameters);
   }
 
   public StopLocation stopByIndex(int index) {
@@ -80,21 +80,21 @@ public final class StopIndexForRaptor {
   /**
    * Create static board/alight cost for Raptor to include for each stop.
    */
-  private static int[] createStopBoardAlightCosts(
+  private static int[] createStopTransferCosts(
     List<StopLocation> stops,
     TransitTuningParameters tuningParams
   ) {
     if (!tuningParams.enableStopTransferPriority()) {
       return null;
     }
-    int[] stopVisitCosts = new int[stops.size()];
+    int[] stopTransferCosts = new int[stops.size()];
 
     for (int i = 0; i < stops.size(); ++i) {
       StopTransferPriority priority = stops.get(i).getPriority();
       int domainCost = tuningParams.stopTransferCost(priority);
-      stopVisitCosts[i] = RaptorCostConverter.toRaptorCost(domainCost);
+      stopTransferCosts[i] = RaptorCostConverter.toRaptorCost(domainCost);
     }
-    return stopVisitCosts;
+    return stopTransferCosts;
   }
 
   /**

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/cost/DefaultCostCalculator.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/cost/DefaultCostCalculator.java
@@ -106,9 +106,9 @@ public final class DefaultCostCalculator implements CostCalculator {
       waitFactor *
       alightSlack;
 
-    if (stopVisitCost != null) {
-      cost += stopVisitCost[toStop];
-    }
+//    if (stopVisitCost != null) {
+//      cost += stopVisitCost[toStop];
+//    }
 
     return cost;
   }
@@ -153,7 +153,7 @@ public final class DefaultCostCalculator implements CostCalculator {
 
     cost += firstBoarding ? boardCostOnly : boardAndTransferCost;
 
-    if (stopVisitCost != null) {
+    if (stopVisitCost != null && !firstBoarding) {
       cost += stopVisitCost[boardStop];
     }
     return cost;
@@ -194,7 +194,7 @@ public final class DefaultCostCalculator implements CostCalculator {
 
       int cost = waitFactor * boardWaitTime;
 
-      if (stopVisitCost != null) {
+      if (stopVisitCost != null && !firstBoarding) {
         cost += stopVisitCost[boardStop];
       }
       return cost;

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/cost/DefaultCostCalculator.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/cost/DefaultCostCalculator.java
@@ -135,13 +135,14 @@ public final class DefaultCostCalculator implements CostCalculator {
   public int costEgress(RaptorTransfer egress) {
     if (egress.hasRides()) {
       return egress.generalizedCost() + transferCostOnly;
-    } else {
+    } else if(stopTransferCost != null) {
       // Remove cost that was added during alighting.
       // We do not want to add this cost on last alighting since it should only be applied on transfers
       // It has to be done here because during alighting we do not know yet if it will be
       // a transfer or not.
-      var transferCost = stopTransferCost != null ? stopTransferCost[egress.stop()] : 0;
-      return egress.generalizedCost() - transferCost;
+      return egress.generalizedCost() - stopTransferCost[egress.stop()];
+    } else {
+      return egress.generalizedCost();  
     }
   }
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/cost/DefaultCostCalculator.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/cost/DefaultCostCalculator.java
@@ -205,10 +205,8 @@ public final class DefaultCostCalculator implements CostCalculator {
 
       int cost = waitFactor * boardWaitTime;
 
-      // If it's first boarding event then it is not a transfer
-      if (stopTransferCost != null && !firstBoarding) {
-        cost += stopTransferCost[boardStop];
-      }
+// StopTransferCost is NOT added to the cost here. This is because a trip-to-trip constrained transfer take
+// precedence over stop-to-stop transfer priority (NeTEx station transfer priority).  
       return cost;
     }
     // fallback to regular transfer

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/cost/DefaultCostCalculator.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/cost/DefaultCostCalculator.java
@@ -135,14 +135,14 @@ public final class DefaultCostCalculator implements CostCalculator {
   public int costEgress(RaptorTransfer egress) {
     if (egress.hasRides()) {
       return egress.generalizedCost() + transferCostOnly;
-    } else if(stopTransferCost != null) {
+    } else if (stopTransferCost != null) {
       // Remove cost that was added during alighting.
       // We do not want to add this cost on last alighting since it should only be applied on transfers
       // It has to be done here because during alighting we do not know yet if it will be
       // a transfer or not.
       return egress.generalizedCost() - stopTransferCost[egress.stop()];
     } else {
-      return egress.generalizedCost();  
+      return egress.generalizedCost();
     }
   }
 
@@ -205,8 +205,8 @@ public final class DefaultCostCalculator implements CostCalculator {
 
       int cost = waitFactor * boardWaitTime;
 
-// StopTransferCost is NOT added to the cost here. This is because a trip-to-trip constrained transfer take
-// precedence over stop-to-stop transfer priority (NeTEx station transfer priority).  
+      // StopTransferCost is NOT added to the cost here. This is because a trip-to-trip constrained transfer take
+      // precedence over stop-to-stop transfer priority (NeTEx station transfer priority).
       return cost;
     }
     // fallback to regular transfer

--- a/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/model/StopPriorityCostCalculator.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/model/StopPriorityCostCalculator.java
@@ -6,15 +6,15 @@ package org.opentripplanner.routing.algorithm.transferoptimization.model;
  */
 public class StopPriorityCostCalculator {
 
-  private final int[] stopVisitCost;
-  private final double extraStopVisitCostFactor;
+  private final int[] stopTransferCost;
+  private final double extraStopTransferCostFactor;
 
-  StopPriorityCostCalculator(double extraStopVisitCostFactor, int[] stopVisitCost) {
-    this.stopVisitCost = stopVisitCost;
-    this.extraStopVisitCostFactor = extraStopVisitCostFactor;
+  StopPriorityCostCalculator(double extraStopTransferCostFactor, int[] stopTransferCost) {
+    this.stopTransferCost = stopTransferCost;
+    this.extraStopTransferCostFactor = extraStopTransferCostFactor;
   }
 
   int extraStopPriorityCost(int stop) {
-    return (int) Math.round((double) stopVisitCost[stop] * extraStopVisitCostFactor);
+    return (int) Math.round((double) stopTransferCost[stop] * extraStopTransferCostFactor);
   }
 }

--- a/src/test/java/org/opentripplanner/transit/raptor/_data/api/TestPathBuilderTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/_data/api/TestPathBuilderTest.java
@@ -26,6 +26,7 @@ import static org.opentripplanner.util.time.TimeUtils.time;
 
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.transit.raptor._data.RaptorTestConstants;
+import org.opentripplanner.transit.raptor._data.stoparrival.BasicPathTestCase;
 import org.opentripplanner.transit.raptor._data.transit.TestTransfer;
 
 /**
@@ -62,11 +63,11 @@ public class TestPathBuilderTest implements RaptorTestConstants {
       STOP_B
     );
 
-    int accessEgressCost = TestTransfer.walkCost(D2m + D1m);
+    int accessEgressCost = COST_CALCULATOR.costEgress(TestTransfer.walk(STOP_B, D2m + D1m));
 
     assertEquals(accessEgressCost + transitCost, path.generalizedCost());
     assertEquals(
-      "Walk 1m ~ A ~ BUS L1 10:02 10:07 ~ B ~ Walk 2m [10:00:15 10:09:15 9m 0tx $798]",
+      "Walk 1m ~ A ~ BUS L1 10:02 10:07 ~ B ~ Walk 2m [10:00:15 10:09:15 9m 0tx $768]",
       path.toString(this::stopIndexToName)
     );
   }


### PR DESCRIPTION
### Summary
Ensure that we do not use transfer priority to apply cost on board/alight events that are not transfers. 

### Issue
This improve/fixes the issue #4078, but make the logic redundant. Ideally we should just have one way of doing this, not one way for NeTEx and one for GTFS. But, porting this to the "GTFS way" have performance challanges that need to be resolved first - NOT before the Transit model refactoring. 

### Unit tests
Added new unit test cases for changed logic.

### Code style
yest

### Documentation
No new documentation added since this is just a bugfix