### PR TITLE
Improve logging of GTFS-RT updates [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/model/Timetable.java
+++ b/src/main/java/org/opentripplanner/model/Timetable.java
@@ -15,6 +15,7 @@ import org.opentripplanner.model.calendar.ServiceDate;
 import org.opentripplanner.routing.core.ServiceDay;
 import org.opentripplanner.routing.trippattern.FrequencyEntry;
 import org.opentripplanner.routing.trippattern.TripTimes;
+import org.opentripplanner.updater.stoptime.TimetableSnapshotSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/org/opentripplanner/model/Timetable.java
+++ b/src/main/java/org/opentripplanner/model/Timetable.java
@@ -15,7 +15,6 @@ import org.opentripplanner.model.calendar.ServiceDate;
 import org.opentripplanner.routing.core.ServiceDay;
 import org.opentripplanner.routing.trippattern.FrequencyEntry;
 import org.opentripplanner.routing.trippattern.TripTimes;
-import org.opentripplanner.updater.stoptime.TimetableSnapshotSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/org/opentripplanner/updater/stoptime/GtfsRealtimeHttpTripUpdateSource.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/GtfsRealtimeHttpTripUpdateSource.java
@@ -9,6 +9,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import org.opentripplanner.model.base.ToStringBuilder;
 import org.opentripplanner.util.HttpUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -86,7 +87,11 @@ public class GtfsRealtimeHttpTripUpdateSource implements TripUpdateSource {
   }
 
   public String toString() {
-    return "GtfsRealtimeHttpUpdateStreamer(" + url + ")";
+    return ToStringBuilder
+      .of(this.getClass())
+      .addStr("feedId", feedId)
+      .addStr("url", url)
+      .toString();
   }
 
   interface Parameters {

--- a/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
@@ -592,7 +592,7 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
     return Optional
       .ofNullable(tripUpdate.getTrip())
       .map(TripDescriptor::getTripId)
-      .filter(String::isBlank)
+      .filter(id -> !id.isBlank())
       .map(tId -> new FeedScopedId(feedId, tId))
       .orElse(new FeedScopedId(feedId, "null"));
   }

--- a/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
@@ -349,7 +349,6 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
     final FeedScopedId tripId,
     final ServiceDate serviceDate
   ) {
-    // This does not include Agency ID or feed ID, trips are feed-unique and we currently assume a single static feed.
     final TripPattern pattern = getPatternForTripId(tripId);
 
     if (pattern == null) {
@@ -1045,7 +1044,7 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
   }
 
   /**
-   * Retrieve route given a route id without an agency
+   * Retrieve route given a route id
    *
    * @return route or null if route can't be found in graph index
    */
@@ -1054,7 +1053,7 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
   }
 
   /**
-   * Retrieve trip given a trip id without an agency
+   * Retrieve trip given a trip id
    *
    * @return trip or null if trip can't be found in graph index
    */
@@ -1063,7 +1062,7 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
   }
 
   /**
-   * Retrieve stop given a feed id and stop id.
+   * Retrieve stop given a stop id.
    *
    * @return stop or null if stop doesn't exist
    */

--- a/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
@@ -454,26 +454,26 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
     final String tripId = tripDescriptor.getTripId();
     final Trip trip = getTripForTripId(feedId, tripId);
 
-    Consumer<String> _warn = (String message) ->
+    Consumer<String> warn = (String message) ->
       TimetableSnapshotSource.warn(feedId, tripId, message);
 
     if (trip != null) {
       // TODO: should we support this and add a new instantiation of this trip (making it
       // frequency based)?
-      _warn.accept("Graph already contains trip id of ADDED trip, skipping.");
+      warn.accept("Graph already contains trip id of ADDED trip, skipping.");
       return false;
     }
 
     // Check whether a start date exists
     if (!tripDescriptor.hasStartDate()) {
       // TODO: should we support this and apply update to all days?
-      _warn.accept("ADDED trip doesn't have a start date in TripDescriptor, skipping.");
+      warn.accept("ADDED trip doesn't have a start date in TripDescriptor, skipping.");
       return false;
     }
 
     // Check whether at least two stop updates exist
     if (tripUpdate.getStopTimeUpdateCount() < 2) {
-      _warn.accept("ADDED trip has less then two stops, skipping.");
+      warn.accept("ADDED trip has less then two stops, skipping.");
       return false;
     }
 
@@ -520,7 +520,7 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
       .map(TripDescriptor::getTripId)
       .orElse("unknown");
 
