### PR TITLE
Add Houston fare calculator

### DIFF
--- a/docs/BuildConfiguration.md
+++ b/docs/BuildConfiguration.md
@@ -478,7 +478,7 @@ The current list of custom fare type is:
 - `highestFareInFreeTransferWindow` Will apply the highest observed transit fare (across all
   operators) within a free transfer window, adding to the cost if a trip is boarded outside the free
   transfer window. It accepts the following parameters:
-    - `freeTransferWindows` the duration (in ISO8601-ish notation) that free transfers are
+    - `freeTransferWindow` the duration (in ISO8601-ish notation) that free transfers are
       possible after the board time of the first transit leg. Default: `2h30m`.
     - `analyzeInterlinedTransfers` If true, will treat interlined transfers as actual transfers.
       This is merely a work-around for transit agencies that choose to code their fares in a

--- a/docs/BuildConfiguration.md
+++ b/docs/BuildConfiguration.md
@@ -475,6 +475,14 @@ The current list of custom fare type is:
 - `san-francisco` (no parameters)
 - `new-york` (no parameters)
 - `seattle` (no parameters)
+- `highestFareInFreeTransferWindow` Will apply the highest observed transit fare (across all
+  operators) within a free transfer window, adding to the cost if a trip is boarded outside the free
+  transfer window. It accepts the following parameters:
+    - `freeTransferWindows` the duration (in ISO8601-ish notation) that free transfers are
+      possible after the board time of the first transit leg. Default: `2h30m`.
+    - `analyzeInterlinedTransfers` If true, will treat interlined transfers as actual transfers.
+      This is merely a work-around for transit agencies that choose to code their fares in a
+      route-based fashion instead of a zone-based fashion. Default: `false`
 - `off` (no parameters)
 
 The current list of `combinationStrategy` is:

--- a/docs/sandbox/Fares.md
+++ b/docs/sandbox/Fares.md
@@ -7,6 +7,7 @@
 ## Changelog
 
 - Initial move into sandbox [#4241](https://github.com/opentripplanner/OpenTripPlanner/pull/4241)
+- Add HighestFareInFreeTransferWindowFareService [#4267](https://github.com/opentripplanner/OpenTripPlanner/pull/4267)
 
 ## Documentation
 
@@ -22,10 +23,11 @@ which are also part of the sandbox code.
 
 The classes and their maintainers are as follows:
 
-| class                    | maintainer |
-|--------------------------|------------|
-| DutchFareServiceImpl     | unknown    |
-| NycFareServiceImpl       | unknown    |
-| SeattleFareServiceImpl   | unknown    |
-| SFBayAreaFareServiceImpl | unknown    |
+| class                                                          | maintainer                                                 |
+|----------------------------------------------------------------|------------------------------------------------------------|
+| HighestFareInFreeTransferWindowFareServiceDutchFareServiceImpl | IBI Group ([David Emory](mailto:david.emory@ibigroup.com)) |
+| DutchFareServiceImpl                                           | unknown                                                    |
+| NycFareServiceImpl                                             | unknown                                                    |
+| SeattleFareServiceImpl                                         | unknown                                                    |
+| SFBayAreaFareServiceImpl                                       | unknown                                                    |
 

--- a/src/ext-test/java/org/opentripplanner/ext/fares/FaresConfigurationTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/fares/FaresConfigurationTest.java
@@ -1,0 +1,37 @@
+package org.opentripplanner.ext.fares;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.ext.fares.impl.HighestFareInFreeTransferWindowFareService;
+import org.opentripplanner.standalone.config.JsonSupport;
+
+class FaresConfigurationTest extends JsonSupport {
+
+  @Test
+  void houston() {
+    var node = jsonNodeForTest("\"highestFareInFreeTransferWindow\"");
+    var service = FaresConfiguration.fromConfig(node).makeFareService();
+    assertSame(HighestFareInFreeTransferWindowFareService.class, service.getClass());
+  }
+
+  @Test
+  void houstonWithParams() {
+    var node = jsonNodeForTest(
+      """
+        {
+          "type": "highestFareInFreeTransferWindow",
+          "freeTransferWindow": "30m",
+          "analyzeInterlinedTransfers": true
+        }
+      """
+    );
+    var service = FaresConfiguration.fromConfig(node).makeFareService();
+    assertInstanceOf(HighestFareInFreeTransferWindowFareService.class, service);
+
+    var houston = (HighestFareInFreeTransferWindowFareService) service;
+    assertEquals(Duration.ofMinutes(30), houston.freeTransferWindow());
+    assertTrue(houston.analyzeInterlinedTransfers());
+  }
+}

--- a/src/ext-test/java/org/opentripplanner/ext/fares/impl/HighestFareInFreeTransferWindowFareServiceTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/fares/impl/HighestFareInFreeTransferWindowFareServiceTest.java
@@ -1,0 +1,228 @@
+package org.opentripplanner.ext.fares.impl;
+
+import static org.opentripplanner.model.plan.TestItineraryBuilder.newItinerary;
+import static org.opentripplanner.transit.model._data.TransitModelForTest.FEED_ID;
+import static org.opentripplanner.transit.model._data.TransitModelForTest.id;
+
+import java.util.LinkedList;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.opentripplanner.model.FareAttribute;
+import org.opentripplanner.model.plan.Itinerary;
+import org.opentripplanner.model.plan.PlanTestConstants;
+import org.opentripplanner.routing.core.Fare;
+import org.opentripplanner.routing.core.FareRuleSet;
+import org.opentripplanner.routing.fares.FareService;
+import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.model.network.Route;
+import org.opentripplanner.transit.model.network.TransitMode;
+import org.opentripplanner.transit.model.organization.Agency;
+
+class HighestFareInFreeTransferWindowFareServiceTest implements PlanTestConstants {
+
+  static Agency agency = Agency
+    .of(id("agency"))
+    .withName("Houston")
+    .withTimezone("America/Houston")
+    .build();
+
+  @ParameterizedTest(name = "[{index}] {0}")
+  @MethodSource("createTestCases")
+  public void canCalculateFare(
+    String testCaseName, // used to create parameterized test name
+    FareService fareService,
+    Itinerary i,
+    float expectedFare
+  ) {
+    Assertions.assertEquals(
+      Math.round(expectedFare * 100),
+      fareService.getCost(i).fare.get(Fare.FareType.regular).getCents()
+    );
+  }
+
+  private static List<Arguments> createTestCases() {
+    List<Arguments> args = new LinkedList<>();
+
+    // create routes
+    Route routeA = route("A", "Route with one dollar fare");
+    Route routeB = route("B", "Route with one dollar fare");
+    Route routeC = route("C", "Route with two dollar fare");
+
+    // create fare attributes and rules
+    List<FareRuleSet> defaultFareRules = new LinkedList<>();
+
+    // $1 fares
+    float oneDollar = 1.0f;
+    FareAttribute oneDollarFareAttribute = new FareAttribute(
+      new FeedScopedId(FEED_ID, "oneDollarAttribute")
+    );
+    oneDollarFareAttribute.setCurrencyType("USD");
+    oneDollarFareAttribute.setPrice(oneDollar);
+    FareRuleSet oneDollarRouteBasedFares = new FareRuleSet(oneDollarFareAttribute);
+    oneDollarRouteBasedFares.addRoute(routeA.getId());
+    oneDollarRouteBasedFares.addRoute(routeB.getId());
+    defaultFareRules.add(oneDollarRouteBasedFares);
+
+    // $2 fares
+    float twoDollars = 2.0f;
+    FareAttribute twoDollarFareAttribute = new FareAttribute(
+      new FeedScopedId(FEED_ID, "twoDollarAttribute")
+    );
+    twoDollarFareAttribute.setCurrencyType("USD");
+    twoDollarFareAttribute.setPrice(twoDollars);
+
+    FareRuleSet twoDollarRouteBasedFares = new FareRuleSet(twoDollarFareAttribute);
+    twoDollarRouteBasedFares.addRoute(routeC.getId());
+    defaultFareRules.add(twoDollarRouteBasedFares);
+
+    FareService defaultFareService = new HighestFareInFreeTransferWindowFareService(
+      defaultFareRules,
+      150,
+      false
+    );
+
+    // a single transit leg should calculate default fare
+    Itinerary singleTransitLegPath = newItinerary(A, T11_06)
+      .bus(routeA, 1, T11_06, T11_12, B)
+      .build();
+
+    args.add(
+      Arguments.of("Single transit leg", defaultFareService, singleTransitLegPath, oneDollar)
+    );
+
+    // a two transit leg itinerary with same route costs within free-transfer window should calculate default fare
+    Itinerary twoTransitLegPath = newItinerary(A, 30)
+      .bus(routeA, 1, 30, 60, B)
+      .bus(routeB, 2, 90, 120, C)
+      .build();
+
+    args.add(
+      Arguments.of(
+        "Two transit legs in free transfer window",
+        defaultFareService,
+        twoTransitLegPath,
+        oneDollar
+      )
+    );
+
+    // a two transit leg itinerary where the first route costs more than the second route, but both are within
+    // the free transfer window should calculate the first route cost
+    Itinerary twoTransitLegFirstRouteCostsTwoDollarsPath = newItinerary(A, 30)
+      .bus(routeC, 1, 30, 60, B)
+      .bus(routeB, 2, 90, 120, C)
+      .build();
+
+    args.add(
+      Arguments.of(
+        "Two transit legs in free transfer window, first leg more expensive",
+        defaultFareService,
+        twoTransitLegFirstRouteCostsTwoDollarsPath,
+        twoDollars
+      )
+    );
+
+    // a two transit leg itinerary where the second route costs more than the first route, but both are within
+    // the free transfer window should calculate the second route cost
+    Itinerary twoTransitLegSecondRouteCostsTwoDollarsPath = newItinerary(A, 30)
+      .bus(routeB, 1, 30, 60, B)
+      .bus(routeC, 2, 90, 120, C)
+      .build();
+    args.add(
+      Arguments.of(
+        "Two transit legs in free transfer window, second leg more expensive",
+        defaultFareService,
+        twoTransitLegSecondRouteCostsTwoDollarsPath,
+        twoDollars
+      )
+    );
+
+    // a two transit leg itinerary with same route costs but where the second leg begins after the free transfer
+    // window should calculate double the default fare
+    Itinerary twoTransitLegSecondRouteHappensAfterFreeTransferWindowPath = newItinerary(A, 30)
+      .bus(routeA, 1, 30, 60, B)
+      .bus(routeB, 2, 10000, 10120, C)
+      .build();
+    args.add(
+      Arguments.of(
+        "Two transit legs, second leg starts outside free transfer window",
+        defaultFareService,
+        twoTransitLegSecondRouteHappensAfterFreeTransferWindowPath,
+        oneDollar + oneDollar
+      )
+    );
+
+    // a three transit leg itinerary with same route costs but where the second leg begins after the free transfer
+    // window, but the third leg is within the second free transfer window should calculate double the default fare
+    Itinerary threeTransitLegSecondRouteHappensAfterFreeTransferWindowPath = newItinerary(A, 30)
+      .bus(routeA, 1, 30, 60, B)
+      .bus(routeB, 2, 10000, 10120, C)
+      .bus(routeA, 3, 10150, 10180, D)
+      .build();
+    args.add(
+      Arguments.of(
+        "Three transit legs, second leg starts outside free transfer window, third leg within second free transfer window",
+        defaultFareService,
+        threeTransitLegSecondRouteHappensAfterFreeTransferWindowPath,
+        oneDollar + oneDollar
+      )
+    );
+
+    // a three transit leg itinerary with same route costs but where each leg begins after the free transfer window,
+    // should calculate triple the default fare
+    Itinerary threeTransitLegAllOutsideFreeTransferWindowPath = newItinerary(A, 30)
+      .bus(routeA, 1, 30, 60, B)
+      .bus(routeB, 2, 10000, 10120, C)
+      .bus(routeA, 3, 20000, 20180, D)
+      .build();
+    args.add(
+      Arguments.of(
+        "Three transit legs, all starting outside free transfer window",
+        defaultFareService,
+        threeTransitLegAllOutsideFreeTransferWindowPath,
+        oneDollar + oneDollar + oneDollar
+      )
+    );
+
+    // a two transit leg itinerary with an interlined transfer where the second route costs more than the first
+    // route, but both are within the free transfer window should calculate the first route cost
+    Itinerary twoTransitLegInterlinedSecondRouteCostsTwoDollarsPath = newItinerary(A, 30)
+      .bus(routeB, 1, 30, 60, B)
+      .staySeatedBus(routeC, 2, 90, 120, C)
+      .build();
+    args.add(
+      Arguments.of(
+        "Two interlined transit legs, second leg more expensive should calculate first leg fare with default config",
+        defaultFareService,
+        twoTransitLegInterlinedSecondRouteCostsTwoDollarsPath,
+        oneDollar
+      )
+    );
+
+    // a two transit leg itinerary with an interlined transfer where the second route costs more than the first
+    // route, but both are within the free transfer window and the fare service is configured with the
+    // analyzeInterlinedTransfers set to true should calculate the second route cost
+    FareService fareServiceWithAnalyzedInterlinedTransfersConfig = new HighestFareInFreeTransferWindowFareService(
+      defaultFareRules,
+      150,
+      true
+    );
+
+    args.add(
+      Arguments.of(
+        "Two interlined transit legs, second leg more expensive should calculate second leg fare with alternate config",
+        fareServiceWithAnalyzedInterlinedTransfersConfig,
+        twoTransitLegInterlinedSecondRouteCostsTwoDollarsPath,
+        twoDollars
+      )
+    );
+
+    return args;
+  }
+
+  private static Route route(String id, String name) {
+    return Route.of(id(id)).withLongName(name).withAgency(agency).withMode(TransitMode.BUS).build();
+  }
+}

--- a/src/ext-test/java/org/opentripplanner/ext/fares/impl/HighestFareInFreeTransferWindowFareServiceTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/fares/impl/HighestFareInFreeTransferWindowFareServiceTest.java
@@ -4,6 +4,7 @@ import static org.opentripplanner.model.plan.TestItineraryBuilder.newItinerary;
 import static org.opentripplanner.transit.model._data.TransitModelForTest.FEED_ID;
 import static org.opentripplanner.transit.model._data.TransitModelForTest.id;
 
+import java.time.Duration;
 import java.util.LinkedList;
 import java.util.List;
 import org.junit.jupiter.api.Assertions;
@@ -80,7 +81,7 @@ class HighestFareInFreeTransferWindowFareServiceTest implements PlanTestConstant
 
     FareService defaultFareService = new HighestFareInFreeTransferWindowFareService(
       defaultFareRules,
-      150,
+      Duration.ofMinutes(150),
       false
     );
 
@@ -206,7 +207,7 @@ class HighestFareInFreeTransferWindowFareServiceTest implements PlanTestConstant
     // analyzeInterlinedTransfers set to true should calculate the second route cost
     FareService fareServiceWithAnalyzedInterlinedTransfersConfig = new HighestFareInFreeTransferWindowFareService(
       defaultFareRules,
-      150,
+      Duration.ofMinutes(150),
       true
     );
 

--- a/src/ext/java/org/opentripplanner/ext/fares/FaresConfiguration.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/FaresConfiguration.java
@@ -11,6 +11,7 @@ import org.opentripplanner.ext.fares.impl.SFBayFareServiceFactory;
 import org.opentripplanner.ext.fares.impl.SeattleFareServiceFactory;
 import org.opentripplanner.ext.fares.impl.TimeBasedVehicleRentalFareServiceFactory;
 import org.opentripplanner.routing.fares.FareServiceFactory;
+import org.opentripplanner.standalone.config.NodeAdapter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/ext/java/org/opentripplanner/ext/fares/FaresConfiguration.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/FaresConfiguration.java
@@ -3,6 +3,7 @@ package org.opentripplanner.ext.fares;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.opentripplanner.ext.fares.impl.DefaultFareServiceFactory;
 import org.opentripplanner.ext.fares.impl.DutchFareServiceFactory;
+import org.opentripplanner.ext.fares.impl.HighestFareInFreeTransferWindowFareServiceFactory;
 import org.opentripplanner.ext.fares.impl.MultipleFareServiceFactory;
 import org.opentripplanner.ext.fares.impl.NoopFareServiceFactory;
 import org.opentripplanner.ext.fares.impl.NycFareServiceFactory;
@@ -77,26 +78,18 @@ public class FaresConfiguration {
   }
 
   private static FareServiceFactory createFactory(String type) {
-    switch (type) {
-      case "default":
-        return new DefaultFareServiceFactory();
-      case "off":
-        return new NoopFareServiceFactory();
-      case "composite:additive":
-        return new MultipleFareServiceFactory.AddingMultipleFareServiceFactory();
-      case "vehicle-rental-time-based":
-      case "bike-rental-time-based": //TODO: deprecated, remove in next major version
-        return new TimeBasedVehicleRentalFareServiceFactory();
-      case "dutch":
-        return new DutchFareServiceFactory();
-      case "san-francisco":
-        return new SFBayFareServiceFactory();
-      case "new-york":
-        return new NycFareServiceFactory();
-      case "seattle":
-        return new SeattleFareServiceFactory();
-      default:
-        throw new IllegalArgumentException(String.format("Unknown fare type: '%s'", type));
-    }
+    return switch (type) {
+      case "default" -> new DefaultFareServiceFactory();
+      case "off" -> new NoopFareServiceFactory();
+      case "composite:additive" -> new MultipleFareServiceFactory.AddingMultipleFareServiceFactory();
+      case "vehicle-rental-time-based",
+        "bike-rental-time-based" -> new TimeBasedVehicleRentalFareServiceFactory(); //TODO: deprecated, remove in next major version
+      case "dutch" -> new DutchFareServiceFactory();
+      case "san-francisco" -> new SFBayFareServiceFactory();
+      case "new-york" -> new NycFareServiceFactory();
+      case "seattle" -> new SeattleFareServiceFactory();
+      case "highestFareInFreeTransferWindow" -> new HighestFareInFreeTransferWindowFareServiceFactory();
+      default -> throw new IllegalArgumentException(String.format("Unknown fare type: '%s'", type));
+    };
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/fares/impl/DefaultFareServiceImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/impl/DefaultFareServiceImpl.java
@@ -218,7 +218,7 @@ public class DefaultFareServiceImpl implements FareService {
   }
 
   protected boolean shouldCombineInterlinedLegs() {
-    return false;
+    return true;
   }
 
   private static List<Leg> combineInterlinedLegs(List<Leg> fareLegs) {

--- a/src/ext/java/org/opentripplanner/ext/fares/impl/DefaultFareServiceImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/impl/DefaultFareServiceImpl.java
@@ -222,60 +222,30 @@ public class DefaultFareServiceImpl implements FareService {
   }
 
   private static List<Leg> combineInterlinedLegs(List<Leg> fareLegs) {
-    return fareLegs
-      .stream()
-      .collect(
-        new Collector<Leg, List<Leg>, List<Leg>>() {
-          @Override
-          public Supplier<List<Leg>> supplier() {
-            return ArrayList::new;
-          }
-
-          @Override
-          public BiConsumer<List<Leg>, Leg> accumulator() {
-            return (legs, leg) -> {
-              if (leg.isInterlinedWithPreviousLeg() && leg instanceof ScheduledTransitLeg stl) {
-                var previousLeg = (ScheduledTransitLeg) legs.get(legs.size() - 1);
-                var combinedLeg = new ScheduledTransitLeg(
-                  previousLeg.getTripTimes(),
-                  previousLeg.getTripPattern(),
-                  0,
-                  0,
-                  previousLeg.getStartTime(),
-                  stl.getEndTime(),
-                  stl.getServiceDate(),
-                  stl.getZoneId(),
-                  null,
-                  null,
-                  0,
-                  null
-                );
-                legs.add(legs.size() - 1, combinedLeg);
-              } else {
-                legs.add(leg);
-              }
-            };
-          }
-
-          @Override
-          public BinaryOperator<List<Leg>> combiner() {
-            return (l1, l2) -> {
-              l1.addAll(l2);
-              return l1;
-            };
-          }
-
-          @Override
-          public Function<List<Leg>, List<Leg>> finisher() {
-            return List::copyOf;
-          }
-
-          @Override
-          public Set<Characteristics> characteristics() {
-            return Set.of();
-          }
-        }
-      );
+    var result = new ArrayList<Leg>();
+    for (var leg : fareLegs) {
+      if (leg.isInterlinedWithPreviousLeg() && leg instanceof ScheduledTransitLeg stl) {
+        var previousLeg = (ScheduledTransitLeg) result.get(result.size() - 1);
+        var combinedLeg = new ScheduledTransitLeg(
+          previousLeg.getTripTimes(),
+          previousLeg.getTripPattern(),
+          0,
+          0,
+          previousLeg.getStartTime(),
+          stl.getEndTime(),
+          stl.getServiceDate(),
+          stl.getZoneId(),
+          null,
+          null,
+          0,
+          null
+        );
+        result.add(result.size() - 1, combinedLeg);
+      } else {
+        result.add(leg);
+      }
+    }
+    return result;
   }
 
   private FareSearch performSearch(

--- a/src/ext/java/org/opentripplanner/ext/fares/impl/HighestFareInFreeTransferWindowFareService.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/impl/HighestFareInFreeTransferWindowFareService.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.ext.fares.impl;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Currency;
 import java.util.List;
@@ -16,15 +17,15 @@ public class HighestFareInFreeTransferWindowFareService extends DefaultFareServi
   private static final long serialVersionUID = 20120229L;
 
   private final boolean analyzeInterlinedTransfers;
-  private final int freeTransferWindowInMinutes;
+  private final Duration freeTransferWindow;
 
   public HighestFareInFreeTransferWindowFareService(
     Collection<FareRuleSet> regularFareRules,
-    int freeTransferWindowInMinutes,
+    Duration freeTransferWindow,
     boolean analyzeInterlinedTransfers
   ) {
     addFareRules(FareType.regular, regularFareRules);
-    this.freeTransferWindowInMinutes = freeTransferWindowInMinutes;
+    this.freeTransferWindow = freeTransferWindow;
     this.analyzeInterlinedTransfers = analyzeInterlinedTransfers;
   }
 
@@ -66,7 +67,7 @@ public class HighestFareInFreeTransferWindowFareService extends DefaultFareServi
         // the new transfer window end time should be calculated by adding the ride's start time (which is in
         // seconds past the epoch) and the number of equivalent seconds in the free transfer window minutes.
         freeTransferWindowEndTimeEpochSeconds =
-          leg.getStartTime().toEpochSecond() + freeTransferWindowInMinutes * 60L;
+          leg.getStartTime().plus(freeTransferWindow).toEpochSecond();
       }
 
       currentTransferWindowCost = Float.max(currentTransferWindowCost, rideCost);

--- a/src/ext/java/org/opentripplanner/ext/fares/impl/HighestFareInFreeTransferWindowFareService.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/impl/HighestFareInFreeTransferWindowFareService.java
@@ -29,6 +29,14 @@ public class HighestFareInFreeTransferWindowFareService extends DefaultFareServi
     this.analyzeInterlinedTransfers = analyzeInterlinedTransfers;
   }
 
+  public boolean analyzeInterlinedTransfers() {
+    return analyzeInterlinedTransfers;
+  }
+
+  public Duration freeTransferWindow() {
+    return freeTransferWindow;
+  }
+
   /**
    * The fare calculation is designed to charge the rider incrementally as they use each service.
    * The total cost of the itinerary will be equal to the leg of the journey that had the maximum

--- a/src/ext/java/org/opentripplanner/ext/fares/impl/HighestFareInFreeTransferWindowFareService.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/impl/HighestFareInFreeTransferWindowFareService.java
@@ -1,0 +1,87 @@
+package org.opentripplanner.ext.fares.impl;
+
+import java.util.Collection;
+import java.util.Currency;
+import java.util.List;
+import org.opentripplanner.model.plan.Leg;
+import org.opentripplanner.routing.core.Fare;
+import org.opentripplanner.routing.core.Fare.FareType;
+import org.opentripplanner.routing.core.FareRuleSet;
+
+/**
+ * This calculator is maintained by IBI Group.
+ */
+public class HighestFareInFreeTransferWindowFareService extends DefaultFareServiceImpl {
+
+  private static final long serialVersionUID = 20120229L;
+
+  private final boolean analyzeInterlinedTransfers;
+  private final int freeTransferWindowInMinutes;
+
+  public HighestFareInFreeTransferWindowFareService(
+    Collection<FareRuleSet> regularFareRules,
+    int freeTransferWindowInMinutes,
+    boolean analyzeInterlinedTransfers
+  ) {
+    addFareRules(FareType.regular, regularFareRules);
+    this.freeTransferWindowInMinutes = freeTransferWindowInMinutes;
+    this.analyzeInterlinedTransfers = analyzeInterlinedTransfers;
+  }
+
+  /**
+   * The fare calculation is designed to charge the rider incrementally as they use each service.
+   * The total cost of the itinerary will be equal to the leg of the journey that had the maximum
+   * fare. Additionally, a free transfer window is taken into account that will apply the current
+   * highest cost within the free transfer window and then reset to a new window and calculate
+   * additional free transfers from there.
+   */
+  @Override
+  protected boolean populateFare(
+    Fare fare,
+    Currency currency,
+    FareType fareType,
+    List<Leg> legs,
+    Collection<FareRuleSet> fareRules
+  ) {
+    float cost = 0;
+    float currentTransferWindowCost = 0;
+    // The initial value of -1 indicates that the free transfer window end time has not yet been set
+    long freeTransferWindowEndTimeEpochSeconds = -1;
+    for (var leg : legs) {
+      float rideCost = calculateCost(fareType, List.of(leg), fareRules);
+
+      if (leg.getStartTime().toEpochSecond() > freeTransferWindowEndTimeEpochSeconds) {
+        // free transfer window has expired or has not yet been initialized. Reset some items and add to the
+        // overall cost. This is fine to do if the free transfer window hasn't been initialized since the
+        // overall cost will be 0.
+        cost += currentTransferWindowCost;
+        // reset current window cost
+        currentTransferWindowCost = 0;
+        // reset transfer window end time to trigger recalculation in next block
+        freeTransferWindowEndTimeEpochSeconds = -1;
+      }
+
+      // recalculate free transfer window if needed
+      if (freeTransferWindowEndTimeEpochSeconds == -1) {
+        // the new transfer window end time should be calculated by adding the ride's start time (which is in
+        // seconds past the epoch) and the number of equivalent seconds in the free transfer window minutes.
+        freeTransferWindowEndTimeEpochSeconds =
+          leg.getStartTime().toEpochSecond() + freeTransferWindowInMinutes * 60L;
+      }
+
+      currentTransferWindowCost = Float.max(currentTransferWindowCost, rideCost);
+    }
+    cost += currentTransferWindowCost;
+    if (cost < Float.POSITIVE_INFINITY) fare.addFare(fareType, getMoney(currency, cost));
+    return cost > 0 && cost < Float.POSITIVE_INFINITY;
+  }
+
+  /**
+   * Returns true if configured to analyze interlined transfers and the previous edge was an
+   * interline transfer.
+   */
+  @Override
+  protected boolean shouldCombineInterlinedLegs() {
+    return !analyzeInterlinedTransfers;
+  }
+}

--- a/src/ext/java/org/opentripplanner/ext/fares/impl/HighestFareInFreeTransferWindowFareServiceFactory.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/impl/HighestFareInFreeTransferWindowFareServiceFactory.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.ext.fares.impl;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
@@ -52,7 +53,7 @@ public class HighestFareInFreeTransferWindowFareServiceFactory extends DefaultFa
   }
 
   @Override
-  public void configure(NodeAdapter config) {
+  public void configure(JsonNode config) {
     var adapter = new NodeAdapter(config, null);
     freeTransferWindow = adapter.asDuration("freeTransferWindow", freeTransferWindow);
 

--- a/src/ext/java/org/opentripplanner/ext/fares/impl/HighestFareInFreeTransferWindowFareServiceFactory.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/impl/HighestFareInFreeTransferWindowFareServiceFactory.java
@@ -1,23 +1,25 @@
 package org.opentripplanner.ext.fares.impl;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import org.opentripplanner.model.OtpTransitService;
 import org.opentripplanner.routing.core.FareRuleSet;
 import org.opentripplanner.routing.fares.FareService;
+import org.opentripplanner.standalone.config.NodeAdapter;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 
 /**
- * This fare service allows transfers between operators and, if the route transferred to is run by an operator with a
- * higher fare, the customer will be charged the higher fare. Also, the higher fare is used up until the end of the free
- * transfer window. The length of the free transfer window is configurable, but defaults to 2.5 hours.
- *
- * Additionally, there is an option to treat interlined transfers as actual transfers (with respect to fares). This
- * means that interlining between two routes with different fares will result in the higher fare being charged. This is
- * a work-around for transit agencies that choose to code their fares in a route-based fashion instead of a zone-based
- * fashion.
- *
+ * This fare service allows transfers between operators and, if the route transferred to is run by
+ * an operator with a higher fare, the customer will be charged the higher fare. Also, the higher
+ * fare is used up until the end of the free transfer window. The length of the free transfer window
+ * is configurable, but defaults to 2.5 hours.
+ * <p>
+ * Additionally, there is an option to treat interlined transfers as actual transfers (with respect
+ * to fares). This means that interlining between two routes with different fares will result in the
+ * higher fare being charged. This is a work-around for transit agencies that choose to code their
+ * fares in a route-based fashion instead of a zone-based fashion.
+ * <p>
  * This calculator is maintained by IBI Group.
  */
 public class HighestFareInFreeTransferWindowFareServiceFactory extends DefaultFareServiceFactory {
@@ -25,17 +27,16 @@ public class HighestFareInFreeTransferWindowFareServiceFactory extends DefaultFa
   protected Map<FeedScopedId, FareRuleSet> regularFareRules = new HashMap<>();
 
   // default to 150 minutes to preserve compatibility with legacy pdx fares
-  private int freeTransferWindowInMinutes = 150;
+  private Duration freeTransferWindow = Duration.ofMinutes(150);
   // If true, will also analyze more than just the first trip of an interlined transfer and will use the highest fare
   private boolean analyzeInterlinedTransfers = false;
 
   public FareService makeFareService() {
-    HighestFareInFreeTransferWindowFareService fareService = new HighestFareInFreeTransferWindowFareService(
+    return new HighestFareInFreeTransferWindowFareService(
       regularFareRules.values(),
-      freeTransferWindowInMinutes,
+      freeTransferWindow,
       analyzeInterlinedTransfers
     );
-    return fareService;
   }
 
   /**
@@ -51,15 +52,11 @@ public class HighestFareInFreeTransferWindowFareServiceFactory extends DefaultFa
   }
 
   @Override
-  public void configure(JsonNode config) {
-    JsonNode freeTransferNode = config.path("freeTransferWindowInMinutes");
-    if (freeTransferNode.isInt()) {
-      freeTransferWindowInMinutes = freeTransferNode.asInt();
-    }
+  public void configure(NodeAdapter config) {
+    var adapter = new NodeAdapter(config, null);
+    freeTransferWindow = adapter.asDuration("freeTransferWindow", freeTransferWindow);
 
-    JsonNode analyzeInterlinedTransfersNode = config.path("analyzeInterlinedTransfers");
-    if (analyzeInterlinedTransfersNode.isBoolean()) {
-      analyzeInterlinedTransfers = analyzeInterlinedTransfersNode.asBoolean();
-    }
+    analyzeInterlinedTransfers =
+      adapter.asBoolean("analyzeInterlinedTransfers", analyzeInterlinedTransfers);
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/fares/impl/HighestFareInFreeTransferWindowFareServiceFactory.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/impl/HighestFareInFreeTransferWindowFareServiceFactory.java
@@ -1,0 +1,65 @@
+package org.opentripplanner.ext.fares.impl;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.HashMap;
+import java.util.Map;
+import org.opentripplanner.model.OtpTransitService;
+import org.opentripplanner.routing.core.FareRuleSet;
+import org.opentripplanner.routing.fares.FareService;
+import org.opentripplanner.transit.model.framework.FeedScopedId;
+
+/**
+ * This fare service allows transfers between operators and, if the route transferred to is run by an operator with a
+ * higher fare, the customer will be charged the higher fare. Also, the higher fare is used up until the end of the free
+ * transfer window. The length of the free transfer window is configurable, but defaults to 2.5 hours.
+ *
+ * Additionally, there is an option to treat interlined transfers as actual transfers (with respect to fares). This
+ * means that interlining between two routes with different fares will result in the higher fare being charged. This is
+ * a work-around for transit agencies that choose to code their fares in a route-based fashion instead of a zone-based
+ * fashion.
+ *
+ * This calculator is maintained by IBI Group.
+ */
+public class HighestFareInFreeTransferWindowFareServiceFactory extends DefaultFareServiceFactory {
+
+  protected Map<FeedScopedId, FareRuleSet> regularFareRules = new HashMap<>();
+
+  // default to 150 minutes to preserve compatibility with legacy pdx fares
+  private int freeTransferWindowInMinutes = 150;
+  // If true, will also analyze more than just the first trip of an interlined transfer and will use the highest fare
+  private boolean analyzeInterlinedTransfers = false;
+
+  public FareService makeFareService() {
+    HighestFareInFreeTransferWindowFareService fareService = new HighestFareInFreeTransferWindowFareService(
+      regularFareRules.values(),
+      freeTransferWindowInMinutes,
+      analyzeInterlinedTransfers
+    );
+    return fareService;
+  }
+
+  /**
+   * This step ensures that the fares in the source GTFS data are accounted for correctly.
+   */
+  @Override
+  public void processGtfs(OtpTransitService transitService) {
+    fillFareRules(
+      transitService.getAllFareAttributes(),
+      transitService.getAllFareRules(),
+      regularFareRules
+    );
+  }
+
+  @Override
+  public void configure(JsonNode config) {
+    JsonNode freeTransferNode = config.path("freeTransferWindowInMinutes");
+    if (freeTransferNode.isInt()) {
+      freeTransferWindowInMinutes = freeTransferNode.asInt();
+    }
+
+    JsonNode analyzeInterlinedTransfersNode = config.path("analyzeInterlinedTransfers");
+    if (analyzeInterlinedTransfersNode.isBoolean()) {
+      analyzeInterlinedTransfers = analyzeInterlinedTransfersNode.asBoolean();
+    }
+  }
+}

--- a/src/main/java/org/opentripplanner/model/plan/ScheduledTransitLeg.java
+++ b/src/main/java/org/opentripplanner/model/plan/ScheduledTransitLeg.java
@@ -98,6 +98,10 @@ public class ScheduledTransitLeg implements Leg {
     setDistanceMeters(getDistanceFromCoordinates(transitLegCoordinates));
   }
 
+  public ZoneId getZoneId() {
+    return zoneId;
+  }
+
   public TripTimes getTripTimes() {
     return tripTimes;
   }

--- a/src/main/java/org/opentripplanner/routing/fares/FareServiceFactory.java
+++ b/src/main/java/org/opentripplanner/routing/fares/FareServiceFactory.java
@@ -8,5 +8,5 @@ public interface FareServiceFactory {
 
   void processGtfs(OtpTransitService transitService);
 
-  void configure(JsonNode onfig);
+  void configure(JsonNode config);
 }

--- a/src/main/java/org/opentripplanner/routing/fares/FareServiceFactory.java
+++ b/src/main/java/org/opentripplanner/routing/fares/FareServiceFactory.java
@@ -8,5 +8,5 @@ public interface FareServiceFactory {
 
   void processGtfs(OtpTransitService transitService);
 
-  void configure(JsonNode config);
+  void configure(JsonNode onfig);
 }

--- a/src/test/java/org/opentripplanner/model/plan/TestItineraryBuilder.java
+++ b/src/test/java/org/opentripplanner/model/plan/TestItineraryBuilder.java
@@ -14,6 +14,8 @@ import java.util.List;
 import org.opentripplanner.model.StopPattern;
 import org.opentripplanner.model.StopTime;
 import org.opentripplanner.model.TripPattern;
+import org.opentripplanner.model.transfer.ConstrainedTransfer;
+import org.opentripplanner.model.transfer.TransferConstraint;
 import org.opentripplanner.routing.core.TraverseMode;
 import org.opentripplanner.routing.trippattern.Deduplicator;
 import org.opentripplanner.routing.trippattern.TripTimes;
@@ -140,12 +142,28 @@ public class TestItineraryBuilder implements PlanTestConstants {
       toStopIndex,
       to,
       serviceDate,
+      null,
       null
     );
   }
 
   public TestItineraryBuilder bus(int tripId, int startTime, int endTime, Place to) {
     return bus(tripId, startTime, endTime, TRIP_FROM_STOP_INDEX, TRIP_TO_STOP_INDEX, to, null);
+  }
+
+  public TestItineraryBuilder bus(Route route, int tripId, int startTime, int endTime, Place to) {
+    return transit(
+      route,
+      tripId,
+      startTime,
+      endTime,
+      TRIP_FROM_STOP_INDEX,
+      TRIP_TO_STOP_INDEX,
+      to,
+      null,
+      null,
+      null
+    );
   }
 
   public TestItineraryBuilder bus(
@@ -179,6 +197,7 @@ public class TestItineraryBuilder implements PlanTestConstants {
       TRIP_TO_STOP_INDEX,
       to,
       null,
+      null,
       null
     );
   }
@@ -204,7 +223,29 @@ public class TestItineraryBuilder implements PlanTestConstants {
       TRIP_TO_STOP_INDEX,
       to,
       null,
-      600
+      600,
+      null
+    );
+  }
+
+  public TestItineraryBuilder staySeatedBus(
+    Route route,
+    int tripId,
+    int startTime,
+    int endTime,
+    Place to
+  ) {
+    return transit(
+      route,
+      tripId,
+      startTime,
+      endTime,
+      TRIP_FROM_STOP_INDEX,
+      TRIP_TO_STOP_INDEX,
+      to,
+      null,
+      null,
+      new ConstrainedTransfer(null, null, null, TransferConstraint.create().staySeated().build())
     );
   }
 
@@ -228,7 +269,8 @@ public class TestItineraryBuilder implements PlanTestConstants {
     int toStopIndex,
     Place to,
     LocalDate serviceDate,
-    Integer headwaySecs
+    Integer headwaySecs,
+    ConstrainedTransfer transferFromPreviousLeg
   ) {
     if (lastPlace == null) {
       throw new IllegalStateException("Trip from place is unknown!");
@@ -278,7 +320,7 @@ public class TestItineraryBuilder implements PlanTestConstants {
           newTime(end),
           serviceDate != null ? serviceDate : SERVICE_DAY,
           UTC,
-          null,
+          transferFromPreviousLeg,
           null,
           legCost,
           headwaySecs,
@@ -295,7 +337,7 @@ public class TestItineraryBuilder implements PlanTestConstants {
           newTime(end),
           serviceDate != null ? serviceDate : SERVICE_DAY,
           UTC,
-          null,
+          transferFromPreviousLeg,
           null,
           legCost,
           null

--- a/src/test/java/org/opentripplanner/standalone/config/BuildConfigTest.java
+++ b/src/test/java/org/opentripplanner/standalone/config/BuildConfigTest.java
@@ -1,12 +1,14 @@
 package org.opentripplanner.standalone.config;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.standalone.config.JsonSupport.jsonNodeForTest;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.ext.fares.impl.DefaultFareServiceImpl;
 
 public class BuildConfigTest {
 
@@ -28,5 +30,12 @@ public class BuildConfigTest {
     var subject = new BuildConfig(node, "Test", false);
 
     assertEquals(Set.of("a-ha", "royksopp"), subject.boardingLocationTags);
+  }
+
+  @Test
+  public void fareService() {
+    var node = jsonNodeForTest("{ 'fares' : \"default\" }");
+    var conf = new BuildConfig(node, "Test", false);
+    assertSame(DefaultFareServiceImpl.class, conf.fareServiceFactory.makeFareService().getClass());
   }
 }

--- a/src/test/java/org/opentripplanner/standalone/config/BuildConfigTest.java
+++ b/src/test/java/org/opentripplanner/standalone/config/BuildConfigTest.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.standalone.config;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.standalone.config.JsonSupport.jsonNodeForTest;
@@ -34,8 +35,8 @@ public class BuildConfigTest {
 
   @Test
   public void fareService() {
-    var node = jsonNodeForTest("{ 'fares' : \"default\" }");
+    var node = jsonNodeForTest("{ 'fares' : \"highestFareInFreeTransferWindow\" }");
     var conf = new BuildConfig(node, "Test", false);
-    assertSame(DefaultFareServiceImpl.class, conf.fareServiceFactory.makeFareService().getClass());
+    assertInstanceOf(DefaultFareServiceImpl.class, conf.fareServiceFactory.makeFareService());
   }
 }


### PR DESCRIPTION
### Summary

Adds a custom fare calculator that is being used in Houston.

It calculates prices based on a so-called free transfer window.

It also restores a feature that was probably lost when migrating to OTP2: combining interlined legs for the purpose of fare calculation. We might want to debate the semantics of this as they are not clear to me and I'm kinda guessing.

### Unit tests

Added.

### Documentation

Added.

This is a port to OTP2 of the original IBI PR: https://github.com/ibi-group/OpenTripPlanner/pull/66