### PR TITLE
Fix problem with submode filter

### DIFF
--- a/src/main/java/org/opentripplanner/model/modes/AllowedTransitMode.java
+++ b/src/main/java/org/opentripplanner/model/modes/AllowedTransitMode.java
@@ -17,6 +17,8 @@ public class AllowedTransitMode {
 
   private final String subMode;
 
+  private static final String UNKNOWN = "unknown";
+
   public AllowedTransitMode(TransitMode mainMode, String subMode) {
     this.mainMode = mainMode;
     this.subMode = subMode;
@@ -55,7 +57,7 @@ public class AllowedTransitMode {
     boolean submodeMatch =
       subMode == null ||
       subMode.equals(netexSubMode) ||
-      (subMode.equals("unknown") && netexSubMode == null);
+      (UNKNOWN.equals(subMode) && netexSubMode == null);
     return mainModeMatch && submodeMatch;
   }
 

--- a/src/main/java/org/opentripplanner/model/modes/AllowedTransitMode.java
+++ b/src/main/java/org/opentripplanner/model/modes/AllowedTransitMode.java
@@ -51,7 +51,12 @@ public class AllowedTransitMode {
    * Check if this filter allows the provided TransitMode
    */
   public boolean allows(TransitMode transitMode, String netexSubMode) {
-    return mainMode == transitMode && (subMode == null || subMode.equals(netexSubMode));
+    boolean mainModeMatch = mainMode == transitMode;
+    boolean submodeMatch =
+      subMode == null ||
+      subMode.equals(netexSubMode) ||
+      (subMode.equals("unknown") && netexSubMode == null);
+    return mainModeMatch && submodeMatch;
   }
 
   public TransitMode getMainMode() {

--- a/src/test/java/org/opentripplanner/model/modes/AllowedTransitModeTest.java
+++ b/src/test/java/org/opentripplanner/model/modes/AllowedTransitModeTest.java
@@ -1,0 +1,37 @@
+package org.opentripplanner.model.modes;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.model.TransitMode;
+
+public class AllowedTransitModeTest {
+
+  @Test
+  public void testMainModeMatch() {
+    final var ALLOWED_TRANSIT_MODE = AllowedTransitMode.fromMainModeEnum(TransitMode.BUS);
+    assertTrue(ALLOWED_TRANSIT_MODE.allows(TransitMode.BUS, null));
+    assertTrue(ALLOWED_TRANSIT_MODE.allows(TransitMode.BUS, "something"));
+    assertFalse(ALLOWED_TRANSIT_MODE.allows(TransitMode.RAIL, null));
+    assertFalse(ALLOWED_TRANSIT_MODE.allows(TransitMode.RAIL, "something"));
+  }
+
+  @Test
+  public void testSubmodeMatch() {
+    final var SUBMODE = "shuttleBus";
+    final var ALLOWED_TRANSIT_MODE = new AllowedTransitMode(TransitMode.BUS, SUBMODE);
+
+    assertTrue(ALLOWED_TRANSIT_MODE.allows(TransitMode.BUS, SUBMODE));
+    assertFalse(ALLOWED_TRANSIT_MODE.allows(TransitMode.BUS, "other"));
+    assertFalse(ALLOWED_TRANSIT_MODE.allows(TransitMode.BUS, null));
+  }
+
+  @Test
+  public void testUnknownSubmodeMatch() {
+    final var SUBMODE = "unknown";
+    final var ALLOWED_TRANSIT_MODE = new AllowedTransitMode(TransitMode.BUS, SUBMODE);
+
+    assertTrue(ALLOWED_TRANSIT_MODE.allows(TransitMode.BUS, null));
+  }
+}


### PR DESCRIPTION
### Summary
Ensure that Transmodel GraphQL UNKNOWN submode matches on nulls as well. This is needed to ensure that filter works with GTFS data.

### Issue
GTFS trips does always have netex submode that is null. This means that no matter which submode filter we set, those trips will always be filtered out (there will be no match on null).

### Unit tests
Created some tests for AllowedTransitMode class

### Code style
Formatted with maven plugin

### Documentation
No new documentation added.