### PR TITLE
Add support filterByInUse in nearest query in Transmodel API [changelog skip]

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
@@ -88,6 +88,7 @@ import org.opentripplanner.ext.transmodelapi.model.timetable.ServiceJourneyType;
 import org.opentripplanner.ext.transmodelapi.model.timetable.TimetabledPassingTimeType;
 import org.opentripplanner.ext.transmodelapi.model.timetable.TripMetadataType;
 import org.opentripplanner.ext.transmodelapi.support.GqlUtil;
+import org.opentripplanner.model.StopLocation;
 import org.opentripplanner.model.calendar.ServiceDate;
 import org.opentripplanner.model.plan.legreference.LegReference;
 import org.opentripplanner.model.plan.legreference.LegReferenceSerializer;
@@ -874,15 +875,15 @@ public class TransmodelGraphQLSchema {
               filterByBikeRentalStations =
                 filterByIds.get("bikeRentalStations") != null
                   ? (List<String>) filterByIds.get("bikeRentalStations")
-                  : Collections.emptyList();
+                  : List.of();
               filterByBikeParks =
                 filterByIds.get("bikeParks") != null
                   ? (List<String>) filterByIds.get("bikeParks")
-                  : Collections.emptyList();
+                  : List.of();
               filterByCarParks =
                 filterByIds.get("carParks") != null
                   ? (List<String>) filterByIds.get("carParks")
-                  : Collections.emptyList();
+                  : List.of();
             }
 
             List<TransitMode> filterByTransportModes = environment.getArgument("filterByModes");
@@ -918,6 +919,23 @@ public class TransmodelGraphQLSchema {
                   GqlUtil.getRoutingService(environment)
                 );
 
+            if (TRUE.equals(environment.getArgument("filterByInUse"))) {
+              places =
+                places
+                  .stream()
+                  .filter(placeAtDistance -> {
+                    if (placeAtDistance.place() instanceof StopLocation stop) {
+                      return !GqlUtil
+                        .getRoutingService(environment)
+                        .getPatternsForStop(stop, true)
+                        .isEmpty();
+                    } else {
+                      return true;
+                    }
+                  })
+                  .toList();
+            }
+
             places =
               PlaceAtDistanceType
                 .convertQuaysToStopPlaces(
@@ -931,7 +949,7 @@ public class TransmodelGraphQLSchema {
                 .collect(Collectors.toList());
             if (places.isEmpty()) {
               return new DefaultConnection<>(
-                Collections.emptyList(),
+                List.of(),
                 new DefaultPageInfo(null, null, false, false)
               );
             }


### PR DESCRIPTION
### Summary

There is a flag, `filterByInUse` which can be specified in the `nearest` query in the Transmodel API. However it has not been implemented. This PR implements it, as it was in OTP1.

### Changelog

The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md)
is generated from the pull-request title, make sure the title describe the feature or issue fixed.
To exclude the PR from the changelog add `[changelog skip]` in the title.
