### PR TITLE
Rename and clean up RepairStopTimesForEachTripOperation

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/flex/ScheduledDeviatedTripTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/flex/ScheduledDeviatedTripTest.java
@@ -20,6 +20,7 @@ import org.opentripplanner.TestServerContext;
 import org.opentripplanner.ext.fares.FaresFilter;
 import org.opentripplanner.ext.flex.trip.FlexTrip;
 import org.opentripplanner.ext.flex.trip.ScheduledDeviatedTrip;
+import org.opentripplanner.graph_builder.module.ValidateAndInterpolateStopTimesForEachTrip;
 import org.opentripplanner.model.GenericLocation;
 import org.opentripplanner.model.StopTime;
 import org.opentripplanner.model.plan.Itinerary;
@@ -196,7 +197,7 @@ public class ScheduledDeviatedTripTest extends FlexTest {
    * Normally these trip times are interpolated/repaired during the graph build but for flex this is
    * exactly what we don't want. Here we check that the interpolation process is skipped.
    *
-   * @see org.opentripplanner.gtfs.RepairStopTimesForEachTripOperation#interpolateStopTimes(List)
+   * @see ValidateAndInterpolateStopTimesForEachTrip#interpolateStopTimes(List)
    */
   @Test
   void shouldNotInterpolateFlexTimes() {

--- a/src/main/java/org/opentripplanner/graph_builder/module/GtfsModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/GtfsModule.java
@@ -32,7 +32,6 @@ import org.opentripplanner.graph_builder.model.GtfsBundle;
 import org.opentripplanner.graph_builder.module.geometry.GeometryProcessor;
 import org.opentripplanner.graph_builder.module.interlining.InterlineProcessor;
 import org.opentripplanner.gtfs.GenerateTripPatternsOperation;
-import org.opentripplanner.gtfs.RepairStopTimesForEachTripOperation;
 import org.opentripplanner.gtfs.mapping.GTFSToOtpTransitServiceMapper;
 import org.opentripplanner.model.OtpTransitService;
 import org.opentripplanner.model.TripStopTimes;
@@ -205,7 +204,7 @@ public class GtfsModule implements GraphBuilderModule {
     TripStopTimes stopTimesByTrip,
     DataImportIssueStore issueStore
   ) {
-    new RepairStopTimesForEachTripOperation(stopTimesByTrip, issueStore).run();
+    new ValidateAndInterpolateStopTimesForEachTrip(stopTimesByTrip, issueStore).run();
   }
 
   /**

--- a/src/main/java/org/opentripplanner/graph_builder/module/GtfsModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/GtfsModule.java
@@ -137,7 +137,7 @@ public class GtfsModule implements GraphBuilderModule {
           builder.getFlexTripsById().addAll(FlexTripsMapper.createFlexTrips(builder, issueStore));
         }
 
-        repairStopTimesForEachTrip(builder.getStopTimesSortedByTrip(), issueStore);
+        validateAndInterpolateStopTimesForEachTrip(builder.getStopTimesSortedByTrip(), issueStore);
 
         GeometryProcessor geometryProcessor = new GeometryProcessor(
           builder,
@@ -200,7 +200,7 @@ public class GtfsModule implements GraphBuilderModule {
   /**
    * This method has side effects, the {@code stopTimesByTrip} is updated.
    */
-  private void repairStopTimesForEachTrip(
+  private void validateAndInterpolateStopTimesForEachTrip(
     TripStopTimes stopTimesByTrip,
     DataImportIssueStore issueStore
   ) {

--- a/src/main/java/org/opentripplanner/graph_builder/module/GtfsModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/GtfsModule.java
@@ -204,7 +204,7 @@ public class GtfsModule implements GraphBuilderModule {
     TripStopTimes stopTimesByTrip,
     DataImportIssueStore issueStore
   ) {
-    new ValidateAndInterpolateStopTimesForEachTrip(stopTimesByTrip, issueStore).run();
+    new ValidateAndInterpolateStopTimesForEachTrip(stopTimesByTrip, true, issueStore).run();
   }
 
   /**

--- a/src/main/java/org/opentripplanner/graph_builder/module/ValidateAndInterpolateStopTimesForEachTrip.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ValidateAndInterpolateStopTimesForEachTrip.java
@@ -1,4 +1,4 @@
-package org.opentripplanner.gtfs;
+package org.opentripplanner.graph_builder.module;
 
 import gnu.trove.list.TIntList;
 import gnu.trove.list.array.TIntArrayList;
@@ -29,17 +29,17 @@ import org.slf4j.LoggerFactory;
  * This class is responsible for cleaning stop times, removing duplicates, correcting bad data and
  * so on. This only applies to GTFS imports.
  */
-public class RepairStopTimesForEachTripOperation {
+public class ValidateAndInterpolateStopTimesForEachTrip {
 
   private static final Logger LOG = LoggerFactory.getLogger(
-    RepairStopTimesForEachTripOperation.class
+    ValidateAndInterpolateStopTimesForEachTrip.class
   );
 
   private final TripStopTimes stopTimesByTrip;
 
   private final DataImportIssueStore issueStore;
 
-  public RepairStopTimesForEachTripOperation(
+  public ValidateAndInterpolateStopTimesForEachTrip(
     TripStopTimes stopTimesByTrip,
     DataImportIssueStore issueStore
   ) {

--- a/src/main/java/org/opentripplanner/graph_builder/module/ValidateAndInterpolateStopTimesForEachTrip.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ValidateAndInterpolateStopTimesForEachTrip.java
@@ -36,14 +36,16 @@ public class ValidateAndInterpolateStopTimesForEachTrip {
   );
 
   private final TripStopTimes stopTimesByTrip;
-
+  private final boolean interpolate;
   private final DataImportIssueStore issueStore;
 
   public ValidateAndInterpolateStopTimesForEachTrip(
     TripStopTimes stopTimesByTrip,
+    boolean interpolate,
     DataImportIssueStore issueStore
   ) {
     this.stopTimesByTrip = stopTimesByTrip;
+    this.interpolate = interpolate;
     this.issueStore = issueStore;
   }
 
@@ -69,8 +71,11 @@ public class ValidateAndInterpolateStopTimesForEachTrip {
       }
       if (!filterStopTimes(stopTimes)) {
         stopTimesByTrip.replace(trip, List.of());
-      } else {
+      } else if (interpolate) {
         interpolateStopTimes(stopTimes);
+        stopTimesByTrip.replace(trip, stopTimes);
+      } else {
+        stopTimes.removeIf(st -> !st.isArrivalTimeSet() || !st.isDepartureTimeSet());
         stopTimesByTrip.replace(trip, stopTimes);
       }
 

--- a/src/main/java/org/opentripplanner/netex/NetexModule.java
+++ b/src/main/java/org/opentripplanner/netex/NetexModule.java
@@ -6,7 +6,9 @@ import org.opentripplanner.graph_builder.DataImportIssueStore;
 import org.opentripplanner.graph_builder.model.GraphBuilderModule;
 import org.opentripplanner.graph_builder.module.AddTransitModelEntitiesToGraph;
 import org.opentripplanner.graph_builder.module.GtfsFeedId;
+import org.opentripplanner.graph_builder.module.ValidateAndInterpolateStopTimesForEachTrip;
 import org.opentripplanner.model.OtpTransitService;
+import org.opentripplanner.model.TripStopTimes;
 import org.opentripplanner.model.calendar.CalendarServiceData;
 import org.opentripplanner.model.calendar.ServiceDateInterval;
 import org.opentripplanner.model.impl.OtpTransitServiceBuilder;
@@ -81,6 +83,8 @@ public class NetexModule implements GraphBuilderModule {
             .addAll(FlexTripsMapper.createFlexTrips(transitBuilder, issueStore));
         }
 
+        validateStopTimesForEachTrip(transitBuilder.getStopTimesSortedByTrip());
+
         OtpTransitService otpService = transitBuilder.build();
 
         // if this or previously processed netex bundle has transit that has not been filtered out
@@ -109,6 +113,10 @@ public class NetexModule implements GraphBuilderModule {
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
+  }
+
+  private void validateStopTimesForEachTrip(TripStopTimes stopTimesByTrip) {
+    new ValidateAndInterpolateStopTimesForEachTrip(stopTimesByTrip, false, issueStore).run();
   }
 
   @Override

--- a/src/test/java/org/opentripplanner/gtfs/GtfsContextBuilder.java
+++ b/src/test/java/org/opentripplanner/gtfs/GtfsContextBuilder.java
@@ -6,6 +6,7 @@ import javax.annotation.Nullable;
 import org.opentripplanner.graph_builder.DataImportIssueStore;
 import org.opentripplanner.graph_builder.module.GtfsFeedId;
 import org.opentripplanner.graph_builder.module.GtfsModule;
+import org.opentripplanner.graph_builder.module.ValidateAndInterpolateStopTimesForEachTrip;
 import org.opentripplanner.graph_builder.module.geometry.GeometryProcessor;
 import org.opentripplanner.gtfs.mapping.GTFSToOtpTransitServiceMapper;
 import org.opentripplanner.model.OtpTransitService;
@@ -132,7 +133,10 @@ public class GtfsContextBuilder {
   }
 
   private void repairStopTimesForEachTrip() {
-    new RepairStopTimesForEachTripOperation(transitBuilder.getStopTimesSortedByTrip(), issueStore)
+    new ValidateAndInterpolateStopTimesForEachTrip(
+      transitBuilder.getStopTimesSortedByTrip(),
+      issueStore
+    )
       .run();
   }
 

--- a/src/test/java/org/opentripplanner/gtfs/GtfsContextBuilder.java
+++ b/src/test/java/org/opentripplanner/gtfs/GtfsContextBuilder.java
@@ -135,6 +135,7 @@ public class GtfsContextBuilder {
   private void repairStopTimesForEachTrip() {
     new ValidateAndInterpolateStopTimesForEachTrip(
       transitBuilder.getStopTimesSortedByTrip(),
+      true,
       issueStore
     )
       .run();


### PR DESCRIPTION
### Summary

In https://github.com/opentripplanner/OpenTripPlanner/pull/4385#discussion_r948031481 I was asked to rename this class, so I pulled it separately. At the same time I applied some cleanups to it, and added it to the `NetexModule`, but without interpolation. Currently it will only filter invalid trips and generate issues in the issue store for suspicious trips for NeTEx bundles.
