### PR TITLE
Fix generalized cost of flex direct legs [changelog skip]

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/flex/FlexIntegrationTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/flex/FlexIntegrationTest.java
@@ -17,6 +17,7 @@ import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -111,20 +112,22 @@ public class FlexIntegrationTest {
     // in the middle of flex zone
     var to = new GenericLocation(33.86701256815635, -84.61787939071655);
 
-    var itin = getItinerary(from, to, 0, true);
+    var itin = getItinerary(from, to, 1, true);
 
-    // walk, flex, walk
-    assertEquals(3, itin.legs.size());
+    // walk, flex
+    assertEquals(2, itin.legs.size());
+    assertEquals("2021-12-02T12:53:12-05:00[America/New_York]", itin.startTime().toString());
+    assertEquals(3173, itin.generalizedCost);
 
     var walkToFlex = itin.legs.get(0);
     assertEquals(TraverseMode.WALK, walkToFlex.getMode());
 
     var flex = itin.legs.get(1);
     assertEquals(BUS, flex.getMode());
-    assertEquals("Zone 1", flex.getRoute().getShortName());
+    assertEquals("Zone 2", flex.getRoute().getShortName());
     assertTrue(flex.isFlexibleTrip());
 
-    assertEquals("2021-12-02T12:30-05:00[America/New_York]", flex.getStartTime().toString());
+    assertEquals("2021-12-02T13:00-05:00[America/New_York]", flex.getStartTime().toString());
   }
 
   @BeforeAll
@@ -193,7 +196,7 @@ public class FlexIntegrationTest {
     GenericLocation from,
     GenericLocation to,
     int index,
-    boolean includeDirect
+    boolean onlyDirect
   ) {
     RoutingRequest request = new RoutingRequest();
     request.setDateTime(dateTime);
@@ -202,8 +205,9 @@ public class FlexIntegrationTest {
     request.numItineraries = 10;
     request.searchWindow = Duration.ofHours(2);
     request.modes.egressMode = FLEXIBLE;
-    if (includeDirect) {
+    if (onlyDirect) {
       request.modes.directMode = FLEXIBLE;
+      request.modes.transitModes = Set.of();
     }
 
     var result = service.route(request, router);

--- a/src/main/java/org/opentripplanner/model/plan/Itinerary.java
+++ b/src/main/java/org/opentripplanner/model/plan/Itinerary.java
@@ -242,7 +242,9 @@ public class Itinerary {
       .stream()
       .map(leg -> leg.withTimeShift(duration))
       .collect(Collectors.toList());
-    return new Itinerary(timeShiftedLegs);
+    var newItin = new Itinerary(timeShiftedLegs);
+    newItin.generalizedCost = generalizedCost;
+    return newItin;
   }
 
   /** @see #equals(Object) */

--- a/src/test/java/org/opentripplanner/routing/algorithm/filterchain/comparator/SortOrderComparatorTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/filterchain/comparator/SortOrderComparatorTest.java
@@ -1,6 +1,6 @@
 package org.opentripplanner.routing.algorithm.filterchain.comparator;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.model.plan.TestItineraryBuilder.newItinerary;
 import static org.opentripplanner.routing.algorithm.filterchain.comparator.SortOrderComparator.defaultComparatorArriveBy;
 import static org.opentripplanner.routing.algorithm.filterchain.comparator.SortOrderComparator.defaultComparatorDepartAfter;
@@ -9,7 +9,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.PlanTestConstants;
 

--- a/src/test/java/org/opentripplanner/routing/algorithm/filterchain/deletionflagger/MaxLimitFilterTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/filterchain/deletionflagger/MaxLimitFilterTest.java
@@ -1,12 +1,12 @@
 package org.opentripplanner.routing.algorithm.filterchain.deletionflagger;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.model.plan.Itinerary.toStr;
 import static org.opentripplanner.model.plan.TestItineraryBuilder.newItinerary;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.PlanTestConstants;
 import org.opentripplanner.routing.algorithm.filterchain.ListSection;

--- a/src/test/java/org/opentripplanner/routing/algorithm/filterchain/deletionflagger/RemoveTransitIfStreetOnlyIsBetterFilterTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/filterchain/deletionflagger/RemoveTransitIfStreetOnlyIsBetterFilterTest.java
@@ -1,11 +1,11 @@
 package org.opentripplanner.routing.algorithm.filterchain.deletionflagger;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.model.plan.Itinerary.toStr;
 import static org.opentripplanner.model.plan.TestItineraryBuilder.newItinerary;
 
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.PlanTestConstants;
 

--- a/src/test/java/org/opentripplanner/routing/algorithm/filterchain/deletionflagger/RemoveWalkOnlyFilterTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/filterchain/deletionflagger/RemoveWalkOnlyFilterTest.java
@@ -1,13 +1,13 @@
 package org.opentripplanner.routing.algorithm.filterchain.deletionflagger;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.model.plan.TestItineraryBuilder.A;
 import static org.opentripplanner.model.plan.TestItineraryBuilder.B;
 import static org.opentripplanner.model.plan.TestItineraryBuilder.E;
 import static org.opentripplanner.model.plan.TestItineraryBuilder.newItinerary;
 
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.util.time.DurationUtils;
 import org.opentripplanner.util.time.TimeUtils;

--- a/src/test/java/org/opentripplanner/routing/algorithm/filterchain/deletionflagger/TransitGeneralizedCostFilterTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/filterchain/deletionflagger/TransitGeneralizedCostFilterTest.java
@@ -1,11 +1,11 @@
 package org.opentripplanner.routing.algorithm.filterchain.deletionflagger;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.model.plan.Itinerary.toStr;
 import static org.opentripplanner.model.plan.TestItineraryBuilder.newItinerary;
 
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.PlanTestConstants;
 import org.opentripplanner.routing.api.request.RequestFunctions;


### PR DESCRIPTION
### Summary

When refactoring the itinerary in #4028 another bug was introduced where timeshifted flex itineries had an incorrect generalized cost of -1. This happened because during copying of the instance the variable was not set.

![Screenshot from 2022-04-20 11-04-25](https://user-images.githubusercontent.com/151346/164197044-da509ae9-f8b2-46db-9a6d-137cb86f7a84.png)

In this PR I'm making the variable generalized cost final so you must set it when constructing an Itinerary.

It also updates tests which were setting the cost after instantiation and migrates a few of them to Junit 5.

### Issue

non

### Unit tests

Test added.

### Code style

yes

### Documentation

none

### Changelog

skipped