### PR TITLE
Solve problems with timezones in Siri Updater module [changelog skip]

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/siri/TimetableHelper.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/TimetableHelper.java
@@ -403,6 +403,7 @@ public class TimetableHelper {
    * @param occupancy
    * @return
    */
+
   private static OccupancyStatus resolveOccupancyStatus(OccupancyEnumeration occupancy) {
     if (occupancy != null) {
       return switch (occupancy) {

--- a/src/ext/java/org/opentripplanner/ext/siri/TimetableHelper.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/TimetableHelper.java
@@ -148,13 +148,7 @@ public class TimetableHelper {
             if (departureDate == null) {
               departureDate = recordedCall.getAimedArrivalTime();
             }
-            if (oldTimes.getDepartureTime(0) > 86400) {
-              // The "departure-date" for this trip is set to "yesterday" (or before) even though it actually departs "today"
-
-              int dayOffsetCount = oldTimes.getDepartureTime(0) / 86400; // calculate number of offset-days
-
-              departureDate = departureDate.minusDays(dayOffsetCount);
-            }
+            departureDate = departureDate.minusDays(calculateDayOffset(oldTimes));
           }
 
           ZonedDateTime startOfService = DateMapper.asStartOfService(
@@ -254,6 +248,7 @@ public class TimetableHelper {
               if (departureDate == null) {
                 departureDate = estimatedCall.getAimedArrivalTime();
               }
+              departureDate = departureDate.minusDays(calculateDayOffset(oldTimes));
             }
 
             boolean isCallPredictionInaccurate =
@@ -395,7 +390,15 @@ public class TimetableHelper {
     return newTimes;
   }
 
-  /**
+  private static int calculateDayOffset(TripTimes oldTimes) {
+    if (oldTimes.getDepartureTime(0) > 86400) {
+      // The "departure-date" for this trip is set to "yesterday" (or before) even though it actually departs "today"
+
+      return oldTimes.getDepartureTime(0) / 86400; // calculate number of offset-days
+    } else {
+      return 0;
+    }
+  }/**
    * Maps the (very limited) SIRI 2.0 OccupancyEnum to internal OccupancyStatus
    * @param occupancy
    * @return
@@ -419,6 +422,7 @@ public class TimetableHelper {
    * @return new copy of updated TripTimes after TripUpdate has been applied on TripTimes of trip
    * with the id specified in the trip descriptor of the TripUpdate; null if something went wrong
    */
+
   public static List<StopLocation> createModifiedStops(
     TripPattern pattern,
     EstimatedVehicleJourney journey,

--- a/src/ext/java/org/opentripplanner/ext/siri/TimetableHelper.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/TimetableHelper.java
@@ -398,12 +398,13 @@ public class TimetableHelper {
     } else {
       return 0;
     }
-  }/**
+  }
+
+  /**
    * Maps the (very limited) SIRI 2.0 OccupancyEnum to internal OccupancyStatus
    * @param occupancy
    * @return
    */
-
   private static OccupancyStatus resolveOccupancyStatus(OccupancyEnumeration occupancy) {
     if (occupancy != null) {
       return switch (occupancy) {
@@ -423,7 +424,6 @@ public class TimetableHelper {
    * @return new copy of updated TripTimes after TripUpdate has been applied on TripTimes of trip
    * with the id specified in the trip descriptor of the TripUpdate; null if something went wrong
    */
-
   public static List<StopLocation> createModifiedStops(
     TripPattern pattern,
     EstimatedVehicleJourney journey,

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/DateMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/DateMapper.java
@@ -46,7 +46,10 @@ public class DateMapper {
     ZonedDateTime dateTime,
     ZoneId zoneId
   ) {
-    ZonedDateTime startOfService = asStartOfService(departureDate.toLocalDate(), zoneId);
+    ZonedDateTime startOfService = asStartOfService(
+      departureDate.withZoneSameInstant(zoneId).toLocalDate(),
+      zoneId
+    );
     return (int) Duration.between(startOfService, dateTime).toSeconds();
   }
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/DateMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/DateMapper.java
@@ -42,12 +42,12 @@ public class DateMapper {
   }
 
   public static int secondsSinceStartOfService(
-    ZonedDateTime departureDate,
+    ZonedDateTime operatingDayDate,
     ZonedDateTime dateTime,
     ZoneId zoneId
   ) {
     ZonedDateTime startOfService = asStartOfService(
-      departureDate.withZoneSameInstant(zoneId).toLocalDate(),
+      operatingDayDate.withZoneSameInstant(zoneId).toLocalDate(),
       zoneId
     );
     return (int) Duration.between(startOfService, dateTime).toSeconds();

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/DateMapperTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/DateMapperTest.java
@@ -3,11 +3,13 @@ package org.opentripplanner.routing.algorithm.raptoradapter.transit.mappers;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.routing.algorithm.raptoradapter.transit.mappers.DateMapper.asStartOfService;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.TimeZone;
 import org.junit.jupiter.api.Test;
 
 public class DateMapperTest {
@@ -99,5 +101,19 @@ public class DateMapperTest {
     // Test the Instant version of this method too
     Instant instant = D2019_04_01.atStartOfDay(ZONE_ID).toInstant();
     assertEquals((23 + 24) * 3600, DateMapper.secondsSinceStartOfTime(Z0, instant));
+  }
+
+  @Test
+  public void secondsSinceStartOfTimeWithZoneId() {
+    var dateTime = ZonedDateTime.parse("2022-05-12T00:43:00+02:00");
+    var operatingDayDate = dateTime.minusDays(1).withZoneSameInstant(ZoneId.of("UTC"));
+    var zoneId = ZoneId.of("CET");
+    var startOfService = ZonedDateTime.of(2022, 5, 11, 0, 0, 0, 0, zoneId);
+
+    var desiredDuration = Duration.between(startOfService, dateTime).toSeconds();
+    assertEquals(
+      desiredDuration,
+      DateMapper.secondsSinceStartOfService(operatingDayDate, dateTime, zoneId)
+    );
   }
 }


### PR DESCRIPTION
### Summary
Make sure that OTP uses right timezone when calculating operating day date based on times from ET message. This PR also adds missing date adjustment for EstimatedCalls

### Issue
Internally OTP transit modules uses operating day date together with seconds after midnight to define departure and arrival times. Currently there is a bug in Siri module which in some cases causes updater to add an extra 24 hours to times. 

For example, if following ET message is sent to OTP:

```
<RecordedCall>
              <StopPointRef>SE:276:Quay:9022012080040049</StopPointRef>
              <Order>1</Order>
              <Cancellation>false</Cancellation>
              <AimedDepartureTime>2022-05-12T00:43:00+02:00</AimedDepartureTime>
              <ActualDepartureTime>2022-05-12T00:43:27+02:00</ActualDepartureTime>
</RecordedCall>
```

Internally, *AimedDepartureTime* will be converted to *2022-05-11T22:43UTC* which is a different date. This will cause updater to add an extra 24 hours to all times. 