### PR TITLE
Add field 'routingErrors' to LegacyGraphQLAPI

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/LegacyGraphQLIndex.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/LegacyGraphQLIndex.java
@@ -55,6 +55,7 @@ import org.opentripplanner.ext.legacygraphqlapi.datafetchers.LegacyGraphQLRental
 import org.opentripplanner.ext.legacygraphqlapi.datafetchers.LegacyGraphQLRentalVehicleTypeImpl;
 import org.opentripplanner.ext.legacygraphqlapi.datafetchers.LegacyGraphQLRouteImpl;
 import org.opentripplanner.ext.legacygraphqlapi.datafetchers.LegacyGraphQLRouteTypeImpl;
+import org.opentripplanner.ext.legacygraphqlapi.datafetchers.LegacyGraphQLRoutingErrorImpl;
 import org.opentripplanner.ext.legacygraphqlapi.datafetchers.LegacyGraphQLStopGeometriesImpl;
 import org.opentripplanner.ext.legacygraphqlapi.datafetchers.LegacyGraphQLStopImpl;
 import org.opentripplanner.ext.legacygraphqlapi.datafetchers.LegacyGraphQLStopOnRouteImpl;
@@ -153,6 +154,7 @@ class LegacyGraphQLIndex {
         .type(IntrospectionTypeWiring.build(LegacyGraphQLStopOnTripImpl.class))
         .type(IntrospectionTypeWiring.build(LegacyGraphQLUnknownImpl.class))
         .type(IntrospectionTypeWiring.build(LegacyGraphQLRouteTypeImpl.class))
+        .type(IntrospectionTypeWiring.build(LegacyGraphQLRoutingErrorImpl.class))
         .type(IntrospectionTypeWiring.build(LegacyGraphQLStopGeometriesImpl.class))
         .type(IntrospectionTypeWiring.build(LegacyGraphQLVehiclePositionImpl.class))
         .type(IntrospectionTypeWiring.build(LegacyGraphQLStopRelationshipImpl.class))

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/LegacyGraphQLUtils.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/LegacyGraphQLUtils.java
@@ -5,7 +5,11 @@ import java.util.Locale;
 import java.util.Map;
 import org.opentripplanner.ext.legacygraphqlapi.generated.LegacyGraphQLTypes.LegacyGraphQLFilterPlaceType;
 import org.opentripplanner.ext.legacygraphqlapi.generated.LegacyGraphQLTypes.LegacyGraphQLFormFactor;
+import org.opentripplanner.ext.legacygraphqlapi.generated.LegacyGraphQLTypes.LegacyGraphQLInputField;
+import org.opentripplanner.ext.legacygraphqlapi.generated.LegacyGraphQLTypes.LegacyGraphQLRoutingErrorCode;
 import org.opentripplanner.ext.legacygraphqlapi.generated.LegacyGraphQLTypes.LegacyGraphQLWheelchairBoarding;
+import org.opentripplanner.routing.api.response.InputField;
+import org.opentripplanner.routing.api.response.RoutingErrorCode;
 import org.opentripplanner.routing.graphfinder.PlaceType;
 import org.opentripplanner.routing.vehicle_rental.RentalVehicleType.FormFactor;
 import org.opentripplanner.transit.model.basic.WheelchairAccessibility;
@@ -40,6 +44,28 @@ public class LegacyGraphQLUtils {
       case NO_INFORMATION -> LegacyGraphQLWheelchairBoarding.NO_INFORMATION;
       case POSSIBLE -> LegacyGraphQLWheelchairBoarding.POSSIBLE;
       case NOT_POSSIBLE -> LegacyGraphQLWheelchairBoarding.NOT_POSSIBLE;
+    };
+  }
+
+  public static LegacyGraphQLRoutingErrorCode toGraphQL(RoutingErrorCode code) {
+    if (code == null) return null;
+    return switch (code) {
+      case LOCATION_NOT_FOUND -> LegacyGraphQLRoutingErrorCode.locationNotFound;
+      case NO_STOPS_IN_RANGE -> LegacyGraphQLRoutingErrorCode.noStopsInRange;
+      case NO_TRANSIT_CONNECTION -> LegacyGraphQLRoutingErrorCode.noTransitConnection;
+      case NO_TRANSIT_CONNECTION_IN_SEARCH_WINDOW -> LegacyGraphQLRoutingErrorCode.noTransitConnectionInSearchWindow;
+      case OUTSIDE_BOUNDS -> LegacyGraphQLRoutingErrorCode.outsideBounds;
+      case OUTSIDE_SERVICE_PERIOD -> LegacyGraphQLRoutingErrorCode.outsideServicePeriod;
+      case SYSTEM_ERROR -> LegacyGraphQLRoutingErrorCode.systemError;
+      case WALKING_BETTER_THAN_TRANSIT -> LegacyGraphQLRoutingErrorCode.walkingBetterThanTransit;
+    };
+  }
+
+  public static LegacyGraphQLInputField toGraphQL(InputField inputField) {
+    return switch (inputField) {
+      case DATE_TIME -> LegacyGraphQLInputField.dateTime;
+      case FROM_PLACE -> LegacyGraphQLInputField.from;
+      case TO_PLACE, INTERMEDIATE_PLACE -> LegacyGraphQLInputField.to;
     };
   }
 

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLPlanImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLPlanImpl.java
@@ -9,6 +9,7 @@ import org.opentripplanner.ext.legacygraphqlapi.generated.LegacyGraphQLDataFetch
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.StopArrival;
 import org.opentripplanner.model.plan.pagecursor.PageCursor;
