### PR TITLE
Support real-time updated wheelchair accessibility for trips

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/accessibilityscore/AccessibilityScoreFilter.java
+++ b/src/ext/java/org/opentripplanner/ext/accessibilityscore/AccessibilityScoreFilter.java
@@ -38,7 +38,7 @@ public record AccessibilityScoreFilter(double wheelchairMaxSlope) implements Iti
   public static float compute(ScheduledTransitLeg leg) {
     var fromStop = leg.getFrom().stop.getWheelchairAccessibility();
     var toStop = leg.getFrom().stop.getWheelchairAccessibility();
-    var trip = leg.getTrip().getWheelchairBoarding();
+    var trip = leg.getTripWheelchairAccessibility();
 
     var values = List.of(trip, fromStop, toStop);
     var sum = (float) values

--- a/src/ext/java/org/opentripplanner/ext/flex/FlexibleTransitLeg.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/FlexibleTransitLeg.java
@@ -15,6 +15,7 @@ import org.opentripplanner.model.plan.Place;
 import org.opentripplanner.model.plan.StopArrival;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.routing.core.TraverseMode;
+import org.opentripplanner.transit.model.basic.WheelchairAccessibility;
 import org.opentripplanner.transit.model.framework.TransitEntity;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.organization.Agency;
@@ -76,6 +77,11 @@ public class FlexibleTransitLeg implements Leg {
   @Override
   public Trip getTrip() {
     return edge.getFlexTrip().getTrip();
+  }
+
+  @Override
+  public WheelchairAccessibility getTripWheelchairAccessibility() {
+    return edge.getFlexTrip().getTrip().getWheelchairBoarding();
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/model/Timetable.java
+++ b/src/main/java/org/opentripplanner/model/Timetable.java
@@ -18,6 +18,7 @@ import org.opentripplanner.routing.trippattern.TripTimes;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.timetable.Direction;
 import org.opentripplanner.transit.model.timetable.Trip;
+import org.opentripplanner.updater.GtfsRealtimeMapper;
 import org.opentripplanner.updater.stoptime.BackwardsDelayPropagationType;
 import org.opentripplanner.util.time.ServiceDateUtils;
 import org.slf4j.Logger;
@@ -316,6 +317,15 @@ public class Timetable implements Serializable {
         tripId
       );
       return null;
+    }
+
+    if (tripUpdate.hasVehicle()) {
+      var vehicleDescriptor = tripUpdate.getVehicle();
+      if (vehicleDescriptor.hasWheelchairAccessible()) {
+        GtfsRealtimeMapper
+          .mapWheelchairAccessible(vehicleDescriptor.getWheelchairAccessible())
+          .ifPresent(newTimes::updateWheelchairAccessibility);
+      }
     }
 
     LOG.debug(

--- a/src/main/java/org/opentripplanner/model/plan/Leg.java
+++ b/src/main/java/org/opentripplanner/model/plan/Leg.java
@@ -17,6 +17,7 @@ import org.opentripplanner.model.plan.legreference.LegReference;
 import org.opentripplanner.model.transfer.ConstrainedTransfer;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.routing.core.TraverseMode;
+import org.opentripplanner.transit.model.basic.WheelchairAccessibility;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.organization.Agency;
@@ -179,6 +180,10 @@ public interface Leg {
    * For transit legs, the trip. For non-transit legs, null.
    */
   default Trip getTrip() {
+    return null;
+  }
+
+  default WheelchairAccessibility getTripWheelchairAccessibility() {
     return null;
   }
 

--- a/src/main/java/org/opentripplanner/model/plan/ScheduledTransitLeg.java
+++ b/src/main/java/org/opentripplanner/model/plan/ScheduledTransitLeg.java
@@ -23,6 +23,7 @@ import org.opentripplanner.model.transfer.ConstrainedTransfer;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.routing.core.TraverseMode;
 import org.opentripplanner.routing.trippattern.TripTimes;
+import org.opentripplanner.transit.model.basic.WheelchairAccessibility;
 import org.opentripplanner.transit.model.framework.TransitEntity;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.organization.Agency;
@@ -153,6 +154,11 @@ public class ScheduledTransitLeg implements Leg {
   @Override
   public Trip getTrip() {
     return tripTimes.getTrip();
+  }
+
+  @Override
+  public WheelchairAccessibility getTripWheelchairAccessibility() {
+    return tripTimes.getWheelchairAccessibility();
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/frequency/FrequencyBoardOrAlightEvent.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/frequency/FrequencyBoardOrAlightEvent.java
@@ -59,8 +59,8 @@ abstract class FrequencyBoardOrAlightEvent<T extends DefaultTripSchedule>
     this.offset = offset;
     this.headway = headway;
     this.serviceDate = serviceDate;
-    wheelChairBoarding = tripTimes.getTrip().getWheelchairBoarding();
-    routeId = pattern.getRoute().getId();
+    this.routeId = pattern.getRoute().getId();
+    this.wheelChairBoarding = tripTimes.getWheelchairAccessibility();
   }
 
   /* RaptorTripScheduleBoardOrAlightEvent implementation */

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RoutingRequestTransitDataProviderFilter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RoutingRequestTransitDataProviderFilter.java
@@ -94,7 +94,7 @@ public class RoutingRequestTransitDataProviderFilter implements TransitDataProvi
     if (wheelchairAccessibility.enabled()) {
       if (
         wheelchairAccessibility.trip().onlyConsiderAccessible() &&
-        trip.getWheelchairBoarding() != WheelchairAccessibility.POSSIBLE
+        tripTimes.getWheelchairAccessibility() != WheelchairAccessibility.POSSIBLE
       ) {
         return false;
       }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripPatternForDates.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripPatternForDates.java
@@ -96,7 +96,7 @@ public class TripPatternForDates
     for (int d = 0; d < tripPatternForDates.size(); d++) {
       int offset = this.offsets[d];
       for (var trip : tripPatternForDates.get(d).tripTimes()) {
-        wheelchairBoardings[i] = trip.getTrip().getWheelchairBoarding();
+        wheelchairBoardings[i] = trip.getWheelchairAccessibility();
         for (int s = 0; s < nStops; s++) {
           this.arrivalTimes[s * numberOfTripSchedules + i] = trip.getArrivalTime(s) + offset;
           this.departureTimes[s * numberOfTripSchedules + i] = trip.getDepartureTime(s) + offset;

--- a/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
+++ b/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
@@ -11,6 +11,7 @@ import java.util.Collection;
 import java.util.List;
 import org.opentripplanner.model.BookingInfo;
 import org.opentripplanner.model.StopTime;
+import org.opentripplanner.transit.model.basic.WheelchairAccessibility;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -106,6 +107,8 @@ public class TripTimes implements Serializable, Comparable<TripTimes> {
    */
   private RealTimeState realTimeState = RealTimeState.SCHEDULED;
 
+  public WheelchairAccessibility wheelchairAccessibility;
+
   /**
    * The provided stopTimes are assumed to be pre-filtered, valid, and monotonically increasing. The
    * non-interpolated stoptimes should already be marked at timepoints by a previous filtering
@@ -153,6 +156,7 @@ public class TripTimes implements Serializable, Comparable<TripTimes> {
     this.departureTimes = null;
     this.stopRealTimeStates = null;
     this.timepoints = deduplicator.deduplicateBitSet(timepoints);
+    this.wheelchairAccessibility = trip.getWheelchairBoarding();
     LOG.trace("trip {} has timepoint at indexes {}", trip, timepoints);
   }
 
@@ -173,6 +177,7 @@ public class TripTimes implements Serializable, Comparable<TripTimes> {
     this.originalGtfsStopSequence = object.originalGtfsStopSequence;
     this.realTimeState = object.realTimeState;
     this.timepoints = object.timepoints;
+    this.wheelchairAccessibility = object.wheelchairAccessibility;
   }
 
   /**
@@ -395,6 +400,14 @@ public class TripTimes implements Serializable, Comparable<TripTimes> {
   public void updateArrivalDelay(final int stop, final int delay) {
     prepareForRealTimeUpdates();
     arrivalTimes[stop] = scheduledArrivalTimes[stop] + timeShift + delay;
+  }
+
+  public WheelchairAccessibility getWheelchairAccessibility() {
+    return wheelchairAccessibility;
+  }
+
+  public void updateWheelchairAccessibility(WheelchairAccessibility wheelchairAccessibility) {
+    this.wheelchairAccessibility = wheelchairAccessibility;
   }
 
   public int getNumStops() {

--- a/src/main/java/org/opentripplanner/updater/GtfsRealtimeMapper.java
+++ b/src/main/java/org/opentripplanner/updater/GtfsRealtimeMapper.java
@@ -1,0 +1,21 @@
+package org.opentripplanner.updater;
+
+import com.google.transit.realtime.GtfsRealtime;
+import java.util.Optional;
+import org.opentripplanner.transit.model.basic.WheelchairAccessibility;
+
+public class GtfsRealtimeMapper {
+
+  public static Optional<WheelchairAccessibility> mapWheelchairAccessible(
+    GtfsRealtime.VehicleDescriptor.WheelchairAccessible wheelchairAccessible
+  ) {
+    return Optional.ofNullable(
+      switch (wheelchairAccessible) {
+        case WHEELCHAIR_ACCESSIBLE -> WheelchairAccessibility.POSSIBLE;
+        case WHEELCHAIR_INACCESSIBLE -> WheelchairAccessibility.NOT_POSSIBLE;
+        case UNKNOWN -> WheelchairAccessibility.NO_INFORMATION;
+        default -> null;
+      }
+    );
+  }
+}

--- a/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
@@ -36,6 +36,7 @@ import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.updater.GtfsRealtimeFuzzyTripMatcher;
+import org.opentripplanner.updater.GtfsRealtimeMapper;
 import org.opentripplanner.util.time.ServiceDateUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -757,6 +758,15 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
 
     // Make sure that updated trip times have the correct real time state
     newTripTimes.setRealTimeState(realTimeState);
+
+    if (tripUpdate.hasVehicle()) {
+      var vehicleDescriptor = tripUpdate.getVehicle();
+      if (vehicleDescriptor.hasWheelchairAccessible()) {
+        GtfsRealtimeMapper
+          .mapWheelchairAccessible(vehicleDescriptor.getWheelchairAccessible())
+          .ifPresent(newTripTimes::updateWheelchairAccessibility);
+      }
+    }
 
     // Add new trip times to the buffer
     return buffer.update(pattern, newTripTimes, serviceDate);

--- a/src/main/proto/gtfs-realtime.proto
+++ b/src/main/proto/gtfs-realtime.proto
@@ -843,6 +843,26 @@ message VehicleDescriptor {
   // The license plate of the vehicle.
   optional string license_plate = 3;
 
+  enum WheelchairAccessible {
+    // The trip doesn't have information about wheelchair accessibility.
+    // This is the **default** behavior. If the static GTFS contains a
+    // _wheelchair_accessible_ value, it won't be overwritten.
+    NO_VALUE = 0;
+
+    // The trip has no accessibility value present.
+    // This value will overwrite the value from the GTFS.
+    UNKNOWN = 1;
+
+    // The trip is wheelchair accessible.
+    // This value will overwrite the value from the GTFS.
+    WHEELCHAIR_ACCESSIBLE = 2;
+
+    // The trip is **not** wheelchair accessible.
+    // This value will overwrite the value from the GTFS.
+    WHEELCHAIR_INACCESSIBLE = 3;
+  }
+  optional WheelchairAccessible wheelchair_accessible = 4 [default = NO_VALUE];
+
   // The extensions namespace allows 3rd-party developers to extend the
   // GTFS Realtime Specification in order to add and evaluate new features and
   // modifications to the spec.

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RoutingRequestTransitDataProviderFilterTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RoutingRequestTransitDataProviderFilterTest.java
@@ -47,6 +47,10 @@ public class RoutingRequestTransitDataProviderFilterTest {
   private static final WheelchairAccessibilityRequest DEFAULT_ACCESSIBILITY =
     WheelchairAccessibilityRequest.DEFAULT;
 
+  private static final WheelchairAccessibilityRequest ENABLED_ACCESSIBILITY = WheelchairAccessibilityRequest.makeDefault(
+    true
+  );
+
   /**
    * Test filter for wheelchair access.
    *
@@ -250,7 +254,7 @@ public class RoutingRequestTransitDataProviderFilterTest {
 
     var filter = new RoutingRequestTransitDataProviderFilter(
       false,
-      WheelchairAccessibilityRequest.makeDefault(true),
+      ENABLED_ACCESSIBILITY,
       false,
       MainAndSubMode.all(),
       Set.of(),
@@ -276,7 +280,7 @@ public class RoutingRequestTransitDataProviderFilterTest {
 
     var filter = new RoutingRequestTransitDataProviderFilter(
       false,
-      DEFAULT_ACCESSIBILITY,
+      ENABLED_ACCESSIBILITY,
       false,
       List.of(new MainAndSubMode(TransitMode.BUS)),
       Set.of(),
@@ -286,6 +290,36 @@ public class RoutingRequestTransitDataProviderFilterTest {
     boolean valid = filter.tripTimesPredicate(wheelchairAccessibleTrip);
 
     assertTrue(valid);
+  }
+
+  @Test
+  public void keepRealTimeAccessibleTrip() {
+    TripTimes realTimeWheelchairAccessibleTrip = createTestTripTimes(
+      TRIP_ID,
+      ROUTE,
+      BikeAccess.NOT_ALLOWED,
+      TransitMode.BUS,
+      null,
+      WheelchairAccessibility.NOT_POSSIBLE,
+      TripAlteration.PLANNED
+    );
+
+    var filter = new RoutingRequestTransitDataProviderFilter(
+      false,
+      ENABLED_ACCESSIBILITY,
+      false,
+      List.of(new MainAndSubMode(TransitMode.BUS)),
+      Set.of(),
+      Set.of()
+    );
+
+    assertFalse(filter.tripTimesPredicate(realTimeWheelchairAccessibleTrip));
+
+    realTimeWheelchairAccessibleTrip.updateWheelchairAccessibility(
+      WheelchairAccessibility.POSSIBLE
+    );
+
+    assertTrue(filter.tripTimesPredicate(realTimeWheelchairAccessibleTrip));
   }
 
   @Test


### PR DESCRIPTION
### Summary

This allows the wheelchair accessibility of trips to be updated using GTFS-realtime. To do so the wheelchair accessibility information is added to `TripTimes`.

The proto changes are proposed in https://github.com/google/transit/pull/340

BKK (Budapest, Hungary) has a GTFS-realtime TripUpdates feed which includes these values ([txt](https://go.bkk.hu/api/query/v1/ws/gtfs-rt/full/TripUpdates.txt) / [pb](https://go.bkk.hu/api/query/v1/ws/gtfs-rt/full/TripUpdates.pb))

### Issue

closes #4252 

### Unit tests

The existing filtering unit tests are updated.

### Documentation

No changes.