### PR TITLE
Fix: NPE in PlaceAtDistanceType [changelog skip]

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/PlaceAtDistanceType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/PlaceAtDistanceType.java
@@ -72,6 +72,9 @@ public class PlaceAtDistanceType {
     String multiModalMode,
     RoutingService routingService
   ) {
+    // Make sure places is mutable
+    places = new ArrayList<>(places);
+
     if (placeTypes == null || placeTypes.contains(TransmodelPlaceType.STOP_PLACE)) {
       // Convert quays to stop places
       List<PlaceAtDistance> stations = places


### PR DESCRIPTION
### Summary

This fixes an exception witch in the PlaceAtDistanceType:
<details>
  <summary>UnsupportedOperationException StackTrace</summary>

<pre>
Exception while fetching data (/nearest) : null
java.lang.UnsupportedOperationException: null
	at java.base/java.util.ImmutableCollections.uoe(ImmutableCollections.java:142)
	at java.base/java.util.ImmutableCollections$AbstractImmutableCollection.addAll(ImmutableCollections.java:148)
	at org.opentripplanner.ext.transmodelapi.model.stop.PlaceAtDistanceType.convertQuaysToStopPlaces(PlaceAtDistanceType.java:89)
	at org.opentripplanner.ext.transmodelapi.TransmodelGraphQLSchema.lambda$create$16(TransmodelGraphQLSchema.java:944)
	at graphql.execution.ExecutionStrategy.fetchField(ExecutionStrategy.java:279)
	at graphql.execution.ExecutionStrategy.resolveFieldWithInfo(ExecutionStrategy.java:210)
	at graphql.execution.AsyncExecutionStrategy.execute(AsyncExecutionStrategy.java:60)
	at graphql.execution.Execution.executeOperation(Execution.java:159)
	at graphql.execution.Execution.execute(Execution.java:105)
	at graphql.GraphQL.execute(GraphQL.java:613)
	at graphql.GraphQL.parseValidateAndExecute(GraphQL.java:538)
	at graphql.GraphQL.executeAsync(GraphQL.java:502)
	at graphql.GraphQL.execute(GraphQL.java:433)
	at org.opentripplanner.ext.transmodelapi.TransmodelGraph.getGraphQLExecutionResult(TransmodelGraph.java:78)
	at org.opentripplanner.ext.transmodelapi.TransmodelGraph.getGraphQLResponse(TransmodelGraph.java:89)
	at org.opentripplanner.ext.transmodelapi.TransmodelAPI.getGraphQL(TransmodelAPI.java:123)
	at jdk.internal.reflect.GeneratedMethodAccessor251.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.glassfish.jersey.server.model.internal.ResourceMethodInvocationHandlerFactory.lambda$static$0(ResourceMethodInvocationHandlerFactory.java:52)
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher$1.run(AbstractJavaResourceMethodDispatcher.java:124)
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.invoke(AbstractJavaResourceMethodDispatcher.java:167)
	at org.glassfish.jersey.server.model.internal.JavaResourceMethodDispatcherProvider$ResponseOutInvoker.doDispatch(JavaResourceMethodDispatcherProvider.java:176)
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.dispatch(AbstractJavaResourceMethodDispatcher.java:79)
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:475)
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:397)
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:81)
	at org.glassfish.jersey.server.ServerRuntime$1.run(ServerRuntime.java:255)
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:248)
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:244)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:292)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:274)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:244)
	at org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:265)
	at org.glassfish.jersey.server.ServerRuntime.process(ServerRuntime.java:234)
	at org.glassfish.jersey.server.ApplicationHandler.handle(ApplicationHandler.java:680)
	at org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpContainer.service(GrizzlyHttpContainer.java:356)
	at org.glassfish.grizzly.http.server.HttpHandler$1.run(HttpHandler.java:200)
	at org.glassfish.grizzly.threadpool.AbstractThreadPool$Worker.doWork(AbstractThreadPool.java:569)
	at org.glassfish.grizzly.threadpool.AbstractThreadPool$Worker.run(AbstractThreadPool.java:549)
	at java.base/java.lang.Thread.run(Thread.java:833)
</pre>
</details>


### Issue
No issue.

### Unit tests
No

### Code style
✅ 

### Documentation
No
