### PR TITLE
Switch from internal jcommander implementation usage to guava [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/api/model/ApiPatternDetail.java
+++ b/src/main/java/org/opentripplanner/api/model/ApiPatternDetail.java
@@ -1,6 +1,6 @@
 package org.opentripplanner.api.model;
 
-import com.beust.jcommander.internal.Lists;
+import com.google.common.collect.Lists;
 import java.util.Collection;
 
 public class ApiPatternDetail extends ApiPatternShort {

--- a/src/main/java/org/opentripplanner/api/parameter/QualifiedModeSet.java
+++ b/src/main/java/org/opentripplanner/api/parameter/QualifiedModeSet.java
@@ -1,6 +1,6 @@
 package org.opentripplanner.api.parameter;
 
-import com.beust.jcommander.internal.Sets;
+import com.google.common.collect.Sets;
 import java.io.Serial;
 import java.io.Serializable;
 import java.util.List;

--- a/src/main/java/org/opentripplanner/graph_builder/module/NearbyStopFinder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/NearbyStopFinder.java
@@ -1,9 +1,9 @@
 package org.opentripplanner.graph_builder.module;
 
-import com.beust.jcommander.internal.Lists;
-import com.beust.jcommander.internal.Sets;
 import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;

--- a/src/main/java/org/opentripplanner/model/Timetable.java
+++ b/src/main/java/org/opentripplanner/model/Timetable.java
@@ -1,6 +1,6 @@
 package org.opentripplanner.model;
 
-import com.beust.jcommander.internal.Lists;
+import com.google.common.collect.Lists;
 import com.google.transit.realtime.GtfsRealtime.TripDescriptor;
 import com.google.transit.realtime.GtfsRealtime.TripUpdate;
 import com.google.transit.realtime.GtfsRealtime.TripUpdate.StopTimeEvent;

--- a/src/main/java/org/opentripplanner/model/TripPattern.java
+++ b/src/main/java/org/opentripplanner/model/TripPattern.java
@@ -1,9 +1,9 @@
 package org.opentripplanner.model;
 
-import com.beust.jcommander.internal.Maps;
-import com.beust.jcommander.internal.Sets;
 import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
 import com.google.common.io.BaseEncoding;

--- a/src/main/java/org/opentripplanner/routing/algorithm/astar/AStar.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/astar/AStar.java
@@ -1,6 +1,6 @@
 package org.opentripplanner.routing.algorithm.astar;
 
-import com.beust.jcommander.internal.Lists;
+import com.google.common.collect.Lists;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.List;

--- a/src/main/java/org/opentripplanner/routing/graphfinder/DirectGraphFinder.java
+++ b/src/main/java/org/opentripplanner/routing/graphfinder/DirectGraphFinder.java
@@ -1,6 +1,6 @@
 package org.opentripplanner.routing.graphfinder;
 
-import com.beust.jcommander.internal.Lists;
+import com.google.common.collect.Lists;
 import java.util.List;
 import org.locationtech.jts.geom.Coordinate;
 import org.opentripplanner.common.geometry.SphericalDistanceLibrary;


### PR DESCRIPTION
This PR aims to clean the wrong usage of internal packages that might be subject of changes, to commonly used guava implementation that is the desired standard in the project.

There is no real functional changes in this PR and it's sole purpose is to cleanup and use the right impl.