### PR TITLE
Take allowed modes in VehicleToStopHeuristics into account

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/vehicletostopheuristics/VehicleToStopSkipEdgeStrategy.java
+++ b/src/ext/java/org/opentripplanner/ext/vehicletostopheuristics/VehicleToStopSkipEdgeStrategy.java
@@ -7,6 +7,8 @@ import static org.opentripplanner.routing.api.request.StreetMode.CAR_RENTAL;
 import static org.opentripplanner.routing.api.request.StreetMode.CAR_TO_PARK;
 import static org.opentripplanner.routing.api.request.StreetMode.SCOOTER_RENTAL;
 
+import java.util.Collection;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Function;
@@ -47,11 +49,16 @@ public class VehicleToStopSkipEdgeStrategy implements SkipEdgeStrategy {
   );
   private final Function<Stop, Set<Route>> getRoutesForStop;
   private final int maxScore;
+  private final EnumSet<TransitMode> allowedModes;
   private double sumOfScores;
 
   private final Set<FeedScopedId> stopsCounted = new HashSet<>();
 
-  public VehicleToStopSkipEdgeStrategy(Function<Stop, Set<Route>> getRoutesForStop) {
+  public VehicleToStopSkipEdgeStrategy(
+    Function<Stop, Set<Route>> getRoutesForStop,
+    Collection<TransitMode> allowedModes
+  ) {
+    this.allowedModes = EnumSet.copyOf(allowedModes);
     this.maxScore = 300;
     this.getRoutesForStop = getRoutesForStop;
   }
@@ -68,6 +75,7 @@ public class VehicleToStopSkipEdgeStrategy implements SkipEdgeStrategy {
           .apply(stop)
           .stream()
           .map(Route::getMode)
+          .filter(allowedModes::contains)
           .mapToInt(VehicleToStopSkipEdgeStrategy::score)
           .sum();
 

--- a/src/main/java/org/opentripplanner/graph_builder/module/NearbyStopFinder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/NearbyStopFinder.java
@@ -35,6 +35,7 @@ import org.opentripplanner.routing.spt.DominanceFunction;
 import org.opentripplanner.routing.spt.ShortestPathTree;
 import org.opentripplanner.routing.vertextype.StreetVertex;
 import org.opentripplanner.routing.vertextype.TransitStopVertex;
+import org.opentripplanner.transit.model.basic.MainAndSubMode;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.site.FlexStopLocation;
 import org.opentripplanner.transit.model.site.Stop;
@@ -285,7 +286,10 @@ public class NearbyStopFinder {
       OTPFeature.VehicleToStopHeuristics.isOn() &&
       VehicleToStopSkipEdgeStrategy.applicableModes.contains(routingRequest.modes.accessMode)
     ) {
-      var strategy = new VehicleToStopSkipEdgeStrategy(transitService::getRoutesForStop);
+      var strategy = new VehicleToStopSkipEdgeStrategy(
+        transitService::getRoutesForStop,
+        routingRequest.modes.transitModes.stream().map(MainAndSubMode::mainMode).toList()
+      );
       return new ComposingSkipEdgeStrategy(strategy, durationSkipEdgeStrategy);
     } else if (
       OTPFeature.VehicleToStopHeuristics.isOn() &&


### PR DESCRIPTION
### Summary

A user has reported that she cannot find the Bike + Ride route that she is looking for.

![Screenshot from 2022-08-09 20-59-14](https://user-images.githubusercontent.com/151346/183741334-382c1b34-73e7-466e-8c5d-e323f86ed4ee.png)

She deactivated the subway mode and wanted to cycle directly to the faster suburban train, like this:

![Screenshot from 2022-08-09 21-05-51](https://user-images.githubusercontent.com/151346/183741311-a231eb74-09fa-4b27-8785-2947b1063a3c.png)

However, she received no route because the search was terminated earlier due to the allowed modes not being respected.

This fixes that problem.