### PR TITLE
Add Stop Location index to transit model

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/traveltime/TravelTimeResource.java
+++ b/src/ext/java/org/opentripplanner/ext/traveltime/TravelTimeResource.java
@@ -250,7 +250,7 @@ public class TravelTimeResource {
       routingRequest.modes.accessMode,
       false
     );
-    return new AccessEgressMapper(transitLayer.getStopIndex()).mapNearbyStops(accessStops, false);
+    return new AccessEgressMapper().mapNearbyStops(accessStops, false);
   }
 
   private List<State> getInitialStates(

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/TransitRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/TransitRouter.java
@@ -96,7 +96,7 @@ public class TransitRouter {
 
     debugTimingAggregator.finishedPatternFiltering();
 
-    var accessEgresses = getAccessEgresses(transitLayer);
+    var accessEgresses = getAccessEgresses();
 
     debugTimingAggregator.finishedAccessEgress(
       accessEgresses.getAccesses().size(),
@@ -155,8 +155,8 @@ public class TransitRouter {
     return new TransitRouterResult(itineraries, transitResponse.requestUsed().searchParams());
   }
 
-  private AccessEgresses getAccessEgresses(TransitLayer transitLayer) {
-    var accessEgressMapper = new AccessEgressMapper(transitLayer.getStopIndex());
+  private AccessEgresses getAccessEgresses() {
+    var accessEgressMapper = new AccessEgressMapper();
     var accessList = new ArrayList<AccessEgress>();
     var egressList = new ArrayList<AccessEgress>();
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/FlexAccessEgressAdapter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/FlexAccessEgressAdapter.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.routing.algorithm.raptoradapter.transit;
 
 import org.opentripplanner.ext.flex.FlexAccessEgress;
-import org.opentripplanner.transit.service.StopModelIndex;
 
 /**
  * This class is used to adapt the FlexAccessEgress into a time-dependent multi-leg AccessEgress.
@@ -10,13 +9,9 @@ public class FlexAccessEgressAdapter extends AccessEgress {
 
   private final FlexAccessEgress flexAccessEgress;
 
-  public FlexAccessEgressAdapter(
-    FlexAccessEgress flexAccessEgress,
-    boolean isEgress,
-    StopModelIndex stopIndex
-  ) {
+  public FlexAccessEgressAdapter(FlexAccessEgress flexAccessEgress, boolean isEgress) {
     super(
-      stopIndex.indexOf(flexAccessEgress.stop),
+      flexAccessEgress.stop.getIndex(),
       isEgress ? flexAccessEgress.lastState.reverse() : flexAccessEgress.lastState
     );
     this.flexAccessEgress = flexAccessEgress;

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TransitLayer.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TransitLayer.java
@@ -14,7 +14,6 @@ import org.opentripplanner.routing.algorithm.raptoradapter.transit.constrainedtr
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.mappers.TripPatternMapper;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.request.RaptorRequestTransferCache;
 import org.opentripplanner.routing.core.RoutingContext;
-import org.opentripplanner.transit.model.site.Stop;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.service.StopModelIndex;
 
@@ -88,10 +87,6 @@ public class TransitLayer {
     this.tripPatternMapper = tripPatternMapper;
     this.transferIndexGenerator = transferIndexGenerator;
     this.stopBoardAlightCosts = stopBoardAlightCosts;
-  }
-
-  public int getIndexByStop(Stop stop) {
-    return stopIndex.indexOf(stop);
   }
 
   @Nullable

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/constrainedtransfer/TransferIndexGenerator.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/constrainedtransfer/TransferIndexGenerator.java
@@ -25,7 +25,6 @@ import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.site.Station;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.timetable.Trip;
-import org.opentripplanner.transit.service.StopModelIndex;
 
 public class TransferIndexGenerator {
 
@@ -37,15 +36,12 @@ public class TransferIndexGenerator {
   private final Map<StopLocation, Set<TripPatternWithRaptorStopIndexes>> patternsByStop = new HashMap<>();
   private final Map<Route, Set<TripPatternWithRaptorStopIndexes>> patternsByRoute = new HashMap<>();
   private final Map<Trip, Set<TripPatternWithRaptorStopIndexes>> patternsByTrip = new HashMap<>();
-  private final StopModelIndex stopIndex;
 
   public TransferIndexGenerator(
     Collection<ConstrainedTransfer> constrainedTransfers,
-    Collection<TripPatternWithRaptorStopIndexes> tripPatterns,
-    StopModelIndex stopIndex
+    Collection<TripPatternWithRaptorStopIndexes> tripPatterns
   ) {
     this.constrainedTransfers = constrainedTransfers;
-    this.stopIndex = stopIndex;
     setupPatternByTripIndex(tripPatterns);
   }
 
@@ -154,7 +150,7 @@ public class TransferIndexGenerator {
       return List.of();
     }
 
-    var sourcePoint = createTransferPointForPattern(station, stopIndex);
+    var sourcePoint = createTransferPointForPattern(station);
     var result = new ArrayList<TPoint>();
 
     for (TripPatternWithRaptorStopIndexes pattern : patterns) {
@@ -176,7 +172,7 @@ public class TransferIndexGenerator {
       return List.of();
     }
 
-    var sourcePoint = createTransferPointForPattern(stopIndex.indexOf(stop));
+    var sourcePoint = createTransferPointForPattern(stop.getIndex());
     var result = new ArrayList<TPoint>();
 
     for (TripPatternWithRaptorStopIndexes pattern : patterns) {

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/AccessEgressMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/AccessEgressMapper.java
@@ -9,15 +9,8 @@ import org.opentripplanner.routing.algorithm.raptoradapter.transit.AccessEgress;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.FlexAccessEgressAdapter;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
 import org.opentripplanner.transit.model.site.Stop;
-import org.opentripplanner.transit.service.StopModelIndex;
 
 public class AccessEgressMapper {
-
-  private final StopModelIndex stopIndex;
-
-  public AccessEgressMapper(StopModelIndex stopIndex) {
-    this.stopIndex = stopIndex;
-  }
 
   public AccessEgress mapNearbyStop(NearbyStop nearbyStop, boolean isEgress) {
     if (!(nearbyStop.stop instanceof Stop)) {
@@ -25,7 +18,7 @@ public class AccessEgressMapper {
     }
 
     return new AccessEgress(
-      stopIndex.indexOf(nearbyStop.stop),
+      nearbyStop.stop.getIndex(),
       isEgress ? nearbyStop.state.reverse() : nearbyStop.state
     );
   }
@@ -44,7 +37,7 @@ public class AccessEgressMapper {
   ) {
     return flexAccessEgresses
       .stream()
-      .map(flexAccessEgress -> new FlexAccessEgressAdapter(flexAccessEgress, isEgress, stopIndex))
+      .map(flexAccessEgress -> new FlexAccessEgressAdapter(flexAccessEgress, isEgress))
       .collect(Collectors.toList());
   }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TransfersMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TransfersMapper.java
@@ -23,7 +23,7 @@ class TransfersMapper {
 
       for (PathTransfer pathTransfer : transitModel.getTransfersByStop(stop)) {
         if (pathTransfer.to instanceof Stop) {
-          int toStopIndex = stopIndex.indexOf((Stop) pathTransfer.to);
+          int toStopIndex = pathTransfer.to.getIndex();
           Transfer newTransfer;
           if (pathTransfer.getEdges() != null) {
             newTransfer = new Transfer(toStopIndex, pathTransfer.getEdges());

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TransitLayerMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TransitLayerMapper.java
@@ -81,8 +81,7 @@ public class TransitLayerMapper {
 
     Collection<TripPattern> allTripPatterns = transitModel.getAllTripPatterns();
     TripPatternMapper tripPatternMapper = new TripPatternMapper();
-    newTripPatternForOld =
-      tripPatternMapper.mapOldTripPatternToRaptorTripPattern(stopIndex, allTripPatterns);
+    newTripPatternForOld = tripPatternMapper.mapOldTripPatternToRaptorTripPattern(allTripPatterns);
 
     tripPatternsByStopByDate = mapTripPatterns(allTripPatterns, newTripPatternForOld);
 
@@ -93,8 +92,7 @@ public class TransitLayerMapper {
       transferIndexGenerator =
         new TransferIndexGenerator(
           transitModel.getTransferService().listAll(),
-          newTripPatternForOld.values(),
-          stopIndex
+          newTripPatternForOld.values()
         );
       transferIndexGenerator.generateTransfers();
     }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TransitLayerUpdater.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TransitLayerUpdater.java
@@ -77,7 +77,6 @@ public class TransitLayerUpdater {
     final Map<TripPattern, TripPatternWithRaptorStopIndexes> newTripPatternForOld = realtimeTransitLayer
       .getTripPatternMapper()
       .mapOldTripPatternToRaptorTripPattern(
-        realtimeTransitLayer.getStopIndex(),
         updatedTimetables.stream().map(Timetable::getPattern).collect(Collectors.toSet())
       );
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TripPatternMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TripPatternMapper.java
@@ -5,7 +5,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripPatternWithRaptorStopIndexes;
 import org.opentripplanner.transit.model.network.TripPattern;
-import org.opentripplanner.transit.service.StopModelIndex;
+import org.opentripplanner.transit.model.site.StopLocation;
 
 public class TripPatternMapper {
 
@@ -17,7 +17,6 @@ public class TripPatternMapper {
    * source data.
    */
   Map<TripPattern, TripPatternWithRaptorStopIndexes> mapOldTripPatternToRaptorTripPattern(
-    StopModelIndex stopIndex,
     Collection<TripPattern> oldTripPatterns
   ) {
     for (TripPattern oldTripPattern : oldTripPatterns) {
@@ -26,7 +25,7 @@ public class TripPatternMapper {
       }
       TripPatternWithRaptorStopIndexes newTripPattern = new TripPatternWithRaptorStopIndexes(
         oldTripPattern,
-        oldTripPattern.getStops().stream().mapToInt(stopIndex::indexOf).toArray()
+        oldTripPattern.getStops().stream().mapToInt(StopLocation::getIndex).toArray()
       );
       newTripPatternForOld.put(oldTripPattern, newTripPattern);
     }

--- a/src/main/java/org/opentripplanner/routing/graph/SerializedGraphObject.java
+++ b/src/main/java/org/opentripplanner/routing/graph/SerializedGraphObject.java
@@ -24,6 +24,7 @@ import org.opentripplanner.routing.graph.kryosupport.KryoBuilder;
 import org.opentripplanner.standalone.config.BuildConfig;
 import org.opentripplanner.standalone.config.RouterConfig;
 import org.opentripplanner.transit.model.basic.SubMode;
+import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.util.OtpAppException;
 import org.opentripplanner.util.logging.ProgressTracker;
@@ -65,6 +66,8 @@ public class SerializedGraphObject implements Serializable {
    */
   public final List<SubMode> allTransitSubModes;
 
+  public final int stopLocationCounter;
+
   public SerializedGraphObject(
     Graph graph,
     TransitModel transitModel,
@@ -77,6 +80,7 @@ public class SerializedGraphObject implements Serializable {
     this.buildConfig = buildConfig;
     this.routerConfig = routerConfig;
     this.allTransitSubModes = SubMode.listAllCachedSubModes();
+    this.stopLocationCounter = StopLocation.numberOfStopLocations();
   }
 
   public static void verifyTheOutputGraphIsWritableIfDataSourceExist(DataSource graphOutput) {
@@ -152,6 +156,7 @@ public class SerializedGraphObject implements Serializable {
       Kryo kryo = KryoBuilder.create();
       SerializedGraphObject serObj = (SerializedGraphObject) kryo.readClassAndObject(input);
       SubMode.deserializeSubModeCache(serObj.allTransitSubModes);
+      StopLocation.setCounterValue(serObj.stopLocationCounter);
       CompactElevationProfile.setDistanceBetweenSamplesM(
         serObj.graph.getDistanceBetweenElevationSamples()
       );

--- a/src/main/java/org/opentripplanner/routing/graph/SerializedGraphObject.java
+++ b/src/main/java/org/opentripplanner/routing/graph/SerializedGraphObject.java
@@ -80,7 +80,7 @@ public class SerializedGraphObject implements Serializable {
     this.buildConfig = buildConfig;
     this.routerConfig = routerConfig;
     this.allTransitSubModes = SubMode.listAllCachedSubModes();
-    this.stopLocationCounter = StopLocation.numberOfStopLocations();
+    this.stopLocationCounter = StopLocation.indexCounter();
   }
 
   public static void verifyTheOutputGraphIsWritableIfDataSourceExist(DataSource graphOutput) {
@@ -156,7 +156,7 @@ public class SerializedGraphObject implements Serializable {
       Kryo kryo = KryoBuilder.create();
       SerializedGraphObject serObj = (SerializedGraphObject) kryo.readClassAndObject(input);
       SubMode.deserializeSubModeCache(serObj.allTransitSubModes);
-      StopLocation.setCounterValue(serObj.stopLocationCounter);
+      StopLocation.initIndexCounter(serObj.stopLocationCounter);
       CompactElevationProfile.setDistanceBetweenSamplesM(
         serObj.graph.getDistanceBetweenElevationSamples()
       );

--- a/src/main/java/org/opentripplanner/transit/model/site/FlexLocationGroup.java
+++ b/src/main/java/org/opentripplanner/transit/model/site/FlexLocationGroup.java
@@ -27,7 +27,7 @@ public class FlexLocationGroup
 
   FlexLocationGroup(FlexLocationGroupBuilder builder) {
     super(builder.getId());
-    this.index = COUNTER.getAndIncrement();
+    this.index = INDEX_COUNTER.getAndIncrement();
     this.name = builder.name();
     this.geometry = builder.geometry();
     this.centroid = builder.centroid();

--- a/src/main/java/org/opentripplanner/transit/model/site/FlexLocationGroup.java
+++ b/src/main/java/org/opentripplanner/transit/model/site/FlexLocationGroup.java
@@ -18,6 +18,7 @@ public class FlexLocationGroup
   extends TransitEntity<FlexLocationGroup, FlexLocationGroupBuilder>
   implements StopLocation {
 
+  private final int index;
   private final Set<StopLocation> stopLocations;
   private final I18NString name;
   private final GeometryCollection geometry;
@@ -26,6 +27,7 @@ public class FlexLocationGroup
 
   FlexLocationGroup(FlexLocationGroupBuilder builder) {
     super(builder.getId());
+    this.index = COUNTER.getAndIncrement();
     this.name = builder.name();
     this.geometry = builder.geometry();
     this.centroid = builder.centroid();
@@ -34,6 +36,11 @@ public class FlexLocationGroup
 
   public static FlexLocationGroupBuilder of(FeedScopedId id) {
     return new FlexLocationGroupBuilder(id);
+  }
+
+  @Override
+  public int getIndex() {
+    return index;
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/transit/model/site/FlexStopLocation.java
+++ b/src/main/java/org/opentripplanner/transit/model/site/FlexStopLocation.java
@@ -19,6 +19,7 @@ public class FlexStopLocation
   extends TransitEntity<FlexStopLocation, FlexStopLocationBuilder>
   implements StopLocation {
 
+  private final int index;
   private final I18NString name;
 
   private final boolean hasFallbackName;
@@ -35,6 +36,7 @@ public class FlexStopLocation
 
   FlexStopLocation(FlexStopLocationBuilder builder) {
     super(builder.getId());
+    this.index = COUNTER.getAndIncrement();
     // according to the spec stop location names are optional for flex zones so, we set the id
     // as the bogus name. *shrug*
     if (builder.name() == null) {
@@ -53,6 +55,11 @@ public class FlexStopLocation
 
   public static FlexStopLocationBuilder of(FeedScopedId id) {
     return new FlexStopLocationBuilder(id);
+  }
+
+  @Override
+  public int getIndex() {
+    return index;
   }
 
   /**

--- a/src/main/java/org/opentripplanner/transit/model/site/FlexStopLocation.java
+++ b/src/main/java/org/opentripplanner/transit/model/site/FlexStopLocation.java
@@ -36,7 +36,7 @@ public class FlexStopLocation
 
   FlexStopLocation(FlexStopLocationBuilder builder) {
     super(builder.getId());
-    this.index = COUNTER.getAndIncrement();
+    this.index = INDEX_COUNTER.getAndIncrement();
     // according to the spec stop location names are optional for flex zones so, we set the id
     // as the bogus name. *shrug*
     if (builder.name() == null) {

--- a/src/main/java/org/opentripplanner/transit/model/site/Stop.java
+++ b/src/main/java/org/opentripplanner/transit/model/site/Stop.java
@@ -21,6 +21,7 @@ import org.opentripplanner.util.geometry.GeometryUtils;
  */
 public final class Stop extends StationElement<Stop, StopBuilder> implements StopLocation {
 
+  private final int index;
   private final String platformCode;
 
   private final I18NString url;
@@ -37,6 +38,7 @@ public final class Stop extends StationElement<Stop, StopBuilder> implements Sto
 
   Stop(StopBuilder builder) {
     super(builder);
+    this.index = COUNTER.getAndIncrement();
     this.platformCode = builder.platformCode();
     this.url = builder.url();
     this.timeZone = builder.timeZone();
@@ -51,6 +53,11 @@ public final class Stop extends StationElement<Stop, StopBuilder> implements Sto
 
   public static StopBuilder of(FeedScopedId id) {
     return new StopBuilder(id);
+  }
+
+  @Override
+  public int getIndex() {
+    return index;
   }
 
   /**

--- a/src/main/java/org/opentripplanner/transit/model/site/Stop.java
+++ b/src/main/java/org/opentripplanner/transit/model/site/Stop.java
@@ -38,7 +38,7 @@ public final class Stop extends StationElement<Stop, StopBuilder> implements Sto
 
   Stop(StopBuilder builder) {
     super(builder);
-    this.index = COUNTER.getAndIncrement();
+    this.index = INDEX_COUNTER.getAndIncrement();
     this.platformCode = builder.platformCode();
     this.url = builder.url();
     this.timeZone = builder.timeZone();

--- a/src/main/java/org/opentripplanner/transit/model/site/StopLocation.java
+++ b/src/main/java/org/opentripplanner/transit/model/site/StopLocation.java
@@ -27,6 +27,13 @@ public interface StopLocation extends LogInfo {
   /** The ID for the StopLocation */
   FeedScopedId getId();
 
+  /**
+   * This is the OTP internal <em>synthetic key</em>, used to reference a StopLocation inside OTP.  This is used
+   * to optimize routing, we do not access the stop instance only keep the {code index}. The index will not change.
+   * <p>
+   * Do NOT expose this index in the APIs, it is not guaranteed to be the same across different OTP instances, 
+   * use the {code id} for external references.
+   */
   int getIndex();
 
   /** Name of the StopLocation, if provided */
@@ -150,7 +157,7 @@ public interface StopLocation extends LogInfo {
   /**
    * Use this ONLY when deserializing the graph. Sets the counter value to the highest recorded value
    */
-  static void setCounterValue(int stopLocationCounter) {
-    COUNTER.set(stopLocationCounter);
+  static void initIndexCounter(int indexCounter) {
+    COUNTER.set(indexCounter);
   }
 }

--- a/src/main/java/org/opentripplanner/transit/model/site/StopLocation.java
+++ b/src/main/java/org/opentripplanner/transit/model/site/StopLocation.java
@@ -22,7 +22,7 @@ import org.opentripplanner.util.lang.ObjectUtils;
  * transit. StopLocations are referred to in stop times.
  */
 public interface StopLocation extends LogInfo {
-  AtomicInteger COUNTER = new AtomicInteger(0);
+  AtomicInteger INDEX_COUNTER = new AtomicInteger(0);
 
   /** The ID for the StopLocation */
   FeedScopedId getId();
@@ -31,7 +31,7 @@ public interface StopLocation extends LogInfo {
    * This is the OTP internal <em>synthetic key</em>, used to reference a StopLocation inside OTP.  This is used
    * to optimize routing, we do not access the stop instance only keep the {code index}. The index will not change.
    * <p>
-   * Do NOT expose this index in the APIs, it is not guaranteed to be the same across different OTP instances, 
+   * Do NOT expose this index in the APIs, it is not guaranteed to be the same across different OTP instances,
    * use the {code id} for external references.
    */
   int getIndex();
@@ -150,14 +150,14 @@ public interface StopLocation extends LogInfo {
     return getId();
   }
 
-  static int numberOfStopLocations() {
-    return COUNTER.get();
+  static int indexCounter() {
+    return INDEX_COUNTER.get();
   }
 
   /**
    * Use this ONLY when deserializing the graph. Sets the counter value to the highest recorded value
    */
   static void initIndexCounter(int indexCounter) {
-    COUNTER.set(indexCounter);
+    INDEX_COUNTER.set(indexCounter);
   }
 }

--- a/src/main/java/org/opentripplanner/transit/model/site/StopLocation.java
+++ b/src/main/java/org/opentripplanner/transit/model/site/StopLocation.java
@@ -3,6 +3,7 @@ package org.opentripplanner.transit.model.site;
 import java.time.ZoneId;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.locationtech.jts.geom.Geometry;
@@ -21,8 +22,12 @@ import org.opentripplanner.util.lang.ObjectUtils;
  * transit. StopLocations are referred to in stop times.
  */
 public interface StopLocation extends LogInfo {
+  AtomicInteger COUNTER = new AtomicInteger(0);
+
   /** The ID for the StopLocation */
   FeedScopedId getId();
+
+  int getIndex();
 
   /** Name of the StopLocation, if provided */
   @Nullable
@@ -136,5 +141,16 @@ public interface StopLocation extends LogInfo {
       return stationElement.getParentStation().getId();
     }
     return getId();
+  }
+
+  static int numberOfStopLocations() {
+    return COUNTER.get();
+  }
+
+  /**
+   * Use this ONLY when deserializing the graph. Sets the counter value to the highest recorded value
+   */
+  static void setCounterValue(int stopLocationCounter) {
+    COUNTER.set(stopLocationCounter);
   }
 }

--- a/src/main/java/org/opentripplanner/transit/service/StopModelIndex.java
+++ b/src/main/java/org/opentripplanner/transit/service/StopModelIndex.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import org.locationtech.jts.geom.Envelope;
 import org.opentripplanner.common.geometry.HashGridSpatialIndex;
@@ -36,11 +35,12 @@ public class StopModelIndex {
   private final Multimap<StopLocation, FlexLocationGroup> locationGroupsByStop = ArrayListMultimap.create();
   private final HashGridSpatialIndex<FlexStopLocation> locationIndex = new HashGridSpatialIndex<>();
   private final Map<FeedScopedId, StopLocation> stopForId = new HashMap<>();
-  private final List<StopLocation> stopsByIndex;
-  private final Map<StopLocation, Integer> indexByStop = new HashMap<>();
+  private final StopLocation[] stopsByIndex;
 
   public StopModelIndex(StopModel stopModel) {
     LOG.info("StopModelIndex init...");
+
+    stopsByIndex = new StopLocation[StopLocation.numberOfStopLocations()];
 
     /* We will keep a separate set of all vertices in case some have the same label.
      * Maybe we should just guarantee unique labels. */
@@ -48,6 +48,7 @@ public class StopModelIndex {
       Stop stop = stopVertex.getStop();
       stopForId.put(stop.getId(), stop);
       stopVertexForStop.put(stop, stopVertex);
+      stopsByIndex[stop.getIndex()] = stop;
     }
     for (TransitStopVertex stopVertex : stopVertexForStop.values()) {
       Envelope envelope = new Envelope(stopVertex.getCoordinate());
@@ -64,15 +65,12 @@ public class StopModelIndex {
         locationGroupsByStop.put(stop, flexLocationGroup);
       }
       stopForId.put(flexLocationGroup.getId(), flexLocationGroup);
+      stopsByIndex[flexLocationGroup.getIndex()] = flexLocationGroup;
     }
     for (FlexStopLocation flexStopLocation : stopModel.getAllFlexLocations()) {
       locationIndex.insert(flexStopLocation.getGeometry().getEnvelopeInternal(), flexStopLocation);
       stopForId.put(flexStopLocation.getId(), flexStopLocation);
-    }
-
-    this.stopsByIndex = List.copyOf(stopForId.values());
-    for (int i = 0; i < stopsByIndex.size(); ++i) {
-      indexByStop.put(stopsByIndex.get(i), i);
+      stopsByIndex[flexStopLocation.getIndex()] = flexStopLocation;
     }
 
     LOG.info("StopModelIndex init complete.");
@@ -99,15 +97,11 @@ public class StopModelIndex {
   }
 
   public StopLocation stopByIndex(int index) {
-    return stopsByIndex.get(index);
-  }
-
-  public int indexOf(StopLocation stop) {
-    return indexByStop.get(stop);
+    return stopsByIndex[index];
   }
 
   public int size() {
-    return stopsByIndex.size();
+    return stopsByIndex.length;
   }
 
   public Collection<FlexStopLocation> queryLocationIndex(Envelope envelope) {

--- a/src/main/java/org/opentripplanner/transit/service/StopModelIndex.java
+++ b/src/main/java/org/opentripplanner/transit/service/StopModelIndex.java
@@ -40,7 +40,7 @@ public class StopModelIndex {
   public StopModelIndex(StopModel stopModel) {
     LOG.info("StopModelIndex init...");
 
-    stopsByIndex = new StopLocation[StopLocation.numberOfStopLocations()];
+    stopsByIndex = new StopLocation[StopLocation.indexCounter()];
 
     /* We will keep a separate set of all vertices in case some have the same label.
      * Maybe we should just guarantee unique labels. */

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/constrainedtransfer/ConstrainedBoardingSearchTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/constrainedtransfer/ConstrainedBoardingSearchTest.java
@@ -5,13 +5,11 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.model.transfer.TransferConstraint.REGULAR_TRANSFER;
-import static org.opentripplanner.routing.algorithm.raptoradapter.transit.request.TestTransitCaseData.RAPTOR_STOP_INDEX;
 import static org.opentripplanner.routing.algorithm.raptoradapter.transit.request.TestTransitCaseData.STATION_B;
 import static org.opentripplanner.routing.algorithm.raptoradapter.transit.request.TestTransitCaseData.STOP_A;
 import static org.opentripplanner.routing.algorithm.raptoradapter.transit.request.TestTransitCaseData.STOP_B;
 import static org.opentripplanner.routing.algorithm.raptoradapter.transit.request.TestTransitCaseData.STOP_C;
 import static org.opentripplanner.routing.algorithm.raptoradapter.transit.request.TestTransitCaseData.STOP_D;
-import static org.opentripplanner.routing.algorithm.raptoradapter.transit.request.TestTransitCaseData.stopIndex;
 
 import java.util.Collection;
 import java.util.List;
@@ -33,8 +31,6 @@ import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.site.Stop;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripScheduleBoardOrAlightEvent;
-import org.opentripplanner.transit.service.StopIndexMock;
-import org.opentripplanner.transit.service.StopModelIndex;
 import org.opentripplanner.util.OTPFeature;
 
 public class ConstrainedBoardingSearchTest {
@@ -75,7 +71,6 @@ public class ConstrainedBoardingSearchTest {
   private TestRouteData route2;
   private TripPatternWithRaptorStopIndexes pattern1;
   private TripPatternWithRaptorStopIndexes pattern2;
-  private StopModelIndex stopIndex;
 
   /**
    * Create transit data with 2 routes with a trip each.
@@ -136,8 +131,6 @@ public class ConstrainedBoardingSearchTest {
 
     this.pattern1 = route1.getRaptorTripPattern();
     this.pattern2 = route2.getRaptorTripPattern();
-
-    this.stopIndex = new StopIndexMock(List.of(RAPTOR_STOP_INDEX));
   }
 
   @Test
@@ -356,7 +349,7 @@ public class ConstrainedBoardingSearchTest {
     var subject = pattern2.constrainedTransferForwardSearch();
 
     int targetStopPos = route2.stopPosition(transferStop);
-    int stopIndex = stopIndex(transferStop);
+    int stopIndex = transferStop.getIndex();
     int sourceArrivalTime = route1.lastTrip().getStopTime(transferStop).getArrivalTime();
 
     // Check that transfer exist
@@ -383,7 +376,7 @@ public class ConstrainedBoardingSearchTest {
     var subject = pattern1.constrainedTransferReverseSearch();
     int targetStopPos = route1.stopPosition(transferStop);
 
-    int stopIndex = stopIndex(transferStop);
+    int stopIndex = transferStop.getIndex();
     int sourceArrivalTime = route2.firstTrip().getStopTime(transferStop).getDepartureTime();
 
     // Check that transfer exist
@@ -435,6 +428,6 @@ public class ConstrainedBoardingSearchTest {
   }
 
   private void generateTransfersForPatterns(Collection<ConstrainedTransfer> txList) {
-    new TransferIndexGenerator(txList, List.of(pattern1, pattern2), stopIndex).generateTransfers();
+    new TransferIndexGenerator(txList, List.of(pattern1, pattern2)).generateTransfers();
   }
 }

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TestRouteData.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TestRouteData.java
@@ -2,7 +2,6 @@ package org.opentripplanner.routing.algorithm.raptoradapter.transit.request;
 
 import static org.opentripplanner.routing.algorithm.raptoradapter.transit.request.TestTransitCaseData.DATE;
 import static org.opentripplanner.routing.algorithm.raptoradapter.transit.request.TestTransitCaseData.OFFSET;
-import static org.opentripplanner.routing.algorithm.raptoradapter.transit.request.TestTransitCaseData.stopIndex;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -132,7 +131,7 @@ public class TestRouteData {
   }
 
   int[] stopIndexes(Collection<StopTime> times) {
-    return times.stream().mapToInt(it -> stopIndex(it.getStop())).toArray();
+    return times.stream().map(StopTime::getStop).mapToInt(StopLocation::getIndex).toArray();
   }
 
   private Trip parseTripInfo(

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TestTransitCaseData.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TestTransitCaseData.java
@@ -4,7 +4,6 @@ import java.time.LocalDate;
 import org.opentripplanner.transit.model._data.TransitModelForTest;
 import org.opentripplanner.transit.model.site.Station;
 import org.opentripplanner.transit.model.site.Stop;
-import org.opentripplanner.transit.model.site.StopLocation;
 
 public final class TestTransitCaseData {
 
@@ -22,20 +21,7 @@ public final class TestTransitCaseData {
   public static final Stop STOP_C = TransitModelForTest.stopForTest("C", 61.0, 11.4);
   public static final Stop STOP_D = TransitModelForTest.stopForTest("D", 61.0, 11.6);
 
-  // Random order stop indexes - should be different from stopPos in pattern to
-  // make sure code-under-test do not mix stopIndex and stopPosition
-  public static final Stop[] RAPTOR_STOP_INDEX = { STOP_D, STOP_A, STOP_C, STOP_B };
-
   public static final LocalDate DATE = LocalDate.of(2021, 12, 24);
 
   public static final int OFFSET = 0;
-
-  public static int stopIndex(StopLocation stop) {
-    for (int i = 0; i < RAPTOR_STOP_INDEX.length; ++i) {
-      if (stop == RAPTOR_STOP_INDEX[i]) {
-        return i;
-      }
-    }
-    throw new IllegalArgumentException();
-  }
 }

--- a/src/test/java/org/opentripplanner/transit/service/StopIndexMock.java
+++ b/src/test/java/org/opentripplanner/transit/service/StopIndexMock.java
@@ -18,11 +18,6 @@ public class StopIndexMock extends StopModelIndex {
   }
 
   @Override
-  public int indexOf(StopLocation stop) {
-    return stops.indexOf(stop);
-  }
-
-  @Override
   public int size() {
     return stops.size();
   }


### PR DESCRIPTION
### Summary

Currently we have a separate StopIndex , that is created runtime, in order to be able to create patterns for RAPTOR in graph build, we need to add these indices to the transit mode. This PR does that.

### Issue

Part of #4002
