### PR TITLE
Flex: when optimizing paths preserve egress transfers

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/model/OptimizedPathTail.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/transferoptimization/model/OptimizedPathTail.java
@@ -11,6 +11,7 @@ import org.opentripplanner.transit.raptor.api.transit.BoardAndAlightTime;
 import org.opentripplanner.transit.raptor.api.transit.CostCalculator;
 import org.opentripplanner.transit.raptor.api.transit.RaptorSlackProvider;
 import org.opentripplanner.transit.raptor.api.transit.RaptorStopNameResolver;
+import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
 import org.opentripplanner.util.lang.ValueObjectToStringBuilder;
 
@@ -71,12 +72,17 @@ public class OptimizedPathTail<T extends RaptorTripSchedule>
   /** Start by adding the last transit leg with the egress leg attached. */
   public OptimizedPathTail<T> addTransitTail(TransitPathLeg<T> leg) {
     var next = leg.nextLeg();
+    var transfer = (RaptorTransfer) null;
     // this can also be a transfer leg to a flex trip
     if (next.isTransferLeg()) {
+      transfer = next.asTransferLeg().transfer();
       next = next.nextLeg();
     }
     if (next.isEgressLeg()) {
       egress(next.asEgressLeg().egress());
+      if (transfer != null) {
+        transfer(transfer, transfer.stop());
+      }
       var times = new BoardAndAlightTime(
         leg.trip(),
         leg.getFromStopPosition(),

--- a/src/main/java/org/opentripplanner/transit/raptor/api/path/PathBuilderLeg.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/path/PathBuilderLeg.java
@@ -166,6 +166,9 @@ public class PathBuilderLeg<T extends RaptorTripSchedule> {
     if (next != null) {
       if (next.isTransfer()) {
         next.timeShiftTransferTime(slackProvider);
+        if (next.next().isEgress()) {
+          next.timeShiftThisAndNextLeg(slackProvider);
+        }
       } else if (next.isEgress()) {
         next.timeShiftEgressTime(slackProvider);
       }

--- a/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/model/OptimizedPathTailTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/transferoptimization/model/OptimizedPathTailTest.java
@@ -96,7 +96,11 @@ class OptimizedPathTailTest implements RaptorTestConstants {
     subject.access(orgPath.accessLeg().access());
 
     var exp =
-      "Walk 3m15s ~ A " + "~ BUS L11 10:04 10:35 ~ B " + "~ Walk 7m45s " + "[$3318 $0pri $3378wtc]";
+      "Walk 3m15s ~ A " +
+      "~ BUS L11 10:04 10:35 ~ B " +
+      "~ Walk 3m45s ~ E " +
+      "~ Flex 7m45s 1x " +
+      "[$3936 $0pri $3996wtc]";
 
     assertEquals(exp, subject.toString());
   }

--- a/src/test/java/org/opentripplanner/transit/raptor/_data/stoparrival/BasicPathTestCase.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/_data/stoparrival/BasicPathTestCase.java
@@ -3,6 +3,7 @@ package org.opentripplanner.transit.raptor._data.stoparrival;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.model.transfer.TransferConstraint.REGULAR_TRANSFER;
 import static org.opentripplanner.routing.algorithm.raptoradapter.transit.cost.RaptorCostConverter.toRaptorCost;
+import static org.opentripplanner.transit.raptor._data.transit.TestTransfer.flexWithOnBoard;
 import static org.opentripplanner.transit.raptor._data.transit.TestTransfer.walk;
 import static org.opentripplanner.transit.raptor._data.transit.TestTripPattern.pattern;
 import static org.opentripplanner.util.time.DurationUtils.durationToStr;
@@ -152,7 +153,7 @@ public class BasicPathTestCase implements RaptorTestConstants {
   private static final RaptorTransfer ACCESS = walk(STOP_A, ACCESS_DURATION, ACCESS_COST);
   private static final RaptorTransfer EGRESS = walk(STOP_E, EGRESS_DURATION, EGRESS_COST);
   // this is of course not a real flex egress
-  private static final RaptorTransfer FLEX = walk(STOP_E, EGRESS_DURATION, EGRESS_COST);
+  private static final RaptorTransfer FLEX = flexWithOnBoard(STOP_E, EGRESS_DURATION, EGRESS_COST);
 
   public static final String LINE_11 = "L11";
   public static final String LINE_21 = "L21";
@@ -297,7 +298,7 @@ public class BasicPathTestCase implements RaptorTestConstants {
       EGRESS_END,
       EGRESS_COST
     );
-    var transfer = TestTransfer.walk(STOP_C, TX_END - TX_START);
+    var transfer = TestTransfer.walk(STOP_E, TX_END - TX_START);
     PathLeg<TestTripSchedule> leg3 = new TransferPathLeg<>(
       STOP_B,
       TX_START,

--- a/src/test/java/org/opentripplanner/transit/raptor/_data/transit/TestTransfer.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/_data/transit/TestTransfer.java
@@ -48,6 +48,14 @@ public class TestTransfer implements RaptorTransfer {
     return new Builder(stop, durationInSeconds).withCost(cost).build();
   }
 
+  public static TestTransfer flexWithOnBoard(int stop, int durationInSeconds, int cost) {
+    return new Builder(stop, durationInSeconds)
+      .withCost(cost)
+      .withNRides(1)
+      .stopReachedOnBoard()
+      .build();
+  }
+
   /**
    * Creates a walk transfer with time restrictions. opening and closing may be specified as seconds
    * since the start of "RAPTOR time" to limit the time periods that the access is traversable,


### PR DESCRIPTION
### Summary

If an itinerary contains multiple transfers and a flex trip, the final transfer is dropped by the transfer optimization. With these changes it is not dropped.

### Issue

closes #4294 

### Unit tests

The existing unit test is updated.