### PR TITLE
Remove usage of gtfsCode from internal enum values

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/flex/FlexTripsMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/FlexTripsMapper.java
@@ -60,9 +60,7 @@ public class FlexTripsMapper {
   private static boolean hasContinuousStops(List<StopTime> stopTimes) {
     return stopTimes
       .stream()
-      .anyMatch(st ->
-        st.getFlexContinuousPickup() != NONE.getGtfsCode() ||
-        st.getFlexContinuousDropOff() != NONE.getGtfsCode()
+      .anyMatch(st -> st.getFlexContinuousPickup() != NONE || st.getFlexContinuousDropOff() != NONE
       );
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTrip.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTrip.java
@@ -60,8 +60,7 @@ public class ScheduledDeviatedTrip extends FlexTrip {
   public static boolean isScheduledFlexTrip(List<StopTime> stopTimes) {
     Predicate<StopTime> notStopType = Predicate.not(st -> st.getStop() instanceof Stop);
     Predicate<StopTime> notContinuousStop = stopTime ->
-      stopTime.getFlexContinuousDropOff() == NONE.getGtfsCode() &&
-      stopTime.getFlexContinuousPickup() == NONE.getGtfsCode();
+      stopTime.getFlexContinuousDropOff() == NONE && stopTime.getFlexContinuousPickup() == NONE;
     return (
       stopTimes.stream().anyMatch(notStopType) && stopTimes.stream().allMatch(notContinuousStop)
     );

--- a/src/ext/java/org/opentripplanner/ext/flex/trip/UnscheduledTrip.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/trip/UnscheduledTrip.java
@@ -64,8 +64,7 @@ public class UnscheduledTrip extends FlexTrip {
       st.isArrivalTimeSet() || st.isDepartureTimeSet()
     );
     Predicate<StopTime> notContinuousStop = stopTime ->
-      stopTime.getFlexContinuousDropOff() == NONE.getGtfsCode() &&
-      stopTime.getFlexContinuousPickup() == NONE.getGtfsCode();
+      stopTime.getFlexContinuousDropOff() == NONE && stopTime.getFlexContinuousPickup() == NONE;
     return (
       N_STOPS.contains(stopTimes.size()) &&
       stopTimes.stream().allMatch(noExplicitTimes) &&

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLAlertImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLAlertImpl.java
@@ -8,6 +8,7 @@ import graphql.relay.Relay;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import java.time.Instant;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -223,7 +224,7 @@ public class LegacyGraphQLAlertImpl implements LegacyGraphQLDataFetchers.LegacyG
                 : getUnknownForAlertEntityPair(
                   agency,
                   routeType,
-                  agency.toString(),
+                  null,
                   Integer.toString(routeType),
                   "agency",
                   "route type"
@@ -249,8 +250,8 @@ public class LegacyGraphQLAlertImpl implements LegacyGraphQLDataFetchers.LegacyG
               : List.of(
                 getUnknownForAlertEntityPair(
                   route,
-                  route.toString(),
                   direction,
+                  null,
                   direction.name(),
                   "route",
                   "direction"
@@ -264,7 +265,7 @@ public class LegacyGraphQLAlertImpl implements LegacyGraphQLDataFetchers.LegacyG
           }
           return List.of();
         })
-        .flatMap(list -> list.stream())
+        .flatMap(Collection::stream)
         .map(Object.class::cast)
         .collect(Collectors.toList());
   }

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLAlertImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLAlertImpl.java
@@ -30,6 +30,7 @@ import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.organization.Agency;
 import org.opentripplanner.transit.model.site.StopLocation;
+import org.opentripplanner.transit.model.timetable.Direction;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.service.TransitService;
 
@@ -235,7 +236,7 @@ public class LegacyGraphQLAlertImpl implements LegacyGraphQLDataFetchers.LegacyG
             return List.of(new LegacyGraphQLRouteTypeModel(null, routeType, feedId));
           }
           if (entitySelector instanceof EntitySelector.DirectionAndRoute) {
-            int directionId = ((DirectionAndRoute) entitySelector).directionId;
+            Direction direction = ((DirectionAndRoute) entitySelector).direction;
             FeedScopedId routeId = ((EntitySelector.DirectionAndRoute) entitySelector).routeId;
             Route route = getTransitService(environment).getRouteForId(routeId);
             return route != null
@@ -243,14 +244,14 @@ public class LegacyGraphQLAlertImpl implements LegacyGraphQLDataFetchers.LegacyG
                 .getPatternsForRoute()
                 .get(route)
                 .stream()
-                .filter(pattern -> pattern.getDirection().gtfsCode == directionId)
+                .filter(pattern -> pattern.getDirection() == direction)
                 .collect(Collectors.toList())
               : List.of(
                 getUnknownForAlertEntityPair(
                   route,
-                  directionId,
                   route.toString(),
-                  Integer.toString(directionId),
+                  direction,
+                  direction.name(),
                   "route",
                   "direction"
                 )

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLPatternImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLPatternImpl.java
@@ -45,7 +45,7 @@ public class LegacyGraphQLPatternImpl implements LegacyGraphQLDataFetchers.Legac
             case PATTERN:
               alerts.addAll(
                 alertService.getDirectionAndRouteAlerts(
-                  getSource(environment).getDirection().gtfsCode,
+                  getSource(environment).getDirection(),
                   getRoute(environment).getId()
                 )
               );
@@ -128,7 +128,7 @@ public class LegacyGraphQLPatternImpl implements LegacyGraphQLDataFetchers.Legac
         return alerts.stream().distinct().collect(Collectors.toList());
       } else {
         return alertService.getDirectionAndRouteAlerts(
-          getSource(environment).getDirection().gtfsCode,
+          getSource(environment).getDirection(),
           getRoute(environment).getId()
         );
       }

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
@@ -35,6 +35,8 @@ import org.opentripplanner.ext.legacygraphqlapi.LegacyGraphQLRequestContext;
 import org.opentripplanner.ext.legacygraphqlapi.LegacyGraphQLUtils;
 import org.opentripplanner.ext.legacygraphqlapi.generated.LegacyGraphQLDataFetchers;
 import org.opentripplanner.ext.legacygraphqlapi.generated.LegacyGraphQLTypes;
+import org.opentripplanner.graph_builder.DataImportIssueStore;
+import org.opentripplanner.gtfs.mapping.DirectionMapper;
 import org.opentripplanner.model.GenericLocation;
 import org.opentripplanner.model.TripPattern;
 import org.opentripplanner.model.TripTimeOnDate;
@@ -72,6 +74,11 @@ import org.opentripplanner.util.time.ServiceDateUtils;
 
 public class LegacyGraphQLQueryTypeImpl
   implements LegacyGraphQLDataFetchers.LegacyGraphQLQueryType {
+
+  // TODO: figure out a runtime solution
+  private static final DirectionMapper DIRECTION_MAPPER = new DirectionMapper(
+    new DataImportIssueStore(false)
+  );
 
   public static <T> boolean hasArgument(Map<String, T> m, String name) {
     return m.containsKey(name) && m.get(name) != null;
@@ -358,7 +365,7 @@ public class LegacyGraphQLQueryTypeImpl
       return new GtfsRealtimeFuzzyTripMatcher(transitService)
         .getTrip(
           transitService.getRouteForId(FeedScopedId.parseId(args.getLegacyGraphQLRoute())),
-          args.getLegacyGraphQLDirection(),
+          DIRECTION_MAPPER.map(args.getLegacyGraphQLDirection()),
           args.getLegacyGraphQLTime(),
           ServiceDateUtils.parseString(args.getLegacyGraphQLDate())
         );

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLRouteImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLRouteImpl.java
@@ -79,16 +79,16 @@ public class LegacyGraphQLRouteImpl implements LegacyGraphQLDataFetchers.LegacyG
                           )
                       )
                   )
-                  .collect(Collectors.toList())
+                  .toList()
               );
               getStops(environment)
-                .forEach(stop -> {
-                  alerts.addAll(alertService.getStopAlerts(((StopLocation) stop).getId()));
-                });
+                .forEach(stop ->
+                  alerts.addAll(alertService.getStopAlerts(((StopLocation) stop).getId()))
+                );
               break;
             case STOPS_ON_TRIPS:
               Iterable<Trip> trips = getTrips(environment);
-              trips.forEach(trip -> {
+              trips.forEach(trip ->
                 alerts.addAll(
                   alertService
                     .getAllAlerts()
@@ -104,9 +104,9 @@ public class LegacyGraphQLRouteImpl implements LegacyGraphQLDataFetchers.LegacyG
                             )
                         )
                     )
-                    .collect(Collectors.toList())
-                );
-              });
+                    .toList()
+                )
+              );
               break;
             case PATTERNS:
               alerts.addAll(
@@ -133,18 +133,12 @@ public class LegacyGraphQLRouteImpl implements LegacyGraphQLDataFetchers.LegacyG
 
   @Override
   public DataFetcher<String> bikesAllowed() {
-    return environment -> {
+    return environment ->
       switch (getSource(environment).getBikesAllowed()) {
-        case UNKNOWN:
-          return "NO_INFORMATION";
-        case ALLOWED:
-          return "POSSIBLE";
-        case NOT_ALLOWED:
-          return "NOT_POSSIBLE";
-        default:
-          return null;
-      }
-    };
+        case UNKNOWN -> "NO_INFORMATION";
+        case ALLOWED -> "POSSIBLE";
+        case NOT_ALLOWED -> "NOT_POSSIBLE";
+      };
   }
 
   @Override
