### PR TITLE
Handle new GTFS route types

### DIFF
--- a/src/main/java/org/opentripplanner/gtfs/GtfsLibrary.java
+++ b/src/main/java/org/opentripplanner/gtfs/GtfsLibrary.java
@@ -27,7 +27,7 @@ public class GtfsLibrary {
     }
 
     public static GtfsContext createContext(GtfsFeedId feedId, OtpTransitService transitService,
-            CalendarService calendarService) {
+                                            CalendarService calendarService) {
         return new GtfsContextImpl(feedId, transitService, calendarService);
     }
 
@@ -55,7 +55,9 @@ public class GtfsLibrary {
         return aid.getAgencyId() + ID_SEPARATOR + aid.getId();
     }
 
-    /** @return the route's short name, or the long name if the short name is null. */
+    /**
+     * @return the route's short name, or the long name if the short name is null.
+     */
     public static String getRouteName(Route route) {
         if (route.getShortName() != null)
             return route.getShortName();
@@ -93,31 +95,35 @@ public class GtfsLibrary {
             return TraverseMode.FUNICULAR;
         } else if (routeType >= 1500 && routeType < 1600) { //Taxi Service
             LOG.warn("Treating taxi route {} (extended route type {}) as a bus.",
-                route.getId(), routeType);
+                    route.getId(), routeType);
             return TraverseMode.BUS;
         } else if (routeType >= 1600 && routeType < 1700) { //Self drive
             return TraverseMode.CAR;
         }
         /* Original GTFS route types. Should these be checked before TPEG types? */
         switch (routeType) {
-        case 0:
-            return TraverseMode.TRAM;
-        case 1:
-            return TraverseMode.SUBWAY;
-        case 2:
-            return TraverseMode.RAIL;
-        case 3:
-            return TraverseMode.BUS;
-        case 4:
-            return TraverseMode.FERRY;
-        case 5:
-            return TraverseMode.CABLE_CAR;
-        case 6:
-            return TraverseMode.GONDOLA;
-        case 7:
-            return TraverseMode.FUNICULAR;
-        default:
-            throw new IllegalArgumentException("unknown gtfs route type " + routeType);
+            case 0:
+                return TraverseMode.TRAM;
+            case 1:
+                return TraverseMode.SUBWAY;
+            case 2:
+                return TraverseMode.RAIL;
+            case 3:
+                return TraverseMode.BUS;
+            case 4:
+                return TraverseMode.FERRY;
+            case 5:
+                return TraverseMode.CABLE_CAR;
+            case 6:
+                return TraverseMode.GONDOLA;
+            case 7:
+                return TraverseMode.FUNICULAR;
+            case 11:
+                return TraverseMode.TROLLEY;
+            case 12:
+                return TraverseMode.MONORAIL;
+            default:
+                throw new IllegalArgumentException("unknown gtfs route type " + routeType);
         }
     }
 
@@ -130,7 +136,7 @@ public class GtfsLibrary {
         private CalendarService calendar;
 
         public GtfsContextImpl(GtfsFeedId feedId, OtpTransitService transitService,
-                CalendarService calendar) {
+                               CalendarService calendar) {
             this.feedId = feedId;
             this.transitService = transitService;
             this.calendar = calendar;

--- a/src/main/java/org/opentripplanner/routing/core/TraverseMode.java
+++ b/src/main/java/org/opentripplanner/routing/core/TraverseMode.java
@@ -11,7 +11,7 @@ import java.util.Set;
 public enum TraverseMode {
     WALK, BICYCLE, CAR,
     TRAM, SUBWAY, RAIL, BUS, FERRY,
-    CABLE_CAR, GONDOLA, FUNICULAR,
+    CABLE_CAR, GONDOLA, FUNICULAR, TROLLEY, MONORAIL,
     TRANSIT, LEG_SWITCH,
     AIRPLANE;
 


### PR DESCRIPTION

### Summary

Update GtfsLibrary.java and TraverseMode.java to handle the updated route types of 11 (Trolley) and 12 (Monorail) as outlined by the most recent GTFS spec: https://developers.google.com/transit/gtfs/reference#routestxt.

### Issue

https://github.com/opentripplanner/OpenTripPlanner/issues/4190

### Unit tests

Code was tested using sample data that contains route_type of 11. Code was able to compile and return valid information.


### Code style

Used IntelliJ "reformat code" option to fix some indentation issues.

