### PR TITLE
Remove "ilegal" dependencies in transit model

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/flex/FlexIntegrationTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/flex/FlexIntegrationTest.java
@@ -77,6 +77,11 @@ public class FlexIntegrationTest {
     assertEquals(BUS, flex.getMode());
     assertEquals("Zone 2", flex.getRoute().getShortName());
     assertTrue(flex.isFlexibleTrip());
+    assertEquals(
+      "corner of Story Place Southwest and service road (part of Flex Zone 2)",
+      flex.getFrom().name.toString()
+    );
+    assertEquals("Destination (part of Flex Zone 2)", flex.getTo().name.toString());
   }
 
   @Test
@@ -129,6 +134,9 @@ public class FlexIntegrationTest {
     assertEquals(BUS, flex.getMode());
     assertEquals("Zone 2", flex.getRoute().getShortName());
     assertTrue(flex.isFlexibleTrip());
+
+    assertEquals("Transfer Point for Route 30", flex.getFrom().name.toString());
+    assertEquals("Destination (part of Flex Zone 2)", flex.getTo().name.toString());
 
     assertEquals("2021-12-02T13:00-05:00[America/New_York]", flex.getStartTime().toString());
   }

--- a/src/main/java/org/opentripplanner/graph_builder/linking/VertexLinker.java
+++ b/src/main/java/org/opentripplanner/graph_builder/linking/VertexLinker.java
@@ -430,7 +430,14 @@ public class VertexLinker {
       tsv.setWheelchairAccessible(originalEdge.isWheelchairAccessible());
       v = tsv;
     } else {
-      v = new SplitterVertex(graph, uniqueSplitLabel, splitPoint.x, splitPoint.y);
+      v =
+        new SplitterVertex(
+          graph,
+          uniqueSplitLabel,
+          splitPoint.x,
+          splitPoint.y,
+          originalEdge.getName()
+        );
     }
 
     // Split the 'edge' at 'v' in 2 new edges and connect these 2 edges to the

--- a/src/main/java/org/opentripplanner/gtfs/mapping/LocationMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/LocationMapper.java
@@ -30,13 +30,9 @@ public class LocationMapper {
   }
 
   private FlexStopLocation doMap(org.onebusaway.gtfs.model.Location gtfsLocation) {
-    FlexStopLocation otpLocation = new FlexStopLocation(mapAgencyAndId(gtfsLocation.getId()));
+    var name = NonLocalizedString.ofNullable(gtfsLocation.getName());
+    FlexStopLocation otpLocation = new FlexStopLocation(mapAgencyAndId(gtfsLocation.getId()), name);
 
-    // according to the spec stop location names are optional for flex zones so, we return the id
-    // when it's null. *shrug*
-    otpLocation.setName(
-      NonLocalizedString.ofNullableOrElse(gtfsLocation.getName(), otpLocation.getId().toString())
-    );
     otpLocation.setUrl(NonLocalizedString.ofNullable(gtfsLocation.getUrl()));
     otpLocation.setDescription(NonLocalizedString.ofNullable(gtfsLocation.getDescription()));
     otpLocation.setZoneId(gtfsLocation.getZoneId());

--- a/src/main/java/org/opentripplanner/model/FlexStopLocation.java
+++ b/src/main/java/org/opentripplanner/model/FlexStopLocation.java
@@ -8,6 +8,7 @@ import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.framework.TransitEntity;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.util.I18NString;
+import org.opentripplanner.util.NonLocalizedString;
 
 /**
  * Location corresponding to a location where riders may request pickup or drop off, defined in the
@@ -16,7 +17,9 @@ import org.opentripplanner.util.I18NString;
 
 public class FlexStopLocation extends TransitEntity implements StopLocation {
 
-  private I18NString name;
+  private final I18NString name;
+
+  private final boolean hasFallbackName;
 
   private I18NString description;
 
@@ -28,8 +31,17 @@ public class FlexStopLocation extends TransitEntity implements StopLocation {
 
   private WgsCoordinate centroid;
 
-  public FlexStopLocation(FeedScopedId id) {
+  public FlexStopLocation(@Nonnull FeedScopedId id, I18NString name) {
     super(id);
+    // according to the spec stop location names are optional for flex zones so, we set the id
+    // as the bogus name. *shrug*
+    if (name == null) {
+      this.name = new NonLocalizedString(id.toString());
+      hasFallbackName = true;
+    } else {
+      this.name = name;
+      hasFallbackName = false;
+    }
   }
 
   /**
@@ -95,11 +107,15 @@ public class FlexStopLocation extends TransitEntity implements StopLocation {
     this.description = description;
   }
 
-  public void setName(I18NString name) {
-    this.name = name;
-  }
-
   public void setZoneId(String zoneId) {
     this.zoneId = zoneId;
+  }
+
+  /**
+   * Names for GTFS flex locations are optional therefore we set the id as the name. When this is
+   * the case then this method returns true.
+   */
+  public boolean hasFallbackName() {
+    return hasFallbackName;
   }
 }

