### PR TITLE
Correct toString() methods for NearbyStop, TripScheduleWithOffset

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripScheduleWithOffset.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripScheduleWithOffset.java
@@ -120,7 +120,7 @@ public final class TripScheduleWithOffset implements TripSchedule {
     return ToStringBuilder
       .of(TripScheduleWithOffset.class)
       .addObj("trip", pattern.debugInfo())
-      .addServiceTime("depart", secondsOffset + tripTimes.getDepartureTime(0))
+      .addServiceTime("depart", secondsOffset + getOriginalTripTimes().getDepartureTime(0))
       .toString();
   }
 

--- a/src/main/java/org/opentripplanner/routing/graphfinder/NearbyStop.java
+++ b/src/main/java/org/opentripplanner/routing/graphfinder/NearbyStop.java
@@ -82,7 +82,7 @@ public class NearbyStop implements Comparable<NearbyStop> {
   public String toString() {
     return String.format(
       Locale.ROOT,
-      "stop %s at %.1f meters%s%s%s",
+      "stop %s at %.1f meters%s%s",
       stop,
       distance,
       edges != null ? " (" + edges.size() + " edges)" : "",


### PR DESCRIPTION
### Summary

This avoids an NPE and corrects the format string in `toString()` methods.