### PR TITLE
Remove parsing of GBFS timezones

### DIFF
--- a/src/main/java/org/opentripplanner/routing/vehicle_rental/VehicleRentalStation.java
+++ b/src/main/java/org/opentripplanner/routing/vehicle_rental/VehicleRentalStation.java
@@ -2,7 +2,7 @@ package org.opentripplanner.routing.vehicle_rental;
 
 import static java.util.Locale.ROOT;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -48,7 +48,7 @@ public class VehicleRentalStation implements VehicleRentalPlace {
   public boolean isInstalled = true;
   public boolean isRenting = true;
   public boolean isReturning = true;
-  public ZonedDateTime lastReported;
+  public Instant lastReported;
 
   // OTP internal data
   public boolean allowOverloading = false;

--- a/src/main/java/org/opentripplanner/routing/vehicle_rental/VehicleRentalSystem.java
+++ b/src/main/java/org/opentripplanner/routing/vehicle_rental/VehicleRentalSystem.java
@@ -17,6 +17,10 @@ public class VehicleRentalSystem {
   public final String email;
   public final String feedContactEmail;
   public final String licenseUrl;
+
+  // this is intentionally a string, not a zone id as the validator doesn't check the correctness
+  // https://github.com/MobilityData/gbfs-validator/issues/76
+  public final String timezone;
   public final VehicleRentalSystemAppInformation androidApp;
   public final VehicleRentalSystemAppInformation iosApp;
 
@@ -32,6 +36,7 @@ public class VehicleRentalSystem {
     String phoneNumber,
     String email,
     String feedContactEmail,
+    String timezone,
     String licenseUrl,
     VehicleRentalSystemAppInformation androidApp,
     VehicleRentalSystemAppInformation iosApp
@@ -47,6 +52,7 @@ public class VehicleRentalSystem {
     this.phoneNumber = phoneNumber;
     this.email = email;
     this.feedContactEmail = feedContactEmail;
+    this.timezone = timezone;
     this.licenseUrl = licenseUrl;
     this.androidApp = androidApp;
     this.iosApp = iosApp;

--- a/src/main/java/org/opentripplanner/routing/vehicle_rental/VehicleRentalSystem.java
+++ b/src/main/java/org/opentripplanner/routing/vehicle_rental/VehicleRentalSystem.java
@@ -1,7 +1,5 @@
 package org.opentripplanner.routing.vehicle_rental;
 
-import java.time.ZoneId;
-
 /**
  * Based on https://github.com/NABSA/gbfs/blob/master/gbfs.md#system_informationjson
  */
@@ -18,7 +16,6 @@ public class VehicleRentalSystem {
   public final String phoneNumber;
   public final String email;
   public final String feedContactEmail;
-  public final ZoneId timezone;
   public final String licenseUrl;
   public final VehicleRentalSystemAppInformation androidApp;
   public final VehicleRentalSystemAppInformation iosApp;
@@ -35,7 +32,6 @@ public class VehicleRentalSystem {
     String phoneNumber,
     String email,
     String feedContactEmail,
-    ZoneId timezone,
     String licenseUrl,
     VehicleRentalSystemAppInformation androidApp,
     VehicleRentalSystemAppInformation iosApp
@@ -51,7 +47,6 @@ public class VehicleRentalSystem {
     this.phoneNumber = phoneNumber;
     this.email = email;
     this.feedContactEmail = feedContactEmail;
-    this.timezone = timezone;
     this.licenseUrl = licenseUrl;
     this.androidApp = androidApp;
     this.iosApp = iosApp;

--- a/src/main/java/org/opentripplanner/routing/vehicle_rental/VehicleRentalVehicle.java
+++ b/src/main/java/org/opentripplanner/routing/vehicle_rental/VehicleRentalVehicle.java
@@ -1,6 +1,6 @@
 package org.opentripplanner.routing.vehicle_rental;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.Set;
 import org.opentripplanner.routing.vehicle_rental.RentalVehicleType.FormFactor;
 import org.opentripplanner.transit.model.basic.I18NString;
@@ -21,7 +21,7 @@ public class VehicleRentalVehicle implements VehicleRentalPlace {
   public VehicleRentalStationUris rentalUris;
   public boolean isReserved = false;
   public boolean isDisabled = false;
-  public ZonedDateTime lastReported;
+  public Instant lastReported;
   public Double currentRangeMeters;
   public VehicleRentalStation station;
   public String pricingPlanId;

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsFreeVehicleStatusMapper.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsFreeVehicleStatusMapper.java
@@ -44,7 +44,7 @@ public class GbfsFreeVehicleStatusMapper {
       rentalVehicle.isDisabled = vehicle.getIsDisabled() != null ? vehicle.getIsDisabled() : false;
       rentalVehicle.lastReported =
         vehicle.getLastReported() != null
-          ? Instant.ofEpochSecond((long) (double) vehicle.getLastReported()).atZone(system.timezone)
+          ? Instant.ofEpochSecond((long) (double) vehicle.getLastReported())
           : null;
       rentalVehicle.currentRangeMeters = vehicle.getCurrentRangeMeters();
       rentalVehicle.pricingPlanId = vehicle.getPricingPlanId();

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsStationStatusMapper.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsStationStatusMapper.java
@@ -75,9 +75,7 @@ public class GbfsStationStatusMapper {
 
     station.lastReported =
       status.getLastReported() != null
-        ? Instant
-          .ofEpochSecond(status.getLastReported().longValue())
-          .atZone(station.system.timezone)
+        ? Instant.ofEpochSecond(status.getLastReported().longValue())
         : null;
   }
 }

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsSystemInformationMapper.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsSystemInformationMapper.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.updater.vehicle_rental.datasources;
 
-import java.time.ZoneId;
 import org.entur.gbfs.v2_2.system_information.GBFSData;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalSystem;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalSystemAppInformation;
@@ -43,6 +42,7 @@ public class GbfsSystemInformationMapper {
       systemInformation.getEmail(),
       systemInformation.getFeedContactEmail(),
       systemInformation.getLicenseUrl(),
+      systemInformation.getTimezone(),
       android,
       ios
     );

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsSystemInformationMapper.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsSystemInformationMapper.java
@@ -42,7 +42,6 @@ public class GbfsSystemInformationMapper {
       systemInformation.getPhoneNumber(),
       systemInformation.getEmail(),
       systemInformation.getFeedContactEmail(),
-      ZoneId.of(systemInformation.getTimezone()),
       systemInformation.getLicenseUrl(),
       android,
       ios


### PR DESCRIPTION
### Summary

Sadly there are many invalid GBFS feeds out there which send an incorrect timezone.

Examples:

- https://gbfs.hopr.city/api/gbfs/20/system_information
- https://gbfs.spin.pm/api/gbfs/v1/atlanta/system_information

Unfortunately, the validator doesn't validate this yet: https://github.com/MobilityData/gbfs-validator/issues/76

This causes OTP to completely reject the feed.

Since we actually don't really need the timezone I've skipped parsing it and using an `Instant` instead.