### PR TITLE
Improve logging of GBFS parsing errors

### DIFF
--- a/src/main/java/org/opentripplanner/updater/GraphUpdaterConfigurator.java
+++ b/src/main/java/org/opentripplanner/updater/GraphUpdaterConfigurator.java
@@ -103,7 +103,7 @@ public abstract class GraphUpdaterConfigurator {
       try {
         updater.setup(graph, transitModel);
       } catch (Exception e) {
-        LOG.warn("Failed to setup updater {}", updater.getConfigRef());
+        LOG.warn("Failed to setup updater {}", updater.getConfigRef(), e);
       }
     }
   }

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdater.java
@@ -90,6 +90,11 @@ public class VehicleRentalUpdater extends PollingGraphUpdater {
   }
 
   @Override
+  public String getConfigRef() {
+    return toString();
+  }
+
+  @Override
   protected void runPolling() {
     LOG.debug("Updating vehicle rental stations from " + source);
     if (!source.update()) {


### PR DESCRIPTION
### Summary

The invalid GBFS located at https://gbfs.hopr.city/api/gbfs/20 is giving IBI a bit of trouble. In order to help debugging the problem, I'd like to improve the logging of the exceptions.

If you apply this patch, then you see the following error:

```
13:51:49.569 WARN (GraphUpdaterConfigurator.java:106) Failed to setup updater GbfsVehicleRentalDataSource{url: 'https://gbfs.hopr.city/api/gbfs/20'}
java.lang.RuntimeException: Feed contains duplicate url for feed station_information. Urls: https://gbfs.hopr.city/api/gbfs/20/station_information, https://gbfs.hopr.city/api/gbfs/20/station_information
	at org.opentripplanner.updater.vehicle_rental.datasources.GbfsFeedLoader.<init>(GbfsFeedLoader.java:79)
	at org.opentripplanner.updater.vehicle_rental.datasources.GbfsVehicleRentalDataSource.setup(GbfsVehicleRentalDataSource.java:150)
	at org.opentripplanner.updater.vehicle_rental.VehicleRentalUpdater.setup(VehicleRentalUpdater.java:81)
	at org.opentripplanner.updater.GraphUpdaterConfigurator.setupUpdaters(GraphUpdaterConfigurator.java:104)
	at org.opentripplanner.updater.GraphUpdaterConfigurator.setupGraph(GraphUpdaterConfigurator.java:75)
	at org.opentripplanner.standalone.configure.OTPAppConstruction.setupTransitRoutingServer(OTPAppConstruction.java:121)
	at org.opentripplanner.standalone.configure.OTPAppConstruction.createApplication(OTPAppConstruction.java:111)
	at org.opentripplanner.standalone.configure.OTPAppConstruction.createGrizzlyServer(OTPAppConstruction.java:66)
	at org.opentripplanner.standalone.OTPMain.startOTPServer(OTPMain.java:198)
	at org.opentripplanner.standalone.OTPMain.main(OTPMain.java:56)
```

Beforehand it was only 

```
13:44:32.349 WARN (GraphUpdaterConfigurator.java:106) Failed to setup updater vehicle-rental.gbfs
```

cc @demory @miles-grant-ibigroup