### PR TITLE
Automatically bump serialization version id [changelog skip]

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -50,12 +50,6 @@ Write a few words on how the new code is tested.
   pass [the continuous integration service](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Developers-Guide.md#continuous-integration)
   ?
 
-### Code style
-
-Have you followed
-the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Codestyle.md)
-?
-
 ### Documentation
 
 - Have you added documentation in code covering design and rationale behind the code?
@@ -69,3 +63,9 @@ the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/bl
 The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md)
 is generated from the pull-request title, make sure the title describe the feature or issue fixed.
 To exclude the PR from the changelog add `[changelog skip]` in the title.
+
+### Bumping the serialization version id
+
+If you have made changes to the way the routing graph is serialized, for example by renaming a field
+in one of the edges, then you must add the label `bump serialization id` to the PR. With this label
+Github Actions will increase the field `otp.serialization.version.id` in `pom.xml`.

--- a/.github/workflows/automatic-changelog.yml
+++ b/.github/workflows/automatic-changelog.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           token: ${{ secrets.CHANGELOG_TOKEN }}
 
-      - name: Configure Git User
+      - name: Configure Git User for changelog
         run: |
           git config --global user.name 'OTP Changelog Bot'
           git config --global user.email 'changelog-bot@opentripplanner.org'
@@ -43,3 +43,23 @@ jobs:
           TITLE: ${{ github.event.pull_request.title }}
           NUMBER: ${{ github.event.pull_request.number }}
           URL: ${{ github.event.pull_request.html_url }}
+
+      - name: Configure Git User for serialization version
+        if: contains(github.event.pull_request.labels.*.name, 'bump serialization version')
+        run: |
+          git config --global user.name 'OTP Serialization Version Bot'
+          git config --global user.email 'serialization-version-bot@opentripplanner.org'
+
+      - name: Bump serialization version if PR has label
+        if: contains(github.event.pull_request.labels.*.name, 'bump serialization version')
+        run: |
+          version=`xmllint --xpath "//*[local-name()='otp.serialization.version.id']/text()" pom.xml`
+          bumped=$((version+1))
+          sed -Ei "s/<otp\.serialization\.version\.id>.*<\/otp\.serialization\.version\.id>/<otp\.serialization\.version\.id>${bumped}<\/otp\.serialization\.version\.id>/" pom.xml 
+ 
+          git add pom.xml
+          git commit -m "Bumping serialization version id for #${NUMBER}"
+          git push ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git HEAD:dev-2.x
+        env:
+          # Use environment variables to prevent injection attack
+          NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           token: ${{ secrets.CHANGELOG_TOKEN }}
 
-      - name: Configure Git User for changelog
+      - name: Configure git user
         run: |
           git config --global user.name 'OTP Changelog Bot'
           git config --global user.email 'changelog-bot@opentripplanner.org'
@@ -44,14 +44,22 @@ jobs:
           NUMBER: ${{ github.event.pull_request.number }}
           URL: ${{ github.event.pull_request.html_url }}
 
-      - name: Configure Git User for serialization version
-        if: contains(github.event.pull_request.labels.*.name, 'bump serialization version')
+  serialization-version:
+    if: github.event.pull_request.merged && github.repository_owner == 'opentripplanner' && contains(github.event.pull_request.labels.*.name, 'bump serialization version')
+    runs-on: ubuntu-latest
+    needs: [changelog-entry]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.CHANGELOG_TOKEN }}
+
+      - name: Configure git user
         run: |
           git config --global user.name 'OTP Serialization Version Bot'
           git config --global user.email 'serialization-version-bot@opentripplanner.org'
 
-      - name: Bump serialization version if PR has label
-        if: contains(github.event.pull_request.labels.*.name, 'bump serialization version')
+      - name: Bump serialization version
         run: |
           version=`xmllint --xpath "//*[local-name()='otp.serialization.version.id']/text()" pom.xml`
           bumped=$((version+1))

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -49,10 +49,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [changelog-entry]
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          token: ${{ secrets.CHANGELOG_TOKEN }}
 
       - name: Install xmllint
         run: |
@@ -62,6 +58,11 @@ jobs:
         run: |
           git config --global user.name 'OTP Serialization Version Bot'
           git config --global user.email 'serialization-version-bot@opentripplanner.org'
+
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.CHANGELOG_TOKEN }}
 
       - name: Bump serialization version
         run: |

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -72,6 +72,8 @@ jobs:
  
           git add pom.xml
           git commit -m "Bumping serialization version id for #${NUMBER}"
+          # just for safety as the git repo can be eventually consistent and this push competes with the changelog entry
+          git pull
           git push ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git HEAD:dev-2.x
         env:
           # Use environment variables to prevent injection attack

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -73,7 +73,7 @@ jobs:
           git add pom.xml
           git commit -m "Bumping serialization version id for #${NUMBER}"
           # just for safety as the git repo can be eventually consistent and this push competes with the changelog entry
-          git pull
+          git pull origin dev-2.x
           git push ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git HEAD:dev-2.x
         env:
           # Use environment variables to prevent injection attack

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -73,7 +73,7 @@ jobs:
           git add pom.xml
           git commit -m "Bumping serialization version id for #${NUMBER}"
           # just for safety as the git repo can be eventually consistent and this push competes with the changelog entry
-          git pull origin dev-2.x
+          git pull --rebase origin dev-2.x
           git push ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git HEAD:dev-2.x
         env:
           # Use environment variables to prevent injection attack

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -1,4 +1,4 @@
-name: Automatic changelog entry
+name: Post-merge
 on:
   pull_request_target:
     branches:
@@ -53,6 +53,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           token: ${{ secrets.CHANGELOG_TOKEN }}
+
+      - name: Install xmllint
+        run: |
+          sudo apt-get install -y libxml2-utils
 
       - name: Configure git user
         run: |

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -45,7 +45,7 @@ jobs:
           URL: ${{ github.event.pull_request.html_url }}
 
   serialization-version:
-    if: github.event.pull_request.merged && github.repository_owner == 'opentripplanner' && contains(github.event.pull_request.labels.*.name, 'bump serialization version')
+    if: github.event.pull_request.merged && github.repository_owner == 'opentripplanner' && contains(github.event.pull_request.labels.*.name, 'bump serialization id')
     runs-on: ubuntu-latest
     needs: [changelog-entry]
     steps:

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -71,8 +71,8 @@ jobs:
           sed -Ei "s/<otp\.serialization\.version\.id>.*<\/otp\.serialization\.version\.id>/<otp\.serialization\.version\.id>${bumped}<\/otp\.serialization\.version\.id>/" pom.xml 
  
           git add pom.xml
-          git commit -m "Bumping serialization version id for #${NUMBER}"
-          # just for safety as the git repo can be eventually consistent and this push competes with the changelog entry
+          git commit -m "Bump serialization version id for #${NUMBER}"
+          # just for safety as the Github repo is eventually consistent, therefore this push competes with the changelog entry one
           git pull --rebase origin dev-2.x
           git push ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git HEAD:dev-2.x
         env:


### PR DESCRIPTION
### Summary

When the label "bump serialization version" is added to a PR, then a CI job automatically bumps the serialization version id in pom.xml and pushes it to Github.

An example of what it looks like is https://github.com/leonardehrenfried/OpenTripPlanner/commit/01eb045a4ae172bb818695cde2e0ead4672c664d

### Issue

Fixes #4003 