### PR TITLE
Refactor, explicit slackIndex on RaptorTripPattern [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/SlackProvider.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/SlackProvider.java
@@ -2,9 +2,9 @@ package org.opentripplanner.routing.algorithm.raptoradapter.transit;
 
 import java.util.Map;
 import org.opentripplanner.model.TransitMode;
+import org.opentripplanner.model.TripPattern;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.request.TripPatternForDates;
 import org.opentripplanner.transit.raptor.api.transit.RaptorSlackProvider;
-import org.opentripplanner.transit.raptor.api.transit.RaptorTripPattern;
 
 /**
  * This class provides transferSlack, boardSlack and alightSlack for the Raptor algorithm.
@@ -48,13 +48,13 @@ public final class SlackProvider implements RaptorSlackProvider {
   }
 
   @Override
-  public int boardSlack(RaptorTripPattern pattern) {
-    return boardSlack[index(pattern)];
+  public int boardSlack(int slackIndex) {
+    return boardSlack[slackIndex];
   }
 
   @Override
-  public int alightSlack(RaptorTripPattern pattern) {
-    return alightSlack[index(pattern)];
+  public int alightSlack(int slackIndex) {
+    return alightSlack[slackIndex];
   }
 
   /* private methods */
@@ -62,16 +62,16 @@ public final class SlackProvider implements RaptorSlackProvider {
   private static int[] slackByMode(Map<TransitMode, Integer> modeSlack, int defaultSlack) {
     int[] result = new int[TransitMode.values().length];
     for (TransitMode mode : TransitMode.values()) {
-      result[index(mode)] = modeSlack.getOrDefault(mode, defaultSlack);
+      result[SlackProvider.slackIndex(mode)] = modeSlack.getOrDefault(mode, defaultSlack);
     }
     return result;
   }
 
-  private static int index(RaptorTripPattern pattern) {
-    return index(((TripPatternForDates) pattern).getTripPattern().getTransitMode());
+  public static int slackIndex(TripPattern pattern) {
+    return slackIndex(pattern.getMode());
   }
 
-  private static int index(final TransitMode mode) {
+  private static int slackIndex(final TransitMode mode) {
     return mode.ordinal();
   }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripPatternForDates.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripPatternForDates.java
@@ -4,6 +4,7 @@ import java.util.BitSet;
 import java.util.List;
 import java.util.function.IntUnaryOperator;
 import org.opentripplanner.model.base.ToStringBuilder;
+import org.opentripplanner.routing.algorithm.raptoradapter.transit.SlackProvider;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripPatternForDate;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripPatternWithRaptorStopIndexes;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripSchedule;
@@ -39,6 +40,8 @@ public class TripPatternForDates
 
   private final boolean isFrequencyBased;
 
+  private final int slackIndex;
+
   /**
    * The arrival times in a nStops * numberOfTripSchedules sized array. The trips are stored first
    * by the stop position and then by trip index, so with stops 1 and 2, and trips A and B, the
@@ -67,6 +70,7 @@ public class TripPatternForDates
     this.offsets = offsets.stream().mapToInt(i -> i).toArray();
     this.boardingPossible = boardingPossible;
     this.alightingPossible = alightningPossible;
+    this.slackIndex = SlackProvider.slackIndex(tripPattern.getPattern());
 
     int numberOfTripSchedules = 0;
     boolean hasFrequencies = false;
@@ -141,7 +145,12 @@ public class TripPatternForDates
     return getTripPattern().constrainedTransferReverseSearch();
   }
 
-  /* Implementing RaptorStopPattern */
+  /* Implementing RaptorTripPattern */
+
+  @Override
+  public int numberOfStopsInPattern() {
+    return tripPattern.getStopIndexes().length;
+  }
 
   @Override
   public int stopIndex(int stopPositionInPattern) {
@@ -159,8 +168,8 @@ public class TripPatternForDates
   }
 
   @Override
-  public int numberOfStopsInPattern() {
-    return tripPattern.getStopIndexes().length;
+  public int slackIndex() {
+    return slackIndex;
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/model/MinSafeTransferTimeCalculator.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/model/MinSafeTransferTimeCalculator.java
@@ -110,6 +110,6 @@ public class MinSafeTransferTimeCalculator<T extends RaptorTripSchedule> {
 
   int durationIncludingSlack(TransitPathLeg<T> leg) {
     var p = leg.trip().pattern();
-    return leg.duration() + slackProvider.transitSlack(p);
+    return leg.duration() + slackProvider.transitSlack(p.slackIndex());
   }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/services/TransferGenerator.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/services/TransferGenerator.java
@@ -200,10 +200,10 @@ public class TransferGenerator<T extends RaptorTripSchedule> {
     } else {
       return (
         fromTime +
-        slackProvider.alightSlack(fromTrip.pattern()) +
+        slackProvider.alightSlack(fromTrip.pattern().slackIndex()) +
         transferDurationInSeconds +
         slackProvider.transferSlack() +
-        slackProvider.boardSlack(toTrip.pattern())
+        slackProvider.boardSlack(toTrip.pattern().slackIndex())
       );
     }
   }

--- a/src/main/java/org/opentripplanner/transit/raptor/api/path/PathBuilderLeg.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/path/PathBuilderLeg.java
@@ -418,7 +418,7 @@ public class PathBuilderLeg<T extends RaptorTripSchedule> {
     if (!isTransit()) {
       return toTime;
     }
-    return toTime + slackProvider.alightSlack(asTransitLeg().trip.pattern());
+    return toTime + slackProvider.alightSlack(asTransitLeg().trip.pattern().slackIndex());
   }
 
   private int waitTimeAfterPrevStopArrival(RaptorSlackProvider slackProvider) {
@@ -438,7 +438,7 @@ public class PathBuilderLeg<T extends RaptorTripSchedule> {
   ) {
     var leg = asTransitLeg();
     int slack =
-      slackProvider.boardSlack(leg.trip.pattern()) +
+      slackProvider.boardSlack(leg.trip.pattern().slackIndex()) +
       (withTransferSlack ? slackProvider.transferSlack() : 0);
 
     return leg.fromTime() - slack;
@@ -471,7 +471,8 @@ public class PathBuilderLeg<T extends RaptorTripSchedule> {
   private void timeShiftTransferTime(RaptorSlackProvider slackProvider) {
     int newFromTime;
     if (prev.isTransit()) {
-      newFromTime = prev.toTime() + slackProvider.alightSlack(prev.asTransitLeg().trip.pattern());
+      newFromTime =
+        prev.toTime() + slackProvider.alightSlack(prev.asTransitLeg().trip.pattern().slackIndex());
     } else if (prev.isAccess()) {
       newFromTime = prev.toTime();
     } else {
@@ -528,7 +529,7 @@ public class PathBuilderLeg<T extends RaptorTripSchedule> {
 
     return costCalculator.transitArrivalCost(
       boardCost,
-      slackProvider.alightSlack(leg.trip.pattern()),
+      slackProvider.alightSlack(leg.trip.pattern().slackIndex()),
       durationInSec(),
       leg.trip.transitReluctanceFactorIndex(),
       toStop()

--- a/src/main/java/org/opentripplanner/transit/raptor/api/transit/Flyweight.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/transit/Flyweight.java
@@ -5,7 +5,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-
 /**
  * This interface is used to tag methods witch return flyweight objects. The implementation may
  * choose not to implement the return type as a flyweight object, but the Raptor implementation

--- a/src/main/java/org/opentripplanner/transit/raptor/api/transit/Flyweight.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/transit/Flyweight.java
@@ -1,0 +1,25 @@
+package org.opentripplanner.transit.raptor.api.transit;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+/**
+ * This interface is used to tag methods witch return flyweight objects. The implementation may
+ * choose not to implement the return type as a flyweight object, but the Raptor implementation
+ * is guaranteed to threat them as such - enabling the optimization.
+ * <p>
+ * A flyweight object is a temporary view to the state of the callee, which the caller can access
+ * immediately after the object is returned, until the next method call to the callee is performed.
+ * Do not store a reference to flyweight objects and make sure you do not access the state after
+ * the next method call.
+ * <p>
+ * The flyweight design pattern is used to avoid unnecessary object creation, and the flyweight
+ * object should be reused.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.SOURCE)
+public @interface Flyweight {
+}

--- a/src/main/java/org/opentripplanner/transit/raptor/api/transit/Flyweight.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/transit/Flyweight.java
@@ -8,7 +8,7 @@ import java.lang.annotation.Target;
 /**
  * This interface is used to tag methods witch return flyweight objects. The implementation may
  * choose not to implement the return type as a flyweight object, but the Raptor implementation
- * is guaranteed to threat them as such - enabling the optimization.
+ * is guaranteed to treat them as such - enabling the optimization.
  * <p>
  * A flyweight object is a temporary view to the state of the callee, which the caller can access
  * immediately after the object is returned, until the next method call to the callee is performed.

--- a/src/main/java/org/opentripplanner/transit/raptor/api/transit/RaptorSlackProvider.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/transit/RaptorSlackProvider.java
@@ -19,12 +19,12 @@ public interface RaptorSlackProvider {
       }
 
       @Override
-      public int boardSlack(RaptorTripPattern pattern) {
+      public int boardSlack(int slackIndex) {
         return boardSlack;
       }
 
       @Override
-      public int alightSlack(RaptorTripPattern pattern) {
+      public int alightSlack(int slackIndex) {
         return alightSlack;
       }
     };
@@ -32,7 +32,7 @@ public interface RaptorSlackProvider {
 
   /**
    * The transfer-slack (duration time in seconds) to add between transfers. This is in addition to
-   * {@link #boardSlack(RaptorTripPattern)} and {@link #alightSlack(RaptorTripPattern)}.
+   * {@link #boardSlack(int)} and {@link #alightSlack(int)}.
    * <p>
    * Unit: seconds.
    */
@@ -47,7 +47,7 @@ public interface RaptorSlackProvider {
    * <p>
    * Unit: seconds.
    */
-  int boardSlack(RaptorTripPattern pattern);
+  int boardSlack(int slackIndex);
 
   /**
    * The alight-slack (duration time in seconds) to add to the trip alight time for the given
@@ -58,15 +58,15 @@ public interface RaptorSlackProvider {
    * <p>
    * Unit: seconds.
    */
-  int alightSlack(RaptorTripPattern pattern);
+  int alightSlack(int slackIndex);
 
   /**
-   * Return the {@link #boardSlack(RaptorTripPattern) plus {@link #alightSlack(RaptorTripPattern)
+   * Return the {@link #boardSlack(int) plus {@link #alightSlack(int)
    * slack.
    * <p>
    * Unit: seconds.
    */
-  default int transitSlack(RaptorTripPattern pattern) {
-    return boardSlack(pattern) + alightSlack(pattern);
+  default int transitSlack(int slackIndex) {
+    return boardSlack(slackIndex) + alightSlack(slackIndex);
   }
 }

--- a/src/main/java/org/opentripplanner/transit/raptor/api/transit/RaptorTransitDataProvider.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/transit/RaptorTransitDataProvider.java
@@ -21,6 +21,12 @@ public interface RaptorTransitDataProvider<T extends RaptorTripSchedule> {
   default void setup() {}
 
   /**
+   * This is the total number of stops, it should be possible to retrieve transfers and pattern for
+   * every stop from 0 to {@code numberOfStops()-1}.
+   */
+  int numberOfStops();
+
+  /**
    * This method is responsible for providing all transfers from a given stop to all possible stops
    * around that stop.
    * <p/>
@@ -50,6 +56,7 @@ public interface RaptorTransitDataProvider<T extends RaptorTripSchedule> {
    *
    * @return a map of distances from the given input stop to all other stops.
    */
+  @Flyweight
   Iterator<? extends RaptorTransfer> getTransfersFromStop(int fromStop);
 
   /**
@@ -58,6 +65,7 @@ public interface RaptorTransitDataProvider<T extends RaptorTripSchedule> {
    *
    * @return a map of distances to the given input stop from all other stops.
    */
+  @Flyweight
   Iterator<? extends RaptorTransfer> getTransfersToStop(int toStop);
 
   /**
@@ -74,12 +82,6 @@ public interface RaptorTransitDataProvider<T extends RaptorTripSchedule> {
    * {@link #getTransfersFromStop(int)} for detail on how to implement this.
    */
   RaptorRoute<T> getRouteForIndex(int routeIndex);
-
-  /**
-   * This is the total number of stops, it should be possible to retrieve transfers and pattern for
-   * every stop from 0 to {@code numberOfStops()-1}.
-   */
-  int numberOfStops();
 
   /**
    * Create/provide the cost criteria calculator.

--- a/src/main/java/org/opentripplanner/transit/raptor/api/transit/RaptorTripPattern.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/transit/RaptorTripPattern.java
@@ -7,6 +7,11 @@ package org.opentripplanner.transit.raptor.api.transit;
  */
 public interface RaptorTripPattern {
   /**
+   * Number of stops in pattern.
+   */
+  int numberOfStopsInPattern();
+
+  /**
    * The stop index
    *
    * @param stopPositionInPattern stop position number in pattern, starting at 0.
@@ -30,9 +35,11 @@ public interface RaptorTripPattern {
   boolean alightingPossibleAt(int stopPositionInPattern);
 
   /**
-   * Number of stops in pattern.
+   * Alight and board slack is added by raptor based on this index. The index allow the data
+   * provider to setup and use different board and alight slacks for each "type" of
+   * RaptorTripPattern. The {@link RaptorSlackProvider} is used to return the actual slack.
    */
-  int numberOfStopsInPattern();
+  int slackIndex();
 
   /**
    * Pattern debug info, return transit mode and route name. This is  used for debugging purposes

--- a/src/main/java/org/opentripplanner/transit/raptor/api/transit/RaptorTripPattern.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/transit/RaptorTripPattern.java
@@ -7,7 +7,7 @@ package org.opentripplanner.transit.raptor.api.transit;
  */
 public interface RaptorTripPattern {
   /**
-   * Number of stops in pattern.
+   * Number of stops in the pattern.
    */
   int numberOfStopsInPattern();
 
@@ -35,7 +35,7 @@ public interface RaptorTripPattern {
   boolean alightingPossibleAt(int stopPositionInPattern);
 
   /**
-   * Alight and board slack is added by raptor based on this index. The index allow the data
+   * Alight and board slack is added by raptor based on this index. The index allows the data
    * provider to setup and use different board and alight slacks for each "type" of
    * RaptorTripPattern. The {@link RaptorSlackProvider} is used to return the actual slack.
    */

--- a/src/main/java/org/opentripplanner/transit/raptor/api/transit/RaptorTripScheduleSearch.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/transit/RaptorTripScheduleSearch.java
@@ -26,6 +26,7 @@ public interface RaptorTripScheduleSearch<T extends RaptorTripSchedule> {
    * @see #search(int, int, int)
    */
   @Nullable
+  @Flyweight
   default RaptorTripScheduleBoardOrAlightEvent<T> search(
     int earliestBoardTime,
     int stopPositionInPattern
@@ -51,6 +52,7 @@ public interface RaptorTripScheduleSearch<T extends RaptorTripSchedule> {
    *                              trips already processed.
    */
   @Nullable
+  @Flyweight
   RaptorTripScheduleBoardOrAlightEvent<T> search(
     int earliestBoardTime,
     int stopPositionInPattern,

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/RangeRaptorWorker.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/RangeRaptorWorker.java
@@ -209,8 +209,8 @@ public final class RangeRaptorWorker<T extends RaptorTripSchedule> implements Wo
             ? calculator.transferConstraintsSearch(route)
             : null;
 
-          int alightSlack = slackProvider.alightSlack(pattern);
-          int boardSlack = slackProvider.boardSlack(pattern);
+          int alightSlack = slackProvider.alightSlack(pattern.slackIndex());
+          int boardSlack = slackProvider.boardSlack(pattern.slackIndex());
 
           transitWorker.prepareForTransitWith();
 
@@ -307,7 +307,7 @@ public final class RangeRaptorWorker<T extends RaptorTripSchedule> implements Wo
 
     int prevTransitArrivalTime = calculator.minusDuration(
       prevTransitStopArrivalTime,
-      slackProvider.alightSlack(sourceStopArrival.trip().pattern())
+      slackProvider.alightSlack(sourceStopArrival.trip().pattern().slackIndex())
     );
 
     int earliestBoardTime = earliestBoardTime(prevArrivalTime, boardSlack);

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/SlackProvider.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/SlackProvider.java
@@ -23,7 +23,7 @@ public interface SlackProvider {
    * <p>
    * Unit: seconds.
    */
-  int boardSlack(RaptorTripPattern pattern);
+  int boardSlack(int slackIndex);
 
   /**
    * The alight-slack (duration time in seconds) to add to the trip alight time for the given
@@ -33,7 +33,7 @@ public interface SlackProvider {
    * <p>
    * Unit: seconds.
    */
-  int alightSlack(RaptorTripPattern pattern);
+  int alightSlack(int slackIndex);
 
   /**
    * Regular transfer slack should be added to all access and egress paths with one or more number

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/MultiCriteriaRoutingStrategy.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/MultiCriteriaRoutingStrategy.java
@@ -92,7 +92,7 @@ public final class MultiCriteriaRoutingStrategy<T extends RaptorTripSchedule>
     if (prevArrival.arrivedByAccess()) {
       // TODO: What if access is FLEX with rides, should not FLEX transfersSlack be taken
       //       into account as well?
-      int latestArrivalTime = boardTime - slackProvider.boardSlack(trip.pattern());
+      int latestArrivalTime = boardTime - slackProvider.boardSlack(trip.pattern().slackIndex());
       prevArrival = prevArrival.timeShiftNewArrivalTime(latestArrivalTime);
     }
 

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/transit/SearchContext.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/transit/SearchContext.java
@@ -266,8 +266,8 @@ public class SearchContext<T extends RaptorTripSchedule> {
     RaptorRequest<?> request
   ) {
     return request.searchDirection().isForward()
-      ? p -> request.slackProvider().boardSlack(p)
-      : p -> request.slackProvider().alightSlack(p);
+      ? p -> request.slackProvider().boardSlack(p.slackIndex())
+      : p -> request.slackProvider().alightSlack(p.slackIndex());
   }
 
   private static <S extends RaptorTripSchedule> PathMapper<S> createPathMapper(

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/transit/SlackProviderAdapter.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/transit/SlackProviderAdapter.java
@@ -54,13 +54,13 @@ public final class SlackProviderAdapter {
     }
 
     @Override
-    public int boardSlack(RaptorTripPattern pattern) {
-      return source.boardSlack(pattern) + transferSlack;
+    public int boardSlack(int slackIndex) {
+      return source.boardSlack(slackIndex) + transferSlack;
     }
 
     @Override
-    public int alightSlack(RaptorTripPattern pattern) {
-      return source.alightSlack(pattern);
+    public int alightSlack(int slackIndex) {
+      return source.alightSlack(slackIndex);
     }
 
     @Override
@@ -84,13 +84,13 @@ public final class SlackProviderAdapter {
     }
 
     @Override
-    public int boardSlack(RaptorTripPattern pattern) {
-      return source.alightSlack(pattern) + transferSlack;
+    public int boardSlack(int slackIndex) {
+      return source.alightSlack(slackIndex) + transferSlack;
     }
 
     @Override
-    public int alightSlack(RaptorTripPattern pattern) {
-      return source.boardSlack(pattern);
+    public int alightSlack(int slackIndex) {
+      return source.boardSlack(slackIndex);
     }
 
     @Override

--- a/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/services/TransferGeneratorTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/services/TransferGeneratorTest.java
@@ -49,7 +49,8 @@ public class TransferGeneratorTest implements RaptorTestConstants {
   @Test
   void findTransferPathWithoutTransfers() {
     data.withRoutes(
-      route("L1", STOP_A, STOP_B, STOP_C).withTimetable(schedule("10:00 10:20 10:30"))
+      route(TestTripPattern.pattern("L1", STOP_A, STOP_B, STOP_C).withSlackIndex(1))
+        .withTimetable(schedule("10:00 10:20 10:30"))
     );
     var schedule = data.getRoute(0).getTripSchedule(0);
 
@@ -187,12 +188,12 @@ public class TransferGeneratorTest implements RaptorTestConstants {
       }
 
       @Override
-      public int boardSlack(RaptorTripPattern pattern) {
-        return ((TestTripPattern) pattern).getName().equals("L1") ? 20 * 60 : 0;
+      public int boardSlack(int slackIndex) {
+        return slackIndex == 1 ? 20 * 60 : 0;
       }
 
       @Override
-      public int alightSlack(RaptorTripPattern pattern) {
+      public int alightSlack(int slackIndex) {
         return 0;
       }
     };

--- a/src/test/java/org/opentripplanner/transit/raptor/_data/transit/TestTripPattern.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/_data/transit/TestTripPattern.java
@@ -11,6 +11,7 @@ public class TestTripPattern implements RaptorTripPattern {
 
   private final String name;
   private final int[] stopIndexes;
+  private int slackIndex = 0;
 
   /**
    * <pre>
@@ -35,6 +36,11 @@ public class TestTripPattern implements RaptorTripPattern {
   /** Create a pattern with name 'R1' and given stop indexes */
   public static TestTripPattern pattern(int... stopIndexes) {
     return new TestTripPattern("R1", stopIndexes, new int[stopIndexes.length]);
+  }
+
+  public TestTripPattern withSlackIndex(int index) {
+    this.slackIndex = index;
+    return this;
   }
 
   /**
@@ -85,6 +91,11 @@ public class TestTripPattern implements RaptorTripPattern {
   @Override
   public boolean alightingPossibleAt(int stopPositionInPattern) {
     return isNotRestricted(stopPositionInPattern, ALIGHTING_MASK);
+  }
+
+  @Override
+  public int slackIndex() {
+    return slackIndex;
   }
 
   @Override

--- a/src/test/java/org/opentripplanner/transit/raptor/_data/transit/TestTripPattern.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/_data/transit/TestTripPattern.java
@@ -11,6 +11,10 @@ public class TestTripPattern implements RaptorTripPattern {
 
   private final String name;
   private final int[] stopIndexes;
+  /**
+   * By caching the index, we avoid looking up the pattern during routing, this reduces memory lookups and
+   * improves the performance.
+   */
   private int slackIndex = 0;
 
   /**

--- a/src/test/java/org/opentripplanner/transit/raptor/rangeraptor/transit/SlackProviderAdapterTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/rangeraptor/transit/SlackProviderAdapterTest.java
@@ -13,15 +13,15 @@ import org.opentripplanner.transit.raptor.rangeraptor.workerlifecycle.LifeCycleS
 
 public class SlackProviderAdapterTest implements RaptorTestConstants {
 
-  public static final int BOARD_SLACK = D20s;
-  public static final int ALIGHT_SLACK = D10s;
-  public static final int TRANSFER_SLACK = D1m;
-  public static final RaptorSlackProvider EXTERNAL_SLACK_PROVIDER = defaultSlackProvider(
+  private static final int BOARD_SLACK = D20s;
+  private static final int ALIGHT_SLACK = D10s;
+  private static final int TRANSFER_SLACK = D1m;
+  private static final RaptorSlackProvider EXTERNAL_SLACK_PROVIDER = defaultSlackProvider(
     TRANSFER_SLACK,
     BOARD_SLACK,
     ALIGHT_SLACK
   );
-  public static final TestTripPattern PATTERN = TestTripPattern.pattern("R1");
+  private static final int ANY_SLACK_INDEX = 0;
 
   @Test
   public void forwardSlackProvider() {
@@ -33,16 +33,16 @@ public class SlackProviderAdapterTest implements RaptorTestConstants {
     var lifeCycle = new LifeCycleEventPublisher(subscriptions);
 
     lifeCycle.prepareForNextRound(0);
-    assertEquals(ALIGHT_SLACK, subject.alightSlack(PATTERN));
-    assertEquals(BOARD_SLACK, subject.boardSlack(PATTERN));
+    assertEquals(ALIGHT_SLACK, subject.alightSlack(ANY_SLACK_INDEX));
+    assertEquals(BOARD_SLACK, subject.boardSlack(ANY_SLACK_INDEX));
 
     lifeCycle.prepareForNextRound(1);
-    assertEquals(ALIGHT_SLACK, subject.alightSlack(PATTERN));
-    assertEquals(BOARD_SLACK, subject.boardSlack(PATTERN));
+    assertEquals(ALIGHT_SLACK, subject.alightSlack(ANY_SLACK_INDEX));
+    assertEquals(BOARD_SLACK, subject.boardSlack(ANY_SLACK_INDEX));
 
     lifeCycle.prepareForNextRound(2);
-    assertEquals(ALIGHT_SLACK, subject.alightSlack(PATTERN));
-    assertEquals(BOARD_SLACK + TRANSFER_SLACK, subject.boardSlack(PATTERN));
+    assertEquals(ALIGHT_SLACK, subject.alightSlack(ANY_SLACK_INDEX));
+    assertEquals(BOARD_SLACK + TRANSFER_SLACK, subject.boardSlack(ANY_SLACK_INDEX));
   }
 
   @Test
@@ -55,15 +55,15 @@ public class SlackProviderAdapterTest implements RaptorTestConstants {
     var lifeCycle = new LifeCycleEventPublisher(subscriptions);
 
     lifeCycle.prepareForNextRound(0);
-    assertEquals(BOARD_SLACK, subject.alightSlack(PATTERN));
-    assertEquals(ALIGHT_SLACK, subject.boardSlack(PATTERN));
+    assertEquals(BOARD_SLACK, subject.alightSlack(ANY_SLACK_INDEX));
+    assertEquals(ALIGHT_SLACK, subject.boardSlack(ANY_SLACK_INDEX));
 
     lifeCycle.prepareForNextRound(1);
-    assertEquals(BOARD_SLACK, subject.alightSlack(PATTERN));
-    assertEquals(ALIGHT_SLACK, subject.boardSlack(PATTERN));
+    assertEquals(BOARD_SLACK, subject.alightSlack(ANY_SLACK_INDEX));
+    assertEquals(ALIGHT_SLACK, subject.boardSlack(ANY_SLACK_INDEX));
 
     lifeCycle.prepareForNextRound(2);
-    assertEquals(BOARD_SLACK, subject.alightSlack(PATTERN));
-    assertEquals(ALIGHT_SLACK + TRANSFER_SLACK, subject.boardSlack(PATTERN));
+    assertEquals(BOARD_SLACK, subject.alightSlack(ANY_SLACK_INDEX));
+    assertEquals(ALIGHT_SLACK + TRANSFER_SLACK, subject.boardSlack(ANY_SLACK_INDEX));
   }
 }


### PR DESCRIPTION
### Summary

Before the SlackProvider toke a RaptorTripPattern as an argument to the boardSlack/alightSlack
methods, this add an implicit responsibility to the RaptorTripPattern, by adding the slackIndex()
method to RaptorTripPattern we make this responsibility explicit, and at the same time decouple
the dependency from the SlackProvider to RaptorTripPattern.

This PR also contain an annotation to document that some of the Raptor API methods should used 
the flyweight design pattern for returned objects.


### Issue
✅ 


### Unit tests
Updated

### Code style
✅ 

### Documentation
JavaDoc Updated


### Performance

This also give us a small performance boost (6 %) (running test-cases tagged with `transit`):


#### Before
```
Test case ids       : [  1   2   3   4  5   6   7   8   9  10  11 12 13  14  15 16 17  18  19 20  21  22   23  24  25   26  27  28  29  30  31  32  33   34  35   36]
Number of paths     : [  2   2   3   2  1   1   3   1   3   3   3  3  2   2   3  2  3   2   1  3   2   2    3   1   1    3   2   3   1   3   3   3   3    3   3    3]
Transit times(ms)   : [232 209 182 230 73 135 364 255 116 348 155 87 69 220 132 84 70 297 220 83 128 297 1236 293 740 1097 285 341 130 480 547 899 658 2855 975 2007]
Total times(ms)     : [235 209 225 248 73 135 484 255 125 349 155 94 77 222 141 84 71 297 220 85 128 297 1237 293 740 1098 285 349 130 481 548 904 661 2855 975 2008]
Successful searches : 34 / 36
Sample              : 10 / 10
Time total          : 17 seconds
!!! UNEXPECTED RESULTS: 2 OF 36 FAILED. SEE LOG ABOVE FOR ERRORS !!!

Worker: 
 ==> mc_destination : [  415,  387,  378,  377,  376,  376,  377,  376,  376,  386 ] Avg: 382,4

Total:  
 ==> mc_destination : [  506,  468,  458,  457,  456,  456,  456,  455,  456,  466 ] Avg: 463,4
```

#### After
```
Test case ids       : [  1   2   3   4  5   6   7   8   9  10  11 12 13  14  15 16 17  18  19 20  21  22   23  24  25   26  27  28  29  30  31  32  33   34  35   36]
Number of paths     : [  2   2   3   2  1   1   3   1   3   3   3  3  2   2   3  2  3   2   1  3   2   2    3   1   1    3   2   3   1   3   3   3   3    3   3    3]
Transit times(ms)   : [220 198 173 220 71 129 339 235 110 322 149 83 67 208 125 80 77 300 227 81 127 280 1150 275 681 1082 272 328 120 423 490 777 570 2591 802 1751]
Total times(ms)     : [223 199 216 238 71 129 457 235 119 322 149 90 75 211 134 80 78 300 227 82 127 281 1150 275 682 1082 272 336 120 424 491 782 573 2592 803 1752]
Successful searches : 34 / 36
Sample              : 10 / 10
Time total          : 15 seconds
!!! UNEXPECTED RESULTS: 2 OF 36 FAILED. SEE LOG ABOVE FOR ERRORS !!!

Worker: 
 ==> mc_destination : [  380,  344,  361,  359,  379,  364,  348,  344,  343,  348 ] Avg: 357,0

Total:  
 ==> mc_destination : [  471,  425,  444,  440,  462,  447,  429,  422,  423,  427 ] Avg: 439,0
```


