### PR TITLE
Fix default date on ServiceJourney estimatedCalls in Transmodel API [changelog skip]

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/ServiceJourneyType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/ServiceJourneyType.java
@@ -27,6 +27,7 @@ import org.opentripplanner.model.Trip;
 import org.opentripplanner.model.TripPattern;
 import org.opentripplanner.model.TripTimeOnDate;
 import org.opentripplanner.model.calendar.ServiceDate;
+import org.opentripplanner.routing.TripTimesShortHelper;
 import org.opentripplanner.util.PolylineEncoder;
 
 public class ServiceJourneyType {
@@ -264,14 +265,16 @@ public class ServiceJourneyType {
               .build()
           )
           .dataFetcher(environment -> {
-            final Trip trip = trip(environment);
-
             var serviceDate = Optional
               .ofNullable(environment.getArgument("date"))
               .map(LocalDate.class::cast)
               .map(ServiceDate::new)
-              .orElse(null);
-            return GqlUtil.getRoutingService(environment).getTripTimesShort(trip, serviceDate);
+              .orElse(new ServiceDate());
+            return TripTimesShortHelper.getTripTimesShort(
+              GqlUtil.getRoutingService(environment),
+              trip(environment),
+              serviceDate
+            );
           })
           .build()
       )

--- a/src/main/java/org/opentripplanner/routing/RoutingService.java
+++ b/src/main/java/org/opentripplanner/routing/RoutingService.java
@@ -223,10 +223,6 @@ public class RoutingService {
       : tripPattern.getScheduledTimetable();
   }
 
-  public List<TripTimeOnDate> getTripTimesShort(Trip trip, ServiceDate serviceDate) {
-    return TripTimesShortHelper.getTripTimesShort(this, trip, serviceDate);
-  }
-
   /** {@link Graph#getTimetableSnapshot()} */
   public TimetableSnapshot getTimetableSnapshot() {
     return this.graph.getTimetableSnapshot();


### PR DESCRIPTION
### Summary

Currently the default value throws an NPE, fix this by initializing a current date when none is specified.