### PR TITLE
Fix init of trip pattern name

### DIFF
--- a/src/main/java/org/opentripplanner/transit/model/network/TripPattern.java
+++ b/src/main/java/org/opentripplanner/transit/model/network/TripPattern.java
@@ -110,7 +110,7 @@ public final class TripPattern
   }
 
   public void initName(String name) {
-    if (name != null) {
+    if (this.name != null) {
       throw new IllegalStateException("Name has already been set");
     }
     this.name = name;

--- a/src/test/java/org/opentripplanner/transit/model/network/TripPatternTest.java
+++ b/src/test/java/org/opentripplanner/transit/model/network/TripPatternTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.transit.model._data.TransitModelForTest;
 
@@ -58,5 +59,24 @@ class TripPatternTest {
     assertFalse(
       subject.sameAs(subject.copy().withStopPattern(StopPattern.create(11).build()).build())
     );
+  }
+
+  @Test
+  void initNameShouldThrow() {
+    Assertions.assertThrows(IllegalStateException.class, () -> subject.initName("abc"));
+  }
+
+  @Test
+  void shouldAddName() {
+    var name = "xyz";
+    var noNameYet = TripPattern
+      .of(TransitModelForTest.id(ID))
+      .withRoute(ROUTE)
+      .withStopPattern(STOP_PATTERN)
+      .build();
+
+    noNameYet.initName(name);
+
+    assertEquals(name, noNameYet.getName());
   }
 }


### PR DESCRIPTION
### Summary
After merging #4338 the graph build runs into the following error:

```
 15:47:57.452 INFO (TripPatternNamer.java:73) Generating unique names for stop patterns on each route.
15:47:57.467 ERROR (OTPMain.java:59) An uncaught error occurred inside OTP: Name has already been set
java.lang.IllegalStateException: Name has already been set
	at org.opentripplanner.transit.model.network.TripPattern.initName(TripPattern.java:114)
	at org.opentripplanner.graph_builder.module.TripPatternNamer.generateUniqueNames(TripPatternNamer.java:151)
	at org.opentripplanner.graph_builder.module.TripPatternNamer.buildGraph(TripPatternNamer.java:32)
	at org.opentripplanner.graph_builder.GraphBuilder.run(GraphBuilder.java:167)
	at org.opentripplanner.standalone.OTPMain.startOTPServer(OTPMain.java:140)
	at org.opentripplanner.standalone.OTPMain.main(OTPMain.java:54)
```

https://github.com/opentripplanner/OpenTripPlanner/runs/7729060343?check_suite_focus=true#step:9:625

There was a very small oversight in the above PR which this corrects.