### PR TITLE
Use way-properties for the Portland test graph

### DIFF
--- a/src/main/java/org/opentripplanner/model/StreetNote.java
+++ b/src/main/java/org/opentripplanner/model/StreetNote.java
@@ -2,6 +2,7 @@ package org.opentripplanner.model;
 
 import java.io.Serializable;
 import java.util.Date;
+import java.util.Objects;
 import org.opentripplanner.transit.model.basic.I18NString;
 import org.opentripplanner.transit.model.basic.NonLocalizedString;
 
@@ -19,5 +20,24 @@ public class StreetNote implements Serializable {
 
   public StreetNote(String note) {
     this.note = new NonLocalizedString(note);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    StreetNote that = (StreetNote) o;
+    return (
+      Objects.equals(note, that.note) &&
+      Objects.equals(descriptionText, that.descriptionText) &&
+      Objects.equals(effectiveStartDate, that.effectiveStartDate) &&
+      Objects.equals(effectiveEndDate, that.effectiveEndDate) &&
+      Objects.equals(url, that.url)
+    );
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(note, descriptionText, effectiveStartDate, effectiveEndDate, url);
   }
 }

--- a/src/main/java/org/opentripplanner/routing/services/notes/MatcherAndStreetNote.java
+++ b/src/main/java/org/opentripplanner/routing/services/notes/MatcherAndStreetNote.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.routing.services.notes;
 
 import java.io.Serializable;
