### PR TITLE
Do not link cars to stop vertices in routing

### DIFF
--- a/src/main/java/org/opentripplanner/routing/graph/Graph.java
+++ b/src/main/java/org/opentripplanner/routing/graph/Graph.java
@@ -859,6 +859,38 @@ public class Graph implements Serializable {
     return stops.stream().map(index.getStopVertexForStop()::get).collect(Collectors.toSet());
   }
 
+  /**
+   * @param id Id of Stop, Station, MultiModalStation or GroupOfStations
+   * @return The coordinate for the transit entity
+   */
+  public WgsCoordinate getCoordinateById(FeedScopedId id) {
+    // GroupOfStations
+    GroupOfStations groupOfStations = groupOfStationsById.get(id);
+    if (groupOfStations != null) {
+      return groupOfStations.getCoordinate();
+    }
+
+    // Multimodal station
+    MultiModalStation multiModalStation = multiModalStationById.get(id);
+    if (multiModalStation != null) {
+      return multiModalStation.getCoordinate();
+    }
+
+    // Station
+    Station station = stationById.get(id);
+    if (station != null) {
+      return station.getCoordinate();
+    }
+
+    // Single stop
+    var stop = index.getStopForId(id);
+    if (stop != null) {
+      return stop.getCoordinate();
+    }
+
+    return null;
+  }
+
   /** An OBA Service Date is a local date without timezone, only year month and day. */
   public BitSet getServicesRunningForDate(ServiceDate date) {
     BitSet services = new BitSet(calendarService.getServiceIds().size());

--- a/src/main/java/org/opentripplanner/routing/impl/StreetVertexIndex.java
+++ b/src/main/java/org/opentripplanner/routing/impl/StreetVertexIndex.java
@@ -2,7 +2,6 @@ package org.opentripplanner.routing.impl;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -205,21 +204,36 @@ public class StreetVertexIndex {
     boolean endVertex,
     Set<DisposableEdgeCollection> tempEdges
   ) {
-    // Check if Stop/StopCollection is found by FeedScopeId
-    if (location.stopId != null) {
-      Set<Vertex> transitStopVertices = graph.getStopVerticesById(location.stopId);
-      if (transitStopVertices != null) {
-        return transitStopVertices;
+    // Differentiate between driving and non-driving, as driving is not available from transit stops
+    TraverseMode nonTransitMode = getTraverseModeForLinker(options, endVertex);
+
+    if (nonTransitMode.isDriving()) {
+      // Fetch coordinate from stop, if not given in request
+      if (location.stopId != null && location.getCoordinate() == null) {
+        var coordinate = graph.getCoordinateById(location.stopId);
+        if (coordinate != null) {
+          location =
+            new GenericLocation(
+              location.label,
+              location.stopId,
+              coordinate.latitude(),
+              coordinate.longitude()
+            );
+        }
+      }
+    } else {
+      // Check if Stop/StopCollection is found by FeedScopeId
+      if (location.stopId != null) {
+        Set<Vertex> transitStopVertices = graph.getStopVerticesById(location.stopId);
+        if (transitStopVertices != null) {
+          return transitStopVertices;
+        }
       }
     }
 
     // Check if coordinate is provided and connect it to graph
-    Coordinate coordinate = location.getCoordinate();
-    if (coordinate != null) {
-      //return getClosestVertex(loc, options, endVertex);
-      return Collections.singleton(
-        createVertexFromLocation(location, options, endVertex, tempEdges)
-      );
+    if (location.getCoordinate() != null) {
+      return Set.of(createVertexFromLocation(location, options, endVertex, tempEdges));
     }
 
     return null;


### PR DESCRIPTION
### Summary

Currently, when doing a search with a car from a stop id, the linker links it directly to the stop vertex. This is not desirable, as the vertices are connected to edges, which are not car-traversable. Instead, we should do the regular temporary vertex linking process with the stop coordinates. This PS fixes this.

### Unit tests

Updated `StreetModeLinkingTest`