@@ -191,7 +185,7 @@ public class LegacyGraphQLRouteImpl implements LegacyGraphQLDataFetchers.LegacyG
 
   @Override
   public DataFetcher<Iterable<Object>> stops() {
-    return environment -> getStops(environment);
+    return this::getStops;
   }
 
   @Override
@@ -201,7 +195,7 @@ public class LegacyGraphQLRouteImpl implements LegacyGraphQLDataFetchers.LegacyG
 
   @Override
   public DataFetcher<Iterable<Trip>> trips() {
-    return environment -> getTrips(environment);
+    return this::getTrips;
   }
 
   @Override

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLRouteImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLRouteImpl.java
@@ -16,6 +16,7 @@ import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.organization.Agency;
 import org.opentripplanner.transit.model.site.StopLocation;
+import org.opentripplanner.transit.model.timetable.Direction;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.service.TransitService;
 
@@ -109,10 +110,16 @@ public class LegacyGraphQLRouteImpl implements LegacyGraphQLDataFetchers.LegacyG
               break;
             case PATTERNS:
               alerts.addAll(
-                alertService.getDirectionAndRouteAlerts(0, getSource(environment).getId())
+                alertService.getDirectionAndRouteAlerts(
+                  Direction.INBOUND,
+                  getSource(environment).getId()
+                )
               );
               alerts.addAll(
-                alertService.getDirectionAndRouteAlerts(1, getSource(environment).getId())
+                alertService.getDirectionAndRouteAlerts(
+                  Direction.OUTBOUND,
+                  getSource(environment).getId()
+                )
               );
               break;
           }

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLStopImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLStopImpl.java
@@ -32,6 +32,7 @@ import org.opentripplanner.routing.graphfinder.NearbyStop;
 import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.routing.stoptimes.ArrivalDeparture;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.model.framework.TransitEntity;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.site.Station;
 import org.opentripplanner.transit.model.site.Stop;
@@ -47,7 +48,7 @@ public class LegacyGraphQLStopImpl implements LegacyGraphQLDataFetchers.LegacyGr
       TransitAlertService alertService = getTransitService(environment).getTransitAlertService();
       var args = new LegacyGraphQLTypes.LegacyGraphQLStopAlertsArgs(environment.getArguments());
       List<LegacyGraphQLTypes.LegacyGraphQLStopAlertType> types = (List) args.getLegacyGraphQLTypes();
