### PR TITLE
Introduce TransitModel and StopModel [changelog skip]

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/flex/FlexIntegrationTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/flex/FlexIntegrationTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.ConstantsForTests;
+import org.opentripplanner.OtpModel;
 import org.opentripplanner.graph_builder.model.GtfsBundle;
 import org.opentripplanner.graph_builder.module.DirectTransferGenerator;
 import org.opentripplanner.graph_builder.module.GtfsModule;
@@ -35,6 +36,7 @@ import org.opentripplanner.routing.core.TraverseMode;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.standalone.config.RouterConfig;
 import org.opentripplanner.standalone.server.Router;
+import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.util.OTPFeature;
 
 /**
@@ -47,6 +49,9 @@ public class FlexIntegrationTest {
     .toInstant();
 
   static Graph graph;
+
+  static TransitModel transitModel;
+
   static RoutingService service;
   static Router router;
 
@@ -137,12 +142,15 @@ public class FlexIntegrationTest {
     var martaGtfsPath = getAbsolutePath(FlexTest.MARTA_BUS_856_GTFS);
     var flexGtfsPath = getAbsolutePath(FlexTest.COBB_FLEX_GTFS);
 
-    graph = ConstantsForTests.buildOsmGraph(osmPath);
-    addGtfsToGraph(graph, List.of(cobblincGtfsPath, martaGtfsPath, flexGtfsPath));
-    router = new Router(graph, RouterConfig.DEFAULT, Metrics.globalRegistry);
+    OtpModel otpModel = ConstantsForTests.buildOsmGraph(osmPath);
+    graph = otpModel.graph;
+    transitModel = otpModel.transitModel;
+
+    addGtfsToGraph(graph, transitModel, List.of(cobblincGtfsPath, martaGtfsPath, flexGtfsPath));
+    router = new Router(graph, transitModel, RouterConfig.DEFAULT, Metrics.globalRegistry);
     router.startup();
 
-    service = new RoutingService(graph);
+    service = new RoutingService(graph, transitModel);
   }
 
   @AfterAll
@@ -158,7 +166,11 @@ public class FlexIntegrationTest {
     }
   }
 
-  private static void addGtfsToGraph(Graph graph, List<String> gtfsFiles) {
+  private static void addGtfsToGraph(
+    Graph graph,
+    TransitModel transitModel,
+    List<String> gtfsFiles
+  ) {
     var extra = new HashMap<Class<?>, Object>();
 
     // GTFS
@@ -167,23 +179,24 @@ public class FlexIntegrationTest {
       .map(f -> new GtfsBundle(new File(f)))
       .collect(Collectors.toList());
     GtfsModule gtfsModule = new GtfsModule(gtfsBundles, ServiceDateInterval.unbounded());
-    gtfsModule.buildGraph(graph, extra);
+    gtfsModule.buildGraph(graph, transitModel, extra);
 
     // link stations to streets
     StreetLinkerModule streetLinkerModule = new StreetLinkerModule();
-    streetLinkerModule.buildGraph(graph, extra);
+    streetLinkerModule.buildGraph(graph, transitModel, extra);
 
     // link flex locations to streets
     var flexMapper = new FlexLocationsToStreetEdgesMapper();
-    flexMapper.buildGraph(graph, new HashMap<>());
+    flexMapper.buildGraph(graph, transitModel, new HashMap<>());
 
     // generate direct transfers
     var req = new RoutingRequest();
 
     // we don't have a complete coverage of the entire area so use straight lines for transfers
     var transfers = new DirectTransferGenerator(Duration.ofMinutes(10), List.of(req));
-    transfers.buildGraph(graph, extra);
+    transfers.buildGraph(graph, transitModel, extra);
 
+    transitModel.index();
     graph.index();
   }
 

--- a/src/ext-test/java/org/opentripplanner/ext/flex/FlexTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/flex/FlexTest.java
@@ -9,6 +9,7 @@ import java.time.LocalTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.opentripplanner.OtpModel;
 import org.opentripplanner.ext.flex.flexpathcalculator.DirectFlexPathCalculator;
 import org.opentripplanner.graph_builder.model.GtfsBundle;
 import org.opentripplanner.graph_builder.module.FakeGraph;
@@ -16,6 +17,9 @@ import org.opentripplanner.graph_builder.module.GtfsModule;
 import org.opentripplanner.model.calendar.ServiceDate;
 import org.opentripplanner.model.calendar.ServiceDateInterval;
 import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.routing.trippattern.Deduplicator;
+import org.opentripplanner.transit.service.StopModel;
+import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.util.OTPFeature;
 
 public abstract class FlexTest {
@@ -37,7 +41,7 @@ public abstract class FlexTest {
   );
   static final FlexParameters params = new FlexParameters(300);
 
-  static Graph buildFlexGraph(String fileName) {
+  static OtpModel buildFlexGraph(String fileName) {
     File file = null;
     try {
       file = FakeGraph.getFileForResource(fileName);
@@ -45,17 +49,21 @@ public abstract class FlexTest {
       throw new RuntimeException(e);
     }
 
-    var graph = new Graph();
+    var deduplicator = new Deduplicator();
+    var stopModel = new StopModel();
+    var graph = new Graph(stopModel, deduplicator);
+    var transitModel = new TransitModel(stopModel, deduplicator);
     GtfsBundle gtfsBundle = new GtfsBundle(file);
     GtfsModule module = new GtfsModule(
       List.of(gtfsBundle),
       new ServiceDateInterval(new ServiceDate(2021, 1, 1), new ServiceDate(2022, 1, 1))
     );
     OTPFeature.enableFeatures(Map.of(OTPFeature.FlexRouting, true));
-    module.buildGraph(graph, new HashMap<>());
+    module.buildGraph(graph, transitModel, new HashMap<>());
+    transitModel.index();
     graph.index();
     OTPFeature.enableFeatures(Map.of(OTPFeature.FlexRouting, false));
-    assertFalse(graph.flexTripsById.isEmpty());
-    return graph;
+    assertFalse(transitModel.flexTripsById.isEmpty());
+    return new OtpModel(graph, transitModel);
   }
 }

--- a/src/ext-test/java/org/opentripplanner/ext/flex/ScheduledDeviatedTripTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/flex/ScheduledDeviatedTripTest.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
+import org.opentripplanner.OtpModel;
 import org.opentripplanner.ext.flex.trip.FlexTrip;
 import org.opentripplanner.ext.flex.trip.ScheduledDeviatedTrip;
 import org.opentripplanner.model.FlexStopLocation;
@@ -38,6 +39,7 @@ import org.opentripplanner.routing.location.StreetLocation;
 import org.opentripplanner.standalone.config.RouterConfig;
 import org.opentripplanner.standalone.server.Router;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.util.OTPFeature;
 import org.opentripplanner.util.PolylineEncoder;
 import org.opentripplanner.util.TestUtils;
@@ -53,12 +55,13 @@ import org.opentripplanner.util.model.EncodedPolyline;
 public class ScheduledDeviatedTripTest extends FlexTest {
 
   static Graph graph;
+  static TransitModel transitModel;
 
   float delta = 0.01f;
 
   @Test
   public void parseCobbCountyAsScheduledDeviatedTrip() {
-    var flexTrips = graph.flexTripsById.values();
+    var flexTrips = transitModel.flexTripsById.values();
     assertFalse(flexTrips.isEmpty());
     assertEquals(72, flexTrips.size());
 
@@ -128,6 +131,7 @@ public class ScheduledDeviatedTripTest extends FlexTest {
 
     var router = new FlexRouter(
       graph,
+      transitModel,
       new FlexParameters(300),
       OffsetDateTime.parse("2021-11-12T10:15:24-05:00").toInstant(),
       false,
@@ -158,9 +162,9 @@ public class ScheduledDeviatedTripTest extends FlexTest {
    */
   @Test
   public void flexTripInTransitMode() {
-    var feedId = graph.getFeedIds().iterator().next();
+    var feedId = transitModel.getFeedIds().iterator().next();
 
-    var router = new Router(graph, RouterConfig.DEFAULT, Metrics.globalRegistry);
+    var router = new Router(graph, transitModel, RouterConfig.DEFAULT, Metrics.globalRegistry);
     router.startup();
 
     // from zone 3 to zone 2
@@ -202,8 +206,8 @@ public class ScheduledDeviatedTripTest extends FlexTest {
    */
   @Test
   public void shouldNotInterpolateFlexTimes() {
-    var feedId = graph.getFeedIds().iterator().next();
-    var pattern = graph.tripPatternForId.get(new FeedScopedId(feedId, "090z:0:01"));
+    var feedId = transitModel.getFeedIds().iterator().next();
+    var pattern = transitModel.tripPatternForId.get(new FeedScopedId(feedId, "090z:0:01"));
 
     assertEquals(3, pattern.numberOfStops());
 
@@ -224,7 +228,9 @@ public class ScheduledDeviatedTripTest extends FlexTest {
 
   @BeforeAll
   static void setup() {
-    graph = FlexTest.buildFlexGraph(COBB_FLEX_GTFS);
+    OtpModel otpModel = FlexTest.buildFlexGraph(COBB_FLEX_GTFS);
+    graph = otpModel.graph;
+    transitModel = otpModel.transitModel;
   }
 
   private static List<Itinerary> getItineraries(
@@ -280,8 +286,8 @@ public class ScheduledDeviatedTripTest extends FlexTest {
   }
 
   private static FlexTrip getFlexTrip() {
-    var feedId = graph.getFeedIds().iterator().next();
+    var feedId = transitModel.getFeedIds().iterator().next();
     var tripId = new FeedScopedId(feedId, "a326c618-d42c-4bd1-9624-c314fbf8ecd8");
-    return graph.flexTripsById.get(tripId);
+    return transitModel.flexTripsById.get(tripId);
   }
 }

--- a/src/ext-test/java/org/opentripplanner/ext/flex/UnscheduledTripTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/flex/UnscheduledTripTest.java
@@ -8,11 +8,12 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.OtpModel;
 import org.opentripplanner.ext.flex.trip.FlexTrip;
 import org.opentripplanner.ext.flex.trip.UnscheduledTrip;
-import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.service.TransitModel;
 
 /**
  * This test makes sure that one of the example feeds in the GTFS-Flex repo works. It's the City of
@@ -24,11 +25,11 @@ import org.opentripplanner.transit.model.framework.FeedScopedId;
  */
 public class UnscheduledTripTest extends FlexTest {
 
-  static Graph graph;
+  static TransitModel transitModel;
 
   @Test
   public void parseAspenTaxiAsUnscheduledTrip() {
-    var flexTrips = graph.flexTripsById.values();
+    var flexTrips = transitModel.flexTripsById.values();
     assertFalse(flexTrips.isEmpty());
     assertEquals(
       Set.of("t_1289262_b_29084_tn_0", "t_1289257_b_28352_tn_0"),
@@ -74,7 +75,8 @@ public class UnscheduledTripTest extends FlexTest {
 
   @BeforeAll
   static void setup() {
-    graph = FlexTest.buildFlexGraph(ASPEN_GTFS);
+    OtpModel otpModel = FlexTest.buildFlexGraph(ASPEN_GTFS);
+    transitModel = otpModel.transitModel;
   }
 
   private static NearbyStop getNearbyStop(FlexTrip trip) {
@@ -84,7 +86,7 @@ public class UnscheduledTripTest extends FlexTest {
   }
 
   private static FlexTrip getFlexTrip() {
-    var flexTrips = graph.flexTripsById.values();
+    var flexTrips = transitModel.flexTripsById.values();
     return flexTrips.iterator().next();
   }
 }

--- a/src/ext-test/java/org/opentripplanner/ext/siri/SiriAlertsUpdateHandlerTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/siri/SiriAlertsUpdateHandlerTest.java
@@ -134,16 +134,16 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
 
   public void init() {
     if (routingService == null) {
-      routingService = new RoutingService(graph);
-      transitService = new DefaultTransitService(graph);
-      graph.updaterManager = new GraphUpdaterManager(graph, List.of());
+      routingService = new RoutingService(graph, transitModel);
+      transitService = new DefaultTransitService(transitModel);
+      transitModel.updaterManager = new GraphUpdaterManager(graph, transitModel, List.of());
     } else {
       transitAlertService.getAllAlerts().clear();
     }
     if (alertsUpdateHandler == null) {
-      alertsUpdateHandler = new SiriAlertsUpdateHandler(FEED_ID, graph);
+      alertsUpdateHandler = new SiriAlertsUpdateHandler(FEED_ID, transitModel);
 
-      transitAlertService = new TransitAlertServiceImpl(graph);
+      transitAlertService = new TransitAlertServiceImpl(transitModel);
       alertsUpdateHandler.setTransitAlertService(transitAlertService);
 
       alertsUpdateHandler.setSiriFuzzyTripMatcher(new SiriFuzzyTripMatcher(transitService));

--- a/src/ext-test/java/org/opentripplanner/ext/vectortiles/StopsLayerTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/vectortiles/StopsLayerTest.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.ext.vectortiles;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.mock;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -9,10 +8,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.ext.vectortiles.layers.stops.DigitransitStopPropertyMapper;
 import org.opentripplanner.routing.graph.Graph;
-import org.opentripplanner.routing.graph.GraphIndex;
-import org.opentripplanner.routing.vertextype.TransitStopVertex;
+import org.opentripplanner.routing.trippattern.Deduplicator;
+import org.opentripplanner.routing.vertextype.TransitStopVertexBuilder;
 import org.opentripplanner.transit.model._data.TransitModelForTest;
 import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.service.StopModel;
+import org.opentripplanner.transit.service.TransitModel;
 
 public class StopsLayerTest {
 
@@ -25,12 +26,24 @@ public class StopsLayerTest {
 
   @Test
   public void digitransitVehicleParkingPropertyMapperTest() {
-    Graph graph = mock(Graph.class);
-    graph.index = mock(GraphIndex.class);
+    var deduplicator = new Deduplicator();
+    var stopModel = new StopModel();
+    var graph = new Graph(stopModel, deduplicator);
+    var transitModel = new TransitModel(stopModel, deduplicator);
+    transitModel.index();
 
-    DigitransitStopPropertyMapper mapper = DigitransitStopPropertyMapper.create(graph);
+    DigitransitStopPropertyMapper mapper = DigitransitStopPropertyMapper.create(transitModel);
+
     Map<String, Object> map = new HashMap<>();
-    mapper.map(new TransitStopVertex(graph, stop, null)).forEach(o -> map.put(o.first, o.second));
+    mapper
+      .map(
+        new TransitStopVertexBuilder()
+          .withGraph(graph)
+          .withStop(stop)
+          .withTransitModel(transitModel)
+          .build()
+      )
+      .forEach(o -> map.put(o.first, o.second));
 
     assertEquals("F:name", map.get("gtfsId"));
     assertEquals("name", map.get("name"));

--- a/src/ext-test/java/org/opentripplanner/ext/vectortiles/VehicleParkingsLayerTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/vectortiles/VehicleParkingsLayerTest.java
@@ -25,6 +25,7 @@ import org.opentripplanner.routing.vehicle_parking.VehicleParkingSpaces;
 import org.opentripplanner.routing.vehicle_parking.VehicleParkingState;
 import org.opentripplanner.transit.model._data.TransitModelForTest;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.util.NonLocalizedString;
 import org.opentripplanner.util.TranslatedString;
 
@@ -68,10 +69,12 @@ public class VehicleParkingsLayerTest {
     when(service.getVehicleParkings()).thenReturn(List.of(vehicleParking).stream());
 
     Graph graph = mock(Graph.class);
+    TransitModel transitModel = mock(TransitModel.class);
     when(graph.getVehicleParkingService()).thenReturn(service);
 
     VehicleParkingsLayerBuilderWithPublicGeometry builder = new VehicleParkingsLayerBuilderWithPublicGeometry(
       graph,
+      transitModel,
       new VectorTilesResource.LayerParameters() {
         @Override
         public String name() {
@@ -165,9 +168,10 @@ public class VehicleParkingsLayerTest {
 
     public VehicleParkingsLayerBuilderWithPublicGeometry(
       Graph graph,
+      TransitModel transitModel,
       VectorTilesResource.LayerParameters layerParameters
     ) {
-      super(graph, layerParameters);
+      super(graph, transitModel, layerParameters);
     }
 
     @Override

--- a/src/ext/java/org/opentripplanner/ext/actuator/ActuatorAPI.java
+++ b/src/ext/java/org/opentripplanner/ext/actuator/ActuatorAPI.java
@@ -59,7 +59,7 @@ public class ActuatorAPI {
   @GET
   @Path("/health")
   public Response health(@Context OTPServer otpServer) {
-    GraphUpdaterManager updaterManager = otpServer.getRouter().graph.updaterManager;
+    GraphUpdaterManager updaterManager = otpServer.getRouter().transitModel.updaterManager;
     if (updaterManager != null) {
       var listUnprimedUpdaters = updaterManager.listUnprimedUpdaters();
 

--- a/src/ext/java/org/opentripplanner/ext/dataoverlay/EdgeUpdaterModule.java
+++ b/src/ext/java/org/opentripplanner/ext/dataoverlay/EdgeUpdaterModule.java
@@ -6,6 +6,7 @@ import org.opentripplanner.ext.dataoverlay.configuration.TimeUnit;
 import org.opentripplanner.graph_builder.DataImportIssueStore;
 import org.opentripplanner.graph_builder.services.GraphBuilderModule;
 import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.transit.service.TransitModel;
 
 /**
  * This class allows updating the graph with the grid data from generic .nc file in accordance with
@@ -35,6 +36,7 @@ public class EdgeUpdaterModule implements GraphBuilderModule {
   @Override
   public void buildGraph(
     Graph graph,
+    TransitModel transitModel,
     HashMap<Class<?>, Object> extra,
     DataImportIssueStore issueStore
   ) {

--- a/src/ext/java/org/opentripplanner/ext/flex/FlexIndex.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/FlexIndex.java
@@ -6,15 +6,13 @@ import com.google.common.collect.Multimap;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
-import org.opentripplanner.common.geometry.HashGridSpatialIndex;
 import org.opentripplanner.ext.flex.trip.FlexTrip;
 import org.opentripplanner.model.FlexLocationGroup;
-import org.opentripplanner.model.FlexStopLocation;
 import org.opentripplanner.model.PathTransfer;
-import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.site.StopLocation;
+import org.opentripplanner.transit.service.TransitModel;
 
 public class FlexIndex {
 
@@ -22,19 +20,15 @@ public class FlexIndex {
 
   public Multimap<StopLocation, FlexTrip> flexTripsByStop = HashMultimap.create();
 
-  public Multimap<StopLocation, FlexLocationGroup> locationGroupsByStop = ArrayListMultimap.create();
-
-  public HashGridSpatialIndex<FlexStopLocation> locationIndex = new HashGridSpatialIndex<>();
-
   public Map<FeedScopedId, Route> routeById = new HashMap<>();
 
   public Map<FeedScopedId, FlexTrip> tripById = new HashMap<>();
 
-  public FlexIndex(Graph graph) {
-    for (PathTransfer transfer : graph.transfersByStop.values()) {
+  public FlexIndex(TransitModel transitModel) {
+    for (PathTransfer transfer : transitModel.transfersByStop.values()) {
       transfersToStop.put(transfer.to, transfer);
     }
-    for (FlexTrip flexTrip : graph.flexTripsById.values()) {
+    for (FlexTrip flexTrip : transitModel.flexTripsById.values()) {
       routeById.put(flexTrip.getTrip().getRoute().getId(), flexTrip.getTrip().getRoute());
       tripById.put(flexTrip.getTrip().getId(), flexTrip);
       for (StopLocation stop : flexTrip.getStops()) {
@@ -46,14 +40,6 @@ public class FlexIndex {
           flexTripsByStop.put(stop, flexTrip);
         }
       }
-    }
-    for (FlexLocationGroup flexLocationGroup : graph.locationGroupsById.values()) {
-      for (StopLocation stop : flexLocationGroup.getLocations()) {
-        locationGroupsByStop.put(stop, flexLocationGroup);
-      }
-    }
-    for (FlexStopLocation flexStopLocation : graph.locationsById.values()) {
-      locationIndex.insert(flexStopLocation.getGeometry().getEnvelopeInternal(), flexStopLocation);
     }
   }
 

--- a/src/ext/java/org/opentripplanner/ext/flex/FlexLocationsToStreetEdgesMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/FlexLocationsToStreetEdgesMapper.java
@@ -11,6 +11,7 @@ import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.routing.impl.StreetVertexIndex;
 import org.opentripplanner.routing.vertextype.StreetVertex;
+import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.util.logging.ProgressTracker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,10 +23,11 @@ public class FlexLocationsToStreetEdgesMapper implements GraphBuilderModule {
   @Override
   public void buildGraph(
     Graph graph,
+    TransitModel transitModel,
     HashMap<Class<?>, Object> extra,
     DataImportIssueStore issueStore
   ) {
-    if (graph.locationsById.isEmpty()) {
+    if (transitModel.getStopModel().locationsById.isEmpty()) {
       return;
     }
 
@@ -34,12 +36,12 @@ public class FlexLocationsToStreetEdgesMapper implements GraphBuilderModule {
     ProgressTracker progress = ProgressTracker.track(
       "Add flex locations to street vertices",
       1,
-      graph.locationsById.size()
+      transitModel.getStopModel().locationsById.size()
     );
 
     LOG.info(progress.startMessage());
     // TODO: Make this into a parallel stream, first calculate vertices per location and then add them.
-    for (FlexStopLocation flexStopLocation : graph.locationsById.values()) {
+    for (FlexStopLocation flexStopLocation : transitModel.getStopModel().locationsById.values()) {
       for (Vertex vertx : streetIndex.getVerticesForEnvelope(
         flexStopLocation.getGeometry().getEnvelopeInternal()
       )) {

--- a/src/ext/java/org/opentripplanner/ext/flex/FlexRouter.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/FlexRouter.java
@@ -30,11 +30,14 @@ import org.opentripplanner.routing.fares.FareService;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
 import org.opentripplanner.transit.model.site.StopLocation;
+import org.opentripplanner.transit.service.TransitModel;
 
 public class FlexRouter {
 
   /* Transit data */
+
   private final Graph graph;
+  private final TransitModel transitModel;
   private final FlexParameters config;
   private final Collection<NearbyStop> streetAccesses;
   private final Collection<NearbyStop> streetEgresses;
@@ -56,6 +59,7 @@ public class FlexRouter {
 
   public FlexRouter(
     Graph graph,
+    TransitModel transitModel,
     FlexParameters config,
     Instant searchInstant,
     boolean arriveBy,
@@ -65,14 +69,15 @@ public class FlexRouter {
     Collection<NearbyStop> egressTransfers
   ) {
     this.graph = graph;
+    this.transitModel = transitModel;
     this.config = config;
     this.streetAccesses = streetAccesses;
     this.streetEgresses = egressTransfers;
-    this.flexIndex = graph.index.getFlexIndex();
+    this.flexIndex = transitModel.index.getFlexIndex();
     this.graphPathToItineraryMapper =
       new GraphPathToItineraryMapper(
-        graph.getTimeZone(),
-        new AlertToLegMapper(graph.getTransitAlertService()),
+        transitModel.getTimeZone(),
+        new AlertToLegMapper(transitModel.getTransitAlertService()),
         graph.streetNotesService,
         graph.ellipsoidToGeoidDifference
       );
@@ -87,7 +92,7 @@ public class FlexRouter {
       this.egressFlexPathCalculator = new DirectFlexPathCalculator();
     }
 
-    ZoneId tz = graph.getTimeZone().toZoneId();
+    ZoneId tz = transitModel.getTimeZone().toZoneId();
     LocalDate searchDate = LocalDate.ofInstant(searchInstant, tz);
     this.startOfTime = DateMapper.asStartOfService(searchDate, tz);
     this.departureTime = DateMapper.secondsSinceStartOfTime(startOfTime, searchInstant);
@@ -105,7 +110,7 @@ public class FlexRouter {
         new FlexServiceDate(
           serviceDate,
           DateMapper.secondsSinceStartOfTime(startOfTime, date),
-          graph.index.getServiceCodesRunningForDate().get(serviceDate)
+          transitModel.index.getServiceCodesRunningForDate().get(serviceDate)
         );
     }
   }
@@ -134,7 +139,7 @@ public class FlexRouter {
             graphPathToItineraryMapper
           );
           if (itinerary != null) {
-            var fareService = graph.getService(FareService.class);
+            var fareService = transitModel.getService(FareService.class);
             if (fareService != null) {
               itinerary.setFare(fareService.getCost(itinerary));
             }
@@ -151,7 +156,7 @@ public class FlexRouter {
     calculateFlexAccessTemplates();
 
     return this.flexAccessTemplates.stream()
-      .flatMap(template -> template.createFlexAccessEgressStream(graph))
+      .flatMap(template -> template.createFlexAccessEgressStream(graph, transitModel))
       .collect(Collectors.toList());
   }
 
@@ -159,7 +164,7 @@ public class FlexRouter {
     calculateFlexEgressTemplates();
 
     return this.flexEgressTemplates.stream()
-      .flatMap(template -> template.createFlexAccessEgressStream(graph))
+      .flatMap(template -> template.createFlexAccessEgressStream(graph, transitModel))
       .collect(Collectors.toList());
   }
 
@@ -176,7 +181,7 @@ public class FlexRouter {
           Arrays
             .stream(dates)
             // Discard if service is not running on date
-            .filter(date -> date.isFlexTripRunning(t2.second, this.graph))
+            .filter(date -> date.isFlexTripRunning(t2.second, this.transitModel))
             // Create templates from trip, boarding at the nearbyStop
             .flatMap(date ->
               t2.second.getFlexAccessTemplates(t2.first, date, accessFlexPathCalculator, config)
@@ -198,7 +203,7 @@ public class FlexRouter {
           Arrays
             .stream(dates)
             // Discard if service is not running on date
-            .filter(date -> date.isFlexTripRunning(t2.second, this.graph))
+            .filter(date -> date.isFlexTripRunning(t2.second, this.transitModel))
             // Create templates from trip, alighting at the nearbyStop
             .flatMap(date ->
               t2.second.getFlexEgressTemplates(t2.first, date, egressFlexPathCalculator, config)

--- a/src/ext/java/org/opentripplanner/ext/flex/FlexServiceDate.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/FlexServiceDate.java
@@ -3,7 +3,7 @@ package org.opentripplanner.ext.flex;
 import gnu.trove.set.TIntSet;
 import org.opentripplanner.ext.flex.trip.FlexTrip;
 import org.opentripplanner.model.calendar.ServiceDate;
-import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.transit.service.TransitModel;
 
 /**
  * This class contains information used in a flex router, and depends on the date the search was
@@ -29,10 +29,12 @@ public class FlexServiceDate {
     this.servicesRunning = servicesRunning;
   }
 
-  boolean isFlexTripRunning(FlexTrip flexTrip, Graph graph) {
+  boolean isFlexTripRunning(FlexTrip flexTrip, TransitModel transitModel) {
     return (
       servicesRunning != null &&
-      servicesRunning.contains(graph.getServiceCodes().get(flexTrip.getTrip().getServiceId()))
+      servicesRunning.contains(
+        transitModel.getServiceCodes().get(flexTrip.getTrip().getServiceId())
+      )
     );
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/flex/template/FlexAccessTemplate.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/template/FlexAccessTemplate.java
@@ -13,12 +13,12 @@ import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.routing.algorithm.mapping.GraphPathToItineraryMapper;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.graph.Edge;
-import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
 import org.opentripplanner.routing.spt.GraphPath;
 import org.opentripplanner.transit.model.site.Stop;
 import org.opentripplanner.transit.model.site.StopLocation;
+import org.opentripplanner.transit.service.TransitModel;
 
 public class FlexAccessTemplate extends FlexAccessEgressTemplate {
 
@@ -110,8 +110,8 @@ public class FlexAccessTemplate extends FlexAccessEgressTemplate {
     return transfer.to instanceof Stop ? (Stop) transfer.to : null;
   }
 
-  protected Collection<PathTransfer> getTransfersFromTransferStop(Graph graph) {
-    return graph.transfersByStop.get(transferStop);
+  protected Collection<PathTransfer> getTransfersFromTransferStop(TransitModel transitModel) {
+    return transitModel.transfersByStop.get(transferStop);
   }
 
   protected Vertex getFlexVertex(Edge edge) {

--- a/src/ext/java/org/opentripplanner/ext/flex/template/FlexEgressTemplate.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/template/FlexEgressTemplate.java
@@ -11,11 +11,11 @@ import org.opentripplanner.ext.flex.trip.FlexTrip;
 import org.opentripplanner.model.PathTransfer;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.graph.Edge;
-import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
 import org.opentripplanner.transit.model.site.Stop;
 import org.opentripplanner.transit.model.site.StopLocation;
+import org.opentripplanner.transit.service.TransitModel;
 
 public class FlexEgressTemplate extends FlexAccessEgressTemplate {
 
@@ -40,8 +40,8 @@ public class FlexEgressTemplate extends FlexAccessEgressTemplate {
     return transfer.from instanceof Stop ? (Stop) transfer.from : null;
   }
 
-  protected Collection<PathTransfer> getTransfersFromTransferStop(Graph graph) {
-    return graph.index.getFlexIndex().transfersToStop.get(transferStop);
+  protected Collection<PathTransfer> getTransfersFromTransferStop(TransitModel transitModel) {
+    return transitModel.index.getFlexIndex().transfersToStop.get(transferStop);
   }
 
   protected Vertex getFlexVertex(Edge edge) {

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/LegacyGraphQLIndex.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/LegacyGraphQLIndex.java
@@ -192,8 +192,8 @@ class LegacyGraphQLIndex {
 
     LegacyGraphQLRequestContext requestContext = new LegacyGraphQLRequestContext(
       router,
-      new RoutingService(router.graph),
-      new DefaultTransitService(router.graph)
+      new RoutingService(router.graph, router.transitModel),
+      new DefaultTransitService(router.transitModel)
     );
 
     ExecutionInput executionInput = ExecutionInput

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLAgencyImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLAgencyImpl.java
@@ -10,7 +10,6 @@ import java.util.stream.Collectors;
 import org.opentripplanner.ext.legacygraphqlapi.LegacyGraphQLRequestContext;
 import org.opentripplanner.ext.legacygraphqlapi.generated.LegacyGraphQLDataFetchers;
 import org.opentripplanner.ext.legacygraphqlapi.generated.LegacyGraphQLTypes;
-import org.opentripplanner.routing.RoutingService;
 import org.opentripplanner.routing.alertpatch.EntitySelector;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.routing.services.TransitAlertService;
@@ -23,7 +22,7 @@ public class LegacyGraphQLAgencyImpl implements LegacyGraphQLDataFetchers.Legacy
   @Override
   public DataFetcher<Iterable<TransitAlert>> alerts() {
     return environment -> {
-      TransitAlertService alertService = getRoutingService(environment).getTransitAlertService();
+      TransitAlertService alertService = getTransitService(environment).getTransitAlertService();
       var args = new LegacyGraphQLTypes.LegacyGraphQLAgencyAlertsArgs(environment.getArguments());
       Iterable<LegacyGraphQLTypes.LegacyGraphQLAgencyAlertType> types = args.getLegacyGraphQLTypes();
       if (types != null) {
@@ -114,10 +113,6 @@ public class LegacyGraphQLAgencyImpl implements LegacyGraphQLDataFetchers.Legacy
       .stream()
       .filter(route -> route.getAgency().equals(getSource(environment)))
       .collect(Collectors.toList());
-  }
-
-  private RoutingService getRoutingService(DataFetchingEnvironment environment) {
-    return environment.<LegacyGraphQLRequestContext>getContext().getRoutingService();
   }
 
   private TransitService getTransitService(DataFetchingEnvironment environment) {

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLFeedImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLFeedImpl.java
@@ -9,7 +9,6 @@ import java.util.stream.Collectors;
 import org.opentripplanner.ext.legacygraphqlapi.LegacyGraphQLRequestContext;
 import org.opentripplanner.ext.legacygraphqlapi.generated.LegacyGraphQLDataFetchers;
 import org.opentripplanner.ext.legacygraphqlapi.generated.LegacyGraphQLTypes;
-import org.opentripplanner.routing.RoutingService;
 import org.opentripplanner.routing.alertpatch.EntitySelector;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.routing.services.TransitAlertService;
@@ -26,7 +25,7 @@ public class LegacyGraphQLFeedImpl implements LegacyGraphQLDataFetchers.LegacyGr
   @Override
   public DataFetcher<Iterable<TransitAlert>> alerts() {
     return environment -> {
-      TransitAlertService alertService = getRoutingService(environment).getTransitAlertService();
+      TransitAlertService alertService = getTransitService(environment).getTransitAlertService();
       var args = new LegacyGraphQLTypes.LegacyGraphQLFeedAlertsArgs(environment.getArguments());
       Iterable<LegacyGraphQLTypes.LegacyGraphQLFeedAlertType> types = args.getLegacyGraphQLTypes();
       if (types != null) {
@@ -72,10 +71,6 @@ public class LegacyGraphQLFeedImpl implements LegacyGraphQLDataFetchers.LegacyGr
       .stream()
       .filter(agency -> agency.getId().getFeedId().equals(id))
       .collect(Collectors.toList());
-  }
-
-  private RoutingService getRoutingService(DataFetchingEnvironment environment) {
-    return environment.<LegacyGraphQLRequestContext>getContext().getRoutingService();
   }
 
   private TransitService getTransitService(DataFetchingEnvironment environment) {

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLPatternImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLPatternImpl.java
@@ -27,13 +27,14 @@ import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.organization.Agency;
 import org.opentripplanner.transit.model.timetable.Trip;
+import org.opentripplanner.transit.service.TransitService;
 
 public class LegacyGraphQLPatternImpl implements LegacyGraphQLDataFetchers.LegacyGraphQLPattern {
 
   @Override
   public DataFetcher<Iterable<TransitAlert>> alerts() {
     return environment -> {
-      TransitAlertService alertService = getRoutingService(environment).getTransitAlertService();
+      TransitAlertService alertService = getTransitService(environment).getTransitAlertService();
       var args = new LegacyGraphQLTypes.LegacyGraphQLPatternAlertsArgs(environment.getArguments());
       Iterable<LegacyGraphQLTypes.LegacyGraphQLPatternAlertType> types = args.getLegacyGraphQLTypes();
       if (types != null) {
@@ -205,7 +206,7 @@ public class LegacyGraphQLPatternImpl implements LegacyGraphQLDataFetchers.Legac
         .getLegacyGraphQLServiceDate();
 
       try {
-        BitSet services = getRoutingService(environment)
+        BitSet services = getTransitService(environment)
           .getServicesRunningForDate(ServiceDate.parseString(servicaDate));
         return getSource(environment)
           .getScheduledTimetable()
@@ -250,6 +251,10 @@ public class LegacyGraphQLPatternImpl implements LegacyGraphQLDataFetchers.Legac
 
   private RoutingService getRoutingService(DataFetchingEnvironment environment) {
     return environment.<LegacyGraphQLRequestContext>getContext().getRoutingService();
+  }
+
+  private TransitService getTransitService(DataFetchingEnvironment environment) {
+    return environment.<LegacyGraphQLRequestContext>getContext().getTransitService();
   }
 
   private TripPattern getSource(DataFetchingEnvironment environment) {

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
@@ -95,7 +95,7 @@ public class LegacyGraphQLQueryTypeImpl
   @Override
   public DataFetcher<Iterable<TransitAlert>> alerts() {
     return environment -> {
-      Collection<TransitAlert> alerts = getRoutingService(environment)
+      Collection<TransitAlert> alerts = getTransitService(environment)
         .getTransitAlertService()
         .getAllAlerts();
       var args = new LegacyGraphQLTypes.LegacyGraphQLQueryTypeAlertsArgs(
@@ -351,10 +351,9 @@ public class LegacyGraphQLQueryTypeImpl
         environment.getArguments()
       );
 
-      RoutingService routingService = getRoutingService(environment);
       TransitService transitService = getTransitService(environment);
 
-      return new GtfsRealtimeFuzzyTripMatcher(routingService, transitService)
+      return new GtfsRealtimeFuzzyTripMatcher(transitService)
         .getTrip(
           transitService.getRouteForId(FeedScopedId.parseId(args.getLegacyGraphQLRoute())),
           args.getLegacyGraphQLDirection(),
@@ -598,7 +597,7 @@ public class LegacyGraphQLQueryTypeImpl
       request.setDateTime(
         environment.getArgument("date"),
         environment.getArgument("time"),
-        context.getRouter().graph.getTimeZone()
+        context.getRouter().transitModel.getTimeZone()
       );
 
       callWith.argument("wheelchair", request::setWheelchairAccessible);
@@ -1013,7 +1012,7 @@ public class LegacyGraphQLQueryTypeImpl
         new Coordinate(args.getLegacyGraphQLMaxLon(), args.getLegacyGraphQLMaxLat())
       );
 
-      Stream<Stop> stopStream = getRoutingService(environment)
+      Stream<Stop> stopStream = getTransitService(environment)
         .getStopSpatialIndex()
         .query(envelope)
         .stream()

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLRouteImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLRouteImpl.java
@@ -10,7 +10,6 @@ import org.opentripplanner.ext.legacygraphqlapi.LegacyGraphQLRequestContext;
 import org.opentripplanner.ext.legacygraphqlapi.generated.LegacyGraphQLDataFetchers;
 import org.opentripplanner.ext.legacygraphqlapi.generated.LegacyGraphQLTypes;
 import org.opentripplanner.model.TripPattern;
-import org.opentripplanner.routing.RoutingService;
 import org.opentripplanner.routing.alertpatch.EntitySelector;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.routing.services.TransitAlertService;
@@ -228,11 +227,7 @@ public class LegacyGraphQLRouteImpl implements LegacyGraphQLDataFetchers.LegacyG
   }
 
   private TransitAlertService getAlertService(DataFetchingEnvironment environment) {
-    return getRoutingService(environment).getTransitAlertService();
-  }
-
-  private RoutingService getRoutingService(DataFetchingEnvironment environment) {
-    return environment.<LegacyGraphQLRequestContext>getContext().getRoutingService();
+    return getTransitService(environment).getTransitAlertService();
   }
 
   private TransitService getTransitService(DataFetchingEnvironment environment) {

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLStopImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLStopImpl.java
@@ -43,7 +43,7 @@ public class LegacyGraphQLStopImpl implements LegacyGraphQLDataFetchers.LegacyGr
   @Override
   public DataFetcher<Iterable<TransitAlert>> alerts() {
     return environment -> {
-      TransitAlertService alertService = getRoutingService(environment).getTransitAlertService();
+      TransitAlertService alertService = getTransitService(environment).getTransitAlertService();
       var args = new LegacyGraphQLTypes.LegacyGraphQLStopAlertsArgs(environment.getArguments());
       List<LegacyGraphQLTypes.LegacyGraphQLStopAlertType> types = (List) args.getLegacyGraphQLTypes();
       FeedScopedId id = getValue(environment, stop -> stop.getId(), station -> station.getId());

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLTripImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLTripImpl.java
@@ -50,7 +50,7 @@ public class LegacyGraphQLTripImpl implements LegacyGraphQLDataFetchers.LegacyGr
   @Override
   public DataFetcher<Iterable<TransitAlert>> alerts() {
     return environment -> {
-      TransitAlertService alertService = getRoutingService(environment).getTransitAlertService();
+      TransitAlertService alertService = getTransitService(environment).getTransitAlertService();
       var args = new LegacyGraphQLTypes.LegacyGraphQLTripAlertsArgs(environment.getArguments());
       Iterable<LegacyGraphQLTypes.LegacyGraphQLTripAlertType> types = args.getLegacyGraphQLTypes();
       if (types != null) {

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLserviceTimeRangeImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLserviceTimeRangeImpl.java
@@ -4,22 +4,22 @@ import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import org.opentripplanner.ext.legacygraphqlapi.LegacyGraphQLRequestContext;
 import org.opentripplanner.ext.legacygraphqlapi.generated.LegacyGraphQLDataFetchers;
-import org.opentripplanner.routing.RoutingService;
+import org.opentripplanner.transit.service.TransitService;
 
 public class LegacyGraphQLserviceTimeRangeImpl
   implements LegacyGraphQLDataFetchers.LegacyGraphQLServiceTimeRange {
 
   @Override
   public DataFetcher<Long> end() {
-    return environment -> getRoutingService(environment).getTransitServiceEnds();
+    return environment -> getTransitService(environment).getTransitServiceEnds();
   }
 
   @Override
   public DataFetcher<Long> start() {
-    return environment -> getRoutingService(environment).getTransitServiceStarts();
+    return environment -> getTransitService(environment).getTransitServiceStarts();
   }
 
-  private RoutingService getRoutingService(DataFetchingEnvironment environment) {
-    return environment.<LegacyGraphQLRequestContext>getContext().getRoutingService();
+  private TransitService getTransitService(DataFetchingEnvironment environment) {
+    return environment.<LegacyGraphQLRequestContext>getContext().getTransitService();
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/reportapi/model/TransfersReport.java
+++ b/src/ext/java/org/opentripplanner/ext/reportapi/model/TransfersReport.java
@@ -13,11 +13,11 @@ import org.opentripplanner.model.transfer.StopTransferPoint;
 import org.opentripplanner.model.transfer.TransferConstraint;
 import org.opentripplanner.model.transfer.TransferPoint;
 import org.opentripplanner.model.transfer.TripTransferPoint;
-import org.opentripplanner.routing.graph.GraphIndex;
 import org.opentripplanner.transit.model.basic.WgsCoordinate;
 import org.opentripplanner.transit.model.site.Station;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.timetable.Trip;
+import org.opentripplanner.transit.service.TransitModelIndex;
 
 /**
  * This class is used to export transfers for human verification to a CSV file. This is useful when
@@ -32,15 +32,15 @@ public class TransfersReport {
   private static final int NOT_SET = -1;
 
   private final List<ConstrainedTransfer> transfers;
-  private final GraphIndex index;
+  private final TransitModelIndex index;
   private final CsvReportBuilder buf = new CsvReportBuilder();
 
-  private TransfersReport(List<ConstrainedTransfer> transfers, GraphIndex index) {
+  private TransfersReport(List<ConstrainedTransfer> transfers, TransitModelIndex index) {
     this.transfers = transfers;
     this.index = index;
   }
 
-  public static String export(List<ConstrainedTransfer> transfers, GraphIndex index) {
+  public static String export(List<ConstrainedTransfer> transfers, TransitModelIndex index) {
     return new TransfersReport(transfers, index).export();
   }
 

--- a/src/ext/java/org/opentripplanner/ext/reportapi/resource/ReportResource.java
+++ b/src/ext/java/org/opentripplanner/ext/reportapi/resource/ReportResource.java
@@ -13,20 +13,20 @@ import javax.ws.rs.core.Response;
 import org.opentripplanner.ext.reportapi.model.BicyleSafetyReport;
 import org.opentripplanner.ext.reportapi.model.TransfersReport;
 import org.opentripplanner.model.transfer.TransferService;
-import org.opentripplanner.routing.graph.GraphIndex;
 import org.opentripplanner.standalone.server.OTPServer;
+import org.opentripplanner.transit.service.TransitModelIndex;
 
 @Path("/report")
 @Produces(MediaType.TEXT_PLAIN)
 public class ReportResource {
 
   private final TransferService transferService;
-  private final GraphIndex index;
+  private final TransitModelIndex index;
 
   @SuppressWarnings("unused")
   public ReportResource(@Context OTPServer server) {
-    this.transferService = server.getRouter().graph.getTransferService();
-    this.index = server.getRouter().graph.index;
+    this.transferService = server.getRouter().transitModel.getTransferService();
+    this.index = server.getRouter().transitModel.index;
   }
 
   @GET

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriAlertsUpdateHandler.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriAlertsUpdateHandler.java
@@ -16,11 +16,11 @@ import org.opentripplanner.routing.alertpatch.StopCondition;
 import org.opentripplanner.routing.alertpatch.TimePeriod;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.mappers.DateMapper;
-import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.SubMode;
 import org.opentripplanner.transit.model.network.TransitMode;
+import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.util.I18NString;
 import org.opentripplanner.util.NonLocalizedString;
 import org.opentripplanner.util.TranslatedString;
@@ -60,16 +60,16 @@ public class SiriAlertsUpdateHandler {
 
   private static final Logger LOG = LoggerFactory.getLogger(SiriAlertsUpdateHandler.class);
   private final String feedId;
-  private final Graph graph;
+  private final TransitModel transitModel;
   private final Set<TransitAlert> alerts = new HashSet<>();
   private TransitAlertService transitAlertService;
   /** How long before the posted start of an event it should be displayed to users */
   private long earlyStart;
   private SiriFuzzyTripMatcher siriFuzzyTripMatcher;
 
-  public SiriAlertsUpdateHandler(String feedId, Graph graph) {
+  public SiriAlertsUpdateHandler(String feedId, TransitModel transitModel) {
     this.feedId = feedId;
-    this.graph = graph;
+    this.transitModel = transitModel;
   }
 
   public void update(ServiceDelivery delivery) {
@@ -403,7 +403,7 @@ public class SiriAlertsUpdateHandler {
               if (dataFrameRef != null && dataFrameRef.getValue() != null) {
                 ZonedDateTime startOfService = DateMapper.asStartOfService(
                   LocalDate.parse(dataFrameRef.getValue()),
-                  graph.getTimeZone().toZoneId()
+                  transitModel.getTimeZone().toZoneId()
                 );
 
                 serviceDate =

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTripPatternCache.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTripPatternCache.java
@@ -11,10 +11,10 @@ import javax.validation.constraints.NotNull;
 import org.opentripplanner.model.StopPattern;
 import org.opentripplanner.model.TripPattern;
 import org.opentripplanner.model.calendar.ServiceDate;
-import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.transit.model.site.Stop;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.timetable.Trip;
+import org.opentripplanner.transit.service.TransitModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,18 +41,18 @@ public class SiriTripPatternCache {
 
   /**
    * Get cached trip pattern or create one if it doesn't exist yet. If a trip pattern is created,
-   * vertices and edges for this trip pattern are also created in the graph.
+   * vertices and edges for this trip pattern are also created in the transitModel.
    *
    * @param stopPattern stop pattern to retrieve/create trip pattern
    * @param trip        Trip containing route of new trip pattern in case a new trip pattern will be
    *                    created
-   * @param graph       graph to add vertices and edges in case a new trip pattern will be created
+   * @param transitModel       transitModel to add vertices and edges in case a new trip pattern will be created
    * @return cached or newly created trip pattern
    */
   public synchronized TripPattern getOrCreateTripPattern(
     @NotNull final StopPattern stopPattern,
     @NotNull final Trip trip,
-    @NotNull final Graph graph,
+    @NotNull final TransitModel transitModel,
     @NotNull ServiceDate serviceDate
   ) {
     // Check cache for trip pattern
@@ -65,18 +65,18 @@ public class SiriTripPatternCache {
       tripPattern = new TripPattern(id, trip.getRoute(), stopPattern);
 
       // Create an empty bitset for service codes (because the new pattern does not contain any trips)
-      tripPattern.setServiceCodes(graph.getServiceCodes());
+      tripPattern.setServiceCodes(transitModel.getServiceCodes());
 
       // Finish scheduled time table
       tripPattern.getScheduledTimetable().finish();
 
       // Create vertices and edges for new TripPattern
       // TODO: purge these vertices and edges once in a while?
-      //            tripPattern.makePatternVerticesAndEdges(graph, graph.index.stopVertexForStop);
+      //            tripPattern.makePatternVerticesAndEdges(transitModel, transitModel.index.stopVertexForStop);
 
-      // TODO - SIRI: Add pattern to graph index?
+      // TODO - SIRI: Add pattern to transitModel index?
 
-      TripPattern originalTripPattern = graph.index.getPatternForTrip().get(trip);
+      TripPattern originalTripPattern = transitModel.index.getPatternForTrip().get(trip);
 
       tripPattern.setCreatedByRealtimeUpdater();
 

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriSXUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriSXUpdater.java
@@ -12,6 +12,7 @@ import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
 import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.transit.service.DefaultTransitService;
+import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.updater.PollingGraphUpdater;
 import org.opentripplanner.updater.WriteToGraphCallback;
 import org.opentripplanner.updater.alerts.TransitAlertProvider;
@@ -71,13 +72,13 @@ public class SiriSXUpdater extends PollingGraphUpdater implements TransitAlertPr
   }
 
   @Override
-  public void setup(Graph graph) {
-    this.transitAlertService = new TransitAlertServiceImpl(graph);
+  public void setup(Graph graph, TransitModel transitModel) {
+    this.transitAlertService = new TransitAlertServiceImpl(transitModel);
     SiriFuzzyTripMatcher fuzzyTripMatcher = new SiriFuzzyTripMatcher(
-      new DefaultTransitService(graph)
+      new DefaultTransitService(transitModel)
     );
     if (updateHandler == null) {
-      updateHandler = new SiriAlertsUpdateHandler(feedId, graph);
+      updateHandler = new SiriAlertsUpdateHandler(feedId, transitModel);
     }
     updateHandler.setEarlyStart(earlyStart);
     updateHandler.setTransitAlertService(transitAlertService);
@@ -107,7 +108,7 @@ public class SiriSXUpdater extends PollingGraphUpdater implements TransitAlertPr
           moreData = BooleanUtils.isTrue(serviceDelivery.isMoreData());
           final boolean markPrimed = !moreData;
           if (serviceDelivery.getSituationExchangeDeliveries() != null) {
-            saveResultOnGraph.execute(graph -> {
+            saveResultOnGraph.execute((graph, transitModel) -> {
               updateHandler.update(serviceDelivery);
               if (markPrimed) primed = true;
             });

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/azure/AbstractAzureSiriUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/azure/AbstractAzureSiriUpdater.java
@@ -12,17 +12,11 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import org.opentripplanner.ext.siri.SiriTimetableSnapshotSource;
-import org.opentripplanner.ext.siri.SiriTimetableSnapshotSource;
 import org.opentripplanner.routing.graph.Graph;
-import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.updater.GraphUpdater;
-import org.opentripplanner.updater.GraphUpdater;
-import org.opentripplanner.updater.GraphUpdaterManager;
-import org.opentripplanner.updater.GraphUpdaterManager;
 import org.opentripplanner.updater.WriteToGraphCallback;
 import org.slf4j.Logger;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.slf4j.LoggerFactory;
 
 public abstract class AbstractAzureSiriUpdater implements GraphUpdater {
@@ -80,8 +74,9 @@ public abstract class AbstractAzureSiriUpdater implements GraphUpdater {
   }
 
   @Override
-  public void setup(Graph graph) throws Exception {
-    snapshotSource = graph.getOrSetupTimetableSnapshotProvider(SiriTimetableSnapshotSource::new);
+  public void setup(Graph graph, TransitModel transitModel) throws Exception {
+    snapshotSource =
+      transitModel.getOrSetupTimetableSnapshotProvider(SiriTimetableSnapshotSource::new);
   }
 
   @Override

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureETUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureETUpdater.java
@@ -104,8 +104,8 @@ public class SiriAzureETUpdater extends AbstractAzureSiriUpdater {
         return;
       }
 
-      super.saveResultOnGraph.execute(graph ->
-        snapshotSource.applyEstimatedTimetable(graph, feedId, false, updates)
+      super.saveResultOnGraph.execute((graph, transitModel) ->
+        snapshotSource.applyEstimatedTimetable(transitModel, feedId, false, updates)
       );
     } catch (JAXBException | XMLStreamException e) {
       LOG.error(e.getLocalizedMessage(), e);
@@ -121,9 +121,9 @@ public class SiriAzureETUpdater extends AbstractAzureSiriUpdater {
         return;
       }
 
-      super.saveResultOnGraph.execute(graph -> {
+      super.saveResultOnGraph.execute((graph, transitModel) -> {
         long t1 = System.currentTimeMillis();
-        snapshotSource.applyEstimatedTimetable(graph, feedId, false, updates);
+        snapshotSource.applyEstimatedTimetable(transitModel, feedId, false, updates);
 
         setPrimed(true);
         LOG.info(

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureSXUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureSXUpdater.java
@@ -24,6 +24,7 @@ import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
 import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.transit.service.DefaultTransitService;
+import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.updater.alerts.TransitAlertProvider;
 import org.opentripplanner.util.HttpUtils;
 import org.rutebanken.siri20.util.SiriXml;
@@ -49,14 +50,14 @@ public class SiriAzureSXUpdater extends AbstractAzureSiriUpdater implements Tran
   }
 
   @Override
-  public void setup(Graph graph) throws Exception {
-    super.setup(graph);
-    this.transitAlertService = new TransitAlertServiceImpl(graph);
+  public void setup(Graph graph, TransitModel transitModel) throws Exception {
+    super.setup(graph, transitModel);
+    this.transitAlertService = new TransitAlertServiceImpl(transitModel);
     SiriFuzzyTripMatcher fuzzyTripMatcher = new SiriFuzzyTripMatcher(
-      new DefaultTransitService(graph)
+      new DefaultTransitService(transitModel)
     );
     if (updateHandler == null) {
-      updateHandler = new SiriAlertsUpdateHandler(feedId, graph);
+      updateHandler = new SiriAlertsUpdateHandler(feedId, transitModel);
     }
     updateHandler.setTransitAlertService(transitAlertService);
     updateHandler.setSiriFuzzyTripMatcher(fuzzyTripMatcher);
@@ -143,7 +144,9 @@ public class SiriAzureSXUpdater extends AbstractAzureSiriUpdater implements Tran
         return;
       }
 
-      super.saveResultOnGraph.execute(graph -> updateHandler.update(siri.getServiceDelivery()));
+      super.saveResultOnGraph.execute((graph, transitModel) ->
+        updateHandler.update(siri.getServiceDelivery())
+      );
     } catch (JAXBException | XMLStreamException e) {
       LOG.error(e.getLocalizedMessage(), e);
     }
@@ -157,7 +160,7 @@ public class SiriAzureSXUpdater extends AbstractAzureSiriUpdater implements Tran
         return;
       }
 
-      super.saveResultOnGraph.execute(graph -> {
+      super.saveResultOnGraph.execute((graph, transitModel) -> {
         long t1 = System.currentTimeMillis();
         updateHandler.update(siri.getServiceDelivery());
 

--- a/src/ext/java/org/opentripplanner/ext/transferanalyzer/DirectTransferAnalyzer.java
+++ b/src/ext/java/org/opentripplanner/ext/transferanalyzer/DirectTransferAnalyzer.java
@@ -13,12 +13,13 @@ import org.opentripplanner.ext.transferanalyzer.annotations.TransferRoutingDista
 import org.opentripplanner.graph_builder.DataImportIssueStore;
 import org.opentripplanner.graph_builder.services.GraphBuilderModule;
 import org.opentripplanner.routing.graph.Graph;
-import org.opentripplanner.routing.graph.GraphIndex;
 import org.opentripplanner.routing.graphfinder.DirectGraphFinder;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
 import org.opentripplanner.routing.graphfinder.StreetGraphFinder;
 import org.opentripplanner.routing.vertextype.TransitStopVertex;
 import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.service.TransitModel;
+import org.opentripplanner.transit.service.TransitModelIndex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,11 +50,12 @@ public class DirectTransferAnalyzer implements GraphBuilderModule {
   @Override
   public void buildGraph(
     Graph graph,
+    TransitModel transitModel,
     HashMap<Class<?>, Object> extra,
     DataImportIssueStore issueStore
   ) {
     /* Initialize graph index which is needed by the nearby stop finder. */
-    graph.index = new GraphIndex(graph);
+    transitModel.index = new TransitModelIndex(transitModel);
 
     LOG.info("Analyzing transfers (this can be time consuming)...");
 

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelAPI.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelAPI.java
@@ -30,9 +30,9 @@ import org.opentripplanner.api.json.GraphQLResponseSerializer;
 import org.opentripplanner.ext.transmodelapi.mapping.TransitIdMapper;
 import org.opentripplanner.ext.transmodelapi.support.GqlUtil;
 import org.opentripplanner.routing.api.request.RoutingRequest;
-import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.standalone.server.OTPServer;
 import org.opentripplanner.standalone.server.Router;
+import org.opentripplanner.transit.service.TransitModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,14 +72,14 @@ public class TransmodelAPI {
    */
   public static void setUp(
     TransmodelAPIParameters config,
-    Graph graph,
+    TransitModel transitModel,
     RoutingRequest defaultRoutingRequest
   ) {
     if (config.hideFeedId()) {
-      TransitIdMapper.setupFixedFeedId(graph.getAgencies());
+      TransitIdMapper.setupFixedFeedId(transitModel.getAgencies());
     }
     tracingHeaderTags = config.tracingHeaderTags();
-    GqlUtil gqlUtil = new GqlUtil(graph.getTimeZone());
+    GqlUtil gqlUtil = new GqlUtil(transitModel.getTimeZone());
     schema = TransmodelGraphQLSchema.create(defaultRoutingRequest, gqlUtil);
   }
 

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraph.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraph.java
@@ -65,8 +65,8 @@ class TransmodelGraph {
 
     TransmodelRequestContext transmodelRequestContext = new TransmodelRequestContext(
       router,
-      new RoutingService(router.graph),
-      new DefaultTransitService(router.graph)
+      new RoutingService(router.graph, router.transitModel),
+      new DefaultTransitService(router.transitModel)
     );
 
     ExecutionInput executionInput = ExecutionInput

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
@@ -90,7 +90,6 @@ import org.opentripplanner.ext.transmodelapi.support.GqlUtil;
 import org.opentripplanner.model.calendar.ServiceDate;
 import org.opentripplanner.model.plan.legreference.LegReference;
 import org.opentripplanner.model.plan.legreference.LegReferenceSerializer;
-import org.opentripplanner.routing.RoutingService;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.error.RoutingValidationException;
@@ -590,7 +589,6 @@ public class TransmodelGraphQLSchema {
               ) {
                 throw new IllegalArgumentException("Unable to combine other filters with ids");
               }
-              RoutingService routingService = GqlUtil.getRoutingService(environment);
               TransitService transitService = GqlUtil.getTransitService(environment);
               return ((List<String>) environment.getArgument("ids")).stream()
                 .map(id -> transitService.getStopForId(TransitIdMapper.mapIDToDomain(id)))
@@ -657,7 +655,7 @@ public class TransmodelGraphQLSchema {
           )
           .dataFetcher(environment -> {
             return GqlUtil
-              .getTransitService(environment)
+              .getRoutingService(environment)
               .getStopsByBoundingBox(
                 environment.getArgument("minimumLatitude"),
                 environment.getArgument("minimumLongitude"),
@@ -1136,7 +1134,7 @@ public class TransmodelGraphQLSchema {
               stream =
                 stream.filter(t ->
                   GqlUtil
-                    .getRoutingService(environment)
+                    .getTransitService(environment)
                     .getFlexIndex()
                     .routeById.containsKey(t.getId())
                 );
@@ -1496,7 +1494,7 @@ public class TransmodelGraphQLSchema {
           )
           .dataFetcher(environment -> {
             Collection<TransitAlert> alerts = GqlUtil
-              .getRoutingService(environment)
+              .getTransitService(environment)
               .getTransitAlertService()
               .getAllAlerts();
             if ((environment.getArgument("authorities") instanceof List)) {
@@ -1535,7 +1533,7 @@ public class TransmodelGraphQLSchema {
           )
           .dataFetcher(environment -> {
             return GqlUtil
-              .getRoutingService(environment)
+              .getTransitService(environment)
               .getTransitAlertService()
               .getAlertById(environment.getArgument("situationNumber"));
           })

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/framework/AuthorityType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/framework/AuthorityType.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.ext.transmodelapi.model.framework;
 
-import static org.opentripplanner.ext.transmodelapi.support.GqlUtil.getRoutingService;
 import static org.opentripplanner.ext.transmodelapi.support.GqlUtil.getTransitService;
 
 import graphql.Scalars;
@@ -85,7 +84,7 @@ public class AuthorityType {
           .description("Get all situations active for the authority.")
           .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(ptSituationElementType))))
           .dataFetcher(environment ->
-            getRoutingService(environment)
+            getTransitService(environment)
               .getTransitAlertService()
               .getAgencyAlerts(((Agency) environment.getSource()).getId())
           )

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/network/JourneyPatternType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/network/JourneyPatternType.java
@@ -86,7 +86,7 @@ public class JourneyPatternType {
           .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(serviceJourneyType))))
           .dataFetcher(environment -> {
             BitSet services = GqlUtil
-              .getRoutingService(environment)
+              .getTransitService(environment)
               .getServicesRunningForDate(
                 Optional
                   .ofNullable((LocalDate) environment.getArgument("date"))
@@ -149,7 +149,7 @@ public class JourneyPatternType {
           .dataFetcher(environment -> {
             TripPattern tripPattern = environment.getSource();
             return GqlUtil
-              .getRoutingService(environment)
+              .getTransitService(environment)
               .getTransitAlertService()
               .getDirectionAndRouteAlerts(
                 tripPattern.getDirection().gtfsCode,

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/network/LineType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/network/LineType.java
@@ -193,7 +193,7 @@ public class LineType {
               // Workaround since flex trips are not part of patterns yet
               result.addAll(
                 GqlUtil
-                  .getRoutingService(environment)
+                  .getTransitService(environment)
                   .getFlexIndex()
                   .tripById.values()
                   .stream()
@@ -225,7 +225,7 @@ public class LineType {
           .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(ptSituationElementType))))
           .dataFetcher(environment ->
             GqlUtil
-              .getRoutingService(environment)
+              .getTransitService(environment)
               .getTransitAlertService()
               .getRouteAlerts(((Route) environment.getSource()).getId())
           )

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/et/EstimatedCallType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/et/EstimatedCallType.java
@@ -22,13 +22,13 @@ import org.opentripplanner.ext.transmodelapi.support.GqlUtil;
 import org.opentripplanner.model.TripTimeOnDate;
 import org.opentripplanner.model.calendar.ServiceDate;
 import org.opentripplanner.routing.DatedServiceJourneyHelper;
-import org.opentripplanner.routing.RoutingService;
 import org.opentripplanner.routing.alertpatch.StopCondition;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.timetable.Trip;
+import org.opentripplanner.transit.service.TransitService;
 
 public class EstimatedCallType {
 
@@ -342,7 +342,7 @@ public class EstimatedCallType {
           .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(ptSituationElementType))))
           .description("Get all relevant situations for this EstimatedCall.")
           .dataFetcher(environment ->
-            getAllRelevantAlerts(environment.getSource(), GqlUtil.getRoutingService(environment))
+            getAllRelevantAlerts(environment.getSource(), GqlUtil.getTransitService(environment))
           )
           .build()
       )
@@ -371,7 +371,7 @@ public class EstimatedCallType {
    */
   private static Collection<TransitAlert> getAllRelevantAlerts(
     TripTimeOnDate tripTimeOnDate,
-    RoutingService routingService
+    TransitService transitService
   ) {
     Trip trip = tripTimeOnDate.getTrip();
     FeedScopedId tripId = trip.getId();
@@ -384,7 +384,7 @@ public class EstimatedCallType {
 
     Collection<TransitAlert> allAlerts = new HashSet<>();
 
-    TransitAlertService alertPatchService = routingService.getTransitAlertService();
+    TransitAlertService alertPatchService = transitService.getTransitAlertService();
 
     final ServiceDate serviceDate = tripTimeOnDate.getServiceDay();
 

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/QuayType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/QuayType.java
@@ -335,7 +335,7 @@ public class QuayType {
           .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(ptSituationElementType))))
           .dataFetcher(env -> {
             return GqlUtil
-              .getRoutingService(env)
+              .getTransitService(env)
               .getTransitAlertService()
               .getStopAlerts(((StopLocation) env.getSource()).getId());
           })

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/StopPlaceType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/StopPlaceType.java
@@ -460,7 +460,7 @@ public class StopPlaceType {
     final RoutingService routingService = GqlUtil.getRoutingService(environment);
     final TransitService transitService = GqlUtil.getTransitService(environment);
 
-    Stream<Station> stations = transitService
+    Stream<Station> stations = routingService
       .getStopsByBoundingBox(minLat, minLon, maxLat, maxLon)
       .stream()
       .map(StopLocation::getParentStation)

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/ServiceJourneyType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/ServiceJourneyType.java
@@ -320,7 +320,7 @@ public class ServiceJourneyType {
           .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(ptSituationElementType))))
           .dataFetcher(environment ->
             GqlUtil
-              .getRoutingService(environment)
+              .getTransitService(environment)
               .getTransitAlertService()
               .getTripAlerts(trip(environment).getId(), null)
           )

--- a/src/ext/java/org/opentripplanner/ext/traveltime/TravelTimeResource.java
+++ b/src/ext/java/org/opentripplanner/ext/traveltime/TravelTimeResource.java
@@ -99,7 +99,7 @@ public class TravelTimeResource {
     @QueryParam("modes") String modes
   ) {
     router = otpServer.getRouter();
-    transitLayer = router.graph.getRealtimeTransitLayer();
+    transitLayer = router.transitModel.getRealtimeTransitLayer();
     ZoneId zoneId = transitLayer.getTransitDataZoneId();
     routingRequest = router.copyDefaultRoutingRequest();
     routingRequest.from = LocationStringParser.fromOldStyleString(location);
@@ -128,12 +128,12 @@ public class TravelTimeResource {
 
     requestTransitDataProvider =
       new RaptorRoutingRequestTransitData(
-        router.graph.getTransferService(),
+        router.transitModel.getTransferService(),
         transitLayer,
         startOfTime,
         0,
         (int) Period.between(startDate, endDate).get(ChronoUnit.DAYS),
-        new RoutingRequestTransitDataProviderFilter(routingRequest, router.graph.index),
+        new RoutingRequestTransitDataProviderFilter(routingRequest, router.transitModel.index),
         new RoutingContext(transferRoutingRequest, router.graph, (Vertex) null, null)
       );
   }
@@ -244,6 +244,7 @@ public class TravelTimeResource {
   ) {
     final Collection<NearbyStop> accessStops = AccessEgressRouter.streetSearch(
       new RoutingContext(accessRequest, router.graph, temporaryVertices),
+      router.transitModel,
       routingRequest.modes.accessMode,
       false
     );
@@ -268,7 +269,7 @@ public class TravelTimeResource {
         final int arrivalTime = arrivals.bestTransitArrivalTime(i);
         StopLocation stopLocation = transitLayer.getStopIndex().stopByIndex(i);
         if (stopLocation instanceof Stop stop) {
-          Vertex v = router.graph.index.getStopVertexForStop().get(stop);
+          Vertex v = router.transitModel.getStopModel().getStopVertexForStop().get(stop);
           if (v != null) {
             Instant time = startOfTime.plusSeconds(arrivalTime).toInstant();
             State s = new State(v, time, routingContext, stateData.clone());

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/LayerBuilderFactory.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/LayerBuilderFactory.java
@@ -1,0 +1,13 @@
+package org.opentripplanner.ext.vectortiles;
+
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.transit.service.TransitModel;
+
+@FunctionalInterface
+public interface LayerBuilderFactory {
+  LayerBuilder create(
+    Graph graph,
+    TransitModel transitModel,
+    VectorTilesResource.LayerParameters layerParameters
+  );
+}

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stations/DigitransitStationPropertyMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stations/DigitransitStationPropertyMapper.java
@@ -7,21 +7,21 @@ import java.util.stream.Collectors;
 import org.json.simple.JSONArray;
 import org.opentripplanner.common.model.T2;
 import org.opentripplanner.ext.vectortiles.PropertyMapper;
-import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.site.Station;
 import org.opentripplanner.transit.model.site.StopLocation;
+import org.opentripplanner.transit.service.TransitModel;
 
 public class DigitransitStationPropertyMapper extends PropertyMapper<Station> {
 
-  private final Graph graph;
+  private final TransitModel transitModel;
 
-  private DigitransitStationPropertyMapper(Graph graph) {
-    this.graph = graph;
+  private DigitransitStationPropertyMapper(TransitModel transitModel) {
+    this.transitModel = transitModel;
   }
 
-  public static DigitransitStationPropertyMapper create(Graph graph) {
-    return new DigitransitStationPropertyMapper(graph);
+  public static DigitransitStationPropertyMapper create(TransitModel transitModel) {
+    return new DigitransitStationPropertyMapper(transitModel);
   }
 
   @Override
@@ -36,7 +36,7 @@ public class DigitransitStationPropertyMapper extends PropertyMapper<Station> {
         "type",
         childStops
           .stream()
-          .flatMap(stop -> graph.index.getPatternsForStop(stop).stream())
+          .flatMap(stop -> transitModel.index.getPatternsForStop(stop).stream())
           .map(tripPattern -> tripPattern.getMode().name())
           .distinct()
           .collect(Collectors.joining(","))
@@ -56,7 +56,7 @@ public class DigitransitStationPropertyMapper extends PropertyMapper<Station> {
         JSONArray.toJSONString(
           childStops
             .stream()
-            .flatMap(stop -> graph.index.getRoutesForStop(stop).stream())
+            .flatMap(stop -> transitModel.index.getRoutesForStop(stop).stream())
             .distinct()
             .map(route ->
               route.getShortName() == null

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stations/StationsLayerBuilder.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stations/StationsLayerBuilder.java
@@ -14,25 +14,31 @@ import org.opentripplanner.ext.vectortiles.PropertyMapper;
 import org.opentripplanner.ext.vectortiles.VectorTilesResource;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.transit.model.site.Station;
+import org.opentripplanner.transit.service.TransitModel;
 
 public class StationsLayerBuilder extends LayerBuilder<Station> {
 
-  static Map<MapperType, Function<Graph, PropertyMapper<Station>>> mappers = Map.of(
+  static Map<MapperType, Function<TransitModel, PropertyMapper<Station>>> mappers = Map.of(
     MapperType.Digitransit,
     DigitransitStationPropertyMapper::create
   );
-  private final Graph graph;
+  private final TransitModel transitModel;
 
-  public StationsLayerBuilder(Graph graph, VectorTilesResource.LayerParameters layerParameters) {
+  public StationsLayerBuilder(
+    Graph graph,
+    TransitModel transitModel,
+    VectorTilesResource.LayerParameters layerParameters
+  ) {
     super(
       layerParameters.name(),
-      mappers.get(MapperType.valueOf(layerParameters.mapper())).apply(graph)
+      mappers.get(MapperType.valueOf(layerParameters.mapper())).apply(transitModel)
     );
-    this.graph = graph;
+    this.transitModel = transitModel;
   }
 
   protected List<Geometry> getGeometries(Envelope query) {
-    return graph
+    return transitModel
+      .getStopModel()
       .getStations()
       .stream()
       .map(station -> {

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/DigitransitStopPropertyMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/DigitransitStopPropertyMapper.java
@@ -11,26 +11,26 @@ import org.json.simple.JSONObject;
 import org.opentripplanner.common.model.T2;
 import org.opentripplanner.ext.vectortiles.PropertyMapper;
 import org.opentripplanner.model.TripPattern;
-import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.vertextype.TransitStopVertex;
 import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.service.TransitModel;
 
 public class DigitransitStopPropertyMapper extends PropertyMapper<TransitStopVertex> {
 
-  private final Graph graph;
+  private final TransitModel transitModel;
 
-  private DigitransitStopPropertyMapper(Graph graph) {
-    this.graph = graph;
+  private DigitransitStopPropertyMapper(TransitModel transitModel) {
+    this.transitModel = transitModel;
   }
 
-  public static DigitransitStopPropertyMapper create(Graph graph) {
-    return new DigitransitStopPropertyMapper(graph);
+  public static DigitransitStopPropertyMapper create(TransitModel transitModel) {
+    return new DigitransitStopPropertyMapper(transitModel);
   }
 
   @Override
   public Collection<T2<String, Object>> map(TransitStopVertex input) {
     Stop stop = input.getStop();
-    Collection<TripPattern> patternsForStop = graph.index.getPatternsForStop(stop);
+    Collection<TripPattern> patternsForStop = transitModel.index.getPatternsForStop(stop);
 
     String type = patternsForStop
       .stream()

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/StopsLayerBuilder.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/StopsLayerBuilder.java
@@ -13,25 +13,30 @@ import org.opentripplanner.ext.vectortiles.PropertyMapper;
 import org.opentripplanner.ext.vectortiles.VectorTilesResource;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.vertextype.TransitStopVertex;
+import org.opentripplanner.transit.service.TransitModel;
 
 public class StopsLayerBuilder extends LayerBuilder<TransitStopVertex> {
 
-  static Map<MapperType, Function<Graph, PropertyMapper<TransitStopVertex>>> mappers = Map.of(
+  static Map<MapperType, Function<TransitModel, PropertyMapper<TransitStopVertex>>> mappers = Map.of(
     MapperType.Digitransit,
     DigitransitStopPropertyMapper::create
   );
-  private final Graph graph;
+  private final TransitModel transitModel;
 
-  public StopsLayerBuilder(Graph graph, VectorTilesResource.LayerParameters layerParameters) {
+  public StopsLayerBuilder(
+    Graph graph,
+    TransitModel transitModel,
+    VectorTilesResource.LayerParameters layerParameters
+  ) {
     super(
       layerParameters.name(),
-      mappers.get(MapperType.valueOf(layerParameters.mapper())).apply(graph)
+      mappers.get(MapperType.valueOf(layerParameters.mapper())).apply(transitModel)
     );
-    this.graph = graph;
+    this.transitModel = transitModel;
   }
 
   protected List<Geometry> getGeometries(Envelope query) {
-    return graph.index
+    return transitModel
       .getStopSpatialIndex()
       .query(query)
       .stream()

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/layers/vehicleparkings/VehicleParkingsLayerBuilder.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/layers/vehicleparkings/VehicleParkingsLayerBuilder.java
@@ -15,6 +15,7 @@ import org.opentripplanner.ext.vectortiles.VectorTilesResource;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.vehicle_parking.VehicleParking;
 import org.opentripplanner.routing.vehicle_parking.VehicleParkingService;
+import org.opentripplanner.transit.service.TransitModel;
 
 public class VehicleParkingsLayerBuilder extends LayerBuilder<VehicleParking> {
 
@@ -26,6 +27,7 @@ public class VehicleParkingsLayerBuilder extends LayerBuilder<VehicleParking> {
 
   public VehicleParkingsLayerBuilder(
     Graph graph,
+    TransitModel transitModel,
     VectorTilesResource.LayerParameters layerParameters
   ) {
     super(

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/layers/vehiclerental/VehicleRentalLayerBuilder.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/layers/vehiclerental/VehicleRentalLayerBuilder.java
@@ -15,6 +15,7 @@ import org.opentripplanner.ext.vectortiles.VectorTilesResource;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalPlace;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalStationService;
+import org.opentripplanner.transit.service.TransitModel;
 
 public class VehicleRentalLayerBuilder extends LayerBuilder<VehicleRentalPlace> {
 
@@ -26,6 +27,7 @@ public class VehicleRentalLayerBuilder extends LayerBuilder<VehicleRentalPlace> 
 
   public VehicleRentalLayerBuilder(
     Graph graph,
+    TransitModel transitModel,
     VectorTilesResource.LayerParameters layerParameters
   ) {
     super(

--- a/src/main/java/org/opentripplanner/api/common/RoutingResource.java
+++ b/src/main/java/org/opentripplanner/api/common/RoutingResource.java
@@ -716,7 +716,7 @@ public abstract class RoutingResource {
     {
       //FIXME: move into setter method on routing request
       TimeZone tz;
-      tz = router.graph.getTimeZone();
+      tz = router.transitModel.getTimeZone();
       if (date == null && time != null) { // Time was provided but not date
         LOG.debug("parsing ISO datetime {}", time);
         try {

--- a/src/main/java/org/opentripplanner/api/model/ApiRouterInfo.java
+++ b/src/main/java/org/opentripplanner/api/model/ApiRouterInfo.java
@@ -8,6 +8,7 @@ import org.opentripplanner.api.mapping.TraverseModeMapper;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.vehicle_parking.VehicleParkingService;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalStationService;
+import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.util.TravelOption;
 import org.opentripplanner.util.TravelOptionsMaker;
 import org.opentripplanner.util.WorldEnvelope;
@@ -31,7 +32,7 @@ public class ApiRouterInfo {
   public List<TravelOption> travelOptions;
 
   /** TODO: Do not pass in the graph here, do this in a mapper instead. */
-  public ApiRouterInfo(String routerId, Graph graph) {
+  public ApiRouterInfo(String routerId, Graph graph, TransitModel transitModel) {
     VehicleRentalStationService vehicleRentalService = graph.getService(
       VehicleRentalStationService.class,
       false
@@ -44,17 +45,17 @@ public class ApiRouterInfo {
     this.routerId = routerId;
     this.polygon = graph.getConvexHull();
     this.buildTime = graph.buildTime;
-    this.transitServiceStarts = graph.getTransitServiceStarts();
-    this.transitServiceEnds = graph.getTransitServiceEnds();
-    this.transitModes = TraverseModeMapper.mapToApi(graph.getTransitModes());
+    this.transitServiceStarts = transitModel.getTransitServiceStarts();
+    this.transitServiceEnds = transitModel.getTransitServiceEnds();
+    this.transitModes = TraverseModeMapper.mapToApi(transitModel.getTransitModes());
     this.envelope = graph.getEnvelope();
     this.hasParkRide = graph.hasParkRide;
     this.hasBikeSharing = mapHasBikeSharing(vehicleRentalService);
     this.hasBikePark = mapHasBikePark(vehicleParkingService);
     this.hasCarPark = mapHasCarPark(vehicleParkingService);
     this.hasVehicleParking = mapHasVehicleParking(vehicleParkingService);
-    this.travelOptions = TravelOptionsMaker.makeOptions(graph);
-    graph.getCenter().ifPresentOrElse(this::setCenter, this::calculateCenter);
+    this.travelOptions = TravelOptionsMaker.makeOptions(graph, transitModel);
+    transitModel.getStopModel().getCenter().ifPresentOrElse(this::setCenter, this::calculateCenter);
   }
 
   public boolean mapHasBikeSharing(VehicleRentalStationService service) {
@@ -88,7 +89,7 @@ public class ApiRouterInfo {
   }
 
   /**
-   * Set center coordinate from transit center in {@link Graph#calculateTransitCenter()} if transit
+   * Set center coordinate from transit center in {@link TransitModel#calculateTransitCenter()} if transit
    * is used.
    * <p>
    * It is first called when OSM is loaded. Then after transit data is loaded. So that center is set

--- a/src/main/java/org/opentripplanner/api/resource/PlannerResource.java
+++ b/src/main/java/org/opentripplanner/api/resource/PlannerResource.java
@@ -71,7 +71,7 @@ public class PlannerResource extends RoutingResource {
       router = otpServer.getRouter();
 
       // Route
-      RoutingService routingService = new RoutingService(router.graph);
+      RoutingService routingService = new RoutingService(router.graph, router.transitModel);
       res = routingService.route(request, router);
 
       // Map to API

--- a/src/main/java/org/opentripplanner/api/resource/Routers.java
+++ b/src/main/java/org/opentripplanner/api/resource/Routers.java
@@ -63,7 +63,7 @@ public class Routers {
   private ApiRouterInfo getRouterInfo() {
     try {
       Router router = otpServer.getRouter();
-      return new ApiRouterInfo("default", router.graph);
+      return new ApiRouterInfo("default", router.graph, router.transitModel);
     } catch (GraphNotFoundException e) {
       return null;
     }

--- a/src/main/java/org/opentripplanner/api/resource/UpdaterStatusResource.java
+++ b/src/main/java/org/opentripplanner/api/resource/UpdaterStatusResource.java
@@ -36,7 +36,7 @@ public class UpdaterStatusResource {
   /** Return a list of all agencies in the graph. */
   @GET
   public Response getUpdaters() {
-    GraphUpdaterManager updaterManager = router.graph.updaterManager;
+    GraphUpdaterManager updaterManager = router.transitModel.updaterManager;
     if (updaterManager == null) {
       return Response.status(Response.Status.NOT_FOUND).entity("No updaters running.").build();
     }
@@ -50,7 +50,7 @@ public class UpdaterStatusResource {
   @GET
   @Path("/{updaterId}")
   public Response getUpdaters(@PathParam("updaterId") int updaterId) {
-    GraphUpdaterManager updaterManager = router.graph.updaterManager;
+    GraphUpdaterManager updaterManager = router.transitModel.updaterManager;
     if (updaterManager == null) {
       return Response.status(Response.Status.NOT_FOUND).entity("No updaters running.").build();
     }

--- a/src/main/java/org/opentripplanner/datastore/OtpDataStore.java
+++ b/src/main/java/org/opentripplanner/datastore/OtpDataStore.java
@@ -25,6 +25,7 @@ import javax.validation.constraints.NotNull;
 import org.opentripplanner.datastore.base.DataSourceRepository;
 import org.opentripplanner.datastore.base.LocalDataSourceRepository;
 import org.opentripplanner.datastore.configure.DataStoreFactory;
+import org.opentripplanner.routing.graph.SerializedGraphObject;
 
 /**
  * The responsibility of this class is to provide access to all data sources OTP uses like the
@@ -77,7 +78,7 @@ public class OtpDataStore {
    *
    * @param path the location where the graph file must exist.
    * @return The graph file - the graph is not loaded, you can use the {@link
-   * org.opentripplanner.routing.graph.SerializedGraphObject#load(File)} to load the graph.
+   * SerializedGraphObject#load(File)} to load the graph.
    */
   public static File graphFile(File path) {
     return new File(path, GRAPH_FILENAME);

--- a/src/main/java/org/opentripplanner/graph_builder/DataImportIssuesToHTML.java
+++ b/src/main/java/org/opentripplanner/graph_builder/DataImportIssuesToHTML.java
@@ -17,6 +17,7 @@ import org.opentripplanner.datastore.CompositeDataSource;
 import org.opentripplanner.datastore.DataSource;
 import org.opentripplanner.graph_builder.services.GraphBuilderModule;
 import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.transit.service.TransitModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,6 +60,7 @@ public class DataImportIssuesToHTML implements GraphBuilderModule {
   @Override
   public void buildGraph(
     Graph graph,
+    TransitModel transitModel,
     HashMap<Class<?>, Object> extra,
     DataImportIssueStore issueStore
   ) {

--- a/src/main/java/org/opentripplanner/graph_builder/GraphStats.java
+++ b/src/main/java/org/opentripplanner/graph_builder/GraphStats.java
@@ -26,6 +26,7 @@ import org.opentripplanner.routing.graph.SerializedGraphObject;
 import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.routing.vertextype.StreetVertex;
 import org.opentripplanner.routing.vertextype.TransitStopVertex;
+import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.util.OtpAppException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,6 +59,8 @@ public class GraphStats {
   private String outPath;
 
   private Graph graph;
+
+  private TransitModel transitModel;
 
   private CsvWriter writer;
 
@@ -92,7 +95,9 @@ public class GraphStats {
   private void run() {
     /* open input graph (same for all commands) */
     File graphFile = new File(graphPath);
-    graph = SerializedGraphObject.load(graphFile);
+    SerializedGraphObject serializedGraphObject = SerializedGraphObject.load(graphFile);
+    graph = serializedGraphObject.graph;
+    transitModel = serializedGraphObject.transitModel;
 
     /* open output stream (same for all commands) */
     if (outPath != null) {
@@ -215,7 +220,7 @@ public class GraphStats {
             "empiricalDistTrips",
           }
         );
-        Collection<TripPattern> patterns = graph.tripPatternForId.values();
+        Collection<TripPattern> patterns = transitModel.tripPatternForId.values();
         Multiset<Integer> counts = TreeMultiset.create();
         int nPatterns = patterns.size();
         LOG.info("total number of patterns is: {}", nPatterns);

--- a/src/main/java/org/opentripplanner/graph_builder/linking/FlexLocationAdder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/linking/FlexLocationAdder.java
@@ -7,19 +7,19 @@ import org.opentripplanner.common.geometry.GeometryUtils;
 import org.opentripplanner.model.FlexStopLocation;
 import org.opentripplanner.routing.edgetype.StreetEdge;
 import org.opentripplanner.routing.edgetype.StreetTraversalPermission;
-import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.vertextype.SplitterVertex;
+import org.opentripplanner.transit.service.StopModel;
 
 class FlexLocationAdder {
 
-  static void addFlexLocations(StreetEdge edge, SplitterVertex v0, Graph graph) {
+  static void addFlexLocations(StreetEdge edge, SplitterVertex v0, StopModel stopModel) {
     if (
-      graph.index != null &&
+      stopModel.getStopModelIndex() != null &&
       edge.getPermission().allows(StreetTraversalPermission.PEDESTRIAN_AND_CAR)
     ) {
       Point p = GeometryUtils.getGeometryFactory().createPoint(v0.getCoordinate());
       Envelope env = p.getEnvelopeInternal();
-      for (FlexStopLocation location : graph.index.getFlexIndex().locationIndex.query(env)) {
+      for (FlexStopLocation location : stopModel.getStopModelIndex().locationIndex.query(env)) {
         if (!location.getGeometry().disjoint(p)) {
           if (v0.flexStopLocations == null) {
             v0.flexStopLocations = new HashSet<>();

--- a/src/main/java/org/opentripplanner/graph_builder/linking/VertexLinker.java
+++ b/src/main/java/org/opentripplanner/graph_builder/linking/VertexLinker.java
@@ -25,6 +25,7 @@ import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.routing.vertextype.SplitterVertex;
 import org.opentripplanner.routing.vertextype.StreetVertex;
 import org.opentripplanner.routing.vertextype.TemporarySplitterVertex;
+import org.opentripplanner.transit.service.StopModel;
 import org.opentripplanner.util.OTPFeature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,7 +61,11 @@ public class VertexLinker {
    * Spatial index of StreetEdges in the graph.
    */
   private final StreetSpatialIndex streetSpatialIndex = new StreetSpatialIndex();
+
   private final Graph graph;
+
+  private final StopModel stopModel;
+
   // TODO Temporary code until we refactor WalkableAreaBuilder  (#3152)
   private Boolean addExtraEdgesToAreas = false;
 
@@ -68,11 +73,12 @@ public class VertexLinker {
    * Construct a new VertexLinker. NOTE: Only one VertexLinker should be active on a graph at any
    * given time.
    */
-  public VertexLinker(Graph graph) {
+  public VertexLinker(Graph graph, StopModel stopModel) {
     for (StreetEdge se : graph.getEdgesOfType(StreetEdge.class)) {
       streetSpatialIndex.insert(se.getGeometry(), se, Scope.PERMANENT);
     }
     this.graph = graph;
+    this.stopModel = stopModel;
   }
 
   public void linkVertexPermanently(
@@ -381,7 +387,7 @@ public class VertexLinker {
 
       // TODO Consider moving this code
       if (OTPFeature.FlexRouting.isOn()) {
-        FlexLocationAdder.addFlexLocations(edge, v0, graph);
+        FlexLocationAdder.addFlexLocations(edge, v0, stopModel);
       }
 
       return v0;

--- a/src/main/java/org/opentripplanner/graph_builder/module/DirectTransferGenerator.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/DirectTransferGenerator.java
@@ -16,11 +16,12 @@ import org.opentripplanner.routing.algorithm.raptoradapter.transit.Transfer;
 import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Graph;
-import org.opentripplanner.routing.graph.GraphIndex;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
 import org.opentripplanner.routing.vertextype.TransitStopVertex;
 import org.opentripplanner.transit.model.site.Stop;
 import org.opentripplanner.transit.model.site.StopLocation;
+import org.opentripplanner.transit.service.TransitModel;
+import org.opentripplanner.transit.service.TransitModelIndex;
 import org.opentripplanner.util.OTPFeature;
 import org.opentripplanner.util.logging.ProgressTracker;
 import org.slf4j.Logger;
@@ -58,16 +59,18 @@ public class DirectTransferGenerator implements GraphBuilderModule {
   @Override
   public void buildGraph(
     Graph graph,
+    TransitModel transitModel,
     HashMap<Class<?>, Object> extra,
     DataImportIssueStore issueStore
   ) {
-    /* Initialize graph index which is needed by the nearby stop finder. */
-    if (graph.index == null) {
-      graph.index = new GraphIndex(graph);
+    /* Initialize transit model index which is needed by the nearby stop finder. */
+    if (transitModel.index == null) {
+      transitModel.index = new TransitModelIndex(transitModel);
+      graph.index();
     }
 
     /* The linker will use streets if they are available, or straight-line distance otherwise. */
-    NearbyStopFinder nearbyStopFinder = new NearbyStopFinder(graph, radiusByDuration);
+    NearbyStopFinder nearbyStopFinder = new NearbyStopFinder(graph, transitModel, radiusByDuration);
     if (nearbyStopFinder.useStreets) {
       LOG.info("Creating direct transfer edges between stops using the street network from OSM...");
     } else {
@@ -162,7 +165,7 @@ public class DirectTransferGenerator implements GraphBuilderModule {
         progress.step(m -> LOG.info(m));
       });
 
-    graph.transfersByStop.putAll(transfersByStop);
+    transitModel.transfersByStop.putAll(transfersByStop);
 
     LOG.info(progress.completeMessage());
     LOG.info(
@@ -170,7 +173,7 @@ public class DirectTransferGenerator implements GraphBuilderModule {
       nTransfersTotal,
       nLinkedStops
     );
-    graph.hasDirectTransfers = true;
+    transitModel.hasDirectTransfers = true;
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/graph_builder/module/GraphCoherencyCheckerModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/GraphCoherencyCheckerModule.java
@@ -8,6 +8,7 @@ import org.opentripplanner.graph_builder.services.GraphBuilderModule;
 import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
+import org.opentripplanner.transit.service.TransitModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,6 +36,7 @@ public class GraphCoherencyCheckerModule implements GraphBuilderModule {
   @Override
   public void buildGraph(
     Graph graph,
+    TransitModel transitModel,
     HashMap<Class<?>, Object> extra,
     DataImportIssueStore issueStore
   ) {

--- a/src/main/java/org/opentripplanner/graph_builder/module/GtfsModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/GtfsModule.java
@@ -42,6 +42,7 @@ import org.opentripplanner.routing.fares.FareServiceFactory;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.standalone.config.BuildConfig;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.util.OTPFeature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -87,6 +88,7 @@ public class GtfsModule implements GraphBuilderModule {
   @Override
   public void buildGraph(
     Graph graph,
+    TransitModel transitModel,
     HashMap<Class<?>, Object> extra,
     DataImportIssueStore issueStore
   ) {
@@ -97,9 +99,9 @@ public class GtfsModule implements GraphBuilderModule {
     // OTP doesn't currently support multiple time zones in a single graph;
     // at least this way we catch the error and log it instead of silently ignoring
     // because the time zone from the first agency is cached
-    graph.clearTimeZone();
+    transitModel.clearTimeZone();
 
-    CalendarServiceData calendarServiceData = graph.getCalendarDataService();
+    CalendarServiceData calendarServiceData = transitModel.getCalendarDataService();
 
     boolean hasTransit = false;
 
@@ -127,16 +129,17 @@ public class GtfsModule implements GraphBuilderModule {
         repairStopTimesForEachTrip(builder.getStopTimesSortedByTrip());
 
         // NB! The calls below have side effects - the builder state is updated!
-        createTripPatterns(graph, builder, calendarServiceData.getServiceIds());
+        createTripPatterns(graph, transitModel, builder, calendarServiceData.getServiceIds());
 
-        OtpTransitService transitModel = builder.build();
+        OtpTransitService otpTransitService = builder.build();
 
         // if this or previously processed gtfs bundle has transit that has not been filtered out
-        hasTransit = hasTransit || transitModel.hasActiveTransit();
+        hasTransit = hasTransit || otpTransitService.hasActiveTransit();
 
-        addTransitModelToGraph(graph, gtfsBundle, transitModel);
+        addTransitModelToGraph(graph, transitModel, gtfsBundle, otpTransitService);
 
-        createGeometryAndBlockProcessor(gtfsBundle, transitModel).run(graph, issueStore);
+        createGeometryAndBlockProcessor(gtfsBundle, otpTransitService)
+          .run(graph, transitModel, issueStore);
       }
     } catch (IOException e) {
       throw new RuntimeException(e);
@@ -146,17 +149,19 @@ public class GtfsModule implements GraphBuilderModule {
       gtfsBundles.forEach(GtfsBundle::close);
     }
 
-    graph.clearCachedCalenderService();
+    transitModel.clearCachedCalenderService();
     // We need to save the calendar service data so we can use it later
-    graph.putService(
+    transitModel.putService(
       org.opentripplanner.model.calendar.CalendarServiceData.class,
       calendarServiceData
     );
-    graph.updateTransitFeedValidity(calendarServiceData, issueStore);
+    transitModel.updateTransitFeedValidity(calendarServiceData, issueStore);
 
     // If the graph's hasTransit flag isn't set to true already, set it based on this module's run
-    graph.hasTransit = graph.hasTransit || hasTransit;
-    graph.calculateTransitCenter();
+    transitModel.hasTransit = transitModel.hasTransit || hasTransit;
+    if (hasTransit) {
+      transitModel.calculateTransitCenter();
+    }
   }
 
   @Override
@@ -180,6 +185,7 @@ public class GtfsModule implements GraphBuilderModule {
    */
   private void createTripPatterns(
     Graph graph,
+    TransitModel transitModel,
     OtpTransitServiceBuilder builder,
     Set<FeedScopedId> calServiceIds
   ) {
@@ -190,20 +196,24 @@ public class GtfsModule implements GraphBuilderModule {
       calServiceIds
     );
     buildTPOp.run();
-    graph.hasFrequencyService = graph.hasFrequencyService || buildTPOp.hasFrequencyBasedTrips();
-    graph.hasScheduledService = graph.hasScheduledService || buildTPOp.hasScheduledTrips();
+    transitModel.hasFrequencyService =
+      transitModel.hasFrequencyService || buildTPOp.hasFrequencyBasedTrips();
+    transitModel.hasScheduledService =
+      transitModel.hasScheduledService || buildTPOp.hasScheduledTrips();
   }
 
   private void addTransitModelToGraph(
     Graph graph,
+    TransitModel transitModel,
     GtfsBundle gtfsBundle,
-    OtpTransitService transitModel
+    OtpTransitService otpTransitService
   ) {
     AddTransitModelEntitiesToGraph.addToGraph(
       gtfsBundle.getFeedId(),
-      transitModel,
+      otpTransitService,
       gtfsBundle.subwayAccessTime,
-      graph
+      graph,
+      transitModel
     );
   }
 

--- a/src/main/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModule.java
@@ -23,6 +23,7 @@ import org.opentripplanner.routing.vertextype.IntersectionVertex;
 import org.opentripplanner.routing.vertextype.OsmBoardingLocationVertex;
 import org.opentripplanner.routing.vertextype.StreetVertex;
 import org.opentripplanner.routing.vertextype.TransitStopVertex;
+import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.util.LocalizedString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,6 +50,7 @@ public class OsmBoardingLocationsModule implements GraphBuilderModule {
   @Override
   public void buildGraph(
     Graph graph,
+    TransitModel transitModel,
     HashMap<Class<?>, Object> extra,
     DataImportIssueStore issueStore
   ) {

--- a/src/main/java/org/opentripplanner/graph_builder/module/PruneNoThruIslands.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/PruneNoThruIslands.java
@@ -33,6 +33,7 @@ import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.routing.vertextype.StreetVertex;
 import org.opentripplanner.routing.vertextype.TransitStopVertex;
+import org.opentripplanner.transit.service.TransitModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -79,6 +80,7 @@ public class PruneNoThruIslands implements GraphBuilderModule {
   @Override
   public void buildGraph(
     Graph graph,
+    TransitModel transitModel,
     HashMap<Class<?>, Object> extra,
     DataImportIssueStore issueStore
   ) {
@@ -108,7 +110,7 @@ public class PruneNoThruIslands implements GraphBuilderModule {
     // reconnect stops that got disconnected
     if (streetLinkerModule != null) {
       LOG.info("Reconnecting stops");
-      streetLinkerModule.linkTransitStops(graph);
+      streetLinkerModule.linkTransitStops(graph, transitModel);
       int isolated = 0;
       for (TransitStopVertex tStop : graph.getVerticesOfType(TransitStopVertex.class)) {
         if (tStop.getDegreeOut() + tStop.getDegreeIn() == 0) {

--- a/src/main/java/org/opentripplanner/graph_builder/module/map/BusRouteStreetMatcher.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/map/BusRouteStreetMatcher.java
@@ -14,6 +14,7 @@ import org.opentripplanner.model.TripPattern;
 import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.transit.model.network.Route;
+import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.util.logging.ProgressTracker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,16 +40,18 @@ public class BusRouteStreetMatcher implements GraphBuilderModule {
 
   public void buildGraph(
     Graph graph,
+    TransitModel transitModel,
     HashMap<Class<?>, Object> extra,
     DataImportIssueStore issueStore
   ) {
     // Mapbuilder needs transit index
+    transitModel.index();
     graph.index();
 
     StreetMatcher matcher = new StreetMatcher(graph);
     log.info("Finding corresponding street edges for trip patterns...");
     // Why do we need to iterate over the routes? Why not just patterns?
-    Collection<Route> allRoutes = graph.index.getAllRoutes();
+    Collection<Route> allRoutes = transitModel.index.getAllRoutes();
 
     // Track progress
     ProgressTracker progress = ProgressTracker.track(
@@ -59,7 +62,7 @@ public class BusRouteStreetMatcher implements GraphBuilderModule {
     log.info(progress.startMessage());
 
     for (Route route : allRoutes) {
-      for (TripPattern pattern : graph.index.getPatternsForRoute().get(route)) {
+      for (TripPattern pattern : transitModel.index.getPatternsForRoute().get(route)) {
         if (pattern.getMode().onStreet()) {
           /* we can only match geometry to streets on bus routes */
           log.debug("Matching {}", pattern);

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -39,6 +39,7 @@ import org.opentripplanner.routing.edgetype.StreetElevationExtension;
 import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
+import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.util.PolylineEncoder;
 import org.opentripplanner.util.logging.ProgressTracker;
 import org.slf4j.Logger;
@@ -136,6 +137,7 @@ public class ElevationModule implements GraphBuilderModule {
   @Override
   public void buildGraph(
     Graph graph,
+    TransitModel transitModel,
     HashMap<Class<?>, Object> extra,
     DataImportIssueStore issueStore
   ) {

--- a/src/main/java/org/opentripplanner/graph_builder/services/GraphBuilderModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/services/GraphBuilderModule.java
@@ -3,6 +3,7 @@ package org.opentripplanner.graph_builder.services;
 import java.util.HashMap;
 import org.opentripplanner.graph_builder.DataImportIssueStore;
 import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.transit.service.TransitModel;
 
 /** Modules that add elements to a graph. These are plugins to the GraphBuilder. */
 public interface GraphBuilderModule {
@@ -10,10 +11,15 @@ public interface GraphBuilderModule {
    * Process whatever inputs were supplied to this module and add the resulting elements to the
    * given graph.
    */
-  void buildGraph(Graph graph, HashMap<Class<?>, Object> extra, DataImportIssueStore issueStore);
+  void buildGraph(
+    Graph graph,
+    TransitModel transitModel,
+    HashMap<Class<?>, Object> extra,
+    DataImportIssueStore issueStore
+  );
 
-  default void buildGraph(Graph graph, HashMap<Class<?>, Object> extra) {
-    buildGraph(graph, extra, new DataImportIssueStore(false));
+  default void buildGraph(Graph graph, TransitModel transitModel, HashMap<Class<?>, Object> extra) {
+    buildGraph(graph, transitModel, extra, new DataImportIssueStore(false));
   }
 
   /** Check that all inputs to the graphbuilder are valid; throw an exception if not. */

--- a/src/main/java/org/opentripplanner/index/IndexAPI.java
+++ b/src/main/java/org/opentripplanner/index/IndexAPI.java
@@ -159,10 +159,10 @@ public class IndexAPI {
     @PathParam("feedId") String feedId,
     @PathParam("agencyId") String agencyId
   ) {
-    RoutingService routingService = createRoutingService();
+    TransitService transitService = createTransitService();
     AlertMapper alertMapper = new AlertMapper(null); // TODO: Add locale
     FeedScopedId id = new FeedScopedId(feedId, agencyId);
-    return alertMapper.mapToApi(routingService.getTransitAlertService().getAgencyAlerts(id));
+    return alertMapper.mapToApi(transitService.getTransitAlertService().getAgencyAlerts(id));
   }
 
   /** Return specific transit stop in the graph, by ID. */
@@ -202,7 +202,7 @@ public class IndexAPI {
 
       radius = Math.min(radius, MAX_STOP_SEARCH_RADIUS);
 
-      return createTransitService()
+      return createRoutingService()
         .getStopsInRadius(new WgsCoordinate(lat, lon), radius)
         .stream()
         .map(it -> StopMapper.mapToApiShort(it.first, it.second.intValue()))
@@ -217,7 +217,7 @@ public class IndexAPI {
         .lessThan("minLat", minLat, "maxLat", maxLat)
         .lessThan("minLon", minLon, "maxLon", maxLon)
         .validate();
-      var stops = createTransitService().getStopsByBoundingBox(minLat, minLon, maxLat, maxLon);
+      var stops = createRoutingService().getStopsByBoundingBox(minLat, minLon, maxLat, maxLon);
       return StopMapper.mapToApiShort(stops);
     }
   }
@@ -327,10 +327,10 @@ public class IndexAPI {
   @GET
   @Path("/stops/{stopId}/alerts")
   public Collection<ApiAlert> getAlertsForStop(@PathParam("stopId") String stopId) {
-    RoutingService routingService = createRoutingService();
+    TransitService transitService = createTransitService();
     AlertMapper alertMapper = new AlertMapper(null); // TODO: Add locale
     FeedScopedId id = createId("stopId", stopId);
-    return alertMapper.mapToApi(routingService.getTransitAlertService().getStopAlerts(id));
+    return alertMapper.mapToApi(transitService.getTransitAlertService().getStopAlerts(id));
   }
 
   /** Return a list of all routes in the graph. */
@@ -411,10 +411,10 @@ public class IndexAPI {
   @GET
   @Path("/routes/{routeId}/alerts")
   public Collection<ApiAlert> getAlertsForRoute(@PathParam("routeId") String routeId) {
-    RoutingService routingService = createRoutingService();
+    TransitService transitService = createTransitService();
     AlertMapper alertMapper = new AlertMapper(null); // TODO: Add locale
     FeedScopedId id = createId("routeId", routeId);
-    return alertMapper.mapToApi(routingService.getTransitAlertService().getRouteAlerts(id));
+    return alertMapper.mapToApi(transitService.getTransitAlertService().getRouteAlerts(id));
   }
 
   // Not implemented, results would be too voluminous.
@@ -470,10 +470,10 @@ public class IndexAPI {
   @GET
   @Path("/trips/{tripId}/alerts")
   public Collection<ApiAlert> getAlertsForTrip(@PathParam("tripId") String tripId) {
-    RoutingService routingService = createRoutingService();
+    TransitService transitService = createTransitService();
     AlertMapper alertMapper = new AlertMapper(null); // TODO: Add locale
     FeedScopedId id = createId("tripId", tripId);
-    return alertMapper.mapToApi(routingService.getTransitAlertService().getTripAlerts(id, null));
+    return alertMapper.mapToApi(transitService.getTransitAlertService().getTripAlerts(id, null));
   }
 
   @GET
@@ -525,11 +525,11 @@ public class IndexAPI {
   @GET
   @Path("/patterns/{patternId}/alerts")
   public Collection<ApiAlert> getAlertsForPattern(@PathParam("patternId") String patternId) {
-    RoutingService routingService = createRoutingService();
+    TransitService transitService = createTransitService();
     AlertMapper alertMapper = new AlertMapper(null); // TODO: Add locale
     TripPattern pattern = getTripPattern(createTransitService(), patternId);
     return alertMapper.mapToApi(
-      routingService
+      transitService
         .getTransitAlertService()
         .getDirectionAndRouteAlerts(pattern.getDirection().gtfsCode, pattern.getRoute().getId())
     );

--- a/src/main/java/org/opentripplanner/model/plan/legreference/ScheduledTransitLegReference.java
+++ b/src/main/java/org/opentripplanner/model/plan/legreference/ScheduledTransitLegReference.java
@@ -54,7 +54,7 @@ public record ScheduledTransitLegReference(
     TripTimes tripTimes = timetable.getTripTimes(trip);
 
     // TODO: What should we have here
-    ZoneId timeZone = routingService.getTimeZone().toZoneId();
+    ZoneId timeZone = transitService.getTimeZone().toZoneId();
 
     int boardingTime = tripTimes.getDepartureTime(fromStopPositionInPattern);
     int alightingTime = tripTimes.getArrivalTime(toStopPositionInPattern);

--- a/src/main/java/org/opentripplanner/netex/NetexModule.java
+++ b/src/main/java/org/opentripplanner/netex/NetexModule.java
@@ -17,6 +17,7 @@ import org.opentripplanner.routing.fares.FareServiceFactory;
 import org.opentripplanner.routing.fares.impl.DefaultFareServiceFactory;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.standalone.config.BuildConfig;
+import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.util.OTPFeature;
 
 /**
@@ -61,11 +62,12 @@ public class NetexModule implements GraphBuilderModule {
   @Override
   public void buildGraph(
     Graph graph,
+    TransitModel transitModel,
     HashMap<Class<?>, Object> extra,
     DataImportIssueStore issueStore
   ) {
-    graph.clearTimeZone();
-    CalendarServiceData calendarServiceData = graph.getCalendarDataService();
+    transitModel.clearTimeZone();
+    CalendarServiceData calendarServiceData = transitModel.getCalendarDataService();
     boolean hasTransit = false;
     try {
       for (NetexBundle netexBundle : netexBundles) {
@@ -79,7 +81,7 @@ public class NetexModule implements GraphBuilderModule {
         for (TripOnServiceDate tripOnServiceDate : transitBuilder
           .getTripOnServiceDates()
           .values()) {
-          graph.getTripOnServiceDates().put(tripOnServiceDate.getId(), tripOnServiceDate);
+          transitModel.getTripOnServiceDates().put(tripOnServiceDate.getId(), tripOnServiceDate);
         }
         calendarServiceData.add(transitBuilder.buildCalendarServiceData());
 
@@ -97,12 +99,18 @@ public class NetexModule implements GraphBuilderModule {
         // TODO OTP2 - Move this into the AddTransitModelEntitiesToGraph
         //           - and make sure thay also work with GTFS feeds - GTFS do no
         //           - have operators and notice assignments.
-        graph.getOperators().addAll(otpService.getAllOperators());
-        graph.addNoticeAssignments(otpService.getNoticeAssignments());
+        transitModel.getOperators().addAll(otpService.getAllOperators());
+        transitModel.addNoticeAssignments(otpService.getNoticeAssignments());
 
         GtfsFeedId feedId = new GtfsFeedId.Builder().id(netexFeedId).build();
 
-        AddTransitModelEntitiesToGraph.addToGraph(feedId, otpService, subwayAccessTime, graph);
+        AddTransitModelEntitiesToGraph.addToGraph(
+          feedId,
+          otpService,
+          subwayAccessTime,
+          graph,
+          transitModel
+        );
 
         new GeometryAndBlockProcessor(
           otpService,
@@ -110,19 +118,21 @@ public class NetexModule implements GraphBuilderModule {
           maxStopToShapeSnapDistance,
           maxInterlineDistance
         )
-          .run(graph, issueStore);
+          .run(graph, transitModel, issueStore);
       }
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
 
-    graph.clearCachedCalenderService();
-    graph.putService(CalendarServiceData.class, calendarServiceData);
-    graph.updateTransitFeedValidity(calendarServiceData, issueStore);
+    transitModel.clearCachedCalenderService();
+    transitModel.putService(CalendarServiceData.class, calendarServiceData);
+    transitModel.updateTransitFeedValidity(calendarServiceData, issueStore);
 
     // If the graph's hasTransit flag isn't set to true already, set it based on this module's run
-    graph.hasTransit = graph.hasTransit || hasTransit;
-    graph.calculateTransitCenter();
+    transitModel.hasTransit = transitModel.hasTransit || hasTransit;
+    if (hasTransit) {
+      transitModel.calculateTransitCenter();
+    }
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/routing/RoutingService.java
+++ b/src/main/java/org/opentripplanner/routing/RoutingService.java
@@ -1,36 +1,22 @@
 package org.opentripplanner.routing;
 
-import gnu.trove.set.TIntSet;
 import java.io.Serializable;
-import java.time.Instant;
-import java.util.BitSet;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
-import java.util.TimeZone;
-import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
-import org.opentripplanner.common.geometry.HashGridSpatialIndex;
-import org.opentripplanner.ext.flex.FlexIndex;
-import org.opentripplanner.graph_builder.DataImportIssueStore;
+import org.opentripplanner.common.model.T2;
 import org.opentripplanner.graph_builder.linking.VertexLinker;
 import org.opentripplanner.graph_builder.module.osm.WayPropertySetSource.DrivingDirection;
 import org.opentripplanner.model.GraphBundle;
-import org.opentripplanner.model.calendar.CalendarServiceData;
-import org.opentripplanner.model.calendar.ServiceDate;
-import org.opentripplanner.model.transfer.TransferService;
 import org.opentripplanner.routing.algorithm.RoutingWorker;
-import org.opentripplanner.routing.algorithm.raptoradapter.transit.TransitLayer;
 import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.api.response.RoutingResponse;
 import org.opentripplanner.routing.core.intersection_model.IntersectionTraversalCostModel;
 import org.opentripplanner.routing.edgetype.StreetEdge;
 import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Graph;
-import org.opentripplanner.routing.graph.GraphIndex;
 import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.routing.graphfinder.GraphFinder;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
@@ -38,14 +24,15 @@ import org.opentripplanner.routing.graphfinder.PlaceAtDistance;
 import org.opentripplanner.routing.graphfinder.PlaceType;
 import org.opentripplanner.routing.impl.StreetVertexIndex;
 import org.opentripplanner.routing.services.RealtimeVehiclePositionService;
-import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.routing.vehicle_parking.VehicleParkingService;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalStationService;
-import org.opentripplanner.routing.vertextype.TransitStopVertex;
 import org.opentripplanner.standalone.server.Router;
+import org.opentripplanner.transit.model.basic.WgsCoordinate;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.TransitMode;
 import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.StopLocation;
+import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.util.WorldEnvelope;
 
@@ -56,19 +43,19 @@ public class RoutingService {
 
   private final Graph graph;
 
-  private final GraphIndex graphIndex;
+  private final TransitModel transitModel;
 
   private final GraphFinder graphFinder;
 
-  public RoutingService(Graph graph) {
+  public RoutingService(Graph graph, TransitModel transitModel) {
     this.graph = graph;
-    this.graphIndex = graph.index;
+    this.transitModel = transitModel;
     this.graphFinder = GraphFinder.getInstance(graph);
   }
 
   // TODO We should probably not have the Router as a parameter here
   public RoutingResponse route(RoutingRequest request, Router router) {
-    var zoneId = graph.getTimeZone().toZoneId();
+    var zoneId = transitModel.getTimeZone().toZoneId();
     RoutingWorker worker = new RoutingWorker(router, request, zoneId);
     return worker.route();
   }
@@ -113,21 +100,6 @@ public class RoutingService {
     return this.graph.getStreetEdges();
   }
 
-  /** {@link Graph#getRealtimeTransitLayer()} */
-  public TransitLayer getRealtimeTransitLayer() {
-    return this.graph.getRealtimeTransitLayer();
-  }
-
-  /** {@link Graph#setRealtimeTransitLayer(TransitLayer)} */
-  public void setRealtimeTransitLayer(TransitLayer realtimeTransitLayer) {
-    this.graph.setRealtimeTransitLayer(realtimeTransitLayer);
-  }
-
-  /** {@link Graph#hasRealtimeTransitLayer()} */
-  public boolean hasRealtimeTransitLayer() {
-    return this.graph.hasRealtimeTransitLayer();
-  }
-
   /** {@link Graph#containsVertex(Vertex)} */
   public boolean containsVertex(Vertex v) {
     return this.graph.containsVertex(v);
@@ -168,21 +140,6 @@ public class RoutingService {
     return this.graph.getExtent();
   }
 
-  /** {@link Graph#getTransferService()} */
-  public TransferService getTransferService() {
-    return this.graph.getTransferService();
-  }
-
-  /** {@link Graph#updateTransitFeedValidity(CalendarServiceData, DataImportIssueStore)} */
-  public void updateTransitFeedValidity(CalendarServiceData data, DataImportIssueStore issueStore) {
-    this.graph.updateTransitFeedValidity(data, issueStore);
-  }
-
-  /** {@link Graph#transitFeedCovers(Instant)} */
-  public boolean transitFeedCovers(Instant time) {
-    return this.graph.transitFeedCovers(time);
-  }
-
   /** {@link Graph#getBundle()} */
   public GraphBundle getBundle() {
     return this.graph.getBundle();
@@ -203,19 +160,6 @@ public class RoutingService {
     return this.graph.countEdges();
   }
 
-  // /** {@link Graph#index()} */
-  // public void index() {this.graph.index();}
-
-  /** {@link Graph#getCalendarDataService()} */
-  public CalendarServiceData getCalendarDataService() {
-    return this.graph.getCalendarDataService();
-  }
-
-  /** {@link Graph#clearCachedCalenderService()} */
-  public void clearCachedCalenderService() {
-    this.graph.clearCachedCalenderService();
-  }
-
   /** {@link Graph#getStreetIndex()} */
   public StreetVertexIndex getStreetIndex() {
     return this.graph.getStreetIndex();
@@ -226,24 +170,9 @@ public class RoutingService {
     return this.graph.getLinker();
   }
 
-  /** {@link Graph#getOrCreateServiceIdForDate(ServiceDate)} */
-  public FeedScopedId getOrCreateServiceIdForDate(ServiceDate serviceDate) {
-    return this.graph.getOrCreateServiceIdForDate(serviceDate);
-  }
-
   /** {@link Graph#removeEdgelessVertices()} */
   public int removeEdgelessVertices() {
     return this.graph.removeEdgelessVertices();
-  }
-
-  /** {@link Graph#getTimeZone()} */
-  public TimeZone getTimeZone() {
-    return this.graph.getTimeZone();
-  }
-
-  /** {@link Graph#clearTimeZone()} */
-  public void clearTimeZone() {
-    this.graph.clearTimeZone();
   }
 
   /** {@link Graph#calculateEnvelope()} */
@@ -271,26 +200,6 @@ public class RoutingService {
     return this.graph.getEnvelope();
   }
 
-  /** {@link Graph#calculateTransitCenter()} */
-  public void calculateTransitCenter() {
-    this.graph.calculateTransitCenter();
-  }
-
-  /** {@link Graph#getCenter()} */
-  public Optional<Coordinate> getCenter() {
-    return this.graph.getCenter();
-  }
-
-  /** {@link Graph#getTransitServiceStarts()} */
-  public long getTransitServiceStarts() {
-    return this.graph.getTransitServiceStarts();
-  }
-
-  /** {@link Graph#getTransitServiceEnds()} */
-  public long getTransitServiceEnds() {
-    return this.graph.getTransitServiceEnds();
-  }
-
   /** {@link Graph#getDistanceBetweenElevationSamples()} */
   public double getDistanceBetweenElevationSamples() {
     return this.graph.getDistanceBetweenElevationSamples();
@@ -301,23 +210,13 @@ public class RoutingService {
     this.graph.setDistanceBetweenElevationSamples(distanceBetweenElevationSamples);
   }
 
-  /** {@link Graph#getTransitAlertService()} */
-  public TransitAlertService getTransitAlertService() {
-    return this.graph.getTransitAlertService();
-  }
-
   public RealtimeVehiclePositionService getVehiclePositionService() {
     return this.graph.getVehiclePositionService();
   }
 
-  /** {@link Graph#getStopVerticesById(FeedScopedId)} */
+  /** {@link org.opentripplanner.transit.service.StopModel#getStopVerticesById(FeedScopedId)} */
   public Set<Vertex> getStopVerticesById(FeedScopedId id) {
-    return this.graph.getStopVerticesById(id);
-  }
-
-  /** {@link Graph#getServicesRunningForDate(ServiceDate)} */
-  public BitSet getServicesRunningForDate(ServiceDate date) {
-    return this.graph.getServicesRunningForDate(date);
+    return this.transitModel.getStopModel().getStopVerticesById(id);
   }
 
   /** {@link Graph#getVehicleRentalStationService()} */
@@ -350,26 +249,6 @@ public class RoutingService {
     IntersectionTraversalCostModel intersectionTraversalCostModel
   ) {
     this.graph.setIntersectionTraversalCostModel(intersectionTraversalCostModel);
-  }
-
-  /** {@link GraphIndex#getStopVertexForStop()} */
-  public Map<Stop, TransitStopVertex> getStopVertexForStop() {
-    return this.graphIndex.getStopVertexForStop();
-  }
-
-  /** {@link GraphIndex#getStopSpatialIndex()} */
-  public HashGridSpatialIndex<TransitStopVertex> getStopSpatialIndex() {
-    return this.graphIndex.getStopSpatialIndex();
-  }
-
-  /** {@link GraphIndex#getServiceCodesRunningForDate()} */
-  public Map<ServiceDate, TIntSet> getServiceCodesRunningForDate() {
-    return this.graphIndex.getServiceCodesRunningForDate();
-  }
-
-  /** {@link GraphIndex#getFlexIndex()} */
-  public FlexIndex getFlexIndex() {
-    return this.graphIndex.getFlexIndex();
   }
 
   /** {@link GraphFinder#findClosestStops(double, double, double)} */
@@ -409,5 +288,20 @@ public class RoutingService {
         routingService,
         transitService
       );
+  }
+
+  /** {@link Graph#getStopsByBoundingBox(double, double, double, double)} */
+  public Collection<StopLocation> getStopsByBoundingBox(
+    double minLat,
+    double minLon,
+    double maxLat,
+    double maxLon
+  ) {
+    return this.graph.getStopsByBoundingBox(minLat, minLon, maxLat, maxLon);
+  }
+
+  /** {@link Graph#getStopsInRadius(WgsCoordinate, double)} */
+  public List<T2<Stop, Double>> getStopsInRadius(WgsCoordinate center, double radius) {
+    return this.graph.getStopsInRadius(center, radius);
   }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
@@ -35,6 +35,7 @@ import org.opentripplanner.transit.raptor.api.path.Path;
 import org.opentripplanner.transit.raptor.api.path.PathLeg;
 import org.opentripplanner.transit.raptor.api.path.TransferPathLeg;
 import org.opentripplanner.transit.raptor.api.path.TransitPathLeg;
+import org.opentripplanner.transit.service.TransitModel;
 
 /**
  * This maps the paths found by the Raptor search algorithm to the itinerary structure currently
@@ -66,6 +67,7 @@ public class RaptorPathToItineraryMapper {
    */
   public RaptorPathToItineraryMapper(
     Graph graph,
+    TransitModel transitModel,
     TransitLayer transitLayer,
     ZonedDateTime transitSearchTimeZero,
     RoutingRequest request
@@ -74,10 +76,10 @@ public class RaptorPathToItineraryMapper {
     this.transitLayer = transitLayer;
     this.transitSearchTimeZero = transitSearchTimeZero;
     this.request = request;
-    this.alertToLegMapper = new AlertToLegMapper(graph.getTransitAlertService());
+    this.alertToLegMapper = new AlertToLegMapper(transitModel.getTransitAlertService());
     this.graphPathToItineraryMapper =
       new GraphPathToItineraryMapper(
-        graph.getTimeZone(),
+        transitModel.getTimeZone(),
         alertToLegMapper,
         graph.streetNotesService,
         graph.ellipsoidToGeoidDifference

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/TransitRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/TransitRouter.java
@@ -30,12 +30,12 @@ import org.opentripplanner.routing.core.TemporaryVerticesContainer;
 import org.opentripplanner.routing.error.RoutingValidationException;
 import org.opentripplanner.routing.fares.FareService;
 import org.opentripplanner.routing.framework.DebugTimingAggregator;
-import org.opentripplanner.routing.graph.GraphIndex;
 import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.standalone.server.Router;
 import org.opentripplanner.transit.raptor.RaptorService;
 import org.opentripplanner.transit.raptor.api.path.Path;
 import org.opentripplanner.transit.raptor.api.response.RaptorResponse;
+import org.opentripplanner.transit.service.TransitModelIndex;
 import org.opentripplanner.util.OTPFeature;
 
 public class TransitRouter {
@@ -84,15 +84,15 @@ public class TransitRouter {
       return new TransitRouterResult(List.of(), null);
     }
 
-    if (!router.graph.transitFeedCovers(request.getDateTime())) {
+    if (!router.transitModel.transitFeedCovers(request.getDateTime())) {
       throw new RoutingValidationException(
         List.of(new RoutingError(RoutingErrorCode.OUTSIDE_SERVICE_PERIOD, InputField.DATE_TIME))
       );
     }
 
     var transitLayer = request.ignoreRealtimeUpdates
-      ? router.graph.getTransitLayer()
-      : router.graph.getRealtimeTransitLayer();
+      ? router.transitModel.getTransitLayer()
+      : router.transitModel.getRealtimeTransitLayer();
 
     var requestTransitDataProvider = createRequestTransitDataProvider(transitLayer);
 
@@ -132,7 +132,7 @@ public class TransitRouter {
           .createOptimizeTransferService(
             transitLayer::getStopByIndex,
             requestTransitDataProvider.stopNameResolver(),
-            router.graph.getTransferService(),
+            router.transitModel.getTransferService(),
             requestTransitDataProvider,
             transitLayer.getStopIndex().stopBoardAlightCosts,
             raptorRequest,
@@ -145,11 +145,12 @@ public class TransitRouter {
 
     RaptorPathToItineraryMapper itineraryMapper = new RaptorPathToItineraryMapper(
       router.graph,
+      router.transitModel,
       transitLayer,
       transitSearchTimeZero,
       request
     );
-    FareService fareService = router.graph.getService(FareService.class);
+    FareService fareService = router.transitModel.getService(FareService.class);
 
     for (Path<TripSchedule> path : paths) {
       // Convert the Raptor/Astar paths to OTP API Itineraries
@@ -222,7 +223,12 @@ public class TransitRouter {
         accessRequest.allowKeepingRentedVehicleAtDestination = false;
       }
 
-      var nearbyStops = AccessEgressRouter.streetSearch(routingContext, mode, isEgress);
+      var nearbyStops = AccessEgressRouter.streetSearch(
+        routingContext,
+        router.transitModel,
+        mode,
+        isEgress
+      );
 
       results.addAll(accessEgressMapper.mapNearbyStops(nearbyStops, isEgress));
 
@@ -230,6 +236,7 @@ public class TransitRouter {
       if (OTPFeature.FlexRouting.isOn() && mode == StreetMode.FLEXIBLE) {
         var flexAccessList = FlexAccessEgressRouter.routeAccessEgress(
           routingContext,
+          router.transitModel,
           additionalSearchDays,
           router.routerConfig.flexParameters(request),
           isEgress
@@ -246,22 +253,25 @@ public class TransitRouter {
     TransitLayer transitLayer
   ) {
     var graph = router.graph;
+    var transitModel = router.transitModel;
 
     RoutingRequest transferRoutingRequest = Transfer.prepareTransferRoutingRequest(request);
 
     return new RaptorRoutingRequestTransitData(
-      graph.getTransferService(),
+      transitModel.getTransferService(),
       transitLayer,
       transitSearchTimeZero,
       additionalSearchDays.additionalSearchDaysInPast(),
       additionalSearchDays.additionalSearchDaysInFuture(),
-      createRequestTransitDataProviderFilter(graph.index),
+      createRequestTransitDataProviderFilter(transitModel.index),
       new RoutingContext(transferRoutingRequest, graph, (Vertex) null, null)
     );
   }
 
-  private TransitDataProviderFilter createRequestTransitDataProviderFilter(GraphIndex graphIndex) {
-    return new RoutingRequestTransitDataProviderFilter(request, graphIndex);
+  private TransitDataProviderFilter createRequestTransitDataProviderFilter(
+    TransitModelIndex transitModelIndex
+  ) {
+    return new RoutingRequestTransitDataProviderFilter(request, transitModelIndex);
   }
 
   private void verifyAccessEgress(Collection<?> access, Collection<?> egress) {

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/AccessEgressRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/AccessEgressRouter.java
@@ -9,6 +9,7 @@ import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.routing.core.RoutingContext;
 import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
+import org.opentripplanner.transit.service.TransitModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,6 +30,7 @@ public class AccessEgressRouter {
    */
   public static Collection<NearbyStop> streetSearch(
     RoutingContext rctx,
+    TransitModel transitModel,
     StreetMode streetMode,
     boolean fromTarget
   ) {
@@ -40,6 +42,7 @@ public class AccessEgressRouter {
 
     NearbyStopFinder nearbyStopFinder = new NearbyStopFinder(
       rctx.graph,
+      transitModel,
       rr.getMaxAccessEgressDuration(streetMode),
       true
     );

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/DirectFlexRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/DirectFlexRouter.java
@@ -35,17 +35,20 @@ public class DirectFlexRouter {
       // Prepare access/egress transfers
       Collection<NearbyStop> accessStops = AccessEgressRouter.streetSearch(
         routingContext,
+        router.transitModel,
         StreetMode.WALK,
         false
       );
       Collection<NearbyStop> egressStops = AccessEgressRouter.streetSearch(
         routingContext,
+        router.transitModel,
         StreetMode.WALK,
         true
       );
 
       FlexRouter flexRouter = new FlexRouter(
         router.graph,
+        router.transitModel,
         router.routerConfig.flexParameters(request),
         directRequest.getDateTime(),
         directRequest.arriveBy,

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/DirectStreetRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/DirectStreetRouter.java
@@ -15,8 +15,6 @@ import org.opentripplanner.routing.error.PathNotFoundException;
 import org.opentripplanner.routing.impl.GraphPathFinder;
 import org.opentripplanner.routing.spt.GraphPath;
 import org.opentripplanner.standalone.server.Router;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class DirectStreetRouter {
 
@@ -43,8 +41,8 @@ public class DirectStreetRouter {
 
       // Convert the internal GraphPaths to itineraries
       final GraphPathToItineraryMapper graphPathToItineraryMapper = new GraphPathToItineraryMapper(
-        router.graph.getTimeZone(),
-        new AlertToLegMapper(router.graph.getTransitAlertService()),
+        router.transitModel.getTimeZone(),
+        new AlertToLegMapper(router.transitModel.getTransitAlertService()),
         router.graph.streetNotesService,
         router.graph.ellipsoidToGeoidDifference
       );

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/FlexAccessEgressRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/FlexAccessEgressRouter.java
@@ -9,6 +9,7 @@ import org.opentripplanner.routing.algorithm.raptoradapter.router.AdditionalSear
 import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.routing.core.RoutingContext;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
+import org.opentripplanner.transit.service.TransitModel;
 
 public class FlexAccessEgressRouter {
 
@@ -16,20 +17,22 @@ public class FlexAccessEgressRouter {
 
   public static Collection<FlexAccessEgress> routeAccessEgress(
     RoutingContext routingContext,
+    TransitModel transitModel,
     AdditionalSearchDays searchDays,
     FlexParameters params,
     boolean isEgress
   ) {
     Collection<NearbyStop> accessStops = !isEgress
-      ? AccessEgressRouter.streetSearch(routingContext, StreetMode.WALK, false)
+      ? AccessEgressRouter.streetSearch(routingContext, transitModel, StreetMode.WALK, false)
       : List.of();
 
     Collection<NearbyStop> egressStops = isEgress
-      ? AccessEgressRouter.streetSearch(routingContext, StreetMode.WALK, true)
+      ? AccessEgressRouter.streetSearch(routingContext, transitModel, StreetMode.WALK, true)
       : List.of();
 
     FlexRouter flexRouter = new FlexRouter(
       routingContext.graph,
+      transitModel,
       params,
       routingContext.opt.getDateTime(),
       routingContext.opt.arriveBy,

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TransitLayerMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TransitLayerMapper.java
@@ -24,8 +24,8 @@ import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripPatternFo
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripPatternWithRaptorStopIndexes;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.constrainedtransfer.TransferIndexGenerator;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.request.RaptorRequestTransferCache;
-import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.trippattern.TripTimes;
+import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.util.OTPFeature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,14 +45,17 @@ public class TransitLayerMapper {
 
   private static final Logger LOG = LoggerFactory.getLogger(TransitLayerMapper.class);
 
-  private final Graph graph;
+  private final TransitModel transitModel;
 
-  private TransitLayerMapper(Graph graph) {
-    this.graph = graph;
+  private TransitLayerMapper(TransitModel transitModel) {
+    this.transitModel = transitModel;
   }
 
-  public static TransitLayer map(TransitTuningParameters tuningParameters, Graph graph) {
-    return new TransitLayerMapper(graph).map(tuningParameters);
+  public static TransitLayer map(
+    TransitTuningParameters tuningParameters,
+    TransitModel transitModel
+  ) {
+    return new TransitLayerMapper(transitModel).map(tuningParameters);
   }
 
   // TODO We can save time by either pre-sorting these or use a sorting algorithm that is
@@ -73,22 +76,26 @@ public class TransitLayerMapper {
 
     LOG.info("Mapping transitLayer from Graph...");
 
-    stopIndex = new StopIndexForRaptor(graph.index.getAllStops(), tuningParameters);
+    stopIndex =
+      new StopIndexForRaptor(
+        transitModel.getStopModel().getStopModelIndex().getAllStops(),
+        tuningParameters
+      );
 
-    Collection<TripPattern> allTripPatterns = graph.tripPatternForId.values();
+    Collection<TripPattern> allTripPatterns = transitModel.tripPatternForId.values();
     TripPatternMapper tripPatternMapper = new TripPatternMapper();
     newTripPatternForOld =
       tripPatternMapper.mapOldTripPatternToRaptorTripPattern(stopIndex, allTripPatterns);
 
     tripPatternsByStopByDate = mapTripPatterns(allTripPatterns, newTripPatternForOld);
 
-    transferByStopIndex = mapTransfers(stopIndex, graph.transfersByStop);
+    transferByStopIndex = mapTransfers(stopIndex, transitModel.transfersByStop);
 
     TransferIndexGenerator transferIndexGenerator = null;
     if (OTPFeature.TransferConstraints.isOn()) {
       transferIndexGenerator =
         new TransferIndexGenerator(
-          graph.getTransferService().listAll(),
+          transitModel.getTransferService().listAll(),
           newTripPatternForOld.values(),
           stopIndex
         );
@@ -102,9 +109,9 @@ public class TransitLayerMapper {
     return new TransitLayer(
       tripPatternsByStopByDate,
       transferByStopIndex,
-      graph.getTransferService(),
+      transitModel.getTransferService(),
       stopIndex,
-      graph.getTimeZone().toZoneId(),
+      transitModel.getTimeZone().toZoneId(),
       transferCache,
       tripPatternMapper,
       transferIndexGenerator
@@ -122,11 +129,11 @@ public class TransitLayerMapper {
     Map<TripPattern, TripPatternWithRaptorStopIndexes> newTripPatternForOld
   ) {
     TripPatternForDateMapper tripPatternForDateMapper = new TripPatternForDateMapper(
-      graph.index.getServiceCodesRunningForDate(),
+      transitModel.index.getServiceCodesRunningForDate(),
       newTripPatternForOld
     );
 
-    Set<ServiceDate> allServiceDates = graph.index.getServiceCodesRunningForDate().keySet();
+    Set<ServiceDate> allServiceDates = transitModel.index.getServiceCodesRunningForDate().keySet();
 
     List<TripPatternForDate> tripPatternForDates = Collections.synchronizedList(new ArrayList<>());
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TransitLayerUpdater.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TransitLayerUpdater.java
@@ -17,8 +17,8 @@ import org.opentripplanner.routing.algorithm.raptoradapter.transit.TransitLayer;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripPatternForDate;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripPatternWithRaptorStopIndexes;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.constrainedtransfer.TransferIndexGenerator;
-import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.trippattern.TripTimes;
+import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.util.OTPFeature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,7 +34,7 @@ public class TransitLayerUpdater {
 
   private static final Logger LOG = LoggerFactory.getLogger(TransitLayerUpdater.class);
 
-  private final Graph graph;
+  private final TransitModel transitModel;
 
   private final Map<ServiceDate, TIntSet> serviceCodesRunningForDate;
 
@@ -52,8 +52,11 @@ public class TransitLayerUpdater {
 
   private final Map<LocalDate, Set<TripPatternForDate>> tripPatternsRunningOnDateMapCache = new HashMap<>();
 
-  public TransitLayerUpdater(Graph graph, Map<ServiceDate, TIntSet> serviceCodesRunningForDate) {
-    this.graph = graph;
+  public TransitLayerUpdater(
+    TransitModel transitModel,
+    Map<ServiceDate, TIntSet> serviceCodesRunningForDate
+  ) {
+    this.transitModel = transitModel;
     this.serviceCodesRunningForDate = serviceCodesRunningForDate;
   }
 
@@ -61,7 +64,7 @@ public class TransitLayerUpdater {
     Set<Timetable> updatedTimetables,
     Map<TripPattern, SortedSet<Timetable>> timetables
   ) {
-    if (!graph.hasRealtimeTransitLayer()) {
+    if (!transitModel.hasRealtimeTransitLayer()) {
       return;
     }
 
@@ -69,7 +72,7 @@ public class TransitLayerUpdater {
 
     // Make a shallow copy of the realtime transit layer. Only the objects that are copied will be
     // changed during this update process.
-    TransitLayer realtimeTransitLayer = new TransitLayer(graph.getRealtimeTransitLayer());
+    TransitLayer realtimeTransitLayer = new TransitLayer(transitModel.getRealtimeTransitLayer());
 
     // Map TripPatterns for this update to Raptor TripPatterns
     final Map<TripPattern, TripPatternWithRaptorStopIndexes> newTripPatternForOld = realtimeTransitLayer
@@ -229,7 +232,7 @@ public class TransitLayerUpdater {
 
     // Switch out the reference with the updated realtimeTransitLayer. This is synchronized to
     // guarantee that the reference is set after all the fields have been updated.
-    graph.setRealtimeTransitLayer(realtimeTransitLayer);
+    transitModel.setRealtimeTransitLayer(realtimeTransitLayer);
 
     LOG.debug(
       "UPDATING {} tripPatterns took {} ms",

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RoutingRequestTransitDataProviderFilter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RoutingRequestTransitDataProviderFilter.java
@@ -9,13 +9,13 @@ import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripPatternWi
 import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.routing.api.request.WheelchairAccessibilityRequest;
-import org.opentripplanner.routing.graph.GraphIndex;
 import org.opentripplanner.routing.trippattern.TripTimes;
 import org.opentripplanner.transit.model.basic.WheelchairAccessibility;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.BikeAccess;
 import org.opentripplanner.transit.model.network.MainAndSubMode;
 import org.opentripplanner.transit.model.timetable.Trip;
+import org.opentripplanner.transit.service.TransitModelIndex;
 
 public class RoutingRequestTransitDataProviderFilter implements TransitDataProviderFilter {
 
@@ -47,13 +47,16 @@ public class RoutingRequestTransitDataProviderFilter implements TransitDataProvi
     this.transitModeFilter = AllowTransitModeFilter.of(allowedTransitModes);
   }
 
-  public RoutingRequestTransitDataProviderFilter(RoutingRequest request, GraphIndex graphIndex) {
+  public RoutingRequestTransitDataProviderFilter(
+    RoutingRequest request,
+    TransitModelIndex transitModelIndex
+  ) {
     this(
       request.modes.transferMode == StreetMode.BIKE,
       request.wheelchairAccessibility,
       request.includePlannedCancellations,
       request.modes.transitModes,
-      request.getBannedRoutes(graphIndex.getAllRoutes()),
+      request.getBannedRoutes(transitModelIndex.getAllRoutes()),
       request.bannedTrips
     );
   }

--- a/src/main/java/org/opentripplanner/routing/alternativelegs/AlternativeLegs.java
+++ b/src/main/java/org/opentripplanner/routing/alternativelegs/AlternativeLegs.java
@@ -117,7 +117,7 @@ public class AlternativeLegs {
     int alightingPosition = tripPatternBetweenStops.positions.alightingPosition;
 
     // TODO: What should we have here
-    ZoneId timeZone = routingService.getTimeZone().toZoneId();
+    ZoneId timeZone = transitService.getTimeZone().toZoneId();
 
     Comparator<TripTimeOnDate> comparator = Comparator.comparing((TripTimeOnDate tts) ->
       tts.getServiceDayMidnight() + tts.getRealtimeDeparture()

--- a/src/main/java/org/opentripplanner/routing/core/RoutingContext.java
+++ b/src/main/java/org/opentripplanner/routing/core/RoutingContext.java
@@ -8,8 +8,6 @@ import org.opentripplanner.routing.error.GraphNotFoundException;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.util.OTPFeature;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A RoutingContext holds information needed to carry out a search for a particular TraverseOptions,

--- a/src/main/java/org/opentripplanner/routing/graph/Graph.java
+++ b/src/main/java/org/opentripplanner/routing/graph/Graph.java
@@ -1,34 +1,21 @@
 package org.opentripplanner.routing.graph;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Multimap;
-import gnu.trove.set.hash.TIntHashSet;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.BitSet;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
-import java.util.TimeZone;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Function;
 import java.util.prefs.Preferences;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import javax.annotation.Nullable;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
@@ -38,56 +25,23 @@ import org.opentripplanner.common.geometry.GraphUtils;
 import org.opentripplanner.common.geometry.SphericalDistanceLibrary;
 import org.opentripplanner.common.model.T2;
 import org.opentripplanner.ext.dataoverlay.configuration.DataOverlayParameterBindings;
-import org.opentripplanner.ext.flex.trip.FlexTrip;
-import org.opentripplanner.graph_builder.DataImportIssueStore;
-import org.opentripplanner.graph_builder.issues.NoFutureDates;
 import org.opentripplanner.graph_builder.linking.VertexLinker;
 import org.opentripplanner.graph_builder.module.osm.WayPropertySetSource.DrivingDirection;
-import org.opentripplanner.model.FeedInfo;
-import org.opentripplanner.model.FlexLocationGroup;
-import org.opentripplanner.model.FlexStopLocation;
 import org.opentripplanner.model.GraphBundle;
-import org.opentripplanner.model.GroupOfStations;
-import org.opentripplanner.model.MultiModalStation;
-import org.opentripplanner.model.Notice;
-import org.opentripplanner.model.PathTransfer;
-import org.opentripplanner.model.TimetableSnapshot;
-import org.opentripplanner.model.TimetableSnapshotProvider;
-import org.opentripplanner.model.TripOnServiceDate;
-import org.opentripplanner.model.TripPattern;
-import org.opentripplanner.model.calendar.CalendarService;
-import org.opentripplanner.model.calendar.CalendarServiceData;
-import org.opentripplanner.model.calendar.ServiceDate;
-import org.opentripplanner.model.calendar.impl.CalendarServiceImpl;
-import org.opentripplanner.model.transfer.TransferService;
-import org.opentripplanner.routing.algorithm.raptoradapter.transit.TransitLayer;
-import org.opentripplanner.routing.algorithm.raptoradapter.transit.mappers.TransitLayerUpdater;
 import org.opentripplanner.routing.core.intersection_model.IntersectionTraversalCostModel;
 import org.opentripplanner.routing.core.intersection_model.SimpleIntersectionTraversalCostModel;
 import org.opentripplanner.routing.edgetype.StreetEdge;
-import org.opentripplanner.routing.impl.DelegatingTransitAlertServiceImpl;
 import org.opentripplanner.routing.impl.StreetVertexIndex;
 import org.opentripplanner.routing.services.RealtimeVehiclePositionService;
-import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.routing.services.notes.StreetNotesService;
 import org.opentripplanner.routing.trippattern.Deduplicator;
-import org.opentripplanner.routing.util.ConcurrentPublished;
 import org.opentripplanner.routing.vehicle_parking.VehicleParkingService;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalStationService;
 import org.opentripplanner.routing.vertextype.TransitStopVertex;
 import org.opentripplanner.transit.model.basic.WgsCoordinate;
-import org.opentripplanner.transit.model.framework.FeedScopedId;
-import org.opentripplanner.transit.model.framework.TransitEntity;
-import org.opentripplanner.transit.model.network.TransitMode;
-import org.opentripplanner.transit.model.organization.Agency;
-import org.opentripplanner.transit.model.organization.Operator;
-import org.opentripplanner.transit.model.site.Station;
 import org.opentripplanner.transit.model.site.Stop;
-import org.opentripplanner.transit.model.site.StopCollection;
 import org.opentripplanner.transit.model.site.StopLocation;
-import org.opentripplanner.updater.GraphUpdaterConfigurator;
-import org.opentripplanner.updater.GraphUpdaterManager;
-import org.opentripplanner.util.MedianCalcForDoubles;
+import org.opentripplanner.transit.service.StopModel;
 import org.opentripplanner.util.WorldEnvelope;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -111,77 +65,34 @@ public class Graph implements Serializable {
 
   public final StreetNotesService streetNotesService = new StreetNotesService();
 
-  /**
-   * Allows a notice element to be attached to an object in the OTP model by its id and then
-   * retrieved by the API when navigating from that object. The map key is entity id: {@link
-   * TransitEntity#getId()}. The notice is part of the static transit data.
-   */
-  private final Multimap<TransitEntity, Notice> noticesByElement = HashMultimap.create();
   private final Map<Class<?>, Serializable> services = new HashMap<>();
-  private final TransferService transferService = new TransferService();
+
   /* Ideally we could just get rid of vertex labels, but they're used in tests and graph building. */
   private final Map<String, Vertex> vertices = new ConcurrentHashMap<>();
-  public final transient Deduplicator deduplicator = new Deduplicator();
-  /**
-   * Map from GTFS ServiceIds to integers close to 0. Allows using BitSets instead of {@code
-   * Set<Object>}. An empty Map is created before the Graph is built to allow registering IDs from
-   * multiple feeds.
-   */
-  private final Map<FeedScopedId, Integer> serviceCodes = Maps.newHashMap();
-  private final Collection<Agency> agencies = new ArrayList<>();
-  private final Collection<Operator> operators = new ArrayList<>();
-  private final Collection<String> feedIds = new HashSet<>();
-  private final Map<String, FeedInfo> feedInfoForId = new HashMap<>();
-  /** List of transit modes that are availible in GTFS data used in this graph **/
-  private final HashSet<TransitMode> transitModes = new HashSet<>();
+  public final transient Deduplicator deduplicator;
+
   public final Date buildTime = new Date();
-  /** Pre-generated transfers between all stops. */
-  public final Multimap<StopLocation, PathTransfer> transfersByStop = HashMultimap.create();
-  /** Data model for Raptor routing, with realtime updates applied (if any). */
-  private final transient ConcurrentPublished<TransitLayer> realtimeTransitLayer = new ConcurrentPublished<>();
-  // transit feed validity information in seconds since epoch
-  private long transitServiceStarts = Long.MAX_VALUE;
-  private long transitServiceEnds = 0;
+  private StopModel stopModel;
+
   private GraphBundle bundle;
-  private transient CalendarService calendarService;
+
   private transient StreetVertexIndex streetIndex;
-  public transient GraphIndex index;
-  private transient TimetableSnapshotProvider timetableSnapshotProvider = null;
-  private transient TimeZone timeZone = null;
+
   //Envelope of all OSM and transit vertices. Calculated during build time
   private WorldEnvelope envelope = null;
   //ConvexHull of all the graph vertices. Generated at Graph build time.
   private Geometry convexHull = null;
-  /** The density center of the graph for determining the initial geographic extent in the client. */
-  private Coordinate center = null;
+
   /* The preferences that were used for graph building. */
   public Preferences preferences = null;
   // TODO OTP2: This is only enabled with static bike rental
   public boolean hasBikeSharing = false;
   public boolean hasParkRide = false;
   public boolean hasBikeRide = false;
-  /**
-   * Manages all updaters of this graph. Is created by the GraphUpdaterConfigurator when there are
-   * graph updaters defined in the configuration.
-   *
-   * @see GraphUpdaterConfigurator
-   */
-  public transient GraphUpdaterManager updaterManager = null;
+
   /** True if OSM data was loaded into this Graph. */
   public boolean hasStreets = false;
-  /** True if GTFS data was loaded into this Graph. */
-  public boolean hasTransit = false;
-  /** True if direct single-edge transfers were generated between transit stops in this Graph. */
-  public boolean hasDirectTransfers = false;
-  /**
-   * True if frequency-based services exist in this Graph (GTFS frequencies with exact_times = 0).
-   */
-  public boolean hasFrequencyService = false;
-  /**
-   * True if schedule-based services exist in this Graph (including GTFS frequencies with
-   * exact_times = 1).
-   */
-  public boolean hasScheduledService = false;
+
   /**
    * Have bike parks already been linked to the graph. As the linking happens twice if a base graph
    * is used, we store information on whether bike park linking should be skipped.
@@ -204,33 +115,9 @@ public class Graph implements Serializable {
    * If this graph contains elevation data, the maximum value.
    */
   public Double maxElevation = null;
-  /** Parent stops **/
-  public Map<FeedScopedId, Station> stationById = new HashMap<>();
-  /**
-   * Optional level above parent stops (only supported in NeTEx)
-   */
-  public Map<FeedScopedId, MultiModalStation> multiModalStationById = new HashMap<>();
-  /**
-   * Optional grouping that can contain both stations and multimodal stations (only supported in
-   * NeTEx)
-   */
-  public Map<FeedScopedId, GroupOfStations> groupOfStationsById = new HashMap<>();
-  /**
-   * TripPatterns used to be reached through hop edges, but we're not creating on-board transit
-   * vertices/edges anymore.
-   */
-  public Map<FeedScopedId, TripPattern> tripPatternForId = Maps.newHashMap();
-  public Map<FeedScopedId, TripOnServiceDate> tripOnServiceDates = Maps.newHashMap();
-  public Map<FeedScopedId, FlexStopLocation> locationsById = new HashMap<>();
-  public Map<FeedScopedId, FlexLocationGroup> locationGroupsById = new HashMap<>();
-  public Map<FeedScopedId, FlexTrip> flexTripsById = new HashMap<>();
+
   /** The distance between elevation samples used in CompactElevationProfile. */
   private double distanceBetweenElevationSamples;
-  /** Data model for Raptor routing, with realtime updates applied (if any). */
-  private transient TransitLayer transitLayer;
-  public transient TransitLayerUpdater transitLayerUpdater;
-
-  private transient TransitAlertService transitAlertService;
 
   private transient RealtimeVehiclePositionService vehiclePositionService;
 
@@ -254,41 +141,14 @@ public class Graph implements Serializable {
    */
   public DataOverlayParameterBindings dataOverlayParameterBindings;
 
-  public Graph(Graph basedOn) {
-    this();
-    this.bundle = basedOn.getBundle();
-    this.drivingDirection = basedOn.drivingDirection;
+  public Graph(StopModel stopModel, Deduplicator deduplicator) {
+    this.stopModel = stopModel;
+    this.deduplicator = deduplicator;
   }
 
   // Constructor for deserialization.
-  public Graph() {}
-
-  public TimetableSnapshot getTimetableSnapshot() {
-    return timetableSnapshotProvider == null
-      ? null
-      : timetableSnapshotProvider.getTimetableSnapshot();
-  }
-
-  /**
-   * TODO OTP2 - This should be replaced by proper dependency injection
-   */
-  @SuppressWarnings("unchecked")
-  public <T extends TimetableSnapshotProvider> T getOrSetupTimetableSnapshotProvider(
-    Function<Graph, T> creator
-  ) {
-    if (timetableSnapshotProvider == null) {
-      timetableSnapshotProvider = creator.apply(this);
-    }
-    try {
-      return (T) timetableSnapshotProvider;
-    } catch (ClassCastException e) {
-      throw new IllegalArgumentException(
-        "We support only one timetableSnapshotSource, there are two implementation; one for GTFS and one " +
-        "for Netex/Siri. They need to be refactored to work together. This cast will fail if updaters " +
-        "try setup both.",
-        e
-      );
-    }
+  public Graph() {
+    this.deduplicator = new Deduplicator();
   }
 
   /**
@@ -396,26 +256,6 @@ public class Graph implements Serializable {
     return getEdgesOfType(StreetEdge.class);
   }
 
-  public TransitLayer getTransitLayer() {
-    return transitLayer;
-  }
-
-  public void setTransitLayer(TransitLayer transitLayer) {
-    this.transitLayer = transitLayer;
-  }
-
-  public TransitLayer getRealtimeTransitLayer() {
-    return realtimeTransitLayer.get();
-  }
-
-  public void setRealtimeTransitLayer(TransitLayer realtimeTransitLayer) {
-    this.realtimeTransitLayer.publish(realtimeTransitLayer);
-  }
-
-  public boolean hasRealtimeTransitLayer() {
-    return realtimeTransitLayer != null;
-  }
-
   public boolean containsVertex(Vertex v) {
     return (v != null) && vertices.get(v.getLabel()) == v;
   }
@@ -470,47 +310,6 @@ public class Graph implements Serializable {
     return env;
   }
 
-  public TransferService getTransferService() {
-    return transferService;
-  }
-
-  // Infer the time period covered by the transit feed
-  public void updateTransitFeedValidity(CalendarServiceData data, DataImportIssueStore issueStore) {
-    long now = new Date().getTime() / 1000;
-    final long SEC_IN_DAY = 24 * 60 * 60;
-    HashSet<String> agenciesWithFutureDates = new HashSet<>();
-    HashSet<String> agencies = new HashSet<>();
-    for (FeedScopedId sid : data.getServiceIds()) {
-      agencies.add(sid.getFeedId());
-      for (ServiceDate sd : data.getServiceDatesForServiceId(sid)) {
-        // Adjust for timezone, assuming there is only one per graph.
-        long t = sd.getAsDate(getTimeZone()).getTime() / 1000;
-        if (t > now) {
-          agenciesWithFutureDates.add(sid.getFeedId());
-        }
-        // assume feed is unreliable after midnight on last service day
-        long u = t + SEC_IN_DAY;
-        if (t < this.transitServiceStarts) {
-          this.transitServiceStarts = t;
-        }
-        if (u > this.transitServiceEnds) {
-          this.transitServiceEnds = u;
-        }
-      }
-    }
-    for (String agency : agencies) {
-      if (!agenciesWithFutureDates.contains(agency)) {
-        issueStore.add(new NoFutureDates(agency));
-      }
-    }
-  }
-
-  // Check to see if we have transit information for a given date
-  public boolean transitFeedCovers(Instant time) {
-    long t = time.getEpochSecond();
-    return t >= this.transitServiceStarts && t < this.transitServiceEnds;
-  }
-
   public GraphBundle getBundle() {
     return bundle;
   }
@@ -538,107 +337,28 @@ public class Graph implements Serializable {
   }
 
   /**
-   * Adds mode of transport to transit modes in graph
-   */
-  public void addTransitMode(TransitMode mode) {
-    transitModes.add(mode);
-  }
-
-  public HashSet<TransitMode> getTransitModes() {
-    return transitModes;
-  }
-
-  /**
-   * Perform indexing on vertices, edges, and timetables, and create transient data structures. This
-   * used to be done in readObject methods upon deserialization, but stand-alone mode now allows
-   * passing graphs from graphbuilder to server in memory, without a round trip through
-   * serialization.
+   * Perform indexing on vertices, edges and create transient data structures. This used to be done
+   * in readObject methods upon deserialization, but stand-alone mode now allows passing graphs from
+   * graphbuilder to server in memory, without a round trip through serialization.
    */
   public void index() {
-    LOG.info("Index graph...");
-    streetIndex = new StreetVertexIndex(this);
-    LOG.debug("Rebuilding edge and vertex indices.");
-    for (TripPattern tp : tripPatternForId.values()) {
-      // Skip frequency-based patterns which have no timetable (null)
-      if (tp != null) tp.getScheduledTimetable().finish();
-    }
-    // TODO: Move this ^ stuff into the graph index
-    this.index = new GraphIndex(this);
-    LOG.info("Index graph complete.");
-  }
-
-  public CalendarService getCalendarService() {
-    if (calendarService == null) {
-      CalendarServiceData data = this.getService(CalendarServiceData.class);
-      if (data != null) {
-        this.calendarService = new CalendarServiceImpl(data);
-      }
-    }
-    return this.calendarService;
-  }
-
-  public CalendarServiceData getCalendarDataService() {
-    CalendarServiceData calendarServiceData;
-    if (this.hasService(CalendarServiceData.class)) {
-      calendarServiceData = this.getService(CalendarServiceData.class);
-    } else {
-      calendarServiceData = new CalendarServiceData();
-    }
-    return calendarServiceData;
-  }
-
-  public void clearCachedCalenderService() {
-    this.calendarService = null;
+    LOG.info("Index street model...");
+    //TODO refactoring transit model - logic changed
+    CompactElevationProfile.setDistanceBetweenSamplesM(getDistanceBetweenElevationSamples());
+    streetIndex = new StreetVertexIndex(this, stopModel);
+    LOG.info("Index street model complete.");
   }
 
   public StreetVertexIndex getStreetIndex() {
+    //TODO refactoring transit model - thread safety
     if (this.streetIndex == null) {
-      streetIndex = new StreetVertexIndex(this);
+      index();
     }
     return this.streetIndex;
   }
 
   public VertexLinker getLinker() {
     return getStreetIndex().getVertexLinker();
-  }
-
-  /**
-   * Get or create a serviceId for a given date. This method is used when a new trip is added from a
-   * realtime data update. It make sure the date is in the existing transit service period.
-   * <p>
-   * TODO OTP2 - This is NOT THREAD-SAFE and is used in the real-time updaters, we need to fix
-   *           - this when doing the issue #3030.
-   *
-   * @param serviceDate service date for the added service id
-   * @return service-id for date if it exist or is created. If the given service date is outside the
-   * service period {@code null} is returned.
-   */
-  @Nullable
-  public FeedScopedId getOrCreateServiceIdForDate(ServiceDate serviceDate) {
-    // Start of day
-    long time = serviceDate.toZonedDateTime(getTimeZone().toZoneId(), 0).toEpochSecond();
-
-    if (time < transitServiceStarts || time >= transitServiceEnds) {
-      return null;
-    }
-
-    // We make an explicit cast here to avoid adding the 'getOrCreateServiceIdForDate(..)'
-    // method to the {@link CalendarService} interface. We do not want to expose it because it
-    // is not thread-safe - and we want to limit the usage. See JavaDoc above as well.
-    FeedScopedId serviceId =
-      ((CalendarServiceImpl) getCalendarService()).getOrCreateServiceIdForDate(serviceDate);
-
-    if (!serviceCodes.containsKey(serviceId)) {
-      // Calculating new unique serviceCode based on size (!)
-      final int serviceCode = serviceCodes.size();
-      serviceCodes.put(serviceId, serviceCode);
-
-      index
-        .getServiceCodesRunningForDate()
-        .computeIfAbsent(serviceDate, ignored -> new TIntHashSet())
-        .add(serviceCode);
-    }
-    return serviceId;
   }
 
   public int removeEdgelessVertices() {
@@ -654,68 +374,6 @@ public class Graph implements Serializable {
       LOG.trace("removed edgeless vertex {}", v);
     }
     return removed;
-  }
-
-  public Collection<String> getFeedIds() {
-    return feedIds;
-  }
-
-  public Collection<Agency> getAgencies() {
-    return agencies;
-  }
-
-  public FeedInfo getFeedInfo(String feedId) {
-    return feedInfoForId.get(feedId);
-  }
-
-  public void addAgency(String feedId, Agency agency) {
-    agencies.add(agency);
-    this.feedIds.add(feedId);
-  }
-
-  public void addFeedInfo(FeedInfo info) {
-    this.feedInfoForId.put(info.getId(), info);
-  }
-
-  /**
-   * Returns the time zone for the first agency in this graph. This is used to interpret times in
-   * API requests. The JVM default time zone cannot be used because we support multiple graphs on
-   * one server via the routerId. Ideally we would want to interpret times in the time zone of the
-   * geographic location where the origin/destination vertex or board/alight event is located. This
-   * may become necessary when we start making graphs with long distance train, boat, or air
-   * services.
-   */
-  public TimeZone getTimeZone() {
-    if (timeZone == null) {
-      if (agencies.size() == 0) {
-        timeZone = TimeZone.getTimeZone("GMT");
-        LOG.warn("graph contains no agencies (yet); API request times will be interpreted as GMT.");
-      } else {
-        CalendarService cs = this.getCalendarService();
-        for (Agency agency : agencies) {
-          TimeZone tz = cs.getTimeZoneForAgencyId(agency.getId());
-          if (timeZone == null) {
-            LOG.debug("graph time zone set to {}", tz);
-            timeZone = tz;
-          } else if (!timeZone.equals(tz)) {
-            LOG.error("agency time zone differs from graph time zone: {}", tz);
-          }
-        }
-      }
-    }
-    return timeZone;
-  }
-
-  public Collection<Operator> getOperators() {
-    return operators;
-  }
-
-  /**
-   * The timezone is cached by the graph. If you've done something to the graph that has the
-   * potential to change the time zone, you should call this to ensure it is reset.
-   */
-  public void clearTimeZone() {
-    this.timeZone = null;
   }
 
   /**
@@ -767,52 +425,6 @@ public class Graph implements Serializable {
     return this.envelope;
   }
 
-  /**
-   * Calculates Transit center from median of coordinates of all transitStops if graph has transit.
-   * If it doesn't it isn't calculated. (mean walue of min, max latitude and longitudes are used)
-   * <p>
-   * Transit center is saved in center variable
-   * <p>
-   * This speeds up calculation, but problem is that median needs to have all of
-   * latitudes/longitudes in memory, this can become problematic in large installations. It works
-   * without a problem on New York State.
-   */
-  public void calculateTransitCenter() {
-    if (hasTransit) {
-      var vertices = getVerticesOfType(TransitStopVertex.class);
-      var medianCalculator = new MedianCalcForDoubles(vertices.size());
-
-      vertices.forEach(v -> medianCalculator.add(v.getLon()));
-      double lon = medianCalculator.median();
-
-      medianCalculator.reset();
-      vertices.forEach(v -> medianCalculator.add(v.getLat()));
-      double lat = medianCalculator.median();
-
-      this.center = new Coordinate(lon, lat);
-    }
-  }
-
-  public Optional<Coordinate> getCenter() {
-    return Optional.ofNullable(center);
-  }
-
-  public long getTransitServiceStarts() {
-    return transitServiceStarts;
-  }
-
-  public long getTransitServiceEnds() {
-    return transitServiceEnds;
-  }
-
-  public Multimap<TransitEntity, Notice> getNoticesByElement() {
-    return noticesByElement;
-  }
-
-  public void addNoticeAssignments(Multimap<TransitEntity, Notice> noticesByElement) {
-    this.noticesByElement.putAll(noticesByElement);
-  }
-
   public double getDistanceBetweenElevationSamples() {
     return distanceBetweenElevationSamples;
   }
@@ -822,77 +434,11 @@ public class Graph implements Serializable {
     CompactElevationProfile.setDistanceBetweenSamplesM(distanceBetweenElevationSamples);
   }
 
-  public TransitAlertService getTransitAlertService() {
-    if (transitAlertService == null) {
-      transitAlertService = new DelegatingTransitAlertServiceImpl(this);
-    }
-    return transitAlertService;
-  }
-
   public RealtimeVehiclePositionService getVehiclePositionService() {
     if (vehiclePositionService == null) {
       vehiclePositionService = new RealtimeVehiclePositionService();
     }
     return vehiclePositionService;
-  }
-
-  /**
-   * @param id Id of Stop, Station, MultiModalStation or GroupOfStations
-   * @return The associated TransitStopVertex or all underlying TransitStopVertices
-   */
-  public Set<Vertex> getStopVerticesById(FeedScopedId id) {
-    var stops = getStopsForId(id);
-
-    if (stops == null) {
-      return null;
-    }
-
-    return stops.stream().map(index.getStopVertexForStop()::get).collect(Collectors.toSet());
-  }
-
-  /**
-   * @param id Id of Stop, Station, MultiModalStation or GroupOfStations
-   * @return The coordinate for the transit entity
-   */
-  public WgsCoordinate getCoordinateById(FeedScopedId id) {
-    // GroupOfStations
-    GroupOfStations groupOfStations = groupOfStationsById.get(id);
-    if (groupOfStations != null) {
-      return groupOfStations.getCoordinate();
-    }
-
-    // Multimodal station
-    MultiModalStation multiModalStation = multiModalStationById.get(id);
-    if (multiModalStation != null) {
-      return multiModalStation.getCoordinate();
-    }
-
-    // Station
-    Station station = stationById.get(id);
-    if (station != null) {
-      return station.getCoordinate();
-    }
-
-    // Single stop
-    var stop = index.getStopForId(id);
-    if (stop != null) {
-      return stop.getCoordinate();
-    }
-
-    return null;
-  }
-
-  /** An OBA Service Date is a local date without timezone, only year month and day. */
-  public BitSet getServicesRunningForDate(ServiceDate date) {
-    BitSet services = new BitSet(calendarService.getServiceIds().size());
-    for (FeedScopedId serviceId : calendarService.getServiceIdsOnDate(date)) {
-      int n = serviceCodes.get(serviceId);
-      if (n < 0) {
-        continue;
-      }
-      services.set(n);
-    }
-    return services;
   }
 
   public VehicleRentalStationService getVehicleRentalStationService() {
@@ -901,27 +447,6 @@ public class Graph implements Serializable {
 
   public VehicleParkingService getVehicleParkingService() {
     return getService(VehicleParkingService.class);
-  }
-
-  public Collection<Notice> getNoticesByEntity(TransitEntity entity) {
-    Collection<Notice> res = getNoticesByElement().get(entity);
-    return res == null ? Collections.emptyList() : res;
-  }
-
-  public TripPattern getTripPatternForId(FeedScopedId id) {
-    return tripPatternForId.get(id);
-  }
-
-  public Collection<TripPattern> getTripPatterns() {
-    return tripPatternForId.values();
-  }
-
-  public Map<FeedScopedId, TripOnServiceDate> getTripOnServiceDates() {
-    return tripOnServiceDates;
-  }
-
-  public Collection<Notice> getNotices() {
-    return getNoticesByElement().values();
   }
 
   /** Get all stops within a given bounding box. */
@@ -955,77 +480,6 @@ public class Graph implements Serializable {
       .collect(Collectors.toList());
   }
 
-  public Station getStationById(FeedScopedId id) {
-    return stationById.get(id);
-  }
-
-  public MultiModalStation getMultiModalStation(FeedScopedId id) {
-    return multiModalStationById.get(id);
-  }
-
-  public Collection<Station> getStations() {
-    return stationById.values();
-  }
-
-  /**
-   * Finds a {@link StopLocation} by id.
-   */
-  public StopLocation getStopLocationById(FeedScopedId id) {
-    var stop = index.getStopForId(id);
-    if (stop != null) {
-      return stop;
-    }
-
-    return getAllFlexStopsFlat()
-      .stream()
-      .filter(stopLocation -> stopLocation.getId().equals(id))
-      .findAny()
-      .orElse(null);
-  }
-
-  /**
-   * Finds a {@link StopCollection} by id.
-   */
-  public StopCollection getStopCollectionById(FeedScopedId id) {
-    var station = stationById.get(id);
-    if (station != null) {
-      return station;
-    }
-
-    var groupOfStations = groupOfStationsById.get(id);
-    if (groupOfStations != null) {
-      return groupOfStations;
-    }
-
-    return multiModalStationById.get(id);
-  }
-
-  /**
-   * Returns all {@link StopLocation}s present in this graph, including normal and flex locations.
-   */
-  public Stream<StopLocation> getAllStopLocations() {
-    return Stream.concat(index.getAllStops().stream(), getAllFlexStopsFlat().stream());
-  }
-
-  /**
-   * Returns all {@link StopCollection}s present in this graph, including stations, group of
-   * stations and multimodal stations.
-   */
-  public Stream<StopCollection> getAllStopCollections() {
-    return Stream.concat(
-      stationById.values().stream(),
-      Stream.concat(groupOfStationsById.values().stream(), multiModalStationById.values().stream())
-    );
-  }
-
-  public Map<FeedScopedId, Integer> getServiceCodes() {
-    return serviceCodes;
-  }
-
-  public Collection<PathTransfer> getTransfersByStop(StopLocation stop) {
-    return transfersByStop.get(stop);
-  }
-
   public DrivingDirection getDrivingDirection() {
     return drivingDirection;
   }
@@ -1044,65 +498,12 @@ public class Graph implements Serializable {
     this.intersectionTraversalCostModel = intersectionTraversalCostModel;
   }
 
-  /**
-   * Flex locations are generated by GTFS graph builder, but consumed only after the street graph is
-   * built
-   */
-  public FlexStopLocation getLocationById(FeedScopedId id) {
-    return locationsById.get(id);
-  }
-
-  /**
-   * Gets all the flex stop locations, including the elements of FlexLocationGroups.
-   */
-  public Set<StopLocation> getAllFlexStopsFlat() {
-    Set<StopLocation> stopLocations = flexTripsById
-      .values()
-      .stream()
-      .flatMap(t -> t.getStops().stream())
-      .collect(Collectors.toSet());
-
-    stopLocations.addAll(
-      stopLocations
-        .stream()
-        .filter(s -> s instanceof FlexLocationGroup)
-        .flatMap(g -> ((FlexLocationGroup) g).getLocations().stream().filter(e -> e instanceof Stop)
-        )
-        .collect(Collectors.toList())
-    );
-
-    return stopLocations;
+  public StopModel getStopModel() {
+    return stopModel;
   }
 
   private void readObject(ObjectInputStream inputStream)
     throws ClassNotFoundException, IOException {
     inputStream.defaultReadObject();
-  }
-
-  private Collection<StopLocation> getStopsForId(FeedScopedId id) {
-    // GroupOfStations
-    GroupOfStations groupOfStations = groupOfStationsById.get(id);
-    if (groupOfStations != null) {
-      return groupOfStations.getChildStops();
-    }
-
-    // Multimodal station
-    MultiModalStation multiModalStation = multiModalStationById.get(id);
-    if (multiModalStation != null) {
-      return multiModalStation.getChildStops();
-    }
-
-    // Station
-    Station station = stationById.get(id);
-    if (station != null) {
-      return station.getChildStops();
-    }
-    // Single stop
-    var stop = index.getStopForId(id);
-    if (stop != null) {
-      return Collections.singleton(stop);
-    }
-
-    return null;
   }
 }

--- a/src/main/java/org/opentripplanner/routing/graph/SerializedGraphObject.java
+++ b/src/main/java/org/opentripplanner/routing/graph/SerializedGraphObject.java
@@ -23,6 +23,7 @@ import org.opentripplanner.routing.graph.kryosupport.KryoBuilder;
 import org.opentripplanner.standalone.config.BuildConfig;
 import org.opentripplanner.standalone.config.RouterConfig;
 import org.opentripplanner.transit.model.network.SubMode;
+import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.util.OtpAppException;
 import org.opentripplanner.util.logging.ProgressTracker;
 import org.slf4j.Logger;
@@ -44,6 +45,7 @@ public class SerializedGraphObject implements Serializable {
   private static final Logger LOG = LoggerFactory.getLogger(SerializedGraphObject.class);
 
   public final Graph graph;
+  public final TransitModel transitModel;
 
   private final Collection<Edge> edges;
 
@@ -62,9 +64,15 @@ public class SerializedGraphObject implements Serializable {
    */
   public final List<SubMode> allTransitSubModes;
 
-  public SerializedGraphObject(Graph graph, BuildConfig buildConfig, RouterConfig routerConfig) {
+  public SerializedGraphObject(
+    Graph graph,
+    TransitModel transitModel,
+    BuildConfig buildConfig,
+    RouterConfig routerConfig
+  ) {
     this.graph = graph;
     this.edges = graph.getEdges();
+    this.transitModel = transitModel;
     this.buildConfig = buildConfig;
     this.routerConfig = routerConfig;
     this.allTransitSubModes = SubMode.listAllCachedSubModes();
@@ -90,10 +98,9 @@ public class SerializedGraphObject implements Serializable {
     return load(source.asInputStream(), source.path());
   }
 
-  public static Graph load(File file) {
+  public static SerializedGraphObject load(File file) {
     try {
-      SerializedGraphObject serObj = load(new FileInputStream(file), file.getAbsolutePath());
-      return serObj == null ? null : serObj.graph;
+      return load(new FileInputStream(file), file.getAbsolutePath());
     } catch (FileNotFoundException e) {
       LOG.error("Graph file not found: " + file, e);
       throw new OtpAppException(e.getMessage());

--- a/src/main/java/org/opentripplanner/routing/graphfinder/PlaceFinderTraverseVisitor.java
+++ b/src/main/java/org/opentripplanner/routing/graphfinder/PlaceFinderTraverseVisitor.java
@@ -5,7 +5,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.opentripplanner.model.TripPattern;
-import org.opentripplanner.routing.RoutingService;
 import org.opentripplanner.routing.algorithm.astar.TraverseVisitor;
 import org.opentripplanner.routing.algorithm.astar.strategies.SkipEdgeStrategy;
 import org.opentripplanner.routing.core.State;
@@ -27,8 +26,6 @@ import org.opentripplanner.transit.service.TransitService;
 public class PlaceFinderTraverseVisitor implements TraverseVisitor {
 
   public final List<PlaceAtDistance> placesFound = new ArrayList<>();
-  private final RoutingService routingService;
-
   private final TransitService transitService;
   private final Set<TransitMode> filterByModes;
   private final Set<FeedScopedId> filterByStops;
@@ -47,7 +44,7 @@ public class PlaceFinderTraverseVisitor implements TraverseVisitor {
   private final double radiusMeters;
 
   /**
-   * @param routingService             A RoutingService used in finding information about the
+   * @param transitService             A TransitService used in finding information about the
    *                                   various places.
    * @param filterByModes              A list of TransitModes for which to find Stops and
    *                                   PatternAtStops. Use null to disable the filtering.
@@ -63,7 +60,6 @@ public class PlaceFinderTraverseVisitor implements TraverseVisitor {
    * @param maxResults                 Maximum number of results to return.
    */
   public PlaceFinderTraverseVisitor(
-    RoutingService routingService,
     TransitService transitService,
     List<TransitMode> filterByModes,
     List<PlaceType> filterByPlaceTypes,
@@ -73,7 +69,6 @@ public class PlaceFinderTraverseVisitor implements TraverseVisitor {
     int maxResults,
     double radiusMeters
   ) {
-    this.routingService = routingService;
     this.transitService = transitService;
     this.filterByModes = toSet(filterByModes);
     this.filterByStops = toSet(filterByStops);

--- a/src/main/java/org/opentripplanner/routing/graphfinder/StreetGraphFinder.java
+++ b/src/main/java/org/opentripplanner/routing/graphfinder/StreetGraphFinder.java
@@ -53,7 +53,6 @@ public class StreetGraphFinder implements GraphFinder {
     TransitService transitService
   ) {
     PlaceFinderTraverseVisitor visitor = new PlaceFinderTraverseVisitor(
-      routingService,
       transitService,
       filterByModes,
       filterByPlaceTypes,

--- a/src/main/java/org/opentripplanner/routing/impl/DelegatingTransitAlertServiceImpl.java
+++ b/src/main/java/org/opentripplanner/routing/impl/DelegatingTransitAlertServiceImpl.java
@@ -6,18 +6,18 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import org.opentripplanner.model.calendar.ServiceDate;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
-import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.updater.alerts.TransitAlertProvider;
 
 public class DelegatingTransitAlertServiceImpl implements TransitAlertService {
 
   private final ArrayList<TransitAlertService> transitAlertServices = new ArrayList<>();
 
-  public DelegatingTransitAlertServiceImpl(Graph graph) {
-    if (graph.updaterManager != null) {
-      graph.updaterManager
+  public DelegatingTransitAlertServiceImpl(TransitModel transitModel) {
+    if (transitModel.updaterManager != null) {
+      transitModel.updaterManager
         .getUpdaterList()
         .stream()
         .filter(TransitAlertProvider.class::isInstance)

--- a/src/main/java/org/opentripplanner/routing/impl/TransitAlertServiceImpl.java
+++ b/src/main/java/org/opentripplanner/routing/impl/TransitAlertServiceImpl.java
@@ -8,9 +8,9 @@ import java.util.Set;
 import org.opentripplanner.model.calendar.ServiceDate;
 import org.opentripplanner.routing.alertpatch.EntitySelector;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
-import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.service.TransitModel;
 
 /**
  * When an alert is added with more than one transit entity, e.g. a Stop and a Trip, both conditions
@@ -19,12 +19,12 @@ import org.opentripplanner.transit.model.framework.FeedScopedId;
  */
 public class TransitAlertServiceImpl implements TransitAlertService {
 
-  private final Graph graph;
+  private final TransitModel transitModel;
 
   private Multimap<EntitySelector, TransitAlert> alerts = HashMultimap.create();
 
-  public TransitAlertServiceImpl(Graph graph) {
-    this.graph = graph;
+  public TransitAlertServiceImpl(TransitModel transitModel) {
+    this.transitModel = transitModel;
   }
 
   @Override
@@ -59,8 +59,8 @@ public class TransitAlertServiceImpl implements TransitAlertService {
     Set<TransitAlert> result = new HashSet<>(alerts.get(new EntitySelector.Stop(stopId)));
     if (result.isEmpty()) {
       // Search for alerts on parent-stop
-      if (graph != null && graph.index != null) {
-        var quay = graph.index.getStopForId(stopId);
+      if (transitModel != null && transitModel.index != null) {
+        var quay = transitModel.getStopModel().getStopModelIndex().getStopForId(stopId);
         if (quay != null) {
           // TODO - SIRI: Add alerts from parent- and multimodal-stops
           /*

--- a/src/main/java/org/opentripplanner/routing/vertextype/TransitStopVertex.java
+++ b/src/main/java/org/opentripplanner/routing/vertextype/TransitStopVertex.java
@@ -2,7 +2,6 @@ package org.opentripplanner.routing.vertextype;
 
 import java.util.HashSet;
 import java.util.Set;
-import org.opentripplanner.routing.RoutingService;
 import org.opentripplanner.routing.edgetype.PathwayEdge;
 import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Graph;
@@ -32,12 +31,12 @@ public class TransitStopVertex extends Vertex {
   private int streetToStopTime = 0;
 
   /**
-   * @param stop  The transit model stop reference. See {@link RoutingService#getStopVertexForStop()}
+   * @param stop  The transit model stop reference. See {@link org.opentripplanner.transit.service.TransitService#getStopVertexForStop()}
    *              for navigation from a Stop to this class.
    * @param modes Set of modes for all Routes using this stop. If {@code null} an empty set is
    *              used.
    */
-  public TransitStopVertex(Graph graph, Stop stop, Set<TransitMode> modes) {
+  TransitStopVertex(Graph graph, Stop stop, Set<TransitMode> modes) {
     super(graph, stop.getId().toString(), stop.getLon(), stop.getLat(), stop.getName());
     this.stop = stop;
     this.modes = modes != null ? modes : new HashSet<>();

--- a/src/main/java/org/opentripplanner/routing/vertextype/TransitStopVertexBuilder.java
+++ b/src/main/java/org/opentripplanner/routing/vertextype/TransitStopVertexBuilder.java
@@ -1,0 +1,45 @@
+package org.opentripplanner.routing.vertextype;
+
+import java.util.Objects;
+import java.util.Set;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.transit.model.network.TransitMode;
+import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.service.TransitModel;
+
+public class TransitStopVertexBuilder {
+
+  private Stop stop;
+  private Graph graph;
+  private TransitModel transitModel;
+  private Set<TransitMode> modes;
+
+  public TransitStopVertexBuilder withStop(Stop stop) {
+    this.stop = stop;
+    return this;
+  }
+
+  public TransitStopVertexBuilder withGraph(Graph graph) {
+    this.graph = graph;
+    return this;
+  }
+
+  public TransitStopVertexBuilder withTransitModel(TransitModel transitModel) {
+    this.transitModel = transitModel;
+    return this;
+  }
+
+  public TransitStopVertexBuilder withModes(Set<TransitMode> modes) {
+    this.modes = modes;
+    return this;
+  }
+
+  public TransitStopVertex build() {
+    Objects.requireNonNull(graph);
+    Objects.requireNonNull(transitModel);
+    Objects.requireNonNull(stop);
+    TransitStopVertex stopVertex = new TransitStopVertex(graph, stop, modes);
+    transitModel.getStopModel().addTransitStopVertex(stopVertex.getStop().getId(), stopVertex);
+    return stopVertex;
+  }
+}

--- a/src/main/java/org/opentripplanner/standalone/OTPMain.java
+++ b/src/main/java/org/opentripplanner/standalone/OTPMain.java
@@ -13,6 +13,7 @@ import org.opentripplanner.standalone.config.CommandLineParameters;
 import org.opentripplanner.standalone.configure.OTPAppConstruction;
 import org.opentripplanner.standalone.server.GrizzlyServer;
 import org.opentripplanner.standalone.server.Router;
+import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.util.OtpAppException;
 import org.opentripplanner.util.ThrowableUtils;
 import org.opentripplanner.visualizer.GraphVisualizer;
@@ -106,6 +107,7 @@ public class OTPMain {
     );
 
     Graph graph = null;
+    TransitModel transitModel = null;
     OTPAppConstruction app = new OTPAppConstruction(params);
 
     // Validate data sources, command line arguments and config before loading and
@@ -117,9 +119,15 @@ public class OTPMain {
       DataSource inputGraph = params.doLoadGraph()
         ? app.store().getGraph()
         : app.store().getStreetGraph();
-      SerializedGraphObject obj = SerializedGraphObject.load(inputGraph);
-      graph = obj.graph;
-      app.config().updateConfigFromSerializedGraph(obj.buildConfig, obj.routerConfig);
+      SerializedGraphObject serializedGraphObject = SerializedGraphObject.load(inputGraph);
+      graph = serializedGraphObject.graph;
+      transitModel = serializedGraphObject.transitModel;
+      app
+        .config()
+        .updateConfigFromSerializedGraph(
+          serializedGraphObject.buildConfig,
+          serializedGraphObject.routerConfig
+        );
     }
 
     /* Start graph builder if requested. */
@@ -134,12 +142,18 @@ public class OTPMain {
         graphBuilder.run();
         // Hand off the graph to the server as the default graph
         graph = graphBuilder.getGraph();
+        transitModel = graphBuilder.getTransitModel();
       } else {
         throw new IllegalStateException("An error occurred while building the graph.");
       }
       // Store graph and config used to build it, also store router-config for easy deployment
       // with using the embedded router config.
-      new SerializedGraphObject(graph, app.config().buildConfig(), app.config().routerConfig())
+      new SerializedGraphObject(
+        graph,
+        transitModel,
+        app.config().buildConfig(),
+        app.config().routerConfig()
+      )
         .save(app.graphOutputDataSource());
       // Log size info for the deduplicator
       LOG.info("Memory optimized {}", graph.deduplicator.toString());
@@ -156,12 +170,18 @@ public class OTPMain {
     }
 
     // Index graph for travel search
+    transitModel.index();
     graph.index();
 
     // publishing the config version info make it available to the APIs
     app.setOtpConfigVersionsOnServerInfo();
 
-    Router router = new Router(graph, app.config().routerConfig(), Metrics.globalRegistry);
+    Router router = new Router(
+      graph,
+      transitModel,
+      app.config().routerConfig(),
+      Metrics.globalRegistry
+    );
     router.startup();
 
     /* Start visualizer if requested. */

--- a/src/main/java/org/opentripplanner/standalone/server/MetricsLogging.java
+++ b/src/main/java/org/opentripplanner/standalone/server/MetricsLogging.java
@@ -17,7 +17,7 @@ import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
 import io.micrometer.core.instrument.binder.system.UptimeMetrics;
 import java.util.List;
 import java.util.concurrent.ForkJoinPool;
-import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.transit.service.TransitModel;
 
 /**
  * This class is responsible for wiring up various metrics to micrometer, which we use for
@@ -39,11 +39,11 @@ public class MetricsLogging {
     new UptimeMetrics().bindTo(Metrics.globalRegistry);
 
     Router router = otpServer.getRouter();
-    Graph graph = router.graph;
+    TransitModel transitModel = router.transitModel;
 
-    if (graph.getTransitLayer() != null) {
+    if (transitModel.getTransitLayer() != null) {
       new GuavaCacheMetrics(
-        graph.getTransitLayer().getTransferCache().getTransferCache(),
+        transitModel.getTransitLayer().getTransferCache().getTransferCache(),
         "raptorTransfersCache",
         List.of(Tag.of("cache", "raptorTransfers"))
       )
@@ -56,16 +56,16 @@ public class MetricsLogging {
     )
       .bindTo(Metrics.globalRegistry);
 
-    if (graph.updaterManager != null) {
+    if (transitModel.updaterManager != null) {
       new ExecutorServiceMetrics(
-        graph.updaterManager.getUpdaterPool(),
+        transitModel.updaterManager.getUpdaterPool(),
         "graphUpdaters",
         List.of(Tag.of("pool", "graphUpdaters"))
       )
         .bindTo(Metrics.globalRegistry);
 
       new ExecutorServiceMetrics(
-        graph.updaterManager.getScheduler(),
+        transitModel.updaterManager.getScheduler(),
         "graphUpdateScheduler",
         List.of(Tag.of("pool", "graphUpdateScheduler"))
       )

--- a/src/main/java/org/opentripplanner/standalone/server/OTPServer.java
+++ b/src/main/java/org/opentripplanner/standalone/server/OTPServer.java
@@ -42,11 +42,11 @@ public class OTPServer {
    * not be visible to the request.
    */
   public RoutingService createRoutingRequestService() {
-    return new RoutingService(router.graph);
+    return new RoutingService(router.graph, router.transitModel);
   }
 
   public TransitService createTransitRequestService() {
-    return new DefaultTransitService(router.graph);
+    return new DefaultTransitService(router.transitModel);
   }
 
   /**

--- a/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
+++ b/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.transit.service;
 
 import com.google.common.collect.Multimap;
+import java.util.BitSet;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.HashSet;
@@ -9,7 +10,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.function.Function;
-import org.opentripplanner.common.model.T2;
+import org.opentripplanner.common.geometry.HashGridSpatialIndex;
+import org.opentripplanner.ext.flex.FlexIndex;
 import org.opentripplanner.model.FeedInfo;
 import org.opentripplanner.model.FlexStopLocation;
 import org.opentripplanner.model.MultiModalStation;
@@ -27,11 +29,10 @@ import org.opentripplanner.model.calendar.CalendarService;
 import org.opentripplanner.model.calendar.ServiceDate;
 import org.opentripplanner.routing.DatedServiceJourneyHelper;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TransitLayer;
-import org.opentripplanner.routing.graph.Graph;
-import org.opentripplanner.routing.graph.GraphIndex;
+import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.routing.stoptimes.ArrivalDeparture;
 import org.opentripplanner.routing.stoptimes.StopTimesHelper;
-import org.opentripplanner.transit.model.basic.WgsCoordinate;
+import org.opentripplanner.routing.vertextype.TransitStopVertex;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.framework.TransitEntity;
 import org.opentripplanner.transit.model.network.GroupOfRoutes;
@@ -52,242 +53,225 @@ import org.opentripplanner.transit.model.timetable.Trip;
  */
 public class DefaultTransitService implements TransitEditorService {
 
-  private final Graph graph;
+  private final TransitModel transitModel;
 
-  private final GraphIndex graphIndex;
+  private final TransitModelIndex transitModelIndex;
 
   /**
    * This should only be accessed through the getTimetableSnapshot method.
    */
   private TimetableSnapshot timetableSnapshot;
 
-  public DefaultTransitService(Graph graph) {
-    this.graph = graph;
-    this.graphIndex = graph.index;
+  public DefaultTransitService(TransitModel transitModel) {
+    this.transitModel = transitModel;
+    this.transitModelIndex = transitModel.index;
   }
 
-  /** {@link Graph#getFeedIds()} */
+  /** {@link TransitModel#getFeedIds()} */
   @Override
   public Collection<String> getFeedIds() {
-    return this.graph.getFeedIds();
+    return this.transitModel.getFeedIds();
   }
 
-  /** {@link Graph#getAgencies()} */
+  /** {@link TransitModel#getAgencies()} */
   @Override
   public Collection<Agency> getAgencies() {
-    return this.graph.getAgencies();
+    return this.transitModel.getAgencies();
   }
 
-  /** {@link Graph#getFeedInfo(String)} ()} */
+  /** {@link TransitModel#getFeedInfo(String)} ()} */
   @Override
   public FeedInfo getFeedInfo(String feedId) {
-    return this.graph.getFeedInfo(feedId);
+    return this.transitModel.getFeedInfo(feedId);
   }
 
-  /** {@link Graph#addAgency(String, Agency)} */
+  /** {@link TransitModel#addAgency(String, Agency)} */
   @Override
   public void addAgency(String feedId, Agency agency) {
-    this.graph.addAgency(feedId, agency);
+    this.transitModel.addAgency(feedId, agency);
   }
 
-  /** {@link Graph#addFeedInfo(FeedInfo)} */
+  /** {@link TransitModel#addFeedInfo(FeedInfo)} */
   @Override
   public void addFeedInfo(FeedInfo info) {
-    this.graph.addFeedInfo(info);
+    this.transitModel.addFeedInfo(info);
   }
 
-  /** {@link Graph#getOperators()} */
+  /** {@link TransitModel#getOperators()} */
   @Override
   public Collection<Operator> getOperators() {
-    return this.graph.getOperators();
+    return this.transitModel.getOperators();
   }
 
-  /** {@link Graph#getNoticesByElement()} */
+  /** {@link TransitModel#getNoticesByElement()} */
   @Override
   public Multimap<TransitEntity, Notice> getNoticesByElement() {
-    return this.graph.getNoticesByElement();
+    return this.transitModel.getNoticesByElement();
   }
 
-  /** {@link Graph#addNoticeAssignments(Multimap)} */
+  /** {@link TransitModel#addNoticeAssignments(Multimap)} */
   @Override
   public void addNoticeAssignments(Multimap<TransitEntity, Notice> noticesByElement) {
-    this.graph.addNoticeAssignments(noticesByElement);
+    this.transitModel.addNoticeAssignments(noticesByElement);
   }
 
-  /** {@link Graph#getNoticesByEntity(TransitEntity)} */
+  /** {@link TransitModel#getNoticesByEntity(TransitEntity)} */
   @Override
   public Collection<Notice> getNoticesByEntity(TransitEntity entity) {
-    return this.graph.getNoticesByEntity(entity);
+    return this.transitModel.getNoticesByEntity(entity);
   }
 
-  /** {@link Graph#getTripPatternForId(FeedScopedId)} */
+  /** {@link TransitModel#getTripPatternForId(FeedScopedId)} */
   @Override
   public TripPattern getTripPatternForId(FeedScopedId id) {
-    return this.graph.getTripPatternForId(id);
+    return this.transitModel.getTripPatternForId(id);
   }
 
-  /** {@link Graph#getTripPatterns()} */
+  /** {@link TransitModel#getTripPatterns()} */
   @Override
   public Collection<TripPattern> getTripPatterns() {
-    return this.graph.getTripPatterns();
+    return this.transitModel.getTripPatterns();
   }
 
-  /** {@link Graph#getNotices()} */
+  /** {@link TransitModel#getNotices()} */
   @Override
   public Collection<Notice> getNotices() {
-    return this.graph.getNotices();
+    return this.transitModel.getNotices();
   }
 
-  /** {@link Graph#getStopsByBoundingBox(double, double, double, double)} */
-  @Override
-  public Collection<StopLocation> getStopsByBoundingBox(
-    double minLat,
-    double minLon,
-    double maxLat,
-    double maxLon
-  ) {
-    return this.graph.getStopsByBoundingBox(minLat, minLon, maxLat, maxLon);
-  }
-
-  /** {@link Graph#getStopsInRadius(WgsCoordinate, double)} */
-  @Override
-  public List<T2<Stop, Double>> getStopsInRadius(WgsCoordinate center, double radius) {
-    return this.graph.getStopsInRadius(center, radius);
-  }
-
-  /** {@link Graph#getStationById(FeedScopedId)} */
+  /** {@link StopModel#getStationById(FeedScopedId)} */
   @Override
   public Station getStationById(FeedScopedId id) {
-    return this.graph.getStationById(id);
+    return this.transitModel.getStopModel().getStationById(id);
   }
 
-  /** {@link Graph#getMultiModalStation(FeedScopedId)} */
+  /** {@link StopModel#getMultiModalStation(FeedScopedId)} */
   @Override
   public MultiModalStation getMultiModalStation(FeedScopedId id) {
-    return this.graph.getMultiModalStation(id);
+    return this.transitModel.getStopModel().getMultiModalStation(id);
   }
 
-  /** {@link Graph#getStations()} */
+  /** {@link StopModel#getStations()} */
   @Override
   public Collection<Station> getStations() {
-    return this.graph.getStations();
+    return this.transitModel.getStopModel().getStations();
   }
 
-  /** {@link Graph#getServiceCodes()} */
+  /** {@link TransitModel#getServiceCodes()} */
   @Override
   public Map<FeedScopedId, Integer> getServiceCodes() {
-    return this.graph.getServiceCodes();
+    return this.transitModel.getServiceCodes();
   }
 
-  /** {@link Graph#getLocationById(FeedScopedId)} */
+  /** {@link StopModel#getLocationById(FeedScopedId)} */
   @Override
   public FlexStopLocation getLocationById(FeedScopedId id) {
-    return this.graph.getLocationById(id);
+    return this.transitModel.getStopModel().getLocationById(id);
   }
 
-  /** {@link Graph#getAllFlexStopsFlat()} */
+  /** {@link TransitModel#getAllFlexStopsFlat()} */
   @Override
   public Set<StopLocation> getAllFlexStopsFlat() {
-    return this.graph.getAllFlexStopsFlat();
+    return this.transitModel.getAllFlexStopsFlat();
   }
 
-  /** {@link GraphIndex#getAgencyForId(FeedScopedId)} */
+  /** {@link TransitModelIndex#getAgencyForId(FeedScopedId)} */
   @Override
   public Agency getAgencyForId(FeedScopedId id) {
-    return this.graphIndex.getAgencyForId(id);
+    return this.transitModelIndex.getAgencyForId(id);
   }
 
-  /** {@link GraphIndex#getStopForId(FeedScopedId)} */
+  /** {@link StopModelIndex#getStopForId(FeedScopedId)} */
   @Override
   public StopLocation getStopForId(FeedScopedId id) {
-    return this.graphIndex.getStopForId(id);
+    return this.transitModel.getStopModel().getStopModelIndex().getStopForId(id);
   }
 
-  /** {@link GraphIndex#getRouteForId(FeedScopedId)} */
+  /** {@link TransitModelIndex#getRouteForId(FeedScopedId)} */
   @Override
   public Route getRouteForId(FeedScopedId id) {
-    return this.graphIndex.getRouteForId(id);
+    return this.transitModelIndex.getRouteForId(id);
   }
 
-  /** {@link GraphIndex#addRoutes(Route)} */
+  /** {@link TransitModelIndex#addRoutes(Route)} */
   @Override
   public void addRoutes(Route route) {
-    this.graphIndex.addRoutes(route);
+    this.transitModelIndex.addRoutes(route);
   }
 
-  /** {@link GraphIndex#getRoutesForStop(StopLocation)} */
+  /** {@link TransitModelIndex#getRoutesForStop(StopLocation)} */
   @Override
   public Set<Route> getRoutesForStop(StopLocation stop) {
-    return this.graphIndex.getRoutesForStop(stop);
+    return this.transitModelIndex.getRoutesForStop(stop);
   }
 
-  /** {@link GraphIndex#getPatternsForStop(StopLocation)} */
+  /** {@link TransitModelIndex#getPatternsForStop(StopLocation)} */
   @Override
   public Collection<TripPattern> getPatternsForStop(StopLocation stop) {
-    return this.graphIndex.getPatternsForStop(stop);
+    return this.transitModelIndex.getPatternsForStop(stop);
   }
 
-  /** {@link GraphIndex#getPatternsForStop(StopLocation, TimetableSnapshot)} */
+  /** {@link TransitModelIndex#getPatternsForStop(StopLocation, TimetableSnapshot)} */
   @Override
   public Collection<TripPattern> getPatternsForStop(
     StopLocation stop,
     TimetableSnapshot timetableSnapshot
   ) {
-    return this.graphIndex.getPatternsForStop(stop, timetableSnapshot);
+    return this.transitModelIndex.getPatternsForStop(stop, timetableSnapshot);
   }
 
-  /** {@link GraphIndex#getAllOperators()} */
+  /** {@link TransitModelIndex#getAllOperators()} */
   @Override
   public Collection<Operator> getAllOperators() {
-    return this.graphIndex.getAllOperators();
+    return this.transitModelIndex.getAllOperators();
   }
 
-  /** {@link GraphIndex#getOperatorForId()} */
+  /** {@link TransitModelIndex#getOperatorForId()} */
   @Override
   public Map<FeedScopedId, Operator> getOperatorForId() {
-    return this.graphIndex.getOperatorForId();
+    return this.transitModelIndex.getOperatorForId();
   }
 
-  /** {@link GraphIndex#getAllStops()} */
+  /** {@link StopModelIndex#getAllStops()} */
   @Override
   public Collection<StopLocation> getAllStops() {
-    return this.graphIndex.getAllStops();
+    return this.transitModel.getStopModel().getStopModelIndex().getAllStops();
   }
 
-  /** {@link GraphIndex#getTripForId()} */
+  /** {@link TransitModelIndex#getTripForId()} */
   @Override
   public Map<FeedScopedId, Trip> getTripForId() {
-    return this.graphIndex.getTripForId();
+    return this.transitModelIndex.getTripForId();
   }
 
-  /** {@link GraphIndex#getAllRoutes()} */
+  /** {@link TransitModelIndex#getAllRoutes()} */
   @Override
   public Collection<Route> getAllRoutes() {
-    return this.graphIndex.getAllRoutes();
+    return this.transitModelIndex.getAllRoutes();
   }
 
-  /** {@link GraphIndex#getPatternForTrip()} */
+  /** {@link TransitModelIndex#getPatternForTrip()} */
   @Override
   public Map<Trip, TripPattern> getPatternForTrip() {
-    return this.graphIndex.getPatternForTrip();
+    return this.transitModelIndex.getPatternForTrip();
   }
 
-  /** {@link GraphIndex#getPatternsForFeedId()} */
+  /** {@link TransitModelIndex#getPatternsForFeedId()} */
   @Override
   public Multimap<String, TripPattern> getPatternsForFeedId() {
-    return this.graphIndex.getPatternsForFeedId();
+    return this.transitModelIndex.getPatternsForFeedId();
   }
 
-  /** {@link GraphIndex#getPatternsForRoute()} */
+  /** {@link TransitModelIndex#getPatternsForRoute()} */
   @Override
   public Multimap<Route, TripPattern> getPatternsForRoute() {
-    return this.graphIndex.getPatternsForRoute();
+    return this.transitModelIndex.getPatternsForRoute();
   }
 
-  /** {@link GraphIndex#getMultiModalStationForStations()} */
+  /** {@link StopModelIndex#getMultiModalStationForStations()} */
   @Override
   public Map<Station, MultiModalStation> getMultiModalStationForStations() {
-    return this.graphIndex.getMultiModalStationForStations();
+    return this.transitModel.getStopModel().getStopModelIndex().getMultiModalStationForStations();
   }
 
   /**
@@ -388,7 +372,7 @@ public class DefaultTransitService implements TransitEditorService {
     StopLocation stop,
     boolean includeRealtimeUpdates
   ) {
-    return graph.index.getPatternsForStop(
+    return transitModel.index.getPatternsForStop(
       stop,
       includeRealtimeUpdates ? lazyGetTimeTableSnapShot() : null
     );
@@ -396,17 +380,17 @@ public class DefaultTransitService implements TransitEditorService {
 
   @Override
   public Collection<GroupOfRoutes> getGroupsOfRoutes() {
-    return graphIndex.getRoutesForGroupOfRoutes().keySet();
+    return transitModelIndex.getRoutesForGroupOfRoutes().keySet();
   }
 
   @Override
   public Collection<Route> getRoutesForGroupOfRoutes(GroupOfRoutes groupOfRoutes) {
-    return graphIndex.getRoutesForGroupOfRoutes().get(groupOfRoutes);
+    return transitModelIndex.getRoutesForGroupOfRoutes().get(groupOfRoutes);
   }
 
   @Override
   public GroupOfRoutes getGroupOfRoutesForId(FeedScopedId id) {
-    return graphIndex.getGroupOfRoutesForId().get(id);
+    return transitModelIndex.getGroupOfRoutesForId().get(id);
   }
 
   /**
@@ -432,7 +416,7 @@ public class DefaultTransitService implements TransitEditorService {
    */
   private TimetableSnapshot lazyGetTimeTableSnapShot() {
     if (this.timetableSnapshot == null) {
-      timetableSnapshot = graph.getTimetableSnapshot();
+      timetableSnapshot = transitModel.getTimetableSnapshot();
     }
     return this.timetableSnapshot;
   }
@@ -452,67 +436,106 @@ public class DefaultTransitService implements TransitEditorService {
 
   @Override
   public Map<TripIdAndServiceDate, TripOnServiceDate> getTripOnServiceDateForTripAndDay() {
-    return graphIndex.getTripOnServiceDateForTripAndDay();
+    return transitModelIndex.getTripOnServiceDateForTripAndDay();
   }
 
   @Override
   public Map<FeedScopedId, TripOnServiceDate> getTripOnServiceDateById() {
-    return graphIndex.getTripOnServiceDateById();
+    return transitModelIndex.getTripOnServiceDateById();
   }
 
-  /** {@link Graph#addTransitMode(TransitMode)} */
+  /** {@link TransitModel#addTransitMode(TransitMode)} */
   @Override
   public void addTransitMode(TransitMode mode) {
-    this.graph.addTransitMode(mode);
+    this.transitModel.addTransitMode(mode);
   }
 
-  /** {@link Graph#getTransitModes()} */
+  /** {@link TransitModel#getTransitModes()} */
   @Override
   public HashSet<TransitMode> getTransitModes() {
-    return this.graph.getTransitModes();
+    return this.transitModel.getTransitModes();
   }
 
-  /** {@link Graph#getTransfersByStop(StopLocation)} */
+  /** {@link TransitModel#getTransfersByStop(StopLocation)} */
   @Override
   public Collection<PathTransfer> getTransfersByStop(StopLocation stop) {
-    return this.graph.getTransfersByStop(stop);
+    return this.transitModel.getTransfersByStop(stop);
   }
 
-  /** {@link Graph#getTimetableSnapshot()} */
+  /** {@link TransitModel#getTimetableSnapshot()} */
   @Override
   public TimetableSnapshot getTimetableSnapshot() {
-    return this.graph.getTimetableSnapshot();
+    return this.transitModel.getTimetableSnapshot();
   }
 
-  /** {@link Graph#getOrSetupTimetableSnapshotProvider(Function)} */
+  /** {@link TransitModel#getOrSetupTimetableSnapshotProvider(Function)} */
   @Override
   public <T extends TimetableSnapshotProvider> T getOrSetupTimetableSnapshotProvider(
-    Function<Graph, T> creator
+    Function<TransitModel, T> creator
   ) {
-    return this.graph.getOrSetupTimetableSnapshotProvider(creator);
+    return this.transitModel.getOrSetupTimetableSnapshotProvider(creator);
   }
 
-  /** {@link Graph#getTransitLayer()} */
+  /** {@link TransitModel#getTransitLayer()} */
   @Override
   public TransitLayer getTransitLayer() {
-    return this.graph.getTransitLayer();
+    return this.transitModel.getTransitLayer();
   }
 
-  /** {@link Graph#setTransitLayer(TransitLayer)} */
+  /** {@link TransitModel#setTransitLayer(TransitLayer)} */
   @Override
   public void setTransitLayer(TransitLayer transitLayer) {
-    this.graph.setTransitLayer(transitLayer);
+    this.transitModel.setTransitLayer(transitLayer);
   }
 
-  /** {@link Graph#getCalendarService()} */
+  /** {@link TransitModel#getCalendarService()} */
   @Override
   public CalendarService getCalendarService() {
-    return this.graph.getCalendarService();
+    return this.transitModel.getCalendarService();
   }
 
-  /** {@link Graph#getTimeZone()} */
+  /** {@link TransitModel#getTimeZone()} */
   @Override
   public TimeZone getTimeZone() {
-    return this.graph.getTimeZone();
+    return this.transitModel.getTimeZone();
+  }
+
+  /** {@link TransitModel#getTransitAlertService()} */
+  @Override
+  public TransitAlertService getTransitAlertService() {
+    return this.transitModel.getTransitAlertService();
+  }
+
+  @Override
+  public FlexIndex getFlexIndex() {
+    return this.transitModelIndex.getFlexIndex();
+  }
+
+  @Override
+  public BitSet getServicesRunningForDate(ServiceDate parseString) {
+    return transitModel.getServicesRunningForDate(parseString);
+  }
+
+  @Override
+  public Long getTransitServiceEnds() {
+    return transitModel.getTransitServiceEnds();
+  }
+
+  @Override
+  public Long getTransitServiceStarts() {
+    return transitModel.getTransitServiceStarts();
+  }
+
+  /** {@link StopModelIndex#getStopVertexForStop()} */
+  @Override
+  public Map<Stop, TransitStopVertex> getStopVertexForStop() {
+    return transitModel.getStopModel().getStopVertexForStop();
+  }
+
+  /** {@link StopModelIndex#getStopSpatialIndex()} */
+
+  @Override
+  public HashGridSpatialIndex<TransitStopVertex> getStopSpatialIndex() {
+    return transitModel.getStopModel().getStopModelIndex().getStopSpatialIndex();
   }
 }

--- a/src/main/java/org/opentripplanner/transit/service/StopModel.java
+++ b/src/main/java/org/opentripplanner/transit/service/StopModel.java
@@ -1,0 +1,249 @@
+package org.opentripplanner.transit.service;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.locationtech.jts.geom.Coordinate;
+import org.opentripplanner.model.FlexLocationGroup;
+import org.opentripplanner.model.FlexStopLocation;
+import org.opentripplanner.model.GroupOfStations;
+import org.opentripplanner.model.MultiModalStation;
+import org.opentripplanner.routing.graph.Vertex;
+import org.opentripplanner.routing.vertextype.TransitStopVertex;
+import org.opentripplanner.transit.model.basic.WgsCoordinate;
+import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.model.site.Station;
+import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.StopCollection;
+import org.opentripplanner.transit.model.site.StopLocation;
+import org.opentripplanner.util.MedianCalcForDoubles;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Repository for Stop entities.
+ */
+public class StopModel implements Serializable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(StopModel.class);
+
+  /** Parent stops **/
+  private Map<FeedScopedId, Station> stationById = new HashMap<>();
+  /**
+   * Optional level above parent stops (only supported in NeTEx)
+   */
+  private Map<FeedScopedId, MultiModalStation> multiModalStationById = new HashMap<>();
+  /**
+   * Optional grouping that can contain both stations and multimodal stations (only supported in
+   * NeTEx)
+   */
+  private Map<FeedScopedId, GroupOfStations> groupOfStationsById = new HashMap<>();
+
+  private Map<FeedScopedId, TransitStopVertex> transitStopVertices = new HashMap<>();
+
+  /** The density center of the graph for determining the initial geographic extent in the client. */
+  private Coordinate center = null;
+
+  public Map<FeedScopedId, FlexStopLocation> locationsById = new HashMap<>();
+
+  public Map<FeedScopedId, FlexLocationGroup> locationGroupsById = new HashMap<>();
+
+  private transient StopModelIndex index;
+
+  public Map<Stop, TransitStopVertex> getStopVertexForStop() {
+    return index.getStopVertexForStop();
+  }
+
+  public void index() {
+    LOG.info("Index stop model...");
+    index = new StopModelIndex(this);
+    LOG.info("Index stop model complete.");
+  }
+
+  public StopModelIndex getStopModelIndex() {
+    //TODO refactoring transit model - thread safety
+    if (index == null) {
+      index();
+    }
+    return index;
+  }
+
+  /**
+   * @param id Id of Stop, Station, MultiModalStation or GroupOfStations
+   * @return The associated TransitStopVertex or all underlying TransitStopVertices
+   */
+  public Set<Vertex> getStopVerticesById(FeedScopedId id) {
+    var stops = getStopsForId(id);
+
+    if (stops == null) {
+      return null;
+    }
+
+    return stops.stream().map(index.getStopVertexForStop()::get).collect(Collectors.toSet());
+  }
+
+  /**
+   * @param id Id of Stop, Station, MultiModalStation or GroupOfStations
+   * @return The coordinate for the transit entity
+   */
+  public WgsCoordinate getCoordinateById(FeedScopedId id) {
+    // GroupOfStations
+    GroupOfStations groupOfStations = groupOfStationsById.get(id);
+    if (groupOfStations != null) {
+      return groupOfStations.getCoordinate();
+    }
+
+    // Multimodal station
+    MultiModalStation multiModalStation = multiModalStationById.get(id);
+    if (multiModalStation != null) {
+      return multiModalStation.getCoordinate();
+    }
+
+    // Station
+    Station station = stationById.get(id);
+    if (station != null) {
+      return station.getCoordinate();
+    }
+
+    // Single stop
+    var stop = index.getStopForId(id);
+    if (stop != null) {
+      return stop.getCoordinate();
+    }
+
+    return null;
+  }
+
+  public Collection<MultiModalStation> getAllMultiModalStations() {
+    return multiModalStationById.values();
+  }
+
+  public Collection<TransitStopVertex> getAllStopVertices() {
+    return transitStopVertices.values();
+  }
+
+  private Collection<StopLocation> getStopsForId(FeedScopedId id) {
+    // GroupOfStations
+    GroupOfStations groupOfStations = groupOfStationsById.get(id);
+    if (groupOfStations != null) {
+      return groupOfStations.getChildStops();
+    }
+
+    // Multimodal station
+    MultiModalStation multiModalStation = multiModalStationById.get(id);
+    if (multiModalStation != null) {
+      return multiModalStation.getChildStops();
+    }
+
+    // Station
+    Station station = stationById.get(id);
+    if (station != null) {
+      return station.getChildStops();
+    }
+    // Single stop
+    var stop = index.getStopForId(id);
+    if (stop != null) {
+      return Collections.singleton(stop);
+    }
+
+    return null;
+  }
+
+  /**
+   * Returns all {@link StopCollection}s present in this graph, including stations, group of
+   * stations and multimodal stations.
+   */
+  public Stream<StopCollection> getAllStopCollections() {
+    return Stream.concat(
+      stationById.values().stream(),
+      Stream.concat(groupOfStationsById.values().stream(), multiModalStationById.values().stream())
+    );
+  }
+
+  public Station getStationById(FeedScopedId id) {
+    return stationById.get(id);
+  }
+
+  public MultiModalStation getMultiModalStation(FeedScopedId id) {
+    return multiModalStationById.get(id);
+  }
+
+  public Collection<Station> getStations() {
+    return stationById.values();
+  }
+
+  /**
+   * Finds a {@link StopCollection} by id.
+   */
+  public StopCollection getStopCollectionById(FeedScopedId id) {
+    var station = stationById.get(id);
+    if (station != null) {
+      return station;
+    }
+
+    var groupOfStations = groupOfStationsById.get(id);
+    if (groupOfStations != null) {
+      return groupOfStations;
+    }
+
+    return multiModalStationById.get(id);
+  }
+
+  public void addTransitStopVertex(FeedScopedId id, TransitStopVertex stopVertex) {
+    transitStopVertices.put(id, stopVertex);
+  }
+
+  /**
+   * Calculates Transit center from median of coordinates of all transitStops if graph has transit.
+   * If it doesn't it isn't calculated. (mean walue of min, max latitude and longitudes are used)
+   * <p>
+   * Transit center is saved in center variable
+   * <p>
+   * This speeds up calculation, but problem is that median needs to have all of
+   * latitudes/longitudes in memory, this can become problematic in large installations. It works
+   * without a problem on New York State.
+   */
+  public void calculateTransitCenter() {
+    var vertices = getAllStopVertices();
+    var medianCalculator = new MedianCalcForDoubles(vertices.size());
+
+    vertices.forEach(v -> medianCalculator.add(v.getLon()));
+    double lon = medianCalculator.median();
+
+    medianCalculator.reset();
+    vertices.forEach(v -> medianCalculator.add(v.getLat()));
+    double lat = medianCalculator.median();
+
+    this.center = new Coordinate(lon, lat);
+  }
+
+  public Optional<Coordinate> getCenter() {
+    return Optional.ofNullable(center);
+  }
+
+  public void addStation(Station station) {
+    stationById.put(station.getId(), station);
+  }
+
+  public void addMultiModalStation(MultiModalStation multiModalStation) {
+    multiModalStationById.put(multiModalStation.getId(), multiModalStation);
+  }
+
+  public void addGroupsOfStations(GroupOfStations groupOfStations) {
+    groupOfStationsById.put(groupOfStations.getId(), groupOfStations);
+  }
+
+  /**
+   * Flex locations are generated by GTFS graph builder, but consumed only after the street graph is
+   * built
+   */
+  public FlexStopLocation getLocationById(FeedScopedId id) {
+    return locationsById.get(id);
+  }
+}

--- a/src/main/java/org/opentripplanner/transit/service/StopModelIndex.java
+++ b/src/main/java/org/opentripplanner/transit/service/StopModelIndex.java
@@ -1,0 +1,109 @@
+package org.opentripplanner.transit.service;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import java.util.Collection;
+import java.util.Map;
+import org.locationtech.jts.geom.Envelope;
+import org.opentripplanner.common.geometry.HashGridSpatialIndex;
+import org.opentripplanner.model.FlexLocationGroup;
+import org.opentripplanner.model.FlexStopLocation;
+import org.opentripplanner.model.MultiModalStation;
+import org.opentripplanner.routing.vertextype.TransitStopVertex;
+import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.model.site.Station;
+import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.StopLocation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Indexed access to Stop entities.
+ * For performance reasons these indexes are not part of the serialized state of the graph.
+ * They are rebuilt at runtime after graph deserialization.
+ */
+public class StopModelIndex {
+
+  private static final Logger LOG = LoggerFactory.getLogger(StopModelIndex.class);
+
+  // TODO: consistently key on model object or id string
+
+  private final Map<Stop, TransitStopVertex> stopVertexForStop = Maps.newHashMap();
+  private final HashGridSpatialIndex<TransitStopVertex> stopSpatialIndex = new HashGridSpatialIndex<>();
+
+  private final Map<Station, MultiModalStation> multiModalStationForStations = Maps.newHashMap();
+
+  public Multimap<StopLocation, FlexLocationGroup> locationGroupsByStop = ArrayListMultimap.create();
+
+  public HashGridSpatialIndex<FlexStopLocation> locationIndex = new HashGridSpatialIndex<>();
+
+  public StopModelIndex(StopModel stopModel) {
+    LOG.info("StopModelIndex init...");
+
+    /* We will keep a separate set of all vertices in case some have the same label.
+     * Maybe we should just guarantee unique labels. */
+    for (TransitStopVertex stopVertex : stopModel.getAllStopVertices()) {
+      Stop stop = stopVertex.getStop();
+      stopVertexForStop.put(stop, stopVertex);
+    }
+    for (TransitStopVertex stopVertex : stopVertexForStop.values()) {
+      Envelope envelope = new Envelope(stopVertex.getCoordinate());
+      stopSpatialIndex.insert(envelope, stopVertex);
+    }
+
+    /* We will keep a separate set of all vertices in case some have the same label.
+     * Maybe we should just guarantee unique labels. */
+    for (TransitStopVertex stopVertex : stopModel.getAllStopVertices()) {
+      Stop stop = stopVertex.getStop();
+      stopForId.put(stop.getId(), stop);
+      stopVertexForStop.put(stop, stopVertex);
+    }
+    for (TransitStopVertex stopVertex : stopVertexForStop.values()) {
+      Envelope envelope = new Envelope(stopVertex.getCoordinate());
+      stopSpatialIndex.insert(envelope, stopVertex);
+    }
+
+    for (MultiModalStation multiModalStation : stopModel.getAllMultiModalStations()) {
+      for (Station childStation : multiModalStation.getChildStations()) {
+        multiModalStationForStations.put(childStation, multiModalStation);
+      }
+    }
+    for (FlexLocationGroup flexLocationGroup : stopModel.locationGroupsById.values()) {
+      for (StopLocation stop : flexLocationGroup.getLocations()) {
+        locationGroupsByStop.put(stop, flexLocationGroup);
+      }
+    }
+    for (FlexStopLocation flexStopLocation : stopModel.locationsById.values()) {
+      locationIndex.insert(flexStopLocation.getGeometry().getEnvelopeInternal(), flexStopLocation);
+    }
+
+    LOG.info("StopModelIndex init complete.");
+  }
+
+  public Map<Stop, TransitStopVertex> getStopVertexForStop() {
+    return stopVertexForStop;
+  }
+
+  public HashGridSpatialIndex<TransitStopVertex> getStopSpatialIndex() {
+    return stopSpatialIndex;
+  }
+
+  private final Map<FeedScopedId, StopLocation> stopForId = Maps.newHashMap();
+
+  public StopLocation getStopForId(FeedScopedId id) {
+    return stopForId.get(id);
+  }
+
+  public void addStop(StopLocation stopLocation) {
+    stopForId.put(stopLocation.getId(), stopLocation);
+  }
+
+  public Map<Station, MultiModalStation> getMultiModalStationForStations() {
+    return multiModalStationForStations;
+  }
+
+  public Collection<StopLocation> getAllStops() {
+    return stopForId.values();
+  }
+}

--- a/src/main/java/org/opentripplanner/transit/service/TransitEditorService.java
+++ b/src/main/java/org/opentripplanner/transit/service/TransitEditorService.java
@@ -6,7 +6,6 @@ import org.opentripplanner.model.FeedInfo;
 import org.opentripplanner.model.Notice;
 import org.opentripplanner.model.TimetableSnapshotProvider;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TransitLayer;
-import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.transit.model.framework.TransitEntity;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.network.TransitMode;
@@ -27,7 +26,7 @@ public interface TransitEditorService extends TransitService {
   void addTransitMode(TransitMode mode);
 
   <T extends TimetableSnapshotProvider> T getOrSetupTimetableSnapshotProvider(
-    Function<Graph, T> creator
+    Function<TransitModel, T> creator
   );
 
   void setTransitLayer(TransitLayer transitLayer);

--- a/src/main/java/org/opentripplanner/transit/service/TransitModel.java
+++ b/src/main/java/org/opentripplanner/transit/service/TransitModel.java
@@ -1,0 +1,564 @@
+package org.opentripplanner.transit.service;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import gnu.trove.set.hash.TIntHashSet;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.Serializable;
+import java.lang.reflect.InvocationTargetException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.TimeZone;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.annotation.Nullable;
+import org.opentripplanner.common.geometry.HashGridSpatialIndex;
+import org.opentripplanner.ext.flex.trip.FlexTrip;
+import org.opentripplanner.graph_builder.DataImportIssueStore;
+import org.opentripplanner.graph_builder.issues.NoFutureDates;
+import org.opentripplanner.model.FeedInfo;
+import org.opentripplanner.model.FlexLocationGroup;
+import org.opentripplanner.model.Notice;
+import org.opentripplanner.model.PathTransfer;
+import org.opentripplanner.model.TimetableSnapshot;
+import org.opentripplanner.model.TimetableSnapshotProvider;
+import org.opentripplanner.model.TripOnServiceDate;
+import org.opentripplanner.model.TripPattern;
+import org.opentripplanner.model.calendar.CalendarService;
+import org.opentripplanner.model.calendar.CalendarServiceData;
+import org.opentripplanner.model.calendar.ServiceDate;
+import org.opentripplanner.model.calendar.impl.CalendarServiceImpl;
+import org.opentripplanner.model.transfer.TransferService;
+import org.opentripplanner.routing.algorithm.raptoradapter.transit.TransitLayer;
+import org.opentripplanner.routing.algorithm.raptoradapter.transit.mappers.TransitLayerUpdater;
+import org.opentripplanner.routing.impl.DelegatingTransitAlertServiceImpl;
+import org.opentripplanner.routing.services.TransitAlertService;
+import org.opentripplanner.routing.trippattern.Deduplicator;
+import org.opentripplanner.routing.util.ConcurrentPublished;
+import org.opentripplanner.routing.vertextype.TransitStopVertex;
+import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.model.framework.TransitEntity;
+import org.opentripplanner.transit.model.network.TransitMode;
+import org.opentripplanner.transit.model.organization.Agency;
+import org.opentripplanner.transit.model.organization.Operator;
+import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.StopLocation;
+import org.opentripplanner.updater.GraphUpdaterConfigurator;
+import org.opentripplanner.updater.GraphUpdaterManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Repository for Transit entities.
+ */
+public class TransitModel implements Serializable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TransitModel.class);
+
+  private static final long serialVersionUID = 1L;
+
+  private final Collection<Agency> agencies = new ArrayList<>();
+  private final Collection<Operator> operators = new ArrayList<>();
+  private final Collection<String> feedIds = new HashSet<>();
+  private final Map<String, FeedInfo> feedInfoForId = new HashMap<>();
+
+  /**
+   * Allows a notice element to be attached to an object in the OTP model by its id and then
+   * retrieved by the API when navigating from that object. The map key is entity id:
+   * {@link TransitEntity#getId()}. The notice is part of the static transit data.
+   */
+  private final Multimap<TransitEntity, Notice> noticesByElement = HashMultimap.create();
+  private final Map<Class<?>, Serializable> services = new HashMap<>();
+  private final TransferService transferService = new TransferService();
+
+  /** List of transit modes that are availible in GTFS data used in this graph **/
+  private final HashSet<TransitMode> transitModes = new HashSet<>();
+
+  /**
+   * Map from GTFS ServiceIds to integers close to 0. Allows using BitSets instead of
+   * {@code Set<Object>}. An empty Map is created before the Graph is built to allow registering IDs
+   * from multiple feeds.
+   */
+  private final Map<FeedScopedId, Integer> serviceCodes = Maps.newHashMap();
+
+  /** Pre-generated transfers between all stops. */
+  public final Multimap<StopLocation, PathTransfer> transfersByStop = HashMultimap.create();
+
+  private StopModel stopModel;
+  // transit feed validity information in seconds since epoch
+  private long transitServiceStarts = Long.MAX_VALUE;
+  private long transitServiceEnds = 0;
+
+  /** Data model for Raptor routing, with realtime updates applied (if any). */
+  private final transient ConcurrentPublished<TransitLayer> realtimeTransitLayer = new ConcurrentPublished<>();
+
+  public final transient Deduplicator deduplicator;
+  private transient CalendarService calendarService;
+
+  public transient TransitModelIndex index;
+  private transient TimetableSnapshotProvider timetableSnapshotProvider = null;
+  private transient TimeZone timeZone = null;
+
+  /**
+   * Manages all updaters of this graph. Is created by the GraphUpdaterConfigurator when there are
+   * graph updaters defined in the configuration.
+   *
+   * @see GraphUpdaterConfigurator
+   */
+  public transient GraphUpdaterManager updaterManager = null;
+
+  /** True if GTFS data was loaded into this Graph. */
+  public boolean hasTransit = false;
+
+  /** True if direct single-edge transfers were generated between transit stops in this Graph. */
+  public boolean hasDirectTransfers = false;
+  /**
+   * True if frequency-based services exist in this Graph (GTFS frequencies with exact_times = 0).
+   */
+  public boolean hasFrequencyService = false;
+  /**
+   * True if schedule-based services exist in this Graph (including GTFS frequencies with
+   * exact_times = 1).
+   */
+  public boolean hasScheduledService = false;
+
+  /**
+   * TripPatterns used to be reached through hop edges, but we're not creating on-board transit
+   * vertices/edges anymore.
+   */
+  public Map<FeedScopedId, TripPattern> tripPatternForId = Maps.newHashMap();
+  public Map<FeedScopedId, TripOnServiceDate> tripOnServiceDates = Maps.newHashMap();
+
+  public Map<FeedScopedId, FlexTrip> flexTripsById = new HashMap<>();
+
+  /** Data model for Raptor routing, with realtime updates applied (if any). */
+  private transient TransitLayer transitLayer;
+  public transient TransitLayerUpdater transitLayerUpdater;
+
+  private transient TransitAlertService transitAlertService;
+
+  public TransitModel(StopModel stopModel, Deduplicator deduplicator) {
+    this.stopModel = stopModel;
+    this.deduplicator = deduplicator;
+  }
+
+  // Constructor for deserialization.
+  public TransitModel() {
+    deduplicator = new Deduplicator();
+  }
+
+  /**
+   * Perform indexing on timetables, and create transient data structures. This used to be done in
+   * readObject methods upon deserialization, but stand-alone mode now allows passing graphs from
+   * graphbuilder to server in memory, without a round trip through serialization.
+   */
+  public void index() {
+    LOG.info("Index transit model...");
+    for (TripPattern tp : tripPatternForId.values()) {
+      // Skip frequency-based patterns which have no timetable (null)
+      if (tp != null) tp.getScheduledTimetable().finish();
+    }
+    this.getStopModel().index();
+    // the transit model indexing updates the stop model index (flex stops added to the stop index)
+    this.index = new TransitModelIndex(this);
+    LOG.info("Index transit model complete.");
+  }
+
+  public TimetableSnapshot getTimetableSnapshot() {
+    return timetableSnapshotProvider == null
+      ? null
+      : timetableSnapshotProvider.getTimetableSnapshot();
+  }
+
+  /**
+   * TODO OTP2 - This should be replaced by proper dependency injection
+   */
+  @SuppressWarnings("unchecked")
+  public <T extends TimetableSnapshotProvider> T getOrSetupTimetableSnapshotProvider(
+    Function<TransitModel, T> creator
+  ) {
+    if (timetableSnapshotProvider == null) {
+      timetableSnapshotProvider = creator.apply(this);
+    }
+    try {
+      return (T) timetableSnapshotProvider;
+    } catch (ClassCastException e) {
+      throw new IllegalArgumentException(
+        "We support only one timetableSnapshotSource, there are two implementation; one for GTFS and one " +
+        "for Netex/Siri. They need to be refactored to work together. This cast will fail if updaters " +
+        "try setup both.",
+        e
+      );
+    }
+  }
+
+  public TransitLayer getTransitLayer() {
+    return transitLayer;
+  }
+
+  public void setTransitLayer(TransitLayer transitLayer) {
+    this.transitLayer = transitLayer;
+  }
+
+  public TransitLayer getRealtimeTransitLayer() {
+    return realtimeTransitLayer.get();
+  }
+
+  public void setRealtimeTransitLayer(TransitLayer realtimeTransitLayer) {
+    this.realtimeTransitLayer.publish(realtimeTransitLayer);
+  }
+
+  public boolean hasRealtimeTransitLayer() {
+    return realtimeTransitLayer != null;
+  }
+
+  @SuppressWarnings("unchecked")
+  public <T extends Serializable> T putService(Class<T> serviceType, T service) {
+    return (T) services.put(serviceType, service);
+  }
+
+  public boolean hasService(Class<? extends Serializable> serviceType) {
+    return services.containsKey(serviceType);
+  }
+
+  @SuppressWarnings("unchecked")
+  public <T extends Serializable> T getService(Class<T> serviceType) {
+    return (T) services.get(serviceType);
+  }
+
+  public <T extends Serializable> T getService(Class<T> serviceType, boolean autoCreate) {
+    T t = (T) services.get(serviceType);
+    if (t == null && autoCreate) {
+      try {
+        t = serviceType.getDeclaredConstructor().newInstance();
+      } catch (
+        IllegalAccessException
+        | InvocationTargetException
+        | NoSuchMethodException
+        | InstantiationException e
+      ) {
+        throw new RuntimeException(e);
+      }
+      services.put(serviceType, t);
+    }
+    return t;
+  }
+
+  public TransferService getTransferService() {
+    return transferService;
+  }
+
+  // Infer the time period covered by the transit feed
+  public void updateTransitFeedValidity(CalendarServiceData data, DataImportIssueStore issueStore) {
+    long now = new Date().getTime() / 1000;
+    final long SEC_IN_DAY = 24 * 60 * 60;
+    HashSet<String> agenciesWithFutureDates = new HashSet<>();
+    HashSet<String> agencies = new HashSet<>();
+    for (FeedScopedId sid : data.getServiceIds()) {
+      agencies.add(sid.getFeedId());
+      for (ServiceDate sd : data.getServiceDatesForServiceId(sid)) {
+        // Adjust for timezone, assuming there is only one per graph.
+        long t = sd.getAsDate(getTimeZone()).getTime() / 1000;
+        if (t > now) {
+          agenciesWithFutureDates.add(sid.getFeedId());
+        }
+        // assume feed is unreliable after midnight on last service day
+        long u = t + SEC_IN_DAY;
+        if (t < this.transitServiceStarts) {
+          this.transitServiceStarts = t;
+        }
+        if (u > this.transitServiceEnds) {
+          this.transitServiceEnds = u;
+        }
+      }
+    }
+    for (String agency : agencies) {
+      if (!agenciesWithFutureDates.contains(agency)) {
+        issueStore.add(new NoFutureDates(agency));
+      }
+    }
+  }
+
+  // Check to see if we have transit information for a given date
+  public boolean transitFeedCovers(Instant time) {
+    long t = time.getEpochSecond();
+    return t >= this.transitServiceStarts && t < this.transitServiceEnds;
+  }
+
+  /**
+   * Adds mode of transport to transit modes in graph
+   */
+  public void addTransitMode(TransitMode mode) {
+    transitModes.add(mode);
+  }
+
+  public HashSet<TransitMode> getTransitModes() {
+    return transitModes;
+  }
+
+  public CalendarService getCalendarService() {
+    if (calendarService == null) {
+      CalendarServiceData data = this.getService(CalendarServiceData.class);
+      if (data != null) {
+        this.calendarService = new CalendarServiceImpl(data);
+      }
+    }
+    return this.calendarService;
+  }
+
+  public CalendarServiceData getCalendarDataService() {
+    CalendarServiceData calendarServiceData;
+    if (this.hasService(CalendarServiceData.class)) {
+      calendarServiceData = this.getService(CalendarServiceData.class);
+    } else {
+      calendarServiceData = new CalendarServiceData();
+    }
+    return calendarServiceData;
+  }
+
+  public void clearCachedCalenderService() {
+    this.calendarService = null;
+  }
+
+  /**
+   * Get or create a serviceId for a given date. This method is used when a new trip is added from a
+   * realtime data update. It make sure the date is in the existing transit service period.
+   * <p>
+   * TODO OTP2 - This is NOT THREAD-SAFE and is used in the real-time updaters, we need to fix
+   *           - this when doing the issue #3030.
+   *
+   * @param serviceDate service date for the added service id
+   * @return service-id for date if it exist or is created. If the given service date is outside the
+   * service period {@code null} is returned.
+   */
+  @Nullable
+  public FeedScopedId getOrCreateServiceIdForDate(ServiceDate serviceDate) {
+    // Start of day
+    long time = serviceDate.toZonedDateTime(getTimeZone().toZoneId(), 0).toEpochSecond();
+
+    if (time < transitServiceStarts || time >= transitServiceEnds) {
+      return null;
+    }
+
+    // We make an explicit cast here to avoid adding the 'getOrCreateServiceIdForDate(..)'
+    // method to the {@link CalendarService} interface. We do not want to expose it because it
+    // is not thread-safe - and we want to limit the usage. See JavaDoc above as well.
+    FeedScopedId serviceId =
+      ((CalendarServiceImpl) getCalendarService()).getOrCreateServiceIdForDate(serviceDate);
+
+    if (!serviceCodes.containsKey(serviceId)) {
+      // Calculating new unique serviceCode based on size (!)
+      final int serviceCode = serviceCodes.size();
+      serviceCodes.put(serviceId, serviceCode);
+
+      index
+        .getServiceCodesRunningForDate()
+        .computeIfAbsent(serviceDate, ignored -> new TIntHashSet())
+        .add(serviceCode);
+    }
+    return serviceId;
+  }
+
+  public Collection<String> getFeedIds() {
+    return feedIds;
+  }
+
+  public Collection<Agency> getAgencies() {
+    return agencies;
+  }
+
+  public FeedInfo getFeedInfo(String feedId) {
+    return feedInfoForId.get(feedId);
+  }
+
+  public void addAgency(String feedId, Agency agency) {
+    agencies.add(agency);
+    this.feedIds.add(feedId);
+  }
+
+  public void addFeedInfo(FeedInfo info) {
+    this.feedInfoForId.put(info.getId(), info);
+  }
+
+  /**
+   * Returns the time zone for the first agency in this graph. This is used to interpret times in
+   * API requests. The JVM default time zone cannot be used because we support multiple graphs on
+   * one server via the routerId. Ideally we would want to interpret times in the time zone of the
+   * geographic location where the origin/destination vertex or board/alight event is located. This
+   * may become necessary when we start making graphs with long distance train, boat, or air
+   * services.
+   */
+  public TimeZone getTimeZone() {
+    if (timeZone == null) {
+      if (agencies.size() == 0) {
+        timeZone = TimeZone.getTimeZone("GMT");
+        LOG.warn("graph contains no agencies (yet); API request times will be interpreted as GMT.");
+      } else {
+        CalendarService cs = this.getCalendarService();
+        for (Agency agency : agencies) {
+          TimeZone tz = cs.getTimeZoneForAgencyId(agency.getId());
+          if (timeZone == null) {
+            LOG.debug("graph time zone set to {}", tz);
+            timeZone = tz;
+          } else if (!timeZone.equals(tz)) {
+            LOG.error("agency time zone differs from graph time zone: {}", tz);
+          }
+        }
+      }
+    }
+    return timeZone;
+  }
+
+  public Collection<Operator> getOperators() {
+    return operators;
+  }
+
+  /**
+   * The timezone is cached by the graph. If you've done something to the graph that has the
+   * potential to change the time zone, you should call this to ensure it is reset.
+   */
+  public void clearTimeZone() {
+    this.timeZone = null;
+  }
+
+  public long getTransitServiceStarts() {
+    return transitServiceStarts;
+  }
+
+  public long getTransitServiceEnds() {
+    return transitServiceEnds;
+  }
+
+  public Multimap<TransitEntity, Notice> getNoticesByElement() {
+    return noticesByElement;
+  }
+
+  public void addNoticeAssignments(Multimap<TransitEntity, Notice> noticesByElement) {
+    this.noticesByElement.putAll(noticesByElement);
+  }
+
+  public TransitAlertService getTransitAlertService() {
+    if (transitAlertService == null) {
+      transitAlertService = new DelegatingTransitAlertServiceImpl(this);
+    }
+    return transitAlertService;
+  }
+
+  /** An OBA Service Date is a local date without timezone, only year month and day. */
+  public BitSet getServicesRunningForDate(ServiceDate date) {
+    BitSet services = new BitSet(calendarService.getServiceIds().size());
+    for (FeedScopedId serviceId : calendarService.getServiceIdsOnDate(date)) {
+      int n = serviceCodes.get(serviceId);
+      if (n < 0) {
+        continue;
+      }
+      services.set(n);
+    }
+    return services;
+  }
+
+  public Collection<Notice> getNoticesByEntity(TransitEntity entity) {
+    Collection<Notice> res = getNoticesByElement().get(entity);
+    return res == null ? Collections.emptyList() : res;
+  }
+
+  public TripPattern getTripPatternForId(FeedScopedId id) {
+    return tripPatternForId.get(id);
+  }
+
+  public Collection<TripPattern> getTripPatterns() {
+    return tripPatternForId.values();
+  }
+
+  public Map<FeedScopedId, TripOnServiceDate> getTripOnServiceDates() {
+    return tripOnServiceDates;
+  }
+
+  public Collection<Notice> getNotices() {
+    return getNoticesByElement().values();
+  }
+
+  /**
+   * Finds a {@link StopLocation} by id.
+   */
+  public StopLocation getStopLocationById(FeedScopedId id) {
+    var stop = stopModel.getStopModelIndex().getStopForId(id);
+    if (stop != null) {
+      return stop;
+    }
+
+    return getAllFlexStopsFlat()
+      .stream()
+      .filter(stopLocation -> stopLocation.getId().equals(id))
+      .findAny()
+      .orElse(null);
+  }
+
+  /**
+   * Returns all {@link StopLocation}s present in this graph, including normal and flex locations.
+   */
+  public Stream<StopLocation> getAllStopLocations() {
+    return Stream.concat(
+      getStopModel().getStopModelIndex().getAllStops().stream(),
+      getAllFlexStopsFlat().stream()
+    );
+  }
+
+  public Map<FeedScopedId, Integer> getServiceCodes() {
+    return serviceCodes;
+  }
+
+  public Collection<PathTransfer> getTransfersByStop(StopLocation stop) {
+    return transfersByStop.get(stop);
+  }
+
+  /**
+   * Gets all the flex stop locations, including the elements of FlexLocationGroups.
+   */
+  public Set<StopLocation> getAllFlexStopsFlat() {
+    Set<StopLocation> stopLocations = flexTripsById
+      .values()
+      .stream()
+      .flatMap(t -> t.getStops().stream())
+      .collect(Collectors.toSet());
+
+    stopLocations.addAll(
+      stopLocations
+        .stream()
+        .filter(s -> s instanceof FlexLocationGroup)
+        .flatMap(g -> ((FlexLocationGroup) g).getLocations().stream().filter(e -> e instanceof Stop)
+        )
+        .collect(Collectors.toList())
+    );
+
+    return stopLocations;
+  }
+
+  public void calculateTransitCenter() {
+    stopModel.calculateTransitCenter();
+  }
+
+  public StopModel getStopModel() {
+    return stopModel;
+  }
+
+  public HashGridSpatialIndex<TransitStopVertex> getStopSpatialIndex() {
+    return stopModel.getStopModelIndex().getStopSpatialIndex();
+  }
+
+  private void readObject(ObjectInputStream inputStream)
+    throws ClassNotFoundException, IOException {
+    inputStream.defaultReadObject();
+  }
+}

--- a/src/main/java/org/opentripplanner/transit/service/TransitService.java
+++ b/src/main/java/org/opentripplanner/transit/service/TransitService.java
@@ -1,13 +1,15 @@
 package org.opentripplanner.transit.service;
 
 import com.google.common.collect.Multimap;
+import java.util.BitSet;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
-import org.opentripplanner.common.model.T2;
+import org.opentripplanner.common.geometry.HashGridSpatialIndex;
+import org.opentripplanner.ext.flex.FlexIndex;
 import org.opentripplanner.model.FeedInfo;
 import org.opentripplanner.model.FlexStopLocation;
 import org.opentripplanner.model.MultiModalStation;
@@ -23,8 +25,9 @@ import org.opentripplanner.model.TripTimeOnDate;
 import org.opentripplanner.model.calendar.CalendarService;
 import org.opentripplanner.model.calendar.ServiceDate;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TransitLayer;
+import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.routing.stoptimes.ArrivalDeparture;
-import org.opentripplanner.transit.model.basic.WgsCoordinate;
+import org.opentripplanner.routing.vertextype.TransitStopVertex;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.framework.TransitEntity;
 import org.opentripplanner.transit.model.network.GroupOfRoutes;
@@ -58,15 +61,6 @@ public interface TransitService {
   Collection<TripPattern> getTripPatterns();
 
   Collection<Notice> getNotices();
-
-  Collection<StopLocation> getStopsByBoundingBox(
-    double minLat,
-    double minLon,
-    double maxLat,
-    double maxLon
-  );
-
-  List<T2<Stop, Double>> getStopsInRadius(WgsCoordinate center, double radius);
 
   Station getStationById(FeedScopedId id);
 
@@ -166,4 +160,18 @@ public interface TransitService {
   CalendarService getCalendarService();
 
   TimeZone getTimeZone();
+
+  TransitAlertService getTransitAlertService();
+
+  FlexIndex getFlexIndex();
+
+  BitSet getServicesRunningForDate(ServiceDate parseString);
+
+  Long getTransitServiceEnds();
+
+  Long getTransitServiceStarts();
+
+  Map<Stop, TransitStopVertex> getStopVertexForStop();
+
+  HashGridSpatialIndex<TransitStopVertex> getStopSpatialIndex();
 }

--- a/src/main/java/org/opentripplanner/updater/GraphUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/GraphUpdater.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.updater;
 
 import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.transit.service.TransitModel;
 
 /**
  * Interface for graph updaters. Objects that implement this interface should always be configured
@@ -24,7 +25,7 @@ public interface GraphUpdater {
    * method won't be called). All updaters' setup methods will be run sequentially in a
    * single-threaded manner before updates begin, in order to avoid concurrent reads/writes.
    */
-  void setup(Graph graph) throws Exception;
+  void setup(Graph graph, TransitModel transitModel) throws Exception;
 
   /**
    * This method will run in its own thread. It pulls or receives updates and applies them to the

--- a/src/main/java/org/opentripplanner/updater/GraphUpdaterManager.java
+++ b/src/main/java/org/opentripplanner/updater/GraphUpdaterManager.java
@@ -13,6 +13,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.transit.service.TransitModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,14 +59,16 @@ public class GraphUpdaterManager implements WriteToGraphCallback {
    * The Graph that will be updated.
    */
   private final Graph graph;
+  private final TransitModel transitModel;
 
   /**
    * Constructor.
    *
-   * @param graph is the Graph that will be updated.
+   * @param transitModel is the Graph that will be updated.
    */
-  public GraphUpdaterManager(Graph graph, List<GraphUpdater> updaters) {
+  public GraphUpdaterManager(Graph graph, TransitModel transitModel, List<GraphUpdater> updaters) {
     this.graph = graph;
+    this.transitModel = transitModel;
     // Thread factory used to create new threads, giving them more human-readable names.
     var threadFactory = new ThreadFactoryBuilder().setNameFormat("GraphUpdater-%d").build();
     this.scheduler = Executors.newSingleThreadScheduledExecutor(threadFactory);
@@ -133,7 +136,7 @@ public class GraphUpdaterManager implements WriteToGraphCallback {
   public Future<?> execute(GraphWriterRunnable runnable) {
     return scheduler.submit(() -> {
       try {
-        runnable.run(graph);
+        runnable.run(graph, transitModel);
       } catch (Exception e) {
         LOG.error("Error while running graph writer {}:", runnable.getClass().getName(), e);
       }

--- a/src/main/java/org/opentripplanner/updater/GraphWriterRunnable.java
+++ b/src/main/java/org/opentripplanner/updater/GraphWriterRunnable.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.updater;
 
 import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.transit.service.TransitModel;
 
 /**
  * The graph should only be modified by a runnable implementing this interface, executed by the
@@ -15,5 +16,5 @@ public interface GraphWriterRunnable {
   /**
    * This function is executed to modify the graph.
    */
-  void run(Graph graph);
+  void run(Graph graph, TransitModel transitModel);
 }

--- a/src/main/java/org/opentripplanner/updater/GtfsRealtimeFuzzyTripMatcher.java
+++ b/src/main/java/org/opentripplanner/updater/GtfsRealtimeFuzzyTripMatcher.java
@@ -5,7 +5,6 @@ import java.text.ParseException;
 import java.util.BitSet;
 import org.opentripplanner.model.TripPattern;
 import org.opentripplanner.model.calendar.ServiceDate;
-import org.opentripplanner.routing.RoutingService;
 import org.opentripplanner.routing.trippattern.TripTimes;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.Route;
@@ -22,17 +21,11 @@ import org.opentripplanner.util.time.TimeUtils;
  */
 public class GtfsRealtimeFuzzyTripMatcher {
 
-  private final RoutingService routingService;
-
   private final TransitService transitService;
   private BitSet servicesRunningForDate;
   private ServiceDate date;
 
-  public GtfsRealtimeFuzzyTripMatcher(
-    RoutingService routingService,
-    TransitService transitService
-  ) {
-    this.routingService = routingService;
+  public GtfsRealtimeFuzzyTripMatcher(TransitService transitService) {
     this.transitService = transitService;
   }
 
@@ -84,7 +77,7 @@ public class GtfsRealtimeFuzzyTripMatcher {
     if (!date.equals(this.date)) {
       this.date = date;
       // TODO: This is slow, we should either precalculate or cache these for all dates in graph
-      this.servicesRunningForDate = routingService.getServicesRunningForDate(date);
+      this.servicesRunningForDate = transitService.getServicesRunningForDate(date);
     }
     for (TripPattern pattern : transitService.getPatternsForRoute().get(route)) {
       if (pattern.getDirection().gtfsCode != direction) continue;

--- a/src/main/java/org/opentripplanner/updater/stoptime/MqttGtfsRealtimeUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/MqttGtfsRealtimeUpdater.java
@@ -12,9 +12,9 @@ import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
 import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.MqttMessage;
 import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
-import org.opentripplanner.routing.RoutingService;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.transit.service.DefaultTransitService;
+import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.updater.GraphUpdater;
 import org.opentripplanner.updater.GtfsRealtimeFuzzyTripMatcher;
 import org.opentripplanner.updater.WriteToGraphCallback;
@@ -71,19 +71,16 @@ public class MqttGtfsRealtimeUpdater implements GraphUpdater {
   }
 
   @Override
-  public void setup(Graph graph) {
+  public void setup(Graph graph, TransitModel transitModel) {
     // Only create a realtime data snapshot source if none exists already
-    TimetableSnapshotSource snapshotSource = graph.getOrSetupTimetableSnapshotProvider(
+    TimetableSnapshotSource snapshotSource = transitModel.getOrSetupTimetableSnapshotProvider(
       TimetableSnapshotSource::ofGraph
     );
 
     // Set properties of realtime data snapshot source
     if (fuzzyTripMatching) {
       snapshotSource.fuzzyTripMatcher =
-        new GtfsRealtimeFuzzyTripMatcher(
-          new RoutingService(graph),
-          new DefaultTransitService(graph)
-        );
+        new GtfsRealtimeFuzzyTripMatcher(new DefaultTransitService(transitModel));
     }
     if (backwardsDelayPropagationType != null) {
       snapshotSource.backwardsDelayPropagationType = backwardsDelayPropagationType;

--- a/src/main/java/org/opentripplanner/updater/stoptime/PollingStoptimeUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/PollingStoptimeUpdater.java
@@ -2,9 +2,9 @@ package org.opentripplanner.updater.stoptime;
 
 import com.google.transit.realtime.GtfsRealtime.TripUpdate;
 import java.util.List;
-import org.opentripplanner.routing.RoutingService;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.transit.service.DefaultTransitService;
+import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.updater.GtfsRealtimeFuzzyTripMatcher;
 import org.opentripplanner.updater.PollingGraphUpdater;
 import org.opentripplanner.updater.WriteToGraphCallback;
@@ -95,17 +95,14 @@ public class PollingStoptimeUpdater extends PollingGraphUpdater {
   }
 
   @Override
-  public void setup(Graph graph) {
+  public void setup(Graph graph, TransitModel transitModel) {
     if (fuzzyTripMatching) {
       this.fuzzyTripMatcher =
-        new GtfsRealtimeFuzzyTripMatcher(
-          new RoutingService(graph),
-          new DefaultTransitService(graph)
-        );
+        new GtfsRealtimeFuzzyTripMatcher(new DefaultTransitService(transitModel));
     }
 
     // Only create a realtime data snapshot source if none exists already
-    TimetableSnapshotSource snapshotSource = graph.getOrSetupTimetableSnapshotProvider(
+    TimetableSnapshotSource snapshotSource = transitModel.getOrSetupTimetableSnapshotProvider(
       TimetableSnapshotSource::ofGraph
     );
 

--- a/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
@@ -23,9 +23,7 @@ import org.opentripplanner.model.TimetableSnapshotProvider;
 import org.opentripplanner.model.TripPattern;
 import org.opentripplanner.model.TripTimesPatch;
 import org.opentripplanner.model.calendar.ServiceDate;
-import org.opentripplanner.routing.RoutingService;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.mappers.TransitLayerUpdater;
-import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.trippattern.Deduplicator;
 import org.opentripplanner.routing.trippattern.RealTimeState;
 import org.opentripplanner.routing.trippattern.TripTimes;
@@ -36,6 +34,7 @@ import org.opentripplanner.transit.model.organization.Agency;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.service.DefaultTransitService;
+import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.updater.GtfsRealtimeFuzzyTripMatcher;
 import org.slf4j.Logger;
@@ -75,7 +74,6 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
    */
   private final TripPatternCache tripPatternCache = new TripPatternCache();
   private final TimeZone timeZone;
-  private final RoutingService routingService;
 
   private final TransitService transitService;
   private final TransitLayerUpdater transitLayerUpdater;
@@ -108,27 +106,24 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
   private final Deduplicator deduplicator;
   private final Map<FeedScopedId, Integer> serviceCodes;
 
-  public static TimetableSnapshotSource ofGraph(final Graph graph) {
+  public static TimetableSnapshotSource ofGraph(final TransitModel transitModel) {
     return new TimetableSnapshotSource(
-      graph.getTimeZone(),
-      new RoutingService(graph),
-      new DefaultTransitService(graph),
-      graph.transitLayerUpdater,
-      graph.deduplicator,
-      graph.getServiceCodes()
+      transitModel.getTimeZone(),
+      new DefaultTransitService(transitModel),
+      transitModel.transitLayerUpdater,
+      transitModel.deduplicator,
+      transitModel.getServiceCodes()
     );
   }
 
   public TimetableSnapshotSource(
     TimeZone timeZone,
-    RoutingService routingService,
     TransitService transitService,
     TransitLayerUpdater transitLayerUpdater,
     Deduplicator deduplicator,
     Map<FeedScopedId, Integer> serviceCodes
   ) {
     this.timeZone = timeZone;
-    this.routingService = routingService;
     this.transitService = transitService;
     this.transitLayerUpdater = transitLayerUpdater;
     this.deduplicator = deduplicator;

--- a/src/main/java/org/opentripplanner/updater/stoptime/TripUpdateGraphWriterRunnable.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/TripUpdateGraphWriterRunnable.java
@@ -4,6 +4,7 @@ import com.google.common.base.Preconditions;
 import com.google.transit.realtime.GtfsRealtime.TripUpdate;
 import java.util.List;
 import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.updater.GraphWriterRunnable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,11 +42,11 @@ class TripUpdateGraphWriterRunnable implements GraphWriterRunnable {
   }
 
   @Override
-  public void run(Graph graph) {
+  public void run(Graph graph, TransitModel transitModel) {
     // Apply updates to graph using realtime snapshot source. The source is retrieved from the graph using the
     // setup method which return the instance, we do not need to provide any creator because the
     // TimetableSnapshotSource should already be set up
-    TimetableSnapshotSource snapshotSource = graph.getOrSetupTimetableSnapshotProvider(null);
+    TimetableSnapshotSource snapshotSource = transitModel.getOrSetupTimetableSnapshotProvider(null);
     if (snapshotSource != null) {
       snapshotSource.applyTripUpdates(fullDataset, updates, feedId);
     } else {

--- a/src/main/java/org/opentripplanner/updater/stoptime/WebsocketGtfsRealtimeUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/WebsocketGtfsRealtimeUpdater.java
@@ -16,6 +16,7 @@ import org.asynchttpclient.ws.WebSocket;
 import org.asynchttpclient.ws.WebSocketListener;
 import org.asynchttpclient.ws.WebSocketUpgradeHandler;
 import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.updater.GraphUpdater;
 import org.opentripplanner.updater.WriteToGraphCallback;
 import org.slf4j.Logger;
@@ -71,9 +72,9 @@ public class WebsocketGtfsRealtimeUpdater implements GraphUpdater {
   }
 
   @Override
-  public void setup(Graph graph) {
+  public void setup(Graph graph, TransitModel transitModel) {
     // Only create a realtime data snapshot source if none exists already
-    graph.getOrSetupTimetableSnapshotProvider(TimetableSnapshotSource::ofGraph);
+    transitModel.getOrSetupTimetableSnapshotProvider(TimetableSnapshotSource::ofGraph);
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/updater/street_notes/WFSNotePollingGraphUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/street_notes/WFSNotePollingGraphUpdater.java
@@ -28,6 +28,7 @@ import org.opentripplanner.routing.services.notes.DynamicStreetNotesSource;
 import org.opentripplanner.routing.services.notes.MatcherAndStreetNote;
 import org.opentripplanner.routing.services.notes.NoteMatcher;
 import org.opentripplanner.routing.services.notes.StreetNotesService;
+import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.updater.GraphWriterRunnable;
 import org.opentripplanner.updater.PollingGraphUpdater;
 import org.opentripplanner.updater.WriteToGraphCallback;
@@ -101,7 +102,7 @@ public abstract class WFSNotePollingGraphUpdater extends PollingGraphUpdater {
    * Setup the WFS data source and add the DynamicStreetNotesSource to the graph
    */
   @Override
-  public void setup(Graph graph) throws IOException, FactoryException {
+  public void setup(Graph graph, TransitModel transitModel) throws IOException, FactoryException {
     this.graph = graph;
     LOG.info("Setup WFS polling updater");
     HashMap<String, Object> connectionParameters = new HashMap<>();
@@ -194,7 +195,7 @@ public abstract class WFSNotePollingGraphUpdater extends PollingGraphUpdater {
    */
   private class WFSGraphWriter implements GraphWriterRunnable {
 
-    public void run(Graph graph) {
+    public void run(Graph graph, TransitModel transitModel) {
       notesSource.setNotes(notesForEdge);
     }
   }

--- a/src/main/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingUpdater.java
@@ -22,6 +22,7 @@ import org.opentripplanner.routing.vehicle_parking.VehicleParkingService;
 import org.opentripplanner.routing.vehicle_parking.VehicleParkingState;
 import org.opentripplanner.routing.vertextype.VehicleParkingEntranceVertex;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.updater.DataSource;
 import org.opentripplanner.updater.GraphWriterRunnable;
 import org.opentripplanner.updater.PollingGraphUpdater;
@@ -65,7 +66,7 @@ public class VehicleParkingUpdater extends PollingGraphUpdater {
   }
 
   @Override
-  public void setup(Graph graph) {
+  public void setup(Graph graph, TransitModel transitModel) {
     // Creation of network linker library will not modify the graph
     linker = graph.getLinker();
     // Adding a vehicle parking station service needs a graph writer runnable
@@ -105,7 +106,7 @@ public class VehicleParkingUpdater extends PollingGraphUpdater {
     }
 
     @Override
-    public void run(Graph graph) {
+    public void run(Graph graph, TransitModel transitModel) {
       // Apply stations to graph
       /* Add any new park and update space available for existing parks */
       Set<VehicleParking> toAdd = new HashSet<>();

--- a/src/main/java/org/opentripplanner/updater/vehicle_positions/PollingVehiclePositionUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_positions/PollingVehiclePositionUpdater.java
@@ -7,6 +7,7 @@ import org.opentripplanner.model.TripPattern;
 import org.opentripplanner.model.calendar.ServiceDate;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.transit.model.timetable.Trip;
+import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.updater.PollingGraphUpdater;
 import org.opentripplanner.updater.WriteToGraphCallback;
 import org.slf4j.Logger;
@@ -55,16 +56,16 @@ public class PollingVehiclePositionUpdater extends PollingGraphUpdater {
   }
 
   @Override
-  public void setup(Graph graph) {
-    var index = graph.index;
+  public void setup(Graph graph, TransitModel transitModel) {
+    var index = transitModel.index;
     vehiclePositionPatternMatcher =
       new VehiclePositionPatternMatcher(
         feedId,
         tripId -> index.getTripForId().get(tripId),
-        trip -> graph.index.getPatternForTrip().get(trip),
-        (trip, date) -> getPatternIncludingRealtime(graph, trip, date),
+        trip -> index.getPatternForTrip().get(trip),
+        (trip, date) -> getPatternIncludingRealtime(transitModel, trip, date),
         graph.getVehiclePositionService(),
-        graph.getTimeZone().toZoneId()
+        transitModel.getTimeZone().toZoneId()
       );
   }
 
@@ -92,10 +93,14 @@ public class PollingVehiclePositionUpdater extends PollingGraphUpdater {
     return "Streaming vehicle position updater with update source = " + s;
   }
 
-  private static TripPattern getPatternIncludingRealtime(Graph graph, Trip trip, ServiceDate sd) {
+  private static TripPattern getPatternIncludingRealtime(
+    TransitModel transitModel,
+    Trip trip,
+    ServiceDate sd
+  ) {
     return Optional
-      .ofNullable(graph.getTimetableSnapshot())
+      .ofNullable(transitModel.getTimetableSnapshot())
       .map(snapshot -> snapshot.getLastAddedTripPattern(trip.getId(), sd))
-      .orElseGet(() -> graph.index.getPatternForTrip().get(trip));
+      .orElseGet(() -> transitModel.index.getPatternForTrip().get(trip));
   }
 }

--- a/src/main/java/org/opentripplanner/updater/vehicle_positions/VehiclePositionUpdaterRunnable.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_positions/VehiclePositionUpdaterRunnable.java
@@ -4,6 +4,7 @@ import com.google.transit.realtime.GtfsRealtime.VehiclePosition;
 import java.util.List;
 import java.util.Objects;
 import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.updater.GraphWriterRunnable;
 
 public record VehiclePositionUpdaterRunnable(
@@ -17,7 +18,7 @@ public record VehiclePositionUpdaterRunnable(
   }
 
   @Override
-  public void run(Graph graph) {
+  public void run(Graph graph, TransitModel transitModel) {
     // Apply new vehicle positions
     matcher.applyVehiclePositionUpdates(updates);
   }

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdater.java
@@ -22,6 +22,7 @@ import org.opentripplanner.routing.vehicle_rental.VehicleRentalPlace;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalStationService;
 import org.opentripplanner.routing.vertextype.VehicleRentalPlaceVertex;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.updater.DataSource;
 import org.opentripplanner.updater.GraphWriterRunnable;
 import org.opentripplanner.updater.PollingGraphUpdater;
@@ -71,7 +72,7 @@ public class VehicleRentalUpdater extends PollingGraphUpdater {
   }
 
   @Override
-  public void setup(Graph graph) {
+  public void setup(Graph graph, TransitModel transitModel) {
     // Creation of network linker library will not modify the graph
     linker = graph.getLinker();
     // Adding a vehicle rental station service needs a graph writer runnable
@@ -113,7 +114,7 @@ public class VehicleRentalUpdater extends PollingGraphUpdater {
     }
 
     @Override
-    public void run(Graph graph) {
+    public void run(Graph graph, TransitModel transitModel) {
       // Apply stations to graph
       Set<FeedScopedId> stationSet = new HashSet<>();
 

--- a/src/main/java/org/opentripplanner/util/TravelOptionsMaker.java
+++ b/src/main/java/org/opentripplanner/util/TravelOptionsMaker.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.opentripplanner.routing.core.TraverseMode;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.transit.model.network.TransitMode;
+import org.opentripplanner.transit.service.TransitModel;
 
 /**
  * Class which creates "Travel by" options list from supported transit modes and which extra modes
@@ -24,9 +25,9 @@ public final class TravelOptionsMaker {
     staticTravelOptions.add(new TravelOption(TraverseMode.CAR.toString()));
   }
 
-  public static List<TravelOption> makeOptions(Graph graph) {
+  public static List<TravelOption> makeOptions(Graph graph, TransitModel transitModel) {
     return makeOptions(
-      graph.getTransitModes(),
+      transitModel.getTransitModes(),
       graph.hasBikeSharing,
       graph.hasBikeRide,
       graph.hasParkRide

--- a/src/test/java/org/opentripplanner/ConstantsForTests.java
+++ b/src/test/java/org/opentripplanner/ConstantsForTests.java
@@ -36,12 +36,15 @@ import org.opentripplanner.routing.edgetype.VehicleRentalEdge;
 import org.opentripplanner.routing.fares.FareServiceFactory;
 import org.opentripplanner.routing.fares.impl.DefaultFareServiceFactory;
 import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.routing.trippattern.Deduplicator;
 import org.opentripplanner.routing.vehicle_rental.RentalVehicleType;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalStation;
 import org.opentripplanner.routing.vertextype.VehicleRentalPlaceVertex;
 import org.opentripplanner.standalone.config.BuildConfig;
 import org.opentripplanner.standalone.config.ConfigLoader;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.service.StopModel;
+import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.util.NonLocalizedString;
 
 public class ConstantsForTests {
@@ -102,8 +105,8 @@ public class ConstantsForTests {
   );
 
   private static ConstantsForTests instance = null;
-  private Graph portlandGraph = null;
-  private Graph portlandGraphWithElevation = null;
+  private OtpModel portlandGraph = null;
+  private OtpModel portlandGraphWithElevation = null;
 
   private ConstantsForTests() {}
 
@@ -124,9 +127,12 @@ public class ConstantsForTests {
   /**
    * Builds a new graph using the Portland test data.
    */
-  public static Graph buildNewPortlandGraph(boolean withElevation) {
+  public static OtpModel buildNewPortlandGraph(boolean withElevation) {
     try {
-      Graph graph = new Graph();
+      var deduplicator = new Deduplicator();
+      var stopModel = new StopModel();
+      var graph = new Graph(stopModel, deduplicator);
+      var transitModel = new TransitModel(stopModel, deduplicator);
       // Add street data from OSM
       {
         File osmFile = new File(PORTLAND_CENTRAL_OSM);
@@ -135,77 +141,93 @@ public class ConstantsForTests {
         osmModule.staticBikeParkAndRide = true;
         osmModule.staticParkAndRide = true;
         osmModule.skipVisibility = true;
-        osmModule.buildGraph(graph, new HashMap<>());
+        osmModule.buildGraph(graph, transitModel, new HashMap<>());
       }
       // Add transit data from GTFS
       {
-        addGtfsToGraph(graph, PORTLAND_GTFS, new DefaultFareServiceFactory(), "prt");
+        addGtfsToGraph(graph, transitModel, PORTLAND_GTFS, new DefaultFareServiceFactory(), "prt");
       }
       // Link transit stops to streets
       {
         GraphBuilderModule streetTransitLinker = new StreetLinkerModule();
-        streetTransitLinker.buildGraph(graph, new HashMap<>());
+        streetTransitLinker.buildGraph(graph, transitModel, new HashMap<>());
       }
       // Add elevation data
       if (withElevation) {
         var elevationModule = new ElevationModule(
           new GeotiffGridCoverageFactoryImpl(new File(PORTLAND_NED_WITH_NODATA))
         );
-        elevationModule.buildGraph(graph, new HashMap<>());
+        elevationModule.buildGraph(graph, transitModel, new HashMap<>());
       }
 
       graph.hasStreets = true;
 
       addPortlandVehicleRentals(graph);
 
+      transitModel.index();
       graph.index();
 
-      return graph;
+      return new OtpModel(graph, transitModel);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
   }
 
-  public static Graph buildOsmGraph(String osmPath) {
+  public static OtpModel buildOsmGraph(String osmPath) {
     try {
-      var graph = new Graph();
+      var deduplicator = new Deduplicator();
+      var stopModel = new StopModel();
+      var graph = new Graph(stopModel, deduplicator);
+      var transitModel = new TransitModel(stopModel, deduplicator);
       // Add street data from OSM
       File osmFile = new File(osmPath);
       OpenStreetMapProvider osmProvider = new OpenStreetMapProvider(osmFile, true);
       OpenStreetMapModule osmModule = new OpenStreetMapModule(osmProvider);
       osmModule.setDefaultWayPropertySetSource(new DefaultWayPropertySetSource());
       osmModule.skipVisibility = true;
-      osmModule.buildGraph(graph, new HashMap<>());
-      return graph;
+      osmModule.buildGraph(graph, transitModel, new HashMap<>());
+      return new OtpModel(graph, transitModel);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
   }
 
-  public static Graph buildOsmAndGtfsGraph(String osmPath, String gtfsPath) {
-    var graph = buildOsmGraph(osmPath);
+  public static OtpModel buildOsmAndGtfsGraph(String osmPath, String gtfsPath) {
+    var otpModel = buildOsmGraph(osmPath);
 
-    addGtfsToGraph(graph, gtfsPath, new DefaultFareServiceFactory(), null);
+    addGtfsToGraph(
+      otpModel.graph,
+      otpModel.transitModel,
+      gtfsPath,
+      new DefaultFareServiceFactory(),
+      null
+    );
 
     // Link transit stops to streets
     GraphBuilderModule streetTransitLinker = new StreetLinkerModule();
-    streetTransitLinker.buildGraph(graph, new HashMap<>());
-    return graph;
+    streetTransitLinker.buildGraph(otpModel.graph, otpModel.transitModel, new HashMap<>());
+    return otpModel;
   }
 
-  public static Graph buildGtfsGraph(String gtfsPath) {
+  public static OtpModel buildGtfsGraph(String gtfsPath) {
     return buildGtfsGraph(gtfsPath, new DefaultFareServiceFactory());
   }
 
-  public static Graph buildGtfsGraph(String gtfsPath, FareServiceFactory fareServiceFactory) {
-    var graph = new Graph();
-    addGtfsToGraph(graph, gtfsPath, fareServiceFactory, null);
-    return graph;
+  public static OtpModel buildGtfsGraph(String gtfsPath, FareServiceFactory fareServiceFactory) {
+    var deduplicator = new Deduplicator();
+    var stopModel = new StopModel();
+    var graph = new Graph(stopModel, deduplicator);
+    var transitModel = new TransitModel(stopModel, deduplicator);
+    addGtfsToGraph(graph, transitModel, gtfsPath, fareServiceFactory, null);
+    return new OtpModel(graph, transitModel);
   }
 
-  public static Graph buildNewMinimalNetexGraph() {
+  public static OtpModel buildNewMinimalNetexGraph() {
     try {
-      Graph graph = new Graph();
+      var deduplicator = new Deduplicator();
+      var stopModel = new StopModel();
+      var graph = new Graph(stopModel, deduplicator);
+      var transitModel = new TransitModel(stopModel, deduplicator);
       // Add street data from OSM
       {
         File osmFile = new File(OSLO_EAST_OSM);
@@ -213,21 +235,22 @@ public class ConstantsForTests {
         OpenStreetMapProvider osmProvider = new OpenStreetMapProvider(osmFile, false);
         OpenStreetMapModule osmModule = new OpenStreetMapModule(osmProvider);
         osmModule.skipVisibility = true;
-        osmModule.buildGraph(graph, new HashMap<>());
+        osmModule.buildGraph(graph, transitModel, new HashMap<>());
       }
       // Add transit data from Netex
       {
         BuildConfig buildParameters = createNetexBuilderParameters();
         List<DataSource> dataSources = Collections.singletonList(NETEX_MINIMAL_DATA_SOURCE);
         NetexModule module = NetexConfig.netexModule(buildParameters, dataSources);
-        module.buildGraph(graph, null);
+        module.buildGraph(graph, transitModel, null);
       }
       // Link transit stops to streets
       {
-        GraphBuilderModule streetTransitLinker = new StreetLinkerModule();
-        streetTransitLinker.buildGraph(graph, new HashMap<>());
+        GraphBuilderModule streetLinkerModule = new StreetLinkerModule();
+
+        streetLinkerModule.buildGraph(graph, transitModel, new HashMap<>());
       }
-      return graph;
+      return new OtpModel(graph, transitModel);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
@@ -236,7 +259,7 @@ public class ConstantsForTests {
   /**
    * Returns a cached copy of the Portland graph, which may have been initialized.
    */
-  public synchronized Graph getCachedPortlandGraph() {
+  public synchronized OtpModel getCachedPortlandGraph() {
     if (portlandGraph == null) {
       portlandGraph = buildNewPortlandGraph(false);
     }
@@ -246,7 +269,7 @@ public class ConstantsForTests {
   /**
    * Returns a cached copy of the Portland graph, which may have been initialized.
    */
-  public synchronized Graph getCachedPortlandGraphWithElevation() {
+  public synchronized OtpModel getCachedPortlandGraphWithElevation() {
     if (portlandGraphWithElevation == null) {
       portlandGraphWithElevation = buildNewPortlandGraph(true);
     }
@@ -255,6 +278,7 @@ public class ConstantsForTests {
 
   private static void addGtfsToGraph(
     Graph graph,
+    TransitModel transitModel,
     String file,
     FareServiceFactory fareServiceFactory,
     @Nullable String feedId
@@ -269,10 +293,11 @@ public class ConstantsForTests {
       false
     );
 
-    module.buildGraph(graph, new HashMap<>());
+    module.buildGraph(graph, transitModel, new HashMap<>());
 
+    transitModel.index();
     graph.index();
-    graph.hasTransit = true;
+    transitModel.hasTransit = true;
   }
 
   private static void addPortlandVehicleRentals(Graph graph) {

--- a/src/test/java/org/opentripplanner/GtfsTest.java
+++ b/src/test/java/org/opentripplanner/GtfsTest.java
@@ -30,9 +30,12 @@ import org.opentripplanner.routing.core.TraverseMode;
 import org.opentripplanner.routing.core.TraverseModeSet;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
+import org.opentripplanner.routing.trippattern.Deduplicator;
 import org.opentripplanner.standalone.config.RouterConfig;
 import org.opentripplanner.standalone.server.Router;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.service.StopModel;
+import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.updater.alerts.AlertsUpdateHandler;
 import org.opentripplanner.updater.stoptime.TimetableSnapshotSource;
 
@@ -40,6 +43,8 @@ import org.opentripplanner.updater.stoptime.TimetableSnapshotSource;
 public abstract class GtfsTest {
 
   public Graph graph;
+  public TransitModel transitModel;
+
   AlertsUpdateHandler alertsUpdateHandler;
   TimetableSnapshotSource timetableSnapshotSource;
   TransitAlertServiceImpl alertPatchServiceImpl;
@@ -95,7 +100,11 @@ public abstract class GtfsTest {
     routingRequest.setWalkBoardCost(30);
     routingRequest.transferSlack = 0;
 
-    RoutingResponse res = new RoutingWorker(router, routingRequest, graph.getTimeZone().toZoneId())
+    RoutingResponse res = new RoutingWorker(
+      router,
+      routingRequest,
+      transitModel.getTimeZone().toZoneId()
+    )
       .route();
     List<Itinerary> itineraries = res.getTripPlan().itineraries;
     // Stored in instance field for use in individual tests
@@ -147,19 +156,23 @@ public abstract class GtfsTest {
     );
 
     alertsUpdateHandler = new AlertsUpdateHandler();
-    graph = new Graph();
+    var deduplicator = new Deduplicator();
+    var stopModel = new StopModel();
+    graph = new Graph(stopModel, deduplicator);
+    transitModel = new TransitModel(stopModel, deduplicator);
 
-    gtfsGraphBuilderImpl.buildGraph(graph, null);
+    gtfsGraphBuilderImpl.buildGraph(graph, transitModel, null);
     // Set the agency ID to be used for tests to the first one in the feed.
-    String agencyId = graph.getAgencies().iterator().next().getId().getId();
+    String agencyId = transitModel.getAgencies().iterator().next().getId().getId();
     System.out.printf("Set the agency ID for this test to %s\n", agencyId);
+    transitModel.index();
     graph.index();
-    router = new Router(graph, RouterConfig.DEFAULT, Metrics.globalRegistry);
+    router = new Router(graph, transitModel, RouterConfig.DEFAULT, Metrics.globalRegistry);
     router.startup();
-    timetableSnapshotSource = TimetableSnapshotSource.ofGraph(graph);
+    timetableSnapshotSource = TimetableSnapshotSource.ofGraph(transitModel);
     timetableSnapshotSource.purgeExpiredData = false;
-    graph.getOrSetupTimetableSnapshotProvider(g -> timetableSnapshotSource);
-    alertPatchServiceImpl = new TransitAlertServiceImpl(graph);
+    transitModel.getOrSetupTimetableSnapshotProvider(g -> timetableSnapshotSource);
+    alertPatchServiceImpl = new TransitAlertServiceImpl(transitModel);
     alertsUpdateHandler.setTransitAlertService(alertPatchServiceImpl);
     alertsUpdateHandler.setFeedId(feedId.getId());
 

--- a/src/test/java/org/opentripplanner/OtpModel.java
+++ b/src/test/java/org/opentripplanner/OtpModel.java
@@ -1,0 +1,15 @@
+package org.opentripplanner;
+
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.transit.service.TransitModel;
+
+public class OtpModel {
+
+  public final Graph graph;
+  public final TransitModel transitModel;
+
+  public OtpModel(Graph graph, TransitModel transitModel) {
+    this.graph = graph;
+    this.transitModel = transitModel;
+  }
+}

--- a/src/test/java/org/opentripplanner/graph_builder/linking/LinkStopToPlatformTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/linking/LinkStopToPlatformTest.java
@@ -20,10 +20,14 @@ import org.opentripplanner.routing.edgetype.AreaEdgeList;
 import org.opentripplanner.routing.edgetype.StreetTransitStopLink;
 import org.opentripplanner.routing.edgetype.StreetTraversalPermission;
 import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.routing.trippattern.Deduplicator;
 import org.opentripplanner.routing.vertextype.IntersectionVertex;
 import org.opentripplanner.routing.vertextype.TransitStopVertex;
+import org.opentripplanner.routing.vertextype.TransitStopVertexBuilder;
 import org.opentripplanner.transit.model._data.TransitModelForTest;
 import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.service.StopModel;
+import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.util.I18NString;
 import org.opentripplanner.util.LocalizedString;
 
@@ -32,12 +36,16 @@ public class LinkStopToPlatformTest {
   private static final GeometryFactory geometryFactory = GeometryUtils.getGeometryFactory();
 
   private Graph graph;
+  private TransitModel transitModel;
 
   @BeforeEach
   public void before() {
     // Set up transit platform
 
-    graph = new Graph();
+    var deduplicator = new Deduplicator();
+    var stopModel = new StopModel();
+    graph = new Graph(stopModel, deduplicator);
+    transitModel = new TransitModel(stopModel, deduplicator);
 
     ArrayList<IntersectionVertex> vertices = new ArrayList<>();
 
@@ -68,7 +76,11 @@ public class LinkStopToPlatformTest {
 
     Stop stop = TransitModelForTest.stop("TestStop").withCoordinate(59.13545, 10.22213).build();
 
-    TransitStopVertex stopVertex = new TransitStopVertex(graph, stop, null);
+    TransitStopVertex stopVertex = new TransitStopVertexBuilder()
+      .withGraph(graph)
+      .withStop(stop)
+      .withTransitModel(transitModel)
+      .build();
   }
 
   /**

--- a/src/test/java/org/opentripplanner/graph_builder/module/DirectTransferGeneratorTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/DirectTransferGeneratorTest.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
+import org.opentripplanner.OtpModel;
 import org.opentripplanner.model.PathTransfer;
 import org.opentripplanner.model.StopPattern;
 import org.opentripplanner.model.TripPattern;
@@ -25,7 +26,6 @@ import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.routing.edgetype.StreetTraversalPermission;
 import org.opentripplanner.routing.graph.Edge;
-import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.vertextype.StreetVertex;
 import org.opentripplanner.routing.vertextype.TransitStopVertex;
 import org.opentripplanner.transit.model._data.TransitModelForTest;
@@ -50,13 +50,14 @@ class DirectTransferGeneratorTest extends GraphRoutingTest {
       List.of(new RoutingRequest(RequestModes.of().withTransferMode(StreetMode.WALK).build()))
     );
 
-    var graph = graph(false);
-    graph.index();
+    var otpModel = graph(false);
+    var graph = otpModel.graph;
+    var transitModel = otpModel.transitModel;
     graph.hasStreets = false;
 
-    generator.buildGraph(graph, null);
+    generator.buildGraph(graph, transitModel, null);
 
-    assertTransfers(graph.transfersByStop);
+    assertTransfers(transitModel.transfersByStop);
   }
 
   @Test
@@ -66,13 +67,15 @@ class DirectTransferGeneratorTest extends GraphRoutingTest {
       List.of(new RoutingRequest(RequestModes.of().withTransferMode(StreetMode.WALK).build()))
     );
 
-    var graph = graph(true);
+    var otpModel = graph(true);
+    var graph = otpModel.graph;
     graph.hasStreets = false;
+    var transitModel = otpModel.transitModel;
 
-    generator.buildGraph(graph, null);
+    generator.buildGraph(graph, transitModel, null);
 
     assertTransfers(
-      graph.transfersByStop,
+      transitModel.transfersByStop,
       tr(S0, 556, S11),
       tr(S0, 935, S21),
       tr(S11, 751, S21),
@@ -89,12 +92,14 @@ class DirectTransferGeneratorTest extends GraphRoutingTest {
       List.of(new RoutingRequest(RequestModes.of().withTransferMode(StreetMode.WALK).build()))
     );
 
-    var graph = graph(false);
+    var otpModel = graph(false);
+    var graph = otpModel.graph;
     graph.hasStreets = true;
+    var transitModel = otpModel.transitModel;
 
-    generator.buildGraph(graph, null);
+    generator.buildGraph(graph, transitModel, null);
 
-    assertTransfers(graph.transfersByStop);
+    assertTransfers(transitModel.transfersByStop);
   }
 
   @Test
@@ -104,13 +109,15 @@ class DirectTransferGeneratorTest extends GraphRoutingTest {
       List.of(new RoutingRequest(RequestModes.of().withTransferMode(StreetMode.WALK).build()))
     );
 
-    var graph = graph(true);
+    var otpModel = graph(true);
+    var graph = otpModel.graph;
     graph.hasStreets = true;
+    var transitModel = otpModel.transitModel;
 
-    generator.buildGraph(graph, null);
+    generator.buildGraph(graph, transitModel, null);
 
     assertTransfers(
-      graph.transfersByStop,
+      transitModel.transfersByStop,
       tr(S0, 100, List.of(V0, V11), S11),
       tr(S0, 100, List.of(V0, V21), S21),
       tr(S11, 100, List.of(V11, V21), S21)
@@ -127,12 +134,14 @@ class DirectTransferGeneratorTest extends GraphRoutingTest {
       )
     );
 
-    var graph = graph(false);
+    var otpModel = graph(false);
+    var graph = otpModel.graph;
     graph.hasStreets = true;
+    var transitModel = otpModel.transitModel;
 
-    generator.buildGraph(graph, null);
+    generator.buildGraph(graph, transitModel, null);
 
-    assertTransfers(graph.transfersByStop);
+    assertTransfers(transitModel.transfersByStop);
   }
 
   @Test
@@ -145,13 +154,14 @@ class DirectTransferGeneratorTest extends GraphRoutingTest {
       )
     );
 
-    var graph = graph(true);
+    OtpModel otpModel = graph(true);
+    var graph = otpModel.graph;
     graph.hasStreets = true;
+    var transitModel = otpModel.transitModel;
 
-    generator.buildGraph(graph, null);
-
+    generator.buildGraph(graph, transitModel, null);
     assertTransfers(
-      graph.transfersByStop,
+      transitModel.transfersByStop,
       tr(S0, 100, List.of(V0, V11), S11),
       tr(S0, 100, List.of(V0, V21), S21),
       tr(S11, 100, List.of(V11, V21), S21),
@@ -159,7 +169,7 @@ class DirectTransferGeneratorTest extends GraphRoutingTest {
     );
   }
 
-  private Graph graph(boolean addPatterns) {
+  private OtpModel graph(boolean addPatterns) {
     return graphOf(
       new Builder() {
         @Override

--- a/src/test/java/org/opentripplanner/graph_builder/module/ElevationModuleTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/ElevationModuleTest.java
@@ -17,7 +17,10 @@ import org.opentripplanner.graph_builder.module.ned.NEDGridCoverageFactoryImpl;
 import org.opentripplanner.routing.edgetype.StreetEdge;
 import org.opentripplanner.routing.edgetype.StreetTraversalPermission;
 import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.routing.trippattern.Deduplicator;
 import org.opentripplanner.routing.vertextype.OsmVertex;
+import org.opentripplanner.transit.service.StopModel;
+import org.opentripplanner.transit.service.TransitModel;
 
 public class ElevationModuleTest {
 
@@ -33,7 +36,10 @@ public class ElevationModuleTest {
   @Disabled
   public void testSetElevationOnEdgesUsingS3BucketTiles() {
     // create a graph with a StreetWithElevationEdge
-    Graph graph = new Graph();
+    var deduplicator = new Deduplicator();
+    var stopModel = new StopModel();
+    var graph = new Graph(stopModel, deduplicator);
+    var transitModel = new TransitModel(stopModel, deduplicator);
     OsmVertex from = new OsmVertex(graph, "from", -122.6932051, 45.5122964, 40513757);
     OsmVertex to = new OsmVertex(graph, "to", -122.6903532, 45.5115309, 1677595882);
     LineString geometry = GeometryUtils.makeLineString(
@@ -97,7 +103,7 @@ public class ElevationModuleTest {
 
     // build to graph to execute the elevation module
     elevationModule.checkInputs();
-    elevationModule.buildGraph(graph, new HashMap<>());
+    elevationModule.buildGraph(graph, transitModel, new HashMap<>());
 
     // verify that elevation data has been set on the StreetWithElevationEdge
     assertNotNull(edge.getElevationProfile());

--- a/src/test/java/org/opentripplanner/graph_builder/module/GtfsModuleTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/GtfsModuleTest.java
@@ -11,19 +11,25 @@ import org.opentripplanner.ConstantsForTests;
 import org.opentripplanner.graph_builder.model.GtfsBundle;
 import org.opentripplanner.model.calendar.ServiceDateInterval;
 import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.routing.trippattern.Deduplicator;
+import org.opentripplanner.transit.service.StopModel;
+import org.opentripplanner.transit.service.TransitModel;
 
 class GtfsModuleTest {
 
   @Test
   public void addShapesForFrequencyTrips() {
-    var graph = new Graph();
+    var deduplicator = new Deduplicator();
+    var stopModel = new StopModel();
+    var graph = new Graph(stopModel, deduplicator);
+    var transitModel = new TransitModel(stopModel, deduplicator);
 
     var bundle = new GtfsBundle(new File(ConstantsForTests.FAKE_GTFS));
     var module = new GtfsModule(List.of(bundle), ServiceDateInterval.unbounded(), null, false);
 
-    module.buildGraph(graph, new HashMap<>());
+    module.buildGraph(graph, transitModel, new HashMap<>());
 
-    var frequencyTripPattern = graph
+    var frequencyTripPattern = transitModel
       .getTripPatterns()
       .stream()
       .filter(p -> !p.getScheduledTimetable().getFrequencyEntries().isEmpty())
@@ -35,7 +41,7 @@ class GtfsModuleTest {
     assertNotNull(tripPattern.getGeometry());
     assertNotNull(tripPattern.getHopGeometry(0));
 
-    var pattern = graph.getTripPatternForId(tripPattern.getId());
+    var pattern = transitModel.getTripPatternForId(tripPattern.getId());
     assertNotNull(pattern.getGeometry());
     assertNotNull(pattern.getHopGeometry(0));
   }

--- a/src/test/java/org/opentripplanner/graph_builder/module/PruneNoThruIslandsTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/PruneNoThruIslandsTest.java
@@ -15,6 +15,9 @@ import org.opentripplanner.openstreetmap.OpenStreetMapProvider;
 import org.opentripplanner.openstreetmap.model.OSMWithTags;
 import org.opentripplanner.routing.edgetype.StreetEdge;
 import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.routing.trippattern.Deduplicator;
+import org.opentripplanner.transit.service.StopModel;
+import org.opentripplanner.transit.service.TransitModel;
 
 public class PruneNoThruIslandsTest {
 
@@ -65,7 +68,10 @@ public class PruneNoThruIslandsTest {
 
   private static Graph buildOsmGraph(String osmPath) {
     try {
-      var graph = new Graph();
+      var deduplicator = new Deduplicator();
+      var stopModel = new StopModel();
+      var graph = new Graph(stopModel, deduplicator);
+      var transitModel = new TransitModel(stopModel, deduplicator);
       // Add street data from OSM
       File osmFile = new File(osmPath);
       OpenStreetMapProvider osmProvider = new OpenStreetMapProvider(osmFile, true);
@@ -88,12 +94,12 @@ public class PruneNoThruIslandsTest {
           public void configure() {}
         };
       osmModule.skipVisibility = true;
-      osmModule.buildGraph(graph, new HashMap<>());
+      osmModule.buildGraph(graph, transitModel, new HashMap<>());
       // Prune floating islands and set noThru where necessary
       PruneNoThruIslands pruneNoThruIslands = new PruneNoThruIslands(null);
       pruneNoThruIslands.setPruningThresholdIslandWithoutStops(40);
       pruneNoThruIslands.setPruningThresholdIslandWithStops(5);
-      pruneNoThruIslands.buildGraph(graph, new HashMap<>());
+      pruneNoThruIslands.buildGraph(graph, transitModel, new HashMap<>());
 
       return graph;
     } catch (Exception e) {

--- a/src/test/java/org/opentripplanner/graph_builder/module/VehicleParkingLinkingTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/VehicleParkingLinkingTest.java
@@ -19,10 +19,12 @@ import org.opentripplanner.routing.vehicle_parking.VehicleParkingTestGraphData;
 import org.opentripplanner.routing.vehicle_parking.VehicleParkingTestUtil;
 import org.opentripplanner.routing.vertextype.IntersectionVertex;
 import org.opentripplanner.routing.vertextype.VehicleParkingEntranceVertex;
+import org.opentripplanner.transit.service.TransitModel;
 
 public class VehicleParkingLinkingTest {
 
   private Graph graph;
+  private TransitModel transitModel;
   private IntersectionVertex A;
   private IntersectionVertex B;
 
@@ -31,6 +33,7 @@ public class VehicleParkingLinkingTest {
     VehicleParkingTestGraphData graphData = new VehicleParkingTestGraphData();
     graphData.initGraph();
     graph = graphData.getGraph();
+    transitModel = graphData.getTransitModel();
     A = graphData.getAVertex();
     B = graphData.getBVertex();
   }
@@ -44,7 +47,12 @@ public class VehicleParkingLinkingTest {
     var parkingVertex = new VehicleParkingEntranceVertex(graph, parking.getEntrances().get(0));
 
     StreetLinkerModule streetLinkerModule = new StreetLinkerModule();
-    streetLinkerModule.buildGraph(graph, new HashMap<>(), new DataImportIssueStore(false));
+    streetLinkerModule.buildGraph(
+      graph,
+      transitModel,
+      new HashMap<>(),
+      new DataImportIssueStore(false)
+    );
 
     assertEquals(1, parkingVertex.getOutgoing().size());
     parkingVertex.getOutgoing().forEach(e -> assertEquals(e.getToVertex(), A));
@@ -64,7 +72,12 @@ public class VehicleParkingLinkingTest {
     var parkingVertex = new VehicleParkingEntranceVertex(graph, parking.getEntrances().get(0));
 
     StreetLinkerModule streetLinkerModule = new StreetLinkerModule();
-    streetLinkerModule.buildGraph(graph, new HashMap<>(), new DataImportIssueStore(false));
+    streetLinkerModule.buildGraph(
+      graph,
+      transitModel,
+      new HashMap<>(),
+      new DataImportIssueStore(false)
+    );
 
     var streetLinks = graph.getEdgesOfType(StreetVehicleParkingLink.class);
     assertEquals(2, streetLinks.size());
@@ -91,7 +104,12 @@ public class VehicleParkingLinkingTest {
     var parkingVertex = new VehicleParkingEntranceVertex(graph, parking.getEntrances().get(0));
 
     StreetLinkerModule streetLinkerModule = new StreetLinkerModule();
-    streetLinkerModule.buildGraph(graph, new HashMap<>(), new DataImportIssueStore(false));
+    streetLinkerModule.buildGraph(
+      graph,
+      transitModel,
+      new HashMap<>(),
+      new DataImportIssueStore(false)
+    );
 
     var streetLinks = graph.getEdgesOfType(StreetVehicleParkingLink.class);
     assertEquals(4, streetLinks.size());
@@ -116,7 +134,12 @@ public class VehicleParkingLinkingTest {
     graph.remove(A);
 
     StreetLinkerModule streetLinkerModule = new StreetLinkerModule();
-    streetLinkerModule.buildGraph(graph, new HashMap<>(), new DataImportIssueStore(false));
+    streetLinkerModule.buildGraph(
+      graph,
+      transitModel,
+      new HashMap<>(),
+      new DataImportIssueStore(false)
+    );
 
     assertEquals(1, vehicleParking.getEntrances().size());
 
@@ -142,7 +165,12 @@ public class VehicleParkingLinkingTest {
     graph.remove(A);
 
     StreetLinkerModule streetLinkerModule = new StreetLinkerModule();
-    streetLinkerModule.buildGraph(graph, new HashMap<>(), new DataImportIssueStore(false));
+    streetLinkerModule.buildGraph(
+      graph,
+      transitModel,
+      new HashMap<>(),
+      new DataImportIssueStore(false)
+    );
 
     assertEquals(0, graph.getVerticesOfType(VehicleParkingEntranceVertex.class).size());
 

--- a/src/test/java/org/opentripplanner/graph_builder/module/geometry/GeometryAndBlockProcessorTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/geometry/GeometryAndBlockProcessorTest.java
@@ -7,6 +7,9 @@ import org.opentripplanner.gtfs.GtfsContext;
 import org.opentripplanner.gtfs.GtfsContextBuilder;
 import org.opentripplanner.gtfs.MockGtfs;
 import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.routing.trippattern.Deduplicator;
+import org.opentripplanner.transit.service.StopModel;
+import org.opentripplanner.transit.service.TransitModel;
 
 public class GeometryAndBlockProcessorTest {
 
@@ -26,7 +29,10 @@ public class GeometryAndBlockProcessorTest {
     );
 
     GtfsFeedId feedId = new GtfsFeedId.Builder().id("FEED").build();
-    Graph graph = new Graph();
+    var deduplicator = new Deduplicator();
+    var stopModel = new StopModel();
+    var graph = new Graph(stopModel, deduplicator);
+    var transitModel = new TransitModel(stopModel, deduplicator);
 
     GtfsContext context = new GtfsContextBuilder(feedId, gtfs.read())
       .withIssueStoreAndDeduplicator(graph)
@@ -34,6 +40,6 @@ public class GeometryAndBlockProcessorTest {
 
     GeometryAndBlockProcessor factory = new GeometryAndBlockProcessor(context);
 
-    factory.run(graph);
+    factory.run(graph, transitModel);
   }
 }

--- a/src/test/java/org/opentripplanner/graph_builder/module/linking/LinkingTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/linking/LinkingTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.LineString;
+import org.opentripplanner.OtpModel;
 import org.opentripplanner.common.geometry.GeometryUtils;
 import org.opentripplanner.common.geometry.SphericalDistanceLibrary;
 import org.opentripplanner.common.model.P2;
@@ -29,6 +30,7 @@ import org.opentripplanner.routing.vertextype.IntersectionVertex;
 import org.opentripplanner.routing.vertextype.SplitterVertex;
 import org.opentripplanner.routing.vertextype.StreetVertex;
 import org.opentripplanner.routing.vertextype.TransitStopVertex;
+import org.opentripplanner.transit.service.TransitModel;
 
 public class LinkingTest {
 
@@ -84,7 +86,6 @@ public class LinkingTest {
         y + delta * splitVal
       );
 
-      var graph = new Graph();
       P2<StreetEdge> sp0 = s0.splitDestructively(sv0);
       P2<StreetEdge> sp1 = s1.splitDestructively(sv1);
 
@@ -108,14 +109,18 @@ public class LinkingTest {
   @Test
   public void testStopsLinkedIdentically() throws URISyntaxException {
     // build the graph without the added stops
-    Graph g1 = buildGraphNoTransit();
-    addRegularStopGrid(g1);
-    link(g1);
+    OtpModel otpModel1 = buildGraphNoTransit();
+    Graph g1 = otpModel1.graph;
+    TransitModel transitModel1 = otpModel1.transitModel;
+    addRegularStopGrid(g1, transitModel1);
+    link(g1, transitModel1);
 
-    Graph g2 = buildGraphNoTransit();
-    addExtraStops(g2);
-    addRegularStopGrid(g2);
-    link(g2);
+    OtpModel otpModel2 = buildGraphNoTransit();
+    Graph g2 = otpModel2.graph;
+    TransitModel transitModel2 = otpModel2.transitModel;
+    addExtraStops(g2, transitModel2);
+    addRegularStopGrid(g2, transitModel2);
+    link(g2, transitModel2);
 
     // compare the linkages
     for (TransitStopVertex ts : Iterables.filter(g1.getVertices(), TransitStopVertex.class)) {

--- a/src/test/java/org/opentripplanner/graph_builder/module/osm/PlatformLinkerTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/osm/PlatformLinkerTest.java
@@ -12,6 +12,9 @@ import org.opentripplanner.openstreetmap.OpenStreetMapProvider;
 import org.opentripplanner.routing.edgetype.AreaEdge;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
+import org.opentripplanner.routing.trippattern.Deduplicator;
+import org.opentripplanner.transit.service.StopModel;
+import org.opentripplanner.transit.service.TransitModel;
 
 public class PlatformLinkerTest {
 
@@ -23,7 +26,10 @@ public class PlatformLinkerTest {
   public void testLinkEntriesToPlatforms() {
     String stairsEndpointLabel = "osm:node:1028861028";
 
-    Graph gg = new Graph();
+    var deduplicator = new Deduplicator();
+    var stopModel = new StopModel();
+    var gg = new Graph(stopModel, deduplicator);
+    var transitModel = new TransitModel(stopModel, deduplicator);
 
     File file = new File(
       URLDecoder.decode(
@@ -34,12 +40,12 @@ public class PlatformLinkerTest {
 
     OpenStreetMapProvider provider = new OpenStreetMapProvider(file, false);
 
-    OpenStreetMapModule loader = new OpenStreetMapModule(provider);
-    loader.platformEntriesLinking = true;
-    loader.skipVisibility = false;
-    loader.setDefaultWayPropertySetSource(new DefaultWayPropertySetSource());
+    OpenStreetMapModule osmModule = new OpenStreetMapModule(provider);
+    osmModule.platformEntriesLinking = true;
+    osmModule.skipVisibility = false;
+    osmModule.setDefaultWayPropertySetSource(new DefaultWayPropertySetSource());
 
-    loader.buildGraph(gg, new HashMap<>());
+    osmModule.buildGraph(gg, transitModel, new HashMap<>());
 
     Vertex stairsEndpoint = gg.getVertex(stairsEndpointLabel);
 

--- a/src/test/java/org/opentripplanner/graph_builder/module/osm/TestIntermediatePlaces.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/osm/TestIntermediatePlaces.java
@@ -12,6 +12,7 @@ import java.util.TimeZone;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.OtpModel;
 import org.opentripplanner.graph_builder.module.FakeGraph;
 import org.opentripplanner.model.GenericLocation;
 import org.opentripplanner.model.plan.Itinerary;
@@ -31,6 +32,7 @@ import org.opentripplanner.routing.impl.GraphPathFinder;
 import org.opentripplanner.routing.spt.GraphPath;
 import org.opentripplanner.standalone.config.RouterConfig;
 import org.opentripplanner.standalone.server.Router;
+import org.opentripplanner.transit.service.TransitModel;
 
 /**
  * Tests for planning with intermediate places
@@ -50,24 +52,28 @@ public class TestIntermediatePlaces {
 
   private static Graph graph;
 
+  private static TransitModel transitModel;
+
   private static GraphPathToItineraryMapper graphPathToItineraryMapper;
 
   @BeforeAll
   public static void setUp() {
     try {
-      graph = FakeGraph.buildGraphNoTransit();
-      FakeGraph.addPerpendicularRoutes(graph);
-      FakeGraph.link(graph);
+      OtpModel otpModel = FakeGraph.buildGraphNoTransit();
+      graph = otpModel.graph;
+      transitModel = otpModel.transitModel;
+      FakeGraph.addPerpendicularRoutes(graph, transitModel);
+      FakeGraph.link(graph, transitModel);
       graph.index();
-      Router router = new Router(graph, RouterConfig.DEFAULT, Metrics.globalRegistry);
+      Router router = new Router(graph, transitModel, RouterConfig.DEFAULT, Metrics.globalRegistry);
       router.startup();
       TestIntermediatePlaces.graphPathFinder = new GraphPathFinder(router);
-      timeZone = graph.getTimeZone();
+      timeZone = transitModel.getTimeZone();
 
       graphPathToItineraryMapper =
         new GraphPathToItineraryMapper(
-          graph.getTimeZone(),
-          new AlertToLegMapper(graph.getTransitAlertService()),
+          transitModel.getTimeZone(),
+          new AlertToLegMapper(transitModel.getTransitAlertService()),
           graph.streetNotesService,
           graph.ellipsoidToGeoidDifference
         );

--- a/src/test/java/org/opentripplanner/graph_builder/module/osm/TriangleInequalityTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/osm/TriangleInequalityTest.java
@@ -9,7 +9,6 @@ import java.io.File;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,10 +28,14 @@ import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.routing.spt.DominanceFunction;
 import org.opentripplanner.routing.spt.GraphPath;
 import org.opentripplanner.routing.spt.ShortestPathTree;
+import org.opentripplanner.routing.trippattern.Deduplicator;
+import org.opentripplanner.transit.service.StopModel;
+import org.opentripplanner.transit.service.TransitModel;
 
 public class TriangleInequalityTest {
 
   private static Graph graph;
+  private static TransitModel transitModel;
 
   private Vertex start;
   private Vertex end;
@@ -40,7 +43,10 @@ public class TriangleInequalityTest {
   @BeforeAll
   public static void onlyOnce() {
     HashMap<Class<?>, Object> extra = new HashMap<>();
-    graph = new Graph();
+    var deduplicator = new Deduplicator();
+    var stopModel = new StopModel();
+    graph = new Graph(stopModel, deduplicator);
+    transitModel = new TransitModel(stopModel, deduplicator);
 
     File file = new File(
       URLDecoder.decode(
@@ -51,9 +57,9 @@ public class TriangleInequalityTest {
     DataSource source = new FileDataSource(file, FileType.OSM);
     OpenStreetMapProvider provider = new OpenStreetMapProvider(source, true);
 
-    OpenStreetMapModule loader = new OpenStreetMapModule(provider);
-    loader.setDefaultWayPropertySetSource(new DefaultWayPropertySetSource());
-    loader.buildGraph(graph, extra);
+    OpenStreetMapModule osmModule = new OpenStreetMapModule(provider);
+    osmModule.setDefaultWayPropertySetSource(new DefaultWayPropertySetSource());
+    osmModule.buildGraph(graph, transitModel, extra);
   }
 
   @BeforeEach

--- a/src/test/java/org/opentripplanner/graph_builder/module/osm/UnconnectedAreasTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/osm/UnconnectedAreasTest.java
@@ -17,7 +17,10 @@ import org.opentripplanner.openstreetmap.OpenStreetMapProvider;
 import org.opentripplanner.routing.edgetype.StreetVehicleParkingLink;
 import org.opentripplanner.routing.edgetype.VehicleParkingEdge;
 import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.routing.trippattern.Deduplicator;
 import org.opentripplanner.routing.vertextype.VehicleParkingEntranceVertex;
+import org.opentripplanner.transit.service.StopModel;
+import org.opentripplanner.transit.service.TransitModel;
 
 public class UnconnectedAreasTest {
 
@@ -144,7 +147,10 @@ public class UnconnectedAreasTest {
   }
 
   private Graph buildOSMGraph(String osmFileName, DataImportIssueStore issueStore) {
-    Graph graph = new Graph();
+    var deduplicator = new Deduplicator();
+    var stopModel = new StopModel();
+    var graph = new Graph(stopModel, deduplicator);
+    var transitModel = new TransitModel(stopModel, deduplicator);
     var fileUrl = getClass().getResource(osmFileName);
     Assertions.assertNotNull(fileUrl);
     File file = new File(fileUrl.getFile());
@@ -155,10 +161,10 @@ public class UnconnectedAreasTest {
     loader.staticParkAndRide = true;
     loader.staticBikeParkAndRide = true;
 
-    loader.buildGraph(graph, new HashMap<>(), issueStore);
+    loader.buildGraph(graph, transitModel, new HashMap<>(), issueStore);
 
     StreetLinkerModule streetLinkerModule = new StreetLinkerModule();
-    streetLinkerModule.buildGraph(graph, new HashMap<>(), issueStore);
+    streetLinkerModule.buildGraph(graph, transitModel, new HashMap<>(), issueStore);
 
     return graph;
   }

--- a/src/test/java/org/opentripplanner/graph_builder/module/osm/UnroutableTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/osm/UnroutableTest.java
@@ -20,6 +20,9 @@ import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.routing.spt.GraphPath;
 import org.opentripplanner.routing.spt.ShortestPathTree;
+import org.opentripplanner.routing.trippattern.Deduplicator;
+import org.opentripplanner.transit.service.StopModel;
+import org.opentripplanner.transit.service.TransitModel;
 
 /**
  * Verify that OSM ways that represent proposed or as yet unbuilt roads are not used for routing.
@@ -30,17 +33,23 @@ import org.opentripplanner.routing.spt.ShortestPathTree;
  */
 public class UnroutableTest {
 
-  private final Graph graph = new Graph();
+  private Graph graph;
+  private TransitModel transitModel;
 
   @BeforeEach
   public void setUp() throws Exception {
+    var deduplicator = new Deduplicator();
+    var stopModel = new StopModel();
+    graph = new Graph(stopModel, deduplicator);
+    transitModel = new TransitModel(stopModel, deduplicator);
+
     URL osmDataUrl = getClass().getResource("bridge_construction.osm.pbf");
     File osmDataFile = new File(URLDecoder.decode(osmDataUrl.getFile(), StandardCharsets.UTF_8));
     OpenStreetMapProvider provider = new OpenStreetMapProvider(osmDataFile, true);
     OpenStreetMapModule osmBuilder = new OpenStreetMapModule(provider);
     osmBuilder.setDefaultWayPropertySetSource(new DefaultWayPropertySetSource());
     HashMap<Class<?>, Object> extra = Maps.newHashMap();
-    osmBuilder.buildGraph(graph, extra); // TODO get rid of this "extra" thing
+    osmBuilder.buildGraph(graph, transitModel, extra); // TODO get rid of this "extra" thing
   }
 
   /**

--- a/src/test/java/org/opentripplanner/model/TimetableSnapshotTest.java
+++ b/src/test/java/org/opentripplanner/model/TimetableSnapshotTest.java
@@ -18,10 +18,11 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.ConstantsForTests;
+import org.opentripplanner.OtpModel;
 import org.opentripplanner.model.calendar.ServiceDate;
-import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.trippattern.TripTimes;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.updater.stoptime.BackwardsDelayPropagationType;
 
 public class TimetableSnapshotTest {
@@ -32,12 +33,13 @@ public class TimetableSnapshotTest {
 
   @BeforeAll
   public static void setUp() throws Exception {
-    Graph graph = ConstantsForTests.buildGtfsGraph(ConstantsForTests.FAKE_GTFS);
+    OtpModel otpModel = ConstantsForTests.buildGtfsGraph(ConstantsForTests.FAKE_GTFS);
+    TransitModel transitModel = otpModel.transitModel;
 
-    feedId = graph.getFeedIds().iterator().next();
+    feedId = transitModel.getFeedIds().iterator().next();
 
     patternIndex = new HashMap<>();
-    for (TripPattern tripPattern : graph.tripPatternForId.values()) {
+    for (TripPattern tripPattern : transitModel.tripPatternForId.values()) {
       tripPattern
         .scheduledTripsAsStream()
         .forEach(trip -> patternIndex.put(trip.getId(), tripPattern));

--- a/src/test/java/org/opentripplanner/model/TimetableTest.java
+++ b/src/test/java/org/opentripplanner/model/TimetableTest.java
@@ -18,6 +18,7 @@ import java.util.TimeZone;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.ConstantsForTests;
+import org.opentripplanner.OtpModel;
 import org.opentripplanner.model.calendar.ServiceDate;
 import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.graph.Graph;
@@ -26,6 +27,7 @@ import org.opentripplanner.routing.spt.GraphPath;
 import org.opentripplanner.routing.spt.ShortestPathTree;
 import org.opentripplanner.routing.trippattern.RealTimeState;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.updater.stoptime.BackwardsDelayPropagationType;
 import org.opentripplanner.util.TestUtils;
 
@@ -34,6 +36,7 @@ public class TimetableTest {
   private static final TimeZone timeZone = TimeZone.getTimeZone("America/New_York");
   private static final ServiceDate serviceDate = new ServiceDate(2009, 8, 7);
   private static Graph graph;
+  private static TransitModel transitModel;
   private static Map<FeedScopedId, TripPattern> patternIndex;
   private static TripPattern pattern;
   private static Timetable timetable;
@@ -41,12 +44,14 @@ public class TimetableTest {
 
   @BeforeAll
   public static void setUp() throws Exception {
-    graph = ConstantsForTests.buildGtfsGraph(ConstantsForTests.FAKE_GTFS);
+    OtpModel otpModel = ConstantsForTests.buildGtfsGraph(ConstantsForTests.FAKE_GTFS);
+    graph = otpModel.graph;
+    transitModel = otpModel.transitModel;
 
-    feedId = graph.getFeedIds().stream().findFirst().get();
+    feedId = transitModel.getFeedIds().stream().findFirst().get();
     patternIndex = new HashMap<>();
 
-    for (TripPattern pattern : graph.tripPatternForId.values()) {
+    for (TripPattern pattern : transitModel.tripPatternForId.values()) {
       pattern.scheduledTripsAsStream().forEach(trip -> patternIndex.put(trip.getId(), pattern));
     }
 

--- a/src/test/java/org/opentripplanner/routing/algorithm/BicycleParkAndRideTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/BicycleParkAndRideTest.java
@@ -18,51 +18,51 @@ public class BicycleParkAndRideTest extends ParkAndRideTest {
 
   @BeforeEach
   public void setUp() throws Exception {
-    graph =
-      graphOf(
-        new Builder() {
-          @Override
-          public void build() {
-            A = intersection("A", 47.500, 19.000);
-            B = intersection("B", 47.510, 19.000);
-            C = intersection("C", 47.520, 19.000);
-            D = intersection("D", 47.530, 19.000);
-            E = intersection("E", 47.540, 19.000);
+    var otpModel = graphOf(
+      new Builder() {
+        @Override
+        public void build() {
+          A = intersection("A", 47.500, 19.000);
+          B = intersection("B", 47.510, 19.000);
+          C = intersection("C", 47.520, 19.000);
+          D = intersection("D", 47.530, 19.000);
+          E = intersection("E", 47.540, 19.000);
 
-            street(A, B, 87, StreetTraversalPermission.ALL, StreetTraversalPermission.ALL);
-            street(B, C, 87, StreetTraversalPermission.PEDESTRIAN);
-            street(C, D, 87, StreetTraversalPermission.PEDESTRIAN);
-            street(D, E, 87, StreetTraversalPermission.ALL);
+          street(A, B, 87, StreetTraversalPermission.ALL, StreetTraversalPermission.ALL);
+          street(B, C, 87, StreetTraversalPermission.PEDESTRIAN);
+          street(C, D, 87, StreetTraversalPermission.PEDESTRIAN);
+          street(D, E, 87, StreetTraversalPermission.ALL);
 
-            vehicleParking(
-              "AllPark",
-              47.500,
-              19.001,
-              true,
-              true,
-              List.of(vehicleParkingEntrance(A, "All Park Entrance", true, true))
-            );
+          vehicleParking(
+            "AllPark",
+            47.500,
+            19.001,
+            true,
+            true,
+            List.of(vehicleParkingEntrance(A, "All Park Entrance", true, true))
+          );
 
-            vehicleParking(
-              "BikePark",
-              47.520,
-              19.001,
-              true,
-              false,
-              List.of(vehicleParkingEntrance(C, "BikePark Entrance", false, true))
-            );
+          vehicleParking(
+            "BikePark",
+            47.520,
+            19.001,
+            true,
+            false,
+            List.of(vehicleParkingEntrance(C, "BikePark Entrance", false, true))
+          );
 
-            vehicleParking(
-              "CarPark",
-              47.530,
-              19.001,
-              false,
-              true,
-              List.of(vehicleParkingEntrance(D, "CarPark Entrance", true, true))
-            );
-          }
+          vehicleParking(
+            "CarPark",
+            47.530,
+            19.001,
+            false,
+            true,
+            List.of(vehicleParkingEntrance(D, "CarPark Entrance", true, true))
+          );
         }
-      );
+      }
+    );
+    graph = otpModel.graph;
   }
 
   // Verify that it is not possible to park at a car-only park

--- a/src/test/java/org/opentripplanner/routing/algorithm/BikeRentalTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/BikeRentalTest.java
@@ -54,39 +54,39 @@ public class BikeRentalTest extends GraphRoutingTest {
     //   D <-> E1
     //   D <-> T2
 
-    graph =
-      graphOf(
-        new Builder() {
-          @Override
-          public void build() {
-            S1 = stop("S1", 47.500, 19.001);
-            A = intersection("A", 47.500, 19.000);
-            B = intersection("B", 47.510, 19.000);
-            C = intersection("C", 47.520, 19.000);
-            D = intersection("D", 47.530, 19.000);
-            E1 = entrance("E1", 47.530, 19.001);
+    var otpModel = graphOf(
+      new Builder() {
+        @Override
+        public void build() {
+          S1 = stop("S1", 47.500, 19.001);
+          A = intersection("A", 47.500, 19.000);
+          B = intersection("B", 47.510, 19.000);
+          C = intersection("C", 47.520, 19.000);
+          D = intersection("D", 47.530, 19.000);
+          E1 = entrance("E1", 47.530, 19.001);
 
-            T1 = streetLocation("T1", 47.500, 18.999, false);
-            T2 = streetLocation("T1", 47.530, 18.999, true);
+          T1 = streetLocation("T1", 47.500, 18.999, false);
+          T2 = streetLocation("T1", 47.530, 18.999, true);
 
-            B1 = vehicleRentalStation("B1", 47.510, 19.001);
-            B2 = vehicleRentalStation("B2", 47.520, 19.001);
+          B1 = vehicleRentalStation("B1", 47.510, 19.001);
+          B2 = vehicleRentalStation("B2", 47.520, 19.001);
 
-            biLink(A, S1);
-            biLink(D, E1);
+          biLink(A, S1);
+          biLink(D, E1);
 
-            biLink(B, B1);
-            biLink(C, B2);
+          biLink(B, B1);
+          biLink(C, B2);
 
-            link(T1, A);
-            link(D, T2);
+          link(T1, A);
+          link(D, T2);
 
-            SE1 = street(A, B, 50, StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE);
-            SE2 = street(B, C, 1000, StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE);
-            SE3 = street(C, D, 50, StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE);
-          }
+          SE1 = street(A, B, 50, StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE);
+          SE2 = street(B, C, 1000, StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE);
+          SE3 = street(C, D, 50, StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE);
         }
-      );
+      }
+    );
+    graph = otpModel.graph;
   }
 
   // This tests exists to test if the cost of walking with a bike changes

--- a/src/test/java/org/opentripplanner/routing/algorithm/BikeWalkingTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/BikeWalkingTest.java
@@ -301,35 +301,35 @@ public class BikeWalkingTest extends GraphRoutingTest {
     //
     //   TS1 <-> A <-> B <-> C <-> D <-> E <-> F <-> E1 <-> S2
 
-    graph =
-      graphOf(
-        new Builder() {
-          @Override
-          public void build() {
-            S1 = stop("S1", 0, 45);
-            S2 = stop("S2", 0.005, 45);
-            E1 = entrance("E1", 0.004, 45);
-            A = intersection("A", 0.001, 45);
-            B = intersection("B", 0.002, 45);
-            C = intersection("C", 0.003, 45);
-            D = intersection("D", 0.004, 45);
-            E = intersection("E", 0.005, 45);
-            F = intersection("F", 0.006, 45);
-            Q = intersection("Q", 0.009, 45);
+    var otpModel = graphOf(
+      new Builder() {
+        @Override
+        public void build() {
+          S1 = stop("S1", 0, 45);
+          S2 = stop("S2", 0.005, 45);
+          E1 = entrance("E1", 0.004, 45);
+          A = intersection("A", 0.001, 45);
+          B = intersection("B", 0.002, 45);
+          C = intersection("C", 0.003, 45);
+          D = intersection("D", 0.004, 45);
+          E = intersection("E", 0.005, 45);
+          F = intersection("F", 0.006, 45);
+          Q = intersection("Q", 0.009, 45);
 
-            elevator(StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE, D, Q);
+          elevator(StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE, D, Q);
 
-            biLink(A, S1);
-            AB = street(A, B, 100, StreetTraversalPermission.PEDESTRIAN);
-            BC = street(B, C, 100, StreetTraversalPermission.PEDESTRIAN);
-            CD = street(C, D, 100, StreetTraversalPermission.ALL);
-            DE = street(D, E, 100, StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE);
-            EF = street(E, F, 100, StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE);
-            biLink(F, E1);
-            pathway(E1, S2, 60, 100);
-          }
+          biLink(A, S1);
+          AB = street(A, B, 100, StreetTraversalPermission.PEDESTRIAN);
+          BC = street(B, C, 100, StreetTraversalPermission.PEDESTRIAN);
+          CD = street(C, D, 100, StreetTraversalPermission.ALL);
+          DE = street(D, E, 100, StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE);
+          EF = street(E, F, 100, StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE);
+          biLink(F, E1);
+          pathway(E1, S2, 60, 100);
         }
-      );
+      }
+    );
+    graph = otpModel.graph;
   }
 
   private void assertBikePath(Vertex fromVertex, Vertex toVertex, String... descriptor) {

--- a/src/test/java/org/opentripplanner/routing/algorithm/CarParkAndRideTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/CarParkAndRideTest.java
@@ -20,69 +20,69 @@ public class CarParkAndRideTest extends ParkAndRideTest {
 
   @BeforeEach
   public void setUp() throws Exception {
-    graph =
-      graphOf(
-        new Builder() {
-          @Override
-          public void build() {
-            A = intersection("A", 47.500, 19.000);
-            B = intersection("B", 47.510, 19.000);
-            C = intersection("C", 47.520, 19.000);
-            D = intersection("D", 47.530, 19.000);
-            E = intersection("E", 47.540, 19.000);
-            F = intersection("F", 47.550, 19.000);
+    var otpModel = graphOf(
+      new Builder() {
+        @Override
+        public void build() {
+          A = intersection("A", 47.500, 19.000);
+          B = intersection("B", 47.510, 19.000);
+          C = intersection("C", 47.520, 19.000);
+          D = intersection("D", 47.530, 19.000);
+          E = intersection("E", 47.540, 19.000);
+          F = intersection("F", 47.550, 19.000);
 
-            street(A, B, 87, StreetTraversalPermission.ALL);
-            street(B, C, 87, StreetTraversalPermission.PEDESTRIAN);
-            street(C, D, 87, StreetTraversalPermission.PEDESTRIAN);
-            street(D, E, 87, StreetTraversalPermission.PEDESTRIAN);
-            street(E, F, 87, StreetTraversalPermission.ALL);
+          street(A, B, 87, StreetTraversalPermission.ALL);
+          street(B, C, 87, StreetTraversalPermission.PEDESTRIAN);
+          street(C, D, 87, StreetTraversalPermission.PEDESTRIAN);
+          street(D, E, 87, StreetTraversalPermission.PEDESTRIAN);
+          street(E, F, 87, StreetTraversalPermission.ALL);
 
-            vehicleParking(
-              "CarPark #1",
-              47.505,
-              19.001,
-              false,
-              true,
-              List.of(
-                vehicleParkingEntrance(A, "CarPark #1 Entrance A", false, true),
-                vehicleParkingEntrance(B, "CarPark #1 Entrance B", true, false)
-              ),
-              "tag1",
-              "tag2",
-              "tag3"
-            );
+          vehicleParking(
+            "CarPark #1",
+            47.505,
+            19.001,
+            false,
+            true,
+            List.of(
+              vehicleParkingEntrance(A, "CarPark #1 Entrance A", false, true),
+              vehicleParkingEntrance(B, "CarPark #1 Entrance B", true, false)
+            ),
+            "tag1",
+            "tag2",
+            "tag3"
+          );
 
-            vehicleParking(
-              "AllPark",
-              47.520,
-              19.001,
-              true,
-              true,
-              List.of(vehicleParkingEntrance(C, "AllPark Entrance", true, true))
-            );
+          vehicleParking(
+            "AllPark",
+            47.520,
+            19.001,
+            true,
+            true,
+            List.of(vehicleParkingEntrance(C, "AllPark Entrance", true, true))
+          );
 
-            vehicleParking(
-              "CarPark #2",
-              47.530,
-              19.001,
-              false,
-              true,
-              true,
-              List.of(vehicleParkingEntrance(D, "CarPark #2 Entrance", true, true))
-            );
+          vehicleParking(
+            "CarPark #2",
+            47.530,
+            19.001,
+            false,
+            true,
+            true,
+            List.of(vehicleParkingEntrance(D, "CarPark #2 Entrance", true, true))
+          );
 
-            vehicleParking(
-              "BikePark",
-              47.540,
-              19.000,
-              true,
-              false,
-              List.of(vehicleParkingEntrance(E, "BikePark Entrance", false, true))
-            );
-          }
+          vehicleParking(
+            "BikePark",
+            47.540,
+            19.000,
+            true,
+            false,
+            List.of(vehicleParkingEntrance(E, "BikePark Entrance", false, true))
+          );
         }
-      );
+      }
+    );
+    graph = otpModel.graph;
   }
 
   @Test

--- a/src/test/java/org/opentripplanner/routing/algorithm/CarPickupTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/CarPickupTest.java
@@ -110,29 +110,29 @@ public class CarPickupTest extends GraphRoutingTest {
     //   A <-> B <-> C <-> D <-> E
     //   TS1 <-^           ^-> TE1
 
-    graph =
-      graphOf(
-        new Builder() {
-          @Override
-          public void build() {
-            S1 = stop("S1", 0, 45);
-            E1 = entrance("E1", 0.004, 45);
-            A = intersection("A", 0.001, 45);
-            B = intersection("B", 0.002, 45);
-            C = intersection("C", 0.003, 45);
-            D = intersection("D", 0.004, 45);
-            E = intersection("E", 0.005, 45);
+    var otpModel = graphOf(
+      new Builder() {
+        @Override
+        public void build() {
+          S1 = stop("S1", 0, 45);
+          E1 = entrance("E1", 0.004, 45);
+          A = intersection("A", 0.001, 45);
+          B = intersection("B", 0.002, 45);
+          C = intersection("C", 0.003, 45);
+          D = intersection("D", 0.004, 45);
+          E = intersection("E", 0.005, 45);
 
-            biLink(B, S1);
-            biLink(C, E1);
+          biLink(B, S1);
+          biLink(C, E1);
 
-            street(A, B, 87, StreetTraversalPermission.PEDESTRIAN);
-            street(B, C, 87, StreetTraversalPermission.CAR);
-            street(C, D, 87, StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE);
-            street(D, E, 87, StreetTraversalPermission.PEDESTRIAN);
-          }
+          street(A, B, 87, StreetTraversalPermission.PEDESTRIAN);
+          street(B, C, 87, StreetTraversalPermission.CAR);
+          street(C, D, 87, StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE);
+          street(D, E, 87, StreetTraversalPermission.PEDESTRIAN);
         }
-      );
+      }
+    );
+    graph = otpModel.graph;
   }
 
   private void assertPath(Vertex fromVertex, Vertex toVertex, String descriptor) {

--- a/src/test/java/org/opentripplanner/routing/algorithm/FaresTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/FaresTest.java
@@ -12,6 +12,7 @@ import java.util.Comparator;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.ConstantsForTests;
+import org.opentripplanner.OtpModel;
 import org.opentripplanner.model.GenericLocation;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.routing.algorithm.raptoradapter.router.AdditionalSearchDays;
@@ -27,6 +28,7 @@ import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.standalone.config.RouterConfig;
 import org.opentripplanner.standalone.server.Router;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.util.TestUtils;
 
 public class FaresTest {
@@ -35,11 +37,13 @@ public class FaresTest {
 
   @Test
   public void testBasic() {
-    var graph = ConstantsForTests.buildGtfsGraph(ConstantsForTests.CALTRAIN_GTFS);
+    OtpModel otpModel = ConstantsForTests.buildGtfsGraph(ConstantsForTests.CALTRAIN_GTFS);
+    var graph = otpModel.graph;
+    var transitModel = otpModel.transitModel;
 
-    var feedId = graph.getFeedIds().iterator().next();
+    var feedId = transitModel.getFeedIds().iterator().next();
 
-    var router = new Router(graph, RouterConfig.DEFAULT, Metrics.globalRegistry);
+    var router = new Router(graph, transitModel, RouterConfig.DEFAULT, Metrics.globalRegistry);
     router.startup();
 
     var start = TestUtils.dateInstant("America/Los_Angeles", 2009, 8, 7, 12, 0, 0);
@@ -52,10 +56,12 @@ public class FaresTest {
 
   @Test
   public void testPortland() {
-    Graph graph = ConstantsForTests.getInstance().getCachedPortlandGraph();
-    var portlandId = graph.getFeedIds().iterator().next();
+    OtpModel otpModel = ConstantsForTests.getInstance().getCachedPortlandGraph();
+    Graph graph = otpModel.graph;
+    TransitModel transitModel = otpModel.transitModel;
+    var portlandId = transitModel.getFeedIds().iterator().next();
 
-    var router = new Router(graph, RouterConfig.DEFAULT, Metrics.globalRegistry);
+    var router = new Router(graph, transitModel, RouterConfig.DEFAULT, Metrics.globalRegistry);
     router.startup();
 
     // from zone 3 to zone 2
@@ -103,18 +109,20 @@ public class FaresTest {
 
   @Test
   public void testKCM() {
-    Graph graph = ConstantsForTests.buildGtfsGraph(
+    OtpModel otpModel = ConstantsForTests.buildGtfsGraph(
       ConstantsForTests.KCM_GTFS,
       new SeattleFareServiceFactory()
     );
+    Graph graph = otpModel.graph;
+    TransitModel transitModel = otpModel.transitModel;
 
-    assertEquals("America/Los_Angeles", graph.getTimeZone().getID());
+    assertEquals("America/Los_Angeles", transitModel.getTimeZone().getID());
 
-    assertEquals(1, graph.getFeedIds().size());
+    assertEquals(1, transitModel.getFeedIds().size());
 
-    var feedId = graph.getFeedIds().iterator().next();
+    var feedId = transitModel.getFeedIds().iterator().next();
 
-    var router = new Router(graph, RouterConfig.DEFAULT, Metrics.globalRegistry);
+    var router = new Router(graph, transitModel, RouterConfig.DEFAULT, Metrics.globalRegistry);
     router.startup();
 
     var from = GenericLocation.fromStopId("Origin", feedId, "2010");
@@ -141,10 +149,12 @@ public class FaresTest {
 
   @Test
   public void testFareComponent() {
-    Graph graph = ConstantsForTests.buildGtfsGraph(ConstantsForTests.FARE_COMPONENT_GTFS);
-    String feedId = graph.getFeedIds().iterator().next();
+    OtpModel otpModel = ConstantsForTests.buildGtfsGraph(ConstantsForTests.FARE_COMPONENT_GTFS);
+    Graph graph = otpModel.graph;
+    TransitModel transitModel = otpModel.transitModel;
+    String feedId = transitModel.getFeedIds().iterator().next();
 
-    var router = new Router(graph, RouterConfig.DEFAULT, Metrics.globalRegistry);
+    var router = new Router(graph, transitModel, RouterConfig.DEFAULT, Metrics.globalRegistry);
     router.startup();
 
     Money tenUSD = new Money(USD, 1000);

--- a/src/test/java/org/opentripplanner/routing/algorithm/GraphPathTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/GraphPathTest.java
@@ -23,7 +23,10 @@ import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.routing.spt.GraphPath;
 import org.opentripplanner.routing.spt.ShortestPathTree;
+import org.opentripplanner.routing.trippattern.Deduplicator;
 import org.opentripplanner.routing.vertextype.TransitStopVertex;
+import org.opentripplanner.transit.service.StopModel;
+import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.util.TestUtils;
 
 /**
@@ -33,19 +36,24 @@ import org.opentripplanner.util.TestUtils;
 public class GraphPathTest {
 
   private Graph graph;
+  private TransitModel transitModel;
 
   @BeforeEach
   public void setUp() throws Exception {
     GtfsContext context = contextBuilder(ConstantsForTests.FAKE_GTFS).build();
-    graph = new Graph();
+    var deduplicator = new Deduplicator();
+    var stopModel = new StopModel();
+    graph = new Graph(stopModel, deduplicator);
+    transitModel = new TransitModel(stopModel, deduplicator);
+
     GeometryAndBlockProcessor hl = new GeometryAndBlockProcessor(context);
-    hl.run(graph);
-    graph.putService(CalendarServiceData.class, context.getCalendarServiceData());
+    hl.run(graph, transitModel);
+    transitModel.putService(CalendarServiceData.class, context.getCalendarServiceData());
   }
 
   @Test
   public void testGraphPathOptimize() {
-    String feedId = graph.getFeedIds().iterator().next();
+    String feedId = transitModel.getFeedIds().iterator().next();
 
     Vertex stop_a = graph.getVertex(feedId + ":A");
     Vertex stop_c = graph.getVertex(feedId + ":C");

--- a/src/test/java/org/opentripplanner/routing/algorithm/StreetModeLinkingTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/StreetModeLinkingTest.java
@@ -18,6 +18,7 @@ import org.opentripplanner.routing.core.TemporaryVerticesContainer;
 import org.opentripplanner.routing.edgetype.StreetTraversalPermission;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.transit.model._data.TransitModelForTest;
+import org.opentripplanner.transit.service.TransitModel;
 
 /**
  * This tests linking of GenericLocations to streets for each StreetMode. The test has 5 parallel
@@ -28,6 +29,7 @@ import org.opentripplanner.transit.model._data.TransitModelForTest;
 public class StreetModeLinkingTest extends GraphRoutingTest {
 
   private Graph graph;
+  private TransitModel transitModel;
 
   @Test
   public void testCarLinking() {
@@ -109,55 +111,55 @@ public class StreetModeLinkingTest extends GraphRoutingTest {
 
   @BeforeEach
   protected void setUp() throws Exception {
-    graph =
-      graphOf(
-        new GraphRoutingTest.Builder() {
-          @Override
-          public void build() {
-            street(
-              intersection("A1", 47.5000, 19.00),
-              intersection("A2", 47.5020, 19.00),
-              100,
-              StreetTraversalPermission.CAR
-            );
+    var otpModel = graphOf(
+      new GraphRoutingTest.Builder() {
+        @Override
+        public void build() {
+          street(
+            intersection("A1", 47.5000, 19.00),
+            intersection("A2", 47.5020, 19.00),
+            100,
+            StreetTraversalPermission.CAR
+          );
 
-            street(
-              intersection("B1", 47.5000, 19.01),
-              intersection("B2", 47.5020, 19.01),
-              100,
-              StreetTraversalPermission.ALL
-            );
+          street(
+            intersection("B1", 47.5000, 19.01),
+            intersection("B2", 47.5020, 19.01),
+            100,
+            StreetTraversalPermission.ALL
+          );
 
-            street(
-              intersection("C1", 47.5000, 19.02),
-              intersection("C2", 47.5020, 19.02),
-              100,
-              StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE
-            );
+          street(
+            intersection("C1", 47.5000, 19.02),
+            intersection("C2", 47.5020, 19.02),
+            100,
+            StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE
+          );
 
-            street(
-              intersection("D1", 47.500, 19.03),
-              intersection("D2", 47.502, 19.03),
-              100,
-              StreetTraversalPermission.PEDESTRIAN
-            )
-              .setWheelchairAccessible(false);
+          street(
+            intersection("D1", 47.500, 19.03),
+            intersection("D2", 47.502, 19.03),
+            100,
+            StreetTraversalPermission.PEDESTRIAN
+          )
+            .setWheelchairAccessible(false);
 
-            street(
-              intersection("E1", 47.500, 19.04),
-              intersection("E2", 47.502, 19.04),
-              100,
-              StreetTraversalPermission.BICYCLE_AND_CAR
-            );
+          street(
+            intersection("E1", 47.500, 19.04),
+            intersection("E2", 47.502, 19.04),
+            100,
+            StreetTraversalPermission.BICYCLE_AND_CAR
+          );
 
-            stop("STOP", 47.501, 19.04);
-          }
+          stop("STOP", 47.501, 19.04);
         }
-      );
+      }
+    );
+    graph = otpModel.graph;
 
     graph.hasStreets = true;
-    graph.index();
-    new StreetLinkerModule().buildGraph(graph, null, new DataImportIssueStore(false));
+    transitModel = otpModel.transitModel;
+    new StreetLinkerModule().buildGraph(graph, transitModel, null, new DataImportIssueStore(false));
   }
 
   private void assertLinkedFromTo(

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/ElevationSnapshotTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/ElevationSnapshotTest.java
@@ -11,13 +11,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.ResourceLock;
 import org.junit.jupiter.api.parallel.Resources;
 import org.opentripplanner.ConstantsForTests;
+import org.opentripplanner.OtpModel;
 import org.opentripplanner.model.GenericLocation;
 import org.opentripplanner.routing.api.request.RequestModes;
 import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.routing.core.BicycleOptimizeType;
 import org.opentripplanner.routing.error.RoutingValidationException;
-import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.transit.model.network.MainAndSubMode;
 
 @ExtendWith(SnapshotExtension.class)
@@ -147,7 +147,7 @@ public class ElevationSnapshotTest extends SnapshotTestBase {
   }
 
   @Override
-  protected Graph getGraph() {
+  protected OtpModel getGraph() {
     return ConstantsForTests.getInstance().getCachedPortlandGraphWithElevation();
   }
 }

--- a/src/test/java/org/opentripplanner/routing/core/StateEditorTest.java
+++ b/src/test/java/org/opentripplanner/routing/core/StateEditorTest.java
@@ -9,8 +9,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.graph.Graph;
-import org.opentripplanner.routing.graph.GraphIndex;
 import org.opentripplanner.routing.graph.Vertex;
+import org.opentripplanner.routing.trippattern.Deduplicator;
+import org.opentripplanner.transit.service.StopModel;
 
 public class StateEditorTest {
 
@@ -35,8 +36,10 @@ public class StateEditorTest {
     RoutingRequest request = new RoutingRequest();
     request.setMode(TraverseMode.CAR);
     request.parkAndRide = true;
-    Graph graph = new Graph();
-    graph.index = new GraphIndex(graph);
+    var deduplicator = new Deduplicator();
+    var stopModel = new StopModel();
+    var graph = new Graph(stopModel, deduplicator);
+
     var temporaryVertices = new TemporaryVerticesContainer(graph, request);
     RoutingContext routingContext = new RoutingContext(request, graph, temporaryVertices);
     State state = new State(routingContext);

--- a/src/test/java/org/opentripplanner/routing/core/TemporaryVerticesContainerTest.java
+++ b/src/test/java/org/opentripplanner/routing/core/TemporaryVerticesContainerTest.java
@@ -23,16 +23,18 @@ import org.opentripplanner.routing.edgetype.TemporaryEdge;
 import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
+import org.opentripplanner.routing.trippattern.Deduplicator;
 import org.opentripplanner.routing.vertextype.IntersectionVertex;
 import org.opentripplanner.routing.vertextype.StreetVertex;
 import org.opentripplanner.routing.vertextype.TemporaryVertex;
+import org.opentripplanner.transit.service.StopModel;
 
 public class TemporaryVerticesContainerTest {
 
   private final GeometryFactory gf = GeometryUtils.getGeometryFactory();
   // Given:
   // - a graph with 3 intersections/vertexes
-  private final Graph g = new Graph();
+  private Graph g = new Graph(new StopModel(), new Deduplicator());
   private final StreetVertex a = new IntersectionVertex(g, "A", 1.0, 1.0);
   private final StreetVertex b = new IntersectionVertex(g, "B", 0.0, 1.0);
   private final StreetVertex c = new IntersectionVertex(g, "C", 1.0, 0.0);

--- a/src/test/java/org/opentripplanner/routing/edgetype/StreetEdgeCostTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/StreetEdgeCostTest.java
@@ -23,16 +23,16 @@ class StreetEdgeCostTest extends GraphRoutingTest {
   Graph graph;
 
   public StreetEdgeCostTest() {
-    graph =
-      graphOf(
-        new Builder() {
-          @Override
-          public void build() {
-            V1 = intersection("V1", 0.0, 0.0);
-            V2 = intersection("V2", 2.0, 0.0);
-          }
+    var otpModel = graphOf(
+      new Builder() {
+        @Override
+        public void build() {
+          V1 = intersection("V1", 0.0, 0.0);
+          V2 = intersection("V2", 2.0, 0.0);
         }
-      );
+      }
+    );
+    graph = otpModel.graph;
   }
 
   static Stream<Arguments> walkReluctanceCases = Stream.of(

--- a/src/test/java/org/opentripplanner/routing/edgetype/StreetEdgeSplittingTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/StreetEdgeSplittingTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.OtpModel;
 import org.opentripplanner.common.TurnRestriction;
 import org.opentripplanner.common.TurnRestrictionType;
 import org.opentripplanner.graph_builder.linking.DisposableEdgeCollection;
@@ -185,7 +186,7 @@ class StreetEdgeSplittingTest extends GraphRoutingTest {
   }
 
   private Graph graph() {
-    return graphOf(
+    OtpModel otpModel = graphOf(
       new Builder() {
         @Override
         public void build() {
@@ -199,6 +200,7 @@ class StreetEdgeSplittingTest extends GraphRoutingTest {
         }
       }
     );
+    return otpModel.graph;
   }
 
   private void assertOriginalRestrictionExists() {

--- a/src/test/java/org/opentripplanner/routing/edgetype/StreetEdgeWheelchairCostTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/StreetEdgeWheelchairCostTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.impl.PackedCoordinateSequence;
+import org.opentripplanner.OtpModel;
 import org.opentripplanner.routing.algorithm.GraphRoutingTest;
 import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.api.request.WheelchairAccessibilityRequest;
@@ -26,16 +27,16 @@ class StreetEdgeWheelchairCostTest extends GraphRoutingTest {
   Graph graph;
 
   public StreetEdgeWheelchairCostTest() {
-    graph =
-      graphOf(
-        new Builder() {
-          @Override
-          public void build() {
-            V1 = intersection("V1", 0.0, 0.0);
-            V2 = intersection("V2", 2.0, 0.0);
-          }
+    OtpModel otpModel = graphOf(
+      new Builder() {
+        @Override
+        public void build() {
+          V1 = intersection("V1", 0.0, 0.0);
+          V2 = intersection("V2", 2.0, 0.0);
         }
-      );
+      }
+    );
+    graph = otpModel.graph;
   }
 
   static Stream<Arguments> slopeCases = Stream.of(

--- a/src/test/java/org/opentripplanner/routing/edgetype/loader/GeometryAndBlockProcessorTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/loader/GeometryAndBlockProcessorTest.java
@@ -41,8 +41,11 @@ import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.routing.spt.GraphPath;
 import org.opentripplanner.routing.spt.ShortestPathTree;
+import org.opentripplanner.routing.trippattern.Deduplicator;
 import org.opentripplanner.routing.vertextype.IntersectionVertex;
 import org.opentripplanner.routing.vertextype.TransitStopVertex;
+import org.opentripplanner.transit.service.StopModel;
+import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.util.TestUtils;
 
 /**
@@ -52,14 +55,18 @@ import org.opentripplanner.util.TestUtils;
 public class GeometryAndBlockProcessorTest {
 
   private Graph graph;
+  private TransitModel transitModel;
+
   private GtfsContext context;
   private String feedId;
   private DataImportIssueStore issueStore;
 
   @BeforeEach
   public void setUp() throws Exception {
-    graph = new Graph();
-
+    var deduplicator = new Deduplicator();
+    var stopModel = new StopModel();
+    graph = new Graph(stopModel, deduplicator);
+    transitModel = new TransitModel(stopModel, deduplicator);
     this.issueStore = new DataImportIssueStore(true);
 
     context =
@@ -67,8 +74,8 @@ public class GeometryAndBlockProcessorTest {
 
     feedId = context.getFeedId().getId();
     GeometryAndBlockProcessor factory = new GeometryAndBlockProcessor(context);
-    factory.run(graph, issueStore);
-    graph.putService(CalendarServiceData.class, context.getCalendarServiceData());
+    factory.run(graph, transitModel, issueStore);
+    transitModel.putService(CalendarServiceData.class, context.getCalendarServiceData());
 
     String[] stops = {
       feedId + ":A",
@@ -128,8 +135,8 @@ public class GeometryAndBlockProcessorTest {
     StreetLinkerModule ttsnm = new StreetLinkerModule();
     //Linkers aren't run otherwise
     graph.hasStreets = true;
-    graph.hasTransit = true;
-    ttsnm.buildGraph(graph, new HashMap<>());
+    transitModel.hasTransit = true;
+    ttsnm.buildGraph(graph, transitModel, new HashMap<>());
   }
 
   @Test

--- a/src/test/java/org/opentripplanner/routing/edgetype/loader/HopFactoryTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/loader/HopFactoryTest.java
@@ -8,7 +8,6 @@ import com.google.common.collect.Lists;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -24,7 +23,10 @@ import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.routing.spt.GraphPath;
 import org.opentripplanner.routing.spt.ShortestPathTree;
+import org.opentripplanner.routing.trippattern.Deduplicator;
 import org.opentripplanner.routing.vertextype.TransitStopVertex;
+import org.opentripplanner.transit.service.StopModel;
+import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.util.TestUtils;
 
 /**
@@ -37,15 +39,20 @@ public class HopFactoryTest {
 
   private Graph graph;
 
+  private TransitModel transitModel;
+
   private String feedId;
 
   @BeforeEach
   public void setUp() throws Exception {
     GtfsContext context = contextBuilder(ConstantsForTests.FAKE_GTFS).build();
-    graph = new Graph();
+    var deduplicator = new Deduplicator();
+    var stopModel = new StopModel();
+    graph = new Graph(stopModel, deduplicator);
+    transitModel = new TransitModel(stopModel, deduplicator);
     GeometryAndBlockProcessor factory = new GeometryAndBlockProcessor(context);
-    factory.run(graph);
-    graph.putService(CalendarServiceData.class, context.getCalendarServiceData());
+    factory.run(graph, transitModel);
+    transitModel.putService(CalendarServiceData.class, context.getCalendarServiceData());
 
     feedId = context.getFeedId().getId();
   }

--- a/src/test/java/org/opentripplanner/routing/graph/EdgeTest.java
+++ b/src/test/java/org/opentripplanner/routing/graph/EdgeTest.java
@@ -2,7 +2,6 @@ package org.opentripplanner.routing.graph;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.routing.edgetype.StreetEdge;
 import org.opentripplanner.routing.edgetype.StreetTraversalPermission;

--- a/src/test/java/org/opentripplanner/routing/graphfinder/DirectGraphFinderTest.java
+++ b/src/test/java/org/opentripplanner/routing/graphfinder/DirectGraphFinderTest.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.GeometryFactory;
+import org.opentripplanner.OtpModel;
 import org.opentripplanner.common.geometry.GeometryUtils;
 import org.opentripplanner.routing.algorithm.GraphRoutingTest;
 import org.opentripplanner.routing.graph.Graph;
@@ -21,17 +22,17 @@ class DirectGraphFinderTest extends GraphRoutingTest {
 
   @BeforeEach
   protected void setUp() throws Exception {
-    graph =
-      graphOf(
-        new Builder() {
-          @Override
-          public void build() {
-            S1 = stop("S1", 47.500, 19);
-            S2 = stop("S2", 47.510, 19);
-            S3 = stop("S3", 47.520, 19);
-          }
+    OtpModel otpModel = graphOf(
+      new Builder() {
+        @Override
+        public void build() {
+          S1 = stop("S1", 47.500, 19);
+          S2 = stop("S2", 47.510, 19);
+          S3 = stop("S3", 47.520, 19);
         }
-      );
+      }
+    );
+    graph = otpModel.graph;
   }
 
   @Test

--- a/src/test/java/org/opentripplanner/routing/graphfinder/StreetGraphFinderTest.java
+++ b/src/test/java/org/opentripplanner/routing/graphfinder/StreetGraphFinderTest.java
@@ -11,7 +11,6 @@ import org.opentripplanner.model.TripPattern;
 import org.opentripplanner.routing.RoutingService;
 import org.opentripplanner.routing.algorithm.GraphRoutingTest;
 import org.opentripplanner.routing.edgetype.StreetTraversalPermission;
-import org.opentripplanner.routing.graph.GraphIndex;
 import org.opentripplanner.routing.vehicle_parking.VehicleParking;
 import org.opentripplanner.routing.vertextype.IntersectionVertex;
 import org.opentripplanner.routing.vertextype.TransitStopVertex;
@@ -37,7 +36,7 @@ class StreetGraphFinderTest extends GraphRoutingTest {
 
   @BeforeEach
   protected void setUp() throws Exception {
-    var graph = graphOf(
+    var otpModel = graphOf(
       new Builder() {
         @Override
         public void build() {
@@ -118,10 +117,11 @@ class StreetGraphFinderTest extends GraphRoutingTest {
       }
     );
 
-    graph.index = new GraphIndex(graph);
+    var graph = otpModel.graph;
+    var transitModel = otpModel.transitModel;
 
-    routingService = new RoutingService(graph);
-    transitService = new DefaultTransitService(graph);
+    routingService = new RoutingService(graph, transitModel);
+    transitService = new DefaultTransitService(transitModel);
     graphFinder = new StreetGraphFinder(graph);
   }
 

--- a/src/test/java/org/opentripplanner/routing/stoptimes/AlternativeLegsTest.java
+++ b/src/test/java/org/opentripplanner/routing/stoptimes/AlternativeLegsTest.java
@@ -29,8 +29,8 @@ class AlternativeLegsTest extends GtfsTest {
 
   @Test
   void testPreviousLegs() throws Exception {
-    var routingService = new RoutingService(graph);
-    var transitService = new DefaultTransitService(graph);
+    var routingService = new RoutingService(graph, transitModel);
+    var transitService = new DefaultTransitService(transitModel);
 
     var originalLeg = new ScheduledTransitLegReference(
       new FeedScopedId(this.feedId.getId(), "1.2"),
@@ -67,8 +67,8 @@ class AlternativeLegsTest extends GtfsTest {
 
   @Test
   void testNextLegs() throws Exception {
-    var routingService = new RoutingService(graph);
-    var transitService = new DefaultTransitService(graph);
+    var routingService = new RoutingService(graph, transitModel);
+    var transitService = new DefaultTransitService(transitModel);
 
     var originalLeg = new ScheduledTransitLegReference(
       new FeedScopedId(this.feedId.getId(), "2.2"),

--- a/src/test/java/org/opentripplanner/routing/street/BicycleRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/street/BicycleRoutingTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Geometry;
 import org.opentripplanner.ConstantsForTests;
+import org.opentripplanner.OtpModel;
 import org.opentripplanner.model.GenericLocation;
 import org.opentripplanner.routing.algorithm.mapping.AlertToLegMapper;
 import org.opentripplanner.routing.algorithm.mapping.GraphPathToItineraryMapper;
@@ -21,12 +22,20 @@ import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.impl.GraphPathFinder;
 import org.opentripplanner.standalone.config.RouterConfig;
 import org.opentripplanner.standalone.server.Router;
+import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.util.PolylineEncoder;
 
 public class BicycleRoutingTest {
 
   static final Instant dateTime = Instant.now();
-  Graph herrenbergGraph = ConstantsForTests.buildOsmGraph(ConstantsForTests.HERRENBERG_OSM);
+  Graph herrenbergGraph;
+  TransitModel herrenbergTransitModel;
+
+  {
+    OtpModel otpModel = ConstantsForTests.buildOsmGraph(ConstantsForTests.HERRENBERG_OSM);
+    herrenbergGraph = otpModel.graph;
+    herrenbergTransitModel = otpModel.transitModel;
+  }
 
   /**
    * https://www.openstreetmap.org/way/22392895 is access=destination which means that both bicycles
@@ -37,10 +46,20 @@ public class BicycleRoutingTest {
     var mozartStr = new GenericLocation(48.59713, 8.86107);
     var fritzLeharStr = new GenericLocation(48.59696, 8.85806);
 
-    var polyline1 = computePolyline(herrenbergGraph, mozartStr, fritzLeharStr);
+    var polyline1 = computePolyline(
+      herrenbergGraph,
+      herrenbergTransitModel,
+      mozartStr,
+      fritzLeharStr
+    );
     assertThatPolylinesAreEqual(polyline1, "_srgHutau@h@B|@Jf@BdAG?\\JT@jA?DSp@_@fFsAT{@DBpC");
 
-    var polyline2 = computePolyline(herrenbergGraph, fritzLeharStr, mozartStr);
+    var polyline2 = computePolyline(
+      herrenbergGraph,
+      herrenbergTransitModel,
+      fritzLeharStr,
+      mozartStr
+    );
     assertThatPolylinesAreEqual(polyline2, "{qrgH{aau@CqCz@ErAU^gFRq@?EAkAKUeACg@A_AM_AEDQF@H?");
   }
 
@@ -53,14 +72,29 @@ public class BicycleRoutingTest {
     var schiessmauer = new GenericLocation(48.59737, 8.86350);
     var zeppelinStr = new GenericLocation(48.59972, 8.86239);
 
-    var polyline1 = computePolyline(herrenbergGraph, schiessmauer, zeppelinStr);
+    var polyline1 = computePolyline(
+      herrenbergGraph,
+      herrenbergTransitModel,
+      schiessmauer,
+      zeppelinStr
+    );
     assertThatPolylinesAreEqual(polyline1, "otrgH{cbu@S_AU_AmAdAyApAGDs@h@_@\\_ClBe@^?S");
 
-    var polyline2 = computePolyline(herrenbergGraph, zeppelinStr, schiessmauer);
+    var polyline2 = computePolyline(
+      herrenbergGraph,
+      herrenbergTransitModel,
+      zeppelinStr,
+      schiessmauer
+    );
     assertThatPolylinesAreEqual(polyline2, "ccsgH{|au@?Rd@_@~BmB^]r@i@FExAqAlAeAT~@R~@");
   }
 
-  private static String computePolyline(Graph graph, GenericLocation from, GenericLocation to) {
+  private static String computePolyline(
+    Graph graph,
+    TransitModel transitModel,
+    GenericLocation from,
+    GenericLocation to
+  ) {
     RoutingRequest request = new RoutingRequest();
     request.setDateTime(dateTime);
     request.from = from;
@@ -71,12 +105,14 @@ public class BicycleRoutingTest {
     var temporaryVertices = new TemporaryVerticesContainer(graph, request);
     RoutingContext routingContext = new RoutingContext(request, graph, temporaryVertices);
 
-    var gpf = new GraphPathFinder(new Router(graph, RouterConfig.DEFAULT, Metrics.globalRegistry));
+    var gpf = new GraphPathFinder(
+      new Router(graph, transitModel, RouterConfig.DEFAULT, Metrics.globalRegistry)
+    );
     var paths = gpf.graphPathFinderEntryPoint(routingContext);
 
     GraphPathToItineraryMapper graphPathToItineraryMapper = new GraphPathToItineraryMapper(
-      graph.getTimeZone(),
-      new AlertToLegMapper(graph.getTransitAlertService()),
+      transitModel.getTimeZone(),
+      new AlertToLegMapper(transitModel.getTransitAlertService()),
       graph.streetNotesService,
       graph.ellipsoidToGeoidDifference
     );

--- a/src/test/java/org/opentripplanner/routing/vehicle_parking/VehicleParkingTestGraphData.java
+++ b/src/test/java/org/opentripplanner/routing/vehicle_parking/VehicleParkingTestGraphData.java
@@ -2,7 +2,10 @@ package org.opentripplanner.routing.vehicle_parking;
 
 import org.opentripplanner.routing.edgetype.StreetTraversalPermission;
 import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.routing.trippattern.Deduplicator;
 import org.opentripplanner.routing.vertextype.IntersectionVertex;
+import org.opentripplanner.transit.service.StopModel;
+import org.opentripplanner.transit.service.TransitModel;
 
 public class VehicleParkingTestGraphData {
 
@@ -10,8 +13,13 @@ public class VehicleParkingTestGraphData {
 
   protected Graph graph;
 
+  protected TransitModel transitModel;
+
   public void initGraph() {
-    graph = new Graph();
+    var deduplicator = new Deduplicator();
+    var stopModel = new StopModel();
+    graph = new Graph(stopModel, deduplicator);
+    transitModel = new TransitModel(stopModel, deduplicator);
     graph.hasStreets = true;
 
     A = new IntersectionVertex(graph, "A", 0, 0);
@@ -22,6 +30,10 @@ public class VehicleParkingTestGraphData {
 
   public Graph getGraph() {
     return graph;
+  }
+
+  public TransitModel getTransitModel() {
+    return transitModel;
   }
 
   public IntersectionVertex getAVertex() {

--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTest.java
@@ -12,6 +12,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.opentripplanner.OtpModel;
 import org.opentripplanner.datastore.OtpDataStore;
 import org.opentripplanner.routing.algorithm.RoutingWorker;
 import org.opentripplanner.routing.api.response.RoutingResponse;
@@ -28,6 +29,7 @@ import org.opentripplanner.transit.raptor.speed_test.model.testcase.TestCaseInpu
 import org.opentripplanner.transit.raptor.speed_test.model.timer.SpeedTestTimer;
 import org.opentripplanner.transit.raptor.speed_test.options.SpeedTestCmdLineOpts;
 import org.opentripplanner.transit.raptor.speed_test.options.SpeedTestConfig;
+import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.util.OtpAppException;
 
 /**
@@ -39,6 +41,7 @@ public class SpeedTest {
   private static final String TRAVEL_SEARCH_FILENAME = "travelSearch";
 
   private final Graph graph;
+  private final TransitModel transitModel;
 
   private final SpeedTestTimer timer = new SpeedTestTimer();
 
@@ -54,14 +57,16 @@ public class SpeedTest {
   private SpeedTest(SpeedTestCmdLineOpts opts) {
     this.opts = opts;
     this.config = SpeedTestConfig.config(opts.rootDir());
-    this.graph = loadGraph(opts.rootDir(), config.graph);
+    OtpModel otpModel = loadGraph(opts.rootDir(), config.graph);
+    this.graph = otpModel.graph;
+    this.transitModel = otpModel.transitModel;
 
     this.tcIO = new CsvFileIO(opts.rootDir(), TRAVEL_SEARCH_FILENAME);
 
     // Read Test-case definitions and expected results from file
     this.testCaseInputs = filterTestCases(opts, tcIO.readTestCasesFromFile());
 
-    this.router = new Router(graph, RouterConfig.DEFAULT, timer.getRegistry());
+    this.router = new Router(graph, transitModel, RouterConfig.DEFAULT, timer.getRegistry());
     this.router.startup();
 
     timer.setUp(opts.groupResultsByCategory());
@@ -88,16 +93,19 @@ public class SpeedTest {
     }
   }
 
-  private static Graph loadGraph(File baseDir, URI path) {
+  private static OtpModel loadGraph(File baseDir, URI path) {
     File file = path == null
       ? OtpDataStore.graphFile(baseDir)
       : path.isAbsolute() ? new File(path) : new File(baseDir, path.getPath());
-    Graph graph = SerializedGraphObject.load(file);
+    SerializedGraphObject serializedGraphObject = SerializedGraphObject.load(file);
+    Graph graph = serializedGraphObject.graph;
     if (graph == null) {
       throw new IllegalStateException();
     }
+    TransitModel transitModel = serializedGraphObject.transitModel;
+    transitModel.index();
     graph.index();
-    return graph;
+    return new OtpModel(graph, transitModel);
   }
 
   /**
@@ -235,7 +243,7 @@ public class SpeedTest {
   }
 
   private ZoneId getTimeZoneId() {
-    return graph.getTimeZone().toZoneId();
+    return transitModel.getTimeZone().toZoneId();
   }
 
   private void forceGCToAvoidGCLater() {

--- a/src/test/java/org/opentripplanner/updater/GtfsRealtimeFuzzyTripMatcherTest.java
+++ b/src/test/java/org/opentripplanner/updater/GtfsRealtimeFuzzyTripMatcherTest.java
@@ -6,18 +6,16 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import com.google.transit.realtime.GtfsRealtime.TripDescriptor;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.GtfsTest;
-import org.opentripplanner.routing.RoutingService;
 import org.opentripplanner.transit.service.DefaultTransitService;
 
 public class GtfsRealtimeFuzzyTripMatcherTest extends GtfsTest {
 
   @Test
   public void testMatch() {
-    String feedId = graph.getFeedIds().iterator().next();
+    String feedId = transitModel.getFeedIds().iterator().next();
 
     GtfsRealtimeFuzzyTripMatcher matcher = new GtfsRealtimeFuzzyTripMatcher(
-      new RoutingService(graph),
-      new DefaultTransitService(graph)
+      new DefaultTransitService(transitModel)
     );
     TripDescriptor trip1 = TripDescriptor
       .newBuilder()

--- a/src/test/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSourceTest.java
+++ b/src/test/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSourceTest.java
@@ -22,19 +22,20 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.ConstantsForTests;
+import org.opentripplanner.OtpModel;
 import org.opentripplanner.model.Timetable;
 import org.opentripplanner.model.TimetableSnapshot;
 import org.opentripplanner.model.TripPattern;
 import org.opentripplanner.model.calendar.ServiceDate;
-import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.trippattern.RealTimeState;
 import org.opentripplanner.routing.trippattern.TripTimes;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.timetable.Trip;
+import org.opentripplanner.transit.service.TransitModel;
 
 public class TimetableSnapshotSourceTest {
 
-  static Graph graph = new Graph();
+  static TransitModel transitModel;
   private static final boolean fullDataset = false;
   private static final ServiceDate serviceDate = new ServiceDate();
   private static byte[] cancellation;
@@ -44,9 +45,10 @@ public class TimetableSnapshotSourceTest {
 
   @BeforeAll
   public static void setUpClass() {
-    graph = ConstantsForTests.buildGtfsGraph(ConstantsForTests.FAKE_GTFS);
+    OtpModel otpModel = ConstantsForTests.buildGtfsGraph(ConstantsForTests.FAKE_GTFS);
+    transitModel = otpModel.transitModel;
 
-    feedId = graph.getFeedIds().stream().findFirst().get();
+    feedId = transitModel.getFeedIds().stream().findFirst().get();
 
     final TripDescriptor.Builder tripDescriptorBuilder = TripDescriptor.newBuilder();
 
@@ -62,7 +64,7 @@ public class TimetableSnapshotSourceTest {
 
   @BeforeEach
   public void setUp() {
-    updater = TimetableSnapshotSource.ofGraph(graph);
+    updater = TimetableSnapshotSource.ofGraph(transitModel);
   }
 
   @Test
@@ -86,8 +88,8 @@ public class TimetableSnapshotSourceTest {
   public void testHandleCanceledTrip() throws InvalidProtocolBufferException {
     final FeedScopedId tripId = new FeedScopedId(feedId, "1.1");
     final FeedScopedId tripId2 = new FeedScopedId(feedId, "1.2");
-    final Trip trip = graph.index.getTripForId().get(tripId);
-    final TripPattern pattern = graph.index.getPatternForTrip().get(trip);
+    final Trip trip = transitModel.index.getTripForId().get(tripId);
+    final TripPattern pattern = transitModel.index.getPatternForTrip().get(trip);
     final int tripIndex = pattern.getScheduledTimetable().getTripIndex(tripId);
     final int tripIndex2 = pattern.getScheduledTimetable().getTripIndex(tripId2);
 
@@ -109,8 +111,8 @@ public class TimetableSnapshotSourceTest {
   public void testHandleDelayedTrip() {
     final FeedScopedId tripId = new FeedScopedId(feedId, "1.1");
     final FeedScopedId tripId2 = new FeedScopedId(feedId, "1.2");
-    final Trip trip = graph.index.getTripForId().get(tripId);
-    final TripPattern pattern = graph.index.getPatternForTrip().get(trip);
+    final Trip trip = transitModel.index.getTripForId().get(tripId);
+    final TripPattern pattern = transitModel.index.getPatternForTrip().get(trip);
     final int tripIndex = pattern.getScheduledTimetable().getTripIndex(tripId);
     final int tripIndex2 = pattern.getScheduledTimetable().getTripIndex(tripId2);
 
@@ -196,7 +198,7 @@ public class TimetableSnapshotSourceTest {
       tripDescriptorBuilder.setScheduleRelationship(TripDescriptor.ScheduleRelationship.ADDED);
       tripDescriptorBuilder.setStartDate(serviceDate.asCompactString());
 
-      final Calendar calendar = serviceDate.getAsCalendar(graph.getTimeZone());
+      final Calendar calendar = serviceDate.getAsCalendar(transitModel.getTimeZone());
       final long midnightSecondsSinceEpoch = calendar.getTimeInMillis() / 1000;
 
       final TripUpdate.Builder tripUpdateBuilder = TripUpdate.newBuilder();
@@ -271,7 +273,10 @@ public class TimetableSnapshotSourceTest {
 
     // THEN
     // Find new pattern in graph starting from stop A
-    var stopA = graph.index.getStopForId(new FeedScopedId(feedId, "A"));
+    var stopA = transitModel
+      .getStopModel()
+      .getStopModelIndex()
+      .getStopForId(new FeedScopedId(feedId, "A"));
     // Get trip pattern of last (most recently added) outgoing edge
     var snapshot = updater.getTimetableSnapshot();
     var patternsAtA = snapshot.getPatternsForStop(stopA);
@@ -315,7 +320,7 @@ public class TimetableSnapshotSourceTest {
       tripDescriptorBuilder.setScheduleRelationship(ScheduleRelationship.REPLACEMENT);
       tripDescriptorBuilder.setStartDate(serviceDate.asCompactString());
 
-      final Calendar calendar = serviceDate.getAsCalendar(graph.getTimeZone());
+      final Calendar calendar = serviceDate.getAsCalendar(transitModel.getTimeZone());
       final long midnightSecondsSinceEpoch = calendar.getTimeInMillis() / 1000;
 
       final TripUpdate.Builder tripUpdateBuilder = TripUpdate.newBuilder();
@@ -416,8 +421,8 @@ public class TimetableSnapshotSourceTest {
     // Original trip pattern
     {
       final FeedScopedId tripId = new FeedScopedId(feedId, modifiedTripId);
-      final Trip trip = graph.index.getTripForId().get(tripId);
-      final TripPattern originalTripPattern = graph.index.getPatternForTrip().get(trip);
+      final Trip trip = transitModel.index.getTripForId().get(tripId);
+      final TripPattern originalTripPattern = transitModel.index.getPatternForTrip().get(trip);
 
       final Timetable originalTimetableForToday = snapshot.resolve(
         originalTripPattern,
@@ -574,8 +579,8 @@ public class TimetableSnapshotSourceTest {
     final TimetableSnapshot snapshot = updater.getTimetableSnapshot();
 
     final FeedScopedId tripId = new FeedScopedId(feedId, scheduledTripId);
-    final Trip trip = graph.index.getTripForId().get(tripId);
-    final TripPattern originalTripPattern = graph.index.getPatternForTrip().get(trip);
+    final Trip trip = transitModel.index.getTripForId().get(tripId);
+    final TripPattern originalTripPattern = transitModel.index.getPatternForTrip().get(trip);
 
     final Timetable originalTimetableForToday = snapshot.resolve(originalTripPattern, serviceDate);
     final Timetable originalTimetableScheduled = snapshot.resolve(originalTripPattern, null);
@@ -669,8 +674,8 @@ public class TimetableSnapshotSourceTest {
     // Original trip pattern
     {
       final FeedScopedId tripId = new FeedScopedId(feedId, scheduledTripId);
-      final Trip trip = graph.index.getTripForId().get(tripId);
-      final TripPattern originalTripPattern = graph.index.getPatternForTrip().get(trip);
+      final Trip trip = transitModel.index.getTripForId().get(tripId);
+      final TripPattern originalTripPattern = transitModel.index.getPatternForTrip().get(trip);
 
       final Timetable originalTimetableForToday = snapshot.resolve(
         originalTripPattern,
@@ -826,8 +831,8 @@ public class TimetableSnapshotSourceTest {
     // Original trip pattern
     {
       final FeedScopedId tripId = new FeedScopedId(feedId, scheduledTripId);
-      final Trip trip = graph.index.getTripForId().get(tripId);
-      final TripPattern originalTripPattern = graph.index.getPatternForTrip().get(trip);
+      final Trip trip = transitModel.index.getTripForId().get(tripId);
+      final TripPattern originalTripPattern = transitModel.index.getPatternForTrip().get(trip);
 
       final Timetable originalTimetableForToday = snapshot.resolve(
         originalTripPattern,
@@ -890,8 +895,8 @@ public class TimetableSnapshotSourceTest {
   public void testPurgeExpiredData() throws InvalidProtocolBufferException {
     final FeedScopedId tripId = new FeedScopedId(feedId, "1.1");
     final ServiceDate previously = serviceDate.previous().previous(); // Just to be safe...
-    final Trip trip = graph.index.getTripForId().get(tripId);
-    final TripPattern pattern = graph.index.getPatternForTrip().get(trip);
+    final Trip trip = transitModel.index.getTripForId().get(tripId);
+    final TripPattern pattern = transitModel.index.getPatternForTrip().get(trip);
 
     updater.maxSnapshotFrequency = 0;
     updater.purgeExpiredData = false;


### PR DESCRIPTION
### Summary

The goal of this PR is to split the Graph class that currently contains all the OTP runtime state into two separate classes Graph and TransitModel that hold references to the street model and the transit model respectively.
In order to break circular dependencies, a third class StopModel is introduced. It holds references to the subset of the TransitModel related to transit stops. StopModel is used by both Graph and TransitModel. As a result there is no direct dependency between Graph and TransitModel.

1. Moved Transit-related state from the Graph class to a new TransitModel class.
2. Moved Stop-related state from the Graph object to a new StopModel class.
3. Moved transient indexes from GraphIndex to respectively TransitModelIndex and StopModelIndex
4. All indexes are moved out of GraphIndex, thus the GraphIndex class is deleted.
6. A TransitStopVertex represents the vertex associated to a transit stop. Instances are stored in both Graph and StopModel. A builder TransitStopVertexBuilder is introduced to enforce that both Graph and StopModel are updated when instances of TransitStopVertex are created

Notes:
- The Graph class contains now street graph-related entities and other unrelated dependencies that should be refactored out in a subsequent PR. This class should eventually be renamed StreetModel.
- The *Model classes could possibly be renamed as *Repository classes to express the fact that they hold the OTP runtime state:
TransitModel --> TransitRepository
StopModel --> StopRepository

### Issue
Part of https://github.com/opentripplanner/OpenTripPlanner/issues/4002


### Unit tests
:white_check_mark: 

### Documentation
No

### Changelog

The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md)
is generated from the pull-request title, make sure the title describe the feature or issue fixed.
To exclude the PR from the changelog add the label `skip changelog` to the PR.
