### PR TITLE
Cleanup site service - part 2

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/flex/ScheduledDeviatedTripTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/flex/ScheduledDeviatedTripTest.java
@@ -37,7 +37,7 @@ import org.opentripplanner.routing.graphfinder.NearbyStop;
 import org.opentripplanner.routing.location.StreetLocation;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
-import org.opentripplanner.transit.model.site.FlexStopLocation;
+import org.opentripplanner.transit.model.site.AreaStop;
 import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.util.OTPFeature;
@@ -262,7 +262,7 @@ public class ScheduledDeviatedTripTest extends FlexTest {
     var stopLocation = trip
       .getStops()
       .stream()
-      .filter(s -> s instanceof FlexStopLocation)
+      .filter(s -> s instanceof AreaStop)
       .findFirst()
       .orElseThrow();
     var r = new RoutingRequest();

--- a/src/ext-test/java/org/opentripplanner/ext/vectortiles/StopsLayerTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/vectortiles/StopsLayerTest.java
@@ -9,14 +9,14 @@ import org.junit.jupiter.api.Test;
 import org.opentripplanner.ext.vectortiles.layers.stops.DigitransitStopPropertyMapper;
 import org.opentripplanner.transit.model._data.TransitModelForTest;
 import org.opentripplanner.transit.model.framework.Deduplicator;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.StopModel;
 import org.opentripplanner.transit.service.TransitModel;
 
 public class StopsLayerTest {
 
-  private Stop stop;
+  private RegularStop stop;
 
   @BeforeEach
   public void setUp() {

--- a/src/ext/java/org/opentripplanner/ext/flex/FlexAccessEgress.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/FlexAccessEgress.java
@@ -2,11 +2,11 @@ package org.opentripplanner.ext.flex;
 
 import org.opentripplanner.ext.flex.trip.FlexTrip;
 import org.opentripplanner.routing.core.State;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 
 public class FlexAccessEgress {
 
-  public final Stop stop;
+  public final RegularStop stop;
   public final int preFlexTime;
   public final int flexTime;
   public final int postFlexTime;
@@ -18,7 +18,7 @@ public class FlexAccessEgress {
   public final boolean directToStop;
 
   public FlexAccessEgress(
-    Stop stop,
+    RegularStop stop,
     int preFlexTime,
     int flexTime,
     int postFlexTime,

--- a/src/ext/java/org/opentripplanner/ext/flex/FlexIndex.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/FlexIndex.java
@@ -10,7 +10,7 @@ import org.opentripplanner.ext.flex.trip.FlexTrip;
 import org.opentripplanner.model.PathTransfer;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.Route;
-import org.opentripplanner.transit.model.site.FlexLocationGroup;
+import org.opentripplanner.transit.model.site.GroupStop;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.service.TransitModel;
 
@@ -32,8 +32,8 @@ public class FlexIndex {
       routeById.put(flexTrip.getTrip().getRoute().getId(), flexTrip.getTrip().getRoute());
       tripById.put(flexTrip.getTrip().getId(), flexTrip);
       for (StopLocation stop : flexTrip.getStops()) {
-        if (stop instanceof FlexLocationGroup) {
-          for (StopLocation stopElement : ((FlexLocationGroup) stop).getLocations()) {
+        if (stop instanceof GroupStop groupStop) {
+          for (StopLocation stopElement : groupStop.getLocations()) {
             flexTripsByStop.put(stopElement, flexTrip);
           }
         } else {

--- a/src/ext/java/org/opentripplanner/ext/flex/FlexLocationsToStreetEdgesMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/FlexLocationsToStreetEdgesMapper.java
@@ -31,7 +31,7 @@ public class FlexLocationsToStreetEdgesMapper implements GraphBuilderModule {
   @Override
   @SuppressWarnings("Convert2MethodRef")
   public void buildGraph() {
-    if (!transitModel.getStopModel().hasFlexLocations()) {
+    if (!transitModel.getStopModel().hasAreaStops()) {
       return;
     }
 
@@ -40,12 +40,12 @@ public class FlexLocationsToStreetEdgesMapper implements GraphBuilderModule {
     ProgressTracker progress = ProgressTracker.track(
       "Add flex locations to street vertices",
       1,
-      transitModel.getStopModel().getAllFlexLocations().size()
+      transitModel.getStopModel().listAreaStops().size()
     );
 
     LOG.info(progress.startMessage());
     // TODO: Make this into a parallel stream, first calculate vertices per location and then add them.
-    for (AreaStop areaStop : transitModel.getStopModel().getAllFlexLocations()) {
+    for (AreaStop areaStop : transitModel.getStopModel().listAreaStops()) {
       for (Vertex vertx : streetIndex.getVerticesForEnvelope(
         areaStop.getGeometry().getEnvelopeInternal()
       )) {

--- a/src/ext/java/org/opentripplanner/ext/flex/FlexLocationsToStreetEdgesMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/FlexLocationsToStreetEdgesMapper.java
@@ -8,7 +8,7 @@ import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.routing.impl.StreetVertexIndex;
 import org.opentripplanner.routing.vertextype.StreetVertex;
-import org.opentripplanner.transit.model.site.FlexStopLocation;
+import org.opentripplanner.transit.model.site.AreaStop;
 import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.util.geometry.GeometryUtils;
 import org.opentripplanner.util.logging.ProgressTracker;
@@ -45,9 +45,9 @@ public class FlexLocationsToStreetEdgesMapper implements GraphBuilderModule {
 
     LOG.info(progress.startMessage());
     // TODO: Make this into a parallel stream, first calculate vertices per location and then add them.
-    for (FlexStopLocation flexStopLocation : transitModel.getStopModel().getAllFlexLocations()) {
+    for (AreaStop areaStop : transitModel.getStopModel().getAllFlexLocations()) {
       for (Vertex vertx : streetIndex.getVerticesForEnvelope(
-        flexStopLocation.getGeometry().getEnvelopeInternal()
+        areaStop.getGeometry().getEnvelopeInternal()
       )) {
         // Check that the vertex is connected to both driveable and walkable edges
         if (!(vertx instanceof StreetVertex streetVertex)) {
@@ -59,15 +59,15 @@ public class FlexLocationsToStreetEdgesMapper implements GraphBuilderModule {
 
         // The street index overselects, so need to check for exact geometry inclusion
         Point p = GeometryUtils.getGeometryFactory().createPoint(vertx.getCoordinate());
-        if (flexStopLocation.getGeometry().disjoint(p)) {
+        if (areaStop.getGeometry().disjoint(p)) {
           continue;
         }
 
-        if (streetVertex.flexStopLocations == null) {
-          streetVertex.flexStopLocations = new HashSet<>();
+        if (streetVertex.areaStops == null) {
+          streetVertex.areaStops = new HashSet<>();
         }
 
-        streetVertex.flexStopLocations.add(flexStopLocation);
+        streetVertex.areaStops.add(areaStop);
       }
       // Keep lambda! A method-ref would cause incorrect class and line number to be logged
       progress.step(m -> LOG.info(m));

--- a/src/ext/java/org/opentripplanner/ext/flex/template/FlexAccessEgressTemplate.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/template/FlexAccessEgressTemplate.java
@@ -19,7 +19,7 @@ import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
 import org.opentripplanner.routing.vertextype.TransitStopVertex;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.util.lang.ToStringBuilder;
@@ -86,10 +86,10 @@ public abstract class FlexAccessEgressTemplate {
     Graph graph,
     TransitService transitService
   ) {
-    if (transferStop instanceof Stop stop) {
+    if (transferStop instanceof RegularStop stop) {
       TransitStopVertex flexVertex = graph.getStopVertexForStopId(stop.getId());
       return Stream
-        .of(getFlexAccessEgress(new ArrayList<>(), flexVertex, (Stop) transferStop))
+        .of(getFlexAccessEgress(new ArrayList<>(), flexVertex, (RegularStop) transferStop))
         .filter(Objects::nonNull);
     }
     // transferStop is Location Area/Line
@@ -131,7 +131,7 @@ public abstract class FlexAccessEgressTemplate {
   /**
    * Get the {@Link Stop} where the connection to the scheduled transit network is made.
    */
-  protected abstract Stop getFinalStop(PathTransfer transfer);
+  protected abstract RegularStop getFinalStop(PathTransfer transfer);
 
   /**
    * Get the transfers to/from stops in the scheduled transit network from the beginning/end of the
@@ -159,7 +159,7 @@ public abstract class FlexAccessEgressTemplate {
   protected FlexAccessEgress getFlexAccessEgress(
     List<Edge> transferEdges,
     Vertex flexVertex,
-    Stop stop
+    RegularStop stop
   ) {
     FlexTripEdge flexEdge = getFlexEdge(flexVertex, transferStop);
 

--- a/src/ext/java/org/opentripplanner/ext/flex/template/FlexAccessTemplate.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/template/FlexAccessTemplate.java
@@ -16,7 +16,7 @@ import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
 import org.opentripplanner.routing.spt.GraphPath;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.service.TransitService;
 
@@ -106,8 +106,8 @@ public class FlexAccessTemplate extends FlexAccessEgressTemplate {
     return transfer.getEdges();
   }
 
-  protected Stop getFinalStop(PathTransfer transfer) {
-    return transfer.to instanceof Stop ? (Stop) transfer.to : null;
+  protected RegularStop getFinalStop(PathTransfer transfer) {
+    return transfer.to instanceof RegularStop ? (RegularStop) transfer.to : null;
   }
 
   protected Collection<PathTransfer> getTransfersFromTransferStop(TransitService transitService) {

--- a/src/ext/java/org/opentripplanner/ext/flex/template/FlexEgressTemplate.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/template/FlexEgressTemplate.java
@@ -13,7 +13,7 @@ import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.service.TransitService;
 
@@ -36,8 +36,8 @@ public class FlexEgressTemplate extends FlexAccessEgressTemplate {
     return Lists.reverse(transfer.getEdges());
   }
 
-  protected Stop getFinalStop(PathTransfer transfer) {
-    return transfer.from instanceof Stop ? (Stop) transfer.from : null;
+  protected RegularStop getFinalStop(PathTransfer transfer) {
+    return transfer.from instanceof RegularStop ? (RegularStop) transfer.from : null;
   }
 
   protected Collection<PathTransfer> getTransfersFromTransferStop(TransitService transitService) {

--- a/src/ext/java/org/opentripplanner/ext/flex/trip/FlexTrip.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/trip/FlexTrip.java
@@ -16,7 +16,7 @@ import org.opentripplanner.model.StopTime;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
 import org.opentripplanner.transit.model.framework.AbstractTransitEntity;
 import org.opentripplanner.transit.model.site.AreaStop;
-import org.opentripplanner.transit.model.site.FlexLocationGroup;
+import org.opentripplanner.transit.model.site.GroupStop;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.timetable.Trip;
 
@@ -40,7 +40,7 @@ public abstract class FlexTrip<T extends FlexTrip<T, B>, B extends FlexTripBuild
   }
 
   public static boolean isFlexStop(StopLocation stop) {
-    return stop instanceof FlexLocationGroup || stop instanceof AreaStop;
+    return stop instanceof GroupStop || stop instanceof AreaStop;
   }
 
   public abstract Stream<FlexAccessTemplate> getFlexAccessTemplates(

--- a/src/ext/java/org/opentripplanner/ext/flex/trip/FlexTrip.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/trip/FlexTrip.java
@@ -15,8 +15,8 @@ import org.opentripplanner.model.PickDrop;
 import org.opentripplanner.model.StopTime;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
 import org.opentripplanner.transit.model.framework.AbstractTransitEntity;
+import org.opentripplanner.transit.model.site.AreaStop;
 import org.opentripplanner.transit.model.site.FlexLocationGroup;
-import org.opentripplanner.transit.model.site.FlexStopLocation;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.timetable.Trip;
 
@@ -40,7 +40,7 @@ public abstract class FlexTrip<T extends FlexTrip<T, B>, B extends FlexTripBuild
   }
 
   public static boolean isFlexStop(StopLocation stop) {
-    return stop instanceof FlexLocationGroup || stop instanceof FlexStopLocation;
+    return stop instanceof FlexLocationGroup || stop instanceof AreaStop;
   }
 
   public abstract Stream<FlexAccessTemplate> getFlexAccessTemplates(

--- a/src/ext/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTrip.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTrip.java
@@ -26,7 +26,7 @@ import org.opentripplanner.model.StopTime;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.framework.TransitBuilder;
-import org.opentripplanner.transit.model.site.FlexLocationGroup;
+import org.opentripplanner.transit.model.site.GroupStop;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.StopLocation;
 
@@ -240,8 +240,8 @@ public class ScheduledDeviatedTrip
   }
 
   private Collection<StopLocation> expandStops(StopLocation stop) {
-    return stop instanceof FlexLocationGroup
-      ? ((FlexLocationGroup) stop).getLocations()
+    return stop instanceof GroupStop groupStop
+      ? groupStop.getLocations()
       : Collections.singleton(stop);
   }
 
@@ -251,8 +251,8 @@ public class ScheduledDeviatedTrip
         continue;
       }
       StopLocation stop = stopTimes[i].stop;
-      if (stop instanceof FlexLocationGroup) {
-        if (((FlexLocationGroup) stop).getLocations().contains(accessEgress.stop)) {
+      if (stop instanceof GroupStop groupStop) {
+        if (groupStop.getLocations().contains(accessEgress.stop)) {
           return i;
         }
       } else {
@@ -270,8 +270,8 @@ public class ScheduledDeviatedTrip
         continue;
       }
       StopLocation stop = stopTimes[i].stop;
-      if (stop instanceof FlexLocationGroup) {
-        if (((FlexLocationGroup) stop).getLocations().contains(accessEgress.stop)) {
+      if (stop instanceof GroupStop groupStop) {
+        if (groupStop.getLocations().contains(accessEgress.stop)) {
           return i;
         }
       } else {

--- a/src/ext/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTrip.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTrip.java
@@ -27,7 +27,7 @@ import org.opentripplanner.routing.graphfinder.NearbyStop;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.framework.TransitBuilder;
 import org.opentripplanner.transit.model.site.FlexLocationGroup;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.StopLocation;
 
 /**
@@ -66,7 +66,7 @@ public class ScheduledDeviatedTrip
   }
 
   public static boolean isScheduledFlexTrip(List<StopTime> stopTimes) {
-    Predicate<StopTime> notStopType = Predicate.not(st -> st.getStop() instanceof Stop);
+    Predicate<StopTime> notStopType = Predicate.not(st -> st.getStop() instanceof RegularStop);
     Predicate<StopTime> notContinuousStop = stopTime ->
       stopTime.getFlexContinuousDropOff() == NONE && stopTime.getFlexContinuousPickup() == NONE;
     return (

--- a/src/ext/java/org/opentripplanner/ext/flex/trip/UnscheduledTrip.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/trip/UnscheduledTrip.java
@@ -24,7 +24,7 @@ import org.opentripplanner.model.StopTime;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.framework.TransitBuilder;
-import org.opentripplanner.transit.model.site.FlexLocationGroup;
+import org.opentripplanner.transit.model.site.GroupStop;
 import org.opentripplanner.transit.model.site.StopLocation;
 
 /**
@@ -233,8 +233,8 @@ public class UnscheduledTrip extends FlexTrip<UnscheduledTrip, UnscheduledTripBu
   }
 
   private Collection<StopLocation> expandStops(StopLocation stop) {
-    return stop instanceof FlexLocationGroup
-      ? ((FlexLocationGroup) stop).getLocations()
+    return stop instanceof GroupStop groupStop
+      ? groupStop.getLocations()
       : Collections.singleton(stop);
   }
 
@@ -244,8 +244,8 @@ public class UnscheduledTrip extends FlexTrip<UnscheduledTrip, UnscheduledTripBu
         continue;
       }
       StopLocation stop = stopTimes[i].stop;
-      if (stop instanceof FlexLocationGroup) {
-        if (((FlexLocationGroup) stop).getLocations().contains(accessEgress.stop)) {
+      if (stop instanceof GroupStop groupStop) {
+        if (groupStop.getLocations().contains(accessEgress.stop)) {
           return i;
         }
       } else {
@@ -263,8 +263,8 @@ public class UnscheduledTrip extends FlexTrip<UnscheduledTrip, UnscheduledTripBu
         continue;
       }
       StopLocation stop = stopTimes[i].stop;
-      if (stop instanceof FlexLocationGroup) {
-        if (((FlexLocationGroup) stop).getLocations().contains(accessEgress.stop)) {
+      if (stop instanceof GroupStop groupStop) {
+        if (groupStop.getLocations().contains(accessEgress.stop)) {
           return i;
         }
       } else {

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLAlertEntityTypeResolver.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLAlertEntityTypeResolver.java
@@ -11,7 +11,7 @@ import org.opentripplanner.ext.legacygraphqlapi.model.LegacyGraphQLUnknownModel;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.organization.Agency;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.timetable.Trip;
 
 public class LegacyGraphQLAlertEntityTypeResolver implements TypeResolver {
@@ -21,7 +21,7 @@ public class LegacyGraphQLAlertEntityTypeResolver implements TypeResolver {
     Object o = environment.getObject();
     GraphQLSchema schema = environment.getSchema();
 
-    if (o instanceof Stop) {
+    if (o instanceof RegularStop) {
       return schema.getObjectType("Stop");
     }
     if (o instanceof Agency) {

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLNodeTypeResolver.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLNodeTypeResolver.java
@@ -18,8 +18,8 @@ import org.opentripplanner.routing.vehicle_rental.VehicleRentalVehicle;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.organization.Agency;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
-import org.opentripplanner.transit.model.site.Stop;
 import org.opentripplanner.transit.model.timetable.Trip;
 
 public class LegacyGraphQLNodeTypeResolver implements TypeResolver {
@@ -67,7 +67,7 @@ public class LegacyGraphQLNodeTypeResolver implements TypeResolver {
     if (o instanceof Route) {
       return schema.getObjectType("Route");
     }
-    if (o instanceof Stop) {
+    if (o instanceof RegularStop) {
       return schema.getObjectType("Stop");
     }
     if (o instanceof Station) {

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLPlaceInterfaceTypeResolver.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLPlaceInterfaceTypeResolver.java
@@ -10,7 +10,7 @@ import org.opentripplanner.routing.graphfinder.PatternAtStop;
 import org.opentripplanner.routing.vehicle_parking.VehicleParking;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalStation;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalVehicle;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 
 public class LegacyGraphQLPlaceInterfaceTypeResolver implements TypeResolver {
 
@@ -41,7 +41,7 @@ public class LegacyGraphQLPlaceInterfaceTypeResolver implements TypeResolver {
     if (o instanceof PatternAtStop) {
       return schema.getObjectType("DepartureRow");
     }
-    if (o instanceof Stop) {
+    if (o instanceof RegularStop) {
       return schema.getObjectType("Stop");
     }
 

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
@@ -63,8 +63,8 @@ import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.organization.Agency;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
-import org.opentripplanner.transit.model.site.Stop;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.updater.GtfsRealtimeFuzzyTripMatcher;
@@ -1032,7 +1032,7 @@ public class LegacyGraphQLQueryTypeImpl
         new Coordinate(args.getLegacyGraphQLMaxLon(), args.getLegacyGraphQLMaxLat())
       );
 
-      Stream<Stop> stopStream = getTransitService(environment)
+      Stream<RegularStop> stopStream = getTransitService(environment)
         .queryStopSpatialIndex(envelope)
         .stream()
         .filter(stop -> envelope.contains(stop.getCoordinate().asJtsCoordinate()));

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
@@ -1033,7 +1033,7 @@ public class LegacyGraphQLQueryTypeImpl
       );
 
       Stream<RegularStop> stopStream = getTransitService(environment)
-        .queryStopSpatialIndex(envelope)
+        .findRegularStop(envelope)
         .stream()
         .filter(stop -> envelope.contains(stop.getCoordinate().asJtsCoordinate()));
 

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLStopImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLStopImpl.java
@@ -34,8 +34,8 @@ import org.opentripplanner.transit.model.framework.AbstractTransitEntity;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.network.TripPattern;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
-import org.opentripplanner.transit.model.site.Stop;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.util.time.ServiceDateUtils;
@@ -418,7 +418,7 @@ public class LegacyGraphQLStopImpl implements LegacyGraphQLDataFetchers.LegacyGr
             .getTransfersByStop(stop)
             .stream()
             .filter(transfer -> maxDistance == null || transfer.getDistanceMeters() < maxDistance)
-            .filter(transfer -> transfer.to instanceof Stop)
+            .filter(transfer -> transfer.to instanceof RegularStop)
             .map(transfer ->
               new NearbyStop(transfer.to, transfer.getDistanceMeters(), transfer.getEdges(), null)
             )

--- a/src/ext/java/org/opentripplanner/ext/parkAndRideApi/ParkAndRideResource.java
+++ b/src/ext/java/org/opentripplanner/ext/parkAndRideApi/ParkAndRideResource.java
@@ -43,7 +43,7 @@ public class ParkAndRideResource {
     //           - serverContext.graphFinder(). This needs at least a comment!
     //           - This can be replaced with a search done with the StopModel
     //           - if we have a radius search there.
-    this.graphFinder = new DirectGraphFinder(serverContext.transitService()::queryStopSpatialIndex);
+    this.graphFinder = new DirectGraphFinder(serverContext.transitService()::findRegularStop);
   }
 
   /** Envelopes are in latitude, longitude format */

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTripPatternCache.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTripPatternCache.java
@@ -12,7 +12,7 @@ import javax.annotation.Nonnull;
 import org.opentripplanner.transit.model.network.StopPattern;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.network.TripPatternBuilder;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.service.TransitModel;
@@ -158,7 +158,7 @@ public class SiriTripPatternCache {
    * @param stop the stop
    * @return list of TripPatterns created by real time sources for the stop.
    */
-  public List<TripPattern> getAddedTripPatternsForStop(Stop stop) {
+  public List<TripPattern> getAddedTripPatternsForStop(RegularStop stop) {
     return patternsForStop.get(stop);
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/transferanalyzer/DirectTransferAnalyzer.java
+++ b/src/ext/java/org/opentripplanner/ext/transferanalyzer/DirectTransferAnalyzer.java
@@ -16,7 +16,7 @@ import org.opentripplanner.routing.graphfinder.DirectGraphFinder;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
 import org.opentripplanner.routing.graphfinder.StreetGraphFinder;
 import org.opentripplanner.routing.vertextype.TransitStopVertex;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.service.TransitModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -80,36 +80,36 @@ public class DirectTransferAnalyzer implements GraphBuilderModule {
 
       /* Find nearby stops by euclidean distance */
       Coordinate c0 = originStopVertex.getCoordinate();
-      Map<Stop, NearbyStop> stopsEuclidean = nearbyStopFinderEuclidian
+      Map<RegularStop, NearbyStop> stopsEuclidean = nearbyStopFinderEuclidian
         .findClosestStops(c0.y, c0.x, radiusMeters)
         .stream()
-        .filter(t -> t.stop instanceof Stop)
-        .collect(Collectors.toMap(t -> (Stop) t.stop, t -> t));
+        .filter(t -> t.stop instanceof RegularStop)
+        .collect(Collectors.toMap(t -> (RegularStop) t.stop, t -> t));
 
       /* Find nearby stops by street distance */
-      Map<Stop, NearbyStop> stopsStreets = nearbyStopFinderStreets
+      Map<RegularStop, NearbyStop> stopsStreets = nearbyStopFinderStreets
         .findClosestStops(c0.y, c0.x, radiusMeters * RADIUS_MULTIPLIER)
         .stream()
-        .filter(t -> t.stop instanceof Stop)
-        .collect(Collectors.toMap(t -> (Stop) t.stop, t -> t));
+        .filter(t -> t.stop instanceof RegularStop)
+        .collect(Collectors.toMap(t -> (RegularStop) t.stop, t -> t));
 
-      Stop originStop = originStopVertex.getStop();
+      RegularStop originStop = originStopVertex.getStop();
 
       /* Get stops found by both street and euclidean search */
-      List<Stop> stopsConnected = stopsEuclidean
+      List<RegularStop> stopsConnected = stopsEuclidean
         .keySet()
         .stream()
         .filter(t -> stopsStreets.containsKey(t) && t != originStop)
         .toList();
 
       /* Get stops found by euclidean search but not street search */
-      List<Stop> stopsUnconnected = stopsEuclidean
+      List<RegularStop> stopsUnconnected = stopsEuclidean
         .keySet()
         .stream()
         .filter(t -> !stopsStreets.containsKey(t) && t != originStop)
         .toList();
 
-      for (Stop destStop : stopsConnected) {
+      for (RegularStop destStop : stopsConnected) {
         NearbyStop euclideanStop = stopsEuclidean.get(destStop);
         NearbyStop streetStop = stopsStreets.get(destStop);
 
@@ -129,7 +129,7 @@ public class DirectTransferAnalyzer implements GraphBuilderModule {
         }
       }
 
-      for (Stop destStop : stopsUnconnected) {
+      for (RegularStop destStop : stopsUnconnected) {
         NearbyStop euclideanStop = stopsEuclidean.get(destStop);
 
         /* Log transfers that are found by euclidean search but not by street search */
@@ -183,13 +183,18 @@ public class DirectTransferAnalyzer implements GraphBuilderModule {
 
   private static class TransferInfo {
 
-    final Stop origin;
-    final Stop destination;
+    final RegularStop origin;
+    final RegularStop destination;
     final double directDistance;
     final double streetDistance;
     final double ratio;
 
-    TransferInfo(Stop origin, Stop destination, double directDistance, double streetDistance) {
+    TransferInfo(
+      RegularStop origin,
+      RegularStop destination,
+      double directDistance,
+      double streetDistance
+    ) {
       this.origin = origin;
       this.destination = destination;
       this.directDistance = directDistance;

--- a/src/ext/java/org/opentripplanner/ext/transferanalyzer/annotations/TransferCouldNotBeRouted.java
+++ b/src/ext/java/org/opentripplanner/ext/transferanalyzer/annotations/TransferCouldNotBeRouted.java
@@ -1,7 +1,7 @@
 package org.opentripplanner.ext.transferanalyzer.annotations;
 
 import org.opentripplanner.graph_builder.DataImportIssue;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 
 /**
  * Represents two stops that are close to each other where no route is found between them using OSM
@@ -18,11 +18,15 @@ public class TransferCouldNotBeRouted implements DataImportIssue {
     "<a href=\"http://www.openstreetmap.org/?mlat=%s&mlon=%s\">\"%s\" (%s)</a> could not be routed. " +
     "Euclidean distance is %.0f.";
 
-  private final Stop origin;
-  private final Stop destination;
+  private final RegularStop origin;
+  private final RegularStop destination;
   private final double directDistance;
 
-  public TransferCouldNotBeRouted(Stop origin, Stop destination, double directDistance) {
+  public TransferCouldNotBeRouted(
+    RegularStop origin,
+    RegularStop destination,
+    double directDistance
+  ) {
     this.origin = origin;
     this.destination = destination;
     this.directDistance = directDistance;

--- a/src/ext/java/org/opentripplanner/ext/transferanalyzer/annotations/TransferRoutingDistanceTooLong.java
+++ b/src/ext/java/org/opentripplanner/ext/transferanalyzer/annotations/TransferRoutingDistanceTooLong.java
@@ -1,7 +1,7 @@
 package org.opentripplanner.ext.transferanalyzer.annotations;
 
 import org.opentripplanner.graph_builder.DataImportIssue;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 
 /**
  * Represents two stops where the routing distance between them (using OSM data) is much longer than
@@ -19,15 +19,15 @@ public class TransferRoutingDistanceTooLong implements DataImportIssue {
     "<a href=\"http://www.openstreetmap.org/?mlat=%s&mlon=%s\">\"%s\" (%s)</a> is %.0f times longer than " +
     "the euclidean distance. Street distance: %.2f, direct distance: %.2f.";
 
-  private final Stop origin;
-  private final Stop destination;
+  private final RegularStop origin;
+  private final RegularStop destination;
   private final double directDistance;
   private final double streetDistance;
   private final double ratio;
 
   public TransferRoutingDistanceTooLong(
-    Stop origin,
-    Stop destination,
+    RegularStop origin,
+    RegularStop destination,
     double directDistance,
     double streetDistance,
     double ratio

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
@@ -669,7 +669,7 @@ public class TransmodelGraphQLSchema {
             );
             return GqlUtil
               .getTransitService(environment)
-              .queryStopSpatialIndex(envelope)
+              .findRegularStop(envelope)
               .stream()
               .filter(stop -> envelope.contains(stop.getCoordinate().asJtsCoordinate()))
               .filter(stop ->

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/PlanPlaceType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/PlanPlaceType.java
@@ -13,7 +13,7 @@ import org.opentripplanner.model.plan.Place;
 import org.opentripplanner.model.plan.VertexType;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalStation;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalVehicle;
-import org.opentripplanner.transit.model.site.FlexStopLocation;
+import org.opentripplanner.transit.model.site.AreaStop;
 import org.opentripplanner.transit.model.site.RegularStop;
 
 public class PlanPlaceType {
@@ -92,9 +92,8 @@ public class PlanPlaceType {
           .description("The flexible area related to the place.")
           .type(GeoJSONCoordinatesScalar.getGraphQGeoJSONCoordinatesScalar())
           .dataFetcher(environment ->
-            ((Place) environment.getSource()).stop instanceof FlexStopLocation
-              ? ((FlexStopLocation) ((Place) environment.getSource()).stop).getGeometry()
-                .getCoordinates()
+            ((Place) environment.getSource()).stop instanceof AreaStop
+              ? ((AreaStop) ((Place) environment.getSource()).stop).getGeometry().getCoordinates()
               : null
           )
           .build()

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/PlanPlaceType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/PlanPlaceType.java
@@ -14,7 +14,7 @@ import org.opentripplanner.model.plan.VertexType;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalStation;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalVehicle;
 import org.opentripplanner.transit.model.site.FlexStopLocation;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 
 public class PlanPlaceType {
 
@@ -79,8 +79,8 @@ public class PlanPlaceType {
           .description("The quay related to the place.")
           .type(quayType)
           .dataFetcher(environment ->
-            ((Place) environment.getSource()).stop instanceof Stop
-              ? ((Stop) ((Place) environment.getSource()).stop)
+            ((Place) environment.getSource()).stop instanceof RegularStop
+              ? ((RegularStop) ((Place) environment.getSource()).stop)
               : null
           )
           .build()

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/PlaceAtDistanceType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/PlaceAtDistanceType.java
@@ -17,8 +17,8 @@ import java.util.stream.Stream;
 import org.opentripplanner.ext.transmodelapi.model.TransmodelPlaceType;
 import org.opentripplanner.routing.graphfinder.PlaceAtDistance;
 import org.opentripplanner.transit.model.site.MultiModalStation;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
-import org.opentripplanner.transit.model.site.Stop;
 import org.opentripplanner.transit.service.TransitService;
 
 public class PlaceAtDistanceType {
@@ -80,7 +80,7 @@ public class PlaceAtDistanceType {
       List<PlaceAtDistance> stations = places
         .stream()
         // Find all stops
-        .filter(p -> p.place() instanceof Stop)
+        .filter(p -> p.place() instanceof RegularStop)
         // Get their parent stations (possibly including multimodal parents)
         .flatMap(p -> getStopPlaces(p, multiModalMode, transitService))
         // Sort by distance
@@ -94,7 +94,10 @@ public class PlaceAtDistanceType {
       if (placeTypes != null && !placeTypes.contains(TransmodelPlaceType.QUAY)) {
         // Remove quays if only stop places are requested
         places =
-          places.stream().filter(p -> !(p.place() instanceof Stop)).collect(Collectors.toList());
+          places
+            .stream()
+            .filter(p -> !(p.place() instanceof RegularStop))
+            .collect(Collectors.toList());
       }
     }
     places.sort(Comparator.comparing(PlaceAtDistance::distance));
@@ -108,7 +111,7 @@ public class PlaceAtDistanceType {
     String multiModalMode,
     TransitService transitService
   ) {
-    Station stopPlace = ((Stop) p.place()).getParentStation();
+    Station stopPlace = ((RegularStop) p.place()).getParentStation();
 
     if (stopPlace == null) {
       return Stream.of();

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/PlaceInterfaceType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/PlaceInterfaceType.java
@@ -8,7 +8,7 @@ import graphql.schema.GraphQLSchema;
 import org.opentripplanner.routing.vehicle_parking.VehicleParking;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalStation;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalVehicle;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 
 public class PlaceInterfaceType {
 
@@ -47,7 +47,7 @@ public class PlaceInterfaceType {
         // we get the type from the schema. This also follows how it is done in the
         // LegacyGraphQLNodeTypeResolver.
 
-        if (o instanceof Stop) {
+        if (o instanceof RegularStop) {
           return schema.getObjectType("Quay");
         }
         if (o instanceof MonoOrMultiModalStation) {

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/QuayType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/QuayType.java
@@ -26,8 +26,8 @@ import org.opentripplanner.routing.stoptimes.ArrivalDeparture;
 import org.opentripplanner.transit.model.basic.I18NString;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.basic.WheelchairAccessibility;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
-import org.opentripplanner.transit.model.site.Stop;
 import org.opentripplanner.transit.model.site.StopLocation;
 
 public class QuayType {
@@ -292,7 +292,7 @@ public class QuayType {
             );
             Integer timeRangeInput = environment.getArgument("timeRange");
             Duration timeRange = Duration.ofSeconds(timeRangeInput.longValue());
-            Stop stop = environment.getSource();
+            RegularStop stop = environment.getSource();
 
             JourneyWhiteListed whiteListed = new JourneyWhiteListed(environment);
             Collection<TransitMode> transitModes = environment.getArgument("whiteListedModes");

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/StopPlaceType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/StopPlaceType.java
@@ -478,7 +478,7 @@ public class StopPlaceType {
     );
 
     Stream<Station> stations = transitService
-      .queryStopSpatialIndex(envelope)
+      .findRegularStop(envelope)
       .stream()
       .filter(stop -> envelope.contains(stop.getCoordinate().asJtsCoordinate()))
       .map(StopLocation::getParentStation)

--- a/src/ext/java/org/opentripplanner/ext/traveltime/TravelTimeResource.java
+++ b/src/ext/java/org/opentripplanner/ext/traveltime/TravelTimeResource.java
@@ -64,7 +64,7 @@ import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
 import org.opentripplanner.routing.spt.DominanceFunction;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.raptor.RaptorService;
 import org.opentripplanner.transit.raptor.api.request.RaptorProfile;
 import org.opentripplanner.transit.raptor.api.request.RaptorRequest;
@@ -263,7 +263,7 @@ public class TravelTimeResource {
     }
 
     // TODO - Add a method to return all Stops, not StopLocations
-    for (Stop stop : transitService.listRegularStops()) {
+    for (RegularStop stop : transitService.listRegularStops()) {
       int index = stop.getIndex();
       if (arrivals.reachedByTransit(index)) {
         final int arrivalTime = arrivals.bestTransitArrivalTime(index);

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/DigitransitStopPropertyMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/DigitransitStopPropertyMapper.java
@@ -11,10 +11,10 @@ import org.json.simple.JSONObject;
 import org.opentripplanner.common.model.T2;
 import org.opentripplanner.ext.vectortiles.PropertyMapper;
 import org.opentripplanner.transit.model.network.TripPattern;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.service.TransitService;
 
-public class DigitransitStopPropertyMapper extends PropertyMapper<Stop> {
+public class DigitransitStopPropertyMapper extends PropertyMapper<RegularStop> {
 
   private final TransitService transitService;
 
@@ -27,7 +27,7 @@ public class DigitransitStopPropertyMapper extends PropertyMapper<Stop> {
   }
 
   @Override
-  public Collection<T2<String, Object>> map(Stop stop) {
+  public Collection<T2<String, Object>> map(RegularStop stop) {
     Collection<TripPattern> patternsForStop = transitService.getPatternsForStop(stop);
 
     String type = patternsForStop

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/StopsLayerBuilder.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/StopsLayerBuilder.java
@@ -10,12 +10,12 @@ import org.opentripplanner.ext.vectortiles.LayerBuilder;
 import org.opentripplanner.ext.vectortiles.PropertyMapper;
 import org.opentripplanner.ext.vectortiles.VectorTilesResource;
 import org.opentripplanner.routing.graph.Graph;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.service.TransitService;
 
-public class StopsLayerBuilder extends LayerBuilder<Stop> {
+public class StopsLayerBuilder extends LayerBuilder<RegularStop> {
 
-  static Map<MapperType, Function<TransitService, PropertyMapper<Stop>>> mappers = Map.of(
+  static Map<MapperType, Function<TransitService, PropertyMapper<RegularStop>>> mappers = Map.of(
     MapperType.Digitransit,
     DigitransitStopPropertyMapper::create
   );

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/StopsLayerBuilder.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/StopsLayerBuilder.java
@@ -35,7 +35,7 @@ public class StopsLayerBuilder extends LayerBuilder<RegularStop> {
 
   protected List<Geometry> getGeometries(Envelope query) {
     return transitService
-      .queryStopSpatialIndex(query)
+      .findRegularStop(query)
       .stream()
       .map(stop -> {
         Geometry point = stop.getGeometry();

--- a/src/ext/java/org/opentripplanner/ext/vehicletostopheuristics/BikeToStopSkipEdgeStrategy.java
+++ b/src/ext/java/org/opentripplanner/ext/vehicletostopheuristics/BikeToStopSkipEdgeStrategy.java
@@ -7,7 +7,7 @@ import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.vertextype.TransitStopVertex;
 import org.opentripplanner.transit.model.network.BikeAccess;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.timetable.Trip;
 
 /**
@@ -20,12 +20,12 @@ public class BikeToStopSkipEdgeStrategy implements SkipEdgeStrategy {
   private static final int LIMIT = 100;
   private static final double MAX_FACTOR = 1.2;
 
-  private final Function<Stop, Collection<Trip>> getTripsForStop;
+  private final Function<RegularStop, Collection<Trip>> getTripsForStop;
 
   int numberOfBikeableTripsReached = 0;
   double distanceLimit = Double.MAX_VALUE;
 
-  public BikeToStopSkipEdgeStrategy(Function<Stop, Collection<Trip>> getTripsForStop) {
+  public BikeToStopSkipEdgeStrategy(Function<RegularStop, Collection<Trip>> getTripsForStop) {
     this.getTripsForStop = getTripsForStop;
   }
 

--- a/src/ext/java/org/opentripplanner/ext/vehicletostopheuristics/VehicleToStopSkipEdgeStrategy.java
+++ b/src/ext/java/org/opentripplanner/ext/vehicletostopheuristics/VehicleToStopSkipEdgeStrategy.java
@@ -20,7 +20,7 @@ import org.opentripplanner.routing.vertextype.TransitStopVertex;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.Route;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 
 /**
  * This strategy terminates when enough "important" stops are found.
@@ -47,7 +47,7 @@ public class VehicleToStopSkipEdgeStrategy implements SkipEdgeStrategy {
     CAR_RENTAL,
     SCOOTER_RENTAL
   );
-  private final Function<Stop, Set<Route>> getRoutesForStop;
+  private final Function<RegularStop, Set<Route>> getRoutesForStop;
   private final int maxScore;
   private final EnumSet<TransitMode> allowedModes;
   private double sumOfScores;
@@ -55,7 +55,7 @@ public class VehicleToStopSkipEdgeStrategy implements SkipEdgeStrategy {
   private final Set<FeedScopedId> stopsCounted = new HashSet<>();
 
   public VehicleToStopSkipEdgeStrategy(
-    Function<Stop, Set<Route>> getRoutesForStop,
+    Function<RegularStop, Set<Route>> getRoutesForStop,
     Collection<TransitMode> allowedModes
   ) {
     this.allowedModes = EnumSet.copyOf(allowedModes);

--- a/src/main/java/org/opentripplanner/api/mapping/PlaceMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/PlaceMapper.java
@@ -15,7 +15,7 @@ import org.opentripplanner.model.plan.Place;
 import org.opentripplanner.model.plan.StopArrival;
 import org.opentripplanner.model.plan.VehicleParkingWithEntrance;
 import org.opentripplanner.routing.vehicle_parking.VehicleParkingSpaces;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 
 public class PlaceMapper {
 
@@ -62,8 +62,11 @@ public class PlaceMapper {
       api.stopId = FeedScopedIdMapper.mapToApi(domain.stop.getId());
       api.stopCode = domain.stop.getCode();
       api.platformCode =
-        domain.stop instanceof Stop ? ((Stop) domain.stop).getPlatformCode() : null;
-      api.zoneId = domain.stop instanceof Stop ? ((Stop) domain.stop).getFirstZoneAsString() : null;
+        domain.stop instanceof RegularStop ? ((RegularStop) domain.stop).getPlatformCode() : null;
+      api.zoneId =
+        domain.stop instanceof RegularStop
+          ? ((RegularStop) domain.stop).getFirstZoneAsString()
+          : null;
     }
 
     if (domain.coordinate != null) {

--- a/src/main/java/org/opentripplanner/graph_builder/linking/FlexLocationAdder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/linking/FlexLocationAdder.java
@@ -6,7 +6,7 @@ import org.locationtech.jts.geom.Point;
 import org.opentripplanner.routing.edgetype.StreetEdge;
 import org.opentripplanner.routing.edgetype.StreetTraversalPermission;
 import org.opentripplanner.routing.vertextype.SplitterVertex;
-import org.opentripplanner.transit.model.site.FlexStopLocation;
+import org.opentripplanner.transit.model.site.AreaStop;
 import org.opentripplanner.transit.service.StopModel;
 import org.opentripplanner.util.geometry.GeometryUtils;
 
@@ -16,12 +16,12 @@ class FlexLocationAdder {
     if (edge.getPermission().allows(StreetTraversalPermission.PEDESTRIAN_AND_CAR)) {
       Point p = GeometryUtils.getGeometryFactory().createPoint(v0.getCoordinate());
       Envelope env = p.getEnvelopeInternal();
-      for (FlexStopLocation location : stopModel.queryLocationIndex(env)) {
+      for (AreaStop location : stopModel.queryLocationIndex(env)) {
         if (!location.getGeometry().disjoint(p)) {
-          if (v0.flexStopLocations == null) {
-            v0.flexStopLocations = new HashSet<>();
+          if (v0.areaStops == null) {
+            v0.areaStops = new HashSet<>();
           }
-          v0.flexStopLocations.add(location);
+          v0.areaStops.add(location);
         }
       }
     }

--- a/src/main/java/org/opentripplanner/graph_builder/module/AddTransitModelEntitiesToGraph.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/AddTransitModelEntitiesToGraph.java
@@ -37,8 +37,8 @@ import org.opentripplanner.transit.model.site.Entrance;
 import org.opentripplanner.transit.model.site.Pathway;
 import org.opentripplanner.transit.model.site.PathwayMode;
 import org.opentripplanner.transit.model.site.PathwayNode;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.StationElement;
-import org.opentripplanner.transit.model.site.Stop;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.util.OTPFeature;
@@ -121,7 +121,7 @@ public class AddTransitModelEntitiesToGraph {
 
     // Add a vertex representing the stop.
     // It is now possible for these vertices to not be connected to any edges.
-    for (Stop stop : otpTransitService.stopModel().listRegularStops()) {
+    for (RegularStop stop : otpTransitService.stopModel().listRegularStops()) {
       Set<TransitMode> modes = stopModeMap.get(stop);
       TransitStopVertex stopVertex = new TransitStopVertexBuilder()
         .withStop(stop)

--- a/src/main/java/org/opentripplanner/graph_builder/module/DirectTransferGenerator.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/DirectTransferGenerator.java
@@ -125,8 +125,8 @@ public class DirectTransferGenerator implements GraphBuilderModule {
             );
           }
           if (OTPFeature.FlexRouting.isOn()) {
-            // This code is for finding transfers from FlexStopLocations to Stops, transfers
-            // from Stops to FlexStopLocations and between Stops are already covered above.
+            // This code is for finding transfers from AreaStops to Stops, transfers
+            // from Stops to AreaStops and between Stops are already covered above.
             for (NearbyStop sd : nearbyStopFinder.findNearbyStopsConsideringPatterns(
               ts0,
               streetRequest,

--- a/src/main/java/org/opentripplanner/graph_builder/module/DirectTransferGenerator.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/DirectTransferGenerator.java
@@ -18,7 +18,7 @@ import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
 import org.opentripplanner.routing.vertextype.TransitStopVertex;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.TransitModel;
@@ -104,7 +104,7 @@ public class DirectTransferGenerator implements GraphBuilderModule {
         /* Make transfers to each nearby stop that has lowest weight on some trip pattern.
          * Use map based on the list of edges, so that only distinct transfers are stored. */
         Map<TransferKey, PathTransfer> distinctTransfers = new HashMap<>();
-        Stop stop = ts0.getStop();
+        RegularStop stop = ts0.getStop();
         LOG.debug("Linking stop '{}' {}", stop, ts0);
 
         for (RoutingRequest transferProfile : transferRequests) {
@@ -136,7 +136,7 @@ public class DirectTransferGenerator implements GraphBuilderModule {
               if (sd.stop == stop) {
                 continue;
               }
-              if (sd.stop instanceof Stop) {
+              if (sd.stop instanceof RegularStop) {
                 continue;
               }
               distinctTransfers.put(

--- a/src/main/java/org/opentripplanner/graph_builder/module/NearbyStopFinder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/NearbyStopFinder.java
@@ -38,7 +38,7 @@ import org.opentripplanner.routing.vertextype.TransitStopVertex;
 import org.opentripplanner.transit.model.basic.MainAndSubMode;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.site.FlexStopLocation;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.util.OTPFeature;
@@ -124,7 +124,7 @@ public class NearbyStopFinder {
     )) {
       StopLocation ts1 = nearbyStop.stop;
 
-      if (ts1 instanceof Stop) {
+      if (ts1 instanceof RegularStop) {
         /* Consider this destination stop as a candidate for every trip pattern passing through it. */
         for (TripPattern pattern : transitService.getPatternsForStop(ts1)) {
           closestStopForPattern.putMin(pattern, nearbyStop);

--- a/src/main/java/org/opentripplanner/graph_builder/module/NearbyStopFinder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/NearbyStopFinder.java
@@ -95,7 +95,7 @@ public class NearbyStopFinder {
       // We need to accommodate straight line distance (in meters) but when streets are present we
       // use an earliest arrival search, which optimizes on time. Ideally we'd specify in meters,
       // but we don't have much of a choice here. Use the default walking speed to convert.
-      this.directGraphFinder = new DirectGraphFinder(transitService::queryStopSpatialIndex);
+      this.directGraphFinder = new DirectGraphFinder(transitService::findRegularStop);
     }
   }
 

--- a/src/main/java/org/opentripplanner/graph_builder/module/NearbyStopFinder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/NearbyStopFinder.java
@@ -37,7 +37,7 @@ import org.opentripplanner.routing.vertextype.StreetVertex;
 import org.opentripplanner.routing.vertextype.TransitStopVertex;
 import org.opentripplanner.transit.model.basic.MainAndSubMode;
 import org.opentripplanner.transit.model.network.TripPattern;
-import org.opentripplanner.transit.model.site.FlexStopLocation;
+import org.opentripplanner.transit.model.site.AreaStop;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.service.TransitService;
@@ -212,7 +212,7 @@ public class NearbyStopFinder {
       .getShortestPathTree();
 
     // Only used if OTPFeature.FlexRouting.isOn()
-    Multimap<FlexStopLocation, State> locationsMap = ArrayListMultimap.create();
+    Multimap<AreaStop, State> locationsMap = ArrayListMultimap.create();
 
     if (spt != null) {
       // TODO use GenericAStar and a traverseVisitor? Add an earliestArrival switch to genericAStar?
@@ -227,16 +227,14 @@ public class NearbyStopFinder {
         if (
           OTPFeature.FlexRouting.isOn() &&
           targetVertex instanceof StreetVertex &&
-          ((StreetVertex) targetVertex).flexStopLocations != null
+          ((StreetVertex) targetVertex).areaStops != null
         ) {
-          for (FlexStopLocation flexStopLocation : (
-            (StreetVertex) targetVertex
-          ).flexStopLocations) {
+          for (AreaStop areaStop : ((StreetVertex) targetVertex).areaStops) {
             // This is for a simplification, so that we only return one vertex from each
             // stop location. All vertices are added to the multimap, which is filtered
             // below, so that only the closest vertex is added to stopsFound
             if (canBoardFlex(state, reverseDirection)) {
-              locationsMap.put(flexStopLocation, state);
+              locationsMap.put(areaStop, state);
             }
           }
         }
@@ -245,20 +243,20 @@ public class NearbyStopFinder {
 
     if (OTPFeature.FlexRouting.isOn()) {
       for (var locationStates : locationsMap.asMap().entrySet()) {
-        FlexStopLocation flexStopLocation = locationStates.getKey();
+        AreaStop areaStop = locationStates.getKey();
         Collection<State> states = locationStates.getValue();
-        // Select the vertex from all vertices that are reachable per FlexStopLocation by taking
+        // Select the vertex from all vertices that are reachable per AreaStop by taking
         // the minimum walking distance
         State min = Collections.min(states, Comparator.comparing(State::getWeight));
 
-        // If the best state for this FlexStopLocation is a SplitterVertex, we want to get the
+        // If the best state for this AreaStop is a SplitterVertex, we want to get the
         // TemporaryStreetLocation instead. This allows us to reach SplitterVertices in both
         // directions when routing later.
         if (min.getBackState().getVertex() instanceof TemporaryStreetLocation) {
           min = min.getBackState();
         }
 
-        stopsFound.add(NearbyStop.nearbyStopForState(min, flexStopLocation));
+        stopsFound.add(NearbyStop.nearbyStopForState(min, areaStop));
       }
     }
 

--- a/src/main/java/org/opentripplanner/graph_builder/module/StreetLinkerModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/StreetLinkerModule.java
@@ -20,7 +20,7 @@ import org.opentripplanner.routing.vehicle_parking.VehicleParkingHelper;
 import org.opentripplanner.routing.vertextype.TransitEntranceVertex;
 import org.opentripplanner.routing.vertextype.TransitStopVertex;
 import org.opentripplanner.routing.vertextype.VehicleParkingEntranceVertex;
-import org.opentripplanner.transit.model.site.FlexLocationGroup;
+import org.opentripplanner.transit.model.site.GroupStop;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.service.TransitModel;
@@ -42,7 +42,7 @@ public class StreetLinkerModule implements GraphBuilderModule {
   private final Graph graph;
   private final TransitModel transitModel;
   private final DataImportIssueStore issueStore;
-  private Boolean addExtraEdgesToAreas;
+  private final Boolean addExtraEdgesToAreas;
 
   public StreetLinkerModule(
     Graph graph,
@@ -100,10 +100,9 @@ public class StreetLinkerModule implements GraphBuilderModule {
       stopLocationsUsedForFlexTrips.addAll(
         stopLocationsUsedForFlexTrips
           .stream()
-          .filter(s -> s instanceof FlexLocationGroup)
-          .flatMap(g ->
-            ((FlexLocationGroup) g).getLocations().stream().filter(e -> e instanceof RegularStop)
-          )
+          .filter(GroupStop.class::isInstance)
+          .map(GroupStop.class::cast)
+          .flatMap(g -> g.getLocations().stream().filter(RegularStop.class::isInstance))
           .toList()
       );
     }

--- a/src/main/java/org/opentripplanner/graph_builder/module/StreetLinkerModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/StreetLinkerModule.java
@@ -21,7 +21,7 @@ import org.opentripplanner.routing.vertextype.TransitEntranceVertex;
 import org.opentripplanner.routing.vertextype.TransitStopVertex;
 import org.opentripplanner.routing.vertextype.VehicleParkingEntranceVertex;
 import org.opentripplanner.transit.model.site.FlexLocationGroup;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.util.OTPFeature;
@@ -102,7 +102,7 @@ public class StreetLinkerModule implements GraphBuilderModule {
           .stream()
           .filter(s -> s instanceof FlexLocationGroup)
           .flatMap(g ->
-            ((FlexLocationGroup) g).getLocations().stream().filter(e -> e instanceof Stop)
+            ((FlexLocationGroup) g).getLocations().stream().filter(e -> e instanceof RegularStop)
           )
           .toList()
       );

--- a/src/main/java/org/opentripplanner/gtfs/RepairStopTimesForEachTripOperation.java
+++ b/src/main/java/org/opentripplanner/gtfs/RepairStopTimesForEachTripOperation.java
@@ -18,7 +18,7 @@ import org.opentripplanner.graph_builder.issues.NegativeHopTime;
 import org.opentripplanner.graph_builder.issues.RepeatedStops;
 import org.opentripplanner.model.StopTime;
 import org.opentripplanner.model.TripStopTimes;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.util.OTPFeature;
 import org.slf4j.Logger;
@@ -61,7 +61,7 @@ public class RepairStopTimesForEachTripOperation {
       // if we don't have flex routing enabled then remove all the flex locations and location
       // groups
       if (OTPFeature.FlexRouting.isOff()) {
-        stopTimes.removeIf(st -> !(st.getStop() instanceof Stop));
+        stopTimes.removeIf(st -> !(st.getStop() instanceof RegularStop));
       }
 
       /* Stop times frequently contain duplicate, missing, or incorrect entries. Repair them. */

--- a/src/main/java/org/opentripplanner/gtfs/mapping/BoardingAreaMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/BoardingAreaMapper.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 import java.util.function.Function;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.site.BoardingArea;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.util.MapUtils;
 
 /**
@@ -22,11 +22,11 @@ class BoardingAreaMapper {
   private final Map<org.onebusaway.gtfs.model.Stop, BoardingArea> mappedBoardingAreas = new HashMap<>();
 
   private final TranslationHelper translationHelper;
-  private final Function<FeedScopedId, Stop> stationLookUp;
+  private final Function<FeedScopedId, RegularStop> stationLookUp;
 
   BoardingAreaMapper(
     TranslationHelper translationHelper,
-    Function<FeedScopedId, Stop> stationLookUp
+    Function<FeedScopedId, RegularStop> stationLookUp
   ) {
     this.translationHelper = translationHelper;
     this.stationLookUp = stationLookUp;

--- a/src/main/java/org/opentripplanner/gtfs/mapping/GTFSToOtpTransitServiceMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/GTFSToOtpTransitServiceMapper.java
@@ -144,7 +144,7 @@ public class GTFSToOtpTransitServiceMapper {
     if (OTPFeature.FlexRouting.isOn()) {
       // Stop areas and Stop groups are only used in FLEX routes
       builder.getLocations().addAll(locationMapper.map(data.getAllLocations()));
-      builder.getLocationGroups().addAll(locationGroupMapper.map(data.getAllLocationGroups()));
+      builder.getGroupStops().addAll(locationGroupMapper.map(data.getAllLocationGroups()));
     }
 
     builder.getPathways().addAll(pathwayMapper.map(data.getAllPathways()));

--- a/src/main/java/org/opentripplanner/gtfs/mapping/GTFSToOtpTransitServiceMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/GTFSToOtpTransitServiceMapper.java
@@ -14,8 +14,8 @@ import org.opentripplanner.graph_builder.DataImportIssueStore;
 import org.opentripplanner.model.ShapePoint;
 import org.opentripplanner.model.impl.OtpTransitServiceBuilder;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
-import org.opentripplanner.transit.model.site.Stop;
 import org.opentripplanner.util.OTPFeature;
 
 /**
@@ -86,7 +86,7 @@ public class GTFSToOtpTransitServiceMapper {
   ) {
     // Create callbacks for mappers to retrieve stop and stations
     Function<FeedScopedId, Station> stationLookup = id -> builder.getStations().get(id);
-    Function<FeedScopedId, Stop> stopLookup = id -> builder.getStops().get(id);
+    Function<FeedScopedId, RegularStop> stopLookup = id -> builder.getStops().get(id);
 
     this.issueStore = issueStore;
     this.data = data;

--- a/src/main/java/org/opentripplanner/gtfs/mapping/LocationGroupMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/LocationGroupMapper.java
@@ -5,60 +5,52 @@ import static org.opentripplanner.gtfs.mapping.AgencyAndIdMapper.mapAgencyAndId;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import org.onebusaway.gtfs.model.Location;
+import org.onebusaway.gtfs.model.Stop;
 import org.opentripplanner.transit.model.basic.NonLocalizedString;
-import org.opentripplanner.transit.model.site.FlexLocationGroup;
-import org.opentripplanner.transit.model.site.FlexLocationGroupBuilder;
+import org.opentripplanner.transit.model.site.GroupStop;
+import org.opentripplanner.transit.model.site.GroupStopBuilder;
 import org.opentripplanner.util.MapUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class LocationGroupMapper {
-
-  private static final Logger LOG = LoggerFactory.getLogger(LocationGroupMapper.class);
 
   private final StopMapper stopMapper;
 
   private final LocationMapper locationMapper;
 
-  private final Map<org.onebusaway.gtfs.model.LocationGroup, FlexLocationGroup> mappedLocationGroups = new HashMap<>();
+  private final Map<org.onebusaway.gtfs.model.LocationGroup, GroupStop> mappedLocationGroups = new HashMap<>();
 
   public LocationGroupMapper(StopMapper stopMapper, LocationMapper locationMapper) {
     this.stopMapper = stopMapper;
     this.locationMapper = locationMapper;
   }
 
-  Collection<FlexLocationGroup> map(
-    Collection<org.onebusaway.gtfs.model.LocationGroup> allLocationGroups
-  ) {
+  Collection<GroupStop> map(Collection<org.onebusaway.gtfs.model.LocationGroup> allLocationGroups) {
     return MapUtils.mapToList(allLocationGroups, this::map);
   }
 
   /** Map from GTFS to OTP model, {@code null} safe. */
-  FlexLocationGroup map(org.onebusaway.gtfs.model.LocationGroup original) {
+  GroupStop map(org.onebusaway.gtfs.model.LocationGroup original) {
     return original == null ? null : mappedLocationGroups.computeIfAbsent(original, this::doMap);
   }
 
-  private FlexLocationGroup doMap(org.onebusaway.gtfs.model.LocationGroup element) {
-    FlexLocationGroupBuilder flexLocationGroupBuilder = FlexLocationGroup
+  private GroupStop doMap(org.onebusaway.gtfs.model.LocationGroup element) {
+    GroupStopBuilder groupStopBuilder = GroupStop
       .of(mapAgencyAndId(element.getId()))
       .withName(new NonLocalizedString(element.getName()));
 
     for (org.onebusaway.gtfs.model.StopLocation location : element.getLocations()) {
-      if (location instanceof org.onebusaway.gtfs.model.Stop) {
-        flexLocationGroupBuilder.addLocation(
-          stopMapper.map((org.onebusaway.gtfs.model.Stop) location)
-        );
-      } else if (location instanceof org.onebusaway.gtfs.model.Location) {
-        flexLocationGroupBuilder.addLocation(
-          locationMapper.map((org.onebusaway.gtfs.model.Location) location)
-        );
+      if (location instanceof Stop) {
+        groupStopBuilder.addLocation(stopMapper.map((Stop) location));
+      } else if (location instanceof Location) {
+        groupStopBuilder.addLocation(locationMapper.map((Location) location));
       } else if (location instanceof org.onebusaway.gtfs.model.LocationGroup) {
-        throw new RuntimeException("Nested LocationGroups are not allowed");
+        throw new RuntimeException("Nested GroupStops are not allowed");
       } else {
         throw new RuntimeException("Unknown location type: " + location.getClass().getSimpleName());
       }
     }
 
-    return flexLocationGroupBuilder.build();
+    return groupStopBuilder.build();
   }
 }

--- a/src/main/java/org/opentripplanner/gtfs/mapping/LocationMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/LocationMapper.java
@@ -8,7 +8,7 @@ import java.util.Map;
 import org.locationtech.jts.geom.Geometry;
 import org.opentripplanner.common.geometry.UnsupportedGeometryException;
 import org.opentripplanner.transit.model.basic.NonLocalizedString;
-import org.opentripplanner.transit.model.site.FlexStopLocation;
+import org.opentripplanner.transit.model.site.AreaStop;
 import org.opentripplanner.util.MapUtils;
 import org.opentripplanner.util.geometry.GeometryUtils;
 import org.slf4j.Logger;
@@ -19,18 +19,18 @@ public class LocationMapper {
 
   private static final Logger LOG = LoggerFactory.getLogger(LocationMapper.class);
 
-  private final Map<org.onebusaway.gtfs.model.Location, FlexStopLocation> mappedLocations = new HashMap<>();
+  private final Map<org.onebusaway.gtfs.model.Location, AreaStop> mappedLocations = new HashMap<>();
 
-  Collection<FlexStopLocation> map(Collection<org.onebusaway.gtfs.model.Location> allLocations) {
+  Collection<AreaStop> map(Collection<org.onebusaway.gtfs.model.Location> allLocations) {
     return MapUtils.mapToList(allLocations, this::map);
   }
 
   /** Map from GTFS to OTP model, {@code null} safe. */
-  FlexStopLocation map(org.onebusaway.gtfs.model.Location orginal) {
+  AreaStop map(org.onebusaway.gtfs.model.Location orginal) {
     return orginal == null ? null : mappedLocations.computeIfAbsent(orginal, this::doMap);
   }
 
-  private FlexStopLocation doMap(org.onebusaway.gtfs.model.Location gtfsLocation) {
+  private AreaStop doMap(org.onebusaway.gtfs.model.Location gtfsLocation) {
     var name = NonLocalizedString.ofNullable(gtfsLocation.getName());
     Geometry geometry = null;
     try {
@@ -39,7 +39,7 @@ public class LocationMapper {
       LOG.error("Unsupported geometry type for {}", gtfsLocation.getId());
     }
 
-    return FlexStopLocation
+    return AreaStop
       .of(mapAgencyAndId(gtfsLocation.getId()))
       .withName(name)
       .withUrl(NonLocalizedString.ofNullable(gtfsLocation.getUrl()))

--- a/src/main/java/org/opentripplanner/gtfs/mapping/StopMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/StopMapper.java
@@ -8,8 +8,8 @@ import java.util.function.Function;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.site.FareZone;
 import org.opentripplanner.transit.model.site.RegularStop;
+import org.opentripplanner.transit.model.site.RegularStopBuilder;
 import org.opentripplanner.transit.model.site.Station;
-import org.opentripplanner.transit.model.site.StopBuilder;
 import org.opentripplanner.util.MapUtils;
 
 /** Responsible for mapping GTFS Stop into the OTP model. */
@@ -45,7 +45,7 @@ class StopMapper {
     }
 
     StopMappingWrapper base = new StopMappingWrapper(gtfsStop);
-    StopBuilder builder = RegularStop
+    RegularStopBuilder builder = RegularStop
       .of(base.getId())
       .withCode(base.getCode())
       .withCoordinate(base.getCoordinate())

--- a/src/main/java/org/opentripplanner/gtfs/mapping/StopMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/StopMapper.java
@@ -7,15 +7,15 @@ import java.util.Map;
 import java.util.function.Function;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.site.FareZone;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
-import org.opentripplanner.transit.model.site.Stop;
 import org.opentripplanner.transit.model.site.StopBuilder;
 import org.opentripplanner.util.MapUtils;
 
 /** Responsible for mapping GTFS Stop into the OTP model. */
 class StopMapper {
 
-  private final Map<org.onebusaway.gtfs.model.Stop, Stop> mappedStops = new HashMap<>();
+  private final Map<org.onebusaway.gtfs.model.Stop, RegularStop> mappedStops = new HashMap<>();
 
   private final TranslationHelper translationHelper;
   private final Function<FeedScopedId, Station> stationLookUp;
@@ -25,16 +25,16 @@ class StopMapper {
     this.stationLookUp = stationLookUp;
   }
 
-  Collection<Stop> map(Collection<org.onebusaway.gtfs.model.Stop> allStops) {
+  Collection<RegularStop> map(Collection<org.onebusaway.gtfs.model.Stop> allStops) {
     return MapUtils.mapToList(allStops, this::map);
   }
 
   /** Map from GTFS to OTP model, {@code null} safe. */
-  Stop map(org.onebusaway.gtfs.model.Stop orginal) {
+  RegularStop map(org.onebusaway.gtfs.model.Stop orginal) {
     return orginal == null ? null : mappedStops.computeIfAbsent(orginal, this::doMap);
   }
 
-  private Stop doMap(org.onebusaway.gtfs.model.Stop gtfsStop) {
+  private RegularStop doMap(org.onebusaway.gtfs.model.Stop gtfsStop) {
     if (gtfsStop.getLocationType() != org.onebusaway.gtfs.model.Stop.LOCATION_TYPE_STOP) {
       throw new IllegalArgumentException(
         "Expected type " +
@@ -45,7 +45,7 @@ class StopMapper {
     }
 
     StopMappingWrapper base = new StopMappingWrapper(gtfsStop);
-    StopBuilder builder = Stop
+    StopBuilder builder = RegularStop
       .of(base.getId())
       .withCode(base.getCode())
       .withCoordinate(base.getCoordinate())

--- a/src/main/java/org/opentripplanner/gtfs/mapping/TransferMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/TransferMapper.java
@@ -22,8 +22,8 @@ import org.opentripplanner.model.transfer.TransferPoint;
 import org.opentripplanner.model.transfer.TransferPriority;
 import org.opentripplanner.model.transfer.TripTransferPoint;
 import org.opentripplanner.transit.model.network.Route;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
-import org.opentripplanner.transit.model.site.Stop;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.timetable.Trip;
 
@@ -219,7 +219,7 @@ class TransferMapper {
   ) {
     Route route = routeMapper.map(rhsRoute);
     Station station = null;
-    Stop stop = null;
+    RegularStop stop = null;
 
     // A transfer is specified using Stops and/or Station, according to the GTFS specification:
     //
@@ -253,7 +253,7 @@ class TransferMapper {
     throw new IllegalStateException("Should not get here!");
   }
 
-  private int stopPosition(Trip trip, Stop stop, Station station, boolean boardTrip) {
+  private int stopPosition(Trip trip, RegularStop stop, Station station, boolean boardTrip) {
     List<StopTime> stopTimes = stopTimesByTrip.get(trip);
 
     // We can board at the first stop, but not alight.
@@ -262,7 +262,7 @@ class TransferMapper {
     final int lastStopPos = stopTimes.size() - (boardTrip ? 1 : 0);
 
     Predicate<StopLocation> stopMatches = station != null
-      ? s -> (s instanceof Stop && ((Stop) s).getParentStation() == station)
+      ? s -> (s instanceof RegularStop && ((RegularStop) s).getParentStation() == station)
       : s -> s == stop;
 
     for (int i = firstStopPos; i < lastStopPos; i++) {

--- a/src/main/java/org/opentripplanner/index/IndexAPI.java
+++ b/src/main/java/org/opentripplanner/index/IndexAPI.java
@@ -202,7 +202,7 @@ public class IndexAPI {
 
       radius = Math.min(radius, MAX_STOP_SEARCH_RADIUS);
 
-      return new DirectGraphFinder(serverContext.transitService()::queryStopSpatialIndex)
+      return new DirectGraphFinder(serverContext.transitService()::findRegularStop)
         .findClosestStops(lat, lon, radius)
         .stream()
         .map(it -> StopMapper.mapToApiShort(it.stop, it.distance))
@@ -223,7 +223,7 @@ public class IndexAPI {
         new Coordinate(maxLon, maxLat)
       );
 
-      var stops = transitService().queryStopSpatialIndex(envelope);
+      var stops = transitService().findRegularStop(envelope);
       return stops
         .stream()
         .filter(stop -> envelope.contains(stop.getCoordinate().asJtsCoordinate()))

--- a/src/main/java/org/opentripplanner/inspector/PathwayEdgeRenderer.java
+++ b/src/main/java/org/opentripplanner/inspector/PathwayEdgeRenderer.java
@@ -7,8 +7,8 @@ import org.opentripplanner.inspector.EdgeVertexTileRenderer.VertexVisualAttribut
 import org.opentripplanner.routing.edgetype.PathwayEdge;
 import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Vertex;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.StationElement;
-import org.opentripplanner.transit.model.site.Stop;
 
 public class PathwayEdgeRenderer implements EdgeVertexRenderer {
 
@@ -74,7 +74,7 @@ public class PathwayEdgeRenderer implements EdgeVertexRenderer {
 
     sb.append(stationElement.getName());
 
-    if (stationElement instanceof Stop stop && stop.getPlatformCode() != null) {
+    if (stationElement instanceof RegularStop stop && stop.getPlatformCode() != null) {
       sb.append(" [").append(stop.getPlatformCode()).append("]");
     }
 

--- a/src/main/java/org/opentripplanner/model/GenericLocation.java
+++ b/src/main/java/org/opentripplanner/model/GenericLocation.java
@@ -19,8 +19,8 @@ public class GenericLocation {
   public final String label;
 
   /**
-   * Refers to a specific element in the OTP model. This can currently be a stop, station,
-   * multi-modal station or group of stations.
+   * Refers to a specific element in the OTP model. This can currently be a regular stop, area stop,
+   * group stop, station, multi-modal station or group of stations.
    */
   public final FeedScopedId stopId;
 

--- a/src/main/java/org/opentripplanner/model/impl/OtpTransitServiceBuilder.java
+++ b/src/main/java/org/opentripplanner/model/impl/OtpTransitServiceBuilder.java
@@ -36,8 +36,8 @@ import org.opentripplanner.transit.model.site.AreaStop;
 import org.opentripplanner.transit.model.site.BoardingArea;
 import org.opentripplanner.transit.model.site.Entrance;
 import org.opentripplanner.transit.model.site.FareZone;
-import org.opentripplanner.transit.model.site.FlexLocationGroup;
 import org.opentripplanner.transit.model.site.GroupOfStations;
+import org.opentripplanner.transit.model.site.GroupStop;
 import org.opentripplanner.transit.model.site.MultiModalStation;
 import org.opentripplanner.transit.model.site.Pathway;
 import org.opentripplanner.transit.model.site.PathwayNode;
@@ -140,11 +140,11 @@ public class OtpTransitServiceBuilder {
   }
 
   public EntityById<GroupOfStations> getGroupsOfStationsById() {
-    return stopModelBuilder().groupOfStationsById();
+    return stopModelBuilder().groupOfStationById();
   }
 
   public EntityById<MultiModalStation> getMultiModalStationsById() {
-    return stopModelBuilder().multiModalStationsById();
+    return stopModelBuilder().multiModalStationById();
   }
 
   /**
@@ -172,11 +172,11 @@ public class OtpTransitServiceBuilder {
   }
 
   public EntityById<Station> getStations() {
-    return stopModelBuilder().stationsById();
+    return stopModelBuilder().stationById();
   }
 
   public EntityById<RegularStop> getStops() {
-    return stopModelBuilder().stopsById();
+    return stopModelBuilder().regularStopsById();
   }
 
   public EntityById<Entrance> getEntrances() {
@@ -192,11 +192,11 @@ public class OtpTransitServiceBuilder {
   }
 
   public EntityById<AreaStop> getLocations() {
-    return stopModelBuilder().flexStopsById();
+    return stopModelBuilder().areaStopById();
   }
 
-  public EntityById<FlexLocationGroup> getLocationGroups() {
-    return stopModelBuilder().flexStopGroupsById();
+  public EntityById<GroupStop> getGroupStops() {
+    return stopModelBuilder().groupStopById();
   }
 
   public TripStopTimes getStopTimesSortedByTrip() {

--- a/src/main/java/org/opentripplanner/model/impl/OtpTransitServiceBuilder.java
+++ b/src/main/java/org/opentripplanner/model/impl/OtpTransitServiceBuilder.java
@@ -32,11 +32,11 @@ import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.organization.Agency;
 import org.opentripplanner.transit.model.organization.Branding;
 import org.opentripplanner.transit.model.organization.Operator;
+import org.opentripplanner.transit.model.site.AreaStop;
 import org.opentripplanner.transit.model.site.BoardingArea;
 import org.opentripplanner.transit.model.site.Entrance;
 import org.opentripplanner.transit.model.site.FareZone;
 import org.opentripplanner.transit.model.site.FlexLocationGroup;
-import org.opentripplanner.transit.model.site.FlexStopLocation;
 import org.opentripplanner.transit.model.site.GroupOfStations;
 import org.opentripplanner.transit.model.site.MultiModalStation;
 import org.opentripplanner.transit.model.site.Pathway;
@@ -191,7 +191,7 @@ public class OtpTransitServiceBuilder {
     return boardingAreasById;
   }
 
-  public EntityById<FlexStopLocation> getLocations() {
+  public EntityById<AreaStop> getLocations() {
     return stopModelBuilder().flexStopsById();
   }
 

--- a/src/main/java/org/opentripplanner/model/impl/OtpTransitServiceBuilder.java
+++ b/src/main/java/org/opentripplanner/model/impl/OtpTransitServiceBuilder.java
@@ -41,8 +41,8 @@ import org.opentripplanner.transit.model.site.GroupOfStations;
 import org.opentripplanner.transit.model.site.MultiModalStation;
 import org.opentripplanner.transit.model.site.Pathway;
 import org.opentripplanner.transit.model.site.PathwayNode;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
-import org.opentripplanner.transit.model.site.Stop;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
 import org.opentripplanner.transit.service.StopModel;
@@ -175,7 +175,7 @@ public class OtpTransitServiceBuilder {
     return stopModelBuilder().stationsById();
   }
 
-  public EntityById<Stop> getStops() {
+  public EntityById<RegularStop> getStops() {
     return stopModelBuilder().stopsById();
   }
 

--- a/src/main/java/org/opentripplanner/model/plan/Place.java
+++ b/src/main/java/org/opentripplanner/model/plan/Place.java
@@ -10,7 +10,7 @@ import org.opentripplanner.routing.vertextype.VehicleRentalPlaceVertex;
 import org.opentripplanner.transit.model.basic.I18NString;
 import org.opentripplanner.transit.model.basic.LocalizedString;
 import org.opentripplanner.transit.model.basic.WgsCoordinate;
-import org.opentripplanner.transit.model.site.FlexStopLocation;
+import org.opentripplanner.transit.model.site.AreaStop;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.util.lang.ToStringBuilder;
 
@@ -95,7 +95,7 @@ public class Place {
   public static Place forFlexStop(StopLocation stop, Vertex vertex) {
     var name = stop.getName();
 
-    if (stop instanceof FlexStopLocation flexArea && vertex instanceof StreetVertex s) {
+    if (stop instanceof AreaStop flexArea && vertex instanceof StreetVertex s) {
       if (flexArea.hasFallbackName()) {
         name = s.getIntersectionName();
       } else {

--- a/src/main/java/org/opentripplanner/netex/mapping/FlexStopLocationMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/FlexStopLocationMapper.java
@@ -11,7 +11,7 @@ import org.opentripplanner.transit.model.basic.NonLocalizedString;
 import org.opentripplanner.transit.model.site.FlexLocationGroup;
 import org.opentripplanner.transit.model.site.FlexLocationGroupBuilder;
 import org.opentripplanner.transit.model.site.FlexStopLocation;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.util.geometry.GeometryUtils;
 import org.rutebanken.netex.model.FlexibleArea;
@@ -33,12 +33,12 @@ class FlexStopLocationMapper {
   private static final String UNRESTRICTED_PUBLIC_TRANSPORT_AREAS_VALUE =
     "UnrestrictedPublicTransportAreas";
   private final FeedScopedIdFactory idFactory;
-  private final HashGridSpatialIndex<Stop> stopsSpatialIndex;
+  private final HashGridSpatialIndex<RegularStop> stopsSpatialIndex;
 
-  FlexStopLocationMapper(FeedScopedIdFactory idFactory, Collection<Stop> stops) {
+  FlexStopLocationMapper(FeedScopedIdFactory idFactory, Collection<RegularStop> stops) {
     this.idFactory = idFactory;
     this.stopsSpatialIndex = new HashGridSpatialIndex<>();
-    for (Stop stop : stops) {
+    for (RegularStop stop : stops) {
       Envelope env = new Envelope(stop.getCoordinate().asJtsCoordinate());
       this.stopsSpatialIndex.insert(env, stop);
     }
@@ -104,7 +104,7 @@ class FlexStopLocationMapper {
 
     Geometry geometry = OpenGisMapper.mapGeometry(area.getPolygon());
 
-    for (Stop stop : stopsSpatialIndex.query(geometry.getEnvelopeInternal())) {
+    for (RegularStop stop : stopsSpatialIndex.query(geometry.getEnvelopeInternal())) {
       Point p = GeometryUtils
         .getGeometryFactory()
         .createPoint(stop.getCoordinate().asJtsCoordinate());

--- a/src/main/java/org/opentripplanner/netex/mapping/FlexStopsMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/FlexStopsMapper.java
@@ -9,8 +9,8 @@ import org.opentripplanner.common.geometry.HashGridSpatialIndex;
 import org.opentripplanner.netex.mapping.support.FeedScopedIdFactory;
 import org.opentripplanner.transit.model.basic.NonLocalizedString;
 import org.opentripplanner.transit.model.site.AreaStop;
-import org.opentripplanner.transit.model.site.FlexLocationGroup;
-import org.opentripplanner.transit.model.site.FlexLocationGroupBuilder;
+import org.opentripplanner.transit.model.site.GroupStop;
+import org.opentripplanner.transit.model.site.GroupStopBuilder;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.util.geometry.GeometryUtils;
@@ -45,7 +45,7 @@ class FlexStopsMapper {
   }
 
   /**
-   * Maps NeTEx FlexibleStopPlace to FlexStopLocation. The support for FlexLocationGroup is
+   * Maps NeTEx FlexibleStopPlace to FlexStopLocation. The support for GroupStop is
    * dependent on a key/value in the NeTEx file, until proper NeTEx support is added.
    */
   StopLocation map(FlexibleStopPlace flexibleStopPlace) {
@@ -97,8 +97,8 @@ class FlexStopsMapper {
   /**
    * Allows pickup / drop off at any regular Stop inside the area
    */
-  FlexLocationGroup mapStopsInFlexArea(FlexibleStopPlace flexibleStopPlace, FlexibleArea area) {
-    FlexLocationGroupBuilder result = FlexLocationGroup
+  GroupStop mapStopsInFlexArea(FlexibleStopPlace flexibleStopPlace, FlexibleArea area) {
+    GroupStopBuilder result = GroupStop
       .of(idFactory.createId(flexibleStopPlace.getId()))
       .withName(new NonLocalizedString(flexibleStopPlace.getName().getValue()));
 

--- a/src/main/java/org/opentripplanner/netex/mapping/FlexStopsMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/FlexStopsMapper.java
@@ -8,9 +8,9 @@ import org.locationtech.jts.geom.Point;
 import org.opentripplanner.common.geometry.HashGridSpatialIndex;
 import org.opentripplanner.netex.mapping.support.FeedScopedIdFactory;
 import org.opentripplanner.transit.model.basic.NonLocalizedString;
+import org.opentripplanner.transit.model.site.AreaStop;
 import org.opentripplanner.transit.model.site.FlexLocationGroup;
 import org.opentripplanner.transit.model.site.FlexLocationGroupBuilder;
-import org.opentripplanner.transit.model.site.FlexStopLocation;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.util.geometry.GeometryUtils;
@@ -20,9 +20,9 @@ import org.rutebanken.netex.model.KeyValueStructure;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-class FlexStopLocationMapper {
+class FlexStopsMapper {
 
-  private static final Logger LOG = LoggerFactory.getLogger(FlexStopLocationMapper.class);
+  private static final Logger LOG = LoggerFactory.getLogger(FlexStopsMapper.class);
   /**
    * Key-value pair used until proper NeTEx support is added
    */
@@ -35,7 +35,7 @@ class FlexStopLocationMapper {
   private final FeedScopedIdFactory idFactory;
   private final HashGridSpatialIndex<RegularStop> stopsSpatialIndex;
 
-  FlexStopLocationMapper(FeedScopedIdFactory idFactory, Collection<RegularStop> stops) {
+  FlexStopsMapper(FeedScopedIdFactory idFactory, Collection<RegularStop> stops) {
     this.idFactory = idFactory;
     this.stopsSpatialIndex = new HashGridSpatialIndex<>();
     for (RegularStop stop : stops) {
@@ -85,9 +85,9 @@ class FlexStopLocationMapper {
   /**
    * Allows pickup / drop off along any eligible street inside the area
    */
-  FlexStopLocation mapFlexArea(FlexibleStopPlace flexibleStopPlace, FlexibleArea area) {
+  AreaStop mapFlexArea(FlexibleStopPlace flexibleStopPlace, FlexibleArea area) {
     var name = new NonLocalizedString(flexibleStopPlace.getName().getValue());
-    return FlexStopLocation
+    return AreaStop
       .of(idFactory.createId(flexibleStopPlace.getId()))
       .withName(name)
       .withGeometry(OpenGisMapper.mapGeometry(area.getPolygon()))

--- a/src/main/java/org/opentripplanner/netex/mapping/NetexMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/NetexMapper.java
@@ -24,8 +24,8 @@ import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.GroupOfRoutes;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.organization.Agency;
+import org.opentripplanner.transit.model.site.AreaStop;
 import org.opentripplanner.transit.model.site.FlexLocationGroup;
-import org.opentripplanner.transit.model.site.FlexStopLocation;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.rutebanken.netex.model.Authority;
@@ -337,15 +337,15 @@ public class NetexMapper {
       return;
     }
 
-    FlexStopLocationMapper flexStopLocationMapper = new FlexStopLocationMapper(
+    FlexStopsMapper flexStopsMapper = new FlexStopsMapper(
       idFactory,
       transitBuilder.getStops().values()
     );
 
     for (FlexibleStopPlace flexibleStopPlace : flexibleStopPlaces) {
-      StopLocation stopLocation = flexStopLocationMapper.map(flexibleStopPlace);
-      if (stopLocation instanceof FlexStopLocation) {
-        transitBuilder.getLocations().add((FlexStopLocation) stopLocation);
+      StopLocation stopLocation = flexStopsMapper.map(flexibleStopPlace);
+      if (stopLocation instanceof AreaStop) {
+        transitBuilder.getLocations().add((AreaStop) stopLocation);
       } else if (stopLocation instanceof FlexLocationGroup) {
         transitBuilder.getLocationGroups().add((FlexLocationGroup) stopLocation);
       }

--- a/src/main/java/org/opentripplanner/netex/mapping/NetexMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/NetexMapper.java
@@ -25,7 +25,7 @@ import org.opentripplanner.transit.model.network.GroupOfRoutes;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.organization.Agency;
 import org.opentripplanner.transit.model.site.AreaStop;
-import org.opentripplanner.transit.model.site.FlexLocationGroup;
+import org.opentripplanner.transit.model.site.GroupStop;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.rutebanken.netex.model.Authority;
@@ -346,8 +346,8 @@ public class NetexMapper {
       StopLocation stopLocation = flexStopsMapper.map(flexibleStopPlace);
       if (stopLocation instanceof AreaStop) {
         transitBuilder.getLocations().add((AreaStop) stopLocation);
-      } else if (stopLocation instanceof FlexLocationGroup) {
-        transitBuilder.getLocationGroups().add((FlexLocationGroup) stopLocation);
+      } else if (stopLocation instanceof GroupStop groupStop) {
+        transitBuilder.getGroupStops().add(groupStop);
       }
     }
   }
@@ -408,7 +408,7 @@ public class NetexMapper {
       transitBuilder.getOperatorsById(),
       transitBuilder.getStops(),
       transitBuilder.getLocations(),
-      transitBuilder.getLocationGroups(),
+      transitBuilder.getGroupStops(),
       transitBuilder.getRoutes(),
       currentNetexIndex.getRouteById(),
       currentNetexIndex.getJourneyPatternsById(),

--- a/src/main/java/org/opentripplanner/netex/mapping/QuayMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/QuayMapper.java
@@ -16,13 +16,13 @@ import org.opentripplanner.transit.model.site.Station;
 import org.rutebanken.netex.model.MultilingualString;
 import org.rutebanken.netex.model.Quay;
 
-class StopMapper {
+class QuayMapper {
 
   private final DataImportIssueStore issueStore;
 
   private final FeedScopedIdFactory idFactory;
 
-  StopMapper(FeedScopedIdFactory idFactory, DataImportIssueStore issueStore) {
+  QuayMapper(FeedScopedIdFactory idFactory, DataImportIssueStore issueStore) {
     this.idFactory = idFactory;
     this.issueStore = issueStore;
   }

--- a/src/main/java/org/opentripplanner/netex/mapping/ServiceLinkMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/ServiceLinkMapper.java
@@ -18,7 +18,7 @@ import org.opentripplanner.netex.index.api.ReadOnlyHierarchicalMapById;
 import org.opentripplanner.netex.mapping.support.FeedScopedIdFactory;
 import org.opentripplanner.transit.model.framework.EntityById;
 import org.opentripplanner.transit.model.network.StopPattern;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.util.geometry.GeometryUtils;
 import org.rutebanken.netex.model.JourneyPattern;
@@ -36,7 +36,7 @@ class ServiceLinkMapper {
   private final FeedScopedIdFactory idFactory;
   private final ReadOnlyHierarchicalMapById<ServiceLink> serviceLinkById;
   private final ReadOnlyHierarchicalMap<String, String> quayIdByStopPointRef;
-  private final EntityById<Stop> stopById;
+  private final EntityById<RegularStop> stopById;
   private final DataImportIssueStore issueStore;
   private final double maxStopToShapeSnapDistance;
 
@@ -44,7 +44,7 @@ class ServiceLinkMapper {
     FeedScopedIdFactory idFactory,
     ReadOnlyHierarchicalMapById<ServiceLink> serviceLinkById,
     ReadOnlyHierarchicalMap<String, String> quayIdByStopPointRef,
-    EntityById<Stop> stopById,
+    EntityById<RegularStop> stopById,
     DataImportIssueStore issueStore,
     double maxStopToShapeSnapDistance
   ) {
@@ -168,10 +168,10 @@ class ServiceLinkMapper {
     int stopIndex
   ) {
     String fromPointQuayId = quayIdByStopPointRef.lookup(serviceLink.getFromPointRef().getRef());
-    Stop fromPointStop = stopById.get(idFactory.createId(fromPointQuayId));
+    RegularStop fromPointStop = stopById.get(idFactory.createId(fromPointQuayId));
 
     String toPointQuayId = quayIdByStopPointRef.lookup(serviceLink.getToPointRef().getRef());
-    Stop toPointStop = stopById.get(idFactory.createId(toPointQuayId));
+    RegularStop toPointStop = stopById.get(idFactory.createId(toPointQuayId));
 
     if (fromPointStop == null || toPointStop == null) {
       issueStore.add(

--- a/src/main/java/org/opentripplanner/netex/mapping/StopAndStationMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/StopAndStationMapper.java
@@ -47,7 +47,7 @@ class StopAndStationMapper {
 
   private final ReadOnlyHierarchicalVersionMapById<Quay> quayIndex;
   private final StationMapper stationMapper;
-  private final StopMapper stopMapper;
+  private final QuayMapper quayMapper;
   private final TariffZoneMapper tariffZoneMapper;
   private final StopPlaceTypeMapper stopPlaceTypeMapper = new StopPlaceTypeMapper();
   private final DataImportIssueStore issueStore;
@@ -68,7 +68,7 @@ class StopAndStationMapper {
     DataImportIssueStore issueStore
   ) {
     this.stationMapper = new StationMapper(issueStore, idFactory);
-    this.stopMapper = new StopMapper(idFactory, issueStore);
+    this.quayMapper = new QuayMapper(idFactory, issueStore);
     this.tariffZoneMapper = tariffZoneMapper;
     this.quayIndex = quayIndex;
     this.issueStore = issueStore;
@@ -174,7 +174,7 @@ class StopAndStationMapper {
 
     var wheelchair = wheelchairAccessibilityFromQuay(quay, stopPlace);
 
-    RegularStop stop = stopMapper.mapQuayToStop(quay, station, fareZones, transitMode, wheelchair);
+    RegularStop stop = quayMapper.mapQuayToStop(quay, station, fareZones, transitMode, wheelchair);
     if (stop == null) {
       return;
     }

--- a/src/main/java/org/opentripplanner/netex/mapping/StopAndStationMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/StopAndStationMapper.java
@@ -22,8 +22,8 @@ import org.opentripplanner.netex.mapping.support.StopPlaceVersionAndValidityComp
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.basic.WheelchairAccessibility;
 import org.opentripplanner.transit.model.site.FareZone;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
-import org.opentripplanner.transit.model.site.Stop;
 import org.rutebanken.netex.model.Quay;
 import org.rutebanken.netex.model.Quays_RelStructure;
 import org.rutebanken.netex.model.StopPlace;
@@ -57,7 +57,7 @@ class StopAndStationMapper {
    */
   private final Set<String> quaysAlreadyProcessed = new HashSet<>();
 
-  final List<Stop> resultStops = new ArrayList<>();
+  final List<RegularStop> resultStops = new ArrayList<>();
   final List<Station> resultStations = new ArrayList<>();
   final Multimap<String, Station> resultStationByMultiModalStationRfs = ArrayListMultimap.create();
 
@@ -174,7 +174,7 @@ class StopAndStationMapper {
 
     var wheelchair = wheelchairAccessibilityFromQuay(quay, stopPlace);
 
-    Stop stop = stopMapper.mapQuayToStop(quay, station, fareZones, transitMode, wheelchair);
+    RegularStop stop = stopMapper.mapQuayToStop(quay, station, fareZones, transitMode, wheelchair);
     if (stop == null) {
       return;
     }

--- a/src/main/java/org/opentripplanner/netex/mapping/StopMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/StopMapper.java
@@ -11,8 +11,8 @@ import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.basic.WgsCoordinate;
 import org.opentripplanner.transit.model.basic.WheelchairAccessibility;
 import org.opentripplanner.transit.model.site.FareZone;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
-import org.opentripplanner.transit.model.site.Stop;
 import org.rutebanken.netex.model.MultilingualString;
 import org.rutebanken.netex.model.Quay;
 
@@ -31,7 +31,7 @@ class StopMapper {
    * Map Netex Quay to OTP Stop
    */
   @Nullable
-  Stop mapQuayToStop(
+  RegularStop mapQuayToStop(
     Quay quay,
     Station parentStation,
     Collection<FareZone> fareZones,
@@ -45,7 +45,7 @@ class StopMapper {
       return null;
     }
 
-    var builder = Stop
+    var builder = RegularStop
       .of(idFactory.createId(quay.getId()))
       .withParentStation(parentStation)
       .withName(parentStation.getName())

--- a/src/main/java/org/opentripplanner/netex/mapping/StopTimesMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/StopTimesMapper.java
@@ -20,7 +20,7 @@ import org.opentripplanner.netex.index.api.ReadOnlyHierarchicalMapById;
 import org.opentripplanner.netex.mapping.support.FeedScopedIdFactory;
 import org.opentripplanner.transit.model.framework.EntityById;
 import org.opentripplanner.transit.model.site.AreaStop;
-import org.opentripplanner.transit.model.site.FlexLocationGroup;
+import org.opentripplanner.transit.model.site.GroupStop;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.timetable.Trip;
@@ -58,7 +58,7 @@ class StopTimesMapper {
 
   private final EntityById<AreaStop> flexibleStopLocationsById;
 
-  private final EntityById<FlexLocationGroup> flexLocationGroupsByid;
+  private final EntityById<GroupStop> groupStopById;
 
   private final ReadOnlyHierarchicalMap<String, String> quayIdByStopPointRef;
 
@@ -77,7 +77,7 @@ class StopTimesMapper {
     FeedScopedIdFactory idFactory,
     EntityById<RegularStop> stopsById,
     EntityById<AreaStop> areaStopById,
-    EntityById<FlexLocationGroup> flexLocationGroupsById,
+    EntityById<GroupStop> groupStopById,
     ReadOnlyHierarchicalMap<String, DestinationDisplay> destinationDisplayById,
     ReadOnlyHierarchicalMap<String, String> quayIdByStopPointRef,
     ReadOnlyHierarchicalMap<String, String> flexibleStopPlaceIdByStopPointRef,
@@ -89,7 +89,7 @@ class StopTimesMapper {
     this.destinationDisplayById = destinationDisplayById;
     this.stopsById = stopsById;
     this.flexibleStopLocationsById = areaStopById;
-    this.flexLocationGroupsByid = flexLocationGroupsById;
+    this.groupStopById = groupStopById;
     this.quayIdByStopPointRef = quayIdByStopPointRef;
     this.flexibleStopPlaceIdByStopPointRef = flexibleStopPlaceIdByStopPointRef;
     this.flexibleLinesById = flexibleLinesById;
@@ -240,7 +240,7 @@ class StopTimesMapper {
       stopTimes.size() == 2 &&
       stopTimes
         .stream()
-        .allMatch(s -> s.getStop() instanceof AreaStop || s.getStop() instanceof FlexLocationGroup)
+        .allMatch(s -> s.getStop() instanceof AreaStop || s.getStop() instanceof GroupStop)
     ) {
       int departureTime = stopTimes.get(0).getDepartureTime();
       int arrivalTime = stopTimes.get(1).getArrivalTime();
@@ -407,13 +407,11 @@ class StopTimesMapper {
       stopLocation = stopsById.get(idFactory.createId(stopId));
     } else {
       AreaStop areaStop = flexibleStopLocationsById.get(idFactory.createId(flexibleStopPlaceId));
-      FlexLocationGroup flexLocationGroup = flexLocationGroupsByid.get(
-        idFactory.createId(flexibleStopPlaceId)
-      );
+      GroupStop groupStop = groupStopById.get(idFactory.createId(flexibleStopPlaceId));
 
       if (areaStop != null) {
         stopLocation = areaStop;
-      } else stopLocation = flexLocationGroup;
+      } else stopLocation = groupStop;
     }
 
     if (stopLocation == null) {

--- a/src/main/java/org/opentripplanner/netex/mapping/StopTimesMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/StopTimesMapper.java
@@ -19,8 +19,8 @@ import org.opentripplanner.netex.index.api.ReadOnlyHierarchicalMap;
 import org.opentripplanner.netex.index.api.ReadOnlyHierarchicalMapById;
 import org.opentripplanner.netex.mapping.support.FeedScopedIdFactory;
 import org.opentripplanner.transit.model.framework.EntityById;
+import org.opentripplanner.transit.model.site.AreaStop;
 import org.opentripplanner.transit.model.site.FlexLocationGroup;
-import org.opentripplanner.transit.model.site.FlexStopLocation;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.timetable.Trip;
@@ -56,7 +56,7 @@ class StopTimesMapper {
 
   private final EntityById<RegularStop> stopsById;
 
-  private final EntityById<FlexStopLocation> flexibleStopLocationsById;
+  private final EntityById<AreaStop> flexibleStopLocationsById;
 
   private final EntityById<FlexLocationGroup> flexLocationGroupsByid;
 
@@ -76,7 +76,7 @@ class StopTimesMapper {
     DataImportIssueStore issueStore,
     FeedScopedIdFactory idFactory,
     EntityById<RegularStop> stopsById,
-    EntityById<FlexStopLocation> flexStopLocationsById,
+    EntityById<AreaStop> areaStopById,
     EntityById<FlexLocationGroup> flexLocationGroupsById,
     ReadOnlyHierarchicalMap<String, DestinationDisplay> destinationDisplayById,
     ReadOnlyHierarchicalMap<String, String> quayIdByStopPointRef,
@@ -88,7 +88,7 @@ class StopTimesMapper {
     this.idFactory = idFactory;
     this.destinationDisplayById = destinationDisplayById;
     this.stopsById = stopsById;
-    this.flexibleStopLocationsById = flexStopLocationsById;
+    this.flexibleStopLocationsById = areaStopById;
     this.flexLocationGroupsByid = flexLocationGroupsById;
     this.quayIdByStopPointRef = quayIdByStopPointRef;
     this.flexibleStopPlaceIdByStopPointRef = flexibleStopPlaceIdByStopPointRef;
@@ -240,9 +240,7 @@ class StopTimesMapper {
       stopTimes.size() == 2 &&
       stopTimes
         .stream()
-        .allMatch(s ->
-          s.getStop() instanceof FlexStopLocation || s.getStop() instanceof FlexLocationGroup
-        )
+        .allMatch(s -> s.getStop() instanceof AreaStop || s.getStop() instanceof FlexLocationGroup)
     ) {
       int departureTime = stopTimes.get(0).getDepartureTime();
       int arrivalTime = stopTimes.get(1).getArrivalTime();
@@ -408,15 +406,13 @@ class StopTimesMapper {
     if (stopId != null) {
       stopLocation = stopsById.get(idFactory.createId(stopId));
     } else {
-      FlexStopLocation flexStopLocation = flexibleStopLocationsById.get(
-        idFactory.createId(flexibleStopPlaceId)
-      );
+      AreaStop areaStop = flexibleStopLocationsById.get(idFactory.createId(flexibleStopPlaceId));
       FlexLocationGroup flexLocationGroup = flexLocationGroupsByid.get(
         idFactory.createId(flexibleStopPlaceId)
       );
 
-      if (flexStopLocation != null) {
-        stopLocation = flexStopLocation;
+      if (areaStop != null) {
+        stopLocation = areaStop;
       } else stopLocation = flexLocationGroup;
     }
 

--- a/src/main/java/org/opentripplanner/netex/mapping/StopTimesMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/StopTimesMapper.java
@@ -21,7 +21,7 @@ import org.opentripplanner.netex.mapping.support.FeedScopedIdFactory;
 import org.opentripplanner.transit.model.framework.EntityById;
 import org.opentripplanner.transit.model.site.FlexLocationGroup;
 import org.opentripplanner.transit.model.site.FlexStopLocation;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.util.OTPFeature;
@@ -54,7 +54,7 @@ class StopTimesMapper {
 
   private final ReadOnlyHierarchicalMap<String, DestinationDisplay> destinationDisplayById;
 
-  private final EntityById<Stop> stopsById;
+  private final EntityById<RegularStop> stopsById;
 
   private final EntityById<FlexStopLocation> flexibleStopLocationsById;
 
@@ -75,7 +75,7 @@ class StopTimesMapper {
   StopTimesMapper(
     DataImportIssueStore issueStore,
     FeedScopedIdFactory idFactory,
-    EntityById<Stop> stopsById,
+    EntityById<RegularStop> stopsById,
     EntityById<FlexStopLocation> flexStopLocationsById,
     EntityById<FlexLocationGroup> flexLocationGroupsById,
     ReadOnlyHierarchicalMap<String, DestinationDisplay> destinationDisplayById,

--- a/src/main/java/org/opentripplanner/netex/mapping/TripPatternMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/TripPatternMapper.java
@@ -20,7 +20,7 @@ import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.network.TripPatternBuilder;
 import org.opentripplanner.transit.model.organization.Operator;
 import org.opentripplanner.transit.model.site.AreaStop;
-import org.opentripplanner.transit.model.site.FlexLocationGroup;
+import org.opentripplanner.transit.model.site.GroupStop;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
@@ -81,9 +81,9 @@ class TripPatternMapper {
     DataImportIssueStore issueStore,
     FeedScopedIdFactory idFactory,
     EntityById<Operator> operatorById,
-    EntityById<RegularStop> stopsById,
+    EntityById<RegularStop> stopById,
     EntityById<AreaStop> areaStopById,
-    EntityById<FlexLocationGroup> flexLocationGroupsById,
+    EntityById<GroupStop> groupStopById,
     EntityById<org.opentripplanner.transit.model.network.Route> otpRouteById,
     ReadOnlyHierarchicalMap<String, Route> routeById,
     ReadOnlyHierarchicalMap<String, JourneyPattern> journeyPatternById,
@@ -92,7 +92,7 @@ class TripPatternMapper {
     ReadOnlyHierarchicalMap<String, DestinationDisplay> destinationDisplayById,
     ReadOnlyHierarchicalMap<String, ServiceJourney> serviceJourneyById,
     ReadOnlyHierarchicalMapById<ServiceLink> serviceLinkById,
-    ReadOnlyHierarchicalMapById<FlexibleLine> flexibleLinesById,
+    ReadOnlyHierarchicalMapById<FlexibleLine> flexibleLineById,
     ReadOnlyHierarchicalMapById<OperatingDay> operatingDayById,
     ReadOnlyHierarchicalMapById<DatedServiceJourney> datedServiceJourneyById,
     Multimap<String, DatedServiceJourney> datedServiceJourneysBySJId,
@@ -120,13 +120,13 @@ class TripPatternMapper {
       new StopTimesMapper(
         issueStore,
         idFactory,
-        stopsById,
+        stopById,
         areaStopById,
-        flexLocationGroupsById,
+        groupStopById,
         destinationDisplayById,
         quayIdByStopPointRef,
         flexibleStopPlaceIdByStopPointRef,
-        flexibleLinesById,
+        flexibleLineById,
         routeById
       );
     this.serviceLinkMapper =
@@ -134,7 +134,7 @@ class TripPatternMapper {
         idFactory,
         serviceLinkById,
         quayIdByStopPointRef,
-        stopsById,
+        stopById,
         issueStore,
         maxStopToShapeSnapDistance
       );
@@ -210,7 +210,7 @@ class TripPatternMapper {
       result.tripStopTimes
         .get(trips.get(0))
         .stream()
-        .anyMatch(t -> t.getStop() instanceof AreaStop || t.getStop() instanceof FlexLocationGroup)
+        .anyMatch(t -> t.getStop() instanceof AreaStop || t.getStop() instanceof GroupStop)
     ) {
       return result;
     }

--- a/src/main/java/org/opentripplanner/netex/mapping/TripPatternMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/TripPatternMapper.java
@@ -19,8 +19,8 @@ import org.opentripplanner.transit.model.network.StopPattern;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.network.TripPatternBuilder;
 import org.opentripplanner.transit.model.organization.Operator;
+import org.opentripplanner.transit.model.site.AreaStop;
 import org.opentripplanner.transit.model.site.FlexLocationGroup;
-import org.opentripplanner.transit.model.site.FlexStopLocation;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
@@ -82,7 +82,7 @@ class TripPatternMapper {
     FeedScopedIdFactory idFactory,
     EntityById<Operator> operatorById,
     EntityById<RegularStop> stopsById,
-    EntityById<FlexStopLocation> flexStopLocationsById,
+    EntityById<AreaStop> areaStopById,
     EntityById<FlexLocationGroup> flexLocationGroupsById,
     EntityById<org.opentripplanner.transit.model.network.Route> otpRouteById,
     ReadOnlyHierarchicalMap<String, Route> routeById,
@@ -121,7 +121,7 @@ class TripPatternMapper {
         issueStore,
         idFactory,
         stopsById,
-        flexStopLocationsById,
+        areaStopById,
         flexLocationGroupsById,
         destinationDisplayById,
         quayIdByStopPointRef,
@@ -204,15 +204,13 @@ class TripPatternMapper {
       return result;
     }
 
-    // TODO OTP2 Trips containing FlexStopLocations are not added to StopPatterns until support
-    //           for this is added.
+    // TODO OTP2 - Trips containing AreaStops are not added to StopPatterns until support
+    //           - for this is added.
     if (
       result.tripStopTimes
         .get(trips.get(0))
         .stream()
-        .anyMatch(t ->
-          t.getStop() instanceof FlexStopLocation || t.getStop() instanceof FlexLocationGroup
-        )
+        .anyMatch(t -> t.getStop() instanceof AreaStop || t.getStop() instanceof FlexLocationGroup)
     ) {
       return result;
     }

--- a/src/main/java/org/opentripplanner/netex/mapping/TripPatternMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/TripPatternMapper.java
@@ -21,7 +21,7 @@ import org.opentripplanner.transit.model.network.TripPatternBuilder;
 import org.opentripplanner.transit.model.organization.Operator;
 import org.opentripplanner.transit.model.site.FlexLocationGroup;
 import org.opentripplanner.transit.model.site.FlexStopLocation;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
 import org.opentripplanner.transit.model.timetable.TripTimes;
@@ -81,7 +81,7 @@ class TripPatternMapper {
     DataImportIssueStore issueStore,
     FeedScopedIdFactory idFactory,
     EntityById<Operator> operatorById,
-    EntityById<Stop> stopsById,
+    EntityById<RegularStop> stopsById,
     EntityById<FlexStopLocation> flexStopLocationsById,
     EntityById<FlexLocationGroup> flexLocationGroupsById,
     EntityById<org.opentripplanner.transit.model.network.Route> otpRouteById,

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/AlertToLegMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/AlertToLegMapper.java
@@ -14,8 +14,8 @@ import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.site.MultiModalStation;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
-import org.opentripplanner.transit.model.site.Stop;
 import org.opentripplanner.transit.model.site.StopLocation;
 
 /**
@@ -60,13 +60,13 @@ public class AlertToLegMapper {
     FeedScopedId tripId = leg.getTrip().getId();
     LocalDate serviceDate = leg.getServiceDate();
 
-    if (fromStop instanceof Stop stop) {
+    if (fromStop instanceof RegularStop stop) {
       Collection<TransitAlert> alerts = getAlertsForStopAndRoute(stop, routeId);
       alerts.addAll(getAlertsForStopAndTrip(stop, tripId, serviceDate));
       alerts.addAll(getAlertsForRelatedStops(stop, transitAlertService::getStopAlerts));
       addTransitAlertsToLeg(leg, departingStopConditions, alerts, legStartTime, legEndTime);
     }
-    if (toStop instanceof Stop stop) {
+    if (toStop instanceof RegularStop stop) {
       Collection<TransitAlert> alerts = getAlertsForStopAndRoute(stop, routeId);
       alerts.addAll(getAlertsForStopAndTrip(stop, tripId, serviceDate));
       alerts.addAll(getAlertsForRelatedStops(stop, transitAlertService::getStopAlerts));
@@ -75,7 +75,7 @@ public class AlertToLegMapper {
 
     if (leg.getIntermediateStops() != null) {
       for (StopArrival visit : leg.getIntermediateStops()) {
-        if (visit.place.stop instanceof Stop stop) {
+        if (visit.place.stop instanceof RegularStop stop) {
           Collection<TransitAlert> alerts = getAlertsForStopAndRoute(stop, routeId);
           alerts.addAll(getAlertsForStopAndTrip(stop, tripId, serviceDate));
           alerts.addAll(getAlertsForRelatedStops(stop, transitAlertService::getStopAlerts));
@@ -160,7 +160,10 @@ public class AlertToLegMapper {
     addTransitAlertsToLeg(leg, null, alerts, fromTime, toTime);
   }
 
-  private Collection<TransitAlert> getAlertsForStopAndRoute(Stop stop, FeedScopedId routeId) {
+  private Collection<TransitAlert> getAlertsForStopAndRoute(
+    RegularStop stop,
+    FeedScopedId routeId
+  ) {
     return getAlertsForRelatedStops(
       stop,
       id -> transitAlertService.getStopAndRouteAlerts(id, routeId)
@@ -168,7 +171,7 @@ public class AlertToLegMapper {
   }
 
   private Collection<TransitAlert> getAlertsForStopAndTrip(
-    Stop stop,
+    RegularStop stop,
     FeedScopedId tripId,
     LocalDate serviceDate
   ) {
@@ -195,7 +198,7 @@ public class AlertToLegMapper {
    * only a specific route at that stop.
    */
   private Collection<TransitAlert> getAlertsForRelatedStops(
-    Stop stop,
+    RegularStop stop,
     Function<FeedScopedId, Collection<TransitAlert>> getAlertsForStop
   ) {
     if (stop == null) {

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/AccessEgressMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/AccessEgressMapper.java
@@ -8,12 +8,12 @@ import org.opentripplanner.ext.flex.FlexAccessEgress;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.AccessEgress;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.FlexAccessEgressAdapter;
 import org.opentripplanner.routing.graphfinder.NearbyStop;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 
 public class AccessEgressMapper {
 
   public AccessEgress mapNearbyStop(NearbyStop nearbyStop, boolean isEgress) {
-    if (!(nearbyStop.stop instanceof Stop)) {
+    if (!(nearbyStop.stop instanceof RegularStop)) {
       return null;
     }
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TransfersMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TransfersMapper.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.opentripplanner.model.PathTransfer;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.Transfer;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.service.StopModel;
 import org.opentripplanner.transit.service.TransitModel;
 
@@ -23,7 +23,7 @@ class TransfersMapper {
       transferByStopIndex.add(list);
 
       for (PathTransfer pathTransfer : transitModel.getTransfersByStop(stop)) {
-        if (pathTransfer.to instanceof Stop) {
+        if (pathTransfer.to instanceof RegularStop) {
           int toStopIndex = pathTransfer.to.getIndex();
           Transfer newTransfer;
           if (pathTransfer.getEdges() != null) {

--- a/src/main/java/org/opentripplanner/routing/graphfinder/DirectGraphFinder.java
+++ b/src/main/java/org/opentripplanner/routing/graphfinder/DirectGraphFinder.java
@@ -9,7 +9,7 @@ import org.locationtech.jts.geom.Envelope;
 import org.opentripplanner.common.geometry.SphericalDistanceLibrary;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.service.TransitService;
 
 /**
@@ -18,9 +18,9 @@ import org.opentripplanner.transit.service.TransitService;
  */
 public class DirectGraphFinder implements GraphFinder {
 
-  private final Function<Envelope, Collection<Stop>> queryNearbyStops;
+  private final Function<Envelope, Collection<RegularStop>> queryNearbyStops;
 
-  public DirectGraphFinder(Function<Envelope, Collection<Stop>> queryNearbyStops) {
+  public DirectGraphFinder(Function<Envelope, Collection<RegularStop>> queryNearbyStops) {
     this.queryNearbyStops = queryNearbyStops;
   }
 
@@ -37,7 +37,7 @@ public class DirectGraphFinder implements GraphFinder {
       SphericalDistanceLibrary.metersToLonDegrees(radiusMeters, coordinate.y),
       SphericalDistanceLibrary.metersToDegrees(radiusMeters)
     );
-    for (Stop it : queryNearbyStops.apply(envelope)) {
+    for (RegularStop it : queryNearbyStops.apply(envelope)) {
       double distance = Math.round(
         SphericalDistanceLibrary.distance(coordinate, it.getCoordinate().asJtsCoordinate())
       );

--- a/src/main/java/org/opentripplanner/routing/graphfinder/GraphFinder.java
+++ b/src/main/java/org/opentripplanner/routing/graphfinder/GraphFinder.java
@@ -7,7 +7,7 @@ import org.locationtech.jts.geom.Envelope;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.service.TransitService;
 
 /**
@@ -21,7 +21,7 @@ public interface GraphFinder {
    */
   static GraphFinder getInstance(
     Graph graph,
-    Function<Envelope, Collection<Stop>> queryNearbyStops
+    Function<Envelope, Collection<RegularStop>> queryNearbyStops
   ) {
     return graph.hasStreets
       ? new StreetGraphFinder(graph)

--- a/src/main/java/org/opentripplanner/routing/graphfinder/PlaceFinderTraverseVisitor.java
+++ b/src/main/java/org/opentripplanner/routing/graphfinder/PlaceFinderTraverseVisitor.java
@@ -17,7 +17,7 @@ import org.opentripplanner.routing.vertextype.VehicleRentalPlaceVertex;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.TripPattern;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.service.TransitService;
 
 /**
@@ -92,7 +92,7 @@ public class PlaceFinderTraverseVisitor implements TraverseVisitor {
     Vertex vertex = state.getVertex();
     double distance = state.getWalkDistance();
     if (vertex instanceof TransitStopVertex transitVertex) {
-      Stop stop = transitVertex.getStop();
+      RegularStop stop = transitVertex.getStop();
       handleStop(stop, distance);
       handlePatternsAtStop(stop, distance);
     } else if (vertex instanceof VehicleRentalPlaceVertex rentalVertex) {
@@ -159,7 +159,7 @@ public class PlaceFinderTraverseVisitor implements TraverseVisitor {
     return filterByPlaceTypes == null || filterByPlaceTypes.contains(type);
   }
 
-  private boolean stopHasRoutesWithMode(Stop stop, Set<TransitMode> modes) {
+  private boolean stopHasRoutesWithMode(RegularStop stop, Set<TransitMode> modes) {
     return transitService
       .getPatternsForStop(stop)
       .stream()
@@ -167,7 +167,7 @@ public class PlaceFinderTraverseVisitor implements TraverseVisitor {
       .anyMatch(modes::contains);
   }
 
-  private void handleStop(Stop stop, double distance) {
+  private void handleStop(RegularStop stop, double distance) {
     if (filterByStops != null && !filterByStops.contains(stop.getId())) {
       return;
     }
@@ -181,7 +181,7 @@ public class PlaceFinderTraverseVisitor implements TraverseVisitor {
     }
   }
 
-  private void handlePatternsAtStop(Stop stop, double distance) {
+  private void handlePatternsAtStop(RegularStop stop, double distance) {
     if (includePatternAtStops) {
       List<TripPattern> patterns = transitService
         .getPatternsForStop(stop)

--- a/src/main/java/org/opentripplanner/routing/impl/StreetVertexIndex.java
+++ b/src/main/java/org/opentripplanner/routing/impl/StreetVertexIndex.java
@@ -34,7 +34,7 @@ import org.opentripplanner.transit.model.basic.I18NString;
 import org.opentripplanner.transit.model.basic.LocalizedString;
 import org.opentripplanner.transit.model.basic.NonLocalizedString;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.service.StopModel;
 import org.opentripplanner.util.geometry.GeometryUtils;
 import org.opentripplanner.util.logging.ProgressTracker;
@@ -261,8 +261,8 @@ public class StreetVertexIndex {
     return stopModel
       .getStopOrChildStops(id)
       .stream()
-      .filter(Stop.class::isInstance)
-      .map(Stop.class::cast)
+      .filter(RegularStop.class::isInstance)
+      .map(RegularStop.class::cast)
       .map(it -> transitStopVertices.get(it.getId()))
       .collect(Collectors.toSet());
   }

--- a/src/main/java/org/opentripplanner/routing/impl/StreetVertexIndex.java
+++ b/src/main/java/org/opentripplanner/routing/impl/StreetVertexIndex.java
@@ -259,7 +259,7 @@ public class StreetVertexIndex {
    */
   private Set<Vertex> getStopVerticesById(FeedScopedId id) {
     return stopModel
-      .getStopOrChildStops(id)
+      .findStopOrChildStops(id)
       .stream()
       .filter(RegularStop.class::isInstance)
       .map(RegularStop.class::cast)

--- a/src/main/java/org/opentripplanner/routing/vertextype/StreetVertex.java
+++ b/src/main/java/org/opentripplanner/routing/vertextype/StreetVertex.java
@@ -12,7 +12,7 @@ import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.transit.model.basic.I18NString;
 import org.opentripplanner.transit.model.basic.LocalizedString;
-import org.opentripplanner.transit.model.site.FlexStopLocation;
+import org.opentripplanner.transit.model.site.AreaStop;
 
 /**
  * Abstract base class for vertices in the street layer of the graph. This includes both vertices
@@ -23,7 +23,7 @@ public abstract class StreetVertex extends Vertex {
   private static final long serialVersionUID = 1L;
 
   /** All locations for flex transit, which this vertex is part of */
-  public Set<FlexStopLocation> flexStopLocations;
+  public Set<AreaStop> areaStops;
 
   public StreetVertex(Graph g, String label, Coordinate coord, I18NString streetName) {
     this(g, label, coord.x, coord.y, streetName);

--- a/src/main/java/org/opentripplanner/routing/vertextype/TransitStopVertex.java
+++ b/src/main/java/org/opentripplanner/routing/vertextype/TransitStopVertex.java
@@ -8,8 +8,8 @@ import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.basic.WheelchairAccessibility;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.StationElement;
-import org.opentripplanner.transit.model.site.Stop;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,7 +22,7 @@ public class TransitStopVertex extends Vertex {
   private final Set<TransitMode> modes;
   private final WheelchairAccessibility wheelchairAccessibility;
 
-  private final Stop stop;
+  private final RegularStop stop;
 
   /**
    * For stops that are deep underground, there is a time cost to entering and exiting the stop; all
@@ -36,7 +36,7 @@ public class TransitStopVertex extends Vertex {
    * @param modes Set of modes for all Routes using this stop. If {@code null} an empty set is
    *              used.
    */
-  TransitStopVertex(Graph graph, Stop stop, Set<TransitMode> modes) {
+  TransitStopVertex(Graph graph, RegularStop stop, Set<TransitMode> modes) {
     super(graph, stop.getId().toString(), stop.getLon(), stop.getLat(), stop.getName());
     this.stop = stop;
     this.modes = modes != null ? modes : new HashSet<>();
@@ -80,7 +80,7 @@ public class TransitStopVertex extends Vertex {
     modes.add(mode);
   }
 
-  public Stop getStop() {
+  public RegularStop getStop() {
     return this.stop;
   }
 

--- a/src/main/java/org/opentripplanner/routing/vertextype/TransitStopVertexBuilder.java
+++ b/src/main/java/org/opentripplanner/routing/vertextype/TransitStopVertexBuilder.java
@@ -4,15 +4,15 @@ import java.util.Objects;
 import java.util.Set;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.transit.model.basic.TransitMode;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 
 public class TransitStopVertexBuilder {
 
-  private Stop stop;
+  private RegularStop stop;
   private Graph graph;
   private Set<TransitMode> modes;
 
-  public TransitStopVertexBuilder withStop(Stop stop) {
+  public TransitStopVertexBuilder withStop(RegularStop stop) {
     this.stop = stop;
     return this;
   }

--- a/src/main/java/org/opentripplanner/standalone/api/OtpServerRequestContext.java
+++ b/src/main/java/org/opentripplanner/standalone/api/OtpServerRequestContext.java
@@ -87,6 +87,6 @@ public interface OtpServerRequestContext {
   TraverseVisitor traverseVisitor();
 
   default GraphFinder graphFinder() {
-    return GraphFinder.getInstance(graph(), transitService()::queryStopSpatialIndex);
+    return GraphFinder.getInstance(graph(), transitService()::findRegularStop);
   }
 }

--- a/src/main/java/org/opentripplanner/transit/model/network/StopPattern.java
+++ b/src/main/java/org/opentripplanner/transit/model/network/StopPattern.java
@@ -10,7 +10,7 @@ import java.util.function.Predicate;
 import javax.annotation.Nonnull;
 import org.opentripplanner.model.PickDrop;
 import org.opentripplanner.model.StopTime;
-import org.opentripplanner.transit.model.site.FlexStopLocation;
+import org.opentripplanner.transit.model.site.AreaStop;
 import org.opentripplanner.transit.model.site.Station;
 import org.opentripplanner.transit.model.site.StopLocation;
 
@@ -206,7 +206,7 @@ public final class StopPattern implements Serializable {
    * (centroids) and might not have times.
    */
   private static PickDrop computePickDrop(StopLocation stop, PickDrop pickDrop) {
-    if (stop instanceof FlexStopLocation) {
+    if (stop instanceof AreaStop) {
       return PickDrop.NONE;
     } else {
       return pickDrop;

--- a/src/main/java/org/opentripplanner/transit/model/site/AreaStop.java
+++ b/src/main/java/org/opentripplanner/transit/model/site/AreaStop.java
@@ -15,8 +15,8 @@ import org.opentripplanner.transit.model.framework.FeedScopedId;
  * GTFS bundle.
  */
 
-public class FlexStopLocation
-  extends AbstractTransitEntity<FlexStopLocation, FlexStopLocationBuilder>
+public class AreaStop
+  extends AbstractTransitEntity<AreaStop, AreaStopBuilder>
   implements StopLocation {
 
   private final int index;
@@ -34,7 +34,7 @@ public class FlexStopLocation
 
   private final WgsCoordinate centroid;
 
-  FlexStopLocation(FlexStopLocationBuilder builder) {
+  AreaStop(AreaStopBuilder builder) {
     super(builder.getId());
     this.index = INDEX_COUNTER.getAndIncrement();
     // according to the spec stop location names are optional for flex zones so, we set the id
@@ -53,8 +53,8 @@ public class FlexStopLocation
     this.centroid = Objects.requireNonNull(builder.centroid());
   }
 
-  public static FlexStopLocationBuilder of(FeedScopedId id) {
-    return new FlexStopLocationBuilder(id);
+  public static AreaStopBuilder of(FeedScopedId id) {
+    return new AreaStopBuilder(id);
   }
 
   @Override
@@ -121,7 +121,7 @@ public class FlexStopLocation
   }
 
   @Override
-  public boolean sameAs(@Nonnull FlexStopLocation other) {
+  public boolean sameAs(@Nonnull AreaStop other) {
     return (
       getId().equals(other.getId()) &&
       Objects.equals(name, other.getName()) &&
@@ -134,7 +134,7 @@ public class FlexStopLocation
 
   @Override
   @Nonnull
-  public FlexStopLocationBuilder copy() {
-    return new FlexStopLocationBuilder(this);
+  public AreaStopBuilder copy() {
+    return new AreaStopBuilder(this);
   }
 }

--- a/src/main/java/org/opentripplanner/transit/model/site/AreaStopBuilder.java
+++ b/src/main/java/org/opentripplanner/transit/model/site/AreaStopBuilder.java
@@ -7,8 +7,7 @@ import org.opentripplanner.transit.model.basic.WgsCoordinate;
 import org.opentripplanner.transit.model.framework.AbstractEntityBuilder;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 
-public class FlexStopLocationBuilder
-  extends AbstractEntityBuilder<FlexStopLocation, FlexStopLocationBuilder> {
+public class AreaStopBuilder extends AbstractEntityBuilder<AreaStop, AreaStopBuilder> {
 
   private I18NString name;
   private boolean hasFallbackName;
@@ -19,11 +18,11 @@ public class FlexStopLocationBuilder
   private I18NString url;
   private String zoneId;
 
-  FlexStopLocationBuilder(FeedScopedId id) {
+  AreaStopBuilder(FeedScopedId id) {
     super(id);
   }
 
-  FlexStopLocationBuilder(@Nonnull FlexStopLocation original) {
+  AreaStopBuilder(@Nonnull AreaStop original) {
     super(original);
     // Optional fields
     this.name = original.getName();
@@ -35,7 +34,7 @@ public class FlexStopLocationBuilder
     this.centroid = original.getCoordinate();
   }
 
-  public FlexStopLocationBuilder withZoneId(String zoneId) {
+  public AreaStopBuilder withZoneId(String zoneId) {
     this.zoneId = zoneId;
     return this;
   }
@@ -45,26 +44,26 @@ public class FlexStopLocationBuilder
   }
 
   @Override
-  protected FlexStopLocation buildFromValues() {
-    return new FlexStopLocation(this);
+  protected AreaStop buildFromValues() {
+    return new AreaStop(this);
   }
 
-  public FlexStopLocationBuilder withName(I18NString name) {
+  public AreaStopBuilder withName(I18NString name) {
     this.name = name;
     return this;
   }
 
-  public FlexStopLocationBuilder withDescription(I18NString description) {
+  public AreaStopBuilder withDescription(I18NString description) {
     this.description = description;
     return this;
   }
 
-  public FlexStopLocationBuilder withUrl(I18NString url) {
+  public AreaStopBuilder withUrl(I18NString url) {
     this.url = url;
     return this;
   }
 
-  public FlexStopLocationBuilder withGeometry(Geometry geometry) {
+  public AreaStopBuilder withGeometry(Geometry geometry) {
     this.geometry = geometry;
     this.centroid = new WgsCoordinate(geometry.getCentroid().getY(), geometry.getCentroid().getX());
     return this;

--- a/src/main/java/org/opentripplanner/transit/model/site/BoardingArea.java
+++ b/src/main/java/org/opentripplanner/transit/model/site/BoardingArea.java
@@ -11,7 +11,7 @@ import org.opentripplanner.transit.model.framework.FeedScopedId;
  */
 public final class BoardingArea extends StationElement<BoardingArea, BoardingAreaBuilder> {
 
-  private final Stop parentStop;
+  private final RegularStop parentStop;
 
   BoardingArea(BoardingAreaBuilder builder) {
     super(builder);
@@ -39,7 +39,7 @@ public final class BoardingArea extends StationElement<BoardingArea, BoardingAre
    * Returns the parent stop this boarding area belongs to.
    */
   @Nonnull
-  public Stop getParentStop() {
+  public RegularStop getParentStop() {
     return parentStop;
   }
 

--- a/src/main/java/org/opentripplanner/transit/model/site/BoardingAreaBuilder.java
+++ b/src/main/java/org/opentripplanner/transit/model/site/BoardingAreaBuilder.java
@@ -6,7 +6,7 @@ import org.opentripplanner.transit.model.framework.FeedScopedId;
 public final class BoardingAreaBuilder
   extends StationElementBuilder<BoardingArea, BoardingAreaBuilder> {
 
-  private Stop parentStop;
+  private RegularStop parentStop;
 
   BoardingAreaBuilder(FeedScopedId id) {
     super(id);
@@ -17,11 +17,11 @@ public final class BoardingAreaBuilder
     this.parentStop = original.getParentStop();
   }
 
-  public Stop parentStop() {
+  public RegularStop parentStop() {
     return parentStop;
   }
 
-  public BoardingAreaBuilder withParentStop(Stop parentStop) {
+  public BoardingAreaBuilder withParentStop(RegularStop parentStop) {
     this.parentStop = parentStop;
     return this;
   }

--- a/src/main/java/org/opentripplanner/transit/model/site/FlexLocationGroupBuilder.java
+++ b/src/main/java/org/opentripplanner/transit/model/site/FlexLocationGroupBuilder.java
@@ -61,7 +61,7 @@ public class FlexLocationGroupBuilder
     for (int i = 0; i < numGeometries; i++) {
       newGeometries[i] = geometry.getGeometryN(i);
     }
-    if (location instanceof Stop) {
+    if (location instanceof RegularStop) {
       WgsCoordinate coordinate = location.getCoordinate();
       Envelope envelope = new Envelope(coordinate.asJtsCoordinate());
       double xscale = Math.cos(coordinate.latitude() * Math.PI / 180);

--- a/src/main/java/org/opentripplanner/transit/model/site/FlexLocationGroupBuilder.java
+++ b/src/main/java/org/opentripplanner/transit/model/site/FlexLocationGroupBuilder.java
@@ -67,7 +67,7 @@ public class FlexLocationGroupBuilder
       double xscale = Math.cos(coordinate.latitude() * Math.PI / 180);
       envelope.expandBy(100 / xscale, 100);
       newGeometries[numGeometries] = GeometryUtils.getGeometryFactory().toGeometry(envelope);
-    } else if (location instanceof FlexStopLocation) {
+    } else if (location instanceof AreaStop) {
       newGeometries[numGeometries] = location.getGeometry();
     } else {
       throw new RuntimeException("Unknown location type");

--- a/src/main/java/org/opentripplanner/transit/model/site/GroupStop.java
+++ b/src/main/java/org/opentripplanner/transit/model/site/GroupStop.java
@@ -14,8 +14,8 @@ import org.opentripplanner.transit.model.framework.FeedScopedId;
 /**
  * A group of stopLocations, which can share a common Stoptime
  */
-public class FlexLocationGroup
-  extends AbstractTransitEntity<FlexLocationGroup, FlexLocationGroupBuilder>
+public class GroupStop
+  extends AbstractTransitEntity<GroupStop, GroupStopBuilder>
   implements StopLocation {
 
   private final int index;
@@ -25,7 +25,7 @@ public class FlexLocationGroup
 
   private final WgsCoordinate centroid;
 
-  FlexLocationGroup(FlexLocationGroupBuilder builder) {
+  GroupStop(GroupStopBuilder builder) {
     super(builder.getId());
     this.index = INDEX_COUNTER.getAndIncrement();
     this.name = builder.name();
@@ -34,8 +34,8 @@ public class FlexLocationGroup
     this.stopLocations = builder.stopLocations();
   }
 
-  public static FlexLocationGroupBuilder of(FeedScopedId id) {
-    return new FlexLocationGroupBuilder(id);
+  public static GroupStopBuilder of(FeedScopedId id) {
+    return new GroupStopBuilder(id);
   }
 
   @Override
@@ -101,7 +101,7 @@ public class FlexLocationGroup
   }
 
   @Override
-  public boolean sameAs(@Nonnull FlexLocationGroup other) {
+  public boolean sameAs(@Nonnull GroupStop other) {
     return (
       getId().equals(other.getId()) &&
       Objects.equals(name, other.getName()) &&
@@ -111,7 +111,7 @@ public class FlexLocationGroup
 
   @Override
   @Nonnull
-  public FlexLocationGroupBuilder copy() {
-    return new FlexLocationGroupBuilder(this);
+  public GroupStopBuilder copy() {
+    return new GroupStopBuilder(this);
   }
 }

--- a/src/main/java/org/opentripplanner/transit/model/site/GroupStopBuilder.java
+++ b/src/main/java/org/opentripplanner/transit/model/site/GroupStopBuilder.java
@@ -12,8 +12,7 @@ import org.opentripplanner.transit.model.framework.AbstractEntityBuilder;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.util.geometry.GeometryUtils;
 
-public class FlexLocationGroupBuilder
-  extends AbstractEntityBuilder<FlexLocationGroup, FlexLocationGroupBuilder> {
+public class GroupStopBuilder extends AbstractEntityBuilder<GroupStop, GroupStopBuilder> {
 
   private I18NString name;
 
@@ -26,11 +25,11 @@ public class FlexLocationGroupBuilder
 
   private WgsCoordinate centroid;
 
-  FlexLocationGroupBuilder(FeedScopedId id) {
+  GroupStopBuilder(FeedScopedId id) {
     super(id);
   }
 
-  FlexLocationGroupBuilder(@Nonnull FlexLocationGroup original) {
+  GroupStopBuilder(@Nonnull GroupStop original) {
     super(original);
     // Optional fields
     this.name = original.getName();
@@ -40,11 +39,11 @@ public class FlexLocationGroupBuilder
   }
 
   @Override
-  protected FlexLocationGroup buildFromValues() {
-    return new FlexLocationGroup(this);
+  protected GroupStop buildFromValues() {
+    return new GroupStop(this);
   }
 
-  public FlexLocationGroupBuilder withName(I18NString name) {
+  public GroupStopBuilder withName(I18NString name) {
     this.name = name;
     return this;
   }
@@ -53,7 +52,7 @@ public class FlexLocationGroupBuilder
     return name;
   }
 
-  public FlexLocationGroupBuilder addLocation(StopLocation location) {
+  public GroupStopBuilder addLocation(StopLocation location) {
     stopLocations.add(location);
 
     int numGeometries = geometry.getNumGeometries();

--- a/src/main/java/org/opentripplanner/transit/model/site/RegularStop.java
+++ b/src/main/java/org/opentripplanner/transit/model/site/RegularStop.java
@@ -19,7 +19,9 @@ import org.opentripplanner.util.geometry.GeometryUtils;
  * A place where actual boarding/departing happens. It can be a bus stop on one side of a road or a
  * platform at a train station. Equivalent to GTFS stop location 0 or NeTEx quay.
  */
-public final class Stop extends StationElement<Stop, StopBuilder> implements StopLocation {
+public final class RegularStop
+  extends StationElement<RegularStop, StopBuilder>
+  implements StopLocation {
 
   private final int index;
   private final String platformCode;
@@ -36,7 +38,7 @@ public final class Stop extends StationElement<Stop, StopBuilder> implements Sto
 
   private final Set<FareZone> fareZones;
 
-  Stop(StopBuilder builder) {
+  RegularStop(StopBuilder builder) {
     super(builder);
     this.index = INDEX_COUNTER.getAndIncrement();
     this.platformCode = builder.platformCode();
@@ -135,7 +137,7 @@ public final class Stop extends StationElement<Stop, StopBuilder> implements Sto
   }
 
   @Override
-  public boolean sameAs(@Nonnull Stop other) {
+  public boolean sameAs(@Nonnull RegularStop other) {
     return (
       super.sameAs(other) &&
       Objects.equals(platformCode, other.platformCode) &&

--- a/src/main/java/org/opentripplanner/transit/model/site/RegularStop.java
+++ b/src/main/java/org/opentripplanner/transit/model/site/RegularStop.java
@@ -20,7 +20,7 @@ import org.opentripplanner.util.geometry.GeometryUtils;
  * platform at a train station. Equivalent to GTFS stop location 0 or NeTEx quay.
  */
 public final class RegularStop
-  extends StationElement<RegularStop, StopBuilder>
+  extends StationElement<RegularStop, RegularStopBuilder>
   implements StopLocation {
 
   private final int index;
@@ -38,7 +38,7 @@ public final class RegularStop
 
   private final Set<FareZone> fareZones;
 
-  RegularStop(StopBuilder builder) {
+  RegularStop(RegularStopBuilder builder) {
     super(builder);
     this.index = INDEX_COUNTER.getAndIncrement();
     this.platformCode = builder.platformCode();
@@ -53,8 +53,8 @@ public final class RegularStop
     }
   }
 
-  public static StopBuilder of(FeedScopedId id) {
-    return new StopBuilder(id);
+  public static RegularStopBuilder of(FeedScopedId id) {
+    return new RegularStopBuilder(id);
   }
 
   @Override
@@ -132,8 +132,8 @@ public final class RegularStop
 
   @Override
   @Nonnull
-  public StopBuilder copy() {
-    return new StopBuilder(this);
+  public RegularStopBuilder copy() {
+    return new RegularStopBuilder(this);
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/transit/model/site/RegularStopBuilder.java
+++ b/src/main/java/org/opentripplanner/transit/model/site/RegularStopBuilder.java
@@ -13,7 +13,8 @@ import org.opentripplanner.transit.model.framework.FeedScopedId;
  * A place where actual boarding/departing happens. It can be a bus stop on one side of a road or a
  * platform at a train station. Equivalent to GTFS stop location 0 or NeTEx quay.
  */
-public final class StopBuilder extends StationElementBuilder<RegularStop, StopBuilder> {
+public final class RegularStopBuilder
+  extends StationElementBuilder<RegularStop, RegularStopBuilder> {
 
   private String platformCode;
 
@@ -29,11 +30,11 @@ public final class StopBuilder extends StationElementBuilder<RegularStop, StopBu
 
   private final Set<FareZone> fareZones = new HashSet<>();
 
-  StopBuilder(FeedScopedId id) {
+  RegularStopBuilder(FeedScopedId id) {
     super(id);
   }
 
-  StopBuilder(RegularStop original) {
+  RegularStopBuilder(RegularStop original) {
     super(original);
     this.platformCode = original.getPlatformCode();
     this.url = original.getUrl();
@@ -46,7 +47,7 @@ public final class StopBuilder extends StationElementBuilder<RegularStop, StopBu
     return platformCode;
   }
 
-  public StopBuilder withPlatformCode(String platformCode) {
+  public RegularStopBuilder withPlatformCode(String platformCode) {
     this.platformCode = platformCode;
     return this;
   }
@@ -55,7 +56,7 @@ public final class StopBuilder extends StationElementBuilder<RegularStop, StopBu
     return url;
   }
 
-  public StopBuilder withUrl(I18NString url) {
+  public RegularStopBuilder withUrl(I18NString url) {
     this.url = url;
     return this;
   }
@@ -64,7 +65,7 @@ public final class StopBuilder extends StationElementBuilder<RegularStop, StopBu
     return gtfsVehicleType;
   }
 
-  public StopBuilder withVehicleType(TransitMode vehicleType) {
+  public RegularStopBuilder withVehicleType(TransitMode vehicleType) {
     this.gtfsVehicleType = vehicleType;
     return this;
   }
@@ -73,7 +74,7 @@ public final class StopBuilder extends StationElementBuilder<RegularStop, StopBu
     return netexVehicleSubmode;
   }
 
-  public StopBuilder withNetexVehicleSubmode(String netexVehicleSubmode) {
+  public RegularStopBuilder withNetexVehicleSubmode(String netexVehicleSubmode) {
     this.netexVehicleSubmode = netexVehicleSubmode;
     return this;
   }
@@ -82,12 +83,12 @@ public final class StopBuilder extends StationElementBuilder<RegularStop, StopBu
     return timeZone;
   }
 
-  public StopBuilder withTimeZone(ZoneId timeZone) {
+  public RegularStopBuilder withTimeZone(ZoneId timeZone) {
     this.timeZone = timeZone;
     return this;
   }
 
-  public StopBuilder addFareZones(FareZone fareZone) {
+  public RegularStopBuilder addFareZones(FareZone fareZone) {
     this.fareZones.add(fareZone);
     return this;
   }
@@ -96,7 +97,7 @@ public final class StopBuilder extends StationElementBuilder<RegularStop, StopBu
     return fareZones;
   }
 
-  public StopBuilder addBoardingArea(BoardingArea boardingArea) {
+  public RegularStopBuilder addBoardingArea(BoardingArea boardingArea) {
     boardingAreas.add(boardingArea);
     return this;
   }
@@ -106,7 +107,7 @@ public final class StopBuilder extends StationElementBuilder<RegularStop, StopBu
   }
 
   @Override
-  StopBuilder instance() {
+  RegularStopBuilder instance() {
     return this;
   }
 

--- a/src/main/java/org/opentripplanner/transit/model/site/Station.java
+++ b/src/main/java/org/opentripplanner/transit/model/site/Station.java
@@ -67,7 +67,7 @@ public class Station
     return new StationBuilder(id);
   }
 
-  void addChildStop(Stop stop) {
+  void addChildStop(RegularStop stop) {
     this.childStops.add(stop);
     this.geometry = computeGeometry(coordinate, childStops);
   }

--- a/src/main/java/org/opentripplanner/transit/model/site/StopBuilder.java
+++ b/src/main/java/org/opentripplanner/transit/model/site/StopBuilder.java
@@ -13,7 +13,7 @@ import org.opentripplanner.transit.model.framework.FeedScopedId;
  * A place where actual boarding/departing happens. It can be a bus stop on one side of a road or a
  * platform at a train station. Equivalent to GTFS stop location 0 or NeTEx quay.
  */
-public final class StopBuilder extends StationElementBuilder<Stop, StopBuilder> {
+public final class StopBuilder extends StationElementBuilder<RegularStop, StopBuilder> {
 
   private String platformCode;
 
@@ -33,7 +33,7 @@ public final class StopBuilder extends StationElementBuilder<Stop, StopBuilder> 
     super(id);
   }
 
-  StopBuilder(Stop original) {
+  StopBuilder(RegularStop original) {
     super(original);
     this.platformCode = original.getPlatformCode();
     this.url = original.getUrl();
@@ -111,7 +111,7 @@ public final class StopBuilder extends StationElementBuilder<Stop, StopBuilder> 
   }
 
   @Override
-  protected Stop buildFromValues() {
-    return new Stop(this);
+  protected RegularStop buildFromValues() {
+    return new RegularStop(this);
   }
 }

--- a/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
+++ b/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
@@ -39,7 +39,7 @@ import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.organization.Agency;
 import org.opentripplanner.transit.model.organization.Operator;
-import org.opentripplanner.transit.model.site.FlexStopLocation;
+import org.opentripplanner.transit.model.site.AreaStop;
 import org.opentripplanner.transit.model.site.MultiModalStation;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
@@ -151,7 +151,7 @@ public class DefaultTransitService implements TransitEditorService {
   }
 
   @Override
-  public FlexStopLocation getLocationById(FeedScopedId id) {
+  public AreaStop getLocationById(FeedScopedId id) {
     return this.transitModel.getStopModel().getFlexStopById(id);
   }
 

--- a/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
+++ b/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
@@ -41,8 +41,8 @@ import org.opentripplanner.transit.model.organization.Agency;
 import org.opentripplanner.transit.model.organization.Operator;
 import org.opentripplanner.transit.model.site.FlexStopLocation;
 import org.opentripplanner.transit.model.site.MultiModalStation;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
-import org.opentripplanner.transit.model.site.Stop;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.site.StopLocationsGroup;
 import org.opentripplanner.transit.model.timetable.Trip;
@@ -206,7 +206,7 @@ public class DefaultTransitService implements TransitEditorService {
   }
 
   @Override
-  public Collection<Stop> listRegularStops() {
+  public Collection<RegularStop> listRegularStops() {
     return transitModel.getStopModel().listRegularStops();
   }
 
@@ -526,7 +526,7 @@ public class DefaultTransitService implements TransitEditorService {
   }
 
   @Override
-  public Collection<Stop> queryStopSpatialIndex(Envelope envelope) {
+  public Collection<RegularStop> queryStopSpatialIndex(Envelope envelope) {
     return transitModel.getStopModel().findRegularStops(envelope);
   }
 

--- a/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
+++ b/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
@@ -135,7 +135,7 @@ public class DefaultTransitService implements TransitEditorService {
 
   @Override
   public Collection<Station> getStations() {
-    return this.transitModel.getStopModel().getStations();
+    return this.transitModel.getStopModel().listStations();
   }
 
   @Override
@@ -151,8 +151,8 @@ public class DefaultTransitService implements TransitEditorService {
   }
 
   @Override
-  public AreaStop getLocationById(FeedScopedId id) {
-    return this.transitModel.getStopModel().getFlexStopById(id);
+  public AreaStop getAreaStop(FeedScopedId id) {
+    return this.transitModel.getStopModel().getAreaStop(id);
   }
 
   @Override
@@ -161,7 +161,7 @@ public class DefaultTransitService implements TransitEditorService {
   }
 
   @Override
-  public StopLocation getRegularStop(FeedScopedId id) {
+  public RegularStop getRegularStop(FeedScopedId id) {
     return this.transitModel.getStopModel().getRegularStop(id);
   }
 
@@ -526,7 +526,7 @@ public class DefaultTransitService implements TransitEditorService {
   }
 
   @Override
-  public Collection<RegularStop> queryStopSpatialIndex(Envelope envelope) {
+  public Collection<RegularStop> findRegularStop(Envelope envelope) {
     return transitModel.getStopModel().findRegularStops(envelope);
   }
 

--- a/src/main/java/org/opentripplanner/transit/service/StopModel.java
+++ b/src/main/java/org/opentripplanner/transit/service/StopModel.java
@@ -14,8 +14,8 @@ import org.opentripplanner.transit.model.site.FlexLocationGroup;
 import org.opentripplanner.transit.model.site.FlexStopLocation;
 import org.opentripplanner.transit.model.site.GroupOfStations;
 import org.opentripplanner.transit.model.site.MultiModalStation;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
-import org.opentripplanner.transit.model.site.Stop;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.site.StopLocationsGroup;
 import org.opentripplanner.util.lang.CollectionsView;
@@ -29,7 +29,7 @@ public class StopModel implements Serializable {
 
   private static final Logger LOG = LoggerFactory.getLogger(StopModel.class);
 
-  private final Map<FeedScopedId, Stop> regularStopsById;
+  private final Map<FeedScopedId, RegularStop> regularStopsById;
   private final Map<FeedScopedId, Station> stationById;
   private final Map<FeedScopedId, MultiModalStation> multiModalStationById;
   private final Map<FeedScopedId, GroupOfStations> groupOfStationsById;
@@ -75,18 +75,18 @@ public class StopModel implements Serializable {
   /**
    * Return a regular transit stop if found(not flex stops).
    */
-  public Stop getRegularStop(FeedScopedId id) {
+  public RegularStop getRegularStop(FeedScopedId id) {
     return regularStopsById.get(id);
   }
 
   /**
    * Return all regular transit stops, not flex stops and flex group of stops.
    */
-  public Collection<Stop> listRegularStops() {
+  public Collection<RegularStop> listRegularStops() {
     return regularStopsById.values();
   }
 
-  public Collection<Stop> findRegularStops(Envelope envelope) {
+  public Collection<RegularStop> findRegularStops(Envelope envelope) {
     return index.queryStopSpatialIndex(envelope);
   }
 

--- a/src/main/java/org/opentripplanner/transit/service/StopModel.java
+++ b/src/main/java/org/opentripplanner/transit/service/StopModel.java
@@ -10,8 +10,8 @@ import javax.inject.Inject;
 import org.locationtech.jts.geom.Envelope;
 import org.opentripplanner.transit.model.basic.WgsCoordinate;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.model.site.AreaStop;
 import org.opentripplanner.transit.model.site.FlexLocationGroup;
-import org.opentripplanner.transit.model.site.FlexStopLocation;
 import org.opentripplanner.transit.model.site.GroupOfStations;
 import org.opentripplanner.transit.model.site.MultiModalStation;
 import org.opentripplanner.transit.model.site.RegularStop;
@@ -33,7 +33,7 @@ public class StopModel implements Serializable {
   private final Map<FeedScopedId, Station> stationById;
   private final Map<FeedScopedId, MultiModalStation> multiModalStationById;
   private final Map<FeedScopedId, GroupOfStations> groupOfStationsById;
-  private final Map<FeedScopedId, FlexStopLocation> flexStopsById;
+  private final Map<FeedScopedId, AreaStop> flexStopsById;
   private final Map<FeedScopedId, FlexLocationGroup> flexStopGroupsById;
 
   /** The density center of the graph for determining the initial geographic extent in the client. */
@@ -99,11 +99,11 @@ public class StopModel implements Serializable {
    * built
    */
   @Nullable
-  public FlexStopLocation getFlexStopById(FeedScopedId id) {
+  public AreaStop getFlexStopById(FeedScopedId id) {
     return flexStopsById.get(id);
   }
 
-  public Collection<FlexStopLocation> getAllFlexLocations() {
+  public Collection<AreaStop> getAllFlexLocations() {
     return flexStopsById.values();
   }
 
@@ -111,7 +111,7 @@ public class StopModel implements Serializable {
     return flexStopGroupsById.values();
   }
 
-  public Collection<FlexStopLocation> queryLocationIndex(Envelope envelope) {
+  public Collection<AreaStop> queryLocationIndex(Envelope envelope) {
     return index.queryLocationIndex(envelope);
   }
 

--- a/src/main/java/org/opentripplanner/transit/service/StopModel.java
+++ b/src/main/java/org/opentripplanner/transit/service/StopModel.java
@@ -11,8 +11,8 @@ import org.locationtech.jts.geom.Envelope;
 import org.opentripplanner.transit.model.basic.WgsCoordinate;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.site.AreaStop;
-import org.opentripplanner.transit.model.site.FlexLocationGroup;
 import org.opentripplanner.transit.model.site.GroupOfStations;
+import org.opentripplanner.transit.model.site.GroupStop;
 import org.opentripplanner.transit.model.site.MultiModalStation;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
@@ -29,12 +29,12 @@ public class StopModel implements Serializable {
 
   private static final Logger LOG = LoggerFactory.getLogger(StopModel.class);
 
-  private final Map<FeedScopedId, RegularStop> regularStopsById;
+  private final Map<FeedScopedId, RegularStop> regularStopById;
   private final Map<FeedScopedId, Station> stationById;
   private final Map<FeedScopedId, MultiModalStation> multiModalStationById;
   private final Map<FeedScopedId, GroupOfStations> groupOfStationsById;
-  private final Map<FeedScopedId, AreaStop> flexStopsById;
-  private final Map<FeedScopedId, FlexLocationGroup> flexStopGroupsById;
+  private final Map<FeedScopedId, AreaStop> areaStopById;
+  private final Map<FeedScopedId, GroupStop> groupStopById;
 
   /** The density center of the graph for determining the initial geographic extent in the client. */
   private final WgsCoordinate stopLocationCenter;
@@ -43,23 +43,23 @@ public class StopModel implements Serializable {
 
   @Inject
   public StopModel() {
-    this.regularStopsById = Map.of();
+    this.regularStopById = Map.of();
     this.stationById = Map.of();
     this.multiModalStationById = Map.of();
     this.groupOfStationsById = Map.of();
-    this.flexStopsById = Map.of();
-    this.flexStopGroupsById = Map.of();
+    this.areaStopById = Map.of();
+    this.groupStopById = Map.of();
     this.stopLocationCenter = null;
     this.index = new StopModelIndex(List.of(), List.of(), List.of(), List.of());
   }
 
   public StopModel(StopModelBuilder builder) {
-    this.regularStopsById = builder.stopsById().asImmutableMap();
-    this.stationById = builder.stationsById().asImmutableMap();
-    this.multiModalStationById = builder.multiModalStationsById().asImmutableMap();
-    this.groupOfStationsById = builder.groupOfStationsById().asImmutableMap();
-    this.flexStopsById = builder.flexStopsById().asImmutableMap();
-    this.flexStopGroupsById = builder.flexStopGroupsById().asImmutableMap();
+    this.regularStopById = builder.regularStopsById().asImmutableMap();
+    this.stationById = builder.stationById().asImmutableMap();
+    this.multiModalStationById = builder.multiModalStationById().asImmutableMap();
+    this.groupOfStationsById = builder.groupOfStationById().asImmutableMap();
+    this.areaStopById = builder.areaStopById().asImmutableMap();
+    this.groupStopById = builder.groupStopById().asImmutableMap();
     this.stopLocationCenter = builder.calculateTransitCenter();
     reindex();
   }
@@ -76,22 +76,22 @@ public class StopModel implements Serializable {
    * Return a regular transit stop if found(not flex stops).
    */
   public RegularStop getRegularStop(FeedScopedId id) {
-    return regularStopsById.get(id);
+    return regularStopById.get(id);
   }
 
   /**
    * Return all regular transit stops, not flex stops and flex group of stops.
    */
   public Collection<RegularStop> listRegularStops() {
-    return regularStopsById.values();
+    return regularStopById.values();
   }
 
   public Collection<RegularStop> findRegularStops(Envelope envelope) {
-    return index.queryStopSpatialIndex(envelope);
+    return index.findRegularStops(envelope);
   }
 
-  public boolean hasFlexLocations() {
-    return !flexStopsById.isEmpty();
+  public boolean hasAreaStops() {
+    return !areaStopById.isEmpty();
   }
 
   /**
@@ -99,20 +99,20 @@ public class StopModel implements Serializable {
    * built
    */
   @Nullable
-  public AreaStop getFlexStopById(FeedScopedId id) {
-    return flexStopsById.get(id);
+  public AreaStop getAreaStop(FeedScopedId id) {
+    return areaStopById.get(id);
   }
 
-  public Collection<AreaStop> getAllFlexLocations() {
-    return flexStopsById.values();
-  }
-
-  public Collection<FlexLocationGroup> getAllFlexStopGroups() {
-    return flexStopGroupsById.values();
+  public Collection<AreaStop> listAreaStops() {
+    return areaStopById.values();
   }
 
   public Collection<AreaStop> queryLocationIndex(Envelope envelope) {
-    return index.queryLocationIndex(envelope);
+    return index.findAreaStops(envelope);
+  }
+
+  public Collection<GroupStop> listGroupStops() {
+    return groupStopById.values();
   }
 
   public StopLocation stopByIndex(int stopIndex) {
@@ -132,7 +132,7 @@ public class StopModel implements Serializable {
    */
   @Nullable
   public StopLocation getStopLocation(FeedScopedId id) {
-    return getById(id, regularStopsById, flexStopsById, flexStopGroupsById);
+    return getById(id, regularStopById, areaStopById, groupStopById);
   }
 
   /**
@@ -140,9 +140,9 @@ public class StopModel implements Serializable {
    */
   public Collection<StopLocation> listStopLocations() {
     return new CollectionsView<>(
-      regularStopsById.values(),
-      flexStopsById.values(),
-      flexStopGroupsById.values()
+      regularStopById.values(),
+      areaStopById.values(),
+      groupStopById.values()
     );
   }
 
@@ -151,7 +151,7 @@ public class StopModel implements Serializable {
     return stationById.get(id);
   }
 
-  public Collection<Station> getStations() {
+  public Collection<Station> listStations() {
     return stationById.values();
   }
 
@@ -160,7 +160,7 @@ public class StopModel implements Serializable {
     return multiModalStationById.get(id);
   }
 
-  public Collection<MultiModalStation> getAllMultiModalStations() {
+  public Collection<MultiModalStation> listMultiModalStations() {
     return multiModalStationById.values();
   }
 
@@ -169,7 +169,7 @@ public class StopModel implements Serializable {
     return index.getMultiModalStationForStation(station);
   }
 
-  public Collection<GroupOfStations> getAllGroupOfStations() {
+  public Collection<GroupOfStations> listGroupOfStations() {
     return groupOfStationsById.values();
   }
 
@@ -226,7 +226,7 @@ public class StopModel implements Serializable {
    * stops, area stop or stop group, then a list with one item is returned.
    * An empty list is if nothing is found.
    */
-  public Collection<StopLocation> getStopOrChildStops(FeedScopedId id) {
+  public Collection<StopLocation> findStopOrChildStops(FeedScopedId id) {
     StopLocationsGroup stops = getStopLocationsGroup(id);
     if (stops != null) {
       return stops.getChildStops();
@@ -244,17 +244,13 @@ public class StopModel implements Serializable {
     reindex();
   }
 
-  /**
-   * This is public to be able to reindex the StopModel after deserialization. DO NOT call
-   * this from other places.
-   */
   private void reindex() {
     LOG.info("Index stop model...");
     index =
       new StopModelIndex(
-        regularStopsById.values(),
-        flexStopsById.values(),
-        flexStopGroupsById.values(),
+        regularStopById.values(),
+        areaStopById.values(),
+        groupStopById.values(),
         multiModalStationById.values()
       );
     LOG.info("Index stop model complete.");

--- a/src/main/java/org/opentripplanner/transit/service/StopModelBuilder.java
+++ b/src/main/java/org/opentripplanner/transit/service/StopModelBuilder.java
@@ -3,8 +3,8 @@ package org.opentripplanner.transit.service;
 import org.opentripplanner.transit.model.basic.WgsCoordinate;
 import org.opentripplanner.transit.model.framework.EntityById;
 import org.opentripplanner.transit.model.site.AreaStop;
-import org.opentripplanner.transit.model.site.FlexLocationGroup;
 import org.opentripplanner.transit.model.site.GroupOfStations;
+import org.opentripplanner.transit.model.site.GroupStop;
 import org.opentripplanner.transit.model.site.MultiModalStation;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
@@ -13,12 +13,12 @@ import org.opentripplanner.util.lang.CollectionsView;
 
 public class StopModelBuilder {
 
-  private final EntityById<RegularStop> stopsById = new EntityById<>();
+  private final EntityById<RegularStop> regularStopById = new EntityById<>();
+  private final EntityById<AreaStop> areaStopById = new EntityById<>();
+  private final EntityById<GroupStop> groupStopById = new EntityById<>();
   private final EntityById<Station> stationById = new EntityById<>();
   private final EntityById<MultiModalStation> multiModalStationById = new EntityById<>();
-  private final EntityById<GroupOfStations> groupOfStationsById = new EntityById<>();
-  private final EntityById<AreaStop> flexStopsById = new EntityById<>();
-  private final EntityById<FlexLocationGroup> flexStopGroupsById = new EntityById<>();
+  private final EntityById<GroupOfStations> groupOfStationById = new EntityById<>();
 
   StopModelBuilder() {}
 
@@ -26,16 +26,16 @@ public class StopModelBuilder {
     addAll(stopModel);
   }
 
-  public EntityById<RegularStop> stopsById() {
-    return stopsById;
+  public EntityById<RegularStop> regularStopsById() {
+    return regularStopById;
   }
 
-  public StopModelBuilder withStop(RegularStop stop) {
-    stopsById.add(stop);
+  public StopModelBuilder withRegularStop(RegularStop stop) {
+    regularStopById.add(stop);
     return this;
   }
 
-  public EntityById<Station> stationsById() {
+  public EntityById<Station> stationById() {
     return stationById;
   }
 
@@ -44,7 +44,7 @@ public class StopModelBuilder {
     return this;
   }
 
-  public EntityById<MultiModalStation> multiModalStationsById() {
+  public EntityById<MultiModalStation> multiModalStationById() {
     return multiModalStationById;
   }
 
@@ -53,30 +53,30 @@ public class StopModelBuilder {
     return this;
   }
 
-  public EntityById<GroupOfStations> groupOfStationsById() {
-    return groupOfStationsById;
+  public EntityById<GroupOfStations> groupOfStationById() {
+    return groupOfStationById;
   }
 
   public StopModelBuilder withGroupOfStation(GroupOfStations station) {
-    groupOfStationsById.add(station);
+    groupOfStationById.add(station);
     return this;
   }
 
-  public EntityById<AreaStop> flexStopsById() {
-    return flexStopsById;
+  public EntityById<AreaStop> areaStopById() {
+    return areaStopById;
   }
 
-  public StopModelBuilder withFlexStop(AreaStop stop) {
-    flexStopsById.add(stop);
+  public StopModelBuilder withAreaStop(AreaStop stop) {
+    areaStopById.add(stop);
     return this;
   }
 
-  public EntityById<FlexLocationGroup> flexStopGroupsById() {
-    return flexStopGroupsById;
+  public EntityById<GroupStop> groupStopById() {
+    return groupStopById;
   }
 
-  public StopModelBuilder withFlexStopGroup(FlexLocationGroup group) {
-    flexStopGroupsById.add(group);
+  public StopModelBuilder withGroupStop(GroupStop group) {
+    groupStopById.add(group);
     return this;
   }
 
@@ -85,12 +85,12 @@ public class StopModelBuilder {
    * {@code other} model, will replace existing entities.
    */
   public StopModelBuilder addAll(StopModel other) {
-    stopsById.addAll(other.listRegularStops());
-    stationById.addAll(other.getStations());
-    multiModalStationById.addAll(other.getAllMultiModalStations());
-    groupOfStationsById.addAll(other.getAllGroupOfStations());
-    flexStopsById.addAll(other.getAllFlexLocations());
-    flexStopGroupsById.addAll(other.getAllFlexStopGroups());
+    regularStopById.addAll(other.listRegularStops());
+    stationById.addAll(other.listStations());
+    multiModalStationById.addAll(other.listMultiModalStations());
+    groupOfStationById.addAll(other.listGroupOfStations());
+    areaStopById.addAll(other.listAreaStops());
+    groupStopById.addAll(other.listGroupStops());
     return this;
   }
 
@@ -106,9 +106,9 @@ public class StopModelBuilder {
    */
   WgsCoordinate calculateTransitCenter() {
     var stops = new CollectionsView<>(
-      stopsById.values(),
-      flexStopsById.values(),
-      flexStopGroupsById.values()
+      regularStopById.values(),
+      areaStopById.values(),
+      groupStopById.values()
     );
 
     if (stops.isEmpty()) {

--- a/src/main/java/org/opentripplanner/transit/service/StopModelBuilder.java
+++ b/src/main/java/org/opentripplanner/transit/service/StopModelBuilder.java
@@ -2,8 +2,8 @@ package org.opentripplanner.transit.service;
 
 import org.opentripplanner.transit.model.basic.WgsCoordinate;
 import org.opentripplanner.transit.model.framework.EntityById;
+import org.opentripplanner.transit.model.site.AreaStop;
 import org.opentripplanner.transit.model.site.FlexLocationGroup;
-import org.opentripplanner.transit.model.site.FlexStopLocation;
 import org.opentripplanner.transit.model.site.GroupOfStations;
 import org.opentripplanner.transit.model.site.MultiModalStation;
 import org.opentripplanner.transit.model.site.RegularStop;
@@ -17,7 +17,7 @@ public class StopModelBuilder {
   private final EntityById<Station> stationById = new EntityById<>();
   private final EntityById<MultiModalStation> multiModalStationById = new EntityById<>();
   private final EntityById<GroupOfStations> groupOfStationsById = new EntityById<>();
-  private final EntityById<FlexStopLocation> flexStopsById = new EntityById<>();
+  private final EntityById<AreaStop> flexStopsById = new EntityById<>();
   private final EntityById<FlexLocationGroup> flexStopGroupsById = new EntityById<>();
 
   StopModelBuilder() {}
@@ -62,11 +62,11 @@ public class StopModelBuilder {
     return this;
   }
 
-  public EntityById<FlexStopLocation> flexStopsById() {
+  public EntityById<AreaStop> flexStopsById() {
     return flexStopsById;
   }
 
-  public StopModelBuilder withFlexStop(FlexStopLocation stop) {
+  public StopModelBuilder withFlexStop(AreaStop stop) {
     flexStopsById.add(stop);
     return this;
   }
@@ -115,7 +115,7 @@ public class StopModelBuilder {
       return null;
     }
 
-    // we need this check because there could be only FlexStopLocations (which don't have vertices)
+    // we need this check because there could be only AreaStops (which don't have vertices)
     // in the graph
     var medianCalculator = new MedianCalcForDoubles(stops.size());
 

--- a/src/main/java/org/opentripplanner/transit/service/StopModelBuilder.java
+++ b/src/main/java/org/opentripplanner/transit/service/StopModelBuilder.java
@@ -6,14 +6,14 @@ import org.opentripplanner.transit.model.site.FlexLocationGroup;
 import org.opentripplanner.transit.model.site.FlexStopLocation;
 import org.opentripplanner.transit.model.site.GroupOfStations;
 import org.opentripplanner.transit.model.site.MultiModalStation;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
-import org.opentripplanner.transit.model.site.Stop;
 import org.opentripplanner.util.MedianCalcForDoubles;
 import org.opentripplanner.util.lang.CollectionsView;
 
 public class StopModelBuilder {
 
-  private final EntityById<Stop> stopsById = new EntityById<>();
+  private final EntityById<RegularStop> stopsById = new EntityById<>();
   private final EntityById<Station> stationById = new EntityById<>();
   private final EntityById<MultiModalStation> multiModalStationById = new EntityById<>();
   private final EntityById<GroupOfStations> groupOfStationsById = new EntityById<>();
@@ -26,11 +26,11 @@ public class StopModelBuilder {
     addAll(stopModel);
   }
 
-  public EntityById<Stop> stopsById() {
+  public EntityById<RegularStop> stopsById() {
     return stopsById;
   }
 
-  public StopModelBuilder withStop(Stop stop) {
+  public StopModelBuilder withStop(RegularStop stop) {
     stopsById.add(stop);
     return this;
   }

--- a/src/main/java/org/opentripplanner/transit/service/StopModelIndex.java
+++ b/src/main/java/org/opentripplanner/transit/service/StopModelIndex.java
@@ -8,8 +8,8 @@ import org.opentripplanner.common.geometry.HashGridSpatialIndex;
 import org.opentripplanner.transit.model.site.FlexLocationGroup;
 import org.opentripplanner.transit.model.site.FlexStopLocation;
 import org.opentripplanner.transit.model.site.MultiModalStation;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
-import org.opentripplanner.transit.model.site.Stop;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.util.lang.CollectionsView;
 
@@ -20,7 +20,7 @@ import org.opentripplanner.util.lang.CollectionsView;
  */
 class StopModelIndex {
 
-  private final HashGridSpatialIndex<Stop> stopSpatialIndex = new HashGridSpatialIndex<>();
+  private final HashGridSpatialIndex<RegularStop> stopSpatialIndex = new HashGridSpatialIndex<>();
   private final Map<Station, MultiModalStation> multiModalStationForStations = new HashMap<>();
   private final HashGridSpatialIndex<FlexStopLocation> locationIndex = new HashGridSpatialIndex<>();
   private final StopLocation[] stopsByIndex;
@@ -29,7 +29,7 @@ class StopModelIndex {
    * @param stops All stops including regular transit and flex
    */
   StopModelIndex(
-    Collection<Stop> stops,
+    Collection<RegularStop> stops,
     Collection<FlexStopLocation> flexStops,
     Collection<FlexLocationGroup> flexLocationGroups,
     Collection<MultiModalStation> multiModalStations
@@ -53,7 +53,7 @@ class StopModelIndex {
     }
   }
 
-  Collection<Stop> queryStopSpatialIndex(Envelope envelope) {
+  Collection<RegularStop> queryStopSpatialIndex(Envelope envelope) {
     return stopSpatialIndex.query(envelope);
   }
 

--- a/src/main/java/org/opentripplanner/transit/service/StopModelIndex.java
+++ b/src/main/java/org/opentripplanner/transit/service/StopModelIndex.java
@@ -5,8 +5,8 @@ import java.util.HashMap;
 import java.util.Map;
 import org.locationtech.jts.geom.Envelope;
 import org.opentripplanner.common.geometry.HashGridSpatialIndex;
+import org.opentripplanner.transit.model.site.AreaStop;
 import org.opentripplanner.transit.model.site.FlexLocationGroup;
-import org.opentripplanner.transit.model.site.FlexStopLocation;
 import org.opentripplanner.transit.model.site.MultiModalStation;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
@@ -22,7 +22,7 @@ class StopModelIndex {
 
   private final HashGridSpatialIndex<RegularStop> stopSpatialIndex = new HashGridSpatialIndex<>();
   private final Map<Station, MultiModalStation> multiModalStationForStations = new HashMap<>();
-  private final HashGridSpatialIndex<FlexStopLocation> locationIndex = new HashGridSpatialIndex<>();
+  private final HashGridSpatialIndex<AreaStop> locationIndex = new HashGridSpatialIndex<>();
   private final StopLocation[] stopsByIndex;
 
   /**
@@ -30,7 +30,7 @@ class StopModelIndex {
    */
   StopModelIndex(
     Collection<RegularStop> stops,
-    Collection<FlexStopLocation> flexStops,
+    Collection<AreaStop> flexStops,
     Collection<FlexLocationGroup> flexLocationGroups,
     Collection<MultiModalStation> multiModalStations
   ) {
@@ -48,7 +48,7 @@ class StopModelIndex {
         multiModalStationForStations.put(childStation, it);
       }
     }
-    for (FlexStopLocation it : flexStops) {
+    for (AreaStop it : flexStops) {
       locationIndex.insert(it.getGeometry().getEnvelopeInternal(), it);
     }
   }
@@ -69,7 +69,7 @@ class StopModelIndex {
     return stopsByIndex.length;
   }
 
-  Collection<FlexStopLocation> queryLocationIndex(Envelope envelope) {
+  Collection<AreaStop> queryLocationIndex(Envelope envelope) {
     return locationIndex.query(envelope);
   }
 }

--- a/src/main/java/org/opentripplanner/transit/service/StopModelIndex.java
+++ b/src/main/java/org/opentripplanner/transit/service/StopModelIndex.java
@@ -6,7 +6,7 @@ import java.util.Map;
 import org.locationtech.jts.geom.Envelope;
 import org.opentripplanner.common.geometry.HashGridSpatialIndex;
 import org.opentripplanner.transit.model.site.AreaStop;
-import org.opentripplanner.transit.model.site.FlexLocationGroup;
+import org.opentripplanner.transit.model.site.GroupStop;
 import org.opentripplanner.transit.model.site.MultiModalStation;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
@@ -20,7 +20,7 @@ import org.opentripplanner.util.lang.CollectionsView;
  */
 class StopModelIndex {
 
-  private final HashGridSpatialIndex<RegularStop> stopSpatialIndex = new HashGridSpatialIndex<>();
+  private final HashGridSpatialIndex<RegularStop> regularStopSpatialIndex = new HashGridSpatialIndex<>();
   private final Map<Station, MultiModalStation> multiModalStationForStations = new HashMap<>();
   private final HashGridSpatialIndex<AreaStop> locationIndex = new HashGridSpatialIndex<>();
   private final StopLocation[] stopsByIndex;
@@ -31,15 +31,15 @@ class StopModelIndex {
   StopModelIndex(
     Collection<RegularStop> stops,
     Collection<AreaStop> flexStops,
-    Collection<FlexLocationGroup> flexLocationGroups,
+    Collection<GroupStop> groupStops,
     Collection<MultiModalStation> multiModalStations
   ) {
     stopsByIndex = new StopLocation[StopLocation.indexCounter()];
 
-    var allStops = new CollectionsView<StopLocation>(stops, flexStops, flexLocationGroups);
+    var allStops = new CollectionsView<StopLocation>(stops, flexStops, groupStops);
     for (StopLocation it : allStops) {
       Envelope envelope = new Envelope(it.getCoordinate().asJtsCoordinate());
-      stopSpatialIndex.insert(envelope, it);
+      regularStopSpatialIndex.insert(envelope, it);
       stopsByIndex[it.getIndex()] = it;
     }
 
@@ -53,8 +53,11 @@ class StopModelIndex {
     }
   }
 
-  Collection<RegularStop> queryStopSpatialIndex(Envelope envelope) {
-    return stopSpatialIndex.query(envelope);
+  /**
+   * Find a regular stop in the spatial index
+   */
+  Collection<RegularStop> findRegularStops(Envelope envelope) {
+    return regularStopSpatialIndex.query(envelope);
   }
 
   MultiModalStation getMultiModalStationForStation(Station station) {
@@ -69,7 +72,7 @@ class StopModelIndex {
     return stopsByIndex.length;
   }
 
-  Collection<AreaStop> queryLocationIndex(Envelope envelope) {
+  Collection<AreaStop> findAreaStops(Envelope envelope) {
     return locationIndex.query(envelope);
   }
 }

--- a/src/main/java/org/opentripplanner/transit/service/TransitService.java
+++ b/src/main/java/org/opentripplanner/transit/service/TransitService.java
@@ -32,7 +32,7 @@ import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.organization.Agency;
 import org.opentripplanner.transit.model.organization.Operator;
-import org.opentripplanner.transit.model.site.FlexStopLocation;
+import org.opentripplanner.transit.model.site.AreaStop;
 import org.opentripplanner.transit.model.site.MultiModalStation;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
@@ -101,7 +101,7 @@ public interface TransitService {
 
   StopLocationsGroup getStopLocationsGroup(FeedScopedId id);
 
-  FlexStopLocation getLocationById(FeedScopedId id);
+  AreaStop getLocationById(FeedScopedId id);
 
   Trip getTripForId(FeedScopedId id);
 

--- a/src/main/java/org/opentripplanner/transit/service/TransitService.java
+++ b/src/main/java/org/opentripplanner/transit/service/TransitService.java
@@ -34,8 +34,8 @@ import org.opentripplanner.transit.model.organization.Agency;
 import org.opentripplanner.transit.model.organization.Operator;
 import org.opentripplanner.transit.model.site.FlexStopLocation;
 import org.opentripplanner.transit.model.site.MultiModalStation;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
-import org.opentripplanner.transit.model.site.Stop;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.site.StopLocationsGroup;
 import org.opentripplanner.transit.model.timetable.Trip;
@@ -93,7 +93,7 @@ public interface TransitService {
 
   Collection<StopLocation> listStopLocations();
 
-  Collection<Stop> listRegularStops();
+  Collection<RegularStop> listRegularStops();
 
   StopLocation getStopLocation(FeedScopedId parseId);
 
@@ -185,7 +185,7 @@ public interface TransitService {
 
   boolean transitFeedCovers(Instant dateTime);
 
-  Collection<Stop> queryStopSpatialIndex(Envelope envelope);
+  Collection<RegularStop> queryStopSpatialIndex(Envelope envelope);
 
   GraphUpdaterStatus getUpdaterStatus();
 }

--- a/src/main/java/org/opentripplanner/transit/service/TransitService.java
+++ b/src/main/java/org/opentripplanner/transit/service/TransitService.java
@@ -89,7 +89,7 @@ public interface TransitService {
 
   Operator getOperatorForId(FeedScopedId id);
 
-  StopLocation getRegularStop(FeedScopedId id);
+  RegularStop getRegularStop(FeedScopedId id);
 
   Collection<StopLocation> listStopLocations();
 
@@ -101,7 +101,7 @@ public interface TransitService {
 
   StopLocationsGroup getStopLocationsGroup(FeedScopedId id);
 
-  AreaStop getLocationById(FeedScopedId id);
+  AreaStop getAreaStop(FeedScopedId id);
 
   Trip getTripForId(FeedScopedId id);
 
@@ -185,7 +185,7 @@ public interface TransitService {
 
   boolean transitFeedCovers(Instant dateTime);
 
-  Collection<RegularStop> queryStopSpatialIndex(Envelope envelope);
+  Collection<RegularStop> findRegularStop(Envelope envelope);
 
   GraphUpdaterStatus getUpdaterStatus();
 }

--- a/src/test/java/org/opentripplanner/graph_builder/linking/LinkStopToPlatformTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/linking/LinkStopToPlatformTest.java
@@ -25,7 +25,7 @@ import org.opentripplanner.transit.model._data.TransitModelForTest;
 import org.opentripplanner.transit.model.basic.I18NString;
 import org.opentripplanner.transit.model.basic.LocalizedString;
 import org.opentripplanner.transit.model.framework.Deduplicator;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.service.StopModel;
 import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.util.geometry.GeometryUtils;
@@ -72,7 +72,10 @@ public class LinkStopToPlatformTest {
     edges.add(createAreaEdge(vertices.get(4), vertices.get(3), areaEdgeList, "edge 9"));
     edges.add(createAreaEdge(vertices.get(0), vertices.get(4), areaEdgeList, "edge 10"));
 
-    Stop stop = TransitModelForTest.stop("TestStop").withCoordinate(59.13545, 10.22213).build();
+    RegularStop stop = TransitModelForTest
+      .stop("TestStop")
+      .withCoordinate(59.13545, 10.22213)
+      .build();
 
     transitModel.index();
     graph.index(transitModel.getStopModel());

--- a/src/test/java/org/opentripplanner/graph_builder/module/FakeGraph.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/FakeGraph.java
@@ -23,7 +23,7 @@ import org.opentripplanner.routing.vertextype.TransitStopVertex;
 import org.opentripplanner.routing.vertextype.TransitStopVertexBuilder;
 import org.opentripplanner.transit.model._data.TransitModelForTest;
 import org.opentripplanner.transit.model.framework.Deduplicator;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.service.StopModel;
 import org.opentripplanner.transit.service.TransitModel;
 
@@ -90,7 +90,7 @@ public class FakeGraph {
     for (double lat = 39.9058; lat < 40.0281; lat += 0.005) {
       for (double lon = -83.1341; lon < -82.8646; lon += 0.005) {
         String id = Integer.toString(count++);
-        Stop stop = TransitModelForTest.stop(id).withCoordinate(lat, lon).build();
+        RegularStop stop = TransitModelForTest.stop(id).withCoordinate(lat, lon).build();
         new TransitStopVertexBuilder().withGraph(g).withStop(stop).build();
       }
     }
@@ -102,7 +102,7 @@ public class FakeGraph {
     double lon = -83;
     for (double lat = 40; lat < 40.01; lat += 0.005) {
       String id = "EXTRA_" + count++;
-      Stop stop = TransitModelForTest.stop(id).withCoordinate(lat, lon).build();
+      RegularStop stop = TransitModelForTest.stop(id).withCoordinate(lat, lon).build();
       new TransitStopVertexBuilder().withGraph(g).withStop(stop).build();
     }
 
@@ -110,7 +110,7 @@ public class FakeGraph {
     lon = -83.1341 + 0.1;
     for (double lat = 39.9058; lat < 40.0281; lat += 0.005) {
       String id = "DUPE_" + count++;
-      Stop stop = TransitModelForTest.stop(id).withCoordinate(lat, lon).build();
+      RegularStop stop = TransitModelForTest.stop(id).withCoordinate(lat, lon).build();
       new TransitStopVertexBuilder().withGraph(g).withStop(stop).build();
     }
 
@@ -118,7 +118,7 @@ public class FakeGraph {
     lon = -83.1341 + 0.15;
     for (double lat = 39.9059; lat < 40.0281; lat += 0.005) {
       String id = "ALMOST_" + count++;
-      Stop stop = TransitModelForTest.stop(id).withCoordinate(lat, lon).build();
+      RegularStop stop = TransitModelForTest.stop(id).withCoordinate(lat, lon).build();
       new TransitStopVertexBuilder().withGraph(g).withStop(stop).build();
     }
   }

--- a/src/test/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModuleTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModuleTest.java
@@ -27,7 +27,7 @@ import org.opentripplanner.transit.model._data.TransitModelForTest;
 import org.opentripplanner.transit.model.basic.NonLocalizedString;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.framework.Deduplicator;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.service.StopModel;
 import org.opentripplanner.transit.service.TransitModel;
 
@@ -38,12 +38,16 @@ import org.opentripplanner.transit.service.TransitModel;
 class OsmBoardingLocationsModuleTest {
 
   File file = new File(ConstantsForTests.HERRENBERG_OSM);
-  Stop platform = TransitModelForTest
+  RegularStop platform = TransitModelForTest
     .stop("de:08115:4512:4:101")
     .withCoordinate(48.59328, 8.86128)
     .build();
-  Stop busStop = TransitModelForTest.stopForTest("de:08115:4512:5:C", 48.59434, 8.86452);
-  Stop floatingBusStop = TransitModelForTest.stopForTest("floating-bus-stop", 48.59417, 8.86464);
+  RegularStop busStop = TransitModelForTest.stopForTest("de:08115:4512:5:C", 48.59434, 8.86452);
+  RegularStop floatingBusStop = TransitModelForTest.stopForTest(
+    "floating-bus-stop",
+    48.59417,
+    8.86464
+  );
 
   static Stream<Arguments> testCases = Stream.of(
     Arguments.of(

--- a/src/test/java/org/opentripplanner/gtfs/mapping/BoardingAreaMapperTest.java
+++ b/src/test/java/org/opentripplanner/gtfs/mapping/BoardingAreaMapperTest.java
@@ -15,6 +15,7 @@ import org.onebusaway.gtfs.model.Stop;
 import org.opentripplanner.transit.model._data.TransitModelForTest;
 import org.opentripplanner.transit.model.basic.WheelchairAccessibility;
 import org.opentripplanner.transit.model.site.BoardingArea;
+import org.opentripplanner.transit.model.site.RegularStop;
 
 public class BoardingAreaMapperTest {
 
@@ -40,9 +41,7 @@ public class BoardingAreaMapperTest {
 
   private static final int WHEELCHAIR_BOARDING = 1;
 
-  private static final org.opentripplanner.transit.model.site.Stop PARENT_STOP = TransitModelForTest
-    .stop(PARENT)
-    .build();
+  private static final RegularStop PARENT_STOP = TransitModelForTest.stop(PARENT).build();
 
   private static final String ZONE_ID = "Zone Id";
   private static final Stop STOP = new Stop();

--- a/src/test/java/org/opentripplanner/gtfs/mapping/StopAndStationMapperTest.java
+++ b/src/test/java/org/opentripplanner/gtfs/mapping/StopAndStationMapperTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.onebusaway.gtfs.model.AgencyAndId;
 import org.onebusaway.gtfs.model.Stop;
 import org.opentripplanner.transit.model.basic.WheelchairAccessibility;
+import org.opentripplanner.transit.model.site.RegularStop;
 
 public class StopAndStationMapperTest {
 
@@ -77,7 +78,7 @@ public class StopAndStationMapperTest {
 
   @Test
   public void testMap() {
-    org.opentripplanner.transit.model.site.Stop result = subject.map(STOP);
+    RegularStop result = subject.map(STOP);
 
     assertEquals("A:1", result.getId().toString());
     assertEquals(CODE, result.getCode());
@@ -96,7 +97,7 @@ public class StopAndStationMapperTest {
     input.setId(AGENCY_AND_ID);
     input.setName(NAME);
 
-    org.opentripplanner.transit.model.site.Stop result = subject.map(input);
+    RegularStop result = subject.map(input);
 
     assertNotNull(result.getId());
     assertNull(result.getCode());
@@ -116,7 +117,7 @@ public class StopAndStationMapperTest {
     input.setId(AGENCY_AND_ID);
     input.setName(NAME);
 
-    org.opentripplanner.transit.model.site.Stop result = subject.map(input);
+    RegularStop result = subject.map(input);
 
     // Getting the coordinate will throw an IllegalArgumentException if not set,
     // this is considered to be a implementation error
@@ -126,8 +127,8 @@ public class StopAndStationMapperTest {
   /** Mapping the same object twice, should return the the same instance. */
   @Test
   public void testMapCache() {
-    org.opentripplanner.transit.model.site.Stop result1 = subject.map(STOP);
-    org.opentripplanner.transit.model.site.Stop result2 = subject.map(STOP);
+    RegularStop result1 = subject.map(STOP);
+    RegularStop result2 = subject.map(STOP);
 
     assertSame(result1, result2);
   }

--- a/src/test/java/org/opentripplanner/model/TripPatternTest.java
+++ b/src/test/java/org/opentripplanner/model/TripPatternTest.java
@@ -11,7 +11,7 @@ import org.opentripplanner.transit.model._data.TransitModelForTest;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.StopPattern;
 import org.opentripplanner.transit.model.network.TripPattern;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.util.geometry.GeometryUtils;
 
 public class TripPatternTest {
@@ -88,8 +88,8 @@ public class TripPatternTest {
    * @return TripPattern with stopPattern
    */
   public TripPattern setupTripPattern(
-    Stop origin,
-    Stop destination,
+    RegularStop origin,
+    RegularStop destination,
     TripPattern originalTripPattern,
     List<LineString> geometry
   ) {
@@ -120,7 +120,11 @@ public class TripPatternTest {
    * @param coordinate Coordinate to inject between stops
    * @return LineString with all coordinates
    */
-  private List<LineString> getLineStrings(Stop origin, Stop destination, Coordinate coordinate) {
+  private List<LineString> getLineStrings(
+    RegularStop origin,
+    RegularStop destination,
+    Coordinate coordinate
+  ) {
     var coordinates = new ArrayList<Coordinate>();
     // Add start and stop first and last
     coordinates.add(new Coordinate(origin.getLon(), origin.getLat()));

--- a/src/test/java/org/opentripplanner/model/impl/OtpTransitServiceBuilderLimitPeriodTest.java
+++ b/src/test/java/org/opentripplanner/model/impl/OtpTransitServiceBuilderLimitPeriodTest.java
@@ -21,7 +21,7 @@ import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.network.StopPattern;
 import org.opentripplanner.transit.model.network.TripPattern;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.timetable.Direction;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripTimes;
@@ -45,8 +45,8 @@ public class OtpTransitServiceBuilderLimitPeriodTest {
   private static final FeedScopedId SERVICE_D_IN = TransitModelForTest.id("CalSrvDIn");
   private static final FeedScopedId SERVICE_C_OUT = TransitModelForTest.id("CalSrvOut");
   private static final FeedScopedId SERVICE_D_OUT = TransitModelForTest.id("CalSrvDOut");
-  private static final Stop STOP_1 = TransitModelForTest.stop("Stop-1").build();
-  private static final Stop STOP_2 = TransitModelForTest.stop("Stop-2").build();
+  private static final RegularStop STOP_1 = TransitModelForTest.stop("Stop-1").build();
+  private static final RegularStop STOP_2 = TransitModelForTest.stop("Stop-2").build();
   private static final Deduplicator DEDUPLICATOR = new Deduplicator();
   private static final List<StopTime> STOP_TIMES = List.of(
     createStopTime(STOP_1, 0),
@@ -165,7 +165,7 @@ public class OtpTransitServiceBuilderLimitPeriodTest {
     return calendar;
   }
 
-  private static StopTime createStopTime(Stop stop, int time) {
+  private static StopTime createStopTime(RegularStop stop, int time) {
     StopTime st = new StopTime();
     st.setStop(stop);
     st.setDepartureTime(time);

--- a/src/test/java/org/opentripplanner/model/impl/OtpTransitServiceImplTest.java
+++ b/src/test/java/org/opentripplanner/model/impl/OtpTransitServiceImplTest.java
@@ -94,7 +94,7 @@ public class OtpTransitServiceImplTest {
 
   @Test
   public void testGetAllStations() {
-    Collection<Station> stations = subject.stopModel().getStations();
+    Collection<Station> stations = subject.stopModel().listStations();
 
     assertEquals(1, stations.size());
     assertEquals("Station{F:station station}", first(stations).toString());

--- a/src/test/java/org/opentripplanner/model/impl/OtpTransitServiceImplTest.java
+++ b/src/test/java/org/opentripplanner/model/impl/OtpTransitServiceImplTest.java
@@ -24,8 +24,8 @@ import org.opentripplanner.transit.model._data.TransitModelForTest;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.organization.Agency;
 import org.opentripplanner.transit.model.site.Pathway;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
-import org.opentripplanner.transit.model.site.Stop;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.timetable.Trip;
 
@@ -102,10 +102,10 @@ public class OtpTransitServiceImplTest {
 
   @Test
   public void testGetAllStops() {
-    Collection<Stop> stops = subject.stopModel().listRegularStops();
+    Collection<RegularStop> stops = subject.stopModel().listRegularStops();
 
     assertEquals(22, stops.size());
-    assertEquals("Stop{F:A A}", first(stops).toString());
+    assertEquals("RegularStop{F:A A}", first(stops).toString());
   }
 
   @Test
@@ -132,8 +132,8 @@ public class OtpTransitServiceImplTest {
 
   @Test
   public void testGetStopForId() {
-    Stop stop = subject.stopModel().getRegularStop(TransitModelForTest.id("P"));
-    assertEquals("Stop{F:P P}", stop.toString());
+    RegularStop stop = subject.stopModel().getRegularStop(TransitModelForTest.id("P"));
+    assertEquals("RegularStop{F:P P}", stop.toString());
   }
 
   @Test
@@ -141,7 +141,7 @@ public class OtpTransitServiceImplTest {
     List<StopLocation> stops = new ArrayList<>(
       subject.stopModel().getStationById(STATION_ID).getChildStops()
     );
-    assertEquals("[Stop{F:A A}]", stops.toString());
+    assertEquals("[RegularStop{F:A A}]", stops.toString());
   }
 
   @Test
@@ -157,7 +157,7 @@ public class OtpTransitServiceImplTest {
   public void testGetStopTimesForTrip() {
     List<StopTime> stopTimes = subject.getStopTimesForTrip(first(subject.getAllTrips()));
     assertEquals(
-      "[Stop{F:A A}, Stop{F:B B}, Stop{F:C C}]",
+      "[RegularStop{F:A A}, RegularStop{F:B B}, RegularStop{F:C C}]",
       stopTimes.stream().map(StopTime::getStop).toList().toString()
     );
   }

--- a/src/test/java/org/opentripplanner/model/plan/PlaceTest.java
+++ b/src/test/java/org/opentripplanner/model/plan/PlaceTest.java
@@ -19,7 +19,7 @@ import org.opentripplanner.transit.model.basic.I18NString;
 import org.opentripplanner.transit.model.basic.NonLocalizedString;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.site.FlexStopLocation;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.util.geometry.GeometryUtils;
 
 public class PlaceTest {
@@ -101,7 +101,7 @@ public class PlaceTest {
     assertNull(p.coordinate);
   }
 
-  private static Place place(Stop stop) {
+  private static Place place(RegularStop stop) {
     return Place.forStop(stop);
   }
 }

--- a/src/test/java/org/opentripplanner/model/plan/PlaceTest.java
+++ b/src/test/java/org/opentripplanner/model/plan/PlaceTest.java
@@ -18,7 +18,7 @@ import org.opentripplanner.transit.model._data.TransitModelForTest;
 import org.opentripplanner.transit.model.basic.I18NString;
 import org.opentripplanner.transit.model.basic.NonLocalizedString;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
-import org.opentripplanner.transit.model.site.FlexStopLocation;
+import org.opentripplanner.transit.model.site.AreaStop;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.util.geometry.GeometryUtils;
 
@@ -77,7 +77,7 @@ public class PlaceTest {
   @ParameterizedTest(name = "Flex stop name of {0} should lead to a place name of {1}")
   @VariableSource("flexStopCases")
   public void flexStop(I18NString stopName, String expectedPlaceName) {
-    var stop = FlexStopLocation
+    var stop = AreaStop
       .of(new FeedScopedId("1", "stop_id"))
       .withGeometry(GEOMETRY)
       .withName(stopName)

--- a/src/test/java/org/opentripplanner/model/transfer/TransferTestData.java
+++ b/src/test/java/org/opentripplanner/model/transfer/TransferTestData.java
@@ -2,8 +2,8 @@ package org.opentripplanner.model.transfer;
 
 import org.opentripplanner.transit.model._data.TransitModelForTest;
 import org.opentripplanner.transit.model.network.Route;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
-import org.opentripplanner.transit.model.site.Stop;
 import org.opentripplanner.transit.model.timetable.Trip;
 
 public class TransferTestData {
@@ -15,18 +15,18 @@ public class TransferTestData {
   static final int POS_3 = 3;
   static final int ANY_POS = 999;
 
-  static final Stop STOP_A = TransitModelForTest
+  static final RegularStop STOP_A = TransitModelForTest
     .stopForTest("A", 60.0, 11.0)
     .copy()
     .withParentStation(STATION)
     .build();
-  static final Stop STOP_B = TransitModelForTest.stopForTest("B", 60.0, 11.0);
-  static final Stop STOP_S = TransitModelForTest
+  static final RegularStop STOP_B = TransitModelForTest.stopForTest("B", 60.0, 11.0);
+  static final RegularStop STOP_S = TransitModelForTest
     .stopForTest("S", 60.0, 11.0)
     .copy()
     .withParentStation(STATION)
     .build();
-  static final Stop ANY_STOP = TransitModelForTest.stopForTest("any", 60.0, 11.0);
+  static final RegularStop ANY_STOP = TransitModelForTest.stopForTest("any", 60.0, 11.0);
 
   static final Route ROUTE_1 = TransitModelForTest.route("1").build();
   static final Route ROUTE_2 = TransitModelForTest.route("2").build();

--- a/src/test/java/org/opentripplanner/netex/NetexBundleSmokeTest.java
+++ b/src/test/java/org/opentripplanner/netex/NetexBundleSmokeTest.java
@@ -67,10 +67,10 @@ public class NetexBundleSmokeTest {
     OtpTransitService otpModel = transitBuilder.build();
 
     assertAgencies(otpModel.getAllAgencies());
-    assertMultiModalStations(otpModel.stopModel().getAllMultiModalStations());
+    assertMultiModalStations(otpModel.stopModel().listMultiModalStations());
     assertOperators(otpModel.getAllOperators());
     assertStops(otpModel.stopModel().listRegularStops());
-    assertStations(otpModel.stopModel().getStations());
+    assertStations(otpModel.stopModel().listStations());
     assertTripPatterns(otpModel.getTripPatterns());
     assertTrips(otpModel.getAllTrips());
     assertServiceIds(otpModel.getAllTrips(), otpModel.getAllServiceIds());

--- a/src/test/java/org/opentripplanner/netex/NetexBundleSmokeTest.java
+++ b/src/test/java/org/opentripplanner/netex/NetexBundleSmokeTest.java
@@ -31,8 +31,8 @@ import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.organization.Agency;
 import org.opentripplanner.transit.model.organization.Operator;
 import org.opentripplanner.transit.model.site.MultiModalStation;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
-import org.opentripplanner.transit.model.site.Stop;
 import org.opentripplanner.transit.model.timetable.StopTimeKey;
 import org.opentripplanner.transit.model.timetable.Trip;
 
@@ -127,10 +127,12 @@ public class NetexBundleSmokeTest {
     assertNull(o.getPhone());
   }
 
-  private void assertStops(Collection<Stop> stops) {
-    Map<FeedScopedId, Stop> map = stops.stream().collect(Collectors.toMap(Stop::getId, s -> s));
+  private void assertStops(Collection<RegularStop> stops) {
+    Map<FeedScopedId, RegularStop> map = stops
+      .stream()
+      .collect(Collectors.toMap(RegularStop::getId, s -> s));
 
-    Stop quay = map.get(fId("NSR:Quay:122003"));
+    RegularStop quay = map.get(fId("NSR:Quay:122003"));
     assertEquals("N/A", quay.getName().toString());
     assertEquals(59.909803, quay.getLat(), 0.000001);
     assertEquals(10.748062, quay.getLon(), 0.000001);
@@ -158,7 +160,7 @@ public class NetexBundleSmokeTest {
     assertEquals("Jernbanetorget", p.getTripHeadsign());
     assertEquals("RB", p.getFeedId());
     assertEquals(
-      "[Stop{RB:NSR:Quay:7203 N/A}, Stop{RB:NSR:Quay:8027 N/A}]",
+      "[RegularStop{RB:NSR:Quay:7203 N/A}, RegularStop{RB:NSR:Quay:8027 N/A}]",
       p.getStops().toString()
     );
     assertEquals(

--- a/src/test/java/org/opentripplanner/netex/mapping/FlexStopLocationMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/FlexStopLocationMapperTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 import org.opentripplanner.transit.model._data.TransitModelForTest;
 import org.opentripplanner.transit.model.site.FlexLocationGroup;
 import org.opentripplanner.transit.model.site.FlexStopLocation;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.rutebanken.netex.model.FlexibleArea;
 import org.rutebanken.netex.model.FlexibleStopPlace;
 import org.rutebanken.netex.model.FlexibleStopPlace_VersionStructure;
@@ -100,8 +100,8 @@ public class FlexStopLocationMapperTest {
 
   @Test
   public void mapFlexStopLocationGroup() {
-    Stop stop1 = TransitModelForTest.stop("A").withCoordinate(59.6505778, 6.3608759).build();
-    Stop stop2 = TransitModelForTest.stop("B").withCoordinate(59.6630333, 6.3697245).build();
+    RegularStop stop1 = TransitModelForTest.stop("A").withCoordinate(59.6505778, 6.3608759).build();
+    RegularStop stop2 = TransitModelForTest.stop("B").withCoordinate(59.6630333, 6.3697245).build();
 
     FlexStopLocationMapper flexStopLocationMapper = new FlexStopLocationMapper(
       ID_FACTORY,

--- a/src/test/java/org/opentripplanner/netex/mapping/FlexStopsMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/FlexStopsMapperTest.java
@@ -14,8 +14,8 @@ import net.opengis.gml._3.LinearRingType;
 import net.opengis.gml._3.PolygonType;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.transit.model._data.TransitModelForTest;
+import org.opentripplanner.transit.model.site.AreaStop;
 import org.opentripplanner.transit.model.site.FlexLocationGroup;
-import org.opentripplanner.transit.model.site.FlexStopLocation;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.rutebanken.netex.model.FlexibleArea;
 import org.rutebanken.netex.model.FlexibleStopPlace;
@@ -24,7 +24,7 @@ import org.rutebanken.netex.model.KeyListStructure;
 import org.rutebanken.netex.model.KeyValueStructure;
 import org.rutebanken.netex.model.MultilingualString;
 
-public class FlexStopLocationMapperTest {
+public class FlexStopsMapperTest {
 
   public static final String FLEXIBLE_STOP_PLACE_ID = "RUT:FlexibleStopPlace:1";
   public static final String FLEXIBLE_STOP_PLACE_NAME = "Sauda-HentMeg";
@@ -83,30 +83,22 @@ public class FlexStopLocationMapperTest {
   );
 
   @Test
-  public void mapFlexStopLocation() {
-    FlexStopLocationMapper flexStopLocationMapper = new FlexStopLocationMapper(
-      ID_FACTORY,
-      List.of()
-    );
+  public void mapAreaStop() {
+    FlexStopsMapper flexStopsMapper = new FlexStopsMapper(ID_FACTORY, List.of());
 
     FlexibleStopPlace flexibleStopPlace = getFlexibleStopPlace();
 
-    FlexStopLocation flexStopLocation = (FlexStopLocation) flexStopLocationMapper.map(
-      flexibleStopPlace
-    );
+    AreaStop areaStop = (AreaStop) flexStopsMapper.map(flexibleStopPlace);
 
-    assertNotNull(flexStopLocation);
+    assertNotNull(areaStop);
   }
 
   @Test
-  public void mapFlexStopLocationGroup() {
+  public void mapFlexLocationGroup() {
     RegularStop stop1 = TransitModelForTest.stop("A").withCoordinate(59.6505778, 6.3608759).build();
     RegularStop stop2 = TransitModelForTest.stop("B").withCoordinate(59.6630333, 6.3697245).build();
 
-    FlexStopLocationMapper flexStopLocationMapper = new FlexStopLocationMapper(
-      ID_FACTORY,
-      List.of(stop1, stop2)
-    );
+    FlexStopsMapper flexStopsMapper = new FlexStopsMapper(ID_FACTORY, List.of(stop1, stop2));
 
     FlexibleStopPlace flexibleStopPlace = getFlexibleStopPlace();
     flexibleStopPlace.setKeyList(
@@ -118,7 +110,7 @@ public class FlexStopLocationMapperTest {
         )
     );
 
-    FlexLocationGroup flexLocationGroup = (FlexLocationGroup) flexStopLocationMapper.map(
+    FlexLocationGroup flexLocationGroup = (FlexLocationGroup) flexStopsMapper.map(
       flexibleStopPlace
     );
 

--- a/src/test/java/org/opentripplanner/netex/mapping/FlexStopsMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/FlexStopsMapperTest.java
@@ -15,7 +15,7 @@ import net.opengis.gml._3.PolygonType;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.transit.model._data.TransitModelForTest;
 import org.opentripplanner.transit.model.site.AreaStop;
-import org.opentripplanner.transit.model.site.FlexLocationGroup;
+import org.opentripplanner.transit.model.site.GroupStop;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.rutebanken.netex.model.FlexibleArea;
 import org.rutebanken.netex.model.FlexibleStopPlace;
@@ -94,11 +94,9 @@ public class FlexStopsMapperTest {
   }
 
   @Test
-  public void mapFlexLocationGroup() {
+  public void mapGroupStop() {
     RegularStop stop1 = TransitModelForTest.stop("A").withCoordinate(59.6505778, 6.3608759).build();
     RegularStop stop2 = TransitModelForTest.stop("B").withCoordinate(59.6630333, 6.3697245).build();
-
-    FlexStopsMapper flexStopsMapper = new FlexStopsMapper(ID_FACTORY, List.of(stop1, stop2));
 
     FlexibleStopPlace flexibleStopPlace = getFlexibleStopPlace();
     flexibleStopPlace.setKeyList(
@@ -110,14 +108,14 @@ public class FlexStopsMapperTest {
         )
     );
 
-    FlexLocationGroup flexLocationGroup = (FlexLocationGroup) flexStopsMapper.map(
-      flexibleStopPlace
-    );
+    FlexStopsMapper subject = new FlexStopsMapper(ID_FACTORY, List.of(stop1, stop2));
+
+    GroupStop groupStop = (GroupStop) subject.map(flexibleStopPlace);
 
     // Only one of the stops should be inside the polygon
-    assertEquals(1, flexLocationGroup.getLocations().size());
+    assertEquals(1, groupStop.getLocations().size());
 
-    assertNotNull(flexLocationGroup);
+    assertNotNull(groupStop);
   }
 
   private FlexibleStopPlace getFlexibleStopPlace() {

--- a/src/test/java/org/opentripplanner/netex/mapping/NetexTestDataSample.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/NetexTestDataSample.java
@@ -16,7 +16,7 @@ import org.opentripplanner.netex.index.hierarchy.HierarchicalMap;
 import org.opentripplanner.netex.index.hierarchy.HierarchicalMapById;
 import org.opentripplanner.transit.model._data.TransitModelForTest;
 import org.opentripplanner.transit.model.framework.EntityById;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.rutebanken.netex.model.AllVehicleModesOfTransportEnumeration;
 import org.rutebanken.netex.model.DatedServiceJourney;
 import org.rutebanken.netex.model.DayType;
@@ -61,7 +61,7 @@ class NetexTestDataSample {
   private final JourneyPattern journeyPattern;
   private final HierarchicalMapById<JourneyPattern> journeyPatternById = new HierarchicalMapById<>();
   private final HierarchicalMapById<DestinationDisplay> destinationDisplayById = new HierarchicalMapById<>();
-  private final EntityById<Stop> stopsById = new EntityById<>();
+  private final EntityById<RegularStop> stopsById = new EntityById<>();
   private final HierarchicalMap<String, String> quayIdByStopPointRef = new HierarchicalMap<>();
   private final List<TimetabledPassingTime> timetabledPassingTimes = new ArrayList<>();
   private final HierarchicalMapById<ServiceJourney> serviceJourneyById = new HierarchicalMapById<>();
@@ -194,7 +194,7 @@ class NetexTestDataSample {
     return destinationDisplayById;
   }
 
-  EntityById<Stop> getStopsById() {
+  EntityById<RegularStop> getStopsById() {
     return stopsById;
   }
 

--- a/src/test/java/org/opentripplanner/netex/mapping/ServiceLinkMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/ServiceLinkMapperTest.java
@@ -21,8 +21,8 @@ import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.basic.WheelchairAccessibility;
 import org.opentripplanner.transit.model.framework.EntityById;
 import org.opentripplanner.transit.model.network.StopPattern;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
-import org.opentripplanner.transit.model.site.Stop;
 import org.rutebanken.netex.model.JourneyPattern;
 import org.rutebanken.netex.model.LinkSequenceProjection;
 import org.rutebanken.netex.model.LinkSequenceProjection_VersionStructure;
@@ -94,7 +94,7 @@ public class ServiceLinkMapperTest {
     quayIdByStopPointRef.add("RUT:StopPoint:2", "NSR:Quay:2");
     quayIdByStopPointRef.add("RUT:StopPoint:3", "NSR:Quay:3");
 
-    EntityById<Stop> stopsById = new EntityById<>();
+    EntityById<RegularStop> stopsById = new EntityById<>();
 
     DataImportIssueStore issueStore = DataImportIssueStore.noopIssueStore();
     StopMapper stopMapper = new StopMapper(ID_FACTORY, issueStore);
@@ -107,7 +107,7 @@ public class ServiceLinkMapperTest {
       .build();
 
     for (int i = 0; i < quaysById.size(); i++) {
-      Stop stop = stopMapper.mapQuayToStop(
+      RegularStop stop = stopMapper.mapQuayToStop(
         quaysById.get(i),
         parentStation,
         List.of(),

--- a/src/test/java/org/opentripplanner/netex/mapping/ServiceLinkMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/ServiceLinkMapperTest.java
@@ -97,7 +97,7 @@ public class ServiceLinkMapperTest {
     EntityById<RegularStop> stopsById = new EntityById<>();
 
     DataImportIssueStore issueStore = DataImportIssueStore.noopIssueStore();
-    StopMapper stopMapper = new StopMapper(ID_FACTORY, issueStore);
+    QuayMapper quayMapper = new QuayMapper(ID_FACTORY, issueStore);
     StopPattern.StopPatternBuilder stopPatternBuilder = StopPattern.create(3);
 
     Station parentStation = Station
@@ -107,7 +107,7 @@ public class ServiceLinkMapperTest {
       .build();
 
     for (int i = 0; i < quaysById.size(); i++) {
-      RegularStop stop = stopMapper.mapQuayToStop(
+      RegularStop stop = quayMapper.mapQuayToStop(
         quaysById.get(i),
         parentStation,
         List.of(),

--- a/src/test/java/org/opentripplanner/netex/mapping/StopAndStationMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/StopAndStationMapperTest.java
@@ -11,8 +11,8 @@ import org.junit.jupiter.api.Test;
 import org.opentripplanner.graph_builder.DataImportIssueStore;
 import org.opentripplanner.netex.index.hierarchy.HierarchicalVersionMapById;
 import org.opentripplanner.transit.model.basic.WheelchairAccessibility;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
-import org.opentripplanner.transit.model.site.Stop;
 import org.rutebanken.netex.model.AccessibilityAssessment;
 import org.rutebanken.netex.model.AccessibilityLimitation;
 import org.rutebanken.netex.model.AccessibilityLimitations_RelStructure;
@@ -151,7 +151,7 @@ public class StopAndStationMapperTest {
 
     stopMapper.mapParentAndChildStops(stopPlaces);
 
-    Collection<Stop> stops = stopMapper.resultStops;
+    Collection<RegularStop> stops = stopMapper.resultStops;
     Collection<Station> stations = stopMapper.resultStations;
 
     assertEquals(3, stops.size());
@@ -162,17 +162,17 @@ public class StopAndStationMapperTest {
       .filter(s -> s.getId().getId().equals("NSR:StopPlace:1"))
       .findFirst()
       .get();
-    Stop childStop1 = stops
+    RegularStop childStop1 = stops
       .stream()
       .filter(s -> s.getId().getId().equals("NSR:Quay:1"))
       .findFirst()
       .get();
-    Stop childStop2 = stops
+    RegularStop childStop2 = stops
       .stream()
       .filter(s -> s.getId().getId().equals("NSR:Quay:2"))
       .findFirst()
       .get();
-    Stop childStop3 = stops
+    RegularStop childStop3 = stops
       .stream()
       .filter(s -> s.getId().getId().equals("NSR:Quay:3"))
       .findFirst()
@@ -241,13 +241,13 @@ public class StopAndStationMapperTest {
   private void assertWheelchairAccessibility(
     String quayId,
     WheelchairAccessibility expected,
-    List<Stop> stops
+    List<RegularStop> stops
   ) {
     var wheelchairAccessibility = stops
       .stream()
       .filter(s -> s.getId().getId().equals(quayId))
       .findAny()
-      .map(Stop::getWheelchairAccessibility)
+      .map(RegularStop::getWheelchairAccessibility)
       .orElse(null);
 
     assertNotNull(wheelchairAccessibility, "wheelchairAccessibility must not be null");

--- a/src/test/java/org/opentripplanner/routing/TestHalfEdges.java
+++ b/src/test/java/org/opentripplanner/routing/TestHalfEdges.java
@@ -165,7 +165,7 @@ public class TestHalfEdges {
     var s1 = TransitModelForTest.stopForTest("fleem station", 40.0099999, -74.005);
     var s2 = TransitModelForTest.stopForTest("morx station", 40.0099999, -74.002);
 
-    transitModel.mergeStopModels(StopModel.of().withStop(s1).withStop(s2).build());
+    transitModel.mergeStopModels(StopModel.of().withRegularStop(s1).withRegularStop(s2).build());
 
     station1 = new TransitStopVertexBuilder().withGraph(graph).withStop(s1).build();
     station2 = new TransitStopVertexBuilder().withGraph(graph).withStop(s2).build();

--- a/src/test/java/org/opentripplanner/routing/algorithm/GraphRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/GraphRoutingTest.java
@@ -237,7 +237,7 @@ public abstract class GraphRoutingTest {
 
     public RegularStop stopEntity(String id, double latitude, double longitude) {
       var stop = TransitModelForTest.stop(id).withCoordinate(latitude, longitude).build();
-      transitModel.mergeStopModels(StopModel.of().withStop(stop).build());
+      transitModel.mergeStopModels(StopModel.of().withRegularStop(stop).build());
       return stop;
     }
 

--- a/src/test/java/org/opentripplanner/routing/algorithm/GraphRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/GraphRoutingTest.java
@@ -58,7 +58,7 @@ import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.organization.Agency;
 import org.opentripplanner.transit.model.site.Entrance;
 import org.opentripplanner.transit.model.site.PathwayMode;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.service.StopModel;
 import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.util.geometry.GeometryUtils;
@@ -235,7 +235,7 @@ public abstract class GraphRoutingTest {
         .build();
     }
 
-    public Stop stopEntity(String id, double latitude, double longitude) {
+    public RegularStop stopEntity(String id, double latitude, double longitude) {
       var stop = TransitModelForTest.stop(id).withCoordinate(latitude, longitude).build();
       transitModel.mergeStopModels(StopModel.of().withStop(stop).build());
       return stop;

--- a/src/test/java/org/opentripplanner/routing/algorithm/filterchain/groupids/GroupByAllSameStationsTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/filterchain/groupids/GroupByAllSameStationsTest.java
@@ -8,8 +8,8 @@ import org.junit.jupiter.api.Test;
 import org.opentripplanner.model.plan.Place;
 import org.opentripplanner.model.plan.PlanTestConstants;
 import org.opentripplanner.transit.model._data.TransitModelForTest;
+import org.opentripplanner.transit.model.site.RegularStopBuilder;
 import org.opentripplanner.transit.model.site.Station;
-import org.opentripplanner.transit.model.site.StopBuilder;
 
 class GroupByAllSameStationsTest implements PlanTestConstants {
 
@@ -82,7 +82,7 @@ class GroupByAllSameStationsTest implements PlanTestConstants {
   }
 
   static Place place(String name, double lat, double lon, Station parent) {
-    StopBuilder stop = TransitModelForTest.stop(name).withCoordinate(lat, lon);
+    RegularStopBuilder stop = TransitModelForTest.stop(name).withCoordinate(lat, lon);
     if (parent != null) {
       stop.withParentStation(parent);
     }

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TripPatternForDateTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TripPatternForDateTest.java
@@ -17,13 +17,13 @@ import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.network.RoutingTripPattern;
 import org.opentripplanner.transit.model.network.StopPattern;
 import org.opentripplanner.transit.model.network.TripPattern;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.timetable.FrequencyEntry;
 import org.opentripplanner.transit.model.timetable.TripTimes;
 
 class TripPatternForDateTest {
 
-  private static final Stop STOP = TransitModelForTest.stopForTest("TEST:STOP", 0, 0);
+  private static final RegularStop STOP = TransitModelForTest.stopForTest("TEST:STOP", 0, 0);
   private static final TripTimes tripTimes = Mockito.mock(TripTimes.class);
 
   static Stream<Arguments> testCases = Stream

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/constrainedtransfer/ConstrainedBoardingSearchTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/constrainedtransfer/ConstrainedBoardingSearchTest.java
@@ -30,7 +30,7 @@ import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.RoutingTripPattern;
 import org.opentripplanner.transit.model.network.TripPattern;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripScheduleBoardOrAlightEvent;
 import org.opentripplanner.util.OTPFeature;
 
@@ -341,7 +341,7 @@ public class ConstrainedBoardingSearchTest {
   }
 
   void testTransferSearch(
-    Stop transferStop,
+    RegularStop transferStop,
     List<ConstrainedTransfer> constraints,
     int expTripIndexFwdSearch,
     int expTripIndexRevSearch,
@@ -352,7 +352,7 @@ public class ConstrainedBoardingSearchTest {
   }
 
   void testTransferSearchForward(
-    Stop transferStop,
+    RegularStop transferStop,
     List<ConstrainedTransfer> txList,
     int expectedTripIndex,
     TransferConstraint expectedConstraint
@@ -382,7 +382,7 @@ public class ConstrainedBoardingSearchTest {
   }
 
   void testTransferSearchReverse(
-    Stop transferStop,
+    RegularStop transferStop,
     List<ConstrainedTransfer> txList,
     int expectedTripIndex,
     TransferConstraint expectedConstraint

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TransitLayerMapperTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TransitLayerMapperTest.java
@@ -7,8 +7,8 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TransitTuningParameters;
 import org.opentripplanner.transit.model._data.TransitModelForTest;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
-import org.opentripplanner.transit.model.site.Stop;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.site.StopTransferPriority;
 import org.opentripplanner.transit.service.StopModelMock;
@@ -32,20 +32,20 @@ class TransitLayerMapperTest {
     .withPriority(StopTransferPriority.PREFERRED)
     .build();
 
-  private final Stop STOP_0 = TransitModelForTest.stop("ID-" + 1).build();
-  private final Stop STOP_1 = TransitModelForTest
+  private final RegularStop STOP_0 = TransitModelForTest.stop("ID-" + 1).build();
+  private final RegularStop STOP_1 = TransitModelForTest
     .stop("ID-" + 2)
     .withParentStation(STATION_A)
     .build();
-  private final Stop STOP_2 = TransitModelForTest
+  private final RegularStop STOP_2 = TransitModelForTest
     .stop("ID-" + 3)
     .withParentStation(STATION_B)
     .build();
-  private final Stop STOP_3 = TransitModelForTest
+  private final RegularStop STOP_3 = TransitModelForTest
     .stop("ID-" + 4)
     .withParentStation(STATION_C)
     .build();
-  private final Stop STOP_4 = TransitModelForTest
+  private final RegularStop STOP_4 = TransitModelForTest
     .stop("ID-" + 5)
     .withParentStation(STATION_D)
     .build();

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RoutingRequestTransitDataProviderFilterTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RoutingRequestTransitDataProviderFilterTest.java
@@ -30,7 +30,7 @@ import org.opentripplanner.transit.model.network.RouteBuilder;
 import org.opentripplanner.transit.model.network.RoutingTripPattern;
 import org.opentripplanner.transit.model.network.StopPattern;
 import org.opentripplanner.transit.model.network.TripPattern;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripAlteration;
 import org.opentripplanner.transit.model.timetable.TripBuilder;
@@ -42,7 +42,11 @@ public class RoutingRequestTransitDataProviderFilterTest {
 
   private static final FeedScopedId TRIP_ID = TransitModelForTest.id("T1");
 
-  private static final Stop STOP_FOR_TEST = TransitModelForTest.stopForTest("TEST:STOP", 0, 0);
+  private static final RegularStop STOP_FOR_TEST = TransitModelForTest.stopForTest(
+    "TEST:STOP",
+    0,
+    0
+  );
 
   private static final WheelchairAccessibilityRequest DEFAULT_ACCESSIBILITY =
     WheelchairAccessibilityRequest.DEFAULT;

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TestRouteData.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TestRouteData.java
@@ -19,7 +19,7 @@ import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.network.RoutingTripPattern;
 import org.opentripplanner.transit.model.network.StopPattern;
 import org.opentripplanner.transit.model.network.TripPattern;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripTimes;
@@ -37,7 +37,7 @@ public class TestRouteData {
   private final TripPattern tripPattern;
   private Trip currentTrip;
 
-  public TestRouteData(String route, TransitMode mode, List<Stop> stops, String... times) {
+  public TestRouteData(String route, TransitMode mode, List<RegularStop> stops, String... times) {
     final Deduplicator deduplicator = new Deduplicator();
     this.route = TransitModelForTest.route(route).withMode(mode).withShortName(route).build();
     this.trips =
@@ -101,7 +101,7 @@ public class TestRouteData {
     return this;
   }
 
-  public StopTime getStopTime(Stop stop) {
+  public StopTime getStopTime(RegularStop stop) {
     return stopTimesByTrip.get(currentTrip).get(stopPosition(stop));
   }
 
@@ -130,7 +130,7 @@ public class TestRouteData {
   private Trip parseTripInfo(
     String route,
     String tripTimes,
-    List<Stop> stops,
+    List<RegularStop> stops,
     Deduplicator deduplicator
   ) {
     var trip = Trip
@@ -147,7 +147,7 @@ public class TestRouteData {
     return stopTimesByTrip.get(currentTrip);
   }
 
-  private List<StopTime> stopTimes(Trip trip, List<Stop> stops, String timesAsString) {
+  private List<StopTime> stopTimes(Trip trip, List<RegularStop> stops, String timesAsString) {
     var times = TimeUtils.times(timesAsString);
     var stopTimes = new ArrayList<StopTime>();
     for (int i = 0; i < stops.size(); i++) {
@@ -156,7 +156,7 @@ public class TestRouteData {
     return stopTimes;
   }
 
-  private StopTime stopTime(Trip trip, Stop stop, int time, int seq) {
+  private StopTime stopTime(Trip trip, RegularStop stop, int time, int seq) {
     var s = new StopTime();
     s.setTrip(trip);
     s.setStop(stop);

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TestTransitCaseData.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TestTransitCaseData.java
@@ -2,8 +2,8 @@ package org.opentripplanner.routing.algorithm.raptoradapter.transit.request;
 
 import java.time.LocalDate;
 import org.opentripplanner.transit.model._data.TransitModelForTest;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
-import org.opentripplanner.transit.model.site.Stop;
 
 public final class TestTransitCaseData {
 
@@ -16,10 +16,20 @@ public final class TestTransitCaseData {
     .withCoordinate(61.0, 11.5)
     .build();
 
-  public static final Stop STOP_A = TransitModelForTest.stopForTest("A", 60.0, 11.0, STATION_A);
-  public static final Stop STOP_B = TransitModelForTest.stopForTest("B", 60.0, 11.2, STATION_B);
-  public static final Stop STOP_C = TransitModelForTest.stopForTest("C", 61.0, 11.4);
-  public static final Stop STOP_D = TransitModelForTest.stopForTest("D", 61.0, 11.6);
+  public static final RegularStop STOP_A = TransitModelForTest.stopForTest(
+    "A",
+    60.0,
+    11.0,
+    STATION_A
+  );
+  public static final RegularStop STOP_B = TransitModelForTest.stopForTest(
+    "B",
+    60.0,
+    11.2,
+    STATION_B
+  );
+  public static final RegularStop STOP_C = TransitModelForTest.stopForTest("C", 61.0, 11.4);
+  public static final RegularStop STOP_D = TransitModelForTest.stopForTest("D", 61.0, 11.6);
 
   public static final LocalDate DATE = LocalDate.of(2021, 12, 24);
 

--- a/src/test/java/org/opentripplanner/routing/edgetype/StreetTransitEntityLinkTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/StreetTransitEntityLinkTest.java
@@ -20,7 +20,7 @@ import org.opentripplanner.routing.vertextype.TransitStopVertexBuilder;
 import org.opentripplanner.transit.model._data.TransitModelForTest;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.framework.Deduplicator;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.service.StopModel;
 import org.opentripplanner.transit.service.TransitModel;
 
@@ -29,7 +29,7 @@ class StreetTransitEntityLinkTest {
   private static Graph graph;
   private static TransitModel transitModel;
 
-  Stop inaccessibleStop = TransitModelForTest.stopForTest(
+  RegularStop inaccessibleStop = TransitModelForTest.stopForTest(
     "A:inaccessible",
     "wheelchair inaccessible stop",
     10.001,
@@ -37,7 +37,7 @@ class StreetTransitEntityLinkTest {
     null,
     NOT_POSSIBLE
   );
-  Stop accessibleStop = TransitModelForTest.stopForTest(
+  RegularStop accessibleStop = TransitModelForTest.stopForTest(
     "A:accessible",
     "wheelchair accessible stop",
     10.001,
@@ -46,7 +46,7 @@ class StreetTransitEntityLinkTest {
     POSSIBLE
   );
 
-  Stop unknownStop = TransitModelForTest.stopForTest(
+  RegularStop unknownStop = TransitModelForTest.stopForTest(
     "A:unknown",
     "unknown",
     10.001,
@@ -84,7 +84,7 @@ class StreetTransitEntityLinkTest {
     assertNull(afterStrictTraversal);
   }
 
-  private State traverse(Stop stop, boolean onlyAccessible) {
+  private State traverse(RegularStop stop, boolean onlyAccessible) {
     var from = new SimpleVertex(graph, "A", 10, 10);
     var to = new TransitStopVertexBuilder()
       .withGraph(graph)

--- a/src/test/java/org/opentripplanner/routing/graph/RoutingServiceTest.java
+++ b/src/test/java/org/opentripplanner/routing/graph/RoutingServiceTest.java
@@ -15,7 +15,7 @@ import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.organization.Agency;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.timetable.Trip;
 
 /**
@@ -36,7 +36,7 @@ public class RoutingServiceTest extends GtfsTest {
     /* Graph vertices */
     for (Vertex vertex : graph.getVertices()) {
       if (vertex instanceof TransitStopVertex) {
-        Stop stop = ((TransitStopVertex) vertex).getStop();
+        RegularStop stop = ((TransitStopVertex) vertex).getStop();
         Vertex index_vertex = graph.getStopVertexForStopId(stop.getId());
         assertEquals(index_vertex, vertex);
       }
@@ -105,7 +105,7 @@ public class RoutingServiceTest extends GtfsTest {
       SphericalDistanceLibrary.metersToLonDegrees(100, stopJ.getLat()),
       SphericalDistanceLibrary.metersToDegrees(100)
     );
-    Collection<Stop> stops = transitModel.getStopModel().findRegularStops(env);
+    Collection<RegularStop> stops = transitModel.getStopModel().findRegularStops(env);
     assertTrue(stops.contains(stopJ));
     assertTrue(stops.contains(stopL));
     assertTrue(stops.contains(stopM));

--- a/src/test/java/org/opentripplanner/routing/trippattern/FrequencyEntryTest.java
+++ b/src/test/java/org/opentripplanner/routing/trippattern/FrequencyEntryTest.java
@@ -10,7 +10,7 @@ import org.opentripplanner.model.StopTime;
 import org.opentripplanner.transit.model._data.TransitModelForTest;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.timetable.FrequencyEntry;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripTimes;
@@ -29,7 +29,7 @@ public class FrequencyEntryTest {
     for (int i = 0; i < STOP_NUM; ++i) {
       FeedScopedId id = TransitModelForTest.id(i + "");
 
-      Stop stop = TransitModelForTest.stopForTest(id.getId(), 0.0, 0.0);
+      RegularStop stop = TransitModelForTest.stopForTest(id.getId(), 0.0, 0.0);
 
       StopTime stopTime = new StopTime();
       stopTime.setStop(stop);

--- a/src/test/java/org/opentripplanner/routing/trippattern/TripTimesTest.java
+++ b/src/test/java/org/opentripplanner/routing/trippattern/TripTimesTest.java
@@ -11,7 +11,7 @@ import org.opentripplanner.model.StopTime;
 import org.opentripplanner.transit.model._data.TransitModelForTest;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
-import org.opentripplanner.transit.model.site.Stop;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.timetable.RealTimeState;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripTimes;
@@ -50,7 +50,7 @@ public class TripTimesTest {
     for (int i = 0; i < stops.length; ++i) {
       StopTime stopTime = new StopTime();
 
-      Stop stop = TransitModelForTest.stopForTest(stops[i].getId(), 0.0, 0.0);
+      RegularStop stop = TransitModelForTest.stopForTest(stops[i].getId(), 0.0, 0.0);
       stopTime.setStop(stop);
       stopTime.setArrivalTime(i * 60);
       stopTime.setDepartureTime(i * 60);
@@ -149,9 +149,9 @@ public class TripTimesTest {
     StopTime stopTime1 = new StopTime();
     StopTime stopTime2 = new StopTime();
 
-    Stop stop0 = TransitModelForTest.stopForTest(stops[0].getId(), 0.0, 0.0);
-    Stop stop1 = TransitModelForTest.stopForTest(stops[1].getId(), 0.0, 0.0);
-    Stop stop2 = TransitModelForTest.stopForTest(stops[2].getId(), 0.0, 0.0);
+    RegularStop stop0 = TransitModelForTest.stopForTest(stops[0].getId(), 0.0, 0.0);
+    RegularStop stop1 = TransitModelForTest.stopForTest(stops[1].getId(), 0.0, 0.0);
+    RegularStop stop2 = TransitModelForTest.stopForTest(stops[2].getId(), 0.0, 0.0);
 
     stopTime0.setStop(stop0);
     stopTime0.setDepartureTime(0);

--- a/src/test/java/org/opentripplanner/transit/model/_data/TransitModelForTest.java
+++ b/src/test/java/org/opentripplanner/transit/model/_data/TransitModelForTest.java
@@ -13,9 +13,9 @@ import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.network.RouteBuilder;
 import org.opentripplanner.transit.model.network.StopPattern;
 import org.opentripplanner.transit.model.organization.Agency;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
 import org.opentripplanner.transit.model.site.StationBuilder;
-import org.opentripplanner.transit.model.site.Stop;
 import org.opentripplanner.transit.model.site.StopBuilder;
 import org.opentripplanner.transit.model.site.StopTransferPriority;
 import org.opentripplanner.transit.model.timetable.Trip;
@@ -55,7 +55,7 @@ public class TransitModelForTest {
     return Trip.of(id(id)).withRoute(route("R" + id).build());
   }
 
-  public static Stop stopForTest(
+  public static RegularStop stopForTest(
     String idAndName,
     WheelchairAccessibility wheelchair,
     double lat,
@@ -65,26 +65,26 @@ public class TransitModelForTest {
   }
 
   public static StopBuilder stop(String idAndName) {
-    return Stop
+    return RegularStop
       .of(id(idAndName))
       .withName(new NonLocalizedString(idAndName))
       .withCode(idAndName)
       .withCoordinate(new WgsCoordinate(60.0, 10.0));
   }
 
-  public static Stop stopForTest(String idAndName, double lat, double lon) {
+  public static RegularStop stopForTest(String idAndName, double lat, double lon) {
     return stopForTest(idAndName, null, lat, lon, null, NO_INFORMATION);
   }
 
-  public static Stop stopForTest(String idAndName, String desc, double lat, double lon) {
+  public static RegularStop stopForTest(String idAndName, String desc, double lat, double lon) {
     return stopForTest(idAndName, desc, lat, lon, null, NO_INFORMATION);
   }
 
-  public static Stop stopForTest(String idAndName, double lat, double lon, Station parent) {
+  public static RegularStop stopForTest(String idAndName, double lat, double lon, Station parent) {
     return stopForTest(idAndName, null, lat, lon, parent, NO_INFORMATION);
   }
 
-  public static Stop stopForTest(
+  public static RegularStop stopForTest(
     String idAndName,
     String desc,
     double lat,
@@ -94,7 +94,7 @@ public class TransitModelForTest {
     return stopForTest(idAndName, desc, lat, lon, parent, null);
   }
 
-  public static Stop stopForTest(
+  public static RegularStop stopForTest(
     String idAndName,
     String desc,
     double lat,
@@ -102,7 +102,7 @@ public class TransitModelForTest {
     Station parent,
     WheelchairAccessibility wheelchair
   ) {
-    return Stop
+    return RegularStop
       .of(id(idAndName))
       .withName(new NonLocalizedString(idAndName))
       .withCode(idAndName)

--- a/src/test/java/org/opentripplanner/transit/model/_data/TransitModelForTest.java
+++ b/src/test/java/org/opentripplanner/transit/model/_data/TransitModelForTest.java
@@ -14,9 +14,9 @@ import org.opentripplanner.transit.model.network.RouteBuilder;
 import org.opentripplanner.transit.model.network.StopPattern;
 import org.opentripplanner.transit.model.organization.Agency;
 import org.opentripplanner.transit.model.site.RegularStop;
+import org.opentripplanner.transit.model.site.RegularStopBuilder;
 import org.opentripplanner.transit.model.site.Station;
 import org.opentripplanner.transit.model.site.StationBuilder;
-import org.opentripplanner.transit.model.site.StopBuilder;
 import org.opentripplanner.transit.model.site.StopTransferPriority;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripBuilder;
@@ -64,7 +64,7 @@ public class TransitModelForTest {
     return stopForTest(idAndName, null, lat, lon, null, wheelchair);
   }
 
-  public static StopBuilder stop(String idAndName) {
+  public static RegularStopBuilder stop(String idAndName) {
     return RegularStop
       .of(id(idAndName))
       .withName(new NonLocalizedString(idAndName))

--- a/src/test/java/org/opentripplanner/transit/model/site/AreaStopTest.java
+++ b/src/test/java/org/opentripplanner/transit/model/site/AreaStopTest.java
@@ -14,7 +14,7 @@ import org.opentripplanner.transit.model.basic.NonLocalizedString;
 import org.opentripplanner.transit.model.basic.WgsCoordinate;
 import org.opentripplanner.util.geometry.GeometryUtils;
 
-class FlexStopLocationTest {
+class AreaStopTest {
 
   private static final String ID = "1";
   private static final I18NString NAME = new NonLocalizedString("name");
@@ -28,7 +28,7 @@ class FlexStopLocationTest {
 
   private static final WgsCoordinate COORDINATE = new WgsCoordinate(2, 11);
 
-  private static final FlexStopLocation subject = FlexStopLocation
+  private static final AreaStop subject = AreaStop
     .of(TransitModelForTest.id(ID))
     .withName(NAME)
     .withDescription(DESCRIPTION)

--- a/src/test/java/org/opentripplanner/transit/model/site/BoardingAreaTest.java
+++ b/src/test/java/org/opentripplanner/transit/model/site/BoardingAreaTest.java
@@ -17,7 +17,7 @@ class BoardingAreaTest {
   private static final String ID = "1";
   private static final I18NString NAME = new NonLocalizedString("name");
   private static final I18NString DESCRIPTION = new NonLocalizedString("description");
-  private static final Stop PARENT_STOP = TransitModelForTest.stop("stopId").build();
+  private static final RegularStop PARENT_STOP = TransitModelForTest.stop("stopId").build();
 
   private static final BoardingArea subject = BoardingArea
     .of(TransitModelForTest.id(ID))

--- a/src/test/java/org/opentripplanner/transit/model/site/GroupStopTest.java
+++ b/src/test/java/org/opentripplanner/transit/model/site/GroupStopTest.java
@@ -11,7 +11,7 @@ import org.opentripplanner.transit.model._data.TransitModelForTest;
 import org.opentripplanner.transit.model.basic.I18NString;
 import org.opentripplanner.transit.model.basic.NonLocalizedString;
 
-class FlexLocationGroupTest {
+class GroupStopTest {
 
   private static final String ID = "1";
   private static final I18NString NAME = new NonLocalizedString("name");
@@ -21,7 +21,7 @@ class FlexLocationGroupTest {
     1d,
     1d
   );
-  private static final FlexLocationGroup subject = FlexLocationGroup
+  private static final GroupStop subject = GroupStop
     .of(TransitModelForTest.id(ID))
     .withName(NAME)
     .addLocation(STOP_LOCATION)

--- a/src/test/java/org/opentripplanner/transit/model/site/PathwayTest.java
+++ b/src/test/java/org/opentripplanner/transit/model/site/PathwayTest.java
@@ -20,7 +20,7 @@ class PathwayTest {
     .of(TransitModelForTest.id("1:node"))
     .withCoordinate(new WgsCoordinate(20, 30))
     .build();
-  private static final Stop TO = TransitModelForTest.stop("1:stop").build();
+  private static final RegularStop TO = TransitModelForTest.stop("1:stop").build();
   public static final int TRAVERSAL_TIME = 120;
 
   private final Pathway subject = Pathway

--- a/src/test/java/org/opentripplanner/transit/model/site/RegularStopTest.java
+++ b/src/test/java/org/opentripplanner/transit/model/site/RegularStopTest.java
@@ -16,7 +16,7 @@ import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.basic.WgsCoordinate;
 import org.opentripplanner.transit.model.basic.WheelchairAccessibility;
 
-class StopTest {
+class RegularStopTest {
 
   private static final String ID = "1";
   private static final I18NString NAME = new NonLocalizedString("name");
@@ -34,7 +34,7 @@ class StopTest {
   public static final ZoneId TIME_ZONE = ZoneId.of(TransitModelForTest.TIME_ZONE_ID);
   private static final String PLATFORM_CODE = "platformCode";
 
-  private static final Stop subject = Stop
+  private static final RegularStop subject = RegularStop
     .of(TransitModelForTest.id(ID))
     .withName(NAME)
     .withDescription(DESCRIPTION)

--- a/src/test/java/org/opentripplanner/transit/service/StopModelTest.java
+++ b/src/test/java/org/opentripplanner/transit/service/StopModelTest.java
@@ -12,8 +12,8 @@ import org.opentripplanner.transit.model.basic.NonLocalizedString;
 import org.opentripplanner.transit.model.basic.WgsCoordinate;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.site.AreaStop;
-import org.opentripplanner.transit.model.site.FlexLocationGroup;
 import org.opentripplanner.transit.model.site.GroupOfStations;
+import org.opentripplanner.transit.model.site.GroupStop;
 import org.opentripplanner.transit.model.site.MultiModalStation;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
@@ -47,10 +47,7 @@ class StopModelTest {
     .withName(NAME)
     .withGeometry(GEOMETRY)
     .build();
-  private static final FlexLocationGroup STOP_GROUP = FlexLocationGroup
-    .of(ID)
-    .addLocation(STOP)
-    .build();
+  private static final GroupStop STOP_GROUP = GroupStop.of(ID).addLocation(STOP).build();
   private static final MultiModalStation MM_STATION = MultiModalStation
     .of(ID)
     .withName(NAME)
@@ -68,7 +65,7 @@ class StopModelTest {
 
   @Test
   void testStop() {
-    var m = StopModel.of().withStop(STOP).build();
+    var m = StopModel.of().withRegularStop(STOP).build();
     assertEquals(STOP, m.getRegularStop(ID));
     assertEquals(STOP, m.getStopLocation(ID));
     assertEquals(EXP_STOPS, m.listRegularStops().toString());
@@ -76,44 +73,44 @@ class StopModelTest {
     assertEquals(COOR_A, m.stopLocationCenter().orElseThrow());
     assertEquals(STOP, m.stopByIndex(STOP.getIndex()));
     assertEquals(COOR_A, m.getCoordinateById(ID));
-    assertFalse(m.hasFlexLocations());
+    assertFalse(m.hasAreaStops());
   }
 
   @Test
   void testAreaStop() {
-    var m = StopModel.of().withFlexStop(STOP_AREA).build();
-    assertEquals(STOP_AREA, m.getFlexStopById(ID));
+    var m = StopModel.of().withAreaStop(STOP_AREA).build();
+    assertEquals(STOP_AREA, m.getAreaStop(ID));
     assertEquals(STOP_AREA, m.getStopLocation(ID));
-    assertEquals("[AreaStop{F:A Name}]", m.getAllFlexLocations().toString());
+    assertEquals("[AreaStop{F:A Name}]", m.listAreaStops().toString());
     assertEquals("[AreaStop{F:A Name}]", m.listStopLocations().toString());
     assertEquals(STOP_AREA, m.stopByIndex(STOP_AREA.getIndex()));
     assertEquals(COOR_A, m.stopLocationCenter().orElseThrow());
     assertEquals(COOR_A, m.getCoordinateById(ID));
-    assertTrue(m.hasFlexLocations());
+    assertTrue(m.hasAreaStops());
   }
 
   @Test
   void testStopGroup() {
-    var m = StopModel.of().withFlexStopGroup(STOP_GROUP).build();
-    assertEquals("[FlexLocationGroup{F:A}]", m.getAllFlexStopGroups().toString());
-    assertEquals("[FlexLocationGroup{F:A}]", m.listStopLocations().toString());
+    var m = StopModel.of().withGroupStop(STOP_GROUP).build();
+    assertEquals("[GroupStop{F:A}]", m.listGroupStops().toString());
+    assertEquals("[GroupStop{F:A}]", m.listStopLocations().toString());
     assertEquals(STOP_GROUP, m.stopByIndex(STOP_GROUP.getIndex()));
     assertEquals(COOR_A, m.stopLocationCenter().orElseThrow());
     assertEquals(COOR_A, m.getCoordinateById(ID));
-    assertFalse(m.hasFlexLocations());
+    assertFalse(m.hasAreaStops());
   }
 
   @Test
   void testStations() {
     var m = StopModel.of().withStation(STATION).build();
     assertEquals(STATION, m.getStationById(ID));
-    assertEquals(EXP_STATIONS, m.getStations().toString());
+    assertEquals(EXP_STATIONS, m.listStations().toString());
     assertEquals(STATION, m.getStopLocationsGroup(ID));
-    assertEquals(EXP_STOPS, m.getStopOrChildStops(ID).toString());
+    assertEquals(EXP_STOPS, m.findStopOrChildStops(ID).toString());
     assertEquals(EXP_STATIONS, m.listStopLocationGroups().toString());
     assertEquals(COOR_B, m.getCoordinateById(ID));
     assertTrue(m.stopLocationCenter().isEmpty());
-    assertFalse(m.hasFlexLocations());
+    assertFalse(m.hasAreaStops());
   }
 
   @Test
@@ -121,24 +118,24 @@ class StopModelTest {
     var m = StopModel.of().withMultiModalStation(MM_STATION).build();
     assertEquals(MM_STATION, m.getMultiModalStation(ID));
     assertEquals(MM_STATION, m.getMultiModalStationForStation(STATION));
-    assertEquals(EXP_MM_STATIONS, m.getAllMultiModalStations().toString());
+    assertEquals(EXP_MM_STATIONS, m.listMultiModalStations().toString());
     assertEquals(MM_STATION, m.getStopLocationsGroup(ID));
-    assertEquals(EXP_STOPS, m.getStopOrChildStops(ID).toString());
+    assertEquals(EXP_STOPS, m.findStopOrChildStops(ID).toString());
     assertEquals(EXP_MM_STATIONS, m.listStopLocationGroups().toString());
     assertEquals(COOR_B, m.getCoordinateById(ID));
     assertTrue(m.stopLocationCenter().isEmpty());
-    assertFalse(m.hasFlexLocations());
+    assertFalse(m.hasAreaStops());
   }
 
   @Test
   void testGroupOfStations() {
     var m = StopModel.of().withGroupOfStation(GROUP_OF_STATIONS).build();
-    assertEquals(EXP_GROUP_OF_STATION, m.getAllGroupOfStations().toString());
+    assertEquals(EXP_GROUP_OF_STATION, m.listGroupOfStations().toString());
     assertEquals(GROUP_OF_STATIONS, m.getStopLocationsGroup(ID));
-    assertEquals(EXP_STOPS, m.getStopOrChildStops(ID).toString());
+    assertEquals(EXP_STOPS, m.findStopOrChildStops(ID).toString());
     assertEquals(EXP_GROUP_OF_STATION, m.listStopLocationGroups().toString());
     assertEquals(COOR_B, m.getCoordinateById(ID));
     assertTrue(m.stopLocationCenter().isEmpty());
-    assertFalse(m.hasFlexLocations());
+    assertFalse(m.hasAreaStops());
   }
 }

--- a/src/test/java/org/opentripplanner/transit/service/StopModelTest.java
+++ b/src/test/java/org/opentripplanner/transit/service/StopModelTest.java
@@ -15,8 +15,8 @@ import org.opentripplanner.transit.model.site.FlexLocationGroup;
 import org.opentripplanner.transit.model.site.FlexStopLocation;
 import org.opentripplanner.transit.model.site.GroupOfStations;
 import org.opentripplanner.transit.model.site.MultiModalStation;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
-import org.opentripplanner.transit.model.site.Stop;
 import org.opentripplanner.util.geometry.GeometryUtils;
 
 class StopModelTest {
@@ -35,7 +35,7 @@ class StopModelTest {
     .build();
   private static final String EXP_STATIONS = List.of(STATION).toString();
 
-  private static final Stop STOP = Stop
+  private static final RegularStop STOP = RegularStop
     .of(ID)
     .withCoordinate(COOR_A)
     .withName(NAME)

--- a/src/test/java/org/opentripplanner/transit/service/StopModelTest.java
+++ b/src/test/java/org/opentripplanner/transit/service/StopModelTest.java
@@ -11,8 +11,8 @@ import org.opentripplanner.transit.model._data.TransitModelForTest;
 import org.opentripplanner.transit.model.basic.NonLocalizedString;
 import org.opentripplanner.transit.model.basic.WgsCoordinate;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.model.site.AreaStop;
 import org.opentripplanner.transit.model.site.FlexLocationGroup;
-import org.opentripplanner.transit.model.site.FlexStopLocation;
 import org.opentripplanner.transit.model.site.GroupOfStations;
 import org.opentripplanner.transit.model.site.MultiModalStation;
 import org.opentripplanner.transit.model.site.RegularStop;
@@ -42,7 +42,7 @@ class StopModelTest {
     .withParentStation(STATION)
     .build();
   private static final String EXP_STOPS = List.of(STOP).toString();
-  private static final FlexStopLocation STOP_AREA = FlexStopLocation
+  private static final AreaStop STOP_AREA = AreaStop
     .of(ID)
     .withName(NAME)
     .withGeometry(GEOMETRY)
@@ -80,12 +80,12 @@ class StopModelTest {
   }
 
   @Test
-  void testStopArea() {
+  void testAreaStop() {
     var m = StopModel.of().withFlexStop(STOP_AREA).build();
     assertEquals(STOP_AREA, m.getFlexStopById(ID));
     assertEquals(STOP_AREA, m.getStopLocation(ID));
-    assertEquals("[FlexStopLocation{F:A Name}]", m.getAllFlexLocations().toString());
-    assertEquals("[FlexStopLocation{F:A Name}]", m.listStopLocations().toString());
+    assertEquals("[AreaStop{F:A Name}]", m.getAllFlexLocations().toString());
+    assertEquals("[AreaStop{F:A Name}]", m.listStopLocations().toString());
     assertEquals(STOP_AREA, m.stopByIndex(STOP_AREA.getIndex()));
     assertEquals(COOR_A, m.stopLocationCenter().orElseThrow());
     assertEquals(COOR_A, m.getCoordinateById(ID));


### PR DESCRIPTION
### Summary

This PR refactor the class names in the Stop model according to the list in #4371 . It also cleanup method names, doc and other related stuff for theses classes.

A few methods are changed. There were a few methods returning StopLocation, but did only get RegularStop, like the 
```Java
 public StopLocation getRegularStop(FeedScopedId id) 

 public RegularStop getRegularStop(FeedScopedId id)
```
(TransitService)


### Issue

Part of #4002

### Unit tests

Pure refactoring, all tests still run.


### Documentation

JavaDoc updated, not other doc.

### Serialization id
Not sure if changing class names require the serialization id to be bumped - but I do it to be safe.
