### PR TITLE
Vehicle rental network whitelisting and banning for legacy API

### DIFF
--- a/docs/sandbox/LegacyGraphQLApi.md
+++ b/docs/sandbox/LegacyGraphQLApi.md
@@ -24,6 +24,7 @@
 - Take free-floating vehicles into account when computing state (February 2022, https://github.com/opentripplanner/OpenTripPlanner/pull/3857)
 - Fix issue with GraphQL code generator (February 2022, https://github.com/opentripplanner/OpenTripPlanner/pull/3881)
 - Add GBFS form factors for `rentalVehicle` (April 2022, https://github.com/opentripplanner/OpenTripPlanner/pull/4062)
+- Implement allowedBikeRentalNetworks while deprecating it and add allowedVehicleRentalNetworks and bannedVehicleRentalNetworks. (July 2022, https://github.com/opentripplanner/OpenTripPlanner/pull/4279)
 
 ## Documentation
 

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -717,10 +718,18 @@ public class LegacyGraphQLQueryTypeImpl
         // ((List<String>)environment.getArgument("allowedTicketTypes")).forEach(ticketType -> request.allowedFares.add(ticketType.replaceFirst("_", ":")));
       }
 
-      if (hasArgument(environment, "allowedBikeRentalNetworks")) {
-        // ArrayList<String> allowedBikeRentalNetworks = environment.getArgument("allowedBikeRentalNetworks");
-        // request.allowedBikeRentalNetworks = new HashSet<>(allowedBikeRentalNetworks);
-      }
+      callWith.argument(
+        "allowedBikeRentalNetworks",
+        (Collection<String> v) -> request.allowedVehicleRentalNetworks = new HashSet<>(v)
+      );
+      callWith.argument(
+        "allowedVehicleRentalNetworks",
+        (Collection<String> v) -> request.allowedVehicleRentalNetworks = new HashSet<>(v)
+      );
+      callWith.argument(
+        "bannedVehicleRentalNetworks",
+        (Collection<String> v) -> request.bannedVehicleRentalNetworks = new HashSet<>(v)
+      );
 
       if (request.vehicleRental && !hasArgument(environment, "bikeSpeed")) {
         //slower bike speed for bike sharing, based on empirical evidence from DC.

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/LegacyGraphQLTypes.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/LegacyGraphQLTypes.java
@@ -1351,8 +1351,10 @@ public class LegacyGraphQLTypes {
     private Boolean allowKeepingRentedBicycleAtDestination;
     private Iterable<String> allowedBikeRentalNetworks;
     private Iterable<String> allowedTicketTypes;
+    private Iterable<String> allowedVehicleRentalNetworks;
     private Boolean arriveBy;
     private LegacyGraphQLInputBannedInput banned;
+    private Iterable<String> bannedVehicleRentalNetworks;
     private Boolean batch;
     private Integer bikeBoardCost;
     private Double bikeReluctance;
@@ -1414,8 +1416,12 @@ public class LegacyGraphQLTypes {
           (Boolean) args.get("allowKeepingRentedBicycleAtDestination");
         this.allowedBikeRentalNetworks = (Iterable<String>) args.get("allowedBikeRentalNetworks");
         this.allowedTicketTypes = (Iterable<String>) args.get("allowedTicketTypes");
+        this.allowedVehicleRentalNetworks =
+          (Iterable<String>) args.get("allowedVehicleRentalNetworks");
         this.arriveBy = (Boolean) args.get("arriveBy");
         this.banned = new LegacyGraphQLInputBannedInput((Map<String, Object>) args.get("banned"));
+        this.bannedVehicleRentalNetworks =
+          (Iterable<String>) args.get("bannedVehicleRentalNetworks");
         this.batch = (Boolean) args.get("batch");
         this.bikeBoardCost = (Integer) args.get("bikeBoardCost");
         this.bikeReluctance = (Double) args.get("bikeReluctance");
@@ -1507,12 +1513,20 @@ public class LegacyGraphQLTypes {
       return this.allowedTicketTypes;
     }
 
+    public Iterable<String> getLegacyGraphQLAllowedVehicleRentalNetworks() {
+      return this.allowedVehicleRentalNetworks;
+    }
+
     public Boolean getLegacyGraphQLArriveBy() {
       return this.arriveBy;
     }
 
     public LegacyGraphQLInputBannedInput getLegacyGraphQLBanned() {
       return this.banned;
+    }
+
+    public Iterable<String> getLegacyGraphQLBannedVehicleRentalNetworks() {
+      return this.bannedVehicleRentalNetworks;
     }
 
     public Boolean getLegacyGraphQLBatch() {
@@ -1747,12 +1761,24 @@ public class LegacyGraphQLTypes {
       this.allowedTicketTypes = allowedTicketTypes;
     }
 
+    public void setLegacyGraphQLAllowedVehicleRentalNetworks(
+      Iterable<String> allowedVehicleRentalNetworks
+    ) {
+      this.allowedVehicleRentalNetworks = allowedVehicleRentalNetworks;
+    }
+
     public void setLegacyGraphQLArriveBy(Boolean arriveBy) {
       this.arriveBy = arriveBy;
     }
 
     public void setLegacyGraphQLBanned(LegacyGraphQLInputBannedInput banned) {
       this.banned = banned;
+    }
+
+    public void setLegacyGraphQLBannedVehicleRentalNetworks(
+      Iterable<String> bannedVehicleRentalNetworks
+    ) {
+      this.bannedVehicleRentalNetworks = bannedVehicleRentalNetworks;
     }
 
     public void setLegacyGraphQLBatch(Boolean batch) {

--- a/src/ext/resources/legacygraphqlapi/schema.graphqls
+++ b/src/ext/resources/legacygraphqlapi/schema.graphqls
@@ -2643,9 +2643,21 @@ type QueryType {
         compactLegsByReversedSearch: Boolean
 
         """
-        Which bike rental networks can be used. By default, all networks are allowed.
+        Which vehicle rental networks can be used. By default, all networks are allowed.
+
+        Deprecated: Use `allowedVehicleRentalNetworks` instead.
         """
-        allowedBikeRentalNetworks: [String]
+        allowedBikeRentalNetworks: [String] @deprecated(reason: "Use allowedBikeRentalNetworks instead")
+
+        """
+        Which vehicle rental networks can be used. By default, all networks are allowed.
+        """
+        allowedVehicleRentalNetworks: [String]
+
+        """
+        Which vehicle rental networks cannot be used. By default, all networks are allowed.
+        """
+        bannedVehicleRentalNetworks: [String]
     ): Plan
 }
 


### PR DESCRIPTION
### Summary

Implements allowedBikeRentalNetworks while deprecating it in legacy GraphQL API and adds allowedVehicleRentalNetworks and bannedVehicleRentalNetworks.

### Issue

Minor sandbox change so not needed.

### Documentation

Not needed

### Changelog

Updated in sandbox

