### PR TITLE
Update Jackson to 2.13.3, fix security vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <otp.serialization.version.id>41</otp.serialization.version.id>
         <!-- Lib versions - keep list sorted on property name -->
         <geotools.version>26.4</geotools.version>
-        <jackson.version>2.13.2</jackson.version>
+        <jackson.version>2.13.3</jackson.version>
         <jersey.version>2.34</jersey.version>
         <junit.version>5.8.2</junit.version>
         <micrometer.version>1.8.3</micrometer.version>


### PR DESCRIPTION
### Summary

Updated from 2.13.2 to 2.13.3. Intellij complained.

### Unit tests
No.
