### PR TITLE
Throw RoutingValidationException if origin and destination are the same

### DIFF
--- a/src/main/java/org/opentripplanner/routing/core/TemporaryVerticesContainer.java
+++ b/src/main/java/org/opentripplanner/routing/core/TemporaryVerticesContainer.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.routing.core;
 
+import com.google.common.collect.Sets;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -95,7 +96,13 @@ public class TemporaryVerticesContainer implements AutoCloseable {
       );
     }
 
-    if (routingErrors.size() > 0) {
+    // if from and to share any vertices, the user is already at their destination, and the result
+    // is a trivial path
+    if (from != null && to != null && !Sets.intersection(from, to).isEmpty()) {
+      routingErrors.add(new RoutingError(RoutingErrorCode.WALKING_BETTER_THAN_TRANSIT, null));
+    }
+
+    if (!routingErrors.isEmpty()) {
       throw new RoutingValidationException(routingErrors);
     }
   }

--- a/src/test/java/org/opentripplanner/routing/algorithm/StreetModeLinkingTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/StreetModeLinkingTest.java
@@ -201,6 +201,9 @@ public class StreetModeLinkingTest extends GraphRoutingTest {
 
       consumer.accept(routingRequest);
 
+      // Remove to, so that origin and destination are different
+      routingRequest.to = new GenericLocation(null, null);
+
       try (var temporaryVertices = new TemporaryVerticesContainer(graph, routingRequest)) {
         RoutingContext routingContext = new RoutingContext(
           routingRequest,
@@ -211,6 +214,21 @@ public class StreetModeLinkingTest extends GraphRoutingTest {
         if (fromStreetName != null) {
           assertFromLink(fromStreetName, streetMode, routingContext);
         }
+      }
+
+      routingRequest = new RoutingRequest().getStreetSearchRequest(streetMode);
+
+      consumer.accept(routingRequest);
+
+      // Remove from, so that origin and destination are different
+      routingRequest.from = new GenericLocation(null, null);
+
+      try (var temporaryVertices = new TemporaryVerticesContainer(graph, routingRequest)) {
+        RoutingContext routingContext = new RoutingContext(
+          routingRequest,
+          graph,
+          temporaryVertices
+        );
 
         if (toStreetName != null) {
           assertToLink(toStreetName, streetMode, routingContext);


### PR DESCRIPTION
### Summary

If the origin and destination share any vertices, the user is already at their destination, and the result is a trivial path.

### Issue

Closes #4350
