### PR TITLE
Improve logging

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
@@ -749,7 +749,7 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
 
     pattern.add(tripTimes);
 
-    OptionalInt invalidStopIndex = tripTimes.timesIncreasing();
+    OptionalInt invalidStopIndex = tripTimes.findFirstNoneIncreasingStopTime();
     Preconditions.checkState(
       invalidStopIndex.isEmpty(),
       "Non-increasing triptimes for added trip at stop index %s",

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
@@ -16,6 +16,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
@@ -748,9 +749,11 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
 
     pattern.add(tripTimes);
 
+    OptionalInt invalidStopIndex = tripTimes.timesIncreasing();
     Preconditions.checkState(
-      tripTimes.timesIncreasing(),
-      "Non-increasing triptimes for added trip"
+      invalidStopIndex.isEmpty(),
+      "Non-increasing triptimes for added trip at stop index %s",
+      invalidStopIndex
     );
 
     return addTripToGraphAndBuffer(

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.ext.siri;
 
+import static com.google.common.base.Strings.lenientFormat;
 import static org.opentripplanner.ext.siri.SiriTransportModeMapper.mapTransitMainMode;
 import static org.opentripplanner.ext.siri.TimetableHelper.createModifiedStopTimes;
 import static org.opentripplanner.ext.siri.TimetableHelper.createModifiedStops;
@@ -749,12 +750,16 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
 
     pattern.add(tripTimes);
 
-    OptionalInt invalidStopIndex = tripTimes.findFirstNoneIncreasingStopTime();
-    Preconditions.checkState(
-      invalidStopIndex.isEmpty(),
-      "Non-increasing triptimes for added trip at stop index %s",
-      invalidStopIndex
-    );
+    tripTimes
+      .findFirstNoneIncreasingStopTime()
+      .ifPresent(invalidStopIndex -> {
+        throw new IllegalStateException(
+          String.format(
+            "Non-increasing triptimes for added trip at stop index %d",
+            invalidStopIndex
+          )
+        );
+      });
 
     return addTripToGraphAndBuffer(
       feedId,

--- a/src/ext/java/org/opentripplanner/ext/siri/TimetableHelper.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/TimetableHelper.java
@@ -373,7 +373,7 @@ public class TimetableHelper {
       newTimes.cancelTrip();
     }
 
-    OptionalInt invalidStopIndex = newTimes.timesIncreasing();
+    OptionalInt invalidStopIndex = newTimes.findFirstNoneIncreasingStopTime();
     if (invalidStopIndex.isPresent()) {
       LOG.info(
         "TripTimes are non-increasing after applying SIRI delay propagation - LineRef {}, TripId {}. Stop index {}",
@@ -766,7 +766,7 @@ public class TimetableHelper {
       }
     }
 
-    OptionalInt invalidStopIndex = newTimes.timesIncreasing();
+    OptionalInt invalidStopIndex = newTimes.findFirstNoneIncreasingStopTime();
     if (invalidStopIndex.isPresent()) {
       LOG.info(
         "TripTimes are non-increasing after applying SIRI delay propagation - LineRef {}, TripId {}. Stop index {}",

--- a/src/ext/java/org/opentripplanner/ext/siri/TimetableHelper.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/TimetableHelper.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -372,11 +373,13 @@ public class TimetableHelper {
       newTimes.cancelTrip();
     }
 
-    if (!newTimes.timesIncreasing()) {
+    OptionalInt invalidStopIndex = newTimes.timesIncreasing();
+    if (invalidStopIndex.isPresent()) {
       LOG.info(
-        "TripTimes are non-increasing after applying SIRI delay propagation - LineRef {}, TripId {}.",
+        "TripTimes are non-increasing after applying SIRI delay propagation - LineRef {}, TripId {}. Stop index {}",
         journey.getLineRef().getValue(),
-        tripId
+        tripId,
+        invalidStopIndex.getAsInt()
       );
       return null;
     }
@@ -763,10 +766,13 @@ public class TimetableHelper {
       }
     }
 
-    if (!newTimes.timesIncreasing()) {
+    OptionalInt invalidStopIndex = newTimes.timesIncreasing();
+    if (invalidStopIndex.isPresent()) {
       LOG.info(
-        "TripTimes are non-increasing after applying SIRI delay propagation - delay: {}",
-        delay
+        "TripTimes are non-increasing after applying SIRI delay propagation - LineRef {}, TripId {}. Stop index {}",
+        timetable.getPattern().getRoute().getId(),
+        tripId,
+        invalidStopIndex.getAsInt()
       );
       return null;
     }

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/ElevationModule.java
@@ -41,6 +41,7 @@ import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.util.PolylineEncoder;
 import org.opentripplanner.util.geometry.GeometryUtils;
 import org.opentripplanner.util.logging.ProgressTracker;
+import org.opentripplanner.util.time.DurationUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -239,6 +240,8 @@ public class ElevationModule implements GraphBuilderModule {
       }
     }
 
+    LOG.info(progress.completeMessage());
+
     // Iterate again to find edges that had elevation calculated.
     LinkedList<StreetEdge> edgesWithCalculatedElevations = new LinkedList<>();
     for (StreetEdge edgeWithElevation : streetsWithElevationEdges) {
@@ -249,6 +252,7 @@ public class ElevationModule implements GraphBuilderModule {
 
     if (writeCachedElevations) {
       // write information from edgesWithElevation to a new cache file for subsequent graph builds
+      LOG.info("Writing elevation cache");
       HashMap<String, PackedCoordinateSequence> newCachedElevations = new HashMap<>();
       for (StreetEdge streetEdge : edgesWithCalculatedElevations) {
         newCachedElevations.put(
@@ -279,8 +283,8 @@ public class ElevationModule implements GraphBuilderModule {
     updateElevationMetadata(graph);
 
     LOG.info(
-      "Finished elevation processing in {}s",
-      Duration.between(start, Instant.now()).toSeconds()
+      "Finished elevation processing in {}",
+      DurationUtils.durationToStr(Duration.between(start, Instant.now()))
     );
   }
 

--- a/src/main/java/org/opentripplanner/model/Timetable.java
+++ b/src/main/java/org/opentripplanner/model/Timetable.java
@@ -12,6 +12,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.timetable.Direction;
@@ -311,10 +312,13 @@ public class Timetable implements Serializable {
         );
       }
     }
-    if (!newTimes.timesIncreasing()) {
+
+    OptionalInt invalidStopIndex = newTimes.timesIncreasing();
+    if (invalidStopIndex.isPresent()) {
       LOG.error(
-        "TripTimes are non-increasing after applying GTFS-RT delay propagation to trip {}.",
-        tripId
+        "TripTimes are non-increasing after applying GTFS-RT delay propagation to trip {} after stop index {}.",
+        tripId,
+        invalidStopIndex.getAsInt()
       );
       return null;
     }

--- a/src/main/java/org/opentripplanner/model/Timetable.java
+++ b/src/main/java/org/opentripplanner/model/Timetable.java
@@ -313,7 +313,7 @@ public class Timetable implements Serializable {
       }
     }
 
-    OptionalInt invalidStopIndex = newTimes.timesIncreasing();
+    OptionalInt invalidStopIndex = newTimes.findFirstNoneIncreasingStopTime();
     if (invalidStopIndex.isPresent()) {
       LOG.error(
         "TripTimes are non-increasing after applying GTFS-RT delay propagation to trip {} after stop index {}.",

--- a/src/main/java/org/opentripplanner/transit/model/timetable/TripTimes.java
+++ b/src/main/java/org/opentripplanner/transit/model/timetable/TripTimes.java
@@ -7,6 +7,7 @@ import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Collection;
 import java.util.List;
+import java.util.OptionalInt;
 import org.opentripplanner.model.BookingInfo;
 import org.opentripplanner.model.StopTime;
 import org.opentripplanner.transit.model.basic.WheelchairAccessibility;
@@ -351,11 +352,11 @@ public class TripTimes implements Serializable, Comparable<TripTimes> {
   /**
    * When creating a scheduled TripTimes or wrapping it in updates, we could potentially imply
    * negative running or dwell times. We really don't want those being used in routing. This method
-   * check that all times are increasing, and logs warnings if this is not the case.
+   * checks that all times are increasing.
    *
-   * @return whether the times were found to be increasing.
+   * @return empty if times were found to be increasing, stop index of the first error otherwise
    */
-  public boolean timesIncreasing() {
+  public OptionalInt timesIncreasing() {
     final int nStops = scheduledArrivalTimes.length;
     int prevDep = -9_999_999;
     for (int s = 0; s < nStops; s++) {
@@ -363,16 +364,14 @@ public class TripTimes implements Serializable, Comparable<TripTimes> {
       final int dep = getDepartureTime(s);
 
       if (dep < arr) {
-        LOG.warn("Negative dwell time in TripTimes at stop index {}.", s);
-        return false;
+        return OptionalInt.of(s);
       }
       if (prevDep > arr) {
-        LOG.warn("Negative running time in TripTimes after stop index {}.", s);
-        return false;
+        return OptionalInt.of(s);
       }
       prevDep = dep;
     }
-    return true;
+    return OptionalInt.empty();
   }
 
   /** Cancel this entire trip */

--- a/src/main/java/org/opentripplanner/transit/model/timetable/TripTimes.java
+++ b/src/main/java/org/opentripplanner/transit/model/timetable/TripTimes.java
@@ -356,7 +356,7 @@ public class TripTimes implements Serializable, Comparable<TripTimes> {
    *
    * @return empty if times were found to be increasing, stop index of the first error otherwise
    */
-  public OptionalInt timesIncreasing() {
+  public OptionalInt findFirstNoneIncreasingStopTime() {
     final int nStops = scheduledArrivalTimes.length;
     int prevDep = -9_999_999;
     for (int s = 0; s < nStops; s++) {

--- a/src/test/java/org/opentripplanner/routing/trippattern/TripTimesTest.java
+++ b/src/test/java/org/opentripplanner/routing/trippattern/TripTimesTest.java
@@ -94,7 +94,7 @@ public class TripTimesTest {
     updatedTripTimesA.updateArrivalTime(1, 60);
     updatedTripTimesA.updateDepartureTime(1, 59);
 
-    OptionalInt invalidStopOIndex = updatedTripTimesA.timesIncreasing();
+    OptionalInt invalidStopOIndex = updatedTripTimesA.findFirstNoneIncreasingStopTime();
     assertTrue(invalidStopOIndex.isPresent());
     assertEquals(1, invalidStopOIndex.getAsInt());
 
@@ -103,7 +103,7 @@ public class TripTimesTest {
     updatedTripTimesB.updateDepartureTime(6, 421);
     updatedTripTimesB.updateArrivalTime(7, 420);
 
-    invalidStopOIndex = updatedTripTimesB.timesIncreasing();
+    invalidStopOIndex = updatedTripTimesB.findFirstNoneIncreasingStopTime();
     assertTrue(invalidStopOIndex.isPresent());
     assertEquals(7, invalidStopOIndex.getAsInt());
   }
@@ -115,7 +115,7 @@ public class TripTimesTest {
     updatedTripTimesA.updateArrivalTime(0, -300); //"Yesterday"
     updatedTripTimesA.updateDepartureTime(0, 50);
 
-    assertTrue(updatedTripTimesA.timesIncreasing().isEmpty());
+    assertTrue(updatedTripTimesA.findFirstNoneIncreasingStopTime().isEmpty());
   }
 
   @Test
@@ -182,7 +182,7 @@ public class TripTimesTest {
     updatedTripTimesA.updateArrivalTime(1, 89);
     updatedTripTimesA.updateDepartureTime(1, 98);
 
-    OptionalInt invalidStopOIndex = updatedTripTimesA.timesIncreasing();
+    OptionalInt invalidStopOIndex = updatedTripTimesA.findFirstNoneIncreasingStopTime();
     assertTrue(invalidStopOIndex.isPresent());
     assertEquals(2, invalidStopOIndex.getAsInt());
   }

--- a/src/test/java/org/opentripplanner/routing/trippattern/TripTimesTest.java
+++ b/src/test/java/org/opentripplanner/routing/trippattern/TripTimesTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.OptionalInt;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.model.StopTime;
 import org.opentripplanner.transit.model._data.TransitModelForTest;
@@ -93,14 +94,18 @@ public class TripTimesTest {
     updatedTripTimesA.updateArrivalTime(1, 60);
     updatedTripTimesA.updateDepartureTime(1, 59);
 
-    assertFalse(updatedTripTimesA.timesIncreasing());
+    OptionalInt invalidStopOIndex = updatedTripTimesA.timesIncreasing();
+    assertTrue(invalidStopOIndex.isPresent());
+    assertEquals(1, invalidStopOIndex.getAsInt());
 
     TripTimes updatedTripTimesB = new TripTimes(originalTripTimes);
 
     updatedTripTimesB.updateDepartureTime(6, 421);
     updatedTripTimesB.updateArrivalTime(7, 420);
 
-    assertFalse(updatedTripTimesB.timesIncreasing());
+    invalidStopOIndex = updatedTripTimesB.timesIncreasing();
+    assertTrue(invalidStopOIndex.isPresent());
+    assertEquals(7, invalidStopOIndex.getAsInt());
   }
 
   @Test
@@ -110,7 +115,7 @@ public class TripTimesTest {
     updatedTripTimesA.updateArrivalTime(0, -300); //"Yesterday"
     updatedTripTimesA.updateDepartureTime(0, 50);
 
-    assertTrue(updatedTripTimesA.timesIncreasing());
+    assertTrue(updatedTripTimesA.timesIncreasing().isEmpty());
   }
 
   @Test
@@ -177,6 +182,8 @@ public class TripTimesTest {
     updatedTripTimesA.updateArrivalTime(1, 89);
     updatedTripTimesA.updateDepartureTime(1, 98);
 
-    assertFalse(updatedTripTimesA.timesIncreasing());
+    OptionalInt invalidStopOIndex = updatedTripTimesA.timesIncreasing();
+    assertTrue(invalidStopOIndex.isPresent());
+    assertEquals(2, invalidStopOIndex.getAsInt());
   }
 }


### PR DESCRIPTION
### Summary

Improve logging in following places
- Calculate duration properly in `ElevationModule`, as it can take tens of minutes. Also log when the tracked period ends. It can take tens of seconds to do the rest of the processing.
- Do not log error in `TripTimes#timesIncreasing`. Instead return the erroneous stop index, and use it in the parent to log the invalid stop index.