### PR TITLE
Add mapping layer between REST API and internal fare model

### DIFF
--- a/src/main/java/org/opentripplanner/api/mapping/FareMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/FareMapper.java
@@ -1,0 +1,61 @@
+package org.opentripplanner.api.mapping;
+
+import java.util.AbstractMap.SimpleEntry;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.opentripplanner.api.model.ApiCurrency;
+import org.opentripplanner.api.model.ApiFare;
+import org.opentripplanner.api.model.ApiFareComponent;
+import org.opentripplanner.api.model.ApiFareType;
+import org.opentripplanner.api.model.ApiMoney;
+import org.opentripplanner.routing.core.Fare;
+import org.opentripplanner.routing.core.FareComponent;
+import org.opentripplanner.routing.core.Money;
+
+public class FareMapper {
+
+  public static ApiFare mapFare(Fare fare) {
+    Map<ApiFareType, ApiMoney> apiFare = fare.fare
+      .entrySet()
+      .stream()
+      .map(e -> {
+        var type = toApiFare(e.getKey());
+        var money = toApiMoney(e.getValue());
+        return new SimpleEntry<>(type, money);
+      })
+      .collect(Collectors.toMap(SimpleEntry::getKey, SimpleEntry::getValue));
+
+    Map<ApiFareType, List<ApiFareComponent>> apiComponent = fare.details
+      .entrySet()
+      .stream()
+      .map(e -> {
+        var type = toApiFare(e.getKey());
+        var money = Arrays.stream(e.getValue()).map(FareMapper::toApiFareComponent).toList();
+        return new SimpleEntry<>(type, money);
+      })
+      .collect(Collectors.toMap(SimpleEntry::getKey, SimpleEntry::getValue));
+
+    return new ApiFare(apiFare, apiComponent);
+  }
+
+  private static ApiFareType toApiFare(Fare.FareType t) {
+    return switch (t) {
+      case regular -> ApiFareType.regular;
+      case student -> ApiFareType.student;
+      case senior -> ApiFareType.senior;
+      case tram -> ApiFareType.tram;
+      case special -> ApiFareType.special;
+      case youth -> ApiFareType.youth;
+    };
+  }
+
+  private static ApiMoney toApiMoney(Money m) {
+    return new ApiMoney(m.getCents(), new ApiCurrency(m.getCurrency().getCurrency()));
+  }
+
+  private static ApiFareComponent toApiFareComponent(FareComponent m) {
+    return new ApiFareComponent(m.fareId, toApiMoney(m.price), m.routes);
+  }
+}

