### PR TITLE
OTP2 no longer crashes on invalid GTFS stop time sequences

### DIFF
--- a/src/main/java/org/opentripplanner/gtfs/RepairStopTimesForEachTripOperation.java
+++ b/src/main/java/org/opentripplanner/gtfs/RepairStopTimesForEachTripOperation.java
@@ -73,11 +73,10 @@ public class RepairStopTimesForEachTripOperation {
       }
       if (!filterStopTimes(stopTimes)) {
         stopTimesByTrip.replace(trip, List.of());
+      } else {
+        interpolateStopTimes(stopTimes);
+        stopTimesByTrip.replace(trip, stopTimes);
       }
-
-      interpolateStopTimes(stopTimes);
-
-      stopTimesByTrip.replace(trip, stopTimes);
     }
   }
 


### PR DESCRIPTION
### Summary

Code which filters bad stop time sequences now correctly replaces the invalid stop time list with empty list.

### Issue

fixes #4114


