### PR TITLE
Replaced TripPatterns leave unwanted Timetables [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/model/TimetableSnapshot.java
+++ b/src/main/java/org/opentripplanner/model/TimetableSnapshot.java
@@ -132,7 +132,10 @@ public class TimetableSnapshot {
 
       if (tripTimesToRemove != null) {
         for (Timetable sortedTimetable : sortedTimetables) {
-          sortedTimetable.getTripTimes().remove(tripTimesToRemove);
+          boolean isDirty = sortedTimetable.getTripTimes().remove(tripTimesToRemove);
+          if (isDirty) {
+            dirtyTimetables.add(sortedTimetable);
+          }
         }
       }
     }


### PR DESCRIPTION
Mark Timetables with removed TripTimes as dirty in order to clean them up in the TransitLayerUpdater

See the related issue for an explanation of the use case
