### PR TITLE
Otp2 make otp server context req scoped

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/LegacyGraphQLAPI.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/LegacyGraphQLAPI.java
@@ -68,7 +68,7 @@ public class LegacyGraphQLAPI {
 
     Locale locale = headers.getAcceptableLanguages().size() > 0
       ? headers.getAcceptableLanguages().get(0)
-      : serverContext.getDefaultLocale();
+      : serverContext.defaultLocale();
 
     String query = (String) queryParameters.get("query");
     Object queryVariables = queryParameters.getOrDefault("variables", null);
@@ -111,7 +111,7 @@ public class LegacyGraphQLAPI {
   ) {
     Locale locale = headers.getAcceptableLanguages().size() > 0
       ? headers.getAcceptableLanguages().get(0)
-      : serverContext.getDefaultLocale();
+      : serverContext.defaultLocale();
     return LegacyGraphQLIndex.getGraphQLResponse(
       query,
       serverContext,
@@ -135,7 +135,7 @@ public class LegacyGraphQLAPI {
     List<Callable<ExecutionResult>> futures = new ArrayList<>();
     Locale locale = headers.getAcceptableLanguages().size() > 0
       ? headers.getAcceptableLanguages().get(0)
-      : serverContext.getDefaultLocale();
+      : serverContext.defaultLocale();
 
     for (HashMap<String, Object> query : queries) {
       Map<String, Object> variables;

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/LegacyGraphQLIndex.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/LegacyGraphQLIndex.java
@@ -216,7 +216,7 @@ class LegacyGraphQLIndex {
 
   static Response getGraphQLResponse(
     String query,
-    OtpServerContext router,
+    OtpServerContext serverContext,
     Map<String, Object> variables,
     String operationName,
     int maxResolves,
@@ -225,7 +225,7 @@ class LegacyGraphQLIndex {
   ) {
     ExecutionResult executionResult = getGraphQLExecutionResult(
       query,
-      router,
+      serverContext,
       variables,
       operationName,
       maxResolves,

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
@@ -592,7 +592,7 @@ public class LegacyGraphQLQueryTypeImpl
   public DataFetcher<DataFetcherResult<RoutingResponse>> plan() {
     return environment -> {
       LegacyGraphQLRequestContext context = environment.<LegacyGraphQLRequestContext>getContext();
-      RoutingRequest request = context.getServerContext().copyDefaultRoutingRequest();
+      RoutingRequest request = context.getServerContext().defaultRoutingRequest();
 
       CallerWithEnvironment callWith = new CallerWithEnvironment(environment);
 

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraph.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraph.java
@@ -82,7 +82,7 @@ class TransmodelGraph {
 
   Response getGraphQLResponse(
     String query,
-    OtpServerContext router,
+    OtpServerContext serverContext,
     Map<String, Object> variables,
     String operationName,
     int maxResolves,
@@ -90,7 +90,7 @@ class TransmodelGraph {
   ) {
     ExecutionResult result = getGraphQLExecutionResult(
       query,
-      router,
+      serverContext,
       variables,
       operationName,
       maxResolves,

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLPlanner.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLPlanner.java
@@ -62,7 +62,7 @@ public class TransmodelGraphQLPlanner {
       response.plan = TripPlanMapper.mapTripPlan(request, List.of());
       response.messages.add(new RoutingError(RoutingErrorCode.SYSTEM_ERROR, null));
     }
-    Locale locale = request == null ? serverContext.getDefaultLocale() : request.locale;
+    Locale locale = request == null ? serverContext.defaultLocale() : request.locale;
     return DataFetcherResult
       .<PlanResponse>newResult()
       .data(response)
@@ -90,7 +90,7 @@ public class TransmodelGraphQLPlanner {
   private RoutingRequest createRequest(DataFetchingEnvironment environment) {
     TransmodelRequestContext context = environment.getContext();
     OtpServerContext serverContext = context.getServerContext();
-    RoutingRequest request = serverContext.copyDefaultRoutingRequest();
+    RoutingRequest request = serverContext.defaultRoutingRequest();
 
     DataFetcherDecorator callWith = new DataFetcherDecorator(environment);
 

--- a/src/ext/java/org/opentripplanner/ext/traveltime/TravelTimeResource.java
+++ b/src/ext/java/org/opentripplanner/ext/traveltime/TravelTimeResource.java
@@ -100,7 +100,7 @@ public class TravelTimeResource {
     this.serverContext = serverContext;
     transitLayer = this.serverContext.transitModel().getRealtimeTransitLayer();
     ZoneId zoneId = transitLayer.getTransitDataZoneId();
-    routingRequest = this.serverContext.copyDefaultRoutingRequest();
+    routingRequest = this.serverContext.defaultRoutingRequest();
     routingRequest.from = LocationStringParser.fromOldStyleString(location);
     if (modes != null) {
       routingRequest.modes = new QualifiedModeSet(modes).getRequestModes();

--- a/src/main/java/org/opentripplanner/api/common/RoutingResource.java
+++ b/src/main/java/org/opentripplanner/api/common/RoutingResource.java
@@ -703,7 +703,7 @@ public abstract class RoutingResource {
    * @param queryParameters incoming request parameters
    */
   protected RoutingRequest buildRequest(MultivaluedMap<String, String> queryParameters) {
-    RoutingRequest request = serverContext.copyDefaultRoutingRequest();
+    RoutingRequest request = serverContext.defaultRoutingRequest();
 
     // The routing request should already contain defaults, which are set when it is initialized or
     // in the JSON router configuration and cloned. We check whether each parameter was supplied
@@ -714,7 +714,7 @@ public abstract class RoutingResource {
 
     {
       //FIXME: move into setter method on routing request
-      ZoneId tz = serverContext.transitModel().getTimeZone();
+      ZoneId tz = serverContext.transitService().getTimeZone();
       if (date == null && time != null) { // Time was provided but not date
         LOG.debug("parsing ISO datetime {}", time);
         try {

--- a/src/main/java/org/opentripplanner/index/IndexAPI.java
+++ b/src/main/java/org/opentripplanner/index/IndexAPI.java
@@ -21,7 +21,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
-import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.api.mapping.AgencyMapper;
 import org.opentripplanner.api.mapping.AlertMapper;
 import org.opentripplanner.api.mapping.FeedInfoMapper;
@@ -47,7 +46,6 @@ import org.opentripplanner.api.model.ApiTrip;
 import org.opentripplanner.api.model.ApiTripShort;
 import org.opentripplanner.api.model.ApiTripTimeShort;
 import org.opentripplanner.model.StopTimesInPattern;
-import org.opentripplanner.model.Timetable;
 import org.opentripplanner.model.TripPattern;
 import org.opentripplanner.model.TripTimeOnDate;
 import org.opentripplanner.routing.RoutingService;
@@ -92,13 +90,13 @@ public class IndexAPI {
   @GET
   @Path("/feeds")
   public Collection<String> getFeeds() {
-    return createTransitService().getFeedIds();
+    return transitService().getFeedIds();
   }
 
   @GET
   @Path("/feeds/{feedId}")
   public ApiFeedInfo getFeedInfo(@PathParam("feedId") String feedId) {
-    ApiFeedInfo feedInfo = FeedInfoMapper.mapToApi(createTransitService().getFeedInfo(feedId));
+    var feedInfo = FeedInfoMapper.mapToApi(transitService().getFeedInfo(feedId));
     return validateExist("FeedInfo", feedInfo, "feedId", feedId);
   }
 
@@ -106,7 +104,7 @@ public class IndexAPI {
   @GET
   @Path("/agencies/{feedId}")
   public Collection<ApiAgency> getAgencies(@PathParam("feedId") String feedId) {
-    Collection<Agency> agencies = createTransitService()
+    Collection<Agency> agencies = transitService()
       .getAgencies()
       .stream()
       .filter(agency -> agency.getId().getFeedId().equals(feedId))
@@ -118,12 +116,11 @@ public class IndexAPI {
   /** Return specific agency in the graph, by ID. */
   @GET
   @Path("/agencies/{feedId}/{agencyId}")
-  public ApiAgency getAgency(
+  public ApiAgency httpGgetAgency(
     @PathParam("feedId") String feedId,
     @PathParam("agencyId") String agencyId
   ) {
-    Agency agency = getAgency(createTransitService(), feedId, agencyId);
-    return AgencyMapper.mapToApi(agency);
+    return AgencyMapper.mapToApi(agency(feedId, agencyId));
   }
 
   /** Return all routes for the specific agency. */
@@ -135,10 +132,9 @@ public class IndexAPI {
     /** Choose short or long form of results. */
     @QueryParam("detail") @DefaultValue("false") Boolean detail
   ) {
-    TransitService transitService = createTransitService();
-    Agency agency = getAgency(transitService, feedId, agencyId);
+    var agency = agency(feedId, agencyId);
 
-    Collection<Route> routes = transitService
+    Collection<Route> routes = transitService()
       .getAllRoutes()
       .stream()
       .filter(r -> r.getAgency() == agency)
@@ -160,18 +156,16 @@ public class IndexAPI {
     @PathParam("feedId") String feedId,
     @PathParam("agencyId") String agencyId
   ) {
-    TransitService transitService = createTransitService();
-    AlertMapper alertMapper = new AlertMapper(null); // TODO: Add locale
-    FeedScopedId id = new FeedScopedId(feedId, agencyId);
-    return alertMapper.mapToApi(transitService.getTransitAlertService().getAgencyAlerts(id));
+    var alertMapper = new AlertMapper(null); // TODO: Add locale
+    var id = new FeedScopedId(feedId, agencyId);
+    return alertMapper.mapToApi(transitService().getTransitAlertService().getAgencyAlerts(id));
   }
 
   /** Return specific transit stop in the graph, by ID. */
   @GET
   @Path("/stops/{stopId}")
   public ApiStop getStop(@PathParam("stopId") String stopIdString) {
-    var stop = getStop(createTransitService(), stopIdString);
-    return StopMapper.mapToApi(stop);
+    return StopMapper.mapToApi(stop(stopIdString));
   }
 
   /** Return a list of all stops within a circle around the given coordinate. */
@@ -189,7 +183,7 @@ public class IndexAPI {
   ) {
     /* When no parameters are supplied, return all stops. */
     if (uriInfo.getQueryParameters().isEmpty()) {
-      return StopMapper.mapToApiShort(createTransitService().getAllStops());
+      return StopMapper.mapToApiShort(transitService().getAllStops());
     }
 
     /* If any of the circle parameters are specified, expect a circle not a box. */
@@ -203,7 +197,7 @@ public class IndexAPI {
 
       radius = Math.min(radius, MAX_STOP_SEARCH_RADIUS);
 
-      return createRoutingService()
+      return routingService()
         .getStopsInRadius(new WgsCoordinate(lat, lon), radius)
         .stream()
         .map(it -> StopMapper.mapToApiShort(it.first, it.second.intValue()))
@@ -218,7 +212,7 @@ public class IndexAPI {
         .lessThan("minLat", minLat, "maxLat", maxLat)
         .lessThan("minLon", minLon, "maxLon", maxLon)
         .validate();
-      var stops = createRoutingService().getStopsByBoundingBox(minLat, minLon, maxLat, maxLon);
+      var stops = routingService().getStopsByBoundingBox(minLat, minLon, maxLat, maxLon);
       return StopMapper.mapToApiShort(stops);
     }
   }
@@ -226,9 +220,8 @@ public class IndexAPI {
   @GET
   @Path("/stops/{stopId}/routes")
   public List<ApiRouteShort> getRoutesForStop(@PathParam("stopId") String stopId) {
-    TransitService transitService = createTransitService();
-    var stop = getStop(transitService, stopId);
-    return transitService
+    var stop = stop(stopId);
+    return transitService()
       .getPatternsForStop(stop)
       .stream()
       .map(TripPattern::getRoute)
@@ -239,9 +232,8 @@ public class IndexAPI {
   @GET
   @Path("/stops/{stopId}/patterns")
   public List<ApiPatternShort> getPatternsForStop(@PathParam("stopId") String stopId) {
-    TransitService transitService = createTransitService();
-    var stop = getStop(transitService, stopId);
-    return transitService
+    var stop = stop(stopId);
+    return transitService()
       .getPatternsForStop(stop)
       .stream()
       .map(TripPatternMapper::mapToApiShort)
@@ -265,12 +257,9 @@ public class IndexAPI {
     @QueryParam("numberOfDepartures") @DefaultValue("2") int numberOfDepartures,
     @QueryParam("omitNonPickups") boolean omitNonPickups
   ) {
-    TransitService transitService = createTransitService();
-    var stop = getStop(transitService, stopIdString);
-
-    return transitService
+    return transitService()
       .stopTimesForStop(
-        stop,
+        stop(stopIdString),
         startTime,
         timeRange,
         numberOfDepartures,
@@ -294,14 +283,14 @@ public class IndexAPI {
     @PathParam("date") String date,
     @QueryParam("omitNonPickups") boolean omitNonPickups
   ) {
-    TransitService transitService = createTransitService();
-    var stop = getStop(transitService, stopId);
-    LocalDate serviceDate = parseServiceDate("date", date);
-    List<StopTimesInPattern> stopTimes = transitService.getStopTimesForStop(
-      stop,
-      serviceDate,
-      omitNonPickups ? ArrivalDeparture.DEPARTURES : ArrivalDeparture.BOTH
-    );
+    var stop = stop(stopId);
+    var serviceDate = parseServiceDate("date", date);
+    List<StopTimesInPattern> stopTimes = transitService()
+      .getStopTimesForStop(
+        stop,
+        serviceDate,
+        omitNonPickups ? ArrivalDeparture.DEPARTURES : ArrivalDeparture.BOTH
+      );
     return StopTimesInPatternMapper.mapToApi(stopTimes);
   }
 
@@ -311,11 +300,10 @@ public class IndexAPI {
   @GET
   @Path("/stops/{stopId}/transfers")
   public Collection<ApiTransfer> getTransfers(@PathParam("stopId") String stopId) {
-    TransitService transitService = createTransitService();
-    var stop = getStop(transitService, stopId);
+    var stop = stop(stopId);
 
     // get the transfers for the stop
-    return transitService
+    return transitService()
       .getTransfersByStop(stop)
       .stream()
       .map(TransferMapper::mapToApi)
@@ -328,10 +316,9 @@ public class IndexAPI {
   @GET
   @Path("/stops/{stopId}/alerts")
   public Collection<ApiAlert> getAlertsForStop(@PathParam("stopId") String stopId) {
-    TransitService transitService = createTransitService();
-    AlertMapper alertMapper = new AlertMapper(null); // TODO: Add locale
-    FeedScopedId id = createId("stopId", stopId);
-    return alertMapper.mapToApi(transitService.getTransitAlertService().getStopAlerts(id));
+    var alertMapper = new AlertMapper(null); // TODO: Add locale
+    var id = createId("stopId", stopId);
+    return alertMapper.mapToApi(transitService().getTransitAlertService().getStopAlerts(id));
   }
 
   /** Return a list of all routes in the graph. */
@@ -339,16 +326,15 @@ public class IndexAPI {
   @GET
   @Path("/routes")
   public List<ApiRouteShort> getRoutes(@QueryParam("hasStop") List<String> stopIds) {
-    TransitService transitService = createTransitService();
-    Collection<Route> routes = transitService.getAllRoutes();
+    Collection<Route> routes = transitService().getAllRoutes();
     // Filter routes to include only those that pass through all given stops
     if (stopIds != null) {
       // Protective copy, we are going to calculate the intersection destructively
       routes = new ArrayList<>(routes);
       for (String stopId : stopIds) {
-        var stop = getStop(transitService, stopId);
+        var stop = stop(stopId);
         Set<Route> routesHere = new HashSet<>();
-        for (TripPattern pattern : transitService.getPatternsForStop(stop)) {
+        for (TripPattern pattern : transitService().getPatternsForStop(stop)) {
           routesHere.add(pattern.getRoute());
         }
         routes.retainAll(routesHere);
@@ -361,18 +347,14 @@ public class IndexAPI {
   @GET
   @Path("/routes/{routeId}")
   public ApiRoute getRoute(@PathParam("routeId") String routeId) {
-    Route route = getRoute(createTransitService(), routeId);
-    return RouteMapper.mapToApi(route);
+    return RouteMapper.mapToApi(route(routeId));
   }
 
   /** Return all stop patterns used by trips on the given route. */
   @GET
   @Path("/routes/{routeId}/patterns")
   public List<ApiPatternShort> getPatternsForRoute(@PathParam("routeId") String routeId) {
-    TransitService transitService = createTransitService();
-    Collection<TripPattern> patterns = transitService
-      .getPatternsForRoute()
-      .get(getRoute(transitService, routeId));
+    Collection<TripPattern> patterns = transitService().getPatternsForRoute().get(route(routeId));
     return TripPatternMapper.mapToApiShort(patterns);
   }
 
@@ -380,11 +362,10 @@ public class IndexAPI {
   @GET
   @Path("/routes/{routeId}/stops")
   public List<ApiStopShort> getStopsForRoute(@PathParam("routeId") String routeId) {
-    TransitService transitService = createTransitService();
-    Route route = getRoute(transitService, routeId);
+    var route = route(routeId);
 
     Set<StopLocation> stops = new HashSet<>();
-    Collection<TripPattern> patterns = transitService.getPatternsForRoute().get(route);
+    Collection<TripPattern> patterns = transitService().getPatternsForRoute().get(route);
     for (TripPattern pattern : patterns) {
       stops.addAll(pattern.getStops());
     }
@@ -395,10 +376,9 @@ public class IndexAPI {
   @GET
   @Path("/routes/{routeId}/trips")
   public List<ApiTripShort> getTripsForRoute(@PathParam("routeId") String routeId) {
-    TransitService transitService = createTransitService();
-    Route route = getRoute(transitService, routeId);
+    var route = route(routeId);
 
-    var patterns = transitService.getPatternsForRoute().get(route);
+    var patterns = transitService().getPatternsForRoute().get(route);
     return patterns
       .stream()
       .flatMap(TripPattern::scheduledTripsAsStream)
@@ -412,10 +392,9 @@ public class IndexAPI {
   @GET
   @Path("/routes/{routeId}/alerts")
   public Collection<ApiAlert> getAlertsForRoute(@PathParam("routeId") String routeId) {
-    TransitService transitService = createTransitService();
-    AlertMapper alertMapper = new AlertMapper(null); // TODO: Add locale
-    FeedScopedId id = createId("routeId", routeId);
-    return alertMapper.mapToApi(transitService.getTransitAlertService().getRouteAlerts(id));
+    var alertMapper = new AlertMapper(null); // TODO: Add locale
+    var id = createId("routeId", routeId);
+    return alertMapper.mapToApi(transitService().getTransitAlertService().getRouteAlerts(id));
   }
 
   // Not implemented, results would be too voluminous.
@@ -424,38 +403,31 @@ public class IndexAPI {
   @GET
   @Path("/trips/{tripId}")
   public ApiTrip getTrip(@PathParam("tripId") String tripId) {
-    Trip trip = getTrip(createTransitService(), tripId);
-    return TripMapper.mapToApi(trip);
+    return TripMapper.mapToApi(trip(tripId));
   }
 
   @GET
   @Path("/trips/{tripId}/stops")
   public List<ApiStopShort> getStopsForTrip(@PathParam("tripId") String tripId) {
-    Collection<StopLocation> stops = getTripPatternForTripId(createTransitService(), tripId)
-      .getStops();
+    Collection<StopLocation> stops = tripPatternForTripId(tripId).getStops();
     return StopMapper.mapToApiShort(stops);
   }
 
   @GET
   @Path("/trips/{tripId}/semanticHash")
   public String getSemanticHashForTrip(@PathParam("tripId") String tripId) {
-    TransitService transitService = createTransitService();
-    Trip trip = getTrip(transitService, tripId);
-    TripPattern pattern = getTripPattern(transitService, trip);
-    return pattern.semanticHashString(trip);
+    var trip = trip(tripId);
+    return tripPattern(trip).semanticHashString(trip);
   }
 
   @GET
   @Path("/trips/{tripId}/stoptimes")
   public List<ApiTripTimeShort> getStoptimesForTrip(@PathParam("tripId") String tripId) {
-    TransitService transitService = createTransitService();
-    Trip trip = getTrip(transitService, tripId);
-    TripPattern pattern = getTripPattern(transitService, trip);
+    var trip = trip(tripId);
+    var pattern = tripPattern(trip);
     // Note, we need the updated timetable not the scheduled one (which contains no real-time updates).
-    Timetable table = transitService.getTimetableForTripPattern(
-      pattern,
-      LocalDate.now(transitService.getTimeZone())
-    );
+    var table = transitService()
+      .getTimetableForTripPattern(pattern, LocalDate.now(transitService().getTimeZone()));
     var tripTimesOnDate = TripTimeOnDate.fromTripTimes(table, trip);
     return TripTimeMapper.mapToApi(tripTimesOnDate);
   }
@@ -464,7 +436,7 @@ public class IndexAPI {
   @GET
   @Path("/trips/{tripId}/geometry")
   public EncodedPolyline getGeometryForTrip(@PathParam("tripId") String tripId) {
-    TripPattern pattern = getTripPatternForTripId(createTransitService(), tripId);
+    var pattern = tripPatternForTripId(tripId);
     return PolylineEncoder.encodeGeometry(pattern.getGeometry());
   }
 
@@ -474,44 +446,43 @@ public class IndexAPI {
   @GET
   @Path("/trips/{tripId}/alerts")
   public Collection<ApiAlert> getAlertsForTrip(@PathParam("tripId") String tripId) {
-    TransitService transitService = createTransitService();
-    AlertMapper alertMapper = new AlertMapper(null); // TODO: Add locale
-    FeedScopedId id = createId("tripId", tripId);
-    return alertMapper.mapToApi(transitService.getTransitAlertService().getTripAlerts(id, null));
+    var alertMapper = new AlertMapper(null); // TODO: Add locale
+    var id = createId("tripId", tripId);
+    return alertMapper.mapToApi(transitService().getTransitAlertService().getTripAlerts(id, null));
   }
 
   @GET
   @Path("/patterns")
   public List<ApiPatternShort> getPatterns() {
-    Collection<TripPattern> patterns = createTransitService().getAllTripPatterns();
+    Collection<TripPattern> patterns = transitService().getAllTripPatterns();
     return TripPatternMapper.mapToApiShort(patterns);
   }
 
   @GET
   @Path("/patterns/{patternId}")
   public ApiPatternShort getPattern(@PathParam("patternId") String patternId) {
-    TripPattern pattern = getTripPattern(createTransitService(), patternId);
+    var pattern = tripPattern(patternId);
     return TripPatternMapper.mapToApiDetailed(pattern);
   }
 
   @GET
   @Path("/patterns/{patternId}/trips")
   public List<ApiTripShort> getTripsForPattern(@PathParam("patternId") String patternId) {
-    var trips = getTripPattern(createTransitService(), patternId).scheduledTripsAsStream();
+    var trips = tripPattern(patternId).scheduledTripsAsStream();
     return TripMapper.mapToApiShort(trips);
   }
 
   @GET
   @Path("/patterns/{patternId}/stops")
   public List<ApiStopShort> getStopsForPattern(@PathParam("patternId") String patternId) {
-    var stops = getTripPattern(createTransitService(), patternId).getStops();
+    var stops = tripPattern(patternId).getStops();
     return StopMapper.mapToApiShort(stops);
   }
 
   @GET
   @Path("/patterns/{patternId}/semanticHash")
   public String getSemanticHashForPattern(@PathParam("patternId") String patternId) {
-    TripPattern tripPattern = getTripPattern(createTransitService(), patternId);
+    var tripPattern = tripPattern(patternId);
     return tripPattern.semanticHashString(null);
   }
 
@@ -519,7 +490,7 @@ public class IndexAPI {
   @GET
   @Path("/patterns/{patternId}/geometry")
   public EncodedPolyline getGeometryForPattern(@PathParam("patternId") String patternId) {
-    LineString line = getTripPattern(createTransitService(), patternId).getGeometry();
+    var line = tripPattern(patternId).getGeometry();
     return PolylineEncoder.encodeGeometry(line);
   }
 
@@ -529,11 +500,10 @@ public class IndexAPI {
   @GET
   @Path("/patterns/{patternId}/alerts")
   public Collection<ApiAlert> getAlertsForPattern(@PathParam("patternId") String patternId) {
-    TransitService transitService = createTransitService();
-    AlertMapper alertMapper = new AlertMapper(null); // TODO: Add locale
-    TripPattern pattern = getTripPattern(createTransitService(), patternId);
+    var alertMapper = new AlertMapper(null); // TODO: Add locale
+    var pattern = tripPattern(patternId);
     return alertMapper.mapToApi(
-      transitService
+      transitService()
         .getTransitAlertService()
         .getDirectionAndRouteAlerts(pattern.getDirection(), pattern.getRoute().getId())
     );
@@ -600,49 +570,49 @@ public class IndexAPI {
     return new NotFoundException(entity + " not found. " + details);
   }
 
-  private static Agency getAgency(TransitService transitService, String feedId, String agencyId) {
-    Agency agency = transitService.getAgencyForId(new FeedScopedId(feedId, agencyId));
+  private Agency agency(String feedId, String agencyId) {
+    var agency = transitService().getAgencyForId(new FeedScopedId(feedId, agencyId));
     if (agency == null) {
       throw notFoundException("Agency", "feedId: " + feedId + ", agencyId: " + agencyId);
     }
     return agency;
   }
 
-  private static StopLocation getStop(TransitService transitService, String stopId) {
-    var stop = transitService.getStopForId(createId("stopId", stopId));
+  private StopLocation stop(String stopId) {
+    var stop = transitService().getStopForId(createId("stopId", stopId));
     return validateExist("Stop", stop, "stopId", stop);
   }
 
-  private static Route getRoute(TransitService transitService, String routeId) {
-    Route route = transitService.getRouteForId(createId("routeId", routeId));
+  private Route route(String routeId) {
+    var route = transitService().getRouteForId(createId("routeId", routeId));
     return validateExist("Route", route, "routeId", routeId);
   }
 
-  private static Trip getTrip(TransitService transitService, String tripId) {
-    Trip trip = transitService.getTripForId().get(createId("tripId", tripId));
+  private Trip trip(String tripId) {
+    var trip = transitService().getTripForId().get(createId("tripId", tripId));
     return validateExist("Trip", trip, "tripId", tripId);
   }
 
-  private static TripPattern getTripPattern(TransitService transitService, String tripPatternId) {
-    FeedScopedId id = createId("patternId", tripPatternId);
-    TripPattern pattern = transitService.getTripPatternForId(id);
+  private TripPattern tripPattern(String tripPatternId) {
+    var id = createId("patternId", tripPatternId);
+    var pattern = transitService().getTripPatternForId(id);
     return validateExist("TripPattern", pattern, "patternId", tripPatternId);
   }
 
-  private static TripPattern getTripPatternForTripId(TransitService transitService, String tripId) {
-    return getTripPattern(transitService, getTrip(transitService, tripId));
+  private TripPattern tripPatternForTripId(String tripId) {
+    return tripPattern(trip(tripId));
   }
 
-  private static TripPattern getTripPattern(TransitService transitService, Trip trip) {
-    TripPattern pattern = transitService.getPatternForTrip().get(trip);
+  private TripPattern tripPattern(Trip trip) {
+    var pattern = transitService().getPatternForTrip().get(trip);
     return validateExist("TripPattern", pattern, "trip", trip.getId());
   }
 
-  private RoutingService createRoutingService() {
-    return serverContext.routingRequestService();
+  private RoutingService routingService() {
+    return serverContext.routingService();
   }
 
-  private TransitService createTransitService() {
-    return serverContext.transitRequestService();
+  private TransitService transitService() {
+    return serverContext.transitService();
   }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/DirectStreetRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/DirectStreetRouter.java
@@ -17,16 +17,18 @@ import org.opentripplanner.standalone.api.OtpServerContext;
 
 public class DirectStreetRouter {
 
-  public static List<Itinerary> route(OtpServerContext router, RoutingRequest request) {
+  public static List<Itinerary> route(OtpServerContext serverContext, RoutingRequest request) {
     if (request.modes.directMode == StreetMode.NOT_SET) {
       return Collections.emptyList();
     }
 
     RoutingRequest directRequest = request.getStreetSearchRequest(request.modes.directMode);
-    try (var temporaryVertices = new TemporaryVerticesContainer(router.graph(), directRequest)) {
+    try (
+      var temporaryVertices = new TemporaryVerticesContainer(serverContext.graph(), directRequest)
+    ) {
       final RoutingContext routingContext = new RoutingContext(
         directRequest,
-        router.graph(),
+        serverContext.graph(),
         temporaryVertices
       );
 
@@ -35,14 +37,14 @@ public class DirectStreetRouter {
       }
 
       // we could also get a persistent router-scoped GraphPathFinder but there's no setup cost here
-      GraphPathFinder gpFinder = new GraphPathFinder(router);
+      GraphPathFinder gpFinder = new GraphPathFinder(serverContext);
       List<GraphPath> paths = gpFinder.graphPathFinderEntryPoint(routingContext);
 
       // Convert the internal GraphPaths to itineraries
       final GraphPathToItineraryMapper graphPathToItineraryMapper = new GraphPathToItineraryMapper(
-        router.transitModel().getTimeZone(),
-        router.graph().streetNotesService,
-        router.graph().ellipsoidToGeoidDifference
+        serverContext.transitModel().getTimeZone(),
+        serverContext.graph().streetNotesService,
+        serverContext.graph().ellipsoidToGeoidDifference
       );
       List<Itinerary> response = graphPathToItineraryMapper.mapItineraries(paths);
       ItinerariesHelper.decorateItinerariesWithRequestData(response, request);

--- a/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
@@ -1104,6 +1104,17 @@ public class RoutingRequest implements Cloneable, Serializable {
     return streetRequest;
   }
 
+  /**
+   * This method is used to clone the default message, and insert a current time. A typical use-case
+   * is to copy the default request(from router-config), and then set all user specified parameters
+   * before performing a routing search.
+   */
+  public RoutingRequest copyWithDateTimeNow() {
+    RoutingRequest copy = clone();
+    copy.setDateTime(Instant.now());
+    return copy;
+  }
+
   @Override
   public RoutingRequest clone() {
     try {

--- a/src/main/java/org/opentripplanner/routing/impl/GraphPathFinder.java
+++ b/src/main/java/org/opentripplanner/routing/impl/GraphPathFinder.java
@@ -67,7 +67,7 @@ public class GraphPathFinder {
       // FORCING the dominance function to weight only
       .setDominanceFunction(new DominanceFunction.MinimumWeight())
       .setContext(routingContext)
-      .setTimeout(serverContext.routerConfig().streetRoutingTimeoutSeconds());
+      .setTimeout(serverContext.routerConfig().streetRoutingTimeout());
 
     // If this Router has a GraphVisualizer attached to it, set it as a callback for the AStar search
     if (serverContext.graphVisualizer() != null) {

--- a/src/main/java/org/opentripplanner/routing/impl/GraphPathFinder.java
+++ b/src/main/java/org/opentripplanner/routing/impl/GraphPathFinder.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.routing.impl;
 
-import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Iterator;
@@ -68,7 +67,7 @@ public class GraphPathFinder {
       // FORCING the dominance function to weight only
       .setDominanceFunction(new DominanceFunction.MinimumWeight())
       .setContext(routingContext)
-      .setTimeout(Duration.ofMillis((long) (serverContext.streetRoutingTimeoutSeconds() * 1000)));
+      .setTimeout(serverContext.routerConfig().streetRoutingTimeoutSeconds());
 
     // If this Router has a GraphVisualizer attached to it, set it as a callback for the AStar search
     if (serverContext.graphVisualizer() != null) {

--- a/src/main/java/org/opentripplanner/standalone/api/HttpRequestScoped.java
+++ b/src/main/java/org/opentripplanner/standalone/api/HttpRequestScoped.java
@@ -1,0 +1,16 @@
+package org.opentripplanner.standalone.api;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to mark methods in the context as request-scoped. There are special constraints
+ * that apply to the components returned by these methods. For example access to these methods
+ * are not thread safe, because thy are lazy-initialized. See {@link OtpServerContext}.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.SOURCE)
+public @interface HttpRequestScoped {
+}

--- a/src/main/java/org/opentripplanner/standalone/api/OtpServerContext.java
+++ b/src/main/java/org/opentripplanner/standalone/api/OtpServerContext.java
@@ -16,32 +16,67 @@ import org.slf4j.Logger;
 
 /**
  * The purpose of this class is to allow APIs (HTTP Resources) to access the OTP Server Context.
- * By using an interface, and not inject the OTPServer class we avoid giving the resources assess
+ * By using an interface, and not inject each service class we avoid giving the resources assess
  * to the server implementation. The context is injected by Jersey. An alternative to inject this
  * interface is to inject each individual component in the context - hence reducing the dependencies
- * further. But there is not a "real" need for this. For example we do not have unit tests on the
+ * further. But there is not a "real" need for this. For example, we do not have unit tests on the
  * Resources. If we in the future would decide to write unit tests for the APIs, then we could
  * eliminate this interface and just inject the components. See the bind method in OTPServer.
+ * <p>
+ * The OTP Server and the implementation of this class is responsible to make the necessary
+ * instances for request scoped objects. Hence; the user of this can assume that:
+ * <ol>
+ *   <li>Calling the methods of this interface will return the same object every time.</li>
+ *   <li>
+ *     If the returned component is mutable, then it will be a unique copy for each HTTP request.
+ *   </li>
+ * </ol>
+ * <p>
+ * This class is not THREAD-SAFE, each HTTP request gets its own copy, but if there are multiple
+ * threads witch access this context within the HTTP Request, then the caller is responsible
+ * for the synchronization. Only request scoped components need to be synchronized - they are
+ * potentially lazy initialized.
  */
 public interface OtpServerContext {
-  RoutingRequest copyDefaultRoutingRequest();
+  /**
+   * A RoutingRequest containing default parameters that will be cloned when handling each request.
+   */
+  @HttpRequestScoped
+  RoutingRequest defaultRoutingRequest();
 
   /**
    * Return the default routing request locale(without cloning the request).
    */
-  Locale getDefaultLocale();
+  Locale defaultLocale();
+
+  RouterConfig routerConfig();
+
+  RaptorConfig<TripSchedule> raptorConfig();
 
   double streetRoutingTimeoutSeconds();
 
   Graph graph();
 
+  /**
+   * @deprecated Use {@link #transitService()} instead. The model should not be used in the APIs
+   * - all APIs are read-only; Hence should be able to use the transit service.
+   */
+  @Deprecated
   TransitModel transitModel();
 
-  RouterConfig routerConfig();
+  @HttpRequestScoped
+  TransitService transitService();
+
+  /**
+   * Get a request-scoped {@link RoutingService} valid for one HTTP request. It guarantees that
+   * the data and services used are consistent and operate on the same transit snapshot. Any
+   * realtime update that happens during the request will not affect the returned service and will
+   * not be visible to the request.
+   */
+  @HttpRequestScoped
+  RoutingService routingService();
 
   MeterRegistry meterRegistry();
-
-  RaptorConfig<TripSchedule> raptorConfig();
 
   /**
    * Separate logger for incoming requests. This should be handled with a Logback logger rather than
@@ -56,14 +91,4 @@ public interface OtpServerContext {
    * A graphical window that is used for visualizing search progress (debugging).
    */
   GraphVisualizer graphVisualizer();
-
-  /**
-   * This method is used to create a {@link RoutingService} valid for one request. It grantees that
-   * the data and services used are consistent and operate on the same transit snapshot. Any
-   * realtime update that happens during the request will not affect the returned service and will
-   * not be visible to the request.
-   */
-  RoutingService routingRequestService();
-
-  TransitService transitRequestService();
 }

--- a/src/main/java/org/opentripplanner/standalone/api/OtpServerContext.java
+++ b/src/main/java/org/opentripplanner/standalone/api/OtpServerContext.java
@@ -53,8 +53,6 @@ public interface OtpServerContext {
 
   RaptorConfig<TripSchedule> raptorConfig();
 
-  double streetRoutingTimeoutSeconds();
-
   Graph graph();
 
   /**

--- a/src/main/java/org/opentripplanner/standalone/api/OtpServerContext.java
+++ b/src/main/java/org/opentripplanner/standalone/api/OtpServerContext.java
@@ -16,8 +16,8 @@ import org.slf4j.Logger;
 
 /**
  * The purpose of this class is to allow APIs (HTTP Resources) to access the OTP Server Context.
- * By using an interface, and not inject each service class we avoid giving the resources assess
- * to the server implementation. The context is injected by Jersey. An alternative to inject this
+ * By using an interface, and not injecting each service class we avoid giving the resources access
+ * to the server implementation. The context is injected by Jersey. An alternative to injecting this
  * interface is to inject each individual component in the context - hence reducing the dependencies
  * further. But there is not a "real" need for this. For example, we do not have unit tests on the
  * Resources. If we in the future would decide to write unit tests for the APIs, then we could
@@ -33,7 +33,7 @@ import org.slf4j.Logger;
  * </ol>
  * <p>
  * This class is not THREAD-SAFE, each HTTP request gets its own copy, but if there are multiple
- * threads witch access this context within the HTTP Request, then the caller is responsible
+ * threads witch accesses this context within the HTTP Request, then the caller is responsible
  * for the synchronization. Only request scoped components need to be synchronized - they are
  * potentially lazy initialized.
  */

--- a/src/main/java/org/opentripplanner/standalone/config/RouterConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/RouterConfig.java
@@ -5,6 +5,8 @@ import static org.opentripplanner.standalone.config.RoutingRequestMapper.mapRout
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.MissingNode;
 import java.io.Serializable;
+import java.time.Duration;
+import java.time.format.DateTimeParseException;
 import org.opentripplanner.ext.flex.FlexParameters;
 import org.opentripplanner.ext.vectortiles.VectorTilesResource;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TransitTuningParameters;
@@ -21,7 +23,7 @@ import org.slf4j.LoggerFactory;
  */
 public class RouterConfig implements Serializable {
 
-  private static final double DEFAULT_STREET_ROUTING_TIMEOUT = 5.0;
+  private static final Duration DEFAULT_STREET_ROUTING_TIMEOUT = Duration.ofSeconds(5);
   private static final Logger LOG = LoggerFactory.getLogger(RouterConfig.class);
 
   public static final RouterConfig DEFAULT = new RouterConfig(
@@ -37,7 +39,7 @@ public class RouterConfig implements Serializable {
   private final String configVersion;
   private final String requestLogFile;
   private final TransmodelAPIConfig transmodelApi;
-  private final double streetRoutingTimeoutSeconds;
+  private final Duration streetRoutingTimeout;
   private final RoutingRequest routingRequestDefaults;
   private final TransitRoutingConfig transitConfig;
   private final UpdatersParameters updatersParameters;
@@ -50,8 +52,7 @@ public class RouterConfig implements Serializable {
     this.configVersion = adapter.asText("configVersion", null);
     this.requestLogFile = adapter.asText("requestLogFile", null);
     this.transmodelApi = new TransmodelAPIConfig(adapter.path("transmodelApi"));
-    this.streetRoutingTimeoutSeconds =
-      adapter.asDouble("streetRoutingTimeout", DEFAULT_STREET_ROUTING_TIMEOUT);
+    this.streetRoutingTimeout = parseStreetRoutingTimeout(adapter);
     this.transitConfig = new TransitRoutingConfig(adapter.path("transit"));
     this.routingRequestDefaults = mapRoutingRequest(adapter.path("routingDefaults"));
     this.updatersParameters = new UpdatersConfig(adapter);
@@ -89,8 +90,8 @@ public class RouterConfig implements Serializable {
    * CAR). So the default timeout for a street search is set quite high. This is used to abort the
    * search if the max distance is not reached within the timeout.
    */
-  public double streetRoutingTimeoutSeconds() {
-    return streetRoutingTimeoutSeconds;
+  public Duration streetRoutingTimeoutSeconds() {
+    return streetRoutingTimeout;
   }
 
   public TransmodelAPIConfig transmodelApi() {
@@ -135,5 +136,33 @@ public class RouterConfig implements Serializable {
   public String toString() {
     // Print ONLY the values set, not deafult values
     return rawJson.toPrettyString();
+  }
+
+  /**
+   * This method is needed, because we want to support the old format for the "streetRoutingTimeout"
+   * parameter. We will keep it for some time, to let OTP deployments update the config.
+   * @since 2.2 - The support for the old format can be removed in version > 2.2.
+   */
+  static Duration parseStreetRoutingTimeout(NodeAdapter adapter) {
+    try {
+      return adapter.asDuration("streetRoutingTimeout", DEFAULT_STREET_ROUTING_TIMEOUT);
+    } catch (DateTimeParseException ex) {
+      LOG.warn(
+        "The `streetRoutingTimeout` parameter input format changed from a real number to a " +
+        "Duration. Update you config, the support for the old format will be removed in the " +
+        "next version after v2.2. Details: " +
+        ex.getMessage()
+      );
+      // This is safe, because the asDouble, will fall back to the default value on parse error
+      return Duration.ofMillis(
+        (long) (
+          1000L *
+          adapter.asDouble(
+            "streetRoutingTimeout",
+            (double) DEFAULT_STREET_ROUTING_TIMEOUT.toSeconds()
+          )
+        )
+      );
+    }
   }
 }

--- a/src/main/java/org/opentripplanner/standalone/config/RouterConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/RouterConfig.java
@@ -90,7 +90,7 @@ public class RouterConfig implements Serializable {
    * CAR). So the default timeout for a street search is set quite high. This is used to abort the
    * search if the max distance is not reached within the timeout.
    */
-  public Duration streetRoutingTimeoutSeconds() {
+  public Duration streetRoutingTimeout() {
     return streetRoutingTimeout;
   }
 

--- a/src/main/java/org/opentripplanner/standalone/configure/OTPAppConstruction.java
+++ b/src/main/java/org/opentripplanner/standalone/configure/OTPAppConstruction.java
@@ -85,7 +85,8 @@ public class OTPAppConstruction {
   public void updateModel(Graph graph, TransitModel transitModel) {
     this.graph = graph;
     this.transitModel = transitModel;
-    this.raptorTuningParameters = new RaptorConfig<>(factory.configModel().routerConfig().raptorTuningParameters());
+    this.raptorTuningParameters =
+      new RaptorConfig<>(factory.configModel().routerConfig().raptorTuningParameters());
     this.context =
       DefaultServerContext.create(
         factory.configModel().routerConfig(),
@@ -161,11 +162,7 @@ public class OTPAppConstruction {
     creatTransitLayerForRaptor(transitModel, routerConfig());
 
     /* Create Graph updater modules from JSON config. */
-    GraphUpdaterConfigurator.setupGraph(
-      graph(),
-      transitModel(),
-      routerConfig().updaterConfig()
-    );
+    GraphUpdaterConfigurator.setupGraph(graph(), transitModel(), routerConfig().updaterConfig());
 
     graph().initEllipsoidToGeoidDifference();
 

--- a/src/main/java/org/opentripplanner/standalone/configure/OTPAppConstruction.java
+++ b/src/main/java/org/opentripplanner/standalone/configure/OTPAppConstruction.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.standalone.configure;
 
+import io.micrometer.core.instrument.Metrics;
 import javax.annotation.Nullable;
 import javax.ws.rs.core.Application;
 import org.opentripplanner.datastore.api.DataSource;
@@ -8,16 +9,19 @@ import org.opentripplanner.ext.transmodelapi.TransmodelAPI;
 import org.opentripplanner.graph_builder.GraphBuilder;
 import org.opentripplanner.graph_builder.GraphBuilderDataSources;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TransitLayer;
+import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripSchedule;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.mappers.TransitLayerMapper;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.mappers.TransitLayerUpdater;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.standalone.api.OtpServerContext;
+import org.opentripplanner.standalone.config.BuildConfig;
 import org.opentripplanner.standalone.config.CommandLineParameters;
 import org.opentripplanner.standalone.config.RouterConfig;
 import org.opentripplanner.standalone.server.DefaultServerContext;
 import org.opentripplanner.standalone.server.GrizzlyServer;
 import org.opentripplanner.standalone.server.MetricsLogging;
 import org.opentripplanner.standalone.server.OTPWebApplication;
+import org.opentripplanner.transit.raptor.configure.RaptorConfig;
 import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.updater.GraphUpdaterConfigurator;
 import org.opentripplanner.util.OTPFeature;
@@ -44,7 +48,22 @@ public class OTPAppConstruction {
 
   private final CommandLineParameters cli;
   private final OTPApplicationFactory factory;
+
+  private RaptorConfig<TripSchedule> raptorTuningParameters;
   private GraphBuilderDataSources graphBuilderDataSources = null;
+
+  /**
+   * The graph should be chased in the factory not here, this is an intermediate step.
+   */
+  private Graph graph;
+
+  /**
+   * The transit model should be created by the factory not cashed here, this is an intermediate
+   * step.
+   */
+  private TransitModel transitModel;
+
+  private DefaultServerContext context;
 
   /**
    * Create a new OTP configuration instance for a given directory.
@@ -60,11 +79,34 @@ public class OTPAppConstruction {
   }
 
   /**
+   * After the graph and transitModel is read from file or build, then it should be set here,
+   * so it can be used during construction of the web server.
+   */
+  public void updateModel(Graph graph, TransitModel transitModel) {
+    this.graph = graph;
+    this.transitModel = transitModel;
+    this.raptorTuningParameters = new RaptorConfig<>(factory.configModel().routerConfig().raptorTuningParameters());
+    this.context =
+      DefaultServerContext.create(
+        factory.configModel().routerConfig(),
+        raptorTuningParameters,
+        graph,
+        transitModel,
+        Metrics.globalRegistry,
+        cli.visualize
+      );
+  }
+
+  public OtpServerContext serverContext() {
+    return context;
+  }
+
+  /**
    * Create a new Grizzly server - call this method once, the new instance is created every time
    * this method is called.
    */
-  public GrizzlyServer createGrizzlyServer(DefaultServerContext serverContext) {
-    return new GrizzlyServer(cli, createApplication(serverContext));
+  public GrizzlyServer createGrizzlyServer() {
+    return new GrizzlyServer(cli, createApplication());
   }
 
   public void validateConfigAndDataSources() {
@@ -80,7 +122,7 @@ public class OTPAppConstruction {
   public GraphBuilder createGraphBuilder(Graph baseGraph) {
     LOG.info("Wiring up and configuring graph builder task.");
     return GraphBuilder.create(
-      factory.buildConfig(),
+      buildConfig(),
       graphBuilderDataSources(),
       baseGraph,
       cli.doLoadStreetGraph(),
@@ -102,36 +144,36 @@ public class OTPAppConstruction {
   private GraphBuilderDataSources graphBuilderDataSources() {
     if (graphBuilderDataSources == null) {
       graphBuilderDataSources =
-        GraphBuilderDataSources.create(cli, factory.buildConfig(), factory.datastore());
+        GraphBuilderDataSources.create(cli, buildConfig(), factory.datastore());
     }
     return graphBuilderDataSources;
   }
 
-  private Application createApplication(DefaultServerContext serverContext) {
+  private Application createApplication() {
     LOG.info("Wiring up and configuring server.");
-    setupTransitRoutingServer(serverContext);
-    return new OTPWebApplication(serverContext);
+    setupTransitRoutingServer();
+    return new OTPWebApplication(() -> context.createHttpRequestScopedCopy());
   }
 
-  private void setupTransitRoutingServer(OtpServerContext context) {
-    new MetricsLogging(context);
+  private void setupTransitRoutingServer() {
+    new MetricsLogging(transitModel(), raptorTuningParameters);
 
-    creatTransitLayerForRaptor(context.transitModel(), context.routerConfig());
+    creatTransitLayerForRaptor(transitModel, routerConfig());
 
     /* Create Graph updater modules from JSON config. */
     GraphUpdaterConfigurator.setupGraph(
-      context.graph(),
-      context.transitModel(),
-      context.routerConfig().updaterConfig()
+      graph(),
+      transitModel(),
+      routerConfig().updaterConfig()
     );
 
-    context.graph().initEllipsoidToGeoidDifference();
+    graph().initEllipsoidToGeoidDifference();
 
     if (OTPFeature.SandboxAPITransmodelApi.isOn()) {
       TransmodelAPI.setUp(
-        context.routerConfig().transmodelApi(),
-        context.transitModel(),
-        context.defaultRoutingRequest()
+        routerConfig().transmodelApi(),
+        transitModel(),
+        routerConfig().routingRequestDefaults()
       );
     }
 
@@ -164,5 +206,25 @@ public class OTPAppConstruction {
         transitModel.getTransitModelIndex().getServiceCodesRunningForDate()
       )
     );
+  }
+
+  public RaptorConfig<TripSchedule> raptorTuningParameters() {
+    return raptorTuningParameters;
+  }
+
+  public TransitModel transitModel() {
+    return transitModel;
+  }
+
+  public Graph graph() {
+    return graph;
+  }
+
+  private BuildConfig buildConfig() {
+    return factory.configModel().buildConfig();
+  }
+
+  private RouterConfig routerConfig() {
+    return factory.configModel().routerConfig();
   }
 }

--- a/src/main/java/org/opentripplanner/standalone/configure/OTPAppConstruction.java
+++ b/src/main/java/org/opentripplanner/standalone/configure/OTPAppConstruction.java
@@ -14,6 +14,7 @@ import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.standalone.api.OtpServerContext;
 import org.opentripplanner.standalone.config.CommandLineParameters;
 import org.opentripplanner.standalone.config.RouterConfig;
+import org.opentripplanner.standalone.server.DefaultServerContext;
 import org.opentripplanner.standalone.server.GrizzlyServer;
 import org.opentripplanner.standalone.server.MetricsLogging;
 import org.opentripplanner.standalone.server.OTPWebApplication;
@@ -62,7 +63,7 @@ public class OTPAppConstruction {
    * Create a new Grizzly server - call this method once, the new instance is created every time
    * this method is called.
    */
-  public GrizzlyServer createGrizzlyServer(OtpServerContext serverContext) {
+  public GrizzlyServer createGrizzlyServer(DefaultServerContext serverContext) {
     return new GrizzlyServer(cli, createApplication(serverContext));
   }
 
@@ -106,7 +107,7 @@ public class OTPAppConstruction {
     return graphBuilderDataSources;
   }
 
-  private Application createApplication(OtpServerContext serverContext) {
+  private Application createApplication(DefaultServerContext serverContext) {
     LOG.info("Wiring up and configuring server.");
     setupTransitRoutingServer(serverContext);
     return new OTPWebApplication(serverContext);
@@ -130,7 +131,7 @@ public class OTPAppConstruction {
       TransmodelAPI.setUp(
         context.routerConfig().transmodelApi(),
         context.transitModel(),
-        context.copyDefaultRoutingRequest()
+        context.defaultRoutingRequest()
       );
     }
 

--- a/src/main/java/org/opentripplanner/standalone/configure/OTPApplicationFactory.java
+++ b/src/main/java/org/opentripplanner/standalone/configure/OTPApplicationFactory.java
@@ -1,7 +1,5 @@
 package org.opentripplanner.standalone.configure;
 
-import static org.opentripplanner.model.projectinfo.OtpProjectInfo.projectInfo;
-
 import dagger.BindsInstance;
 import dagger.Component;
 import java.io.File;
@@ -9,12 +7,9 @@ import javax.inject.Singleton;
 import org.opentripplanner.datastore.OtpDataStore;
 import org.opentripplanner.datastore.configure.DataStoreModule;
 import org.opentripplanner.ext.datastore.gs.GsDataSourceModule;
-import org.opentripplanner.standalone.config.BuildConfig;
 import org.opentripplanner.standalone.config.ConfigModel;
 import org.opentripplanner.standalone.config.ConfigModule;
 import org.opentripplanner.standalone.config.OtpBaseDirectory;
-import org.opentripplanner.standalone.config.OtpConfig;
-import org.opentripplanner.standalone.config.RouterConfig;
 
 /**
  * This abstract class provide the top level service created and wired together using the Dagger 2
@@ -23,17 +18,8 @@ import org.opentripplanner.standalone.config.RouterConfig;
 @Singleton
 @Component(modules = { ConfigModule.class, DataStoreModule.class, GsDataSourceModule.class })
 public interface OTPApplicationFactory {
-  OtpConfig otpConfig();
-  BuildConfig buildConfig();
-  RouterConfig routerConfig();
   OtpDataStore datastore();
   ConfigModel configModel();
-
-  default void setOtpConfigVersionsOnServerInfo() {
-    projectInfo().otpConfigVersion = otpConfig().configVersion;
-    projectInfo().buildConfigVersion = buildConfig().configVersion;
-    projectInfo().routerConfigVersion = routerConfig().getConfigVersion();
-  }
 
   @Component.Builder
   interface Builder {

--- a/src/main/java/org/opentripplanner/standalone/server/DefaultServerContext.java
+++ b/src/main/java/org/opentripplanner/standalone/server/DefaultServerContext.java
@@ -6,7 +6,6 @@ import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.FileAppender;
 import io.micrometer.core.instrument.MeterRegistry;
-import java.time.Instant;
 import java.util.Locale;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -93,8 +92,7 @@ public class DefaultServerContext implements OtpServerContext {
   public RoutingRequest defaultRoutingRequest() {
     // Lazy initialize request-scoped request to avoid doing this when not needed
     if (routingRequest == null) {
-      routingRequest = routerConfig.routingRequestDefaults().clone();
-      routingRequest.setDateTime(Instant.now());
+      routingRequest = routerConfig.routingRequestDefaults().copyWithDateTimeNow();
     }
     return routingRequest;
   }

--- a/src/main/java/org/opentripplanner/standalone/server/DefaultServerContext.java
+++ b/src/main/java/org/opentripplanner/standalone/server/DefaultServerContext.java
@@ -111,11 +111,6 @@ public class DefaultServerContext implements OtpServerContext {
   }
 
   @Override
-  public double streetRoutingTimeoutSeconds() {
-    return routerConfig.streetRoutingTimeoutSeconds();
-  }
-
-  @Override
   public RouterConfig routerConfig() {
     return routerConfig;
   }

--- a/src/main/java/org/opentripplanner/standalone/server/MetricsLogging.java
+++ b/src/main/java/org/opentripplanner/standalone/server/MetricsLogging.java
@@ -17,7 +17,7 @@ import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
 import io.micrometer.core.instrument.binder.system.UptimeMetrics;
 import java.util.List;
 import java.util.concurrent.ForkJoinPool;
-import org.opentripplanner.standalone.api.OtpServerContext;
+import org.opentripplanner.transit.raptor.configure.RaptorConfig;
 import org.opentripplanner.transit.service.TransitModel;
 
 /**
@@ -26,7 +26,7 @@ import org.opentripplanner.transit.service.TransitModel;
  */
 public class MetricsLogging {
 
-  public MetricsLogging(OtpServerContext serverContext) {
+  public MetricsLogging(TransitModel transitModel, RaptorConfig<?> raptorConfig) {
     new ClassLoaderMetrics().bindTo(Metrics.globalRegistry);
     new FileDescriptorMetrics().bindTo(Metrics.globalRegistry);
     new JvmCompilationMetrics().bindTo(Metrics.globalRegistry);
@@ -38,8 +38,6 @@ public class MetricsLogging {
     new LogbackMetrics().bindTo(Metrics.globalRegistry);
     new ProcessorMetrics().bindTo(Metrics.globalRegistry);
     new UptimeMetrics().bindTo(Metrics.globalRegistry);
-
-    TransitModel transitModel = serverContext.transitModel();
 
     if (transitModel.getTransitLayer() != null) {
       new GuavaCacheMetrics(
@@ -72,9 +70,9 @@ public class MetricsLogging {
         .bindTo(Metrics.globalRegistry);
     }
 
-    if (serverContext.raptorConfig().isMultiThreaded()) {
+    if (raptorConfig.isMultiThreaded()) {
       new ExecutorServiceMetrics(
-        serverContext.raptorConfig().threadPool(),
+        raptorConfig.threadPool(),
         "raptorHeuristics",
         List.of(Tag.of("pool", "raptorHeuristics"))
       )

--- a/src/main/java/org/opentripplanner/standalone/server/OTPWebApplication.java
+++ b/src/main/java/org/opentripplanner/standalone/server/OTPWebApplication.java
@@ -33,7 +33,7 @@ import org.slf4j.bridge.SLF4JBridgeHandler;
 public class OTPWebApplication extends Application {
 
   /* This object groups together all the modules for a single running OTP server. */
-  private final OtpServerContext serverContext;
+  private final DefaultServerContext serverContext;
 
   static {
     // Remove existing handlers attached to the j.u.l root logger
@@ -43,7 +43,7 @@ public class OTPWebApplication extends Application {
     SLF4JBridgeHandler.install();
   }
 
-  public OTPWebApplication(OtpServerContext serverContext) {
+  public OTPWebApplication(DefaultServerContext serverContext) {
     this.serverContext = serverContext;
   }
 
@@ -120,11 +120,11 @@ public class OTPWebApplication extends Application {
    * <p>
    * More on custom injection in Jersey 2: http://jersey.576304.n2.nabble.com/Custom-providers-in-Jersey-2-tp7580699p7580715.html
    */
-  private Binder makeBinder(OtpServerContext context) {
+  private Binder makeBinder(DefaultServerContext context) {
     return new AbstractBinder() {
       @Override
       protected void configure() {
-        bind(context).to(OtpServerContext.class);
+        bindFactory(context::createHttpRequestScopedCopy).to(OtpServerContext.class);
       }
     };
   }

--- a/src/main/java/org/opentripplanner/standalone/server/OTPWebApplication.java
+++ b/src/main/java/org/opentripplanner/standalone/server/OTPWebApplication.java
@@ -9,6 +9,7 @@ import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 import javax.ws.rs.core.Application;
 import org.glassfish.jersey.CommonProperties;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
@@ -33,7 +34,7 @@ import org.slf4j.bridge.SLF4JBridgeHandler;
 public class OTPWebApplication extends Application {
 
   /* This object groups together all the modules for a single running OTP server. */
-  private final DefaultServerContext serverContext;
+  private final Supplier<OtpServerContext> contextProvider;
 
   static {
     // Remove existing handlers attached to the j.u.l root logger
@@ -43,8 +44,8 @@ public class OTPWebApplication extends Application {
     SLF4JBridgeHandler.install();
   }
 
-  public OTPWebApplication(DefaultServerContext serverContext) {
-    this.serverContext = serverContext;
+  public OTPWebApplication(Supplier<OtpServerContext> contextProvider) {
+    this.contextProvider = contextProvider;
   }
 
   /**
@@ -86,7 +87,7 @@ public class OTPWebApplication extends Application {
       // Serialize POJOs (unannotated) JSON using Jackson
       new JSONObjectMapperProvider(),
       // Allow injecting the OTP server object into Jersey resource classes
-      makeBinder(serverContext),
+      makeBinder(contextProvider),
       // Add performance instrumentation of Jersey requests to micrometer
       getMetricsApplicationEventListener()
     );
@@ -120,11 +121,11 @@ public class OTPWebApplication extends Application {
    * <p>
    * More on custom injection in Jersey 2: http://jersey.576304.n2.nabble.com/Custom-providers-in-Jersey-2-tp7580699p7580715.html
    */
-  private Binder makeBinder(DefaultServerContext context) {
+  private Binder makeBinder(Supplier<OtpServerContext> contextProvider) {
     return new AbstractBinder() {
       @Override
       protected void configure() {
-        bindFactory(context::createHttpRequestScopedCopy).to(OtpServerContext.class);
+        bindFactory(contextProvider).to(OtpServerContext.class);
       }
     };
   }

--- a/src/main/java/org/opentripplanner/standalone/server/Router.java
+++ b/src/main/java/org/opentripplanner/standalone/server/Router.java
@@ -1,7 +1,0 @@
-package org.opentripplanner.standalone.server;
-
-/**
- * Represents the configuration of a single router (a single graph for a specific geographic area)
- * in an OTP server.
- */
-public class Router {}

--- a/src/main/java/org/opentripplanner/util/time/DurationUtils.java
+++ b/src/main/java/org/opentripplanner/util/time/DurationUtils.java
@@ -106,8 +106,8 @@ public class DurationUtils {
       return Duration.parse(d);
     } catch (DateTimeParseException e) {
       throw new DateTimeParseException(
-        e.getMessage() + ": " + e.getParsedString(),
-        e.getParsedString(),
+        e.getMessage() + ": '" + duration + "'",
+        duration,
         e.getErrorIndex()
       );
     }

--- a/src/test/java/org/opentripplanner/TestServerContext.java
+++ b/src/test/java/org/opentripplanner/TestServerContext.java
@@ -7,6 +7,7 @@ import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.standalone.api.OtpServerContext;
 import org.opentripplanner.standalone.config.RouterConfig;
 import org.opentripplanner.standalone.server.DefaultServerContext;
+import org.opentripplanner.transit.raptor.configure.RaptorConfig;
 import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.transit.service.TransitModelIndex;
 
@@ -19,6 +20,7 @@ public class TestServerContext {
     transitModel.setTransitModelIndex(new TransitModelIndex(transitModel));
     DefaultServerContext context = DefaultServerContext.create(
       RouterConfig.DEFAULT,
+      new RaptorConfig<>(RouterConfig.DEFAULT.raptorTuningParameters()),
       graph,
       transitModel,
       Metrics.globalRegistry,

--- a/src/test/java/org/opentripplanner/TestServerContext.java
+++ b/src/test/java/org/opentripplanner/TestServerContext.java
@@ -17,10 +17,10 @@ public class TestServerContext {
   /** Create a context for unit testing, using the default RoutingRequest. */
   public static OtpServerContext createServerContext(Graph graph, TransitModel transitModel) {
     transitModel.setTransitModelIndex(new TransitModelIndex(transitModel));
-    DefaultServerContext context = new DefaultServerContext(
+    DefaultServerContext context = DefaultServerContext.create(
+      RouterConfig.DEFAULT,
       graph,
       transitModel,
-      RouterConfig.DEFAULT,
       Metrics.globalRegistry,
       false
     );

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/SnapshotTestBase.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/SnapshotTestBase.java
@@ -102,7 +102,7 @@ public abstract class SnapshotTestBase {
   ) {
     OtpServerContext serverContext = serverContext();
 
-    RoutingRequest request = serverContext.copyDefaultRoutingRequest();
+    RoutingRequest request = serverContext.defaultRoutingRequest();
     request.setDateTime(
       TestUtils.dateInstant(
         serverContext.transitModel().getTimeZone().getId(),

--- a/src/test/java/org/opentripplanner/routing/street/BarrierRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/street/BarrierRoutingTest.java
@@ -168,10 +168,10 @@ public class BarrierRoutingTest {
     RoutingContext routingContext = new RoutingContext(request, graph, temporaryVertices);
 
     var gpf = new GraphPathFinder(
-      new DefaultServerContext(
+      DefaultServerContext.create(
+        RouterConfig.DEFAULT,
         graph,
         Mockito.mock(TransitModel.class),
-        RouterConfig.DEFAULT,
         null,
         false
       )

--- a/src/test/java/org/opentripplanner/routing/street/BarrierRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/street/BarrierRoutingTest.java
@@ -33,6 +33,7 @@ import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.impl.GraphPathFinder;
 import org.opentripplanner.standalone.config.RouterConfig;
 import org.opentripplanner.standalone.server.DefaultServerContext;
+import org.opentripplanner.transit.raptor.configure.RaptorConfig;
 import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.util.PolylineEncoder;
 
@@ -170,6 +171,7 @@ public class BarrierRoutingTest {
     var gpf = new GraphPathFinder(
       DefaultServerContext.create(
         RouterConfig.DEFAULT,
+        new RaptorConfig<>(RouterConfig.DEFAULT.raptorTuningParameters()),
         graph,
         Mockito.mock(TransitModel.class),
         null,

--- a/src/test/java/org/opentripplanner/routing/street/BicycleRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/street/BicycleRoutingTest.java
@@ -22,6 +22,7 @@ import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.impl.GraphPathFinder;
 import org.opentripplanner.standalone.config.RouterConfig;
 import org.opentripplanner.standalone.server.DefaultServerContext;
+import org.opentripplanner.transit.raptor.configure.RaptorConfig;
 import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.util.PolylineEncoder;
 
@@ -81,6 +82,7 @@ public class BicycleRoutingTest {
     var gpf = new GraphPathFinder(
       DefaultServerContext.create(
         RouterConfig.DEFAULT,
+        new RaptorConfig<>(RouterConfig.DEFAULT.raptorTuningParameters()),
         graph,
         Mockito.mock(TransitModel.class),
         null,

--- a/src/test/java/org/opentripplanner/routing/street/BicycleRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/street/BicycleRoutingTest.java
@@ -79,10 +79,10 @@ public class BicycleRoutingTest {
     RoutingContext routingContext = new RoutingContext(request, graph, temporaryVertices);
 
     var gpf = new GraphPathFinder(
-      new DefaultServerContext(
+      DefaultServerContext.create(
+        RouterConfig.DEFAULT,
         graph,
         Mockito.mock(TransitModel.class),
-        RouterConfig.DEFAULT,
         null,
         false
       )

--- a/src/test/java/org/opentripplanner/routing/street/CarRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/street/CarRoutingTest.java
@@ -136,10 +136,10 @@ public class CarRoutingTest {
     final RoutingContext routingContext = new RoutingContext(request, graph, temporaryVertices);
 
     var gpf = new GraphPathFinder(
-      new DefaultServerContext(
+      DefaultServerContext.create(
+        RouterConfig.DEFAULT,
         graph,
         Mockito.mock(TransitModel.class),
-        RouterConfig.DEFAULT,
         null,
         false
       )

--- a/src/test/java/org/opentripplanner/routing/street/CarRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/street/CarRoutingTest.java
@@ -23,6 +23,7 @@ import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.impl.GraphPathFinder;
 import org.opentripplanner.standalone.config.RouterConfig;
 import org.opentripplanner.standalone.server.DefaultServerContext;
+import org.opentripplanner.transit.raptor.configure.RaptorConfig;
 import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.util.PolylineEncoder;
 
@@ -138,6 +139,7 @@ public class CarRoutingTest {
     var gpf = new GraphPathFinder(
       DefaultServerContext.create(
         RouterConfig.DEFAULT,
+        new RaptorConfig<>(RouterConfig.DEFAULT.raptorTuningParameters()),
         graph,
         Mockito.mock(TransitModel.class),
         null,

--- a/src/test/java/org/opentripplanner/routing/street/SplitEdgeTurnRestrictionsTest.java
+++ b/src/test/java/org/opentripplanner/routing/street/SplitEdgeTurnRestrictionsTest.java
@@ -21,6 +21,7 @@ import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.impl.GraphPathFinder;
 import org.opentripplanner.standalone.config.RouterConfig;
 import org.opentripplanner.standalone.server.DefaultServerContext;
+import org.opentripplanner.transit.raptor.configure.RaptorConfig;
 import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.util.PolylineEncoder;
 import org.opentripplanner.util.TestUtils;
@@ -157,6 +158,7 @@ public class SplitEdgeTurnRestrictionsTest {
     var gpf = new GraphPathFinder(
       DefaultServerContext.create(
         RouterConfig.DEFAULT,
+        new RaptorConfig<>(RouterConfig.DEFAULT.raptorTuningParameters()),
         graph,
         Mockito.mock(TransitModel.class),
         null,

--- a/src/test/java/org/opentripplanner/routing/street/SplitEdgeTurnRestrictionsTest.java
+++ b/src/test/java/org/opentripplanner/routing/street/SplitEdgeTurnRestrictionsTest.java
@@ -155,10 +155,10 @@ public class SplitEdgeTurnRestrictionsTest {
     RoutingContext routingContext = new RoutingContext(request, graph, temporaryVertices);
 
     var gpf = new GraphPathFinder(
-      new DefaultServerContext(
+      DefaultServerContext.create(
+        RouterConfig.DEFAULT,
         graph,
         Mockito.mock(TransitModel.class),
-        RouterConfig.DEFAULT,
         null,
         false
       )

--- a/src/test/java/org/opentripplanner/standalone/config/RouterConfigTest.java
+++ b/src/test/java/org/opentripplanner/standalone/config/RouterConfigTest.java
@@ -10,7 +10,7 @@ class RouterConfigTest {
 
   @Test
   void parseStreetRoutingTimeout() {
-    var DEFAULT_TIMEOUT = RouterConfig.DEFAULT.streetRoutingTimeoutSeconds();
+    var DEFAULT_TIMEOUT = RouterConfig.DEFAULT.streetRoutingTimeout();
     NodeAdapter c;
 
     // Fall back to default 5 seconds

--- a/src/test/java/org/opentripplanner/standalone/config/RouterConfigTest.java
+++ b/src/test/java/org/opentripplanner/standalone/config/RouterConfigTest.java
@@ -1,0 +1,32 @@
+package org.opentripplanner.standalone.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.standalone.config.JsonSupport.jsonNodeForTest;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+class RouterConfigTest {
+
+  @Test
+  void parseStreetRoutingTimeout() {
+    var DEFAULT_TIMEOUT = RouterConfig.DEFAULT.streetRoutingTimeoutSeconds();
+    NodeAdapter c;
+
+    // Fall back to default 5 seconds
+    c = new NodeAdapter(jsonNodeForTest("{}"), "Test");
+    assertEquals(DEFAULT_TIMEOUT, RouterConfig.parseStreetRoutingTimeout(c));
+
+    // New format: 3 seconds
+    c = new NodeAdapter(jsonNodeForTest("{streetRoutingTimeout: '33s'}"), "Test");
+    assertEquals(Duration.ofSeconds(33), RouterConfig.parseStreetRoutingTimeout(c));
+
+    // Old format: 3.2 seconds
+    c = new NodeAdapter(jsonNodeForTest("{streetRoutingTimeout: 3.7}"), "Test");
+    assertEquals(Duration.ofMillis(3700), RouterConfig.parseStreetRoutingTimeout(c));
+
+    // Illegal format
+    c = new NodeAdapter(jsonNodeForTest("{streetRoutingTimeout: 'Hi'}"), "Test");
+    assertEquals(DEFAULT_TIMEOUT, RouterConfig.parseStreetRoutingTimeout(c));
+  }
+}

--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTest.java
@@ -69,10 +69,10 @@ public class SpeedTest {
     this.testCaseInputs = filterTestCases(opts, tcIO.readTestCasesFromFile());
 
     this.serverContext =
-      new DefaultServerContext(
+      DefaultServerContext.create(
+        RouterConfig.DEFAULT,
         graph,
         transitModel,
-        RouterConfig.DEFAULT,
         timer.getRegistry(),
         false
       );

--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTest.java
@@ -24,6 +24,7 @@ import org.opentripplanner.standalone.OtpStartupInfo;
 import org.opentripplanner.standalone.api.OtpServerContext;
 import org.opentripplanner.standalone.config.RouterConfig;
 import org.opentripplanner.standalone.server.DefaultServerContext;
+import org.opentripplanner.transit.raptor.configure.RaptorConfig;
 import org.opentripplanner.transit.raptor.speed_test.model.SpeedTestProfile;
 import org.opentripplanner.transit.raptor.speed_test.model.testcase.CsvFileIO;
 import org.opentripplanner.transit.raptor.speed_test.model.testcase.TestCase;
@@ -71,6 +72,7 @@ public class SpeedTest {
     this.serverContext =
       DefaultServerContext.create(
         RouterConfig.DEFAULT,
+        new RaptorConfig<>(RouterConfig.DEFAULT.raptorTuningParameters()),
         graph,
         transitModel,
         timer.getRegistry(),


### PR DESCRIPTION
### Summary

Make the `OtpServerContext` handle HTTP request scope. The context injected into each HTTP Resource (per HTTP request), will hold request scoped components - so it become safe to modify these and to fetch them as many times from the scope as the resource needs too - without cashing it in the resource. We will use this to enforce consistency. We use lazy-init to create expensive components in the context. If the Resource is multi-threaded it need to synchronize access to all request-scoped components.

This build on to of #4301 

Next: The OtpServerContext should only be injected into Resources, not in other places. So, we should inject the config and services used to non resource components. Then we should replace the usage of `getTransitModel()` with `getTransitService()` in all resources.


### Unit tests

Nothing changed.

### Documentation
JavaDoc updated and added to new code.
