### PR TITLE
Fix name and label for OsmBoardingLocationVertex

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModule.java
@@ -145,8 +145,10 @@ public class OsmBoardingLocationsModule implements GraphBuilderModule {
         (stopCode != null && edgeList.references.contains(stopCode)) ||
         edgeList.references.contains(stopId)
       ) {
-        var name = Optional
-          .ofNullable(edgeList.getAreas().get(0))
+        var name = edgeList
+          .getAreas()
+          .stream()
+          .findFirst()
           .map(NamedArea::getName)
           .orElse(new LocalizedString("name.platform"));
         var label = "platform-centroid/%s".formatted(ts.getStop().getId().toString());

--- a/src/main/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModule.java
@@ -2,6 +2,7 @@ package org.opentripplanner.graph_builder.module;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.locationtech.jts.geom.Envelope;
 import org.opentripplanner.common.geometry.GeometryUtils;
@@ -13,6 +14,7 @@ import org.opentripplanner.routing.core.TraverseMode;
 import org.opentripplanner.routing.core.TraverseModeSet;
 import org.opentripplanner.routing.edgetype.AreaEdge;
 import org.opentripplanner.routing.edgetype.BoardingLocationToStopLink;
+import org.opentripplanner.routing.edgetype.NamedArea;
 import org.opentripplanner.routing.edgetype.StreetEdge;
 import org.opentripplanner.routing.edgetype.StreetTransitStopLink;
 import org.opentripplanner.routing.edgetype.StreetTraversalPermission;
@@ -127,7 +129,7 @@ public class OsmBoardingLocationsModule implements GraphBuilderModule {
       }
     }
 
-    // if the boarding location is a OSM way (an area) then we are generating the vertex here and
+    // if the boarding location is an OSM way (an area) then we are generating the vertex here and
     // use the AreaEdgeList to link it to the correct vertices of the platform edge
     var nearbyEdgeLists = index
       .getEdgesForEnvelope(envelope)
@@ -144,7 +146,10 @@ public class OsmBoardingLocationsModule implements GraphBuilderModule {
         (stopCode != null && edgeList.references.contains(stopCode)) ||
         edgeList.references.contains(stopId)
       ) {
-        var name = edgeList.getAreas().get(0).getName();
+        var name = Optional
+          .ofNullable(edgeList.getAreas().get(0))
+          .map(NamedArea::getName)
+          .orElse(new LocalizedString("name.platform"));
         var label =
           "platform-centroid/%s".formatted(
               edgeList.visibilityVertices

--- a/src/main/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModule.java
@@ -21,7 +21,6 @@ import org.opentripplanner.routing.edgetype.StreetTraversalPermission;
 import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.impl.StreetVertexIndex;
-import org.opentripplanner.routing.vertextype.IntersectionVertex;
 import org.opentripplanner.routing.vertextype.OsmBoardingLocationVertex;
 import org.opentripplanner.routing.vertextype.StreetVertex;
 import org.opentripplanner.routing.vertextype.TransitStopVertex;
@@ -150,13 +149,7 @@ public class OsmBoardingLocationsModule implements GraphBuilderModule {
           .ofNullable(edgeList.getAreas().get(0))
           .map(NamedArea::getName)
           .orElse(new LocalizedString("name.platform"));
-        var label =
-          "platform-centroid/%s".formatted(
-              edgeList.visibilityVertices
-                .stream()
-                .map(IntersectionVertex::getLabel)
-                .collect(Collectors.joining("/"))
-            );
+        var label = "platform-centroid/%s".formatted(ts.getStop().getId().toString());
         var centroid = edgeList.getGeometry().getCentroid();
         var boardingLocation = new OsmBoardingLocationVertex(
           graph,


### PR DESCRIPTION
### Summary

#4244 reports that sometimes a name could not be generated for a boarding location. When fixing this I also noticed that there could be cases where a duplicate vertex label was generated, which I also fixed.

### Issue

closes #4244