### PR TITLE
Return null when deserializing empty page cursor [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/model/plan/pagecursor/PageCursorSerializer.java
+++ b/src/main/java/org/opentripplanner/model/plan/pagecursor/PageCursorSerializer.java
@@ -50,7 +50,7 @@ final class PageCursorSerializer {
 
   @Nullable
   public static PageCursor decode(String cursor) {
-    if (cursor == null) {
+    if (cursor == null || cursor.isBlank()) {
       return null;
     }
 

--- a/src/test/java/org/opentripplanner/model/plan/pagecursor/PageCursorTest.java
+++ b/src/test/java/org/opentripplanner/model/plan/pagecursor/PageCursorTest.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.model.plan.pagecursor;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.opentripplanner.model.plan.SortOrder.STREET_AND_ARRIVAL_TIME;
 import static org.opentripplanner.model.plan.SortOrder.STREET_AND_DEPARTURE_TIME;
 import static org.opentripplanner.model.plan.pagecursor.PageType.NEXT_PAGE;
@@ -75,5 +76,12 @@ public class PageCursorTest {
     buf = subjectArriveBy.encode();
     before = PageCursor.decode(buf);
     assertEquals(subjectArriveBy.toString(), before.toString());
+  }
+
+  @Test
+  public void testDecodeEmptyCursor() {
+    assertNull(PageCursor.decode(null));
+    assertNull(PageCursor.decode(""));
+    assertNull(PageCursor.decode(" "));
   }
 }


### PR DESCRIPTION
### Summary

I've noticed that some times clients pass in an empty string for the page cursor. In these cases we should probably not crash, but treat it as not providing a page cursor at all, thus the deserializer should return null.
