### PR TITLE
Remove log error that frequencies are not supported [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/model/impl/OtpTransitServiceImpl.java
+++ b/src/main/java/org/opentripplanner/model/impl/OtpTransitServiceImpl.java
@@ -122,14 +122,7 @@ class OtpTransitServiceImpl implements OtpTransitService {
     this.transfers = immutableList(builder.getTransfers());
     this.tripPatterns = immutableList(builder.getTripPatterns().values());
     this.trips = immutableList(builder.getTripsById().values());
-    this.flexTrips = immutableList(builder.getFlexTripsById().values());
-
-    if (!builder.getFrequencies().isEmpty()) {
-      LOG.error(
-        "OTP2 do not support GTFS Trip Frequencies. " +
-        "See https://github.com/opentripplanner/OpenTripPlanner/issues/3243."
-      );
-    }
+    this.flexTrips = immutableList(builder.getFlexTripsById().values());    
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/model/impl/OtpTransitServiceImpl.java
+++ b/src/main/java/org/opentripplanner/model/impl/OtpTransitServiceImpl.java
@@ -122,7 +122,7 @@ class OtpTransitServiceImpl implements OtpTransitService {
     this.transfers = immutableList(builder.getTransfers());
     this.tripPatterns = immutableList(builder.getTripPatterns().values());
     this.trips = immutableList(builder.getTripsById().values());
-    this.flexTrips = immutableList(builder.getFlexTripsById().values());    
+    this.flexTrips = immutableList(builder.getFlexTripsById().values());
   }
 
   @Override


### PR DESCRIPTION
closes #4100 4100

## PR Instructions

In release 2.1 there is still a error logged that frequencies are not supported.

### Summary

Remove the logged error because frequencies are supported. 

### Issue

See #4100 


