### PR TITLE
Use try-with-resources for GBFS loading, improve logging

### DIFF
--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsFeedLoader.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsFeedLoader.java
@@ -121,33 +121,20 @@ public class GbfsFeedLoader {
   /* private static methods */
 
   private static <T> T fetchFeed(URI uri, Map<String, String> httpHeaders, Class<T> clazz) {
-    try {
-      InputStream is;
-
-      String proto = uri.getScheme();
-      if (proto.equals("http") || proto.equals("https")) {
-        is = HttpUtils.getData(uri, httpHeaders);
-      } else {
-        // Local file probably, try standard java
-        is = uri.toURL().openStream();
-      }
+    try (InputStream is = HttpUtils.openInputStream(uri, httpHeaders);) {
       if (is == null) {
         LOG.warn("Failed to get data from url {}", uri);
         return null;
       }
-      T data = objectMapper.readValue(is, clazz);
-      is.close();
-      return data;
+      return objectMapper.readValue(is, clazz);
     } catch (IllegalArgumentException e) {
-      LOG.warn("Error parsing vehicle rental feed from " + uri, e);
+      LOG.warn("Error parsing vehicle rental feed from {}", uri, e);
       return null;
     } catch (JsonProcessingException e) {
-      LOG.warn("Error parsing vehicle rental feed from (bad JSON of some sort)" + uri);
-      LOG.warn(e.getMessage());
+      LOG.warn("Error parsing vehicle rental feed from (bad JSON of some sort) {}", uri, e);
       return null;
     } catch (IOException e) {
-      LOG.warn("Error reading vehicle rental feed from (connection error)" + uri);
-      LOG.warn(e.getMessage());
+      LOG.warn("Error reading vehicle rental feed from {} (connection error)", uri, e);
       return null;
     }
   }

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsFeedLoader.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/GbfsFeedLoader.java
@@ -127,14 +127,8 @@ public class GbfsFeedLoader {
         return null;
       }
       return objectMapper.readValue(is, clazz);
-    } catch (IllegalArgumentException e) {
-      LOG.warn("Error parsing vehicle rental feed from {}", uri, e);
-      return null;
-    } catch (JsonProcessingException e) {
-      LOG.warn("Error parsing vehicle rental feed from (bad JSON of some sort) {}", uri, e);
-      return null;
-    } catch (IOException e) {
-      LOG.warn("Error reading vehicle rental feed from {} (connection error)", uri, e);
+    } catch (IllegalArgumentException | IOException e) {
+      LOG.warn("Error parsing vehicle rental feed from {}. Details: {}.", uri, e.getMessage(), e);
       return null;
     }
   }


### PR DESCRIPTION
### Summary

Right now if an exception is thrown during download of GBFS data, the input stream is not closed causing a resource leak. How bad this is is actually up for debate but I'm investigating a production issue that could be related.

### Issue

Maybe related to #2811

### Unit tests
n/a 