### PR TITLE
Do not crash if PageCursorFactory can't be created

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/RoutingResponseMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/RoutingResponseMapper.java
@@ -77,10 +77,12 @@ public class RoutingResponseMapper {
 
     if (searchParams != null) {
       if (!searchParams.isSearchWindowSet()) {
-        throw new IllegalArgumentException("SearchWindow not set");
+        LOG.debug("SearchWindow not set");
+        return factory;
       }
       if (!searchParams.isEarliestDepartureTimeSet()) {
-        throw new IllegalArgumentException("Earliest departure time not set");
+        LOG.debug("Earliest departure time not set");
+        return factory;
       }
 
       long t0 = transitSearchTimeZero.toEpochSecond();


### PR DESCRIPTION
### Summary

This happens eg. when forward search fails, and no search window/earliest departure time can be set.

### Issue

Related to #4396
