### PR TITLE
Do not try to rename patterns with already existing names

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/module/TripPatternNamer.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/TripPatternNamer.java
@@ -81,6 +81,11 @@ public class TripPatternNamer implements GraphBuilderModule {
     /* Iterate over all routes, giving the patterns within each route unique names. */
     for (Route route : patternsByRoute.keySet()) {
       Collection<TripPattern> routeTripPatterns = patternsByRoute.get(route);
+
+      // Only generate name for patterns with at least one missing name
+      if (routeTripPatterns.stream().allMatch(tripPattern -> tripPattern.getName() != null)) {
+        continue;
+      }
       String routeName = route.getName();
 
       /* Simplest case: there's only one route variant, so we'll just give it the route's name. */
@@ -109,6 +114,9 @@ public class TripPatternNamer implements GraphBuilderModule {
         }
       }
       PATTERN:for (TripPattern pattern : routeTripPatterns) {
+        if (pattern.getName() != null) {
+          continue;
+        }
         StringBuilder sb = new StringBuilder(routeName);
         String headsign = pattern.getTripHeadsign();
         if (headsign != null && signs.get(headsign).size() == 1) {


### PR DESCRIPTION
### Summary

After https://github.com/opentripplanner/OpenTripPlanner/commit/bae9de1b8d7a52ce0628e9ed34a310bee1058ba2 we make sure that the pattern name is only set once. Some Netex feeds provide names for the JourneyPatterns, so that we need to filter out the patterns that already have a name set. Previously we would have overridden these, causing an error after the commit was included.