--- a/src/main/java/org/opentripplanner/model/plan/Place.java
+++ b/src/main/java/org/opentripplanner/model/plan/Place.java
@@ -1,14 +1,17 @@
 package org.opentripplanner.model.plan;
 
+import org.opentripplanner.model.FlexStopLocation;
 import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.core.TraverseMode;
 import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalPlace;
+import org.opentripplanner.routing.vertextype.StreetVertex;
 import org.opentripplanner.routing.vertextype.VehicleParkingEntranceVertex;
 import org.opentripplanner.routing.vertextype.VehicleRentalPlaceVertex;
 import org.opentripplanner.transit.model.basic.WgsCoordinate;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.util.I18NString;
+import org.opentripplanner.util.LocalizedString;
 import org.opentripplanner.util.lang.ToStringBuilder;
 
 /**
@@ -90,10 +93,19 @@ public class Place {
   }
 
   public static Place forFlexStop(StopLocation stop, Vertex vertex) {
+    var name = stop.getName();
+
+    if (stop instanceof FlexStopLocation flexArea && vertex instanceof StreetVertex s) {
+      if (flexArea.hasFallbackName()) {
+        name = s.getIntersectionName();
+      } else {
+        name = new LocalizedString("partOf", s.getIntersectionName(), flexArea.getName());
+      }
+    }
     // The actual vertex is used because the StopLocation coordinates may not be equal to the vertex's
     // coordinates.
     return new Place(
-      stop.getName(),
+      name,
       WgsCoordinate.creatOptionalCoordinate(vertex.getLat(), vertex.getLon()),
       VertexType.TRANSIT,
       stop,

--- a/src/main/java/org/opentripplanner/netex/mapping/FlexStopLocationMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/FlexStopLocationMapper.java
@@ -85,8 +85,11 @@ class FlexStopLocationMapper {
    * Allows pickup / drop off along any eligible street inside the area
    */
   FlexStopLocation mapFlexArea(FlexibleStopPlace flexibleStopPlace, FlexibleArea area) {
-    FlexStopLocation result = new FlexStopLocation(idFactory.createId(flexibleStopPlace.getId()));
-    result.setName(new NonLocalizedString(flexibleStopPlace.getName().getValue()));
+    var name = new NonLocalizedString(flexibleStopPlace.getName().getValue());
+    FlexStopLocation result = new FlexStopLocation(
+      idFactory.createId(flexibleStopPlace.getId()),
+      name
+    );
     result.setGeometry(OpenGisMapper.mapGeometry(area.getPolygon()));
     return result;
   }

--- a/src/main/java/org/opentripplanner/routing/location/StreetLocation.java
+++ b/src/main/java/org/opentripplanner/routing/location/StreetLocation.java
@@ -36,6 +36,11 @@ public class StreetLocation extends StreetVertex {
   }
 
   @Override
+  public I18NString getIntersectionName() {
+    return super.getName();
+  }
+
+  @Override
   public int hashCode() {
     return getCoordinate().hashCode();
   }

