### PR TITLE
Fix inconsistent mapping of NeTEx quay publicCode

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/QuayType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/QuayType.java
@@ -152,7 +152,7 @@ public class QuayType {
           .description(
             "Public code used to identify this quay within the stop place. For instance a platform code."
           )
-          .dataFetcher(environment -> (((StopLocation) environment.getSource()).getCode()))
+          .dataFetcher(environment -> (((StopLocation) environment.getSource()).getPlatformCode()))
           .build()
       )
       .field(

--- a/src/main/java/org/opentripplanner/netex/mapping/StopMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/StopMapper.java
@@ -49,7 +49,7 @@ class StopMapper {
       .of(idFactory.createId(quay.getId()))
       .withParentStation(parentStation)
       .withName(parentStation.getName())
-      .withCode(quay.getPublicCode())
+      .withPlatformCode(quay.getPublicCode())
       .withDescription(
         NonLocalizedString.ofNullable(quay.getDescription(), MultilingualString::getValue)
       )

--- a/src/test/java/org/opentripplanner/netex/NetexBundleSmokeTest.java
+++ b/src/test/java/org/opentripplanner/netex/NetexBundleSmokeTest.java
@@ -135,7 +135,7 @@ public class NetexBundleSmokeTest {
     assertEquals(59.909803, quay.getLat(), 0.000001);
     assertEquals(10.748062, quay.getLon(), 0.000001);
     assertEquals("RB:NSR:StopPlace:3995", quay.getParentStation().getId().toString());
-    assertEquals("L", quay.getCode());
+    assertEquals("L", quay.getPlatformCode());
     assertEquals(16, stops.size());
   }
 

--- a/src/test/java/org/opentripplanner/netex/mapping/StopAndStationMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/StopAndStationMapperTest.java
@@ -185,7 +185,7 @@ public class StopAndStationMapperTest {
 
     assertEquals(59.909911, childStop1.getLat(), 0.0001);
     assertEquals(10.753008, childStop1.getLon(), 0.0001);
-    assertEquals("A", childStop1.getCode());
+    assertEquals("A", childStop1.getPlatformCode());
   }
 
   private static StopPlace createStopPlace(


### PR DESCRIPTION
### Summary

Currently the NeTEx `publicCode` is mapped to the stop's `code`. The value is the platform number, and should be mapped to `platformCode` instead.

### Issue

Closes #3141