+import java.util.Objects;
 import org.opentripplanner.model.StreetNote;
 
 /**
@@ -25,5 +26,18 @@ public class MatcherAndStreetNote implements Serializable {
 
   public StreetNote getNote() {
     return note;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    MatcherAndStreetNote that = (MatcherAndStreetNote) o;
+    return matcher.equals(that.matcher) && note.equals(that.note);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(matcher, note);
   }
 }

--- a/src/test/java/org/opentripplanner/ConstantsForTests.java
+++ b/src/test/java/org/opentripplanner/ConstantsForTests.java
@@ -141,6 +141,7 @@ public class ConstantsForTests {
         osmModule.staticBikeParkAndRide = true;
         osmModule.staticParkAndRide = true;
         osmModule.skipVisibility = true;
+        new DefaultWayPropertySetSource().populateProperties(osmModule.wayPropertySet);
         osmModule.buildGraph(graph, transitModel, new HashMap<>());
       }
       // Add transit data from GTFS

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/BikeRentalSnapshotTest.snap
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/BikeRentalSnapshotTest.snap
@@ -44,7 +44,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
           }
         }
       },
-      "generalizedCost": 2087,
+      "generalizedCost": 2209,
       "legs": [
         {
           "agencyTimeZoneOffset": -25200000,
@@ -108,7 +108,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.7003923,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "way -102328 from 0",
+              "streetName": "path",
               "walkingBike": false
             }
           ],
@@ -145,7 +145,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             ],
             "vertexType": "BIKESHARE"
           },
-          "generalizedCost": 288,
+          "generalizedCost": 409,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 7,
@@ -168,7 +168,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.7003879,
               "relativeDirection": "HARD_RIGHT",
               "stayOn": false,
-              "streetName": "way -102328 from 0",
+              "streetName": "path",
               "walkingBike": true
             },
             {
@@ -607,7 +607,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.700835,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "way 113897002 from 7",
+              "streetName": "path",
               "walkingBike": false
             }
           ],
@@ -1275,7 +1275,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
           }
         }
       },
-      "generalizedCost": 2087,
+      "generalizedCost": 2209,
       "legs": [
         {
           "agencyTimeZoneOffset": -25200000,
@@ -1339,7 +1339,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.7003923,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "way -102328 from 0",
+              "streetName": "path",
               "walkingBike": false
             }
           ],
@@ -1376,7 +1376,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             ],
             "vertexType": "BIKESHARE"
           },
-          "generalizedCost": 288,
+          "generalizedCost": 409,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 7,
@@ -1399,7 +1399,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.7003879,
               "relativeDirection": "HARD_RIGHT",
               "stayOn": false,
-              "streetName": "way -102328 from 0",
+              "streetName": "path",
               "walkingBike": true
             },
             {
@@ -1748,7 +1748,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
           }
         }
       },
-      "generalizedCost": 2087,
+      "generalizedCost": 2209,
       "legs": [
         {
           "agencyTimeZoneOffset": -25200000,
@@ -1812,7 +1812,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.7003923,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "way -102328 from 0",
+              "streetName": "path",
               "walkingBike": false
             }
           ],
@@ -1849,7 +1849,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
             ],
             "vertexType": "BIKESHARE"
           },
-          "generalizedCost": 288,
+          "generalizedCost": 409,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 7,
@@ -1872,7 +1872,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.accessBikeR
               "lon": -122.7003879,
               "relativeDirection": "HARD_RIGHT",
               "stayOn": false,
-              "streetName": "way -102328 from 0",
+              "streetName": "path",
               "walkingBike": true
             },
             {
@@ -2520,7 +2520,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
         "details": { },
         "fare": { }
       },
-      "generalizedCost": 915,
+      "generalizedCost": 1036,
       "legs": [
         {
           "agencyTimeZoneOffset": -25200000,
@@ -2584,7 +2584,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
               "lon": -122.7003923,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "way -102328 from 0",
+              "streetName": "path",
               "walkingBike": false
             }
           ],
@@ -2621,7 +2621,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
             ],
             "vertexType": "BIKESHARE"
           },
-          "generalizedCost": 288,
+          "generalizedCost": 409,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 7,
@@ -2644,7 +2644,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
               "lon": -122.7003879,
               "relativeDirection": "HARD_RIGHT",
               "stayOn": false,
-              "streetName": "way -102328 from 0",
+              "streetName": "path",
               "walkingBike": true
             },
             {
@@ -2783,7 +2783,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
         "details": { },
         "fare": { }
       },
-      "generalizedCost": 652,
+      "generalizedCost": 830,
       "legs": [
         {
           "agencyTimeZoneOffset": -25200000,
@@ -2847,7 +2847,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
               "lon": -122.7003923,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "way -102328 from 0",
+              "streetName": "path",
               "walkingBike": false
             }
           ],
@@ -2884,7 +2884,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
             ],
             "vertexType": "BIKESHARE"
           },
-          "generalizedCost": 363,
+          "generalizedCost": 541,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 11,
@@ -2907,7 +2907,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
               "lon": -122.7003879,
               "relativeDirection": "HARD_RIGHT",
               "stayOn": false,
-              "streetName": "way -102328 from 0",
+              "streetName": "path",
               "walkingBike": true
             },
             {
@@ -2986,7 +2986,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
         "details": { },
         "fare": { }
       },
-      "generalizedCost": 652,
+      "generalizedCost": 829,
       "legs": [
         {
           "agencyTimeZoneOffset": -25200000,
@@ -3050,7 +3050,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
               "lon": -122.7003923,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "way -102328 from 0",
+              "streetName": "path",
               "walkingBike": false
             }
           ],
@@ -3087,7 +3087,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
             ],
             "vertexType": "BIKESHARE"
           },
-          "generalizedCost": 363,
+          "generalizedCost": 540,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 10,
@@ -3110,7 +3110,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.directBikeR
               "lon": -122.7003879,
               "relativeDirection": "HARD_RIGHT",
               "stayOn": false,
-              "streetName": "way -102328 from 0",
+              "streetName": "path",
               "walkingBike": true
             },
             {
@@ -3223,7 +3223,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
           }
         }
       },
-      "generalizedCost": 1998,
+      "generalizedCost": 2119,
       "legs": [
         {
           "agencyTimeZoneOffset": -25200000,
@@ -3558,7 +3558,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             ],
             "vertexType": "BIKESHARE"
           },
-          "generalizedCost": 277,
+          "generalizedCost": 399,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 7,
@@ -3594,7 +3594,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.7003923,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "way -102328 from 0",
+              "streetName": "path",
               "walkingBike": true
             }
           ],
@@ -3654,7 +3654,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.7003879,
               "relativeDirection": "HARD_RIGHT",
               "stayOn": false,
-              "streetName": "way -102328 from 0",
+              "streetName": "path",
               "walkingBike": false
             },
             {
@@ -4230,7 +4230,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.6764917,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "way 156261070 from 2",
+              "streetName": "path",
               "walkingBike": false
             }
           ],
@@ -4532,7 +4532,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
           }
         }
       },
-      "generalizedCost": 1998,
+      "generalizedCost": 2119,
       "legs": [
         {
           "agencyTimeZoneOffset": -25200000,
@@ -4867,7 +4867,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
             ],
             "vertexType": "BIKESHARE"
           },
-          "generalizedCost": 277,
+          "generalizedCost": 399,
           "interlineWithPreviousLeg": false,
           "legGeometry": {
             "length": 7,
@@ -4903,7 +4903,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.7003923,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "way -102328 from 0",
+              "streetName": "path",
               "walkingBike": true
             }
           ],
@@ -4963,7 +4963,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.7003879,
               "relativeDirection": "HARD_RIGHT",
               "stayOn": false,
-              "streetName": "way -102328 from 0",
+              "streetName": "path",
               "walkingBike": false
             },
             {
@@ -5539,7 +5539,7 @@ org.opentripplanner.routing.algorithm.mapping.BikeRentalSnapshotTest.egressBikeR
               "lon": -122.6764917,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "way 156261070 from 2",
+              "streetName": "path",
               "walkingBike": false
             }
           ],

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/ElevationSnapshotTest.snap
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/ElevationSnapshotTest.snap
@@ -44,7 +44,7 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
           }
         }
       },
-      "generalizedCost": 2160,
+      "generalizedCost": 2282,
       "legs": [
         {
           "agencyTimeZoneOffset": -25200000,
@@ -109,7 +109,7 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
               "lon": -122.7003923,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "way -102328 from 0",
+              "streetName": "path",
               "walkingBike": false
             }
           ],
@@ -146,7 +146,7 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
             ],
             "vertexType": "BIKESHARE"
           },
-          "generalizedCost": 343,
+          "generalizedCost": 464,
           "interlineWithPreviousLeg": false,
           "legElevation": "0,66.2,13,66.6,23,65.7,33,64.9,43,64.1,53,63.1,63,62.5,73,62.5,83,62.1,93,61.9,103,61.7,113,61.4,123,61.1,133,60.9,143,60.6,158,60.2,168,59.9,178,59.6,188,59.3,198,59.0,208,58.7,218,58.4,228,58.1,238,57.8,248,57.5,258,57.1,268,56.8,278,56.6,288,56.4,298,56.2,308,55.9,316,55.7,326,55.5,336,55.3,346,55.0,356,54.7,366,54.4,376,54.1,386,53.8,396,53.6,406,53.5,416,53.3,426,53.3,440,53.0,450,52.9,460,52.8,474,52.6,474,52.6,484,52.4,493,52.2",
           "legGeometry": {
@@ -170,7 +170,7 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
               "lon": -122.7003879,
               "relativeDirection": "HARD_RIGHT",
               "stayOn": false,
-              "streetName": "way -102328 from 0",
+              "streetName": "path",
               "walkingBike": true
             },
             {
@@ -808,6 +808,335 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
     },
     {
       "arrivedAtDestinationWithRentedBicycle": false,
+      "duration": 1112,
+      "elevationGained": 2.28,
+      "elevationLost": 13.43,
+      "endTime": "2009-10-21T23:45:25.000+00:00",
+      "fare": {
+        "details": {
+          "regular": [
+            {
+              "fareId": {
+                "feedId": "prt",
+                "id": "8"
+              },
+              "price": {
+                "cents": 200,
+                "currency": {
+                  "currency": "USD",
+                  "currencyCode": "USD",
+                  "defaultFractionDigits": 2,
+                  "symbol": "$"
+                }
+              },
+              "routes": [
+                {
+                  "feedId": "prt",
+                  "id": "17"
+                }
+              ]
+            }
+          ]
+        },
+        "fare": {
+          "regular": {
+            "cents": 200,
+            "currency": {
+              "currency": "USD",
+              "currencyCode": "USD",
+              "defaultFractionDigits": 2,
+              "symbol": "$"
+            }
+          }
+        }
+      },
+      "generalizedCost": 2235,
+      "legs": [
+        {
+          "agencyTimeZoneOffset": -25200000,
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 545.48,
+          "endTime": "2009-10-21T23:33:25.000+00:00",
+          "from": {
+            "departure": "2009-10-21T23:26:53.000+00:00",
+            "lat": 45.52832,
+            "lon": -122.70059,
+            "name": "SW Johnson St. & NW 24th Ave. (P1)",
+            "vertexType": "NORMAL"
+          },
+          "generalizedCost": 773,
+          "interlineWithPreviousLeg": false,
+          "legElevation": "0,63.7,1,63.7,1,63.7,11,63.2,21,62.9,31,62.7,41,62.3,51,62.0,61,61.6,71,61.3,81,61.0,91,60.5,101,60.1,111,59.7,121,59.5,131,59.4,142,59.1,152,58.9,160,58.8,170,58.5,180,58.2,190,58.1,200,57.9,210,57.6,220,57.3,230,57.0,240,56.7,250,56.5,260,56.3,270,55.9,280,55.6,290,55.3,300,55.0,310,54.7,319,54.5,329,54.2,339,53.9,349,53.6,359,53.4,369,53.2,379,52.8,389,52.5,399,52.2,409,51.9,419,51.6,429,51.6,439,51.5,449,51.2,459,51.1,469,50.9,476,50.7,486,50.9,496,51.2,506,51.4,516,51.7,526,51.9,536,52.2,545,52.4",
+          "legGeometry": {
+            "length": 9,
+            "points": "}f{tGv}{kVC?EiJ?k@GwKGsKL?nBC?H"
+          },
+          "mode": "WALK",
+          "pathway": false,
+          "realTime": false,
+          "rentedBike": false,
+          "route": "",
+          "startTime": "2009-10-21T23:26:53.000+00:00",
+          "steps": [
+            {
+              "absoluteDirection": "NORTH",
+              "area": false,
+              "bogusName": false,
+              "distance": 1.42,
+              "elevation": "0,63.7,1,63.7",
+              "lat": 45.5283199,
+              "lon": -122.7005963,
+              "relativeDirection": "DEPART",
+              "stayOn": false,
+              "streetName": "Northwest 24th Avenue",
+              "walkingBike": false
+            },
+            {
+              "absoluteDirection": "EAST",
+              "area": false,
+              "bogusName": false,
+              "distance": 474.52,
+              "elevation": "0,63.7,10,63.2,20,62.9,30,62.7,40,62.3,50,62.0,60,61.6,70,61.3,80,61.0,90,60.5,100,60.1,110,59.7,120,59.5,130,59.4,141,59.1,141,59.1,151,58.9,158,58.8,158,58.8,168,58.5,178,58.2,188,58.1,198,57.9,208,57.6,218,57.3,228,57.0,238,56.7,248,56.5,258,56.3,268,55.9,278,55.6,288,55.3,298,55.0,308,54.7,317,54.5,317,54.5,327,54.2,337,53.9,347,53.6,357,53.4,367,53.2,377,52.8,387,52.5,397,52.2,407,51.9,417,51.6,427,51.6,437,51.5,447,51.2,457,51.1,467,50.9,475,50.7",
+              "lat": 45.5283327,
+              "lon": -122.7005966,
+              "relativeDirection": "RIGHT",
+              "stayOn": false,
+              "streetName": "Northwest Johnson Street",
+              "walkingBike": false
+            },
+            {
+              "absoluteDirection": "SOUTH",
+              "area": false,
+              "bogusName": false,
+              "distance": 69.54,
+              "elevation": "0,50.7,10,50.9,20,51.2,30,51.4,40,51.7,50,51.9,60,52.2,70,52.4",
+              "lat": 45.5284442,
+              "lon": -122.6945071,
+              "relativeDirection": "RIGHT",
+              "stayOn": false,
+              "streetName": "Northwest 21st Avenue",
+              "walkingBike": false
+            }
+          ],
+          "to": {
+            "arrival": "2009-10-21T23:33:25.000+00:00",
+            "departure": "2009-10-21T23:33:25.000+00:00",
+            "lat": 45.527818,
+            "lon": -122.694539,
+            "name": "NW 21st & Irving",
+            "stopCode": "7114",
+            "stopId": "prt:7114",
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "transitLeg": false,
+          "walkingBike": false
+        },
+        {
+          "agencyId": "prt:prt",
+          "agencyName": "TriMet",
+          "agencyTimeZoneOffset": -25200000,
+          "agencyUrl": "http://trimet.org",
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 1629.43,
+          "endTime": "2009-10-21T23:43:00.000+00:00",
+          "from": {
+            "arrival": "2009-10-21T23:33:25.000+00:00",
+            "departure": "2009-10-21T23:33:25.000+00:00",
+            "lat": 45.527818,
+            "lon": -122.694539,
+            "name": "NW 21st & Irving",
+            "stopCode": "7114",
+            "stopId": "prt:7114",
+            "stopIndex": 15,
+            "stopSequence": 16,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "generalizedCost": 1175,
+          "headsign": "136th Ave",
+          "interlineWithPreviousLeg": false,
+          "intermediateStops": [
+            {
+              "arrival": "2009-10-21T23:34:20.000+00:00",
+              "departure": "2009-10-21T23:34:20.000+00:00",
+              "lat": 45.526408,
+              "lon": -122.694503,
+              "name": "NW 21st & Glisan",
+              "stopCode": "7112",
+              "stopId": "prt:7112",
+              "stopIndex": 16,
+              "stopSequence": 17,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-10-21T23:35:31.000+00:00",
+              "departure": "2009-10-21T23:35:31.000+00:00",
+              "lat": 45.524833,
+              "lon": -122.69398,
+              "name": "NW Everett & 21st",
+              "stopCode": "1615",
+              "stopId": "prt:1615",
+              "stopIndex": 17,
+              "stopSequence": 18,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-10-21T23:37:07.000+00:00",
+              "departure": "2009-10-21T23:37:07.000+00:00",
+              "lat": 45.524935,
+              "lon": -122.690502,
+              "name": "NW Everett & 19th",
+              "stopCode": "1611",
+              "stopId": "prt:1611",
+              "stopIndex": 18,
+              "stopSequence": 19,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-10-21T23:39:28.000+00:00",
+              "departure": "2009-10-21T23:39:28.000+00:00",
+              "lat": 45.524981,
+              "lon": -122.68537,
+              "name": "NW Everett & 14th",
+              "stopCode": "1608",
+              "stopId": "prt:1608",
+              "stopIndex": 19,
+              "stopSequence": 20,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
+            },
+            {
+              "arrival": "2009-10-21T23:41:04.000+00:00",
+              "departure": "2009-10-21T23:41:04.000+00:00",
+              "lat": 45.525061,
+              "lon": -122.68187,
+              "name": "NW Everett & 11th",
+              "stopCode": "1607",
+              "stopId": "prt:1607",
+              "stopIndex": 20,
+              "stopSequence": 21,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
+            },
+            {
+              "arrival": "2009-10-21T23:42:15.000+00:00",
+              "departure": "2009-10-21T23:42:15.000+00:00",
+              "lat": 45.525096,
+              "lon": -122.67929,
+              "name": "NW Everett & Park",
+              "stopCode": "8402",
+              "stopId": "prt:8402",
+              "stopIndex": 21,
+              "stopSequence": 22,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
+            }
+          ],
+          "legGeometry": {
+            "length": 39,
+            "points": "{c{tGnwzkVR?lCEvBC??VAlCClCEAkA??A}BCkEAkECaD???g@CiECiEEiE?c@?o@?]Aa@?w@AoD???YEkEAkECiEA_A??AiCCkECmD???[A_CCiD"
+          },
+          "mode": "BUS",
+          "pathway": false,
+          "realTime": false,
+          "route": "Holgate/NW 21st",
+          "routeId": "prt:17",
+          "routeLongName": "Holgate/NW 21st",
+          "routeShortName": "17",
+          "routeType": 3,
+          "serviceDate": "2009-10-21",
+          "startTime": "2009-10-21T23:33:25.000+00:00",
+          "steps": [ ],
+          "to": {
+            "arrival": "2009-10-21T23:43:00.000+00:00",
+            "departure": "2009-10-21T23:43:00.000+00:00",
+            "lat": 45.525112,
+            "lon": -122.677664,
+            "name": "NW Everett & Broadway",
+            "stopCode": "1606",
+            "stopId": "prt:1606",
+            "stopIndex": 22,
+            "stopSequence": 23,
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
+          },
+          "transitLeg": true,
+          "tripBlockId": "1708",
+          "tripId": "prt:170W1470"
+        },
+        {
+          "agencyTimeZoneOffset": -25200000,
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 188.35,
+          "endTime": "2009-10-21T23:45:25.000+00:00",
+          "from": {
+            "arrival": "2009-10-21T23:43:00.000+00:00",
+            "departure": "2009-10-21T23:43:00.000+00:00",
+            "lat": 45.525112,
+            "lon": -122.677664,
+            "name": "NW Everett & Broadway",
+            "stopCode": "1606",
+            "stopId": "prt:1606",
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
+          },
+          "generalizedCost": 286,
+          "interlineWithPreviousLeg": false,
+          "legElevation": "0,29.3,13,29.5,23,29.5,33,29.5,43,29.5,53,29.5,63,29.4,73,29.4,83,29.3,88,29.2,98,29.4,108,29.5,118,29.5,128,29.5,138,29.5,148,29.4,161,29.3,170,29.3,170,29.3,180,29.5,188,29.6",
+          "legGeometry": {
+            "length": 15,
+            "points": "}rztGlnwkVM??C?[?SC_D?M?E?MCgD?A?O?C?M?a@"
+          },
+          "mode": "WALK",
+          "pathway": false,
+          "realTime": false,
+          "rentedBike": false,
+          "route": "",
+          "startTime": "2009-10-21T23:43:00.000+00:00",
+          "steps": [
+            {
+              "absoluteDirection": "EAST",
+              "area": false,
+              "bogusName": false,
+              "distance": 188.36,
+              "elevation": "0,29.3,13,29.5,26,29.5,36,29.5,46,29.5,56,29.5,66,29.5,76,29.4,86,29.4,96,29.3,101,29.2,101,29.2,111,29.4,121,29.5,131,29.5,141,29.5,151,29.5,161,29.4,174,29.3,174,29.3,183,29.3,183,29.3,193,29.5,201,29.6",
+              "lat": 45.5251827,
+              "lon": -122.6776666,
+              "relativeDirection": "DEPART",
+              "stayOn": false,
+              "streetName": "Northwest Everett Street",
+              "walkingBike": false
+            }
+          ],
+          "to": {
+            "arrival": "2009-10-21T23:45:25.000+00:00",
+            "lat": 45.52523,
+            "lon": -122.67525,
+            "name": "NW Everett St. & NW 5th Ave. (P3)",
+            "vertexType": "NORMAL"
+          },
+          "transitLeg": false,
+          "walkingBike": false
+        }
+      ],
+      "startTime": "2009-10-21T23:26:53.000+00:00",
+      "tooSloped": false,
+      "transfers": 0,
+      "transitTime": 575,
+      "waitingTime": 0,
+      "walkDistance": 733.83,
+      "walkLimitExceeded": false,
+      "walkTime": 537
+    },
+    {
+      "arrivedAtDestinationWithRentedBicycle": false,
       "duration": 1035,
       "elevationGained": 5.01,
       "elevationLost": 16.15,
@@ -850,7 +1179,7 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
           }
         }
       },
-      "generalizedCost": 2160,
+      "generalizedCost": 2282,
       "legs": [
         {
           "agencyTimeZoneOffset": -25200000,
@@ -915,7 +1244,7 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
               "lon": -122.7003923,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "way -102328 from 0",
+              "streetName": "path",
               "walkingBike": false
             }
           ],
@@ -952,7 +1281,7 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
             ],
             "vertexType": "BIKESHARE"
           },
-          "generalizedCost": 343,
+          "generalizedCost": 464,
           "interlineWithPreviousLeg": false,
           "legElevation": "0,66.2,13,66.6,23,65.7,33,64.9,43,64.1,53,63.1,63,62.5,73,62.5,83,62.1,93,61.9,103,61.7,113,61.4,123,61.1,133,60.9,143,60.6,158,60.2,168,59.9,178,59.6,188,59.3,198,59.0,208,58.7,218,58.4,228,58.1,238,57.8,248,57.5,258,57.1,268,56.8,278,56.6,288,56.4,298,56.2,308,55.9,316,55.7,326,55.5,336,55.3,346,55.0,356,54.7,366,54.4,376,54.1,386,53.8,396,53.6,406,53.5,416,53.3,426,53.3,440,53.0,450,52.9,460,52.8,474,52.6,474,52.6,484,52.4,493,52.2",
           "legGeometry": {
@@ -976,7 +1305,7 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
               "lon": -122.7003879,
               "relativeDirection": "HARD_RIGHT",
               "stayOn": false,
-              "streetName": "way -102328 from 0",
+              "streetName": "path",
               "walkingBike": true
             },
             {
@@ -1285,6 +1614,335 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
     },
     {
       "arrivedAtDestinationWithRentedBicycle": false,
+      "duration": 1112,
+      "elevationGained": 2.28,
+      "elevationLost": 13.43,
+      "endTime": "2009-10-21T23:54:25.000+00:00",
+      "fare": {
+        "details": {
+          "regular": [
+            {
+              "fareId": {
+                "feedId": "prt",
+                "id": "8"
+              },
+              "price": {
+                "cents": 200,
+                "currency": {
+                  "currency": "USD",
+                  "currencyCode": "USD",
+                  "defaultFractionDigits": 2,
+                  "symbol": "$"
+                }
+              },
+              "routes": [
+                {
+                  "feedId": "prt",
+                  "id": "17"
+                }
+              ]
+            }
+          ]
+        },
+        "fare": {
+          "regular": {
+            "cents": 200,
+            "currency": {
+              "currency": "USD",
+              "currencyCode": "USD",
+              "defaultFractionDigits": 2,
+              "symbol": "$"
+            }
+          }
+        }
+      },
+      "generalizedCost": 2235,
+      "legs": [
+        {
+          "agencyTimeZoneOffset": -25200000,
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 545.48,
+          "endTime": "2009-10-21T23:42:25.000+00:00",
+          "from": {
+            "departure": "2009-10-21T23:35:53.000+00:00",
+            "lat": 45.52832,
+            "lon": -122.70059,
+            "name": "SW Johnson St. & NW 24th Ave. (P1)",
+            "vertexType": "NORMAL"
+          },
+          "generalizedCost": 773,
+          "interlineWithPreviousLeg": false,
+          "legElevation": "0,63.7,1,63.7,1,63.7,11,63.2,21,62.9,31,62.7,41,62.3,51,62.0,61,61.6,71,61.3,81,61.0,91,60.5,101,60.1,111,59.7,121,59.5,131,59.4,142,59.1,152,58.9,160,58.8,170,58.5,180,58.2,190,58.1,200,57.9,210,57.6,220,57.3,230,57.0,240,56.7,250,56.5,260,56.3,270,55.9,280,55.6,290,55.3,300,55.0,310,54.7,319,54.5,329,54.2,339,53.9,349,53.6,359,53.4,369,53.2,379,52.8,389,52.5,399,52.2,409,51.9,419,51.6,429,51.6,439,51.5,449,51.2,459,51.1,469,50.9,476,50.7,486,50.9,496,51.2,506,51.4,516,51.7,526,51.9,536,52.2,545,52.4",
+          "legGeometry": {
+            "length": 9,
+            "points": "}f{tGv}{kVC?EiJ?k@GwKGsKL?nBC?H"
+          },
+          "mode": "WALK",
+          "pathway": false,
+          "realTime": false,
+          "rentedBike": false,
+          "route": "",
+          "startTime": "2009-10-21T23:35:53.000+00:00",
+          "steps": [
+            {
+              "absoluteDirection": "NORTH",
+              "area": false,
+              "bogusName": false,
+              "distance": 1.42,
+              "elevation": "0,63.7,1,63.7",
+              "lat": 45.5283199,
+              "lon": -122.7005963,
+              "relativeDirection": "DEPART",
+              "stayOn": false,
+              "streetName": "Northwest 24th Avenue",
+              "walkingBike": false
+            },
+            {
+              "absoluteDirection": "EAST",
+              "area": false,
+              "bogusName": false,
+              "distance": 474.52,
+              "elevation": "0,63.7,10,63.2,20,62.9,30,62.7,40,62.3,50,62.0,60,61.6,70,61.3,80,61.0,90,60.5,100,60.1,110,59.7,120,59.5,130,59.4,141,59.1,141,59.1,151,58.9,158,58.8,158,58.8,168,58.5,178,58.2,188,58.1,198,57.9,208,57.6,218,57.3,228,57.0,238,56.7,248,56.5,258,56.3,268,55.9,278,55.6,288,55.3,298,55.0,308,54.7,317,54.5,317,54.5,327,54.2,337,53.9,347,53.6,357,53.4,367,53.2,377,52.8,387,52.5,397,52.2,407,51.9,417,51.6,427,51.6,437,51.5,447,51.2,457,51.1,467,50.9,475,50.7",
+              "lat": 45.5283327,
+              "lon": -122.7005966,
+              "relativeDirection": "RIGHT",
+              "stayOn": false,
+              "streetName": "Northwest Johnson Street",
+              "walkingBike": false
+            },
+            {
+              "absoluteDirection": "SOUTH",
+              "area": false,
+              "bogusName": false,
+              "distance": 69.54,
+              "elevation": "0,50.7,10,50.9,20,51.2,30,51.4,40,51.7,50,51.9,60,52.2,70,52.4",
+              "lat": 45.5284442,
+              "lon": -122.6945071,
+              "relativeDirection": "RIGHT",
+              "stayOn": false,
+              "streetName": "Northwest 21st Avenue",
+              "walkingBike": false
+            }
+          ],
+          "to": {
+            "arrival": "2009-10-21T23:42:25.000+00:00",
+            "departure": "2009-10-21T23:42:25.000+00:00",
+            "lat": 45.527818,
+            "lon": -122.694539,
+            "name": "NW 21st & Irving",
+            "stopCode": "7114",
+            "stopId": "prt:7114",
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "transitLeg": false,
+          "walkingBike": false
+        },
+        {
+          "agencyId": "prt:prt",
+          "agencyName": "TriMet",
+          "agencyTimeZoneOffset": -25200000,
+          "agencyUrl": "http://trimet.org",
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 1629.43,
+          "endTime": "2009-10-21T23:52:00.000+00:00",
+          "from": {
+            "arrival": "2009-10-21T23:42:25.000+00:00",
+            "departure": "2009-10-21T23:42:25.000+00:00",
+            "lat": 45.527818,
+            "lon": -122.694539,
+            "name": "NW 21st & Irving",
+            "stopCode": "7114",
+            "stopId": "prt:7114",
+            "stopIndex": 50,
+            "stopSequence": 51,
+            "vertexType": "TRANSIT",
+            "zoneId": "1"
+          },
+          "generalizedCost": 1175,
+          "headsign": "136th Ave",
+          "interlineWithPreviousLeg": false,
+          "intermediateStops": [
+            {
+              "arrival": "2009-10-21T23:43:20.000+00:00",
+              "departure": "2009-10-21T23:43:20.000+00:00",
+              "lat": 45.526408,
+              "lon": -122.694503,
+              "name": "NW 21st & Glisan",
+              "stopCode": "7112",
+              "stopId": "prt:7112",
+              "stopIndex": 51,
+              "stopSequence": 52,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-10-21T23:44:31.000+00:00",
+              "departure": "2009-10-21T23:44:31.000+00:00",
+              "lat": 45.524833,
+              "lon": -122.69398,
+              "name": "NW Everett & 21st",
+              "stopCode": "1615",
+              "stopId": "prt:1615",
+              "stopIndex": 52,
+              "stopSequence": 53,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-10-21T23:46:07.000+00:00",
+              "departure": "2009-10-21T23:46:07.000+00:00",
+              "lat": 45.524935,
+              "lon": -122.690502,
+              "name": "NW Everett & 19th",
+              "stopCode": "1611",
+              "stopId": "prt:1611",
+              "stopIndex": 53,
+              "stopSequence": 54,
+              "vertexType": "TRANSIT",
+              "zoneId": "1"
+            },
+            {
+              "arrival": "2009-10-21T23:48:28.000+00:00",
+              "departure": "2009-10-21T23:48:28.000+00:00",
+              "lat": 45.524981,
+              "lon": -122.68537,
+              "name": "NW Everett & 14th",
+              "stopCode": "1608",
+              "stopId": "prt:1608",
+              "stopIndex": 54,
+              "stopSequence": 55,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
+            },
+            {
+              "arrival": "2009-10-21T23:50:04.000+00:00",
+              "departure": "2009-10-21T23:50:04.000+00:00",
+              "lat": 45.525061,
+              "lon": -122.68187,
+              "name": "NW Everett & 11th",
+              "stopCode": "1607",
+              "stopId": "prt:1607",
+              "stopIndex": 55,
+              "stopSequence": 56,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
+            },
+            {
+              "arrival": "2009-10-21T23:51:15.000+00:00",
+              "departure": "2009-10-21T23:51:15.000+00:00",
+              "lat": 45.525096,
+              "lon": -122.67929,
+              "name": "NW Everett & Park",
+              "stopCode": "8402",
+              "stopId": "prt:8402",
+              "stopIndex": 56,
+              "stopSequence": 57,
+              "vertexType": "TRANSIT",
+              "zoneId": "0"
+            }
+          ],
+          "legGeometry": {
+            "length": 39,
+            "points": "{c{tGnwzkVR?lCEvBC??VAlCClCEAkA??A}BCkEAkECaD???g@CiECiEEiE?c@?o@?]Aa@?w@AoD???YEkEAkECiEA_A??AiCCkECmD???[A_CCiD"
+          },
+          "mode": "BUS",
+          "pathway": false,
+          "realTime": false,
+          "route": "Holgate/NW 21st",
+          "routeId": "prt:17",
+          "routeLongName": "Holgate/NW 21st",
+          "routeShortName": "17",
+          "routeType": 3,
+          "serviceDate": "2009-10-21",
+          "startTime": "2009-10-21T23:42:25.000+00:00",
+          "steps": [ ],
+          "to": {
+            "arrival": "2009-10-21T23:52:00.000+00:00",
+            "departure": "2009-10-21T23:52:00.000+00:00",
+            "lat": 45.525112,
+            "lon": -122.677664,
+            "name": "NW Everett & Broadway",
+            "stopCode": "1606",
+            "stopId": "prt:1606",
+            "stopIndex": 57,
+            "stopSequence": 58,
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
+          },
+          "transitLeg": true,
+          "tripBlockId": "1705",
+          "tripId": "prt:170W1480"
+        },
+        {
+          "agencyTimeZoneOffset": -25200000,
+          "arrivalDelay": 0,
+          "departureDelay": 0,
+          "distance": 188.35,
+          "endTime": "2009-10-21T23:54:25.000+00:00",
+          "from": {
+            "arrival": "2009-10-21T23:52:00.000+00:00",
+            "departure": "2009-10-21T23:52:00.000+00:00",
+            "lat": 45.525112,
+            "lon": -122.677664,
+            "name": "NW Everett & Broadway",
+            "stopCode": "1606",
+            "stopId": "prt:1606",
+            "vertexType": "TRANSIT",
+            "zoneId": "0"
+          },
+          "generalizedCost": 286,
+          "interlineWithPreviousLeg": false,
+          "legElevation": "0,29.3,13,29.5,23,29.5,33,29.5,43,29.5,53,29.5,63,29.4,73,29.4,83,29.3,88,29.2,98,29.4,108,29.5,118,29.5,128,29.5,138,29.5,148,29.4,161,29.3,170,29.3,170,29.3,180,29.5,188,29.6",
+          "legGeometry": {
+            "length": 15,
+            "points": "}rztGlnwkVM??C?[?SC_D?M?E?MCgD?A?O?C?M?a@"
+          },
+          "mode": "WALK",
+          "pathway": false,
+          "realTime": false,
+          "rentedBike": false,
+          "route": "",
+          "startTime": "2009-10-21T23:52:00.000+00:00",
+          "steps": [
+            {
+              "absoluteDirection": "EAST",
+              "area": false,
+              "bogusName": false,
+              "distance": 188.36,
+              "elevation": "0,29.3,13,29.5,26,29.5,36,29.5,46,29.5,56,29.5,66,29.5,76,29.4,86,29.4,96,29.3,101,29.2,101,29.2,111,29.4,121,29.5,131,29.5,141,29.5,151,29.5,161,29.4,174,29.3,174,29.3,183,29.3,183,29.3,193,29.5,201,29.6",
+              "lat": 45.5251827,
+              "lon": -122.6776666,
+              "relativeDirection": "DEPART",
+              "stayOn": false,
+              "streetName": "Northwest Everett Street",
+              "walkingBike": false
+            }
+          ],
+          "to": {
+            "arrival": "2009-10-21T23:54:25.000+00:00",
+            "lat": 45.52523,
+            "lon": -122.67525,
+            "name": "NW Everett St. & NW 5th Ave. (P3)",
+            "vertexType": "NORMAL"
+          },
+          "transitLeg": false,
+          "walkingBike": false
+        }
+      ],
+      "startTime": "2009-10-21T23:35:53.000+00:00",
+      "tooSloped": false,
+      "transfers": 0,
+      "transitTime": 575,
+      "waitingTime": 0,
+      "walkDistance": 733.83,
+      "walkLimitExceeded": false,
+      "walkTime": 537
+    },
+    {
+      "arrivedAtDestinationWithRentedBicycle": false,
       "duration": 1035,
       "elevationGained": 5.01,
       "elevationLost": 16.15,
@@ -1327,7 +1985,7 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
           }
         }
       },
-      "generalizedCost": 2160,
+      "generalizedCost": 2282,
       "legs": [
         {
           "agencyTimeZoneOffset": -25200000,
@@ -1392,7 +2050,7 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
               "lon": -122.7003923,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "way -102328 from 0",
+              "streetName": "path",
               "walkingBike": false
             }
           ],
@@ -1429,7 +2087,7 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
             ],
             "vertexType": "BIKESHARE"
           },
-          "generalizedCost": 343,
+          "generalizedCost": 464,
           "interlineWithPreviousLeg": false,
           "legElevation": "0,66.2,13,66.6,23,65.7,33,64.9,43,64.1,53,63.1,63,62.5,73,62.5,83,62.1,93,61.9,103,61.7,113,61.4,123,61.1,133,60.9,143,60.6,158,60.2,168,59.9,178,59.6,188,59.3,198,59.0,208,58.7,218,58.4,228,58.1,238,57.8,248,57.5,258,57.1,268,56.8,278,56.6,288,56.4,298,56.2,308,55.9,316,55.7,326,55.5,336,55.3,346,55.0,356,54.7,366,54.4,376,54.1,386,53.8,396,53.6,406,53.5,416,53.3,426,53.3,440,53.0,450,52.9,460,52.8,474,52.6,474,52.6,484,52.4,493,52.2",
           "legGeometry": {
@@ -1453,7 +2111,7 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
               "lon": -122.7003879,
               "relativeDirection": "HARD_RIGHT",
               "stayOn": false,
-              "streetName": "way -102328 from 0",
+              "streetName": "path",
               "walkingBike": true
             },
             {
@@ -1759,812 +2417,6 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.accessBikeRe
       "walkDistance": 817.83,
       "walkLimitExceeded": false,
       "walkTime": 460
-    },
-    {
-      "arrivedAtDestinationWithRentedBicycle": false,
-      "duration": 1000,
-      "elevationGained": 3.15,
-      "elevationLost": 3.93,
-      "endTime": "2009-10-21T23:56:10.000+00:00",
-      "fare": {
-        "details": {
-          "regular": [
-            {
-              "fareId": {
-                "feedId": "prt",
-                "id": "8"
-              },
-              "price": {
-                "cents": 200,
-                "currency": {
-                  "currency": "USD",
-                  "currencyCode": "USD",
-                  "defaultFractionDigits": 2,
-                  "symbol": "$"
-                }
-              },
-              "routes": [
-                {
-                  "feedId": "prt",
-                  "id": "77"
-                }
-              ]
-            }
-          ]
-        },
-        "fare": {
-          "regular": {
-            "cents": 200,
-            "currency": {
-              "currency": "USD",
-              "currencyCode": "USD",
-              "defaultFractionDigits": 2,
-              "symbol": "$"
-            }
-          }
-        }
-      },
-      "generalizedCost": 1803,
-      "legs": [
-        {
-          "agencyTimeZoneOffset": -25200000,
-          "arrivalDelay": 0,
-          "departureDelay": 0,
-          "distance": 220.15,
-          "endTime": "2009-10-21T23:42:21.000+00:00",
-          "from": {
-            "departure": "2009-10-21T23:39:30.000+00:00",
-            "lat": 45.52832,
-            "lon": -122.70059,
-            "name": "SW Johnson St. & NW 24th Ave. (P1)",
-            "vertexType": "NORMAL"
-          },
-          "generalizedCost": 334,
-          "interlineWithPreviousLeg": false,
-          "legElevation": "0,63.7,1,63.7,1,63.7,11,63.4,21,63.2,31,63.3,41,63.5,51,63.3,61,62.9,71,62.5,81,62.2,91,62.0,101,61.7,111,61.5,121,61.2,131,60.9,141,60.6,151,60.3,160,60.2,170,60.7,180,61.1,190,61.6,200,61.9,210,62.4,220,62.9",
-          "legGeometry": {
-            "length": 6,
-            "points": "}f{tGv}{kVC?mCBmCD@zCN?"
-          },
-          "mode": "WALK",
-          "pathway": false,
-          "realTime": false,
-          "rentedBike": false,
-          "route": "",
-          "startTime": "2009-10-21T23:39:30.000+00:00",
-          "steps": [
-            {
-              "absoluteDirection": "NORTH",
-              "area": false,
-              "bogusName": false,
-              "distance": 159.62,
-              "elevation": "0,63.7,1,63.7,3,63.7,13,63.4,23,63.2,33,63.3,43,63.5,53,63.3,63,62.9,73,62.5,83,62.2,83,62.2,93,62.0,103,61.7,113,61.5,123,61.2,133,60.9,143,60.6,153,60.3,161,60.2",
-              "lat": 45.5283199,
-              "lon": -122.7005963,
-              "relativeDirection": "DEPART",
-              "stayOn": false,
-              "streetName": "Northwest 24th Avenue",
-              "walkingBike": false
-            },
-            {
-              "absoluteDirection": "WEST",
-              "area": false,
-              "bogusName": false,
-              "distance": 60.52,
-              "elevation": "0,60.2,10,60.7,20,61.1,30,61.6,40,61.9,50,62.4,61,62.9",
-              "lat": 45.529755,
-              "lon": -122.7006488,
-              "relativeDirection": "LEFT",
-              "stayOn": false,
-              "streetName": "Northwest Lovejoy Street",
-              "walkingBike": false
-            }
-          ],
-          "to": {
-            "arrival": "2009-10-21T23:42:21.000+00:00",
-            "departure": "2009-10-21T23:42:21.000+00:00",
-            "lat": 45.529662,
-            "lon": -122.701423,
-            "name": "2400 Block NW Lovejoy",
-            "stopCode": "3589",
-            "stopId": "prt:3589",
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
-          },
-          "transitLeg": false,
-          "walkingBike": false
-        },
-        {
-          "agencyId": "prt:prt",
-          "agencyName": "TriMet",
-          "agencyTimeZoneOffset": -25200000,
-          "agencyUrl": "http://trimet.org",
-          "arrivalDelay": 0,
-          "departureDelay": 0,
-          "distance": 2804.13,
-          "endTime": "2009-10-21T23:55:32.000+00:00",
-          "from": {
-            "arrival": "2009-10-21T23:42:21.000+00:00",
-            "departure": "2009-10-21T23:42:21.000+00:00",
-            "lat": 45.529662,
-            "lon": -122.701423,
-            "name": "2400 Block NW Lovejoy",
-            "stopCode": "3589",
-            "stopId": "prt:3589",
-            "stopIndex": 6,
-            "stopSequence": 7,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
-          },
-          "generalizedCost": 1391,
-          "headsign": "Troutdale",
-          "interlineWithPreviousLeg": false,
-          "intermediateStops": [
-            {
-              "arrival": "2009-10-21T23:43:54.000+00:00",
-              "departure": "2009-10-21T23:43:54.000+00:00",
-              "lat": 45.529746,
-              "lon": -122.69688,
-              "name": "NW Lovejoy & 22nd",
-              "stopCode": "3596",
-              "stopId": "prt:3596",
-              "stopIndex": 7,
-              "stopSequence": 8,
-              "vertexType": "TRANSIT",
-              "zoneId": "1"
-            },
-            {
-              "arrival": "2009-10-21T23:44:39.000+00:00",
-              "departure": "2009-10-21T23:44:39.000+00:00",
-              "lat": 45.529833,
-              "lon": -122.694676,
-              "name": "NW Lovejoy & 21st",
-              "stopCode": "3595",
-              "stopId": "prt:3595",
-              "stopIndex": 8,
-              "stopSequence": 9,
-              "vertexType": "TRANSIT",
-              "zoneId": "1"
-            },
-            {
-              "arrival": "2009-10-21T23:46:23.000+00:00",
-              "departure": "2009-10-21T23:46:23.000+00:00",
-              "lat": 45.529925,
-              "lon": -122.689587,
-              "name": "NW Lovejoy & 18th",
-              "stopCode": "10751",
-              "stopId": "prt:10751",
-              "stopIndex": 9,
-              "stopSequence": 10,
-              "vertexType": "TRANSIT",
-              "zoneId": "1"
-            },
-            {
-              "arrival": "2009-10-21T23:48:05.000+00:00",
-              "departure": "2009-10-21T23:48:05.000+00:00",
-              "lat": 45.529997,
-              "lon": -122.684611,
-              "name": "NW Lovejoy & 13th",
-              "stopCode": "10752",
-              "stopId": "prt:10752",
-              "stopIndex": 10,
-              "stopSequence": 11,
-              "vertexType": "TRANSIT",
-              "zoneId": "1"
-            },
-            {
-              "arrival": "2009-10-21T23:49:07.000+00:00",
-              "departure": "2009-10-21T23:49:07.000+00:00",
-              "lat": 45.530034,
-              "lon": -122.68155,
-              "name": "NW Lovejoy & 10th",
-              "stopCode": "11000",
-              "stopId": "prt:11000",
-              "stopIndex": 11,
-              "stopSequence": 12,
-              "vertexType": "TRANSIT",
-              "zoneId": "1"
-            },
-            {
-              "arrival": "2009-10-21T23:50:00.000+00:00",
-              "departure": "2009-10-21T23:50:00.000+00:00",
-              "lat": 45.531086,
-              "lon": -122.680302,
-              "name": "NW 9th & Marshall",
-              "stopCode": "12803",
-              "stopId": "prt:12803",
-              "stopIndex": 12,
-              "stopSequence": 13,
-              "vertexType": "TRANSIT",
-              "zoneId": "1"
-            },
-            {
-              "arrival": "2009-10-21T23:52:50.000+00:00",
-              "departure": "2009-10-21T23:52:50.000+00:00",
-              "lat": 45.528405,
-              "lon": -122.676979,
-              "name": "NW Station Way & Union Station",
-              "stopCode": "12804",
-              "stopId": "prt:12804",
-              "stopIndex": 13,
-              "stopSequence": 14,
-              "vertexType": "TRANSIT",
-              "zoneId": "0"
-            }
-          ],
-          "legGeometry": {
-            "length": 60,
-            "points": "yo{tG|b|kVC}CEuKGwI???}@G{J???YGsKEuKCuD???UCiECeEAgA?{@AkA?WAwDE{C???i@CiECkECcD??Ae@?mE{BDQ@q@@??{ADCsDbBiB`DaEt@_AVANIX?tBCLK`@c@\\c@l@w@??\\c@FKDCFEXCCgEvBEVAlCClCEnCECoD"
-          },
-          "mode": "BUS",
-          "pathway": false,
-          "realTime": false,
-          "route": "Broadway/Halsey",
-          "routeId": "prt:77",
-          "routeLongName": "Broadway/Halsey",
-          "routeShortName": "77",
-          "routeType": 3,
-          "serviceDate": "2009-10-21",
-          "startTime": "2009-10-21T23:42:21.000+00:00",
-          "steps": [ ],
-          "to": {
-            "arrival": "2009-10-21T23:55:32.000+00:00",
-            "departure": "2009-10-21T23:55:32.000+00:00",
-            "lat": 45.525183,
-            "lon": -122.674607,
-            "name": "NW Everett & 4th",
-            "stopCode": "9546",
-            "stopId": "prt:9546",
-            "stopIndex": 14,
-            "stopSequence": 15,
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
-          },
-          "transitLeg": true,
-          "tripBlockId": "7703",
-          "tripId": "prt:770W1400"
-        },
-        {
-          "agencyTimeZoneOffset": -25200000,
-          "arrivalDelay": 0,
-          "departureDelay": 0,
-          "distance": 49.94,
-          "endTime": "2009-10-21T23:56:10.000+00:00",
-          "from": {
-            "arrival": "2009-10-21T23:55:32.000+00:00",
-            "departure": "2009-10-21T23:55:32.000+00:00",
-            "lat": 45.525183,
-            "lon": -122.674607,
-            "name": "NW Everett & 4th",
-            "stopCode": "9546",
-            "stopId": "prt:9546",
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
-          },
-          "generalizedCost": 77,
-          "interlineWithPreviousLeg": false,
-          "legElevation": "0,29.5,10,29.5,20,29.5,30,29.5,40,29.6,50,29.6",
-          "legGeometry": {
-            "length": 3,
-            "points": "ksztGh{vkVI?@~B"
-          },
-          "mode": "WALK",
-          "pathway": false,
-          "realTime": false,
-          "rentedBike": false,
-          "route": "",
-          "startTime": "2009-10-21T23:55:32.000+00:00",
-          "steps": [
-            {
-              "absoluteDirection": "WEST",
-              "area": false,
-              "bogusName": false,
-              "distance": 49.94,
-              "elevation": "0,29.5,10,29.5,20,29.5,30,29.5,40,29.6,50,29.6",
-              "lat": 45.5252397,
-              "lon": -122.6746091,
-              "relativeDirection": "DEPART",
-              "stayOn": false,
-              "streetName": "Northwest Everett Street",
-              "walkingBike": false
-            }
-          ],
-          "to": {
-            "arrival": "2009-10-21T23:56:10.000+00:00",
-            "lat": 45.52523,
-            "lon": -122.67525,
-            "name": "NW Everett St. & NW 5th Ave. (P3)",
-            "vertexType": "NORMAL"
-          },
-          "transitLeg": false,
-          "walkingBike": false
-        }
-      ],
-      "startTime": "2009-10-21T23:39:30.000+00:00",
-      "tooSloped": false,
-      "transfers": 0,
-      "transitTime": 791,
-      "waitingTime": 0,
-      "walkDistance": 270.09,
-      "walkLimitExceeded": false,
-      "walkTime": 209
-    },
-    {
-      "arrivedAtDestinationWithRentedBicycle": false,
-      "duration": 1035,
-      "elevationGained": 5.01,
-      "elevationLost": 16.15,
-      "endTime": "2009-10-22T00:03:25.000+00:00",
-      "fare": {
-        "details": {
-          "regular": [
-            {
-              "fareId": {
-                "feedId": "prt",
-                "id": "8"
-              },
-              "price": {
-                "cents": 200,
-                "currency": {
-                  "currency": "USD",
-                  "currencyCode": "USD",
-                  "defaultFractionDigits": 2,
-                  "symbol": "$"
-                }
-              },
-              "routes": [
-                {
-                  "feedId": "prt",
-                  "id": "17"
-                }
-              ]
-            }
-          ]
-        },
-        "fare": {
-          "regular": {
-            "cents": 200,
-            "currency": {
-              "currency": "USD",
-              "currencyCode": "USD",
-              "defaultFractionDigits": 2,
-              "symbol": "$"
-            }
-          }
-        }
-      },
-      "generalizedCost": 2160,
-      "legs": [
-        {
-          "agencyTimeZoneOffset": -25200000,
-          "arrivalDelay": 0,
-          "departureDelay": 0,
-          "distance": 106.59,
-          "endTime": "2009-10-21T23:48:48.000+00:00",
-          "from": {
-            "departure": "2009-10-21T23:46:10.000+00:00",
-            "lat": 45.52832,
-            "lon": -122.70059,
-            "name": "SW Johnson St. & NW 24th Ave. (P1)",
-            "vertexType": "NORMAL"
-          },
-          "generalizedCost": 304,
-          "interlineWithPreviousLeg": false,
-          "legElevation": "0,63.7,9,64.1,19,64.7,29,65.2,39,65.8,49,66.3,59,66.8,69,67.2,79,67.4,79,67.4,93,66.6,107,66.2",
-          "legGeometry": {
-            "length": 4,
-            "points": "}f{tGv}{kVjCA?e@WA"
-          },
-          "mode": "WALK",
-          "pathway": false,
-          "realTime": false,
-          "rentedBike": false,
-          "route": "",
-          "startTime": "2009-10-21T23:46:10.000+00:00",
-          "steps": [
-            {
-              "absoluteDirection": "SOUTH",
-              "area": false,
-              "bogusName": false,
-              "distance": 78.53,
-              "elevation": "0,63.7,9,64.1,19,64.7,29,65.2,39,65.8,49,66.3,59,66.8,69,67.2,79,67.4",
-              "lat": 45.5283199,
-              "lon": -122.7005963,
-              "relativeDirection": "DEPART",
-              "stayOn": false,
-              "streetName": "Northwest 24th Avenue",
-              "walkingBike": false
-            },
-            {
-              "absoluteDirection": "EAST",
-              "area": false,
-              "bogusName": false,
-              "distance": 14.7,
-              "elevation": "0,67.4,15,66.6",
-              "lat": 45.5276138,
-              "lon": -122.700581,
-              "relativeDirection": "LEFT",
-              "stayOn": false,
-              "streetName": "Northwest Irving Street",
-              "walkingBike": false
-            },
-            {
-              "absoluteDirection": "NORTH",
-              "area": false,
-              "bogusName": true,
-              "distance": 13.36,
-              "elevation": "0,66.6,13,66.2",
-              "lat": 45.5276173,
-              "lon": -122.7003923,
-              "relativeDirection": "LEFT",
-              "stayOn": false,
-              "streetName": "way -102328 from 0",
-              "walkingBike": false
-            }
-          ],
-          "to": {
-            "arrival": "2009-10-21T23:48:48.000+00:00",
-            "bikeShareId": "-102309",
-            "departure": "2009-10-21T23:48:48.000+00:00",
-            "lat": 45.5277374,
-            "lon": -122.7003879,
-            "name": "-102309",
-            "networks": [
-              "test-network"
-            ],
-            "vertexType": "BIKESHARE"
-          },
-          "transitLeg": false,
-          "walkingBike": false
-        },
-        {
-          "agencyTimeZoneOffset": -25200000,
-          "arrivalDelay": 0,
-          "departureDelay": 0,
-          "distance": 493.43,
-          "endTime": "2009-10-21T23:50:57.000+00:00",
-          "from": {
-            "arrival": "2009-10-21T23:48:48.000+00:00",
-            "bikeShareId": "-102309",
-            "departure": "2009-10-21T23:48:48.000+00:00",
-            "lat": 45.5277374,
-            "lon": -122.7003879,
-            "name": "-102309",
-            "networks": [
-              "test-network"
-            ],
-            "vertexType": "BIKESHARE"
-          },
-          "generalizedCost": 343,
-          "interlineWithPreviousLeg": false,
-          "legElevation": "0,66.2,13,66.6,23,65.7,33,64.9,43,64.1,53,63.1,63,62.5,73,62.5,83,62.1,93,61.9,103,61.7,113,61.4,123,61.1,133,60.9,143,60.6,158,60.2,168,59.9,178,59.6,188,59.3,198,59.0,208,58.7,218,58.4,228,58.1,238,57.8,248,57.5,258,57.1,268,56.8,278,56.6,288,56.4,298,56.2,308,55.9,316,55.7,326,55.5,336,55.3,346,55.0,356,54.7,366,54.4,376,54.1,386,53.8,396,53.6,406,53.5,416,53.3,426,53.3,440,53.0,450,52.9,460,52.8,474,52.6,474,52.6,484,52.4,493,52.2",
-          "legGeometry": {
-            "length": 7,
-            "points": "ic{tGl|{kVV@GsJEuKE}HAwAAo@"
-          },
-          "mode": "BICYCLE",
-          "pathway": false,
-          "realTime": false,
-          "rentedBike": true,
-          "route": "",
-          "startTime": "2009-10-21T23:48:48.000+00:00",
-          "steps": [
-            {
-              "absoluteDirection": "SOUTH",
-              "area": false,
-              "bogusName": true,
-              "distance": 13.36,
-              "elevation": "0,66.2,13,66.6",
-              "lat": 45.5277374,
-              "lon": -122.7003879,
-              "relativeDirection": "HARD_RIGHT",
-              "stayOn": false,
-              "streetName": "way -102328 from 0",
-              "walkingBike": true
-            },
-            {
-              "absoluteDirection": "EAST",
-              "area": false,
-              "bogusName": false,
-              "distance": 480.08,
-              "elevation": "0,66.6,10,65.7,20,64.9,30,64.1,40,63.1,50,62.5,60,62.5,70,62.1,80,61.9,90,61.7,100,61.4,110,61.1,120,60.9,130,60.6,145,60.2,289,60.2,299,59.9,309,59.6,319,59.3,329,59.0,339,58.7,349,58.4,359,58.1,369,57.8,379,57.5,389,57.1,399,56.8,409,56.6,419,56.4,429,56.2,439,55.9,447,55.7,447,55.7,457,55.5,467,55.3,477,55.0,487,54.7,497,54.4,507,54.1,517,53.8,527,53.6,537,53.5,547,53.3,557,53.3,571,53.0,571,53.0,581,52.9,591,52.8,605,52.6,605,52.6,615,52.4,625,52.2",
-              "lat": 45.5276173,
-              "lon": -122.7003923,
-              "relativeDirection": "LEFT",
-              "stayOn": false,
-              "streetName": "Northwest Irving Street",
-              "walkingBike": false
-            }
-          ],
-          "to": {
-            "arrival": "2009-10-21T23:50:57.000+00:00",
-            "bikeShareId": "-102323",
-            "departure": "2009-10-21T23:50:57.000+00:00",
-            "lat": 45.5278491,
-            "lon": -122.6942362,
-            "name": "-102323",
-            "networks": [
-              "test-network"
-            ],
-            "vertexType": "BIKESHARE"
-          },
-          "transitLeg": false,
-          "walkingBike": false
-        },
-        {
-          "agencyTimeZoneOffset": -25200000,
-          "arrivalDelay": 0,
-          "departureDelay": 0,
-          "distance": 29.46,
-          "endTime": "2009-10-21T23:51:25.000+00:00",
-          "from": {
-            "arrival": "2009-10-21T23:50:57.000+00:00",
-            "bikeShareId": "-102323",
-            "departure": "2009-10-21T23:50:57.000+00:00",
-            "lat": 45.5278491,
-            "lon": -122.6942362,
-            "name": "-102323",
-            "networks": [
-              "test-network"
-            ],
-            "vertexType": "BIKESHARE"
-          },
-          "generalizedCost": 50,
-          "interlineWithPreviousLeg": false,
-          "legElevation": "0,52.2,2,52.2,12,52.5,19,52.6,19,52.6,29,52.4",
-          "legGeometry": {
-            "length": 5,
-            "points": "ic{tG~uzkV@n@M@C??H"
-          },
-          "mode": "WALK",
-          "pathway": false,
-          "realTime": false,
-          "rentedBike": false,
-          "route": "",
-          "startTime": "2009-10-21T23:50:57.000+00:00",
-          "steps": [
-            {
-              "absoluteDirection": "WEST",
-              "area": false,
-              "bogusName": false,
-              "distance": 19.29,
-              "elevation": "0,52.2,2,52.2,12,52.5,19,52.6",
-              "lat": 45.5277322,
-              "lon": -122.6942318,
-              "relativeDirection": "HARD_LEFT",
-              "stayOn": false,
-              "streetName": "Northwest Irving Street",
-              "walkingBike": false
-            },
-            {
-              "absoluteDirection": "NORTH",
-              "area": false,
-              "bogusName": false,
-              "distance": 10.17,
-              "elevation": "0,52.6,10,52.4",
-              "lat": 45.5277276,
-              "lon": -122.6944793,
-              "relativeDirection": "RIGHT",
-              "stayOn": false,
-              "streetName": "Northwest 21st Avenue",
-              "walkingBike": false
-            }
-          ],
-          "to": {
-            "arrival": "2009-10-21T23:51:25.000+00:00",
-            "departure": "2009-10-21T23:51:25.000+00:00",
-            "lat": 45.527818,
-            "lon": -122.694539,
-            "name": "NW 21st & Irving",
-            "stopCode": "7114",
-            "stopId": "prt:7114",
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
-          },
-          "transitLeg": false,
-          "walkingBike": false
-        },
-        {
-          "agencyId": "prt:prt",
-          "agencyName": "TriMet",
-          "agencyTimeZoneOffset": -25200000,
-          "agencyUrl": "http://trimet.org",
-          "arrivalDelay": 0,
-          "departureDelay": 0,
-          "distance": 1629.43,
-          "endTime": "2009-10-22T00:01:00.000+00:00",
-          "from": {
-            "arrival": "2009-10-21T23:51:25.000+00:00",
-            "departure": "2009-10-21T23:51:25.000+00:00",
-            "lat": 45.527818,
-            "lon": -122.694539,
-            "name": "NW 21st & Irving",
-            "stopCode": "7114",
-            "stopId": "prt:7114",
-            "stopIndex": 8,
-            "stopSequence": 9,
-            "vertexType": "TRANSIT",
-            "zoneId": "1"
-          },
-          "generalizedCost": 1175,
-          "headsign": "136th Ave",
-          "interlineWithPreviousLeg": false,
-          "intermediateStops": [
-            {
-              "arrival": "2009-10-21T23:52:20.000+00:00",
-              "departure": "2009-10-21T23:52:20.000+00:00",
-              "lat": 45.526408,
-              "lon": -122.694503,
-              "name": "NW 21st & Glisan",
-              "stopCode": "7112",
-              "stopId": "prt:7112",
-              "stopIndex": 9,
-              "stopSequence": 10,
-              "vertexType": "TRANSIT",
-              "zoneId": "1"
-            },
-            {
-              "arrival": "2009-10-21T23:53:31.000+00:00",
-              "departure": "2009-10-21T23:53:31.000+00:00",
-              "lat": 45.524833,
-              "lon": -122.69398,
-              "name": "NW Everett & 21st",
-              "stopCode": "1615",
-              "stopId": "prt:1615",
-              "stopIndex": 10,
-              "stopSequence": 11,
-              "vertexType": "TRANSIT",
-              "zoneId": "1"
-            },
-            {
-              "arrival": "2009-10-21T23:55:07.000+00:00",
-              "departure": "2009-10-21T23:55:07.000+00:00",
-              "lat": 45.524935,
-              "lon": -122.690502,
-              "name": "NW Everett & 19th",
-              "stopCode": "1611",
-              "stopId": "prt:1611",
-              "stopIndex": 11,
-              "stopSequence": 12,
-              "vertexType": "TRANSIT",
-              "zoneId": "1"
-            },
-            {
-              "arrival": "2009-10-21T23:57:28.000+00:00",
-              "departure": "2009-10-21T23:57:28.000+00:00",
-              "lat": 45.524981,
-              "lon": -122.68537,
-              "name": "NW Everett & 14th",
-              "stopCode": "1608",
-              "stopId": "prt:1608",
-              "stopIndex": 12,
-              "stopSequence": 13,
-              "vertexType": "TRANSIT",
-              "zoneId": "0"
-            },
-            {
-              "arrival": "2009-10-21T23:59:04.000+00:00",
-              "departure": "2009-10-21T23:59:04.000+00:00",
-              "lat": 45.525061,
-              "lon": -122.68187,
-              "name": "NW Everett & 11th",
-              "stopCode": "1607",
-              "stopId": "prt:1607",
-              "stopIndex": 13,
-              "stopSequence": 14,
-              "vertexType": "TRANSIT",
-              "zoneId": "0"
-            },
-            {
-              "arrival": "2009-10-22T00:00:15.000+00:00",
-              "departure": "2009-10-22T00:00:15.000+00:00",
-              "lat": 45.525096,
-              "lon": -122.67929,
-              "name": "NW Everett & Park",
-              "stopCode": "8402",
-              "stopId": "prt:8402",
-              "stopIndex": 14,
-              "stopSequence": 15,
-              "vertexType": "TRANSIT",
-              "zoneId": "0"
-            }
-          ],
-          "legGeometry": {
-            "length": 39,
-            "points": "{c{tGnwzkVR?lCEvBC??VAlCClCEAkA??A}BCkEAkECaD???g@CiECiEEiE?c@?o@?]Aa@?w@AoD???YEkEAkECiEA_A??AiCCkECmD???[A_CCiD"
-          },
-          "mode": "BUS",
-          "pathway": false,
-          "realTime": false,
-          "route": "Holgate/NW 21st",
-          "routeId": "prt:17",
-          "routeLongName": "Holgate/NW 21st",
-          "routeShortName": "17",
-          "routeType": 3,
-          "serviceDate": "2009-10-21",
-          "startTime": "2009-10-21T23:51:25.000+00:00",
-          "steps": [ ],
-          "to": {
-            "arrival": "2009-10-22T00:01:00.000+00:00",
-            "departure": "2009-10-22T00:01:00.000+00:00",
-            "lat": 45.525112,
-            "lon": -122.677664,
-            "name": "NW Everett & Broadway",
-            "stopCode": "1606",
-            "stopId": "prt:1606",
-            "stopIndex": 15,
-            "stopSequence": 16,
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
-          },
-          "transitLeg": true,
-          "tripBlockId": "1717",
-          "tripId": "prt:170W1490"
-        },
-        {
-          "agencyTimeZoneOffset": -25200000,
-          "arrivalDelay": 0,
-          "departureDelay": 0,
-          "distance": 188.35,
-          "endTime": "2009-10-22T00:03:25.000+00:00",
-          "from": {
-            "arrival": "2009-10-22T00:01:00.000+00:00",
-            "departure": "2009-10-22T00:01:00.000+00:00",
-            "lat": 45.525112,
-            "lon": -122.677664,
-            "name": "NW Everett & Broadway",
-            "stopCode": "1606",
-            "stopId": "prt:1606",
-            "vertexType": "TRANSIT",
-            "zoneId": "0"
-          },
-          "generalizedCost": 286,
-          "interlineWithPreviousLeg": false,
-          "legElevation": "0,29.3,13,29.5,23,29.5,33,29.5,43,29.5,53,29.5,63,29.4,73,29.4,83,29.3,88,29.2,98,29.4,108,29.5,118,29.5,128,29.5,138,29.5,148,29.4,161,29.3,170,29.3,170,29.3,180,29.5,188,29.6",
-          "legGeometry": {
-            "length": 15,
-            "points": "}rztGlnwkVM??C?[?SC_D?M?E?MCgD?A?O?C?M?a@"
-          },
-          "mode": "WALK",
-          "pathway": false,
-          "realTime": false,
-          "rentedBike": false,
-          "route": "",
-          "startTime": "2009-10-22T00:01:00.000+00:00",
-          "steps": [
-            {
-              "absoluteDirection": "EAST",
-              "area": false,
-              "bogusName": false,
-              "distance": 188.36,
-              "elevation": "0,29.3,13,29.5,26,29.5,36,29.5,46,29.5,56,29.5,66,29.5,76,29.4,86,29.4,96,29.3,101,29.2,101,29.2,111,29.4,121,29.5,131,29.5,141,29.5,151,29.5,161,29.4,174,29.3,174,29.3,183,29.3,183,29.3,193,29.5,201,29.6",
-              "lat": 45.5251827,
-              "lon": -122.6776666,
-              "relativeDirection": "DEPART",
-              "stayOn": false,
-              "streetName": "Northwest Everett Street",
-              "walkingBike": false
-            }
-          ],
-          "to": {
-            "arrival": "2009-10-22T00:03:25.000+00:00",
-            "lat": 45.52523,
-            "lon": -122.67525,
-            "name": "NW Everett St. & NW 5th Ave. (P3)",
-            "vertexType": "NORMAL"
-          },
-          "transitLeg": false,
-          "walkingBike": false
-        }
-      ],
-      "startTime": "2009-10-21T23:46:10.000+00:00",
-      "tooSloped": false,
-      "transfers": 0,
-      "transitTime": 575,
-      "waitingTime": 0,
-      "walkDistance": 817.83,
-      "walkLimitExceeded": false,
-      "walkTime": 460
     }
   ]
 ]
@@ -2574,7 +2426,7 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.directBike=[
   [
     {
       "arrivedAtDestinationWithRentedBicycle": false,
-      "duration": 724,
+      "duration": 731,
       "elevationGained": 18.9,
       "elevationLost": 30.64,
       "endTime": "2009-10-21T23:10:00.000+00:00",
@@ -2582,41 +2434,41 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.directBike=[
         "details": { },
         "fare": { }
       },
-      "generalizedCost": 1374,
+      "generalizedCost": 1602,
       "legs": [
         {
           "agencyTimeZoneOffset": -25200000,
           "arrivalDelay": 0,
           "departureDelay": 0,
-          "distance": 2635.31,
+          "distance": 2636.74,
           "endTime": "2009-10-21T23:10:00.000+00:00",
           "from": {
-            "departure": "2009-10-21T22:57:56.000+00:00",
+            "departure": "2009-10-21T22:57:49.000+00:00",
             "lat": 45.52832,
             "lon": -122.70059,
             "name": "SW Johnson St. & NW 24th Ave. (P1)",
             "vertexType": "NORMAL"
           },
-          "generalizedCost": 1374,
+          "generalizedCost": 1602,
           "interlineWithPreviousLeg": false,
-          "legElevation": "0,63.7,1,63.7,1,63.7,11,63.4,21,63.2,31,63.3,41,63.5,51,63.3,61,62.9,71,62.5,81,62.2,91,62.0,101,61.7,111,61.5,121,61.2,131,60.9,141,60.6,151,60.3,160,60.2,240,60.2,1032,60.2,1190,55.5,1430,55.5,1506,40.4,1849,40.4,1919,37.3,1931,37.3,2078,55.5,2503,55.5,2503,NaN,2635,NaN",
+          "legElevation": "0,63.7,1,63.7,1,63.7,11,63.4,21,63.2,31,63.3,41,63.5,51,63.3,61,62.9,71,62.5,81,62.2,91,62.0,101,61.7,111,61.5,121,61.2,131,60.9,141,60.6,151,60.3,160,60.2,240,60.2,1193,60.2,1272,55.5,1589,55.5,1668,40.4,1851,40.4,1920,37.3,1932,37.3,2079,55.5,2504,55.5,2504,NaN,2637,NaN",
           "legGeometry": {
-            "length": 59,
-            "points": "}f{tGv}{kVC?mCBmCDoCDmCDmCBoCDmCDkCDoCB_CBM@iGEE@MB[H}@@s@@GsKAkCCkCA}BCkE?EAcEoCB{BBS@K?wDD}@@I?IAECKMKOIKyAmBCCQScB`DeAzBOVYj@eCxECF{@eAq@nAcAzBeAbBKDy@Ou@a@k@]c@_@Ws@M{@BsA"
+            "length": 60,
+            "points": "}f{tGv}{kVC?mCBmCDoCDmCDmCBoCDmCDkCDoCB_CBM@iGEE@MB[H}@@s@@oCDmCBC@CkEAiEAg@AaC?YCqEAkECiEK?wDD}@@I?IAECKMKOIKyAmBCCQScB`DeAzBOVYj@eCxECF{@eAq@nAcAzBeAbBKDy@Ou@a@k@]c@_@Ws@M{@BsA"
           },
           "mode": "BICYCLE",
           "pathway": false,
           "realTime": false,
           "rentedBike": false,
           "route": "",
-          "startTime": "2009-10-21T22:57:56.000+00:00",
+          "startTime": "2009-10-21T22:57:49.000+00:00",
           "steps": [
             {
               "absoluteDirection": "NORTH",
               "area": false,
               "bogusName": false,
-              "distance": 1032.39,
-              "elevation": "0,63.7,1,63.7,3,63.7,13,63.4,23,63.2,33,63.3,43,63.5,53,63.3,63,62.9,73,62.5,83,62.2,83,62.2,93,62.0,103,61.7,113,61.5,123,61.2,133,60.9,143,60.6,153,60.3,161,60.2,161,60.2,241,60.2,241,60.2,320,60.2,320,60.2,399,60.2,399,60.2,479,60.2,479,60.2,558,60.2,558,60.2,636,60.2,636,60.2,717,60.2,717,60.2,795,60.2,795,60.2,947,60.2,947,60.2,955,60.2,955,60.2,1005,60.2,1005,60.2,1034,60.2",
+              "distance": 1193.29,
+              "elevation": "0,63.7,1,63.7,3,63.7,13,63.4,23,63.2,33,63.3,43,63.5,53,63.3,63,62.9,73,62.5,83,62.2,83,62.2,93,62.0,103,61.7,113,61.5,123,61.2,133,60.9,143,60.6,153,60.3,161,60.2,161,60.2,241,60.2,241,60.2,320,60.2,320,60.2,399,60.2,399,60.2,479,60.2,479,60.2,558,60.2,558,60.2,636,60.2,636,60.2,717,60.2,717,60.2,795,60.2,795,60.2,947,60.2,947,60.2,955,60.2,955,60.2,1005,60.2,1005,60.2,1034,60.2,1034,60.2,1114,60.2,1114,60.2,1195,60.2",
               "lat": 45.5283199,
               "lon": -122.7005963,
               "relativeDirection": "DEPART",
@@ -2628,23 +2480,23 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.directBike=[
               "absoluteDirection": "EAST",
               "area": false,
               "bogusName": false,
-              "distance": 473.92,
-              "elevation": "0,60.2,157,55.5,157,55.5,212,55.5,212,55.5,266,55.5,266,55.5,316,55.5,316,55.5,395,55.5,395,55.5,397,55.5,397,55.5,474,40.4",
-              "lat": 45.5375956,
-              "lon": -122.7009344,
+              "distance": 474.29,
+              "elevation": "0,60.2,79,55.5,79,55.5,158,55.5,158,55.5,173,55.5,173,55.5,224,55.5,224,55.5,234,55.5,234,55.5,316,55.5,316,55.5,396,55.5,396,55.5,474,40.4",
+              "lat": 45.539042,
+              "lon": -122.7009919,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "Northwest Wilson Street",
+              "streetName": "Northwest York Street",
               "walkingBike": false
             },
             {
               "absoluteDirection": "NORTH",
               "area": false,
               "bogusName": false,
-              "distance": 424.41,
-              "elevation": "0,40.4,80,40.4,80,40.4,160,40.4,160,40.4,268,40.4,268,40.4,314,40.4,314,40.4,343,40.4,343,40.4,412,37.3,412,37.3,424,37.3",
-              "lat": 45.5377086,
-              "lon": -122.6948518,
+              "distance": 264.57,
+              "elevation": "0,40.4,109,40.4,109,40.4,155,40.4,155,40.4,183,40.4,183,40.4,252,37.3,252,37.3,265,37.3",
+              "lat": 45.5391456,
+              "lon": -122.6949041,
               "relativeDirection": "LEFT",
               "stayOn": false,
               "streetName": "Northwest 21st Avenue",
@@ -2667,39 +2519,13 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.directBike=[
               "absoluteDirection": "NORTHEAST",
               "area": false,
               "bogusName": true,
-              "distance": 42.88,
-              "elevation": "0,55.5,43,55.5",
+              "distance": 406.0,
+              "elevation": "0,55.5,43,55.5,43,55.5,201,55.5,201,55.5,273,55.5",
               "lat": 45.5430449,
               "lon": -122.6969354,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "way 5512747 from 0",
-              "walkingBike": false
-            },
-            {
-              "absoluteDirection": "NORTHWEST",
-              "area": false,
-              "bogusName": true,
-              "distance": 158.35,
-              "elevation": "0,55.5,158,55.5",
-              "lat": 45.5433447,
-              "lon": -122.6965891,
-              "relativeDirection": "LEFT",
-              "stayOn": true,
-              "streetName": "way 5509965 from 20",
-              "walkingBike": false
-            },
-            {
-              "absoluteDirection": "NORTH",
-              "area": false,
-              "bogusName": true,
-              "distance": 204.77,
-              "elevation": "0,55.5,72,55.5",
-              "lat": 45.544288,
-              "lon": -122.6981088,
-              "relativeDirection": "RIGHT",
-              "stayOn": true,
-              "streetName": "way 5509965 from 17",
+              "streetName": "service road",
               "walkingBike": false
             }
           ],
@@ -2714,14 +2540,14 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.directBike=[
           "walkingBike": false
         }
       ],
-      "startTime": "2009-10-21T22:57:56.000+00:00",
+      "startTime": "2009-10-21T22:57:49.000+00:00",
       "tooSloped": false,
       "transfers": 0,
       "transitTime": 0,
       "waitingTime": 0,
-      "walkDistance": 2635.31,
+      "walkDistance": 2636.74,
       "walkLimitExceeded": false,
-      "walkTime": 724
+      "walkTime": 731
     }
   ]
 ]
@@ -2739,7 +2565,7 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.directBikeRe
         "details": { },
         "fare": { }
       },
-      "generalizedCost": 982,
+      "generalizedCost": 1103,
       "legs": [
         {
           "agencyTimeZoneOffset": -25200000,
@@ -2804,7 +2630,7 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.directBikeRe
               "lon": -122.7003923,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "way -102328 from 0",
+              "streetName": "path",
               "walkingBike": false
             }
           ],
@@ -2841,7 +2667,7 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.directBikeRe
             ],
             "vertexType": "BIKESHARE"
           },
-          "generalizedCost": 343,
+          "generalizedCost": 464,
           "interlineWithPreviousLeg": false,
           "legElevation": "0,66.2,13,66.6,23,65.7,33,64.9,43,64.1,53,63.1,63,62.5,73,62.5,83,62.1,93,61.9,103,61.7,113,61.4,123,61.1,133,60.9,143,60.6,158,60.2,168,59.9,178,59.6,188,59.3,198,59.0,208,58.7,218,58.4,228,58.1,238,57.8,248,57.5,258,57.1,268,56.8,278,56.6,288,56.4,298,56.2,308,55.9,316,55.7,326,55.5,336,55.3,346,55.0,356,54.7,366,54.4,376,54.1,386,53.8,396,53.6,406,53.5,416,53.3,426,53.3,440,53.0,450,52.9,460,52.8,474,52.6,474,52.6,484,52.4,493,52.2",
           "legGeometry": {
@@ -2865,7 +2691,7 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.directBikeRe
               "lon": -122.7003879,
               "relativeDirection": "HARD_RIGHT",
               "stayOn": false,
-              "streetName": "way -102328 from 0",
+              "streetName": "path",
               "walkingBike": true
             },
             {
@@ -3090,39 +2916,13 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.directWalk=[
               "absoluteDirection": "NORTHEAST",
               "area": false,
               "bogusName": true,
-              "distance": 42.88,
-              "elevation": "0,55.5,43,55.5",
+              "distance": 406.0,
+              "elevation": "0,55.5,43,55.5,43,55.5,201,55.5,201,55.5,273,55.5",
               "lat": 45.5430449,
               "lon": -122.6969354,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "way 5512747 from 0",
-              "walkingBike": false
-            },
-            {
-              "absoluteDirection": "NORTHWEST",
-              "area": false,
-              "bogusName": true,
-              "distance": 158.35,
-              "elevation": "0,55.5,158,55.5",
-              "lat": 45.5433447,
-              "lon": -122.6965891,
-              "relativeDirection": "LEFT",
-              "stayOn": true,
-              "streetName": "way 5509965 from 20",
-              "walkingBike": false
-            },
-            {
-              "absoluteDirection": "NORTH",
-              "area": false,
-              "bogusName": true,
-              "distance": 204.77,
-              "elevation": "0,55.5,72,55.5",
-              "lat": 45.544288,
-              "lon": -122.6981088,
-              "relativeDirection": "RIGHT",
-              "stayOn": true,
-              "streetName": "way 5509965 from 17",
+              "streetName": "service road",
               "walkingBike": false
             }
           ],
@@ -4062,7 +3862,7 @@ org.opentripplanner.routing.algorithm.mapping.ElevationSnapshotTest.transit=[
               "lon": -122.6764917,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "way 156261070 from 2",
+              "streetName": "path",
               "walkingBike": false
             }
           ],

--- a/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/TransitSnapshotTest.snap
+++ b/src/test/java/org/opentripplanner/routing/algorithm/mapping/__snapshots__/TransitSnapshotTest.snap
@@ -61,7 +61,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.6594795,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "way 261187797 from 2",
+              "streetName": "parking aisle",
               "walkingBike": false
             },
             {
@@ -113,7 +113,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.6658345,
               "relativeDirection": "CONTINUE",
               "stayOn": false,
-              "streetName": "way 131623794 from 0",
+              "streetName": "path",
               "walkingBike": false
             },
             {
@@ -152,7 +152,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.6738909,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "way 144373674 from 1",
+              "streetName": "path",
               "walkingBike": false
             },
             {
@@ -3054,7 +3054,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.6536338,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "way 162042138 from 0",
+              "streetName": "path",
               "walkingBike": false
             }
           ],
@@ -3527,7 +3527,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.6536338,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "way 162042138 from 0",
+              "streetName": "path",
               "walkingBike": false
             }
           ],
@@ -4000,7 +4000,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.6536338,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "way 162042138 from 0",
+              "streetName": "path",
               "walkingBike": false
             }
           ],
@@ -4974,7 +4974,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.6536338,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "way 162042138 from 0",
+              "streetName": "path",
               "walkingBike": false
             }
           ],
@@ -5469,39 +5469,13 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "absoluteDirection": "NORTH",
               "area": false,
               "bogusName": true,
-              "distance": 7.08,
+              "distance": 131.76,
               "elevation": "",
               "lat": 45.5193421,
               "lon": -122.6537305,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "way 226431264 from 0",
-              "walkingBike": false
-            },
-            {
-              "absoluteDirection": "NORTHWEST",
-              "area": false,
-              "bogusName": true,
-              "distance": 55.96,
-              "elevation": "",
-              "lat": 45.5194058,
-              "lon": -122.6537325,
-              "relativeDirection": "LEFT",
-              "stayOn": true,
-              "streetName": "way 226431263 from 21",
-              "walkingBike": false
-            },
-            {
-              "absoluteDirection": "NORTH",
-              "area": false,
-              "bogusName": true,
-              "distance": 68.72,
-              "elevation": "",
-              "lat": 45.5196271,
-              "lon": -122.6543172,
-              "relativeDirection": "RIGHT",
-              "stayOn": true,
-              "streetName": "way 226431263 from 23",
+              "streetName": "path",
               "walkingBike": false
             },
             {
@@ -5527,7 +5501,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.6612814,
               "relativeDirection": "RIGHT",
               "stayOn": false,
-              "streetName": "way 257064467 from 1",
+              "streetName": "parking aisle",
               "walkingBike": false
             },
             {
@@ -5949,7 +5923,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.6682216,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "way 125785939 from 4",
+              "streetName": "path",
               "walkingBike": false
             },
             {
@@ -5975,7 +5949,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.6719792,
               "relativeDirection": "LEFT",
               "stayOn": false,
-              "streetName": "way 117315127 from 2",
+              "streetName": "steps",
               "walkingBike": false
             },
             {
@@ -5988,7 +5962,7 @@ org.opentripplanner.routing.algorithm.mapping.TransitSnapshotTest.test_trip_plan
               "lon": -122.672028,
               "relativeDirection": "RIGHT",
               "stayOn": true,
-              "streetName": "way 117315115 from 0",
+              "streetName": "footbridge",
               "walkingBike": false
             },
             {

--- a/src/test/java/org/opentripplanner/routing/graph/GraphSerializationTest.java
+++ b/src/test/java/org/opentripplanner/routing/graph/GraphSerializationTest.java
@@ -129,7 +129,9 @@ public class GraphSerializationTest {
       "tripPatternForId",
       "transitLayer",
       "realtimeTransitLayer",
-      "dateTime"
+      "dateTime",
+      "notesForEdge",
+      "uniqueMatchers"
     );
     // Edges have very detailed String representation including lat/lon coordinates and OSM IDs. They should be unique.
     objectDiffer.setKeyExtractor("turnRestrictions", edge -> edge.toString());


### PR DESCRIPTION
### Summary

The Portland graph used for testing doesn't have any way properties set. Once way properties were added to the graph, the round trip serialization failed due to the `StaticStreetNoteService` which used a `Map<Edge, ...>` to store the notes. So the related fields are now ignored.

With these changes:
 * the Portland test graph has differing street types (and better resembles a _real_ graph)
 * the graph round-trip serialization test passes
 * and interning `StreetNote`s is fixed

The way properties were needed for adding tests for #4317 