### PR TITLE
Remove duplicate stop index from Graph

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/flex/ScheduledDeviatedTripTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/flex/ScheduledDeviatedTripTest.java
@@ -274,7 +274,6 @@ public class ScheduledDeviatedTripTest extends FlexTest {
         stopLocation,
         0,
         List.of(),
-        null,
         new State(new StreetLocation(id, new Coordinate(0, 0), id), r, routingContext)
       );
     }

--- a/src/ext-test/java/org/opentripplanner/ext/flex/UnscheduledTripTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/flex/UnscheduledTripTest.java
@@ -82,7 +82,7 @@ public class UnscheduledTripTest extends FlexTest {
   private static NearbyStop getNearbyStop(FlexTrip trip) {
     assertEquals(1, trip.getStops().size());
     var stopLocation = trip.getStops().iterator().next();
-    return new NearbyStop(stopLocation, 0, List.of(), null, null);
+    return new NearbyStop(stopLocation, 0, List.of(), null);
   }
 
   private static FlexTrip getFlexTrip() {

--- a/src/ext-test/java/org/opentripplanner/ext/vectortiles/StopsLayerTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/vectortiles/StopsLayerTest.java
@@ -7,7 +7,6 @@ import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.ext.vectortiles.layers.stops.DigitransitStopPropertyMapper;
-import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.transit.model._data.TransitModelForTest;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.site.Stop;
@@ -28,7 +27,6 @@ public class StopsLayerTest {
   public void digitransitVehicleParkingPropertyMapperTest() {
     var deduplicator = new Deduplicator();
     var stopModel = new StopModel();
-    var graph = new Graph(stopModel, deduplicator);
     var transitModel = new TransitModel(stopModel, deduplicator);
     transitModel.index();
     var transitService = new DefaultTransitService(transitModel);

--- a/src/ext-test/java/org/opentripplanner/ext/vectortiles/StopsLayerTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/vectortiles/StopsLayerTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.ext.vectortiles.layers.stops.DigitransitStopPropertyMapper;
 import org.opentripplanner.routing.graph.Graph;
-import org.opentripplanner.routing.vertextype.TransitStopVertexBuilder;
 import org.opentripplanner.transit.model._data.TransitModelForTest;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.site.Stop;
@@ -37,15 +36,7 @@ public class StopsLayerTest {
     DigitransitStopPropertyMapper mapper = DigitransitStopPropertyMapper.create(transitService);
 
     Map<String, Object> map = new HashMap<>();
-    mapper
-      .map(
-        new TransitStopVertexBuilder()
-          .withGraph(graph)
-          .withStop(stop)
-          .withTransitModel(transitModel)
-          .build()
-      )
-      .forEach(o -> map.put(o.first, o.second));
+    mapper.map(stop).forEach(o -> map.put(o.first, o.second));
 
     assertEquals("F:name", map.get("gtfsId"));
     assertEquals("name", map.get("name"));

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
@@ -1037,8 +1037,7 @@ public class LegacyGraphQLQueryTypeImpl
       Stream<Stop> stopStream = getTransitService(environment)
         .queryStopSpatialIndex(envelope)
         .stream()
-        .filter(transitStopVertex -> envelope.contains(transitStopVertex.getCoordinate()))
-        .map(TransitStopVertex::getStop);
+        .filter(stop -> envelope.contains(stop.getCoordinate().asJtsCoordinate()));
 
       if (args.getLegacyGraphQLFeeds() != null) {
         List<String> feedIds = Lists.newArrayList(args.getLegacyGraphQLFeeds());

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
@@ -58,7 +58,6 @@ import org.opentripplanner.routing.vehicle_rental.VehicleRentalPlace;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalStation;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalStationService;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalVehicle;
-import org.opentripplanner.routing.vertextype.TransitStopVertex;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.Route;
@@ -548,7 +547,7 @@ public class LegacyGraphQLQueryTypeImpl
             var stop = transitService.getStopForId(FeedScopedId.parseId(parts[1]));
 
             // TODO: Add geometry
-            return new NearbyStop(stop, Integer.parseInt(parts[0]), null, null, null);
+            return new NearbyStop(stop, Integer.parseInt(parts[0]), null, null);
           }
         case "TicketType":
           return null; //TODO

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLStopImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLStopImpl.java
@@ -27,7 +27,6 @@ import org.opentripplanner.routing.RoutingService;
 import org.opentripplanner.routing.alertpatch.EntitySelector;
 import org.opentripplanner.routing.alertpatch.EntitySelector.StopAndRoute;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
-import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
 import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.routing.stoptimes.ArrivalDeparture;
@@ -425,15 +424,7 @@ public class LegacyGraphQLStopImpl implements LegacyGraphQLDataFetchers.LegacyGr
             .filter(transfer -> maxDistance == null || transfer.getDistanceMeters() < maxDistance)
             .filter(transfer -> transfer.to instanceof Stop)
             .map(transfer ->
-              new NearbyStop(
-                transfer.to,
-                transfer.getDistanceMeters(),
-                transfer.getEdges(),
-                GeometryUtils.concatenateLineStrings(
-                  transfer.getEdges().stream().map(Edge::getGeometry).collect(Collectors.toList())
-                ),
-                null
-              )
+              new NearbyStop(transfer.to, transfer.getDistanceMeters(), transfer.getEdges(), null)
             )
             .collect(Collectors.toList());
         },

--- a/src/ext/java/org/opentripplanner/ext/parkAndRideApi/ParkAndRideResource.java
+++ b/src/ext/java/org/opentripplanner/ext/parkAndRideApi/ParkAndRideResource.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.ext.parkAndRideApi;
 
-import java.util.List;
 import java.util.Optional;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -13,10 +12,9 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Envelope;
-import org.opentripplanner.routing.impl.StreetVertexIndex;
+import org.opentripplanner.routing.graphfinder.DirectGraphFinder;
 import org.opentripplanner.routing.vehicle_parking.VehicleParking;
 import org.opentripplanner.routing.vehicle_parking.VehicleParkingService;
-import org.opentripplanner.routing.vertextype.TransitStopVertex;
 import org.opentripplanner.standalone.api.OtpServerContext;
 import org.opentripplanner.transit.model.basic.I18NString;
 
@@ -28,7 +26,7 @@ import org.opentripplanner.transit.model.basic.I18NString;
 public class ParkAndRideResource {
 
   private final VehicleParkingService vehicleParkingService;
-  private final StreetVertexIndex streetIndex;
+  private final DirectGraphFinder graphFinder;
 
   public ParkAndRideResource(
     @Context OtpServerContext serverContext,
@@ -39,7 +37,7 @@ public class ParkAndRideResource {
     @Deprecated @PathParam("ignoreRouterId") String ignoreRouterId
   ) {
     this.vehicleParkingService = serverContext.graph().getVehicleParkingService();
-    this.streetIndex = serverContext.graph().getStreetIndex();
+    this.graphFinder = new DirectGraphFinder(serverContext.graph());
   }
 
   /** Envelopes are in latitude, longitude format */
@@ -83,10 +81,7 @@ public class ParkAndRideResource {
     if (maxTransitDistance == null) {
       return true;
     } else {
-      List<TransitStopVertex> stops = streetIndex.getNearbyTransitStops(
-        new Coordinate(lot.getX(), lot.getY()),
-        maxTransitDistance
-      );
+      var stops = graphFinder.findClosestStops(lot.getY(), lot.getX(), maxTransitDistance);
       return !stops.isEmpty();
     }
   }

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/DigitransitStopPropertyMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/DigitransitStopPropertyMapper.java
@@ -15,7 +15,7 @@ import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.site.Stop;
 import org.opentripplanner.transit.service.TransitService;
 
-public class DigitransitStopPropertyMapper extends PropertyMapper<TransitStopVertex> {
+public class DigitransitStopPropertyMapper extends PropertyMapper<Stop> {
 
   private final TransitService transitService;
 
@@ -28,8 +28,7 @@ public class DigitransitStopPropertyMapper extends PropertyMapper<TransitStopVer
   }
 
   @Override
-  public Collection<T2<String, Object>> map(TransitStopVertex input) {
-    Stop stop = input.getStop();
+  public Collection<T2<String, Object>> map(Stop stop) {
     Collection<TripPattern> patternsForStop = transitService.getPatternsForStop(stop);
 
     String type = patternsForStop

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/StopsLayerBuilder.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/StopsLayerBuilder.java
@@ -6,18 +6,16 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
-import org.locationtech.jts.geom.Point;
 import org.opentripplanner.ext.vectortiles.LayerBuilder;
 import org.opentripplanner.ext.vectortiles.PropertyMapper;
 import org.opentripplanner.ext.vectortiles.VectorTilesResource;
 import org.opentripplanner.routing.graph.Graph;
-import org.opentripplanner.routing.vertextype.TransitStopVertex;
+import org.opentripplanner.transit.model.site.Stop;
 import org.opentripplanner.transit.service.TransitService;
-import org.opentripplanner.util.geometry.GeometryUtils;
 
-public class StopsLayerBuilder extends LayerBuilder<TransitStopVertex> {
+public class StopsLayerBuilder extends LayerBuilder<Stop> {
 
-  static Map<MapperType, Function<TransitService, PropertyMapper<TransitStopVertex>>> mappers = Map.of(
+  static Map<MapperType, Function<TransitService, PropertyMapper<Stop>>> mappers = Map.of(
     MapperType.Digitransit,
     DigitransitStopPropertyMapper::create
   );
@@ -39,12 +37,10 @@ public class StopsLayerBuilder extends LayerBuilder<TransitStopVertex> {
     return transitService
       .queryStopSpatialIndex(query)
       .stream()
-      .map(transitStopVertex -> {
-        Point point = GeometryUtils
-          .getGeometryFactory()
-          .createPoint(transitStopVertex.getCoordinate());
+      .map(stop -> {
+        Geometry point = stop.getGeometry();
 
-        point.setUserData(transitStopVertex);
+        point.setUserData(stop);
 
         return point;
       })

--- a/src/main/java/org/opentripplanner/api/mapping/StopMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/StopMapper.java
@@ -70,13 +70,13 @@ public class StopMapper {
   }
 
   /** @param distance in integral meters, to avoid serializing a bunch of decimal places. */
-  public static ApiStopShort mapToApiShort(Stop domain, int distance) {
+  public static ApiStopShort mapToApiShort(StopLocation domain, double distance) {
     if (domain == null) {
       return null;
     }
 
     ApiStopShort api = mapToApiShort(domain);
-    api.dist = distance;
+    api.dist = (int) distance;
 
     return api;
   }
@@ -85,10 +85,7 @@ public class StopMapper {
     if (domain == null) {
       return null;
     }
-    return StreamSupport
-      .stream(domain.spliterator(), false)
-      .map(StopMapper::mapToApiShort)
-      .toList();
+    return domain.stream().map(StopMapper::mapToApiShort).toList();
   }
 
   /**

--- a/src/main/java/org/opentripplanner/graph_builder/module/NearbyStopFinder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/NearbyStopFinder.java
@@ -190,10 +190,10 @@ public class NearbyStopFinder {
 
     /* Add the origin vertices if they are stops */
     for (Vertex vertex : originVertices) {
-      if (vertex instanceof TransitStopVertex) {
+      if (vertex instanceof TransitStopVertex tsv) {
         stopsFound.add(
           new NearbyStop(
-            (TransitStopVertex) vertex,
+            tsv.getStop(),
             0,
             Collections.emptyList(),
             new State(vertex, routingRequest, routingContext)

--- a/src/main/java/org/opentripplanner/routing/RoutingService.java
+++ b/src/main/java/org/opentripplanner/routing/RoutingService.java
@@ -185,19 +185,4 @@ public class RoutingService {
         transitService
       );
   }
-
-  /** {@link Graph#getStopsByBoundingBox(double, double, double, double)} */
-  public Collection<StopLocation> getStopsByBoundingBox(
-    double minLat,
-    double minLon,
-    double maxLat,
-    double maxLon
-  ) {
-    return this.graph.getStopsByBoundingBox(minLat, minLon, maxLat, maxLon);
-  }
-
-  /** {@link Graph#getStopsInRadius(WgsCoordinate, double)} */
-  public List<T2<Stop, Double>> getStopsInRadius(WgsCoordinate center, double radius) {
-    return this.graph.getStopsInRadius(center, radius);
-  }
 }

--- a/src/main/java/org/opentripplanner/routing/graph/Graph.java
+++ b/src/main/java/org/opentripplanner/routing/graph/Graph.java
@@ -22,8 +22,6 @@ import org.locationtech.jts.geom.Geometry;
 import org.opentripplanner.common.TurnRestriction;
 import org.opentripplanner.common.geometry.CompactElevationProfile;
 import org.opentripplanner.common.geometry.GraphUtils;
-import org.opentripplanner.common.geometry.SphericalDistanceLibrary;
-import org.opentripplanner.common.model.T2;
 import org.opentripplanner.ext.dataoverlay.configuration.DataOverlayParameterBindings;
 import org.opentripplanner.graph_builder.linking.VertexLinker;
 import org.opentripplanner.graph_builder.module.osm.WayPropertySetSource.DrivingDirection;
@@ -37,11 +35,7 @@ import org.opentripplanner.routing.services.RealtimeVehiclePositionService;
 import org.opentripplanner.routing.services.notes.StreetNotesService;
 import org.opentripplanner.routing.vehicle_parking.VehicleParkingService;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalStationService;
-import org.opentripplanner.routing.vertextype.TransitStopVertex;
-import org.opentripplanner.transit.model.basic.WgsCoordinate;
 import org.opentripplanner.transit.model.framework.Deduplicator;
-import org.opentripplanner.transit.model.site.Stop;
-import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.service.StopModel;
 import org.opentripplanner.util.ElevationUtils;
 import org.opentripplanner.util.WorldEnvelope;
@@ -473,37 +467,6 @@ public class Graph implements Serializable {
 
   public VehicleParkingService getVehicleParkingService() {
     return getService(VehicleParkingService.class);
-  }
-
-  /** Get all stops within a given bounding box. */
-  public Collection<StopLocation> getStopsByBoundingBox(
-    double minLat,
-    double minLon,
-    double maxLat,
-    double maxLon
-  ) {
-    Envelope envelope = new Envelope(
-      new Coordinate(minLon, minLat),
-      new Coordinate(maxLon, maxLat)
-    );
-    return streetIndex
-      .getTransitStopForEnvelope(envelope)
-      .stream()
-      .map(TransitStopVertex::getStop)
-      .collect(Collectors.toList());
-  }
-
-  /** Get all stops within a given radius. Unit: meters. */
-  public List<T2<Stop, Double>> getStopsInRadius(WgsCoordinate center, double radius) {
-    Coordinate coord = new Coordinate(center.longitude(), center.latitude());
-    return streetIndex
-      .getNearbyTransitStops(coord, radius)
-      .stream()
-      .map(v ->
-        new T2<>(v.getStop(), SphericalDistanceLibrary.fastDistance(v.getCoordinate(), coord))
-      )
-      .filter(t -> t.second < radius)
-      .collect(Collectors.toList());
   }
 
   public DrivingDirection getDrivingDirection() {

--- a/src/main/java/org/opentripplanner/routing/graphfinder/NearbyStop.java
+++ b/src/main/java/org/opentripplanner/routing/graphfinder/NearbyStop.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
-import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.spt.GraphPath;
@@ -21,25 +20,13 @@ public class NearbyStop implements Comparable<NearbyStop> {
   public final double distance;
 
   public final List<Edge> edges;
-  public final LineString geometry;
   public final State state;
 
-  public NearbyStop(
-    StopLocation stop,
-    double distance,
-    List<Edge> edges,
-    LineString geometry,
-    State state
-  ) {
+  public NearbyStop(StopLocation stop, double distance, List<Edge> edges, State state) {
     this.stop = stop;
     this.distance = distance;
     this.edges = edges;
-    this.geometry = geometry;
     this.state = state;
-  }
-
-  public NearbyStop(TransitStopVertex stopVertex, double distance, List<Edge> edges, State state) {
-    this(stopVertex.getStop(), distance, edges, null, state);
   }
 
   /**
@@ -54,7 +41,7 @@ public class NearbyStop implements Comparable<NearbyStop> {
       effectiveWalkDistance += edge.getEffectiveWalkDistance();
       edges.add(edge);
     }
-    return new NearbyStop(stop, effectiveWalkDistance, edges, null, state);
+    return new NearbyStop(stop, effectiveWalkDistance, edges, state);
   }
 
   @Override
@@ -73,7 +60,7 @@ public class NearbyStop implements Comparable<NearbyStop> {
 
   @Override
   public int hashCode() {
-    return Objects.hash(stop, distance, edges, geometry, state);
+    return Objects.hash(stop, distance, edges, state);
   }
 
   @Override
@@ -89,7 +76,6 @@ public class NearbyStop implements Comparable<NearbyStop> {
       Double.compare(that.distance, distance) == 0 &&
       stop.equals(that.stop) &&
       Objects.equals(edges, that.edges) &&
-      Objects.equals(geometry, that.geometry) &&
       Objects.equals(state, that.state)
     );
   }
@@ -101,7 +87,6 @@ public class NearbyStop implements Comparable<NearbyStop> {
       stop,
       distance,
       edges != null ? " (" + edges.size() + " edges)" : "",
-      geometry != null ? " w/geometry" : "",
       state != null ? " w/state" : ""
     );
   }

--- a/src/main/java/org/opentripplanner/transit/model/site/Stop.java
+++ b/src/main/java/org/opentripplanner/transit/model/site/Stop.java
@@ -94,7 +94,7 @@ public final class Stop extends StationElement<Stop, StopBuilder> implements Sto
   }
 
   @Override
-  @Nullable
+  @Nonnull
   public Geometry getGeometry() {
     return GeometryUtils.getGeometryFactory().createPoint(getCoordinate().asJtsCoordinate());
   }

--- a/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
+++ b/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
@@ -542,7 +542,7 @@ public class DefaultTransitService implements TransitEditorService {
   }
 
   @Override
-  public Collection<TransitStopVertex> queryStopSpatialIndex(Envelope envelope) {
+  public Collection<Stop> queryStopSpatialIndex(Envelope envelope) {
     return transitModel.getStopModel().getStopModelIndex().queryStopSpatialIndex(envelope);
   }
 

--- a/src/main/java/org/opentripplanner/transit/service/StopModelIndex.java
+++ b/src/main/java/org/opentripplanner/transit/service/StopModelIndex.java
@@ -32,7 +32,7 @@ public class StopModelIndex {
   // TODO: consistently key on model object or id string
 
   private final Map<Stop, TransitStopVertex> stopVertexForStop = Maps.newHashMap();
-  private final HashGridSpatialIndex<TransitStopVertex> stopSpatialIndex = new HashGridSpatialIndex<>();
+  private final HashGridSpatialIndex<Stop> stopSpatialIndex = new HashGridSpatialIndex<>();
   private final Map<Station, MultiModalStation> multiModalStationForStations = Maps.newHashMap();
   private final Multimap<StopLocation, FlexLocationGroup> locationGroupsByStop = ArrayListMultimap.create();
   private final HashGridSpatialIndex<FlexStopLocation> locationIndex = new HashGridSpatialIndex<>();
@@ -52,7 +52,7 @@ public class StopModelIndex {
     }
     for (TransitStopVertex stopVertex : stopVertexForStop.values()) {
       Envelope envelope = new Envelope(stopVertex.getCoordinate());
-      stopSpatialIndex.insert(envelope, stopVertex);
+      stopSpatialIndex.insert(envelope, stopVertex.getStop());
     }
 
     for (MultiModalStation multiModalStation : stopModel.getAllMultiModalStations()) {
@@ -83,7 +83,7 @@ public class StopModelIndex {
     return stopVertexForStop.get(stop);
   }
 
-  public Collection<TransitStopVertex> queryStopSpatialIndex(Envelope envelope) {
+  public Collection<Stop> queryStopSpatialIndex(Envelope envelope) {
     return stopSpatialIndex.query(envelope);
   }
 

--- a/src/main/java/org/opentripplanner/transit/service/TransitModel.java
+++ b/src/main/java/org/opentripplanner/transit/service/TransitModel.java
@@ -407,10 +407,6 @@ public class TransitModel implements Serializable {
     return stopModel;
   }
 
-  public Collection<TransitStopVertex> queryStopSpatialIndex(Envelope envelope) {
-    return stopModel.getStopModelIndex().queryStopSpatialIndex(envelope);
-  }
-
   public void addTripPattern(FeedScopedId id, TripPattern tripPattern) {
     tripPatternForId.put(id, tripPattern);
   }

--- a/src/main/java/org/opentripplanner/transit/service/TransitService.java
+++ b/src/main/java/org/opentripplanner/transit/service/TransitService.java
@@ -189,7 +189,7 @@ public interface TransitService {
 
   boolean transitFeedCovers(Instant dateTime);
 
-  Collection<TransitStopVertex> queryStopSpatialIndex(Envelope envelope);
+  Collection<Stop> queryStopSpatialIndex(Envelope envelope);
 
   GraphUpdaterStatus getUpdaterStatus();
 }

--- a/src/test/java/org/opentripplanner/routing/TestHalfEdges.java
+++ b/src/test/java/org/opentripplanner/routing/TestHalfEdges.java
@@ -34,6 +34,8 @@ import org.opentripplanner.routing.edgetype.StreetTraversalPermission;
 import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
+import org.opentripplanner.routing.graphfinder.DirectGraphFinder;
+import org.opentripplanner.routing.graphfinder.GraphFinder;
 import org.opentripplanner.routing.impl.StreetVertexIndex;
 import org.opentripplanner.routing.location.TemporaryStreetLocation;
 import org.opentripplanner.routing.services.notes.StreetNotesService;
@@ -571,10 +573,10 @@ public class TestHalfEdges {
     transitModel.index();
     graph.index();
     StreetVertexIndex finder = graph.getStreetIndex();
+    GraphFinder graphFinder = new DirectGraphFinder(graph);
     Set<DisposableEdgeCollection> tempEdges = new HashSet<>();
     // test that the local stop finder finds stops
-    GenericLocation loc = new GenericLocation(40.01, -74.005000001);
-    assertTrue(finder.getNearbyTransitStops(loc.getCoordinate(), 100).size() > 0);
+    assertTrue(graphFinder.findClosestStops(40.01, -74.005000001, 100).size() > 0);
 
     // test that the closest vertex finder returns the closest vertex
     TemporaryStreetLocation some = (TemporaryStreetLocation) finder.getVertexForLocationForTest(

--- a/src/test/java/org/opentripplanner/routing/graph/RoutingServiceTest.java
+++ b/src/test/java/org/opentripplanner/routing/graph/RoutingServiceTest.java
@@ -120,13 +120,13 @@ public class RoutingServiceTest extends GtfsTest {
       SphericalDistanceLibrary.metersToLonDegrees(100, stopJ.getLat()),
       SphericalDistanceLibrary.metersToDegrees(100)
     );
-    Collection<TransitStopVertex> stops = transitModel
+    Collection<Stop> stops = transitModel
       .getStopModel()
       .getStopModelIndex()
       .queryStopSpatialIndex(env);
-    assertTrue(stops.contains(stopvJ));
-    assertTrue(stops.contains(stopvL));
-    assertTrue(stops.contains(stopvM));
+    assertTrue(stops.contains(stopJ));
+    assertTrue(stops.contains(stopL));
+    assertTrue(stops.contains(stopM));
     assertTrue(stops.size() >= 3); // Query can overselect
   }
 

--- a/src/test/java/org/opentripplanner/routing/graphfinder/DirectGraphFinderTest.java
+++ b/src/test/java/org/opentripplanner/routing/graphfinder/DirectGraphFinderTest.java
@@ -37,8 +37,8 @@ class DirectGraphFinderTest extends GraphRoutingTest {
 
   @Test
   void findClosestStops() {
-    var ns1 = new NearbyStop(S1.getStop(), 0, null, null, null);
-    var ns2 = new NearbyStop(S2.getStop(), 1112, null, null, null);
+    var ns1 = new NearbyStop(S1.getStop(), 0, null, null);
+    var ns2 = new NearbyStop(S2.getStop(), 1112, null, null);
 
     var testee = new DirectGraphFinder(graph);
     assertEquals(List.of(ns1), testee.findClosestStops(47.500, 19.000, 100));

--- a/src/test/java/org/opentripplanner/routing/graphfinder/StreetGraphFinderTest.java
+++ b/src/test/java/org/opentripplanner/routing/graphfinder/StreetGraphFinderTest.java
@@ -121,8 +121,8 @@ class StreetGraphFinderTest extends GraphRoutingTest {
 
   @Test
   void findClosestStops() {
-    var ns1 = new NearbyStop(S1.getStop(), 0, null, null, null);
-    var ns2 = new NearbyStop(S2.getStop(), 100, null, null, null);
+    var ns1 = new NearbyStop(S1.getStop(), 0, null, null);
+    var ns2 = new NearbyStop(S2.getStop(), 100, null, null);
 
     assertEquals(List.of(ns1), simplify(graphFinder.findClosestStops(47.500, 19.000, 10)));
 
@@ -433,7 +433,7 @@ class StreetGraphFinderTest extends GraphRoutingTest {
   private List<NearbyStop> simplify(List<NearbyStop> closestStops) {
     return closestStops
       .stream()
-      .map(ns -> new NearbyStop(ns.stop, ns.distance, null, null, null))
+      .map(ns -> new NearbyStop(ns.stop, ns.distance, null, null))
       .collect(Collectors.toList());
   }
 }


### PR DESCRIPTION
### Summary

Currently we index `Stop`s in two places, `StreetVertexIndex` and `StopModelIndex`. This removes the first usage, and converts all to use the one in `StopModelIndex`. Also, it changes from indexing `TransitStopVertex ` to indexing `Stop`s
