### PR TITLE
Do not crash Transmodel API when pattern for trip is not found

### DIFF
--- a/docs/sandbox/TransmodelApi.md
+++ b/docs/sandbox/TransmodelApi.md
@@ -51,6 +51,8 @@
   [#4198](https://github.com/opentripplanner/OpenTripPlanner/pull/4198)
 - Add support for groupOfLines in top level query
   [#4232](https://github.com/opentripplanner/OpenTripPlanner/pull/4232)
+- Fix issue when ServiceJourney is created by an updater and expose necessary information via DSJ
+  [#4365](https://github.com/opentripplanner/OpenTripPlanner/pull/4365)
 
 ## Documentation
 

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLTripImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLTripImpl.java
@@ -337,15 +337,8 @@ public class LegacyGraphQLTripImpl implements LegacyGraphQLDataFetchers.LegacyGr
           ? ServiceDateUtils.parseString(args.getLegacyGraphQLServiceDate())
           : LocalDate.now(timeZone);
 
-        TripPattern tripPattern = transitService.getRealtimeAddedTripPattern(
-          trip.getId(),
-          serviceDate
-        );
-        // timetableSnapshot is null or no realtime added pattern found
-        if (tripPattern == null) {
-          tripPattern = getTripPattern(environment);
-        }
-        // no matching pattern found anywhere
+        TripPattern tripPattern = transitService.getPatternForTrip(trip, serviceDate);
+        // no matching pattern found
         if (tripPattern == null) {
           return List.of();
         }

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
@@ -322,6 +322,9 @@ public class TransmodelGraphQLSchema {
 
     GraphQLOutputType datedServiceJourneyType = DatedServiceJourneyType.create(
       serviceJourneyType,
+      journeyPatternType,
+      estimatedCallType,
+      quayType,
       gqlUtil
     );
 

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/DatedServiceJourneyType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/DatedServiceJourneyType.java
@@ -160,15 +160,10 @@ public class DatedServiceJourneyType {
   private static TripPattern tripPattern(DataFetchingEnvironment env) {
     TransitService transitService = GqlUtil.getTransitService(env);
     TripOnServiceDate tripOnServiceDate = tripOnServiceDate(env);
-    Trip trip = tripOnServiceDate.getTrip();
-    TripPattern tripPattern = transitService.getRealtimeAddedTripPattern(
-      trip.getId(),
+    return transitService.getPatternForTrip(
+      tripOnServiceDate.getTrip(),
       tripOnServiceDate.getServiceDate()
     );
-    if (tripPattern == null) {
-      tripPattern = transitService.getPatternForTrip(trip);
-    }
-    return tripPattern;
   }
 
   private static TripOnServiceDate tripOnServiceDate(DataFetchingEnvironment environment) {

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/DatedServiceJourneyType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/DatedServiceJourneyType.java
@@ -2,16 +2,26 @@ package org.opentripplanner.ext.transmodelapi.model.timetable;
 
 import static org.opentripplanner.ext.transmodelapi.model.EnumTypes.SERVICE_ALTERATION;
 
+import graphql.AssertException;
+import graphql.Scalars;
 import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLList;
 import graphql.schema.GraphQLNonNull;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLOutputType;
+import graphql.schema.GraphQLType;
 import graphql.schema.GraphQLTypeReference;
+import java.util.List;
 import java.util.Optional;
 import org.opentripplanner.ext.transmodelapi.support.GqlUtil;
+import org.opentripplanner.routing.TripTimesShortHelper;
+import org.opentripplanner.transit.model.network.TripPattern;
+import org.opentripplanner.transit.model.site.StopLocation;
+import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
+import org.opentripplanner.transit.service.TransitService;
 
 /**
  * A DatedServiceJourney GraphQL Type for use in endpoints fetching DatedServiceJourney data
@@ -21,7 +31,13 @@ public class DatedServiceJourneyType {
   private static final String NAME = "DatedServiceJourney";
   public static final GraphQLTypeReference REF = new GraphQLTypeReference(NAME);
 
-  public static GraphQLObjectType create(GraphQLOutputType serviceJourneyType, GqlUtil gqlUtil) {
+  public static GraphQLObjectType create(
+    GraphQLOutputType serviceJourneyType,
+    GraphQLOutputType journeyPatternType,
+    GraphQLType estimatedCallType,
+    GraphQLType quayType,
+    GqlUtil gqlUtil
+  ) {
     return GraphQLObjectType
       .newObject()
       .name(NAME)
@@ -66,7 +82,93 @@ public class DatedServiceJourneyType {
           .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(REF))))
           .dataFetcher(environment -> tripOnServiceDate(environment).getReplacementFor())
       )
+      .field(
+        GraphQLFieldDefinition
+          .newFieldDefinition()
+          .name("journeyPattern")
+          .description("JourneyPattern for the dated service journey.")
+          .type(journeyPatternType)
+          .dataFetcher(DatedServiceJourneyType::tripPattern)
+          .build()
+      )
+      .field(
+        GraphQLFieldDefinition
+          .newFieldDefinition()
+          .name("quays")
+          .description("Quays visited by the dated service journey.")
+          .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(quayType))))
+          .argument(
+            GraphQLArgument
+              .newArgument()
+              .name("first")
+              .description("Only fetch the first n quays on the service journey")
+              .type(Scalars.GraphQLInt)
+              .build()
+          )
+          .argument(
+            GraphQLArgument
+              .newArgument()
+              .name("last")
+              .description("Only fetch the last n quays on the service journey")
+              .type(Scalars.GraphQLInt)
+              .build()
+          )
+          .dataFetcher(environment -> {
+            Integer first = environment.getArgument("first");
+            Integer last = environment.getArgument("last");
+            TripPattern tripPattern = tripPattern(environment);
+            List<StopLocation> stops = tripPattern.getStops();
+
+            if (first != null && last != null) {
+              throw new AssertException("Both first and last can't be defined simultaneously.");
+            } else if (first != null) {
+              if (first > stops.size()) {
+                return stops.subList(0, first);
+              }
+            } else if (last != null) {
+              if (last > stops.size()) {
+                return stops.subList(stops.size() - last, stops.size());
+              }
+            }
+            return stops;
+          })
+          .build()
+      )
+      .field(
+        GraphQLFieldDefinition
+          .newFieldDefinition()
+          .name("estimatedCalls")
+          .type(new GraphQLList(estimatedCallType))
+          .withDirective(gqlUtil.timingData)
+          .description(
+            "Returns scheduled passingTimes for this dated service journey, " +
+            "updated with realtime-updates (if available). "
+          )
+          .dataFetcher(environment -> {
+            TripOnServiceDate tripOnServiceDate = tripOnServiceDate(environment);
+            return TripTimesShortHelper.getTripTimesShort(
+              GqlUtil.getTransitService(environment),
+              tripOnServiceDate.getTrip(),
+              tripOnServiceDate.getServiceDate()
+            );
+          })
+          .build()
+      )
       .build();
+  }
+
+  private static TripPattern tripPattern(DataFetchingEnvironment env) {
+    TransitService transitService = GqlUtil.getTransitService(env);
+    TripOnServiceDate tripOnServiceDate = tripOnServiceDate(env);
+    Trip trip = tripOnServiceDate.getTrip();
+    TripPattern tripPattern = transitService.getRealtimeAddedTripPattern(
+      trip.getId(),
+      tripOnServiceDate.getServiceDate()
+    );
+    if (tripPattern == null) {
+      tripPattern = transitService.getPatternForTrip(trip);
+    }
+    return tripPattern;
   }
 
   private static TripOnServiceDate tripOnServiceDate(DataFetchingEnvironment environment) {

--- a/src/main/java/org/opentripplanner/model/plan/legreference/ScheduledTransitLegReference.java
+++ b/src/main/java/org/opentripplanner/model/plan/legreference/ScheduledTransitLegReference.java
@@ -30,13 +30,7 @@ public record ScheduledTransitLegReference(
       return null;
     }
 
-    // Check if pattern is changed by real-time updater
-    TripPattern tripPattern = transitService.getRealtimeAddedTripPattern(tripId, serviceDate);
-
-    // Otherwise use scheduled pattern
-    if (tripPattern == null) {
-      tripPattern = transitService.getPatternForTrip(trip);
-    }
+    TripPattern tripPattern = transitService.getPatternForTrip(trip, serviceDate);
 
     // no matching pattern found anywhere
     if (tripPattern == null) {

--- a/src/main/java/org/opentripplanner/routing/TripTimesShortHelper.java
+++ b/src/main/java/org/opentripplanner/routing/TripTimesShortHelper.java
@@ -10,9 +10,14 @@ import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripTimes;
 import org.opentripplanner.transit.service.TransitService;
+import org.opentripplanner.util.logging.AbstractFilterLogger;
 import org.opentripplanner.util.time.ServiceDateUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TripTimesShortHelper {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TripTimesShortHelper.class);
 
   public static List<TripTimeOnDate> getTripTimesShort(
     TransitService transitService,
@@ -25,6 +30,10 @@ public class TripTimesShortHelper {
 
     // If realtime moved pattern back to original trip, fetch it instead
     if (timetable.getTripIndex(trip.getId()) == -1) {
+      LOG.warn(
+        "Trip {} not found in realtime pattern. This should not happen, and indicates a bug.",
+        trip
+      );
       pattern = transitService.getPatternForTrip(trip);
       timetable = transitService.getTimetableForTripPattern(pattern, serviceDate);
     }

--- a/src/main/java/org/opentripplanner/routing/TripTimesShortHelper.java
+++ b/src/main/java/org/opentripplanner/routing/TripTimesShortHelper.java
@@ -19,11 +19,7 @@ public class TripTimesShortHelper {
     Trip trip,
     LocalDate serviceDate
   ) {
-    // Check if realtime-data changed pattern for trip, otherwise use original
-    TripPattern pattern = transitService.getRealtimeAddedTripPattern(trip.getId(), serviceDate);
-    if (pattern == null) {
-      pattern = transitService.getPatternForTrip(trip);
-    }
+    TripPattern pattern = transitService.getPatternForTrip(trip, serviceDate);
 
     Timetable timetable = transitService.getTimetableForTripPattern(pattern, serviceDate);
 

--- a/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
+++ b/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
@@ -265,6 +265,15 @@ public class DefaultTransitService implements TransitEditorService {
     return this.transitModelIndex.getPatternForTrip().get(trip);
   }
 
+  @Override
+  public TripPattern getPatternForTrip(Trip trip, LocalDate serviceDate) {
+    TripPattern realtimePattern = getRealtimeAddedTripPattern(trip.getId(), serviceDate);
+    if (realtimePattern != null) {
+      return realtimePattern;
+    }
+    return getPatternForTrip(trip);
+  }
+
   /** {@link TransitModelIndex#getPatternsForRoute()} */
   @Override
   public Collection<TripPattern> getPatternsForRoute(Route route) {

--- a/src/main/java/org/opentripplanner/transit/service/TransitService.java
+++ b/src/main/java/org/opentripplanner/transit/service/TransitService.java
@@ -110,6 +110,8 @@ public interface TransitService {
 
   TripPattern getPatternForTrip(Trip trip);
 
+  TripPattern getPatternForTrip(Trip trip, LocalDate serviceDate);
+
   Collection<TripPattern> getPatternsForRoute(Route route);
 
   MultiModalStation getMultiModalStationForStation(Station station);


### PR DESCRIPTION
### Summary

Fix NPE in the Transmodel API, and expose the necessary information via the DatedServiceJourney type instead.

### Issue

Currently we get an error, if we try to fetch scheduled stops for a trip, which is created by the realtime updater.
