### PR TITLE
Allow parsing of legacy leg references

### DIFF
--- a/src/main/java/org/opentripplanner/model/plan/legreference/LegReferenceSerializer.java
+++ b/src/main/java/org/opentripplanner/model/plan/legreference/LegReferenceSerializer.java
@@ -1,5 +1,9 @@
 package org.opentripplanner.model.plan.legreference;
 
+import static java.time.temporal.ChronoField.DAY_OF_MONTH;
+import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
+import static java.time.temporal.ChronoField.YEAR;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -7,6 +11,8 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.text.ParseException;
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
 import java.util.Base64;
 import javax.annotation.Nullable;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
@@ -19,6 +25,17 @@ import org.slf4j.LoggerFactory;
 public class LegReferenceSerializer {
 
   private static final Logger LOG = LoggerFactory.getLogger(LegReferenceSerializer.class);
+  private static final DateTimeFormatter LENIENT_ISO_LOCAL_DATE = new DateTimeFormatterBuilder()
+    .appendValue(YEAR, 4)
+    .optionalStart()
+    .appendLiteral('-')
+    .optionalEnd()
+    .appendValue(MONTH_OF_YEAR, 2)
+    .optionalStart()
+    .appendLiteral('-')
+    .optionalEnd()
+    .appendValue(DAY_OF_MONTH, 2)
+    .toFormatter();
 
   /** private constructor to prevent instantiating this utility class */
   private LegReferenceSerializer() {}
@@ -83,7 +100,7 @@ public class LegReferenceSerializer {
     throws IOException {
     return new ScheduledTransitLegReference(
       FeedScopedId.parseId(objectInputStream.readUTF()),
-      LocalDate.parse(objectInputStream.readUTF()),
+      LocalDate.parse(objectInputStream.readUTF(), LENIENT_ISO_LOCAL_DATE),
       objectInputStream.readInt(),
       objectInputStream.readInt()
     );

--- a/src/main/java/org/opentripplanner/model/plan/legreference/LegReferenceSerializer.java
+++ b/src/main/java/org/opentripplanner/model/plan/legreference/LegReferenceSerializer.java
@@ -25,6 +25,8 @@ import org.slf4j.LoggerFactory;
 public class LegReferenceSerializer {
 
   private static final Logger LOG = LoggerFactory.getLogger(LegReferenceSerializer.class);
+
+  // TODO: This is for backwards compatibility. Change to use ISO_LOCAL_DATE after OTP v2.2 is released
   private static final DateTimeFormatter LENIENT_ISO_LOCAL_DATE = new DateTimeFormatterBuilder()
     .appendValue(YEAR, 4)
     .optionalStart()

--- a/src/test/java/org/opentripplanner/model/plan/legreference/LegReferenceSerializerTest.java
+++ b/src/test/java/org/opentripplanner/model/plan/legreference/LegReferenceSerializerTest.java
@@ -14,6 +14,8 @@ class LegReferenceSerializerTest {
   private static final int TO_STOP_POS = 3;
   private static final String ENCODED_TOKEN =
     "rO0ABXc2ABhTQ0hFRFVMRURfVFJBTlNJVF9MRUdfVjEABkY6VHJpcAAKMjAyMi0wMS0zMQAAAAEAAAAD";
+  private static final String ENCODED_LEGACY_TOKEN =
+    "rO0ABXc0ABhTQ0hFRFVMRURfVFJBTlNJVF9MRUdfVjEABkY6VHJpcAAIMjAyMjAxMzEAAAABAAAAAw==";
 
   @Test
   void testScheduledTransitLegReferenceRoundTrip() {
@@ -31,6 +33,16 @@ class LegReferenceSerializerTest {
   @Test
   void testScheduledTransitLegReferenceDeserialize() {
     var ref = (ScheduledTransitLegReference) LegReferenceSerializer.decode(ENCODED_TOKEN);
+
+    assertEquals(TRIP_ID, ref.tripId());
+    assertEquals(SERVICE_DATE, ref.serviceDate());
+    assertEquals(FROM_STOP_POS, ref.fromStopPositionInPattern());
+    assertEquals(TO_STOP_POS, ref.toStopPositionInPattern());
+  }
+
+  @Test
+  void testScheduledTransitLegReferenceLegacyDeserialize() {
+    var ref = (ScheduledTransitLegReference) LegReferenceSerializer.decode(ENCODED_LEGACY_TOKEN);
 
     assertEquals(TRIP_ID, ref.tripId());
     assertEquals(SERVICE_DATE, ref.serviceDate());


### PR DESCRIPTION
### Summary

Currently an error is thrown if we receive a leg reference created with an older version of OTP. Fix this by allow lenient paring of service dates.
