### PR TITLE
Guard against null nameType in Netex mapper [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/netex/mapping/StationMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/StationMapper.java
@@ -30,7 +30,7 @@ class StationMapper {
       Map<String, String> translations = new HashMap<>();
       translations.put(null, stopPlace.getName().getValue());
       for (var translation : stopPlace.getAlternativeNames().getAlternativeName()) {
-        if (translation.getNameType().equals(NameTypeEnumeration.TRANSLATION)) {
+        if (translation.getNameType() == NameTypeEnumeration.TRANSLATION) {
           String lang = translation.getLang() != null
             ? translation.getLang()
             : translation.getName().getLang();


### PR DESCRIPTION
### Summary

Some Netex profiles allow the name type not to be defined. Previously this caused an NPE, which this PR fixes. As the type is an enum, it is safe to use the equals sign for comparison.
