### PR TITLE
Split journey pattern geometries [changelog skip]

### DIFF
--- a/docs/sandbox/TransmodelApi.md
+++ b/docs/sandbox/TransmodelApi.md
@@ -45,6 +45,8 @@
   [#4123](https://github.com/opentripplanner/OpenTripPlanner/pull/4123)
 - Expose datedServiceJourney from EstimatedCall 
   [#4128](https://github.com/opentripplanner/OpenTripPlanner/pull/4128)
+- Expose stop-to-stop journey pattern geometries
+  [#4161](https://github.com/opentripplanner/OpenTripPlanner/pull/4161)
 
 ## Documentation
 

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
@@ -56,11 +56,7 @@ import org.opentripplanner.ext.transmodelapi.model.framework.RentalVehicleTypeTy
 import org.opentripplanner.ext.transmodelapi.model.framework.ServerInfoType;
 import org.opentripplanner.ext.transmodelapi.model.framework.SystemNoticeType;
 import org.opentripplanner.ext.transmodelapi.model.framework.ValidityPeriodType;
-import org.opentripplanner.ext.transmodelapi.model.network.DestinationDisplayType;
-import org.opentripplanner.ext.transmodelapi.model.network.GroupOfLinesType;
-import org.opentripplanner.ext.transmodelapi.model.network.JourneyPatternType;
-import org.opentripplanner.ext.transmodelapi.model.network.LineType;
-import org.opentripplanner.ext.transmodelapi.model.network.PresentationType;
+import org.opentripplanner.ext.transmodelapi.model.network.*;
 import org.opentripplanner.ext.transmodelapi.model.plan.LegType;
 import org.opentripplanner.ext.transmodelapi.model.plan.PathGuidanceType;
 import org.opentripplanner.ext.transmodelapi.model.plan.PlanPlaceType;
@@ -245,6 +241,12 @@ public class TransmodelGraphQLSchema {
       tariffZoneType,
       gqlUtil
     );
+
+    GraphQLOutputType stopToStopGeometryType = StopToStopGeometryType.create(
+      linkGeometryType,
+      quayType
+    );
+
     GraphQLNamedOutputType quayAtDistance = QuayAtDistanceType.createQD(quayType, relay);
     GraphQLNamedOutputType placeAtDistanceType = PlaceAtDistanceType.create(relay, placeInterface);
 
@@ -284,6 +286,7 @@ public class TransmodelGraphQLSchema {
       quayType,
       lineType,
       ServiceJourneyType.REF,
+      stopToStopGeometryType,
       ptSituationElementType,
       gqlUtil
     );

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/mapping/GeometryMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/mapping/GeometryMapper.java
@@ -21,10 +21,11 @@ public class GeometryMapper {
       var endLocation = tripPattern.getStop(i + 1);
       var geometry = PolylineEncoder.encodeGeometry(tripPattern.getHopGeometry(i));
 
-      var stopToStopGeometry = new EncodedPolylineBeanWithStops();
-      stopToStopGeometry.setFromQuay(startLocation);
-      stopToStopGeometry.setToQuay(endLocation);
-      stopToStopGeometry.setEncodedPolylineBean(geometry);
+      var stopToStopGeometry = new EncodedPolylineBeanWithStops(
+        startLocation,
+        endLocation,
+        geometry
+      );
 
       stopToStopGeometries.add(stopToStopGeometry);
     }

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/mapping/GeometryMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/mapping/GeometryMapper.java
@@ -1,0 +1,34 @@
+package org.opentripplanner.ext.transmodelapi.mapping;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.opentripplanner.ext.transmodelapi.model.util.EncodedPolylineBeanWithStops;
+import org.opentripplanner.model.TripPattern;
+import org.opentripplanner.util.PolylineEncoder;
+
+public class GeometryMapper {
+
+  /**
+   * Based Trip Pattern, create a list of geometries for each stop-to-stop section in the pattern
+   */
+  public static List<EncodedPolylineBeanWithStops> mapStopToStopGeometries(
+    TripPattern tripPattern
+  ) {
+    var stopToStopGeometries = new ArrayList<EncodedPolylineBeanWithStops>();
+
+    for (int i = 0; i < tripPattern.numberOfStops() - 1; i++) {
+      var startLocation = tripPattern.getStop(i);
+      var endLocation = tripPattern.getStop(i + 1);
+      var geometry = PolylineEncoder.encodeGeometry(tripPattern.getHopGeometry(i));
+
+      var stopToStopGeometry = new EncodedPolylineBeanWithStops();
+      stopToStopGeometry.setFromQuay(startLocation);
+      stopToStopGeometry.setToQuay(endLocation);
+      stopToStopGeometry.setEncodedPolylineBean(geometry);
+
+      stopToStopGeometries.add(stopToStopGeometry);
+    }
+
+    return stopToStopGeometries;
+  }
+}

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/network/JourneyPatternType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/network/JourneyPatternType.java
@@ -14,6 +14,7 @@ import java.util.BitSet;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.locationtech.jts.geom.LineString;
+import org.opentripplanner.ext.transmodelapi.mapping.GeometryMapper;
 import org.opentripplanner.ext.transmodelapi.model.EnumTypes;
 import org.opentripplanner.ext.transmodelapi.support.GqlUtil;
 import org.opentripplanner.model.TripPattern;
@@ -32,6 +33,7 @@ public class JourneyPatternType {
     GraphQLOutputType quayType,
     GraphQLOutputType lineType,
     GraphQLOutputType serviceJourneyType,
+    GraphQLOutputType stopToStopGeometryType,
     GraphQLNamedOutputType ptSituationElementType,
     GqlUtil gqlUtil
   ) {
@@ -123,6 +125,19 @@ public class JourneyPatternType {
               return PolylineEncoder.encodeGeometry(geometry);
             }
           })
+          .build()
+      )
+      .field(
+        GraphQLFieldDefinition
+          .newFieldDefinition()
+          .name("stopToStopGeometries")
+          .description(
+            "Detailed path travelled by journey pattern divided into stop-to-stop sections."
+          )
+          .type(new GraphQLList(stopToStopGeometryType))
+          .dataFetcher(environment ->
+            GeometryMapper.mapStopToStopGeometries(environment.getSource())
+          )
           .build()
       )
       .field(

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/network/StopToStopGeometryType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/network/StopToStopGeometryType.java
@@ -23,9 +23,7 @@ public class StopToStopGeometryType {
             "A list of coordinates encoded as a polyline string between two stops (see http://code.google.com/apis/maps/documentation/polylinealgorithm.html)"
           )
           .type(linkGeometryType)
-          .dataFetcher(env ->
-            ((EncodedPolylineBeanWithStops) env.getSource()).getEncodedPolylineBean()
-          )
+          .dataFetcher(env -> ((EncodedPolylineBeanWithStops) env.getSource()).pointsOnLink())
           .build()
       )
       .field(
@@ -34,7 +32,7 @@ public class StopToStopGeometryType {
           .name("fromQuay")
           .description("Origin Quay")
           .type(quayType)
-          .dataFetcher(env -> ((EncodedPolylineBeanWithStops) env.getSource()).getFromQuay())
+          .dataFetcher(env -> ((EncodedPolylineBeanWithStops) env.getSource()).fromQuay())
           .build()
       )
       .field(
@@ -43,7 +41,7 @@ public class StopToStopGeometryType {
           .name("toQuay")
           .description("Destination Quay")
           .type(quayType)
-          .dataFetcher(env -> ((EncodedPolylineBeanWithStops) env.getSource()).getToQuay())
+          .dataFetcher(env -> ((EncodedPolylineBeanWithStops) env.getSource()).toQuay())
           .build()
       )
       .build();

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/network/StopToStopGeometryType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/network/StopToStopGeometryType.java
@@ -1,0 +1,51 @@
+package org.opentripplanner.ext.transmodelapi.model.network;
+
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLOutputType;
+import org.opentripplanner.ext.transmodelapi.model.util.EncodedPolylineBeanWithStops;
+
+public class StopToStopGeometryType {
+
+  public static GraphQLObjectType create(
+    GraphQLOutputType linkGeometryType,
+    GraphQLOutputType quayType
+  ) {
+    return GraphQLObjectType
+      .newObject()
+      .name("StopToStopGeometry")
+      .description("List of coordinates between two stops as a polyline")
+      .field(
+        GraphQLFieldDefinition
+          .newFieldDefinition()
+          .name("pointsOnLink")
+          .description(
+            "A list of coordinates encoded as a polyline string between two stops (see http://code.google.com/apis/maps/documentation/polylinealgorithm.html)"
+          )
+          .type(linkGeometryType)
+          .dataFetcher(env ->
+            ((EncodedPolylineBeanWithStops) env.getSource()).getEncodedPolylineBean()
+          )
+          .build()
+      )
+      .field(
+        GraphQLFieldDefinition
+          .newFieldDefinition()
+          .name("fromQuay")
+          .description("Origin Quay")
+          .type(quayType)
+          .dataFetcher(env -> ((EncodedPolylineBeanWithStops) env.getSource()).getFromQuay())
+          .build()
+      )
+      .field(
+        GraphQLFieldDefinition
+          .newFieldDefinition()
+          .name("toQuay")
+          .description("Destination Quay")
+          .type(quayType)
+          .dataFetcher(env -> ((EncodedPolylineBeanWithStops) env.getSource()).getToQuay())
+          .build()
+      )
+      .build();
+  }
+}

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/util/EncodedPolylineBeanWithStops.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/util/EncodedPolylineBeanWithStops.java
@@ -1,0 +1,35 @@
+package org.opentripplanner.ext.transmodelapi.model.util;
+
+import org.opentripplanner.model.StopLocation;
+import org.opentripplanner.util.model.EncodedPolyline;
+
+public class EncodedPolylineBeanWithStops {
+
+  private StopLocation fromQuay;
+  private StopLocation toQuay;
+  private EncodedPolyline pointsOnLink;
+
+  public StopLocation getFromQuay() {
+    return fromQuay;
+  }
+
+  public StopLocation getToQuay() {
+    return toQuay;
+  }
+
+  public void setFromQuay(StopLocation fromQuay) {
+    this.fromQuay = fromQuay;
+  }
+
+  public void setToQuay(StopLocation toQuay) {
+    this.toQuay = toQuay;
+  }
+
+  public void setEncodedPolylineBean(EncodedPolyline encodedPolylineBean) {
+    this.pointsOnLink = encodedPolylineBean;
+  }
+
+  public EncodedPolyline getEncodedPolylineBean() {
+    return pointsOnLink;
+  }
+}

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/util/EncodedPolylineBeanWithStops.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/util/EncodedPolylineBeanWithStops.java
@@ -3,33 +3,8 @@ package org.opentripplanner.ext.transmodelapi.model.util;
 import org.opentripplanner.model.StopLocation;
 import org.opentripplanner.util.model.EncodedPolyline;
 
-public class EncodedPolylineBeanWithStops {
-
-  private StopLocation fromQuay;
-  private StopLocation toQuay;
-  private EncodedPolyline pointsOnLink;
-
-  public StopLocation getFromQuay() {
-    return fromQuay;
-  }
-
-  public StopLocation getToQuay() {
-    return toQuay;
-  }
-
-  public void setFromQuay(StopLocation fromQuay) {
-    this.fromQuay = fromQuay;
-  }
-
-  public void setToQuay(StopLocation toQuay) {
-    this.toQuay = toQuay;
-  }
-
-  public void setEncodedPolylineBean(EncodedPolyline encodedPolylineBean) {
-    this.pointsOnLink = encodedPolylineBean;
-  }
-
-  public EncodedPolyline getEncodedPolylineBean() {
-    return pointsOnLink;
-  }
-}
+public record EncodedPolylineBeanWithStops(
+  StopLocation fromQuay,
+  StopLocation toQuay,
+  EncodedPolyline pointsOnLink
+) {}


### PR DESCRIPTION
### Summary

in Transmodel GraphQL API app new graphql object with stop-to-stop geometries on trip pattern

So it can be fetched by following query:

```
{
  line(id: "...") {
    journeyPatterns {
      stopToStopGeometries {
        fromQuay {
          id
          stopPlace {
            id
          }
        }
        toQuay {
          id
          stopPlace {
            id
          }
        }
        pointsOnLink {
          length
          points
        }
      }
    }
  }
}
```
### Issue
We need to be able to fetch from OTP geometries for trip patterns so that they are divided into stop-to-stop chunks.

It have to look something like this:

```
[
  {
    fromStop: A
    toStop: B 
    geometry: "..."
  },
  {
    fromStop: B
    toStop: C
    geometry: "..."
  },
  {
    fromStop: C
    toStop: D
    geometry: "..."
  }
]
```

#### Question

I have a question regarding Transmodel graphQL api. We have a new requirement on our API and we need to be able to fetch geometries for trip patterns / lines divided into specific stop-to-stop chunks. Right now there's a field on trip pattern for the geometry but it's not divided into separate chunks. It looks like we will have to create a new object for that. So there's gonna be separate field for the whole geometry and another, new one for the stop-to-stop geometry. Not a really big fan of that since it kinda duplicates existing fields but I do not see any other way for solving the problem that we have. I've already created new draft for the implementation and would wanna hear your opinion on it.
