### PR TITLE
Remove commons-math3 dependency and use internal java alternative [changelog skip]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -731,11 +731,6 @@
             <version>1.82</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-math3</artifactId>
-            <version>3.6.1</version>
-        </dependency>
-        <dependency>
             <groupId>com.graphql-java</groupId>
             <artifactId>graphql-java</artifactId>
             <version>17.3</version>

--- a/src/main/java/com/jhlabs/awt/TextStroke.java
+++ b/src/main/java/com/jhlabs/awt/TextStroke.java
@@ -14,7 +14,6 @@ import java.awt.geom.FlatteningPathIterator;
 import java.awt.geom.GeneralPath;
 import java.awt.geom.PathIterator;
 import java.awt.geom.Point2D;
-import org.apache.commons.math3.util.FastMath;
 
 /**
  * Stroke that paint a text.
@@ -86,10 +85,10 @@ public class TextStroke implements Stroke {
           thisY = points[1];
           float dx = thisX - lastX;
           float dy = thisY - lastY;
-          float distance = (float) FastMath.sqrt(dx * dx + dy * dy);
+          float distance = (float) Math.sqrt(dx * dx + dy * dy);
           if (distance >= next) {
             float r = 1.0f / distance;
-            float angle = (float) FastMath.atan2(dy, dx);
+            float angle = (float) Math.atan2(dy, dx);
             while (currentChar < length && distance >= next) {
               Shape glyph = glyphVector.getGlyphOutline(currentChar);
               Point2D p = glyphVector.getGlyphPosition(currentChar);

--- a/src/main/java/org/opentripplanner/common/geometry/DirectionUtils.java
+++ b/src/main/java/org/opentripplanner/common/geometry/DirectionUtils.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.common.geometry;
 
-import org.apache.commons.math3.util.FastMath;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.LineString;
@@ -17,13 +16,13 @@ public class DirectionUtils {
    * in the range (-180° to +180°). The computation is exact for small delta between A and B.
    */
   public static synchronized double getAzimuth(Coordinate a, Coordinate b) {
-    double cosLat = FastMath.cos(FastMath.toRadians((a.y + b.y) / 2.0));
+    double cosLat = Math.cos(Math.toRadians((a.y + b.y) / 2.0));
     double dY = (b.y - a.y); // in degrees, we do not care about the units
     double dX = (b.x - a.x) * cosLat; // same
     if (Math.abs(dX) < 1e-10 && Math.abs(dY) < 1e-10) {
       return 180;
     }
-    return FastMath.toDegrees(FastMath.atan2(dX, dY));
+    return Math.toDegrees(Math.atan2(dX, dY));
   }
 
   /**

--- a/src/main/java/org/opentripplanner/common/geometry/SphericalDistanceLibrary.java
+++ b/src/main/java/org/opentripplanner/common/geometry/SphericalDistanceLibrary.java
@@ -1,14 +1,13 @@
 package org.opentripplanner.common.geometry;
 
-import static org.apache.commons.math3.util.FastMath.abs;
-import static org.apache.commons.math3.util.FastMath.atan2;
-import static org.apache.commons.math3.util.FastMath.cos;
-import static org.apache.commons.math3.util.FastMath.sin;
-import static org.apache.commons.math3.util.FastMath.sqrt;
-import static org.apache.commons.math3.util.FastMath.toDegrees;
-import static org.apache.commons.math3.util.FastMath.toRadians;
+import static java.lang.Math.abs;
+import static java.lang.Math.atan2;
+import static java.lang.Math.cos;
+import static java.lang.Math.sin;
+import static java.lang.Math.sqrt;
+import static java.lang.Math.toDegrees;
+import static java.lang.Math.toRadians;
 
-import org.apache.commons.math3.util.FastMath;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.LineString;
@@ -52,9 +51,9 @@ public abstract class SphericalDistanceLibrary {
   public static double fastDistance(Coordinate point, LineString lineString) {
     // Transform in equirectangular projection on sphere of radius 1,
     // centered at point
-    double lat = Math.toRadians(point.y);
-    double cosLat = FastMath.cos(lat);
-    double lon = Math.toRadians(point.x) * cosLat;
+    double lat = toRadians(point.y);
+    double cosLat = cos(lat);
+    double lon = toRadians(point.x) * cosLat;
     Point point2 = GeometryUtils.getGeometryFactory().createPoint(new Coordinate(lon, lat));
     LineString lineString2 = equirectangularProject(lineString, cosLat);
     return lineString2.distance(point2) * RADIUS_OF_EARTH_IN_M;
@@ -87,7 +86,7 @@ public abstract class SphericalDistanceLibrary {
     // for degenerated geometry (same first/last point).
     Coordinate[] coordinates = lineString.getCoordinates();
     double middleY = (coordinates[0].y + coordinates[coordinates.length - 1].y) / 2.0;
-    double cosLat = FastMath.cos(Math.toRadians(middleY));
+    double cosLat = cos(toRadians(middleY));
     return equirectangularProject(lineString, cosLat).getLength() * RADIUS_OF_EARTH_IN_M;
   }
 
@@ -184,9 +183,9 @@ public abstract class SphericalDistanceLibrary {
      */
     double minCosLat;
     if (latDeg > 0) {
-      minCosLat = FastMath.cos(FastMath.toRadians(latDeg + dLatDeg));
+      minCosLat = cos(toRadians(latDeg + dLatDeg));
     } else {
-      minCosLat = FastMath.cos(FastMath.toRadians(latDeg - dLatDeg));
+      minCosLat = cos(toRadians(latDeg - dLatDeg));
     }
     return dLatDeg / minCosLat;
   }
