### PR TITLE
Filter out GBFS stations that are missing required information [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsStationInformationMapper.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsStationInformationMapper.java
@@ -29,6 +29,16 @@ public class GbfsStationInformationMapper {
 
   public VehicleRentalStation mapStationInformation(GBFSStation station) {
     VehicleRentalStation rentalStation = new VehicleRentalStation();
+    if (
+      station.getStationId() == null ||
+      station.getStationId().isBlank() ||
+      station.getName() == null ||
+      station.getName().isBlank() ||
+      station.getLon() == null ||
+      station.getLat() == null
+    ) {
+      return null;
+    }
     rentalStation.id = new FeedScopedId(system.systemId, station.getStationId());
     rentalStation.system = system;
     rentalStation.longitude = station.getLon();
@@ -81,7 +91,6 @@ public class GbfsStationInformationMapper {
       String webUri = rentalUris.getWeb();
       rentalStation.rentalUris = new VehicleRentalStationUris(androidUri, iosUri, webUri);
     }
-
     return rentalStation;
   }
 }

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsStationInformationMapper.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsStationInformationMapper.java
@@ -10,8 +10,12 @@ import org.opentripplanner.routing.vehicle_rental.VehicleRentalStation;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalStationUris;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalSystem;
 import org.opentripplanner.util.NonLocalizedString;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class GbfsStationInformationMapper {
+
+  private static final Logger LOG = LoggerFactory.getLogger(GbfsStationInformationMapper.class);
 
   private final VehicleRentalSystem system;
   private final Map<String, RentalVehicleType> vehicleTypes;
@@ -37,6 +41,13 @@ public class GbfsStationInformationMapper {
       station.getLon() == null ||
       station.getLat() == null
     ) {
+      LOG.info(
+        String.format(
+          "GBFS station for %s system has issues with required fields: \n%s",
+          system.systemId,
+          station
+        )
+      );
       return null;
     }
     rentalStation.id = new FeedScopedId(system.systemId, station.getStationId());

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsVehicleRentalDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsVehicleRentalDataSource.java
@@ -112,6 +112,7 @@ class GbfsVehicleRentalDataSource implements DataSource<VehicleRentalPlace> {
           .getStations()
           .stream()
           .map(stationInformationMapper::mapStationInformation)
+          .filter(Objects::nonNull)
           .peek(stationStatusMapper::fillStationStatus)
           .collect(Collectors.toList())
       );

--- a/src/test/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsVehicleRentalDataSourceTest.java
+++ b/src/test/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsVehicleRentalDataSourceTest.java
@@ -72,12 +72,13 @@ class GbfsVehicleRentalDataSourceTest {
     assertTrue(dataSource.update());
 
     List<VehicleRentalPlace> stations = dataSource.getUpdates();
-    assertEquals(10, stations.size());
+    // There are 10 stations in the data but 5 are missing required data
+    assertEquals(5, stations.size());
     assertTrue(
       stations
         .stream()
         .anyMatch(vehicleRentalStation ->
-          vehicleRentalStation.getName().toString().equals("Kasarmitori")
+          vehicleRentalStation.getName().toString().equals("Viiskulma")
         )
     );
     assertTrue(

--- a/src/test/resources/gbfs/helsinki/station_information.json
+++ b/src/test/resources/gbfs/helsinki/station_information.json
@@ -39,14 +39,14 @@
         "capacity": 32
       },
       {
-        "station_id": "006",
+        "station_id": null,
         "name": "Hietalahdentori",
         "lat": 60.1622251,
         "lon": 24.9297099,
         "capacity": 24
       },
       {
-        "station_id": "007",
+        "station_id": "",
         "name": "Designmuseo",
         "lat": 60.1631032,
         "lon": 24.94596,
@@ -54,14 +54,14 @@
       },
       {
         "station_id": "008",
-        "name": "Vanha kirkkopuisto",
+        "name": null,
         "lat": 60.1652883,
         "lon": 24.9391499,
         "capacity": 24
       },
       {
         "station_id": "009",
-        "name": "Erottajan aukio",
+        "name": "",
         "lat": 60.166890083486,
         "lon": 24.9442610720753,
         "capacity": 44
@@ -69,8 +69,8 @@
       {
         "station_id": "010",
         "name": "Kasarmitori",
-        "lat": 60.1650171805,
-        "lon": 24.94947287873,
+        "lat": null,
+        "lon": null,
         "capacity": 28
       }
     ]


### PR DESCRIPTION
### Summary

Adds validation that GBFS stations have required fields and ignoring those that don't instead of ignoring all stations if any have issues.

### Issue

closes #4148

### Unit tests

Updated tests

### Code style

Have you followed
the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Codestyle.md)
?
Yes

### Documentation

Not needed

### Changelog

Not needed
