### PR TITLE
Only crash build if none of the transit data sets have active data [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
@@ -53,7 +53,7 @@ public class GraphBuilder implements Runnable {
 
   private final Graph graph;
 
-  private boolean hasTransitData = false;
+  private boolean hasTransitDataSets = false;
 
   private GraphBuilder(Graph baseGraph) {
     this.graph = baseGraph == null ? new Graph() : baseGraph;
@@ -73,10 +73,10 @@ public class GraphBuilder implements Runnable {
     boolean hasOsm = dataSources.has(OSM);
     boolean hasGtfs = dataSources.has(GTFS);
     boolean hasNetex = dataSources.has(NETEX);
-    boolean hasTransitData = hasGtfs || hasNetex;
+    boolean hasTransitDataSets = hasGtfs || hasNetex;
 
     GraphBuilder graphBuilder = new GraphBuilder(baseGraph);
-    graphBuilder.hasTransitData = hasTransitData;
+    graphBuilder.hasTransitDataSets = hasTransitDataSets;
 
     if (hasOsm) {
       List<BinaryOpenStreetMapProvider> osmProviders = Lists.newArrayList();
@@ -118,7 +118,7 @@ public class GraphBuilder implements Runnable {
       graphBuilder.addModule(netexModule(config, dataSources.get(NETEX)));
     }
 
-    if (hasTransitData && (hasOsm || graphBuilder.graph.hasStreets)) {
+    if (hasTransitDataSets && (hasOsm || graphBuilder.graph.hasStreets)) {
       if (config.matchBusRoutesToStreets) {
         graphBuilder.addModule(new BusRouteStreetMatcher());
       }
@@ -181,7 +181,7 @@ public class GraphBuilder implements Runnable {
         )
       );
     }
-    if (hasTransitData) {
+    if (hasTransitDataSets) {
       // Add links to flex areas after the streets has been split, so that also the split edges are connected
       if (OTPFeature.FlexRouting.isOn()) {
         graphBuilder.addModule(new FlexLocationsToStreetEdgesMapper());
@@ -232,8 +232,8 @@ public class GraphBuilder implements Runnable {
     return graph;
   }
 
-  public boolean hasTransitData() {
-    return hasTransitData;
+  public boolean hasTransitDataSets() {
+    return hasTransitDataSets;
   }
 
   public void run() {

--- a/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
@@ -54,7 +54,7 @@ public class GraphBuilder implements Runnable {
 
   private final Graph graph;
 
-  private boolean hasTransitDataSets = false;
+  private boolean hasTransitData = false;
 
   private GraphBuilder(Graph baseGraph) {
     this.graph = baseGraph == null ? new Graph() : baseGraph;
@@ -74,10 +74,10 @@ public class GraphBuilder implements Runnable {
     boolean hasOsm = dataSources.has(OSM);
     boolean hasGtfs = dataSources.has(GTFS);
     boolean hasNetex = dataSources.has(NETEX);
-    boolean hasTransitDataSets = hasGtfs || hasNetex;
+    boolean hasTransitData = hasGtfs || hasNetex;
 
     GraphBuilder graphBuilder = new GraphBuilder(baseGraph);
-    graphBuilder.hasTransitDataSets = hasTransitDataSets;
+    graphBuilder.hasTransitData = hasTransitData;
 
     if (hasOsm) {
       List<BinaryOpenStreetMapProvider> osmProviders = Lists.newArrayList();
@@ -119,7 +119,7 @@ public class GraphBuilder implements Runnable {
       graphBuilder.addModule(netexModule(config, dataSources.get(NETEX)));
     }
 
-    if (hasTransitDataSets && (hasOsm || graphBuilder.graph.hasStreets)) {
+    if (hasTransitData && (hasOsm || graphBuilder.graph.hasStreets)) {
       if (config.matchBusRoutesToStreets) {
         graphBuilder.addModule(new BusRouteStreetMatcher());
       }
@@ -182,7 +182,7 @@ public class GraphBuilder implements Runnable {
         )
       );
     }
-    if (hasTransitDataSets) {
+    if (hasTransitData) {
       // Add links to flex areas after the streets has been split, so that also the split edges are connected
       if (OTPFeature.FlexRouting.isOn()) {
         graphBuilder.addModule(new FlexLocationsToStreetEdgesMapper());
@@ -263,8 +263,8 @@ public class GraphBuilder implements Runnable {
     graphBuilderModules.add(loader);
   }
 
-  private boolean hasTransitDataSets() {
-    return hasTransitDataSets;
+  private boolean hasTransitData() {
+    return hasTransitData;
   }
 
   /**
@@ -273,7 +273,7 @@ public class GraphBuilder implements Runnable {
    * for example, then this function will throw a {@link OtpAppException}.
    */
   private void validate() {
-    if (hasTransitDataSets() && !graph.hasTransit) {
+    if (hasTransitData() && !graph.hasTransit) {
       throw new OtpAppException(
         "The provided transit data have no trips within the configured transit " +
         "service period. See build config 'transitServiceStart' and " +

--- a/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
@@ -53,6 +53,8 @@ public class GraphBuilder implements Runnable {
 
   private final Graph graph;
 
+  private boolean hasTransitData = false;
+
   private GraphBuilder(Graph baseGraph) {
     this.graph = baseGraph == null ? new Graph() : baseGraph;
   }
@@ -74,6 +76,7 @@ public class GraphBuilder implements Runnable {
     boolean hasTransitData = hasGtfs || hasNetex;
 
     GraphBuilder graphBuilder = new GraphBuilder(baseGraph);
+    graphBuilder.hasTransitData = hasTransitData;
 
     if (hasOsm) {
       List<BinaryOpenStreetMapProvider> osmProviders = Lists.newArrayList();
@@ -227,6 +230,10 @@ public class GraphBuilder implements Runnable {
 
   public Graph getGraph() {
     return graph;
+  }
+
+  public boolean hasTransitData() {
+    return hasTransitData;
   }
 
   public void run() {

--- a/src/main/java/org/opentripplanner/graph_builder/module/GtfsModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/GtfsModule.java
@@ -98,6 +98,8 @@ public class GtfsModule implements GraphBuilderModule {
 
     CalendarServiceData calendarServiceData = graph.getCalendarDataService();
 
+    boolean hasTransit = false;
+
     try {
       for (GtfsBundle gtfsBundle : gtfsBundles) {
         GtfsMutableRelationalDao gtfsDao = loadBundle(gtfsBundle);
@@ -125,6 +127,8 @@ public class GtfsModule implements GraphBuilderModule {
 
         OtpTransitService transitModel = builder.build();
 
+        hasTransit = transitModel.getAllServiceIds().size() > 0;
+
         addTransitModelToGraph(graph, gtfsBundle, transitModel);
 
         createGeometryAndBlockProcessor(gtfsBundle, transitModel).run(graph, issueStore);
@@ -145,7 +149,7 @@ public class GtfsModule implements GraphBuilderModule {
     );
     graph.updateTransitFeedValidity(calendarServiceData, issueStore);
 
-    graph.hasTransit = true;
+    graph.hasTransit = hasTransit;
     graph.calculateTransitCenter();
   }
 

--- a/src/main/java/org/opentripplanner/graph_builder/module/GtfsModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/GtfsModule.java
@@ -127,7 +127,8 @@ public class GtfsModule implements GraphBuilderModule {
 
         OtpTransitService transitModel = builder.build();
 
-        hasTransit = transitModel.hasActiveTransit();
+        // if this or previously processed gtfs bundle has transit that has not been filtered out
+        hasTransit = hasTransit || transitModel.hasActiveTransit();
 
         addTransitModelToGraph(graph, gtfsBundle, transitModel);
 
@@ -149,7 +150,8 @@ public class GtfsModule implements GraphBuilderModule {
     );
     graph.updateTransitFeedValidity(calendarServiceData, issueStore);
 
-    graph.hasTransit = hasTransit;
+    // If the graph's hasTransit flag isn't set to true already, set it based on this module's run
+    graph.hasTransit = graph.hasTransit || hasTransit;
     graph.calculateTransitCenter();
   }
 

--- a/src/main/java/org/opentripplanner/graph_builder/module/GtfsModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/GtfsModule.java
@@ -127,7 +127,7 @@ public class GtfsModule implements GraphBuilderModule {
 
         OtpTransitService transitModel = builder.build();
 
-        hasTransit = transitModel.getAllServiceIds().size() > 0;
+        hasTransit = transitModel.hasActiveTransit();
 
         addTransitModelToGraph(graph, gtfsBundle, transitModel);
 

--- a/src/main/java/org/opentripplanner/model/OtpTransitService.java
+++ b/src/main/java/org/opentripplanner/model/OtpTransitService.java
@@ -77,4 +77,9 @@ public interface OtpTransitService {
   Collection<Trip> getAllTrips();
 
   Collection<FlexTrip> getAllFlexTrips();
+
+  /**
+   * @return if transit service has any active services
+   */
+  boolean hasActiveTransit();
 }

--- a/src/main/java/org/opentripplanner/model/OtpTransitService.java
+++ b/src/main/java/org/opentripplanner/model/OtpTransitService.java
@@ -79,7 +79,8 @@ public interface OtpTransitService {
   Collection<FlexTrip> getAllFlexTrips();
 
   /**
-   * @return if transit service has any active services
+   * @return if transit service has any active services. The graph build might filter out all
+   * transit services if they are outside the configured 'transitServiceStart' and 'transitServiceEnd'
    */
   boolean hasActiveTransit();
 }

--- a/src/main/java/org/opentripplanner/model/impl/OtpTransitServiceBuilder.java
+++ b/src/main/java/org/opentripplanner/model/impl/OtpTransitServiceBuilder.java
@@ -47,7 +47,6 @@ import org.opentripplanner.model.calendar.ServiceDateInterval;
 import org.opentripplanner.model.calendar.impl.CalendarServiceDataFactoryImpl;
 import org.opentripplanner.model.transfer.ConstrainedTransfer;
 import org.opentripplanner.model.transfer.TransferPoint;
-import org.opentripplanner.util.OtpAppException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -297,18 +296,7 @@ public class OtpTransitServiceBuilder {
       calendars.addAll(keepCal);
       logRemove("ServiceCalendar", orgSize, calendars.size(), "Outside time period.");
     }
-    final int originalNumOfTrips = numberOfTrips();
     removeEntitiesWithInvalidReferences(issues);
-
-    // All trips are removed, then exit with error
-    if (originalNumOfTrips > 0 && numberOfTrips() == 0) {
-      throw new OtpAppException(
-        "The provided transit date have no trips within the configured transit " +
-        "service period. See build config 'transitServiceStart' and " +
-        "'transitServiceEnd': " +
-        periodLimit
-      );
-    }
     LOG.info("Limiting transit service days to time period complete.");
   }
 
@@ -331,10 +319,6 @@ public class OtpTransitServiceBuilder {
       return;
     }
     LOG.info("{} of {} {}(s) removed. Reason: {}", orgSize - newSize, orgSize, type, reason);
-  }
-
-  private int numberOfTrips() {
-    return tripsById.size() + flexTripsById.size();
   }
 
   /**

--- a/src/main/java/org/opentripplanner/model/impl/OtpTransitServiceImpl.java
+++ b/src/main/java/org/opentripplanner/model/impl/OtpTransitServiceImpl.java
@@ -261,6 +261,11 @@ class OtpTransitServiceImpl implements OtpTransitService {
     return flexTrips;
   }
 
+  @Override
+  public boolean hasActiveTransit() {
+    return serviceIds.size() > 0;
+  }
+
   /*  Private Methods */
 
   /**

--- a/src/main/java/org/opentripplanner/netex/NetexModule.java
+++ b/src/main/java/org/opentripplanner/netex/NetexModule.java
@@ -66,6 +66,7 @@ public class NetexModule implements GraphBuilderModule {
   ) {
     graph.clearTimeZone();
     CalendarServiceData calendarServiceData = graph.getCalendarDataService();
+    boolean hasTransit = false;
     try {
       for (NetexBundle netexBundle : netexBundles) {
         netexBundle.checkInputs();
@@ -89,6 +90,8 @@ public class NetexModule implements GraphBuilderModule {
         }
 
         OtpTransitService otpService = transitBuilder.build();
+
+        hasTransit = otpService.getAllServiceIds().size() > 0;
 
         // TODO OTP2 - Move this into the AddTransitModelEntitiesToGraph
         //           - and make sure thay also work with GTFS feeds - GTFS do no
@@ -116,7 +119,7 @@ public class NetexModule implements GraphBuilderModule {
     graph.putService(CalendarServiceData.class, calendarServiceData);
     graph.updateTransitFeedValidity(calendarServiceData, issueStore);
 
-    graph.hasTransit = true;
+    graph.hasTransit = hasTransit;
     graph.calculateTransitCenter();
   }
 

--- a/src/main/java/org/opentripplanner/netex/NetexModule.java
+++ b/src/main/java/org/opentripplanner/netex/NetexModule.java
@@ -91,7 +91,8 @@ public class NetexModule implements GraphBuilderModule {
 
         OtpTransitService otpService = transitBuilder.build();
 
-        hasTransit = otpService.hasActiveTransit();
+        // if this or previously processed netex bundle has transit that has not been filtered out
+        hasTransit = hasTransit || otpService.hasActiveTransit();
 
         // TODO OTP2 - Move this into the AddTransitModelEntitiesToGraph
         //           - and make sure thay also work with GTFS feeds - GTFS do no
@@ -119,7 +120,8 @@ public class NetexModule implements GraphBuilderModule {
     graph.putService(CalendarServiceData.class, calendarServiceData);
     graph.updateTransitFeedValidity(calendarServiceData, issueStore);
 
-    graph.hasTransit = hasTransit;
+    // If the graph's hasTransit flag isn't set to true already, set it based on this module's run
+    graph.hasTransit = graph.hasTransit || hasTransit;
     graph.calculateTransitCenter();
   }
 

--- a/src/main/java/org/opentripplanner/netex/NetexModule.java
+++ b/src/main/java/org/opentripplanner/netex/NetexModule.java
@@ -91,7 +91,7 @@ public class NetexModule implements GraphBuilderModule {
 
         OtpTransitService otpService = transitBuilder.build();
 
-        hasTransit = otpService.getAllServiceIds().size() > 0;
+        hasTransit = otpService.hasActiveTransit();
 
         // TODO OTP2 - Move this into the AddTransitModelEntitiesToGraph
         //           - and make sure thay also work with GTFS feeds - GTFS do no

--- a/src/main/java/org/opentripplanner/standalone/OTPMain.java
+++ b/src/main/java/org/opentripplanner/standalone/OTPMain.java
@@ -134,6 +134,13 @@ public class OTPMain {
         graphBuilder.run();
         // Hand off the graph to the server as the default graph
         graph = graphBuilder.getGraph();
+        if (graphBuilder.hasTransitData() && !graph.hasTransit) {
+          throw new OtpAppException(
+            "The provided transit data have no trips within the configured transit " +
+            "service period. See build config 'transitServiceStart' and " +
+            "'transitServiceEnd'"
+          );
+        }
       } else {
         throw new IllegalStateException("An error occurred while building the graph.");
       }

--- a/src/main/java/org/opentripplanner/standalone/OTPMain.java
+++ b/src/main/java/org/opentripplanner/standalone/OTPMain.java
@@ -134,7 +134,7 @@ public class OTPMain {
         graphBuilder.run();
         // Hand off the graph to the server as the default graph
         graph = graphBuilder.getGraph();
-        if (graphBuilder.hasTransitData() && !graph.hasTransit) {
+        if (graphBuilder.hasTransitDataSets() && !graph.hasTransit) {
           throw new OtpAppException(
             "The provided transit data have no trips within the configured transit " +
             "service period. See build config 'transitServiceStart' and " +

--- a/src/main/java/org/opentripplanner/standalone/OTPMain.java
+++ b/src/main/java/org/opentripplanner/standalone/OTPMain.java
@@ -134,13 +134,6 @@ public class OTPMain {
         graphBuilder.run();
         // Hand off the graph to the server as the default graph
         graph = graphBuilder.getGraph();
-        if (graphBuilder.hasTransitDataSets() && !graph.hasTransit) {
-          throw new OtpAppException(
-            "The provided transit data have no trips within the configured transit " +
-            "service period. See build config 'transitServiceStart' and " +
-            "'transitServiceEnd'"
-          );
-        }
       } else {
         throw new IllegalStateException("An error occurred while building the graph.");
       }

--- a/src/test/java/org/opentripplanner/model/impl/OtpTransitServiceImplTest.java
+++ b/src/test/java/org/opentripplanner/model/impl/OtpTransitServiceImplTest.java
@@ -4,6 +4,7 @@ import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.gtfs.GtfsContextBuilder.contextBuilder;
 
 import java.io.IOException;
@@ -188,6 +189,11 @@ public class OtpTransitServiceImplTest {
 
     assertEquals(2, serviceIds.size());
     assertEquals("Z:alldays", first(serviceIds).toString());
+  }
+
+  @Test
+  public void testHasActiveTransit() {
+    assertTrue(subject.hasActiveTransit());
   }
 
   private static FareRule createFareRule() {


### PR DESCRIPTION
### Summary

Reverts https://github.com/opentripplanner/OpenTripPlanner/commit/3bb43a730ceb1476588be3103b522f88e6383267 and reimplements it by only crashing the build when there are transit data sets given but none of them have active data.

### Issue

closes #4063

### Unit tests
Not added

### Code style

Have you followed
the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Codestyle.md)
?
Yes

### Documentation

Maybe not needed

### Changelog

From title
