### PR TITLE
Solve problem with negative running time validation [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
+++ b/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
@@ -349,7 +349,7 @@ public class TripTimes implements Serializable, Comparable<TripTimes> {
    */
   public boolean timesIncreasing() {
     final int nStops = scheduledArrivalTimes.length;
-    int prevDep = Integer.MIN_VALUE;
+    int prevDep = Integer.MIN_VALUE + 5; // +5 to protect against number underflow
     for (int s = 0; s < nStops; s++) {
       final int arr = getArrivalTime(s);
       final int dep = getDepartureTime(s);

--- a/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
+++ b/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
@@ -349,7 +349,7 @@ public class TripTimes implements Serializable, Comparable<TripTimes> {
    */
   public boolean timesIncreasing() {
     final int nStops = scheduledArrivalTimes.length;
-    int prevDep = -1;
+    int prevDep = Integer.MIN_VALUE;
     for (int s = 0; s < nStops; s++) {
       final int arr = getArrivalTime(s);
       final int dep = getDepartureTime(s);

--- a/src/test/java/org/opentripplanner/routing/trippattern/TripTimesTest.java
+++ b/src/test/java/org/opentripplanner/routing/trippattern/TripTimesTest.java
@@ -11,6 +11,11 @@ import org.opentripplanner.model.Stop;
 import org.opentripplanner.model.StopTime;
 import org.opentripplanner.model.Trip;
 
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
 public class TripTimesTest {
 
   private static final FeedScopedId TRIP_ID = new FeedScopedId("agency", "testTripId");
@@ -100,6 +105,16 @@ public class TripTimesTest {
   }
 
   @Test
+    public void testNonIncreasingUpdateCrossingMidnight() {
+        TripTimes updatedTripTimesA = new TripTimes(originalTripTimes);
+
+        updatedTripTimesA.updateArrivalTime(0, -300); //"Yesterday"
+        updatedTripTimesA.updateDepartureTime(0, 50);
+
+        assertTrue(updatedTripTimesA.timesIncreasing());
+    }
+
+    @Test
   public void testDelay() {
     TripTimes updatedTripTimesA = new TripTimes(originalTripTimes);
     updatedTripTimesA.updateDepartureDelay(0, 10);


### PR DESCRIPTION
### Summary

Ensure that OTP does throw negative running time errors on times that begin before midnight.

### Issue
Consider following case:

Service Journey has operating day date 2022-05-02
but first arrival for the journey is 2022-05-01 23:55

In this case first arrival would be 5 minutes before midnight and validation would not allow this time since it expect all of them to be positive

### Unit tests
- new unit test added

### Code style
yes

### Documentation
n/a
