### PR TITLE
Configure idempotent upload to Google Cloud Storage

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/datastore/gs/GsFileDataSource.java
+++ b/src/ext/java/org/opentripplanner/ext/datastore/gs/GsFileDataSource.java
@@ -4,6 +4,7 @@ import static java.nio.channels.Channels.newInputStream;
 import static java.nio.channels.Channels.newOutputStream;
 
 import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.Storage;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -71,6 +72,6 @@ class GsFileDataSource extends AbstractGsDataSource implements DataSource {
 
   @Override
   public OutputStream asOutputStream() {
-    return newOutputStream(blob.writer());
+    return newOutputStream(blob.writer(Storage.BlobWriteOption.generationMatch()));
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/datastore/gs/GsOutFileDataSource.java
+++ b/src/ext/java/org/opentripplanner/ext/datastore/gs/GsOutFileDataSource.java
@@ -33,6 +33,6 @@ class GsOutFileDataSource extends AbstractGsDataSource implements DataSource {
   @Override
   public OutputStream asOutputStream() {
     BlobInfo blobInfo = BlobInfo.newBuilder(blobId()).build();
-    return newOutputStream(storage.writer(blobInfo));
+    return newOutputStream(storage.writer(blobInfo, Storage.BlobWriteOption.doesNotExist()));
   }
 }


### PR DESCRIPTION
### Summary
The goal of this PR is to prevent failure to upload graph building artifacts to Google Cloud Storage due to transient network issues/ server errors as described in issue #4268
By default the Google Storage client library does not retry failed upload operations.
See https://cloud.google.com/storage/docs/retry-strategy#java for more details about which operations are retried by default.
To activate retry on error, it is necessary to make the operation "conditionally idempotent" by detecting concurrent update:
- if the blob already exists in the target bucket and must be updated: check that the blob version ("generation") did not change between the beginning and the end of the upload operation.
- if the blob does not exist yet in the target bucket and must be created: check that the blob still does not exist when the upload operation completes.

Expected behavior: if a transient network issue/server error prevents an upload operation to complete, it will be retried with the default retry settings: 6 attempts, exponential backoff factor: 2, initial delay: 1s
(See https://cloud.google.com/storage/docs/retry-strategy#client-libraries for details on the default retry settings)

Side effect: if another process concurrently updates the blob, the upload process will fail.

### Issue
closes #4268

### Unit tests
:white_check_mark: 

### Documentation
No

### Changelog

The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md)
is generated from the pull-request title, make sure the title describe the feature or issue fixed.
To exclude the PR from the changelog add the label `skip changelog` to the PR.

### Bumping the serialization version id

If you have made changes to the way the routing graph is serialized, for example by renaming a field
in one of the edges, then you must add the label `bump serialization id` to the PR. With this label
Github Actions will increase the field `otp.serialization.version.id` in `pom.xml`.
