### PR TITLE
Upgrade siri-protobuf-mapper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -551,7 +551,7 @@
         <dependency>
             <groupId>org.entur</groupId>
             <artifactId>siri-protobuf-mapper</artifactId>
-            <version>0.6</version>
+            <version>0.8</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Upgrading dependency `siri-protobuf-mapper` - only used in sandbox-class _SiriETGooglePubsubUpdater_.

(Upgrade required for mapping SIRI-object "_RecordedCall.Expected*Time_")