### PR TITLE
Filter out parks with no bike/car spaces for legacy type

### DIFF
--- a/docs/sandbox/LegacyGraphQLApi.md
+++ b/docs/sandbox/LegacyGraphQLApi.md
@@ -25,6 +25,7 @@
 - Fix issue with GraphQL code generator (February 2022, https://github.com/opentripplanner/OpenTripPlanner/pull/3881)
 - Add GBFS form factors for `rentalVehicle` (April 2022, https://github.com/opentripplanner/OpenTripPlanner/pull/4062)
 - Implement allowedBikeRentalNetworks while deprecating it and add allowedVehicleRentalNetworks and bannedVehicleRentalNetworks. (July 2022, https://github.com/opentripplanner/OpenTripPlanner/pull/4279)
+- Filters place types in legacy GraphQL API so that a bike park type is not returned if a vehicle parking has no bicycle spaces and car park type is not returned if a parking has no car spaces. (July 2022, https://github.com/opentripplanner/OpenTripPlanner/pull/4296)
 
 ## Documentation
 

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLPlaceImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLPlaceImpl.java
@@ -25,7 +25,7 @@ public class LegacyGraphQLPlaceImpl implements LegacyGraphQLDataFetchers.LegacyG
 
   @Override
   public DataFetcher<VehicleParking> bikePark() {
-    return this::getVehicleParking;
+    return this::getBikePark;
   }
 
   @Override
@@ -43,7 +43,7 @@ public class LegacyGraphQLPlaceImpl implements LegacyGraphQLDataFetchers.LegacyG
 
   @Override
   public DataFetcher<VehicleParking> carPark() {
-    return this::getVehicleParking;
+    return this::getCarPark;
   }
 
   @Override
@@ -128,6 +128,30 @@ public class LegacyGraphQLPlaceImpl implements LegacyGraphQLDataFetchers.LegacyG
           throw new IllegalStateException("Unhandled vertexType: " + place.vertexType.name());
       }
     };
+  }
+
+  private VehicleParking getBikePark(DataFetchingEnvironment environment) {
+    var vehicleParkingWithEntrance = getSource(environment).place.vehicleParkingWithEntrance;
+    if (
+      vehicleParkingWithEntrance == null ||
+      !vehicleParkingWithEntrance.getVehicleParking().hasBicyclePlaces()
+    ) {
+      return null;
+    }
+
+    return vehicleParkingWithEntrance.getVehicleParking();
+  }
+
+  private VehicleParking getCarPark(DataFetchingEnvironment environment) {
+    var vehicleParkingWithEntrance = getSource(environment).place.vehicleParkingWithEntrance;
+    if (
+      vehicleParkingWithEntrance == null ||
+      !vehicleParkingWithEntrance.getVehicleParking().hasAnyCarPlaces()
+    ) {
+      return null;
+    }
+
+    return vehicleParkingWithEntrance.getVehicleParking();
   }
 
   private VehicleParking getVehicleParking(DataFetchingEnvironment environment) {


### PR DESCRIPTION
### Summary

Filters place types in legacy GraphQL API so that a bike park type is not returned if a vehicle parking has no bicycle spaces and car park type is not returned if a parking has no car spaces.

### Issue

No issue as minor sandbox adjustment

### Unit tests

No

### Documentation

No

### Changelog
Added for sandbox
