### PR TITLE
Otp doc update

### DIFF
--- a/CODE_CONVENTIONS.md
+++ b/CODE_CONVENTIONS.md
@@ -12,33 +12,55 @@ These conventions are not "hard" rules, and often there might be other forces wh
 decision in another direction, in that case documenting your choice is often enough to pass the
 review.
 
-
-
 ## Best practices - in focus
-
-
 
 - [ ] Document `public` interfaces, classes and methods - especially those part of a module api.
 - [ ] Leave Things BETTER than you found them - clean up code you visit or/and add unit tests.
 - [ ] [Feature envy](https://refactoring.guru/smells/feature-envy)
-- [ ] Make types immutable if possible. References to other Entities might need to be mutable, if 
-      so try to init them once, and throw an exception if set again. 
+- [ ] Make types immutable if possible. References to other Entities might need to be mutable, if
+      so try to init them once, and throw an exception if set again.
       Example:
-```java 
-Builder initStop(Stop stop) { 
+
+```java
+Builder initStop(Stop stop) {
    this.stop = requireNotInitialized(this.stop, stop);
 }
-``` 
-
+```
 
 ## Naming Conventions
+
+### Packages
+
+Try to arrange code by domain functionality, not technology. The main structure of a package should
+be `org.opentripplanner.<domain>.<component>.<sub-component>`.
+
+| Package                         | Description                                                                                                                                                                                              |
+| ------------------------------- |----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `o.o.<domain>`                  | At the top level we should divide OTP into "domain"s like `apis`, `framework`, `transit`, `street`, `astar`, `raptor`, `feeds`, `updators`, and `application`.                                           |
+| `component` and `sub-component` | A group of packages/classes witch naturally belong together, think aggregate as in Domain Driven Design.                                                                                                 |
+| `component.api`                 | Used for components to define the programing interface for the component. If present, (see Raptor) all outside dependencies to the component should be through the `api`.                                |
+| `component.model`               | Used to create a model of a Entites, ValueObjects, ++. If exposed outside the component you should include an entry point like `xyz.model.XyzModel` and/or a Service (in api or component root package). |
+| `component.service`             | Implementation of the service like `DefaultTransitService`, may also contain use-case specific code. Note, the Service interface goes into the component root or `api`, not in the service package.      |
+| `component.configure`           | Component creation/orchestration. Put Dependency Injection code here, like the Dagger Module.                                                                                                            |
+| `support`                       | Sometimes domain logic get complicated, then extracting/isolating it helps. `support` is used internally in a component, not outside.                                                                    |
+| `framework`                     | (Abstract) building blocks internal to a domain/parent package. In some cases accessed outside the component, e.g. `OptAppException`, `TransitEntity`.                                                   |
+| `mapping`                       | Map between two domains/components.                                                                                                                                                                      |
+| `util`                          | General "util" functionality, often characterized by `static` methods. Dependencies to other OTP packages is NOT allowed, only 3rd party utils libs.                                                     |
+| `o.o.apis`                      | OTP external endpoints. Note! Many apis are in the Sandbox where they are in the `o.o.ext` package.                                                                                                      |
+
+> **Note!** The above is the goal, the current package structure needs cleanup. 
+
+> **Note!** Util methods depending on an OTP type/component should go into that type/component, not in the
+utils class. E.g. static factory methods. Warning the "pure" utilities right now are placed into 
+sub-packages of `o.o.util`, the root package needs cleanup.
+
 
 ### Methods
 
 Here are a list of common prefixes used, and what to expect.
 
 | Good method prefixes                                  | Description                                                                 |
-|-------------------------------------------------------|-----------------------------------------------------------------------------|
+| ----------------------------------------------------- | --------------------------------------------------------------------------- |
 | `stop() : Stop`                                       | Field accessor, equivalent to `getStop` as in the Java Bean standard        |
 | `getStop(ID id) : Stop`                               | Get Stop by ID, throws exception if not found                               |
 | `getStops(Collection<ID> id) : List/Collection<Stop>` | Get ALL Stops by set of IDs, throws exception if not found                  |
@@ -49,19 +71,18 @@ Here are a list of common prefixes used, and what to expect.
 | `initStop(Stop stop) : void/Builder`                  | Set property ONCE, a second call throws an exception                        |
 | `addStops(Collection<Stop> stops) : void/Builder`     | add set of stops to existing set, consider using a builder                  |
 
-
 These prefixes are also "allowed", but not preferred - they have some kind of negative "force" to them.
 
 | Ok method prefixes, but ...                 | Description                                                                                           |
-|---------------------------------------------|-------------------------------------------------------------------------------------------------------|
+| ------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
 | `withStops(Collection<Stop> stops) : this`) | Replace all stops in builder with new set, consider using `addStops(...)` instead                     |
 | `addStop(Stop stop) : void`                 | Add a stop to collection, consider using a builder instead                                            |
 | `setStop(Stop stop)`                        | Set a mutable stop reference. Avoid if not part of natural lifecycle. Use `initStop(...)` if possible |
 | `getStop() : Stop`                          | Old style accessor, use the shorter form `stop() : Stop`                                              |
 
