### PR TITLE
Take nullable transit alert dates into account

### DIFF
--- a/src/main/java/org/opentripplanner/api/mapping/AlertMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/AlertMapper.java
@@ -1,9 +1,11 @@
 package org.opentripplanner.api.mapping;
 
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.opentripplanner.api.model.ApiAlert;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
@@ -40,9 +42,13 @@ public class AlertMapper {
       api.alertUrl = domain.alertUrl.toString(locale);
     }
 
-    api.effectiveStartDate = Date.from(domain.getEffectiveStartDate());
-    api.effectiveEndDate = Date.from(domain.getEffectiveEndDate());
+    api.effectiveStartDate = ofNullableInstant(domain.getEffectiveStartDate());
+    api.effectiveEndDate = ofNullableInstant(domain.getEffectiveEndDate());
 
     return api;
+  }
+
+  private static Date ofNullableInstant(Instant instant) {
+    return Optional.ofNullable(instant).map(Date::from).orElse(null);
   }
 }

--- a/src/main/java/org/opentripplanner/routing/alertpatch/TransitAlert.java
+++ b/src/main/java/org/opentripplanner/routing/alertpatch/TransitAlert.java
@@ -8,6 +8,7 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.opentripplanner.transit.model.basic.I18NString;
 
 public class TransitAlert implements Serializable {
@@ -99,6 +100,7 @@ public class TransitAlert implements Serializable {
    *
    * @return First startDate for this Alert, <code>null</code> if 0 (not set)
    */
+  @Nullable
   public Instant getEffectiveStartDate() {
     return timePeriods
       .stream()
@@ -115,6 +117,7 @@ public class TransitAlert implements Serializable {
    *
    * @return Last endDate for this Alert, <code>null</code> if open-ended
    */
+  @Nullable
   public Instant getEffectiveEndDate() {
     return timePeriods
       .stream()


### PR DESCRIPTION
### Summary

In GTFS-RT the transit alert start/end dates are optional but the API mapper throws an error when this is actually the case:

```
11:59:08.649 ERROR (PlannerResource.java:103) System error
java.lang.NullPointerException: Cannot invoke "java.time.Instant.toEpochMilli()" because "instant" is null
    at java.base/java.util.Date.from(Date.java:1363)
    at org.opentripplanner.api.mapping.AlertMapper.mapToApi(AlertMapper.java:44)
    at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
    at java.base/java.util.HashMap$KeySpliterator.forEachRemaining(HashMap.java:1694)
    at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
    at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
    at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
    at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
    at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
    at org.opentripplanner.api.mapping.AlertMapper.mapToApi(AlertMapper.java:26)
    at org.opentripplanner.api.mapping.LegMapper.mapLeg(LegMapper.java:133)
    at org.opentripplanner.api.mapping.LegMapper.mapLegs(LegMapper.java:46)
    at org.opentripplanner.api.mapping.ItineraryMapper.mapItinerary(ItineraryMapper.java:48)
    at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
    at java.base/java.util.AbstractList$RandomAccessSpliterator.forEachRemaining(AbstractList.java:720)
```

This fixes that problem.

cc @miles-grant-ibigroup