+import org.opentripplanner.routing.api.response.RoutingError;
 import org.opentripplanner.routing.api.response.RoutingResponse;
 import org.opentripplanner.routing.api.response.TripSearchMetadata;
 
@@ -55,6 +56,11 @@ public class LegacyGraphQLPlanImpl implements LegacyGraphQLDataFetchers.LegacyGr
         .map(PlannerErrorMapper::mapMessage)
         .map(plannerError -> plannerError.message.get(environment.getLocale()))
         .collect(Collectors.toList());
+  }
+
+  @Override
+  public DataFetcher<Iterable<RoutingError>> routingErrors() {
+    return environment -> getSource(environment).getRoutingErrors();
   }
 
   @Override

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLRoutingErrorImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLRoutingErrorImpl.java
@@ -1,0 +1,34 @@
+package org.opentripplanner.ext.legacygraphqlapi.datafetchers;
+
+import static org.opentripplanner.ext.legacygraphqlapi.LegacyGraphQLUtils.toGraphQL;
+
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import org.opentripplanner.api.mapping.PlannerErrorMapper;
+import org.opentripplanner.ext.legacygraphqlapi.generated.LegacyGraphQLDataFetchers;
+import org.opentripplanner.ext.legacygraphqlapi.generated.LegacyGraphQLTypes;
+import org.opentripplanner.routing.api.response.RoutingError;
+
+public class LegacyGraphQLRoutingErrorImpl
+  implements LegacyGraphQLDataFetchers.LegacyGraphQLRoutingError {
+
+  @Override
+  public DataFetcher<LegacyGraphQLTypes.LegacyGraphQLRoutingErrorCode> code() {
+    return environment -> toGraphQL(getSource(environment).code);
+  }
+
+  @Override
+  public DataFetcher<String> description() {
+    return environment ->
+      PlannerErrorMapper.mapMessage(getSource(environment)).message.get(environment.getLocale());
+  }
+
+  @Override
+  public DataFetcher<LegacyGraphQLTypes.LegacyGraphQLInputField> inputField() {
+    return environment -> toGraphQL(getSource(environment).inputField);
+  }
+
+  private RoutingError getSource(DataFetchingEnvironment environment) {
+    return environment.getSource();
+  }
+}

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/LegacyGraphQLDataFetchers.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/LegacyGraphQLDataFetchers.java
@@ -2,14 +2,23 @@
 package org.opentripplanner.ext.legacygraphqlapi.generated;
 
 import graphql.relay.Connection;
+import graphql.relay.Connection;
+import graphql.relay.Edge;
 import graphql.relay.Edge;
 import graphql.schema.DataFetcher;
 import graphql.schema.TypeResolver;
+import java.util.Map;
 import java.util.Map;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.opentripplanner.api.resource.DebugOutput;
 import org.opentripplanner.common.model.P2;
