### PR TITLE
Rename 'WheelChairBoarding' to 'WheelchairBoarding' [changelog skip]

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/LegacyGraphQLUtils.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/LegacyGraphQLUtils.java
@@ -5,7 +5,7 @@ import java.util.Locale;
 import java.util.Map;
 import org.opentripplanner.ext.legacygraphqlapi.generated.LegacyGraphQLTypes.LegacyGraphQLFormFactor;
 import org.opentripplanner.ext.legacygraphqlapi.generated.LegacyGraphQLTypes.LegacyGraphQLWheelchairBoarding;
-import org.opentripplanner.model.WheelChairBoarding;
+import org.opentripplanner.model.WheelchairBoarding;
 import org.opentripplanner.routing.vehicle_rental.RentalVehicleType.FormFactor;
 import org.opentripplanner.util.I18NString;
 
@@ -32,7 +32,7 @@ public class LegacyGraphQLUtils {
     return input.toString(getLocale(environment));
   }
 
-  public static LegacyGraphQLWheelchairBoarding toGraphQL(WheelChairBoarding boarding) {
+  public static LegacyGraphQLWheelchairBoarding toGraphQL(WheelchairBoarding boarding) {
     if (boarding == null) return null;
     return switch (boarding) {
       case NO_INFORMATION -> LegacyGraphQLWheelchairBoarding.NO_INFORMATION;

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/QuayType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/QuayType.java
@@ -23,7 +23,7 @@ import org.opentripplanner.model.Stop;
 import org.opentripplanner.model.StopLocation;
 import org.opentripplanner.model.TransitMode;
 import org.opentripplanner.model.TripTimeOnDate;
-import org.opentripplanner.model.WheelChairBoarding;
+import org.opentripplanner.model.WheelchairBoarding;
 import org.opentripplanner.routing.stoptimes.ArrivalDeparture;
 
 public class QuayType {
@@ -127,7 +127,7 @@ public class QuayType {
             var wheelChairBoarding =
               (((StopLocation) environment.getSource()).getWheelchairBoarding());
 
-            return Objects.requireNonNullElse(wheelChairBoarding, WheelChairBoarding.NO_INFORMATION)
+            return Objects.requireNonNullElse(wheelChairBoarding, WheelchairBoarding.NO_INFORMATION)
               .gtfsCode;
           })
           .build()

--- a/src/main/java/org/opentripplanner/api/mapping/WheelchairBoardingMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/WheelchairBoardingMapper.java
@@ -1,10 +1,10 @@
 package org.opentripplanner.api.mapping;
 
-import org.opentripplanner.model.WheelChairBoarding;
+import org.opentripplanner.model.WheelchairBoarding;
 
 public class WheelchairBoardingMapper {
 
-  public static Integer mapToApi(WheelChairBoarding domain) {
-    return domain == null ? WheelChairBoarding.NO_INFORMATION.gtfsCode : domain.gtfsCode;
+  public static Integer mapToApi(WheelchairBoarding domain) {
+    return domain == null ? WheelchairBoarding.NO_INFORMATION.gtfsCode : domain.gtfsCode;
   }
 }

--- a/src/main/java/org/opentripplanner/graph_builder/module/AddTransitModelEntitiesToGraph.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/AddTransitModelEntitiesToGraph.java
@@ -25,7 +25,7 @@ import org.opentripplanner.model.Stop;
 import org.opentripplanner.model.StopLocation;
 import org.opentripplanner.model.TransitMode;
 import org.opentripplanner.model.TripPattern;
-import org.opentripplanner.model.WheelChairBoarding;
+import org.opentripplanner.model.WheelchairBoarding;
 import org.opentripplanner.routing.edgetype.ElevatorAlightEdge;
 import org.opentripplanner.routing.edgetype.ElevatorBoardEdge;
 import org.opentripplanner.routing.edgetype.ElevatorHopEdge;
@@ -175,7 +175,7 @@ public class AddTransitModelEntitiesToGraph {
       stationElementNodes.put(boardingArea, boardingAreaVertex);
       if (boardingArea.getParentStop() != null) {
         var platformVertex = stationElementNodes.get(boardingArea.getParentStop());
-        boolean wheelchair = boardingArea.getWheelchairBoarding() == WheelChairBoarding.POSSIBLE;
+        boolean wheelchair = boardingArea.getWheelchairBoarding() == WheelchairBoarding.POSSIBLE;
 
         PathwayEdge.lowCost(
           boardingAreaVertex,

--- a/src/main/java/org/opentripplanner/gtfs/mapping/StopMappingWrapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/StopMappingWrapper.java
@@ -7,7 +7,7 @@ import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.model.StationElement;
 import org.opentripplanner.model.StopLevel;
 import org.opentripplanner.model.WgsCoordinate;
-import org.opentripplanner.model.WheelChairBoarding;
+import org.opentripplanner.model.WheelchairBoarding;
 
 /**
  * Wrap GTFS Stop to provide a common base mapping for all {@link StationElement}s.
@@ -40,8 +40,8 @@ class StopMappingWrapper {
     return WgsCoordinateMapper.mapToDomain(stop);
   }
 
-  public WheelChairBoarding getWheelchairBoarding() {
-    return WheelChairBoarding.valueOfGtfsCode(stop.getWheelchairBoarding());
+  public WheelchairBoarding getWheelchairBoarding() {
+    return WheelchairBoarding.valueOfGtfsCode(stop.getWheelchairBoarding());
   }
 
   public StopLevel getLevel() {

--- a/src/main/java/org/opentripplanner/gtfs/mapping/TripMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/TripMapper.java
@@ -5,7 +5,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.opentripplanner.model.Direction;
 import org.opentripplanner.model.Trip;
-import org.opentripplanner.model.WheelChairBoarding;
+import org.opentripplanner.model.WheelchairBoarding;
 import org.opentripplanner.util.MapUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,7 +59,7 @@ class TripMapper {
     lhs.setDirection(Direction.valueOfGtfsCode(mapDirectionId(rhs)));
     lhs.setBlockId(rhs.getBlockId());
     lhs.setShapeId(AgencyAndIdMapper.mapAgencyAndId(rhs.getShapeId()));
-    lhs.setWheelchairBoarding(WheelChairBoarding.valueOfGtfsCode(rhs.getWheelchairAccessible()));
+    lhs.setWheelchairBoarding(WheelchairBoarding.valueOfGtfsCode(rhs.getWheelchairAccessible()));
     lhs.setBikesAllowed(BikeAccessMapper.mapForTrip(rhs));
     lhs.setFareId(rhs.getFareId());
 

--- a/src/main/java/org/opentripplanner/inspector/WheelchairEdgeRenderer.java
+++ b/src/main/java/org/opentripplanner/inspector/WheelchairEdgeRenderer.java
@@ -2,7 +2,7 @@ package org.opentripplanner.inspector;
 
 import java.awt.Color;
 import org.opentripplanner.inspector.EdgeVertexTileRenderer.EdgeVertexRenderer;
-import org.opentripplanner.model.WheelChairBoarding;
+import org.opentripplanner.model.WheelchairBoarding;
 import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.edgetype.ElevatorHopEdge;
 import org.opentripplanner.routing.edgetype.StreetEdge;
@@ -58,13 +58,13 @@ public class WheelchairEdgeRenderer implements EdgeVertexRenderer {
     if (v instanceof TransitStopVertex) {
       if (
         ((TransitStopVertex) v).getStop().getWheelchairBoarding() ==
-        WheelChairBoarding.NO_INFORMATION
+        WheelchairBoarding.NO_INFORMATION
       ) attrs.color = NO_WHEELCHAIR_INFORMATION_COLOR;
       if (
-        ((TransitStopVertex) v).getStop().getWheelchairBoarding() == WheelChairBoarding.POSSIBLE
+        ((TransitStopVertex) v).getStop().getWheelchairBoarding() == WheelchairBoarding.POSSIBLE
       ) attrs.color = YES_WHEELCHAIR_COLOR;
       if (
-        ((TransitStopVertex) v).getStop().getWheelchairBoarding() == WheelChairBoarding.NOT_POSSIBLE
+        ((TransitStopVertex) v).getStop().getWheelchairBoarding() == WheelchairBoarding.NOT_POSSIBLE
       ) attrs.color = NO_WHEELCHAIR_COLOR;
       attrs.label = v.getDefaultName();
     } else {

--- a/src/main/java/org/opentripplanner/model/BoardingArea.java
+++ b/src/main/java/org/opentripplanner/model/BoardingArea.java
@@ -18,7 +18,7 @@ public final class BoardingArea extends StationElement {
     String code,
     String description,
     WgsCoordinate coordinate,
-    WheelChairBoarding wheelchairBoarding,
+    WheelchairBoarding wheelchairBoarding,
     StopLevel level
   ) {
     super(id, name, code, description, coordinate, wheelchairBoarding, level);

--- a/src/main/java/org/opentripplanner/model/Entrance.java
+++ b/src/main/java/org/opentripplanner/model/Entrance.java
@@ -14,7 +14,7 @@ public final class Entrance extends StationElement {
     String code,
     String description,
     WgsCoordinate coordinate,
-    WheelChairBoarding wheelchairBoarding,
+    WheelchairBoarding wheelchairBoarding,
     StopLevel level
   ) {
     super(id, name, code, description, coordinate, wheelchairBoarding, level);

--- a/src/main/java/org/opentripplanner/model/PathwayNode.java
+++ b/src/main/java/org/opentripplanner/model/PathwayNode.java
@@ -14,7 +14,7 @@ public final class PathwayNode extends StationElement {
     String code,
     String description,
     WgsCoordinate coordinate,
-    WheelChairBoarding wheelchairBoarding,
+    WheelchairBoarding wheelchairBoarding,
     StopLevel level
   ) {
     super(id, name, code, description, coordinate, wheelchairBoarding, level);

--- a/src/main/java/org/opentripplanner/model/StationElement.java
+++ b/src/main/java/org/opentripplanner/model/StationElement.java
@@ -19,7 +19,7 @@ public abstract class StationElement extends TransitEntity {
 
   private final WgsCoordinate coordinate;
 
-  private final WheelChairBoarding wheelchairBoarding;
+  private final WheelchairBoarding wheelchairBoarding;
 
   private final StopLevel level;
 
@@ -31,7 +31,7 @@ public abstract class StationElement extends TransitEntity {
     String code,
     String description,
     WgsCoordinate coordinate,
-    WheelChairBoarding wheelchairBoarding,
+    WheelchairBoarding wheelchairBoarding,
     StopLevel level
   ) {
     super(id);
@@ -40,7 +40,7 @@ public abstract class StationElement extends TransitEntity {
     this.description = description;
     this.coordinate = coordinate;
     this.wheelchairBoarding =
-      Objects.requireNonNullElse(wheelchairBoarding, WheelChairBoarding.NO_INFORMATION);
+      Objects.requireNonNullElse(wheelchairBoarding, WheelchairBoarding.NO_INFORMATION);
     this.level = level;
   }
 
@@ -84,7 +84,7 @@ public abstract class StationElement extends TransitEntity {
    * Returns whether this station element is accessible for wheelchair users.
    */
   @Nonnull
-  public WheelChairBoarding getWheelchairBoarding() {
+  public WheelchairBoarding getWheelchairBoarding() {
     return wheelchairBoarding;
   }
 

--- a/src/main/java/org/opentripplanner/model/Stop.java
+++ b/src/main/java/org/opentripplanner/model/Stop.java
@@ -1,7 +1,7 @@
 /* This file is based on code copied from project OneBusAway, see the LICENSE file for further information. */
 package org.opentripplanner.model;
 
-import static org.opentripplanner.model.WheelChairBoarding.NO_INFORMATION;
+import static org.opentripplanner.model.WheelchairBoarding.NO_INFORMATION;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -52,7 +52,7 @@ public final class Stop extends StationElement implements StopLocation {
     String code,
     String description,
     WgsCoordinate coordinate,
-    WheelChairBoarding wheelchairBoarding,
+    WheelchairBoarding wheelchairBoarding,
     StopLevel level,
     String platformCode,
     Collection<FareZone> fareZones,
@@ -72,7 +72,7 @@ public final class Stop extends StationElement implements StopLocation {
 
   public static Stop stopForTest(
     String idAndName,
-    WheelChairBoarding wheelChairBoarding,
+    WheelchairBoarding wheelChairBoarding,
     double lat,
     double lon
   ) {
@@ -121,7 +121,7 @@ public final class Stop extends StationElement implements StopLocation {
     double lat,
     double lon,
     Station parent,
-    WheelChairBoarding wheelChairBoarding
+    WheelchairBoarding wheelChairBoarding
   ) {
     var stop = new Stop(
       new FeedScopedId("F", idAndName),

--- a/src/main/java/org/opentripplanner/model/StopLocation.java
+++ b/src/main/java/org/opentripplanner/model/StopLocation.java
@@ -64,8 +64,8 @@ public interface StopLocation {
   }
 
   @Nonnull
-  default WheelChairBoarding getWheelchairBoarding() {
-    return WheelChairBoarding.NO_INFORMATION;
+  default WheelchairBoarding getWheelchairBoarding() {
+    return WheelchairBoarding.NO_INFORMATION;
   }
 
   /**

--- a/src/main/java/org/opentripplanner/model/Trip.java
+++ b/src/main/java/org/opentripplanner/model/Trip.java
@@ -33,7 +33,7 @@ public final class Trip extends TransitEntity {
 
   private FeedScopedId shapeId;
 
-  private WheelChairBoarding wheelchairBoarding = WheelChairBoarding.NO_INFORMATION;
+  private WheelchairBoarding wheelchairBoarding = WheelchairBoarding.NO_INFORMATION;
 
   /**
    * 0 = unknown / unspecified, 1 = bikes allowed, 2 = bikes NOT allowed
@@ -228,13 +228,13 @@ public final class Trip extends TransitEntity {
     this.shapeId = shapeId;
   }
 
-  public WheelChairBoarding getWheelchairBoarding() {
+  public WheelchairBoarding getWheelchairBoarding() {
     return wheelchairBoarding;
   }
 
-  public void setWheelchairBoarding(WheelChairBoarding boarding) {
+  public void setWheelchairBoarding(WheelchairBoarding boarding) {
     this.wheelchairBoarding =
-      Objects.requireNonNullElse(boarding, WheelChairBoarding.NO_INFORMATION);
+      Objects.requireNonNullElse(boarding, WheelchairBoarding.NO_INFORMATION);
   }
 
   public BikeAccess getBikesAllowed() {

--- a/src/main/java/org/opentripplanner/model/TripPattern.java
+++ b/src/main/java/org/opentripplanner/model/TripPattern.java
@@ -484,7 +484,7 @@ public final class TripPattern extends TransitEntity implements Cloneable, Seria
 
   /** Returns whether a given stop is wheelchair-accessible. */
   public boolean wheelchairAccessible(int stopIndex) {
-    return stopPattern.getStop(stopIndex).getWheelchairBoarding() == WheelChairBoarding.POSSIBLE;
+    return stopPattern.getStop(stopIndex).getWheelchairBoarding() == WheelchairBoarding.POSSIBLE;
   }
 
   public PickDrop getAlightType(int stopIndex) {

--- a/src/main/java/org/opentripplanner/model/WheelchairBoarding.java
+++ b/src/main/java/org/opentripplanner/model/WheelchairBoarding.java
@@ -1,18 +1,18 @@
 package org.opentripplanner.model;
 
-public enum WheelChairBoarding {
+public enum WheelchairBoarding {
   NO_INFORMATION(0),
   POSSIBLE(1),
   NOT_POSSIBLE(2);
 
   public final int gtfsCode;
 
-  WheelChairBoarding(int gtfsCode) {
+  WheelchairBoarding(int gtfsCode) {
     this.gtfsCode = gtfsCode;
   }
 
-  public static WheelChairBoarding valueOfGtfsCode(int gtfsCode) {
-    for (WheelChairBoarding value : values()) {
+  public static WheelchairBoarding valueOfGtfsCode(int gtfsCode) {
+    for (WheelchairBoarding value : values()) {
       if (value.gtfsCode == gtfsCode) {
         return value;
       }

--- a/src/main/java/org/opentripplanner/netex/mapping/StopAndStationMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/StopAndStationMapper.java
@@ -19,7 +19,7 @@ import org.opentripplanner.model.FareZone;
 import org.opentripplanner.model.Station;
 import org.opentripplanner.model.Stop;
 import org.opentripplanner.model.TransitMode;
-import org.opentripplanner.model.WheelChairBoarding;
+import org.opentripplanner.model.WheelchairBoarding;
 import org.opentripplanner.netex.index.api.ReadOnlyHierarchicalVersionMapById;
 import org.opentripplanner.netex.issues.StopPlaceWithoutQuays;
 import org.opentripplanner.netex.mapping.support.FeedScopedIdFactory;
@@ -223,14 +223,14 @@ class StopAndStationMapper {
    * @param stopPlace Parent StopPlace for given Quay
    * @return not null value with default NO_INFORMATION if nothing defined in quay or parentStation.
    */
-  private WheelChairBoarding wheelChairBoardingFromQuay(Quay quay, StopPlace stopPlace) {
-    var defaultWheelChairBoarding = WheelChairBoarding.NO_INFORMATION;
+  private WheelchairBoarding wheelChairBoardingFromQuay(Quay quay, StopPlace stopPlace) {
+    var defaultWheelChairBoarding = WheelchairBoarding.NO_INFORMATION;
 
     if (stopPlace != null) {
       defaultWheelChairBoarding =
         WheelChairMapper.wheelChairBoarding(
           stopPlace.getAccessibilityAssessment(),
-          WheelChairBoarding.NO_INFORMATION
+          WheelchairBoarding.NO_INFORMATION
         );
     }
 

--- a/src/main/java/org/opentripplanner/netex/mapping/StopMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/StopMapper.java
@@ -9,7 +9,7 @@ import org.opentripplanner.model.Station;
 import org.opentripplanner.model.Stop;
 import org.opentripplanner.model.TransitMode;
 import org.opentripplanner.model.WgsCoordinate;
-import org.opentripplanner.model.WheelChairBoarding;
+import org.opentripplanner.model.WheelchairBoarding;
 import org.opentripplanner.netex.issues.QuayWithoutCoordinates;
 import org.opentripplanner.netex.mapping.support.FeedScopedIdFactory;
 import org.rutebanken.netex.model.Quay;
@@ -34,7 +34,7 @@ class StopMapper {
     Station parentStation,
     Collection<FareZone> fareZones,
     T2<TransitMode, String> transitMode,
-    WheelChairBoarding wheelChairBoarding
+    WheelchairBoarding wheelChairBoarding
   ) {
     WgsCoordinate coordinate = WgsCoordinateMapper.mapToDomain(quay.getCentroid());
 

--- a/src/main/java/org/opentripplanner/netex/mapping/TripMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/TripMapper.java
@@ -10,7 +10,7 @@ import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.model.Operator;
 import org.opentripplanner.model.TransitMode;
 import org.opentripplanner.model.Trip;
-import org.opentripplanner.model.WheelChairBoarding;
+import org.opentripplanner.model.WheelchairBoarding;
 import org.opentripplanner.model.impl.EntityById;
 import org.opentripplanner.netex.index.api.ReadOnlyHierarchicalMap;
 import org.opentripplanner.netex.mapping.support.FeedScopedIdFactory;
@@ -95,7 +95,7 @@ class TripMapper {
 
     var wheelChairBoarding = WheelChairMapper.wheelChairBoarding(
       serviceJourney.getAccessibilityAssessment(),
-      WheelChairBoarding.NO_INFORMATION
+      WheelchairBoarding.NO_INFORMATION
     );
 
     Trip trip = new Trip(id);

--- a/src/main/java/org/opentripplanner/netex/mapping/WheelChairMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/WheelChairMapper.java
@@ -1,7 +1,7 @@
 package org.opentripplanner.netex.mapping;
 
 import java.util.Optional;
-import org.opentripplanner.model.WheelChairBoarding;
+import org.opentripplanner.model.WheelchairBoarding;
 import org.rutebanken.netex.model.AccessibilityAssessment;
 import org.rutebanken.netex.model.AccessibilityLimitation;
 import org.rutebanken.netex.model.AccessibilityLimitations_RelStructure;
@@ -11,19 +11,19 @@ public class WheelChairMapper {
 
   /**
    * If input and containing objects are not null, get the LimitationStatusEnumeration and map to
-   * internal {@link WheelChairBoarding} enumeration.
+   * internal {@link WheelchairBoarding} enumeration.
    *
    * @param accessibilityAssessment NeTEx object wrapping information regarding WheelChairBoarding
    * @param defaultValue            If no {@link AccessibilityAssessment} is defined, default to
    *                                this value
-   * @return Mapped enumerator, {@link WheelChairBoarding#NO_INFORMATION} if no value is found
+   * @return Mapped enumerator, {@link WheelchairBoarding#NO_INFORMATION} if no value is found
    */
-  public static WheelChairBoarding wheelChairBoarding(
+  public static WheelchairBoarding wheelChairBoarding(
     AccessibilityAssessment accessibilityAssessment,
-    WheelChairBoarding defaultValue
+    WheelchairBoarding defaultValue
   ) {
     if (defaultValue == null) {
-      defaultValue = WheelChairBoarding.NO_INFORMATION;
+      defaultValue = WheelchairBoarding.NO_INFORMATION;
     }
 
     return Optional
@@ -35,20 +35,20 @@ public class WheelChairMapper {
       .orElse(defaultValue);
   }
 
-  public static WheelChairBoarding fromLimitationStatusEnumeration(
+  public static WheelchairBoarding fromLimitationStatusEnumeration(
     LimitationStatusEnumeration wheelChairLimitation
   ) {
     if (wheelChairLimitation == null) {
-      return WheelChairBoarding.NO_INFORMATION;
+      return WheelchairBoarding.NO_INFORMATION;
     }
 
     switch (wheelChairLimitation.value()) {
       case "true":
-        return WheelChairBoarding.POSSIBLE;
+        return WheelchairBoarding.POSSIBLE;
       case "false":
-        return WheelChairBoarding.NOT_POSSIBLE;
+        return WheelchairBoarding.NOT_POSSIBLE;
       default:
-        return WheelChairBoarding.NO_INFORMATION;
+        return WheelchairBoarding.NO_INFORMATION;
     }
   }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/filterchain/filter/AccessibilityScoreFilter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/filterchain/filter/AccessibilityScoreFilter.java
@@ -3,7 +3,7 @@ package org.opentripplanner.routing.algorithm.filterchain.filter;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
-import org.opentripplanner.model.WheelChairBoarding;
+import org.opentripplanner.model.WheelchairBoarding;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.model.plan.ScheduledTransitLeg;
@@ -65,7 +65,7 @@ public class AccessibilityScoreFilter implements ItineraryListFilter {
     return sum / values.size();
   }
 
-  public static double accessibilityScore(WheelChairBoarding wheelchair) {
+  public static double accessibilityScore(WheelchairBoarding wheelchair) {
     return switch (wheelchair) {
       case NO_INFORMATION -> 0.5;
       case POSSIBLE -> 1;

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/cost/WheelchairCostCalculator.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/cost/WheelchairCostCalculator.java
@@ -1,8 +1,8 @@
 package org.opentripplanner.routing.algorithm.raptoradapter.transit.cost;
 
-import static org.opentripplanner.model.WheelChairBoarding.NOT_POSSIBLE;
-import static org.opentripplanner.model.WheelChairBoarding.NO_INFORMATION;
-import static org.opentripplanner.model.WheelChairBoarding.POSSIBLE;
+import static org.opentripplanner.model.WheelchairBoarding.NOT_POSSIBLE;
+import static org.opentripplanner.model.WheelchairBoarding.NO_INFORMATION;
+import static org.opentripplanner.model.WheelchairBoarding.POSSIBLE;
 
 import javax.annotation.Nonnull;
 import org.opentripplanner.routing.api.request.WheelchairAccessibilityRequest;

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/frequency/FrequencyBoardOrAlightEvent.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/frequency/FrequencyBoardOrAlightEvent.java
@@ -2,7 +2,7 @@ package org.opentripplanner.routing.algorithm.raptoradapter.transit.frequency;
 
 import java.time.LocalDate;
 import org.opentripplanner.model.TripPattern;
-import org.opentripplanner.model.WheelChairBoarding;
+import org.opentripplanner.model.WheelchairBoarding;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripSchedule;
 import org.opentripplanner.routing.trippattern.TripTimes;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTransferConstraint;
@@ -37,7 +37,7 @@ abstract class FrequencyBoardOrAlightEvent<T extends RaptorTripSchedule>
   protected final int offset;
   protected final int headway;
   protected final LocalDate serviceDate;
-  private final WheelChairBoarding wheelChairBoarding;
+  private final WheelchairBoarding wheelChairBoarding;
 
   public FrequencyBoardOrAlightEvent(
     RaptorTripPattern raptorTripPattern,
@@ -138,7 +138,7 @@ abstract class FrequencyBoardOrAlightEvent<T extends RaptorTripSchedule>
   }
 
   @Override
-  public WheelChairBoarding wheelchairBoarding() {
+  public WheelchairBoarding wheelchairBoarding() {
     return wheelChairBoarding;
   }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RoutingRequestTransitDataProviderFilter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RoutingRequestTransitDataProviderFilter.java
@@ -9,7 +9,7 @@ import org.opentripplanner.model.BikeAccess;
 import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.model.TransitMode;
 import org.opentripplanner.model.Trip;
-import org.opentripplanner.model.WheelChairBoarding;
+import org.opentripplanner.model.WheelchairBoarding;
 import org.opentripplanner.model.modes.AllowedTransitMode;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripPatternForDate;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripPatternWithRaptorStopIndexes;
@@ -110,7 +110,7 @@ public class RoutingRequestTransitDataProviderFilter implements TransitDataProvi
     if (wheelchairAccessibility.enabled()) {
       if (
         wheelchairAccessibility.trips().onlyConsiderAccessible() &&
-        trip.getWheelchairBoarding() != WheelChairBoarding.POSSIBLE
+        trip.getWheelchairBoarding() != WheelchairBoarding.POSSIBLE
       ) {
         return false;
       }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripPatternForDates.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripPatternForDates.java
@@ -3,7 +3,7 @@ package org.opentripplanner.routing.algorithm.raptoradapter.transit.request;
 import java.util.BitSet;
 import java.util.List;
 import java.util.function.IntUnaryOperator;
-import org.opentripplanner.model.WheelChairBoarding;
+import org.opentripplanner.model.WheelchairBoarding;
 import org.opentripplanner.model.base.ToStringBuilder;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.SlackProvider;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripPatternForDate;
@@ -56,7 +56,7 @@ public class TripPatternForDates
    */
   private final int[] departureTimes;
 
-  private final WheelChairBoarding[] wheelchairBoardings;
+  private final WheelchairBoarding[] wheelchairBoardings;
 
   // bit arrays with boarding/alighting information for all stops on trip pattern
   private final BitSet boardingPossible;
@@ -87,7 +87,7 @@ public class TripPatternForDates
     this.numberOfTripSchedules = numberOfTripSchedules;
     this.isFrequencyBased = hasFrequencies;
 
-    wheelchairBoardings = new WheelChairBoarding[numberOfTripSchedules];
+    wheelchairBoardings = new WheelchairBoarding[numberOfTripSchedules];
 
     final int nStops = tripPattern.getStopIndexes().length;
     this.arrivalTimes = new int[nStops * numberOfTripSchedules];
@@ -263,7 +263,7 @@ public class TripPatternForDates
       .toString();
   }
 
-  public WheelChairBoarding wheelchairBoardingForTrip(int index) {
+  public WheelchairBoarding wheelchairBoardingForTrip(int index) {
     return wheelchairBoardings[index];
   }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripScheduleWithOffset.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripScheduleWithOffset.java
@@ -3,7 +3,7 @@ package org.opentripplanner.routing.algorithm.raptoradapter.transit.request;
 import java.time.LocalDate;
 import java.util.function.IntUnaryOperator;
 import org.opentripplanner.model.TripPattern;
-import org.opentripplanner.model.WheelChairBoarding;
+import org.opentripplanner.model.WheelchairBoarding;
 import org.opentripplanner.model.base.ToStringBuilder;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripPatternForDate;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripSchedule;
@@ -72,7 +72,7 @@ public final class TripScheduleWithOffset implements TripSchedule {
   }
 
   @Override
-  public WheelChairBoarding wheelchairBoarding() {
+  public WheelchairBoarding wheelchairBoarding() {
     return pattern.wheelchairBoardingForTrip(tripIndexForDates);
   }
 

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetTransitEntityLink.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetTransitEntityLink.java
@@ -4,7 +4,7 @@ import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.common.geometry.GeometryUtils;
 import org.opentripplanner.model.Trip;
-import org.opentripplanner.model.WheelChairBoarding;
+import org.opentripplanner.model.WheelchairBoarding;
 import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.core.StateEditor;
@@ -25,15 +25,15 @@ public abstract class StreetTransitEntityLink<T extends Vertex>
 
   private final T transitEntityVertex;
 
-  private final WheelChairBoarding wheelchairBoarding;
+  private final WheelchairBoarding wheelchairBoarding;
 
-  public StreetTransitEntityLink(StreetVertex fromv, T tov, WheelChairBoarding wheelchairBoarding) {
+  public StreetTransitEntityLink(StreetVertex fromv, T tov, WheelchairBoarding wheelchairBoarding) {
     super(fromv, tov);
     this.transitEntityVertex = tov;
     this.wheelchairBoarding = wheelchairBoarding;
   }
 
-  public StreetTransitEntityLink(T fromv, StreetVertex tov, WheelChairBoarding wheelchairBoarding) {
+  public StreetTransitEntityLink(T fromv, StreetVertex tov, WheelchairBoarding wheelchairBoarding) {
     super(fromv, tov);
     this.transitEntityVertex = fromv;
     this.wheelchairBoarding = wheelchairBoarding;
@@ -87,12 +87,12 @@ public abstract class StreetTransitEntityLink<T extends Vertex>
     if (accessibility.enabled()) {
       if (
         accessibility.stops().onlyConsiderAccessible() &&
-        wheelchairBoarding != WheelChairBoarding.POSSIBLE
+        wheelchairBoarding != WheelchairBoarding.POSSIBLE
       ) {
         return null;
-      } else if (wheelchairBoarding == WheelChairBoarding.NO_INFORMATION) {
+      } else if (wheelchairBoarding == WheelchairBoarding.NO_INFORMATION) {
         s1.incrementWeight(req.wheelchairAccessibility.stops().unknownCost());
-      } else if (wheelchairBoarding == WheelChairBoarding.NOT_POSSIBLE) {
+      } else if (wheelchairBoarding == WheelchairBoarding.NOT_POSSIBLE) {
         s1.incrementWeight(req.wheelchairAccessibility.stops().inaccessibleCost());
       }
     }

--- a/src/main/java/org/opentripplanner/routing/vertextype/TransitBoardingAreaVertex.java
+++ b/src/main/java/org/opentripplanner/routing/vertextype/TransitBoardingAreaVertex.java
@@ -2,7 +2,7 @@ package org.opentripplanner.routing.vertextype;
 
 import org.opentripplanner.model.BoardingArea;
 import org.opentripplanner.model.StationElement;
-import org.opentripplanner.model.WheelChairBoarding;
+import org.opentripplanner.model.WheelchairBoarding;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
 
@@ -27,7 +27,7 @@ public class TransitBoardingAreaVertex extends Vertex {
     );
     this.boardingArea = boardingArea;
     this.wheelchairAccessible =
-      boardingArea.getWheelchairBoarding() != WheelChairBoarding.NOT_POSSIBLE;
+      boardingArea.getWheelchairBoarding() != WheelchairBoarding.NOT_POSSIBLE;
     //Adds this vertex into graph envelope so that we don't need to loop over all vertices
     graph.expandToInclude(
       boardingArea.getCoordinate().longitude(),

--- a/src/main/java/org/opentripplanner/routing/vertextype/TransitEntranceVertex.java
+++ b/src/main/java/org/opentripplanner/routing/vertextype/TransitEntranceVertex.java
@@ -2,7 +2,7 @@ package org.opentripplanner.routing.vertextype;
 
 import org.opentripplanner.model.Entrance;
 import org.opentripplanner.model.StationElement;
-import org.opentripplanner.model.WheelChairBoarding;
+import org.opentripplanner.model.WheelchairBoarding;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
 
@@ -10,7 +10,7 @@ public class TransitEntranceVertex extends Vertex {
 
   private static final long serialVersionUID = 1L;
 
-  private final WheelChairBoarding wheelchairBoarding;
+  private final WheelchairBoarding wheelchairBoarding;
 
   private final Entrance entrance;
 
@@ -34,7 +34,7 @@ public class TransitEntranceVertex extends Vertex {
     );
   }
 
-  public WheelChairBoarding getWheelchairBoarding() {
+  public WheelchairBoarding getWheelchairBoarding() {
     return wheelchairBoarding;
   }
 

--- a/src/main/java/org/opentripplanner/routing/vertextype/TransitPathwayNodeVertex.java
+++ b/src/main/java/org/opentripplanner/routing/vertextype/TransitPathwayNodeVertex.java
@@ -2,7 +2,7 @@ package org.opentripplanner.routing.vertextype;
 
 import org.opentripplanner.model.PathwayNode;
 import org.opentripplanner.model.StationElement;
-import org.opentripplanner.model.WheelChairBoarding;
+import org.opentripplanner.model.WheelchairBoarding;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
 import org.slf4j.Logger;
@@ -30,7 +30,7 @@ public class TransitPathwayNodeVertex extends Vertex {
       node.getName()
     );
     this.node = node;
-    this.wheelchairEntrance = node.getWheelchairBoarding() != WheelChairBoarding.NOT_POSSIBLE;
+    this.wheelchairEntrance = node.getWheelchairBoarding() != WheelchairBoarding.NOT_POSSIBLE;
     //Adds this vertex into graph envelope so that we don't need to loop over all vertices
     graph.expandToInclude(node.getCoordinate().longitude(), node.getCoordinate().latitude());
   }

--- a/src/main/java/org/opentripplanner/routing/vertextype/TransitStopVertex.java
+++ b/src/main/java/org/opentripplanner/routing/vertextype/TransitStopVertex.java
@@ -5,7 +5,7 @@ import java.util.Set;
 import org.opentripplanner.model.StationElement;
 import org.opentripplanner.model.Stop;
 import org.opentripplanner.model.TransitMode;
-import org.opentripplanner.model.WheelChairBoarding;
+import org.opentripplanner.model.WheelchairBoarding;
 import org.opentripplanner.routing.RoutingService;
 import org.opentripplanner.routing.edgetype.PathwayEdge;
 import org.opentripplanner.routing.graph.Edge;
@@ -21,7 +21,7 @@ public class TransitStopVertex extends Vertex {
   // Do we actually need a set of modes for each stop?
   // It's nice to have for the index web API but can be generated on demand.
   private final Set<TransitMode> modes;
-  private final WheelChairBoarding wheelchairBoarding;
+  private final WheelchairBoarding wheelchairBoarding;
 
   private final Stop stop;
 
@@ -46,7 +46,7 @@ public class TransitStopVertex extends Vertex {
     graph.expandToInclude(stop.getLon(), stop.getLat());
   }
 
-  public WheelChairBoarding getWheelchairBoarding() {
+  public WheelchairBoarding getWheelchairBoarding() {
     return wheelchairBoarding;
   }
 

--- a/src/main/java/org/opentripplanner/transit/raptor/api/transit/RaptorTripPattern.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/transit/RaptorTripPattern.java
@@ -1,7 +1,5 @@
 package org.opentripplanner.transit.raptor.api.transit;
 
-import org.opentripplanner.model.WheelChairBoarding;
-
 /**
  * This interface represent a trip pattern. A trip-pattern in the raptor context is just a list of
  * stops visited by ALL trips in the pattern. The stops must be ordered in the same sequence, with

--- a/src/main/java/org/opentripplanner/transit/raptor/api/transit/RaptorTripSchedule.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/transit/RaptorTripSchedule.java
@@ -1,6 +1,6 @@
 package org.opentripplanner.transit.raptor.api.transit;
 
-import org.opentripplanner.model.WheelChairBoarding;
+import org.opentripplanner.model.WheelchairBoarding;
 
 /**
  * The purpose of this interface is to provide information about the trip schedule. The trip is a
@@ -119,5 +119,5 @@ public interface RaptorTripSchedule {
    */
   int transitReluctanceFactorIndex();
 
-  WheelChairBoarding wheelchairBoarding();
+  WheelchairBoarding wheelchairBoarding();
 }

--- a/src/test/java/org/opentripplanner/gtfs/mapping/BoardingAreaMapperTest.java
+++ b/src/test/java/org/opentripplanner/gtfs/mapping/BoardingAreaMapperTest.java
@@ -11,7 +11,7 @@ import java.util.Collections;
 import org.junit.Test;
 import org.onebusaway.gtfs.model.AgencyAndId;
 import org.onebusaway.gtfs.model.Stop;
-import org.opentripplanner.model.WheelChairBoarding;
+import org.opentripplanner.model.WheelchairBoarding;
 import org.opentripplanner.util.TranslationHelper;
 
 public class BoardingAreaMapperTest {
@@ -36,7 +36,7 @@ public class BoardingAreaMapperTest {
 
   private static final int VEHICLE_TYPE = 5;
 
-  private static final WheelChairBoarding WHEELCHAIR_BOARDING = WheelChairBoarding.POSSIBLE;
+  private static final WheelchairBoarding WHEELCHAIR_BOARDING = WheelchairBoarding.POSSIBLE;
 
   private static final String ZONE_ID = "Zone Id";
 
@@ -93,7 +93,7 @@ public class BoardingAreaMapperTest {
     assertEquals(BoardingAreaMapper.DEFAULT_NAME, result.getName().toString());
     assertNull(result.getParentStop());
     assertNull(result.getCode());
-    assertEquals(WheelChairBoarding.NO_INFORMATION, result.getWheelchairBoarding());
+    assertEquals(WheelchairBoarding.NO_INFORMATION, result.getWheelchairBoarding());
   }
 
   @Test(expected = NullPointerException.class)

--- a/src/test/java/org/opentripplanner/gtfs/mapping/EntranceMapperTest.java
+++ b/src/test/java/org/opentripplanner/gtfs/mapping/EntranceMapperTest.java
@@ -11,7 +11,7 @@ import java.util.Collections;
 import org.junit.Test;
 import org.onebusaway.gtfs.model.AgencyAndId;
 import org.onebusaway.gtfs.model.Stop;
-import org.opentripplanner.model.WheelChairBoarding;
+import org.opentripplanner.model.WheelchairBoarding;
 import org.opentripplanner.util.TranslationHelper;
 
 public class EntranceMapperTest {
@@ -38,7 +38,7 @@ public class EntranceMapperTest {
 
   private static final int WHEELCHAIR_BOARDING = 1;
 
-  private static final WheelChairBoarding WHEELCHAIR_BOARDING_ENUM = WheelChairBoarding.POSSIBLE;
+  private static final WheelchairBoarding WHEELCHAIR_BOARDING_ENUM = WheelchairBoarding.POSSIBLE;
 
   private static final String ZONE_ID = "Zone Id";
 
@@ -78,7 +78,7 @@ public class EntranceMapperTest {
     assertEquals(LAT, result.getCoordinate().latitude(), 0.0001d);
     assertEquals(LON, result.getCoordinate().longitude(), 0.0001d);
     assertEquals(NAME, result.getName().toString());
-    assertEquals(WheelChairBoarding.POSSIBLE, result.getWheelchairBoarding());
+    assertEquals(WheelchairBoarding.POSSIBLE, result.getWheelchairBoarding());
   }
 
   @Test
@@ -96,7 +96,7 @@ public class EntranceMapperTest {
     assertEquals(NAME, result.getName().toString());
     assertNull(result.getParentStation());
     assertNull(result.getCode());
-    assertEquals(WheelChairBoarding.NO_INFORMATION, result.getWheelchairBoarding());
+    assertEquals(WheelchairBoarding.NO_INFORMATION, result.getWheelchairBoarding());
   }
 
   @Test(expected = IllegalStateException.class)

--- a/src/test/java/org/opentripplanner/gtfs/mapping/PathwayNodeMapperTest.java
+++ b/src/test/java/org/opentripplanner/gtfs/mapping/PathwayNodeMapperTest.java
@@ -11,7 +11,7 @@ import java.util.Collections;
 import org.junit.Test;
 import org.onebusaway.gtfs.model.AgencyAndId;
 import org.onebusaway.gtfs.model.Stop;
-import org.opentripplanner.model.WheelChairBoarding;
+import org.opentripplanner.model.WheelchairBoarding;
 import org.opentripplanner.util.TranslationHelper;
 
 public class PathwayNodeMapperTest {
@@ -38,7 +38,7 @@ public class PathwayNodeMapperTest {
 
   private static final int WHEELCHAIR_BOARDING = 1;
 
-  private static final WheelChairBoarding WHEELCHAIR_BOARDING_ENUM = WheelChairBoarding.POSSIBLE;
+  private static final WheelchairBoarding WHEELCHAIR_BOARDING_ENUM = WheelchairBoarding.POSSIBLE;
 
   private static final String ZONE_ID = "Zone Id";
 
@@ -78,7 +78,7 @@ public class PathwayNodeMapperTest {
     assertEquals(LAT, result.getCoordinate().latitude(), 0.0001d);
     assertEquals(LON, result.getCoordinate().longitude(), 0.0001d);
     assertEquals(NAME, result.getName().toString());
-    assertEquals(WheelChairBoarding.POSSIBLE, result.getWheelchairBoarding());
+    assertEquals(WheelchairBoarding.POSSIBLE, result.getWheelchairBoarding());
   }
 
   @Test
@@ -95,7 +95,7 @@ public class PathwayNodeMapperTest {
     assertEquals(PathwayNodeMapper.DEFAULT_NAME, result.getName().toString());
     assertNull(result.getParentStation());
     assertNull(result.getCode());
-    assertEquals(WheelChairBoarding.NO_INFORMATION, result.getWheelchairBoarding());
+    assertEquals(WheelchairBoarding.NO_INFORMATION, result.getWheelchairBoarding());
   }
 
   @Test(expected = IllegalStateException.class)

--- a/src/test/java/org/opentripplanner/gtfs/mapping/StopAndStationMapperTest.java
+++ b/src/test/java/org/opentripplanner/gtfs/mapping/StopAndStationMapperTest.java
@@ -11,7 +11,7 @@ import java.util.Collections;
 import org.junit.Test;
 import org.onebusaway.gtfs.model.AgencyAndId;
 import org.onebusaway.gtfs.model.Stop;
-import org.opentripplanner.model.WheelChairBoarding;
+import org.opentripplanner.model.WheelchairBoarding;
 import org.opentripplanner.util.TranslationHelper;
 
 public class StopAndStationMapperTest {
@@ -42,7 +42,7 @@ public class StopAndStationMapperTest {
 
   private static final int WHEELCHAIR_BOARDING = 1;
 
-  private static final WheelChairBoarding WHEELCHAIR_BOARDING_ENUM = WheelChairBoarding.POSSIBLE;
+  private static final WheelchairBoarding WHEELCHAIR_BOARDING_ENUM = WheelchairBoarding.POSSIBLE;
 
   private static final String ZONE_ID = "Zone Id";
 
@@ -84,7 +84,7 @@ public class StopAndStationMapperTest {
     assertEquals(LON, result.getLon(), 0.0001d);
     assertEquals(NAME, result.getName().toString());
     assertEquals(URL, result.getUrl().toString());
-    assertEquals(WheelChairBoarding.POSSIBLE, result.getWheelchairBoarding());
+    assertEquals(WheelchairBoarding.POSSIBLE, result.getWheelchairBoarding());
     assertEquals(ZONE_ID, result.getFirstZoneAsString());
   }
 
@@ -104,7 +104,7 @@ public class StopAndStationMapperTest {
     assertNull(result.getCode());
     assertNull(result.getUrl());
     // Skip getting coordinate, it will throw an exception
-    assertEquals(WheelChairBoarding.NO_INFORMATION, result.getWheelchairBoarding());
+    assertEquals(WheelchairBoarding.NO_INFORMATION, result.getWheelchairBoarding());
     assertNull(result.getFirstZoneAsString());
   }
 

--- a/src/test/java/org/opentripplanner/gtfs/mapping/TripMapperTest.java
+++ b/src/test/java/org/opentripplanner/gtfs/mapping/TripMapperTest.java
@@ -14,7 +14,7 @@ import org.onebusaway.gtfs.model.Route;
 import org.onebusaway.gtfs.model.Trip;
 import org.opentripplanner.graph_builder.DataImportIssueStore;
 import org.opentripplanner.model.BikeAccess;
-import org.opentripplanner.model.WheelChairBoarding;
+import org.opentripplanner.model.WheelchairBoarding;
 
 public class TripMapperTest {
 
@@ -38,7 +38,7 @@ public class TripMapperTest {
 
   private static final String TRIP_SHORT_NAME = "Trip Short Name";
 
-  private static final WheelChairBoarding WHEELCHAIR_ACCESSIBLE = WheelChairBoarding.POSSIBLE;
+  private static final WheelchairBoarding WHEELCHAIR_ACCESSIBLE = WheelchairBoarding.POSSIBLE;
 
   private static final Trip TRIP = new Trip();
   private final TripMapper subject = new TripMapper(
@@ -104,7 +104,7 @@ public class TripMapperTest {
     assertNull(result.getTripHeadsign());
     assertNull(result.getTripShortName());
     assertEquals(-1, result.getDirection().gtfsCode);
-    assertEquals(WheelChairBoarding.NO_INFORMATION, result.getWheelchairBoarding());
+    assertEquals(WheelchairBoarding.NO_INFORMATION, result.getWheelchairBoarding());
     assertEquals(BikeAccess.UNKNOWN, result.getBikesAllowed());
   }
 

--- a/src/test/java/org/opentripplanner/netex/NetexBundleSmokeTest.java
+++ b/src/test/java/org/opentripplanner/netex/NetexBundleSmokeTest.java
@@ -30,7 +30,7 @@ import org.opentripplanner.model.StopTimeKey;
 import org.opentripplanner.model.TransitEntity;
 import org.opentripplanner.model.Trip;
 import org.opentripplanner.model.TripPattern;
-import org.opentripplanner.model.WheelChairBoarding;
+import org.opentripplanner.model.WheelchairBoarding;
 import org.opentripplanner.model.calendar.CalendarServiceData;
 import org.opentripplanner.model.calendar.ServiceDate;
 import org.opentripplanner.model.impl.OtpTransitServiceBuilder;
@@ -178,7 +178,7 @@ public class NetexBundleSmokeTest {
     assertEquals("Ruter", t.getOperator().getName());
     assertEquals("Ruter", t.getTripOperator().getName());
     assertEquals(BikeAccess.UNKNOWN, t.getBikesAllowed());
-    assertEquals(WheelChairBoarding.NO_INFORMATION, t.getWheelchairBoarding());
+    assertEquals(WheelchairBoarding.NO_INFORMATION, t.getWheelchairBoarding());
     assertEquals(4, trips.size());
   }
 

--- a/src/test/java/org/opentripplanner/netex/mapping/FlexStopLocationMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/FlexStopLocationMapperTest.java
@@ -17,7 +17,7 @@ import org.opentripplanner.model.FlexLocationGroup;
 import org.opentripplanner.model.FlexStopLocation;
 import org.opentripplanner.model.Stop;
 import org.opentripplanner.model.WgsCoordinate;
-import org.opentripplanner.model.WheelChairBoarding;
+import org.opentripplanner.model.WheelchairBoarding;
 import org.opentripplanner.util.NonLocalizedString;
 import org.rutebanken.netex.model.FlexibleArea;
 import org.rutebanken.netex.model.FlexibleStopPlace;
@@ -162,7 +162,7 @@ public class FlexStopLocationMapperTest {
       id,
       null,
       WgsCoordinate.creatOptionalCoordinate(latitude, longitude),
-      WheelChairBoarding.NO_INFORMATION,
+      WheelchairBoarding.NO_INFORMATION,
       null,
       null,
       null,

--- a/src/test/java/org/opentripplanner/netex/mapping/StopAndStationMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/StopAndStationMapperTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.opentripplanner.graph_builder.DataImportIssueStore;
 import org.opentripplanner.model.Station;
 import org.opentripplanner.model.Stop;
-import org.opentripplanner.model.WheelChairBoarding;
+import org.opentripplanner.model.WheelchairBoarding;
 import org.opentripplanner.netex.index.hierarchy.HierarchicalVersionMapById;
 import org.rutebanken.netex.model.AccessibilityAssessment;
 import org.rutebanken.netex.model.AccessibilityLimitation;
@@ -77,9 +77,9 @@ public class StopAndStationMapperTest {
 
     assertEquals(3, stops.size(), "Stops.size must be 3 found " + stops.size());
 
-    assertWheelChairBoarding("ST:Quay:1", WheelChairBoarding.POSSIBLE, stops);
-    assertWheelChairBoarding("ST:Quay:2", WheelChairBoarding.NOT_POSSIBLE, stops);
-    assertWheelChairBoarding("ST:Quay:3", WheelChairBoarding.NO_INFORMATION, stops);
+    assertWheelChairBoarding("ST:Quay:1", WheelchairBoarding.POSSIBLE, stops);
+    assertWheelChairBoarding("ST:Quay:2", WheelchairBoarding.NOT_POSSIBLE, stops);
+    assertWheelChairBoarding("ST:Quay:3", WheelchairBoarding.NO_INFORMATION, stops);
 
     // Now test with AccessibilityAssessment set on StopPlace (should be default)
     stopPlace.withAccessibilityAssessment(
@@ -92,7 +92,7 @@ public class StopAndStationMapperTest {
     stopAndStationMapper.mapParentAndChildStops(List.of(stopPlace));
 
     assertEquals(4, stops.size(), "stops.size must be 4 found " + stops.size());
-    assertWheelChairBoarding("ST:Quay:4", WheelChairBoarding.POSSIBLE, stops);
+    assertWheelChairBoarding("ST:Quay:4", WheelchairBoarding.POSSIBLE, stops);
   }
 
   @Test
@@ -240,7 +240,7 @@ public class StopAndStationMapperTest {
    */
   private void assertWheelChairBoarding(
     String quayId,
-    WheelChairBoarding expected,
+    WheelchairBoarding expected,
     List<Stop> stops
   ) {
     var wheelChairBoarding = stops

--- a/src/test/java/org/opentripplanner/netex/mapping/TripMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/TripMapperTest.java
@@ -13,7 +13,7 @@ import org.opentripplanner.graph_builder.DataImportIssueStore;
 import org.opentripplanner.model.FeedScopedId;
 import org.opentripplanner.model.Route;
 import org.opentripplanner.model.Trip;
-import org.opentripplanner.model.WheelChairBoarding;
+import org.opentripplanner.model.WheelchairBoarding;
 import org.opentripplanner.model.impl.OtpTransitServiceBuilder;
 import org.opentripplanner.netex.index.hierarchy.HierarchicalMap;
 import org.opentripplanner.netex.index.hierarchy.HierarchicalMapById;
@@ -72,7 +72,7 @@ public class TripMapperTest {
     assertNotNull(trip, "trip must not be null");
     assertEquals(
       trip.getWheelchairBoarding(),
-      WheelChairBoarding.POSSIBLE,
+      WheelchairBoarding.POSSIBLE,
       "Wheelchair accessibility not possible on trip"
     );
   }

--- a/src/test/java/org/opentripplanner/routing/algorithm/GraphRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/GraphRoutingTest.java
@@ -17,7 +17,7 @@ import org.opentripplanner.model.StopTime;
 import org.opentripplanner.model.TransitMode;
 import org.opentripplanner.model.TripPattern;
 import org.opentripplanner.model.WgsCoordinate;
-import org.opentripplanner.model.WheelChairBoarding;
+import org.opentripplanner.model.WheelchairBoarding;
 import org.opentripplanner.routing.algorithm.astar.AStarBuilder;
 import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.core.RoutingContext;
@@ -214,7 +214,7 @@ public abstract class GraphRoutingTest {
         id,
         null,
         WgsCoordinate.creatOptionalCoordinate(latitude, longitude),
-        WheelChairBoarding.NO_INFORMATION,
+        WheelchairBoarding.NO_INFORMATION,
         null
       );
     }
@@ -226,7 +226,7 @@ public abstract class GraphRoutingTest {
         id,
         null,
         WgsCoordinate.creatOptionalCoordinate(latitude, longitude),
-        WheelChairBoarding.NO_INFORMATION,
+        WheelchairBoarding.NO_INFORMATION,
         null,
         null,
         null,

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/cost/WheelchairCostCalculatorTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/cost/WheelchairCostCalculatorTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.opentripplanner.model.WheelChairBoarding;
+import org.opentripplanner.model.WheelchairBoarding;
 import org.opentripplanner.routing.api.request.WheelchairAccessibilityFeature;
 import org.opentripplanner.routing.api.request.WheelchairAccessibilityRequest;
 import org.opentripplanner.test.support.VariableSource;
@@ -40,14 +40,14 @@ public class WheelchairCostCalculatorTest {
   private final TestTripSchedule.Builder scheduleBuilder = TestTripSchedule.schedule("12:00 12:01");
 
   static Stream<Arguments> testCases = Stream.of(
-    Arguments.of(WheelChairBoarding.POSSIBLE, 0),
-    Arguments.of(WheelChairBoarding.NO_INFORMATION, UNKNOWN_ACCESSIBILITY_COST),
-    Arguments.of(WheelChairBoarding.NOT_POSSIBLE, INACCESSIBLE_TRIP_COST)
+    Arguments.of(WheelchairBoarding.POSSIBLE, 0),
+    Arguments.of(WheelchairBoarding.NO_INFORMATION, UNKNOWN_ACCESSIBILITY_COST),
+    Arguments.of(WheelchairBoarding.NOT_POSSIBLE, INACCESSIBLE_TRIP_COST)
   );
 
   @ParameterizedTest(name = "accessibility of {0} should add an extra cost of {1}")
   @VariableSource("testCases")
-  public void calculateExtraBoardingCost(WheelChairBoarding wcb, int expectedExtraCost) {
+  public void calculateExtraBoardingCost(WheelchairBoarding wcb, int expectedExtraCost) {
     var schedule = scheduleBuilder.wheelchairBoarding(wcb).build();
 
     int defaultCost = calculateBoardingCost(schedule, defaultCostCalculator);

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RoutingRequestTransitDataProviderFilterTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RoutingRequestTransitDataProviderFilterTest.java
@@ -3,8 +3,8 @@ package org.opentripplanner.routing.algorithm.raptoradapter.transit.request;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.opentripplanner.model.WheelChairBoarding.NOT_POSSIBLE;
-import static org.opentripplanner.model.WheelChairBoarding.POSSIBLE;
+import static org.opentripplanner.model.WheelchairBoarding.NOT_POSSIBLE;
+import static org.opentripplanner.model.WheelchairBoarding.POSSIBLE;
 
 import java.time.LocalDate;
 import java.util.BitSet;
@@ -25,7 +25,7 @@ import org.opentripplanner.model.TransitMode;
 import org.opentripplanner.model.Trip;
 import org.opentripplanner.model.TripAlteration;
 import org.opentripplanner.model.TripPattern;
-import org.opentripplanner.model.WheelChairBoarding;
+import org.opentripplanner.model.WheelchairBoarding;
 import org.opentripplanner.model.modes.AllowedTransitMode;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripPatternForDate;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripPatternWithRaptorStopIndexes;
@@ -241,7 +241,7 @@ public class RoutingRequestTransitDataProviderFilterTest {
       NOT_POSSIBLE,
       null
     );
-    tripTimes.getTrip().setWheelchairBoarding(WheelChairBoarding.NOT_POSSIBLE);
+    tripTimes.getTrip().setWheelchairBoarding(WheelchairBoarding.NOT_POSSIBLE);
 
     var filter = new RoutingRequestTransitDataProviderFilter(
       false,
@@ -499,7 +499,7 @@ public class RoutingRequestTransitDataProviderFilterTest {
     BikeAccess bikeAccess,
     TransitMode mode,
     String submode,
-    WheelChairBoarding wheelchairBoarding,
+    WheelchairBoarding wheelchairBoarding,
     TripAlteration tripAlteration
   ) {
     Trip trip = new Trip(tripId);

--- a/src/test/java/org/opentripplanner/routing/edgetype/StreetTransitEntityLinkTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/StreetTransitEntityLinkTest.java
@@ -2,9 +2,9 @@ package org.opentripplanner.routing.edgetype;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.opentripplanner.model.WheelChairBoarding.NOT_POSSIBLE;
-import static org.opentripplanner.model.WheelChairBoarding.NO_INFORMATION;
-import static org.opentripplanner.model.WheelChairBoarding.POSSIBLE;
+import static org.opentripplanner.model.WheelchairBoarding.NOT_POSSIBLE;
+import static org.opentripplanner.model.WheelchairBoarding.NO_INFORMATION;
+import static org.opentripplanner.model.WheelchairBoarding.POSSIBLE;
 
 import java.util.Set;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/opentripplanner/transit/raptor/_data/transit/TestTripPattern.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/_data/transit/TestTripPattern.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.transit.raptor._data.transit;
 
-import org.opentripplanner.model.WheelChairBoarding;
 import org.opentripplanner.model.base.ToStringBuilder;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripPattern;
 

--- a/src/test/java/org/opentripplanner/transit/raptor/_data/transit/TestTripSchedule.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/_data/transit/TestTripSchedule.java
@@ -1,8 +1,8 @@
 package org.opentripplanner.transit.raptor._data.transit;
 
-import static org.opentripplanner.model.WheelChairBoarding.NO_INFORMATION;
+import static org.opentripplanner.model.WheelchairBoarding.NO_INFORMATION;
 
-import org.opentripplanner.model.WheelChairBoarding;
+import org.opentripplanner.model.WheelchairBoarding;
 import org.opentripplanner.model.base.ToStringBuilder;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripPattern;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
@@ -20,14 +20,14 @@ public class TestTripSchedule implements RaptorTripSchedule {
   private final int[] arrivalTimes;
   private final int[] departureTimes;
   private final int transitReluctanceIndex;
-  private final WheelChairBoarding wheelchairBoarding;
+  private final WheelchairBoarding wheelchairBoarding;
 
   protected TestTripSchedule(
     TestTripPattern pattern,
     int[] arrivalTimes,
     int[] departureTimes,
     int transitReluctanceIndex,
-    WheelChairBoarding wheelchairBoarding
+    WheelchairBoarding wheelchairBoarding
   ) {
     this.pattern = pattern;
     this.arrivalTimes = arrivalTimes;
@@ -75,7 +75,7 @@ public class TestTripSchedule implements RaptorTripSchedule {
   }
 
   @Override
-  public WheelChairBoarding wheelchairBoarding() {
+  public WheelchairBoarding wheelchairBoarding() {
     return wheelchairBoarding;
   }
 
@@ -106,7 +106,7 @@ public class TestTripSchedule implements RaptorTripSchedule {
     private int[] departureTimes;
     private int arrivalDepartureOffset = DEFAULT_DEPARTURE_DELAY;
     private int transitReluctanceIndex = 0;
-    private WheelChairBoarding wheelchairBoarding = NO_INFORMATION;
+    private WheelchairBoarding wheelchairBoarding = NO_INFORMATION;
 
     public TestTripSchedule.Builder pattern(TestTripPattern pattern) {
       this.pattern = pattern;
@@ -172,7 +172,7 @@ public class TestTripSchedule implements RaptorTripSchedule {
       return this;
     }
 
-    public TestTripSchedule.Builder wheelchairBoarding(WheelChairBoarding wcb) {
+    public TestTripSchedule.Builder wheelchairBoarding(WheelchairBoarding wcb) {
       this.wheelchairBoarding = wcb;
       return this;
     }


### PR DESCRIPTION
### Summary

This corrects the spelling of the type `WheelChairBoarding` to `WheelchairBoarding`. No other change was made.