### PR TITLE
Reactivate GTFS-RT tests [changelog skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ the [GitHub Actions](https://github.com/opentripplanner/OpenTripPlanner/actions/
 can [download the NeTex file](https://leonard.io/otp/rb_norway-aggregated-netex-2021-12-11.zip) from
 the Continuous Integration Pipeline. There is
 a [text file](test/ci-performance-test/travelSearch-expected-results.csv) with the expected results
-witch might need to be updated when OTP is changed and the test fails. The OSM data used is
+which might need to be updated when OTP is changed and the test fails. The OSM data used is
 the [norway-210101.osm.pbf](https://download.geofabrik.de/europe/norway-210101.osm.pbf) file from
 Geofabrik OSM extract from January 1st 2021.
 

--- a/src/main/java/org/opentripplanner/graph_builder/module/AddTransitModelEntitiesToGraph.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/AddTransitModelEntitiesToGraph.java
@@ -8,7 +8,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.opentripplanner.ext.flex.trip.FlexTrip;
-import org.opentripplanner.gtfs.GtfsContext;
 import org.opentripplanner.model.Agency;
 import org.opentripplanner.model.BoardingArea;
 import org.opentripplanner.model.Entrance;
@@ -59,10 +58,6 @@ public class AddTransitModelEntitiesToGraph {
 
   private final int subwayAccessTime;
 
-  private AddTransitModelEntitiesToGraph(GtfsContext context) {
-    this(context.getFeedId(), context.getTransitService(), 0);
-  }
-
   /**
    * @param subwayAccessTime a positive integer for the extra time to access a subway platform, if
    *                         negative the default value of zero is used.
@@ -75,10 +70,6 @@ public class AddTransitModelEntitiesToGraph {
     this.feedId = feedId;
     this.transitService = transitModel;
     this.subwayAccessTime = Math.max(subwayAccessTime, 0);
-  }
-
-  public static void addToGraph(GtfsContext context, Graph graph) {
-    new AddTransitModelEntitiesToGraph(context).applyToGraph(graph);
   }
 
   public static void addToGraph(

--- a/src/main/java/org/opentripplanner/model/calendar/ServiceDate.java
+++ b/src/main/java/org/opentripplanner/model/calendar/ServiceDate.java
@@ -88,18 +88,6 @@ public final class ServiceDate implements Serializable, Comparable<ServiceDate> 
   }
 
   /**
-   * @deprecated Convert to {@link java.time.ZonedDateTime} instead of old Calendar.
-   */
-  @Deprecated
-  public ServiceDate(Calendar calendar) {
-    this(
-      calendar.get(Calendar.YEAR),
-      calendar.get(Calendar.MONTH) + 1,
-      calendar.get(Calendar.DAY_OF_MONTH)
-    );
-  }
-
-  /**
    * Construct a ServiceDate from the specified {@link Date} object, using the default {@link
    * TimeZone} object for the current VM to localize the date.
    *

--- a/src/main/java/org/opentripplanner/model/calendar/impl/CalendarServiceDataFactoryImpl.java
+++ b/src/main/java/org/opentripplanner/model/calendar/impl/CalendarServiceDataFactoryImpl.java
@@ -3,6 +3,7 @@ package org.opentripplanner.model.calendar.impl;
 
 import static java.util.stream.Collectors.groupingBy;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collection;
@@ -196,7 +197,8 @@ public class CalendarServiceDataFactoryImpl {
       }
 
       if (active) {
-        addServiceDate(activeDates, new ServiceDate(c));
+        var localDate = LocalDate.ofInstant(c.toInstant(), timeZone.toZoneId());
+        addServiceDate(activeDates, new ServiceDate(localDate));
       }
 
       c.add(java.util.Calendar.DAY_OF_YEAR, 1);

--- a/src/main/java/org/opentripplanner/updater/stoptime/PollingStoptimeUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/PollingStoptimeUpdater.java
@@ -139,7 +139,8 @@ public class PollingStoptimeUpdater extends PollingGraphUpdater {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
+    return MoreObjects
+      .toStringHelper(this)
       .add("updateSource", updateSource)
       .add("feedId", feedId)
       .add("fuzzyTripMatching", fuzzyTripMatching)

--- a/src/main/java/org/opentripplanner/updater/stoptime/PollingStoptimeUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/PollingStoptimeUpdater.java
@@ -1,8 +1,8 @@
 package org.opentripplanner.updater.stoptime;
 
-import com.google.common.base.MoreObjects;
 import com.google.transit.realtime.GtfsRealtime.TripUpdate;
 import java.util.List;
+import org.opentripplanner.model.base.ToStringBuilder;
 import org.opentripplanner.routing.RoutingService;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.updater.GtfsRealtimeFuzzyTripMatcher;
@@ -139,11 +139,11 @@ public class PollingStoptimeUpdater extends PollingGraphUpdater {
 
   @Override
   public String toString() {
-    return MoreObjects
-      .toStringHelper(this)
-      .add("updateSource", updateSource)
-      .add("feedId", feedId)
-      .add("fuzzyTripMatching", fuzzyTripMatching)
+    return ToStringBuilder
+      .of(this.getClass())
+      .addObj("updateSource", updateSource)
+      .addStr("feedId", feedId)
+      .addBoolIfTrue("fuzzyTripMatching", fuzzyTripMatching)
       .toString();
   }
 

--- a/src/main/java/org/opentripplanner/updater/stoptime/PollingStoptimeUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/PollingStoptimeUpdater.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.updater.stoptime;
 
+import com.google.common.base.MoreObjects;
 import com.google.transit.realtime.GtfsRealtime.TripUpdate;
 import java.util.List;
 import org.opentripplanner.routing.RoutingService;
@@ -136,9 +137,13 @@ public class PollingStoptimeUpdater extends PollingGraphUpdater {
     }
   }
 
+  @Override
   public String toString() {
-    String s = (updateSource == null) ? "NONE" : updateSource.toString();
-    return "Streaming stoptime updater with update source = " + s;
+    return MoreObjects.toStringHelper(this)
+      .add("updateSource", updateSource)
+      .add("feedId", feedId)
+      .add("fuzzyTripMatching", fuzzyTripMatching)
+      .toString();
   }
 
   private static TripUpdateSource createSource(PollingStoptimeUpdaterParameters parameters) {

--- a/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
@@ -656,7 +656,7 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
    * @param stops         list of stops corresponding to stop time updates
    * @param serviceDate   service date of trip
    * @param realTimeState real-time state of new trip
-   * @return true iff successful
+   * @return true if successful
    */
   private boolean addTripToGraphAndBuffer(
     final Deduplicator deduplicator,
@@ -870,7 +870,11 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
     Trip trip = getTripForTripId(feedId, tripId);
     if (trip == null) {
       // TODO: should we support this and consider it an ADDED trip?
-      LOG.warn("Graph does not contain trip id of MODIFIED trip, skipping.");
+      LOG.warn(
+        "Feed '{}' does not contain trip id '{}' of MODIFIED trip, skipping.",
+        feedId,
+        tripDescriptor.getTripId()
+      );
       return false;
     }
 

--- a/src/test/java/org/opentripplanner/model/TimetableSnapshotTest.java
+++ b/src/test/java/org/opentripplanner/model/TimetableSnapshotTest.java
@@ -1,11 +1,11 @@
 package org.opentripplanner.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.transit.realtime.GtfsRealtime.TripDescriptor;
 import com.google.transit.realtime.GtfsRealtime.TripDescriptor.ScheduleRelationship;
@@ -14,8 +14,9 @@ import java.util.ConcurrentModificationException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TimeZone;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.opentripplanner.ConstantsForTests;
 import org.opentripplanner.graph_builder.module.geometry.GeometryAndBlockProcessor;
 import org.opentripplanner.gtfs.GtfsContext;
@@ -30,7 +31,7 @@ public class TimetableSnapshotTest {
   private static final TimeZone timeZone = TimeZone.getTimeZone("GMT");
   private static Map<FeedScopedId, TripPattern> patternIndex;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
     Graph graph = new Graph();
     GtfsContext context = GtfsContextBuilder
@@ -97,90 +98,100 @@ public class TimetableSnapshotTest {
     assertEquals(scheduled, resolver.resolve(pattern, null));
   }
 
-  @Test(expected = ConcurrentModificationException.class)
+  @Test
   public void testUpdate() {
-    ServiceDate today = new ServiceDate();
-    ServiceDate yesterday = today.previous();
-    TripPattern pattern = patternIndex.get(new FeedScopedId("agency", "1.1"));
+    Assertions.assertThrows(
+      ConcurrentModificationException.class,
+      () -> {
+        ServiceDate today = new ServiceDate();
+        ServiceDate yesterday = today.previous();
+        TripPattern pattern = patternIndex.get(new FeedScopedId("agency", "1.1"));
 
-    TimetableSnapshot resolver = new TimetableSnapshot();
-    Timetable origNow = resolver.resolve(pattern, today);
+        TimetableSnapshot resolver = new TimetableSnapshot();
+        Timetable origNow = resolver.resolve(pattern, today);
 
-    TripDescriptor.Builder tripDescriptorBuilder = TripDescriptor.newBuilder();
+        TripDescriptor.Builder tripDescriptorBuilder = TripDescriptor.newBuilder();
 
-    tripDescriptorBuilder.setTripId("1.1");
-    tripDescriptorBuilder.setScheduleRelationship(ScheduleRelationship.CANCELED);
+        tripDescriptorBuilder.setTripId("1.1");
+        tripDescriptorBuilder.setScheduleRelationship(ScheduleRelationship.CANCELED);
 
-    TripUpdate.Builder tripUpdateBuilder = TripUpdate.newBuilder();
+        TripUpdate.Builder tripUpdateBuilder = TripUpdate.newBuilder();
 
-    tripUpdateBuilder.setTrip(tripDescriptorBuilder);
+        tripUpdateBuilder.setTrip(tripDescriptorBuilder);
 
-    TripUpdate tripUpdate = tripUpdateBuilder.build();
+        TripUpdate tripUpdate = tripUpdateBuilder.build();
 
-    // new timetable for today
-    updateResolver(resolver, pattern, tripUpdate, today);
-    Timetable updatedNow = resolver.resolve(pattern, today);
-    assertNotSame(origNow, updatedNow);
+        // new timetable for today
+        updateResolver(resolver, pattern, tripUpdate, today);
+        Timetable updatedNow = resolver.resolve(pattern, today);
+        assertNotSame(origNow, updatedNow);
 
-    // reuse timetable for today
-    updateResolver(resolver, pattern, tripUpdate, today);
-    assertEquals(updatedNow, resolver.resolve(pattern, today));
+        // reuse timetable for today
+        updateResolver(resolver, pattern, tripUpdate, today);
+        assertEquals(updatedNow, resolver.resolve(pattern, today));
 
-    // create new timetable for tomorrow
-    updateResolver(resolver, pattern, tripUpdate, yesterday);
-    assertNotSame(origNow, resolver.resolve(pattern, yesterday));
-    assertNotSame(updatedNow, resolver.resolve(pattern, yesterday));
+        // create new timetable for tomorrow
+        updateResolver(resolver, pattern, tripUpdate, yesterday);
+        assertNotSame(origNow, resolver.resolve(pattern, yesterday));
+        assertNotSame(updatedNow, resolver.resolve(pattern, yesterday));
 
-    // exception if we try to modify a snapshot
-    TimetableSnapshot snapshot = resolver.commit();
-    updateResolver(snapshot, pattern, tripUpdate, yesterday);
+        // exception if we try to modify a snapshot
+        TimetableSnapshot snapshot = resolver.commit();
+        updateResolver(snapshot, pattern, tripUpdate, yesterday);
+      }
+    );
   }
 
-  @Test(expected = ConcurrentModificationException.class)
+  @Test
   public void testCommit() {
-    ServiceDate today = new ServiceDate();
-    ServiceDate yesterday = today.previous();
-    TripPattern pattern = patternIndex.get(new FeedScopedId("agency", "1.1"));
+    Assertions.assertThrows(
+      ConcurrentModificationException.class,
+      () -> {
+        ServiceDate today = new ServiceDate();
+        ServiceDate yesterday = today.previous();
+        TripPattern pattern = patternIndex.get(new FeedScopedId("agency", "1.1"));
 
-    TimetableSnapshot resolver = new TimetableSnapshot();
+        TimetableSnapshot resolver = new TimetableSnapshot();
 
-    // only return a new snapshot if there are changes
-    TimetableSnapshot snapshot = resolver.commit();
-    assertNull(snapshot);
+        // only return a new snapshot if there are changes
+        TimetableSnapshot snapshot = resolver.commit();
+        assertNull(snapshot);
 
-    TripDescriptor.Builder tripDescriptorBuilder = TripDescriptor.newBuilder();
+        TripDescriptor.Builder tripDescriptorBuilder = TripDescriptor.newBuilder();
 
-    tripDescriptorBuilder.setTripId("1.1");
-    tripDescriptorBuilder.setScheduleRelationship(ScheduleRelationship.CANCELED);
+        tripDescriptorBuilder.setTripId("1.1");
+        tripDescriptorBuilder.setScheduleRelationship(ScheduleRelationship.CANCELED);
 
-    TripUpdate.Builder tripUpdateBuilder = TripUpdate.newBuilder();
+        TripUpdate.Builder tripUpdateBuilder = TripUpdate.newBuilder();
 
-    tripUpdateBuilder.setTrip(tripDescriptorBuilder);
+        tripUpdateBuilder.setTrip(tripDescriptorBuilder);
 
-    TripUpdate tripUpdate = tripUpdateBuilder.build();
+        TripUpdate tripUpdate = tripUpdateBuilder.build();
 
-    // add a new timetable for today, commit, and everything should match
-    assertTrue(updateResolver(resolver, pattern, tripUpdate, today));
-    snapshot = resolver.commit();
-    assertEquals(snapshot.resolve(pattern, today), resolver.resolve(pattern, today));
-    assertEquals(snapshot.resolve(pattern, yesterday), resolver.resolve(pattern, yesterday));
+        // add a new timetable for today, commit, and everything should match
+        assertTrue(updateResolver(resolver, pattern, tripUpdate, today));
+        snapshot = resolver.commit();
+        assertEquals(snapshot.resolve(pattern, today), resolver.resolve(pattern, today));
+        assertEquals(snapshot.resolve(pattern, yesterday), resolver.resolve(pattern, yesterday));
 
-    // add a new timetable for today, don't commit, and everything should not match
-    assertTrue(updateResolver(resolver, pattern, tripUpdate, today));
-    assertNotSame(snapshot.resolve(pattern, today), resolver.resolve(pattern, today));
-    assertEquals(snapshot.resolve(pattern, yesterday), resolver.resolve(pattern, yesterday));
+        // add a new timetable for today, don't commit, and everything should not match
+        assertTrue(updateResolver(resolver, pattern, tripUpdate, today));
+        assertNotSame(snapshot.resolve(pattern, today), resolver.resolve(pattern, today));
+        assertEquals(snapshot.resolve(pattern, yesterday), resolver.resolve(pattern, yesterday));
 
-    // add a new timetable for today, on another day, and things should still not match
-    assertTrue(updateResolver(resolver, pattern, tripUpdate, yesterday));
-    assertNotSame(snapshot.resolve(pattern, yesterday), resolver.resolve(pattern, yesterday));
+        // add a new timetable for today, on another day, and things should still not match
+        assertTrue(updateResolver(resolver, pattern, tripUpdate, yesterday));
+        assertNotSame(snapshot.resolve(pattern, yesterday), resolver.resolve(pattern, yesterday));
 
-    // commit, and things should match
-    snapshot = resolver.commit();
-    assertEquals(snapshot.resolve(pattern, today), resolver.resolve(pattern, today));
-    assertEquals(snapshot.resolve(pattern, yesterday), resolver.resolve(pattern, yesterday));
+        // commit, and things should match
+        snapshot = resolver.commit();
+        assertEquals(snapshot.resolve(pattern, today), resolver.resolve(pattern, today));
+        assertEquals(snapshot.resolve(pattern, yesterday), resolver.resolve(pattern, yesterday));
 
-    // exception if we try to commit to a snapshot
-    snapshot.commit();
+        // exception if we try to commit to a snapshot
+        snapshot.commit();
+      }
+    );
   }
 
   @Test

--- a/src/test/java/org/opentripplanner/model/TimetableSnapshotTest.java
+++ b/src/test/java/org/opentripplanner/model/TimetableSnapshotTest.java
@@ -18,10 +18,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.ConstantsForTests;
-import org.opentripplanner.graph_builder.module.geometry.GeometryAndBlockProcessor;
-import org.opentripplanner.gtfs.GtfsContext;
-import org.opentripplanner.gtfs.GtfsContextBuilder;
-import org.opentripplanner.model.calendar.CalendarServiceData;
 import org.opentripplanner.model.calendar.ServiceDate;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.trippattern.TripTimes;
@@ -30,18 +26,13 @@ public class TimetableSnapshotTest {
 
   private static final TimeZone timeZone = TimeZone.getTimeZone("GMT");
   private static Map<FeedScopedId, TripPattern> patternIndex;
+  static String feedId;
 
   @BeforeAll
   public static void setUp() throws Exception {
-    Graph graph = new Graph();
-    GtfsContext context = GtfsContextBuilder
-      .contextBuilder(ConstantsForTests.FAKE_GTFS)
-      .withIssueStoreAndDeduplicator(graph)
-      .build();
+    Graph graph = ConstantsForTests.buildGtfsGraph(ConstantsForTests.FAKE_GTFS);
 
-    GeometryAndBlockProcessor factory = new GeometryAndBlockProcessor(context);
-    factory.run(graph);
-    graph.putService(CalendarServiceData.class, context.getCalendarServiceData());
+    feedId = graph.getFeedIds().iterator().next();
 
     patternIndex = new HashMap<>();
     for (TripPattern tripPattern : graph.tripPatternForId.values()) {
@@ -64,7 +55,7 @@ public class TimetableSnapshotTest {
     ServiceDate today = new ServiceDate();
     ServiceDate yesterday = today.previous();
     ServiceDate tomorrow = today.next();
-    TripPattern pattern = patternIndex.get(new FeedScopedId("agency", "1.1"));
+    TripPattern pattern = patternIndex.get(new FeedScopedId(feedId, "1.1"));
     TimetableSnapshot resolver = new TimetableSnapshot();
 
     Timetable scheduled = resolver.resolve(pattern, today);
@@ -105,7 +96,7 @@ public class TimetableSnapshotTest {
       () -> {
         ServiceDate today = new ServiceDate();
         ServiceDate yesterday = today.previous();
-        TripPattern pattern = patternIndex.get(new FeedScopedId("agency", "1.1"));
+        TripPattern pattern = patternIndex.get(new FeedScopedId(feedId, "1.1"));
 
         TimetableSnapshot resolver = new TimetableSnapshot();
         Timetable origNow = resolver.resolve(pattern, today);
@@ -149,7 +140,7 @@ public class TimetableSnapshotTest {
       () -> {
         ServiceDate today = new ServiceDate();
         ServiceDate yesterday = today.previous();
-        TripPattern pattern = patternIndex.get(new FeedScopedId("agency", "1.1"));
+        TripPattern pattern = patternIndex.get(new FeedScopedId(feedId, "1.1"));
 
         TimetableSnapshot resolver = new TimetableSnapshot();
 
@@ -198,7 +189,7 @@ public class TimetableSnapshotTest {
   public void testPurge() {
     ServiceDate today = new ServiceDate();
     ServiceDate yesterday = today.previous();
-    TripPattern pattern = patternIndex.get(new FeedScopedId("agency", "1.1"));
+    TripPattern pattern = patternIndex.get(new FeedScopedId(feedId, "1.1"));
 
     TripDescriptor.Builder tripDescriptorBuilder = TripDescriptor.newBuilder();
 

--- a/src/test/java/org/opentripplanner/model/TimetableTest.java
+++ b/src/test/java/org/opentripplanner/model/TimetableTest.java
@@ -114,22 +114,7 @@ public class TimetableTest {
 
     //---
     long startTime = TestUtils.dateInSeconds("America/New_York", 2009, AUGUST, 7, 0, 0, 0);
-    long endTime;
     options.setDateTime(Instant.ofEpochSecond(startTime));
-
-    //---
-    /*
-    spt =
-      AStarBuilder
-        .oneToOne()
-        .setContext(new RoutingContext(options, graph, stop_a, stop_c))
-        .getShortestPathTree();
-
-    path = spt.getPath(stop_c);
-    Assertions.assertNotNull(path);
-    endTime = startTime + 20 * 60;
-    Assertions.assertEquals(endTime, path.getEndTime());
-    */
 
     // update trip
     tripDescriptorBuilder = TripDescriptor.newBuilder();
@@ -155,57 +140,6 @@ public class TimetableTest {
     Assertions.assertNotNull(updatedTripTimes);
     timetable.setTripTimes(trip_1_1_index, updatedTripTimes);
     assertEquals(20 * 60 + 120, timetable.getTripTimes(trip_1_1_index).getArrivalTime(2));
-
-    //---
-
-    /*spt =
-      AStarBuilder
-        .oneToOne()
-        .setContext(new RoutingContext(options, graph, stop_a, stop_c))
-        .getShortestPathTree();
-
-    path = spt.getPath(stop_c);
-    Assertions.assertNotNull(path);
-    endTime = startTime + 20 * 60 + 120;
-    Assertions.assertEquals(endTime, path.getEndTime());
-     */
-
-    // cancel trip
-    tripDescriptorBuilder = TripDescriptor.newBuilder();
-    tripDescriptorBuilder.setTripId("1.1");
-    tripDescriptorBuilder.setScheduleRelationship(TripDescriptor.ScheduleRelationship.CANCELED);
-    tripUpdateBuilder = TripUpdate.newBuilder();
-    tripUpdateBuilder.setTrip(tripDescriptorBuilder);
-    tripUpdate = tripUpdateBuilder.build();
-    patch = timetable.createUpdatedTripTimes(tripUpdate, timeZone, serviceDate);
-    updatedTripTimes = patch.getTripTimes();
-    Assertions.assertNotNull(updatedTripTimes);
-    timetable.setTripTimes(trip_1_1_index, updatedTripTimes);
-
-    TripTimes tripTimes = timetable.getTripTimes(trip_1_1_index);
-    assertEquals(RealTimeState.CANCELED, tripTimes.getRealTimeState());
-
-    // TODO This will not work since individual stops cannot be cancelled using GTFS updates
-    //      yet
-    /*
-    for (int i = 0; i < tripTimes.getNumStops(); i++) {
-      Assertions.assertEquals(PickDrop.CANCELLED, pattern.getBoardType(i));
-      Assertions.assertEquals(PickDrop.CANCELLED, pattern.getAlightType(i));
-    }
-
-    //---
-
-    spt =
-      AStarBuilder
-        .oneToOne()
-        .setContext(new RoutingContext(options, graph, stop_a, stop_c))
-        .getShortestPathTree();
-
-    path = spt.getPath(stop_c);
-    Assertions.assertNotNull(path);
-    endTime = startTime + 40 * 60;
-    Assertions.assertEquals(endTime, path.getEndTime());
-     */
 
     // update trip arrival time incorrectly
     tripDescriptorBuilder = TripDescriptor.newBuilder();

--- a/src/test/java/org/opentripplanner/model/TimetableTest.java
+++ b/src/test/java/org/opentripplanner/model/TimetableTest.java
@@ -1,8 +1,5 @@
 package org.opentripplanner.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.opentripplanner.gtfs.GtfsContextBuilder.contextBuilder;
 import static org.opentripplanner.util.TestUtils.AUGUST;
 
@@ -14,9 +11,9 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TimeZone;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.opentripplanner.ConstantsForTests;
 import org.opentripplanner.graph_builder.module.geometry.GeometryAndBlockProcessor;
 import org.opentripplanner.gtfs.GtfsContext;
@@ -32,10 +29,6 @@ import org.opentripplanner.routing.spt.ShortestPathTree;
 import org.opentripplanner.routing.trippattern.TripTimes;
 import org.opentripplanner.util.TestUtils;
 
-/**
- * TODO OTP2 - Test is too close to the implementation and will need to be reimplemented.
- */
-@Ignore
 public class TimetableTest {
 
   private static final TimeZone timeZone = TimeZone.getTimeZone("America/New_York");
@@ -45,7 +38,7 @@ public class TimetableTest {
   private static TripPattern pattern;
   private static Timetable timetable;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
     GtfsContext context = contextBuilder(ConstantsForTests.FAKE_GTFS).build();
     graph = new Graph();
@@ -96,7 +89,7 @@ public class TimetableTest {
       serviceDate
     );
     TripTimes updatedTripTimes = tripTimesPatch.getTripTimes();
-    assertNull(updatedTripTimes);
+    Assertions.assertNull(updatedTripTimes);
 
     // update trip with bad data
     tripDescriptorBuilder = TripDescriptor.newBuilder();
@@ -110,7 +103,7 @@ public class TimetableTest {
     tripUpdate = tripUpdateBuilder.build();
     tripTimesPatch = timetable.createUpdatedTripTimes(tripUpdate, timeZone, serviceDate);
     updatedTripTimes = tripTimesPatch.getTripTimes();
-    assertNull(updatedTripTimes);
+    Assertions.assertNull(updatedTripTimes);
 
     // update trip with non-increasing data
     tripDescriptorBuilder = TripDescriptor.newBuilder();
@@ -132,7 +125,7 @@ public class TimetableTest {
     tripUpdate = tripUpdateBuilder.build();
     tripTimesPatch = timetable.createUpdatedTripTimes(tripUpdate, timeZone, serviceDate);
     updatedTripTimes = tripTimesPatch.getTripTimes();
-    assertNull(updatedTripTimes);
+    Assertions.assertNull(updatedTripTimes);
 
     //---
     long startTime = TestUtils.dateInSeconds("America/New_York", 2009, AUGUST, 7, 0, 0, 0);
@@ -147,9 +140,9 @@ public class TimetableTest {
         .getShortestPathTree();
 
     path = spt.getPath(stop_c);
-    assertNotNull(path);
+    Assertions.assertNotNull(path);
     endTime = startTime + 20 * 60;
-    assertEquals(endTime, path.getEndTime());
+    Assertions.assertEquals(endTime, path.getEndTime());
 
     // update trip
     tripDescriptorBuilder = TripDescriptor.newBuilder();
@@ -169,12 +162,15 @@ public class TimetableTest {
       TestUtils.dateInSeconds("America/New_York", 2009, AUGUST, 7, 0, 2, 0)
     );
     tripUpdate = tripUpdateBuilder.build();
-    assertEquals(20 * 60, timetable.getTripTimes(trip_1_1_index).getArrivalTime(2));
+    Assertions.assertEquals(20 * 60, timetable.getTripTimes(trip_1_1_index).getArrivalTime(2));
     tripTimesPatch = timetable.createUpdatedTripTimes(tripUpdate, timeZone, serviceDate);
     updatedTripTimes = tripTimesPatch.getTripTimes();
-    assertNotNull(updatedTripTimes);
+    Assertions.assertNotNull(updatedTripTimes);
     timetable.setTripTimes(trip_1_1_index, updatedTripTimes);
-    assertEquals(20 * 60 + 120, timetable.getTripTimes(trip_1_1_index).getArrivalTime(2));
+    Assertions.assertEquals(
+      20 * 60 + 120,
+      timetable.getTripTimes(trip_1_1_index).getArrivalTime(2)
+    );
 
     //---
 
@@ -185,9 +181,9 @@ public class TimetableTest {
         .getShortestPathTree();
 
     path = spt.getPath(stop_c);
-    assertNotNull(path);
+    Assertions.assertNotNull(path);
     endTime = startTime + 20 * 60 + 120;
-    assertEquals(endTime, path.getEndTime());
+    Assertions.assertEquals(endTime, path.getEndTime());
 
     // cancel trip
     tripDescriptorBuilder = TripDescriptor.newBuilder();
@@ -198,7 +194,7 @@ public class TimetableTest {
     tripUpdate = tripUpdateBuilder.build();
     tripTimesPatch = timetable.createUpdatedTripTimes(tripUpdate, timeZone, serviceDate);
     updatedTripTimes = tripTimesPatch.getTripTimes();
-    assertNotNull(updatedTripTimes);
+    Assertions.assertNotNull(updatedTripTimes);
     timetable.setTripTimes(trip_1_1_index, updatedTripTimes);
 
     TripTimes tripTimes = timetable.getTripTimes(trip_1_1_index);
@@ -206,8 +202,8 @@ public class TimetableTest {
     // TODO This will not work since individual stops cannot be cancelled using GTFS updates
     //      yet
     for (int i = 0; i < tripTimes.getNumStops(); i++) {
-      assertEquals(PickDrop.CANCELLED, pattern.getBoardType(i));
-      assertEquals(PickDrop.CANCELLED, pattern.getAlightType(i));
+      Assertions.assertEquals(PickDrop.CANCELLED, pattern.getBoardType(i));
+      Assertions.assertEquals(PickDrop.CANCELLED, pattern.getAlightType(i));
     }
 
     //---
@@ -219,9 +215,9 @@ public class TimetableTest {
         .getShortestPathTree();
 
     path = spt.getPath(stop_c);
-    assertNotNull(path);
+    Assertions.assertNotNull(path);
     endTime = startTime + 40 * 60;
-    assertEquals(endTime, path.getEndTime());
+    Assertions.assertEquals(endTime, path.getEndTime());
 
     // update trip arrival time incorrectly
     tripDescriptorBuilder = TripDescriptor.newBuilder();
@@ -237,7 +233,7 @@ public class TimetableTest {
     tripUpdate = tripUpdateBuilder.build();
     tripTimesPatch = timetable.createUpdatedTripTimes(tripUpdate, timeZone, serviceDate);
     updatedTripTimes = tripTimesPatch.getTripTimes();
-    assertNotNull(updatedTripTimes);
+    Assertions.assertNotNull(updatedTripTimes);
     timetable.setTripTimes(trip_1_1_index, updatedTripTimes);
 
     // update trip arrival time only
@@ -254,7 +250,7 @@ public class TimetableTest {
     tripUpdate = tripUpdateBuilder.build();
     tripTimesPatch = timetable.createUpdatedTripTimes(tripUpdate, timeZone, serviceDate);
     updatedTripTimes = tripTimesPatch.getTripTimes();
-    assertNotNull(updatedTripTimes);
+    Assertions.assertNotNull(updatedTripTimes);
     timetable.setTripTimes(trip_1_1_index, updatedTripTimes);
 
     // update trip departure time only
@@ -271,7 +267,7 @@ public class TimetableTest {
     tripUpdate = tripUpdateBuilder.build();
     tripTimesPatch = timetable.createUpdatedTripTimes(tripUpdate, timeZone, serviceDate);
     updatedTripTimes = tripTimesPatch.getTripTimes();
-    assertNotNull(updatedTripTimes);
+    Assertions.assertNotNull(updatedTripTimes);
     timetable.setTripTimes(trip_1_1_index, updatedTripTimes);
 
     // update trip using stop id
@@ -288,7 +284,7 @@ public class TimetableTest {
     tripUpdate = tripUpdateBuilder.build();
     tripTimesPatch = timetable.createUpdatedTripTimes(tripUpdate, timeZone, serviceDate);
     updatedTripTimes = tripTimesPatch.getTripTimes();
-    assertNotNull(updatedTripTimes);
+    Assertions.assertNotNull(updatedTripTimes);
     timetable.setTripTimes(trip_1_1_index, updatedTripTimes);
 
     // update trip arrival time at first stop and make departure time incoherent at second stop
@@ -310,6 +306,6 @@ public class TimetableTest {
     tripUpdate = tripUpdateBuilder.build();
     tripTimesPatch = timetable.createUpdatedTripTimes(tripUpdate, timeZone, serviceDate);
     updatedTripTimes = tripTimesPatch.getTripTimes();
-    assertNull(updatedTripTimes);
+    Assertions.assertNull(updatedTripTimes);
   }
 }

--- a/src/test/java/org/opentripplanner/model/TimetableTest.java
+++ b/src/test/java/org/opentripplanner/model/TimetableTest.java
@@ -34,18 +34,20 @@ public class TimetableTest {
   private static Map<FeedScopedId, TripPattern> patternIndex;
   private static TripPattern pattern;
   private static Timetable timetable;
+  private static String feedId;
 
   @BeforeAll
   public static void setUp() throws Exception {
     graph = ConstantsForTests.buildGtfsGraph(ConstantsForTests.FAKE_GTFS);
 
+    feedId = graph.getFeedIds().stream().findFirst().get();
     patternIndex = new HashMap<>();
 
     for (TripPattern pattern : graph.tripPatternForId.values()) {
       pattern.scheduledTripsAsStream().forEach(trip -> patternIndex.put(trip.getId(), pattern));
     }
 
-    pattern = patternIndex.get(new FeedScopedId("agency", "1.1"));
+    pattern = patternIndex.get(new FeedScopedId(feedId, "1.1"));
     timetable = pattern.getScheduledTimetable();
   }
 
@@ -57,9 +59,7 @@ public class TimetableTest {
     StopTimeUpdate.Builder stopTimeUpdateBuilder;
     StopTimeEvent.Builder stopTimeEventBuilder;
 
-    String feedId = graph.getFeedIds().iterator().next();
-
-    int trip_1_1_index = timetable.getTripIndex(new FeedScopedId("agency", "1.1"));
+    int trip_1_1_index = timetable.getTripIndex(new FeedScopedId(feedId, "1.1"));
 
     Vertex stop_a = graph.getVertex(feedId + ":A");
     Vertex stop_c = graph.getVertex(feedId + ":C");

--- a/src/test/java/org/opentripplanner/model/TimetableTest.java
+++ b/src/test/java/org/opentripplanner/model/TimetableTest.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.opentripplanner.util.TestUtils.AUGUST;
 
@@ -137,7 +138,7 @@ public class TimetableTest {
     assertEquals(20 * 60, timetable.getTripTimes(trip_1_1_index).getArrivalTime(2));
     patch = timetable.createUpdatedTripTimes(tripUpdate, timeZone, serviceDate);
     var updatedTripTimes = patch.getTripTimes();
-    Assertions.assertNotNull(updatedTripTimes);
+    assertNotNull(updatedTripTimes);
     timetable.setTripTimes(trip_1_1_index, updatedTripTimes);
     assertEquals(20 * 60 + 120, timetable.getTripTimes(trip_1_1_index).getArrivalTime(2));
 
@@ -155,7 +156,7 @@ public class TimetableTest {
     tripUpdate = tripUpdateBuilder.build();
     patch = timetable.createUpdatedTripTimes(tripUpdate, timeZone, serviceDate);
     updatedTripTimes = patch.getTripTimes();
-    Assertions.assertNotNull(updatedTripTimes);
+    assertNotNull(updatedTripTimes);
     timetable.setTripTimes(trip_1_1_index, updatedTripTimes);
 
     // update trip arrival time only
@@ -172,7 +173,7 @@ public class TimetableTest {
     tripUpdate = tripUpdateBuilder.build();
     patch = timetable.createUpdatedTripTimes(tripUpdate, timeZone, serviceDate);
     updatedTripTimes = patch.getTripTimes();
-    Assertions.assertNotNull(updatedTripTimes);
+    assertNotNull(updatedTripTimes);
     timetable.setTripTimes(trip_1_1_index, updatedTripTimes);
 
     // update trip departure time only
@@ -189,7 +190,7 @@ public class TimetableTest {
     tripUpdate = tripUpdateBuilder.build();
     patch = timetable.createUpdatedTripTimes(tripUpdate, timeZone, serviceDate);
     updatedTripTimes = patch.getTripTimes();
-    Assertions.assertNotNull(updatedTripTimes);
+    assertNotNull(updatedTripTimes);
     timetable.setTripTimes(trip_1_1_index, updatedTripTimes);
 
     // update trip using stop id
@@ -206,7 +207,7 @@ public class TimetableTest {
     tripUpdate = tripUpdateBuilder.build();
     patch = timetable.createUpdatedTripTimes(tripUpdate, timeZone, serviceDate);
     updatedTripTimes = patch.getTripTimes();
-    Assertions.assertNotNull(updatedTripTimes);
+    assertNotNull(updatedTripTimes);
     timetable.setTripTimes(trip_1_1_index, updatedTripTimes);
 
     // update trip arrival time at first stop and make departure time incoherent at second stop

--- a/src/test/java/org/opentripplanner/model/TimetableTest.java
+++ b/src/test/java/org/opentripplanner/model/TimetableTest.java
@@ -75,11 +75,7 @@ public class TimetableTest {
     tripUpdateBuilder = TripUpdate.newBuilder();
     tripUpdateBuilder.setTrip(tripDescriptorBuilder);
     tripUpdate = tripUpdateBuilder.build();
-    var patch = timetable.createUpdatedTripTimes(
-      tripUpdate,
-      timeZone,
-      serviceDate
-    );
+    var patch = timetable.createUpdatedTripTimes(tripUpdate, timeZone, serviceDate);
     assertNull(patch);
 
     // update trip with bad data
@@ -158,10 +154,7 @@ public class TimetableTest {
     var updatedTripTimes = patch.getTripTimes();
     Assertions.assertNotNull(updatedTripTimes);
     timetable.setTripTimes(trip_1_1_index, updatedTripTimes);
-    assertEquals(
-      20 * 60 + 120,
-      timetable.getTripTimes(trip_1_1_index).getArrivalTime(2)
-    );
+    assertEquals(20 * 60 + 120, timetable.getTripTimes(trip_1_1_index).getArrivalTime(2));
 
     //---
 
@@ -190,7 +183,7 @@ public class TimetableTest {
     timetable.setTripTimes(trip_1_1_index, updatedTripTimes);
 
     TripTimes tripTimes = timetable.getTripTimes(trip_1_1_index);
-    assertEquals(RealTimeState.CANCELED,tripTimes.getRealTimeState());
+    assertEquals(RealTimeState.CANCELED, tripTimes.getRealTimeState());
 
     // TODO This will not work since individual stops cannot be cancelled using GTFS updates
     //      yet

--- a/src/test/java/org/opentripplanner/model/calendar/impl/CalendarServiceDataFactoryImplTest.java
+++ b/src/test/java/org/opentripplanner/model/calendar/impl/CalendarServiceDataFactoryImplTest.java
@@ -3,9 +3,8 @@ package org.opentripplanner.model.calendar.impl;
 import static java.util.Arrays.asList;
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.toList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.gtfs.GtfsContextBuilder.contextBuilder;
 import static org.opentripplanner.model.calendar.ServiceCalendarDate.EXCEPTION_TYPE_REMOVE;
 import static org.opentripplanner.model.calendar.impl.CalendarServiceDataFactoryImpl.merge;
@@ -15,8 +14,9 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.TimeZone;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.opentripplanner.ConstantsForTests;
 import org.opentripplanner.graph_builder.DataImportIssueStore;
 import org.opentripplanner.gtfs.GtfsContext;
@@ -55,7 +55,7 @@ public class CalendarServiceDataFactoryImplTest {
 
   private static CalendarService calendarService;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws IOException {
     // The context builder uses the CalendarServiceDataFactoryImpl to create data
     data = createCtxBuilder().getCalendarServiceData();
@@ -66,7 +66,7 @@ public class CalendarServiceDataFactoryImplTest {
   public void testMerge() {
     Set<Character> result = merge(asList('A', 'B'), asList('B', 'C'));
 
-    assertTrue(result.toString(), result.containsAll(asList('A', 'B', 'C')));
+    assertTrue(result.containsAll(asList('A', 'B', 'C')), result.toString());
     assertEquals(3, result.size());
   }
 
@@ -136,7 +136,7 @@ public class CalendarServiceDataFactoryImplTest {
     Set<ServiceDate> weekdays = calendarService.getServiceDatesForServiceId(SERVICE_WEEKDAYS_ID);
 
     assertTrue(weekdays.contains(A_FRIDAY));
-    assertFalse(weekdays.contains(A_SUNDAY));
+    Assertions.assertFalse(weekdays.contains(A_SUNDAY));
     assertEquals(10697, weekdays.size());
   }
 

--- a/src/test/java/org/opentripplanner/routing/algorithm/AStarTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/AStarTest.java
@@ -1,14 +1,14 @@
 package org.opentripplanner.routing.algorithm;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.opentripplanner.routing.algorithm.astar.AStarBuilder;
 import org.opentripplanner.routing.algorithm.astar.strategies.SearchTerminationStrategy;
@@ -29,7 +29,7 @@ public class AStarTest {
 
   private Graph graph;
 
-  @Before
+  @BeforeEach
   public void before() {
     graph = new Graph();
 
@@ -256,7 +256,7 @@ public class AStarTest {
 
     for (Vertex v : targets) {
       GraphPath path = tree.getPath(v);
-      assertNotNull("No path found for target " + v.getLabel(), path);
+      assertNotNull(path, "No path found for target " + v.getLabel());
     }
   }
 

--- a/src/test/java/org/opentripplanner/routing/algorithm/FaresTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/FaresTest.java
@@ -107,6 +107,9 @@ public class FaresTest {
       ConstantsForTests.KCM_GTFS,
       new SeattleFareServiceFactory()
     );
+
+    assertEquals("America/Los_Angeles", graph.getTimeZone().getID());
+
     var feedId = graph.getFeedIds().iterator().next();
 
     var router = new Router(graph, RouterConfig.DEFAULT, Metrics.globalRegistry);
@@ -124,8 +127,13 @@ public class FaresTest {
     var onPeakStartTime = TestUtils.dateInstant("America/Los_Angeles", 2016, 5, 24, 8, 0, 0);
     var peakItinerary = getItineraries(from, to, onPeakStartTime, router).get(1);
     var leg = peakItinerary.legs.get(0);
+
     assertTrue(toLocalTime(leg.getStartTime()).isAfter(LocalTime.parse("08:00")));
-    assertTrue(toLocalTime(leg.getStartTime()).isBefore(LocalTime.parse("09:00")));
+    var startTime = toLocalTime(leg.getStartTime());
+    assertTrue(
+      startTime.isBefore(LocalTime.parse("09:00")),
+      "Leg's start should be before 09:00 but is " + startTime
+    );
 
     assertEquals(new Money(USD, 275), peakItinerary.fare.getFare(FareType.regular));
   }

--- a/src/test/java/org/opentripplanner/routing/algorithm/FaresTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/FaresTest.java
@@ -153,7 +153,7 @@ public class FaresTest {
     assertEquals(fareComponents.size(), 1);
     assertEquals(fareComponents.get(0).price, tenUSD);
     assertEquals(fareComponents.get(0).fareId, new FeedScopedId(feedId, "AB"));
-    assertEquals(fareComponents.get(0).routes.get(0), new FeedScopedId("agency", "1"));
+    assertEquals(fareComponents.get(0).routes.get(0), new FeedScopedId(feedId, "1"));
 
     // D -> E, null case
 
@@ -172,10 +172,10 @@ public class FaresTest {
     assertEquals(fareComponents.size(), 2);
     assertEquals(fareComponents.get(0).price, tenUSD);
     assertEquals(fareComponents.get(0).fareId, new FeedScopedId(feedId, "AB"));
-    assertEquals(fareComponents.get(0).routes.get(0), new FeedScopedId("agency", "1"));
+    assertEquals(fareComponents.get(0).routes.get(0), new FeedScopedId(feedId, "1"));
     assertEquals(fareComponents.get(1).price, tenUSD);
     assertEquals(fareComponents.get(1).fareId, new FeedScopedId(feedId, "BC"));
-    assertEquals(fareComponents.get(1).routes.get(0), new FeedScopedId("agency", "2"));
+    assertEquals(fareComponents.get(1).routes.get(0), new FeedScopedId(feedId, "2"));
 
     // B -> D, 2 fully connected components
     from = GenericLocation.fromStopId("Origin", feedId, "B");
@@ -186,8 +186,8 @@ public class FaresTest {
     assertEquals(fareComponents.size(), 1);
     assertEquals(fareComponents.get(0).price, tenUSD);
     assertEquals(fareComponents.get(0).fareId, new FeedScopedId(feedId, "BD"));
-    assertEquals(fareComponents.get(0).routes.get(0), new FeedScopedId("agency", "2"));
-    assertEquals(fareComponents.get(0).routes.get(1), new FeedScopedId("agency", "3"));
+    assertEquals(fareComponents.get(0).routes.get(0), new FeedScopedId(feedId, "2"));
+    assertEquals(fareComponents.get(0).routes.get(1), new FeedScopedId(feedId, "3"));
 
     // E -> G, missing in between fare
     from = GenericLocation.fromStopId("Origin", feedId, "E");
@@ -198,8 +198,8 @@ public class FaresTest {
     assertEquals(fareComponents.size(), 1);
     assertEquals(fareComponents.get(0).price, tenUSD);
     assertEquals(fareComponents.get(0).fareId, new FeedScopedId(feedId, "EG"));
-    assertEquals(fareComponents.get(0).routes.get(0), new FeedScopedId("agency", "5"));
-    assertEquals(fareComponents.get(0).routes.get(1), new FeedScopedId("agency", "6"));
+    assertEquals(fareComponents.get(0).routes.get(0), new FeedScopedId(feedId, "5"));
+    assertEquals(fareComponents.get(0).routes.get(1), new FeedScopedId(feedId, "6"));
 
     // C -> E, missing fare after
     from = GenericLocation.fromStopId("Origin", feedId, "C");
@@ -210,7 +210,7 @@ public class FaresTest {
     assertEquals(fareComponents.size(), 1);
     assertEquals(fareComponents.get(0).price, tenUSD);
     assertEquals(fareComponents.get(0).fareId, new FeedScopedId(feedId, "CD"));
-    assertEquals(fareComponents.get(0).routes.get(0), new FeedScopedId("agency", "3"));
+    assertEquals(fareComponents.get(0).routes.get(0), new FeedScopedId(feedId, "3"));
 
     // D -> G, missing fare before
     from = GenericLocation.fromStopId("Origin", feedId, "D");
@@ -221,8 +221,8 @@ public class FaresTest {
     assertEquals(fareComponents.size(), 1);
     assertEquals(fareComponents.get(0).price, tenUSD);
     assertEquals(fareComponents.get(0).fareId, new FeedScopedId(feedId, "EG"));
-    assertEquals(fareComponents.get(0).routes.get(0), new FeedScopedId("agency", "5"));
-    assertEquals(fareComponents.get(0).routes.get(1), new FeedScopedId("agency", "6"));
+    assertEquals(fareComponents.get(0).routes.get(0), new FeedScopedId(feedId, "5"));
+    assertEquals(fareComponents.get(0).routes.get(1), new FeedScopedId(feedId, "6"));
 
     // A -> D, use individual component parts
     from = GenericLocation.fromStopId("Origin", feedId, "A");
@@ -233,11 +233,11 @@ public class FaresTest {
     assertEquals(fareComponents.size(), 2);
     assertEquals(fareComponents.get(0).price, tenUSD);
     assertEquals(fareComponents.get(0).fareId, new FeedScopedId(feedId, "AB"));
-    assertEquals(fareComponents.get(0).routes.get(0), new FeedScopedId("agency", "1"));
+    assertEquals(fareComponents.get(0).routes.get(0), new FeedScopedId(feedId, "1"));
     assertEquals(fareComponents.get(1).price, tenUSD);
     assertEquals(fareComponents.get(1).fareId, new FeedScopedId(feedId, "BD"));
-    assertEquals(fareComponents.get(1).routes.get(0), new FeedScopedId("agency", "2"));
-    assertEquals(fareComponents.get(1).routes.get(1), new FeedScopedId("agency", "3"));
+    assertEquals(fareComponents.get(1).routes.get(0), new FeedScopedId(feedId, "2"));
+    assertEquals(fareComponents.get(1).routes.get(1), new FeedScopedId(feedId, "3"));
   }
 
   private static Fare getFare(

--- a/src/test/java/org/opentripplanner/routing/algorithm/FaresTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/FaresTest.java
@@ -9,6 +9,7 @@ import java.time.Instant;
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.Calendar;
+import java.util.Comparator;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.ConstantsForTests;
@@ -109,6 +110,8 @@ public class FaresTest {
     );
 
     assertEquals("America/Los_Angeles", graph.getTimeZone().getID());
+
+    assertEquals(1, graph.getFeedIds().size());
 
     var feedId = graph.getFeedIds().iterator().next();
 
@@ -279,7 +282,11 @@ public class FaresTest {
       additionalSearchDays,
       new DebugTimingAggregator()
     );
-    return result.getItineraries();
+    return result
+      .getItineraries()
+      .stream()
+      .sorted(Comparator.comparingInt(x -> x.generalizedCost))
+      .toList();
   }
 
   private static LocalTime toLocalTime(Calendar time) {

--- a/src/test/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSourceTest.java
+++ b/src/test/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSourceTest.java
@@ -137,11 +137,6 @@ public class TimetableSnapshotSourceTest {
 
     final TripTimes tripTimes = forToday.getTripTimes(tripIndex);
 
-    /*
-    for (int i = 0; i < tripTimes.getNumStops(); i++) {
-      assertEquals(PickDrop.CANCELLED, pattern.getBoardType(i));
-      assertEquals(PickDrop.CANCELLED, pattern.getAlightType(i));
-    }*/
     assertEquals(RealTimeState.CANCELED, tripTimes.getRealTimeState());
   }
 

--- a/src/test/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSourceTest.java
+++ b/src/test/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSourceTest.java
@@ -335,7 +335,7 @@ public class TimetableSnapshotSourceTest {
     );
 
     final int scheduleTripIndex = schedule.getTripIndex(addedTripId);
-    assertEquals( -1, scheduleTripIndex, "Added trip should not be found in scheduled time table");
+    assertEquals(-1, scheduleTripIndex, "Added trip should not be found in scheduled time table");
   }
 
   @Test
@@ -517,7 +517,7 @@ public class TimetableSnapshotSourceTest {
         new FeedScopedId(feedId, modifiedTripId),
         serviceDate
       );
-      assertNotNull(newTripPattern,"New trip pattern should be found");
+      assertNotNull(newTripPattern, "New trip pattern should be found");
 
       final Timetable newTimetableForToday = snapshot.resolve(newTripPattern, serviceDate);
       final Timetable newTimetableScheduled = snapshot.resolve(newTripPattern, null);

--- a/src/test/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSourceTest.java
+++ b/src/test/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSourceTest.java
@@ -40,13 +40,15 @@ public class TimetableSnapshotSourceTest {
   private static final boolean fullDataset = false;
   private static final ServiceDate serviceDate = new ServiceDate();
   private static byte[] cancellation;
-  private static final String feedId = "agency"; // TODO: find out where this id comes from
+  private static String feedId;
 
   private TimetableSnapshotSource updater;
 
   @BeforeAll
   public static void setUpClass() {
     graph = ConstantsForTests.buildGtfsGraph(ConstantsForTests.FAKE_GTFS);
+
+    feedId = graph.getFeedIds().stream().findFirst().get();
 
     final TripDescriptor.Builder tripDescriptorBuilder = TripDescriptor.newBuilder();
 
@@ -296,8 +298,6 @@ public class TimetableSnapshotSourceTest {
     Deduplicator deduplicator = graph.deduplicator;
     GraphIndex graphIndex = graph.index;
 
-    var feedId = "1"; // TODO figure why this is required
-
     Map<FeedScopedId, Integer> serviceCodes = graph.getServiceCodes();
     updater.applyTripUpdates(
       calendarService,
@@ -446,8 +446,6 @@ public class TimetableSnapshotSourceTest {
 
       tripUpdate = tripUpdateBuilder.build();
     }
-
-    var feedId = "1"; // TODO figure why this is required
 
     // WHEN
     CalendarService calendarService = graph.getCalendarService();


### PR DESCRIPTION
### Summary

Previously all tests for the realtime updates were completely disabled and this PR reactivates them.

It also reduces the usages of `GtfsContext` which I would like to remove eventually.

I recognize that these tests are not really unit tests, more integration or module tests but they do provides useful test scenarios nontheless. I fully expect to help migrate these once the refactoring of the transit layer progresses.

### Issue
none

### Unit tests
yes :)

### Code style

yes

### Documentation
n/a

### Changelog

skip