### PR TITLE
Remove remaining traces of maxWalkDistance [changelog skip]

### DIFF
--- a/src/client/js/otp/modules/planner/Itinerary.js
+++ b/src/client/js/otp/modules/planner/Itinerary.js
@@ -48,8 +48,7 @@ otp.modules.planner.Itinerary = otp.Class({
     getIconSummaryHTML : function(padding) {
         var html = '';
         for(var i=0; i<this.itinData.legs.length; i++) {
-            var exceedsWalk = (this.itinData.legs[i].mode == "WALK" && this.itinData.legs[i].distance > this.tripPlan.queryParams.maxWalkDistance);
-            html += '<img src="images/mode/'+this.itinData.legs[i].mode.toLowerCase()+'.png" '+(exceedsWalk ? 'style="background:#f88; padding: 0px 2px;"' : "")+'>';
+            html += '<img src="images/mode/'+this.itinData.legs[i].mode.toLowerCase()+'.png" />';
             if(i < this.itinData.legs.length-1)
                 html += '<img src="images/mode/arrow.png" style="margin: 0px '+(padding || '3')+'px;">';
         }

--- a/src/client/js/otp/modules/planner/PlannerModule.js
+++ b/src/client/js/otp/modules/planner/PlannerModule.js
@@ -22,9 +22,6 @@ otp.modules.planner.defaultQueryParams = {
     arriveBy                        : false,
     wheelchair                      : false,
     mode                            : "TRANSIT,WALK",
-    maxWalkDistance                 : 4828.032, // 3 mi.
-    metricDefaultMaxWalkDistance    : 5000, // meters
-    imperialDefaultMaxWalkDistance  : 4828.032, // 3 mile
     preferredRoutes                 : null,
     otherThanPreferredRoutesPenalty : 300,
     bannedTrips                     : null,
@@ -69,7 +66,6 @@ otp.modules.planner.PlannerModule =
     date                    : null,
     arriveBy                : false,
     mode                    : "TRANSIT,WALK",
-    maxWalkDistance         : null,
     preferredRoutes         : null,
     bannedTrips             : null,
     optimize                : null,
@@ -133,12 +129,6 @@ otp.modules.planner.PlannerModule =
         this.planTripFunction = this.planTrip;
 
         this.defaultQueryParams = _.clone(otp.modules.planner.defaultQueryParams);
-
-        if (otp.config.metric) {
-            this.defaultQueryParams.maxWalkDistance = this.defaultQueryParams.metricDefaultMaxWalkDistance;
-        } else {
-            this.defaultQueryParams.maxWalkDistance = this.defaultQueryParams.imperialDefaultMaxWalkDistance;
-        }
 
         _.extend(this.defaultQueryParams, this.getExtendedQueryParams());
 
@@ -345,7 +335,6 @@ otp.modules.planner.PlannerModule =
                 date : (this.date) ? moment(this.date, otp.config.locale.time.date_format).format(otp.config.apiDateFormat) : moment().format(otp.config.apiDateFormat),
                 mode: this.mode
             };
-            if(this.mode !== "CAR") _.extend(queryParams, { maxWalkDistance: this.maxWalkDistance} );
             if(this.arriveBy !== null) _.extend(queryParams, { arriveBy : this.arriveBy } );
             if(this.wheelchair !== null) _.extend(queryParams, { wheelchair : this.wheelchair });
             if(this.preferredRoutes !== null) {

--- a/src/main/java/org/opentripplanner/api/common/RoutingResource.java
+++ b/src/main/java/org/opentripplanner/api/common/RoutingResource.java
@@ -165,19 +165,6 @@ public abstract class RoutingResource {
   protected Boolean wheelchair;
 
   /**
-   * The maximum distance (in meters) the user is willing to walk. Defaults to unlimited.
-   * <p>
-   * See https://github.com/opentripplanner/OpenTripPlanner/issues/2886
-   *
-   * @deprecated TODO OTP2 Regression. Not currently working in OTP2. We might not implement the
-   * old functionality the same way, but we will try to map this parameter
-   * so it does work similar as before.
-   */
-  @Deprecated
-  @QueryParam("maxWalkDistance")
-  protected Double maxWalkDistance;
-
-  /**
    * The maximum time (in seconds) of pre-transit travel when using drive-to-transit (park and ride
    * or kiss and ride). Defaults to unlimited.
    * <p>

--- a/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
@@ -52,8 +52,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * A trip planning request. Some parameters may not be honored by the trip planner for some or all
- * itineraries. For example, maxWalkDistance may be relaxed if the alternative is to not provide a
- * route.
+ * itineraries.
  * <p>
  * All defaults should be specified here in the RoutingRequest, NOT as annotations on query
  * parameters in web services that create RoutingRequests. This establishes a priority chain for


### PR DESCRIPTION
### Summary

`maxWalkDistance` is gone for a while but the debug client and a couple of other places still were using it. 

This PR removes it.