### PR TITLE
Improve HTML message for a stop linked to an island [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/common/OsmLinkGenerator.java
+++ b/src/main/java/org/opentripplanner/common/OsmLinkGenerator.java
@@ -1,0 +1,22 @@
+package org.opentripplanner.common;
+
+import org.locationtech.jts.geom.Coordinate;
+
+public class OsmLinkGenerator {
+
+  public static String fromCoordinate(Coordinate c) {
+    return fromCoordinate(c, 19);
+  }
+
+  public static String fromCoordinate(Coordinate c, int zoom) {
+    var lat = c.y;
+    var lon = c.x;
+    return "https://www.openstreetmap.org/?mlat=%s&mlon=%s#map=%s/%s/%s".formatted(
+        lat,
+        lon,
+        zoom,
+        lat,
+        lon
+      );
+  }
+}

--- a/src/main/java/org/opentripplanner/common/OsmUrlGenerator.java
+++ b/src/main/java/org/opentripplanner/common/OsmUrlGenerator.java
@@ -2,7 +2,7 @@ package org.opentripplanner.common;
 
 import org.locationtech.jts.geom.Coordinate;
 
-public class OsmLinkGenerator {
+public class OsmUrlGenerator {
 
   public static String fromCoordinate(Coordinate c) {
     return fromCoordinate(c, 19);

--- a/src/main/java/org/opentripplanner/graph_builder/issues/PrunedIslandStop.java
+++ b/src/main/java/org/opentripplanner/graph_builder/issues/PrunedIslandStop.java
@@ -1,11 +1,12 @@
 package org.opentripplanner.graph_builder.issues;
 
+import org.opentripplanner.common.OsmLinkGenerator;
 import org.opentripplanner.graph_builder.DataImportIssue;
 import org.opentripplanner.routing.graph.Vertex;
 
 public class PrunedIslandStop implements DataImportIssue {
 
-  public static final String FMT = "Stop %s was mapped to a pruned sub graph";
+  public static final String FMT = "Stop %s was linked to a pruned sub graph";
 
   final Vertex vertex;
 
@@ -20,7 +21,8 @@ public class PrunedIslandStop implements DataImportIssue {
 
   @Override
   public String getHTMLMessage() {
-    return String.format(FMT, vertex.getLabel());
+    var url = OsmLinkGenerator.fromCoordinate(vertex.getCoordinate());
+    return "<a href=\"%s\">%s</a>".formatted(url, getMessage());
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/graph_builder/issues/PrunedIslandStop.java
+++ b/src/main/java/org/opentripplanner/graph_builder/issues/PrunedIslandStop.java
@@ -1,6 +1,6 @@
 package org.opentripplanner.graph_builder.issues;
 
-import org.opentripplanner.common.OsmLinkGenerator;
+import org.opentripplanner.common.OsmUrlGenerator;
 import org.opentripplanner.graph_builder.DataImportIssue;
 import org.opentripplanner.routing.graph.Vertex;
 
@@ -21,7 +21,7 @@ public class PrunedIslandStop implements DataImportIssue {
 
   @Override
   public String getHTMLMessage() {
-    var url = OsmLinkGenerator.fromCoordinate(vertex.getCoordinate());
+    var url = OsmUrlGenerator.fromCoordinate(vertex.getCoordinate());
     return "<a href=\"%s\">%s</a>".formatted(url, getMessage());
   }
 


### PR DESCRIPTION
Adds a link to the HTML issue report so that you can jump directly to the place in OSM to see what is wrong.

It produces URLs like these: https://www.openstreetmap.org/?mlat=19.59292&mlon=-99.25773000000001#map=19/19.59292/-99.25773