### PR TITLE
Use correct routing request when traversing transfers [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
@@ -272,7 +272,12 @@ public class RaptorPathToItineraryMapper {
       // may be re-traversed to create the leg(s) from the list of edges.
       RoutingRequest traverseRequest = Transfer.prepareTransferRoutingRequest(request);
       traverseRequest.arriveBy = false;
-      RoutingContext routingContext = new RoutingContext(request, graph, (Vertex) null, null);
+      RoutingContext routingContext = new RoutingContext(
+        traverseRequest,
+        graph,
+        (Vertex) null,
+        null
+      );
 
       StateEditor se = new StateEditor(routingContext, edges.get(0).getFromVertex());
       se.setTimeSeconds(createZonedDateTime(pathLeg.fromTime()).toEpochSecond());


### PR DESCRIPTION
### Summary

In #4041, I made an error when creating the routing context for traversing Transfers. This is wrong in arrive-by searches. This PR makes use of the correct RoutingRequest.
