### PR TITLE
Make DataImportIssueStore a Singleton

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/DataImportIssueStore.java
+++ b/src/main/java/org/opentripplanner/graph_builder/DataImportIssueStore.java
@@ -6,9 +6,11 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Singleton
 public class DataImportIssueStore {
 
   private static final Logger ISSUE_LOG = LoggerFactory.getLogger("DATA_IMPORT_ISSUES");


### PR DESCRIPTION
### Summary

Currently each consumer of `DataImportIssueStore` gets a new instance. Fix this by making it a `Singleton`
