### PR TITLE
Fix filtering for frequency-based trips

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TripPatternForDate.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TripPatternForDate.java
@@ -176,6 +176,10 @@ public class TripPatternForDate {
       return null;
     }
 
+    if (hasFrequencies() && filteredTripTimes.isEmpty() && filteredFrequencies.isEmpty()) {
+      return null;
+    }
+
     if (tripTimes.size() == filteredTripTimes.size()) {
       return this;
     }

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TripPatternForDateTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TripPatternForDateTest.java
@@ -5,7 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.time.LocalDate;
 import java.util.List;
-import org.junit.jupiter.api.Test;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.mockito.Mockito;
 import org.opentripplanner.model.Frequency;
 import org.opentripplanner.model.StopPattern;
@@ -13,6 +15,7 @@ import org.opentripplanner.model.StopTime;
 import org.opentripplanner.model.TripPattern;
 import org.opentripplanner.routing.trippattern.FrequencyEntry;
 import org.opentripplanner.routing.trippattern.TripTimes;
+import org.opentripplanner.test.support.VariableSource;
 import org.opentripplanner.transit.model._data.TransitModelForTest;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.site.Stop;
@@ -22,8 +25,13 @@ class TripPatternForDateTest {
   private static final Stop STOP = TransitModelForTest.stopForTest("TEST:STOP", 0, 0);
   private static final TripTimes tripTimes = Mockito.mock(TripTimes.class);
 
-  @Test
-  void shouldExcludeAndIncludeBasedOnFrequency() {
+  static Stream<Arguments> testCases = Stream
+    .of(List.of(new FrequencyEntry(new Frequency(), tripTimes)), List.of())
+    .map(Arguments::of);
+
+  @ParameterizedTest(name = "trip with frequencies {0} should be correctly filtered")
+  @VariableSource("testCases")
+  void shouldExcludeAndIncludeBasedOnFrequency(List<FrequencyEntry> freqs) {
     Route route = TransitModelForTest.route("1").build();
 
     var stopTime = new StopTime();
@@ -40,7 +48,7 @@ class TripPatternForDateTest {
     var withFrequencies = new TripPatternForDate(
       tripPattern,
       List.of(tripTimes),
-      List.of(new FrequencyEntry(f, tripTimes)),
+      freqs,
       LocalDate.now()
     );
 

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TripPatternForDateTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TripPatternForDateTest.java
@@ -1,0 +1,50 @@
+package org.opentripplanner.routing.algorithm.raptoradapter.transit;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.opentripplanner.model.Frequency;
+import org.opentripplanner.model.StopPattern;
+import org.opentripplanner.model.StopTime;
+import org.opentripplanner.model.TripPattern;
+import org.opentripplanner.routing.trippattern.FrequencyEntry;
+import org.opentripplanner.routing.trippattern.TripTimes;
+import org.opentripplanner.transit.model._data.TransitModelForTest;
+import org.opentripplanner.transit.model.network.Route;
+import org.opentripplanner.transit.model.site.Stop;
+
+class TripPatternForDateTest {
+
+  private static final Stop STOP = TransitModelForTest.stopForTest("TEST:STOP", 0, 0);
+  private static final TripTimes tripTimes = Mockito.mock(TripTimes.class);
+
+  @Test
+  void shouldExcludeAndIncludeBasedOnFrequency() {
+    Route route = TransitModelForTest.route("1").build();
+
+    var stopTime = new StopTime();
+    stopTime.setStop(STOP);
+    StopPattern stopPattern = new StopPattern(List.of(stopTime));
+    TripPattern pattern = new TripPattern(TransitModelForTest.id("P1"), route, stopPattern);
+
+    TripPatternWithRaptorStopIndexes tripPattern = new TripPatternWithRaptorStopIndexes(
+      pattern,
+      new int[0]
+    );
+
+    var f = new Frequency();
+    var withFrequencies = new TripPatternForDate(
+      tripPattern,
+      List.of(tripTimes),
+      List.of(new FrequencyEntry(f, tripTimes)),
+      LocalDate.now()
+    );
+
+    assertNull(withFrequencies.newWithFilteredTripTimes(t -> false));
+    assertNotNull(withFrequencies.newWithFilteredTripTimes(t -> true));
+  }
+}


### PR DESCRIPTION
### Summary

Frequency-based trips are not correctly removed when you filter by mode, for example.

### Issue

closes #4248

### Unit tests

Added.