### PR TITLE
Make it explicit when an itinerary's deletion flags are removed

### DIFF
--- a/src/main/java/org/opentripplanner/model/plan/Itinerary.java
+++ b/src/main/java/org/opentripplanner/model/plan/Itinerary.java
@@ -162,7 +162,14 @@ public class Itinerary {
    * also used by other filters to see the already filtered itineraries.
    */
   public void flagForDeletion(SystemNotice notice) {
-    getSystemNotices().add(notice);
+    systemNotices.add(notice);
+  }
+
+  /**
+   * Remove all deletion flags of this itinerary, in effect undeleting it from the result.
+   */
+  public void removeDeletionFlags() {
+    systemNotices.clear();
   }
 
   public boolean isFlaggedForDeletion() {
@@ -312,7 +319,7 @@ public class Itinerary {
    * expected trips.
    */
   public List<SystemNotice> getSystemNotices() {
-    return systemNotices;
+    return List.copyOf(systemNotices);
   }
 
   /**

--- a/src/main/java/org/opentripplanner/routing/algorithm/filterchain/filter/RemoveDeletionFlagForLeastTransfersItinerary.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/filterchain/filter/RemoveDeletionFlagForLeastTransfersItinerary.java
@@ -17,7 +17,7 @@ public class RemoveDeletionFlagForLeastTransfersItinerary implements ItineraryLi
     itineraries
       .stream()
       .min(numberOfTransfersComparator())
-      .ifPresent(itinerary -> itinerary.getSystemNotices().clear());
+      .ifPresent(Itinerary::removeDeletionFlags);
 
     return itineraries;
   }

--- a/src/test/java/org/opentripplanner/routing/algorithm/filterchain/filter/GroupByFilterTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/filterchain/filter/GroupByFilterTest.java
@@ -20,8 +20,6 @@ public class GroupByFilterTest implements PlanTestConstants {
    */
   @Test
   public void aSimpleTestGroupByMatchingTripIdsNoMerge() {
-    List<Itinerary> result;
-
     // Group 1
     Itinerary i1 = newItinerary(A).bus(1, 0, 10, E).build();
 
@@ -38,7 +36,7 @@ public class GroupByFilterTest implements PlanTestConstants {
     assertTrue(i2b.isFlaggedForDeletion());
 
     // Remove notice after asserting
-    i2b.getSystemNotices().remove(0);
+    i2b.removeDeletionFlags();
 
     // With min Limit = 2, we get two from each group
     createFilter(2).filter(all);
@@ -80,9 +78,9 @@ public class GroupByFilterTest implements PlanTestConstants {
 
       // Remove notices after asserting
       assertTrue(i11.isFlaggedForDeletion());
-      i11.getSystemNotices().remove(0);
+      i11.removeDeletionFlags();
       assertTrue(i12.isFlaggedForDeletion());
-      i12.getSystemNotices().remove(0);
+      i12.removeDeletionFlags();
     }
   }
 


### PR DESCRIPTION
### Summary

Last week I was debugging a problem with the filter chain and I was wondering why my previously flagged itinerary was still included in the result.

Then the penny dropped: there is a filter that undeletes itineraries again!

This PR makes this explicit so that in the future debugging becomes a little easier.

### Issue

n/a

### Unit tests

Tests adjusted.
