### PR TITLE
Make dependency on Graph optional in TimetableSnapshotSource [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/updater/stoptime/MqttGtfsRealtimeUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/MqttGtfsRealtimeUpdater.java
@@ -71,7 +71,7 @@ public class MqttGtfsRealtimeUpdater implements GraphUpdater {
   public void setup(Graph graph) {
     // Only create a realtime data snapshot source if none exists already
     TimetableSnapshotSource snapshotSource = graph.getOrSetupTimetableSnapshotProvider(
-      TimetableSnapshotSource::new
+      TimetableSnapshotSource::ofGraph
     );
 
     // Set properties of realtime data snapshot source

--- a/src/main/java/org/opentripplanner/updater/stoptime/PollingStoptimeUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/PollingStoptimeUpdater.java
@@ -95,7 +95,7 @@ public class PollingStoptimeUpdater extends PollingGraphUpdater {
 
     // Only create a realtime data snapshot source if none exists already
     TimetableSnapshotSource snapshotSource = graph.getOrSetupTimetableSnapshotProvider(
-      TimetableSnapshotSource::new
+      TimetableSnapshotSource::ofGraph
     );
 
     // Set properties of realtime data snapshot source

--- a/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
@@ -758,7 +758,7 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
    * @param serviceDate service date
    * @return true if scheduled trip was cancelled
    */
-  private boolean cancelScheduledTrip(FeedScopedId tripId, final ServiceDate serviceDate) {
+  private boolean cancelScheduledTrip(final FeedScopedId tripId, final ServiceDate serviceDate) {
     boolean success = false;
 
     final TripPattern pattern = getPatternForTripId(tripId);
@@ -792,7 +792,10 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
    * @param serviceDate service date
    * @return true if a previously added trip was cancelled
    */
-  private boolean cancelPreviouslyAddedTrip(FeedScopedId tripId, final ServiceDate serviceDate) {
+  private boolean cancelPreviouslyAddedTrip(
+    final FeedScopedId tripId,
+    final ServiceDate serviceDate
+  ) {
     boolean success = false;
 
     final TripPattern pattern = buffer.getLastAddedTripPattern(tripId, serviceDate);

--- a/src/main/java/org/opentripplanner/updater/stoptime/TripUpdateGraphWriterRunnable.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/TripUpdateGraphWriterRunnable.java
@@ -3,12 +3,7 @@ package org.opentripplanner.updater.stoptime;
 import com.google.common.base.Preconditions;
 import com.google.transit.realtime.GtfsRealtime.TripUpdate;
 import java.util.List;
-import java.util.Map;
-import org.opentripplanner.model.FeedScopedId;
-import org.opentripplanner.model.calendar.CalendarService;
 import org.opentripplanner.routing.graph.Graph;
-import org.opentripplanner.routing.graph.GraphIndex;
-import org.opentripplanner.routing.trippattern.Deduplicator;
 import org.opentripplanner.updater.GraphWriterRunnable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,19 +47,7 @@ class TripUpdateGraphWriterRunnable implements GraphWriterRunnable {
     // TimetableSnapshotSource should already be set up
     TimetableSnapshotSource snapshotSource = graph.getOrSetupTimetableSnapshotProvider(null);
     if (snapshotSource != null) {
-      CalendarService calendarService = graph.getCalendarService();
-      Deduplicator deduplicator = graph.deduplicator;
-      GraphIndex graphIndex = graph.index;
-      Map<FeedScopedId, Integer> serviceCodes = graph.getServiceCodes();
-      snapshotSource.applyTripUpdates(
-        calendarService,
-        deduplicator,
-        graphIndex,
-        serviceCodes,
-        fullDataset,
-        updates,
-        feedId
-      );
+      snapshotSource.applyTripUpdates(fullDataset, updates, feedId);
     } else {
       LOG.error(
         "Could not find realtime data snapshot source in graph." +

--- a/src/main/java/org/opentripplanner/updater/stoptime/WebsocketGtfsRealtimeUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/WebsocketGtfsRealtimeUpdater.java
@@ -73,7 +73,7 @@ public class WebsocketGtfsRealtimeUpdater implements GraphUpdater {
   @Override
   public void setup(Graph graph) {
     // Only create a realtime data snapshot source if none exists already
-    graph.getOrSetupTimetableSnapshotProvider(TimetableSnapshotSource::new);
+    graph.getOrSetupTimetableSnapshotProvider(TimetableSnapshotSource::ofGraph);
   }
 
   @Override

--- a/src/test/java/org/opentripplanner/GtfsTest.java
+++ b/src/test/java/org/opentripplanner/GtfsTest.java
@@ -160,7 +160,7 @@ public abstract class GtfsTest {
     graph.index();
     router = new Router(graph, RouterConfig.DEFAULT, Metrics.globalRegistry);
     router.startup();
-    timetableSnapshotSource = new TimetableSnapshotSource(graph);
+    timetableSnapshotSource = TimetableSnapshotSource.ofGraph(graph);
     timetableSnapshotSource.purgeExpiredData = false;
     graph.getOrSetupTimetableSnapshotProvider(g -> timetableSnapshotSource);
     alertPatchServiceImpl = new TransitAlertServiceImpl(graph);
@@ -176,19 +176,7 @@ public abstract class GtfsTest {
       for (FeedEntity feedEntity : feedEntityList) {
         updates.add(feedEntity.getTripUpdate());
       }
-      CalendarService calendarService = graph.getCalendarService();
-      Deduplicator deduplicator = graph.deduplicator;
-      GraphIndex graphIndex = graph.index;
-      Map<FeedScopedId, Integer> serviceCodes = graph.getServiceCodes();
-      timetableSnapshotSource.applyTripUpdates(
-        calendarService,
-        deduplicator,
-        graphIndex,
-        serviceCodes,
-        fullDataset,
-        updates,
-        feedId.getId()
-      );
+      timetableSnapshotSource.applyTripUpdates(fullDataset, updates, feedId.getId());
       alertsUpdateHandler.update(feedMessage);
     } catch (Exception exception) {}
   }

--- a/src/test/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSourceTest.java
+++ b/src/test/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSourceTest.java
@@ -17,7 +17,6 @@ import com.google.transit.realtime.GtfsRealtime.TripUpdate.StopTimeUpdate;
 import java.time.LocalDate;
 import java.util.Calendar;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,11 +27,8 @@ import org.opentripplanner.model.Timetable;
 import org.opentripplanner.model.TimetableSnapshot;
 import org.opentripplanner.model.Trip;
 import org.opentripplanner.model.TripPattern;
-import org.opentripplanner.model.calendar.CalendarService;
 import org.opentripplanner.model.calendar.ServiceDate;
 import org.opentripplanner.routing.graph.Graph;
-import org.opentripplanner.routing.graph.GraphIndex;
-import org.opentripplanner.routing.trippattern.Deduplicator;
 import org.opentripplanner.routing.trippattern.RealTimeState;
 import org.opentripplanner.routing.trippattern.TripTimes;
 
@@ -66,38 +62,18 @@ public class TimetableSnapshotSourceTest {
 
   @BeforeEach
   public void setUp() {
-    updater = new TimetableSnapshotSource(graph);
+    updater = TimetableSnapshotSource.ofGraph(graph);
   }
 
   @Test
   public void testGetSnapshot() throws InvalidProtocolBufferException {
-    CalendarService calendarService = graph.getCalendarService();
-    Deduplicator deduplicator = graph.deduplicator;
-    GraphIndex graphIndex = graph.index;
-    Map<FeedScopedId, Integer> serviceCodes = graph.getServiceCodes();
-    updater.applyTripUpdates(
-      calendarService,
-      deduplicator,
-      graphIndex,
-      serviceCodes,
-      fullDataset,
-      List.of(TripUpdate.parseFrom(cancellation)),
-      feedId
-    );
+    updater.applyTripUpdates(fullDataset, List.of(TripUpdate.parseFrom(cancellation)), feedId);
 
     final TimetableSnapshot snapshot = updater.getTimetableSnapshot();
     assertNotNull(snapshot);
     assertSame(snapshot, updater.getTimetableSnapshot());
 
-    updater.applyTripUpdates(
-      calendarService,
-      deduplicator,
-      graphIndex,
-      serviceCodes,
-      fullDataset,
-      List.of(TripUpdate.parseFrom(cancellation)),
-      feedId
-    );
+    updater.applyTripUpdates(fullDataset, List.of(TripUpdate.parseFrom(cancellation)), feedId);
     assertSame(snapshot, updater.getTimetableSnapshot());
 
     updater.maxSnapshotFrequency = (-1);
@@ -115,20 +91,7 @@ public class TimetableSnapshotSourceTest {
     final int tripIndex = pattern.getScheduledTimetable().getTripIndex(tripId);
     final int tripIndex2 = pattern.getScheduledTimetable().getTripIndex(tripId2);
 
-    CalendarService calendarService = graph.getCalendarService();
-    Deduplicator deduplicator = graph.deduplicator;
-    GraphIndex graphIndex = graph.index;
-    Map<FeedScopedId, Integer> serviceCodes = graph.getServiceCodes();
-
-    updater.applyTripUpdates(
-      calendarService,
-      deduplicator,
-      graphIndex,
-      serviceCodes,
-      fullDataset,
-      List.of(TripUpdate.parseFrom(cancellation)),
-      feedId
-    );
+    updater.applyTripUpdates(fullDataset, List.of(TripUpdate.parseFrom(cancellation)), feedId);
 
     final TimetableSnapshot snapshot = updater.getTimetableSnapshot();
     final Timetable forToday = snapshot.resolve(pattern, serviceDate);
@@ -173,19 +136,7 @@ public class TimetableSnapshotSourceTest {
 
     final TripUpdate tripUpdate = tripUpdateBuilder.build();
 
-    CalendarService calendarService = graph.getCalendarService();
-    Deduplicator deduplicator = graph.deduplicator;
-    GraphIndex graphIndex = graph.index;
-    Map<FeedScopedId, Integer> serviceCodes = graph.getServiceCodes();
-    updater.applyTripUpdates(
-      calendarService,
-      deduplicator,
-      graphIndex,
-      serviceCodes,
-      fullDataset,
-      List.of(tripUpdate),
-      feedId
-    );
+    updater.applyTripUpdates(fullDataset, List.of(tripUpdate), feedId);
 
     final TimetableSnapshot snapshot = updater.getTimetableSnapshot();
     final Timetable forToday = snapshot.resolve(pattern, serviceDate);
@@ -221,19 +172,7 @@ public class TimetableSnapshotSourceTest {
         tripUpdateBuilder.setTrip(tripDescriptorBuilder);
         var tripUpdate = tripUpdateBuilder.build();
 
-        CalendarService calendarService = graph.getCalendarService();
-        Deduplicator deduplicator = graph.deduplicator;
-        GraphIndex graphIndex = graph.index;
-        Map<FeedScopedId, Integer> serviceCodes = graph.getServiceCodes();
-        updater.applyTripUpdates(
-          calendarService,
-          deduplicator,
-          graphIndex,
-          serviceCodes,
-          fullDataset,
-          List.of(tripUpdate),
-          feedId
-        );
+        updater.applyTripUpdates(fullDataset, List.of(tripUpdate), feedId);
 
         var snapshot = updater.getTimetableSnapshot();
         assertNull(snapshot);
@@ -328,20 +267,7 @@ public class TimetableSnapshotSourceTest {
     }
 
     // WHEN
-    CalendarService calendarService = graph.getCalendarService();
-    Deduplicator deduplicator = graph.deduplicator;
-    GraphIndex graphIndex = graph.index;
-
-    Map<FeedScopedId, Integer> serviceCodes = graph.getServiceCodes();
-    updater.applyTripUpdates(
-      calendarService,
-      deduplicator,
-      graphIndex,
-      serviceCodes,
-      fullDataset,
-      List.of(tripUpdate),
-      feedId
-    );
+    updater.applyTripUpdates(fullDataset, List.of(tripUpdate), feedId);
 
     // THEN
     // Find new pattern in graph starting from stop A
@@ -482,19 +408,7 @@ public class TimetableSnapshotSourceTest {
     }
 
     // WHEN
-    CalendarService calendarService = graph.getCalendarService();
-    Deduplicator deduplicator = graph.deduplicator;
-    GraphIndex graphIndex = graph.index;
-    Map<FeedScopedId, Integer> serviceCodes = graph.getServiceCodes();
-    updater.applyTripUpdates(
-      calendarService,
-      deduplicator,
-      graphIndex,
-      serviceCodes,
-      fullDataset,
-      List.of(tripUpdate),
-      feedId
-    );
+    updater.applyTripUpdates(fullDataset, List.of(tripUpdate), feedId);
 
     // THEN
     final TimetableSnapshot snapshot = updater.getTimetableSnapshot();
@@ -587,19 +501,7 @@ public class TimetableSnapshotSourceTest {
     updater.maxSnapshotFrequency = 0;
     updater.purgeExpiredData = false;
 
-    CalendarService calendarService = graph.getCalendarService();
-    Deduplicator deduplicator = graph.deduplicator;
-    GraphIndex graphIndex = graph.index;
-    Map<FeedScopedId, Integer> serviceCodes = graph.getServiceCodes();
-    updater.applyTripUpdates(
-      calendarService,
-      deduplicator,
-      graphIndex,
-      serviceCodes,
-      fullDataset,
-      List.of(TripUpdate.parseFrom(cancellation)),
-      feedId
-    );
+    updater.applyTripUpdates(fullDataset, List.of(TripUpdate.parseFrom(cancellation)), feedId);
     final TimetableSnapshot snapshotA = updater.getTimetableSnapshot();
 
     updater.purgeExpiredData = true;
@@ -616,15 +518,7 @@ public class TimetableSnapshotSourceTest {
 
     final TripUpdate tripUpdate = tripUpdateBuilder.build();
 
-    updater.applyTripUpdates(
-      calendarService,
-      deduplicator,
-      graphIndex,
-      serviceCodes,
-      fullDataset,
-      List.of(tripUpdate),
-      feedId
-    );
+    updater.applyTripUpdates(fullDataset, List.of(tripUpdate), feedId);
     final TimetableSnapshot snapshotB = updater.getTimetableSnapshot();
 
     assertNotSame(snapshotA, snapshotB);


### PR DESCRIPTION
### Summary

In a previous PR by @optionsome I requested that some parameters from `Graph` are passed along in the method chains. I now see that it was a mistake. Sorry, @optionsome.

This moves the parameters from the method calls to the constructors and I think this makes the code much cleaner.

I also made it possible to instantiate a `TimetableSnapshotSource` without having an instance of `Graph`. This will enable easier tests in the future.

### Issue

None.

### Unit tests

I re-enabled tests previously.

### Code style

yes.

### Documentation
n/a

### Changelog

Skip.