### PR TITLE
Explicitly set timezones for speed test

### DIFF
--- a/test/performance/baden-wuerttemberg/build-config.json
+++ b/test/performance/baden-wuerttemberg/build-config.json
@@ -1,5 +1,6 @@
 {
   "osmWayPropertySet": "germany",
   "staticBikeParkAndRide": true,
-  "discardMinTransferTimes": true
+  "discardMinTransferTimes": true,
+  "timeZone": "Europe/Berlin"
 }

--- a/test/performance/norway/build-config.json
+++ b/test/performance/norway/build-config.json
@@ -26,6 +26,7 @@
   "distanceBetweenElevationSamples": 25,
   "multiThreadElevationCalculations": true,
   "boardingLocationTags": [],
+  "timeZone": "Europe/Oslo",
   "netex": {
     "sharedFilePattern": "_stops.xml",
     "sharedGroupFilePattern": "_(\\w{3})(_flexible)?_shared_data.xml",


### PR DESCRIPTION
### Summary

Due to #4355, we can't build the speed test graphs since https://github.com/opentripplanner/OpenTripPlanner/pull/4320 was merged. Fix the issue by hardcoding the time zones.
