### PR TITLE
Fix TransmodelGraphQLSchema after GraphQL lib update [changelog skip]

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchemaTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchemaTest.java
@@ -1,0 +1,19 @@
+package org.opentripplanner.ext.transmodelapi;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.time.ZoneId;
+import java.util.TimeZone;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.ext.transmodelapi.support.GqlUtil;
+import org.opentripplanner.routing.api.request.RoutingRequest;
+
+class TransmodelGraphQLSchemaTest {
+
+  @Test
+  void testSchemaBuild() {
+    GqlUtil gqlUtil = new GqlUtil(TimeZone.getTimeZone(ZoneId.of("Europe/Oslo")));
+    var schema = TransmodelGraphQLSchema.create(new RoutingRequest(), gqlUtil);
+    assertNotNull(schema);
+  }
+}

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
@@ -25,14 +25,12 @@ import graphql.schema.GraphQLNonNull;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLOutputType;
 import graphql.schema.GraphQLSchema;
-import graphql.schema.GraphQLType;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -56,7 +54,12 @@ import org.opentripplanner.ext.transmodelapi.model.framework.RentalVehicleTypeTy
 import org.opentripplanner.ext.transmodelapi.model.framework.ServerInfoType;
 import org.opentripplanner.ext.transmodelapi.model.framework.SystemNoticeType;
 import org.opentripplanner.ext.transmodelapi.model.framework.ValidityPeriodType;
-import org.opentripplanner.ext.transmodelapi.model.network.*;
+import org.opentripplanner.ext.transmodelapi.model.network.DestinationDisplayType;
+import org.opentripplanner.ext.transmodelapi.model.network.GroupOfLinesType;
+import org.opentripplanner.ext.transmodelapi.model.network.JourneyPatternType;
+import org.opentripplanner.ext.transmodelapi.model.network.LineType;
+import org.opentripplanner.ext.transmodelapi.model.network.PresentationType;
+import org.opentripplanner.ext.transmodelapi.model.network.StopToStopGeometryType;
 import org.opentripplanner.ext.transmodelapi.model.plan.LegType;
 import org.opentripplanner.ext.transmodelapi.model.plan.PathGuidanceType;
 import org.opentripplanner.ext.transmodelapi.model.plan.PlanPlaceType;
@@ -1547,12 +1550,14 @@ public class TransmodelGraphQLSchema {
       .field(DatedServiceJourneyQuery.createQuery(datedServiceJourneyType, gqlUtil))
       .build();
 
-    Set<GraphQLType> dictionary = new HashSet<>();
-    dictionary.add(placeInterface);
-    dictionary.add(timetabledPassingTime);
-    dictionary.add(Relay.pageInfoType);
-
-    return GraphQLSchema.newSchema().query(queryType).build(dictionary);
+    return GraphQLSchema
+      .newSchema()
+      .query(queryType)
+      .additionalType(placeInterface)
+      .additionalType(timetabledPassingTime)
+      .additionalType(Relay.pageInfoType)
+      .additionalDirective(gqlUtil.timingData)
+      .build();
   }
 
   private List<FeedScopedId> toIdList(List<String> ids) {


### PR DESCRIPTION
### Summary

The Transmodel GraphQL API stoped working after the GraphQL lib update earlier. This fixes the problem. The Schema builder had changed slightly. There are no changes to the schema it selt.

### Issue

closes #4209


### Unit tests

One unit test on building the schema is added.


### Code style
✅ 

