### PR TITLE
Use modified timetables in planning

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.6.0 (2022-04-14)
+
+- Changed PatternHop timeLowerBound calculation, to use updated timetables
+- Added a configurable addStops-method to TimetableSnapshotSource, to help creating valid TripPatterns
+
 ## 1.5.0 (2020-11-27)
 
 - Add application/x-protobuf to accepted protobuf content-types (#2839)

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -650,6 +650,8 @@ Real-time data sources are configured in `router-config.json`. The `updaters` se
 of which has a `type` field and other configuration fields specific to that type. Common to all updater entries that
 connect to a network resource is the `url` field.
 
+There is an optional `addMissingStopsFromOriginalJourney` field, to add all stops from a journey for TripUpdates that may not have all stops.
+
 ```JSON
 // router-config.json
 {
@@ -726,6 +728,12 @@ connect to a network resource is the `url` field.
         // Streaming differential GTFS-RT TripUpdates over websockets
         {
             "type": "websocket-gtfs-rt-updater"
+        },
+
+        // Add missing stops for journeys that could miss stops
+        {
+          // other config-fields
+          "addMissingStopsFromOriginalJourney": true
         }
     ]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>org.opentripplanner</groupId>
     <artifactId>otp</artifactId>
-    <version>1.6.0-SNAPSHOT</version>
+    <version>1.6.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <licenses>

--- a/src/main/java/org/opentripplanner/routing/edgetype/PatternHop.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/PatternHop.java
@@ -7,6 +7,7 @@ import org.opentripplanner.model.Stop;
 import org.opentripplanner.common.geometry.GeometryUtils;
 import org.opentripplanner.common.geometry.SphericalDistanceLibrary;
 import org.opentripplanner.gtfs.GtfsLibrary;
+import org.opentripplanner.model.calendar.ServiceDate;
 import org.opentripplanner.routing.core.RoutingRequest;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.core.StateEditor;
@@ -89,6 +90,11 @@ public class PatternHop extends TablePatternEdge implements OnboardEdge, HopEdge
 
     @Override
     public double timeLowerBound(RoutingRequest options) {
+        // Find the timetable at the request date for this pattern, if it's available
+        if (options.rctx.timetableSnapshot != null) {
+            return options.rctx.timetableSnapshot.resolve(getPattern(), new ServiceDate(options.getDateTime()))
+                    .getBestRunningTime(stopIndex);
+        }
         return getPattern().scheduledTimetable.getBestRunningTime(stopIndex);
     }
 

--- a/src/main/java/org/opentripplanner/updater/stoptime/PollingStoptimeUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/PollingStoptimeUpdater.java
@@ -59,6 +59,13 @@ public class PollingStoptimeUpdater extends PollingGraphUpdater {
     private String feedId;
 
     /**
+     * StopTimeUpdates in TripUpdates can be incomplete in some translation cases (e.g. Dutch KV17 --> GTFS). The
+     * missing stops can be added automatically.
+     * default: false
+     */
+    private boolean addMissingStopsFromOriginalJourney = false;
+
+    /**
      * Set only if we should attempt to match the trip_id from other data in TripDescriptor
      */
     private GtfsRealtimeFuzzyTripMatcher fuzzyTripMatcher;
@@ -102,6 +109,7 @@ public class PollingStoptimeUpdater extends PollingGraphUpdater {
         if (config.path("fuzzyTripMatching").asBoolean(false)) {
             this.fuzzyTripMatcher = new GtfsRealtimeFuzzyTripMatcher(graph.index);
         }
+        this.addMissingStopsFromOriginalJourney = config.path("addMissingStopsFromOriginalJourney").asBoolean(false);
         LOG.info("Creating stop time updater running every {} seconds : {}", pollingPeriodSeconds, updateSource);
     }
 
@@ -127,6 +135,7 @@ public class PollingStoptimeUpdater extends PollingGraphUpdater {
         if (fuzzyTripMatcher != null) {
             snapshotSource.fuzzyTripMatcher = fuzzyTripMatcher;
         }
+        snapshotSource.addMissingStopsFromOriginalJourney = addMissingStopsFromOriginalJourney;
     }
 
     /**

--- a/src/test/java/org/opentripplanner/routing/edgetype/PatternHopTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/PatternHopTest.java
@@ -1,0 +1,99 @@
+package org.opentripplanner.routing.edgetype;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opentripplanner.model.*;
+import org.opentripplanner.model.calendar.ServiceDate;
+import org.opentripplanner.routing.core.RoutingContext;
+import org.opentripplanner.routing.core.RoutingRequest;
+import org.opentripplanner.routing.core.TraverseMode;
+import org.opentripplanner.routing.core.TraverseModeSet;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.routing.trippattern.Deduplicator;
+import org.opentripplanner.routing.trippattern.TripTimes;
+import org.opentripplanner.routing.vertextype.PatternStopVertex;
+import org.opentripplanner.updater.stoptime.TimetableSnapshotSource;
+
+import java.util.Date;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class PatternHopTest {
+
+    private Graph graph;
+    private Route route;
+    private StopPattern sp;
+    private final Stop s0 = new Stop();
+    private final Stop s1 = new Stop();
+    private StopTime st0;
+    private StopTime st1;
+
+    @Before
+    public void setUp() {
+        graph = new Graph();
+        route = new Route();
+
+        st0 = new StopTime();
+        st0.setStop(s0);
+        st0.setDepartureTime(10);
+        st1 = new StopTime();
+        st1.setStop(s1);
+        st1.setArrivalTime(15);
+
+        sp = new StopPattern(asList(st0, st1));
+    }
+
+    @Test
+    public void testThatTheSnapshotWillBeUsedForToday() {
+        TripPattern tp = new TripPattern(route, sp);
+
+        PatternStopVertex v0 = new PatternStopVertex(graph, "maple_0th", tp, s0);
+        PatternStopVertex v1 = new PatternStopVertex(graph, "maple_1st", tp, s1);
+
+        final RoutingRequest rrMock = mock(RoutingRequest.class);
+        final TimetableSnapshot tsMock = mock(TimetableSnapshot.class);
+        final Timetable ttMock = mock(Timetable.class);
+        final TimetableSnapshotSource tssMock = mock(TimetableSnapshotSource.class);
+
+        graph.timetableSnapshotSource = tssMock;
+
+        rrMock.modes = new TraverseModeSet(TraverseMode.TRANSIT);
+        when(rrMock.getDateTime()).thenReturn(new Date());
+        when(tssMock.getTimetableSnapshot()).thenReturn(tsMock);
+        when(tsMock.resolve(any(TripPattern.class), any(ServiceDate.class))).thenReturn(ttMock);
+        rrMock.rctx = new RoutingContext(rrMock, graph, v0, v1);
+
+        when(ttMock.getBestRunningTime(anyInt())).thenReturn(5);
+
+        assertEquals(5, new PatternHop(v0, v1, s0, s1, 0).timeLowerBound(rrMock), 4);
+    }
+
+    @Test
+    public void testThatTheScheduledTimetableWillBeUsed() {
+        graph = new Graph();
+
+        TripPattern tp = new TripPattern(route, sp);
+        tp.add(new TripTimes(new Trip(), asList(st0, st1), new Deduplicator()));
+        tp.scheduledTimetable.finish();
+
+        PatternStopVertex v0 = new PatternStopVertex(graph, "maple_0th", tp, s0);
+        PatternStopVertex v1 = new PatternStopVertex(graph, "maple_1st", tp, s1);
+
+        final RoutingRequest rrMock = mock(RoutingRequest.class);
+        final TimetableSnapshotSource tssMock = mock(TimetableSnapshotSource.class);
+
+        graph.timetableSnapshotSource = tssMock;
+
+        rrMock.modes = new TraverseModeSet(TraverseMode.TRANSIT);
+        when(rrMock.getDateTime()).thenReturn(new Date());
+        when(tssMock.getTimetableSnapshot()).thenReturn(null);
+        rrMock.rctx = new RoutingContext(rrMock, graph, v0, v1);
+
+        assertEquals(5, new PatternHop(v0, v1, s0, s1, 0).timeLowerBound(rrMock), 4);
+    }
+}


### PR DESCRIPTION
## PR Instructions

When creating a pull request, please follow the format below. For each section, *replace* the
guidance text with your own text, keeping the section heading. If you have nothing to say in a
particular section, you can completely delete the section including its heading to indicate that you
have taken the requested steps. None of these instructions or the guidance text (non-heading text)
should be present in the submitted PR. These sections serve as a checklist: when you have replaced
or deleted all of them, the PR is considered complete. As of 2021, most regular OTP contributors
participate in our twice-weekly conference calls. For all but the simplest and smallest PRs,
participation in these discussions is necessary to facilitate the review and merge process. Other
developers can ask questions and provide immediate feedback on technical design and code style, and
resolve any concerns about long term maintenance and comprehension of new code.

### Summary

There are two changes:
- mutated TripPatterns are now never (?) used in routes, due to MAX_INTEGER wait time, due to having no scheduledTimetable
- when a GTFS feed misses stops, due to a translation to that feed, those missing stops can be added automatically

### Issue

There has been a discussion for this problem [here](https://groups.google.com/g/opentripplanner-users/c/SiU-sgHggfg).
In short:
In the Netherlands, we use KV-messages for mutating and updating our journeys. The KV17-message is used to mutate a scheduled trip. We use an external service (OVApi) that translates all Dutch KV-messages and combines them in a single GTFS [feed](http://gtfs.ovapi.nl/nl/).
There are various KV17 message types, but the one causing problems is the SHORTEN-message. It skips (multiple) stops in a single journey. In the GTFS feed, these stops are SKIPPED.
However, when we use this feed, the resulting journeys are never used, and the trip is not usable anymore.

The solution in our case consists of two steps:
1. The translation only adds the first, the skipped and the first non-skipped stop. The resulting journey is not usable. So we've added an option to add all missing stops from the journey to the TripUpdate.
2. The new TripPattern, as generated in TimetableSnapshotSource, has no scheduledTimetable. However, this scheduledTimetable is used in the PatternHop, to find out in the heuristic step of A* if this pattern is useful. Due to having no scheduledTimetable, the resulting weight is MAX_INTEGER, and thus the new TripPattern is never used.

### Unit tests

We've added a test for the new functionality in the PatternHop, to verify it uses the correct timetable.
We've also added tests for the new functionality in TimetableSnapshotSource, for adding missing stops in the mutated journey.

### Code style

Yes!

### Documentation

Yes!

### Changelog

Yes!
