### PR TITLE
Remove duplicated documentation file [changelog skip]

### DIFF
--- a/docs/sandbox/SiriAzureUpdaters.md
+++ b/docs/sandbox/SiriAzureUpdaters.md
@@ -1,7 +1,0 @@
-# Siri Azure Updater
-
-This is module developed by Skånetrafiken. It provides support for fetching SIRI SX / ET messages through
-**Azure Service Bus**. The updater is developed to support the Norwegian SIRI profile which is a 
-subset of the SIRI specification. 
-
-See `examples/skanetrafiken` for example configuration. 


### PR DESCRIPTION
### Summary

There are two files describing the Azure Service Bus integration. Remove the one not linked from the sandbox listing.

