### PR TITLE
Skip opening hours if no time-zone configured

### DIFF
--- a/src/main/java/org/opentripplanner/common/RepeatingTimePeriod.java
+++ b/src/main/java/org/opentripplanner/common/RepeatingTimePeriod.java
@@ -5,6 +5,7 @@ import java.time.DayOfWeek;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.function.Supplier;
 
 /**
  * Represents a repeating time period, used for opening hours etc. For instance: Monday - Friday 8AM
@@ -15,7 +16,6 @@ import java.time.ZonedDateTime;
  */
 public class RepeatingTimePeriod implements Serializable {
 
-  private static final long serialVersionUID = -5977328371879835782L;
   /**
    * The timezone this is represented in.
    */
@@ -32,9 +32,8 @@ public class RepeatingTimePeriod implements Serializable {
   private int[][] saturday;
   private int[][] sunday;
 
-  private RepeatingTimePeriod() {
-    // TODO: Timezone/locale
-    this.timeZone = ZoneId.of("GMT");
+  public RepeatingTimePeriod(ZoneId timeZone) {
+    this.timeZone = timeZone;
   }
 
   /**
@@ -44,8 +43,14 @@ public class RepeatingTimePeriod implements Serializable {
     String day_on,
     String day_off,
     String hour_on,
-    String hour_off
+    String hour_off,
+    Supplier<ZoneId> timeZoneSupplier
   ) {
+    ZoneId timeZone = timeZoneSupplier.get();
+    if (timeZone == null) {
+      return null;
+    }
+
     // first, create the opening and closing times. This is easy because there is the same one
     // every day of the week that this restriction is in force.
     String[] parsedOn = hour_on.split(";");
@@ -61,7 +66,7 @@ public class RepeatingTimePeriod implements Serializable {
     }
 
     boolean active = false;
-    RepeatingTimePeriod ret = new RepeatingTimePeriod();
+    RepeatingTimePeriod ret = new RepeatingTimePeriod(timeZone);
 
     // loop through twice to handle cases like Saturday - Tuesday
     for (String today : new String[] {

--- a/src/main/java/org/opentripplanner/graph_builder/module/configure/GraphBuilderFactory.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/configure/GraphBuilderFactory.java
@@ -4,6 +4,7 @@ import dagger.BindsInstance;
 import dagger.Component;
 import java.time.ZoneId;
 import java.util.List;
+import javax.annotation.Nullable;
 import javax.inject.Singleton;
 import org.opentripplanner.ext.dataoverlay.EdgeUpdaterModule;
 import org.opentripplanner.ext.flex.FlexLocationsToStreetEdgesMapper;
@@ -64,7 +65,7 @@ public interface GraphBuilderFactory {
     Builder dataSources(GraphBuilderDataSources graphBuilderDataSources);
 
     @BindsInstance
-    Builder timeZoneId(ZoneId zoneId);
+    Builder timeZoneId(@Nullable ZoneId zoneId);
 
     GraphBuilderFactory build();
   }

--- a/src/main/java/org/opentripplanner/graph_builder/module/configure/GraphBuilderModules.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/configure/GraphBuilderModules.java
@@ -12,6 +12,7 @@ import java.time.Duration;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nullable;
 import javax.inject.Singleton;
 import org.opentripplanner.datastore.api.CompositeDataSource;
 import org.opentripplanner.datastore.api.DataSource;
@@ -52,7 +53,7 @@ public class GraphBuilderModules {
     GraphBuilderDataSources dataSources,
     BuildConfig config,
     Graph graph,
-    ZoneId zoneId,
+    @Nullable ZoneId zoneId,
     DataImportIssueStore issueStore
   ) {
     List<OpenStreetMapProvider> providers = new ArrayList<>();

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/OSMDatabase.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/OSMDatabase.java
@@ -9,6 +9,7 @@ import gnu.trove.map.TLongObjectMap;
 import gnu.trove.map.hash.TLongObjectHashMap;
 import gnu.trove.set.TLongSet;
 import gnu.trove.set.hash.TLongHashSet;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -18,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Supplier;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
@@ -128,10 +130,20 @@ public class OSMDatabase {
    */
   public boolean noZeroLevels = true;
   private final Set<String> boardingAreaRefTags;
+  private final Supplier<ZoneId> timeZone;
 
-  public OSMDatabase(DataImportIssueStore issueStore, Set<String> boardingAreaRefTags) {
+  public OSMDatabase(
+    DataImportIssueStore issueStore,
+    Set<String> boardingAreaRefTags,
+    Supplier<ZoneId> timeZoneId
+  ) {
     this.issueStore = issueStore;
     this.boardingAreaRefTags = boardingAreaRefTags;
+    this.timeZone = timeZoneId;
+  }
+
+  public OSMDatabase(DataImportIssueStore issueStore, Set<String> boardingAreaRefTags) {
+    this(issueStore, boardingAreaRefTags, () -> ZoneId.of("UTC"));
   }
 
   public OSMNode getNode(Long nodeId) {
@@ -1035,7 +1047,8 @@ public class OSMDatabase {
             relation.getTag("day_on"),
             relation.getTag("day_off"),
             relation.getTag("hour_on"),
-            relation.getTag("hour_off")
+            relation.getTag("hour_off"),
+            timeZone
           );
       } catch (NumberFormatException e) {
         LOG.info("Unparseable turn restriction: " + relation.getId());

--- a/src/main/java/org/opentripplanner/openstreetmap/OSMOpeningHoursParser.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/OSMOpeningHoursParser.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.opentripplanner.graph_builder.DataImportIssueStore;
@@ -44,7 +45,7 @@ public class OSMOpeningHoursParser {
 
   private final OpeningHoursCalendarService openingHoursCalendarService;
 
-  private final ZoneId zoneId;
+  private final Supplier<ZoneId> zoneIdSupplier;
 
   private final DataImportIssueStore issueStore;
 
@@ -77,12 +78,12 @@ public class OSMOpeningHoursParser {
 
   public OSMOpeningHoursParser(
     OpeningHoursCalendarService openingHoursCalendarService,
-    ZoneId zoneId,
+    Supplier<ZoneId> zoneIdSupplier,
     DataImportIssueStore issueStore
   ) {
     this.openingHoursCalendarService = openingHoursCalendarService;
     // TODO, zoneId should depend on the coordinates of the object
-    this.zoneId = zoneId;
+    this.zoneIdSupplier = zoneIdSupplier;
     this.issueStore = issueStore;
   }
 
@@ -92,7 +93,7 @@ public class OSMOpeningHoursParser {
   ) {
     this.openingHoursCalendarService = openingHoursCalendarService;
     // TODO, zoneId should depend on the coordinates of the object
-    this.zoneId = zoneId;
+    this.zoneIdSupplier = () -> zoneId;
     this.issueStore = null;
   }
 
@@ -102,6 +103,10 @@ public class OSMOpeningHoursParser {
    */
   public OHCalendar parseOpeningHours(String openingHoursTag, String id, String link)
     throws OpeningHoursParseException {
+    ZoneId zoneId = zoneIdSupplier.get();
+    if (zoneId == null) {
+      return null;
+    }
     var calendarBuilder = openingHoursCalendarService.newBuilder(zoneId);
     var parser = new OpeningHoursParser(new ByteArrayInputStream(openingHoursTag.getBytes()));
     var rules = parser.rules(false);


### PR DESCRIPTION
### Summary

Skip Opening hours if no time-zone configured. Log a warning, that timeZone should be added to the build config.

### Issue

closes #4355

### Unit tests

Migrated

### Changelog

The [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Changelog.md)
is generated from the pull-request title, make sure the title describe the feature or issue fixed.
To exclude the PR from the changelog add the label `skip changelog` to the PR.

### Bumping the serialization version id

If you have made changes to the way the routing graph is serialized, for example by renaming a field
in one of the edges, then you must add the label `bump serialization id` to the PR. With this label
Github Actions will increase the field `otp.serialization.version.id` in `pom.xml`.