+import org.opentripplanner.ext.legacygraphqlapi.generated.LegacyGraphQLTypes.LegacyGraphQLInputField;
+import org.opentripplanner.ext.legacygraphqlapi.generated.LegacyGraphQLTypes.LegacyGraphQLRoutingErrorCode;
+import org.opentripplanner.ext.legacygraphqlapi.model.LegacyGraphQLRouteTypeModel;
+import org.opentripplanner.ext.legacygraphqlapi.model.LegacyGraphQLStopOnRouteModel;
+import org.opentripplanner.ext.legacygraphqlapi.model.LegacyGraphQLStopOnTripModel;
+import org.opentripplanner.ext.legacygraphqlapi.model.LegacyGraphQLUnknownModel;
 import org.opentripplanner.model.StopTimesInPattern;
 import org.opentripplanner.model.SystemNotice;
 import org.opentripplanner.model.TripPattern;
@@ -21,17 +30,21 @@ import org.opentripplanner.model.plan.WalkStep;
 import org.opentripplanner.model.vehicle_position.RealtimeVehiclePosition;
 import org.opentripplanner.model.vehicle_position.RealtimeVehiclePosition.StopRelationship;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
+import org.opentripplanner.routing.api.response.RoutingError;
 import org.opentripplanner.routing.core.FareComponent;
 import org.opentripplanner.routing.core.FareRuleSet;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
 import org.opentripplanner.routing.graphfinder.PatternAtStop;
 import org.opentripplanner.routing.graphfinder.PlaceAtDistance;
 import org.opentripplanner.routing.vehicle_parking.VehicleParking;
+import org.opentripplanner.routing.vehicle_parking.VehicleParking;
+import org.opentripplanner.routing.vehicle_parking.VehicleParking;
 import org.opentripplanner.routing.vehicle_parking.VehicleParkingSpaces;
 import org.opentripplanner.routing.vehicle_parking.VehicleParkingState;
 import org.opentripplanner.routing.vehicle_rental.RentalVehicleType;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalPlace;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalStation;
+import org.opentripplanner.routing.vehicle_rental.VehicleRentalStationUris;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalStationUris;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalVehicle;
 import org.opentripplanner.transit.model.network.Route;
