### PR TITLE
Generate trip patterns for flex trips [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/issues/TripDegenerate.java
+++ b/src/main/java/org/opentripplanner/graph_builder/issues/TripDegenerate.java
@@ -3,17 +3,10 @@ package org.opentripplanner.graph_builder.issues;
 import org.opentripplanner.graph_builder.DataImportIssue;
 import org.opentripplanner.model.Trip;
 
-public class TripDegenerate implements DataImportIssue {
-
+public record TripDegenerate(Trip trip) implements DataImportIssue {
   public static final String FMT =
     "Trip %s has fewer than two stops. " +
     "We will not use it for routing. This is probably an error in your data";
-
-  final Trip trip;
-
-  public TripDegenerate(Trip trip) {
-    this.trip = trip;
-  }
 
   @Override
   public String getMessage() {

--- a/src/main/java/org/opentripplanner/gtfs/GenerateTripPatternsOperation.java
+++ b/src/main/java/org/opentripplanner/gtfs/GenerateTripPatternsOperation.java
@@ -122,8 +122,11 @@ public class GenerateTripPatternsOperation {
     List<StopTime> stopTimes = transitDaoBuilder.getStopTimesSortedByTrip().get(trip);
 
     // If after filtering this trip does not contain at least 2 stoptimes, it does not serve any purpose.
+    var staticTripWithFewerThan2Stops =
+      !FlexTrip.containsFlexStops(stopTimes) && stopTimes.size() < 2;
     // flex trips are allowed to have a single stop because that can be an area or a group of stops
-    if (!FlexTrip.containsFlexStops(stopTimes) && stopTimes.size() < 2) {
+    var flexTripWithZeroStops = FlexTrip.containsFlexStops(stopTimes) && stopTimes.size() < 1;
+    if (staticTripWithFewerThan2Stops || flexTripWithZeroStops) {
       issueStore.add(new TripDegenerate(trip));
       return;
     }

--- a/src/main/java/org/opentripplanner/gtfs/GenerateTripPatternsOperation.java
+++ b/src/main/java/org/opentripplanner/gtfs/GenerateTripPatternsOperation.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.opentripplanner.ext.flex.trip.FlexTrip;
 import org.opentripplanner.graph_builder.DataImportIssueStore;
 import org.opentripplanner.graph_builder.issues.GTFSModeNotSupported;
 import org.opentripplanner.graph_builder.issues.TripDegenerate;
@@ -118,10 +119,11 @@ public class GenerateTripPatternsOperation {
       return; // Invalid trip, skip it, it will break later
     }
 
-    Collection<StopTime> stopTimes = transitDaoBuilder.getStopTimesSortedByTrip().get(trip);
+    List<StopTime> stopTimes = transitDaoBuilder.getStopTimesSortedByTrip().get(trip);
 
     // If after filtering this trip does not contain at least 2 stoptimes, it does not serve any purpose.
-    if (stopTimes.size() < 2) {
+    // flex trips are allowed to have a single stop because that can be an area or a group of stops
+    if (!FlexTrip.containsFlexStops(stopTimes) && stopTimes.size() < 2) {
       issueStore.add(new TripDegenerate(trip));
       return;
     }


### PR DESCRIPTION
### Summary

Flex trips are added to the routing graph via the `FlexTrip` but if they only have a single `StopLocatation` or `LocationGroup` then they don't end up in the API.

This PR fixes that.

### Issue
n/a

### Unit tests

none

### Documentation

n/a

### Changelog

skip