### PR TITLE
Automatic container image build

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -9,6 +9,7 @@ on:
       - master
       - dev-1.x
       - dev-2.x
+      - container-image
   pull_request:
     branches:
       - master
@@ -51,3 +52,25 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: mvn --batch-mode deploy --settings maven-settings.xml -DskipTests -DGITHUB_REPOSITORY=$GITHUB_REPOSITORY -P prettierCheck
+
+  container-image:
+    runs-on: ubuntu-latest
+    env:
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2.3.2
+        with:
+          fetch-depth: 0
+      - name: Set up JDK 17
+        uses: actions/setup-java@v1
+        with:
+          java-version: 17
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Build container image with Jib, push to Dockerhub
+        run: mvn --batch-mode compile com.google.cloud.tools:jib-maven-plugin:build -Djib.to.tags=latest,${{ github.sha }}

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -54,6 +54,7 @@ jobs:
         run: mvn --batch-mode deploy --settings maven-settings.xml -DskipTests -DGITHUB_REPOSITORY=$GITHUB_REPOSITORY -P prettierCheck
 
   container-image:
+    if: github.repository_owner == 'opentripplanner' #&& github.event_name == 'push' && github.ref == 'refs/heads/dev-2.x'
     runs-on: ubuntu-latest
     needs: build
     env:

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -55,7 +55,9 @@ jobs:
 
   container-image:
     runs-on: ubuntu-latest
+    needs: build
     env:
+      DOCKERHUB_USER: otpbot
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2.3.2

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -59,7 +59,7 @@ jobs:
     needs: build
     env:
       DOCKERHUB_USER: otpbot
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
     steps:
       - uses: actions/checkout@v2.3.2
         with:

--- a/docs/Container-Image.md
+++ b/docs/Container-Image.md
@@ -1,0 +1,26 @@
+# Container image
+
+The CI pipeline deploys container images for runtimes like Docker, Kubernetes or Podman to 
+[Dockerhub](https://hub.docker.com/r/lehrenfried/opentripplanner/tags).
+
+The image assumes you use a volume to mount the input data (GTFS/NeTex, OSM) and config files into 
+`/var/opentripplanner/`. When serving a graph it's also expected to be in this directory.
+
+## Quick start
+
+Let's use the image to build a graph in Berlin.
+
+```bash
+# create directory for data and config
+mkdir berlin
+# download OSM
+curl -L https://download.geofabrik.de/europe/germany/berlin-latest.osm.pbf -o berlin/osm.pbf  
+# download GTFS
+curl -L https://vbb.de/vbbgtfs -o berlin/vbb-gtfs.zip
+# build graph and save it onto the host system via the volume
+docker run --rm -v ./berlin:/var/opentripplanner docker.io/opentripplanner/opentripplanner:latest --build --save
+# load and serve graph
+docker run -it --rm -p 8080:8080 -v ./berlin:/var/opentripplanner docker.io/opentripplanner/opentripplanner:latest --load --serve
+```
+
+Now open [http://localhost:8080](http://localhost:8080) to see your running OTP instance.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,7 @@ pages:
 - 'Usage':
     - Basic Tutorial: 'Basic-Tutorial.md'
     - Getting OTP: 'Getting-OTP.md'
+    - Container image: 'Container-Image.md'
     - Configuration:
         - Introduction: 'Configuration.md'
         - Build: 'BuildConfiguration.md'

--- a/pom.xml
+++ b/pom.xml
@@ -374,11 +374,7 @@
                 <configuration>
                     <container>
                         <mainClass>org.opentripplanner.standalone.OTPMain</mainClass>
-                        <entrypoint>
-                            <arg>/bin/sh</arg>
-                            <arg>-e</arg>
-                            <arg>exec java $JAVA_OPTS -cp $( cat /app/jib-classpath-file ) $( cat /app/jib-main-class-file ) /var/opentripplanner/ $@</arg>
-                        </entrypoint>
+                        <entrypoint>/docker-entrypoint.sh</entrypoint>
                         <volumes>
                             <volume>
                                 /var/opentripplanner/
@@ -398,6 +394,10 @@
                     </to>
                     <extraDirectories>
                         <permissions>
+                            <permission>
+                                <file>/docker-entrypoint.sh</file>
+                                <mode>755</mode>
+                            </permission>
                             <permission>
                                 <file>/var/opentripplanner/</file>
                                 <mode>755</mode>

--- a/pom.xml
+++ b/pom.xml
@@ -384,6 +384,10 @@
                                 /var/opentripplanner/
                             </volume>
                         </volumes>
+                        <ports>
+                            <port>8080</port>
+                            <port>8081</port>
+                        </ports>
                     </container>
                     <to>
                         <image>docker.io/lehrenfried/opentripplanner</image>

--- a/pom.xml
+++ b/pom.xml
@@ -376,7 +376,7 @@
                         <mainClass>org.opentripplanner.standalone.OTPMain</mainClass>
                         <entrypoint>
                             <arg>/bin/sh</arg>
-                            <arg>-c</arg>
+                            <arg>-e</arg>
                             <arg>exec java $JAVA_OPTS -cp $( cat /app/jib-classpath-file ) $( cat /app/jib-main-class-file ) /var/opentripplanner/ $@</arg>
                         </entrypoint>
                         <volumes>

--- a/pom.xml
+++ b/pom.xml
@@ -388,8 +388,8 @@
                     <to>
                         <image>docker.io/lehrenfried/opentripplanner</image>
                         <auth>
-                            <username>lehrenfried</username>
-                            <password>${env.DOCKERHUB_TOKEN}</password>
+                            <username>${env.DOCKERHUB_USER}</username>
+                            <password>${env.DOCKERHUB_PASSWORD}</password>
                         </auth>
                     </to>
                     <extraDirectories>

--- a/pom.xml
+++ b/pom.xml
@@ -367,6 +367,41 @@
                 </executions>
 
             </plugin>
+            <plugin>
+                <groupId>com.google.cloud.tools</groupId>
+                <artifactId>jib-maven-plugin</artifactId>
+                <version>3.2.1</version>
+                <configuration>
+                    <container>
+                        <mainClass>org.opentripplanner.standalone.OTPMain</mainClass>
+                        <entrypoint>
+                            <arg>/bin/sh</arg>
+                            <arg>-c</arg>
+                            <arg>exec java $JAVA_OPTS -cp $( cat /app/jib-classpath-file ) $( cat /app/jib-main-class-file ) /var/opentripplanner/</arg>
+                        </entrypoint>
+                        <volumes>
+                            <volume>
+                                /var/opentripplanner/
+                            </volume>
+                        </volumes>
+                    </container>
+                    <to>
+                        <image>docker.io/lehrenfried/opentripplanner</image>
+                        <auth>
+                            <username>lehrenfried</username>
+                            <password>${env.DOCKERHUB_TOKEN}</password>
+                        </auth>
+                    </to>
+                    <extraDirectories>
+                        <permissions>
+                            <permission>
+                                <file>/var/opentripplanner/</file>
+                                <mode>755</mode>
+                            </permission>
+                        </permissions>
+                    </extraDirectories>
+                </configuration>
+            </plugin>
 
             <!-- compile the gtfs-realtime.proto file to Java code
                To update the proto file run the following command:

--- a/pom.xml
+++ b/pom.xml
@@ -377,7 +377,7 @@
                         <entrypoint>
                             <arg>/bin/sh</arg>
                             <arg>-c</arg>
-                            <arg>exec java $JAVA_OPTS -cp $( cat /app/jib-classpath-file ) $( cat /app/jib-main-class-file ) /var/opentripplanner/</arg>
+                            <arg>exec java $JAVA_OPTS -cp $( cat /app/jib-classpath-file ) $( cat /app/jib-main-class-file ) /var/opentripplanner/ $@</arg>
                         </entrypoint>
                         <volumes>
                             <volume>

--- a/src/main/jib/docker-entrypoint.sh
+++ b/src/main/jib/docker-entrypoint.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+
+java $JAVA_OPTS -cp @/app/jib-classpath-file @/app/jib-main-class-file /var/opentripplanner/ $@


### PR DESCRIPTION
### Summary

This integrates a docker image build and push to Dockerhub to the CI pipeline.

Until I have figured out access to the `opentripplanner` org on Dockerhub I'm deploying to my personal account. I'm working with @abyrd to figure it out.

If you want to test it already, you can use the modified tutorial.

```bash
# create directory for data and config
mkdir berlin
# download OSM
curl -L https://download.geofabrik.de/europe/germany/berlin-latest.osm.pbf -o berlin/osm.pbf  
# download GTFS
curl -L https://vbb.de/vbbgtfs -o berlin/vbb-gtfs.zip
# build graph and save it onto the host system via the volume
docker run --rm -v ./berlin:/var/opentripplanner docker.io/lehrenfried/opentripplanner:latest --build --save
# load and serve graph
docker run -it --rm -p 8080:8080 -v ./berlin:/var/opentripplanner docker.io/lehrenfried/opentripplanner:latest --load --serve
```

@optionsome @tvainika @jannefleischer Do you want to try this out?

### Documentation

Page added.