### PR TITLE
Otp2 simplify allowed transit modes [changelog skip]

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLPlanner.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLPlanner.java
@@ -8,7 +8,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -285,7 +284,7 @@ public class TransmodelGraphQLPlanner {
 
       List<AllowedTransitMode> transitModes = new ArrayList<>();
       if (transportModes.get() == null) {
-        transitModes.addAll(AllowedTransitMode.getAllTransitModes());
+        transitModes.add(AllowedTransitMode.ALLOWED_ALL_TRANSIT_MODES);
       } else {
         for (LinkedHashMap<String, ?> modeWithSubmodes : transportModes.get()) {
           if (modeWithSubmodes.containsKey("transportMode")) {
@@ -294,8 +293,12 @@ public class TransmodelGraphQLPlanner {
               List<TransmodelTransportSubmode> transportSubModes = (List<TransmodelTransportSubmode>) modeWithSubmodes.get(
                 "transportSubModes"
               );
-              for (TransmodelTransportSubmode transitMode : transportSubModes) {
-                transitModes.add(new AllowedTransitMode(mainMode, transitMode.getValue()));
+              for (TransmodelTransportSubmode submode : transportSubModes) {
+                if (submode == TransmodelTransportSubmode.UNKNOWN) {
+                  transitModes.add(AllowedTransitMode.ofUnknownSubModes(mainMode));
+                } else {
+                  transitModes.add(AllowedTransitMode.of(mainMode, submode.getValue()));
+                }
               }
             } else {
               transitModes.add(AllowedTransitMode.fromMainModeEnum(mainMode));

--- a/src/main/java/org/opentripplanner/api/parameter/ApiRequestMode.java
+++ b/src/main/java/org/opentripplanner/api/parameter/ApiRequestMode.java
@@ -21,7 +21,7 @@ public enum ApiRequestMode {
   CABLE_CAR(fromMainModeEnum(TransitMode.CABLE_CAR)),
   GONDOLA(fromMainModeEnum(TransitMode.GONDOLA)),
   FUNICULAR(fromMainModeEnum(TransitMode.FUNICULAR)),
-  TRANSIT(AllowedTransitMode.getAllTransitModes()),
+  TRANSIT(AllowedTransitMode.ofAllTransitModes()),
   AIRPLANE(fromMainModeEnum(TransitMode.AIRPLANE)),
   TROLLEYBUS(fromMainModeEnum(TransitMode.TROLLEYBUS)),
   MONORAIL(fromMainModeEnum(TransitMode.MONORAIL)),

--- a/src/main/java/org/opentripplanner/model/modes/AllowedAllTransitModes.java
+++ b/src/main/java/org/opentripplanner/model/modes/AllowedAllTransitModes.java
@@ -1,0 +1,28 @@
+package org.opentripplanner.model.modes;
+
+import org.opentripplanner.transit.model.network.TransitMode;
+
+public class AllowedAllTransitModes implements AllowedTransitMode {
+
+  /**
+   * Check if this filter allows the provided TransitMode
+   */
+  public boolean allows(TransitMode transitMode, String netexSubMode) {
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    return 293344561;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return obj != null && obj.getClass() == AllowedAllTransitModes.class;
+  }
+
+  @Override
+  public String toString() {
+    return "AllowedAllTransitModes{}";
+  }
+}

--- a/src/main/java/org/opentripplanner/model/modes/AllowedMainAndSubTransitMode.java
+++ b/src/main/java/org/opentripplanner/model/modes/AllowedMainAndSubTransitMode.java
@@ -1,0 +1,46 @@
+package org.opentripplanner.model.modes;
+
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import org.opentripplanner.transit.model.network.TransitMode;
+
+public class AllowedMainAndSubTransitMode implements AllowedTransitMode {
+
+  private final TransitMode mainMode;
+
+  private final String subMode;
+
+  public AllowedMainAndSubTransitMode(@Nonnull TransitMode mainMode, @Nonnull String subMode) {
+    this.mainMode = mainMode;
+    this.subMode = subMode;
+  }
+
+  /**
+   * Check if this filter allows the provided TransitMode
+   */
+  public boolean allows(TransitMode transitMode, String netexSubMode) {
+    return mainMode == transitMode && subMode.equals(netexSubMode);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(mainMode, subMode);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    AllowedMainAndSubTransitMode that = (AllowedMainAndSubTransitMode) o;
+    return mainMode == that.mainMode && subMode.equals(that.subMode);
+  }
+
+  @Override
+  public String toString() {
+    return "AllowedMainAndSubTransitMode{ mainMode: " + mainMode + ", subMode: " + subMode + "}";
+  }
+}

--- a/src/main/java/org/opentripplanner/model/modes/AllowedMainTransitMode.java
+++ b/src/main/java/org/opentripplanner/model/modes/AllowedMainTransitMode.java
@@ -1,0 +1,41 @@
+package org.opentripplanner.model.modes;
+
+import org.opentripplanner.transit.model.network.TransitMode;
+
+public class AllowedMainTransitMode implements AllowedTransitMode {
+
+  private final TransitMode mainMode;
+
+  public AllowedMainTransitMode(TransitMode mainMode) {
+    this.mainMode = mainMode;
+  }
+
+  /**
+   * Check if this filter allows the provided TransitMode
+   */
+  public boolean allows(TransitMode transitMode, String netexSubMode) {
+    return mainMode == transitMode;
+  }
+
+  @Override
+  public int hashCode() {
+    return mainMode.hashCode() + 176393;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    AllowedMainTransitMode that = (AllowedMainTransitMode) o;
+    return mainMode == that.mainMode;
+  }
+
+  @Override
+  public String toString() {
+    return "AllowedMainTransitMode{ mainMode: " + mainMode + "}";
+  }
+}

--- a/src/main/java/org/opentripplanner/model/modes/AllowedUnknownSubTransitMode.java
+++ b/src/main/java/org/opentripplanner/model/modes/AllowedUnknownSubTransitMode.java
@@ -1,0 +1,41 @@
+package org.opentripplanner.model.modes;
+
+import org.opentripplanner.transit.model.network.TransitMode;
+
+public class AllowedUnknownSubTransitMode implements AllowedTransitMode {
+
+  private final TransitMode mainMode;
+
+  public AllowedUnknownSubTransitMode(TransitMode mainMode) {
+    this.mainMode = mainMode;
+  }
+
+  /**
+   * Check if this filter allows the provided TransitMode
+   */
+  public boolean allows(TransitMode transitMode, String netexSubMode) {
+    return mainMode == transitMode && netexSubMode == null;
+  }
+
+  @Override
+  public int hashCode() {
+    return mainMode.hashCode() + 275347561;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    AllowedUnknownSubTransitMode that = (AllowedUnknownSubTransitMode) o;
+    return mainMode == that.mainMode;
+  }
+
+  @Override
+  public String toString() {
+    return "AllowedUnknownSubTransitMode{ mainMode: " + mainMode + "}";
+  }
+}

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RoutingRequestTransitDataProviderFilter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RoutingRequestTransitDataProviderFilter.java
@@ -1,10 +1,8 @@
 package org.opentripplanner.routing.algorithm.raptoradapter.transit.request;
 
 import java.util.BitSet;
-import java.util.EnumSet;
 import java.util.Set;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 import org.opentripplanner.model.WheelchairAccessibility;
 import org.opentripplanner.model.modes.AllowedTransitMode;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripPatternForDate;
@@ -46,26 +44,15 @@ public class RoutingRequestTransitDataProviderFilter implements TransitDataProvi
     this.includePlannedCancellations = includePlannedCancellations;
     this.bannedRoutes = bannedRoutes;
     this.bannedTrips = bannedTrips;
-    boolean hasOnlyMainModeFilters = allowedTransitModes
-      .stream()
-      .noneMatch(AllowedTransitMode::hasSubMode);
 
     // It is much faster to do a lookup in an EnumSet, so we use it if we don't want to filter
     // using submodes
-    if (hasOnlyMainModeFilters) {
-      EnumSet<TransitMode> allowedMainModes = allowedTransitModes
-        .stream()
-        .map(AllowedTransitMode::getMainMode)
-        .collect(Collectors.toCollection(() -> EnumSet.noneOf(TransitMode.class)));
-      transitModeIsAllowed = (Trip trip) -> allowedMainModes.contains(trip.getMode());
-    } else {
-      transitModeIsAllowed =
-        (Trip trip) -> {
-          TransitMode transitMode = trip.getMode();
-          String netexSubmode = trip.getNetexSubmode();
-          return allowedTransitModes.stream().anyMatch(m -> m.allows(transitMode, netexSubmode));
-        };
-    }
+    transitModeIsAllowed =
+      (Trip trip) -> {
+        TransitMode transitMode = trip.getMode();
+        String netexSubmode = trip.getNetexSubmode();
+        return allowedTransitModes.stream().anyMatch(m -> m.allows(transitMode, netexSubmode));
+      };
   }
 
   public RoutingRequestTransitDataProviderFilter(RoutingRequest request, GraphIndex graphIndex) {

--- a/src/main/java/org/opentripplanner/routing/api/request/RequestModes.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/RequestModes.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.routing.api.request;
 
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -14,7 +13,7 @@ public class RequestModes {
     StreetMode.WALK,
     StreetMode.WALK,
     StreetMode.WALK,
-    new HashSet<>(AllowedTransitMode.getAllTransitModes())
+    AllowedTransitMode.ofAllTransitModes()
   );
 
   @Nonnull
@@ -44,7 +43,7 @@ public class RequestModes {
       (transferMode != null && transferMode.transfer) ? transferMode : StreetMode.NOT_SET;
     this.egressMode = (egressMode != null && egressMode.egress) ? egressMode : StreetMode.NOT_SET;
     this.directMode = directMode != null ? directMode : StreetMode.NOT_SET;
-    this.transitModes = transitModes != null ? new HashSet<>(transitModes) : Set.of();
+    this.transitModes = transitModes != null ? Set.copyOf(transitModes) : Set.of();
   }
 
   public boolean contains(StreetMode streetMode) {

--- a/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
@@ -152,7 +152,7 @@ public class RoutingRequest implements Cloneable, Serializable {
     StreetMode.WALK,
     StreetMode.WALK,
     StreetMode.WALK,
-    AllowedTransitMode.getAllTransitModes()
+    AllowedTransitMode.ofAllTransitModes()
   );
   /**
    * The set of TraverseModes allowed when doing creating sub requests and doing street routing. //

--- a/src/test/java/org/opentripplanner/model/modes/AllowedTransitModeTest.java
+++ b/src/test/java/org/opentripplanner/model/modes/AllowedTransitModeTest.java
@@ -10,7 +10,7 @@ public class AllowedTransitModeTest {
 
   @Test
   public void testMainModeMatch() {
-    final var ALLOWED_TRANSIT_MODE = AllowedTransitMode.fromMainModeEnum(TransitMode.BUS);
+    final var ALLOWED_TRANSIT_MODE = AllowedTransitMode.of(TransitMode.BUS);
     assertTrue(ALLOWED_TRANSIT_MODE.allows(TransitMode.BUS, null));
     assertTrue(ALLOWED_TRANSIT_MODE.allows(TransitMode.BUS, "something"));
     assertFalse(ALLOWED_TRANSIT_MODE.allows(TransitMode.RAIL, null));
@@ -20,18 +20,18 @@ public class AllowedTransitModeTest {
   @Test
   public void testSubmodeMatch() {
     final var SUBMODE = "shuttleBus";
-    final var ALLOWED_TRANSIT_MODE = new AllowedTransitMode(TransitMode.BUS, SUBMODE);
+    final var subject = AllowedTransitMode.of(TransitMode.BUS, SUBMODE);
 
-    assertTrue(ALLOWED_TRANSIT_MODE.allows(TransitMode.BUS, SUBMODE));
-    assertFalse(ALLOWED_TRANSIT_MODE.allows(TransitMode.BUS, "other"));
-    assertFalse(ALLOWED_TRANSIT_MODE.allows(TransitMode.BUS, null));
+    assertTrue(subject.allows(TransitMode.BUS, SUBMODE));
+    assertFalse(subject.allows(TransitMode.BUS, "other"));
+    assertFalse(subject.allows(TransitMode.BUS, null));
   }
 
   @Test
   public void testUnknownSubmodeMatch() {
-    final var SUBMODE = "unknown";
-    final var ALLOWED_TRANSIT_MODE = new AllowedTransitMode(TransitMode.BUS, SUBMODE);
+    final var ALLOWED_TRANSIT_MODE = AllowedTransitMode.ofUnknownSubModes(TransitMode.BUS);
 
     assertTrue(ALLOWED_TRANSIT_MODE.allows(TransitMode.BUS, null));
+    assertFalse(ALLOWED_TRANSIT_MODE.allows(TransitMode.BUS, "shuttleBus"));
   }
 }

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/BikeRentalSnapshotTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/BikeRentalSnapshotTest.java
@@ -115,7 +115,7 @@ public class BikeRentalSnapshotTest extends SnapshotTestBase {
         StreetMode.WALK,
         StreetMode.WALK,
         null,
-        AllowedTransitMode.getAllTransitModes()
+        AllowedTransitMode.ofAllTransitModes()
       );
     request.from = p1;
     request.to = p3;
@@ -138,7 +138,7 @@ public class BikeRentalSnapshotTest extends SnapshotTestBase {
         StreetMode.WALK,
         StreetMode.BIKE_RENTAL,
         null,
-        AllowedTransitMode.getAllTransitModes()
+        AllowedTransitMode.ofAllTransitModes()
       );
     request.from = p3;
     request.to = p1;

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/ElevationSnapshotTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/ElevationSnapshotTest.java
@@ -113,7 +113,7 @@ public class ElevationSnapshotTest extends SnapshotTestBase {
         StreetMode.WALK,
         StreetMode.WALK,
         null,
-        AllowedTransitMode.getAllTransitModes()
+        AllowedTransitMode.ofAllTransitModes()
       );
     request.from = p1;
     request.to = p3;
@@ -136,7 +136,7 @@ public class ElevationSnapshotTest extends SnapshotTestBase {
         StreetMode.WALK,
         StreetMode.WALK,
         null,
-        AllowedTransitMode.getAllTransitModes()
+        AllowedTransitMode.ofAllTransitModes()
       );
     request.from = p3;
     request.to = p1;

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/TransitSnapshotTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/TransitSnapshotTest.java
@@ -130,7 +130,7 @@ public class TransitSnapshotTest extends SnapshotTestBase {
         StreetMode.WALK,
         StreetMode.WALK,
         StreetMode.WALK,
-        AllowedTransitMode.getAllTransitModes()
+        AllowedTransitMode.ofAllTransitModes()
       );
     request.from = p1;
     request.to = p2;
@@ -148,7 +148,7 @@ public class TransitSnapshotTest extends SnapshotTestBase {
         StreetMode.WALK,
         StreetMode.WALK,
         StreetMode.WALK,
-        AllowedTransitMode.getAllTransitModes()
+        AllowedTransitMode.ofAllTransitModes()
       );
     request.from = ps;
     request.to = p3;
@@ -167,7 +167,7 @@ public class TransitSnapshotTest extends SnapshotTestBase {
         StreetMode.WALK,
         StreetMode.WALK,
         StreetMode.WALK,
-        AllowedTransitMode.getAllTransitModes()
+        AllowedTransitMode.ofAllTransitModes()
       );
     request.from = ptc;
     request.to = p3;

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RoutingRequestTransitDataProviderFilterTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RoutingRequestTransitDataProviderFilterTest.java
@@ -175,14 +175,14 @@ public class RoutingRequestTransitDataProviderFilterTest {
 
     assertFalse(validateModesOnTripTimes(Set.of(), tripTimes));
     assertFalse(
-      validateModesOnTripTimes(Set.of(new AllowedTransitMode(BUS, REGIONAL_BUS)), tripTimes)
+      validateModesOnTripTimes(Set.of(AllowedTransitMode.of(BUS, REGIONAL_BUS)), tripTimes)
     );
     assertFalse(
-      validateModesOnTripTimes(Set.of(new AllowedTransitMode(RAIL, LOCAL_BUS)), tripTimes)
+      validateModesOnTripTimes(Set.of(AllowedTransitMode.of(RAIL, LOCAL_BUS)), tripTimes)
     );
 
-    assertTrue(validateModesOnTripTimes(Set.of(new AllowedTransitMode(BUS, null)), tripTimes));
-    assertTrue(validateModesOnTripTimes(Set.of(new AllowedTransitMode(BUS, LOCAL_BUS)), tripTimes));
+    assertTrue(validateModesOnTripTimes(Set.of(AllowedTransitMode.of(BUS)), tripTimes));
+    assertTrue(validateModesOnTripTimes(Set.of(AllowedTransitMode.of(BUS, LOCAL_BUS)), tripTimes));
   }
 
   @Test
@@ -227,7 +227,7 @@ public class RoutingRequestTransitDataProviderFilterTest {
       true,
       DEFAULT_ACCESSIBILITY,
       false,
-      AllowedTransitMode.getAllTransitModes(),
+      AllowedTransitMode.ofAllTransitModes(),
       Set.of(),
       Set.of()
     );
@@ -253,7 +253,7 @@ public class RoutingRequestTransitDataProviderFilterTest {
       false,
       WheelchairAccessibilityRequest.makeDefault(true),
       false,
-      AllowedTransitMode.getAllTransitModes(),
+      AllowedTransitMode.ofAllTransitModes(),
       Set.of(),
       Set.of()
     );


### PR DESCRIPTION
### Summary

This PR refactor the AllowedTransitModes. The existing class is converted into an interface, and concreate implementations is made for each case:
 - `AllowedAllTransitModes` - Single class is implementing matching all modes, before a filter for each mode was added.
 - `AllowedMainAndSubTransitMode` - Match both a non null main- and sub- mode
 - `AllowedMainTransitMode` - Match main mode, any sub.mode.
 - `AllowedUnknownSubTransitMode` - Match only main modes without a sub-mode set.
 
### Issue/PR

This is trying to help out the PR #4179 


### Unit tests

One extra missing test case is added.

### Code style
✅ 

### Documentation

JavaDoc added.
