### PR TITLE
Remove JUnit 4 [changelog skip]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -626,12 +626,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.tngtech.archunit</groupId>
             <artifactId>archunit</artifactId>
             <version>0.23.1</version>

--- a/src/test/java/org/opentripplanner/test/support/PolylineAssert.java
+++ b/src/test/java/org/opentripplanner/test/support/PolylineAssert.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.test.support;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -21,7 +20,7 @@ public class PolylineAssert {
       "Actual:    " +
       makeUrl(actual) +
       "\n";
-    assertThat(reason, actual, is(expected));
+    assertEquals(actual, expected, reason);
   }
 
   private static String toBase64(String line) {

--- a/src/test/java/org/opentripplanner/updater/alerts/AlertsUpdateHandlerTest.java
+++ b/src/test/java/org/opentripplanner/updater/alerts/AlertsUpdateHandlerTest.java
@@ -1,7 +1,7 @@
 package org.opentripplanner.updater.alerts;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
@@ -18,11 +18,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.opentripplanner.routing.alertpatch.AlertCause;
 import org.opentripplanner.routing.alertpatch.AlertEffect;
 import org.opentripplanner.routing.alertpatch.AlertSeverity;
@@ -31,15 +29,13 @@ import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.util.TranslatedString;
 
-@RunWith(MockitoJUnitRunner.class)
 public class AlertsUpdateHandlerTest {
 
   private AlertsUpdateHandler handler;
 
-  @Spy
-  private FakeTransitAlertService service;
+  private final FakeTransitAlertService service = Mockito.spy(FakeTransitAlertService.class);
 
-  @Before
+  @BeforeEach
   public void setUp() {
     handler = new AlertsUpdateHandler();
     handler.setFeedId("1");


### PR DESCRIPTION
### Summary

It migrates the last remaining test to Junit 4 and removes the compatibility jar.

### Issue

#3402

### Unit tests

It's just tests

### Code style

Autoformatted.

### Documentation

n/a

### Changelog

skip