### PR TITLE
When restoring debug UI from URL, zoom to route bounds and keep selected map layer [changelog skip]

### DIFF
--- a/src/client/js/otp/config.js
+++ b/src/client/js/otp/config.js
@@ -101,7 +101,8 @@ otp.config = {
         {
             name: 'OSM Standard Tiles',
             tileUrl: 'https://a.tile.openstreetmap.org/{z}/{x}/{y}.png',
-            attribution : 'Map data and tiles © OpenStreetMap contributors'
+            attribution : 'Map data and tiles © OpenStreetMap contributors',
+            isDefault: true
         }
     ],
     
@@ -153,7 +154,6 @@ otp.config = {
         {
             id : 'planner',
             className : 'otp.modules.multimodal.MultimodalPlannerModule',
-            defaultBaseLayer : 'OSM Standard Tiles',
             isDefault: true
         }
     ],

--- a/src/client/js/otp/core/Map.js
+++ b/src/client/js/otp/core/Map.js
@@ -25,14 +25,16 @@ otp.core.Map = otp.Class({
     contextMenuModuleItems  : null,
     contextMenuLatLng       : null,
     
-    baseLayers  : {},
+    baseLayers          : {},
+    currentBaseLayer    : null,
     
     initialize : function(webapp) {
         var this_ = this;
         this.webapp = webapp;
-        
-        
-                
+
+        const baseLayerId = this.webapp.urlParams.baseLayer || otp.config.baseLayers.find(m => m.isDefault).name;
+        this.currentBaseLayer = baseLayerId;
+
         //var baseLayers = {};
         var defaultBaseLayer = null;
         
@@ -46,7 +48,8 @@ otp.core.Map = otp.Class({
             var layer = new L.TileLayer(layerConfig.tileUrl, layerProps);
 
 	        this.baseLayers[layerConfig.name] = layer;
-            if(i == 0) defaultBaseLayer = layer;            
+            const id = layerConfig.name;
+            if(id === baseLayerId) defaultBaseLayer = layer;
 	        
 	        if(typeof layerConfig.getTileUrl != 'undefined') {
         	    layer.getTileUrl = otp.config.getTileUrl;
@@ -132,7 +135,9 @@ otp.core.Map = otp.Class({
         this.lmap.on('dragend', function(event) {
             webapp.mapBoundsChanged(event);        
         });
-        
+
+        this.lmap.on('baselayerchange', (e) => { this.currentBaseLayer = e.name; });
+
         // setup context menu
         var this_ = this;
         
@@ -190,7 +195,11 @@ otp.core.Map = otp.Class({
     $ : function() {
         return $("#map");
     },
-    
+
+    getActiveBaseLayerName() {
+        return this.currentBaseLayer;
+    },
+
     CLASS_NAME : "otp.core.Map"
 });
 

--- a/src/client/js/otp/core/Map.js
+++ b/src/client/js/otp/core/Map.js
@@ -32,12 +32,7 @@ otp.core.Map = otp.Class({
         var this_ = this;
         this.webapp = webapp;
 
-        const baseLayerId = this.webapp.urlParams.baseLayer || otp.config.baseLayers.find(m => m.isDefault).name;
-        this.currentBaseLayer = baseLayerId;
 
-        //var baseLayers = {};
-        var defaultBaseLayer = null;
-        
         for(var i=0; i<otp.config.baseLayers.length; i++) { //otp.config.baseLayers.length-1; i >= 0; i--) {
             var layerConfig = otp.config.baseLayers[i];
 
@@ -48,17 +43,18 @@ otp.core.Map = otp.Class({
             var layer = new L.TileLayer(layerConfig.tileUrl, layerProps);
 
 	        this.baseLayers[layerConfig.name] = layer;
-            const id = layerConfig.name;
-            if(id === baseLayerId) defaultBaseLayer = layer;
-	        
+
 	        if(typeof layerConfig.getTileUrl != 'undefined') {
         	    layer.getTileUrl = otp.config.getTileUrl;
             }
         }
-        
+        const selectedLayer = otp.config.baseLayers.find(l => l.name === this.webapp.urlParams.baseLayer) || otp.config.baseLayers.find(m => m.isDefault);
+        this.currentBaseLayer = selectedLayer.name;
+
+        const baseLayer = this.baseLayers[this.currentBaseLayer];
 
         var mapProps = { 
-            layers  : [ defaultBaseLayer ],
+            layers  : [ baseLayer ],
             center : (otp.config.initLatLng || new L.LatLng(0,0)),
             zoom : (otp.config.initZoom || 2),
             zoomControl : false

--- a/src/client/js/otp/modules/multimodal/MultimodalPlannerModule.js
+++ b/src/client/js/otp/modules/multimodal/MultimodalPlannerModule.js
@@ -134,6 +134,9 @@ otp.modules.multimodal.MultimodalPlannerModule =
         }*/
         if (tripPlan.itineraries.length > 0) {
             this.drawItinerary(tripPlan.itineraries[0]);
+            if(restoring) {
+                this.zoomToBounds(tripPlan.itineraries[0]);
+            }
         }
     },
 

--- a/src/client/js/otp/modules/planner/PlannerModule.js
+++ b/src/client/js/otp/modules/planner/PlannerModule.js
@@ -488,6 +488,13 @@ otp.modules.planner.PlannerModule =
             otp.util.Text.constructUrlParamString(_.extend(_.clone(queryParams), additionalParams));
     },
 
+    zoomToBounds: function(itin) {
+        const geometries = itin.itinData.legs.map(l => otp.util.Geo.decodePolyline(l.legGeometry.points)).flat();
+        const bounds = L.latLngBounds(geometries).pad(0.2);
+        this.webapp.map.lmap.fitBounds(bounds);
+        console.log(`Zooming map to bounds ${bounds.toBBoxString()}`);
+    },
+
     drawItinerary : function(itin) {
         var this_ = this;
 
@@ -496,7 +503,6 @@ otp.modules.planner.PlannerModule =
 
         var queryParams = itin.tripPlan.queryParams;
 
-        console.log(itin.itinData);
         for(var i=0; i < itin.itinData.legs.length; i++) {
             var leg = itin.itinData.legs[i];
 

--- a/src/client/js/otp/modules/planner/PlannerModule.js
+++ b/src/client/js/otp/modules/planner/PlannerModule.js
@@ -484,14 +484,15 @@ otp.modules.planner.PlannerModule =
 
     constructLink : function(queryParams, additionalParams) {
         additionalParams = additionalParams ||  { };
+        additionalParams.baseLayer = this.webapp.map.getActiveBaseLayerName();
         return otp.config.siteUrl + '?module=' + this.id + "&" +
             otp.util.Text.constructUrlParamString(_.extend(_.clone(queryParams), additionalParams));
     },
 
     zoomToBounds: function(itin) {
         const geometries = itin.itinData.legs.map(l => otp.util.Geo.decodePolyline(l.legGeometry.points)).flat();
-        const bounds = L.latLngBounds(geometries).pad(0.2);
-        this.webapp.map.lmap.fitBounds(bounds);
+        const bounds = L.latLngBounds(geometries).pad(0.1);
+        this.webapp.map.setBounds(bounds);
         console.log(`Zooming map to bounds ${bounds.toBBoxString()}`);
     },
 


### PR DESCRIPTION
### Summary

- When restoring the debug UI from a URL zoom to the bounds of the first itinerary returned.
- Store the selected map layer in the URL and restore the selected layer, too.

### Issue

n/a

### Unit tests

n/a

### Code style

autoformatted.

cc @FrancoisG-WIMT