### PR TITLE
Add support for adding alerts from multimodal parent stations

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/flex/FlexRouter.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/FlexRouter.java
@@ -72,7 +72,10 @@ public class FlexRouter {
     this.graphPathToItineraryMapper =
       new GraphPathToItineraryMapper(
         graph.getTimeZone(),
-        new AlertToLegMapper(graph.getTransitAlertService()),
+        new AlertToLegMapper(
+          graph.getTransitAlertService(),
+          graph.index.getMultiModalStationForStations()::get
+        ),
         graph.streetNotesService,
         graph.ellipsoidToGeoidDifference
       );

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
@@ -74,7 +74,11 @@ public class RaptorPathToItineraryMapper {
     this.transitLayer = transitLayer;
     this.transitSearchTimeZero = transitSearchTimeZero;
     this.request = request;
-    this.alertToLegMapper = new AlertToLegMapper(graph.getTransitAlertService());
+    this.alertToLegMapper =
+      new AlertToLegMapper(
+        graph.getTransitAlertService(),
+        graph.index.getMultiModalStationForStations()::get
+      );
     this.graphPathToItineraryMapper =
       new GraphPathToItineraryMapper(
         graph.getTimeZone(),

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/DirectStreetRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/DirectStreetRouter.java
@@ -15,8 +15,6 @@ import org.opentripplanner.routing.error.PathNotFoundException;
 import org.opentripplanner.routing.impl.GraphPathFinder;
 import org.opentripplanner.routing.spt.GraphPath;
 import org.opentripplanner.standalone.server.Router;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class DirectStreetRouter {
 
@@ -44,7 +42,10 @@ public class DirectStreetRouter {
       // Convert the internal GraphPaths to itineraries
       final GraphPathToItineraryMapper graphPathToItineraryMapper = new GraphPathToItineraryMapper(
         router.graph.getTimeZone(),
-        new AlertToLegMapper(router.graph.getTransitAlertService()),
+        new AlertToLegMapper(
+          router.graph.getTransitAlertService(),
+          router.graph.index.getMultiModalStationForStations()::get
+        ),
         router.graph.streetNotesService,
         router.graph.ellipsoidToGeoidDifference
       );

--- a/src/test/java/org/opentripplanner/graph_builder/module/osm/TestIntermediatePlaces.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/osm/TestIntermediatePlaces.java
@@ -67,7 +67,7 @@ public class TestIntermediatePlaces {
       graphPathToItineraryMapper =
         new GraphPathToItineraryMapper(
           graph.getTimeZone(),
-          new AlertToLegMapper(graph.getTransitAlertService()),
+          new AlertToLegMapper(graph.getTransitAlertService(), ignore -> null),
           graph.streetNotesService,
           graph.ellipsoidToGeoidDifference
         );

--- a/src/test/java/org/opentripplanner/routing/street/BarrierRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/street/BarrierRoutingTest.java
@@ -167,7 +167,7 @@ public class BarrierRoutingTest {
 
     GraphPathToItineraryMapper graphPathToItineraryMapper = new GraphPathToItineraryMapper(
       graph.getTimeZone(),
-      new AlertToLegMapper(graph.getTransitAlertService()),
+      new AlertToLegMapper(graph.getTransitAlertService(), ignore -> null),
       graph.streetNotesService,
       graph.ellipsoidToGeoidDifference
     );

--- a/src/test/java/org/opentripplanner/routing/street/BicycleRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/street/BicycleRoutingTest.java
@@ -76,7 +76,7 @@ public class BicycleRoutingTest {
 
     GraphPathToItineraryMapper graphPathToItineraryMapper = new GraphPathToItineraryMapper(
       graph.getTimeZone(),
-      new AlertToLegMapper(graph.getTransitAlertService()),
+      new AlertToLegMapper(graph.getTransitAlertService(), ignore -> null),
       graph.streetNotesService,
       graph.ellipsoidToGeoidDifference
     );

--- a/src/test/java/org/opentripplanner/routing/street/CarRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/street/CarRoutingTest.java
@@ -135,7 +135,7 @@ public class CarRoutingTest {
 
     GraphPathToItineraryMapper graphPathToItineraryMapper = new GraphPathToItineraryMapper(
       graph.getTimeZone(),
-      new AlertToLegMapper(graph.getTransitAlertService()),
+      new AlertToLegMapper(graph.getTransitAlertService(), ignore -> null),
       graph.streetNotesService,
       graph.ellipsoidToGeoidDifference
     );

--- a/src/test/java/org/opentripplanner/routing/street/SplitEdgeTurnRestrictionsTest.java
+++ b/src/test/java/org/opentripplanner/routing/street/SplitEdgeTurnRestrictionsTest.java
@@ -156,7 +156,7 @@ public class SplitEdgeTurnRestrictionsTest {
 
     GraphPathToItineraryMapper graphPathToItineraryMapper = new GraphPathToItineraryMapper(
       graph.getTimeZone(),
-      new AlertToLegMapper(graph.getTransitAlertService()),
+      new AlertToLegMapper(graph.getTransitAlertService(), ignore -> null),
       graph.streetNotesService,
       graph.ellipsoidToGeoidDifference
     );


### PR DESCRIPTION
### Summary

Currently the alerts from a SIRI-SX feed, which target a multi-modal stop place are never matched, as only the mono-modal parent station is used for searching alerts. This implements the TODOs regarding this, fetching also alerts targeting those multi-modal stop places.

### Changelog

The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md)
is generated from the pull-request title, make sure the title describe the feature or issue fixed.
To exclude the PR from the changelog add `[changelog skip]` in the title.
