### PR TITLE
Performance improvements for DefaultFareServiceImpl

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/fares/impl/DefaultFareServiceImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/impl/DefaultFareServiceImpl.java
@@ -23,6 +23,7 @@ import org.opentripplanner.routing.core.FareRuleSet;
 import org.opentripplanner.routing.core.Money;
 import org.opentripplanner.routing.fares.FareService;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.model.site.FareZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,8 +76,6 @@ class FareAndId {
  * http://groups.google.com/group/gtfs-changes/browse_thread/thread/8a4a48ae1e742517/4f81b826cb732f3b
  */
 public class DefaultFareServiceImpl implements FareService {
-
-  private static final long serialVersionUID = 20120229L;
 
   private static final Logger LOG = LoggerFactory.getLogger(DefaultFareServiceImpl.class);
 
@@ -299,13 +298,13 @@ public class DefaultFareServiceImpl implements FareService {
     var firstRide = legs.get(0);
     ZonedDateTime startTime = firstRide.getStartTime();
     String startZone = firstRide.getFrom().stop.getFirstZoneAsString();
-    String endZone = firstRide.getTo().stop.getFirstZoneAsString();
+    String endZone = null;
     // stops don't really have an agency id, they have the per-feed default id
-    String feedId = firstRide.getFrom().stop.getId().getFeedId();
-    ZonedDateTime lastRideStartTime = firstRide.getStartTime();
-    ZonedDateTime lastRideEndTime = firstRide.getEndTime();
+    String feedId = firstRide.getTrip().getId().getFeedId();
+    ZonedDateTime lastRideStartTime = null;
+    ZonedDateTime lastRideEndTime = null;
     for (var leg : legs) {
-      if (!leg.getFrom().stop.getId().getFeedId().equals(feedId)) {
+      if (!leg.getTrip().getId().getFeedId().equals(feedId)) {
         LOG.debug("skipped multi-feed ride sequence {}", legs);
         return new FareAndId(Float.POSITIVE_INFINITY, null);
       }
@@ -313,8 +312,10 @@ public class DefaultFareServiceImpl implements FareService {
       lastRideEndTime = leg.getEndTime();
       endZone = leg.getTo().stop.getFirstZoneAsString();
       routes.add(leg.getRoute().getId());
-      zones.addAll(leg.getFareZones().stream().map(z -> z.getId().getId()).toList());
       trips.add(leg.getTrip().getId());
+      for (FareZone z : leg.getFareZones()) {
+        zones.add(z.getId().getId());
+      }
       transfersUsed += 1;
     }
 

--- a/src/ext/java/org/opentripplanner/ext/fares/impl/DefaultFareServiceImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/impl/DefaultFareServiceImpl.java
@@ -133,10 +133,6 @@ public class DefaultFareServiceImpl implements FareService {
     return new Money(currency, cents);
   }
 
-  protected float addFares(List<Leg> ride0, List<Leg> ride1, float cost0, float cost1) {
-    return cost0 + cost1;
-  }
-
   protected float getLowestCost(
     FareType fareType,
     List<Leg> rides,
@@ -268,12 +264,7 @@ public class DefaultFareServiceImpl implements FareService {
         r.resultTable[j][j + i] = cost;
         r.fareIds[j][j + i] = best.fareId;
         for (int k = 0; k < i; k++) {
-          float via = addFares(
-            rides.subList(j, j + k + 1),
-            rides.subList(j + k + 1, j + i + 1),
-            r.resultTable[j][j + k],
-            r.resultTable[j + k + 1][j + i]
-          );
+          float via = r.resultTable[j][j + k] + r.resultTable[j + k + 1][j + i];
           if (r.resultTable[j][j + i] > via) {
             r.resultTable[j][j + i] = via;
             r.endOfComponent[j] = j + i;

--- a/src/main/java/org/opentripplanner/transit/model/site/RegularStop.java
+++ b/src/main/java/org/opentripplanner/transit/model/site/RegularStop.java
@@ -122,7 +122,7 @@ public final class RegularStop
   @Override
   @Nonnull
   public Collection<FareZone> getFareZones() {
-    return Collections.unmodifiableCollection(fareZones);
+    return fareZones;
   }
 
   @Nonnull

--- a/src/main/java/org/opentripplanner/transit/model/site/StopLocation.java
+++ b/src/main/java/org/opentripplanner/transit/model/site/StopLocation.java
@@ -101,7 +101,10 @@ public interface StopLocation extends LogInfo {
    */
   @Nullable
   default String getFirstZoneAsString() {
-    return getFareZones().stream().map(t -> t.getId().getId()).findFirst().orElse(null);
+    for (FareZone t : getFareZones()) {
+      return t.getId().getId();
+    }
+    return null;
   }
 
   /**


### PR DESCRIPTION
### Summary

When profiling with a dataset including GTFS-fares, i noticed that a large share of time was spent in calculating fares. In couple of places we could easily simplify to get some performance benefits.

<img width="1043" alt="image" src="https://user-images.githubusercontent.com/698100/186015518-6e5def4d-0be3-4601-8711-70afc5386db7.png">
