### PR TITLE
Preserve language in SIRI/GTFS-RT alert messages

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/vectortiles/VehicleParkingsLayerTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/vectortiles/VehicleParkingsLayerTest.java
@@ -37,7 +37,7 @@ public class VehicleParkingsLayerTest {
       VehicleParking
         .builder()
         .id(new FeedScopedId("id", "id"))
-        .name(TranslatedString.getI18NString(Map.of("", "name", "de", "DE")))
+        .name(TranslatedString.getI18NString(Map.of("", "name", "de", "DE"), false, false))
         .x(1)
         .y(2)
         .bicyclePlaces(true)

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriAlertsUpdateHandler.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriAlertsUpdateHandler.java
@@ -588,6 +588,8 @@ public class SiriAlertsUpdateHandler {
       translations.put("", "");
     }
 
-    return translations.isEmpty() ? null : TranslatedString.getI18NString(translations);
+    return translations.isEmpty()
+      ? null
+      : TranslatedString.getI18NString(translations, false, true);
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/vehicleparking/hslpark/HslParkToVehicleParkingMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/vehicleparking/hslpark/HslParkToVehicleParkingMapper.java
@@ -70,7 +70,7 @@ public class HslParkToVehicleParkingMapper {
         });
       I18NString name = translations.isEmpty()
         ? new NonLocalizedString(vehicleParkId.getId())
-        : TranslatedString.getI18NString(translations);
+        : TranslatedString.getI18NString(translations, true, false);
       Geometry geometry = GEOMETRY_PARSER.geometryFromJson(jsonNode.path("location"));
       double x = geometry.getCentroid().getX();
       double y = geometry.getCentroid().getY();

--- a/src/ext/java/org/opentripplanner/ext/vehicleparking/parkapi/ParkAPIUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/vehicleparking/parkapi/ParkAPIUpdater.java
@@ -45,7 +45,7 @@ abstract class ParkAPIUpdater extends GenericJsonDataSource<VehicleParking> {
         var noteFiled = noteFieldIterator.next();
         noteLocalizations.put(noteFiled.getKey(), noteFiled.getValue().asText());
       }
-      note = TranslatedString.getI18NString(noteLocalizations);
+      note = TranslatedString.getI18NString(noteLocalizations, true, false);
     }
 
     var vehicleParkId = createIdForNode(jsonNode);

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/NoteProperties.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/NoteProperties.java
@@ -30,7 +30,7 @@ public class NoteProperties {
     if (patternMatcher.matcher(notePattern).matches()) {
       //This gets language -> translation of notePattern and all tags (which can have translations name:en for example)
       Map<String, String> noteText = TemplateLibrary.generateI18N(notePattern, way);
-      text = TranslatedString.getI18NString(noteText);
+      text = TranslatedString.getI18NString(noteText, true, false);
     } else {
       text = new LocalizedString(notePattern, way);
     }

--- a/src/main/java/org/opentripplanner/netex/mapping/StationMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/StationMapper.java
@@ -38,7 +38,7 @@ class StationMapper {
         }
       }
 
-      name = TranslatedString.getI18NString(translations);
+      name = TranslatedString.getI18NString(translations, true, false);
     } else {
       name = new NonLocalizedString(stopPlace.getName().getValue());
     }

