### PR TITLE
How about turning off the default build reports generation feature [changelog skip]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -232,7 +232,7 @@
                         --add-opens java.xml/org.xml.sax.helpers=ALL-UNNAMED
                     </argLine>
                     <!-- Jenkins needs XML test reports to determine whether the build is stable. -->
-                    <disableXmlReport>false</disableXmlReport>
+                    <disableXmlReport>true</disableXmlReport>
                     <trimStackTrace>false</trimStackTrace>
                 </configuration>
             </plugin>


### PR DESCRIPTION

That report generation takes time, slowing down the overall build. Reports are definitely useful, but do you need them every time you run the build. We can conditionally disable generating test reports by setting `<disableXmlReport>true<disableXmlReport>`. If you need to generate reports, just add `-DcloseTestReports=false` to the end of mvn build command.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
