### PR TITLE
Make maxWheelchairSlope not a hard cut-off, but apply a cost instead

### DIFF
--- a/src/main/java/org/opentripplanner/model/plan/Itinerary.java
+++ b/src/main/java/org/opentripplanner/model/plan/Itinerary.java
@@ -100,11 +100,17 @@ public class Itinerary {
    * -1 indicate that the cost is not set/computed.
    */
   public int transferPriorityCost = -1;
+
   /**
-   * This itinerary has a greater slope than the user requested (but there are no possible
-   * itineraries with a good slope).
+   * This itinerary has a greater slope than the user requested.
    */
   public boolean tooSloped = false;
+
+  /**
+   * The maximum slope for any part of the itinerary.
+   */
+  public Double maxSlope = null;
+
   /**
    * If {@link org.opentripplanner.routing.api.request.RoutingRequest#allowKeepingRentedVehicleAtDestination}
    * is set than it is possible to end a trip without dropping off the rented bicycle.

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/ItinerariesHelper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/ItinerariesHelper.java
@@ -1,23 +1,42 @@
 package org.opentripplanner.routing.algorithm.mapping;
 
 import java.util.List;
+import java.util.OptionalDouble;
 import org.opentripplanner.model.plan.Itinerary;
-import org.opentripplanner.routing.core.RoutingContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.opentripplanner.model.plan.StreetLeg;
+import org.opentripplanner.routing.api.request.RoutingRequest;
+import org.opentripplanner.routing.edgetype.StreetEdge;
 
 public class ItinerariesHelper {
 
-  private static final Logger LOG = LoggerFactory.getLogger(ItinerariesHelper.class);
-
   public static void decorateItinerariesWithRequestData(
     List<Itinerary> itineraries,
-    RoutingContext routingContext
+    RoutingRequest routingRequest
   ) {
     for (Itinerary it : itineraries) {
-      // Communicate the fact that the only way we were able to get a response
-      // was by removing a slope limit.
-      it.tooSloped = routingContext.slopeRestrictionRemoved;
+      if (routingRequest.wheelchairAccessible) {
+        // Communicate the fact that the only way we were able to get a response
+        // was by removing a slope limit.
+        OptionalDouble maxSlope = getMaxSlope(it);
+        if (maxSlope.isPresent()) {
+          it.tooSloped = maxSlope.getAsDouble() > routingRequest.maxWheelchairSlope;
+          it.maxSlope = maxSlope.getAsDouble();
+        }
+      }
     }
+  }
+
+  private static OptionalDouble getMaxSlope(Itinerary it) {
+    return it.legs
+      .stream()
+      .filter(StreetLeg.class::isInstance)
+      .map(StreetLeg.class::cast)
+      .map(StreetLeg::getWalkSteps)
+      .flatMap(List::stream)
+      .map(step -> step.edges)
+      .filter(StreetEdge.class::isInstance)
+      .map(StreetEdge.class::cast)
+      .mapToDouble(StreetEdge::getMaxSlope)
+      .max();
   }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/DirectStreetRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/DirectStreetRouter.java
@@ -51,7 +51,7 @@ public class DirectStreetRouter {
         router.graph.ellipsoidToGeoidDifference
       );
       List<Itinerary> response = graphPathToItineraryMapper.mapItineraries(paths);
-      ItinerariesHelper.decorateItinerariesWithRequestData(response, routingContext);
+      ItinerariesHelper.decorateItinerariesWithRequestData(response, request);
       return response;
     } catch (PathNotFoundException e) {
       return Collections.emptyList();

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/Transfer.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/Transfer.java
@@ -52,6 +52,7 @@ public class Transfer {
 
     rr.wheelchairAccessible = request.wheelchairAccessible;
     rr.maxWheelchairSlope = request.maxWheelchairSlope;
+    rr.wheelchairSlopeTooSteepCostFactor = request.wheelchairSlopeTooSteepCostFactor;
 
     rr.walkSpeed = roundToHalf(request.walkSpeed);
     rr.bikeSpeed = roundToHalf(request.bikeSpeed);

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RaptorRequestTransferCache.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RaptorRequestTransferCache.java
@@ -96,6 +96,7 @@ public class RaptorRequestTransferCache {
     private final double bikeTriangleTimeFactor;
     private final boolean wheelchairAccessible;
     private final double maxWheelchairSlope;
+    private final double wheelchairSlopeTooSteepCostFactor;
     private final double walkSpeed;
     private final double bikeSpeed;
     private final double walkReluctance;
@@ -121,6 +122,7 @@ public class RaptorRequestTransferCache {
 
       this.wheelchairAccessible = routingRequest.wheelchairAccessible;
       this.maxWheelchairSlope = routingRequest.maxWheelchairSlope;
+      this.wheelchairSlopeTooSteepCostFactor = routingRequest.wheelchairSlopeTooSteepCostFactor;
 
       this.walkSpeed = routingRequest.walkSpeed;
       this.bikeSpeed = routingRequest.bikeSpeed;
@@ -146,6 +148,7 @@ public class RaptorRequestTransferCache {
         bikeTriangleTimeFactor,
         wheelchairAccessible,
         maxWheelchairSlope,
+        wheelchairSlopeTooSteepCostFactor,
         walkSpeed,
         bikeSpeed,
         walkReluctance,
@@ -175,6 +178,8 @@ public class RaptorRequestTransferCache {
         Double.compare(that.bikeTriangleSlopeFactor, bikeTriangleSlopeFactor) == 0 &&
         Double.compare(that.bikeTriangleTimeFactor, bikeTriangleTimeFactor) == 0 &&
         Double.compare(that.maxWheelchairSlope, maxWheelchairSlope) == 0 &&
+        Double.compare(that.wheelchairSlopeTooSteepCostFactor, wheelchairSlopeTooSteepCostFactor) ==
+        0 &&
         Double.compare(that.walkSpeed, walkSpeed) == 0 &&
         Double.compare(that.bikeSpeed, bikeSpeed) == 0 &&
         Double.compare(that.walkReluctance, walkReluctance) == 0 &&

--- a/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
@@ -257,6 +257,13 @@ public class RoutingRequest implements Cloneable, Serializable {
   public int numItineraries = 50;
   /** The maximum slope of streets for wheelchair trips. */
   public double maxWheelchairSlope = 0.0833333333333; // ADA max wheelchair ramp slope is a good default.
+
+  /**
+   * What penalty factor should be given to street edges, which are over the max slope.
+   * Set to negative for disable routing on too steep edges.
+   */
+  public double wheelchairSlopeTooSteepCostFactor = 10.0;
+
   /** Whether the planner should return intermediate stops lists for transit legs. */
   public boolean showIntermediateStops = false;
   /**

--- a/src/main/java/org/opentripplanner/routing/core/RoutingContext.java
+++ b/src/main/java/org/opentripplanner/routing/core/RoutingContext.java
@@ -37,12 +37,6 @@ public class RoutingContext {
   public boolean aborted;
 
   /**
-   * Indicates that a maximum slope constraint was specified but was removed during routing to
-   * produce a result.
-   */
-  public boolean slopeRestrictionRemoved = false;
-
-  /**
    * DataOverlay Sandbox module context.
    */
   public DataOverlayContext dataOverlayContext;

--- a/src/main/java/org/opentripplanner/routing/edgetype/PathwayEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/PathwayEdge.java
@@ -5,6 +5,7 @@ import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.common.geometry.GeometryUtils;
 import org.opentripplanner.model.FeedScopedId;
+import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.core.StateEditor;
 import org.opentripplanner.routing.core.TraverseMode;
@@ -83,32 +84,39 @@ public class PathwayEdge extends Edge implements BikeWalkableEdge {
       return null;
     }
 
+    RoutingRequest options = s0.getOptions();
+
     /* TODO: Consider mode, so that passing through multiple fare gates is not possible */
     int time = traversalTime;
-    if (s0.getOptions().wheelchairAccessible) {
+    if (options.wheelchairAccessible) {
       if (!this.wheelchairAccessible) {
-        return null;
-      }
-      if (this.slope > s0.getOptions().maxWheelchairSlope) {
         return null;
       }
     }
 
     if (time == 0) {
       if (distance > 0) {
-        time = (int) (distance * s0.getOptions().walkSpeed);
+        time = (int) (distance * options.walkSpeed);
       } else if (steps > 0) {
         // 1 step corresponds to 20cm, doubling that to compensate for elevation;
-        time = (int) (0.4 * Math.abs(steps) * s0.getOptions().walkSpeed);
+        time = (int) (0.4 * Math.abs(steps) * options.walkSpeed);
       }
     }
 
     if (time > 0) {
       double weight =
         time *
-        s0
-          .getOptions()
-          .getReluctance(TraverseMode.WALK, s0.getNonTransitMode() == TraverseMode.BICYCLE);
+        options.getReluctance(TraverseMode.WALK, s0.getNonTransitMode() == TraverseMode.BICYCLE);
+
+      if (options.wheelchairAccessible) {
+        if (this.slope > options.maxWheelchairSlope) {
+          double tooSteepCostFactor = options.wheelchairSlopeTooSteepCostFactor;
+          if (tooSteepCostFactor < 0) {
+            return null;
+          }
+          weight *= tooSteepCostFactor;
+        }
+      }
 
       s1.incrementTimeInSeconds(time);
       s1.incrementWeight(weight);

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
@@ -230,9 +230,6 @@ public class StreetEdge extends Edge implements BikeWalkableEdge, Cloneable, Car
       if (!isWheelchairAccessible()) {
         return false;
       }
-      if (getMaxSlope() > options.maxWheelchairSlope) {
-        return false;
-      }
     }
     return canTraverseIncludingBarrier(mode);
   }
@@ -1012,6 +1009,14 @@ public class StreetEdge extends Edge implements BikeWalkableEdge, Cloneable, Car
         if (options.wheelchairAccessible) {
           time = getEffectiveWalkDistance() / speed;
           weight = getEffectiveBikeDistance() / speed;
+
+          if (getMaxSlope() > options.maxWheelchairSlope) {
+            double tooSteepCostFactor = options.wheelchairSlopeTooSteepCostFactor;
+            if (tooSteepCostFactor < 0) {
+              return null;
+            }
+            weight *= tooSteepCostFactor;
+          }
         } else if (walkingBike) {
           // take slopes into account when walking bikes
           time = weight = getEffectiveBikeDistance() / speed;

--- a/src/main/java/org/opentripplanner/routing/impl/GraphPathFinder.java
+++ b/src/main/java/org/opentripplanner/routing/impl/GraphPathFinder.java
@@ -94,33 +94,7 @@ public class GraphPathFinder {
     RoutingRequest request = routingContext.opt;
     long reqTime = request.getDateTime().getEpochSecond();
 
-    // We used to perform a protective clone of the RoutingRequest here.
-    // There is no reason to do this if we don't modify the request.
-    // Any code that changes them should be performing the copy!
-
-    List<GraphPath> paths;
-    try {
-      paths = getPaths(routingContext);
-      if (paths == null && request.wheelchairAccessible) {
-        // There are no paths that meet the user's slope restrictions.
-        // Try again without slope restrictions, and warn the user in the response.
-        RoutingRequest relaxedRequest = request.clone();
-        relaxedRequest.maxWheelchairSlope = Double.MAX_VALUE;
-        routingContext.slopeRestrictionRemoved = true;
-        var relaxedContext = new RoutingContext(
-          relaxedRequest,
-          routingContext.graph,
-          routingContext.fromVertices,
-          routingContext.toVertices
-        );
-        paths = getPaths(relaxedContext);
-      }
-    } catch (RoutingValidationException e) {
-      if (e.getRoutingErrors().get(0).code.equals(RoutingErrorCode.LOCATION_NOT_FOUND)) LOG.info(
-        "Vertex not found: " + request.from + " : " + request.to
-      );
-      throw e;
-    }
+    List<GraphPath> paths = getPaths(routingContext);
 
     // Detect and report that most obnoxious of bugs: path reversal asymmetry.
     // Removing paths might result in an empty list, so do this check before the empty list check.

--- a/src/main/java/org/opentripplanner/standalone/config/RoutingRequestMapper.java
+++ b/src/main/java/org/opentripplanner/standalone/config/RoutingRequestMapper.java
@@ -95,6 +95,8 @@ public class RoutingRequestMapper {
       c.asDouble("maxDirectStreetDurationSeconds", dft.maxDirectStreetDurationSeconds);
     request.maxJourneyDuration = c.asDuration("maxJourneyDuration", dft.maxJourneyDuration);
     request.maxWheelchairSlope = c.asDouble("maxWheelchairSlope", dft.maxWheelchairSlope); // ADA max wheelchair ramp slope is a good default.
+    request.wheelchairSlopeTooSteepCostFactor =
+      c.asDouble("wheelchairSlopeTooSteepCostFactor", dft.wheelchairSlopeTooSteepCostFactor);
     request.modes = c.asRequestModes("modes", RequestModes.defaultRequestModes);
     request.nonpreferredTransferCost =
       c.asInt("nonpreferredTransferPenalty", dft.nonpreferredTransferCost);


### PR DESCRIPTION
### Summary

This changes the behaviour when an edge has steeper slope than the `maxWheelchairSlope`. Previously, if no path was found, the limit was dropped and the search was re-done. In this PR the behaviour is changed, and instead a cost factor is applied, if the slope is too steep.

### Open questions
- Should we apply also a time penalty
- Should the cost be a static cost per request, per edge or a multiplier?