### PR TITLE
Include trips with skipped stops in stopTimesForPattern query

### DIFF
--- a/docs/sandbox/LegacyGraphQLApi.md
+++ b/docs/sandbox/LegacyGraphQLApi.md
@@ -26,6 +26,7 @@
 - Add GBFS form factors for `rentalVehicle` (April 2022, https://github.com/opentripplanner/OpenTripPlanner/pull/4062)
 - Implement allowedBikeRentalNetworks while deprecating it and add allowedVehicleRentalNetworks and bannedVehicleRentalNetworks. (July 2022, https://github.com/opentripplanner/OpenTripPlanner/pull/4279)
 - Filters place types in legacy GraphQL API so that a bike park type is not returned if a vehicle parking has no bicycle spaces and car park type is not returned if a parking has no car spaces. (July 2022, https://github.com/opentripplanner/OpenTripPlanner/pull/4296)
+- Include departures with skipped stops in the Stop type's stopTimesForPattern query. (July 2022, https://github.com/opentripplanner/OpenTripPlanner/pull/4299)
 
 ## Documentation
 

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLStopImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLStopImpl.java
@@ -249,6 +249,10 @@ public class LegacyGraphQLStopImpl implements LegacyGraphQLDataFetchers.LegacyGr
           TimetableSnapshot timetableSnapshot = transitService.getTimetableSnapshot();
           long startTime = args.getLegacyGraphQLStartTime();
           if (timetableSnapshot != null && timetableSnapshot.hasLastAddedTripPatterns()) {
+            LocalDate date = Instant
+              .ofEpochSecond(startTime == 0 ? System.currentTimeMillis() / 1000 : startTime)
+              .atZone(transitService.getTimeZone())
+              .toLocalDate();
             return Stream
               .concat(
                 getPatterns(environment)
@@ -256,15 +260,7 @@ public class LegacyGraphQLStopImpl implements LegacyGraphQLDataFetchers.LegacyGr
                   .flatMap(tripPattern ->
                     tripPattern
                       .scheduledTripsAsStream()
-                      .map(trip -> {
-                        LocalDate date = Instant
-                          .ofEpochSecond(
-                            startTime == 0 ? System.currentTimeMillis() / 1000 : startTime
-                          )
-                          .atZone(transitService.getTimeZone())
-                          .toLocalDate();
-                        return timetableSnapshot.getLastAddedTripPattern(trip.getId(), date);
-                      })
+                      .map(trip -> timetableSnapshot.getLastAddedTripPattern(trip.getId(), date))
                   )
                   // We only return realtime added patterns if they have the same stops in the same
                   // order as the original pattern

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLStopImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLStopImpl.java
@@ -249,10 +249,11 @@ public class LegacyGraphQLStopImpl implements LegacyGraphQLDataFetchers.LegacyGr
           TimetableSnapshot timetableSnapshot = transitService.getTimetableSnapshot();
           long startTime = args.getLegacyGraphQLStartTime();
           if (timetableSnapshot != null && timetableSnapshot.hasLastAddedTripPatterns()) {
-            LocalDate date = (startTime == 0 ? Instant.now() : Instant.ofEpochSecond(startTime))
-              
-              .atZone(transitService.getTimeZone())
-              .toLocalDate();
+            LocalDate date =
+              (startTime == 0 ? Instant.now() : Instant.ofEpochSecond(startTime)).atZone(
+                  transitService.getTimeZone()
+                )
+                .toLocalDate();
             return Stream
               .concat(
                 getRealtimeAddedPatternsAsStream(pattern, timetableSnapshot, date),

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLStopImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLStopImpl.java
@@ -249,8 +249,8 @@ public class LegacyGraphQLStopImpl implements LegacyGraphQLDataFetchers.LegacyGr
           TimetableSnapshot timetableSnapshot = transitService.getTimetableSnapshot();
           long startTime = args.getLegacyGraphQLStartTime();
           if (timetableSnapshot != null && timetableSnapshot.hasLastAddedTripPatterns()) {
-            LocalDate date = Instant
-              .ofEpochSecond(startTime == 0 ? System.currentTimeMillis() / 1000 : startTime)
+            LocalDate date = (startTime == 0 ? Instant.now() : Instant.ofEpochSecond(startTime))
+              
               .atZone(transitService.getTimeZone())
               .toLocalDate();
             return Stream

--- a/src/main/java/org/opentripplanner/model/StopPattern.java
+++ b/src/main/java/org/opentripplanner/model/StopPattern.java
@@ -112,8 +112,7 @@ public final class StopPattern implements Serializable {
    * Checks that stops equal without taking into account if pickup or dropoff is allowed.
    */
   public boolean stopsEqual(Object other) {
-    if (other instanceof StopPattern) {
-      StopPattern that = (StopPattern) other;
+    if (other instanceof StopPattern that) {
       return Arrays.equals(this.stops, that.stops);
     } else {
       return false;

--- a/src/main/java/org/opentripplanner/model/StopPattern.java
+++ b/src/main/java/org/opentripplanner/model/StopPattern.java
@@ -108,6 +108,18 @@ public final class StopPattern implements Serializable {
     }
   }
 
+  /**
+   * Checks that stops equal without taking into account if pickup or dropoff is allowed.
+   */
+  public boolean stopsEqual(Object other) {
+    if (other instanceof StopPattern) {
+      StopPattern that = (StopPattern) other;
+      return Arrays.equals(this.stops, that.stops);
+    } else {
+      return false;
+    }
+  }
+
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("StopPattern: ");

--- a/src/main/java/org/opentripplanner/model/TimetableSnapshot.java
+++ b/src/main/java/org/opentripplanner/model/TimetableSnapshot.java
@@ -158,6 +158,13 @@ public class TimetableSnapshot {
   }
 
   /**
+   * @return if any trip patterns were added.
+   */
+  public boolean hasLastAddedTripPatterns() {
+    return !lastAddedTripPattern.isEmpty();
+  }
+
+  /**
    * Update the trip times of one trip in a timetable of a trip pattern. If the trip of the trip
    * times does not exist yet in the timetable, add it.
    *

--- a/src/main/java/org/opentripplanner/model/TripPattern.java
+++ b/src/main/java/org/opentripplanner/model/TripPattern.java
@@ -527,6 +527,18 @@ public final class TripPattern extends TransitEntity implements Cloneable, Seria
   }
 
   /**
+   * Checks that this is TripPattern is based of the provided TripPattern and contains same stops
+   * (but not necessarily with same pickup and dropoff values).
+   */
+  public boolean isModifiedFromTripPatternWithEqualStops(TripPattern other) {
+    return (
+      originalTripPattern != null &&
+      originalTripPattern.equals(other) &&
+      getStopPattern().stopsEqual(other.getStopPattern())
+    );
+  }
+
+  /**
    * The direction for all the trips in this pattern.
    */
   public Direction getDirection() {


### PR DESCRIPTION
### Summary

Includes departures with skipped stops for stopTimesForPattern query in the legacy GraphQL API. If a realtime update contains skipped stops, a new pattern with a new code is created but it makes sense to include the stop times from the new pattern in the query for the original pattern.

Contains a few new methods in non-sandbox code.

### Issue

Minor sandbox improvement so no issue

### Unit tests

None

### Documentation

Not needed

### Changelog

Added for sandbox
