### PR TITLE
Move transit alert mapping to itinerary filter chain

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/flex/FlexRouter.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/FlexRouter.java
@@ -22,7 +22,6 @@ import org.opentripplanner.ext.flex.template.FlexAccessTemplate;
 import org.opentripplanner.ext.flex.template.FlexEgressTemplate;
 import org.opentripplanner.ext.flex.trip.FlexTrip;
 import org.opentripplanner.model.plan.Itinerary;
-import org.opentripplanner.routing.algorithm.mapping.AlertToLegMapper;
 import org.opentripplanner.routing.algorithm.mapping.GraphPathToItineraryMapper;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
@@ -75,10 +74,6 @@ public class FlexRouter {
     this.graphPathToItineraryMapper =
       new GraphPathToItineraryMapper(
         transitModel.getTimeZone(),
-        new AlertToLegMapper(
-          transitModel.getTransitAlertService(),
-          transitModel.getStopModel().getStopModelIndex().getMultiModalStationForStations()::get
-        ),
         graph.streetNotesService,
         graph.ellipsoidToGeoidDifference
       );

--- a/src/main/java/org/opentripplanner/routing/algorithm/RoutingWorker.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/RoutingWorker.java
@@ -125,7 +125,9 @@ public class RoutingWorker {
       it -> firstRemovedItinerary = it,
       request.wheelchairAccessibility.enabled(),
       request.wheelchairAccessibility.maxSlope(),
-      router.graph.getService(FareService.class)
+      router.graph.getService(FareService.class),
+      router.transitModel.getTransitAlertService(),
+      router.transitModel.getStopModel().getStopModelIndex().getMultiModalStationForStations()::get
     );
 
     List<Itinerary> filteredItineraries = filterChain.filter(itineraries);

--- a/src/main/java/org/opentripplanner/routing/algorithm/filterchain/filter/TransitAlertFilter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/filterchain/filter/TransitAlertFilter.java
@@ -1,0 +1,39 @@
+package org.opentripplanner.routing.algorithm.filterchain.filter;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+import org.opentripplanner.model.MultiModalStation;
+import org.opentripplanner.model.plan.Itinerary;
+import org.opentripplanner.model.plan.Leg;
+import org.opentripplanner.routing.algorithm.filterchain.ItineraryListFilter;
+import org.opentripplanner.routing.algorithm.mapping.AlertToLegMapper;
+import org.opentripplanner.routing.services.TransitAlertService;
+import org.opentripplanner.transit.model.site.Station;
+
+public class TransitAlertFilter implements ItineraryListFilter {
+
+  private final AlertToLegMapper alertToLegMapper;
+
+  public TransitAlertFilter(
+    TransitAlertService transitAlertService,
+    Function<Station, MultiModalStation> getMultiModalStation
+  ) {
+    alertToLegMapper = new AlertToLegMapper(transitAlertService, getMultiModalStation);
+  }
+
+  @Override
+  public List<Itinerary> filter(List<Itinerary> itineraries) {
+    for (Itinerary itinerary : itineraries) {
+      boolean firstLeg = true;
+      for (Leg leg : itinerary.getLegs()) {
+        if (leg.isTransitLeg()) {
+          alertToLegMapper.addTransitAlertsToLeg(leg, firstLeg);
+          firstLeg = false;
+        }
+      }
+    }
+
+    return itineraries;
+  }
+}

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/GraphPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/GraphPathToItineraryMapper.java
@@ -50,18 +50,15 @@ import org.opentripplanner.util.OTPFeature;
 public class GraphPathToItineraryMapper {
 
   private final ZoneId timeZone;
-  private final AlertToLegMapper alertToLegMapper;
   private final StreetNotesService streetNotesService;
   private final double ellipsoidToGeoidDifference;
 
   public GraphPathToItineraryMapper(
     ZoneId timeZone,
-    AlertToLegMapper alertToLegMapper,
     StreetNotesService streetNotesService,
     double ellipsoidToGeoidDifference
   ) {
     this.timeZone = timeZone;
-    this.alertToLegMapper = alertToLegMapper;
     this.streetNotesService = streetNotesService;
     this.ellipsoidToGeoidDifference = ellipsoidToGeoidDifference;
   }
@@ -356,10 +353,7 @@ public class GraphPathToItineraryMapper {
     ZonedDateTime endTime = toState.getTime().atZone(timeZone);
     int generalizedCost = (int) (toState.getWeight() - fromState.getWeight());
 
-    Leg leg = new FlexibleTransitLeg(flexEdge, startTime, endTime, generalizedCost);
-
-    alertToLegMapper.addTransitAlertsToLeg(leg, true);
-    return leg;
+    return new FlexibleTransitLeg(flexEdge, startTime, endTime, generalizedCost);
   }
 
   /**

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/RoutingRequestToFilterChainMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/RoutingRequestToFilterChainMapper.java
@@ -2,6 +2,8 @@ package org.opentripplanner.routing.algorithm.mapping;
 
 import java.time.Instant;
 import java.util.function.Consumer;
+import java.util.function.Function;
+import org.opentripplanner.model.MultiModalStation;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.SortOrder;
 import org.opentripplanner.routing.algorithm.filterchain.GroupBySimilarity;
@@ -10,6 +12,8 @@ import org.opentripplanner.routing.algorithm.filterchain.ItineraryListFilterChai
 import org.opentripplanner.routing.algorithm.filterchain.ListSection;
 import org.opentripplanner.routing.api.request.ItineraryFilterParameters;
 import org.opentripplanner.routing.fares.FareService;
+import org.opentripplanner.routing.services.TransitAlertService;
+import org.opentripplanner.transit.model.site.Station;
 
 public class RoutingRequestToFilterChainMapper {
 
@@ -29,7 +33,9 @@ public class RoutingRequestToFilterChainMapper {
     Consumer<Itinerary> maxLimitReachedSubscriber,
     boolean wheelchairAccessible,
     double wheelchairMaxSlope,
-    FareService fareService
+    FareService fareService,
+    TransitAlertService transitAlertService,
+    Function<Station, MultiModalStation> getMultiModalStation
   ) {
     var builder = new ItineraryListFilterChainBuilder(sortOrder);
 
@@ -64,6 +70,7 @@ public class RoutingRequestToFilterChainMapper {
       .withSameFirstOrLastTripFilter(params.filterItinerariesWithSameFirstOrLastTrip)
       .withAccessibilityScore(params.accessibilityScore && wheelchairAccessible, wheelchairMaxSlope)
       .withFares(fareService)
+      .withTransitAlerts(transitAlertService, getMultiModalStation)
       .withRemoveTransitWithHigherCostThanBestOnStreetOnly(true)
       .withLatestDepartureTimeLimit(filterOnLatestDepartureTime)
       .withMaxLimitReachedSubscriber(maxLimitReachedSubscriber)

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/DirectStreetRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/DirectStreetRouter.java
@@ -4,7 +4,6 @@ import java.util.Collections;
 import java.util.List;
 import org.opentripplanner.common.geometry.SphericalDistanceLibrary;
 import org.opentripplanner.model.plan.Itinerary;
-import org.opentripplanner.routing.algorithm.mapping.AlertToLegMapper;
 import org.opentripplanner.routing.algorithm.mapping.GraphPathToItineraryMapper;
 import org.opentripplanner.routing.algorithm.mapping.ItinerariesHelper;
 import org.opentripplanner.routing.api.request.RoutingRequest;
@@ -42,13 +41,6 @@ public class DirectStreetRouter {
       // Convert the internal GraphPaths to itineraries
       final GraphPathToItineraryMapper graphPathToItineraryMapper = new GraphPathToItineraryMapper(
         router.transitModel.getTimeZone(),
-        new AlertToLegMapper(
-          router.transitModel.getTransitAlertService(),
-          router.transitModel
-            .getStopModel()
-            .getStopModelIndex()
-            .getMultiModalStationForStations()::get
-        ),
         router.graph.streetNotesService,
         router.graph.ellipsoidToGeoidDifference
       );

--- a/src/test/java/org/opentripplanner/graph_builder/module/osm/TestIntermediatePlaces.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/osm/TestIntermediatePlaces.java
@@ -19,7 +19,6 @@ import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.Leg;
 import org.opentripplanner.model.plan.Place;
 import org.opentripplanner.model.plan.TripPlan;
-import org.opentripplanner.routing.algorithm.mapping.AlertToLegMapper;
 import org.opentripplanner.routing.algorithm.mapping.GraphPathToItineraryMapper;
 import org.opentripplanner.routing.algorithm.mapping.TripPlanMapper;
 import org.opentripplanner.routing.api.request.RoutingRequest;
@@ -52,8 +51,6 @@ public class TestIntermediatePlaces {
 
   private static Graph graph;
 
-  private static TransitModel transitModel;
-
   private static GraphPathToItineraryMapper graphPathToItineraryMapper;
 
   @BeforeAll
@@ -61,7 +58,7 @@ public class TestIntermediatePlaces {
     try {
       OtpModel otpModel = FakeGraph.buildGraphNoTransit();
       graph = otpModel.graph;
-      transitModel = otpModel.transitModel;
+      TransitModel transitModel = otpModel.transitModel;
       FakeGraph.addPerpendicularRoutes(graph, transitModel);
       FakeGraph.link(graph, transitModel);
       graph.index();
@@ -72,8 +69,7 @@ public class TestIntermediatePlaces {
 
       graphPathToItineraryMapper =
         new GraphPathToItineraryMapper(
-          transitModel.getTimeZone(),
-          new AlertToLegMapper(transitModel.getTransitAlertService(), ignore -> null),
+          timeZone,
           graph.streetNotesService,
           graph.ellipsoidToGeoidDifference
         );

--- a/src/test/java/org/opentripplanner/routing/algorithm/filterchain/ItineraryListFilterChainTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/filterchain/ItineraryListFilterChainTest.java
@@ -3,9 +3,11 @@ package org.opentripplanner.routing.algorithm.filterchain;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.opentripplanner.model.plan.Itinerary.toStr;
 import static org.opentripplanner.model.plan.SortOrder.STREET_AND_ARRIVAL_TIME;
 import static org.opentripplanner.model.plan.SortOrder.STREET_AND_DEPARTURE_TIME;
+import static org.opentripplanner.model.plan.TestItineraryBuilder.BUS_ROUTE;
 import static org.opentripplanner.model.plan.TestItineraryBuilder.newItinerary;
 import static org.opentripplanner.model.plan.TestItineraryBuilder.newTime;
 
@@ -14,11 +16,14 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.PlanTestConstants;
 import org.opentripplanner.model.plan.TestItineraryBuilder;
 import org.opentripplanner.routing.api.response.RoutingError;
 import org.opentripplanner.routing.api.response.RoutingErrorCode;
+import org.opentripplanner.routing.services.TransitAlertService;
+import org.opentripplanner.transit.model.framework.FeedScopedId;
 
 /**
  * This class test the whole filter chain with a few test cases. Each filter should be tested with a
@@ -171,6 +176,24 @@ public class ItineraryListFilterChainTest implements PlanTestConstants {
       RoutingErrorCode.NO_TRANSIT_CONNECTION_IN_SEARCH_WINDOW,
       routingErrors.get(0).code
     );
+  }
+
+  @Test
+  void transitAlertsTest() {
+    var transitAlertService = Mockito.mock(TransitAlertService.class);
+
+    // Given a chain with transit alerts
+    var chain = createBuilder(false, false, 20)
+      .withTransitAlerts(transitAlertService, ignore -> null)
+      .build();
+
+    // When running it with transit itineraries
+    chain.filter(List.of(i1, i2, i3));
+
+    // Then transitAlertService should have been called with stop and route ids
+    Mockito.verify(transitAlertService, Mockito.atLeastOnce()).getStopAlerts(A.stop.getId());
+    Mockito.verify(transitAlertService, Mockito.atLeastOnce()).getStopAlerts(E.stop.getId());
+    Mockito.verify(transitAlertService, Mockito.atLeastOnce()).getRouteAlerts(BUS_ROUTE.getId());
   }
 
   private ItineraryListFilterChainBuilder createBuilder(

--- a/src/test/java/org/opentripplanner/routing/algorithm/filterchain/filter/TransitAlertFilterTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/filterchain/filter/TransitAlertFilterTest.java
@@ -1,0 +1,63 @@
+package org.opentripplanner.routing.algorithm.filterchain.filter;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.opentripplanner.model.plan.TestItineraryBuilder.BUS_ROUTE;
+import static org.opentripplanner.model.plan.TestItineraryBuilder.newItinerary;
+
+import java.util.Collection;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.opentripplanner.model.plan.Itinerary;
+import org.opentripplanner.model.plan.PlanTestConstants;
+import org.opentripplanner.routing.alertpatch.TimePeriod;
+import org.opentripplanner.routing.alertpatch.TransitAlert;
+import org.opentripplanner.routing.services.TransitAlertService;
+import org.opentripplanner.transit.model.framework.FeedScopedId;
+
+class TransitAlertFilterTest implements PlanTestConstants {
+
+  @Test
+  void testFilter() {
+    TransitAlertFilter filter = new TransitAlertFilter(
+      Mockito.spy(TestTransitAlertService.class),
+      ignore -> null
+    );
+
+    // Expect filter to no fail on an empty list
+    assertEquals(List.of(), filter.filter(List.of()));
+
+    // Given a list with one itinerary
+    List<Itinerary> list = List.of(
+      newItinerary(A).bus(31, 0, 30, E).build(),
+      newItinerary(B).rail(21, 0, 30, E).build()
+    );
+
+    list = filter.filter(list);
+
+    // Then: expect correct alerts to be added
+    Itinerary first = list.get(0);
+    assertEquals(1, first.getLegs().get(0).getTransitAlerts().size());
+    assertEquals("BUS", first.getLegs().get(0).getTransitAlerts().iterator().next().getId());
+    assertEquals(0, list.get(1).getLegs().get(0).getTransitAlerts().size());
+  }
+
+  abstract static class TestTransitAlertService implements TransitAlertService {
+
+    public static final TransitAlert BUS_ALERT = new TransitAlert();
+
+    static {
+      BUS_ALERT.setId("BUS");
+      BUS_ALERT.setTimePeriods(List.of(new TimePeriod(0, TimePeriod.OPEN_ENDED)));
+    }
+
+    @Override
+    public Collection<TransitAlert> getRouteAlerts(FeedScopedId route) {
+      if (route.equals(BUS_ROUTE.getId())) {
+        return List.of(BUS_ALERT);
+      }
+
+      return List.of();
+    }
+  }
+}

--- a/src/test/java/org/opentripplanner/routing/street/BarrierRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/street/BarrierRoutingTest.java
@@ -10,7 +10,6 @@ import io.micrometer.core.instrument.Metrics;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.List;
-import java.util.TimeZone;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -25,7 +24,6 @@ import org.opentripplanner.OtpModel;
 import org.opentripplanner.model.GenericLocation;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.WalkStep;
-import org.opentripplanner.routing.algorithm.mapping.AlertToLegMapper;
 import org.opentripplanner.routing.algorithm.mapping.GraphPathToItineraryMapper;
 import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.core.RoutingContext;
@@ -182,7 +180,6 @@ public class BarrierRoutingTest {
 
     GraphPathToItineraryMapper graphPathToItineraryMapper = new GraphPathToItineraryMapper(
       ZoneId.of("Europe/Berlin"),
-      Mockito.mock(AlertToLegMapper.class),
       graph.streetNotesService,
       graph.ellipsoidToGeoidDifference
     );

--- a/src/test/java/org/opentripplanner/routing/street/BicycleRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/street/BicycleRoutingTest.java
@@ -5,7 +5,6 @@ import static org.opentripplanner.test.support.PolylineAssert.assertThatPolyline
 import io.micrometer.core.instrument.Metrics;
 import java.time.Instant;
 import java.time.ZoneId;
-import java.util.TimeZone;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Geometry;
@@ -13,7 +12,6 @@ import org.mockito.Mockito;
 import org.opentripplanner.ConstantsForTests;
 import org.opentripplanner.OtpModel;
 import org.opentripplanner.model.GenericLocation;
-import org.opentripplanner.routing.algorithm.mapping.AlertToLegMapper;
 import org.opentripplanner.routing.algorithm.mapping.GraphPathToItineraryMapper;
 import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.core.BicycleOptimizeType;
@@ -93,7 +91,6 @@ public class BicycleRoutingTest {
 
     GraphPathToItineraryMapper graphPathToItineraryMapper = new GraphPathToItineraryMapper(
       ZoneId.of("Europe/Berlin"),
-      Mockito.mock(AlertToLegMapper.class),
       graph.streetNotesService,
       graph.ellipsoidToGeoidDifference
     );

--- a/src/test/java/org/opentripplanner/routing/street/CarRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/street/CarRoutingTest.java
@@ -5,7 +5,6 @@ import static org.opentripplanner.test.support.PolylineAssert.assertThatPolyline
 import io.micrometer.core.instrument.Metrics;
 import java.time.Instant;
 import java.time.ZoneId;
-import java.util.TimeZone;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -15,7 +14,6 @@ import org.mockito.Mockito;
 import org.opentripplanner.ConstantsForTests;
 import org.opentripplanner.OtpModel;
 import org.opentripplanner.model.GenericLocation;
-import org.opentripplanner.routing.algorithm.mapping.AlertToLegMapper;
 import org.opentripplanner.routing.algorithm.mapping.GraphPathToItineraryMapper;
 import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.core.RoutingContext;
@@ -150,7 +148,6 @@ public class CarRoutingTest {
 
     GraphPathToItineraryMapper graphPathToItineraryMapper = new GraphPathToItineraryMapper(
       ZoneId.of("Europe/Berlin"),
-      Mockito.mock(AlertToLegMapper.class),
       graph.streetNotesService,
       graph.ellipsoidToGeoidDifference
     );

--- a/src/test/java/org/opentripplanner/routing/street/SplitEdgeTurnRestrictionsTest.java
+++ b/src/test/java/org/opentripplanner/routing/street/SplitEdgeTurnRestrictionsTest.java
@@ -5,7 +5,6 @@ import static org.opentripplanner.test.support.PolylineAssert.assertThatPolyline
 import io.micrometer.core.instrument.Metrics;
 import java.time.Instant;
 import java.time.ZoneId;
-import java.util.TimeZone;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Geometry;
@@ -13,7 +12,6 @@ import org.mockito.Mockito;
 import org.opentripplanner.ConstantsForTests;
 import org.opentripplanner.OtpModel;
 import org.opentripplanner.model.GenericLocation;
-import org.opentripplanner.routing.algorithm.mapping.AlertToLegMapper;
 import org.opentripplanner.routing.algorithm.mapping.GraphPathToItineraryMapper;
 import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.core.RoutingContext;
@@ -169,7 +167,6 @@ public class SplitEdgeTurnRestrictionsTest {
 
     GraphPathToItineraryMapper graphPathToItineraryMapper = new GraphPathToItineraryMapper(
       ZoneId.of("Europe/Berlin"),
-      Mockito.mock(AlertToLegMapper.class),
       graph.streetNotesService,
       graph.ellipsoidToGeoidDifference
     );


### PR DESCRIPTION
### Summary

Currently the transit alert mapping is spread out in multiple places in the code. Replace these by a single filter mapper.