--- a/src/main/java/org/opentripplanner/routing/vertextype/SplitterVertex.java
+++ b/src/main/java/org/opentripplanner/routing/vertextype/SplitterVertex.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.routing.vertextype;
 
 import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.util.I18NString;
 
 /**
  * A vertex representing a place along a street between two intersections that is not derived from
@@ -11,8 +12,8 @@ public class SplitterVertex extends IntersectionVertex {
 
   private static final long serialVersionUID = 1L;
 
-  public SplitterVertex(Graph g, String label, double x, double y) {
-    super(g, label, x, y);
+  public SplitterVertex(Graph g, String label, double x, double y, I18NString name) {
+    super(g, label, x, y, name);
     // splitter vertices don't represent something that exists in the world, so traversing them is
     // always free.
     this.freeFlowing = true;

--- a/src/main/java/org/opentripplanner/routing/vertextype/TemporarySplitterVertex.java
+++ b/src/main/java/org/opentripplanner/routing/vertextype/TemporarySplitterVertex.java
@@ -20,7 +20,7 @@ public class TemporarySplitterVertex extends SplitterVertex implements Temporary
     StreetEdge streetEdge,
     boolean endVertex
   ) {
-    super(null, label, x, y);
+    super(null, label, x, y, streetEdge.getName());
     this.endVertex = endVertex;
     this.wheelchairAccessible = streetEdge.isWheelchairAccessible();
   }

--- a/src/main/java/org/opentripplanner/util/LocalizedString.java
+++ b/src/main/java/org/opentripplanner/util/LocalizedString.java
@@ -55,7 +55,7 @@ public class LocalizedString implements I18NString, Serializable {
    * Creates String which can be localized
    *
    * @param key    key of translation for this way set in {@link org.opentripplanner.graph_builder.module.osm.DefaultWayPropertySetSource}
-   *               and translations read from from properties Files
+   *               and translations read from properties Files
    * @param params Values with which tagNames are replaced in translations.
    */
   public LocalizedString(String key, I18NString... params) {

--- a/src/main/java/org/opentripplanner/util/ResourceBundleAdaptor.java
+++ b/src/main/java/org/opentripplanner/util/ResourceBundleAdaptor.java
@@ -36,7 +36,7 @@ public class ResourceBundleAdaptor {
       return ResourceBundle.getBundle(name, l);
     } catch (MissingResourceException e) {
       LOG.error(
-        "Uh oh...no .properties file could be found, so things are most definately not going to turn out well!!!",
+        "Uh oh...no .properties file could be found, so things are most definitely not going to turn out well!!!",
         e
       );
       throw e;

--- a/src/main/java/org/opentripplanner/util/ResourceBundleSingleton.java
+++ b/src/main/java/org/opentripplanner/util/ResourceBundleSingleton.java
@@ -38,7 +38,8 @@ public enum ResourceBundleSingleton {
         key.equals("corner") ||
         key.equals("unnamedStreet") ||
         key.equals("origin") ||
-        key.equals("destination")
+        key.equals("destination") ||
+        key.equals("partOf")
       ) {
         resourceBundle = ResourceBundle.getBundle("internals", locale, noFallbackControl);
       } else {

--- a/src/main/resources/internals.properties
+++ b/src/main/resources/internals.properties
@@ -2,3 +2,4 @@ corner = corner of %s and %s
 unnamedStreet = unnamed
 origin = Origin
 destination = Destination
+partOf = %s (part of %s)

--- a/src/main/resources/internals_de.properties
+++ b/src/main/resources/internals_de.properties
@@ -1,2 +1,3 @@
 corner = Kreuzung %s mit %s
 unnamedStreet = unbekannte Strasse
+partOf = %s (Teil von %s)

--- a/src/main/resources/internals_fi.properties
+++ b/src/main/resources/internals_fi.properties
@@ -2,3 +2,4 @@ corner = katujen %s ja %s kulma
 unnamedStreet = nimetön
 origin = Lähtöpaikka
 destination = Määränpää
+partOf = %s (alueella %s)

--- a/src/main/resources/internals_fr.properties
+++ b/src/main/resources/internals_fr.properties
@@ -1,2 +1,3 @@
 corner = intersection de %s et %s
 unnamedStreet = rue sans nom
+partOf = %s (partie de %s)

--- a/src/main/resources/internals_hu.properties
+++ b/src/main/resources/internals_hu.properties
@@ -2,3 +2,4 @@ corner = %s \u00E9s %s sarok
 unnamedStreet = n\u00E9vtelen
 origin = Kiindul\u00E1si pont
 destination = C\u00E9lpont
+partOf = %s (%s része)

--- a/src/main/resources/internals_no.properties
+++ b/src/main/resources/internals_no.properties
@@ -1,2 +1,3 @@
 corner = krysset mellom %s og %s
 unnamedStreet = gate uten navn
+partOf = %s (del av %)

--- a/src/main/resources/internals_sv.properties
+++ b/src/main/resources/internals_sv.properties
@@ -1,2 +1,3 @@
 corner = hörnet av %s och %s
 unnamedStreet = namnlös
+partOf = %s (del av %)

--- a/src/test/java/org/opentripplanner/graph_builder/module/linking/LinkingTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/linking/LinkingTest.java
@@ -30,6 +30,7 @@ import org.opentripplanner.routing.vertextype.IntersectionVertex;
 import org.opentripplanner.routing.vertextype.SplitterVertex;
 import org.opentripplanner.routing.vertextype.StreetVertex;
 import org.opentripplanner.routing.vertextype.TransitStopVertex;
+import org.opentripplanner.util.NonLocalizedString;
 import org.opentripplanner.transit.service.TransitModel;
 
 public class LinkingTest {
@@ -77,13 +78,15 @@ public class LinkingTest {
         null,
         "split",
         x + delta * splitVal,
-        y + delta * splitVal
+        y + delta * splitVal,
+        new NonLocalizedString("split")
       );
       SplitterVertex sv1 = new SplitterVertex(
         null,
         "split",
         x + delta * splitVal,
-        y + delta * splitVal
+        y + delta * splitVal,
+        new NonLocalizedString("split")
       );
 
       P2<StreetEdge> sp0 = s0.splitDestructively(sv0);

--- a/src/test/java/org/opentripplanner/gtfs/mapping/LocationMapperTest.java
+++ b/src/test/java/org/opentripplanner/gtfs/mapping/LocationMapperTest.java
@@ -1,0 +1,39 @@
+package org.opentripplanner.gtfs.mapping;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.stream.Stream;
+import org.geojson.LngLatAlt;
+import org.geojson.Polygon;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.onebusaway.gtfs.model.AgencyAndId;
+import org.onebusaway.gtfs.model.Location;
+import org.opentripplanner.test.support.VariableSource;
+
+class LocationMapperTest {
+
+  static Stream<Arguments> testCases = Stream.of(
+    Arguments.of(null, true),
+    Arguments.of("a name", false)
+  );
+
+  @ParameterizedTest(name = "a name of <{0}> should set bogusName={1}")
+  @VariableSource("testCases")
+  void testMapping(String name, boolean isBogusName) {
+    var gtfsLocation = new Location();
+    gtfsLocation.setId(new AgencyAndId("1", "zone-3"));
+    gtfsLocation.setName(name);
+    gtfsLocation.setGeometry(
+      new Polygon(
+        List.of(new LngLatAlt(1, 1), new LngLatAlt(1, 2), new LngLatAlt(1, 3), new LngLatAlt(1, 1))
+      )
+    );
+
+    var mapper = new LocationMapper();
+    var flexLocation = mapper.map(gtfsLocation);
+
+    assertEquals(isBogusName, flexLocation.hasFallbackName());
+  }
+}

--- a/src/test/java/org/opentripplanner/model/plan/PlaceTest.java
+++ b/src/test/java/org/opentripplanner/model/plan/PlaceTest.java
@@ -1,12 +1,22 @@
 package org.opentripplanner.model.plan;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.opentripplanner.model.FlexStopLocation;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.routing.vertextype.SimpleVertex;
+import org.opentripplanner.test.support.VariableSource;
 import org.opentripplanner.transit.model._data.TransitModelForTest;
+import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.util.I18NString;
 import org.opentripplanner.util.NonLocalizedString;
 
 public class PlaceTest {
@@ -46,6 +56,32 @@ public class PlaceTest {
     assertTrue(samePlace.sameLocation(aPlace), "same place(symmetric)");
     assertFalse(aPlace.sameLocation(otherPlace), "other place");
     assertFalse(otherPlace.sameLocation(aPlace), "other place(symmetric)");
+  }
+
+  static Stream<Arguments> flexStopCases = Stream.of(
+    Arguments.of(null, "an intersection name"),
+    Arguments.of(new NonLocalizedString("1:stop_id"), "an intersection name (part of 1:stop_id)"),
+    Arguments.of(
+      new NonLocalizedString("Flex Zone 123"),
+      "an intersection name (part of Flex Zone 123)"
+    )
+  );
+
+  @ParameterizedTest(name = "Flex stop name of {0} should lead to a place name of {1}")
+  @VariableSource("flexStopCases")
+  public void flexStop(I18NString stopName, String expectedPlaceName) {
+    var stop = new FlexStopLocation(new FeedScopedId("1", "stop_id"), stopName);
+
+    var vertex = new SimpleVertex(new Graph(), "corner", 1, 1) {
+      @Override
+      public I18NString getIntersectionName() {
+        return new NonLocalizedString("an intersection name");
+      }
+    };
+
+    var place = Place.forFlexStop(stop, vertex);
+
+    assertEquals(expectedPlaceName, place.name.toString());
   }
 
   @Test

--- a/src/test/java/org/opentripplanner/model/plan/RelativeDirectionTest.java
+++ b/src/test/java/org/opentripplanner/model/plan/RelativeDirectionTest.java
@@ -44,7 +44,7 @@ class RelativeDirectionTest {
     tc(-181, HARD_RIGHT)
   );
 
-  @ParameterizedTest(name = "Turing {0} degrees should give a relative direction of {1}")
+  @ParameterizedTest(name = "Turning {0} degrees should give a relative direction of {1}")
   @VariableSource("testCasesNormal")
   void testCalculateForNormalIntersections(int thisAngleDegrees, RelativeDirection expected) {
     assertEquals(expected, RelativeDirection.calculate(angle(thisAngleDegrees), false));

--- a/src/test/java/org/opentripplanner/routing/edgetype/StreetEdgeSplittingTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/StreetEdgeSplittingTest.java
@@ -18,6 +18,7 @@ import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.vertextype.SplitterVertex;
 import org.opentripplanner.routing.vertextype.StreetVertex;
 import org.opentripplanner.routing.vertextype.TemporarySplitterVertex;
+import org.opentripplanner.util.NonLocalizedString;
 
 class StreetEdgeSplittingTest extends GraphRoutingTest {
 
@@ -32,7 +33,13 @@ class StreetEdgeSplittingTest extends GraphRoutingTest {
 
   @Test
   public void turnRestrictionFromEdgeSplit() {
-    var splitVtx = new SplitterVertex(graph, "Split_Vertex", 1.0, 0.0);
+    var splitVtx = new SplitterVertex(
+      graph,
+      "Split_Vertex",
+      1.0,
+      0.0,
+      new NonLocalizedString("a name")
+    );
 
     var splitResult = streetEdge1.splitDestructively(splitVtx);
     assertTrue(splitResult.first.getTurnRestrictions().isEmpty());
@@ -51,7 +58,13 @@ class StreetEdgeSplittingTest extends GraphRoutingTest {
 
   @Test
   public void turnRestrictionToEdgeSplit() {
-    var splitVtx = new SplitterVertex(graph, "Split_Vertex", 1.0, 1.0);
+    var splitVtx = new SplitterVertex(
+      graph,
+      "Split_Vertex",
+      1.0,
+      1.0,
+      new NonLocalizedString("a name")
+    );
 
     var splitResult = streetEdge2.splitDestructively(splitVtx);
     assertEquals(splitResult.first, addedRestriction(streetEdge1).to);


### PR DESCRIPTION
### Summary

This is mostly moving some of the transit classes into the appropriate packages. But some parsing logic is also removed from LocalizedString into the osm builder where it is used. This PR updates the TransitModelArchitectureTest, declaring the allowed dependencies. 

There is not new code in this PR, the code has only been moved around.


### Issue
No

### Unit tests

Updated and new architecture tests added.


### Documentation
Not changed

