### PR TITLE
Otp2 patch ci test

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
@@ -171,22 +171,7 @@ public class GraphBuilder implements Runnable {
     issueStore.summarize();
     validate();
 
-    long endTime = System.currentTimeMillis();
-    LOG.info(
-      "Graph building took {}.",
-      DurationUtils.durationToStr(Duration.ofMillis(endTime - startTime))
-    );
-    var f = new OtpNumberFormat();
-    LOG.info(
-      "Main graph size: |V|={} |E|={}",
-      f.formatNumber(graph.countVertices()),
-      f.formatNumber(graph.countEdges())
-    );
-    LOG.info(
-      "Transit model size: |Stops|={}, |Patterns|={}",
-      f.formatNumber(transitModel.getStopModel().size()),
-      f.formatNumber(transitModel.getAllTripPatterns().size())
-    );
+    logGraphBuilderCompleteStatus(startTime, graph, transitModel);
   }
 
   private void addModule(GraphBuilderModule module) {
@@ -216,5 +201,23 @@ public class GraphBuilder implements Runnable {
         "'transitServiceEnd'"
       );
     }
+  }
+
+  private static void logGraphBuilderCompleteStatus(
+    long startTime,
+    Graph graph,
+    TransitModel transitModel
+  ) {
+    long endTime = System.currentTimeMillis();
+    String time = DurationUtils.durationToStr(Duration.ofMillis(endTime - startTime));
+    var f = new OtpNumberFormat();
+    var nStops = f.formatNumber(transitModel.getStopModel().size());
+    var nPatterns = f.formatNumber(transitModel.getAllTripPatterns().size());
+    var nVertices = f.formatNumber(graph.countVertices());
+    var nEdges = f.formatNumber(graph.countEdges());
+
+    LOG.info("Graph building took {}.", time);
+    LOG.info("Graph built.   |V|={} |E|={}", nVertices, nEdges);
+    LOG.info("Transit built. |Stops|={} |Patterns|={}", nStops, nPatterns);
   }
 }

--- a/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
@@ -16,6 +16,7 @@ import org.opentripplanner.standalone.config.BuildConfig;
 import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.util.OTPFeature;
 import org.opentripplanner.util.OtpAppException;
+import org.opentripplanner.util.lang.OtpNumberFormat;
 import org.opentripplanner.util.time.DurationUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -175,7 +176,17 @@ public class GraphBuilder implements Runnable {
       "Graph building took {}.",
       DurationUtils.durationToStr(Duration.ofMillis(endTime - startTime))
     );