-    Consumer<String> _warn = (String message) ->
+    Consumer<String> warn = (String message) ->
       TimetableSnapshotSource.warn(feedId, tripId, message);
 
     for (int index = 0; index < stopTimeUpdates.size(); ++index) {
@@ -532,13 +532,13 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
 
         // Check non-negative
         if (stopSequence < 0) {
-          _warn.accept("Trip update contains negative stop sequence, skipping.");
+          warn.accept("Trip update contains negative stop sequence, skipping.");
           return null;
         }
 
         // Check whether sequence is increasing
         if (previousStopSequence != null && previousStopSequence > stopSequence) {
-          _warn.accept("Trip update contains decreasing stop sequence, skipping.");
+          warn.accept("Trip update contains decreasing stop sequence, skipping.");
           return null;
         }
         previousStopSequence = stopSequence;
@@ -577,12 +577,12 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
         // Check for increasing time
         final Long time = stopTimeUpdate.getArrival().getTime();
         if (previousTime != null && previousTime > time) {
-          _warn.accept("Trip update contains decreasing times, skipping.");
+          warn.accept("Trip update contains decreasing times, skipping.");
           return null;
         }
         previousTime = time;
       } else {
-        _warn.accept("Trip update misses arrival time, skipping.");
+        warn.accept("Trip update misses arrival time, skipping.");
         return null;
       }
 
@@ -591,12 +591,12 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
         // Check for increasing time
         final Long time = stopTimeUpdate.getDeparture().getTime();
         if (previousTime != null && previousTime > time) {
-          _warn.accept("Trip update contains decreasing times, skipping.");
+          warn.accept("Trip update contains decreasing times, skipping.");
           return null;
         }
         previousTime = time;
       } else {
-        _warn.accept("Trip update misses departure time, skipping.");
+        warn.accept("Trip update misses departure time, skipping.");
         return null;
       }
     }
@@ -732,7 +732,7 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
       "number of stop should match the number of stop time updates"
     );
 
-    Consumer<String> _warn = (String message) ->
+    Consumer<String> warn = (String message) ->
       TimetableSnapshotSource.warn(trip.getId().getFeedId(), trip.getId().getId(), message);
 
     // Calculate seconds since epoch on GTFS midnight (noon minus 12h) of service date
