### PR TITLE
Enable codecov report on PRs [changelog skip]

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,1 +1,1 @@
-comment: false
+comment: true


### PR DESCRIPTION
### Summary

In a previous developer meeting we talked about including the codecov report when opening PRs. This PR enables it.

An example of such a report looks like this: https://docs.codecov.com/docs/pull-request-comments

Lets discuss this at the dev meeting.