### PR TITLE
Fix if condition when bumping serialization id

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -39,7 +39,10 @@ jobs:
           URL: ${{ github.event.pull_request.html_url }}
 
   serialization-version:
-    if: github.event.pull_request.merged && github.repository_owner == 'opentripplanner' && contains(github.event.pull_request.labels.*.name, 'bump serialization id')
+    # if you have a dependent job that is skipped (ie. you want to bump the version but not have a changelog entry) you must add
+    # always() before your actual condition you want for the job
+    #   https://github.com/actions/runner/issues/491#issuecomment-660122693
+    if: always() && github.event.pull_request.merged && github.repository_owner == 'opentripplanner' && contains(github.event.pull_request.labels.*.name, 'bump serialization id')
     runs-on: ubuntu-latest
     needs: [changelog-entry]
     steps:


### PR DESCRIPTION
When merging #4241 I noticed that the if-condition of the post-merge workflow doesn't work properly.

I found some help in a Github ticket which I'm trying out.

I will use my admin priviledges to force this getting merged without review.