--- a/src/main/java/org/opentripplanner/openstreetmap/model/OSMWithTags.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/model/OSMWithTags.java
@@ -166,7 +166,11 @@ public class OSMWithTags {
       return null;
     }
     if (tags.containsKey("name")) {
-      return TranslatedString.getI18NString(TemplateLibrary.generateI18N("{name}", this));
+      return TranslatedString.getI18NString(
+        TemplateLibrary.generateI18N("{name}", this),
+        true,
+        false
+      );
     }
     if (tags.containsKey("otp:route_name")) {
       return new NonLocalizedString(tags.get("otp:route_name"));

--- a/src/main/java/org/opentripplanner/updater/alerts/AlertsUpdateHandler.java
+++ b/src/main/java/org/opentripplanner/updater/alerts/AlertsUpdateHandler.java
@@ -178,7 +178,7 @@ public class AlertsUpdateHandler {
   }
 
   /**
-   * Convert a GTFS-RT Protobuf TranslatedString to a OTP TranslatedString or NonLocalizedString.
+   * Convert a GTFS-RT Protobuf TranslatedString to an TranslatedString.
    *
    * @return An OTP TranslatedString containing the same information as the input GTFS-RT Protobuf
    * TranslatedString.
@@ -190,6 +190,6 @@ public class AlertsUpdateHandler {
       String string = translation.getText();
       translations.put(language, string);
     }
-    return translations.isEmpty() ? null : TranslatedString.getI18NString(translations);
+    return translations.isEmpty() ? null : TranslatedString.getI18NString(translations, true, true);
   }
 }

--- a/src/main/java/org/opentripplanner/util/TranslationHelper.java
+++ b/src/main/java/org/opentripplanner/util/TranslationHelper.java
@@ -151,7 +151,7 @@ public final class TranslationHelper {
           hm.put(translation.getLanguage(), translation.getTranslation());
         }
       }
-      return TranslatedString.getI18NString(hm);
+      return TranslatedString.getI18NString(hm, true, false);
     }
     return NonLocalizedString.ofNullable(defaultValue);
   }

--- a/src/test/java/org/opentripplanner/util/TranslatedStringTest.java
+++ b/src/test/java/org/opentripplanner/util/TranslatedStringTest.java
@@ -1,28 +1,34 @@
 package org.opentripplanner.util;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.HashMap;
 import java.util.Locale;
-import junit.framework.TestCase;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
 
-public class TranslatedStringTest extends TestCase {
+public class TranslatedStringTest {
 
-  public void testGetI18NString() throws Exception {
+  @Test
+  public void testGetI18NString() {
     HashMap<String, String> translations = new HashMap<>();
 
     translations.put(null, "Test");
-    I18NString string1 = TranslatedString.getI18NString(translations);
+    I18NString string1 = TranslatedString.getI18NString(translations, false, false);
     assertEquals("Test", string1.toString());
     assertEquals("Test", string1.toString(Locale.ENGLISH));
     assertTrue(string1 instanceof NonLocalizedString);
 
     translations.put("en", "Test");
-    I18NString string2 = TranslatedString.getI18NString(translations);
+    I18NString string2 = TranslatedString.getI18NString(translations, false, false);
     assertEquals("Test", string2.toString());
     assertEquals("Test", string2.toString(Locale.ENGLISH));
     assertTrue(string2 instanceof NonLocalizedString);
 
     translations.put("fi", "Testi");
-    I18NString string3 = TranslatedString.getI18NString(translations);
+    I18NString string3 = TranslatedString.getI18NString(translations, true, false);
     assertEquals("Test", string3.toString());
     assertEquals("Test", string3.toString(Locale.ENGLISH));
     assertEquals("Testi", string3.toString(new Locale("fi")));
@@ -32,7 +38,27 @@ public class TranslatedStringTest extends TestCase {
     translations2.put(null, "Test");
     translations2.put("en", "Test");
     translations2.put("fi", "Testi");
-    I18NString string4 = TranslatedString.getI18NString(translations2);
+    I18NString string4 = TranslatedString.getI18NString(translations2, true, false);
     assertSame(string3, string4);
+  }
+
+  @Test
+  public void testForceTransltaedString() {
+    HashMap<String, String> translations = new HashMap<>();
+
+    translations.put("en", "Test");
+
+    I18NString translatedString = TranslatedString.getI18NString(translations, false, true);
+    assertEquals("Test", translatedString.toString());
+    assertEquals("Test", translatedString.toString(Locale.ENGLISH));
+    assertTrue(translatedString instanceof TranslatedString);
+
+    I18NString emptyLanguageString = TranslatedString.getI18NString(
+      Map.of("", "Test"),
+      false,
+      true
+    );
+    assertEquals("Test", emptyLanguageString.toString());
+    assertTrue(emptyLanguageString instanceof NonLocalizedString);
   }
 }


### PR DESCRIPTION
### Summary

Currently we discard the translation language, if only one message is provided. This adds a flag to `TranslatedString#getI18NString` to select if the language information should be preserved even in those cases. It also adds a second flag to prevent memory leaks when used at runtime.

### Issue

closes #4110

### Unit tests

✅ 
