### PR TITLE
Take short transit legs into account when applying the similar legs filter [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/filterchain/groupids/GroupByTripIdAndDistance.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/filterchain/groupids/GroupByTripIdAndDistance.java
@@ -77,21 +77,22 @@ public class GroupByTripIdAndDistance implements GroupId<GroupByTripIdAndDistanc
   static List<Leg> getKeySetOfLegsByLimit(List<Leg> legs, double distanceLimitMeters) {
     // Sort legs descending on distance
     legs =
-      legs
-        .stream()
-        .sorted(Comparator.comparingDouble(Leg::getDistanceMeters).reversed())
-        .collect(Collectors.toList());
+      legs.stream().sorted(Comparator.comparingDouble(Leg::getDistanceMeters).reversed()).toList();
+    if (legs.size() < 2) {
+      return legs;
+    }
     double sum = 0.0;
     int i = 0;
     while (sum < distanceLimitMeters) {
-      // If the transit legs is not long enough, threat the itinerary as non-transit
+      // If the transit legs are not long enough, treat the itinerary as non-transit
+      // TODO: why?
       if (i == legs.size()) {
         return List.of();
       }
       sum += legs.get(i).getDistanceMeters();
       ++i;
     }
-    return legs.stream().limit(i).collect(Collectors.toList());
+    return legs.stream().limit(i).toList();
   }
 
   /** Read-only access to key-set to allow unit-tests access. */

--- a/src/main/java/org/opentripplanner/routing/algorithm/filterchain/groupids/GroupByTripIdAndDistance.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/filterchain/groupids/GroupByTripIdAndDistance.java
@@ -106,7 +106,7 @@ public class GroupByTripIdAndDistance implements GroupId<GroupByTripIdAndDistanc
    * sets are different in size any extra elements are ignored.
    */
   private static boolean isTheSame(List<Leg> a, List<Leg> b) {
-    // If a and b is different in length, than we want to use the shortest list and
+    // If a and b is different in length, then we want to use the shortest list and
     // make sure all elements in it also exist in the other. We ignore the extra legs in
     // the longer list og legs. We do this by making sure 'a' is the shortest list, if not
     // we swap a and b.

--- a/src/test/java/org/opentripplanner/model/plan/PlanTestConstants.java
+++ b/src/test/java/org/opentripplanner/model/plan/PlanTestConstants.java
@@ -2,6 +2,7 @@ package org.opentripplanner.model.plan;
 
 import static org.opentripplanner.util.time.TimeUtils.time;
 
+import java.time.LocalDate;
 import org.opentripplanner.model.Stop;
 import org.opentripplanner.model.WgsCoordinate;
 import org.opentripplanner.transit.model._data.TransitModelForTest;
@@ -21,6 +22,9 @@ public interface PlanTestConstants {
   float BUS_SPEED = 12.5f;
   float RAIL_SPEED = 25.0f;
   float CAR_SPEED = 25.0f;
+
+  LocalDate DATE_1 = LocalDate.parse("2022-06-09");
+  LocalDate DATE_2 = LocalDate.parse("2022-06-10");
 
   // Time duration(D) constants, all values are in seconds
   int D1m = DurationUtils.durationInSeconds("1m");

--- a/src/test/java/org/opentripplanner/routing/algorithm/filterchain/ItineraryListFilterChainTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/filterchain/ItineraryListFilterChainTest.java
@@ -11,9 +11,7 @@ import static org.opentripplanner.model.plan.TestItineraryBuilder.newTime;
 
 import java.time.Instant;
 import java.util.List;
-import org.geotools.xml.xsi.XSISimpleTypes.ID;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.model.plan.Itinerary;
@@ -130,6 +128,32 @@ public class ItineraryListFilterChainTest implements PlanTestConstants {
     Itinerary i1 = newItinerary(A).bus(ID_1, 0, 50, B).bus(ID_2, 52, 100, C).build();
 
     Itinerary i2 = newItinerary(A).bus(ID_1, 0, 50, B).bus(ID_3, 52, 150, C).build();
+
+    List<Itinerary> input = List.of(i1, i2);
+
+    chain.filter(input);
+
+    assertFalse(i1.isFlaggedForDeletion());
+    assertTrue(i2.isFlaggedForDeletion());
+  }
+
+  @Test
+  public void removeDuplicateTripIsWithDifferentStops() {
+    ItineraryListFilterChain chain = createBuilder(false, false, 20)
+      .addGroupBySimilarity(GroupBySimilarity.createWithOneItineraryPerGroup(0.85))
+      .build();
+
+    var i1 = newItinerary(A, T11_00)
+      .walk(T11_05, B)
+      .bus(11, T11_05, T11_10, 5, 10, E, DATE_1)
+      .walk(D5m, G)
+      .build();
+
+    var i2 = newItinerary(A, T11_00)
+      .walk(T11_05, B)
+      .bus(11, T11_05, T11_15, 5, 11, F, DATE_1)
+      .walk(D5m, G)
+      .build();
 
     List<Itinerary> input = List.of(i1, i2);
 

--- a/src/test/java/org/opentripplanner/routing/algorithm/filterchain/groupids/GroupByTripIdAndDistanceTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/filterchain/groupids/GroupByTripIdAndDistanceTest.java
@@ -1,15 +1,16 @@
 package org.opentripplanner.routing.algorithm.filterchain.groupids;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static graphql.Assert.assertFalse;
+import static graphql.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.opentripplanner.model.plan.TestItineraryBuilder.newItinerary;
 import static org.opentripplanner.routing.algorithm.filterchain.groupids.GroupByTripIdAndDistance.calculateTotalDistance;
 import static org.opentripplanner.routing.algorithm.filterchain.groupids.GroupByTripIdAndDistance.getKeySetOfLegsByLimit;
 
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.model.plan.PlanTestConstants;
@@ -173,13 +174,19 @@ public class GroupByTripIdAndDistanceTest implements PlanTestConstants {
     assertFalse(g_31_11.match(g_11_21));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void illegalRangeForPUpperBound() {
-    new GroupByTripIdAndDistance(newItinerary(A).bus(21, T11_01, T11_02, E).build(), 0.991);
+    Assertions.assertThrows(
+      IllegalArgumentException.class,
+      () -> new GroupByTripIdAndDistance(newItinerary(A).bus(21, T11_01, T11_02, E).build(), 0.991)
+    );
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void illegalRangeForPLowerBound() {
-    new GroupByTripIdAndDistance(newItinerary(A).bus(21, T11_01, T11_02, E).build(), 0.499);
+    Assertions.assertThrows(
+      IllegalArgumentException.class,
+      () -> new GroupByTripIdAndDistance(newItinerary(A).bus(21, T11_01, T11_02, E).build(), 0.499)
+    );
   }
 }

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/BikeRentalSnapshotTest.snap
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/BikeRentalSnapshotTest.snap
@@ -469,418 +469,6 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
     },
     {
       "arrivedAtDestinationWithRentedBicycle": false,
-      "duration": 1281,
-      "elevationGained": 0.0,
-      "elevationLost": 0.0,
-      "endTime": "2009-10-21T23:37:54.000+00:00",
-      "fare": {
-        "details": {
-          "regular": [
-            {
-              "fareId": {
-                "feedId": "prt",
-                "id": "8"
-              },
-              "price": {
-                "cents": 200,
-                "currency": {
-                  "value": "USD"
-                }
-              },
-              "routes": [
-                {
-                  "feedId": "prt",
-                  "id": "20"
-                }
-              ]
-            }
-          ]
-        },
-        "fare": {
-          "regular": {
-            "cents": 200,
-            "currency": {
-              "value": "USD"
-            }
-          }
-        }
-      },
-      "generalizedCost": 2577,
-      "legs": [
-        {
-          "agencyTimeZoneOffset": -25200000,
-          "arrivalDelay": 0,
-          "departureDelay": 0,
-          "distance": 565.958,
-          "endTime": "2009-10-21T23:23:59.000+00:00",
-          "from": {
-            "departure": "2009-10-21T23:16:33.000+00:00",
-            "lat": 45.52832,
-            "lon": -122.70059,
-            "name": "SW Johnson St. & NW 24th Ave. (P1)",
-            "vertexType": "NORMAL"
-          },
-          "generalizedCost": 865,
-          "interlineWithPreviousLeg": false,
-          "legGeometry": {
-            "length": 34,
-            "points": "}f{tGv}{kVjCAjCEnCCFCFErACj@CLMHGFJLNNNDBDBDBF@FBLBH@FBDBNHNJLDPLb@Z^XPNNTBQT{ARJEP"
-          },
-          "mode": "WALK",
-          "pathway": false,
-          "realTime": false,
-          "rentedBike": false,
-          "route": "",
-          "startTime": "2009-10-21T23:16:33.000+00:00",
-          "steps": [
-            {
-              "absoluteDirection": "SOUTH",
-              "area": false,
-              "bogusName": false,
-              "distance": 317.401,
-              "elevation": "",
-              "lat": 45.52831993266165,
-              "lon": -122.70059632295107,
-              "relativeDirection": "DEPART",
-              "stayOn": false,
-              "streetName": "Northwest 24th Avenue",
-              "walkingBike": false
-            },
-            {
-              "absoluteDirection": "SOUTHEAST",
-              "area": false,
-              "bogusName": false,
-              "distance": 15.262,
-              "elevation": "",
-              "lat": 45.525472400000005,
-              "lon": -122.7004445,
-              "relativeDirection": "SLIGHTLY_LEFT",
-              "stayOn": false,
-              "streetName": "Northwest Westover Road",
-              "walkingBike": false
-            },
-            {
-              "absoluteDirection": "SOUTHWEST",
-              "area": false,
-              "bogusName": false,
-              "distance": 176.41,
-              "elevation": "",
-              "lat": 45.5253583,
-              "lon": -122.70033570000001,
-              "relativeDirection": "RIGHT",
-              "stayOn": false,
-              "streetName": "Northwest 24th Place",
-              "walkingBike": false
-            },
-            {
-              "absoluteDirection": "EAST",
-              "area": false,
-              "bogusName": false,
-              "distance": 45.172,
-              "elevation": "",
-              "lat": 45.5239733,
-              "lon": -122.701384,
-              "relativeDirection": "LEFT",
-              "stayOn": false,
-              "streetName": "West Burnside Street",
-              "walkingBike": false
-            },
-            {
-              "absoluteDirection": "SOUTHWEST",
-              "area": false,
-              "bogusName": true,
-              "distance": 11.713,
-              "elevation": "",
-              "lat": 45.5238426,
-              "lon": -122.70083500000001,
-              "relativeDirection": "RIGHT",
-              "stayOn": false,
-              "streetName": "way 113897002 from 7",
-              "walkingBike": false
-            }
-          ],
-          "to": {
-            "arrival": "2009-10-21T23:23:59.000+00:00",
-            "departure": "2009-10-21T23:23:59.000+00:00",
-            "lat": 45.523773,
-            "lon": -122.700988,
-            "name": "W Burnside & SW Osage",
-            "stopCode": "9354",
-            "stopId": "prt:9354",
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
-          },
-          "transitLeg": false,
-          "walkingBike": false
-        },
-        {
-          "agencyId": "prt:prt",
-          "agencyName": "TriMet",
-          "agencyTimeZoneOffset": -25200000,
-          "agencyUrl": "http://trimet.org",
-          "arrivalDelay": 0,
-          "departureDelay": 0,
-          "distance": 1879.0379409561187,
-          "endTime": "2009-10-21T23:32:52.000+00:00",
-          "from": {
-            "arrival": "2009-10-21T23:23:59.000+00:00",
-            "departure": "2009-10-21T23:23:59.000+00:00",
-            "lat": 45.523773,
-            "lon": -122.700988,
-            "name": "W Burnside & SW Osage",
-            "stopCode": "9354",
-            "stopId": "prt:9354",
-            "stopIndex": 36,
-            "stopSequence": 37,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
-          },
-          "generalizedCost": 1133,
-          "headsign": "Gresham TC",
-          "interlineWithPreviousLeg": false,
-          "intermediateStops": [
-            {
-              "arrival": "2009-10-21T23:24:42.000+00:00",
-              "departure": "2009-10-21T23:24:42.000+00:00",
-              "lat": 45.523287,
-              "lon": -122.696995,
-              "name": "W Burnside & SW St Clair",
-              "stopCode": "718",
-              "stopId": "prt:718",
-              "stopIndex": 37,
-              "stopSequence": 38,
-              "vertexType": "TRANSIT",
-              "zoneId": "1"
-            },
-            {
-              "arrival": "2009-10-21T23:25:10.000+00:00",
-              "departure": "2009-10-21T23:25:10.000+00:00",
-              "lat": 45.523106,
-              "lon": -122.69445,
-              "name": "W Burnside & SW 21st",
-              "stopCode": "749",
-              "stopId": "prt:749",
-              "stopIndex": 38,
-              "stopSequence": 39,
-              "vertexType": "TRANSIT",
-              "zoneId": "1"
-            },
-            {
-              "arrival": "2009-10-21T23:25:30.000+00:00",
-              "departure": "2009-10-21T23:25:30.000+00:00",
-              "lat": 45.523089,
-              "lon": -122.692567,
-              "name": "W Burnside & SW 20th",
-              "stopCode": "8511",
-              "stopId": "prt:8511",
-              "stopIndex": 39,
-              "stopSequence": 40,
-              "vertexType": "TRANSIT",
-              "zoneId": "1"
-            },
-            {
-              "arrival": "2009-10-21T23:26:00.000+00:00",
-              "departure": "2009-10-21T23:26:00.000+00:00",
-              "lat": 45.522942,
-              "lon": -122.689797,
-              "name": "W Burnside & SW 18th",
-              "stopCode": "9860",
-              "stopId": "prt:9860",
-              "stopIndex": 40,
-              "stopSequence": 41,
-              "vertexType": "TRANSIT",
-              "zoneId": "1"
-            },
-            {
-              "arrival": "2009-10-21T23:27:40.000+00:00",
-              "departure": "2009-10-21T23:27:40.000+00:00",
-              "lat": 45.522786,
-              "lon": -122.686682,
-              "name": "W Burnside & SW 15th",
-              "stopCode": "725",
-              "stopId": "prt:725",
-              "stopIndex": 41,
-              "stopSequence": 42,
-              "vertexType": "TRANSIT",
-              "zoneId": "1"
-            },
-            {
-              "arrival": "2009-10-21T23:28:53.000+00:00",
-              "departure": "2009-10-21T23:28:53.000+00:00",
-              "lat": 45.522829,
-              "lon": -122.68439,
-              "name": "W Burnside & SW 13th",
-              "stopCode": "723",
-              "stopId": "prt:723",
-              "stopIndex": 42,
-              "stopSequence": 43,
-              "vertexType": "TRANSIT",
-              "zoneId": "0"
-            },
-            {
-              "arrival": "2009-10-21T23:30:31.000+00:00",
-              "departure": "2009-10-21T23:30:31.000+00:00",
-              "lat": 45.522919,
-              "lon": -122.681327,
-              "name": "W Burnside & SW 10th",
-              "stopCode": "10792",
-              "stopId": "prt:10792",
-              "stopIndex": 43,
-              "stopSequence": 44,
-              "vertexType": "TRANSIT",
-              "zoneId": "0"
-            },
-            {
-              "arrival": "2009-10-21T23:32:01.000+00:00",
-              "departure": "2009-10-21T23:32:01.000+00:00",
-              "lat": 45.522977,
-              "lon": -122.678526,
-              "name": "W Burnside & SW 8th",
-              "stopCode": "715",
-              "stopId": "prt:715",
-              "stopIndex": 44,
-              "stopSequence": 45,
-              "vertexType": "TRANSIT",
-              "zoneId": "0"
-            }
-          ],
-          "legGeometry": {
-            "length": 53,
-            "points": "gkztGz_|kVTmALiBt@mJJ_DBoA??@e@D}AFyDBgADwB??@]BaADgCDmC??By@FiEJoEBuA??DsBD}BBiADmC@y@AiB???Y?g@As@?_@?YAeB@uD???{@G{D?mECeBAu@??Ai@CoEASAuDAmB???MCqEA_B"
-          },
-          "mode": "BUS",
-          "pathway": false,
-          "realTime": false,
-          "route": "Burnside/Stark",
-          "routeId": "prt:20",
-          "routeLongName": "Burnside/Stark",
-          "routeShortName": "20",
-          "routeType": 3,
-          "serviceDate": "2009-10-21",
-          "startTime": "2009-10-21T23:23:59.000+00:00",
-          "steps": [ ],
-          "to": {
-            "arrival": "2009-10-21T23:32:52.000+00:00",
-            "departure": "2009-10-21T23:32:52.000+00:00",
-            "lat": 45.522961,
-            "lon": -122.676924,
-            "name": "W Burnside & SW 6th",
-            "stopCode": "792",
-            "stopId": "prt:792",
-            "stopIndex": 45,
-            "stopSequence": 46,
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
-          },
-          "transitLeg": true,
-          "tripBlockId": "1237",
-          "tripId": "prt:201W1450"
-        },
-        {
-          "agencyTimeZoneOffset": -25200000,
-          "arrivalDelay": 0,
-          "departureDelay": 0,
-          "distance": 379.277,
-          "endTime": "2009-10-21T23:37:54.000+00:00",
-          "from": {
-            "arrival": "2009-10-21T23:32:52.000+00:00",
-            "departure": "2009-10-21T23:32:52.000+00:00",
-            "lat": 45.522961,
-            "lon": -122.676924,
-            "name": "W Burnside & SW 6th",
-            "stopCode": "792",
-            "stopId": "prt:792",
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
-          },
-          "generalizedCost": 579,
-          "interlineWithPreviousLeg": false,
-          "legGeometry": {
-            "length": 23,
-            "points": "oeztGxiwkVE?AgA?OKCKAM?iBBI?K?wBBK?K?sBDM@?E?MCgD?A?O?C?M?a@"
-          },
-          "mode": "WALK",
-          "pathway": false,
-          "realTime": false,
-          "rentedBike": false,
-          "route": "",
-          "startTime": "2009-10-21T23:32:52.000+00:00",
-          "steps": [
-            {
-              "absoluteDirection": "EAST",
-              "area": false,
-              "bogusName": false,
-              "distance": 34.205,
-              "elevation": "",
-              "lat": 45.52299572692338,
-              "lon": -122.67692504190299,
-              "relativeDirection": "DEPART",
-              "stayOn": false,
-              "streetName": "West Burnside Street",
-              "walkingBike": false
-            },
-            {
-              "absoluteDirection": "NORTH",
-              "area": false,
-              "bogusName": false,
-              "distance": 13.464,
-              "elevation": "",
-              "lat": 45.523002600000005,
-              "lon": -122.6764861,
-              "relativeDirection": "LEFT",
-              "stayOn": false,
-              "streetName": "Southwest 6th Avenue",
-              "walkingBike": false
-            },
-            {
-              "absoluteDirection": "NORTH",
-              "area": false,
-              "bogusName": false,
-              "distance": 231.502,
-              "elevation": "",
-              "lat": 45.5231221,
-              "lon": -122.67645900000001,
-              "relativeDirection": "CONTINUE",
-              "stayOn": false,
-              "streetName": "Northwest 6th Avenue",
-              "walkingBike": false
-            },
-            {
-              "absoluteDirection": "EAST",
-              "area": false,
-              "bogusName": false,
-              "distance": 100.106,
-              "elevation": "",
-              "lat": 45.525202900000004,
-              "lon": -122.6765342,
-              "relativeDirection": "RIGHT",
-              "stayOn": false,
-              "streetName": "Northwest Everett Street",
-              "walkingBike": false
-            }
-          ],
-          "to": {
-            "arrival": "2009-10-21T23:37:54.000+00:00",
-            "lat": 45.52523,
-            "lon": -122.67525,
-            "name": "NW Everett St. & NW 5th Ave. (P3)",
-            "vertexType": "NORMAL"
-          },
-          "transitLeg": false,
-          "walkingBike": false
-        }
-      ],
-      "startTime": "2009-10-21T23:16:33.000+00:00",
-      "tooSloped": false,
-      "transfers": 0,
-      "transitTime": 533,
-      "waitingTime": 0,
-      "walkDistance": 945.2349999999999,
-      "walkLimitExceeded": false,
-      "walkTime": 748
-    },
-    {
-      "arrivedAtDestinationWithRentedBicycle": false,
       "duration": 1296,
       "elevationGained": 0.0,
       "elevationLost": 0.0,
@@ -2558,6 +2146,327 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
       "walkDistance": 817.83,
       "walkLimitExceeded": false,
       "walkTime": 474
+    },
+    {
+      "arrivedAtDestinationWithRentedBicycle": false,
+      "duration": 1001,
+      "elevationGained": 0.0,
+      "elevationLost": 0.0,
+      "endTime": "2009-10-21T23:56:10.000+00:00",
+      "fare": {
+        "details": {
+          "regular": [
+            {
+              "fareId": {
+                "feedId": "prt",
+                "id": "8"
+              },
+              "price": {
+                "cents": 200,
+                "currency": {
+                  "value": "USD"
+                }
+              },
+              "routes": [
+                {
+                  "feedId": "prt",
+                  "id": "77"
+                }
+              ]
+            }
+          ]
+        },
+        "fare": {
+          "regular": {
+            "cents": 200,
+            "currency": {
+              "value": "USD"
+            }
+          }
+        }
+      },
+      "generalizedCost": 1805,
+      "legs": [
+        {
+          "agencyTimeZoneOffset": -25200000,
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 220.146,
+          "endTime": "2009-10-21T23:42:21.000+00:00",
+          "from": {
+            "departure": "2009-10-21T23:39:29.000+00:00",
+            "lat": 45.52832,
+            "lon": -122.70059,
+            "name": "SW Johnson St. & NW 24th Ave. (P1)",
+            "vertexType": "NORMAL"
+          },
+          "generalizedCost": 336,
+          "interlineWithPreviousLeg": false,
+          "legGeometry": {
+            "length": 6,
+            "points": "}f{tGv}{kVC?mCBmCD@zCN?"
+          },
+          "mode": "WALK",
+          "pathway": false,
+          "realTime": false,
+          "rentedBike": false,
+          "route": "",
+          "startTime": "2009-10-21T23:39:29.000+00:00",
+          "steps": [
+            {
+              "absoluteDirection": "NORTH",
+              "area": false,
+              "bogusName": false,
+              "distance": 159.625,
+              "elevation": "",
+              "lat": 45.52831993266165,
+              "lon": -122.70059632295107,
+              "relativeDirection": "DEPART",
+              "stayOn": false,
+              "streetName": "Northwest 24th Avenue",
+              "walkingBike": false
+            },
+            {
+              "absoluteDirection": "WEST",
+              "area": false,
+              "bogusName": false,
+              "distance": 60.521,
+              "elevation": "",
+              "lat": 45.529755,
+              "lon": -122.70064880000001,
+              "relativeDirection": "LEFT",
+              "stayOn": false,
+              "streetName": "Northwest Lovejoy Street",
+              "walkingBike": false
+            }
+          ],
+          "to": {
+            "arrival": "2009-10-21T23:42:21.000+00:00",
+            "departure": "2009-10-21T23:42:21.000+00:00",
+            "lat": 45.529662,
+            "lon": -122.701423,
+            "name": "2400 Block NW Lovejoy",
+            "stopCode": "3589",
+            "stopId": "prt:3589",
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "transitLeg": false,
+          "walkingBike": false
+        },
+        {
+          "agencyId": "prt:prt",
+          "agencyName": "TriMet",
+          "agencyTimeZoneOffset": -25200000,
+          "agencyUrl": "http://trimet.org",
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 2804.1297859664874,
+          "endTime": "2009-10-21T23:55:32.000+00:00",
+          "from": {
+            "arrival": "2009-10-21T23:42:21.000+00:00",
+            "departure": "2009-10-21T23:42:21.000+00:00",
+            "lat": 45.529662,
+            "lon": -122.701423,
+            "name": "2400 Block NW Lovejoy",
+            "stopCode": "3589",
+            "stopId": "prt:3589",
+            "stopIndex": 6,
+            "stopSequence": 7,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "generalizedCost": 1391,
+          "headsign": "Troutdale",
+          "interlineWithPreviousLeg": false,
+          "intermediateStops": [
+            {
+              "arrival": "2009-10-21T23:43:54.000+00:00",
+              "departure": "2009-10-21T23:43:54.000+00:00",
+              "lat": 45.529746,
+              "lon": -122.69688,
+              "name": "NW Lovejoy & 22nd",
+              "stopCode": "3596",
+              "stopId": "prt:3596",
+              "stopIndex": 7,
+              "stopSequence": 8,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-10-21T23:44:39.000+00:00",
+              "departure": "2009-10-21T23:44:39.000+00:00",
+              "lat": 45.529833,
+              "lon": -122.694676,
+              "name": "NW Lovejoy & 21st",
+              "stopCode": "3595",
+              "stopId": "prt:3595",
+              "stopIndex": 8,
+              "stopSequence": 9,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-10-21T23:46:23.000+00:00",
+              "departure": "2009-10-21T23:46:23.000+00:00",
+              "lat": 45.529925,
+              "lon": -122.689587,
+              "name": "NW Lovejoy & 18th",
+              "stopCode": "10751",
+              "stopId": "prt:10751",
+              "stopIndex": 9,
+              "stopSequence": 10,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-10-21T23:48:05.000+00:00",
+              "departure": "2009-10-21T23:48:05.000+00:00",
+              "lat": 45.529997,
+              "lon": -122.684611,
+              "name": "NW Lovejoy & 13th",
+              "stopCode": "10752",
+              "stopId": "prt:10752",
+              "stopIndex": 10,
+              "stopSequence": 11,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-10-21T23:49:07.000+00:00",
+              "departure": "2009-10-21T23:49:07.000+00:00",
+              "lat": 45.530034,
+              "lon": -122.68155,
+              "name": "NW Lovejoy & 10th",
+              "stopCode": "11000",
+              "stopId": "prt:11000",
+              "stopIndex": 11,
+              "stopSequence": 12,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-10-21T23:50:00.000+00:00",
+              "departure": "2009-10-21T23:50:00.000+00:00",
+              "lat": 45.531086,
+              "lon": -122.680302,
+              "name": "NW 9th & Marshall",
+              "stopCode": "12803",
+              "stopId": "prt:12803",
+              "stopIndex": 12,
+              "stopSequence": 13,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-10-21T23:52:50.000+00:00",
+              "departure": "2009-10-21T23:52:50.000+00:00",
+              "lat": 45.528405,
+              "lon": -122.676979,
+              "name": "NW Station Way & Union Station",
+              "stopCode": "12804",
+              "stopId": "prt:12804",
+              "stopIndex": 13,
+              "stopSequence": 14,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
+            }
+          ],
+          "legGeometry": {
+            "length": 60,
+            "points": "yo{tG|b|kVC}CEuKGwI???}@G{J???YGsKEuKCuD???UCiECeEAgA?{@AkA?WAwDE{C???i@CiECkECcD??Ae@?mE{BDQ@q@@??{ADCsDbBiB`DaEt@_AVANIX?tBCLK`@c@\\c@l@w@??\\c@FKDCFEXCCgEvBEVAlCClCEnCECoD"
+          },
+          "mode": "BUS",
+          "pathway": false,
+          "realTime": false,
+          "route": "Broadway/Halsey",
+          "routeId": "prt:77",
+          "routeLongName": "Broadway/Halsey",
+          "routeShortName": "77",
+          "routeType": 3,
+          "serviceDate": "2009-10-21",
+          "startTime": "2009-10-21T23:42:21.000+00:00",
+          "steps": [ ],
+          "to": {
+            "arrival": "2009-10-21T23:55:32.000+00:00",
+            "departure": "2009-10-21T23:55:32.000+00:00",
+            "lat": 45.525183,
+            "lon": -122.674607,
+            "name": "NW Everett & 4th",
+            "stopCode": "9546",
+            "stopId": "prt:9546",
+            "stopIndex": 14,
+            "stopSequence": 15,
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
+          },
+          "transitLeg": true,
+          "tripBlockId": "7703",
+          "tripId": "prt:770W1400"
+        },
+        {
+          "agencyTimeZoneOffset": -25200000,
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 49.938,
+          "endTime": "2009-10-21T23:56:10.000+00:00",
+          "from": {
+            "arrival": "2009-10-21T23:55:32.000+00:00",
+            "departure": "2009-10-21T23:55:32.000+00:00",
+            "lat": 45.525183,
+            "lon": -122.674607,
+            "name": "NW Everett & 4th",
+            "stopCode": "9546",
+            "stopId": "prt:9546",
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
+          },
+          "generalizedCost": 77,
+          "interlineWithPreviousLeg": false,
+          "legGeometry": {
+            "length": 3,
+            "points": "ksztGh{vkVI?@~B"
+          },
+          "mode": "WALK",
+          "pathway": false,
+          "realTime": false,
+          "rentedBike": false,
+          "route": "",
+          "startTime": "2009-10-21T23:55:32.000+00:00",
+          "steps": [
+            {
+              "absoluteDirection": "WEST",
+              "area": false,
+              "bogusName": false,
+              "distance": 49.938,
+              "elevation": "",
+              "lat": 45.525239650875925,
+              "lon": -122.67460910872424,
+              "relativeDirection": "DEPART",
+              "stayOn": false,
+              "streetName": "Northwest Everett Street",
+              "walkingBike": false
+            }
+          ],
+          "to": {
+            "arrival": "2009-10-21T23:56:10.000+00:00",
+            "lat": 45.52523,
+            "lon": -122.67525,
+            "name": "NW Everett St. & NW 5th Ave. (P3)",
+            "vertexType": "NORMAL"
+          },
+          "transitLeg": false,
+          "walkingBike": false
+        }
+      ],
+      "startTime": "2009-10-21T23:39:29.000+00:00",
+      "tooSloped": false,
+      "transfers": 0,
+      "transitTime": 791,
+      "waitingTime": 0,
+      "walkDistance": 270.084,
+      "walkLimitExceeded": false,
+      "walkTime": 210
     }
   ]
 ]

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/TransitSnapshotTest.snap
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/TransitSnapshotTest.snap
@@ -2086,10 +2086,10 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
     },
     {
       "arrivedAtDestinationWithRentedBicycle": false,
-      "duration": 1940,
+      "duration": 1941,
       "elevationGained": 0.0,
       "elevationLost": 0.0,
-      "endTime": "2009-11-17T19:25:04.000+00:00",
+      "endTime": "2009-11-17T19:25:05.000+00:00",
       "fare": {
         "details": {
           "regular": [
@@ -2122,7 +2122,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           }
         }
       },
-      "generalizedCost": 3290,
+      "generalizedCost": 3245,
       "legs": [
         {
           "agencyTimeZoneOffset": -28800000,
@@ -2214,8 +2214,8 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           "agencyUrl": "http://trimet.org",
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distance": 4569.033127779713,
-          "endTime": "2009-11-17T19:21:00.000+00:00",
+          "distance": 4844.785407243491,
+          "endTime": "2009-11-17T19:22:04.000+00:00",
           "from": {
             "arrival": "2009-11-17T19:02:00.000+00:00",
             "departure": "2009-11-17T19:02:00.000+00:00",
@@ -2229,7 +2229,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
-          "generalizedCost": 1740,
+          "generalizedCost": 1804,
           "headsign": "NW 27th & Thurman",
           "interlineWithPreviousLeg": false,
           "intermediateStops": [
@@ -2492,11 +2492,24 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "stopSequence": 73,
               "vertexType": "TRANSIT",
               "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T19:21:00.000+00:00",
+              "departure": "2009-11-17T19:21:00.000+00:00",
+              "lat": 45.529681,
+              "lon": -122.698529,
+              "name": "NW 23rd & Lovejoy",
+              "stopCode": "7163",
+              "stopId": "prt:7163",
+              "stopIndex": 73,
+              "stopSequence": 74,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
             }
           ],
           "legGeometry": {
-            "length": 120,
-            "points": "oaytG|zrkV?tBAjE?nD???X?hE?xC??Ah@?pE?~C???J?`@?vAAvBEbE?jEAlE?`BAbB@d@??@tAAj@Cx@Cb@Cp@_@dEcAtFoA`IS~@i@`BmAzDi@zAc@pAi@~C??Id@u@jEm@bD??If@u@jEk@bD??If@u@|DW`B??CPs@|Du@lElBz@??VJbCfAk@dD??Id@w@rEWvAId@AF??Q~@s@`Ei@~C??Ib@u@dEWzA??]jB]MQSe@WOKOKIIQe@GWE]GnD??AXKnEGnD???XGjD??AZEfCC`AEzB??AXCfAGxDE|AEtBIlC??APkAh@o@?sCB{BD??S?mCDmCDyBB??U?mCDmCDyBB"
+            "length": 126,
+            "points": "oaytG|zrkV?tBAjE?nD???X?hE?xC??Ah@?pE?~C???J?`@?vAAvBEbE?jEAlE?`BAbB@d@??@tAAj@Cx@Cb@Cp@_@dEcAtFoA`IS~@i@`BmAzDi@zAc@pAi@~C??Id@u@jEm@bD??If@u@jEk@bD??If@u@|DW`B??CPs@|Du@lElBz@??VJbCfAk@dD??Id@w@rEWvAId@AF??Q~@s@`Ei@~C??Ib@u@dEWzA??]jB]MQSe@WOKOKIIQe@GWE]GnD??AXKnEGnD???XGjD??AZEfCC`AEzB??AXCfAGxDE|AEtBIlC??APkAh@o@?sCB{BD??S?mCDmCDyBB??U?mCDmCDyBB??S?oCDmCDmCBo@@"
           },
           "mode": "BUS",
           "pathway": false,
@@ -2510,15 +2523,15 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           "startTime": "2009-11-17T19:02:00.000+00:00",
           "steps": [ ],
           "to": {
-            "arrival": "2009-11-17T19:21:00.000+00:00",
-            "departure": "2009-11-17T19:21:00.000+00:00",
-            "lat": 45.529681,
-            "lon": -122.698529,
-            "name": "NW 23rd & Lovejoy",
-            "stopCode": "7163",
-            "stopId": "prt:7163",
-            "stopIndex": 73,
-            "stopSequence": 74,
+            "arrival": "2009-11-17T19:22:04.000+00:00",
+            "departure": "2009-11-17T19:22:04.000+00:00",
+            "lat": 45.532159,
+            "lon": -122.698634,
+            "name": "NW 23rd & Overton",
+            "stopCode": "8981",
+            "stopId": "prt:8981",
+            "stopIndex": 74,
+            "stopSequence": 75,
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
@@ -2530,55 +2543,42 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           "agencyTimeZoneOffset": -28800000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distance": 297.11,
-          "endTime": "2009-11-17T19:25:04.000+00:00",
+          "distance": 231.459,
+          "endTime": "2009-11-17T19:25:05.000+00:00",
           "from": {
-            "arrival": "2009-11-17T19:21:00.000+00:00",
-            "departure": "2009-11-17T19:21:00.000+00:00",
-            "lat": 45.529681,
-            "lon": -122.698529,
-            "name": "NW 23rd & Lovejoy",
-            "stopCode": "7163",
-            "stopId": "prt:7163",
+            "arrival": "2009-11-17T19:22:04.000+00:00",
+            "departure": "2009-11-17T19:22:04.000+00:00",
+            "lat": 45.532159,
+            "lon": -122.698634,
+            "name": "NW 23rd & Overton",
+            "stopCode": "8981",
+            "stopId": "prt:8981",
             "vertexType": "TRANSIT",
             "zoneId": "1"
           },
-          "generalizedCost": 462,
+          "generalizedCost": 353,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
-            "length": 15,
-            "points": "oo{tGxp{kVG@?NM?M?_CD?B?FM?G@K?GBwADK?DpH"
+            "length": 10,
+            "points": "}~{tGnq{kV?LVAF?J?L?rBCLA?RDpH"
           },
           "mode": "WALK",
           "pathway": false,
           "realTime": false,
           "rentedBike": false,
           "route": "",
-          "startTime": "2009-11-17T19:21:00.000+00:00",
+          "startTime": "2009-11-17T19:22:04.000+00:00",
           "steps": [
             {
-              "absoluteDirection": "WEST",
+              "absoluteDirection": "SOUTH",
               "area": false,
-              "bogusName": true,
-              "distance": 6.44,
+              "bogusName": false,
+              "distance": 104.452,
               "elevation": "",
-              "lat": 45.529726790620664,
-              "lon": -122.69853023095405,
+              "lat": 45.53215782420268,
+              "lon": -122.69870264831422,
               "relativeDirection": "DEPART",
               "stayOn": false,
-              "streetName": "way 158083864 from 0",
-              "walkingBike": false
-            },
-            {
-              "absoluteDirection": "NORTH",
-              "area": false,
-              "bogusName": false,
-              "distance": 87.181,
-              "elevation": "",
-              "lat": 45.5297257,
-              "lon": -122.69861290000001,
-              "relativeDirection": "RIGHT",
-              "stayOn": false,
               "streetName": "Northwest 23rd Avenue",
               "walkingBike": false
             },
@@ -2586,70 +2586,18 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "absoluteDirection": "WEST",
               "area": false,
               "bogusName": false,
-              "distance": 4.768,
+              "distance": 127.007,
               "elevation": "",
-              "lat": 45.5305094,
-              "lon": -122.69864600000001,
-              "relativeDirection": "LEFT",
-              "stayOn": false,
-              "streetName": "Northwest Marshall Street",
-              "walkingBike": false
-            },
-            {
-              "absoluteDirection": "NORTH",
-              "area": false,
-              "bogusName": true,
-              "distance": 7.274,
-              "elevation": "",
-              "lat": 45.5305085,
-              "lon": -122.6987072,
+              "lat": 45.531218800000005,
+              "lon": -122.69866750000001,
               "relativeDirection": "RIGHT",
-              "stayOn": false,
-              "streetName": "way 158083033 from 0",
-              "walkingBike": false
-            },
-            {
-              "absoluteDirection": "NORTH",
-              "area": false,
-              "bogusName": false,
-              "distance": 64.974,
-              "elevation": "",
-              "lat": 45.5305739,
-              "lon": -122.69870940000001,
-              "relativeDirection": "CONTINUE",
-              "stayOn": false,
-              "streetName": "Northwest 23rd Avenue",
-              "walkingBike": false
-            },
-            {
-              "absoluteDirection": "NORTH",
-              "area": false,
-              "bogusName": true,
-              "distance": 7.294,
-              "elevation": "",
-              "lat": 45.531153,
-              "lon": -122.69876060000001,
-              "relativeDirection": "CONTINUE",
-              "stayOn": false,
-              "streetName": "way 158083032 from 0",
-              "walkingBike": false
-            },
-            {
-              "absoluteDirection": "WEST",
-              "area": false,
-              "bogusName": false,
-              "distance": 119.179,
-              "elevation": "",
-              "lat": 45.5312184,
-              "lon": -122.698768,
-              "relativeDirection": "LEFT",
               "stayOn": false,
               "streetName": "Northwest Northrup Street",
               "walkingBike": false
             }
           ],
           "to": {
-            "arrival": "2009-11-17T19:25:04.000+00:00",
+            "arrival": "2009-11-17T19:25:05.000+00:00",
             "lat": 45.531,
             "lon": -122.70029,
             "name": "NW Northrup St. & NW 24th Ave. (P3)",
@@ -2662,11 +2610,11 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
       "startTime": "2009-11-17T18:52:44.000+00:00",
       "tooSloped": false,
       "transfers": 0,
-      "transitTime": 1140,
+      "transitTime": 1204,
       "waitingTime": 0,
-      "walkDistance": 1015.832,
+      "walkDistance": 950.181,
       "walkLimitExceeded": false,
-      "walkTime": 800
+      "walkTime": 737
     }
   ]
 ]


### PR DESCRIPTION
### Summary

Issue #3462 describes a problem with the similar legs filter.

I think that the problem is that short transit trips (those that take up too much time in the itinerary) are explicitly excluded from the similar legs filter. There is even a test to make sure that this is the case: https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/src/test/java/org/opentripplanner/routing/algorithm/filterchain/groupids/GroupByTripIdAndDistanceTest.java#L78-L87

I've added a special case for when there is only a single leg but I'm not sure if the solution should be more general.

### Issue

Fixes #3462

### Unit tests

Added.

### Documentation

n/a