### PR TITLE
Fix geometries for frequency-based trips [changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/model/TripPattern.java
+++ b/src/main/java/org/opentripplanner/model/TripPattern.java
@@ -412,9 +412,9 @@ public final class TripPattern extends TransitEntity implements Cloneable, Seria
 
   /**
    * Find the first stop position in pattern matching the given {@code stop}. The search start at
-   * position {@code 0}. Return a negative number if not found. Use {@link
-   * #findAlightStopPositionInPattern(StopLocation)} or {@link #findBoardingStopPositionInPattern(StopLocation)}
-   * if possible.
+   * position {@code 0}. Return a negative number if not found. Use
+   * {@link #findAlightStopPositionInPattern(StopLocation)} or
+   * {@link #findBoardingStopPositionInPattern(StopLocation)} if possible.
    */
   public int findStopPosition(StopLocation stop) {
     return stopPattern.findStopPosition(stop);
@@ -568,7 +568,12 @@ public final class TripPattern extends TransitEntity implements Cloneable, Seria
    * trips/TripIds in the Timetable rather than the enclosing TripPattern.
    */
   public Stream<Trip> scheduledTripsAsStream() {
-    return scheduledTimetable.getTripTimes().stream().map(TripTimes::getTrip).distinct();
+    var trips = scheduledTimetable.getTripTimes().stream().map(TripTimes::getTrip);
+    var freqTrips = scheduledTimetable
+      .getFrequencyEntries()
+      .stream()
+      .map(e -> e.tripTimes.getTrip());
+    return Stream.concat(trips, freqTrips).distinct();
   }
 
   /**

--- a/src/test/java/org/opentripplanner/graph_builder/module/GtfsModuleTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/GtfsModuleTest.java
@@ -1,0 +1,42 @@
+package org.opentripplanner.graph_builder.module;
+
+import static graphql.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.ConstantsForTests;
+import org.opentripplanner.graph_builder.model.GtfsBundle;
+import org.opentripplanner.model.calendar.ServiceDateInterval;
+import org.opentripplanner.routing.graph.Graph;
+
+class GtfsModuleTest {
+
+  @Test
+  public void addShapesForFrequencyTrips() {
+    var graph = new Graph();
+
+    var bundle = new GtfsBundle(new File(ConstantsForTests.FAKE_GTFS));
+    var module = new GtfsModule(List.of(bundle), ServiceDateInterval.unbounded(), null, false);
+
+    module.buildGraph(graph, new HashMap<>());
+
+    var frequencyTripPattern = graph
+      .getTripPatterns()
+      .stream()
+      .filter(p -> !p.getScheduledTimetable().getFrequencyEntries().isEmpty())
+      .toList();
+
+    assertEquals(1, frequencyTripPattern.size());
+
+    var tripPattern = frequencyTripPattern.get(0);
+    assertNotNull(tripPattern.getGeometry());
+    assertNotNull(tripPattern.getHopGeometry(0));
+
+    var pattern = graph.getTripPatternForId(tripPattern.getId());
+    assertNotNull(pattern.getGeometry());
+    assertNotNull(pattern.getHopGeometry(0));
+  }
+}

--- a/src/test/java/org/opentripplanner/graph_builder/module/geometry/GeometryAndBlockProcessorTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/geometry/GeometryAndBlockProcessorTest.java
@@ -1,21 +1,11 @@
 package org.opentripplanner.graph_builder.module.geometry;
 
-import static graphql.Assert.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import java.io.File;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.List;
 import org.junit.jupiter.api.Test;
-import org.opentripplanner.ConstantsForTests;
-import org.opentripplanner.graph_builder.model.GtfsBundle;
 import org.opentripplanner.graph_builder.module.GtfsFeedId;
-import org.opentripplanner.graph_builder.module.GtfsModule;
 import org.opentripplanner.gtfs.GtfsContext;
 import org.opentripplanner.gtfs.GtfsContextBuilder;
 import org.opentripplanner.gtfs.MockGtfs;
-import org.opentripplanner.model.calendar.ServiceDateInterval;
 import org.opentripplanner.routing.graph.Graph;
 
 public class GeometryAndBlockProcessorTest {
@@ -45,30 +35,5 @@ public class GeometryAndBlockProcessorTest {
     GeometryAndBlockProcessor factory = new GeometryAndBlockProcessor(context);
 
     factory.run(graph);
-  }
-
-  @Test
-  public void addShapesForFrequencyTrips() {
-    var graph = new Graph();
-
-    var bundle = new GtfsBundle(new File(ConstantsForTests.FAKE_GTFS));
-    bundle.setFeedId(new GtfsFeedId.Builder().id("1").build());
-    var module = new GtfsModule(List.of(bundle), ServiceDateInterval.unbounded(), null, false);
-
-    module.buildGraph(graph, new HashMap<>());
-
-    var frequencyTripPattern = graph
-      .getTripPatterns()
-      .stream()
-      .filter(p -> !p.getScheduledTimetable().getFrequencyEntries().isEmpty())
-      .toList();
-
-    assertEquals(1, frequencyTripPattern.size());
-
-    var id = frequencyTripPattern.get(0);
-
-    var pattern = graph.getTripPatternForId(id.getId());
-    assertNotNull(pattern.getGeometry());
-    assertNotNull(pattern.getHopGeometry(0));
   }
 }

--- a/src/test/resources/testagency/trips.txt
+++ b/src/test/resources/testagency/trips.txt
@@ -26,7 +26,7 @@ route_id,service_id,trip_id,shape_id,block_id,wheelchair_accessible,trip_bikes_a
 13,alldays,13.1,,,,,
 14,alldays,14.1,,,,,
 14,alldays,14.2,,,,,
-15,alldays,15.1,,,,,
+15,alldays,15.1,5,,,,
 16,alldays,16.1,,,,,
 17,alldays,17.1,,,,,
 18,alldays,18.1,,,,,N


### PR DESCRIPTION
### Summary

This PR also returns frequency-based trips when getting all trips in `TripPattern#scheduledTripsAsStream`. This means that when computing geometries the frequency trips are also included.

### Issue

Fixes #4202

### Unit tests

added.

### Code style

autoformatted.

### Documentation

n/a