### PR TITLE
Solve bug in SameFirstOrLastTripFilter [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/filterchain/filter/SameFirstOrLastTripFilter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/filterchain/filter/SameFirstOrLastTripFilter.java
@@ -21,6 +21,10 @@ public class SameFirstOrLastTripFilter implements ItineraryListFilter {
     List<GroupBySameFirstOrLastTrip> groups = new ArrayList<>();
 
     OUTER_LOOP:for (Itinerary it : itineraries) {
+      if (it.isFlaggedForDeletion()) {
+        continue;
+      }
+
       GroupBySameFirstOrLastTrip currentGroup = new GroupBySameFirstOrLastTrip(it);
 
       for (GroupBySameFirstOrLastTrip group : groups) {

--- a/src/test/java/org/opentripplanner/routing/algorithm/filterchain/filter/SameFirstOrLastTripFilterTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/filterchain/filter/SameFirstOrLastTripFilterTest.java
@@ -48,4 +48,24 @@ public class SameFirstOrLastTripFilterTest implements PlanTestConstants {
     // Would match with i3 and i4, but they are filtered out
     assertFalse(i5.isFlaggedForDeletion());
   }
+
+  @Test
+  public void testFilterLogicOnTripsThatAreAlreadyFlagged() {
+    final int ID_1 = 1;
+    final int ID_2 = 2;
+    final int ID_3 = 3;
+
+    Itinerary i1 = newItinerary(A).bus(ID_1, 0, 50, B).bus(ID_2, 52, 100, C).build();
+    i1.flagForDeletion(null);
+
+    Itinerary i2 = newItinerary(A).bus(ID_1, 0, 50, B).bus(ID_3, 52, 100, C).build();
+
+    List<Itinerary> input = List.of(i1, i2);
+
+    final SameFirstOrLastTripFilter filter = new SameFirstOrLastTripFilter();
+    filter.filter(input);
+
+    // i2 should not be flagged for deletion since i1 was already removed before applying the filter
+    assertFalse(i2.isFlaggedForDeletion());
+  }
 }


### PR DESCRIPTION
### Summary
This PR ensures that the filter works as it should in case one of itineraries was already flagged for deletion through previous filter.
### Issue
In case itinerary A and B both start with same journey but itinerary A was already flagged for deletion in previous filter, B should not be flagged for deletion (since A is already deleted and should not count).

### Unit tests
Added new unit test for the edge case

### Code style
Formatted with maven plugin

### Documentation
No new documentation added