### PR TITLE
Convert Legs to Java 8 time classes [changelog skip]

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/flex/FlexibleTransitLeg.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/FlexibleTransitLeg.java
@@ -182,7 +182,7 @@ public class FlexibleTransitLeg implements Leg {
   }
 
   @Override
-  public Leg timeShiftBy(Duration duration) {
+  public Leg withTimeShift(Duration duration) {
     FlexibleTransitLeg copy = new FlexibleTransitLeg(
       edge,
       startTime.plus(duration),

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLItineraryImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLItineraryImpl.java
@@ -36,7 +36,7 @@ public class LegacyGraphQLItineraryImpl
 
   @Override
   public DataFetcher<Long> endTime() {
-    return environment -> getSource(environment).endTime().getTime().getTime();
+    return environment -> getSource(environment).endTime().toInstant().toEpochMilli();
   }
 
   @Override
@@ -72,7 +72,7 @@ public class LegacyGraphQLItineraryImpl
 
   @Override
   public DataFetcher<Long> startTime() {
-    return environment -> getSource(environment).startTime().getTime().getTime();
+    return environment -> getSource(environment).startTime().toInstant().toEpochMilli();
   }
 
   @Override

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLLegImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLLegImpl.java
@@ -63,7 +63,7 @@ public class LegacyGraphQLLegImpl implements LegacyGraphQLDataFetchers.LegacyGra
 
   @Override
   public DataFetcher<Long> endTime() {
-    return environment -> getSource(environment).getEndTime().getTime().getTime();
+    return environment -> getSource(environment).getEndTime().toInstant().toEpochMilli();
   }
 
   @Override
@@ -169,7 +169,7 @@ public class LegacyGraphQLLegImpl implements LegacyGraphQLDataFetchers.LegacyGra
 
   @Override
   public DataFetcher<Long> startTime() {
-    return environment -> getSource(environment).getStartTime().getTime().getTime();
+    return environment -> getSource(environment).getStartTime().toInstant().toEpochMilli();
   }
 
   @Override

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLPlaceImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLPlaceImpl.java
@@ -20,7 +20,7 @@ public class LegacyGraphQLPlaceImpl implements LegacyGraphQLDataFetchers.LegacyG
 
   @Override
   public DataFetcher<Long> arrivalTime() {
-    return environment -> getSource(environment).arrival.getTime().getTime();
+    return environment -> getSource(environment).arrival.toInstant().toEpochMilli();
   }
 
   @Override
@@ -48,7 +48,7 @@ public class LegacyGraphQLPlaceImpl implements LegacyGraphQLDataFetchers.LegacyG
 
   @Override
   public DataFetcher<Long> departureTime() {
-    return environment -> getSource(environment).departure.getTime().getTime();
+    return environment -> getSource(environment).departure.toInstant().toEpochMilli();
   }
 
   @Override

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/LegType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/LegType.java
@@ -2,7 +2,6 @@ package org.opentripplanner.ext.transmodelapi.model.plan;
 
 import static org.opentripplanner.ext.transmodelapi.model.EnumTypes.ALTERNATIVE_LEGS_FILTER;
 import static org.opentripplanner.ext.transmodelapi.model.EnumTypes.MODE;
-import static org.opentripplanner.routing.alternativelegs.AlternativeLegsFilter.NO_FILTER;
 
 import graphql.Scalars;
 import graphql.scalars.ExtendedScalars;
@@ -71,7 +70,11 @@ public class LegType {
           .description("The aimed date and time this leg starts.")
           .type(new GraphQLNonNull(gqlUtil.dateTimeScalar))
           .dataFetcher(env -> // startTime is already adjusted for realtime - need to subtract delay to get aimed time
-            leg(env).getStartTime().getTimeInMillis() - (1000L * leg(env).getDepartureDelay())
+            leg(env)
+              .getStartTime()
+              .minusSeconds(leg(env).getDepartureDelay())
+              .toInstant()
+              .toEpochMilli()
           )
           .build()
       )
@@ -81,7 +84,7 @@ public class LegType {
           .name("expectedStartTime")
           .description("The expected, realtime adjusted date and time this leg starts.")
           .type(new GraphQLNonNull(gqlUtil.dateTimeScalar))
-          .dataFetcher(env -> leg(env).getStartTime().getTimeInMillis())
+          .dataFetcher(env -> leg(env).getStartTime().toInstant().toEpochMilli())
           .build()
       )
       .field(
@@ -91,7 +94,11 @@ public class LegType {
           .description("The aimed date and time this leg ends.")
           .type(new GraphQLNonNull(gqlUtil.dateTimeScalar))
           .dataFetcher(env -> // endTime is already adjusted for realtime - need to subtract delay to get aimed time
-            leg(env).getEndTime().getTimeInMillis() - 1000L * leg(env).getArrivalDelay()
+            leg(env)
+              .getEndTime()
+              .minusSeconds(leg(env).getArrivalDelay())
+              .toInstant()
+              .toEpochMilli()
           )
           .build()
       )
@@ -101,7 +108,7 @@ public class LegType {
           .name("expectedEndTime")
           .description("The expected, realtime adjusted date and time this leg ends.")
           .type(new GraphQLNonNull(gqlUtil.dateTimeScalar))
-          .dataFetcher(env -> leg(env).getEndTime().getTimeInMillis())
+          .dataFetcher(env -> leg(env).getEndTime().toInstant().toEpochMilli())
           .build()
       )
       .field(

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/TripPatternType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/TripPatternType.java
@@ -31,7 +31,7 @@ public class TripPatternType {
           .description("Time that the trip departs.")
           .type(gqlUtil.dateTimeScalar)
           .deprecate("Replaced with expectedStartTime")
-          .dataFetcher(env -> itinerary(env).startTime().getTime().getTime())
+          .dataFetcher(env -> itinerary(env).startTime().toInstant().toEpochMilli())
           .build()
       )
       .field(
@@ -41,7 +41,7 @@ public class TripPatternType {
           .description("Time that the trip arrives.")
           .type(gqlUtil.dateTimeScalar)
           .deprecate("Replaced with expectedEndTime")
-          .dataFetcher(env -> itinerary(env).endTime().getTime().getTime())
+          .dataFetcher(env -> itinerary(env).endTime().toInstant().toEpochMilli())
           .build()
       )
       .field(
@@ -51,7 +51,11 @@ public class TripPatternType {
           .description("The aimed date and time the trip starts.")
           .type(new GraphQLNonNull(gqlUtil.dateTimeScalar))
           .dataFetcher(env -> // startTime is already adjusted for realtime - need to subtract delay to get aimed time
-            itinerary(env).startTime().getTime().getTime() - 1000L * itinerary(env).departureDelay()
+            itinerary(env)
+              .startTime()
+              .minusSeconds(itinerary(env).departureDelay())
+              .toInstant()
+              .toEpochMilli()
           )
           .build()
       )
@@ -61,7 +65,7 @@ public class TripPatternType {
           .name("expectedStartTime")
           .description("The expected, realtime adjusted date and time the trip starts.")
           .type(new GraphQLNonNull(gqlUtil.dateTimeScalar))
-          .dataFetcher(env -> itinerary(env).startTime().getTime().getTime())
+          .dataFetcher(env -> itinerary(env).startTime().toInstant().toEpochMilli())
           .build()
       )
       .field(
@@ -71,7 +75,11 @@ public class TripPatternType {
           .description("The aimed date and time the trip ends.")
           .type(new GraphQLNonNull(gqlUtil.dateTimeScalar))
           .dataFetcher(env -> // endTime is already adjusted for realtime - need to subtract delay to get aimed time
-            itinerary(env).endTime().getTime().getTime() - 1000L * itinerary(env).arrivalDelay()
+            itinerary(env)
+              .endTime()
+              .minusSeconds(itinerary(env).arrivalDelay())
+              .toInstant()
+              .toEpochMilli()
           )
           .build()
       )
@@ -81,7 +89,7 @@ public class TripPatternType {
           .name("expectedEndTime")
           .description("The expected, realtime adjusted date and time the trip ends.")
           .type(new GraphQLNonNull(gqlUtil.dateTimeScalar))
-          .dataFetcher(env -> itinerary(env).endTime().getTime().getTime())
+          .dataFetcher(env -> itinerary(env).endTime().toInstant().toEpochMilli())
           .build()
       )
       .field(

--- a/src/main/java/org/opentripplanner/api/mapping/ItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/ItineraryMapper.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.api.mapping;
 
 import java.util.Collection;
+import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
@@ -29,8 +30,8 @@ public class ItineraryMapper {
     ApiItinerary api = new ApiItinerary();
 
     api.duration = (long) domain.durationSeconds;
-    api.startTime = domain.startTime();
-    api.endTime = domain.endTime();
+    api.startTime = GregorianCalendar.from(domain.startTime());
+    api.endTime = GregorianCalendar.from(domain.endTime());
     api.walkTime = domain.nonTransitTimeSeconds;
     api.transitTime = domain.transitTimeSeconds;
     api.waitingTime = domain.waitingTimeSeconds;

--- a/src/main/java/org/opentripplanner/api/mapping/LegMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/LegMapper.java
@@ -2,8 +2,9 @@ package org.opentripplanner.api.mapping;
 
 import static org.opentripplanner.api.mapping.ElevationMapper.mapElevation;
 
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
-import java.util.Calendar;
+import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Locale;
 import org.opentripplanner.api.model.ApiAlert;
@@ -39,35 +40,39 @@ public class LegMapper {
     final int lastIdx = size - 1;
 
     for (int i = 0; i < size; ++i) {
-      Calendar arrivalTimeFromPlace = (i == 0) ? null : domain.get(i - 1).getEndTime();
-      Calendar departureTimeToPlace = (i == lastIdx) ? null : domain.get(i + 1).getStartTime();
+      ZonedDateTime arrivalTimeFromPlace = (i == 0) ? null : domain.get(i - 1).getEndTime();
+      ZonedDateTime departureTimeToPlace = (i == lastIdx) ? null : domain.get(i + 1).getStartTime();
 
       apiLegs.add(mapLeg(domain.get(i), arrivalTimeFromPlace, departureTimeToPlace));
     }
     return apiLegs;
   }
 
-  public ApiLeg mapLeg(Leg domain, Calendar arrivalTimeFromPlace, Calendar departureTimeToPlace) {
+  public ApiLeg mapLeg(
+    Leg domain,
+    ZonedDateTime arrivalTimeFromPlace,
+    ZonedDateTime departureTimeToPlace
+  ) {
     if (domain == null) {
       return null;
     }
     ApiLeg api = new ApiLeg();
-    api.startTime = domain.getStartTime();
-    api.endTime = domain.getEndTime();
+    api.startTime = GregorianCalendar.from(domain.getStartTime());
+    api.endTime = GregorianCalendar.from(domain.getEndTime());
 
     // Set the arrival and departure times, even if this is redundant information
     api.from =
       placeMapper.mapPlace(
         domain.getFrom(),
         arrivalTimeFromPlace,
-        api.startTime,
+        domain.getStartTime(),
         domain.getBoardStopPosInPattern(),
         domain.getBoardingGtfsStopSequence()
       );
     api.to =
       placeMapper.mapPlace(
         domain.getTo(),
-        api.endTime,
+        domain.getEndTime(),
         departureTimeToPlace,
         domain.getAlightStopPosInPattern(),
         domain.getAlightGtfsStopSequence()

--- a/src/main/java/org/opentripplanner/api/mapping/PlaceMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/PlaceMapper.java
@@ -1,10 +1,12 @@
 package org.opentripplanner.api.mapping;
 
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Collection;
+import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.opentripplanner.api.model.ApiPlace;
 import org.opentripplanner.api.model.ApiVehicleParkingSpaces;
@@ -43,8 +45,8 @@ public class PlaceMapper {
 
   public ApiPlace mapPlace(
     Place domain,
-    Calendar arrival,
-    Calendar departure,
+    ZonedDateTime arrival,
+    ZonedDateTime departure,
     Integer stopIndex,
     Integer gtfsStopSequence
   ) {
@@ -69,8 +71,8 @@ public class PlaceMapper {
       api.lat = domain.coordinate.latitude();
     }
 
-    api.arrival = arrival;
-    api.departure = departure;
+    api.arrival = Optional.ofNullable(arrival).map(GregorianCalendar::from).orElse(null);
+    api.departure = Optional.ofNullable(departure).map(GregorianCalendar::from).orElse(null);
     api.stopIndex = stopIndex;
     api.stopSequence = gtfsStopSequence;
     api.vertexType = VertexTypeMapper.mapVertexType(domain.vertexType);

--- a/src/main/java/org/opentripplanner/model/base/ToStringBuilder.java
+++ b/src/main/java/org/opentripplanner/model/base/ToStringBuilder.java
@@ -2,14 +2,13 @@ package org.opentripplanner.model.base;
 
 import static java.lang.Boolean.TRUE;
 
-import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.BitSet;
-import java.util.Calendar;
 import java.util.Collection;
-import java.util.Date;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -44,7 +43,6 @@ public class ToStringBuilder {
   private final StringBuilder sb = new StringBuilder();
   private final OtpNumberFormat numFormat = new OtpNumberFormat();
 
-  private SimpleDateFormat calendarTimeFormat;
   boolean first = true;
 
   private ToStringBuilder(String name) {
@@ -183,8 +181,8 @@ public class ToStringBuilder {
    * Add the TIME part in the local system timezone using 24 hours. Format:  HH:mm:ss. Note! The
    * DATE is not printed. {@code null} value is ignored.
    */
-  public ToStringBuilder addTimeCal(String name, Calendar time) {
-    return addIfNotNull(name, time, t -> formatTime(t.getTime()));
+  public ToStringBuilder addTimeCal(String name, ZonedDateTime time) {
+    return addIfNotNull(name, time, this::formatTime);
   }
 
   /**
@@ -304,10 +302,7 @@ public class ToStringBuilder {
     sb.append(value);
   }
 
-  private String formatTime(Date time) {
-    if (calendarTimeFormat == null) {
-      calendarTimeFormat = new SimpleDateFormat("HH:mm:ss");
-    }
-    return calendarTimeFormat.format(time.getTime());
+  private String formatTime(ZonedDateTime time) {
+    return time.format(DateTimeFormatter.ISO_LOCAL_TIME);
   }
 }

--- a/src/main/java/org/opentripplanner/model/plan/FrequencyTransitLeg.java
+++ b/src/main/java/org/opentripplanner/model/plan/FrequencyTransitLeg.java
@@ -2,9 +2,8 @@ package org.opentripplanner.model.plan;
 
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.GregorianCalendar;
 import java.util.List;
 import org.opentripplanner.model.StopLocation;
 import org.opentripplanner.model.TripPattern;
@@ -25,8 +24,8 @@ public class FrequencyTransitLeg extends ScheduledTransitLeg {
     TripPattern tripPattern,
     int boardStopIndexInPattern,
     int alightStopIndexInPattern,
-    Calendar startTime,
-    Calendar endTime,
+    ZonedDateTime startTime,
+    ZonedDateTime endTime,
     LocalDate serviceDate,
     ZoneId zoneId,
     ConstrainedTransfer transferFromPreviousLeg,
@@ -72,8 +71,8 @@ public class FrequencyTransitLeg extends ScheduledTransitLeg {
 
       StopArrival visit = new StopArrival(
         Place.forStop(stop),
-        GregorianCalendar.from(serviceDate.toZonedDateTime(zoneId, arrivalTime)),
-        GregorianCalendar.from(serviceDate.toZonedDateTime(zoneId, departureTime)),
+        serviceDate.toZonedDateTime(zoneId, arrivalTime),
+        serviceDate.toZonedDateTime(zoneId, departureTime),
         i,
         tripTimes.getOriginalGtfsStopSequence(i)
       );

--- a/src/main/java/org/opentripplanner/model/plan/ItinerariesCalculateLegTotals.java
+++ b/src/main/java/org/opentripplanner/model/plan/ItinerariesCalculateLegTotals.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.model.plan;
 
+import java.time.Duration;
 import java.util.List;
 
 /**
@@ -30,10 +31,10 @@ class ItinerariesCalculateLegTotals {
   }
 
   private void calculate(List<Leg> legs) {
-    long startTimeMs = legs.get(0).getStartTime().getTimeInMillis();
-    long endTimeMs = legs.get(legs.size() - 1).getEndTime().getTimeInMillis();
-
-    totalDurationSeconds = (int) Math.round((endTimeMs - startTimeMs) / 1000.0);
+    totalDurationSeconds =
+      (int) Duration
+        .between(legs.get(0).getStartTime(), legs.get(legs.size() - 1).getEndTime())
+        .toSeconds();
 
     for (Leg leg : legs) {
       long dt = leg.getDuration();

--- a/src/main/java/org/opentripplanner/model/plan/Itinerary.java
+++ b/src/main/java/org/opentripplanner/model/plan/Itinerary.java
@@ -2,8 +2,9 @@ package org.opentripplanner.model.plan;
 
 import static java.util.Locale.ROOT;
 
+import java.time.Duration;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -147,14 +148,14 @@ public class Itinerary {
   /**
    * Time that the trip departs.
    */
-  public Calendar startTime() {
+  public ZonedDateTime startTime() {
     return firstLeg().getStartTime();
   }
 
   /**
    * Time that the trip arrives.
    */
-  public Calendar endTime() {
+  public ZonedDateTime endTime() {
     return lastLeg().getEndTime();
   }
 
@@ -235,10 +236,13 @@ public class Itinerary {
     return !systemNotices.isEmpty();
   }
 
-  public void timeShiftToStartAt(Calendar afterTime) {
-    Calendar startTimeFirstLeg = firstLeg().getStartTime();
-    long adjustmentMilliSeconds = afterTime.getTimeInMillis() - startTimeFirstLeg.getTimeInMillis();
-    timeShift(adjustmentMilliSeconds);
+  public Itinerary getItineraryShiftedToStartAt(ZonedDateTime afterTime) {
+    Duration duration = Duration.between(firstLeg().getStartTime(), afterTime);
+    List<Leg> timeShiftedLegs = legs
+      .stream()
+      .map(leg -> leg.timeShiftBy(duration))
+      .collect(Collectors.toList());
+    return new Itinerary(timeShiftedLegs);
   }
 
   /** @see #equals(Object) */
@@ -315,14 +319,5 @@ public class Itinerary {
     buf.space().append(String.format(ROOT, "[ $%d ]", generalizedCost));
 
     return buf.toString();
-  }
-
-  private void timeShift(long adjustmentMilliSeconds) {
-    for (Leg leg : this.legs) {
-      leg
-        .getStartTime()
-        .setTimeInMillis(leg.getStartTime().getTimeInMillis() + adjustmentMilliSeconds);
-      leg.getEndTime().setTimeInMillis(leg.getEndTime().getTimeInMillis() + adjustmentMilliSeconds);
-    }
   }
 }

--- a/src/main/java/org/opentripplanner/model/plan/Itinerary.java
+++ b/src/main/java/org/opentripplanner/model/plan/Itinerary.java
@@ -236,11 +236,11 @@ public class Itinerary {
     return !systemNotices.isEmpty();
   }
 
-  public Itinerary getItineraryShiftedToStartAt(ZonedDateTime afterTime) {
+  public Itinerary withTimeShiftToStartAt(ZonedDateTime afterTime) {
     Duration duration = Duration.between(firstLeg().getStartTime(), afterTime);
     List<Leg> timeShiftedLegs = legs
       .stream()
-      .map(leg -> leg.timeShiftBy(duration))
+      .map(leg -> leg.withTimeShift(duration))
       .collect(Collectors.toList());
     return new Itinerary(timeShiftedLegs);
   }

--- a/src/main/java/org/opentripplanner/model/plan/Leg.java
+++ b/src/main/java/org/opentripplanner/model/plan/Leg.java
@@ -376,7 +376,7 @@ public interface Leg {
     throw new UnsupportedOperationException();
   }
 
-  default Leg timeShiftBy(Duration duration) {
+  default Leg withTimeShift(Duration duration) {
     throw new UnsupportedOperationException();
   }
 }

--- a/src/main/java/org/opentripplanner/model/plan/Leg.java
+++ b/src/main/java/org/opentripplanner/model/plan/Leg.java
@@ -1,9 +1,9 @@
 package org.opentripplanner.model.plan;
 
-import java.util.Calendar;
+import java.time.Duration;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Set;
-import java.util.TimeZone;
 import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.common.model.P2;
 import org.opentripplanner.model.Agency;
@@ -60,8 +60,7 @@ public interface Leg {
    * The leg's duration in seconds
    */
   default long getDuration() {
-    // Round to the closest second; Hence subtract 500 ms before dividing by 1000
-    return (500 + getEndTime().getTimeInMillis() - getStartTime().getTimeInMillis()) / 1000;
+    return Duration.between(getStartTime(), getEndTime()).toSeconds();
   }
 
   /**
@@ -131,12 +130,12 @@ public interface Leg {
   /**
    * The date and time this leg begins.
    */
-  Calendar getStartTime();
+  ZonedDateTime getStartTime();
 
   /**
    * The date and time this leg ends.
    */
-  Calendar getEndTime();
+  ZonedDateTime getEndTime();
 
   /**
    * For transit leg, the offset from the scheduled departure-time of the boarding stop in this leg.
@@ -198,9 +197,12 @@ public interface Leg {
     return null;
   }
 
+  /**
+   * Get the timezone offset in milliseconds.
+   */
   default int getAgencyTimeZoneOffset() {
-    TimeZone timeZone = getStartTime().getTimeZone();
-    return timeZone.getOffset(getStartTime().getTimeInMillis());
+    int MILLIS_TO_SECONDS = 1000;
+    return getStartTime().getOffset().getTotalSeconds() * MILLIS_TO_SECONDS;
   }
 
   /**
@@ -371,6 +373,10 @@ public interface Leg {
   }
 
   default void addAlert(TransitAlert alert) {
+    throw new UnsupportedOperationException();
+  }
+
+  default Leg timeShiftBy(Duration duration) {
     throw new UnsupportedOperationException();
   }
 }

--- a/src/main/java/org/opentripplanner/model/plan/ScheduledTransitLeg.java
+++ b/src/main/java/org/opentripplanner/model/plan/ScheduledTransitLeg.java
@@ -3,10 +3,9 @@ package org.opentripplanner.model.plan;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Calendar;
-import java.util.GregorianCalendar;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -40,8 +39,8 @@ public class ScheduledTransitLeg implements Leg {
   protected final TripTimes tripTimes;
   protected final TripPattern tripPattern;
 
-  private final Calendar startTime;
-  private final Calendar endTime;
+  private final ZonedDateTime startTime;
+  private final ZonedDateTime endTime;
   private final LineString legGeometry;
   private final Set<TransitAlert> transitAlerts = new HashSet<>();
   private final ConstrainedTransfer transferFromPrevLeg;
@@ -58,8 +57,8 @@ public class ScheduledTransitLeg implements Leg {
     TripPattern tripPattern,
     int boardStopIndexInPattern,
     int alightStopIndexInPattern,
-    Calendar startTime,
-    Calendar endTime,
+    ZonedDateTime startTime,
+    ZonedDateTime endTime,
     LocalDate serviceDate,
     ZoneId zoneId,
     ConstrainedTransfer transferFromPreviousLeg,
@@ -151,12 +150,12 @@ public class ScheduledTransitLeg implements Leg {
   }
 
   @Override
-  public Calendar getStartTime() {
+  public ZonedDateTime getStartTime() {
     return startTime;
   }
 
   @Override
-  public Calendar getEndTime() {
+  public ZonedDateTime getEndTime() {
     return endTime;
   }
 
@@ -219,8 +218,8 @@ public class ScheduledTransitLeg implements Leg {
 
       StopArrival visit = new StopArrival(
         Place.forStop(stop),
-        GregorianCalendar.from(serviceDate.toZonedDateTime(zoneId, tripTimes.getArrivalTime(i))),
-        GregorianCalendar.from(serviceDate.toZonedDateTime(zoneId, tripTimes.getDepartureTime(i))),
+        serviceDate.toZonedDateTime(zoneId, tripTimes.getArrivalTime(i)),
+        serviceDate.toZonedDateTime(zoneId, tripTimes.getDepartureTime(i)),
         i,
         tripTimes.getOriginalGtfsStopSequence(i)
       );

--- a/src/main/java/org/opentripplanner/model/plan/StopArrival.java
+++ b/src/main/java/org/opentripplanner/model/plan/StopArrival.java
@@ -1,6 +1,6 @@
 package org.opentripplanner.model.plan;
 
-import java.util.Calendar;
+import java.time.ZonedDateTime;
 import org.opentripplanner.model.base.ToStringBuilder;
 
 /**
@@ -13,12 +13,12 @@ public class StopArrival {
   /**
    * The time the rider will arrive at the place.
    */
-  public final Calendar arrival;
+  public final ZonedDateTime arrival;
 
   /**
    * The time the rider will depart the place.
    */
-  public final Calendar departure;
+  public final ZonedDateTime departure;
 
   /**
    * For transit trips, the stop index (numbered from zero from the start of the trip).
@@ -32,8 +32,8 @@ public class StopArrival {
 
   public StopArrival(
     Place place,
-    Calendar arrival,
-    Calendar departure,
+    ZonedDateTime arrival,
+    ZonedDateTime departure,
     Integer stopPosInPattern,
     Integer gtfsStopSequence
   ) {

--- a/src/main/java/org/opentripplanner/model/plan/StreetLeg.java
+++ b/src/main/java/org/opentripplanner/model/plan/StreetLeg.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.model.plan;
 
-import java.util.Calendar;
+import java.time.Duration;
+import java.time.ZonedDateTime;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -19,9 +20,9 @@ public class StreetLeg implements Leg {
 
   private final TraverseMode mode;
 
-  private final Calendar startTime;
+  private final ZonedDateTime startTime;
 
-  private final Calendar endTime;
+  private final ZonedDateTime endTime;
 
   private final double distanceMeters;
 
@@ -33,21 +34,19 @@ public class StreetLeg implements Leg {
   private final List<WalkStep> walkSteps;
   private final Set<StreetNote> streetNotes = new HashSet<>();
   private final int generalizedCost;
-  private List<P2<Double>> legElevation;
+  private final List<P2<Double>> legElevation;
   private Double elevationLost = null;
   private Double elevationGained = null;
+
   private FeedScopedId pathwayId;
-
   private Boolean walkingBike;
-
   private Boolean rentedVehicle;
-
   private String vehicleRentalNetwork;
 
   public StreetLeg(
     TraverseMode mode,
-    Calendar startTime,
-    Calendar endTime,
+    ZonedDateTime startTime,
+    ZonedDateTime endTime,
     Place from,
     Place to,
     double distanceMeters,
@@ -96,12 +95,12 @@ public class StreetLeg implements Leg {
   }
 
   @Override
-  public Calendar getStartTime() {
+  public ZonedDateTime getStartTime() {
     return startTime;
   }
 
   @Override
-  public Calendar getEndTime() {
+  public ZonedDateTime getEndTime() {
     return endTime;
   }
 
@@ -193,6 +192,29 @@ public class StreetLeg implements Leg {
 
   public void addStretNote(StreetNote streetNote) {
     streetNotes.add(streetNote);
+  }
+
+  @Override
+  public Leg timeShiftBy(Duration duration) {
+    StreetLeg copy = new StreetLeg(
+      mode,
+      startTime.plus(duration),
+      endTime.plus(duration),
+      from,
+      to,
+      distanceMeters,
+      generalizedCost,
+      legGeometry,
+      legElevation,
+      walkSteps
+    );
+
+    copy.setPathwayId(pathwayId);
+    copy.setWalkingBike(walkingBike);
+    copy.setRentedVehicle(rentedVehicle);
+    copy.setVehicleRentalNetwork(vehicleRentalNetwork);
+
+    return copy;
   }
 
   /**

--- a/src/main/java/org/opentripplanner/model/plan/StreetLeg.java
+++ b/src/main/java/org/opentripplanner/model/plan/StreetLeg.java
@@ -195,7 +195,7 @@ public class StreetLeg implements Leg {
   }
 
   @Override
-  public Leg timeShiftBy(Duration duration) {
+  public Leg withTimeShift(Duration duration) {
     StreetLeg copy = new StreetLeg(
       mode,
       startTime.plus(duration),

--- a/src/main/java/org/opentripplanner/model/plan/legreference/ScheduledTransitLegReference.java
+++ b/src/main/java/org/opentripplanner/model/plan/legreference/ScheduledTransitLegReference.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.model.plan.legreference;
 
 import java.time.ZoneId;
-import java.util.GregorianCalendar;
 import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.model.Timetable;
 import org.opentripplanner.model.TimetableSnapshot;
@@ -64,8 +63,8 @@ public record ScheduledTransitLegReference(
       tripPattern,
       fromStopPositionInPattern,
       toStopPositionInPattern,
-      GregorianCalendar.from(serviceDate.toZonedDateTime(timeZone, boardingTime)),
-      GregorianCalendar.from(serviceDate.toZonedDateTime(timeZone, alightingTime)),
+      serviceDate.toZonedDateTime(timeZone, boardingTime),
+      serviceDate.toZonedDateTime(timeZone, alightingTime),
       serviceDate.toLocalDate(),
       timeZone,
       null,

--- a/src/main/java/org/opentripplanner/routing/alertpatch/TransitAlert.java
+++ b/src/main/java/org/opentripplanner/routing/alertpatch/TransitAlert.java
@@ -60,10 +60,6 @@ public class TransitAlert implements Serializable {
     this.alertUrlList = alertUrlList;
   }
 
-  public boolean displayDuring(State state) {
-    return displayDuring(state.getStartTimeSeconds(), state.getTimeSeconds());
-  }
-
   public boolean displayDuring(long startTimeSeconds, long endTimeSeconds) {
     for (TimePeriod timePeriod : timePeriods) {
       if (endTimeSeconds >= timePeriod.startTime) {

--- a/src/main/java/org/opentripplanner/routing/algorithm/filterchain/deletionflagger/LatestDepartureTimeFilter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/filterchain/deletionflagger/LatestDepartureTimeFilter.java
@@ -8,10 +8,10 @@ public class LatestDepartureTimeFilter implements ItineraryDeletionFlagger {
 
   public static final String TAG = "latest-departure-time-limit";
 
-  private final long limitMs;
+  private final Instant limit;
 
   public LatestDepartureTimeFilter(Instant latestDepartureTime) {
-    this.limitMs = latestDepartureTime.toEpochMilli();
+    this.limit = latestDepartureTime;
   }
 
   @Override
@@ -21,7 +21,7 @@ public class LatestDepartureTimeFilter implements ItineraryDeletionFlagger {
 
   @Override
   public Predicate<Itinerary> predicate() {
-    return it -> it.startTime().getTimeInMillis() > limitMs;
+    return it -> it.startTime().toInstant().isAfter(limit);
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/AlertToLegMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/AlertToLegMapper.java
@@ -1,8 +1,8 @@
 package org.opentripplanner.routing.algorithm.mapping;
 
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 import org.opentripplanner.model.FeedScopedId;
@@ -33,8 +33,8 @@ public class AlertToLegMapper {
       ? StopCondition.DEPARTURE
       : StopCondition.FIRST_DEPARTURE;
 
-    Date legStartTime = leg.getStartTime().getTime();
-    Date legEndTime = leg.getEndTime().getTime();
+    ZonedDateTime legStartTime = leg.getStartTime();
+    ZonedDateTime legEndTime = leg.getEndTime();
     StopLocation fromStop = leg.getFrom() == null ? null : leg.getFrom().stop;
     StopLocation toStop = leg.getTo() == null ? null : leg.getTo().stop;
 
@@ -60,8 +60,8 @@ public class AlertToLegMapper {
           alerts.addAll(getAlertsForStopAndTrip(stop, tripId, leg.getServiceDate()));
           alerts.addAll(getAlertsForStop(stop));
 
-          Date stopArrival = visit.arrival.getTime();
-          Date stopDepature = visit.departure.getTime();
+          ZonedDateTime stopArrival = visit.arrival;
+          ZonedDateTime stopDepature = visit.departure;
 
           addTransitAlertPatchesToLeg(
             leg,
@@ -97,8 +97,8 @@ public class AlertToLegMapper {
       .getTransitAlerts()
       .removeIf(alertPatch ->
         !alertPatch.displayDuring(
-          leg.getStartTime().getTimeInMillis() / 1000,
-          leg.getEndTime().getTimeInMillis() / 1000
+          leg.getStartTime().toEpochSecond(),
+          leg.getEndTime().toEpochSecond()
         )
       );
   }
@@ -107,12 +107,12 @@ public class AlertToLegMapper {
     Leg leg,
     Collection<StopCondition> stopConditions,
     Collection<TransitAlert> alertPatches,
-    Date fromTime,
-    Date toTime
+    ZonedDateTime fromTime,
+    ZonedDateTime toTime
   ) {
     if (alertPatches != null) {
       for (TransitAlert alert : alertPatches) {
-        if (alert.displayDuring(fromTime.getTime() / 1000, toTime.getTime() / 1000)) {
+        if (alert.displayDuring(fromTime.toEpochSecond(), toTime.toEpochSecond())) {
           if (
             !alert.getStopConditions().isEmpty() && // Skip if stopConditions are not set for alert
             stopConditions != null &&
@@ -135,8 +135,8 @@ public class AlertToLegMapper {
   private static void addTransitAlertPatchesToLeg(
     Leg leg,
     Collection<TransitAlert> alertPatches,
-    Date fromTime,
-    Date toTime
+    ZonedDateTime fromTime,
+    ZonedDateTime toTime
   ) {
     addTransitAlertPatchesToLeg(leg, null, alertPatches, fromTime, toTime);
   }

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/GraphPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/GraphPathToItineraryMapper.java
@@ -1,7 +1,9 @@
 package org.opentripplanner.routing.algorithm.mapping;
 
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
@@ -52,7 +54,7 @@ public class GraphPathToItineraryMapper {
 
   private static final Logger LOG = LoggerFactory.getLogger(GraphPathToItineraryMapper.class);
 
-  private final TimeZone timeZone;
+  private final ZoneId timeZone;
   private final AlertToLegMapper alertToLegMapper;
   private final StreetNotesService streetNotesService;
   private final double ellipsoidToGeoidDifference;
@@ -63,7 +65,7 @@ public class GraphPathToItineraryMapper {
     StreetNotesService streetNotesService,
     double ellipsoidToGeoidDifference
   ) {
-    this.timeZone = timeZone;
+    this.timeZone = timeZone.toZoneId();
     this.alertToLegMapper = alertToLegMapper;
     this.streetNotesService = streetNotesService;
     this.ellipsoidToGeoidDifference = ellipsoidToGeoidDifference;
@@ -348,10 +350,8 @@ public class GraphPathToItineraryMapper {
     }
   }
 
-  private Calendar makeCalendar(State state) {
-    Calendar calendar = Calendar.getInstance(timeZone);
-    calendar.setTimeInMillis(state.getTimeInMillis());
-    return calendar;
+  private ZonedDateTime makeCalendar(State state) {
+    return Instant.ofEpochMilli(state.getTimeInMillis()).atZone(timeZone);
   }
 
   /**
@@ -361,8 +361,8 @@ public class GraphPathToItineraryMapper {
     State fromState = states.get(0);
     State toState = states.get(1);
     FlexTripEdge flexEdge = (FlexTripEdge) toState.backEdge;
-    Calendar startTime = makeCalendar(fromState);
-    Calendar endTime = makeCalendar(toState);
+    ZonedDateTime startTime = makeCalendar(fromState);
+    ZonedDateTime endTime = makeCalendar(toState);
     int generalizedCost = (int) (toState.getWeight() - fromState.getWeight());
 
     Leg leg = new FlexibleTransitLeg(flexEdge, startTime, endTime, generalizedCost);
@@ -411,7 +411,7 @@ public class GraphPathToItineraryMapper {
     var previousStateIsVehicleParking =
       firstState.getBackState() != null && firstState.getBackEdge() instanceof VehicleParkingEdge;
 
-    Calendar startTime = makeCalendar(
+    ZonedDateTime startTime = makeCalendar(
       previousStateIsVehicleParking ? firstState.getBackState() : firstState
     );
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/GraphPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/GraphPathToItineraryMapper.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.routing.algorithm.mapping;
 
-import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -350,10 +349,6 @@ public class GraphPathToItineraryMapper {
     }
   }
 
-  private ZonedDateTime makeCalendar(State state) {
-    return Instant.ofEpochMilli(state.getTimeInMillis()).atZone(timeZone);
-  }
-
   /**
    * Generate a flex leg from the states belonging to the flex leg
    */
@@ -361,8 +356,8 @@ public class GraphPathToItineraryMapper {
     State fromState = states.get(0);
     State toState = states.get(1);
     FlexTripEdge flexEdge = (FlexTripEdge) toState.backEdge;
-    ZonedDateTime startTime = makeCalendar(fromState);
-    ZonedDateTime endTime = makeCalendar(toState);
+    ZonedDateTime startTime = fromState.getTime().atZone(timeZone);
+    ZonedDateTime endTime = toState.getTime().atZone(timeZone);
     int generalizedCost = (int) (toState.getWeight() - fromState.getWeight());
 
     Leg leg = new FlexibleTransitLeg(flexEdge, startTime, endTime, generalizedCost);
@@ -411,14 +406,12 @@ public class GraphPathToItineraryMapper {
     var previousStateIsVehicleParking =
       firstState.getBackState() != null && firstState.getBackEdge() instanceof VehicleParkingEdge;
 
-    ZonedDateTime startTime = makeCalendar(
-      previousStateIsVehicleParking ? firstState.getBackState() : firstState
-    );
+    State startTimeState = previousStateIsVehicleParking ? firstState.getBackState() : firstState;
 
     StreetLeg leg = new StreetLeg(
       resolveMode(states),
-      startTime,
-      makeCalendar(lastState),
+      startTimeState.getTime().atZone(timeZone),
+      lastState.getTime().atZone(timeZone),
       makePlace(firstState),
       makePlace(lastState),
       distanceMeters,

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
@@ -4,9 +4,7 @@ import static org.opentripplanner.routing.algorithm.raptoradapter.transit.cost.R
 
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.List;
-import java.util.TimeZone;
 import org.opentripplanner.common.geometry.GeometryUtils;
 import org.opentripplanner.model.plan.FrequencyTransitLeg;
 import org.opentripplanner.model.plan.Itinerary;
@@ -153,9 +151,7 @@ public class RaptorPathToItineraryMapper {
       return List.of();
     }
 
-    subItinerary.timeShiftToStartAt(createCalendar(accessPathLeg.fromTime()));
-
-    return subItinerary.legs;
+    return subItinerary.getItineraryShiftedToStartAt(createCalendar(accessPathLeg.fromTime())).legs;
   }
 
   private Leg mapTransitLeg(
@@ -245,9 +241,7 @@ public class RaptorPathToItineraryMapper {
       return null;
     }
 
-    subItinerary.timeShiftToStartAt(createCalendar(egressPathLeg.fromTime()));
-
-    return subItinerary;
+    return subItinerary.getItineraryShiftedToStartAt(createCalendar(egressPathLeg.fromTime()));
   }
 
   private List<Leg> mapNonTransitLeg(
@@ -281,7 +275,7 @@ public class RaptorPathToItineraryMapper {
       RoutingContext routingContext = new RoutingContext(request, graph, (Vertex) null, null);
 
       StateEditor se = new StateEditor(routingContext, edges.get(0).getFromVertex());
-      se.setTimeSeconds(createCalendar(pathLeg.fromTime()).getTimeInMillis() / 1000);
+      se.setTimeSeconds(createCalendar(pathLeg.fromTime()).toEpochSecond());
 
       State s = se.makeState();
       ArrayList<State> transferStates = new ArrayList<>();
@@ -304,10 +298,7 @@ public class RaptorPathToItineraryMapper {
     }
   }
 
-  private Calendar createCalendar(int timeInSeconds) {
-    ZonedDateTime zdt = transitSearchTimeZero.plusSeconds(timeInSeconds);
-    Calendar c = Calendar.getInstance(TimeZone.getTimeZone(zdt.getZone()));
-    c.setTimeInMillis(zdt.toInstant().toEpochMilli());
-    return c;
+  private ZonedDateTime createCalendar(int timeInSeconds) {
+    return transitSearchTimeZero.plusSeconds(timeInSeconds);
   }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
@@ -151,7 +151,7 @@ public class RaptorPathToItineraryMapper {
       return List.of();
     }
 
-    return subItinerary.withTimeShiftToStartAt(createCalendar(accessPathLeg.fromTime())).legs;
+    return subItinerary.withTimeShiftToStartAt(createZonedDateTime(accessPathLeg.fromTime())).legs;
   }
 
   private Leg mapTransitLeg(
@@ -182,8 +182,8 @@ public class RaptorPathToItineraryMapper {
           tripSchedule.getOriginalTripPattern(),
           boardStopIndexInPattern,
           alightStopIndexInPattern,
-          createCalendar(pathLeg.fromTime() + frequencyHeadwayInSeconds),
-          createCalendar(pathLeg.toTime()),
+          createZonedDateTime(pathLeg.fromTime() + frequencyHeadwayInSeconds),
+          createZonedDateTime(pathLeg.toTime()),
           tripSchedule.getServiceDate(),
           transitSearchTimeZero.getZone().normalized(),
           (prevTransitLeg == null ? null : prevTransitLeg.getTransferToNextLeg()),
@@ -198,8 +198,8 @@ public class RaptorPathToItineraryMapper {
           tripSchedule.getOriginalTripPattern(),
           boardStopIndexInPattern,
           alightStopIndexInPattern,
-          createCalendar(pathLeg.fromTime()),
-          createCalendar(pathLeg.toTime()),
+          createZonedDateTime(pathLeg.fromTime()),
+          createZonedDateTime(pathLeg.toTime()),
           tripSchedule.getServiceDate(),
           transitSearchTimeZero.getZone().normalized(),
           (prevTransitLeg == null ? null : prevTransitLeg.getTransferToNextLeg()),
@@ -241,7 +241,7 @@ public class RaptorPathToItineraryMapper {
       return null;
     }
 
-    return subItinerary.withTimeShiftToStartAt(createCalendar(egressPathLeg.fromTime()));
+    return subItinerary.withTimeShiftToStartAt(createZonedDateTime(egressPathLeg.fromTime()));
   }
 
   private List<Leg> mapNonTransitLeg(
@@ -256,8 +256,8 @@ public class RaptorPathToItineraryMapper {
       return List.of(
         new StreetLeg(
           transferMode,
-          createCalendar(pathLeg.fromTime()),
-          createCalendar(pathLeg.toTime()),
+          createZonedDateTime(pathLeg.fromTime()),
+          createZonedDateTime(pathLeg.toTime()),
           from,
           to,
           transfer.getDistanceMeters(),
@@ -275,7 +275,7 @@ public class RaptorPathToItineraryMapper {
       RoutingContext routingContext = new RoutingContext(request, graph, (Vertex) null, null);
 
       StateEditor se = new StateEditor(routingContext, edges.get(0).getFromVertex());
-      se.setTimeSeconds(createCalendar(pathLeg.fromTime()).toEpochSecond());
+      se.setTimeSeconds(createZonedDateTime(pathLeg.fromTime()).toEpochSecond());
 
       State s = se.makeState();
       ArrayList<State> transferStates = new ArrayList<>();
@@ -298,7 +298,7 @@ public class RaptorPathToItineraryMapper {
     }
   }
 
-  private ZonedDateTime createCalendar(int timeInSeconds) {
+  private ZonedDateTime createZonedDateTime(int timeInSeconds) {
     return transitSearchTimeZero.plusSeconds(timeInSeconds);
   }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
@@ -151,7 +151,7 @@ public class RaptorPathToItineraryMapper {
       return List.of();
     }
 
-    return subItinerary.getItineraryShiftedToStartAt(createCalendar(accessPathLeg.fromTime())).legs;
+    return subItinerary.withTimeShiftToStartAt(createCalendar(accessPathLeg.fromTime())).legs;
   }
 
   private Leg mapTransitLeg(
@@ -241,7 +241,7 @@ public class RaptorPathToItineraryMapper {
       return null;
     }
 
-    return subItinerary.getItineraryShiftedToStartAt(createCalendar(egressPathLeg.fromTime()));
+    return subItinerary.withTimeShiftToStartAt(createCalendar(egressPathLeg.fromTime()));
   }
 
   private List<Leg> mapNonTransitLeg(

--- a/src/main/java/org/opentripplanner/routing/alternativelegs/AlternativeLegs.java
+++ b/src/main/java/org/opentripplanner/routing/alternativelegs/AlternativeLegs.java
@@ -6,10 +6,8 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Calendar;
 import java.util.Collection;
 import java.util.Comparator;
-import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.PriorityQueue;
 import java.util.Queue;
@@ -106,7 +104,7 @@ public class AlternativeLegs {
     RoutingService routingService,
     TimetableSnapshot timetableSnapshot,
     TripPatternBetweenStops tripPatternBetweenStops,
-    Calendar departureTime,
+    ZonedDateTime departureTime,
     ServiceDate originalDate,
     boolean searchBackward
   ) {
@@ -127,7 +125,7 @@ public class AlternativeLegs {
 
     Queue<TripTimeOnDate> pq = new PriorityQueue<>(comparator);
 
-    long startTime = departureTime.getTimeInMillis() / 1000;
+    long startTime = departureTime.toEpochSecond();
 
     // Loop through all possible days
     ServiceDate[] serviceDates = { originalDate.previous(), originalDate, originalDate.next() };
@@ -201,8 +199,8 @@ public class AlternativeLegs {
       pattern,
       boardingPosition,
       alightingPosition,
-      GregorianCalendar.from(boardingTime),
-      GregorianCalendar.from(alightingTime),
+      boardingTime,
+      alightingTime,
       serviceDay.toLocalDate(),
       timeZone,
       null,

--- a/src/main/java/org/opentripplanner/routing/core/State.java
+++ b/src/main/java/org/opentripplanner/routing/core/State.java
@@ -1,9 +1,10 @@
 package org.opentripplanner.routing.core;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Date;
 import java.util.Objects;
+import org.opentripplanner.model.base.ToStringBuilder;
 import org.opentripplanner.routing.algorithm.astar.NegativeWeightException;
 import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.edgetype.StreetEdge;
@@ -233,24 +234,6 @@ public class State implements Cloneable {
     return new StateEditor(this, e);
   }
 
-  public String toStringVerbose() {
-    return (
-      "<State " +
-      new Date(getTimeInMillis()) +
-      " w=" +
-      this.getWeight() +
-      " t=" +
-      this.getElapsedTimeSeconds() +
-      " d=" +
-      this.getWalkDistance() +
-      " r=" +
-      this.isRentingVehicle() +
-      " pr=" +
-      this.isVehicleParked() +
-      ">"
-    );
-  }
-
   /*
    * FIELD ACCESSOR METHODS States are immutable, so they have only get methods. The corresponding
    * set methods are in StateEditor.
@@ -372,10 +355,6 @@ public class State implements Cloneable {
     return this.backEdge;
   }
 
-  public long getStartTimeSeconds() {
-    return stateData.startTime;
-  }
-
   /**
    * Optional next result that allows {@link Edge} to return multiple results.
    *
@@ -428,8 +407,8 @@ public class State implements Cloneable {
     return stateData.currentMode;
   }
 
-  public long getTimeInMillis() {
-    return time;
+  public Instant getTime() {
+    return Instant.ofEpochMilli(time);
   }
 
   public void timeshiftBySeconds(int timeShift) {
@@ -577,23 +556,20 @@ public class State implements Cloneable {
   }
 
   public String toString() {
-    return (
-      "<State " +
-      new Date(getTimeInMillis()) +
-      " [" +
-      weight +
-      "] " +
-      (isRentingVehicle() ? "VEHICLE_RENT " : "") +
-      (isVehicleParked() ? "VEHICLE_PARKED " : "") +
-      vertex +
-      ">"
-    );
+    return ToStringBuilder
+      .of(State.class)
+      .addTime("time", getTime())
+      .addNum("weight", weight)
+      .addObj("vertex", vertex)
+      .addBoolIfTrue("VEHICLE_RENT", isRentingVehicle())
+      .addBoolIfTrue("VEHICLE_PARKED", isVehicleParked())
+      .toString();
   }
 
   void checkNegativeWeight() {
     double dw = this.weight - backState.weight;
     if (dw < 0) {
-      throw new NegativeWeightException(String.valueOf(dw) + " on edge " + backEdge);
+      throw new NegativeWeightException(dw + " on edge " + backEdge);
     }
   }
 

--- a/src/main/java/org/opentripplanner/routing/core/StateData.java
+++ b/src/main/java/org/opentripplanner/routing/core/StateData.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.routing.core;
 
+import java.time.Instant;
 import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.vehicle_rental.RentalVehicleType.FormFactor;
 
@@ -11,7 +12,7 @@ import org.opentripplanner.routing.vehicle_rental.RentalVehicleType.FormFactor;
 public class StateData implements Cloneable {
 
   // the time at which the search started
-  protected long startTime;
+  protected Instant startTime;
 
   // TODO OTP2 Many of these could be replaced by a more generic state machine implementation
 

--- a/src/main/java/org/opentripplanner/routing/core/StateEditor.java
+++ b/src/main/java/org/opentripplanner/routing/core/StateEditor.java
@@ -333,10 +333,6 @@ public class StateEditor {
     }
   }
 
-  public long getTimeSeconds() {
-    return child.getTimeSeconds();
-  }
-
   public void setTimeSeconds(long seconds) {
     child.time = seconds * 1000;
   }

--- a/src/main/java/org/opentripplanner/routing/core/StateEditor.java
+++ b/src/main/java/org/opentripplanner/routing/core/StateEditor.java
@@ -296,11 +296,6 @@ public class StateEditor {
     child.stateData.currentMode = nonTransitMode;
   }
 
-  public void setStartTimeSeconds(long seconds) {
-    cloneStateDataAsNeeded();
-    child.stateData.startTime = seconds;
-  }
-
   /**
    * Set non-incremental state values from an existing state. Incremental values are not currently
    * set.

--- a/src/main/java/org/opentripplanner/routing/fares/impl/RideMapper.java
+++ b/src/main/java/org/opentripplanner/routing/fares/impl/RideMapper.java
@@ -6,7 +6,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.Leg;
-import org.opentripplanner.util.time.TimeUtils;
 
 /**
  * Convert an OTP2 Itinerary to a list of Ride objects used by the fare calculators.
@@ -55,8 +54,8 @@ public class RideMapper {
     ride.route = leg.getRoute().getId();
     ride.trip = leg.getTrip().getId();
 
-    ride.startTime = TimeUtils.zonedDateTime(leg.getStartTime());
-    ride.endTime = TimeUtils.zonedDateTime(leg.getEndTime());
+    ride.startTime = leg.getStartTime();
+    ride.endTime = leg.getEndTime();
 
     // In the default fare service, we classify rides by mode.
     ride.classifier = leg.getMode();

--- a/src/main/java/org/opentripplanner/routing/impl/GraphPathFinder.java
+++ b/src/main/java/org/opentripplanner/routing/impl/GraphPathFinder.java
@@ -2,6 +2,7 @@ package org.opentripplanner.routing.impl;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Iterator;
 import java.util.List;
 import org.opentripplanner.routing.algorithm.astar.AStarBuilder;
@@ -93,7 +94,7 @@ public class GraphPathFinder {
    */
   public List<GraphPath> graphPathFinderEntryPoint(RoutingContext routingContext) {
     RoutingRequest request = routingContext.opt;
-    Instant reqTime = request.getDateTime();
+    Instant reqTime = request.getDateTime().truncatedTo(ChronoUnit.MILLIS);
 
     // We used to perform a protective clone of the RoutingRequest here.
     // There is no reason to do this if we don't modify the request.

--- a/src/main/java/org/opentripplanner/routing/impl/GraphPathFinder.java
+++ b/src/main/java/org/opentripplanner/routing/impl/GraphPathFinder.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.routing.impl;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Iterator;
 import java.util.List;
 import org.opentripplanner.routing.algorithm.astar.AStarBuilder;
@@ -92,7 +93,7 @@ public class GraphPathFinder {
    */
   public List<GraphPath> graphPathFinderEntryPoint(RoutingContext routingContext) {
     RoutingRequest request = routingContext.opt;
-    long reqTime = request.getDateTime().getEpochSecond();
+    Instant reqTime = request.getDateTime();
 
     // We used to perform a protective clone of the RoutingRequest here.
     // There is no reason to do this if we don't modify the request.
@@ -130,12 +131,12 @@ public class GraphPathFinder {
         GraphPath graphPath = gpi.next();
         // TODO check, is it possible that arriveBy and time are modifed in-place by the search?
         if (request.arriveBy) {
-          if (graphPath.states.getLast().getTimeSeconds() > reqTime) {
+          if (graphPath.states.getLast().getTime().isAfter(reqTime)) {
             LOG.error("A graph path arrives after the requested time. This implies a bug.");
             gpi.remove();
           }
         } else {
-          if (graphPath.states.getFirst().getTimeSeconds() < reqTime) {
+          if (graphPath.states.getFirst().getTime().isBefore(reqTime)) {
             LOG.error("A graph path leaves before the requested time. This implies a bug.");
             gpi.remove();
           }

--- a/src/main/java/org/opentripplanner/transit/raptor/util/PathStringBuilder.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/util/PathStringBuilder.java
@@ -1,6 +1,6 @@
 package org.opentripplanner.transit.raptor.util;
 
-import java.util.Calendar;
+import java.time.ZonedDateTime;
 import javax.annotation.Nullable;
 import org.opentripplanner.model.base.OtpNumberFormat;
 import org.opentripplanner.routing.core.TraverseMode;
@@ -78,13 +78,13 @@ public class PathStringBuilder {
   public PathStringBuilder transit(
     TraverseMode mode,
     String trip,
-    Calendar fromTime,
-    Calendar toTime
+    ZonedDateTime fromTime,
+    ZonedDateTime toTime
   ) {
     return start().append(mode.name()).space().append(trip).space().time(fromTime, toTime).end();
   }
 
-  public PathStringBuilder other(TraverseMode mode, Calendar fromTime, Calendar toTime) {
+  public PathStringBuilder other(TraverseMode mode, ZonedDateTime fromTime, ZonedDateTime toTime) {
     return start().append(mode.name()).space().time(fromTime, toTime).end();
   }
 
@@ -145,7 +145,7 @@ public class PathStringBuilder {
 
   /* private helpers */
 
-  private PathStringBuilder time(Calendar from, Calendar to) {
+  private PathStringBuilder time(ZonedDateTime from, ZonedDateTime to) {
     return append(TimeUtils.timeToStrCompact(from)).space().append(TimeUtils.timeToStrCompact(to));
   }
 

--- a/src/main/java/org/opentripplanner/util/time/RelativeTime.java
+++ b/src/main/java/org/opentripplanner/util/time/RelativeTime.java
@@ -4,7 +4,6 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.util.Calendar;
 import org.opentripplanner.model.calendar.ServiceDate;
 
 /**
@@ -68,13 +67,8 @@ class RelativeTime {
     }
   }
 
-  static RelativeTime from(Calendar time) {
-    return new RelativeTime(
-      0,
-      time.get(Calendar.HOUR_OF_DAY),
-      time.get(Calendar.MINUTE),
-      time.get(Calendar.SECOND)
-    );
+  static RelativeTime from(ZonedDateTime time) {
+    return new RelativeTime(0, time.getHour(), time.getMinute(), time.getSecond());
   }
 
   String toLongStr() {

--- a/src/main/java/org/opentripplanner/util/time/TimeUtils.java
+++ b/src/main/java/org/opentripplanner/util/time/TimeUtils.java
@@ -5,7 +5,6 @@ import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
-import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -119,7 +118,7 @@ public class TimeUtils {
     return time == notSetValue ? "" : RelativeTime.ofSeconds(time).toCompactStr();
   }
 
-  public static String timeToStrCompact(Calendar time) {
+  public static String timeToStrCompact(ZonedDateTime time) {
     return time == null ? "" : RelativeTime.from(time).toCompactStr();
   }
 
@@ -131,21 +130,12 @@ public class TimeUtils {
     return time == notSetValue ? "" : RelativeTime.ofSeconds(time).toLongStr();
   }
 
-  public static String timeToStrLong(Calendar time) {
+  public static String timeToStrLong(ZonedDateTime time) {
     return RelativeTime.from(time).toLongStr();
   }
 
   public static String timeToStrLong(LocalTime time) {
     return time.toString();
-  }
-
-  public static Calendar midnightOf(Calendar time) {
-    final Calendar midnight = (Calendar) time.clone();
-    midnight.set(Calendar.HOUR, 0);
-    midnight.set(Calendar.MINUTE, 0);
-    midnight.set(Calendar.SECOND, 0);
-    midnight.set(Calendar.MILLISECOND, 0);
-    return midnight;
   }
 
   /**
@@ -164,13 +154,5 @@ public class TimeUtils {
    */
   public static ZonedDateTime zonedDateTime(LocalDate date, int seconds, ZoneId zoneId) {
     return RelativeTime.ofSeconds(seconds).toZonedDateTime(date, zoneId);
-  }
-
-  public static ZonedDateTime zonedDateTime(Calendar time) {
-    return time.toInstant().atZone(time.getTimeZone().toZoneId());
-  }
-
-  public static LocalTime localTime(Calendar time) {
-    return zonedDateTime(time).toLocalTime();
   }
 }

--- a/src/test/java/org/opentripplanner/GtfsTest.java
+++ b/src/test/java/org/opentripplanner/GtfsTest.java
@@ -118,8 +118,8 @@ public abstract class GtfsTest {
     String fromStopId,
     String alert
   ) {
-    assertEquals(startTime, leg.getStartTime().getTimeInMillis());
-    assertEquals(endTime, leg.getEndTime().getTimeInMillis());
+    assertEquals(startTime, leg.getStartTime().toInstant().toEpochMilli());
+    assertEquals(endTime, leg.getEndTime().toInstant().toEpochMilli());
     assertEquals(toStopId, leg.getTo().stop.getId().getId());
     assertEquals(feedId.getId(), leg.getTo().stop.getId().getFeedId());
     if (fromStopId != null) {

--- a/src/test/java/org/opentripplanner/graph_builder/module/osm/TestIntermediatePlaces.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/osm/TestIntermediatePlaces.java
@@ -6,7 +6,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import io.micrometer.core.instrument.Metrics;
-import java.util.Calendar;
+import java.time.Instant;
 import java.util.List;
 import java.util.TimeZone;
 import org.junit.BeforeClass;
@@ -307,26 +307,26 @@ public class TestIntermediatePlaces {
 
   // Check that the start time and end time of each leg are consistent
   private void validateLegsTemporally(RoutingRequest request, Itinerary itinerary) {
-    Calendar departTime = Calendar.getInstance(timeZone);
-    Calendar arriveTime = Calendar.getInstance(timeZone);
+    Instant departTime;
+    Instant arriveTime;
     if (request.arriveBy) {
-      departTime = itinerary.legs.get(0).getStartTime();
-      arriveTime.setTimeInMillis(request.getDateTime().toEpochMilli());
+      departTime = itinerary.legs.get(0).getStartTime().toInstant();
+      arriveTime = request.getDateTime();
     } else {
-      departTime.setTimeInMillis(request.getDateTime().toEpochMilli());
-      arriveTime = itinerary.legs.get(itinerary.legs.size() - 1).getEndTime();
+      departTime = request.getDateTime();
+      arriveTime = itinerary.legs.get(itinerary.legs.size() - 1).getEndTime().toInstant();
     }
     long sumOfDuration = 0;
     for (Leg leg : itinerary.legs) {
-      assertFalse(departTime.after(leg.getStartTime()));
-      assertFalse(leg.getStartTime().after(leg.getEndTime()));
+      assertFalse(departTime.isAfter(leg.getStartTime().toInstant()));
+      assertFalse(leg.getStartTime().isAfter(leg.getEndTime()));
 
-      departTime = leg.getEndTime();
+      departTime = leg.getEndTime().toInstant();
       sumOfDuration += leg.getDuration();
     }
     sumOfDuration += itinerary.waitingTimeSeconds;
 
-    assertFalse(departTime.after(arriveTime));
+    assertFalse(departTime.isAfter(arriveTime));
 
     // Check the total duration of the legs,
     int accuracy = itinerary.legs.size(); // allow 1 second per leg for rounding errors

--- a/src/test/java/org/opentripplanner/model/base/ToStringBuilderTest.java
+++ b/src/test/java/org/opentripplanner/model/base/ToStringBuilderTest.java
@@ -7,8 +7,6 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.BitSet;
-import java.util.Calendar;
-import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Objects;
 import org.junit.jupiter.api.Test;
@@ -158,8 +156,9 @@ public class ToStringBuilderTest {
 
   @Test
   public void addCalTime() {
-    Calendar c = GregorianCalendar.from(
-      ZonedDateTime.of(LocalDateTime.of(2012, 1, 28, 23, 45, 12), ZoneId.systemDefault())
+    ZonedDateTime c = ZonedDateTime.of(
+      LocalDateTime.of(2012, 1, 28, 23, 45, 12),
+      ZoneId.systemDefault()
     );
     assertEquals("ToStringBuilderTest{c: 23:45:12}", subject().addTimeCal("c", c).toString());
   }

--- a/src/test/java/org/opentripplanner/model/plan/ItineraryTest.java
+++ b/src/test/java/org/opentripplanner/model/plan/ItineraryTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.model.plan.TestItineraryBuilder.newItinerary;
 import static org.opentripplanner.model.plan.TestItineraryBuilder.newTime;
 
-import java.util.GregorianCalendar;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.routing.core.TraverseMode;
@@ -28,8 +27,8 @@ public class ItineraryTest implements PlanTestConstants {
 
     // Expected fields on walking leg set
     assertSameLocation(A, result.firstLeg().getFrom());
-    assertEquals(GregorianCalendar.from(newTime(T11_00)), result.firstLeg().getStartTime());
-    assertEquals(GregorianCalendar.from(newTime(T11_05)), result.firstLeg().getEndTime());
+    assertEquals(newTime(T11_00), result.firstLeg().getStartTime());
+    assertEquals(newTime(T11_05), result.firstLeg().getEndTime());
     assertEquals(TraverseMode.WALK, result.firstLeg().getMode());
     assertEquals(420.0d, result.firstLeg().getDistanceMeters(), 1E-3);
     assertSameLocation(B, result.lastLeg().getTo());
@@ -52,8 +51,8 @@ public class ItineraryTest implements PlanTestConstants {
     // Expected fields on bus leg set
     assertSameLocation(A, result.firstLeg().getFrom());
     assertSameLocation(B, result.firstLeg().getTo());
-    assertEquals(GregorianCalendar.from(newTime(T11_00)), result.firstLeg().getStartTime());
-    assertEquals(GregorianCalendar.from(newTime(T11_10)), result.firstLeg().getEndTime());
+    assertEquals(newTime(T11_00), result.firstLeg().getStartTime());
+    assertEquals(newTime(T11_10), result.firstLeg().getEndTime());
     assertEquals(TraverseMode.BUS, result.firstLeg().getMode());
     assertEquals(new FeedScopedId("F", "55"), result.firstLeg().getTrip().getId());
     assertEquals(7500, result.firstLeg().getDistanceMeters(), 1E-3);
@@ -76,8 +75,8 @@ public class ItineraryTest implements PlanTestConstants {
     // Expected fields on bus leg set
     assertSameLocation(A, result.firstLeg().getFrom());
     assertSameLocation(B, result.firstLeg().getTo());
-    assertEquals(GregorianCalendar.from(newTime(T11_05)), result.firstLeg().getStartTime());
-    assertEquals(GregorianCalendar.from(newTime(T11_15)), result.firstLeg().getEndTime());
+    assertEquals(newTime(T11_05), result.firstLeg().getStartTime());
+    assertEquals(newTime(T11_15), result.firstLeg().getEndTime());
     assertEquals(TraverseMode.RAIL, result.firstLeg().getMode());
     assertEquals(new FeedScopedId("F", "20"), result.firstLeg().getTrip().getId());
     assertEquals(15_000, result.firstLeg().getDistanceMeters(), 1E-3);

--- a/src/test/java/org/opentripplanner/model/plan/TestItineraryBuilder.java
+++ b/src/test/java/org/opentripplanner/model/plan/TestItineraryBuilder.java
@@ -18,7 +18,6 @@ import org.opentripplanner.model.StopTime;
 import org.opentripplanner.model.TransitMode;
 import org.opentripplanner.model.Trip;
 import org.opentripplanner.model.TripPattern;
-import org.opentripplanner.routing.core.ServiceDay;
 import org.opentripplanner.routing.core.TraverseMode;
 import org.opentripplanner.routing.trippattern.Deduplicator;
 import org.opentripplanner.routing.trippattern.TripTimes;
@@ -263,8 +262,8 @@ public class TestItineraryBuilder implements PlanTestConstants {
       tripPattern,
       fromStopIndex,
       toStopIndex,
-      GregorianCalendar.from(newTime(start)),
-      GregorianCalendar.from(newTime(end)),
+      newTime(start),
+      newTime(end),
       serviceDate != null ? serviceDate : SERVICE_DAY,
       UTC,
       null,
@@ -287,8 +286,8 @@ public class TestItineraryBuilder implements PlanTestConstants {
   private Leg streetLeg(TraverseMode mode, int startTime, int endTime, Place to, int legCost) {
     StreetLeg leg = new StreetLeg(
       mode,
-      GregorianCalendar.from(newTime(startTime)),
-      GregorianCalendar.from(newTime(endTime)),
+      newTime(startTime),
+      newTime(endTime),
       stop(lastPlace),
       stop(to),
       speed(mode) * (endTime - startTime),

--- a/src/test/java/org/opentripplanner/routing/algorithm/FaresTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/FaresTest.java
@@ -8,7 +8,6 @@ import io.micrometer.core.instrument.Metrics;
 import java.time.Instant;
 import java.time.LocalTime;
 import java.time.ZoneId;
-import java.util.Calendar;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.ConstantsForTests;
@@ -124,8 +123,8 @@ public class FaresTest {
     var onPeakStartTime = TestUtils.dateInstant("America/Los_Angeles", 2016, 5, 24, 8, 0, 0);
     var peakItinerary = getItineraries(from, to, onPeakStartTime, router).get(1);
     var leg = peakItinerary.legs.get(0);
-    assertTrue(toLocalTime(leg.getStartTime()).isAfter(LocalTime.parse("08:00")));
-    assertTrue(toLocalTime(leg.getStartTime()).isBefore(LocalTime.parse("09:00")));
+    assertTrue(leg.getStartTime().toLocalTime().isAfter(LocalTime.parse("08:00")));
+    assertTrue(leg.getStartTime().toLocalTime().isBefore(LocalTime.parse("09:00")));
 
     assertEquals(new Money(USD, 275), peakItinerary.fare.getFare(FareType.regular));
   }
@@ -272,9 +271,5 @@ public class FaresTest {
       new DebugTimingAggregator()
     );
     return result.getItineraries();
-  }
-
-  private static LocalTime toLocalTime(Calendar time) {
-    return time.toInstant().atZone(time.getTimeZone().toZoneId()).toLocalTime();
   }
 }

--- a/src/test/java/org/opentripplanner/routing/algorithm/TestDominanceFunction.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/TestDominanceFunction.java
@@ -2,6 +2,7 @@ package org.opentripplanner.routing.algorithm;
 
 import static org.mockito.Mockito.mock;
 
+import java.time.Instant;
 import junit.framework.TestCase;
 import org.junit.Assert;
 import org.opentripplanner.routing.api.request.RoutingRequest;
@@ -20,8 +21,8 @@ public class TestDominanceFunction extends TestCase {
 
     // Test if domination works in the general case
 
-    State stateA = new State(fromVertex, 0, request, null);
-    State stateB = new State(toVertex, 0, request, null);
+    State stateA = new State(fromVertex, Instant.EPOCH, request, null);
+    State stateB = new State(toVertex, Instant.EPOCH, request, null);
     stateA.weight = 1;
     stateB.weight = 2;
 

--- a/src/test/java/org/opentripplanner/routing/core/TraverseResultTest.java
+++ b/src/test/java/org/opentripplanner/routing/core/TraverseResultTest.java
@@ -3,6 +3,7 @@ package org.opentripplanner.routing.core;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
+import java.time.Instant;
 import org.junit.Test;
 import org.opentripplanner.routing.api.request.RoutingRequest;
 
@@ -15,7 +16,7 @@ public class TraverseResultTest {
     /* note: times are rounded to seconds toward zero */
 
     for (int i = 0; i < 4; i++) {
-      State r = new State(null, i * 1000, new RoutingRequest(), null);
+      State r = new State(null, Instant.ofEpochSecond(i * 1000), new RoutingRequest(), null);
       resultChain = r.addToExistingResultChain(resultChain);
     }
 

--- a/src/test/java/org/opentripplanner/routing/edgetype/PlainStreetEdgeTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/PlainStreetEdgeTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.time.Instant;
 import org.junit.Before;
 import org.junit.Test;
 import org.locationtech.jts.geom.Coordinate;
@@ -258,7 +259,7 @@ public class PlainStreetEdgeTest {
     StreetEdge e1 = edge(v1, v2, 18.4, StreetTraversalPermission.ALL);
     RoutingRequest routingRequest = proto.clone();
     RoutingContext routingContext = new RoutingContext(routingRequest, graph, v0, v2);
-    State state = new State(v2, 0, routingRequest, routingContext);
+    State state = new State(v2, Instant.EPOCH, routingRequest, routingContext);
 
     state.getOptions().setArriveBy(true);
     e1.addTurnRestriction(new TurnRestriction(e1, e0, null, TraverseModeSet.allModes(), null));

--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/model/testcase/ItineraryResultMapper.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/model/testcase/ItineraryResultMapper.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.transit.raptor.speed_test.model.testcase;
 
+import java.time.temporal.ChronoField;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumSet;
@@ -15,7 +16,6 @@ import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.routing.core.TraverseMode;
 import org.opentripplanner.transit.raptor.util.PathStringBuilder;
-import org.opentripplanner.util.time.TimeUtils;
 
 /**
  * Map an Itinerary to a result instance. We do this to normalize the Itinerary for the purpose of
@@ -85,8 +85,8 @@ class ItineraryResultMapper {
       } else if (leg.isTransitLeg()) {
         buf.transit(
           leg.getMode().name() + " " + leg.getRoute().getShortName(),
-          TimeUtils.localTime(leg.getStartTime()).toSecondOfDay(),
-          TimeUtils.localTime(leg.getEndTime()).toSecondOfDay()
+          leg.getStartTime().get(ChronoField.SECOND_OF_DAY),
+          leg.getEndTime().get(ChronoField.SECOND_OF_DAY)
         );
       }
     }
@@ -137,8 +137,8 @@ class ItineraryResultMapper {
         .filter(Leg::isWalkingLeg)
         .mapToInt(l -> (int) Math.round(l.getDistanceMeters()))
         .sum(),
-      TimeUtils.localTime(itinerary.startTime()).toSecondOfDay(),
-      TimeUtils.localTime(itinerary.endTime()).toSecondOfDay(),
+      itinerary.startTime().get(ChronoField.SECOND_OF_DAY),
+      itinerary.endTime().get(ChronoField.SECOND_OF_DAY),
       agencies,
       modes,
       routes,

--- a/src/test/java/org/opentripplanner/util/time/TimeUtilsTest.java
+++ b/src/test/java/org/opentripplanner/util/time/TimeUtilsTest.java
@@ -4,16 +4,21 @@ import static java.time.ZoneOffset.UTC;
 import static org.junit.Assert.assertEquals;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.time.Month;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Arrays;
-import java.util.Calendar;
-import java.util.TimeZone;
 import org.junit.Test;
 
 public class TimeUtilsTest {
 
-  private static final Calendar CAL = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+  private static final ZonedDateTime CAL = ZonedDateTime.of(
+    LocalDate.of(2019, Month.JANUARY, 15),
+    LocalTime.of(9, 36, 7),
+    ZoneId.of("UTC")
+  );
+
   private final int T00_00_01 = time(0, 0, 1);
   private final int T00_01_00 = time(0, 1, 0);
   private final int T01_00_00 = time(1, 0, 0);
@@ -23,11 +28,6 @@ public class TimeUtilsTest {
   private final int T26_03_15 = time(26, 3, 15);
 
   private final int NOT_SET = 999_999;
-
-  static {
-    CAL.clear();
-    CAL.set(2019, Calendar.JANUARY, 15, 9, 36, 7);
-  }
 
   @Test
   public void timeToStrCompact() {
@@ -112,18 +112,6 @@ public class TimeUtilsTest {
     assertEquals("[3723]", Arrays.toString(TimeUtils.times("01:02:03")));
     assertEquals("[3600, 60, 1]", Arrays.toString(TimeUtils.times("1 0:1 0:0:1")));
     assertEquals("[3600, 60, 1, 7200]", Arrays.toString(TimeUtils.times("1,0:1;0:0:1,; 2")));
-  }
-
-  @Test
-  public void midnightOf() {
-    // When
-    Calendar midnight = TimeUtils.midnightOf(CAL);
-
-    // Then
-    assertEquals(0, midnight.get(Calendar.HOUR_OF_DAY));
-    assertEquals(0, midnight.get(Calendar.MINUTE));
-    assertEquals(0, midnight.get(Calendar.SECOND));
-    assertEquals(0, midnight.get(Calendar.MILLISECOND));
   }
 
   @Test


### PR DESCRIPTION
### Summary

As discussed in https://github.com/opentripplanner/OpenTripPlanner/pull/4071#discussion_r843585232, we want to move to Java 8 time classes. This implements that.

### Unit tests

Updated

### Changelog

The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md)
is generated from the pull-request title, make sure the title describe the feature or issue fixed.
To exclude the PR from the changelog add `[changelog skip]` in the title.
