### PR TITLE
Option to add customized logging features [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModule.java
@@ -69,7 +69,7 @@ public class OsmBoardingLocationsModule implements GraphBuilderModule {
       if (!ts.hasPathways()) {
         if (!connectVertexToStop(ts, streetIndex, graph.getLinker())) {
           LOG.debug(
-            "Could not connect " + ts.getStop().getCode() + " at " + ts.getCoordinate().toString()
+            String.format("Could not connect %s at %s", ts.getStop().getCode(), ts.getCoordinate())
           );
         } else {
           successes++;
@@ -126,16 +126,14 @@ public class OsmBoardingLocationsModule implements GraphBuilderModule {
         new BoardingLocationToStopLink(ts, osmVertex);
         new BoardingLocationToStopLink(osmVertex, ts);
         LOG.debug(
-          "Connected " +
-          ts.toString() +
-          " (" +
-          stopCode +
-          ") to " +
-          osmVertex.getLabel() +
-          " at " +
-          osmVertex.getCoordinate().toString()
+          String.format(
+            "Connected %s (%s) to %s at %s",
+            ts,
+            stopCode,
+            osmVertex.getLabel(),
+            osmVertex.getCoordinate()
+          )
         );
-
         return true;
       }
     }

--- a/src/main/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModule.java
@@ -124,11 +124,11 @@ public class OsmBoardingLocationsModule implements GraphBuilderModule {
         new BoardingLocationToStopLink(ts, osmVertex);
         new BoardingLocationToStopLink(osmVertex, ts);
         LOG.debug(
-            "Connected {} ({}) to {} at {}",
-            ts,
-            stopCode,
-            osmVertex.getLabel(),
-            osmVertex.getCoordinate()
+          "Connected {} ({}) to {} at {}",
+          ts,
+          stopCode,
+          osmVertex.getLabel(),
+          osmVertex.getCoordinate()
         );
         return true;
       }

--- a/src/main/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModule.java
@@ -68,9 +68,7 @@ public class OsmBoardingLocationsModule implements GraphBuilderModule {
       // only connect transit stops that are not part of a pathway network
       if (!ts.hasPathways()) {
         if (!connectVertexToStop(ts, streetIndex, graph.getLinker())) {
-          LOG.debug(
-            "Could not connect {} at {}", ts.getStop().getCode(), ts.getCoordinate()
-          );
+          LOG.debug("Could not connect {} at {}", ts.getStop().getCode(), ts.getCoordinate());
         } else {
           successes++;
         }
@@ -131,14 +129,6 @@ public class OsmBoardingLocationsModule implements GraphBuilderModule {
             stopCode,
             osmVertex.getLabel(),
             osmVertex.getCoordinate()
-        );
-          String.format(
-            "Connected %s (%s) to %s at %s",
-            ts,
-            stopCode,
-            osmVertex.getLabel(),
-            osmVertex.getCoordinate()
-          )
         );
         return true;
       }

--- a/src/main/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModule.java
@@ -126,6 +126,12 @@ public class OsmBoardingLocationsModule implements GraphBuilderModule {
         new BoardingLocationToStopLink(ts, osmVertex);
         new BoardingLocationToStopLink(osmVertex, ts);
         LOG.debug(
+            "Connected {} ({}) to {} at {}",
+            ts,
+            stopCode,
+            osmVertex.getLabel(),
+            osmVertex.getCoordinate()
+        );
           String.format(
             "Connected %s (%s) to %s at %s",
             ts,

--- a/src/main/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModule.java
@@ -125,6 +125,17 @@ public class OsmBoardingLocationsModule implements GraphBuilderModule {
         }
         new BoardingLocationToStopLink(ts, osmVertex);
         new BoardingLocationToStopLink(osmVertex, ts);
+        LOG.debug(
+          "Connected " +
+          ts.toString() +
+          " (" +
+          stopCode +
+          ") to " +
+          osmVertex.getLabel() +
+          " at " +
+          osmVertex.getCoordinate().toString()
+        );
+
         return true;
       }
     }

--- a/src/main/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModule.java
@@ -69,7 +69,7 @@ public class OsmBoardingLocationsModule implements GraphBuilderModule {
       if (!ts.hasPathways()) {
         if (!connectVertexToStop(ts, streetIndex, graph.getLinker())) {
           LOG.debug(
-            String.format("Could not connect %s at %s", ts.getStop().getCode(), ts.getCoordinate())
+            "Could not connect {} at {}", ts.getStop().getCode(), ts.getCoordinate()
           );
         } else {
           successes++;

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -64,6 +64,6 @@
   <logger name="org.glassfish.grizzly" level="info" />
 
   <!-- optional logging configuration to define your own custom logging needs -->
-  <include optional="true" resource="customLog.xml" />
+  <include optional="true" resource="logback-addendum.xml" />
 
 </configuration>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -34,7 +34,7 @@
 
   <logger name="org.opentripplanner.routing" level="info"/>
   <logger name="org.opentripplanner.routing.algorithm.transferoptimization" level="info"/>
-  
+
   <logger name="org.opentripplanner.routing.algorithm.GenericAStar" level="info"/>
 
   <!-- Avoid printing debug messages when walk limits are exceeded -->
@@ -63,5 +63,7 @@
   <!-- Suppress an inconsequential IOException that is logged at debug level. -->
   <logger name="org.glassfish.grizzly" level="info" />
 
+  <!-- optional logging configuration to define your own custom logging needs -->
   <include optional="true" resource="customLog.xml" />
+
 </configuration>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -63,4 +63,5 @@
   <!-- Suppress an inconsequential IOException that is logged at debug level. -->
   <logger name="org.glassfish.grizzly" level="info" />
 
+  <include optional="true" resource="customLog.xml" />
 </configuration>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -64,6 +64,7 @@
   <logger name="org.glassfish.grizzly" level="info" />
 
   <!-- optional logging configuration to define your own custom logging needs -->
-  <include optional="true" resource="logback-addendum.xml" />
+  <!-- add it to the root of OTP runtime folder -->
+  <include optional="true" file="logback-include-extensions.xml" />
 
 </configuration>


### PR DESCRIPTION

### Summary

This pull request expands the standard logback configuration with an inclusion of an optional log configuration. It provides a very lightweight solution for OTP users to implement their own custom logging needs. The optional inclusion does not require any changes to an existing logging setup.

Also, debug logging of OSM boarding location matching with transit stops is made more detailed. The new log line is useful for all OTP users who wish to debug stop matching. 

As an example, at HSL OTP instance, the debug level logging for OSM boarding location matching is activated in the additional log configuration and log lines are redirected to a separate file. The generated file provides a way to automatically monitor success rate of the mentioned stop matching process.

