### PR TITLE
Fix building of graphs with only FlexStopLocations

### DIFF
--- a/src/main/java/org/opentripplanner/transit/service/StopModel.java
+++ b/src/main/java/org/opentripplanner/transit/service/StopModel.java
@@ -236,16 +236,22 @@ public class StopModel implements Serializable {
    */
   public void calculateTransitCenter() {
     var vertices = getAllStopVertices();
-    var medianCalculator = new MedianCalcForDoubles(vertices.size());
 
-    vertices.forEach(v -> medianCalculator.add(v.getLon()));
-    double lon = medianCalculator.median();
+    // we need this check because there could be only FlexStopLocations (which don't have vertices)
+    // in the graph
+    if (!vertices.isEmpty()) {
+      this.center = vertices.iterator().next().getCoordinate();
+      var medianCalculator = new MedianCalcForDoubles(vertices.size());
 
-    medianCalculator.reset();
-    vertices.forEach(v -> medianCalculator.add(v.getLat()));
-    double lat = medianCalculator.median();
+      vertices.forEach(v -> medianCalculator.add(v.getLon()));
+      double lon = medianCalculator.median();
 
-    this.center = new Coordinate(lon, lat);
+      medianCalculator.reset();
+      vertices.forEach(v -> medianCalculator.add(v.getLat()));
+      double lat = medianCalculator.median();
+
+      this.center = new Coordinate(lon, lat);
+    }
   }
 
   public Optional<Coordinate> getCenter() {

--- a/src/main/java/org/opentripplanner/transit/service/StopModel.java
+++ b/src/main/java/org/opentripplanner/transit/service/StopModel.java
@@ -240,7 +240,6 @@ public class StopModel implements Serializable {
     // we need this check because there could be only FlexStopLocations (which don't have vertices)
     // in the graph
     if (!vertices.isEmpty()) {
-      this.center = vertices.iterator().next().getCoordinate();
       var medianCalculator = new MedianCalcForDoubles(vertices.size());
 
       vertices.forEach(v -> medianCalculator.add(v.getLon()));


### PR DESCRIPTION
### Summary

When there is only FlexStopLocations in the graph then building the graph fails as the center point of the transit stops cannot be computed.

To solve it I'm checking if there are any vertices in the list before computing.