### PR TITLE
Adapt documentation for walkReluctance, comment on performance [changelog skip]

### DIFF
--- a/src/ext/resources/legacygraphqlapi/schema.graphqls
+++ b/src/ext/resources/legacygraphqlapi/schema.graphqls
@@ -2343,10 +2343,12 @@ type QueryType {
 
         """
         A multiplier for how bad walking is, compared to being in transit for equal
-        lengths of time.Empirically, values between 10 and 20 seem to correspond
+        lengths of time. Empirically, values between 2 and 4 seem to correspond
         well to the concept of not wanting to walk too much without asking for
         totally ridiculous itineraries, but this observation should in no way be
-        taken as scientific or definitive. Your mileage may vary. Default value: 2.0
+        taken as scientific or definitive. Your mileage may vary. See 
+        https://github.com/opentripplanner/OpenTripPlanner/issues/4090 for impact on
+        performance with high values. Default value: 2.0
         """
         walkReluctance: Float
 

--- a/src/main/java/org/opentripplanner/api/common/RoutingResource.java
+++ b/src/main/java/org/opentripplanner/api/common/RoutingResource.java
@@ -197,10 +197,13 @@ public abstract class RoutingResource {
   protected Double bikeWalkingReluctance;
 
   /**
-   * A multiplier for how bad walking is, compared to being in transit for equal lengths of time.
-   * Defaults to 2. Empirically, values between 10 and 20 seem to correspond well to the concept of
-   * not wanting to walk too much without asking for totally ridiculous itineraries, but this
-   * observation should in no way be taken as scientific or definitive. Your mileage may vary.
+   * A multiplier for how bad walking is, compared to being in transit for equal
+   * lengths of time. Empirically, values between 2 and 4 seem to correspond
+   * well to the concept of not wanting to walk too much without asking for
+   * totally ridiculous itineraries, but this observation should in no way be
+   * taken as scientific or definitive. Your mileage may vary. See
+   * https://github.com/opentripplanner/OpenTripPlanner/issues/4090 for impact on
+   * performance with high values. Default value: 2.0
    */
   @QueryParam("walkReluctance")
   protected Double walkReluctance;

--- a/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
@@ -323,10 +323,13 @@ public class RoutingRequest implements Cloneable, Serializable {
   public int nonpreferredTransferCost = 180;
 
   /**
-   * A multiplier for how bad walking is, compared to being in transit for equal lengths of time.
-   * Defaults to 2. Empirically, values between 10 and 20 seem to correspond well to the concept of
-   * not wanting to walk too much without asking for totally ridiculous itineraries, but this
-   * observation should in no way be taken as scientific or definitive. Your mileage may vary.
+   * A multiplier for how bad walking is, compared to being in transit for equal
+   * lengths of time. Empirically, values between 2 and 4 seem to correspond
+   * well to the concept of not wanting to walk too much without asking for
+   * totally ridiculous itineraries, but this observation should in no way be
+   * taken as scientific or definitive. Your mileage may vary. See
+   * https://github.com/opentripplanner/OpenTripPlanner/issues/4090 for impact on
+   * performance with high values. Default value: 2.0
    */
   public double walkReluctance = 2.0;
   public double bikeWalkingReluctance = 5.0;


### PR DESCRIPTION
### Summary

As discussed, update documentation for walkReluctance parameter to reflect usual expected values and add a comment on performance impact.

### Issue

https://github.com/opentripplanner/OpenTripPlanner/issues/4090