@@ -221,8 +220,7 @@ public abstract class SphericalDistanceLibrary {
     Coordinate[] coords = lineString.getCoordinates();
     Coordinate[] coords2 = new Coordinate[coords.length];
     for (int i = 0; i < coords.length; i++) {
-      coords2[i] =
-        new Coordinate(Math.toRadians(coords[i].x) * cosLat, Math.toRadians(coords[i].y));
+      coords2[i] = new Coordinate(toRadians(coords[i].x) * cosLat, toRadians(coords[i].y));
     }
     return GeometryUtils.getGeometryFactory().createLineString(coords2);
   }

--- a/src/main/java/org/opentripplanner/graph_builder/module/geometry/GeometryAndBlockProcessor.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/geometry/GeometryAndBlockProcessor.java
@@ -14,7 +14,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import org.apache.commons.math3.util.FastMath;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.CoordinateSequence;
 import org.locationtech.jts.geom.Geometry;
@@ -343,7 +342,7 @@ public class GeometryAndBlockProcessor {
         Coordinate to = shape.getCoordinateN(j + 1);
         double xd = from.x - to.x;
         double yd = from.y - to.y;
-        distanceSoFar += FastMath.sqrt(xd * xd + yd * yd);
+        distanceSoFar += Math.sqrt(xd * xd + yd * yd);
       }
       last = startLocation.getSegmentIndex();
 
@@ -355,7 +354,7 @@ public class GeometryAndBlockProcessor {
         Coordinate to = shape.getCoordinateN(j + 1);
         double xd = from.x - to.x;
         double yd = from.y - to.y;
-        distanceSoFar += FastMath.sqrt(xd * xd + yd * yd);
+        distanceSoFar += Math.sqrt(xd * xd + yd * yd);
       }
       last = startLocation.getSegmentIndex();
       double endIndex =

--- a/src/main/java/org/opentripplanner/graph_builder/module/geometry/IndexedLineSegment.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/geometry/IndexedLineSegment.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.graph_builder.module.geometry;
 
-import org.apache.commons.math3.util.FastMath;
 import org.locationtech.jts.geom.Coordinate;
 import org.opentripplanner.common.geometry.SphericalDistanceLibrary;
 
