### PR TITLE
Use full seconds for A-star state

### DIFF
--- a/src/main/java/org/opentripplanner/routing/core/State.java
+++ b/src/main/java/org/opentripplanner/routing/core/State.java
@@ -16,7 +16,7 @@ public class State implements Cloneable {
 
   /* Data which is likely to change at most traversals */
 
-  // the current time at this state, in milliseconds
+  // the current time at this state, in seconds since UNIX epoch
   protected long time;
 
   // accumulated weight up to this state
@@ -79,7 +79,7 @@ public class State implements Cloneable {
     this.stateData.rctx = routingContext;
     this.stateData.startTime = startTime;
     this.walkDistance = 0;
-    this.time = startTime.toEpochMilli();
+    this.time = startTime.getEpochSecond();
   }
 
   /**
@@ -118,7 +118,7 @@ public class State implements Cloneable {
 
   /** Returns time in seconds since epoch */
   public long getTimeSeconds() {
-    return time / 1000;
+    return time;
   }
 
   /** returns the length of the trip in seconds up to this state */
@@ -281,7 +281,7 @@ public class State implements Cloneable {
   }
 
   public Instant getTime() {
-    return Instant.ofEpochMilli(time);
+    return Instant.ofEpochSecond(time);
   }
 
   public String getVehicleRentalNetwork() {

--- a/src/main/java/org/opentripplanner/routing/core/StateEditor.java
+++ b/src/main/java/org/opentripplanner/routing/core/StateEditor.java
@@ -157,11 +157,7 @@ public class StateEditor {
    * backward when traversing backward.
    */
   public void incrementTimeInSeconds(int seconds) {
-    incrementTimeInMilliseconds(seconds * 1000L);
-  }
-
-  public void incrementTimeInMilliseconds(long milliseconds) {
-    if (milliseconds < 0) {
+    if (seconds < 0) {
       LOG.warn(
         "A state's time is being incremented by a negative amount while traversing edge " +
         child.getBackEdge()
@@ -169,7 +165,7 @@ public class StateEditor {
       defectiveTraversal = true;
       return;
     }
-    child.time += (traversingBackward ? -milliseconds : milliseconds);
+    child.time += (traversingBackward ? -seconds : seconds);
   }
 
   public void incrementWalkDistance(double length) {
@@ -313,7 +309,7 @@ public class StateEditor {
   }
 
   public void setTimeSeconds(long seconds) {
-    child.time = seconds * 1000;
+    child.time = seconds;
   }
 
   /* PUBLIC GETTER METHODS */

--- a/src/main/java/org/opentripplanner/routing/impl/GraphPathFinder.java
+++ b/src/main/java/org/opentripplanner/routing/impl/GraphPathFinder.java
@@ -95,7 +95,7 @@ public class GraphPathFinder {
    */
   public List<GraphPath> graphPathFinderEntryPoint(RoutingContext routingContext) {
     RoutingRequest request = routingContext.opt;
-    Instant reqTime = request.getDateTime().truncatedTo(ChronoUnit.MILLIS);
+    Instant reqTime = request.getDateTime().truncatedTo(ChronoUnit.SECONDS);
 
     List<GraphPath> paths = getPaths(routingContext);
 


### PR DESCRIPTION
### Summary

Currently the state for the A-star algorithm uses milliseconds for time. As we always set or increment the state by full seconds, and use seconds for the weight, I simplified the code, to store the times in full seconds, similar to how RAPTOR state stores them.