### PR TITLE
Add possibility to filter dated service journeys by replacementFor in the Transmodel API [changelog skip]

### DIFF
--- a/docs/sandbox/TransmodelApi.md
+++ b/docs/sandbox/TransmodelApi.md
@@ -47,6 +47,8 @@
   [#4128](https://github.com/opentripplanner/OpenTripPlanner/pull/4128)
 - Expose stop-to-stop journey pattern geometries
   [#4161](https://github.com/opentripplanner/OpenTripPlanner/pull/4161)
+- Add possibility to filter dated service journeys by replacementFor
+  [#4198](https://github.com/opentripplanner/OpenTripPlanner/pull/4198)
 
 ## Documentation
 


### PR DESCRIPTION
### Summary

Support a new use case, where the user can query new DSJs for old DSJs, which are replacing the old ones, that might be eg. on an issued ticket.