@@ -753,7 +753,7 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
       if (stopTimeUpdate.hasArrival() && stopTimeUpdate.getArrival().hasTime()) {
         final long arrivalTime = stopTimeUpdate.getArrival().getTime() - midnightSecondsSinceEpoch;
         if (arrivalTime < 0 || arrivalTime > MAX_ARRIVAL_DEPARTURE_TIME) {
-          _warn.accept(
+          warn.accept(
             "ADDED trip has invalid arrival time (compared to start date in " +
             "TripDescriptor), skipping."
           );
@@ -766,7 +766,7 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
         final long departureTime =
           stopTimeUpdate.getDeparture().getTime() - midnightSecondsSinceEpoch;
         if (departureTime < 0 || departureTime > MAX_ARRIVAL_DEPARTURE_TIME) {
-          _warn.accept(
+          warn.accept(
             "ADDED trip has invalid departure time (compared to start date in " +
             "TripDescriptor), skipping."
           );
@@ -934,33 +934,33 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
     String tripId = tripDescriptor.getTripId();
     Trip trip = getTripForTripId(feedId, tripId);
 
-    Consumer<String> _warn = (String message) ->
+    Consumer<String> warn = (String message) ->
       TimetableSnapshotSource.warn(feedId, tripId, message);
 
     if (trip == null) {
       // TODO: should we support this and consider it an ADDED trip?
-      _warn.accept("Feed does not contain trip id of MODIFIED trip, skipping.");
+      warn.accept("Feed does not contain trip id of MODIFIED trip, skipping.");
       return false;
     }
 
     // Check whether a start date exists
     if (!tripDescriptor.hasStartDate()) {
       // TODO: should we support this and apply update to all days?
-      _warn.accept("MODIFIED trip doesn't have a start date in TripDescriptor, skipping.");
+      warn.accept("MODIFIED trip doesn't have a start date in TripDescriptor, skipping.");
       return false;
     } else {
       // Check whether service date is served by trip
       final Set<FeedScopedId> serviceIds = calendarService.getServiceIdsOnDate(serviceDate);
       if (!serviceIds.contains(trip.getServiceId())) {
         // TODO: should we support this and change service id of trip?
-        _warn.accept("MODIFIED trip has a service date that is not served by trip, skipping.");
+        warn.accept("MODIFIED trip has a service date that is not served by trip, skipping.");
         return false;
       }
     }
 
     // Check whether at least two stop updates exist
     if (tripUpdate.getStopTimeUpdateCount() < 2) {
-      _warn.accept("MODIFIED trip has less then two stops, skipping.");
+      warn.accept("MODIFIED trip has less then two stops, skipping.");
       return false;
     }
 

--- a/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
@@ -145,7 +145,7 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
    * @param deduplicator    deduplicator for different types
    * @param graphIndex      graph's index
    * @param serviceCodes    graph's service codes
-   * @param fullDataset     true iff the list with updates represent all updates that are active
+   * @param fullDataset     true if the list with updates represent all updates that are active
    *                        right now, i.e. all previous updates should be disregarded
    * @param updates         GTFS-RT TripUpdate's that should be applied atomically
    */
@@ -280,18 +280,20 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
         }
       }
 
-      LOG.info(
-        "[feedId: {}] {} of {} update messages were applied successfully",
-        feedId,
-        successfullyApplied,
-        updates.size()
-      );
-      if (!failuresByRelationship.isEmpty()) {
+      if (fullDataset) {
         LOG.info(
-          "[feedId: {}] Failures by scheduleRelationship {}",
+          "[feedId: {}] {} of {} update messages were applied successfully",
           feedId,
-          failuresByRelationship
+          successfullyApplied,
+          updates.size()
         );
+        if (!failuresByRelationship.isEmpty()) {
+          LOG.info(
+            "[feedId: {}] Failures by scheduleRelationship {}",
+            feedId,
+            failuresByRelationship
+          );
+        }
       }
 
       // Make a snapshot after each message in anticipation of incoming requests
@@ -425,7 +427,7 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
    * @param serviceCodes    graph's service codes
    * @param tripUpdate      GTFS-RT TripUpdate message
    * @param tripDescriptor  GTFS-RT TripDescriptor
-   * @return true iff successful
+   * @return true if successful
    */
   private boolean validateAndHandleAddedTrip(
     final CalendarService calendarService,
@@ -612,7 +614,7 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
    * @param tripDescriptor  GTFS-RT TripDescriptor
    * @param stops           the stops of each StopTimeUpdate in the TripUpdate message
    * @param serviceDate     service date for added trip
-   * @return true iff successful
+   * @return true if successful
    */
   private boolean handleAddedTrip(
     final CalendarService calendarService,
@@ -994,7 +996,7 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
    * @param tripUpdate   GTFS-RT TripUpdate message
    * @param stops        the stops of each StopTimeUpdate in the TripUpdate message
    * @param serviceDate  service date for modified trip
-   * @return true iff successful
+   * @return true if successful
    */
   private boolean handleModifiedTrip(
     final Deduplicator deduplicator,

--- a/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
@@ -454,7 +454,8 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
     final String tripId = tripDescriptor.getTripId();
     final Trip trip = getTripForTripId(feedId, tripId);
 
-    Consumer<String> warn = (String message) -> TimetableSnapshotSource.warn(trip.getId(), message);
+    Consumer<String> warn = (String message) ->
+      TimetableSnapshotSource.warn(feedId, tripId, message);
 
     if (trip != null) {
       // TODO: should we support this and add a new instantiation of this trip (making it

--- a/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
@@ -875,12 +875,7 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
       final Timetable timetable = buffer.resolve(pattern, serviceDate);
       final int tripIndex = timetable.getTripIndex(tripId);
       if (tripIndex == -1) {
-        warn(
-          tripId.getFeedId(),
-          tripId.getId(),
-          "Could not cancel previously added trip {}",
-          tripId
-        );
+        warn(tripId, "Could not cancel previously added trip on ", serviceDate);
       } else {
         final TripTimes newTripTimes = new TripTimes(timetable.getTripTimes(tripIndex));
         newTripTimes.cancelTrip();
@@ -1121,7 +1116,11 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
     return routingService.getStopForId(new FeedScopedId(feedId, stopId));
   }
 
-  public static void warn(String feedId, String tripId, String message, Object... params) {
+  private static void warn(FeedScopedId id, String message, Object... params) {
+    warn(id.getFeedId(), id.getId(), message, params);
+  }
+
+  private static void warn(String feedId, String tripId, String message, Object... params) {
     String m = "[feedId: %s, tripId: %s] %s".formatted(feedId, tripId, message);
     LOG.warn(m, params);
   }


### PR DESCRIPTION
### Summary

This improves the logging of the GTFS-RT update process so that it always contains the feed id and trip id. It also adds some very basic statistics about the update success rate.

Logs look now like this:

```
13:20:12.374 WARN (TimetableSnapshotSource.java:1141) [feedId: mtba, tripId: mtba:504749] Failed to apply TripUpdate.
13:20:12.374 WARN (TimetableSnapshotSource.java:1141) [feedId: mtba, tripId: mtba:499199] Graph doesn't contain stop id 'de:14713:12994' of trip update, skipping.
13:20:12.374 WARN (TimetableSnapshotSource.java:1141) [feedId: mtba, tripId: mtba:499199] Failed to apply TripUpdate.
13:20:12.374 WARN (TimetableSnapshotSource.java:1141) [feedId: mtba, tripId: mtba:927487] Graph doesn't contain stop id 'de:14713:11404' of trip update, skipping.
13:20:12.374 WARN (TimetableSnapshotSource.java:1141) [feedId: mtba, tripId: mtba:927487] Failed to apply TripUpdate.
13:20:12.374 WARN (TimetableSnapshotSource.java:1141) [feedId: mtba, tripId: mtba:104428] Trip update misses a stop id at stop time list index 0, skipping.
13:20:12.374 WARN (TimetableSnapshotSource.java:1141) [feedId: mtba, tripId: mtba:104428] Failed to apply TripUpdate.
13:20:12.374 WARN (TimetableSnapshotSource.java:1141) [feedId: mtba, tripId: mtba:645172] Trip update misses a stop id at stop time list index 0, skipping.
13:20:12.374 WARN (TimetableSnapshotSource.java:1141) [feedId: mtba, tripId: mtba:645172] Failed to apply TripUpdate.
13:20:12.374 WARN (TimetableSnapshotSource.java:1141) [feedId: mtba, tripId: mtba:315431] Trip update misses a stop id at stop time list index 0, skipping.
13:20:12.374 WARN (TimetableSnapshotSource.java:1141) [feedId: mtba, tripId: mtba:315431] Failed to apply TripUpdate.
13:20:12.374 WARN (TimetableSnapshotSource.java:1141) [feedId: mtba, tripId: mtba:104426] Graph doesn't contain stop id 'osm:w23532855' of trip update, skipping.
13:20:12.374 WARN (TimetableSnapshotSource.java:1141) [feedId: mtba, tripId: mtba:104426] Failed to apply TripUpdate.
13:20:12.374 WARN (TimetableSnapshotSource.java:1141) [feedId: mtba, tripId: mtba:103981] Trip update misses a stop id at stop time list index 0, skipping.
13:20:12.374 WARN (TimetableSnapshotSource.java:1141) [feedId: mtba, tripId: mtba:103981] Failed to apply TripUpdate.
13:20:12.375 WARN (TimetableSnapshotSource.java:1141) [feedId: mtba, tripId: mtba:104217] Trip update misses a stop id at stop time list index 40, skipping.
13:20:12.375 WARN (TimetableSnapshotSource.java:1141) [feedId: mtba, tripId: mtba:104217] Failed to apply TripUpdate.
13:20:12.375 WARN (TimetableSnapshotSource.java:1141) [feedId: mtba, tripId: mtba:104218] Trip update misses a stop id at stop time list index 40, skipping.
13:20:12.375 WARN (TimetableSnapshotSource.java:1141) [feedId: mtba, tripId: mtba:104218] Failed to apply TripUpdate.
13:20:12.375 WARN (TimetableSnapshotSource.java:1141) [feedId: mtba, tripId: mtba:104194] No pattern found for tripId. Skipping cancellation.
13:20:12.375 WARN (TimetableSnapshotSource.java:1141) [feedId: mtba, tripId: mtba:104194] Failed to apply TripUpdate.
13:20:12.375 WARN (TimetableSnapshotSource.java:1141) [feedId: mtba, tripId: mtba:104194] No pattern found for tripId. Skipping cancellation.
13:20:12.375 WARN (TimetableSnapshotSource.java:1141) [feedId: mtba, tripId: mtba:104194] Failed to apply TripUpdate.
13:20:12.375 WARN (TimetableSnapshotSource.java:1141) [feedId: mtba, tripId: mtba:104181] No pattern found for tripId. Skipping cancellation.
13:20:12.375 WARN (TimetableSnapshotSource.java:1141) [feedId: mtba, tripId: mtba:104181] Failed to apply TripUpdate.
13:20:12.375 WARN (TimetableSnapshotSource.java:1141) [feedId: mtba, tripId: mtba:104181] No pattern found for tripId. Skipping cancellation.
13:20:12.375 WARN (TimetableSnapshotSource.java:1141) [feedId: mtba, tripId: mtba:104181] Failed to apply TripUpdate.
13:20:12.375 INFO (TimetableSnapshotSource.java:283) [feedId: mtba] 14 of 344 update messages were applied successfully
13:20:12.375 INFO (TimetableSnapshotSource.java:290) [feedId: mtba] Failures by scheduleRelationship {CANCELED=4, ADDED=326}
```

### Future work

What I really want to do in the future is to make all these methods return an `Optional<UpdateError>` rather than a boolean so you can have statistics about the sort of problems that are in the feed.

### Issue

no

### Unit tests

I reactivated the unit tests in a previous PR.

### Code style

yes

### Documentation

n/a

### Changelog

skip