### PR TITLE
Add rental networks to REST API [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/api/mapping/PlaceMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/PlaceMapper.java
@@ -78,6 +78,8 @@ public class PlaceMapper {
     api.vertexType = VertexTypeMapper.mapVertexType(domain.vertexType);
     if (domain.vehicleRentalPlace != null) {
       api.bikeShareId = domain.vehicleRentalPlace.getStationId();
+      // for backwards-compatibility with the IBI frontend this always returns a list of a single item
+      api.networks = List.of(domain.vehicleRentalPlace.getNetwork());
     }
     if (domain.vehicleParkingWithEntrance != null) {
       api.vehicleParking = mapVehicleParking(domain.vehicleParkingWithEntrance);

--- a/src/main/java/org/opentripplanner/api/model/ApiPlace.java
+++ b/src/main/java/org/opentripplanner/api/model/ApiPlace.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.api.model;
 
 import java.util.Calendar;
+import java.util.List;
 
 /**
  * A Place is where a journey starts or ends, or a transit stop along the way.
@@ -70,6 +71,11 @@ public class ApiPlace {
    * In case the vertex is of type Bike sharing station.
    */
   public String bikeShareId;
+
+  /**
+   * The vehicle rental networks that are available at this place.
+   */
+  public List<String> networks;
 
   /**
    * In case the vertex is of type VEHICLEPARKING.

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/BikeRentalSnapshotTest.snap
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/BikeRentalSnapshotTest.snap
@@ -113,6 +113,9 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "lat": 45.5277374,
             "lon": -122.7003879,
             "name": "-102309",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "transitLeg": false,
@@ -131,6 +134,9 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "lat": 45.5277374,
             "lon": -122.7003879,
             "name": "-102309",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "generalizedCost": 288,
@@ -180,6 +186,9 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "lat": 45.5278491,
             "lon": -122.6942362,
             "name": "-102323",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "transitLeg": false,
@@ -198,6 +207,9 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "lat": 45.5278491,
             "lon": -122.6942362,
             "name": "-102323",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "generalizedCost": 49,
@@ -1726,6 +1738,9 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "lat": 45.5277374,
             "lon": -122.7003879,
             "name": "-102309",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "transitLeg": false,
@@ -1744,6 +1759,9 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "lat": 45.5277374,
             "lon": -122.7003879,
             "name": "-102309",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "generalizedCost": 288,
@@ -1793,6 +1811,9 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "lat": 45.5278491,
             "lon": -122.6942362,
             "name": "-102323",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "transitLeg": false,
@@ -1811,6 +1832,9 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "lat": 45.5278491,
             "lon": -122.6942362,
             "name": "-102323",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "generalizedCost": 49,
@@ -2181,6 +2205,9 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "lat": 45.5277374,
             "lon": -122.7003879,
             "name": "-102309",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "transitLeg": false,
@@ -2199,6 +2226,9 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "lat": 45.5277374,
             "lon": -122.7003879,
             "name": "-102309",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "generalizedCost": 288,
@@ -2248,6 +2278,9 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "lat": 45.5278491,
             "lon": -122.6942362,
             "name": "-102323",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "transitLeg": false,
@@ -2266,6 +2299,9 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             "lat": 45.5278491,
             "lon": -122.6942362,
             "name": "-102323",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "generalizedCost": 49,
@@ -2614,6 +2650,9 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
             "lat": 45.5277374,
             "lon": -122.7003879,
             "name": "-102309",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "transitLeg": false,
@@ -2632,6 +2671,9 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
             "lat": 45.5277374,
             "lon": -122.7003879,
             "name": "-102309",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "generalizedCost": 288,
@@ -2681,6 +2723,9 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
             "lat": 45.5278491,
             "lon": -122.6942362,
             "name": "-102323",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "transitLeg": false,
@@ -2699,6 +2744,9 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
             "lat": 45.5278491,
             "lon": -122.6942362,
             "name": "-102323",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "generalizedCost": 338,
@@ -2865,6 +2913,9 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
             "lat": 45.5277374,
             "lon": -122.7003879,
             "name": "-102309",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "transitLeg": false,
@@ -2883,6 +2934,9 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
             "lat": 45.5277374,
             "lon": -122.7003879,
             "name": "-102309",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "generalizedCost": 363,
@@ -3062,6 +3116,9 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
             "lat": 45.5277374,
             "lon": -122.7003879,
             "name": "-102309",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "transitLeg": false,
@@ -3080,6 +3137,9 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
             "lat": 45.5277374,
             "lon": -122.7003879,
             "name": "-102309",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "generalizedCost": 363,
@@ -3521,6 +3581,9 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "lat": 45.5278491,
             "lon": -122.6942362,
             "name": "-102323",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "transitLeg": false,
@@ -3539,6 +3602,9 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "lat": 45.5278491,
             "lon": -122.6942362,
             "name": "-102323",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "generalizedCost": 277,
@@ -3588,6 +3654,9 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "lat": 45.5277374,
             "lon": -122.7003879,
             "name": "-102309",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "transitLeg": false,
@@ -3606,6 +3675,9 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "lat": 45.5277374,
             "lon": -122.7003879,
             "name": "-102309",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "generalizedCost": 168,
@@ -4800,6 +4872,9 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "lat": 45.5278491,
             "lon": -122.6942362,
             "name": "-102323",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "transitLeg": false,
@@ -4818,6 +4893,9 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "lat": 45.5278491,
             "lon": -122.6942362,
             "name": "-102323",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "generalizedCost": 277,
@@ -4867,6 +4945,9 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "lat": 45.5277374,
             "lon": -122.7003879,
             "name": "-102309",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "transitLeg": false,
@@ -4885,6 +4966,9 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             "lat": 45.5277374,
             "lon": -122.7003879,
             "name": "-102309",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "generalizedCost": 168,

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/ElevationSnapshotTest.snap
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/ElevationSnapshotTest.snap
@@ -114,6 +114,9 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
             "lat": 45.5277374,
             "lon": -122.7003879,
             "name": "-102309",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "transitLeg": false,
@@ -132,6 +135,9 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
             "lat": 45.5277374,
             "lon": -122.7003879,
             "name": "-102309",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "generalizedCost": 343,
@@ -182,6 +188,9 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
             "lat": 45.5278491,
             "lon": -122.6942362,
             "name": "-102323",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "transitLeg": false,
@@ -200,6 +209,9 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
             "lat": 45.5278491,
             "lon": -122.6942362,
             "name": "-102323",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "generalizedCost": 50,
@@ -896,6 +908,9 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
             "lat": 45.5277374,
             "lon": -122.7003879,
             "name": "-102309",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "transitLeg": false,
@@ -914,6 +929,9 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
             "lat": 45.5277374,
             "lon": -122.7003879,
             "name": "-102309",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "generalizedCost": 343,
@@ -964,6 +982,9 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
             "lat": 45.5278491,
             "lon": -122.6942362,
             "name": "-102323",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "transitLeg": false,
@@ -982,6 +1003,9 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
             "lat": 45.5278491,
             "lon": -122.6942362,
             "name": "-102323",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "generalizedCost": 50,
@@ -1355,6 +1379,9 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
             "lat": 45.5277374,
             "lon": -122.7003879,
             "name": "-102309",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "transitLeg": false,
@@ -1373,6 +1400,9 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
             "lat": 45.5277374,
             "lon": -122.7003879,
             "name": "-102309",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "generalizedCost": 343,
@@ -1423,6 +1453,9 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
             "lat": 45.5278491,
             "lon": -122.6942362,
             "name": "-102323",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "transitLeg": false,
@@ -1441,6 +1474,9 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
             "lat": 45.5278491,
             "lon": -122.6942362,
             "name": "-102323",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "generalizedCost": 50,
@@ -2137,6 +2173,9 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
             "lat": 45.5277374,
             "lon": -122.7003879,
             "name": "-102309",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "transitLeg": false,
@@ -2155,6 +2194,9 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
             "lat": 45.5277374,
             "lon": -122.7003879,
             "name": "-102309",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "generalizedCost": 343,
@@ -2205,6 +2247,9 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
             "lat": 45.5278491,
             "lon": -122.6942362,
             "name": "-102323",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "transitLeg": false,
@@ -2223,6 +2268,9 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
             "lat": 45.5278491,
             "lon": -122.6942362,
             "name": "-102323",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "generalizedCost": 50,
@@ -2731,6 +2779,9 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.directBikeRe
             "lat": 45.5277374,
             "lon": -122.7003879,
             "name": "-102309",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "transitLeg": false,
@@ -2749,6 +2800,9 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.directBikeRe
             "lat": 45.5277374,
             "lon": -122.7003879,
             "name": "-102309",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "generalizedCost": 343,
@@ -2799,6 +2853,9 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.directBikeRe
             "lat": 45.5278491,
             "lon": -122.6942362,
             "name": "-102323",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "transitLeg": false,
@@ -2817,6 +2874,9 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.directBikeRe
             "lat": 45.5278491,
             "lon": -122.6942362,
             "name": "-102323",
+            "networks": [
+              "test-network"
+            ],
             "vertexType": "BIKESHARE"
           },
           "generalizedCost": 334,


### PR DESCRIPTION
### Summary

IBI has added the field `networks` to their fork of OTP1. Since we are currently migrating to OTP2, we would - as the official maintainers of the REST API - like to add this field to the upstream API. 

Yes, returning a list that only ever has a single item is strange but is in line with the rest of the REST API.

@miles-grant-ibigroup Can you confirm that this is in the correct place?

![Screenshot from 2022-05-25 14-19-37](https://user-images.githubusercontent.com/151346/170261648-71052961-8e51-4cd8-9a2b-a23bf956e36b.png)

(The reason for not migrating to GraphQL already is that IBI has a middleware component which relies on the REST API)