### PR TITLE
Add support to unprefer certain modes

### DIFF
--- a/docs/RouterConfiguration.md
+++ b/docs/RouterConfiguration.md
@@ -185,6 +185,20 @@ multiplier for transit leg  travel time `x` (in seconds). Example configuration:
 }
 ```
 
+## Unpreferred transit modes
+Routing engine can be configured to define unpreferred transit modes by adding penalty. This is
+configured in `router-config.json` setting list of modes and a linear cost function. The function
+is defined as linear function of the form A + B x, where A is a fixed cost (in seconds) and B is
+reluctance multiplier for transit leg travel time x (in seconds). Example configuration:
+````JSON
+// router-config.json
+"routingDefaults": {
+"unpreferredModeCost": "840 + 1.5 x",
+"unpreferredModes": ["RAIL", "BUS"]
+}
+````
+
+
 ## Timeout
 
 In OTP1 path searches sometimes toke a long time to complete. With the new Raptor algorithm this not

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/cost/CostCalculatorFactory.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/cost/CostCalculatorFactory.java
@@ -21,7 +21,16 @@ public class CostCalculatorFactory {
         new RouteCostCalculator(
           calculator,
           mcCostParams.unpreferredRoutes(),
-          mcCostParams.unnpreferredCost()
+          mcCostParams.unpreferredCost()
+        );
+    }
+
+    if (!mcCostParams.unpreferredModes().isEmpty()) {
+      calculator =
+        new UnpreferredModesCostCalculator(
+          calculator,
+          mcCostParams.unpreferredModes(),
+          mcCostParams.unpreferredModesCost()
         );
     }
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/cost/DefaultTripSchedule.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/cost/DefaultTripSchedule.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.routing.algorithm.raptoradapter.transit.cost;
 
+import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.basic.WheelchairAccessibility;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
@@ -21,4 +22,10 @@ public interface DefaultTripSchedule extends RaptorTripSchedule {
    * give unpreferred routes or agencies a generalized-cost penalty.
    */
   FeedScopedId routeId();
+
+  /**
+   * This is not used by the default calculatorm but by the {@link UnpreferredModesCostCalculator} to
+   * give unpreferred modes a generalized-cost penalty
+   */
+  TransitMode transitMode();
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/cost/McCostParams.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/cost/McCostParams.java
@@ -7,6 +7,7 @@ import javax.annotation.Nullable;
 import org.opentripplanner.routing.api.request.RequestFunctions;
 import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.api.request.WheelchairAccessibilityRequest;
+import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
 import org.opentripplanner.util.lang.ToStringBuilder;
@@ -28,6 +29,8 @@ public class McCostParams {
   private final WheelchairAccessibilityRequest accessibilityRequest;
   private final Set<FeedScopedId> unpreferredRoutes;
   private final DoubleFunction<Double> unpreferredCost;
+  private final Set<TransitMode> unpreferredModes;
+  private final DoubleFunction<Double> unpreferredModesCost;
 
   /**
    * Default constructor defines default values. These defaults are overridden by defaults in the
@@ -41,6 +44,9 @@ public class McCostParams {
     this.accessibilityRequest = WheelchairAccessibilityRequest.DEFAULT;
     this.unpreferredRoutes = Set.of();
     this.unpreferredCost = RequestFunctions.createLinearFunction(0.0, DEFAULT_TRANSIT_RELUCTANCE);
+    this.unpreferredModes = Set.of();
+    this.unpreferredModesCost =
+      RequestFunctions.createLinearFunction(0.0, DEFAULT_TRANSIT_RELUCTANCE);
   }
 
   McCostParams(McCostParamsBuilder builder) {
@@ -51,6 +57,8 @@ public class McCostParams {
     this.accessibilityRequest = builder.wheelchairAccessibility();
     this.unpreferredRoutes = builder.unpreferredRoutes();
     this.unpreferredCost = builder.unpreferredCost();
+    this.unpreferredModes = builder.unpreferredModes();
+    this.unpreferredModesCost = builder.unpreferredModesCost();
   }
 
   public int boardCost() {
@@ -89,8 +97,16 @@ public class McCostParams {
     return unpreferredRoutes;
   }
 
-  public DoubleFunction<Double> unnpreferredCost() {
+  public DoubleFunction<Double> unpreferredCost() {
     return unpreferredCost;
+  }
+
+  public Set<TransitMode> unpreferredModes() {
+    return unpreferredModes;
+  }
+
+  public DoubleFunction<Double> unpreferredModesCost() {
+    return unpreferredModesCost;
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/cost/McCostParamsBuilder.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/cost/McCostParamsBuilder.java
@@ -3,6 +3,7 @@ package org.opentripplanner.routing.algorithm.raptoradapter.transit.cost;
 import java.util.Set;
 import java.util.function.DoubleFunction;
 import org.opentripplanner.routing.api.request.WheelchairAccessibilityRequest;
+import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 
 /**
@@ -18,6 +19,8 @@ public class McCostParamsBuilder {
   private WheelchairAccessibilityRequest accessibilityRequest;
   private Set<FeedScopedId> unpreferredRoutes;
   private DoubleFunction<Double> unpreferredCost;
+  private Set<TransitMode> unpreferredModes;
+  private DoubleFunction<Double> unpreferredModesCost;
 
   public McCostParamsBuilder() {
     this(McCostParams.DEFAULTS);
@@ -30,6 +33,8 @@ public class McCostParamsBuilder {
     this.waitReluctanceFactor = other.waitReluctanceFactor();
     this.accessibilityRequest = other.accessibilityRequirements();
     this.unpreferredRoutes = other.unpreferredRoutes();
+    this.unpreferredModes = other.unpreferredModes();
+    this.unpreferredModesCost = other.unpreferredModesCost();
   }
 
   public int boardCost() {
@@ -92,6 +97,24 @@ public class McCostParamsBuilder {
 
   public McCostParamsBuilder unpreferredCost(DoubleFunction<Double> unpreferredCost) {
     this.unpreferredCost = unpreferredCost;
+    return this;
+  }
+
+  public Set<TransitMode> unpreferredModes() {
+    return unpreferredModes;
+  }
+
+  public McCostParamsBuilder unpreferredModes(Set<TransitMode> unpreferredModes) {
+    this.unpreferredModes = unpreferredModes;
+    return this;
+  }
+
+  public DoubleFunction<Double> unpreferredModesCost() {
+    return unpreferredModesCost;
+  }
+
+  public McCostParamsBuilder unpreferredModesCost(DoubleFunction<Double> unpreferredModesCost) {
+    this.unpreferredModesCost = unpreferredModesCost;
     return this;
   }
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/cost/UnpreferredModesCostCalculator.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/cost/UnpreferredModesCostCalculator.java
@@ -1,0 +1,93 @@
+package org.opentripplanner.routing.algorithm.raptoradapter.transit.cost;
+
+import java.util.Set;
+import java.util.function.DoubleFunction;
+import javax.annotation.Nonnull;
+import org.opentripplanner.transit.model.basic.TransitMode;
+import org.opentripplanner.transit.raptor.api.transit.CostCalculator;
+import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
+import org.opentripplanner.transit.raptor.api.transit.RaptorTransferConstraint;
+
+/**
+ * Cost calculator for {@link TransitMode}(s) that have been configured to be unpreferred.
+ */
+public class UnpreferredModesCostCalculator<T extends DefaultTripSchedule>
+  implements CostCalculator<T> {
+
+  private CostCalculator<T> delegate;
+  private Set<TransitMode> unpreferredModes;
+  private DoubleFunction<Double> unpreferredModesCost;
+
+  public UnpreferredModesCostCalculator(
+    @Nonnull CostCalculator<T> delegate,
+    Set<TransitMode> unpreferredModes,
+    DoubleFunction<Double> unpreferredModesCost
+  ) {
+    this.delegate = delegate;
+    this.unpreferredModes = unpreferredModes;
+    this.unpreferredModesCost = unpreferredModesCost;
+  }
+
+  @Override
+  public int boardingCost(
+    boolean firstBoarding,
+    int prevArrivalTime,
+    int boardStop,
+    int boardTime,
+    T trip,
+    RaptorTransferConstraint transferConstraints
+  ) {
+    return delegate.boardingCost(
+      firstBoarding,
+      prevArrivalTime,
+      boardStop,
+      boardTime,
+      trip,
+      transferConstraints
+    );
+  }
+
+  @Override
+  public int onTripRelativeRidingCost(int boardTime, T tripScheduledBoarded) {
+    return delegate.onTripRelativeRidingCost(boardTime, tripScheduledBoarded);
+  }
+
+  @Override
+  public int transitArrivalCost(
+    int boardCost,
+    int alightSlack,
+    int transitTime,
+    T trip,
+    int toStop
+  ) {
+    var defaultCost = delegate.transitArrivalCost(
+      boardCost,
+      alightSlack,
+      transitTime,
+      trip,
+      toStop
+    );
+    var mode = trip.transitMode();
+    if (unpreferredModes.contains(mode)) {
+      return (
+        defaultCost + RaptorCostConverter.toRaptorCost(unpreferredModesCost.apply(transitTime))
+      );
+    }
+    return defaultCost;
+  }
+
+  @Override
+  public int waitCost(int waitTimeInSeconds) {
+    return delegate.waitCost(waitTimeInSeconds);
+  }
+
+  @Override
+  public int calculateMinCost(int minTravelTime, int minNumTransfers) {
+    return delegate.calculateMinCost(minTravelTime, minNumTransfers);
+  }
+
+  @Override
+  public int costEgress(RaptorTransfer egress) {
+    return delegate.costEgress(egress);
+  }
+}

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/frequency/FrequencyAlightEvent.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/frequency/FrequencyAlightEvent.java
@@ -2,6 +2,7 @@ package org.opentripplanner.routing.algorithm.raptoradapter.transit.frequency;
 
 import java.time.LocalDate;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.cost.DefaultTripSchedule;
+import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.timetable.TripTimes;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripPattern;
@@ -43,5 +44,10 @@ final class FrequencyAlightEvent<T extends DefaultTripSchedule>
   @Override
   public int departure(int stopPosInPattern) {
     return tripTimes.getDepartureTime(stopPosInPattern) - headway + offset;
+  }
+
+  @Override
+  public TransitMode transitMode() {
+    return pattern.getMode();
   }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/frequency/FrequencyBoardingEvent.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/frequency/FrequencyBoardingEvent.java
@@ -2,6 +2,7 @@ package org.opentripplanner.routing.algorithm.raptoradapter.transit.frequency;
 
 import java.time.LocalDate;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.cost.DefaultTripSchedule;
+import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.timetable.TripTimes;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripPattern;
@@ -43,5 +44,10 @@ final class FrequencyBoardingEvent<T extends DefaultTripSchedule>
   @Override
   public int departure(int stopPosInPattern) {
     return tripTimes.getDepartureTime(stopPosInPattern) + offset;
+  }
+
+  @Override
+  public TransitMode transitMode() {
+    return pattern.getMode();
   }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/McCostParamsMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/McCostParamsMapper.java
@@ -28,6 +28,9 @@ public class McCostParamsMapper {
     builder.unpreferredRoutes(request.unpreferredRoutes.stream().collect(Collectors.toSet()));
     builder.unpreferredCost(request.unpreferredRouteCost);
 
+    builder.unpreferredModes(request.unpreferredModes);
+    builder.unpreferredModesCost(request.unpreferredModeCost);
+
     return builder.build();
   }
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripScheduleWithOffset.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripScheduleWithOffset.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.function.IntUnaryOperator;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripPatternForDate;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripSchedule;
+import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.basic.WheelchairAccessibility;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.TripPattern;
@@ -82,6 +83,11 @@ public final class TripScheduleWithOffset implements TripSchedule {
   @Override
   public FeedScopedId routeId() {
     return routeId;
+  }
+
+  @Override
+  public TransitMode transitMode() {
+    return pattern.getTripPattern().getPattern().getMode();
   }
 
   /*

--- a/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
@@ -684,6 +684,19 @@ public class RoutingRequest implements Cloneable, Serializable {
    */
   public Set<RoutingTag> tags = Set.of();
 
+  /**
+   * Set of TransitModes that should have a penalty cost added to them during routing
+   */
+  public Set<TransitMode> unpreferredModes = Set.of();
+
+  /**
+   * The function applying a penalty cost to unpreferred TransitModes
+   */
+  public DoubleFunction<Double> unpreferredModeCost = RequestFunctions.createLinearFunction(
+    0.0,
+    DEFAULT_ROUTE_RELUCTANCE
+  );
+
   private Envelope fromEnvelope;
 
   private Envelope toEnvelope;

--- a/src/main/java/org/opentripplanner/standalone/config/RoutingRequestMapper.java
+++ b/src/main/java/org/opentripplanner/standalone/config/RoutingRequestMapper.java
@@ -135,6 +135,9 @@ public class RoutingRequestMapper {
         "useVehicleParkingAvailabilityInformation",
         dft.useVehicleParkingAvailabilityInformation
       );
+    request.unpreferredModes = c.asEnumSet("unpreferredModes", TransitMode.class);
+    request.unpreferredModeCost =
+      c.asLinearFunction("unpreferredModeCost", dft.unpreferredModeCost);
     request.unpreferredRouteCost =
       c.asLinearFunction("unpreferredRouteCost", dft.unpreferredRouteCost);
     request.vehicleRental = c.asBoolean("allowBikeRental", dft.vehicleRental);

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/cost/RouteCostCalculatorTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/cost/RouteCostCalculatorTest.java
@@ -81,7 +81,7 @@ public class RouteCostCalculatorTest {
 
     // test creation of linear cost function
     double expected = (double) 300 + 1.0 * TRANSIT_TIME;
-    double actual = costParams.unnpreferredCost().apply(TRANSIT_TIME);
+    double actual = costParams.unpreferredCost().apply(TRANSIT_TIME);
 
     assertEquals(expected, actual);
   }

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/cost/UnpreferredModeCostCalculatorTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/cost/UnpreferredModeCostCalculatorTest.java
@@ -1,0 +1,86 @@
+package org.opentripplanner.routing.algorithm.raptoradapter.transit.cost;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Set;
+import java.util.function.DoubleFunction;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.routing.api.request.RequestFunctions;
+import org.opentripplanner.transit.model.basic.TransitMode;
+import org.opentripplanner.transit.raptor._data.transit.TestTripPattern;
+import org.opentripplanner.transit.raptor._data.transit.TestTripSchedule;
+
+public class UnpreferredModeCostCalculatorTest {
+
+  private static final int BOARD_COST_SEC = 5;
+  private static final int TRANSFER_COST_SEC = 2;
+  private static final double WAIT_RELUCTANCE_FACTOR = 0.5;
+  private static final double TRANSIT_RELUCTANCE_FACTOR_1 = 1.0;
+  private static final double TRANSIT_RELUCTANCE_FACTOR_2 = 0.8;
+  private static final int STOP_A = 0;
+  private static final int STOP_B = 1;
+  private static final int UNPREFERRED_MODE_CONSTANT = 5;
+  private static final double UNPREFERRED_MODE_COEFFICIENT = 0.3;
+
+  private static final DoubleFunction<Double> unprefModeCost = RequestFunctions.createLinearFunction(
+    UNPREFERRED_MODE_CONSTANT,
+    UNPREFERRED_MODE_COEFFICIENT
+  );
+
+  private static final Set<TransitMode> unpreferredModes = Set.of(TransitMode.BUS);
+  private final DefaultCostCalculator defaultCostCalculator = new DefaultCostCalculator(
+    BOARD_COST_SEC,
+    TRANSFER_COST_SEC,
+    WAIT_RELUCTANCE_FACTOR,
+    new double[] { TRANSIT_RELUCTANCE_FACTOR_1, TRANSIT_RELUCTANCE_FACTOR_2 },
+    new int[] { 0, 25 }
+  );
+
+  private final UnpreferredModesCostCalculator subject = new UnpreferredModesCostCalculator(
+    defaultCostCalculator,
+    unpreferredModes,
+    unprefModeCost
+  );
+
+  @Test
+  public void transitArrivalCost() {
+    TestTripSchedule trip = TestTripSchedule
+      .schedule(TestTripPattern.pattern("L31", STOP_A, STOP_B))
+      .arrivals("10:00 10:05")
+      .departures("10:01 10:06")
+      .build();
+
+    assertEquals(
+      RaptorCostConverter.toRaptorCost(UNPREFERRED_MODE_CONSTANT),
+      subject.transitArrivalCost(0, 0, 0, trip, STOP_A),
+      "Unpreferred constant penalty"
+    );
+    assertEquals(1800, subject.transitArrivalCost(0, 0, 10, trip, STOP_A), "Unpreferred mode cost");
+  }
+
+  @Test
+  public void transitArrivalCost_notUnpreferred() {
+    TestTripSchedule trip = TestTripSchedule
+      .schedule(TestTripPattern.pattern("L31", STOP_A, STOP_B))
+      .arrivals("10:00 10:05")
+      .departures("10:01 10:06")
+      .build();
+
+    UnpreferredModesCostCalculator subject = new UnpreferredModesCostCalculator(
+      defaultCostCalculator,
+      Set.of(TransitMode.RAIL),
+      unprefModeCost
+    );
+
+    assertEquals(0, subject.transitArrivalCost(0, 0, 0, trip, STOP_A), "Zero cost");
+    assertEquals(1000, subject.transitArrivalCost(1000, 0, 0, trip, STOP_A), "Board cost");
+    assertEquals(50, subject.transitArrivalCost(0, 1, 0, trip, STOP_A), "Alight wait time cost");
+    assertEquals(100, subject.transitArrivalCost(0, 0, 1, trip, STOP_A), "Transit time cost");
+    assertEquals(25, subject.transitArrivalCost(0, 0, 0, trip, STOP_B), "Alight stop cost");
+    assertEquals(1175, subject.transitArrivalCost(1000, 1, 1, trip, STOP_B), "Total cost");
+    assertEquals(50, subject.transitArrivalCost(0, 1, 0, trip, STOP_A), "Alight wait time cost");
+    assertEquals(100, subject.transitArrivalCost(0, 0, 1, trip, STOP_A), "Transit time cost");
+    assertEquals(25, subject.transitArrivalCost(0, 0, 0, trip, STOP_B), "Alight stop cost");
+    assertEquals(1175, subject.transitArrivalCost(1000, 1, 1, trip, STOP_B), "Total cost");
+  }
+}

--- a/src/test/java/org/opentripplanner/transit/raptor/_data/transit/TestTripSchedule.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/_data/transit/TestTripSchedule.java
@@ -3,6 +3,7 @@ package org.opentripplanner.transit.raptor._data.transit;
 import static org.opentripplanner.transit.model.basic.WheelchairAccessibility.NO_INFORMATION;
 
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.cost.DefaultTripSchedule;
+import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.basic.WheelchairAccessibility;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripPattern;
@@ -26,6 +27,7 @@ public class TestTripSchedule implements DefaultTripSchedule {
   private final int transitReluctanceIndex;
   private final WheelchairAccessibility wheelchairBoarding;
   private final FeedScopedId routeId;
+  private final TransitMode transitMode;
 
   protected TestTripSchedule(
     TestTripPattern pattern,
@@ -33,7 +35,8 @@ public class TestTripSchedule implements DefaultTripSchedule {
     int[] departureTimes,
     int transitReluctanceIndex,
     WheelchairAccessibility wheelchairBoarding,
-    FeedScopedId routeId
+    FeedScopedId routeId,
+    TransitMode transitMode
   ) {
     this.pattern = pattern;
     this.arrivalTimes = arrivalTimes;
@@ -41,6 +44,7 @@ public class TestTripSchedule implements DefaultTripSchedule {
     this.transitReluctanceIndex = transitReluctanceIndex;
     this.wheelchairBoarding = wheelchairBoarding;
     this.routeId = routeId;
+    this.transitMode = transitMode;
   }
 
   public static TestTripSchedule.Builder schedule() {
@@ -91,6 +95,11 @@ public class TestTripSchedule implements DefaultTripSchedule {
     return routeId;
   }
 
+  @Override
+  public TransitMode transitMode() {
+    return transitMode;
+  }
+
   public int size() {
     return arrivalTimes.length;
   }
@@ -120,6 +129,7 @@ public class TestTripSchedule implements DefaultTripSchedule {
     private int transitReluctanceIndex = 0;
     private WheelchairAccessibility wheelchairBoarding = NO_INFORMATION;
     private FeedScopedId routeId;
+    private TransitMode transitMode;
 
     public TestTripSchedule.Builder pattern(TestTripPattern pattern) {
       this.pattern = pattern;
@@ -195,6 +205,11 @@ public class TestTripSchedule implements DefaultTripSchedule {
       return this;
     }
 
+    public TestTripSchedule.Builder transitMode() {
+      this.transitMode = transitMode;
+      return this;
+    }
+
     public TestTripSchedule build() {
       if (arrivalTimes == null) {
         arrivalTimes = copyWithOffset(departureTimes, -arrivalDepartureOffset);
@@ -225,13 +240,19 @@ public class TestTripSchedule implements DefaultTripSchedule {
       if (routeId == null) {
         routeId = new FeedScopedId(DEFAULT_ROUTE_FEED, DEFAULT_ROUTE_ID_STR);
       }
+
+      if (transitMode == null) {
+        transitMode = TransitMode.BUS;
+      }
+
       return new TestTripSchedule(
         pattern,
         arrivalTimes,
         departureTimes,
         transitReluctanceIndex,
         wheelchairBoarding,
-        routeId
+        routeId,
+        transitMode
       );
     }
 


### PR DESCRIPTION
### Summary

Add support for adding a penalty cost during routing to trips using one or more specified TransitModes using a defined linear function.

Configurable in router-config.json as follows:
```json
"routingDefaults": {
   "unpreferredModeCost": "840 + 1.5 x",
   "unpreferredModes": ["RAIL", "BUS"]
}
```

With no modes specified the calculator is not created.

### Unit tests

- Added unit tests for verifying the effects of the penalty cost
- Performance is impacted by this change but only if using the new calculator i.e. configured which modes should be penalized.