-      FeedScopedId id = getValue(environment, stop -> stop.getId(), station -> station.getId());
+      FeedScopedId id = getValue(environment, StopLocation::getId, TransitEntity::getId);
       if (types != null) {
         Collection<TransitAlert> alerts = new ArrayList<>();
         if (types.contains(LegacyGraphQLStopAlertType.STOP)) {
@@ -448,7 +449,6 @@ public class LegacyGraphQLStopImpl implements LegacyGraphQLDataFetchers.LegacyGr
             .orElse(null);
         },
         station -> {
-          RoutingService routingService = getRoutingService(environment);
           TransitService transitService = getTransitService(environment);
           return station
             .getChildStops()

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLStopImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLStopImpl.java
@@ -90,7 +90,7 @@ public class LegacyGraphQLStopImpl implements LegacyGraphQLDataFetchers.LegacyGr
               if (types.contains(LegacyGraphQLStopAlertType.PATTERNS)) {
                 alerts.addAll(
                   alertService.getDirectionAndRouteAlerts(
-                    pattern.getDirection().gtfsCode,
+                    pattern.getDirection(),
                     pattern.getRoute().getId()
                   )
                 );

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLStoptimeImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLStoptimeImpl.java
@@ -24,20 +24,14 @@ public class LegacyGraphQLStoptimeImpl implements LegacyGraphQLDataFetchers.Lega
 
   @Override
   public DataFetcher<String> dropoffType() {
-    return environment -> {
-      switch (getSource(environment).getDropoffType().getGtfsCode()) {
-        case 0:
-          return "SCHEDULED";
-        case 1:
-          return "NONE";
-        case 2:
-          return "CALL_AGENCY";
-        case 3:
-          return "COORDINATE_WITH_DRIVER";
-        default:
-          return null;
-      }
-    };
+    return environment ->
+      switch (getSource(environment).getDropoffType()) {
+        case SCHEDULED -> "SCHEDULED";
+        case NONE -> "NONE";
+        case CALL_AGENCY -> "CALL_AGENCY";
+        case COORDINATE_WITH_DRIVER -> "COORDINATE_WITH_DRIVER";
+        case CANCELLED -> null;
+      };
   }
 
   @Override
@@ -47,20 +41,14 @@ public class LegacyGraphQLStoptimeImpl implements LegacyGraphQLDataFetchers.Lega
 
   @Override
   public DataFetcher<String> pickupType() {
-    return environment -> {
-      switch (getSource(environment).getPickupType().getGtfsCode()) {
-        case 0:
-          return "SCHEDULED";
-        case 1:
-          return "NONE";
-        case 2:
-          return "CALL_AGENCY";
-        case 3:
-          return "COORDINATE_WITH_DRIVER";
-        default:
-          return null;
-      }
-    };
+    return environment ->
+      switch (getSource(environment).getPickupType()) {
+        case SCHEDULED -> "SCHEDULED";
+        case NONE -> "NONE";
+        case CALL_AGENCY -> "CALL_AGENCY";
+        case COORDINATE_WITH_DRIVER -> "COORDINATE_WITH_DRIVER";
+        case CANCELLED -> null;
+      };
   }
 
   @Override

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLTripImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLTripImpl.java
@@ -11,7 +11,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.locationtech.jts.geom.Geometry;
@@ -86,7 +85,6 @@ public class LegacyGraphQLTripImpl implements LegacyGraphQLDataFetchers.LegacyGr
             case PATTERN:
               alerts.addAll(
                 alertService.getDirectionAndRouteAlerts(
-                  getSource(environment).getDirection().gtfsCode,
                   getSource(environment).getDirection(),
                   getRoute(environment).getId()
                 )
@@ -175,18 +173,12 @@ public class LegacyGraphQLTripImpl implements LegacyGraphQLDataFetchers.LegacyGr
 
   @Override
   public DataFetcher<String> bikesAllowed() {
-    return environment -> {
+    return environment ->
       switch (getSource(environment).getBikesAllowed()) {
-        case UNKNOWN:
-          return "NO_INFORMATION";
-        case ALLOWED:
-          return "POSSIBLE";
-        case NOT_ALLOWED:
-          return "NOT_POSSIBLE";
-        default:
-          return null;
-      }
-    };
+        case UNKNOWN -> "NO_INFORMATION";
+        case ALLOWED -> "POSSIBLE";
+        case NOT_ALLOWED -> "NOT_POSSIBLE";
+      };
   }
 
   @Override
@@ -335,7 +327,6 @@ public class LegacyGraphQLTripImpl implements LegacyGraphQLDataFetchers.LegacyGr
   public DataFetcher<Iterable<TripTimeOnDate>> stoptimesForDate() {
     return environment -> {
       try {
-        RoutingService routingService = getRoutingService(environment);
         TransitService transitService = getTransitService(environment);
         Trip trip = getSource(environment);
         var args = new LegacyGraphQLTypes.LegacyGraphQLTripStoptimesForDateArgs(

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLTripImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLTripImpl.java
@@ -34,6 +34,7 @@ import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.organization.Agency;
 import org.opentripplanner.transit.model.site.StopLocation;
+import org.opentripplanner.transit.model.timetable.Direction;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.util.time.ServiceDateUtils;
@@ -86,6 +87,7 @@ public class LegacyGraphQLTripImpl implements LegacyGraphQLDataFetchers.LegacyGr
               alerts.addAll(
                 alertService.getDirectionAndRouteAlerts(
                   getSource(environment).getDirection().gtfsCode,
+                  getSource(environment).getDirection(),
                   getRoute(environment).getId()
                 )
               );
@@ -228,7 +230,13 @@ public class LegacyGraphQLTripImpl implements LegacyGraphQLDataFetchers.LegacyGr
 
   @Override
   public DataFetcher<String> directionId() {
-    return environment -> getSource(environment).getGtfsDirectionIdAsString(null);
+    return environment -> {
+      Direction direction = getSource(environment).getDirection();
+      if (direction == Direction.UNKNOWN) {
+        return null;
+      }
+      return Integer.toString(direction.gtfsCode);
+    };
   }
 
   @Override

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTripPatternIdGenerator.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTripPatternIdGenerator.java
@@ -4,6 +4,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.opentripplanner.gtfs.GenerateTripPatternsOperation;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.Route;
+import org.opentripplanner.transit.model.timetable.Direction;
 import org.opentripplanner.transit.model.timetable.Trip;
 
 /**
@@ -18,17 +19,16 @@ class SiriTripPatternIdGenerator {
 
   /**
    * Generate unique trip pattern code for real-time added trip pattern. This function roughly
-   * follows the format of {@link GenerateTripPatternsOperation#generateUniqueIdForTripPattern(Route,
-   * int)}.
+   * follows the format of {@link GenerateTripPatternsOperation}.
    * <p>
    * The generator add a postfix 'RT' to indicate that this trip pattern is generated at REAL-TIME.
    */
   FeedScopedId generateUniqueTripPatternId(Trip trip) {
     Route route = trip.getRoute();
     FeedScopedId routeId = route.getId();
-    String directionId = trip.getGtfsDirectionIdAsString("");
+    Direction direction = trip.getDirection();
+    String directionId = direction == Direction.UNKNOWN ? "" : Integer.toString(direction.gtfsCode);
 
-    // OBA library uses underscore as separator, we're moving toward colon.
     String id = String.format(
       "%s:%s:%03d:RT",
       routeId.getId(),

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/EnumTypes.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/EnumTypes.java
@@ -19,6 +19,7 @@ import org.opentripplanner.routing.stoptimes.ArrivalDeparture;
 import org.opentripplanner.routing.trippattern.OccupancyStatus;
 import org.opentripplanner.routing.trippattern.RealTimeState;
 import org.opentripplanner.transit.model.basic.TransitMode;
+import org.opentripplanner.transit.model.basic.WheelchairAccessibility;
 import org.opentripplanner.transit.model.network.BikeAccess;
 import org.opentripplanner.transit.model.timetable.Direction;
 import org.opentripplanner.transit.model.timetable.TripAlteration;
@@ -28,13 +29,21 @@ public class EnumTypes {
   public static GraphQLEnumType WHEELCHAIR_BOARDING = GraphQLEnumType
     .newEnum()
     .name("WheelchairBoarding")
-    .value("noInformation", 0, "There is no accessibility information for the stopPlace/quay.")
+    .value(
+      "noInformation",
+      WheelchairAccessibility.NO_INFORMATION,
+      "There is no accessibility information for the stopPlace/quay."
+    )
     .value(
       "possible",
-      1,
+      WheelchairAccessibility.POSSIBLE,
       "Boarding wheelchair-accessible serviceJourneys is possible at this stopPlace/quay."
     )
-    .value("notPossible", 2, "Wheelchair boarding/alighting is not possible at this stop.")
+    .value(
+      "notPossible",
+      WheelchairAccessibility.NOT_POSSIBLE,
+      "Wheelchair boarding/alighting is not possible at this stop."
+    )
     .build();
 
   public static GraphQLEnumType INTERCHANGE_WEIGHTING = GraphQLEnumType

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/EnumTypes.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/EnumTypes.java
@@ -358,7 +358,7 @@ public class EnumTypes {
   public static GraphQLEnumType TRANSPORT_SUBMODE = createEnum(
     "TransportSubmode",
     TransmodelTransportSubmode.values(),
-    (t -> t.getValue())
+    TransmodelTransportSubmode::getValue
   );
   /*
 
@@ -504,7 +504,7 @@ public class EnumTypes {
     .value("sameLine", AlternativeLegsFilter.SAME_ROUTE)
     .build();
 
-  private static <T extends Enum> GraphQLEnumType createEnum(
+  private static <T extends Enum<?>> GraphQLEnumType createEnum(
     String name,
     T[] values,
     Function<T, String> mapping

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/network/JourneyPatternType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/network/JourneyPatternType.java
@@ -150,7 +150,7 @@ public class JourneyPatternType {
               .getTransitService(environment)
               .getTransitAlertService()
               .getDirectionAndRouteAlerts(
-                tripPattern.getDirection().gtfsCode,
+                tripPattern.getDirection(),
                 tripPattern.getRoute().getId()
               );
           })

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/et/EstimatedCallType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/et/EstimatedCallType.java
@@ -403,9 +403,7 @@ public class EstimatedCallType {
     // TODO OTP2 This should probably have a FeedScopeId argument instead of string
     allAlerts.addAll(alertPatchService.getAgencyAlerts(trip.getRoute().getAgency().getId()));
     // Route's direction
-    allAlerts.addAll(
-      alertPatchService.getDirectionAndRouteAlerts(trip.getDirection().gtfsCode, routeId)
-    );
+    allAlerts.addAll(alertPatchService.getDirectionAndRouteAlerts(trip.getDirection(), routeId));
 
     long serviceDay = tripTimeOnDate.getServiceDayMidnight();
     long arrivalTime = tripTimeOnDate.getRealtimeArrival();

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/QuayType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/QuayType.java
@@ -132,16 +132,12 @@ public class QuayType {
           .name("wheelchairAccessible")
           .type(EnumTypes.WHEELCHAIR_BOARDING)
           .description("Whether this quay is suitable for wheelchair boarding.")
-          .dataFetcher(environment -> {
-            var wheelChairBoarding =
-              (((StopLocation) environment.getSource()).getWheelchairAccessibility());
-
-            return Objects.requireNonNullElse(
-              wheelChairBoarding,
+          .dataFetcher(environment ->
+            Objects.requireNonNullElse(
+              (((StopLocation) environment.getSource()).getWheelchairAccessibility()),
               WheelchairAccessibility.NO_INFORMATION
             )
-              .gtfsCode;
-          })
+          )
           .build()
       )
       .field(

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/ServiceJourneyType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/ServiceJourneyType.java
@@ -156,6 +156,7 @@ public class ServiceJourneyType {
           .newFieldDefinition()
           .name("wheelchairAccessible")
           .type(EnumTypes.WHEELCHAIR_BOARDING)
+          .dataFetcher(environment -> trip(environment).getWheelchairBoarding())
           .description("Whether service journey is accessible with wheelchair.")
           .build()
       )

--- a/src/main/java/org/opentripplanner/api/mapping/DirectionMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/DirectionMapper.java
@@ -1,0 +1,14 @@
+package org.opentripplanner.api.mapping;
+
+import org.opentripplanner.transit.model.timetable.Direction;
+
+public class DirectionMapper {
+
+  public static Integer mapToApi(Direction direction) {
+    if (direction == Direction.UNKNOWN) {
+      return null;
+    }
+
+    return direction.gtfsCode;
+  }
+}

--- a/src/main/java/org/opentripplanner/api/mapping/TripMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/TripMapper.java
@@ -22,7 +22,10 @@ public class TripMapper {
     api.tripShortName = obj.getShortName();
     api.tripHeadsign = obj.getHeadsign();
     api.routeShortName = obj.getRoute().getShortName();
-    api.directionId = obj.getGtfsDirectionIdAsString(null);
+    final Integer directionId = DirectionMapper.mapToApi(obj.getDirection());
+    if (directionId != null) {
+      api.directionId = Integer.toString(directionId);
+    }
     api.blockId = obj.getGtfsBlockId();
     api.shapeId = FeedScopedIdMapper.mapToApi(obj.getShapeId());
     api.wheelchairAccessible = WheelchairAccessibilityMapper.mapToApi(obj.getWheelchairBoarding());
@@ -45,7 +48,7 @@ public class TripMapper {
 
     // TODO OTP2 - All ids should be fully qualified including feed scope id.
     api.shapeId = shape == null ? null : shape.getId();
-    api.direction = domain.getDirection().gtfsCode;
+    api.direction = DirectionMapper.mapToApi(domain.getDirection());
 
     return api;
   }

--- a/src/main/java/org/opentripplanner/api/mapping/TripMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/TripMapper.java
@@ -25,7 +25,7 @@ public class TripMapper {
     api.directionId = obj.getGtfsDirectionIdAsString(null);
     api.blockId = obj.getGtfsBlockId();
     api.shapeId = FeedScopedIdMapper.mapToApi(obj.getShapeId());
-    api.wheelchairAccessible = obj.getWheelchairBoarding().gtfsCode;
+    api.wheelchairAccessible = WheelchairAccessibilityMapper.mapToApi(obj.getWheelchairBoarding());
     api.bikesAllowed = BikeAccessMapper.mapToApi(obj.getBikesAllowed());
     api.fareId = obj.getGtfsFareId();
 

--- a/src/main/java/org/opentripplanner/api/mapping/WheelchairAccessibilityMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/WheelchairAccessibilityMapper.java
@@ -5,6 +5,14 @@ import org.opentripplanner.transit.model.basic.WheelchairAccessibility;
 public class WheelchairAccessibilityMapper {
 
   public static Integer mapToApi(WheelchairAccessibility domain) {
-    return domain == null ? WheelchairAccessibility.NO_INFORMATION.gtfsCode : domain.gtfsCode;
+    if (domain == null) {
+      return 0;
+    }
+
+    return switch (domain) {
+      case NO_INFORMATION -> 0;
+      case POSSIBLE -> 1;
+      case NOT_POSSIBLE -> 2;
+    };
   }
 }

--- a/src/main/java/org/opentripplanner/gtfs/GenerateTripPatternsOperation.java
+++ b/src/main/java/org/opentripplanner/gtfs/GenerateTripPatternsOperation.java
@@ -166,7 +166,7 @@ public class GenerateTripPatternsOperation {
         return tripPattern;
       }
     }
-    FeedScopedId patternId = generateUniqueIdForTripPattern(route, direction.gtfsCode);
+    FeedScopedId patternId = generateUniqueIdForTripPattern(route, direction);
     TripPattern tripPattern = new TripPattern(patternId, route, stopPattern);
     tripPatterns.put(stopPattern, tripPattern);
     return tripPattern;
@@ -177,17 +177,16 @@ public class GenerateTripPatternsOperation {
    * the direction and an integer. This only works if the Collection of TripPattern includes every
    * TripPattern for the agency.
    */
-  private FeedScopedId generateUniqueIdForTripPattern(Route route, int directionId) {
+  private FeedScopedId generateUniqueIdForTripPattern(Route route, Direction direction) {
     FeedScopedId routeId = route.getId();
-    String direction = directionId != -1 ? String.valueOf(directionId) : "";
+    String directionId = direction == Direction.UNKNOWN ? "" : Integer.toString(direction.gtfsCode);
     String key = routeId.getId() + ":" + direction;
 
     // Add 1 to counter and update it
     int counter = tripPatternIdCounters.getOrDefault(key, 0) + 1;
     tripPatternIdCounters.put(key, counter);
 
-    // OBA library uses underscore as separator, we're moving toward colon.
-    String id = String.format("%s:%s:%02d", routeId.getId(), direction, counter);
+    String id = String.format("%s:%s:%02d", routeId.getId(), directionId, counter);
 
     return new FeedScopedId(routeId.getFeedId(), id);
   }

--- a/src/main/java/org/opentripplanner/gtfs/mapping/DirectionMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/DirectionMapper.java
@@ -1,0 +1,38 @@
+package org.opentripplanner.gtfs.mapping;
+
+import org.opentripplanner.graph_builder.DataImportIssueStore;
+import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.model.timetable.Direction;
+
+public class DirectionMapper {
+
+  private final DataImportIssueStore issueStore;
+
+  public DirectionMapper(DataImportIssueStore issueStore) {
+    this.issueStore = issueStore;
+  }
+
+  Direction map(String gtfsCode, FeedScopedId id) {
+    try {
+      if (gtfsCode == null || gtfsCode.isBlank()) {
+        return Direction.UNKNOWN;
+      }
+      return map(Integer.parseInt(gtfsCode));
+    } catch (NumberFormatException e) {
+      issueStore.add(
+        "InvalidGTFSDirectionId",
+        "Trip %s does not have direction id, defaults to -1",
+        id
+      );
+    }
+    return Direction.UNKNOWN;
+  }
+
+  public Direction map(int gtfsCode) {
+    return switch (gtfsCode) {
+      case 0 -> Direction.OUTBOUND;
+      case 1 -> Direction.INBOUND;
+      default -> Direction.UNKNOWN;
+    };
+  }
+}

--- a/src/main/java/org/opentripplanner/gtfs/mapping/GTFSToOtpTransitServiceMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/GTFSToOtpTransitServiceMapper.java
@@ -63,6 +63,8 @@ public class GTFSToOtpTransitServiceMapper {
 
   private final FareRuleMapper fareRuleMapper;
 
+  private final DirectionMapper directionMapper;
+
   private final DataImportIssueStore issueStore;
 
   private final GtfsRelationalDao data;
@@ -97,7 +99,8 @@ public class GTFSToOtpTransitServiceMapper {
     pathwayMapper =
       new PathwayMapper(stopMapper, entranceMapper, pathwayNodeMapper, boardingAreaMapper);
     routeMapper = new RouteMapper(agencyMapper, issueStore);
-    tripMapper = new TripMapper(routeMapper);
+    directionMapper = new DirectionMapper(issueStore);
+    tripMapper = new TripMapper(routeMapper, directionMapper);
     bookingRuleMapper = new BookingRuleMapper();
     stopTimeMapper =
       new StopTimeMapper(

--- a/src/main/java/org/opentripplanner/gtfs/mapping/PickDropMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/PickDropMapper.java
@@ -1,0 +1,25 @@
+package org.opentripplanner.gtfs.mapping;
+
+import static org.opentripplanner.model.StopTime.MISSING_VALUE;
+
+import org.opentripplanner.model.PickDrop;
+
+public class PickDropMapper {
+
+  static PickDrop map(int gtfsCode) {
+    return switch (gtfsCode) {
+      case 0 -> PickDrop.SCHEDULED;
+      case 1 -> PickDrop.NONE;
+      case 2 -> PickDrop.CALL_AGENCY;
+      case 3 -> PickDrop.COORDINATE_WITH_DRIVER;
+      default -> throw new IllegalArgumentException("Not a valid gtfs code: " + gtfsCode);
+    };
+  }
+
+  public static PickDrop mapFlexContinuousPickDrop(int gtfsCode) {
+    if (gtfsCode == MISSING_VALUE) {
+      return PickDrop.NONE;
+    }
+    return map(gtfsCode);
+  }
+}

--- a/src/main/java/org/opentripplanner/gtfs/mapping/StopMappingWrapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/StopMappingWrapper.java
@@ -41,7 +41,7 @@ class StopMappingWrapper {
   }
 
   public WheelchairAccessibility getWheelchairAccessibility() {
-    return WheelchairAccessibility.valueOfGtfsCode(stop.getWheelchairBoarding());
+    return WheelchairAccessibilityMapper.map(stop.getWheelchairBoarding());
   }
 
   public StopLevel getLevel() {

--- a/src/main/java/org/opentripplanner/gtfs/mapping/StopTimeMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/StopTimeMapper.java
@@ -66,14 +66,18 @@ class StopTimeMapper {
     lhs.setStopSequence(rhs.getStopSequence());
     lhs.setStopHeadsign(rhs.getStopHeadsign());
     lhs.setRouteShortName(rhs.getRouteShortName());
-    lhs.setPickupType(PickDrop.fromGtfsCode(rhs.getPickupType()));
-    lhs.setDropOffType(PickDrop.fromGtfsCode(rhs.getDropOffType()));
+    lhs.setPickupType(PickDropMapper.map(rhs.getPickupType()));
+    lhs.setDropOffType(PickDropMapper.map(rhs.getDropOffType()));
     lhs.setShapeDistTraveled(rhs.getShapeDistTraveled());
     lhs.setFarePeriodId(rhs.getFarePeriodId());
     lhs.setFlexWindowStart(rhs.getStartPickupDropOffWindow());
     lhs.setFlexWindowEnd(rhs.getEndPickupDropOffWindow());
-    lhs.setFlexContinuousPickup(rhs.getContinuousPickup());
-    lhs.setFlexContinuousDropOff(rhs.getContinuousDropOff());
+    lhs.setFlexContinuousPickup(
+      PickDropMapper.mapFlexContinuousPickDrop(rhs.getContinuousPickup())
+    );
+    lhs.setFlexContinuousDropOff(
+      PickDropMapper.mapFlexContinuousPickDrop(rhs.getContinuousDropOff())
+    );
     lhs.setPickupBookingInfo(bookingRuleMapper.map(rhs.getPickupBookingRule()));
     lhs.setDropOffBookingInfo(bookingRuleMapper.map(rhs.getDropOffBookingRule()));
 

--- a/src/main/java/org/opentripplanner/gtfs/mapping/TripMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/TripMapper.java
@@ -3,7 +3,6 @@ package org.opentripplanner.gtfs.mapping;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import org.opentripplanner.transit.model.basic.WheelchairAccessibility;
 import org.opentripplanner.transit.model.timetable.Direction;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.util.MapUtils;
@@ -58,9 +57,7 @@ class TripMapper {
     lhs.withDirection(Direction.valueOfGtfsCode(mapDirectionId(rhs)));
     lhs.withGtfsBlockId(rhs.getBlockId());
     lhs.withShapeId(AgencyAndIdMapper.mapAgencyAndId(rhs.getShapeId()));
-    lhs.withWheelchairBoarding(
-      WheelchairAccessibility.valueOfGtfsCode(rhs.getWheelchairAccessible())
-    );
+    lhs.withWheelchairBoarding(WheelchairAccessibilityMapper.map(rhs.getWheelchairAccessible()));
     lhs.withBikesAllowed(BikeAccessMapper.mapForTrip(rhs));
     lhs.withGtfsFareId(rhs.getFareId());
 

--- a/src/main/java/org/opentripplanner/gtfs/mapping/TripMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/TripMapper.java
@@ -3,23 +3,20 @@ package org.opentripplanner.gtfs.mapping;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import org.opentripplanner.transit.model.timetable.Direction;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.util.MapUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /** Responsible for mapping GTFS TripMapper into the OTP model. */
 class TripMapper {
 
-  private static final Logger LOG = LoggerFactory.getLogger(TripMapper.class);
-
   private final RouteMapper routeMapper;
+  private final DirectionMapper directionMapper;
 
   private final Map<org.onebusaway.gtfs.model.Trip, Trip> mappedTrips = new HashMap<>();
 
-  TripMapper(RouteMapper routeMapper) {
+  TripMapper(RouteMapper routeMapper, DirectionMapper directionMapper) {
     this.routeMapper = routeMapper;
+    this.directionMapper = directionMapper;
   }
 
   Collection<Trip> map(Collection<org.onebusaway.gtfs.model.Trip> trips) {
@@ -34,19 +31,6 @@ class TripMapper {
     return mappedTrips.values();
   }
 
-  private static int mapDirectionId(org.onebusaway.gtfs.model.Trip trip) {
-    try {
-      String directionId = trip.getDirectionId();
-      if (directionId == null || directionId.isBlank()) {
-        return -1;
-      }
-      return Integer.parseInt(directionId);
-    } catch (NumberFormatException e) {
-      LOG.debug("Trip {} does not have direction id, defaults to -1", trip);
-    }
-    return -1;
-  }
-
   private Trip doMap(org.onebusaway.gtfs.model.Trip rhs) {
     var lhs = Trip.of(AgencyAndIdMapper.mapAgencyAndId(rhs.getId()));
 
@@ -54,7 +38,7 @@ class TripMapper {
     lhs.withServiceId(AgencyAndIdMapper.mapAgencyAndId(rhs.getServiceId()));
     lhs.withShortName(rhs.getTripShortName());
     lhs.withHeadsign(rhs.getTripHeadsign());
-    lhs.withDirection(Direction.valueOfGtfsCode(mapDirectionId(rhs)));
+    lhs.withDirection(directionMapper.map(rhs.getDirectionId(), lhs.getId()));
     lhs.withGtfsBlockId(rhs.getBlockId());
     lhs.withShapeId(AgencyAndIdMapper.mapAgencyAndId(rhs.getShapeId()));
     lhs.withWheelchairBoarding(WheelchairAccessibilityMapper.map(rhs.getWheelchairAccessible()));

--- a/src/main/java/org/opentripplanner/gtfs/mapping/WheelchairAccessibilityMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/WheelchairAccessibilityMapper.java
@@ -1,0 +1,17 @@
+package org.opentripplanner.gtfs.mapping;
+
+import org.opentripplanner.transit.model.basic.WheelchairAccessibility;
+
+public class WheelchairAccessibilityMapper {
+
+  static WheelchairAccessibility map(int gtfsCode) {
+    return switch (gtfsCode) {
+      case 0 -> WheelchairAccessibility.NO_INFORMATION;
+      case 1 -> WheelchairAccessibility.POSSIBLE;
+      case 2 -> WheelchairAccessibility.NOT_POSSIBLE;
+      default -> throw new IllegalArgumentException(
+        "Unknown GTFS WheelChairBoardingType: " + gtfsCode
+      );
+    };
+  }
+}

--- a/src/main/java/org/opentripplanner/index/IndexAPI.java
+++ b/src/main/java/org/opentripplanner/index/IndexAPI.java
@@ -535,7 +535,7 @@ public class IndexAPI {
     return alertMapper.mapToApi(
       transitService
         .getTransitAlertService()
-        .getDirectionAndRouteAlerts(pattern.getDirection().gtfsCode, pattern.getRoute().getId())
+        .getDirectionAndRouteAlerts(pattern.getDirection(), pattern.getRoute().getId())
     );
   }
 

--- a/src/main/java/org/opentripplanner/model/PickDrop.java
+++ b/src/main/java/org/opentripplanner/model/PickDrop.java
@@ -1,26 +1,16 @@
 package org.opentripplanner.model;
 
 public enum PickDrop {
-  SCHEDULED(true, 0),
-  NONE(false, 1),
-  CALL_AGENCY(true, 2),
-  COORDINATE_WITH_DRIVER(true, 3),
-  CANCELLED(false, -1);
+  SCHEDULED(true),
+  NONE(false),
+  CALL_AGENCY(true),
+  COORDINATE_WITH_DRIVER(true),
+  CANCELLED(false);
 
   private final boolean routable;
 
-  private final int gtfsCode;
-
-  PickDrop(boolean routable, int gtfsCode) {
+  PickDrop(boolean routable) {
     this.routable = routable;
-    this.gtfsCode = gtfsCode;
-  }
-
-  public static PickDrop fromGtfsCode(int gtfsCode) {
-    for (PickDrop pickDrop : PickDrop.values()) {
-      if (pickDrop.gtfsCode == gtfsCode) return pickDrop;
-    }
-    throw new IllegalArgumentException("Not a valid gtfs code: " + gtfsCode);
   }
 
   public boolean is(PickDrop value) {
@@ -33,9 +23,5 @@ public enum PickDrop {
 
   public boolean isNotRoutable() {
     return !routable;
-  }
-
-  public int getGtfsCode() {
-    return gtfsCode;
   }
 }

--- a/src/main/java/org/opentripplanner/model/StopPattern.java
+++ b/src/main/java/org/opentripplanner/model/StopPattern.java
@@ -166,8 +166,8 @@ public final class StopPattern implements Serializable {
     // Use hops rather than stops because drop-off at stop 0 and pick-up at last stop are
     // not important and have changed between OTP versions.
     for (int hop = 0; hop < size - 1; hop++) {
-      hasher.putInt(pickups[hop].getGtfsCode());
-      hasher.putInt(dropoffs[hop + 1].getGtfsCode());
+      hasher.putInt(pickups[hop].ordinal());
+      hasher.putInt(dropoffs[hop + 1].ordinal());
     }
     return hasher.hash();
   }

--- a/src/main/java/org/opentripplanner/model/StopTime.java
+++ b/src/main/java/org/opentripplanner/model/StopTime.java
@@ -49,10 +49,10 @@ public final class StopTime implements Comparable<StopTime> {
   private int flexWindowEnd = MISSING_VALUE;
 
   // Disabled by default
-  private int flexContinuousPickup = MISSING_VALUE;
+  private PickDrop flexContinuousPickup = PickDrop.NONE;
 
   // Disabled by default
-  private int flexContinuousDropOff = MISSING_VALUE;
+  private PickDrop flexContinuousDropOff = PickDrop.NONE;
 
   private BookingInfo dropOffBookingInfo;
 
@@ -248,19 +248,19 @@ public final class StopTime implements Comparable<StopTime> {
     this.flexWindowEnd = flexWindowEnd;
   }
 
-  public int getFlexContinuousPickup() {
-    return flexContinuousPickup == MISSING_VALUE ? 1 : flexContinuousPickup;
+  public PickDrop getFlexContinuousPickup() {
+    return flexContinuousPickup;
   }
 
-  public void setFlexContinuousPickup(int flexContinuousPickup) {
+  public void setFlexContinuousPickup(PickDrop flexContinuousPickup) {
     this.flexContinuousPickup = flexContinuousPickup;
   }
 
-  public int getFlexContinuousDropOff() {
-    return flexContinuousDropOff == MISSING_VALUE ? 1 : flexContinuousDropOff;
+  public PickDrop getFlexContinuousDropOff() {
+    return flexContinuousDropOff;
   }
 
-  public void setFlexContinuousDropOff(int flexContinuousDropOff) {
+  public void setFlexContinuousDropOff(PickDrop flexContinuousDropOff) {
     this.flexContinuousDropOff = flexContinuousDropOff;
   }
 

--- a/src/main/java/org/opentripplanner/routing/alertpatch/EntitySelector.java
+++ b/src/main/java/org/opentripplanner/routing/alertpatch/EntitySelector.java
@@ -3,6 +3,7 @@ package org.opentripplanner.routing.alertpatch;
 import java.time.LocalDate;
 import java.util.Objects;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.model.timetable.Direction;
 
 public interface EntitySelector {
   class Agency implements EntitySelector {
@@ -272,19 +273,19 @@ public interface EntitySelector {
 
   class DirectionAndRoute implements EntitySelector {
 
-    public final int directionId;
+    public final Direction direction;
 
     public final FeedScopedId routeId;
 
-    public DirectionAndRoute(int directionId, FeedScopedId routeId) {
-      this.directionId = directionId;
+    public DirectionAndRoute(Direction direction, FeedScopedId routeId) {
+      this.direction = direction;
       this.routeId = routeId;
     }
 
     @Override
     public int hashCode() {
       int routeHash = Objects.hash(routeId);
-      return 41 * directionId * routeHash;
+      return 41 * direction.ordinal() * routeHash;
     }
 
     @Override
@@ -296,7 +297,7 @@ public interface EntitySelector {
         return false;
       }
       DirectionAndRoute that = (DirectionAndRoute) o;
-      return directionId == that.directionId && routeId.equals(that.routeId);
+      return direction == that.direction && routeId.equals(that.routeId);
     }
   }
 

--- a/src/main/java/org/opentripplanner/routing/impl/DelegatingTransitAlertServiceImpl.java
+++ b/src/main/java/org/opentripplanner/routing/impl/DelegatingTransitAlertServiceImpl.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.model.timetable.Direction;
 import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.updater.alerts.TransitAlertProvider;
 
@@ -130,11 +131,13 @@ public class DelegatingTransitAlertServiceImpl implements TransitAlertService {
   }
 
   @Override
-  public Collection<TransitAlert> getDirectionAndRouteAlerts(int directionId, FeedScopedId route) {
+  public Collection<TransitAlert> getDirectionAndRouteAlerts(
+    Direction direction,
+    FeedScopedId route
+  ) {
     return transitAlertServices
       .stream()
-      .map(transitAlertService -> transitAlertService.getDirectionAndRouteAlerts(directionId, route)
-      )
+      .map(transitAlertService -> transitAlertService.getDirectionAndRouteAlerts(direction, route))
       .flatMap(Collection::stream)
       .collect(Collectors.toList());
   }

--- a/src/main/java/org/opentripplanner/routing/impl/TransitAlertServiceImpl.java
+++ b/src/main/java/org/opentripplanner/routing/impl/TransitAlertServiceImpl.java
@@ -10,6 +10,7 @@ import org.opentripplanner.routing.alertpatch.EntitySelector;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.model.timetable.Direction;
 import org.opentripplanner.transit.service.TransitModel;
 
 /**
@@ -119,7 +120,10 @@ public class TransitAlertServiceImpl implements TransitAlertService {
   }
 
   @Override
-  public Collection<TransitAlert> getDirectionAndRouteAlerts(int directionId, FeedScopedId route) {
-    return alerts.get(new EntitySelector.DirectionAndRoute(directionId, route));
+  public Collection<TransitAlert> getDirectionAndRouteAlerts(
+    Direction direction,
+    FeedScopedId route
+  ) {
+    return alerts.get(new EntitySelector.DirectionAndRoute(direction, route));
   }
 }

--- a/src/main/java/org/opentripplanner/routing/services/TransitAlertService.java
+++ b/src/main/java/org/opentripplanner/routing/services/TransitAlertService.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.Collection;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.model.timetable.Direction;
 
 public interface TransitAlertService {
   void setAlerts(Collection<TransitAlert> alerts);
@@ -32,5 +33,5 @@ public interface TransitAlertService {
 
   Collection<TransitAlert> getRouteTypeAlerts(int routeType, String feedId);
 
-  Collection<TransitAlert> getDirectionAndRouteAlerts(int directionId, FeedScopedId route);
+  Collection<TransitAlert> getDirectionAndRouteAlerts(Direction direction, FeedScopedId route);
 }

--- a/src/main/java/org/opentripplanner/transit/model/basic/WheelchairAccessibility.java
+++ b/src/main/java/org/opentripplanner/transit/model/basic/WheelchairAccessibility.java
@@ -1,22 +1,7 @@
 package org.opentripplanner.transit.model.basic;
 
 public enum WheelchairAccessibility {
-  NO_INFORMATION(0),
-  POSSIBLE(1),
-  NOT_POSSIBLE(2);
-
-  public final int gtfsCode;
-
-  WheelchairAccessibility(int gtfsCode) {
-    this.gtfsCode = gtfsCode;
-  }
-
-  public static WheelchairAccessibility valueOfGtfsCode(int gtfsCode) {
-    for (WheelchairAccessibility value : values()) {
-      if (value.gtfsCode == gtfsCode) {
-        return value;
-      }
-    }
-    throw new IllegalArgumentException("Unknown GTFS WheelChairBoardingType: " + gtfsCode);
-  }
+  NO_INFORMATION,
+  POSSIBLE,
+  NOT_POSSIBLE,
 }

--- a/src/main/java/org/opentripplanner/transit/model/timetable/Direction.java
+++ b/src/main/java/org/opentripplanner/transit/model/timetable/Direction.java
@@ -18,15 +18,4 @@ public enum Direction {
   Direction(int gtfsCode) {
     this.gtfsCode = gtfsCode;
   }
-
-  public static Direction valueOfGtfsCode(int gtfsCode) {
-    switch (gtfsCode) {
-      case 0:
-        return Direction.OUTBOUND;
-      case 1:
-        return Direction.INBOUND;
-      default:
-        return Direction.UNKNOWN;
-    }
-  }
 }

--- a/src/main/java/org/opentripplanner/transit/model/timetable/Trip.java
+++ b/src/main/java/org/opentripplanner/transit/model/timetable/Trip.java
@@ -130,12 +130,6 @@ public final class Trip extends TransitEntity2<Trip, TripBuilder> implements Log
     return direction;
   }
 
-  public String getGtfsDirectionIdAsString(String unknownValue) {
-    return direction.equals(Direction.UNKNOWN)
-      ? unknownValue
-      : Integer.toString(direction.gtfsCode);
-  }
-
   @Nonnull
   public BikeAccess getBikesAllowed() {
     return bikesAllowed;

--- a/src/main/java/org/opentripplanner/updater/alerts/AlertsUpdateHandler.java
+++ b/src/main/java/org/opentripplanner/updater/alerts/AlertsUpdateHandler.java
@@ -13,6 +13,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import org.opentripplanner.graph_builder.DataImportIssueStore;
+import org.opentripplanner.gtfs.mapping.DirectionMapper;
 import org.opentripplanner.routing.alertpatch.EntitySelector;
 import org.opentripplanner.routing.alertpatch.TimePeriod;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
@@ -38,6 +40,11 @@ public class AlertsUpdateHandler {
 
   /** Set only if we should attempt to match the trip_id from other data in TripDescriptor */
   private GtfsRealtimeFuzzyTripMatcher fuzzyTripMatcher;
+
+  // TODO: replace this with a runtime solution
+  private final DirectionMapper directionMapper = new DirectionMapper(
+    new DataImportIssueStore(false)
+  );
 
   public void update(FeedMessage message) {
     Collection<TransitAlert> alerts = new ArrayList<>();
@@ -144,7 +151,10 @@ public class AlertsUpdateHandler {
           );
         } else if (directionId != MISSING_INT_FIELD_VALUE) {
           alertText.addEntity(
-            new EntitySelector.DirectionAndRoute(directionId, new FeedScopedId(feedId, routeId))
+            new EntitySelector.DirectionAndRoute(
+              directionMapper.map(directionId),
+              new FeedScopedId(feedId, routeId)
+            )
           );
         } else {
           alertText.addEntity(new EntitySelector.Route(new FeedScopedId(feedId, routeId)));

--- a/src/main/java/org/opentripplanner/updater/stoptime/TripPatternCache.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/TripPatternCache.java
@@ -8,6 +8,7 @@ import org.opentripplanner.model.StopPattern;
 import org.opentripplanner.model.TripPattern;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.Route;
+import org.opentripplanner.transit.model.timetable.Direction;
 import org.opentripplanner.transit.model.timetable.Trip;
 
 /**
@@ -76,20 +77,14 @@ public class TripPatternCache {
    */
   private FeedScopedId generateUniqueTripPatternCode(Trip trip) {
     FeedScopedId routeId = trip.getRoute().getId();
-    String directionId = trip.getGtfsDirectionIdAsString("");
+    Direction direction = trip.getDirection();
+    String directionId = direction == Direction.UNKNOWN ? "" : Integer.toString(direction.gtfsCode);
     if (counter == Integer.MAX_VALUE) {
       counter = 0;
     } else {
       counter++;
     }
-    // OBA library uses underscore as separator, we're moving toward colon.
-    String code = String.format(
-      "%s:%s:%s:rt#%d",
-      routeId.getFeedId(),
-      routeId.getId(),
-      directionId,
-      counter
-    );
-    return new FeedScopedId(trip.getId().getFeedId(), code);
+    String code = String.format("%s:%s:rt#%d", routeId.getId(), directionId, counter);
+    return new FeedScopedId(routeId.getFeedId(), code);
   }
 }

--- a/src/test/java/org/opentripplanner/gtfs/mapping/BoardingAreaMapperTest.java
+++ b/src/test/java/org/opentripplanner/gtfs/mapping/BoardingAreaMapperTest.java
@@ -38,8 +38,7 @@ public class BoardingAreaMapperTest {
 
   private static final int VEHICLE_TYPE = 5;
 
-  private static final WheelchairAccessibility WHEELCHAIR_BOARDING =
-    WheelchairAccessibility.POSSIBLE;
+  private static final int WHEELCHAIR_BOARDING = 1;
 
   private static final org.opentripplanner.transit.model.site.Stop PARENT_STOP = TransitModelForTest
     .stop(PARENT)
@@ -65,7 +64,7 @@ public class BoardingAreaMapperTest {
     STOP.setParentStation(PARENT);
     STOP.setTimezone(TIMEZONE);
     STOP.setVehicleType(VEHICLE_TYPE);
-    STOP.setWheelchairBoarding(WHEELCHAIR_BOARDING.gtfsCode);
+    STOP.setWheelchairBoarding(WHEELCHAIR_BOARDING);
     STOP.setZoneId(ZONE_ID);
   }
 
@@ -86,7 +85,7 @@ public class BoardingAreaMapperTest {
     assertEquals(LAT, result.getCoordinate().latitude(), 0.0001d);
     assertEquals(LON, result.getCoordinate().longitude(), 0.0001d);
     assertEquals(NAME, result.getName().toString());
-    assertEquals(WHEELCHAIR_BOARDING, result.getWheelchairAccessibility());
+    assertEquals(WheelchairAccessibility.POSSIBLE, result.getWheelchairAccessibility());
     assertEquals(PARENT_STOP, result.getParentStop());
   }
 

--- a/src/test/java/org/opentripplanner/gtfs/mapping/FrequencyMapperTest.java
+++ b/src/test/java/org/opentripplanner/gtfs/mapping/FrequencyMapperTest.java
@@ -29,8 +29,11 @@ public class FrequencyMapperTest {
 
   private static final int LABEL_ONLY = 1;
 
+  public static final DataImportIssueStore ISSUE_STORE = new DataImportIssueStore(false);
+
   private static final TripMapper TRIP_MAPPER = new TripMapper(
-    new RouteMapper(new AgencyMapper(FEED_ID), new DataImportIssueStore(false))
+    new RouteMapper(new AgencyMapper(FEED_ID), ISSUE_STORE),
+    new DirectionMapper(ISSUE_STORE)
   );
 
   private static final Frequency FREQUENCY = new Frequency();

--- a/src/test/java/org/opentripplanner/gtfs/mapping/StopTimesMapperTest.java
+++ b/src/test/java/org/opentripplanner/gtfs/mapping/StopTimesMapperTest.java
@@ -53,6 +53,8 @@ public class StopTimesMapperTest {
 
   private static final StopTime STOP_TIME = new StopTime();
 
+  public static final DataImportIssueStore ISSUE_STORE = new DataImportIssueStore(false);
+
   private final StopMapper stopMapper = new StopMapper(new TranslationHelper(), stationId -> null);
   private final BookingRuleMapper bookingRuleMapper = new BookingRuleMapper();
   private final LocationMapper locationMapper = new LocationMapper();
@@ -64,7 +66,10 @@ public class StopTimesMapperTest {
     stopMapper,
     locationMapper,
     locationGroupMapper,
-    new TripMapper(new RouteMapper(new AgencyMapper(FEED_ID), new DataImportIssueStore(false))),
+    new TripMapper(
+      new RouteMapper(new AgencyMapper(FEED_ID), ISSUE_STORE),
+      new DirectionMapper(ISSUE_STORE)
+    ),
     bookingRuleMapper
   );
 

--- a/src/test/java/org/opentripplanner/gtfs/mapping/StopTimesMapperTest.java
+++ b/src/test/java/org/opentripplanner/gtfs/mapping/StopTimesMapperTest.java
@@ -15,6 +15,7 @@ import org.onebusaway.gtfs.model.Stop;
 import org.onebusaway.gtfs.model.StopTime;
 import org.onebusaway.gtfs.model.Trip;
 import org.opentripplanner.graph_builder.DataImportIssueStore;
+import org.opentripplanner.model.PickDrop;
 
 public class StopTimesMapperTest {
 
@@ -100,9 +101,9 @@ public class StopTimesMapperTest {
 
     assertEquals(ARRIVAL_TIME, result.getArrivalTime());
     assertEquals(DEPARTURE_TIME, result.getDepartureTime());
-    assertEquals(DROP_OFF_TYPE, result.getDropOffType().getGtfsCode());
+    assertEquals(PickDrop.CALL_AGENCY, result.getDropOffType());
     assertEquals(FARE_PERIOD_ID, result.getFarePeriodId());
-    assertEquals(PICKUP_TYPE, result.getPickupType().getGtfsCode());
+    assertEquals(PickDrop.COORDINATE_WITH_DRIVER, result.getPickupType());
     assertEquals(ROUTE_SHORT_NAME, result.getRouteShortName());
     assertEquals(SHAPE_DIST_TRAVELED, result.getShapeDistTraveled(), 0.0001d);
     assertNotNull(result.getStop());
@@ -118,9 +119,9 @@ public class StopTimesMapperTest {
 
     assertFalse(result.isArrivalTimeSet());
     assertFalse(result.isDepartureTimeSet());
-    assertEquals(0, result.getDropOffType().getGtfsCode());
+    assertEquals(PickDrop.SCHEDULED, result.getDropOffType());
     assertNull(result.getFarePeriodId());
-    assertEquals(0, result.getPickupType().getGtfsCode());
+    assertEquals(PickDrop.SCHEDULED, result.getPickupType());
     assertNull(result.getRouteShortName());
     assertFalse(result.isShapeDistTraveledSet());
     assertNull(result.getStop());

--- a/src/test/java/org/opentripplanner/gtfs/mapping/TransferMapperTest.java
+++ b/src/test/java/org/opentripplanner/gtfs/mapping/TransferMapperTest.java
@@ -14,12 +14,17 @@ public class TransferMapperTest {
 
   private static final TranslationHelper TRANSLATION_HELPER = new TranslationHelper();
 
+  public static final DataImportIssueStore ISSUE_STORE = new DataImportIssueStore(false);
+
   private static final RouteMapper ROUTE_MAPPER = new RouteMapper(
     new AgencyMapper(FEED_ID),
-    new DataImportIssueStore(false)
+    ISSUE_STORE
   );
 
-  private static final TripMapper TRIP_MAPPER = new TripMapper(ROUTE_MAPPER);
+  private static final TripMapper TRIP_MAPPER = new TripMapper(
+    ROUTE_MAPPER,
+    new DirectionMapper(ISSUE_STORE)
+  );
 
   private static final StationMapper STATION_MAPPER = new StationMapper(TRANSLATION_HELPER);
 

--- a/src/test/java/org/opentripplanner/gtfs/mapping/TripMapperTest.java
+++ b/src/test/java/org/opentripplanner/gtfs/mapping/TripMapperTest.java
@@ -28,8 +28,7 @@ public class TripMapperTest {
   private static final String TRIP_HEADSIGN = "Trip Headsign";
   private static final String TRIP_SHORT_NAME = "Trip Short Name";
 
-  private static final WheelchairAccessibility WHEELCHAIR_ACCESSIBLE =
-    WheelchairAccessibility.POSSIBLE;
+  private static final int WHEELCHAIR_ACCESSIBLE = 1;
 
   private static final Trip TRIP = new Trip();
 
@@ -50,7 +49,7 @@ public class TripMapperTest {
     TRIP.setShapeId(AGENCY_AND_ID);
     TRIP.setTripHeadsign(TRIP_HEADSIGN);
     TRIP.setTripShortName(TRIP_SHORT_NAME);
-    TRIP.setWheelchairAccessible(WHEELCHAIR_ACCESSIBLE.gtfsCode);
+    TRIP.setWheelchairAccessible(WHEELCHAIR_ACCESSIBLE);
   }
 
   @Test
@@ -73,7 +72,7 @@ public class TripMapperTest {
     assertEquals("A:1", result.getShapeId().toString());
     assertEquals(TRIP_HEADSIGN, result.getHeadsign());
     assertEquals(TRIP_SHORT_NAME, result.getShortName());
-    assertEquals(WHEELCHAIR_ACCESSIBLE, result.getWheelchairBoarding());
+    assertEquals(WheelchairAccessibility.POSSIBLE, result.getWheelchairBoarding());
     assertEquals(BikeAccess.ALLOWED, result.getBikesAllowed());
   }
 

--- a/src/test/java/org/opentripplanner/gtfs/mapping/TripMapperTest.java
+++ b/src/test/java/org/opentripplanner/gtfs/mapping/TripMapperTest.java
@@ -10,11 +10,11 @@ import java.util.Collection;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
 import org.onebusaway.gtfs.model.AgencyAndId;
-import org.onebusaway.gtfs.model.Route;
 import org.onebusaway.gtfs.model.Trip;
 import org.opentripplanner.graph_builder.DataImportIssueStore;
 import org.opentripplanner.transit.model.basic.WheelchairAccessibility;
 import org.opentripplanner.transit.model.network.BikeAccess;
+import org.opentripplanner.transit.model.timetable.Direction;
 
 public class TripMapperTest {
 
@@ -24,7 +24,6 @@ public class TripMapperTest {
   private static final String BLOCK_ID = "Block Id";
   private static final int DIRECTION_ID = 1;
   private static final String FARE_ID = "Fare Id";
-  private static final Route ROUTE = new Route();
   private static final String TRIP_HEADSIGN = "Trip Headsign";
   private static final String TRIP_SHORT_NAME = "Trip Short Name";
 
@@ -32,8 +31,11 @@ public class TripMapperTest {
 
   private static final Trip TRIP = new Trip();
 
+  public static final DataImportIssueStore ISSUE_STORE = new DataImportIssueStore(false);
+
   private final TripMapper subject = new TripMapper(
-    new RouteMapper(new AgencyMapper(FEED_ID), new DataImportIssueStore(false))
+    new RouteMapper(new AgencyMapper(FEED_ID), ISSUE_STORE),
+    new DirectionMapper(ISSUE_STORE)
   );
 
   static {
@@ -65,7 +67,7 @@ public class TripMapperTest {
 
     assertEquals("A:1", result.getId().toString());
     assertEquals(BLOCK_ID, result.getGtfsBlockId());
-    assertEquals(DIRECTION_ID, result.getDirection().gtfsCode);
+    assertEquals(Direction.INBOUND, result.getDirection());
     assertEquals(FARE_ID, result.getGtfsFareId());
     assertNotNull(result.getRoute());
     assertEquals("A:1", result.getServiceId().toString());
@@ -93,7 +95,7 @@ public class TripMapperTest {
     assertNull(result.getShapeId());
     assertNull(result.getHeadsign());
     assertNull(result.getShortName());
-    assertEquals(-1, result.getDirection().gtfsCode);
+    assertEquals(Direction.UNKNOWN, result.getDirection());
     assertEquals(WheelchairAccessibility.NO_INFORMATION, result.getWheelchairBoarding());
     assertEquals(BikeAccess.UNKNOWN, result.getBikesAllowed());
   }

--- a/src/test/java/org/opentripplanner/model/impl/OtpTransitServiceBuilderLimitPeriodTest.java
+++ b/src/test/java/org/opentripplanner/model/impl/OtpTransitServiceBuilderLimitPeriodTest.java
@@ -195,7 +195,7 @@ public class OtpTransitServiceBuilderLimitPeriodTest {
     return TransitModelForTest
       .trip(id)
       .withServiceId(serviceId)
-      .withDirection(Direction.valueOfGtfsCode(1))
+      .withDirection(Direction.INBOUND)
       .withRoute(route)
       .build();
   }


### PR DESCRIPTION
### Summary

Currently we are relying on the numerical GTFS values in some of the internal enums. This removes most of the usage of those, and uses explicit input and output mappers instead.