-    LOG.info("Main graph size: |V|={} |E|={}", graph.countVertices(), graph.countEdges());
+    var f = new OtpNumberFormat();
+    LOG.info(
+      "Main graph size: |V|={} |E|={}",
+      f.formatNumber(graph.countVertices()),
+      f.formatNumber(graph.countEdges())
+    );
+    LOG.info(
+      "Transit model size: |Stops|={}, |Patterns|={}",
+      f.formatNumber(transitModel.getStopModel().size()),
+      f.formatNumber(transitModel.getAllTripPatterns().size())
+    );
   }
 
   private void addModule(GraphBuilderModule module) {

--- a/src/main/java/org/opentripplanner/routing/graph/SerializedGraphObject.java
+++ b/src/main/java/org/opentripplanner/routing/graph/SerializedGraphObject.java
@@ -27,6 +27,7 @@ import org.opentripplanner.transit.model.basic.SubMode;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.util.OtpAppException;
+import org.opentripplanner.util.lang.OtpNumberFormat;
 import org.opentripplanner.util.logging.ProgressTracker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -160,10 +161,9 @@ public class SerializedGraphObject implements Serializable {
       CompactElevationProfile.setDistanceBetweenSamplesM(
         serObj.graph.getDistanceBetweenElevationSamples()
       );
-      Graph graph = serObj.graph;
       LOG.debug("Graph read.");
       serObj.reconstructEdgeLists();
-      LOG.info("Graph read. |V|={} |E|={}", graph.countVertices(), graph.countEdges());
+      logSerializationCompleteStatus(serObj.graph, serObj.transitModel);
       return serObj;
     } catch (IOException e) {
       LOG.error("Exception while loading graph: {}", e.getLocalizedMessage(), e);
@@ -227,5 +227,16 @@ public class SerializedGraphObject implements Serializable {
     LOG.info("Graph written: {}", graphName);
     // Summarize serialized classes and associated serializers to stdout:
     // ((InstanceCountingClassResolver) kryo.getClassResolver()).summarize();
+  }
+
+  private static void logSerializationCompleteStatus(Graph graph, TransitModel transitModel) {
+    var f = new OtpNumberFormat();
+    var nStops = f.formatNumber(transitModel.getStopModel().size());
+    var nPatterns = f.formatNumber(transitModel.getAllTripPatterns().size());
+    var nVertices = f.formatNumber(graph.countVertices());
+    var nEdges = f.formatNumber(graph.countEdges());
+
+    LOG.info("Graph loaded.   |V|={} |E|={}", nVertices, nEdges);
+    LOG.info("Transit loaded. |Stops|={} |Patterns|={}", nStops, nPatterns);
   }
 }

--- a/src/main/java/org/opentripplanner/transit/service/StopModel.java
+++ b/src/main/java/org/opentripplanner/transit/service/StopModel.java
@@ -92,7 +92,7 @@ public class StopModel implements Serializable {
       .stream()
       .filter(Stop.class::isInstance)
       .map(Stop.class::cast)
-      .map(index::getStopVertexForStop)
+      .map(it -> getStopModelIndex().getStopVertexForStop(it))
       .collect(Collectors.toSet());
   }
 
@@ -121,7 +121,7 @@ public class StopModel implements Serializable {
     }
 
     // Single stop
-    var stop = index.getStopForId(id);
+    var stop = getStopModelIndex().getStopForId(id);
     if (stop != null) {
       return stop.getCoordinate();
     }
@@ -176,7 +176,7 @@ public class StopModel implements Serializable {
       return station.getChildStops();
     }
     // Single stop
-    var stop = index.getStopForId(id);
+    var stop = getStopModelIndex().getStopForId(id);
     if (stop != null) {
       return Collections.singleton(stop);
     }

--- a/src/main/java/org/opentripplanner/transit/service/StopModel.java
+++ b/src/main/java/org/opentripplanner/transit/service/StopModel.java
@@ -142,6 +142,7 @@ public class StopModel implements Serializable {
   }
 
   public void addFlexLocation(FeedScopedId id, FlexStopLocation flexStopLocation) {
+    invalidateIndex();
     locationsById.put(id, flexStopLocation);
   }
 
@@ -154,6 +155,7 @@ public class StopModel implements Serializable {
   }
 
   public void addFlexLocationGroup(FeedScopedId id, FlexLocationGroup flexLocationGroup) {
+    invalidateIndex();
     locationGroupsById.put(id, flexLocationGroup);
   }
 
@@ -225,6 +227,7 @@ public class StopModel implements Serializable {
   }
 
   public void addTransitStopVertex(FeedScopedId id, TransitStopVertex stopVertex) {
+    invalidateIndex();
     transitStopVertices.put(id, stopVertex);
   }
 
@@ -262,14 +265,17 @@ public class StopModel implements Serializable {
   }
 
   public void addStation(Station station) {
+    invalidateIndex();
     stationById.put(station.getId(), station);
   }
 
   public void addMultiModalStation(MultiModalStation multiModalStation) {
+    invalidateIndex();
     multiModalStationById.put(multiModalStation.getId(), multiModalStation);
   }
 
   public void addGroupsOfStations(GroupOfStations groupOfStations) {
+    invalidateIndex();
     groupOfStationsById.put(groupOfStations.getId(), groupOfStations);
   }
 
@@ -314,5 +320,9 @@ public class StopModel implements Serializable {
 
   public Collection<FlexStopLocation> queryLocationIndex(Envelope envelope) {
     return getStopModelIndex().queryLocationIndex(envelope);
+  }
+
+  private void invalidateIndex() {
+    this.index = null;
   }
 }

--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/support/AssertSpeedTestSetup.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/support/AssertSpeedTestSetup.java
@@ -1,0 +1,41 @@
+package org.opentripplanner.transit.raptor.speed_test.support;
+
+import org.opentripplanner.standalone.config.BuildConfig;
+import org.opentripplanner.transit.raptor.speed_test.options.SpeedTestConfig;
+import org.opentripplanner.transit.service.TransitModel;
+import org.opentripplanner.util.OtpAppException;
+
+public class AssertSpeedTestSetup {
+
+  public static void assertTestDateHasData(
+    TransitModel transitModel,
+    SpeedTestConfig config,
+    BuildConfig buildConfig
+  ) {
+    int numberOfPatternForTestDate = transitModel
+      .getTransitLayer()
+      .getTripPatternsForDate(config.testDate)
+      .size();
+
+    if (numberOfPatternForTestDate < 10) {
+      throw new OtpAppException(
+        """
+        Number of trip patterns on test date is less than 10. There is probably something wrong
+        with your config or data. Check that the graph build contains transit stops and patterns
+        (see build log) and check that the 'testDate' is in the period of your data.
+
+          number of patterns on date: %d    
+          "testDate":                 %s (speed-test-config.json)
+          "transitServiceStart":      %s (build-config.json)
+          "transitServiceEnd":        %s (build-config.json)
+        
+        """.formatted(
+            numberOfPatternForTestDate,
+            config.testDate,
+            buildConfig.transitServiceStart,
+            buildConfig.transitServiceEnd
+          )
+      );
+    }
+  }
+}


### PR DESCRIPTION
### Summary
This PR fixes an issue with the SpeedTest failing, because the StopModelIndex is not initialized. This is a bug make the CI SpeedTest fail, so it is good to fix it ASP, then I will make a better cleanup in the #4371.

### Issue
No.

### Unit tests
No.

### Documentation

I have added more logging to the OTP build/startup and an assertions that prevent the SpeedTest from running if no transit data exist. The assertion comes with a good explanation to what might be wrong and what config parameters to check(it prints the values as well). I think this is better than writing more doc. 