+### Services, Models, Editors and Builders
 
-###  Services, Models, Editors and Builders 
-Naming convention for builders with and without a context. 
+Naming convention for builders with and without a context.
 
 ##### Graph Build and tests run without a context
 
@@ -74,4 +95,5 @@ stop = stop.copyOf().withPrivateCode("TEX").build();
 ```
 
 #### Updaters run with a context(editor)
+
 TODO See issue 4002 - Document when implemented

--- a/CODE_CONVENTIONS.md
+++ b/CODE_CONVENTIONS.md
@@ -36,7 +36,7 @@ be `org.opentripplanner.<domain>.<component>.<sub-component>`.
 
 | Package                         | Description                                                                                                                                                                                              |
 | ------------------------------- |----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `o.o.<domain>`                  | At the top level we should divide OTP into "domain"s like `apis`, `framework`, `transit`, `street`, `astar`, `raptor`, `feeds`, `updators`, and `application`.                                           |
+| `o.o.<domain>`                  | At the top level we should divide OTP into "domain"s like `apis`, `framework`, `transit`, `street`, `astar`, `raptor`, `feeds`, `updaters`, and `application`.                                           |
 | `component` and `sub-component` | A group of packages/classes witch naturally belong together, think aggregate as in Domain Driven Design.                                                                                                 |
 | `component.api`                 | Used for components to define the programing interface for the component. If present, (see Raptor) all outside dependencies to the component should be through the `api`.                                |
 | `component.model`               | Used to create a model of a Entites, ValueObjects, ++. If exposed outside the component you should include an entry point like `xyz.model.XyzModel` and/or a Service (in api or component root package). |

--- a/CODE_CONVENTIONS.md
+++ b/CODE_CONVENTIONS.md
@@ -60,3 +60,18 @@ These prefixes are also "allowed", but not preferred - they have some kind of ne
 | `getStop() : Stop`                          | Old style accessor, use the shorter form `stop() : Stop`                                              |
 
 
+###  Services, Models, Editors and Builders 
+Naming convention for builders with and without a context. 
+
+##### Graph Build and tests run without a context
+
+```Java
+// Create a new Stop
+trip = Trip.of(id).withName("The Express").build();
+
+// Modify and existing stop
+stop = stop.copyOf().withPrivateCode("TEX").build();
+```
+
+#### Updaters run with a context(editor)
+TODO See issue 4002 - Document when implemented

--- a/docs/sandbox/SiriUpdator.md
+++ b/docs/sandbox/SiriUpdator.md
@@ -26,7 +26,7 @@ the [Norwegian SIRI profile](https://enturas.atlassian.net/wiki/spaces/PUBLIC/pa
 
 ### Configuration
 
-To enable the SIRI updator you need to add it to the updators section of the `router-config.json`.
+To enable the SIRI updator you need to add it to the updaters section of the `router-config.json`.
 
 ```
 {


### PR DESCRIPTION
### Summary

This PR updates the naming conventions for builder (discussed in yesterdays dev meeting) and package structure described in issue #4285.


### Issue

Document the package naming convention part of #4285. I will update the issue, referencing the code conventions after this PR is merged. 


### Unit tests

No.

### Documentation

Yes.
