### PR TITLE
refactor: Remove `transitFactorIndex` and `wheelchairBoarding` from RaptorTripSchedule[changelog skip]

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TripSchedule.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TripSchedule.java
@@ -2,14 +2,14 @@ package org.opentripplanner.routing.algorithm.raptoradapter.transit;
 
 import java.time.LocalDate;
 import org.opentripplanner.model.TripPattern;
+import org.opentripplanner.routing.algorithm.raptoradapter.transit.cost.DefaultTripSchedule;
 import org.opentripplanner.routing.trippattern.TripTimes;
-import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
 
 /**
  * Extension of RaptorTripSchedule passed through Raptor searches to be able to retrieve the
  * original trip from the path when creating itineraries.
  */
-public interface TripSchedule extends RaptorTripSchedule {
+public interface TripSchedule extends DefaultTripSchedule {
   LocalDate getServiceDate();
 
   /**

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/cost/CostCalculatorFactory.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/cost/CostCalculatorFactory.java
@@ -4,15 +4,15 @@ import org.opentripplanner.transit.raptor.api.transit.CostCalculator;
 
 public class CostCalculatorFactory {
 
-  public static CostCalculator createCostCalculator(
+  public static <T extends DefaultTripSchedule> CostCalculator<T> createCostCalculator(
     McCostParams mcCostParams,
     int[] stopBoardAlightCosts
   ) {
-    CostCalculator calculator = new DefaultCostCalculator(mcCostParams, stopBoardAlightCosts);
+    CostCalculator<T> calculator = new DefaultCostCalculator<>(mcCostParams, stopBoardAlightCosts);
 
     if (mcCostParams.accessibilityRequirements().enabled()) {
       calculator =
-        new WheelchairCostCalculator(calculator, mcCostParams.accessibilityRequirements());
+        new WheelchairCostCalculator<>(calculator, mcCostParams.accessibilityRequirements());
     }
 
     return calculator;

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/cost/DefaultTripSchedule.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/cost/DefaultTripSchedule.java
@@ -1,0 +1,17 @@
+package org.opentripplanner.routing.algorithm.raptoradapter.transit.cost;
+
+import org.opentripplanner.model.WheelchairAccessibility;
+import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
+
+public interface DefaultTripSchedule extends RaptorTripSchedule {
+  /**
+   * This index is used to lookup the transit factor/reluctance to be used with this trip schedule.
+   */
+  int transitReluctanceFactorIndex();
+
+  /**
+   * This is not used by the default calculator, but by the {@link WheelchairCostCalculator} to
+   * give none wheelchair friendly trips a generalized-cost penalty.
+   */
+  WheelchairAccessibility wheelchairBoarding();
+}

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/frequency/FrequencyAlightEvent.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/frequency/FrequencyAlightEvent.java
@@ -2,14 +2,14 @@ package org.opentripplanner.routing.algorithm.raptoradapter.transit.frequency;
 
 import java.time.LocalDate;
 import org.opentripplanner.model.TripPattern;
+import org.opentripplanner.routing.algorithm.raptoradapter.transit.cost.DefaultTripSchedule;
 import org.opentripplanner.routing.trippattern.TripTimes;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripPattern;
-import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
 
 /**
  * Represents a result of a {@link TripFrequencyAlightSearch}, with materialized {@link TripTimes}
  */
-final class FrequencyAlightEvent<T extends RaptorTripSchedule>
+final class FrequencyAlightEvent<T extends DefaultTripSchedule>
   extends FrequencyBoardOrAlightEvent<T> {
 
   public FrequencyAlightEvent(

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/frequency/FrequencyBoardOrAlightEvent.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/frequency/FrequencyBoardOrAlightEvent.java
@@ -4,10 +4,10 @@ import java.time.LocalDate;
 import org.opentripplanner.model.TripPattern;
 import org.opentripplanner.model.WheelchairAccessibility;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripSchedule;
+import org.opentripplanner.routing.algorithm.raptoradapter.transit.cost.DefaultTripSchedule;
 import org.opentripplanner.routing.trippattern.TripTimes;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTransferConstraint;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripPattern;
-import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripScheduleBoardOrAlightEvent;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripScheduleSearch;
 
@@ -26,7 +26,7 @@ import org.opentripplanner.transit.raptor.api.transit.RaptorTripScheduleSearch;
  * save some resources. This kind of optimization is probably easier to do after a a clean up of the
  * internal OTP transit model.
  */
-abstract class FrequencyBoardOrAlightEvent<T extends RaptorTripSchedule>
+abstract class FrequencyBoardOrAlightEvent<T extends DefaultTripSchedule>
   implements RaptorTripScheduleBoardOrAlightEvent<T>, TripSchedule {
 
   protected final RaptorTripPattern raptorTripPattern;

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/frequency/FrequencyBoardingEvent.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/frequency/FrequencyBoardingEvent.java
@@ -2,14 +2,14 @@ package org.opentripplanner.routing.algorithm.raptoradapter.transit.frequency;
 
 import java.time.LocalDate;
 import org.opentripplanner.model.TripPattern;
+import org.opentripplanner.routing.algorithm.raptoradapter.transit.cost.DefaultTripSchedule;
 import org.opentripplanner.routing.trippattern.TripTimes;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripPattern;
-import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
 
 /**
  * Represents a result of a {@link TripFrequencyBoardSearch}, with materialized {@link TripTimes}
  */
-final class FrequencyBoardingEvent<T extends RaptorTripSchedule>
+final class FrequencyBoardingEvent<T extends DefaultTripSchedule>
   extends FrequencyBoardOrAlightEvent<T> {
 
   public FrequencyBoardingEvent(

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/frequency/TripFrequencyAlightSearch.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/frequency/TripFrequencyAlightSearch.java
@@ -1,11 +1,11 @@
 package org.opentripplanner.routing.algorithm.raptoradapter.transit.frequency;
 
+import org.opentripplanner.routing.algorithm.raptoradapter.transit.cost.DefaultTripSchedule;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.request.TripPatternForDates;
 import org.opentripplanner.routing.trippattern.FrequencyEntry;
 import org.opentripplanner.routing.trippattern.TripTimes;
 import org.opentripplanner.transit.raptor.api.transit.IntIterator;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTimeTable;
-import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripScheduleBoardOrAlightEvent;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripScheduleSearch;
 
@@ -13,7 +13,7 @@ import org.opentripplanner.transit.raptor.api.transit.RaptorTripScheduleSearch;
  * Searches for a concrete trip time for a frequency based pattern. The {@link FrequencyEntry}s are
  * scanned to find the earliest possible departure time.
  */
-public final class TripFrequencyAlightSearch<T extends RaptorTripSchedule>
+public final class TripFrequencyAlightSearch<T extends DefaultTripSchedule>
   implements RaptorTripScheduleSearch<T> {
 
   private final TripPatternForDates timeTable;

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/frequency/TripFrequencyBoardSearch.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/frequency/TripFrequencyBoardSearch.java
@@ -1,10 +1,10 @@
 package org.opentripplanner.routing.algorithm.raptoradapter.transit.frequency;
 
+import org.opentripplanner.routing.algorithm.raptoradapter.transit.cost.DefaultTripSchedule;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.request.TripPatternForDates;
 import org.opentripplanner.routing.trippattern.FrequencyEntry;
 import org.opentripplanner.routing.trippattern.TripTimes;
 import org.opentripplanner.transit.raptor.api.transit.IntIterator;
-import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripScheduleBoardOrAlightEvent;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripScheduleSearch;
 
@@ -12,7 +12,7 @@ import org.opentripplanner.transit.raptor.api.transit.RaptorTripScheduleSearch;
  * Searches for a concrete trip time for a frequency based pattern. The {@link FrequencyEntry}s are
  * scanned to find the latest possible alighting time.
  */
-public final class TripFrequencyBoardSearch<T extends RaptorTripSchedule>
+public final class TripFrequencyBoardSearch<T extends DefaultTripSchedule>
   implements RaptorTripScheduleSearch<T> {
 
   private final TripPatternForDates patternForDates;

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RaptorRoutingRequestTransitData.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RaptorRoutingRequestTransitData.java
@@ -10,8 +10,6 @@ import org.opentripplanner.routing.algorithm.raptoradapter.transit.RaptorTransfe
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TransitLayer;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripSchedule;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.cost.CostCalculatorFactory;
-import org.opentripplanner.routing.algorithm.raptoradapter.transit.cost.DefaultCostCalculator;
-import org.opentripplanner.routing.algorithm.raptoradapter.transit.cost.WheelchairCostCalculator;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.mappers.DateMapper;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.mappers.McCostParamsMapper;
 import org.opentripplanner.routing.core.RoutingContext;
@@ -54,7 +52,7 @@ public class RaptorRoutingRequestTransitData implements RaptorTransitDataProvide
 
   private final ZonedDateTime transitSearchTimeZero;
 
-  private final CostCalculator generalizedCostCalculator;
+  private final CostCalculator<TripSchedule> generalizedCostCalculator;
 
   private final int validTransitDataStartTime;
 
@@ -72,7 +70,6 @@ public class RaptorRoutingRequestTransitData implements RaptorTransitDataProvide
     this.transferService = transferService;
     this.transitLayer = transitLayer;
     this.transitSearchTimeZero = transitSearchTimeZero;
-    var accessibility = routingContext.opt.wheelchairAccessibility;
 
     // Delegate to the creator to construct the needed data structures. The code is messy so
     // it is nice to NOT have it in the class. It isolate this code to only be available at
@@ -146,7 +143,7 @@ public class RaptorRoutingRequestTransitData implements RaptorTransitDataProvide
   }
 
   @Override
-  public CostCalculator multiCriteriaCostCalculator() {
+  public CostCalculator<TripSchedule> multiCriteriaCostCalculator() {
     return generalizedCostCalculator;
   }
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/configure/TransferOptimizationServiceConfigurator.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/configure/TransferOptimizationServiceConfigurator.java
@@ -113,7 +113,7 @@ public class TransferOptimizationServiceConfigurator<T extends RaptorTripSchedul
     TransferGenerator<T> transferGenerator,
     MinCostFilterChain<OptimizedPathTail<T>> transferPointFilter,
     TransferWaitTimeCostCalculator transferWaitTimeCostCalculator,
-    CostCalculator costCalculator
+    CostCalculator<T> costCalculator
   ) {
     return new OptimizePathDomainService<>(
       transferGenerator,

--- a/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/model/OptimizedPathTail.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/model/OptimizedPathTail.java
@@ -38,7 +38,7 @@ public class OptimizedPathTail<T extends RaptorTripSchedule>
 
   public OptimizedPathTail(
     RaptorSlackProvider slackProvider,
-    CostCalculator costCalculator,
+    CostCalculator<T> costCalculator,
     TransferWaitTimeCostCalculator waitTimeCostCalculator,
     int[] stopBoardAlightCosts,
     double extraStopBoardAlightCostsFactor,

--- a/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/services/OptimizePathDomainService.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/services/OptimizePathDomainService.java
@@ -67,7 +67,7 @@ import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
 public class OptimizePathDomainService<T extends RaptorTripSchedule> {
 
   private final TransferGenerator<T> transferGenerator;
-  private final CostCalculator costCalculator;
+  private final CostCalculator<T> costCalculator;
   private final RaptorSlackProvider slackProvider;
   private final MinCostFilterChain<OptimizedPathTail<T>> minCostFilterChain;
   private final RaptorStopNameResolver stopNameTranslator;
@@ -82,7 +82,7 @@ public class OptimizePathDomainService<T extends RaptorTripSchedule> {
 
   public OptimizePathDomainService(
     TransferGenerator<T> transferGenerator,
-    CostCalculator costCalculator,
+    CostCalculator<T> costCalculator,
     RaptorSlackProvider slackProvider,
     @Nullable TransferWaitTimeCostCalculator waitTimeCostCalculator,
     int[] stopBoardAlightCosts,

--- a/src/main/java/org/opentripplanner/transit/raptor/api/path/PathBuilder.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/path/PathBuilder.java
@@ -45,7 +45,7 @@ public abstract class PathBuilder<T extends RaptorTripSchedule> {
   protected final RaptorSlackProvider slackProvider;
 
   @Nullable
-  protected final CostCalculator costCalculator;
+  protected final CostCalculator<T> costCalculator;
 
   private final RaptorStopNameResolver stopNameResolver;
 
@@ -69,7 +69,7 @@ public abstract class PathBuilder<T extends RaptorTripSchedule> {
   protected PathBuilder(
     @Nullable RaptorPathConstrainedTransferSearch<T> transferConstraintsSearch,
     RaptorSlackProvider slackProvider,
-    @Nullable CostCalculator costCalculator,
+    @Nullable CostCalculator<T> costCalculator,
     @Nullable RaptorStopNameResolver stopNameResolver
   ) {
     this.transferConstraintsSearch = transferConstraintsSearch;
@@ -88,7 +88,7 @@ public abstract class PathBuilder<T extends RaptorTripSchedule> {
   public static <T extends RaptorTripSchedule> PathBuilder<T> headPathBuilder(
     @Nullable RaptorPathConstrainedTransferSearch<T> transferConstraintsSearch,
     RaptorSlackProvider slackProvider,
-    @Nullable CostCalculator costCalculator,
+    @Nullable CostCalculator<T> costCalculator,
     @Nullable RaptorStopNameResolver stopNameResolver
   ) {
     return new HeadPathBuilder<>(
@@ -109,7 +109,7 @@ public abstract class PathBuilder<T extends RaptorTripSchedule> {
   public static <T extends RaptorTripSchedule> PathBuilder<T> tailPathBuilder(
     RaptorPathConstrainedTransferSearch<T> transferConstraintsSearch,
     RaptorSlackProvider slackProvider,
-    @Nullable CostCalculator costCalculator,
+    @Nullable CostCalculator<T> costCalculator,
     @Nullable RaptorStopNameResolver stopNameResolver
   ) {
     return new TailPathBuilder<>(
@@ -200,7 +200,7 @@ public abstract class PathBuilder<T extends RaptorTripSchedule> {
   /* private methods */
 
   protected AccessPathLeg<T> createPathLegs(
-    CostCalculator costCalculator,
+    CostCalculator<T> costCalculator,
     RaptorSlackProvider slackProvider
   ) {
     return head.createAccessPathLeg(costCalculator, slackProvider);
@@ -255,7 +255,7 @@ public abstract class PathBuilder<T extends RaptorTripSchedule> {
     private HeadPathBuilder(
       @Nullable RaptorPathConstrainedTransferSearch<T> transferConstraintsSearch,
       RaptorSlackProvider slackProvider,
-      CostCalculator costCalculator,
+      CostCalculator<T> costCalculator,
       @Nullable RaptorStopNameResolver stopNameResolver
     ) {
       super(transferConstraintsSearch, slackProvider, costCalculator, stopNameResolver);
@@ -272,7 +272,7 @@ public abstract class PathBuilder<T extends RaptorTripSchedule> {
     private TailPathBuilder(
       @Nullable RaptorPathConstrainedTransferSearch<T> transferConstraintsSearch,
       RaptorSlackProvider slackProvider,
-      CostCalculator costCalculator,
+      CostCalculator<T> costCalculator,
       @Nullable RaptorStopNameResolver stopNameResolver
     ) {
       super(transferConstraintsSearch, slackProvider, costCalculator, stopNameResolver);

--- a/src/main/java/org/opentripplanner/transit/raptor/api/path/PathBuilderLeg.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/path/PathBuilderLeg.java
@@ -178,7 +178,7 @@ public class PathBuilderLeg<T extends RaptorTripSchedule> {
    * <p>
    * This method is safe to use event as long as the next leg is set.
    */
-  public int generalizedCost(CostCalculator costCalculator, RaptorSlackProvider slackProvider) {
+  public int generalizedCost(CostCalculator<T> costCalculator, RaptorSlackProvider slackProvider) {
     if (costCalculator == null) {
       return ZERO_COST;
     }
@@ -313,7 +313,7 @@ public class PathBuilderLeg<T extends RaptorTripSchedule> {
   }
 
   AccessPathLeg<T> createAccessPathLeg(
-    CostCalculator costCalculator,
+    CostCalculator<T> costCalculator,
     RaptorSlackProvider slackProvider
   ) {
     PathLeg<T> nextLeg = next.createPathLeg(costCalculator, slackProvider);
@@ -324,7 +324,7 @@ public class PathBuilderLeg<T extends RaptorTripSchedule> {
 
   /* Build helper methods, package local */
 
-  private static int cost(CostCalculator costCalculator, RaptorTransfer streetPath) {
+  private static int cost(CostCalculator<?> costCalculator, RaptorTransfer streetPath) {
     return costCalculator != null ? streetPath.generalizedCost() : ZERO_COST;
   }
 
@@ -357,7 +357,7 @@ public class PathBuilderLeg<T extends RaptorTripSchedule> {
   }
 
   private PathLeg<T> createPathLeg(
-    CostCalculator costCalculator,
+    CostCalculator<T> costCalculator,
     RaptorSlackProvider slackProvider
   ) {
     if (isAccess()) {
@@ -376,7 +376,7 @@ public class PathBuilderLeg<T extends RaptorTripSchedule> {
   }
 
   private TransferPathLeg<T> createTransferPathLeg(
-    CostCalculator costCalculator,
+    CostCalculator<T> costCalculator,
     RaptorSlackProvider slackProvider
   ) {
     PathLeg<T> nextLeg = next.createPathLeg(costCalculator, slackProvider);
@@ -388,7 +388,7 @@ public class PathBuilderLeg<T extends RaptorTripSchedule> {
   /* private methods */
 
   private TransitPathLeg<T> createTransitPathLeg(
-    CostCalculator costCalculator,
+    CostCalculator<T> costCalculator,
     RaptorSlackProvider slackProvider
   ) {
     PathLeg<T> nextLeg = next.createPathLeg(costCalculator, slackProvider);
@@ -404,7 +404,7 @@ public class PathBuilderLeg<T extends RaptorTripSchedule> {
   }
 
   private EgressPathLeg<T> createEgressPathLeg(
-    CostCalculator costCalculator,
+    CostCalculator<T> costCalculator,
     RaptorSlackProvider slackProvider
   ) {
     int cost = egressCost(costCalculator, slackProvider);
@@ -493,7 +493,7 @@ public class PathBuilderLeg<T extends RaptorTripSchedule> {
     setTime(newFromTime, newFromTime + egressPath.durationInSeconds());
   }
 
-  private int transitCost(CostCalculator costCalculator, RaptorSlackProvider slackProvider) {
+  private int transitCost(CostCalculator<T> costCalculator, RaptorSlackProvider slackProvider) {
     if (costCalculator == null) {
       return ZERO_COST;
     }
@@ -531,12 +531,12 @@ public class PathBuilderLeg<T extends RaptorTripSchedule> {
       boardCost,
       slackProvider.alightSlack(leg.trip.pattern().slackIndex()),
       durationInSec(),
-      leg.trip.transitReluctanceFactorIndex(),
+      leg.trip,
       toStop()
     );
   }
 
-  private int egressCost(CostCalculator costCalculator, RaptorSlackProvider slackProvider) {
+  private int egressCost(CostCalculator<T> costCalculator, RaptorSlackProvider slackProvider) {
     if (costCalculator == null) {
       return ZERO_COST;
     }

--- a/src/main/java/org/opentripplanner/transit/raptor/api/transit/CostCalculator.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/transit/CostCalculator.java
@@ -5,7 +5,7 @@ package org.opentripplanner.transit.raptor.api.transit;
  * <p/>
  * The implementation should be immutable and thread safe.
  */
-public interface CostCalculator {
+public interface CostCalculator<T extends RaptorTripSchedule> {
   /**
    * The cost is zero(0) it it is not calculated or if the cost "element" have no cost associated
    * with it.
@@ -23,7 +23,7 @@ public interface CostCalculator {
     int prevArrivalTime,
     int boardStop,
     int boardTime,
-    RaptorTripSchedule trip,
+    T trip,
     RaptorTransferConstraint transferConstraints
   );
 
@@ -32,24 +32,13 @@ public interface CostCalculator {
    * transfer cost, and the penalty for the board stop visit. This cost should NOT include the
    * previous stop arrival cost, but the incremental cost to be added to the previous stop arrival
    * cost.
-   *
-   * @param boardTime          The time of boarding
-   * @param transitFactorIndex The index used to look up the transit reluctance/factor
    */
-  int onTripRelativeRidingCost(int boardTime, int transitFactorIndex);
+  int onTripRelativeRidingCost(int boardTime, T tripScheduledBoarded);
 
   /**
    * Calculate the value when arriving by transit.
-   *
-   * @param transitFactorIndex The index used to look up the transit reluctance/factor
    */
-  int transitArrivalCost(
-    int boardCost,
-    int alightSlack,
-    int transitTime,
-    int transitFactorIndex,
-    int toStop
-  );
+  int transitArrivalCost(int boardCost, int alightSlack, int transitTime, T trip, int toStop);
 
   /**
    * Calculate the value, when waiting between the last transit and egress paths

--- a/src/main/java/org/opentripplanner/transit/raptor/api/transit/RaptorTransitDataProvider.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/transit/RaptorTransitDataProvider.java
@@ -86,7 +86,7 @@ public interface RaptorTransitDataProvider<T extends RaptorTripSchedule> {
   /**
    * Create/provide the cost criteria calculator.
    */
-  CostCalculator multiCriteriaCostCalculator();
+  CostCalculator<T> multiCriteriaCostCalculator();
 
   /**
    * Implement this method to provide a service to search for {@link RaptorTransferConstraint}. This

--- a/src/main/java/org/opentripplanner/transit/raptor/api/transit/RaptorTripSchedule.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/transit/RaptorTripSchedule.java
@@ -2,7 +2,6 @@ package org.opentripplanner.transit.raptor.api.transit;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.opentripplanner.model.WheelchairAccessibility;
 
 /**
  * The purpose of this interface is to provide information about the trip schedule. The trip is a
@@ -148,11 +147,4 @@ public interface RaptorTripSchedule {
 
     return stops;
   }
-
-  /**
-   * This index is used to lookup the transit factor/reluctance to be used with this trip schedule.
-   */
-  int transitReluctanceFactorIndex();
-
-  WheelchairAccessibility wheelchairBoarding();
 }

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/McRangeRaptorWorkerState.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/McRangeRaptorWorkerState.java
@@ -36,7 +36,7 @@ public final class McRangeRaptorWorkerState<T extends RaptorTripSchedule>
   private final DestinationArrivalPaths<T> paths;
   private final HeuristicsProvider<T> heuristics;
   private final List<AbstractStopArrival<T>> arrivalsCache = new ArrayList<>();
-  private final CostCalculator costCalculator;
+  private final CostCalculator<T> costCalculator;
   private final TransitCalculator<T> transitCalculator;
 
   /**
@@ -47,7 +47,7 @@ public final class McRangeRaptorWorkerState<T extends RaptorTripSchedule>
     StopArrivals<T> arrivals,
     DestinationArrivalPaths<T> paths,
     HeuristicsProvider<T> heuristics,
-    CostCalculator costCalculator,
+    CostCalculator<T> costCalculator,
     TransitCalculator<T> transitCalculator,
     WorkerLifeCycle lifeCycle
   ) {
@@ -134,7 +134,7 @@ public final class McRangeRaptorWorkerState<T extends RaptorTripSchedule>
       ride.boardCost,
       alightSlack,
       alightTime - ride.boardTime,
-      ride.trip.transitReluctanceFactorIndex(),
+      ride.trip,
       alightStop
     );
 

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/MultiCriteriaRoutingStrategy.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/MultiCriteriaRoutingStrategy.java
@@ -24,7 +24,7 @@ public final class MultiCriteriaRoutingStrategy<T extends RaptorTripSchedule>
   implements RoutingStrategy<T> {
 
   private final McRangeRaptorWorkerState<T> state;
-  private final CostCalculator costCalculator;
+  private final CostCalculator<T> costCalculator;
   private final SlackProvider slackProvider;
   private final ParetoSet<PatternRide<T>> patternRides;
 
@@ -33,7 +33,7 @@ public final class MultiCriteriaRoutingStrategy<T extends RaptorTripSchedule>
   public MultiCriteriaRoutingStrategy(
     McRangeRaptorWorkerState<T> state,
     SlackProvider slackProvider,
-    CostCalculator costCalculator,
+    CostCalculator<T> costCalculator,
     DebugHandlerFactory<T> debugHandlerFactory
   ) {
     this.state = state;
@@ -98,8 +98,7 @@ public final class MultiCriteriaRoutingStrategy<T extends RaptorTripSchedule>
 
     final int boardCost = calculateCostAtBoardTime(prevArrival, boarding);
 
-    final int relativeBoardCost =
-      boardCost + calculateOnTripRelativeCost(trip.transitReluctanceFactorIndex(), boardTime);
+    final int relativeBoardCost = boardCost + calculateOnTripRelativeCost(boardTime, trip);
 
     patternRides.add(
       new PatternRide<>(
@@ -146,7 +145,7 @@ public final class MultiCriteriaRoutingStrategy<T extends RaptorTripSchedule>
    * point in place or time - as long as it can be used to compare to paths that started at the
    * origin in the same iteration, having used the same number-of-rounds to board the same trip.
    */
-  private int calculateOnTripRelativeCost(int transitReluctanceIndex, int boardTime) {
-    return costCalculator.onTripRelativeRidingCost(boardTime, transitReluctanceIndex);
+  private int calculateOnTripRelativeCost(int boardTime, T tripSchedule) {
+    return costCalculator.onTripRelativeRidingCost(boardTime, tripSchedule);
   }
 }

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/heuristic/HeuristicsProvider.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/heuristic/HeuristicsProvider.java
@@ -19,7 +19,7 @@ public final class HeuristicsProvider<T extends RaptorTripSchedule> {
   private final Heuristics heuristics;
   private final RoundProvider roundProvider;
   private final DestinationArrivalPaths<T> paths;
-  private final CostCalculator costCalculator;
+  private final CostCalculator<T> costCalculator;
   private final HeuristicAtStop[] stops;
   private final DebugHandlerFactory<T> debugHandlerFactory;
 
@@ -31,7 +31,7 @@ public final class HeuristicsProvider<T extends RaptorTripSchedule> {
     Heuristics heuristics,
     RoundProvider roundProvider,
     DestinationArrivalPaths<T> paths,
-    CostCalculator costCalculator,
+    CostCalculator<T> costCalculator,
     DebugHandlerFactory<T> debugHandlerFactory
   ) {
     this.heuristics = heuristics;

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/path/DestinationArrivalPaths.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/path/DestinationArrivalPaths.java
@@ -45,7 +45,7 @@ public class DestinationArrivalPaths<T extends RaptorTripSchedule> {
   private final TransitCalculator<T> transitCalculator;
 
   @Nullable
-  private final CostCalculator costCalculator;
+  private final CostCalculator<T> costCalculator;
 
   private final SlackProvider slackProvider;
   private final PathMapper<T> pathMapper;
@@ -57,7 +57,7 @@ public class DestinationArrivalPaths<T extends RaptorTripSchedule> {
   public DestinationArrivalPaths(
     ParetoComparator<Path<T>> paretoComparator,
     TransitCalculator<T> transitCalculator,
-    @Nullable CostCalculator costCalculator,
+    @Nullable CostCalculator<T> costCalculator,
     SlackProvider slackProvider,
     PathMapper<T> pathMapper,
     DebugHandlerFactory<T> debugHandlerFactory,

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/path/ForwardPathMapper.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/path/ForwardPathMapper.java
@@ -19,7 +19,7 @@ public final class ForwardPathMapper<T extends RaptorTripSchedule> implements Pa
 
   private final RaptorPathConstrainedTransferSearch<T> transferConstraintsSearch;
   private final RaptorSlackProvider slackProvider;
-  private final CostCalculator costCalculator;
+  private final CostCalculator<T> costCalculator;
   private final BoardAndAlightTimeSearch tripSearch;
   private final RaptorStopNameResolver stopNameResolver;
 
@@ -28,7 +28,7 @@ public final class ForwardPathMapper<T extends RaptorTripSchedule> implements Pa
   public ForwardPathMapper(
     RaptorPathConstrainedTransferSearch<T> transferConstraintsSearch,
     RaptorSlackProvider slackProvider,
-    CostCalculator costCalculator,
+    CostCalculator<T> costCalculator,
     RaptorStopNameResolver stopNameResolver,
     WorkerLifeCycle lifeCycle,
     boolean useApproximateTripTimesSearch

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/path/ReversePathMapper.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/path/ReversePathMapper.java
@@ -26,7 +26,7 @@ public final class ReversePathMapper<T extends RaptorTripSchedule> implements Pa
 
   private final RaptorPathConstrainedTransferSearch<T> transferConstraintsSearch;
   private final RaptorSlackProvider slackProvider;
-  private final CostCalculator costCalculator;
+  private final CostCalculator<T> costCalculator;
   private final RaptorStopNameResolver stopNameResolver;
   private final BoardAndAlightTimeSearch tripSearch;
 
@@ -35,7 +35,7 @@ public final class ReversePathMapper<T extends RaptorTripSchedule> implements Pa
   public ReversePathMapper(
     RaptorPathConstrainedTransferSearch<T> transferConstraintsSearch,
     RaptorSlackProvider slackProvider,
-    CostCalculator costCalculator,
+    CostCalculator<T> costCalculator,
     RaptorStopNameResolver stopNameResolver,
     WorkerLifeCycle lifeCycle,
     boolean useApproximateTripTimesSearch

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/transit/SearchContext.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/transit/SearchContext.java
@@ -51,7 +51,7 @@ public class SearchContext<T extends RaptorTripSchedule> {
   protected final RaptorTransitDataProvider<T> transit;
 
   private final TransitCalculator<T> calculator;
-  private final CostCalculator costCalculator;
+  private final CostCalculator<T> costCalculator;
   private final RaptorTuningParameters tuningParameters;
   private final RoundTracker roundTracker;
   private final PathMapper<T> pathMapper;
@@ -150,7 +150,7 @@ public class SearchContext<T extends RaptorTripSchedule> {
   }
 
   @Nullable
-  public CostCalculator costCalculator() {
+  public CostCalculator<T> costCalculator() {
     return costCalculator;
   }
 
@@ -272,7 +272,7 @@ public class SearchContext<T extends RaptorTripSchedule> {
 
   private static <S extends RaptorTripSchedule> PathMapper<S> createPathMapper(
     RaptorPathConstrainedTransferSearch<S> txConstraintsSearch,
-    CostCalculator costCalculator,
+    CostCalculator<S> costCalculator,
     RaptorStopNameResolver stopNameResolver,
     RaptorRequest<S> request,
     WorkerLifeCycle lifeCycle

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/cost/DefaultCostCalculatorTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/cost/DefaultCostCalculatorTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.transit.raptor._data.transit.TestTransfer;
+import org.opentripplanner.transit.raptor._data.transit.TestTripSchedule;
 
 public class DefaultCostCalculatorTest {
 
@@ -16,8 +17,19 @@ public class DefaultCostCalculatorTest {
   private static final int TRANSIT_RELUCTANCE_2 = 1;
   private static final int STOP_A = 0;
   private static final int STOP_B = 1;
+  private static final String ANY_SCHEDULE = "10:00 11:00";
 
-  private final DefaultCostCalculator subject = new DefaultCostCalculator(
+  private static final TestTripSchedule TRIP_1 = TestTripSchedule
+    .schedule(ANY_SCHEDULE)
+    .transitReluctanceIndex(TRANSIT_RELUCTANCE_1)
+    .build();
+
+  private static final TestTripSchedule TRIP_2 = TestTripSchedule
+    .schedule("10:00 11:00")
+    .transitReluctanceIndex(TRANSIT_RELUCTANCE_2)
+    .build();
+
+  private final DefaultCostCalculator<TestTripSchedule> subject = new DefaultCostCalculator<>(
     BOARD_COST_SEC,
     TRANSFER_COST_SEC,
     WAIT_RELUCTANCE_FACTOR,
@@ -40,40 +52,20 @@ public class DefaultCostCalculatorTest {
 
   @Test
   public void transitArrivalCost() {
-    assertEquals(0, subject.transitArrivalCost(0, 0, 0, TRANSIT_RELUCTANCE_1, STOP_A), "Zero cost");
-    assertEquals(
-      1000,
-      subject.transitArrivalCost(1000, 0, 0, TRANSIT_RELUCTANCE_1, STOP_A),
-      "Board cost"
-    );
-    assertEquals(
-      50,
-      subject.transitArrivalCost(0, 1, 0, TRANSIT_RELUCTANCE_1, STOP_A),
-      "Alight wait time cost"
-    );
-    assertEquals(
-      100,
-      subject.transitArrivalCost(0, 0, 1, TRANSIT_RELUCTANCE_1, STOP_A),
-      "Transit time cost"
-    );
-    assertEquals(
-      25,
-      subject.transitArrivalCost(0, 0, 0, TRANSIT_RELUCTANCE_1, STOP_B),
-      "Alight stop cost"
-    );
-    assertEquals(
-      1175,
-      subject.transitArrivalCost(1000, 1, 1, TRANSIT_RELUCTANCE_1, STOP_B),
-      "Total cost"
-    );
+    assertEquals(0, subject.transitArrivalCost(0, 0, 0, TRIP_1, STOP_A), "Zero cost");
+    assertEquals(1000, subject.transitArrivalCost(1000, 0, 0, TRIP_1, STOP_A), "Board cost");
+    assertEquals(50, subject.transitArrivalCost(0, 1, 0, TRIP_1, STOP_A), "Alight wait time cost");
+    assertEquals(100, subject.transitArrivalCost(0, 0, 1, TRIP_1, STOP_A), "Transit time cost");
+    assertEquals(25, subject.transitArrivalCost(0, 0, 0, TRIP_1, STOP_B), "Alight stop cost");
+    assertEquals(1175, subject.transitArrivalCost(1000, 1, 1, TRIP_1, STOP_B), "Total cost");
   }
 
   @Test
   public void onTripRidingCost() {
-    assertEquals(0, subject.onTripRelativeRidingCost(0, TRANSIT_RELUCTANCE_1), "Board cost");
-    assertEquals(0, subject.onTripRelativeRidingCost(0, TRANSIT_RELUCTANCE_2), "Board cost");
-    assertEquals(-100, subject.onTripRelativeRidingCost(1, TRANSIT_RELUCTANCE_1), "Board cost");
-    assertEquals(-80, subject.onTripRelativeRidingCost(1, TRANSIT_RELUCTANCE_2), "Board cost");
+    assertEquals(0, subject.onTripRelativeRidingCost(0, TRIP_1), "Board cost");
+    assertEquals(0, subject.onTripRelativeRidingCost(0, TRIP_2), "Board cost");
+    assertEquals(-100, subject.onTripRelativeRidingCost(1, TRIP_1), "Board cost");
+    assertEquals(-80, subject.onTripRelativeRidingCost(1, TRIP_2), "Board cost");
   }
 
   @Test

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/cost/WheelchairCostCalculatorTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/cost/WheelchairCostCalculatorTest.java
@@ -21,7 +21,7 @@ public class WheelchairCostCalculatorTest {
   private static final int TRANSFER_COST_SEC = 2;
   private static final double WAIT_RELUCTANCE_FACTOR = 0.5;
 
-  private final DefaultCostCalculator defaultCostCalculator = new DefaultCostCalculator(
+  private final DefaultCostCalculator<TestTripSchedule> defaultCostCalculator = new DefaultCostCalculator<>(
     BOARD_COST_SEC,
     TRANSFER_COST_SEC,
     WAIT_RELUCTANCE_FACTOR,
@@ -29,7 +29,7 @@ public class WheelchairCostCalculatorTest {
     null
   );
 
-  private final WheelchairCostCalculator wheelchairCostCalculator = new WheelchairCostCalculator(
+  private final WheelchairCostCalculator<TestTripSchedule> wheelchairCostCalculator = new WheelchairCostCalculator<>(
     defaultCostCalculator,
     new WheelchairAccessibilityRequest(
       true,
@@ -58,7 +58,10 @@ public class WheelchairCostCalculatorTest {
     assertEquals(expected, wheelchairBoardCost);
   }
 
-  private int calculateBoardingCost(TestTripSchedule schedule, CostCalculator calc) {
+  private int calculateBoardingCost(
+    TestTripSchedule schedule,
+    CostCalculator<TestTripSchedule> calc
+  ) {
     return calc.boardingCost(true, 0, 5, 100, schedule, RaptorTransferConstraint.REGULAR_TRANSFER);
   }
 }

--- a/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/services/OptimizePathDomainServiceTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/services/OptimizePathDomainServiceTest.java
@@ -38,7 +38,7 @@ public class OptimizePathDomainServiceTest implements RaptorTestConstants {
     ALIGHT_SLACK
   );
 
-  public static final CostCalculator COST_CALCULATOR = new DefaultCostCalculator(
+  public static final CostCalculator<TestTripSchedule> COST_CALCULATOR = new DefaultCostCalculator<>(
     BOARD_COST_SEC,
     TRANSFER_COST_SEC,
     WAIT_RELUCTANCE,

--- a/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/services/TransitPathLegSelectorTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/services/TransitPathLegSelectorTest.java
@@ -32,7 +32,7 @@ public class TransitPathLegSelectorTest implements RaptorTestConstants {
     ALIGHT_SLACK
   );
 
-  private static final CostCalculator COST_CALCULATOR = new DefaultCostCalculator(
+  private static final CostCalculator<TestTripSchedule> COST_CALCULATOR = new DefaultCostCalculator<>(
     20,
     60,
     1.0,

--- a/src/test/java/org/opentripplanner/transit/raptor/_data/api/TestPathBuilder.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/_data/api/TestPathBuilder.java
@@ -23,13 +23,16 @@ public class TestPathBuilder {
   private static final int BOARD_ALIGHT_OFFSET = 30;
 
   @Nullable
-  private final CostCalculator costCalculator;
+  private final CostCalculator<TestTripSchedule> costCalculator;
 
   private final int alightSlack;
   private PathBuilder<TestTripSchedule> builder;
   private int startTime;
 
-  public TestPathBuilder(int alightSlack, @Nullable CostCalculator costCalculator) {
+  public TestPathBuilder(
+    int alightSlack,
+    @Nullable CostCalculator<TestTripSchedule> costCalculator
+  ) {
     this.alightSlack = alightSlack;
     this.costCalculator = costCalculator;
   }

--- a/src/test/java/org/opentripplanner/transit/raptor/_data/api/TestPathBuilderTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/_data/api/TestPathBuilderTest.java
@@ -18,7 +18,7 @@ import static org.opentripplanner.transit.raptor._data.stoparrival.BasicPathTest
 import static org.opentripplanner.transit.raptor._data.stoparrival.BasicPathTestCase.LINE_21;
 import static org.opentripplanner.transit.raptor._data.stoparrival.BasicPathTestCase.LINE_31;
 import static org.opentripplanner.transit.raptor._data.stoparrival.BasicPathTestCase.TOTAL_COST;
-import static org.opentripplanner.transit.raptor._data.stoparrival.BasicPathTestCase.TRANSIT_RELUCTANCE_INDEX;
+import static org.opentripplanner.transit.raptor._data.stoparrival.BasicPathTestCase.TRIP_1;
 import static org.opentripplanner.transit.raptor._data.stoparrival.BasicPathTestCase.TX_COST;
 import static org.opentripplanner.transit.raptor._data.stoparrival.BasicPathTestCase.TX_DURATION;
 import static org.opentripplanner.util.time.DurationUtils.durationInSeconds;
@@ -26,7 +26,6 @@ import static org.opentripplanner.util.time.TimeUtils.time;
 
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.transit.raptor._data.RaptorTestConstants;
-import org.opentripplanner.transit.raptor._data.stoparrival.BasicPathTestCase;
 import org.opentripplanner.transit.raptor._data.transit.TestTransfer;
 
 /**
@@ -59,7 +58,7 @@ public class TestPathBuilderTest implements RaptorTestConstants {
       boardCost,
       ALIGHT_SLACK,
       transitDuration,
-      TRANSIT_RELUCTANCE_INDEX,
+      TRIP_1,
       STOP_B
     );
 

--- a/src/test/java/org/opentripplanner/transit/raptor/_data/stoparrival/BasicPathTestCase.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/_data/stoparrival/BasicPathTestCase.java
@@ -158,21 +158,27 @@ public class BasicPathTestCase implements RaptorTestConstants {
   public static final String LINE_21 = "L21";
   public static final String LINE_31 = "L31";
 
-  private static final TestTripSchedule TRIP_1 = TestTripSchedule
+  public static final TestTripSchedule TRIP_1 = TestTripSchedule
     .schedule(pattern(LINE_11, STOP_A, STOP_B))
     .times(L11_START, L11_END)
+    .transitReluctanceIndex(TRANSIT_RELUCTANCE_INDEX)
     .build();
-  private static final TestTripSchedule TRIP_2 = TestTripSchedule
+
+  public static final TestTripSchedule TRIP_2 = TestTripSchedule
     .schedule(pattern(LINE_21, STOP_C, STOP_D))
     .times(L21_START, L21_END)
+    .transitReluctanceIndex(TRANSIT_RELUCTANCE_INDEX)
     .build();
-  private static final TestTripSchedule TRIP_3 = TestTripSchedule
+
+  public static final TestTripSchedule TRIP_3 = TestTripSchedule
     .schedule(pattern(LINE_31, STOP_D, STOP_E))
     // The early arrival and late departure should not have any effect on tests
     .arrivals(VERY_EARLY, L31_END)
     .departures(L31_START, VERY_LATE)
+    .transitReluctanceIndex(TRANSIT_RELUCTANCE_INDEX)
     .build();
-  public static final CostCalculator COST_CALCULATOR = new DefaultCostCalculator(
+
+  public static final CostCalculator<TestTripSchedule> COST_CALCULATOR = new DefaultCostCalculator<>(
     BOARD_COST_SEC,
     TRANSFER_COST_SEC,
     WAIT_RELUCTANCE,
@@ -402,7 +408,7 @@ public class BasicPathTestCase implements RaptorTestConstants {
       boardCost,
       ALIGHT_SLACK,
       alightTime - boardTime,
-      trip.transitReluctanceFactorIndex(),
+      trip,
       alightStop
     );
   }

--- a/src/test/java/org/opentripplanner/transit/raptor/_data/stoparrival/FlexAccessAndEgressPathTestCase.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/_data/stoparrival/FlexAccessAndEgressPathTestCase.java
@@ -48,7 +48,7 @@ public class FlexAccessAndEgressPathTestCase implements RaptorTestConstants {
   public static final int BOARD_COST_SEC = 60;
   public static final int TRANSFER_COST_SEC = 120;
   // The COST_CALCULATOR is not under test, so we use it to calculate correct cost values.
-  public static final DefaultCostCalculator COST_CALCULATOR = new DefaultCostCalculator(
+  public static final DefaultCostCalculator<TestTripSchedule> COST_CALCULATOR = new DefaultCostCalculator<>(
     BOARD_COST_SEC,
     TRANSFER_COST_SEC,
     WAIT_RELUCTANCE,
@@ -92,13 +92,7 @@ public class FlexAccessAndEgressPathTestCase implements RaptorTestConstants {
 
   // Wait at least 1m45s (45s BOARD_SLACK and 60s TRANSFER_SLACK)
   public static final int L1_TRANSIT_DURATION = L1_END - L1_START;
-  public static final int L1_COST_EX_WAIT = COST_CALCULATOR.transitArrivalCost(
-    COST_CALCULATOR.boardingCostRegularTransfer(false, L1_START, STOP_B, L1_START),
-    ZERO,
-    L1_TRANSIT_DURATION,
-    TRANSIT_RELUCTANCE_INDEX,
-    STOP_C
-  );
+
   // Transfers (C ~ Walk 2m ~ D) (Used in Case B only)
   public static final int TX2_START = time("10:20:15");
   public static final int TX2_END = time("10:22:15");
@@ -129,14 +123,26 @@ public class FlexAccessAndEgressPathTestCase implements RaptorTestConstants {
 
   public static final String LINE_A = "A";
   public static final String LINE_B = "B";
+
   public static final TestTripSchedule TRIP_A = TestTripSchedule
     .schedule(pattern(LINE_A, STOP_A, STOP_D))
     .times(L1_START, L1_END)
+    .transitReluctanceIndex(TRANSIT_RELUCTANCE_INDEX)
     .build();
+
   public static final TestTripSchedule TRIP_B = TestTripSchedule
     .schedule(pattern(LINE_B, STOP_B, STOP_C))
     .times(L1_START, L1_END)
+    .transitReluctanceIndex(TRANSIT_RELUCTANCE_INDEX)
     .build();
+
+  public static final int L1_COST_EX_WAIT = COST_CALCULATOR.transitArrivalCost(
+    COST_CALCULATOR.boardingCostRegularTransfer(false, L1_START, STOP_B, L1_START),
+    ZERO,
+    L1_TRANSIT_DURATION,
+    TRIP_A,
+    STOP_C
+  );
 
   private static final int TOT_COST_A = toRaptorCost(2564);
   private static final int TOT_COST_W_OPENING_HOURS_A = toRaptorCost(3512);

--- a/src/test/java/org/opentripplanner/transit/raptor/_data/transit/TestTransitData.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/_data/transit/TestTransitData.java
@@ -6,7 +6,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.opentripplanner.model.transfer.ConstrainedTransfer;
 import org.opentripplanner.model.transfer.TransferConstraint;
@@ -87,8 +86,8 @@ public class TestTransitData
   }
 
   @Override
-  public CostCalculator multiCriteriaCostCalculator() {
-    return new DefaultCostCalculator(costParamsBuilder.build(), stopBoarAlightCost());
+  public CostCalculator<TestTripSchedule> multiCriteriaCostCalculator() {
+    return new DefaultCostCalculator<>(costParamsBuilder.build(), stopBoarAlightCost());
   }
 
   @Override
@@ -109,7 +108,7 @@ public class TestTransitData
           .filter(tx -> tx.getSourceStopPos() == fromStopPosition)
           .filter(tx -> tx.getTrip().equals(toTrip))
           .filter(tx -> tx.getStopPositionInPattern() == toStopPosition)
-          .collect(Collectors.toList());
+          .toList();
 
         if (list.isEmpty()) {
           return null;
@@ -133,7 +132,7 @@ public class TestTransitData
     return this.routes.stream()
       .mapToInt(route -> route.timetable().getTripSchedule(0).departure(0))
       .min()
-      .getAsInt();
+      .orElseThrow();
   }
 
   @Override
@@ -147,7 +146,7 @@ public class TestTransitData
           .departure(pattern.numberOfStopsInPattern() - 1);
       })
       .max()
-      .getAsInt();
+      .orElseThrow();
   }
 
   public TestRoute getRoute(int index) {

--- a/src/test/java/org/opentripplanner/transit/raptor/_data/transit/TestTripSchedule.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/_data/transit/TestTripSchedule.java
@@ -3,6 +3,7 @@ package org.opentripplanner.transit.raptor._data.transit;
 import static org.opentripplanner.model.WheelchairAccessibility.NO_INFORMATION;
 
 import org.opentripplanner.model.WheelchairAccessibility;
+import org.opentripplanner.routing.algorithm.raptoradapter.transit.cost.DefaultTripSchedule;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripPattern;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
 import org.opentripplanner.util.lang.ToStringBuilder;
@@ -13,7 +14,7 @@ import org.opentripplanner.util.time.TimeUtils;
  * <p>
  * The {@link RaptorTripPattern} for this schedule return {@code stopIndex == stopPosInPattern + 1 }
  */
-public class TestTripSchedule implements RaptorTripSchedule {
+public class TestTripSchedule implements DefaultTripSchedule {
 
   private static final int DEFAULT_DEPARTURE_DELAY = 10;
   private final RaptorTripPattern pattern;


### PR DESCRIPTION
### Summary

The generalized cost calculation is not a responsibility of Raptor, only the Transit model and the
cost calculator implementations need to know about the properties of the trip. I have refactored so
these properties are not handled within Raptor anymore. This should make it easier to implement
different cost calculation strategies. Instead of passing the filed, the trip-schedule is passed to
the calculators.


### Issue

Prepare for implementing #4199 

### Unit tests

This is a pure refactoring PR, all appropriate unit tests are updated, but no new tests are added, not relevant.


### Code style
✅ 


### Documentation
Some JavaDoc is updated.
