### PR TITLE
Do not attempt to remove scheduled timetables [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TransitLayerUpdater.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TransitLayerUpdater.java
@@ -187,7 +187,11 @@ public class TransitLayerUpdater {
 
       for (TripPatternForDate tripPatternForDate : previouslyUsedPatterns) {
         if (tripPatternForDate.getLocalDate().equals(date)) {
-          var oldTimeTable = timetables.get(tripPatternForDate.getTripPattern().getPattern());
+          TripPattern pattern = tripPatternForDate.getTripPattern().getPattern();
+          if (!pattern.isCreatedByRealtimeUpdater()) {
+            continue;
+          }
+          var oldTimeTable = timetables.get(pattern);
           if (oldTimeTable != null) {
             var toRemove = oldTimeTable
               .stream()
@@ -199,6 +203,8 @@ public class TransitLayerUpdater {
             if (toRemove) {
               patternsForDate.remove(tripPatternForDate);
             }
+          } else {
+            LOG.warn("Could not fetch timetable for {}", pattern);
           }
         }
       }


### PR DESCRIPTION
### Summary

In #4038 we added cleanup for unused timetables. However, there is an edge case, when no scheduled timetables are left, and it is removed. This should not be done, and they should be left as is. Also add logging when null check triggers, in order to ease debugging. After implementing the check, I have not seen the null check being triggered.
