### PR TITLE
Fix param names in docs

### DIFF
--- a/docs/OTP2-MigrationGuide.md
+++ b/docs/OTP2-MigrationGuide.md
@@ -53,8 +53,8 @@ of this type:
 
 #### Parameters whose names were changed
 
-- `alightTimes` to `routingDefaults.alightSlackByMode`. Since v2.0
-- `boardTimes` to `routingDefaults.boardSlackByMode`. Since v2.0
+- `alightTimes` to `routingDefaults.alightSlackForMode`. Since v2.0
+- `boardTimes` to `routingDefaults.boardSlackForMode`. Since v2.0
 - `htmlAnnotations` to `dataImportReport`. Since v2.0
 - `maxHtmlAnnotationsPerFile` to `maxDataImportIssuesPerFile`. Since v2.0
 - `maxTransferDistance` to `maxTransferDurationSeconds`. Since v2.1
@@ -179,11 +179,11 @@ permanently from OTP2, but may require some development to support valid importa
 
 #### New parameters in OTP2
 
-- `alightSlackByMode` How much time alighting a vehicle takes for each given mode. Since 2.0
+- `alightSlackForMode` How much time alighting a vehicle takes for each given mode. Since 2.0
 - `allowedVehicleRentalNetworks` and `bannedVehicleRentalNetworks`. Since 2.1
 - `bikeReluctance`, `bikeWalkingReluctance`, `bikeWalkingSpeed`, `carReluctance`, and `walkingBike`
   Add explicit bike / bike-walking / car / walk reluctance. Since 2.1
-- `boardSlackByMode` How much time ride a vehicle takes for each given mode. Since 2.0
+- `boardSlackForMode` How much time ride a vehicle takes for each given mode. Since 2.0
 - `carPickupCost` and `carPickupTime`. Add a cost/time for CarPickup changes when a pickup or drop
   off takes place. Since 2.1
 - `maxAccessEgressDurationForMode` Limit access/egress per street mode. Since 2.2


### PR DESCRIPTION
### Summary

This just fixes some parameter names in documentation.