@@ -39,17 +38,17 @@ class IndexedLineSegment {
 
   // in radians
   static double bearing(Coordinate c1, Coordinate c2) {
-    double deltaLon = (c2.x - c1.x) * FastMath.PI / 180;
-    double lat1Radians = c1.y * FastMath.PI / 180;
-    double lat2Radians = c2.y * FastMath.PI / 180;
-    double y = FastMath.sin(deltaLon) * FastMath.cos(lat2Radians);
+    double deltaLon = (c2.x - c1.x) * Math.PI / 180;
+    double lat1Radians = c1.y * Math.PI / 180;
+    double lat2Radians = c2.y * Math.PI / 180;
+    double y = Math.sin(deltaLon) * Math.cos(lat2Radians);
     double x =
-      FastMath.cos(lat1Radians) *
-      FastMath.sin(lat2Radians) -
-      FastMath.sin(lat1Radians) *
-      FastMath.cos(lat2Radians) *
-      FastMath.cos(deltaLon);
-    return FastMath.atan2(y, x);
+      Math.cos(lat1Radians) *
+      Math.sin(lat2Radians) -
+      Math.sin(lat1Radians) *
+      Math.cos(lat2Radians) *
+      Math.cos(deltaLon);
+    return Math.atan2(y, x);
   }
 
   double crossTrackError(Coordinate coord) {
@@ -57,9 +56,7 @@ class IndexedLineSegment {
     double bearingToCoord = bearing(start, coord);
     double bearingToEnd = bearing(start, end);
     return (
-      FastMath.asin(
-        FastMath.sin(distanceFromStart / RADIUS) * FastMath.sin(bearingToCoord - bearingToEnd)
-      ) *
+      Math.asin(Math.sin(distanceFromStart / RADIUS) * Math.sin(bearingToCoord - bearingToEnd)) *
       RADIUS
     );
   }
@@ -95,9 +92,7 @@ class IndexedLineSegment {
   private double inverseAlongTrackDistance(Coordinate coord, double inverseCrossTrackError) {
     double distanceFromEnd = SphericalDistanceLibrary.fastDistance(end, coord);
     return (
-      FastMath.acos(
-        FastMath.cos(distanceFromEnd / RADIUS) / FastMath.cos(inverseCrossTrackError / RADIUS)
-      ) *
+      Math.acos(Math.cos(distanceFromEnd / RADIUS) / Math.cos(inverseCrossTrackError / RADIUS)) *
       RADIUS
     );
   }
@@ -105,10 +100,7 @@ class IndexedLineSegment {
   private double alongTrackDistance(Coordinate coord, double crossTrackError) {
     double distanceFromStart = SphericalDistanceLibrary.fastDistance(start, coord);
     return (
-      FastMath.acos(
-        FastMath.cos(distanceFromStart / RADIUS) / FastMath.cos(crossTrackError / RADIUS)
-      ) *
-      RADIUS
+      Math.acos(Math.cos(distanceFromStart / RADIUS) / Math.cos(crossTrackError / RADIUS)) * RADIUS
     );
   }
 }

--- a/src/main/java/org/opentripplanner/graph_builder/module/geometry/IndexedLineSegmentComparator.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/geometry/IndexedLineSegmentComparator.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.graph_builder.module.geometry;
 
 import java.util.Comparator;
-import org.apache.commons.math3.util.FastMath;
 import org.locationtech.jts.geom.Coordinate;
 
 class IndexedLineSegmentComparator implements Comparator<IndexedLineSegment> {
@@ -14,6 +13,6 @@ class IndexedLineSegmentComparator implements Comparator<IndexedLineSegment> {
 
   @Override
   public int compare(IndexedLineSegment a, IndexedLineSegment b) {
-    return (int) FastMath.signum(a.distance(coord) - b.distance(coord));
+    return (int) Math.signum(a.distance(coord) - b.distance(coord));
   }
 }

--- a/src/main/java/org/opentripplanner/routing/graph/Graph.java
+++ b/src/main/java/org/opentripplanner/routing/graph/Graph.java
@@ -4,8 +4,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
-import gnu.trove.list.TDoubleList;
-import gnu.trove.list.linked.TDoubleLinkedList;
 import gnu.trove.set.hash.TIntHashSet;
 import java.io.IOException;
 import java.io.ObjectInputStream;
@@ -31,7 +29,6 @@ import java.util.prefs.Preferences;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
-import org.apache.commons.math3.stat.descriptive.rank.Median;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
@@ -781,24 +778,14 @@ public class Graph implements Serializable {
    */
   public void calculateTransitCenter() {
     if (hasTransit) {
-      TDoubleList latitudes = new TDoubleLinkedList();
-      TDoubleList longitudes = new TDoubleLinkedList();
-      Median median = new Median();
+      Envelope tempEnvelope = new Envelope();
 
       getVerticesOfType(TransitStopVertex.class)
-        .stream()
         .forEach(v -> {
-          latitudes.add(v.getLat());
-          longitudes.add(v.getLon());
+          tempEnvelope.expandToInclude(v.getLon(), v.getLat());
         });
 
-      median.setData(latitudes.toArray());
-      double medianLatitude = median.evaluate();
-      median = new Median();
-      median.setData(longitudes.toArray());
-      double medianLongitude = median.evaluate();
-
-      this.center = new Coordinate(medianLongitude, medianLatitude);
+      this.center = tempEnvelope.centre();
     }
   }
 

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/BikeRentalSnapshotTest.snap
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/BikeRentalSnapshotTest.snap
@@ -261,7 +261,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
           "agencyUrl": "http://trimet.org",
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distance": 1629.4275918538026,
+          "distance": 1629.427591853719,
           "endTime": "2009-10-21T23:30:00.000+00:00",
           "from": {
             "arrival": "2009-10-21T23:20:25.000+00:00",
@@ -608,7 +608,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
           "agencyUrl": "http://trimet.org",
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distance": 1879.0379409561187,
+          "distance": 1879.0379409581171,
           "endTime": "2009-10-21T23:32:52.000+00:00",
           "from": {
             "arrival": "2009-10-21T23:23:59.000+00:00",
@@ -1020,7 +1020,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
           "agencyUrl": "http://trimet.org",
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distance": 2044.4088086831664,
+          "distance": 2044.408808683184,
           "endTime": "2009-10-21T23:34:00.000+00:00",
           "from": {
             "arrival": "2009-10-21T23:23:59.000+00:00",
@@ -1406,7 +1406,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
           "agencyUrl": "http://trimet.org",
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distance": 2804.1297859664874,
+          "distance": 2804.129785965508,
           "endTime": "2009-10-21T23:39:32.000+00:00",
           "from": {
             "arrival": "2009-10-21T23:26:21.000+00:00",
@@ -1874,7 +1874,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
           "agencyUrl": "http://trimet.org",
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distance": 1629.4275918538026,
+          "distance": 1629.427591853719,
           "endTime": "2009-10-21T23:43:00.000+00:00",
           "from": {
             "arrival": "2009-10-21T23:33:25.000+00:00",
@@ -2329,7 +2329,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
           "agencyUrl": "http://trimet.org",
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distance": 1629.4275918538026,
+          "distance": 1629.427591853719,
           "endTime": "2009-10-21T23:52:00.000+00:00",
           "from": {
             "arrival": "2009-10-21T23:42:25.000+00:00",
@@ -3301,7 +3301,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
           "agencyUrl": "http://trimet.org",
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distance": 1631.0313510234191,
+          "distance": 1631.0313510226179,
           "endTime": "2009-10-21T23:23:32.000+00:00",
           "from": {
             "arrival": "2009-10-21T23:14:50.000+00:00",
@@ -3808,7 +3808,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
           "agencyUrl": "http://trimet.org",
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distance": 1942.2498485359197,
+          "distance": 1942.2498485359536,
           "endTime": "2009-10-21T23:28:03.000+00:00",
           "from": {
             "arrival": "2009-10-21T23:18:00.000+00:00",
@@ -4220,7 +4220,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
           "agencyUrl": "http://trimet.org",
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distance": 2232.3107878360292,
+          "distance": 2232.3107878389246,
           "endTime": "2009-10-21T23:29:50.000+00:00",
           "from": {
             "arrival": "2009-10-21T23:21:53.000+00:00",
@@ -4580,7 +4580,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
           "agencyUrl": "http://trimet.org",
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distance": 1631.0313510234191,
+          "distance": 1631.0313510226179,
           "endTime": "2009-10-21T23:38:32.000+00:00",
           "from": {
             "arrival": "2009-10-21T23:29:50.000+00:00",
@@ -5087,7 +5087,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
           "agencyUrl": "http://trimet.org",
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distance": 1942.2498485359197,
+          "distance": 1942.2498485359536,
           "endTime": "2009-10-21T23:44:03.000+00:00",
           "from": {
             "arrival": "2009-10-21T23:33:00.000+00:00",
@@ -5499,7 +5499,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
           "agencyUrl": "http://trimet.org",
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distance": 2232.3107878360292,
+          "distance": 2232.3107878389246,
           "endTime": "2009-10-21T23:48:50.000+00:00",
           "from": {
             "arrival": "2009-10-21T23:40:53.000+00:00",

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/ElevationSnapshotTest.snap
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/ElevationSnapshotTest.snap
@@ -264,7 +264,7 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
           "agencyUrl": "http://trimet.org",
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distance": 1629.4275918538026,
+          "distance": 1629.427591853719,
           "endTime": "2009-10-21T23:30:00.000+00:00",
           "from": {
             "arrival": "2009-10-21T23:20:25.000+00:00",
@@ -574,7 +574,7 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
           "agencyUrl": "http://trimet.org",
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distance": 2804.1297859664874,
+          "distance": 2804.129785965508,
           "endTime": "2009-10-21T23:39:32.000+00:00",
           "from": {
             "arrival": "2009-10-21T23:26:21.000+00:00",
@@ -1046,7 +1046,7 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
           "agencyUrl": "http://trimet.org",
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distance": 1629.4275918538026,
+          "distance": 1629.427591853719,
           "endTime": "2009-10-21T23:43:00.000+00:00",
           "from": {
             "arrival": "2009-10-21T23:33:25.000+00:00",
@@ -1505,7 +1505,7 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
           "agencyUrl": "http://trimet.org",
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distance": 1629.4275918538026,
+          "distance": 1629.427591853719,
           "endTime": "2009-10-21T23:52:00.000+00:00",
           "from": {
             "arrival": "2009-10-21T23:42:25.000+00:00",
@@ -1815,7 +1815,7 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
           "agencyUrl": "http://trimet.org",
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distance": 2804.1297859664874,
+          "distance": 2804.129785965508,
           "endTime": "2009-10-21T23:55:32.000+00:00",
           "from": {
             "arrival": "2009-10-21T23:42:21.000+00:00",
@@ -2287,7 +2287,7 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
           "agencyUrl": "http://trimet.org",
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distance": 1629.4275918538026,
+          "distance": 1629.427591853719,
           "endTime": "2009-10-22T00:01:00.000+00:00",
           "from": {
             "arrival": "2009-10-21T23:51:25.000+00:00",
@@ -3184,7 +3184,7 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.transit=[
           "agencyUrl": "http://trimet.org",
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distance": 1631.0313510234191,
+          "distance": 1631.0313510226179,
           "endTime": "2009-10-21T23:23:32.000+00:00",
           "from": {
             "arrival": "2009-10-21T23:14:50.000+00:00",
@@ -3559,7 +3559,7 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.transit=[
           "agencyUrl": "http://trimet.org",
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distance": 1942.2498485359197,
+          "distance": 1942.2498485359536,
           "endTime": "2009-10-21T23:28:03.000+00:00",
           "from": {
             "arrival": "2009-10-21T23:18:00.000+00:00",
@@ -3973,7 +3973,7 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.transit=[
           "agencyUrl": "http://trimet.org",
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distance": 2232.3107878360292,
+          "distance": 2232.3107878389246,
           "endTime": "2009-10-21T23:29:50.000+00:00",
           "from": {
             "arrival": "2009-10-21T23:21:53.000+00:00",
@@ -4348,7 +4348,7 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.transit=[
           "agencyUrl": "http://trimet.org",
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distance": 2504.4167988693757,
+          "distance": 2504.4167988683976,
           "endTime": "2009-10-21T23:42:47.000+00:00",
           "from": {
             "arrival": "2009-10-21T23:29:00.000+00:00",
@@ -4788,7 +4788,7 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.transit=[
           "agencyUrl": "http://trimet.org",
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distance": 1631.0313510234191,
+          "distance": 1631.0313510226179,
           "endTime": "2009-10-21T23:38:32.000+00:00",
           "from": {
             "arrival": "2009-10-21T23:29:50.000+00:00",
@@ -5163,7 +5163,7 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.transit=[
           "agencyUrl": "http://trimet.org",
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distance": 1942.2498485359197,
+          "distance": 1942.2498485359536,
           "endTime": "2009-10-21T23:44:03.000+00:00",
           "from": {
             "arrival": "2009-10-21T23:33:00.000+00:00",

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/TransitSnapshotTest.snap
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/TransitSnapshotTest.snap
@@ -309,7 +309,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           "agencyUrl": "http://trimet.org",
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distance": 3729.9737283822847,
+          "distance": 3729.973728382417,
           "endTime": "2009-11-17T18:26:49.000+00:00",
           "from": {
             "arrival": "2009-11-17T18:14:00.000+00:00",
@@ -776,7 +776,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           "agencyUrl": "http://trimet.org",
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distance": 3729.9737283822847,
+          "distance": 3729.973728382417,
           "endTime": "2009-11-17T18:42:19.000+00:00",
           "from": {
             "arrival": "2009-11-17T18:29:00.000+00:00",
@@ -1243,7 +1243,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           "agencyUrl": "http://trimet.org",
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distance": 3729.9737283822847,
+          "distance": 3729.973728382417,
           "endTime": "2009-11-17T18:57:49.000+00:00",
           "from": {
             "arrival": "2009-11-17T18:45:00.000+00:00",
@@ -1701,7 +1701,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           "agencyUrl": "http://trimet.org",
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distance": 1355.2067620852858,
+          "distance": 1355.2067620849755,
           "endTime": "2009-11-17T18:51:01.000+00:00",
           "from": {
             "arrival": "2009-11-17T18:46:00.000+00:00",
@@ -1812,7 +1812,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           "agencyUrl": "http://trimet.org",
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distance": 3838.714938283576,
+          "distance": 3838.7149382852913,
           "endTime": "2009-11-17T19:08:50.000+00:00",
           "from": {
             "arrival": "2009-11-17T18:51:01.000+00:00",
@@ -2214,7 +2214,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           "agencyUrl": "http://trimet.org",
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distance": 4569.033127779713,
+          "distance": 4569.033127778724,
           "endTime": "2009-11-17T19:21:00.000+00:00",
           "from": {
             "arrival": "2009-11-17T19:02:00.000+00:00",


### PR DESCRIPTION
## PR Instructions

When creating a pull request, please follow the format below. For each section, *replace* the
guidance text with your own text, keeping the section heading. If you have nothing to say in a
particular section, you can completely delete the section including its heading to indicate that you
have taken the requested steps. None of these instructions or the guidance text (non-heading text)
should be present in the submitted PR. These sections serve as a checklist: when you have replaced
or deleted all of them, the PR is considered complete. As of 2021, most regular OTP contributors
participate in our twice-weekly conference calls. For all but the simplest and smallest PRs,
participation in these discussions is necessary to facilitate the review and merge process. Other
developers can ask questions and provide immediate feedback on technical design and code style, and
resolve any concerns about long term maintenance and comprehension of new code.

### Summary

The scope of this PR is to remove unneeded commons-math3 dependency and reduce the overall shaded jar size with about 2.3 Mb.

### Issue

There is no functional issue just an improvement in used dependencies. I believe is not useful to bring big dependencies for using a very small part of them. This change aims to remove a dependency that is barely used and reduce the fat jar size. 

### Unit tests
As seen in the PR unit test had to be barely updated since the calculation outcome is a bit different because of using Math instead of FastMath for calculations 
