### PR TITLE
Use actual distance for walk distance in StreetEdge

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     </scm>
 
     <properties>
-        <otp.serialization.version.id>23</otp.serialization.version.id>
+        <otp.serialization.version.id>24</otp.serialization.version.id>
         <!-- Lib versions - keep list sorted on property name -->
         <geotools.version>26.2</geotools.version>
         <jackson.version>2.13.2</jackson.version>

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
@@ -455,6 +455,12 @@ public class StreetEdge extends Edge implements BikeWalkableEdge, Cloneable, Car
     return length_mm / 1000.0;
   }
 
+  private double getDistanceWithElevation() {
+    return hasElevationExtension()
+      ? elevationExtension.getDistanceWithElevation()
+      : getDistanceMeters();
+  }
+
   @Override
   public double getEffectiveWalkDistance() {
     return hasElevationExtension()
@@ -1113,7 +1119,7 @@ public class StreetEdge extends Edge implements BikeWalkableEdge, Cloneable, Car
     }
 
     if (!traverseMode.isDriving()) {
-      s1.incrementWalkDistance(getDistanceMeters());
+      s1.incrementWalkDistance(getDistanceWithElevation());
     }
 
     if (costExtension != null) {

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
@@ -325,9 +325,9 @@ public class StreetEdge extends Edge implements BikeWalkableEdge, Cloneable, Car
    * This gets the effective work amount for bikes, taking the effort required to traverse the
    * slopes into account.
    */
-  public double getEffectiveBikeWorkCost() {
+  public double getEffectiveBikeDistanceForWorkCost() {
     return hasElevationExtension()
-      ? elevationExtension.getEffectiveBikeWorkCost()
+      ? elevationExtension.getEffectiveBikeDistanceForWorkCost()
       : getDistanceMeters();
   }
 
@@ -989,7 +989,7 @@ public class StreetEdge extends Edge implements BikeWalkableEdge, Cloneable, Car
             break;
           case FLAT:
             /* see notes in StreetVertex on speed overhead */
-            weight = getEffectiveBikeWorkCost() / speed;
+            weight = getEffectiveBikeDistanceForWorkCost() / speed;
             break;
           case QUICK:
             weight = getEffectiveBikeDistance() / speed;
@@ -997,7 +997,7 @@ public class StreetEdge extends Edge implements BikeWalkableEdge, Cloneable, Car
           case TRIANGLE:
             double quick = getEffectiveBikeDistance();
             double safety = getEffectiveBicycleSafetyDistance();
-            double slope = getEffectiveBikeWorkCost();
+            double slope = getEffectiveBikeDistanceForWorkCost();
             weight =
               quick *
               options.bikeTriangleTimeFactor +

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
@@ -1113,7 +1113,7 @@ public class StreetEdge extends Edge implements BikeWalkableEdge, Cloneable, Car
     }
 
     if (!traverseMode.isDriving()) {
-      s1.incrementWalkDistance(getEffectiveBikeDistance());
+      s1.incrementWalkDistance(getDistanceMeters());
     }
 
     if (costExtension != null) {

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetElevationExtension.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetElevationExtension.java
@@ -22,7 +22,7 @@ public class StreetElevationExtension implements Serializable {
 
   private final double effectiveBikeDistance;
 
-  private final double effectiveBikeWorkCost;
+  private final double effectiveBikeDistanceForWorkCost;
 
   private final double effectiveWalkDistance;
 
@@ -47,7 +47,7 @@ public class StreetElevationExtension implements Serializable {
     this.distanceMeters = distanceMeters;
     this.effectiveBicycleSafetyDistance = effectiveBicycleSafetyFactor * distanceMeters;
     this.effectiveBikeDistance = effectiveBikeDistanceFactor * distanceMeters;
-    this.effectiveBikeWorkCost = effectiveBikeWorkFactor * distanceMeters;
+    this.effectiveBikeDistanceForWorkCost = effectiveBikeWorkFactor * distanceMeters;
     this.effectiveWalkDistance = effectiveWalkDistanceFactor * distanceMeters;
     this.distanceWithElevation = lengthMultiplier * distanceMeters;
     this.maxSlope = maxSlope;
@@ -107,8 +107,8 @@ public class StreetElevationExtension implements Serializable {
    * The distance multiplied by a factor considering how much more/less convenient it is to bike
    * the edge, compared to if it was flat. This is calculated form the energy usage of the cyclist.
    */
-  public double getEffectiveBikeWorkCost() {
-    return effectiveBikeWorkCost;
+  public double getEffectiveBikeDistanceForWorkCost() {
+    return effectiveBikeDistanceForWorkCost;
   }
 
   /**
@@ -141,7 +141,7 @@ public class StreetElevationExtension implements Serializable {
       .addNum("distanceMeters", distanceMeters)
       .addNum("effectiveBicycleSafetyFactor", effectiveBicycleSafetyDistance)
       .addNum("effectiveBikeDistance", effectiveBikeDistance)
-      .addNum("effectiveBikeWorkCost", effectiveBikeWorkCost)
+      .addNum("effectiveBikeDistanceForWorkCost", effectiveBikeDistanceForWorkCost)
       .addNum("effectiveWalkDistance", effectiveWalkDistance)
       .addNum("maxSlope", maxSlope)
       .toString();

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetElevationExtension.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetElevationExtension.java
@@ -9,6 +9,9 @@ import org.opentripplanner.routing.util.SlopeCosts;
 
 public class StreetElevationExtension implements Serializable {
 
+  /**
+   * Distance of the edge projected on a 2d plane.
+   */
   private final double distanceMeters;
 
   private final byte[] compactedElevationProfile;
@@ -23,6 +26,8 @@ public class StreetElevationExtension implements Serializable {
 
   private final double effectiveWalkDistance;
 
+  private final double distanceWithElevation;
+
   private final float maxSlope;
 
   private final boolean flattened;
@@ -35,6 +40,7 @@ public class StreetElevationExtension implements Serializable {
     double effectiveBikeDistanceFactor,
     double effectiveBikeWorkFactor,
     double effectiveWalkDistanceFactor,
+    double lengthMultiplier,
     float maxSlope,
     boolean flattened
   ) {
@@ -43,6 +49,7 @@ public class StreetElevationExtension implements Serializable {
     this.effectiveBikeDistance = effectiveBikeDistanceFactor * distanceMeters;
     this.effectiveBikeWorkCost = effectiveBikeWorkFactor * distanceMeters;
     this.effectiveWalkDistance = effectiveWalkDistanceFactor * distanceMeters;
+    this.distanceWithElevation = lengthMultiplier * distanceMeters;
     this.maxSlope = maxSlope;
     this.flattened = flattened;
 
@@ -80,20 +87,43 @@ public class StreetElevationExtension implements Serializable {
     }
   }
 
+  /**
+   * The distance multiplied by the {@link StreetEdge#bicycleSafetyFactor}, but also considering the
+   * increased length caused by the slope.
+   */
   public double getEffectiveBicycleSafetyDistance() {
     return effectiveBicycleSafetyDistance;
   }
 
+  /**
+   * The distance multiplied by a factor considering how much faster/slower it is to bile the edge,
+   * compared to if it was flat.
+   */
   public double getEffectiveBikeDistance() {
     return effectiveBikeDistance;
   }
 
+  /**
+   * The distance multiplied by a factor considering how much more/less convenient it is to bike
+   * the edge, compared to if it was flat. This is calculated form the energy usage of the cyclist.
+   */
   public double getEffectiveBikeWorkCost() {
     return effectiveBikeWorkCost;
   }
 
+  /**
+   * The distance multiplied by a factor considering how much faster/slower it is to walk the edge,
+   * compared to if it was flat.
+   */
   public double getEffectiveWalkDistance() {
     return effectiveWalkDistance;
+  }
+
+  /**
+   * Physical distance which takes the elevation into account. The distanceMeters is a 2d distance.
+   */
+  public double getDistanceWithElevation() {
+    return distanceWithElevation;
   }
 
   public float getMaxSlope() {
@@ -160,6 +190,7 @@ public class StreetElevationExtension implements Serializable {
       effectiveBikeDistanceFactor,
       effectiveBikeWorkFactor,
       effectiveWalkDistanceFactor,
+      costs.lengthMultiplier,
       maxSlope,
       flattened
     );

--- a/src/test/java/org/opentripplanner/routing/edgetype/TriangleTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/TriangleTest.java
@@ -111,7 +111,7 @@ public class TriangleTest {
 
     SlopeCosts costs = ElevationUtils.getSlopeCosts(elev, true);
     double trueLength = costs.lengthMultiplier * length;
-    double slopeWorkLength = testStreet.getEffectiveBikeWorkCost();
+    double slopeWorkLength = testStreet.getEffectiveBikeDistanceForWorkCost();
     double slopeSpeedLength = testStreet.getEffectiveBikeDistance();
 
     RoutingRequest options = new RoutingRequest(TraverseMode.BICYCLE);


### PR DESCRIPTION
### Summary

Not an "effective distance", which heavily distorts hilly streets.

### Issue

Currently the distances are over-reported heavily in hilly areas, due to the "effective distance" being used. The effective distance is based on energy usage required for traversing the edge. 