--- a/src/main/java/org/opentripplanner/api/mapping/ItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/ItineraryMapper.java
@@ -42,7 +42,7 @@ public class ItineraryMapper {
     api.transfers = domain.getNumberOfTransfers();
     api.tooSloped = domain.isTooSloped();
     api.arrivedAtDestinationWithRentedBicycle = domain.isArrivedAtDestinationWithRentedVehicle();
-    api.fare = domain.getFare();
+    api.fare = FareMapper.mapFare(domain.getFare());
     api.legs = legMapper.mapLegs(domain.getLegs());
     api.systemNotices = SystemNoticeMapper.mapSystemNotices(domain.getSystemNotices());
     api.accessibilityScore = domain.getAccessibilityScore();

--- a/src/main/java/org/opentripplanner/api/model/ApiCurrency.java
+++ b/src/main/java/org/opentripplanner/api/model/ApiCurrency.java
@@ -1,0 +1,20 @@
+package org.opentripplanner.api.model;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.Currency;
+
+public record ApiCurrency(@JsonSerialize Currency currency) {
+  @JsonSerialize
+  public int getDefaultFractionDigits() {
+    return currency.getDefaultFractionDigits();
+  }
+
+  @JsonSerialize
+  public String getCurrencyCode() {
+    return currency.getCurrencyCode();
+  }
+  @JsonSerialize
+  public String getSymbol() {
+    return currency.getSymbol();
+  }
+}

--- a/src/main/java/org/opentripplanner/api/model/ApiFare.java
+++ b/src/main/java/org/opentripplanner/api/model/ApiFare.java
@@ -1,0 +1,9 @@
+package org.opentripplanner.api.model;
+
+import java.util.List;
+import java.util.Map;
+
+public record ApiFare(
+  Map<ApiFareType, ApiMoney> fare,
+  Map<ApiFareType, List<ApiFareComponent>> details
+) {}

--- a/src/main/java/org/opentripplanner/api/model/ApiFareComponent.java
+++ b/src/main/java/org/opentripplanner/api/model/ApiFareComponent.java
@@ -1,0 +1,6 @@
+package org.opentripplanner.api.model;
+
+import java.util.List;
+import org.opentripplanner.transit.model.framework.FeedScopedId;
+
+public record ApiFareComponent(FeedScopedId fareId, ApiMoney price, List<FeedScopedId> routes) {}

--- a/src/main/java/org/opentripplanner/api/model/ApiFareType.java
+++ b/src/main/java/org/opentripplanner/api/model/ApiFareType.java
@@ -1,0 +1,12 @@
+package org.opentripplanner.api.model;
+
+import java.io.Serializable;
+
+public enum ApiFareType implements Serializable {
+  regular,
+  student,
+  senior,
+  tram,
+  special,
+  youth,
+}

--- a/src/main/java/org/opentripplanner/api/model/ApiItinerary.java
+++ b/src/main/java/org/opentripplanner/api/model/ApiItinerary.java
@@ -3,6 +3,7 @@ package org.opentripplanner.api.model;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
+import java.util.Map;
 import org.opentripplanner.routing.api.request.ItineraryFilterParameters;
 import org.opentripplanner.routing.core.Fare;
 
@@ -77,7 +78,7 @@ public class ApiItinerary {
   /**
    * The cost of this trip
    */
-  public Fare fare = new Fare();
+  public ApiFare fare = new ApiFare(Map.of(), Map.of());
 
   /**
    * A list of Legs. Each Leg is either a walking (cycling, car) portion of the trip, or a transit

--- a/src/main/java/org/opentripplanner/api/model/ApiMoney.java
+++ b/src/main/java/org/opentripplanner/api/model/ApiMoney.java
@@ -1,0 +1,3 @@
+package org.opentripplanner.api.model;
+
+public record ApiMoney(int cents, ApiCurrency currency) {}

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/BikeRentalSnapshotTest.snap
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/BikeRentalSnapshotTest.snap
@@ -17,7 +17,10 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "price": {
                 "cents": 200,
                 "currency": {
-                  "value": "USD"
+                  "currency": "USD",
+                  "currencyCode": "USD",
+                  "defaultFractionDigits": 2,
+                  "symbol": "$"
                 }
               },
               "routes": [
@@ -33,7 +36,10 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
           "regular": {
             "cents": 200,
             "currency": {
-              "value": "USD"
+              "currency": "USD",
+              "currencyCode": "USD",
+              "defaultFractionDigits": 2,
+              "symbol": "$"
             }
           }
         }
@@ -484,7 +490,10 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "price": {
                 "cents": 200,
                 "currency": {
-                  "value": "USD"
+                  "currency": "USD",
+                  "currencyCode": "USD",
+                  "defaultFractionDigits": 2,
+                  "symbol": "$"
                 }
               },
               "routes": [
@@ -500,7 +509,10 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
           "regular": {
             "cents": 200,
             "currency": {
-              "value": "USD"
+              "currency": "USD",
+              "currencyCode": "USD",
+              "defaultFractionDigits": 2,
+              "symbol": "$"
             }
           }
         }
@@ -896,7 +908,10 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "price": {
                 "cents": 200,
                 "currency": {
-                  "value": "USD"
+                  "currency": "USD",
+                  "currencyCode": "USD",
+                  "defaultFractionDigits": 2,
+                  "symbol": "$"
                 }
               },
               "routes": [
@@ -912,7 +927,10 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
           "regular": {
             "cents": 200,
             "currency": {
-              "value": "USD"
+              "currency": "USD",
+              "currencyCode": "USD",
+              "defaultFractionDigits": 2,
+              "symbol": "$"
             }
           }
         }
@@ -1321,7 +1339,10 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "price": {
                 "cents": 200,
                 "currency": {
-                  "value": "USD"
+                  "currency": "USD",
+                  "currencyCode": "USD",
+                  "defaultFractionDigits": 2,
+                  "symbol": "$"
                 }
               },
               "routes": [
@@ -1337,7 +1358,10 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
           "regular": {
             "cents": 200,
             "currency": {
-              "value": "USD"
+              "currency": "USD",
+              "currencyCode": "USD",
+              "defaultFractionDigits": 2,
+              "symbol": "$"
             }
           }
         }
@@ -1642,7 +1666,10 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "price": {
                 "cents": 200,
                 "currency": {
-                  "value": "USD"
+                  "currency": "USD",
+                  "currencyCode": "USD",
+                  "defaultFractionDigits": 2,
+                  "symbol": "$"
                 }
               },
               "routes": [
@@ -1658,7 +1685,10 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
           "regular": {
             "cents": 200,
             "currency": {
-              "value": "USD"
+              "currency": "USD",
+              "currencyCode": "USD",
+              "defaultFractionDigits": 2,
+              "symbol": "$"
             }
           }
         }
@@ -2109,7 +2139,10 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "price": {
                 "cents": 200,
                 "currency": {
-                  "value": "USD"
+                  "currency": "USD",
+                  "currencyCode": "USD",
+                  "defaultFractionDigits": 2,
+                  "symbol": "$"
                 }
               },
               "routes": [
@@ -2125,7 +2158,10 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
           "regular": {
             "cents": 200,
             "currency": {
-              "value": "USD"
+              "currency": "USD",
+              "currencyCode": "USD",
+              "defaultFractionDigits": 2,
+              "symbol": "$"
             }
           }
         }
@@ -3251,7 +3287,10 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "price": {
                 "cents": 200,
                 "currency": {
-                  "value": "USD"
+                  "currency": "USD",
+                  "currencyCode": "USD",
+                  "defaultFractionDigits": 2,
+                  "symbol": "$"
                 }
               },
               "routes": [
@@ -3267,7 +3306,10 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
           "regular": {
             "cents": 200,
             "currency": {
-              "value": "USD"
+              "currency": "USD",
+              "currencyCode": "USD",
+              "defaultFractionDigits": 2,
+              "symbol": "$"
             }
           }
         }
@@ -3770,7 +3812,10 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "price": {
                 "cents": 200,
                 "currency": {
-                  "value": "USD"
+                  "currency": "USD",
+                  "currencyCode": "USD",
+                  "defaultFractionDigits": 2,
+                  "symbol": "$"
                 }
               },
               "routes": [
@@ -3786,7 +3831,10 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
           "regular": {
             "cents": 200,
             "currency": {
-              "value": "USD"
+              "currency": "USD",
+              "currencyCode": "USD",
+              "defaultFractionDigits": 2,
+              "symbol": "$"
             }
           }
         }
@@ -4169,7 +4217,10 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "price": {
                 "cents": 200,
                 "currency": {
-                  "value": "USD"
+                  "currency": "USD",
+                  "currencyCode": "USD",
+                  "defaultFractionDigits": 2,
+                  "symbol": "$"
                 }
               },
               "routes": [
@@ -4185,7 +4236,10 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
           "regular": {
             "cents": 200,
             "currency": {
-              "value": "USD"
+              "currency": "USD",
+              "currencyCode": "USD",
+              "defaultFractionDigits": 2,
+              "symbol": "$"
             }
           }
         }
@@ -4542,7 +4596,10 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "price": {
                 "cents": 200,
                 "currency": {
-                  "value": "USD"
+                  "currency": "USD",
+                  "currencyCode": "USD",
+                  "defaultFractionDigits": 2,
+                  "symbol": "$"
                 }
               },
               "routes": [
@@ -4558,7 +4615,10 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
           "regular": {
             "cents": 200,
             "currency": {
-              "value": "USD"
+              "currency": "USD",
+              "currencyCode": "USD",
+              "defaultFractionDigits": 2,
+              "symbol": "$"
             }
           }
         }
@@ -5061,7 +5121,10 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "price": {
                 "cents": 200,
                 "currency": {
-                  "value": "USD"
+                  "currency": "USD",
+                  "currencyCode": "USD",
+                  "defaultFractionDigits": 2,
+                  "symbol": "$"
                 }
               },
               "routes": [
@@ -5077,7 +5140,10 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
           "regular": {
             "cents": 200,
             "currency": {
-              "value": "USD"
+              "currency": "USD",
+              "currencyCode": "USD",
+              "defaultFractionDigits": 2,
+              "symbol": "$"
             }
           }
         }
@@ -5460,7 +5526,10 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "price": {
                 "cents": 200,
                 "currency": {
-                  "value": "USD"
+                  "currency": "USD",
+                  "currencyCode": "USD",
+                  "defaultFractionDigits": 2,
+                  "symbol": "$"
                 }
               },
               "routes": [
@@ -5476,7 +5545,10 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
           "regular": {
             "cents": 200,
             "currency": {
-              "value": "USD"
+              "currency": "USD",
+              "currencyCode": "USD",
+              "defaultFractionDigits": 2,
+              "symbol": "$"
             }
           }
         }

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/ElevationSnapshotTest.snap
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/ElevationSnapshotTest.snap
@@ -17,7 +17,10 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
               "price": {
                 "cents": 200,
                 "currency": {
-                  "value": "USD"
+                  "currency": "USD",
+                  "currencyCode": "USD",
+                  "defaultFractionDigits": 2,
+                  "symbol": "$"
                 }
               },
               "routes": [
@@ -33,7 +36,10 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
           "regular": {
             "cents": 200,
             "currency": {
-              "value": "USD"
+              "currency": "USD",
+              "currencyCode": "USD",
+              "defaultFractionDigits": 2,
+              "symbol": "$"
             }
           }
         }
@@ -488,7 +494,10 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
               "price": {
                 "cents": 200,
                 "currency": {
-                  "value": "USD"
+                  "currency": "USD",
+                  "currencyCode": "USD",
+                  "defaultFractionDigits": 2,
+                  "symbol": "$"
                 }
               },
               "routes": [
@@ -504,7 +513,10 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
           "regular": {
             "cents": 200,
             "currency": {
-              "value": "USD"
+              "currency": "USD",
+              "currencyCode": "USD",
+              "defaultFractionDigits": 2,
+              "symbol": "$"
             }
           }
         }
@@ -811,7 +823,10 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
               "price": {
                 "cents": 200,
                 "currency": {
-                  "value": "USD"
+                  "currency": "USD",
+                  "currencyCode": "USD",
+                  "defaultFractionDigits": 2,
+                  "symbol": "$"
                 }
               },
               "routes": [
@@ -827,7 +842,10 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
           "regular": {
             "cents": 200,
             "currency": {
-              "value": "USD"
+              "currency": "USD",
+              "currencyCode": "USD",
+              "defaultFractionDigits": 2,
+              "symbol": "$"
             }
           }
         }
@@ -1282,7 +1300,10 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
               "price": {
                 "cents": 200,
                 "currency": {
-                  "value": "USD"
+                  "currency": "USD",
+                  "currencyCode": "USD",
+                  "defaultFractionDigits": 2,
+                  "symbol": "$"
                 }
               },
               "routes": [
@@ -1298,7 +1319,10 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
           "regular": {
             "cents": 200,
             "currency": {
-              "value": "USD"
+              "currency": "USD",
+              "currencyCode": "USD",
+              "defaultFractionDigits": 2,
+              "symbol": "$"
             }
           }
         }
@@ -1753,7 +1777,10 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
               "price": {
                 "cents": 200,
                 "currency": {
-                  "value": "USD"
+                  "currency": "USD",
+                  "currencyCode": "USD",
+                  "defaultFractionDigits": 2,
+                  "symbol": "$"
                 }
               },
               "routes": [
@@ -1769,7 +1796,10 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
           "regular": {
             "cents": 200,
             "currency": {
-              "value": "USD"
+              "currency": "USD",
+              "currencyCode": "USD",
+              "defaultFractionDigits": 2,
+              "symbol": "$"
             }
           }
         }
@@ -2076,7 +2106,10 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
               "price": {
                 "cents": 200,
                 "currency": {
-                  "value": "USD"
+                  "currency": "USD",
+                  "currencyCode": "USD",
+                  "defaultFractionDigits": 2,
+                  "symbol": "$"
                 }
               },
               "routes": [
@@ -2092,7 +2125,10 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
           "regular": {
             "cents": 200,
             "currency": {
-              "value": "USD"
+              "currency": "USD",
+              "currencyCode": "USD",
+              "defaultFractionDigits": 2,
+              "symbol": "$"
             }
           }
         }
@@ -3133,7 +3169,10 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.transit=[
               "price": {
                 "cents": 200,
                 "currency": {
-                  "value": "USD"
+                  "currency": "USD",
+                  "currencyCode": "USD",
+                  "defaultFractionDigits": 2,
+                  "symbol": "$"
                 }
               },
               "routes": [
@@ -3149,7 +3188,10 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.transit=[
           "regular": {
             "cents": 200,
             "currency": {
-              "value": "USD"
+              "currency": "USD",
+              "currencyCode": "USD",
+              "defaultFractionDigits": 2,
+              "symbol": "$"
             }
           }
         }
@@ -3508,7 +3550,10 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.transit=[
               "price": {
                 "cents": 200,
                 "currency": {
-                  "value": "USD"
+                  "currency": "USD",
+                  "currencyCode": "USD",
+                  "defaultFractionDigits": 2,
+                  "symbol": "$"
                 }
               },
               "routes": [
@@ -3524,7 +3569,10 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.transit=[
           "regular": {
             "cents": 200,
             "currency": {
-              "value": "USD"
+              "currency": "USD",
+              "currencyCode": "USD",
+              "defaultFractionDigits": 2,
+              "symbol": "$"
             }
           }
         }
@@ -3909,7 +3957,10 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.transit=[
               "price": {
                 "cents": 200,
                 "currency": {
-                  "value": "USD"
+                  "currency": "USD",
+                  "currencyCode": "USD",
+                  "defaultFractionDigits": 2,
+                  "symbol": "$"
                 }
               },
               "routes": [
@@ -3925,7 +3976,10 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.transit=[
           "regular": {
             "cents": 200,
             "currency": {
-              "value": "USD"
+              "currency": "USD",
+              "currencyCode": "USD",
+              "defaultFractionDigits": 2,
+              "symbol": "$"
             }
           }
         }
@@ -4284,7 +4338,10 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.transit=[
               "price": {
                 "cents": 200,
                 "currency": {
-                  "value": "USD"
+                  "currency": "USD",
+                  "currencyCode": "USD",
+                  "defaultFractionDigits": 2,
+                  "symbol": "$"
                 }
               },
               "routes": [
@@ -4300,7 +4357,10 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.transit=[
           "regular": {
             "cents": 200,
             "currency": {
-              "value": "USD"
+              "currency": "USD",
+              "currencyCode": "USD",
+              "defaultFractionDigits": 2,
+              "symbol": "$"
             }
           }
         }
@@ -4737,7 +4797,10 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.transit=[
               "price": {
                 "cents": 200,
                 "currency": {
-                  "value": "USD"
+                  "currency": "USD",
+                  "currencyCode": "USD",
+                  "defaultFractionDigits": 2,
+                  "symbol": "$"
                 }
               },
               "routes": [
@@ -4753,7 +4816,10 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.transit=[
           "regular": {
             "cents": 200,
             "currency": {
-              "value": "USD"
+              "currency": "USD",
+              "currencyCode": "USD",
+              "defaultFractionDigits": 2,
+              "symbol": "$"
             }
           }
         }
@@ -5112,7 +5178,10 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.transit=[
               "price": {
                 "cents": 200,
                 "currency": {
-                  "value": "USD"
+                  "currency": "USD",
+                  "currencyCode": "USD",
+                  "defaultFractionDigits": 2,
+                  "symbol": "$"
                 }
               },
               "routes": [
@@ -5128,7 +5197,10 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.transit=[
           "regular": {
             "cents": 200,
             "currency": {
-              "value": "USD"
+              "currency": "USD",
+              "currencyCode": "USD",
+              "defaultFractionDigits": 2,
+              "symbol": "$"
             }
           }
         }

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/TransitSnapshotTest.snap
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/TransitSnapshotTest.snap
@@ -245,7 +245,10 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "price": {
                 "cents": 200,
                 "currency": {
-                  "value": "USD"
+                  "currency": "USD",
+                  "currencyCode": "USD",
+                  "defaultFractionDigits": 2,
+                  "symbol": "$"
                 }
               },
               "routes": [
@@ -261,7 +264,10 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           "regular": {
             "cents": 200,
             "currency": {
-              "value": "USD"
+              "currency": "USD",
+              "currencyCode": "USD",
+              "defaultFractionDigits": 2,
+              "symbol": "$"
             }
           }
         }
@@ -709,7 +715,10 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "price": {
                 "cents": 200,
                 "currency": {
-                  "value": "USD"
+                  "currency": "USD",
+                  "currencyCode": "USD",
+                  "defaultFractionDigits": 2,
+                  "symbol": "$"
                 }
               },
               "routes": [
@@ -725,7 +734,10 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           "regular": {
             "cents": 200,
             "currency": {
-              "value": "USD"
+              "currency": "USD",
+              "currencyCode": "USD",
+              "defaultFractionDigits": 2,
+              "symbol": "$"
             }
           }
         }
@@ -1238,7 +1250,10 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "price": {
                 "cents": 200,
                 "currency": {
-                  "value": "USD"
+                  "currency": "USD",
+                  "currencyCode": "USD",
+                  "defaultFractionDigits": 2,
+                  "symbol": "$"
                 }
               },
               "routes": [
@@ -1254,7 +1269,10 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           "regular": {
             "cents": 200,
             "currency": {
-              "value": "USD"
+              "currency": "USD",
+              "currencyCode": "USD",
+              "defaultFractionDigits": 2,
+              "symbol": "$"
             }
           }
         }
@@ -1702,7 +1720,10 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "price": {
                 "cents": 200,
                 "currency": {
-                  "value": "USD"
+                  "currency": "USD",
+                  "currencyCode": "USD",
+                  "defaultFractionDigits": 2,
+                  "symbol": "$"
                 }
               },
               "routes": [
@@ -1718,7 +1739,10 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           "regular": {
             "cents": 200,
             "currency": {
-              "value": "USD"
+              "currency": "USD",
+              "currencyCode": "USD",
+              "defaultFractionDigits": 2,
+              "symbol": "$"
             }
           }
         }
@@ -2231,7 +2255,10 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "price": {
                 "cents": 200,
                 "currency": {
-                  "value": "USD"
+                  "currency": "USD",
+                  "currencyCode": "USD",
+                  "defaultFractionDigits": 2,
+                  "symbol": "$"
                 }
               },
               "routes": [
@@ -2251,7 +2278,10 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           "regular": {
             "cents": 200,
             "currency": {
-              "value": "USD"
+              "currency": "USD",
+              "currencyCode": "USD",
+              "defaultFractionDigits": 2,
+              "symbol": "$"
             }
           }
         }
@@ -2943,7 +2973,10 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "price": {
                 "cents": 200,
                 "currency": {
-                  "value": "USD"
+                  "currency": "USD",
+                  "currencyCode": "USD",
+                  "defaultFractionDigits": 2,
+                  "symbol": "$"
                 }
               },
               "routes": [
@@ -2959,7 +2992,10 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           "regular": {
             "cents": 200,
             "currency": {
-              "value": "USD"
+              "currency": "USD",
+              "currencyCode": "USD",
+              "defaultFractionDigits": 2,
+              "symbol": "$"
             }
           }
         }
@@ -3410,7 +3446,10 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "price": {
                 "cents": 200,
                 "currency": {
-                  "value": "USD"
+                  "currency": "USD",
+                  "currencyCode": "USD",
+                  "defaultFractionDigits": 2,
+                  "symbol": "$"
                 }
               },
               "routes": [
@@ -3426,7 +3465,10 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           "regular": {
             "cents": 200,
             "currency": {
-              "value": "USD"
+              "currency": "USD",
+              "currencyCode": "USD",
+              "defaultFractionDigits": 2,
+              "symbol": "$"
             }
           }
         }
@@ -3877,7 +3919,10 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "price": {
                 "cents": 200,
                 "currency": {
-                  "value": "USD"
+                  "currency": "USD",
+                  "currencyCode": "USD",
+                  "defaultFractionDigits": 2,
+                  "symbol": "$"
                 }
               },
               "routes": [
@@ -3893,7 +3938,10 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           "regular": {
             "cents": 200,
             "currency": {
-              "value": "USD"
+              "currency": "USD",
+              "currencyCode": "USD",
+              "defaultFractionDigits": 2,
+              "symbol": "$"
             }
           }
         }
@@ -4344,7 +4392,10 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "price": {
                 "cents": 200,
                 "currency": {
-                  "value": "USD"
+                  "currency": "USD",
+                  "currencyCode": "USD",
+                  "defaultFractionDigits": 2,
+                  "symbol": "$"
                 }
               },
               "routes": [
@@ -4364,7 +4415,10 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           "regular": {
             "cents": 200,
             "currency": {
-              "value": "USD"
+              "currency": "USD",
+              "currencyCode": "USD",
+              "defaultFractionDigits": 2,
+              "symbol": "$"
             }
           }
         }
@@ -4835,7 +4889,10 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "price": {
                 "cents": 200,
                 "currency": {
-                  "value": "USD"
+                  "currency": "USD",
+                  "currencyCode": "USD",
+                  "defaultFractionDigits": 2,
+                  "symbol": "$"
                 }
               },
               "routes": [
@@ -4851,7 +4908,10 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
           "regular": {
             "cents": 200,
             "currency": {
-              "value": "USD"
+              "currency": "USD",
+              "currencyCode": "USD",
+              "defaultFractionDigits": 2,
+              "symbol": "$"
             }
           }
         }


### PR DESCRIPTION
### Summary

In order to be able to freely change the internal fare model, I added a mapping layer between it and the REST API response.

### Issue

none

### Unit tests

I've updated the snapshot test expectation. You may have noticed that I changed the snapshot expectation: this is because I took extra care that the API response matches what is currently on dev-2.x.

![image](https://user-images.githubusercontent.com/151346/176206767-5fe8ba83-93f6-4d64-8a8c-046b78acbfe0.png)

It turns out that the snapshot test does a slightly different serialization of the currency as the REST API. I added annotations to make sure it does the same thing.