### PR TITLE
Reactivate snapshot test

### DIFF
--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/TransitSnapshotTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/TransitSnapshotTest.java
@@ -113,7 +113,6 @@ public class TransitSnapshotTest extends SnapshotTestBase {
   }
 
   @Test
-  @Disabled("This test fails on some machines, but not others, snapshot @line 2704")
   public void test_trip_planning_with_transit() {
     RoutingRequest request = createTestRequest(2009, 11, 17, 10, 0, 0);
 

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/TransitSnapshotTest.snap
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/TransitSnapshotTest.snap
@@ -1,3 +1,2737 @@
+org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_planning_with_transit=[
+  [
+    {
+      "arrivedAtDestinationWithRentedBicycle": false,
+      "duration": 3821,
+      "elevationGained": 0.0,
+      "elevationLost": 0.0,
+      "endTime": "2009-11-17T19:03:41.000+00:00",
+      "fare": {
+        "details": { },
+        "fare": { }
+      },
+      "generalizedCost": 7447,
+      "legs": [
+        {
+          "agencyTimeZoneOffset": -28800000,
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 4923.15,
+          "endTime": "2009-11-17T19:03:41.000+00:00",
+          "from": {
+            "departure": "2009-11-17T18:00:00.000+00:00",
+            "lat": 45.51726,
+            "lon": -122.64847,
+            "name": "SE Morrison St. & SE 17th Ave. (P1)",
+            "vertexType": "NORMAL"
+          },
+          "generalizedCost": 7447,
+          "interlineWithPreviousLeg": false,
+          "legGeometry": {
+            "length": 205,
+            "points": "kaytG~wqkV?T?fCAl@?R?jE?rC?t@?hEAvD?R?R?|@?dBAP?PAxD?nD?X?jE?bA?t@?N?Z?ZAX?^@bBrA?DF?l@V?Z??xB?t@?F?NLNBH?vB?\\?JAFEP?NCpD?lECfE?H?`E@T`@@LBBCD?D?HHCJAF@ZAL?FAJGTCJGLQPKLWVSVMLILY`@c@v@INKRGNELEPENKb@iAvGkAxGETCRGd@If@Eb@Ip@APANAJ?J?H?H?L?DG@E?A@?@?@AB?HOhCIvAFBCRGPKRERg@xCETGXg@zCETGZg@vCCPADERADi@|CEXABCTi@vCCRGZm@fD[jBm@jDCJAFEVk@|CCVCFALk@|CEVETk@|CERG\\SjASnAGVCPAFg@tCCPCRm@lDw@fEi@bDCNETKf@EVEHMNATAh@ElCIlD?D?VARA`@EpB?N?TEjBCfAAP?RC`BATClAI|DK?G?mCBkCDoCDmCBoCDkCBoCB[?sBD]?Y@eA@K?C?K?W@{A@M@C@I?_CB?G"
+          },
+          "mode": "WALK",
+          "pathway": false,
+          "realTime": false,
+          "rentedBike": false,
+          "route": "",
+          "startTime": "2009-11-17T18:00:00.000+00:00",
+          "steps": [
+            {
+              "absoluteDirection": "WEST",
+              "area": false,
+              "bogusName": false,
+              "distance": 857.89,
+              "elevation": "",
+              "lat": 45.517186,
+              "lon": -122.6484704,
+              "relativeDirection": "DEPART",
+              "stayOn": false,
+              "streetName": "Southeast Morrison Street",
+              "walkingBike": false
+            },
+            {
+              "absoluteDirection": "SOUTH",
+              "area": false,
+              "bogusName": true,
+              "distance": 69.99,
+              "elevation": "",
+              "lat": 45.517229,
+              "lon": -122.6594795,
+              "relativeDirection": "LEFT",
+              "stayOn": false,
+              "streetName": "way 261187797 from 2",
+              "walkingBike": false
+            },
+            {
+              "absoluteDirection": "SOUTH",
+              "area": false,
+              "bogusName": false,
+              "distance": 28.34,
+              "elevation": "",
+              "lat": 45.5167705,
+              "lon": -122.6597431,
+              "relativeDirection": "LEFT",
+              "stayOn": false,
+              "streetName": "Southeast 6th Avenue",
+              "walkingBike": false
+            },
+            {
+              "absoluteDirection": "WEST",
+              "area": false,
+              "bogusName": false,
+              "distance": 78.11,
+              "elevation": "",
+              "lat": 45.5165156,
+              "lon": -122.6597447,
+              "relativeDirection": "RIGHT",
+              "stayOn": false,
+              "streetName": "Southeast Belmont Street",
+              "walkingBike": false
+            },
+            {
+              "absoluteDirection": "SOUTHWEST",
+              "area": false,
+              "bogusName": false,
+              "distance": 401.95,
+              "elevation": "",
+              "lat": 45.5165185,
+              "lon": -122.6607471,
+              "relativeDirection": "LEFT",
+              "stayOn": true,
+              "streetName": "Southeast Belmont Street",
+              "walkingBike": false
+            },
+            {
+              "absoluteDirection": "WEST",
+              "area": false,
+              "bogusName": true,
+              "distance": 8.77,
+              "elevation": "",
+              "lat": 45.5165001,
+              "lon": -122.6658345,
+              "relativeDirection": "CONTINUE",
+              "stayOn": false,
+              "streetName": "way 131623794 from 0",
+              "walkingBike": false
+            },
+            {
+              "absoluteDirection": "SOUTH",
+              "area": false,
+              "bogusName": false,
+              "distance": 43.8,
+              "elevation": "",
+              "lat": 45.5164998,
+              "lon": -122.665947,
+              "relativeDirection": "LEFT",
+              "stayOn": false,
+              "streetName": "Southeast Water Avenue",
+              "walkingBike": false
+            },
+            {
+              "absoluteDirection": "WEST",
+              "area": false,
+              "bogusName": false,
+              "distance": 697.32,
+              "elevation": "",
+              "lat": 45.5161288,
+              "lon": -122.6660075,
+              "relativeDirection": "RIGHT",
+              "stayOn": false,
+              "streetName": "Morrison Bridge",
+              "walkingBike": false
+            },
+            {
+              "absoluteDirection": "SOUTH",
+              "area": false,
+              "bogusName": true,
+              "distance": 5.12,
+              "elevation": "",
+              "lat": 45.5185836,
+              "lon": -122.6738909,
+              "relativeDirection": "LEFT",
+              "stayOn": false,
+              "streetName": "way 144373674 from 1",
+              "walkingBike": false
+            },
+            {
+              "absoluteDirection": "NORTHWEST",
+              "area": false,
+              "bogusName": false,
+              "distance": 1368.86,
+              "elevation": "",
+              "lat": 45.5185401,
+              "lon": -122.6739123,
+              "relativeDirection": "RIGHT",
+              "stayOn": false,
+              "streetName": "Southwest Alder Street",
+              "walkingBike": false
+            },
+            {
+              "absoluteDirection": "WEST",
+              "area": false,
+              "bogusName": false,
+              "distance": 477.25,
+              "elevation": "",
+              "lat": 45.5230171,
+              "lon": -122.6902466,
+              "relativeDirection": "LEFT",
+              "stayOn": false,
+              "streetName": "West Burnside Street",
+              "walkingBike": false
+            },
+            {
+              "absoluteDirection": "NORTH",
+              "area": false,
+              "bogusName": false,
+              "distance": 882.16,
+              "elevation": "",
+              "lat": 45.5233204,
+              "lon": -122.696357,
+              "relativeDirection": "RIGHT",
+              "stayOn": false,
+              "streetName": "Northwest 22nd Avenue",
+              "walkingBike": false
+            },
+            {
+              "absoluteDirection": "EAST",
+              "area": false,
+              "bogusName": false,
+              "distance": 3.68,
+              "elevation": "",
+              "lat": 45.5312508,
+              "lon": -122.6966386,
+              "relativeDirection": "RIGHT",
+              "stayOn": false,
+              "streetName": "Northwest Northrup Street",
+              "walkingBike": false
+            }
+          ],
+          "to": {
+            "arrival": "2009-11-17T19:03:41.000+00:00",
+            "lat": 45.53122,
+            "lon": -122.69659,
+            "name": "NW Northrup St. & NW 22nd Ave. (P2)",
+            "vertexType": "NORMAL"
+          },
+          "transitLeg": false,
+          "walkingBike": false
+        }
+      ],
+      "startTime": "2009-11-17T18:00:00.000+00:00",
+      "tooSloped": false,
+      "transfers": 0,
+      "transitTime": 0,
+      "waitingTime": 0,
+      "walkDistance": 4923.15,
+      "walkLimitExceeded": false,
+      "walkTime": 3821
+    },
+    {
+      "arrivedAtDestinationWithRentedBicycle": false,
+      "duration": 2261,
+      "elevationGained": 0.0,
+      "elevationLost": 0.0,
+      "endTime": "2009-11-17T18:38:41.000+00:00",
+      "fare": {
+        "details": {
+          "regular": [
+            {
+              "fareId": {
+                "feedId": "prt",
+                "id": "8"
+              },
+              "price": {
+                "cents": 200,
+                "currency": {
+                  "value": "USD"
+                }
+              },
+              "routes": [
+                {
+                  "feedId": "prt",
+                  "id": "20"
+                }
+              ]
+            }
+          ]
+        },
+        "fare": {
+          "regular": {
+            "cents": 200,
+            "currency": {
+              "value": "USD"
+            }
+          }
+        }
+      },
+      "generalizedCost": 4281,
+      "legs": [
+        {
+          "agencyTimeZoneOffset": -28800000,
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 920.33,
+          "endTime": "2009-11-17T18:12:58.000+00:00",
+          "from": {
+            "departure": "2009-11-17T18:01:00.000+00:00",
+            "lat": 45.51726,
+            "lon": -122.64847,
+            "name": "SE Morrison St. & SE 17th Ave. (P1)",
+            "vertexType": "NORMAL"
+          },
+          "generalizedCost": 1398,
+          "interlineWithPreviousLeg": false,
+          "legGeometry": {
+            "length": 45,
+            "points": "kaytG~wqkV?T?fCAl@?RmC?oCAmCAoC?_CAM?aC??A?A?A?A??AA?AAA??AAA???A?A?A???A@A??@A@?@??A@?@?BcC?mCAmCAmC?QBIYIWOH"
+          },
+          "mode": "WALK",
+          "pathway": false,
+          "realTime": false,
+          "rentedBike": false,
+          "route": "",
+          "startTime": "2009-11-17T18:01:00.000+00:00",
+          "steps": [
+            {
+              "absoluteDirection": "WEST",
+              "area": false,
+              "bogusName": false,
+              "distance": 87.68,
+              "elevation": "",
+              "lat": 45.517186,
+              "lon": -122.6484704,
+              "relativeDirection": "DEPART",
+              "stayOn": false,
+              "streetName": "Southeast Morrison Street",
+              "walkingBike": false
+            },
+            {
+              "absoluteDirection": "NORTH",
+              "area": false,
+              "bogusName": false,
+              "distance": 641.04,
+              "elevation": "",
+              "lat": 45.5171903,
+              "lon": -122.6495956,
+              "relativeDirection": "RIGHT",
+              "stayOn": false,
+              "streetName": "Southeast 16th Avenue",
+              "walkingBike": false
+            },
+            {
+              "absoluteDirection": "NORTH",
+              "area": false,
+              "bogusName": false,
+              "distance": 168.89,
+              "elevation": "",
+              "lat": 45.5228912,
+              "lon": -122.6495528,
+              "relativeDirection": "CONTINUE",
+              "stayOn": false,
+              "streetName": "Northeast 16th Avenue",
+              "walkingBike": false
+            },
+            {
+              "absoluteDirection": "NORTHEAST",
+              "area": false,
+              "bogusName": false,
+              "distance": 22.74,
+              "elevation": "",
+              "lat": 45.524409,
+              "lon": -122.6495675,
+              "relativeDirection": "RIGHT",
+              "stayOn": false,
+              "streetName": "Northeast Sandy Boulevard",
+              "walkingBike": false
+            }
+          ],
+          "to": {
+            "arrival": "2009-11-17T18:12:58.000+00:00",
+            "departure": "2009-11-17T18:12:58.000+00:00",
+            "lat": 45.524581,
+            "lon": -122.649367,
+            "name": "NE Sandy & 16th",
+            "stopCode": "5060",
+            "stopId": "prt:5060",
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "transitLeg": false,
+          "walkingBike": false
+        },
+        {
+          "agencyId": "prt:prt",
+          "agencyName": "TriMet",
+          "agencyTimeZoneOffset": -28800000,
+          "agencyUrl": "http://trimet.org",
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 3602.73,
+          "endTime": "2009-11-17T18:25:49.000+00:00",
+          "from": {
+            "arrival": "2009-11-17T18:12:58.000+00:00",
+            "departure": "2009-11-17T18:12:58.000+00:00",
+            "lat": 45.524581,
+            "lon": -122.649367,
+            "name": "NE Sandy & 16th",
+            "stopCode": "5060",
+            "stopId": "prt:5060",
+            "stopIndex": 92,
+            "stopSequence": 93,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "generalizedCost": 1371,
+          "headsign": "Beaverton TC",
+          "interlineWithPreviousLeg": false,
+          "intermediateStops": [
+            {
+              "arrival": "2009-11-17T18:13:32.000+00:00",
+              "departure": "2009-11-17T18:13:32.000+00:00",
+              "lat": 45.523767,
+              "lon": -122.651428,
+              "name": "NE Sandy & 14th",
+              "stopCode": "5058",
+              "stopId": "prt:5058",
+              "stopIndex": 93,
+              "stopSequence": 94,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:14:00.000+00:00",
+              "departure": "2009-11-17T18:14:00.000+00:00",
+              "lat": 45.523103,
+              "lon": -122.653064,
+              "name": "NE Sandy & 12th",
+              "stopCode": "5055",
+              "stopId": "prt:5055",
+              "stopIndex": 94,
+              "stopSequence": 95,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:14:47.000+00:00",
+              "departure": "2009-11-17T18:14:47.000+00:00",
+              "lat": 45.523024,
+              "lon": -122.656526,
+              "name": "E Burnside & NE 9th",
+              "stopCode": "819",
+              "stopId": "prt:819",
+              "stopIndex": 95,
+              "stopSequence": 96,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:15:24.000+00:00",
+              "departure": "2009-11-17T18:15:24.000+00:00",
+              "lat": 45.523012,
+              "lon": -122.659365,
+              "name": "E Burnside & NE 6th",
+              "stopCode": "805",
+              "stopId": "prt:805",
+              "stopIndex": 96,
+              "stopSequence": 97,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:15:52.000+00:00",
+              "departure": "2009-11-17T18:15:52.000+00:00",
+              "lat": 45.523015,
+              "lon": -122.661534,
+              "name": "E Burnside & NE M L King",
+              "stopCode": "705",
+              "stopId": "prt:705",
+              "stopIndex": 97,
+              "stopSequence": 98,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:18:00.000+00:00",
+              "departure": "2009-11-17T18:18:00.000+00:00",
+              "lat": 45.523249,
+              "lon": -122.671269,
+              "name": "W Burnside & Burnside Bridge",
+              "stopCode": "689",
+              "stopId": "prt:689",
+              "stopIndex": 98,
+              "stopSequence": 99,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
+            },
+            {
+              "arrival": "2009-11-17T18:19:00.000+00:00",
+              "departure": "2009-11-17T18:19:00.000+00:00",
+              "lat": 45.523169,
+              "lon": -122.675893,
+              "name": "W Burnside & NW 5th",
+              "stopCode": "782",
+              "stopId": "prt:782",
+              "stopIndex": 99,
+              "stopSequence": 100,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
+            },
+            {
+              "arrival": "2009-11-17T18:20:17.000+00:00",
+              "departure": "2009-11-17T18:20:17.000+00:00",
+              "lat": 45.523115,
+              "lon": -122.678939,
+              "name": "W Burnside & NW Park",
+              "stopCode": "716",
+              "stopId": "prt:716",
+              "stopIndex": 100,
+              "stopSequence": 101,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
+            },
+            {
+              "arrival": "2009-11-17T18:21:25.000+00:00",
+              "departure": "2009-11-17T18:21:25.000+00:00",
+              "lat": 45.523048,
+              "lon": -122.681606,
+              "name": "W Burnside & NW 10th",
+              "stopCode": "10791",
+              "stopId": "prt:10791",
+              "stopIndex": 101,
+              "stopSequence": 102,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
+            },
+            {
+              "arrival": "2009-11-17T18:22:14.000+00:00",
+              "departure": "2009-11-17T18:22:14.000+00:00",
+              "lat": 45.523,
+              "lon": -122.683535,
+              "name": "W Burnside & NW 12th",
+              "stopCode": "11032",
+              "stopId": "prt:11032",
+              "stopIndex": 102,
+              "stopSequence": 103,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
+            },
+            {
+              "arrival": "2009-11-17T18:24:09.000+00:00",
+              "departure": "2009-11-17T18:24:09.000+00:00",
+              "lat": 45.522985,
+              "lon": -122.688091,
+              "name": "W Burnside & NW 17th",
+              "stopCode": "10809",
+              "stopId": "prt:10809",
+              "stopIndex": 103,
+              "stopSequence": 104,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:25:00.000+00:00",
+              "departure": "2009-11-17T18:25:00.000+00:00",
+              "lat": 45.523097,
+              "lon": -122.690083,
+              "name": "W Burnside & NW 19th",
+              "stopCode": "735",
+              "stopId": "prt:735",
+              "stopIndex": 104,
+              "stopSequence": 105,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:25:21.000+00:00",
+              "departure": "2009-11-17T18:25:21.000+00:00",
+              "lat": 45.523176,
+              "lon": -122.692139,
+              "name": "W Burnside & NW 20th",
+              "stopCode": "741",
+              "stopId": "prt:741",
+              "stopIndex": 105,
+              "stopSequence": 106,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:25:31.000+00:00",
+              "departure": "2009-11-17T18:25:31.000+00:00",
+              "lat": 45.52322,
+              "lon": -122.69313,
+              "name": "W Burnside & NW 20th Pl",
+              "stopCode": "742",
+              "stopId": "prt:742",
+              "stopIndex": 106,
+              "stopSequence": 107,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            }
+          ],
+          "legGeometry": {
+            "length": 94,
+            "points": "coztGd}qkVNl@r@`CZhA`A`D??Ph@l@tBb@rARh@Pd@???BPj@@jA?jEAhE?pD???VAjE?hE?dB?b@???`AAhE?dD???l@C`EAhEEhE?bAA|@?XAZ@\\AzACnGKbKAjC?bE???JEnE@fEDlE@hE@~A??@rBBzDBpE@~A???Z@tD@RBnEB|A???@BdB?lEBjA??BnBApF@dB?X?^@r@?f@@bCAx@EtB???VChAE|BGnD??AXKnEGnD???XGjD??AZEfCC`AEzB"
+          },
+          "mode": "BUS",
+          "pathway": false,
+          "realTime": false,
+          "route": "Burnside/Stark",
+          "routeId": "prt:20",
+          "routeLongName": "Burnside/Stark",
+          "routeShortName": "20",
+          "routeType": 3,
+          "serviceDate": "2009-11-17",
+          "startTime": "2009-11-17T18:12:58.000+00:00",
+          "steps": [ ],
+          "to": {
+            "arrival": "2009-11-17T18:25:49.000+00:00",
+            "departure": "2009-11-17T18:25:49.000+00:00",
+            "lat": 45.523312,
+            "lon": -122.694901,
+            "name": "W Burnside & NW King",
+            "stopCode": "747",
+            "stopId": "prt:747",
+            "stopIndex": 107,
+            "stopSequence": 108,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "transitLeg": true,
+          "tripBlockId": "2002",
+          "tripId": "prt:200W1200"
+        },
+        {
+          "agencyTimeZoneOffset": -28800000,
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 999.1,
+          "endTime": "2009-11-17T18:38:41.000+00:00",
+          "from": {
+            "arrival": "2009-11-17T18:25:49.000+00:00",
+            "departure": "2009-11-17T18:25:49.000+00:00",
+            "lat": 45.523312,
+            "lon": -122.694901,
+            "name": "W Burnside & NW King",
+            "stopCode": "747",
+            "stopId": "prt:747",
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "generalizedCost": 1511,
+          "interlineWithPreviousLeg": false,
+          "legGeometry": {
+            "length": 29,
+            "points": "ugztGdzzkVL?ATClAI|DK?G?mCBkCDoCDmCBoCDkCBoCB[?sBD]?Y@eA@K?C?K?W@{A@M@C@I?_CB?G"
+          },
+          "mode": "WALK",
+          "pathway": false,
+          "realTime": false,
+          "rentedBike": false,
+          "route": "",
+          "startTime": "2009-11-17T18:25:49.000+00:00",
+          "steps": [
+            {
+              "absoluteDirection": "WEST",
+              "area": false,
+              "bogusName": false,
+              "distance": 113.27,
+              "elevation": "",
+              "lat": 45.5232491,
+              "lon": -122.6949067,
+              "relativeDirection": "DEPART",
+              "stayOn": false,
+              "streetName": "West Burnside Street",
+              "walkingBike": false
+            },
+            {
+              "absoluteDirection": "NORTH",
+              "area": false,
+              "bogusName": false,
+              "distance": 882.16,
+              "elevation": "",
+              "lat": 45.5233204,
+              "lon": -122.696357,
+              "relativeDirection": "RIGHT",
+              "stayOn": false,
+              "streetName": "Northwest 22nd Avenue",
+              "walkingBike": false
+            },
+            {
+              "absoluteDirection": "EAST",
+              "area": false,
+              "bogusName": false,
+              "distance": 3.68,
+              "elevation": "",
+              "lat": 45.5312508,
+              "lon": -122.6966386,
+              "relativeDirection": "RIGHT",
+              "stayOn": false,
+              "streetName": "Northwest Northrup Street",
+              "walkingBike": false
+            }
+          ],
+          "to": {
+            "arrival": "2009-11-17T18:38:41.000+00:00",
+            "lat": 45.53122,
+            "lon": -122.69659,
+            "name": "NW Northrup St. & NW 22nd Ave. (P2)",
+            "vertexType": "NORMAL"
+          },
+          "transitLeg": false,
+          "walkingBike": false
+        }
+      ],
+      "startTime": "2009-11-17T18:01:00.000+00:00",
+      "tooSloped": false,
+      "transfers": 0,
+      "transitTime": 771,
+      "waitingTime": 0,
+      "walkDistance": 1919.43,
+      "walkLimitExceeded": false,
+      "walkTime": 1490
+    },
+    {
+      "arrivedAtDestinationWithRentedBicycle": false,
+      "duration": 1470,
+      "elevationGained": 0.0,
+      "elevationLost": 0.0,
+      "endTime": "2009-11-17T18:39:22.000+00:00",
+      "fare": {
+        "details": {
+          "regular": [
+            {
+              "fareId": {
+                "feedId": "prt",
+                "id": "8"
+              },
+              "price": {
+                "cents": 200,
+                "currency": {
+                  "value": "USD"
+                }
+              },
+              "routes": [
+                {
+                  "feedId": "prt",
+                  "id": "15"
+                }
+              ]
+            }
+          ]
+        },
+        "fare": {
+          "regular": {
+            "cents": 200,
+            "currency": {
+              "value": "USD"
+            }
+          }
+        }
+      },
+      "generalizedCost": 2315,
+      "legs": [
+        {
+          "agencyTimeZoneOffset": -28800000,
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 62.01,
+          "endTime": "2009-11-17T18:15:40.000+00:00",
+          "from": {
+            "departure": "2009-11-17T18:14:52.000+00:00",
+            "lat": 45.51726,
+            "lon": -122.64847,
+            "name": "SE Morrison St. & SE 17th Ave. (P1)",
+            "vertexType": "NORMAL"
+          },
+          "generalizedCost": 95,
+          "interlineWithPreviousLeg": false,
+          "legGeometry": {
+            "length": 4,
+            "points": "kaytG~wqkV?T?fCG?"
+          },
+          "mode": "WALK",
+          "pathway": false,
+          "realTime": false,
+          "rentedBike": false,
+          "route": "",
+          "startTime": "2009-11-17T18:14:52.000+00:00",
+          "steps": [
+            {
+              "absoluteDirection": "WEST",
+              "area": false,
+              "bogusName": false,
+              "distance": 62.02,
+              "elevation": "",
+              "lat": 45.517186,
+              "lon": -122.6484704,
+              "relativeDirection": "DEPART",
+              "stayOn": false,
+              "streetName": "Southeast Morrison Street",
+              "walkingBike": false
+            }
+          ],
+          "to": {
+            "arrival": "2009-11-17T18:15:40.000+00:00",
+            "departure": "2009-11-17T18:15:40.000+00:00",
+            "lat": 45.517226,
+            "lon": -122.649266,
+            "name": "SE Morrison & 16th",
+            "stopCode": "4019",
+            "stopId": "prt:4019",
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "transitLeg": false,
+          "walkingBike": false
+        },
+        {
+          "agencyId": "prt:prt",
+          "agencyName": "TriMet",
+          "agencyTimeZoneOffset": -28800000,
+          "agencyUrl": "http://trimet.org",
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 5218.86,
+          "endTime": "2009-11-17T18:35:54.000+00:00",
+          "from": {
+            "arrival": "2009-11-17T18:15:40.000+00:00",
+            "departure": "2009-11-17T18:15:40.000+00:00",
+            "lat": 45.517226,
+            "lon": -122.649266,
+            "name": "SE Morrison & 16th",
+            "stopCode": "4019",
+            "stopId": "prt:4019",
+            "stopIndex": 50,
+            "stopSequence": 51,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "generalizedCost": 1814,
+          "headsign": "Montgomery Park",
+          "interlineWithPreviousLeg": false,
+          "intermediateStops": [
+            {
+              "arrival": "2009-11-17T18:16:15.000+00:00",
+              "departure": "2009-11-17T18:16:15.000+00:00",
+              "lat": 45.517253,
+              "lon": -122.651354,
+              "name": "SE Morrison & 14th",
+              "stopCode": "4016",
+              "stopId": "prt:4016",
+              "stopIndex": 51,
+              "stopSequence": 52,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:17:00.000+00:00",
+              "departure": "2009-11-17T18:17:00.000+00:00",
+              "lat": 45.517299,
+              "lon": -122.654067,
+              "name": "SE Morrison & 12th",
+              "stopCode": "4014",
+              "stopId": "prt:4014",
+              "stopIndex": 52,
+              "stopSequence": 53,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:17:38.000+00:00",
+              "departure": "2009-11-17T18:17:38.000+00:00",
+              "lat": 45.517292,
+              "lon": -122.656563,
+              "name": "SE Morrison & 9th",
+              "stopCode": "4026",
+              "stopId": "prt:4026",
+              "stopIndex": 53,
+              "stopSequence": 54,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:18:08.000+00:00",
+              "departure": "2009-11-17T18:18:08.000+00:00",
+              "lat": 45.517322,
+              "lon": -122.65847,
+              "name": "SE Morrison & 7th",
+              "stopCode": "4025",
+              "stopId": "prt:4025",
+              "stopIndex": 54,
+              "stopSequence": 55,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:18:39.000+00:00",
+              "departure": "2009-11-17T18:18:39.000+00:00",
+              "lat": 45.517298,
+              "lon": -122.660523,
+              "name": "SE Morrison & Grand",
+              "stopCode": "4013",
+              "stopId": "prt:4013",
+              "stopIndex": 55,
+              "stopSequence": 56,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:20:03.000+00:00",
+              "departure": "2009-11-17T18:20:03.000+00:00",
+              "lat": 45.517351,
+              "lon": -122.66601,
+              "name": "Morrison Bridge",
+              "stopCode": "4029",
+              "stopId": "prt:4029",
+              "stopIndex": 56,
+              "stopSequence": 57,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:22:27.000+00:00",
+              "departure": "2009-11-17T18:22:27.000+00:00",
+              "lat": 45.51959,
+              "lon": -122.674599,
+              "name": "SW Washington & 3rd",
+              "stopCode": "6158",
+              "stopId": "prt:6158",
+              "stopIndex": 57,
+              "stopSequence": 58,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
+            },
+            {
+              "arrival": "2009-11-17T18:23:00.000+00:00",
+              "departure": "2009-11-17T18:23:00.000+00:00",
+              "lat": 45.520129,
+              "lon": -122.676635,
+              "name": "SW Washington & 5th",
+              "stopCode": "6160",
+              "stopId": "prt:6160",
+              "stopIndex": 58,
+              "stopSequence": 59,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
+            },
+            {
+              "arrival": "2009-11-17T18:23:52.000+00:00",
+              "departure": "2009-11-17T18:23:52.000+00:00",
+              "lat": 45.520695,
+              "lon": -122.678657,
+              "name": "SW Washington & Broadway",
+              "stopCode": "6137",
+              "stopId": "prt:6137",
+              "stopIndex": 59,
+              "stopSequence": 60,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
+            },
+            {
+              "arrival": "2009-11-17T18:24:34.000+00:00",
+              "departure": "2009-11-17T18:24:34.000+00:00",
+              "lat": 45.521124,
+              "lon": -122.6803,
+              "name": "SW Washington & 9th",
+              "stopCode": "6169",
+              "stopId": "prt:6169",
+              "stopIndex": 60,
+              "stopSequence": 61,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
+            },
+            {
+              "arrival": "2009-11-17T18:25:47.000+00:00",
+              "departure": "2009-11-17T18:25:47.000+00:00",
+              "lat": 45.521094,
+              "lon": -122.682819,
+              "name": "SW 11th & Alder",
+              "stopCode": "9600",
+              "stopId": "prt:9600",
+              "stopIndex": 61,
+              "stopSequence": 62,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
+            },
+            {
+              "arrival": "2009-11-17T18:26:36.000+00:00",
+              "departure": "2009-11-17T18:26:36.000+00:00",
+              "lat": 45.52055,
+              "lon": -122.683933,
+              "name": "SW Morrison & 12th",
+              "stopCode": "9598",
+              "stopId": "prt:9598",
+              "stopIndex": 62,
+              "stopSequence": 63,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
+            },
+            {
+              "arrival": "2009-11-17T18:27:25.000+00:00",
+              "departure": "2009-11-17T18:27:25.000+00:00",
+              "lat": 45.521063,
+              "lon": -122.685848,
+              "name": "SW Morrison & 14th",
+              "stopCode": "9708",
+              "stopId": "prt:9708",
+              "stopIndex": 63,
+              "stopSequence": 64,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:28:18.000+00:00",
+              "departure": "2009-11-17T18:28:18.000+00:00",
+              "lat": 45.521641,
+              "lon": -122.687932,
+              "name": "SW Morrison & 16th",
+              "stopCode": "9613",
+              "stopId": "prt:9613",
+              "stopIndex": 64,
+              "stopSequence": 65,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:29:00.000+00:00",
+              "departure": "2009-11-17T18:29:00.000+00:00",
+              "lat": 45.52206,
+              "lon": -122.689577,
+              "name": "SW Morrison & 17th",
+              "stopCode": "9599",
+              "stopId": "prt:9599",
+              "stopIndex": 65,
+              "stopSequence": 66,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:29:54.000+00:00",
+              "departure": "2009-11-17T18:29:54.000+00:00",
+              "lat": 45.523097,
+              "lon": -122.690083,
+              "name": "W Burnside & NW 19th",
+              "stopCode": "735",
+              "stopId": "prt:735",
+              "stopIndex": 66,
+              "stopSequence": 67,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:30:31.000+00:00",
+              "departure": "2009-11-17T18:30:31.000+00:00",
+              "lat": 45.523176,
+              "lon": -122.692139,
+              "name": "W Burnside & NW 20th",
+              "stopCode": "741",
+              "stopId": "prt:741",
+              "stopIndex": 67,
+              "stopSequence": 68,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:30:48.000+00:00",
+              "departure": "2009-11-17T18:30:48.000+00:00",
+              "lat": 45.52322,
+              "lon": -122.69313,
+              "name": "W Burnside & NW 20th Pl",
+              "stopCode": "742",
+              "stopId": "prt:742",
+              "stopIndex": 68,
+              "stopSequence": 69,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:31:20.000+00:00",
+              "departure": "2009-11-17T18:31:20.000+00:00",
+              "lat": 45.523312,
+              "lon": -122.694901,
+              "name": "W Burnside & NW King",
+              "stopCode": "747",
+              "stopId": "prt:747",
+              "stopIndex": 69,
+              "stopSequence": 70,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:32:18.000+00:00",
+              "departure": "2009-11-17T18:32:18.000+00:00",
+              "lat": 45.523512,
+              "lon": -122.698081,
+              "name": "W Burnside & NW 23rd",
+              "stopCode": "755",
+              "stopId": "prt:755",
+              "stopIndex": 70,
+              "stopSequence": 71,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:33:11.000+00:00",
+              "departure": "2009-11-17T18:33:11.000+00:00",
+              "lat": 45.525416,
+              "lon": -122.698381,
+              "name": "NW 23rd & Flanders",
+              "stopCode": "7157",
+              "stopId": "prt:7157",
+              "stopIndex": 71,
+              "stopSequence": 72,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:34:05.000+00:00",
+              "departure": "2009-11-17T18:34:05.000+00:00",
+              "lat": 45.527543,
+              "lon": -122.698473,
+              "name": "NW 23rd & Irving",
+              "stopCode": "7161",
+              "stopId": "prt:7161",
+              "stopIndex": 72,
+              "stopSequence": 73,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:35:00.000+00:00",
+              "departure": "2009-11-17T18:35:00.000+00:00",
+              "lat": 45.529681,
+              "lon": -122.698529,
+              "name": "NW 23rd & Lovejoy",
+              "stopCode": "7163",
+              "stopId": "prt:7163",
+              "stopIndex": 73,
+              "stopSequence": 74,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            }
+          ],
+          "legGeometry": {
+            "length": 135,
+            "points": "kaytG||qkVA~@?jE?tC???r@AhE?jE?rA???tBAjE?nD???X?hE?xC??Ah@?pE?~C???J?`@?vAAvBEbE?jEAlE?`BAbB@d@??@tAAj@Cx@Cb@Cp@_@dEcAtFoA`IS~@i@`BmAzDi@zAc@pAi@~C??Id@u@jEm@bD??If@u@jEk@bD??If@u@|DW`B??CPs@|Du@lElBz@??VJbCfAk@dD??Id@w@rEWvAId@AF??Q~@s@`Ei@~C??Ib@u@dEWzA??]jB]MQSe@WOKOKIIQe@GWE]GnD??AXKnEGnD???XGjD??AZEfCC`AEzB??AXCfAGxDE|AEtBIlC??APkAh@o@?sCB{BD??S?mCDmCDyBB??U?mCDmCDyBB??S?oCDmCDmCBo@@"
+          },
+          "mode": "BUS",
+          "pathway": false,
+          "realTime": false,
+          "route": "Belmont/NW 23rd",
+          "routeId": "prt:15",
+          "routeLongName": "Belmont/NW 23rd",
+          "routeShortName": "15",
+          "routeType": 3,
+          "serviceDate": "2009-11-17",
+          "startTime": "2009-11-17T18:15:40.000+00:00",
+          "steps": [ ],
+          "to": {
+            "arrival": "2009-11-17T18:35:54.000+00:00",
+            "departure": "2009-11-17T18:35:54.000+00:00",
+            "lat": 45.532159,
+            "lon": -122.698634,
+            "name": "NW 23rd & Overton",
+            "stopCode": "8981",
+            "stopId": "prt:8981",
+            "stopIndex": 74,
+            "stopSequence": 75,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "transitLeg": true,
+          "tripBlockId": "1549",
+          "tripId": "prt:150W1400"
+        },
+        {
+          "agencyTimeZoneOffset": -28800000,
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 266.21,
+          "endTime": "2009-11-17T18:39:22.000+00:00",
+          "from": {
+            "arrival": "2009-11-17T18:35:54.000+00:00",
+            "departure": "2009-11-17T18:35:54.000+00:00",
+            "lat": 45.532159,
+            "lon": -122.698634,
+            "name": "NW 23rd & Overton",
+            "stopCode": "8981",
+            "stopId": "prt:8981",
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "generalizedCost": 405,
+          "interlineWithPreviousLeg": false,
+          "legGeometry": {
+            "length": 13,
+            "points": "}~{tGnq{kV?LVAF?J?L?rBCLA?Q?EAyAEcH?G"
+          },
+          "mode": "WALK",
+          "pathway": false,
+          "realTime": false,
+          "rentedBike": false,
+          "route": "",
+          "startTime": "2009-11-17T18:35:54.000+00:00",
+          "steps": [
+            {
+              "absoluteDirection": "SOUTH",
+              "area": false,
+              "bogusName": false,
+              "distance": 104.46,
+              "elevation": "",
+              "lat": 45.5321578,
+              "lon": -122.6987026,
+              "relativeDirection": "DEPART",
+              "stayOn": false,
+              "streetName": "Northwest 23rd Avenue",
+              "walkingBike": false
+            },
+            {
+              "absoluteDirection": "EAST",
+              "area": false,
+              "bogusName": false,
+              "distance": 161.77,
+              "elevation": "",
+              "lat": 45.5312188,
+              "lon": -122.6986675,
+              "relativeDirection": "LEFT",
+              "stayOn": false,
+              "streetName": "Northwest Northrup Street",
+              "walkingBike": false
+            }
+          ],
+          "to": {
+            "arrival": "2009-11-17T18:39:22.000+00:00",
+            "lat": 45.53122,
+            "lon": -122.69659,
+            "name": "NW Northrup St. & NW 22nd Ave. (P2)",
+            "vertexType": "NORMAL"
+          },
+          "transitLeg": false,
+          "walkingBike": false
+        }
+      ],
+      "startTime": "2009-11-17T18:14:52.000+00:00",
+      "tooSloped": false,
+      "transfers": 0,
+      "transitTime": 1214,
+      "waitingTime": 0,
+      "walkDistance": 328.22,
+      "walkLimitExceeded": false,
+      "walkTime": 256
+    },
+    {
+      "arrivedAtDestinationWithRentedBicycle": false,
+      "duration": 2275,
+      "elevationGained": 0.0,
+      "elevationLost": 0.0,
+      "endTime": "2009-11-17T18:53:55.000+00:00",
+      "fare": {
+        "details": {
+          "regular": [
+            {
+              "fareId": {
+                "feedId": "prt",
+                "id": "8"
+              },
+              "price": {
+                "cents": 200,
+                "currency": {
+                  "value": "USD"
+                }
+              },
+              "routes": [
+                {
+                  "feedId": "prt",
+                  "id": "20"
+                }
+              ]
+            }
+          ]
+        },
+        "fare": {
+          "regular": {
+            "cents": 200,
+            "currency": {
+              "value": "USD"
+            }
+          }
+        }
+      },
+      "generalizedCost": 4295,
+      "legs": [
+        {
+          "agencyTimeZoneOffset": -28800000,
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 920.33,
+          "endTime": "2009-11-17T18:27:58.000+00:00",
+          "from": {
+            "departure": "2009-11-17T18:16:00.000+00:00",
+            "lat": 45.51726,
+            "lon": -122.64847,
+            "name": "SE Morrison St. & SE 17th Ave. (P1)",
+            "vertexType": "NORMAL"
+          },
+          "generalizedCost": 1398,
+          "interlineWithPreviousLeg": false,
+          "legGeometry": {
+            "length": 45,
+            "points": "kaytG~wqkV?T?fCAl@?RmC?oCAmCAoC?_CAM?aC??A?A?A?A??AA?AAA??AAA???A?A?A???A@A??@A@?@??A@?@?BcC?mCAmCAmC?QBIYIWOH"
+          },
+          "mode": "WALK",
+          "pathway": false,
+          "realTime": false,
+          "rentedBike": false,
+          "route": "",
+          "startTime": "2009-11-17T18:16:00.000+00:00",
+          "steps": [
+            {
+              "absoluteDirection": "WEST",
+              "area": false,
+              "bogusName": false,
+              "distance": 87.68,
+              "elevation": "",
+              "lat": 45.517186,
+              "lon": -122.6484704,
+              "relativeDirection": "DEPART",
+              "stayOn": false,
+              "streetName": "Southeast Morrison Street",
+              "walkingBike": false
+            },
+            {
+              "absoluteDirection": "NORTH",
+              "area": false,
+              "bogusName": false,
+              "distance": 641.04,
+              "elevation": "",
+              "lat": 45.5171903,
+              "lon": -122.6495956,
+              "relativeDirection": "RIGHT",
+              "stayOn": false,
+              "streetName": "Southeast 16th Avenue",
+              "walkingBike": false
+            },
+            {
+              "absoluteDirection": "NORTH",
+              "area": false,
+              "bogusName": false,
+              "distance": 168.89,
+              "elevation": "",
+              "lat": 45.5228912,
+              "lon": -122.6495528,
+              "relativeDirection": "CONTINUE",
+              "stayOn": false,
+              "streetName": "Northeast 16th Avenue",
+              "walkingBike": false
+            },
+            {
+              "absoluteDirection": "NORTHEAST",
+              "area": false,
+              "bogusName": false,
+              "distance": 22.74,
+              "elevation": "",
+              "lat": 45.524409,
+              "lon": -122.6495675,
+              "relativeDirection": "RIGHT",
+              "stayOn": false,
+              "streetName": "Northeast Sandy Boulevard",
+              "walkingBike": false
+            }
+          ],
+          "to": {
+            "arrival": "2009-11-17T18:27:58.000+00:00",
+            "departure": "2009-11-17T18:27:58.000+00:00",
+            "lat": 45.524581,
+            "lon": -122.649367,
+            "name": "NE Sandy & 16th",
+            "stopCode": "5060",
+            "stopId": "prt:5060",
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "transitLeg": false,
+          "walkingBike": false
+        },
+        {
+          "agencyId": "prt:prt",
+          "agencyName": "TriMet",
+          "agencyTimeZoneOffset": -28800000,
+          "agencyUrl": "http://trimet.org",
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 3602.73,
+          "endTime": "2009-11-17T18:41:03.000+00:00",
+          "from": {
+            "arrival": "2009-11-17T18:27:58.000+00:00",
+            "departure": "2009-11-17T18:27:58.000+00:00",
+            "lat": 45.524581,
+            "lon": -122.649367,
+            "name": "NE Sandy & 16th",
+            "stopCode": "5060",
+            "stopId": "prt:5060",
+            "stopIndex": 92,
+            "stopSequence": 93,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "generalizedCost": 1385,
+          "headsign": "23rd Ave to Tichner",
+          "interlineWithPreviousLeg": false,
+          "intermediateStops": [
+            {
+              "arrival": "2009-11-17T18:28:32.000+00:00",
+              "departure": "2009-11-17T18:28:32.000+00:00",
+              "lat": 45.523767,
+              "lon": -122.651428,
+              "name": "NE Sandy & 14th",
+              "stopCode": "5058",
+              "stopId": "prt:5058",
+              "stopIndex": 93,
+              "stopSequence": 94,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:29:00.000+00:00",
+              "departure": "2009-11-17T18:29:00.000+00:00",
+              "lat": 45.523103,
+              "lon": -122.653064,
+              "name": "NE Sandy & 12th",
+              "stopCode": "5055",
+              "stopId": "prt:5055",
+              "stopIndex": 94,
+              "stopSequence": 95,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:29:47.000+00:00",
+              "departure": "2009-11-17T18:29:47.000+00:00",
+              "lat": 45.523024,
+              "lon": -122.656526,
+              "name": "E Burnside & NE 9th",
+              "stopCode": "819",
+              "stopId": "prt:819",
+              "stopIndex": 95,
+              "stopSequence": 96,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:30:24.000+00:00",
+              "departure": "2009-11-17T18:30:24.000+00:00",
+              "lat": 45.523012,
+              "lon": -122.659365,
+              "name": "E Burnside & NE 6th",
+              "stopCode": "805",
+              "stopId": "prt:805",
+              "stopIndex": 96,
+              "stopSequence": 97,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:30:52.000+00:00",
+              "departure": "2009-11-17T18:30:52.000+00:00",
+              "lat": 45.523015,
+              "lon": -122.661534,
+              "name": "E Burnside & NE M L King",
+              "stopCode": "705",
+              "stopId": "prt:705",
+              "stopIndex": 97,
+              "stopSequence": 98,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:33:00.000+00:00",
+              "departure": "2009-11-17T18:33:00.000+00:00",
+              "lat": 45.523249,
+              "lon": -122.671269,
+              "name": "W Burnside & Burnside Bridge",
+              "stopCode": "689",
+              "stopId": "prt:689",
+              "stopIndex": 98,
+              "stopSequence": 99,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
+            },
+            {
+              "arrival": "2009-11-17T18:34:00.000+00:00",
+              "departure": "2009-11-17T18:34:00.000+00:00",
+              "lat": 45.523169,
+              "lon": -122.675893,
+              "name": "W Burnside & NW 5th",
+              "stopCode": "782",
+              "stopId": "prt:782",
+              "stopIndex": 99,
+              "stopSequence": 100,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
+            },
+            {
+              "arrival": "2009-11-17T18:35:17.000+00:00",
+              "departure": "2009-11-17T18:35:17.000+00:00",
+              "lat": 45.523115,
+              "lon": -122.678939,
+              "name": "W Burnside & NW Park",
+              "stopCode": "716",
+              "stopId": "prt:716",
+              "stopIndex": 100,
+              "stopSequence": 101,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
+            },
+            {
+              "arrival": "2009-11-17T18:36:25.000+00:00",
+              "departure": "2009-11-17T18:36:25.000+00:00",
+              "lat": 45.523048,
+              "lon": -122.681606,
+              "name": "W Burnside & NW 10th",
+              "stopCode": "10791",
+              "stopId": "prt:10791",
+              "stopIndex": 101,
+              "stopSequence": 102,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
+            },
+            {
+              "arrival": "2009-11-17T18:37:14.000+00:00",
+              "departure": "2009-11-17T18:37:14.000+00:00",
+              "lat": 45.523,
+              "lon": -122.683535,
+              "name": "W Burnside & NW 12th",
+              "stopCode": "11032",
+              "stopId": "prt:11032",
+              "stopIndex": 102,
+              "stopSequence": 103,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
+            },
+            {
+              "arrival": "2009-11-17T18:39:09.000+00:00",
+              "departure": "2009-11-17T18:39:09.000+00:00",
+              "lat": 45.522985,
+              "lon": -122.688091,
+              "name": "W Burnside & NW 17th",
+              "stopCode": "10809",
+              "stopId": "prt:10809",
+              "stopIndex": 103,
+              "stopSequence": 104,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:40:00.000+00:00",
+              "departure": "2009-11-17T18:40:00.000+00:00",
+              "lat": 45.523097,
+              "lon": -122.690083,
+              "name": "W Burnside & NW 19th",
+              "stopCode": "735",
+              "stopId": "prt:735",
+              "stopIndex": 104,
+              "stopSequence": 105,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:40:27.000+00:00",
+              "departure": "2009-11-17T18:40:27.000+00:00",
+              "lat": 45.523176,
+              "lon": -122.692139,
+              "name": "W Burnside & NW 20th",
+              "stopCode": "741",
+              "stopId": "prt:741",
+              "stopIndex": 105,
+              "stopSequence": 106,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:40:40.000+00:00",
+              "departure": "2009-11-17T18:40:40.000+00:00",
+              "lat": 45.52322,
+              "lon": -122.69313,
+              "name": "W Burnside & NW 20th Pl",
+              "stopCode": "742",
+              "stopId": "prt:742",
+              "stopIndex": 106,
+              "stopSequence": 107,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            }
+          ],
+          "legGeometry": {
+            "length": 94,
+            "points": "coztGd}qkVNl@r@`CZhA`A`D??Ph@l@tBb@rARh@Pd@???BPj@@jA?jEAhE?pD???VAjE?hE?dB?b@???`AAhE?dD???l@C`EAhEEhE?bAA|@?XAZ@\\AzACnGKbKAjC?bE???JEnE@fEDlE@hE@~A??@rBBzDBpE@~A???Z@tD@RBnEB|A???@BdB?lEBjA??BnBApF@dB?X?^@r@?f@@bCAx@EtB???VChAE|BGnD??AXKnEGnD???XGjD??AZEfCC`AEzB"
+          },
+          "mode": "BUS",
+          "pathway": false,
+          "realTime": false,
+          "route": "Burnside/Stark",
+          "routeId": "prt:20",
+          "routeLongName": "Burnside/Stark",
+          "routeShortName": "20",
+          "routeType": 3,
+          "serviceDate": "2009-11-17",
+          "startTime": "2009-11-17T18:27:58.000+00:00",
+          "steps": [ ],
+          "to": {
+            "arrival": "2009-11-17T18:41:03.000+00:00",
+            "departure": "2009-11-17T18:41:03.000+00:00",
+            "lat": 45.523312,
+            "lon": -122.694901,
+            "name": "W Burnside & NW King",
+            "stopCode": "747",
+            "stopId": "prt:747",
+            "stopIndex": 107,
+            "stopSequence": 108,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "transitLeg": true,
+          "tripBlockId": "2071",
+          "tripId": "prt:200W1210"
+        },
+        {
+          "agencyTimeZoneOffset": -28800000,
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 999.1,
+          "endTime": "2009-11-17T18:53:55.000+00:00",
+          "from": {
+            "arrival": "2009-11-17T18:41:03.000+00:00",
+            "departure": "2009-11-17T18:41:03.000+00:00",
+            "lat": 45.523312,
+            "lon": -122.694901,
+            "name": "W Burnside & NW King",
+            "stopCode": "747",
+            "stopId": "prt:747",
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "generalizedCost": 1511,
+          "interlineWithPreviousLeg": false,
+          "legGeometry": {
+            "length": 29,
+            "points": "ugztGdzzkVL?ATClAI|DK?G?mCBkCDoCDmCBoCDkCBoCB[?sBD]?Y@eA@K?C?K?W@{A@M@C@I?_CB?G"
+          },
+          "mode": "WALK",
+          "pathway": false,
+          "realTime": false,
+          "rentedBike": false,
+          "route": "",
+          "startTime": "2009-11-17T18:41:03.000+00:00",
+          "steps": [
+            {
+              "absoluteDirection": "WEST",
+              "area": false,
+              "bogusName": false,
+              "distance": 113.27,
+              "elevation": "",
+              "lat": 45.5232491,
+              "lon": -122.6949067,
+              "relativeDirection": "DEPART",
+              "stayOn": false,
+              "streetName": "West Burnside Street",
+              "walkingBike": false
+            },
+            {
+              "absoluteDirection": "NORTH",
+              "area": false,
+              "bogusName": false,
+              "distance": 882.16,
+              "elevation": "",
+              "lat": 45.5233204,
+              "lon": -122.696357,
+              "relativeDirection": "RIGHT",
+              "stayOn": false,
+              "streetName": "Northwest 22nd Avenue",
+              "walkingBike": false
+            },
+            {
+              "absoluteDirection": "EAST",
+              "area": false,
+              "bogusName": false,
+              "distance": 3.68,
+              "elevation": "",
+              "lat": 45.5312508,
+              "lon": -122.6966386,
+              "relativeDirection": "RIGHT",
+              "stayOn": false,
+              "streetName": "Northwest Northrup Street",
+              "walkingBike": false
+            }
+          ],
+          "to": {
+            "arrival": "2009-11-17T18:53:55.000+00:00",
+            "lat": 45.53122,
+            "lon": -122.69659,
+            "name": "NW Northrup St. & NW 22nd Ave. (P2)",
+            "vertexType": "NORMAL"
+          },
+          "transitLeg": false,
+          "walkingBike": false
+        }
+      ],
+      "startTime": "2009-11-17T18:16:00.000+00:00",
+      "tooSloped": false,
+      "transfers": 0,
+      "transitTime": 785,
+      "waitingTime": 0,
+      "walkDistance": 1919.43,
+      "walkLimitExceeded": false,
+      "walkTime": 1490
+    },
+    {
+      "arrivedAtDestinationWithRentedBicycle": false,
+      "duration": 1540,
+      "elevationGained": 0.0,
+      "elevationLost": 0.0,
+      "endTime": "2009-11-17T18:55:32.000+00:00",
+      "fare": {
+        "details": {
+          "regular": [
+            {
+              "fareId": {
+                "feedId": "prt",
+                "id": "8"
+              },
+              "price": {
+                "cents": 200,
+                "currency": {
+                  "value": "USD"
+                }
+              },
+              "routes": [
+                {
+                  "feedId": "prt",
+                  "id": "15"
+                }
+              ]
+            }
+          ]
+        },
+        "fare": {
+          "regular": {
+            "cents": 200,
+            "currency": {
+              "value": "USD"
+            }
+          }
+        }
+      },
+      "generalizedCost": 2385,
+      "legs": [
+        {
+          "agencyTimeZoneOffset": -28800000,
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 62.01,
+          "endTime": "2009-11-17T18:30:40.000+00:00",
+          "from": {
+            "departure": "2009-11-17T18:29:52.000+00:00",
+            "lat": 45.51726,
+            "lon": -122.64847,
+            "name": "SE Morrison St. & SE 17th Ave. (P1)",
+            "vertexType": "NORMAL"
+          },
+          "generalizedCost": 95,
+          "interlineWithPreviousLeg": false,
+          "legGeometry": {
+            "length": 4,
+            "points": "kaytG~wqkV?T?fCG?"
+          },
+          "mode": "WALK",
+          "pathway": false,
+          "realTime": false,
+          "rentedBike": false,
+          "route": "",
+          "startTime": "2009-11-17T18:29:52.000+00:00",
+          "steps": [
+            {
+              "absoluteDirection": "WEST",
+              "area": false,
+              "bogusName": false,
+              "distance": 62.02,
+              "elevation": "",
+              "lat": 45.517186,
+              "lon": -122.6484704,
+              "relativeDirection": "DEPART",
+              "stayOn": false,
+              "streetName": "Southeast Morrison Street",
+              "walkingBike": false
+            }
+          ],
+          "to": {
+            "arrival": "2009-11-17T18:30:40.000+00:00",
+            "departure": "2009-11-17T18:30:40.000+00:00",
+            "lat": 45.517226,
+            "lon": -122.649266,
+            "name": "SE Morrison & 16th",
+            "stopCode": "4019",
+            "stopId": "prt:4019",
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "transitLeg": false,
+          "walkingBike": false
+        },
+        {
+          "agencyId": "prt:prt",
+          "agencyName": "TriMet",
+          "agencyTimeZoneOffset": -28800000,
+          "agencyUrl": "http://trimet.org",
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 5218.86,
+          "endTime": "2009-11-17T18:52:04.000+00:00",
+          "from": {
+            "arrival": "2009-11-17T18:30:40.000+00:00",
+            "departure": "2009-11-17T18:30:40.000+00:00",
+            "lat": 45.517226,
+            "lon": -122.649266,
+            "name": "SE Morrison & 16th",
+            "stopCode": "4019",
+            "stopId": "prt:4019",
+            "stopIndex": 50,
+            "stopSequence": 51,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "generalizedCost": 1884,
+          "headsign": "NW 27th & Thurman",
+          "interlineWithPreviousLeg": false,
+          "intermediateStops": [
+            {
+              "arrival": "2009-11-17T18:31:15.000+00:00",
+              "departure": "2009-11-17T18:31:15.000+00:00",
+              "lat": 45.517253,
+              "lon": -122.651354,
+              "name": "SE Morrison & 14th",
+              "stopCode": "4016",
+              "stopId": "prt:4016",
+              "stopIndex": 51,
+              "stopSequence": 52,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:32:00.000+00:00",
+              "departure": "2009-11-17T18:32:00.000+00:00",
+              "lat": 45.517299,
+              "lon": -122.654067,
+              "name": "SE Morrison & 12th",
+              "stopCode": "4014",
+              "stopId": "prt:4014",
+              "stopIndex": 52,
+              "stopSequence": 53,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:32:38.000+00:00",
+              "departure": "2009-11-17T18:32:38.000+00:00",
+              "lat": 45.517292,
+              "lon": -122.656563,
+              "name": "SE Morrison & 9th",
+              "stopCode": "4026",
+              "stopId": "prt:4026",
+              "stopIndex": 53,
+              "stopSequence": 54,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:33:08.000+00:00",
+              "departure": "2009-11-17T18:33:08.000+00:00",
+              "lat": 45.517322,
+              "lon": -122.65847,
+              "name": "SE Morrison & 7th",
+              "stopCode": "4025",
+              "stopId": "prt:4025",
+              "stopIndex": 54,
+              "stopSequence": 55,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:33:39.000+00:00",
+              "departure": "2009-11-17T18:33:39.000+00:00",
+              "lat": 45.517298,
+              "lon": -122.660523,
+              "name": "SE Morrison & Grand",
+              "stopCode": "4013",
+              "stopId": "prt:4013",
+              "stopIndex": 55,
+              "stopSequence": 56,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:35:03.000+00:00",
+              "departure": "2009-11-17T18:35:03.000+00:00",
+              "lat": 45.517351,
+              "lon": -122.66601,
+              "name": "Morrison Bridge",
+              "stopCode": "4029",
+              "stopId": "prt:4029",
+              "stopIndex": 56,
+              "stopSequence": 57,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:37:27.000+00:00",
+              "departure": "2009-11-17T18:37:27.000+00:00",
+              "lat": 45.51959,
+              "lon": -122.674599,
+              "name": "SW Washington & 3rd",
+              "stopCode": "6158",
+              "stopId": "prt:6158",
+              "stopIndex": 57,
+              "stopSequence": 58,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
+            },
+            {
+              "arrival": "2009-11-17T18:38:00.000+00:00",
+              "departure": "2009-11-17T18:38:00.000+00:00",
+              "lat": 45.520129,
+              "lon": -122.676635,
+              "name": "SW Washington & 5th",
+              "stopCode": "6160",
+              "stopId": "prt:6160",
+              "stopIndex": 58,
+              "stopSequence": 59,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
+            },
+            {
+              "arrival": "2009-11-17T18:38:52.000+00:00",
+              "departure": "2009-11-17T18:38:52.000+00:00",
+              "lat": 45.520695,
+              "lon": -122.678657,
+              "name": "SW Washington & Broadway",
+              "stopCode": "6137",
+              "stopId": "prt:6137",
+              "stopIndex": 59,
+              "stopSequence": 60,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
+            },
+            {
+              "arrival": "2009-11-17T18:39:34.000+00:00",
+              "departure": "2009-11-17T18:39:34.000+00:00",
+              "lat": 45.521124,
+              "lon": -122.6803,
+              "name": "SW Washington & 9th",
+              "stopCode": "6169",
+              "stopId": "prt:6169",
+              "stopIndex": 60,
+              "stopSequence": 61,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
+            },
+            {
+              "arrival": "2009-11-17T18:40:47.000+00:00",
+              "departure": "2009-11-17T18:40:47.000+00:00",
+              "lat": 45.521094,
+              "lon": -122.682819,
+              "name": "SW 11th & Alder",
+              "stopCode": "9600",
+              "stopId": "prt:9600",
+              "stopIndex": 61,
+              "stopSequence": 62,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
+            },
+            {
+              "arrival": "2009-11-17T18:41:36.000+00:00",
+              "departure": "2009-11-17T18:41:36.000+00:00",
+              "lat": 45.52055,
+              "lon": -122.683933,
+              "name": "SW Morrison & 12th",
+              "stopCode": "9598",
+              "stopId": "prt:9598",
+              "stopIndex": 62,
+              "stopSequence": 63,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
+            },
+            {
+              "arrival": "2009-11-17T18:42:25.000+00:00",
+              "departure": "2009-11-17T18:42:25.000+00:00",
+              "lat": 45.521063,
+              "lon": -122.685848,
+              "name": "SW Morrison & 14th",
+              "stopCode": "9708",
+              "stopId": "prt:9708",
+              "stopIndex": 63,
+              "stopSequence": 64,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:43:18.000+00:00",
+              "departure": "2009-11-17T18:43:18.000+00:00",
+              "lat": 45.521641,
+              "lon": -122.687932,
+              "name": "SW Morrison & 16th",
+              "stopCode": "9613",
+              "stopId": "prt:9613",
+              "stopIndex": 64,
+              "stopSequence": 65,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:44:00.000+00:00",
+              "departure": "2009-11-17T18:44:00.000+00:00",
+              "lat": 45.52206,
+              "lon": -122.689577,
+              "name": "SW Morrison & 17th",
+              "stopCode": "9599",
+              "stopId": "prt:9599",
+              "stopIndex": 65,
+              "stopSequence": 66,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:45:03.000+00:00",
+              "departure": "2009-11-17T18:45:03.000+00:00",
+              "lat": 45.523097,
+              "lon": -122.690083,
+              "name": "W Burnside & NW 19th",
+              "stopCode": "735",
+              "stopId": "prt:735",
+              "stopIndex": 66,
+              "stopSequence": 67,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:45:46.000+00:00",
+              "departure": "2009-11-17T18:45:46.000+00:00",
+              "lat": 45.523176,
+              "lon": -122.692139,
+              "name": "W Burnside & NW 20th",
+              "stopCode": "741",
+              "stopId": "prt:741",
+              "stopIndex": 67,
+              "stopSequence": 68,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:46:07.000+00:00",
+              "departure": "2009-11-17T18:46:07.000+00:00",
+              "lat": 45.52322,
+              "lon": -122.69313,
+              "name": "W Burnside & NW 20th Pl",
+              "stopCode": "742",
+              "stopId": "prt:742",
+              "stopIndex": 68,
+              "stopSequence": 69,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:46:44.000+00:00",
+              "departure": "2009-11-17T18:46:44.000+00:00",
+              "lat": 45.523312,
+              "lon": -122.694901,
+              "name": "W Burnside & NW King",
+              "stopCode": "747",
+              "stopId": "prt:747",
+              "stopIndex": 69,
+              "stopSequence": 70,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:47:51.000+00:00",
+              "departure": "2009-11-17T18:47:51.000+00:00",
+              "lat": 45.523512,
+              "lon": -122.698081,
+              "name": "W Burnside & NW 23rd",
+              "stopCode": "755",
+              "stopId": "prt:755",
+              "stopIndex": 70,
+              "stopSequence": 71,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:48:53.000+00:00",
+              "departure": "2009-11-17T18:48:53.000+00:00",
+              "lat": 45.525416,
+              "lon": -122.698381,
+              "name": "NW 23rd & Flanders",
+              "stopCode": "7157",
+              "stopId": "prt:7157",
+              "stopIndex": 71,
+              "stopSequence": 72,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:49:56.000+00:00",
+              "departure": "2009-11-17T18:49:56.000+00:00",
+              "lat": 45.527543,
+              "lon": -122.698473,
+              "name": "NW 23rd & Irving",
+              "stopCode": "7161",
+              "stopId": "prt:7161",
+              "stopIndex": 72,
+              "stopSequence": 73,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:51:00.000+00:00",
+              "departure": "2009-11-17T18:51:00.000+00:00",
+              "lat": 45.529681,
+              "lon": -122.698529,
+              "name": "NW 23rd & Lovejoy",
+              "stopCode": "7163",
+              "stopId": "prt:7163",
+              "stopIndex": 73,
+              "stopSequence": 74,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            }
+          ],
+          "legGeometry": {
+            "length": 135,
+            "points": "kaytG||qkVA~@?jE?tC???r@AhE?jE?rA???tBAjE?nD???X?hE?xC??Ah@?pE?~C???J?`@?vAAvBEbE?jEAlE?`BAbB@d@??@tAAj@Cx@Cb@Cp@_@dEcAtFoA`IS~@i@`BmAzDi@zAc@pAi@~C??Id@u@jEm@bD??If@u@jEk@bD??If@u@|DW`B??CPs@|Du@lElBz@??VJbCfAk@dD??Id@w@rEWvAId@AF??Q~@s@`Ei@~C??Ib@u@dEWzA??]jB]MQSe@WOKOKIIQe@GWE]GnD??AXKnEGnD???XGjD??AZEfCC`AEzB??AXCfAGxDE|AEtBIlC??APkAh@o@?sCB{BD??S?mCDmCDyBB??U?mCDmCDyBB??S?oCDmCDmCBo@@"
+          },
+          "mode": "BUS",
+          "pathway": false,
+          "realTime": false,
+          "route": "Belmont/NW 23rd",
+          "routeId": "prt:15",
+          "routeLongName": "Belmont/NW 23rd",
+          "routeShortName": "15",
+          "routeType": 3,
+          "serviceDate": "2009-11-17",
+          "startTime": "2009-11-17T18:30:40.000+00:00",
+          "steps": [ ],
+          "to": {
+            "arrival": "2009-11-17T18:52:04.000+00:00",
+            "departure": "2009-11-17T18:52:04.000+00:00",
+            "lat": 45.532159,
+            "lon": -122.698634,
+            "name": "NW 23rd & Overton",
+            "stopCode": "8981",
+            "stopId": "prt:8981",
+            "stopIndex": 74,
+            "stopSequence": 75,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "transitLeg": true,
+          "tripBlockId": "1541",
+          "tripId": "prt:150W1410"
+        },
+        {
+          "agencyTimeZoneOffset": -28800000,
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 266.21,
+          "endTime": "2009-11-17T18:55:32.000+00:00",
+          "from": {
+            "arrival": "2009-11-17T18:52:04.000+00:00",
+            "departure": "2009-11-17T18:52:04.000+00:00",
+            "lat": 45.532159,
+            "lon": -122.698634,
+            "name": "NW 23rd & Overton",
+            "stopCode": "8981",
+            "stopId": "prt:8981",
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "generalizedCost": 405,
+          "interlineWithPreviousLeg": false,
+          "legGeometry": {
+            "length": 13,
+            "points": "}~{tGnq{kV?LVAF?J?L?rBCLA?Q?EAyAEcH?G"
+          },
+          "mode": "WALK",
+          "pathway": false,
+          "realTime": false,
+          "rentedBike": false,
+          "route": "",
+          "startTime": "2009-11-17T18:52:04.000+00:00",
+          "steps": [
+            {
+              "absoluteDirection": "SOUTH",
+              "area": false,
+              "bogusName": false,
+              "distance": 104.46,
+              "elevation": "",
+              "lat": 45.5321578,
+              "lon": -122.6987026,
+              "relativeDirection": "DEPART",
+              "stayOn": false,
+              "streetName": "Northwest 23rd Avenue",
+              "walkingBike": false
+            },
+            {
+              "absoluteDirection": "EAST",
+              "area": false,
+              "bogusName": false,
+              "distance": 161.77,
+              "elevation": "",
+              "lat": 45.5312188,
+              "lon": -122.6986675,
+              "relativeDirection": "LEFT",
+              "stayOn": false,
+              "streetName": "Northwest Northrup Street",
+              "walkingBike": false
+            }
+          ],
+          "to": {
+            "arrival": "2009-11-17T18:55:32.000+00:00",
+            "lat": 45.53122,
+            "lon": -122.69659,
+            "name": "NW Northrup St. & NW 22nd Ave. (P2)",
+            "vertexType": "NORMAL"
+          },
+          "transitLeg": false,
+          "walkingBike": false
+        }
+      ],
+      "startTime": "2009-11-17T18:29:52.000+00:00",
+      "tooSloped": false,
+      "transfers": 0,
+      "transitTime": 1284,
+      "waitingTime": 0,
+      "walkDistance": 328.22,
+      "walkLimitExceeded": false,
+      "walkTime": 256
+    },
+    {
+      "arrivedAtDestinationWithRentedBicycle": false,
+      "duration": 1849,
+      "elevationGained": 0.0,
+      "elevationLost": 0.0,
+      "endTime": "2009-11-17T19:08:19.000+00:00",
+      "fare": {
+        "details": {
+          "regular": [
+            {
+              "fareId": {
+                "feedId": "prt",
+                "id": "8"
+              },
+              "price": {
+                "cents": 200,
+                "currency": {
+                  "value": "USD"
+                }
+              },
+              "routes": [
+                {
+                  "feedId": "prt",
+                  "id": "70"
+                },
+                {
+                  "feedId": "prt",
+                  "id": "77"
+                }
+              ]
+            }
+          ]
+        },
+        "fare": {
+          "regular": {
+            "cents": 200,
+            "currency": {
+              "value": "USD"
+            }
+          }
+        }
+      },
+      "generalizedCost": 3375,
+      "legs": [
+        {
+          "agencyTimeZoneOffset": -28800000,
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 419.62,
+          "endTime": "2009-11-17T18:42:54.000+00:00",
+          "from": {
+            "departure": "2009-11-17T18:37:30.000+00:00",
+            "lat": 45.51726,
+            "lon": -122.64847,
+            "name": "SE Morrison St. & SE 17th Ave. (P1)",
+            "vertexType": "NORMAL"
+          },
+          "generalizedCost": 636,
+          "interlineWithPreviousLeg": false,
+          "legGeometry": {
+            "length": 14,
+            "points": "kaytG~wqkV?T?fCAl@?R?jE?rC?t@?hEAvD?RN?L??O"
+          },
+          "mode": "WALK",
+          "pathway": false,
+          "realTime": false,
+          "rentedBike": false,
+          "route": "",
+          "startTime": "2009-11-17T18:37:30.000+00:00",
+          "steps": [
+            {
+              "absoluteDirection": "WEST",
+              "area": false,
+              "bogusName": false,
+              "distance": 403.66,
+              "elevation": "",
+              "lat": 45.517186,
+              "lon": -122.6484704,
+              "relativeDirection": "DEPART",
+              "stayOn": false,
+              "streetName": "Southeast Morrison Street",
+              "walkingBike": false
+            },
+            {
+              "absoluteDirection": "SOUTH",
+              "area": false,
+              "bogusName": false,
+              "distance": 15.96,
+              "elevation": "",
+              "lat": 45.5172031,
+              "lon": -122.6536511,
+              "relativeDirection": "LEFT",
+              "stayOn": false,
+              "streetName": "Southeast 12th Avenue",
+              "walkingBike": false
+            }
+          ],
+          "to": {
+            "arrival": "2009-11-17T18:42:54.000+00:00",
+            "departure": "2009-11-17T18:42:54.000+00:00",
+            "lat": 45.517059,
+            "lon": -122.65358,
+            "name": "SE 12th & Morrison",
+            "stopCode": "6588",
+            "stopId": "prt:6588",
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "transitLeg": false,
+          "walkingBike": false
+        },
+        {
+          "agencyId": "prt:prt",
+          "agencyName": "TriMet",
+          "agencyTimeZoneOffset": -28800000,
+          "agencyUrl": "http://trimet.org",
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 2035.62,
+          "endTime": "2009-11-17T18:51:01.000+00:00",
+          "from": {
+            "arrival": "2009-11-17T18:42:54.000+00:00",
+            "departure": "2009-11-17T18:42:54.000+00:00",
+            "lat": 45.517059,
+            "lon": -122.65358,
+            "name": "SE 12th & Morrison",
+            "stopCode": "6588",
+            "stopId": "prt:6588",
+            "stopIndex": 31,
+            "stopSequence": 32,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "generalizedCost": 1087,
+          "headsign": "Rose Qtr TC",
+          "interlineWithPreviousLeg": false,
+          "intermediateStops": [
+            {
+              "arrival": "2009-11-17T18:44:00.000+00:00",
+              "departure": "2009-11-17T18:44:00.000+00:00",
+              "lat": 45.519229,
+              "lon": -122.653546,
+              "name": "SE 12th & Stark",
+              "stopCode": "6594",
+              "stopId": "prt:6594",
+              "stopIndex": 32,
+              "stopSequence": 33,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:44:44.000+00:00",
+              "departure": "2009-11-17T18:44:44.000+00:00",
+              "lat": 45.520674,
+              "lon": -122.653544,
+              "name": "SE 12th & Pine",
+              "stopCode": "6589",
+              "stopId": "prt:6589",
+              "stopIndex": 33,
+              "stopSequence": 34,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:46:00.000+00:00",
+              "departure": "2009-11-17T18:46:00.000+00:00",
+              "lat": 45.52318,
+              "lon": -122.653507,
+              "name": "NE 12th & Sandy",
+              "stopCode": "6592",
+              "stopId": "prt:6592",
+              "stopIndex": 34,
+              "stopSequence": 35,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:47:45.000+00:00",
+              "departure": "2009-11-17T18:47:45.000+00:00",
+              "lat": 45.527449,
+              "lon": -122.653462,
+              "name": "NE 12th & Irving",
+              "stopCode": "6582",
+              "stopId": "prt:6582",
+              "stopIndex": 35,
+              "stopSequence": 36,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T18:49:00.000+00:00",
+              "departure": "2009-11-17T18:49:00.000+00:00",
+              "lat": 45.529793,
+              "lon": -122.654429,
+              "name": "NE 11th & Holladay",
+              "stopCode": "8513",
+              "stopId": "prt:8513",
+              "stopIndex": 36,
+              "stopSequence": 37,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
+            },
+            {
+              "arrival": "2009-11-17T18:49:39.000+00:00",
+              "departure": "2009-11-17T18:49:39.000+00:00",
+              "lat": 45.53135,
+              "lon": -122.654497,
+              "name": "NE 11th & Multnomah",
+              "stopCode": "8938",
+              "stopId": "prt:8938",
+              "stopIndex": 37,
+              "stopSequence": 38,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
+            },
+            {
+              "arrival": "2009-11-17T18:50:15.000+00:00",
+              "departure": "2009-11-17T18:50:15.000+00:00",
+              "lat": 45.531573,
+              "lon": -122.656408,
+              "name": "NE Multnomah & 9th",
+              "stopCode": "4056",
+              "stopId": "prt:4056",
+              "stopIndex": 38,
+              "stopSequence": 39,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
+            }
+          ],
+          "legGeometry": {
+            "length": 49,
+            "points": "s`ytGhxrkV[?mCAmC?wBA??W?mC?{BA??Q?oC?mC?kBAa@?w@???wA?mCAmC?oCA}C?sDC??aBAm@@k@AY?uABU@I@IBQFb@fC}@d@OFO@q@???Q?]?gGA??[??nJ???b@?vK?rA"
+          },
+          "mode": "BUS",
+          "pathway": false,
+          "realTime": false,
+          "route": "12th Ave",
+          "routeId": "prt:70",
+          "routeLongName": "12th Ave",
+          "routeShortName": "70",
+          "routeType": 3,
+          "serviceDate": "2009-11-17",
+          "startTime": "2009-11-17T18:42:54.000+00:00",
+          "steps": [ ],
+          "to": {
+            "arrival": "2009-11-17T18:51:01.000+00:00",
+            "departure": "2009-11-17T18:54:29.000+00:00",
+            "lat": 45.531569,
+            "lon": -122.659045,
+            "name": "NE Multnomah & 7th",
+            "stopCode": "4054",
+            "stopId": "prt:4054",
+            "stopIndex": 39,
+            "stopSequence": 40,
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
+          },
+          "transitLeg": true,
+          "tripBlockId": "7002",
+          "tripId": "prt:700W1170"
+        },
+        {
+          "agencyId": "prt:prt",
+          "agencyName": "TriMet",
+          "agencyTimeZoneOffset": -28800000,
+          "agencyUrl": "http://trimet.org",
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 3560.24,
+          "endTime": "2009-11-17T19:07:55.000+00:00",
+          "from": {
+            "arrival": "2009-11-17T18:51:01.000+00:00",
+            "departure": "2009-11-17T18:54:29.000+00:00",
+            "lat": 45.531569,
+            "lon": -122.659045,
+            "name": "NE Multnomah & 7th",
+            "stopCode": "4054",
+            "stopId": "prt:4054",
+            "stopIndex": 81,
+            "stopSequence": 82,
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
+          },
+          "generalizedCost": 1614,
+          "headsign": "Montgomery Park",
+          "interlineWithPreviousLeg": false,
+          "intermediateStops": [
+            {
+              "arrival": "2009-11-17T18:55:05.000+00:00",
+              "departure": "2009-11-17T18:55:05.000+00:00",
+              "lat": 45.531586,
+              "lon": -122.660482,
+              "name": "NE Multnomah & Grand",
+              "stopCode": "4043",
+              "stopId": "prt:4043",
+              "stopIndex": 82,
+              "stopSequence": 83,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
+            },
+            {
+              "arrival": "2009-11-17T18:56:09.000+00:00",
+              "departure": "2009-11-17T18:56:09.000+00:00",
+              "lat": 45.531159,
+              "lon": -122.66293,
+              "name": "NE Multnomah & 3rd",
+              "stopCode": "11492",
+              "stopId": "prt:11492",
+              "stopIndex": 83,
+              "stopSequence": 84,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
+            },
+            {
+              "arrival": "2009-11-17T18:58:00.000+00:00",
+              "departure": "2009-11-17T18:58:00.000+00:00",
+              "lat": 45.530005,
+              "lon": -122.666476,
+              "name": "Rose Quarter Transit Center",
+              "stopCode": "2592",
+              "stopId": "prt:2592",
+              "stopIndex": 84,
+              "stopSequence": 85,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
+            },
+            {
+              "arrival": "2009-11-17T19:01:20.000+00:00",
+              "departure": "2009-11-17T19:01:20.000+00:00",
+              "lat": 45.526655,
+              "lon": -122.676462,
+              "name": "NW Glisan & 6th",
+              "stopCode": "10803",
+              "stopId": "prt:10803",
+              "stopIndex": 85,
+              "stopSequence": 86,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
+            },
+            {
+              "arrival": "2009-11-17T19:02:15.000+00:00",
+              "departure": "2009-11-17T19:02:15.000+00:00",
+              "lat": 45.528799,
+              "lon": -122.677238,
+              "name": "NW Station Way & Union Station",
+              "stopCode": "12801",
+              "stopId": "prt:12801",
+              "stopIndex": 86,
+              "stopSequence": 87,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
+            },
+            {
+              "arrival": "2009-11-17T19:04:00.000+00:00",
+              "departure": "2009-11-17T19:04:00.000+00:00",
+              "lat": 45.531582,
+              "lon": -122.681193,
+              "name": "NW Northrup & 10th",
+              "stopCode": "12802",
+              "stopId": "prt:12802",
+              "stopIndex": 87,
+              "stopSequence": 88,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T19:04:33.000+00:00",
+              "departure": "2009-11-17T19:04:33.000+00:00",
+              "lat": 45.531534,
+              "lon": -122.683319,
+              "name": "NW 12th & Northrup",
+              "stopCode": "12796",
+              "stopId": "prt:12796",
+              "stopIndex": 88,
+              "stopSequence": 89,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T19:05:04.000+00:00",
+              "departure": "2009-11-17T19:05:04.000+00:00",
+              "lat": 45.531503,
+              "lon": -122.685357,
+              "name": "NW Northrup & 14th",
+              "stopCode": "10775",
+              "stopId": "prt:10775",
+              "stopIndex": 89,
+              "stopSequence": 90,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T19:06:07.000+00:00",
+              "departure": "2009-11-17T19:06:07.000+00:00",
+              "lat": 45.531434,
+              "lon": -122.689417,
+              "name": "NW Northrup & 18th",
+              "stopCode": "10776",
+              "stopId": "prt:10776",
+              "stopIndex": 90,
+              "stopSequence": 91,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-11-17T19:07:24.000+00:00",
+              "departure": "2009-11-17T19:07:24.000+00:00",
+              "lat": 45.531346,
+              "lon": -122.694455,
+              "name": "NW Northrup & 21st",
+              "stopCode": "10777",
+              "stopId": "prt:10777",
+              "stopIndex": 91,
+              "stopSequence": 92,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            }
+          ],
+          "legGeometry": {
+            "length": 104,
+            "points": "yz{tG`zskV?tBCfD???^?nE?V@Z?PH\\Nb@`@~@Rf@??`@bANb@FV@R?P?pE?jA@h@AnAbBl@LFJN\\f@LT??NXJPPVJFf@Vf@Pp@Nd@NRLB@RNXZR\\vAhC@BhAhD`AhClAbDBrDCnG@n@@^@d@HdAP`CBjEDvD???LqCFmCDYBGDEBGJkAzAQR??KNa@b@MJuBBY?OHW@u@~@aD`EcBhBBrD@xC??@l@BlE@lD???XBjEBpD???VBlE?dA@t@?b@?h@BfEBrD???VBhEFtKDvJ??@\\DnJ"
+          },
+          "mode": "BUS",
+          "pathway": false,
+          "realTime": false,
+          "route": "Broadway/Halsey",
+          "routeId": "prt:77",
+          "routeLongName": "Broadway/Halsey",
+          "routeShortName": "77",
+          "routeType": 3,
+          "serviceDate": "2009-11-17",
+          "startTime": "2009-11-17T18:54:29.000+00:00",
+          "steps": [ ],
+          "to": {
+            "arrival": "2009-11-17T19:07:55.000+00:00",
+            "departure": "2009-11-17T19:07:55.000+00:00",
+            "lat": 45.531308,
+            "lon": -122.696445,
+            "name": "NW Northrup & 22nd",
+            "stopCode": "10778",
+            "stopId": "prt:10778",
+            "stopIndex": 92,
+            "stopSequence": 93,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "transitLeg": true,
+          "tripBlockId": "7702",
+          "tripId": "prt:771W1180"
+        },
+        {
+          "agencyTimeZoneOffset": -28800000,
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 18.81,
+          "endTime": "2009-11-17T19:08:19.000+00:00",
+          "from": {
+            "arrival": "2009-11-17T19:07:55.000+00:00",
+            "departure": "2009-11-17T19:07:55.000+00:00",
+            "lat": 45.531308,
+            "lon": -122.696445,
+            "name": "NW Northrup & 22nd",
+            "stopCode": "10778",
+            "stopId": "prt:10778",
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "generalizedCost": 37,
+          "interlineWithPreviousLeg": false,
+          "legGeometry": {
+            "length": 7,
+            "points": "sy{tGxc{kV???LABF?B??J"
+          },
+          "mode": "WALK",
+          "pathway": false,
+          "realTime": false,
+          "rentedBike": false,
+          "route": "",
+          "startTime": "2009-11-17T19:07:55.000+00:00",
+          "steps": [
+            {
+              "absoluteDirection": "WEST",
+              "area": false,
+              "bogusName": false,
+              "distance": 18.81,
+              "elevation": "",
+              "lat": 45.5313019,
+              "lon": -122.6964448,
+              "relativeDirection": "DEPART",
+              "stayOn": false,
+              "streetName": "Northwest Northrup Street",
+              "walkingBike": false
+            }
+          ],
+          "to": {
+            "arrival": "2009-11-17T19:08:19.000+00:00",
+            "lat": 45.53122,
+            "lon": -122.69659,
+            "name": "NW Northrup St. & NW 22nd Ave. (P2)",
+            "vertexType": "NORMAL"
+          },
+          "transitLeg": false,
+          "walkingBike": false
+        }
+      ],
+      "startTime": "2009-11-17T18:37:30.000+00:00",
+      "tooSloped": false,
+      "transfers": 1,
+      "transitTime": 1293,
+      "waitingTime": 208,
+      "walkDistance": 438.43,
+      "walkLimitExceeded": false,
+      "walkTime": 348
+    }
+  ]
+]
+
+
 org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_planning_with_transit_stop=[
   [
     {


### PR DESCRIPTION
### Summary

We disabled a snapshot test when we migrated to Java 17 as the floating point arithmetic was machine-dependent. Now that we are actually rounding the floating point numbers this should no longer be a problem. :crossed_fingers: 