### PR TITLE
Allow single SIRI-situations to fail without affecting others

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/siri/SiriAlertsUpdateHandler.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriAlertsUpdateHandler.java
@@ -97,8 +97,17 @@ public class SiriAlertsUpdateHandler {
             alerts.removeIf(transitAlert -> transitAlert.getId().equals(situationNumber));
             expiredCounter++;
           } else {
-            TransitAlert alert = handleAlert(sxElement);
-            addedCounter++;
+            TransitAlert alert = null;
+            try {
+              alert = handleAlert(sxElement);
+              addedCounter++;
+            } catch (Exception e) {
+              LOG.info(
+                "Caught exception when processing situation with situationNumber {}: {}",
+                situationNumber,
+                e
+              );
+            }
             if (alert != null) {
               alert.setId(situationNumber);
               if (alert.getEntities().isEmpty()) {


### PR DESCRIPTION
Allow single SIRI SX-messages to fail in runtime without affecting/skipping the rest of the messages in the list.

Sandbox-changes only.