### PR TITLE
Fix error with transfer-slack and GTFS minTransferTime

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/constrainedtransfer/ConstrainedBoardingSearch.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/constrainedtransfer/ConstrainedBoardingSearch.java
@@ -25,7 +25,7 @@ public final class ConstrainedBoardingSearch
    * these trips are probably a better match. We abort to avoid stepping through all trips, possibly
    * a large number (several days).
    */
-  private static final int ABORT_SEARCH_AFTER_N_VAILD_NORMAL_TRIPS = 5;
+  private static final int ABORT_SEARCH_AFTER_N_VALID_NORMAL_TRIPS = 5;
 
   private static final ConstrainedBoardingSearchStrategy FORWARD_STRATEGY = new ConstrainedBoardingSearchForward();
   private static final ConstrainedBoardingSearchStrategy REVERSE_STRATEGY = new ConstrainedBoardingSearchReverse();
@@ -211,7 +211,7 @@ public final class ConstrainedBoardingSearch
         onTripTxConstraint = TransferConstraint.REGULAR_TRANSFER;
         return true;
       }
-      if (nAllowedBoardings == ABORT_SEARCH_AFTER_N_VAILD_NORMAL_TRIPS) {
+      if (nAllowedBoardings == ABORT_SEARCH_AFTER_N_VALID_NORMAL_TRIPS) {
         return false;
       }
     }


### PR DESCRIPTION
### Summary

The current version of OTP2 add transfer-slack to GTFS `minTransferTime` in the OptimizedTransfer service, but not in Raptor. This causes the Optimized transfer to fail, trying to make a transfer witch is no longer possible because of the "extra" transfer-slack added. 

### Issue

closes #4114


### Unit tests

- [ ] TODO

### Code style
✅ 


### Documentation

No do adde

### Changelog

The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md)
is generated from the pull-request title, make sure the title describe the feature or issue fixed.
To exclude the PR from the changelog add `[changelog skip]` in the title.
