### PR TITLE
Fix stop time repair for trips with single flex stop

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/flex/FlexIntegrationTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/flex/FlexIntegrationTest.java
@@ -68,6 +68,11 @@ public class FlexIntegrationTest {
   }
 
   @Test
+  public void addFlexTripsAndPatternsToGraph() {
+    assertFalse(transitModel.getAllTripPatterns().isEmpty());
+  }
+
+  @Test
   public void shouldReturnARouteTransferringFromBusToFlex() {
     var from = new GenericLocation(33.84329482265106, -84.583740234375);
     var to = new GenericLocation(33.86701256815635, -84.61787939071655);

--- a/src/ext-test/java/org/opentripplanner/ext/flex/FlexIntegrationTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/flex/FlexIntegrationTest.java
@@ -68,12 +68,12 @@ public class FlexIntegrationTest {
   }
 
   @Test
-  public void addFlexTripsAndPatternsToGraph() {
+  void addFlexTripsAndPatternsToGraph() {
     assertFalse(transitModel.getAllTripPatterns().isEmpty());
   }
 
   @Test
-  public void shouldReturnARouteTransferringFromBusToFlex() {
+  void shouldReturnARouteTransferringFromBusToFlex() {
     var from = new GenericLocation(33.84329482265106, -84.583740234375);
     var to = new GenericLocation(33.86701256815635, -84.61787939071655);
 
@@ -103,7 +103,7 @@ public class FlexIntegrationTest {
   }
 
   @Test
-  public void shouldReturnARouteWithTwoTransfers() {
+  void shouldReturnARouteWithTwoTransfers() {
     var from = GenericLocation.fromStopId("ALEX DR@ALEX WAY", "MARTA", "97266");
     var to = new GenericLocation(33.86701256815635, -84.61787939071655);
 
@@ -132,7 +132,7 @@ public class FlexIntegrationTest {
   }
 
   @Test
-  public void flexDirect() {
+  void flexDirect() {
     // near flex zone
     var from = new GenericLocation(33.85281, -84.60271);
     // in the middle of flex zone

--- a/src/ext-test/java/org/opentripplanner/ext/flex/ScheduledDeviatedTripTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/flex/ScheduledDeviatedTripTest.java
@@ -61,7 +61,7 @@ public class ScheduledDeviatedTripTest extends FlexTest {
   float delta = 0.01f;
 
   @Test
-  public void parseCobbCountyAsScheduledDeviatedTrip() {
+  void parseCobbCountyAsScheduledDeviatedTrip() {
     var flexTrips = transitModel.getAllFlexTrips();
     assertFalse(flexTrips.isEmpty());
     assertEquals(72, flexTrips.size());
@@ -92,7 +92,7 @@ public class ScheduledDeviatedTripTest extends FlexTest {
   }
 
   @Test
-  public void calculateAccessTemplate() {
+  void calculateAccessTemplate() {
     var trip = getFlexTrip();
     var nearbyStop = getNearbyStop(trip);
 
@@ -106,7 +106,7 @@ public class ScheduledDeviatedTripTest extends FlexTest {
   }
 
   @Test
-  public void calculateEgressTemplate() {
+  void calculateEgressTemplate() {
     var trip = getFlexTrip();
     var nearbyStop = getNearbyStop(trip);
     var egresses = trip.getFlexEgressTemplates(nearbyStop, flexDate, calculator, params).toList();
@@ -119,7 +119,7 @@ public class ScheduledDeviatedTripTest extends FlexTest {
   }
 
   @Test
-  public void calculateDirectFare() {
+  void calculateDirectFare() {
     OTPFeature.enableFeatures(Map.of(OTPFeature.FlexRouting, true));
     var trip = getFlexTrip();
 
@@ -157,7 +157,7 @@ public class ScheduledDeviatedTripTest extends FlexTest {
    * cannot board or alight.
    */
   @Test
-  public void flexTripInTransitMode() {
+  void flexTripInTransitMode() {
     var feedId = transitModel.getFeedIds().iterator().next();
 
     var serverContext = TestServerContext.createServerContext(graph, transitModel);
@@ -200,7 +200,7 @@ public class ScheduledDeviatedTripTest extends FlexTest {
    * @see org.opentripplanner.gtfs.RepairStopTimesForEachTripOperation#interpolateStopTimes(List)
    */
   @Test
-  public void shouldNotInterpolateFlexTimes() {
+  void shouldNotInterpolateFlexTimes() {
     var feedId = transitModel.getFeedIds().iterator().next();
     var pattern = transitModel.getTripPatternForId(new FeedScopedId(feedId, "090z:0:01"));
 
@@ -216,7 +216,7 @@ public class ScheduledDeviatedTripTest extends FlexTest {
    * Checks that trips which have continuous pick up/drop off set are parsed correctly.
    */
   @Test
-  public void parseContinuousPickup() {
+  void parseContinuousPickup() {
     var lincolnGraph = FlexTest.buildFlexGraph(LINCOLN_COUNTY_GBFS);
     assertNotNull(lincolnGraph);
   }

--- a/src/ext-test/java/org/opentripplanner/ext/flex/UnscheduledTripTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/flex/UnscheduledTripTest.java
@@ -69,6 +69,11 @@ public class UnscheduledTripTest extends FlexTest {
     assertEquals(0, egress.toStopIndex);
   }
 
+  @Test
+  public void shouldGeneratePatternForFlexTripWithSingleStop() {
+    assertFalse(transitModel.getAllTripPatterns().isEmpty());
+  }
+
   @BeforeAll
   static void setup() {
     TestOtpModel model = FlexTest.buildFlexGraph(ASPEN_GTFS);

--- a/src/ext-test/java/org/opentripplanner/ext/flex/UnscheduledTripTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/flex/UnscheduledTripTest.java
@@ -28,7 +28,7 @@ public class UnscheduledTripTest extends FlexTest {
   static TransitModel transitModel;
 
   @Test
-  public void parseAspenTaxiAsUnscheduledTrip() {
+  void parseAspenTaxiAsUnscheduledTrip() {
     var flexTrips = transitModel.getAllFlexTrips();
     assertFalse(flexTrips.isEmpty());
     assertEquals(
@@ -43,7 +43,7 @@ public class UnscheduledTripTest extends FlexTest {
   }
 
   @Test
-  public void calculateAccessTemplate() {
+  void calculateAccessTemplate() {
     var trip = getFlexTrip();
     var nearbyStop = getNearbyStop(trip);
 
@@ -57,7 +57,7 @@ public class UnscheduledTripTest extends FlexTest {
   }
 
   @Test
-  public void calculateEgressTemplate() {
+  void calculateEgressTemplate() {
     var trip = getFlexTrip();
     var nearbyStop = getNearbyStop(trip);
     var egresses = trip.getFlexEgressTemplates(nearbyStop, flexDate, calculator, params).toList();
@@ -70,7 +70,7 @@ public class UnscheduledTripTest extends FlexTest {
   }
 
   @Test
-  public void shouldGeneratePatternForFlexTripWithSingleStop() {
+  void shouldGeneratePatternForFlexTripWithSingleStop() {
     assertFalse(transitModel.getAllTripPatterns().isEmpty());
   }
 

--- a/src/main/java/org/opentripplanner/gtfs/RepairStopTimesForEachTripOperation.java
+++ b/src/main/java/org/opentripplanner/gtfs/RepairStopTimesForEachTripOperation.java
@@ -71,7 +71,7 @@ public class RepairStopTimesForEachTripOperation {
       if (!removedStopSequences.isEmpty()) {
         issueStore.add(new RepeatedStops(trip, removedStopSequences));
       }
-      if (!filterStopTimes(stopTimes)) {
+      if (!FlexTrip.containsFlexStops(stopTimes) && !filterStopTimes(stopTimes)) {
         stopTimesByTrip.replace(trip, List.of());
       } else {
         interpolateStopTimes(stopTimes);

--- a/src/main/java/org/opentripplanner/gtfs/RepairStopTimesForEachTripOperation.java
+++ b/src/main/java/org/opentripplanner/gtfs/RepairStopTimesForEachTripOperation.java
@@ -34,8 +34,6 @@ public class RepairStopTimesForEachTripOperation {
     RepairStopTimesForEachTripOperation.class
   );
 
-  private static final int SECONDS_IN_HOUR = 60 * 60;
-
   private final TripStopTimes stopTimesByTrip;
 
   private final DataImportIssueStore issueStore;
@@ -71,7 +69,7 @@ public class RepairStopTimesForEachTripOperation {
       if (!removedStopSequences.isEmpty()) {
         issueStore.add(new RepeatedStops(trip, removedStopSequences));
       }
-      if (!FlexTrip.containsFlexStops(stopTimes) && !filterStopTimes(stopTimes)) {
+      if (!filterStopTimes(stopTimes)) {
         stopTimesByTrip.replace(trip, List.of());
       } else {
         interpolateStopTimes(stopTimes);
@@ -132,7 +130,7 @@ public class RepairStopTimesForEachTripOperation {
    * @return whether the stop time is usable
    */
   private boolean filterStopTimes(List<StopTime> stopTimes) {
-    if (stopTimes.size() < 2) {
+    if (stopTimes.size() < 2 && !FlexTrip.containsFlexStops(stopTimes)) {
       return false;
     }
 


### PR DESCRIPTION
### Summary

Right now there is a feature to "repair" GTFS trips which contain nonsensical data. Among the checks there is one for trips that contain fewer than two stops. In a regular static GTFS trip this makes sense but in flex trip this is actually valid so this "repair" should not happen for flex trips.

Note: I spoke to the OTP team at IBI and they are in favour of disabling this repair module by default. 

### Issue

n/a

### Unit tests

Added.