### PR TITLE
doc: add headers GBFS config doc

### DIFF
--- a/docs/RouterConfiguration.md
+++ b/docs/RouterConfiguration.md
@@ -517,6 +517,26 @@ For this to be possible three things need to be configured:
    `keepingRentedBicycleAtDestinationCost` (default: `0`) may also be set in the
    [routing defaults](#routing-defaults).
 
+##### Header Settings
+Sometimes GBFS Feeds might need some headers e.g. for authentication. 
+For those use cases headers can be configured as a json.
+```JSON
+// router-config.json
+{
+  "type": "vehicle-rental",
+  "sourceType": "gbfs",
+  "frequencySec": 60,
+  "url": "<https://some-gbfs-feed/gbfs.json>",
+  "headers": {
+    // example for authentication headers
+    "Auth": "<any-token>",
+    // example for any header
+    "<key>": "<value>"
+  }
+}
+```
+Any header key, value can be inserted.
+
 #### Vehicle Rental Service Directory configuration (sandbox feature)
 
 To configure and url for


### PR DESCRIPTION
### Summary

This PR provides documentation, on how GBFS headers can be configured in the `router-config.json`

### Issue

In one Google Group discussion, we discussed how to configure headers and authorization on GBFS feeds.
Sometimes GBFS Feeds need headers. For those use cases, there is already the functionality to add headers. This PR just adds documentation for this feature.
https://groups.google.com/g/opentripplanner-dev/c/WrW1siP7njk

### Documentation

- edited `docs/RouterConfiguration.md` to document, how to pass GBFS request headers