@@ -514,6 +527,8 @@ public class LegacyGraphQLDataFetchers {
 
     public DataFetcher<String> previousPageCursor();
 
+    public DataFetcher<Iterable<RoutingError>> routingErrors();
+
     public DataFetcher<Long> searchWindowUsed();
 
     public DataFetcher<StopArrival> to();
@@ -679,6 +694,15 @@ public class LegacyGraphQLDataFetchers {
     public DataFetcher<Integer> routeType();
 
     public DataFetcher<Iterable<Route>> routes();
+  }
+
+  /** Description of the reason, why the planner did not return any results */
+  public interface LegacyGraphQLRoutingError {
+    public DataFetcher<LegacyGraphQLRoutingErrorCode> code();
+
+    public DataFetcher<String> description();
+
+    public DataFetcher<LegacyGraphQLInputField> inputField();
   }
 
   /**

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/LegacyGraphQLTypes.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/LegacyGraphQLTypes.java
@@ -346,6 +346,12 @@ public class LegacyGraphQLTypes {
     }
   }
 
+  public enum LegacyGraphQLInputField {
+    dateTime,
+    from,
+    to,
+  }
+
   public static class LegacyGraphQLInputFiltersInput {
 
     private Iterable<String> bikeParks;
@@ -2505,6 +2511,17 @@ public class LegacyGraphQLTypes {
     STOPS_ON_ROUTE,
     STOPS_ON_TRIPS,
     TRIPS,
+  }
+
+  public enum LegacyGraphQLRoutingErrorCode {
+    locationNotFound,
+    noStopsInRange,
+    noTransitConnection,
+    noTransitConnectionInSearchWindow,
+    outsideBounds,
+    outsideServicePeriod,
+    systemError,
+    walkingBetterThanTransit,
   }
 
   public static class LegacyGraphQLStopAlertsArgs {

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/graphql-codegen.yml
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/graphql-codegen.yml
@@ -51,6 +51,7 @@ config:
     fareComponent: org.opentripplanner.routing.core.FareComponent#FareComponent
     Feed: String
     Geometry: org.locationtech.jts.geom.Geometry#Geometry
+    InputField: org.opentripplanner.ext.legacygraphqlapi.generated.LegacyGraphQLTypes.LegacyGraphQLInputField#LegacyGraphQLInputField
     Itinerary: org.opentripplanner.model.plan.Itinerary#Itinerary
     Leg: org.opentripplanner.model.plan.Leg#Leg
     Mode: String
@@ -64,6 +65,8 @@ config:
     Plan: graphql.execution.DataFetcherResult<org.opentripplanner.routing.api.response.RoutingResponse>
     RealtimeState: String
     Route: org.opentripplanner.transit.model.network.Route#Route
+    RoutingError: org.opentripplanner.routing.api.response.RoutingError#RoutingError
+    RoutingErrorCode: org.opentripplanner.ext.legacygraphqlapi.generated.LegacyGraphQLTypes.LegacyGraphQLRoutingErrorCode#LegacyGraphQLRoutingErrorCode
     serviceTimeRange: Object
     step: org.opentripplanner.model.plan.WalkStep#WalkStep
     Stop: Object # Can be either Stop or Station
@@ -89,4 +92,3 @@ config:
     FormFactor: org.opentripplanner.ext.legacygraphqlapi.generated.LegacyGraphQLTypes.LegacyGraphQLFormFactor
     PropulsionType: org.opentripplanner.ext.legacygraphqlapi.generated.LegacyGraphQLTypes.LegacyGraphQLPropulsionType
     RentalVehicleType: org.opentripplanner.routing.vehicle_rental.RentalVehicleType#RentalVehicleType
-

--- a/src/ext/resources/legacygraphqlapi/schema.graphqls
+++ b/src/ext/resources/legacygraphqlapi/schema.graphqls
@@ -1120,6 +1120,50 @@ input InputUnpreferred {
     useUnpreferredRoutesPenalty: Int
 }
 
+enum RoutingErrorCode {
+    """No transit connection was found between the origin and destination withing the operating day or the next day"""
+    noTransitConnection
+
+    """Transit connection was found, but it was outside the search window, see metadata for the next search window"""
+    noTransitConnectionInSearchWindow
+
+    """The date specified is outside the range of data currently loaded into the system"""
+    outsideServicePeriod
+
+    """The coordinates are outside the bounds of the data currently loaded into the system"""
+    outsideBounds
+
+    """The specified location is not close to any streets or transit stops"""
+    locationNotFound
+
+    """No stops are reachable from the location specified. You can try searching using a different access or egress mode"""
+    noStopsInRange
+
+    """The origin and destination are so close to each other, that walking is always better, but no direct mode was specified for the search"""
+    walkingBetterThanTransit
+
+    """An unknown error happened during the search. The details have been logged to the server logs"""
+    systemError
+}
+
+enum InputField {
+    dateTime
+    from
+    to
+}
+
+"""Description of the reason, why the planner did not return any results"""
+type RoutingError {
+    """An enum describing the reason"""
+    code: RoutingErrorCode!
+
+    """An enum describing the field which should be changed, in order for the search to succeed"""
+    inputField: InputField
+
+    """A textual description of why the search failed. The clients are expected to have their own translations based on the code, for user visible error messages."""
+    description: String!
+}
+
 type Itinerary {
     """
     Time when the user leaves from the origin. Format: Unix timestamp in milliseconds.
@@ -1723,6 +1767,9 @@ type Plan {
 
     """A list of possible error messages in cleartext"""
     messageStrings: [String]!
+
+    """A list of routing errors, and fields which caused them"""
+    routingErrors: [RoutingError!]!
 
     """
     Use the cursor to go to the next "page" of itineraries. Copy the cursor from the last response


### PR DESCRIPTION
### Summary

With current errors given by LegacyGraphQLAPI, it's not possible to know if eg. geocoding issue is related to _fromPlace_ or _toPlace_ (or intermediate point). This PR adds list field `routingErrors` to LegacyGraphQLAPI's `Plan` type as in Transmodel API.

As OTP2 currently doesn't support routing via intermediate places, intermediate point errors are mapped for destination (InputField.to).

### Unit tests

- Test suite passes.

### Documentation

- Documentation from Transmodel API copied to LegacyGraphQLAPI's `schema.graphqls`.

