### PR TITLE
Fix platform edge name [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModule.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.graph_builder.module;
 
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import org.locationtech.jts.geom.Envelope;
@@ -18,11 +17,11 @@ import org.opentripplanner.routing.edgetype.StreetTransitStopLink;
 import org.opentripplanner.routing.edgetype.StreetTraversalPermission;
 import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Graph;
-import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.routing.impl.StreetVertexIndex;
 import org.opentripplanner.routing.vertextype.OsmBoardingLocationVertex;
 import org.opentripplanner.routing.vertextype.StreetVertex;
 import org.opentripplanner.routing.vertextype.TransitStopVertex;
+import org.opentripplanner.util.LocalizedString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -137,7 +136,7 @@ public class OsmBoardingLocationsModule implements GraphBuilderModule {
       from,
       to,
       line,
-      from.getName(),
+      new LocalizedString("name.platform"),
       SphericalDistanceLibrary.length(line),
       StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE,
       false

--- a/src/main/java/org/opentripplanner/util/LocalizedString.java
+++ b/src/main/java/org/opentripplanner/util/LocalizedString.java
@@ -44,7 +44,7 @@ public class LocalizedString implements I18NString, Serializable {
    * Creates String which can be localized
    *
    * @param key key of translation for this way set in {@link org.opentripplanner.graph_builder.module.osm.DefaultWayPropertySetSource}
-   *            and translations read from from properties Files
+   *            and translations read from properties Files
    */
   public LocalizedString(String key) {
     this.key = key;

--- a/src/test/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModuleTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModuleTest.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.graph_builder.module;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 import java.util.HashMap;
@@ -72,5 +73,16 @@ class OsmBoardingLocationsModuleTest {
           edges.stream().map(Edge::getClass).collect(Collectors.toSet())
         )
       );
+
+    platformCentroids
+      .stream()
+      .flatMap(c -> Stream.concat(c.getIncoming().stream(), c.getOutgoing().stream()))
+      .forEach(e -> assertNotNull(e.getName(), "Edge " + e + " returns null for getName()"));
+
+    platformCentroids
+      .stream()
+      .flatMap(c -> Stream.concat(c.getIncoming().stream(), c.getOutgoing().stream()))
+      .filter(StreetEdge.class::isInstance)
+      .forEach(e -> assertEquals("platform", e.getName().toString()));
   }
 }


### PR DESCRIPTION
### Summary

In #4116 I introduced a bug that I noticed when looking at the [logs of the speed test](https://github.com/opentripplanner/OpenTripPlanner/runs/6270408339?check_suite_focus=true):

```
java.lang.NullPointerException: Cannot invoke "org.opentripplanner.util.I18NString.toString()" because the return value of "org.opentripplanner.routing.graph.Edge.getName()" is null
	at org.opentripplanner.routing.algorithm.mapping.StatesToWalkStepsMapper.processState(StatesToWalkStepsMapper.java:186)
	at org.opentripplanner.routing.algorithm.mapping.StatesToWalkStepsMapper.generateWalkSteps(StatesToWalkStepsMapper.java:87)
	at org.opentripplanner.routing.algorithm.mapping.GraphPathToItineraryMapper.generateLeg(GraphPathToItineraryMapper.java:400)
	at org.opentripplanner.routing.algorithm.mapping.GraphPathToItineraryMapper.generateItinerary(GraphPathToItineraryMapper.java:115)
	at org.opentripplanner.routing.algorithm.mapping.RaptorPathToItineraryMapper.mapNonTransitLeg(RaptorPathToItineraryMapper.java:298)
	at org.opentripplanner.routing.algorithm.mapping.RaptorPathToItineraryMapper.mapTransferLeg(RaptorPathToItineraryMapper.java:228)
	at org.opentripplanner.routing.algorithm.mapping.RaptorPathToItineraryMapper.createItinerary(RaptorPathToItineraryMapper.java:108)
	at org.opentripplanner.routing.algorithm.raptoradapter.router.TransitRouter.route(TransitRouter.java:155)
	at org.opentripplanner.routing.algorithm.raptoradapter.router.TransitRouter.route(TransitRouter.java:79)
	at org.opentripplanner.routing.algorithm.RoutingWorker.routeTransit(RoutingWorker.java:236)
	at org.opentripplanner.routing.algorithm.RoutingWorker.route(RoutingWorker.java:111)
	at org.opentripplanner.transit.raptor.speed_test.SpeedTest.runSingleTestCase(SpeedTest.java:200)
	at org.opentripplanner.transit.raptor.speed_test.SpeedTest.runSingleTest(SpeedTest.java:167)
	at org.opentripplanner.transit.raptor.speed_test.SpeedTest.runTest(SpeedTest.java:134)
	at org.opentripplanner.transit.raptor.speed_test.SpeedTest.main(SpeedTest.java:80)
	at org.codehaus.mojo.exec.ExecJavaMojo$1.run(ExecJavaMojo.java:254)
	at java.base/java.lang.Thread.run(Thread.java:833)
```
This is because the newly created `StreetEdge` seems to have a name of `null`. 

I had not noticed this when testing in Finland and the US.

This fixes the issue.

@hannesj It also shows that some stops in Norway are automatically matched by this feature. If you want to turn it completely off, you should to the following in build-config.json:

```
 "boardingLocationTags": []
```

### Issue

none

### Unit tests

Test added.

### Code style

autoformatted

### Documentation

n/a

### Changelog

Skip