### PR TITLE
Optimize RAPTOR adapter layer

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TripPatternForDate.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TripPatternForDate.java
@@ -59,8 +59,8 @@ public class TripPatternForDate {
     LocalDate localDate
   ) {
     this.tripPattern = tripPattern;
-    this.tripTimes = tripTimes;
-    this.frequencies = frequencies;
+    this.tripTimes = List.copyOf(tripTimes);
+    this.frequencies = List.copyOf(frequencies);
     this.localDate = localDate;
 
     // TODO: We expect a pattern only containing trips or frequencies, fix ability to merge

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TripPatternForDate.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/TripPatternForDate.java
@@ -59,7 +59,7 @@ public class TripPatternForDate {
     LocalDate localDate
   ) {
     this.tripPattern = tripPattern;
-    this.tripTimes = new ArrayList<>(tripTimes);
+    this.tripTimes = tripTimes;
     this.frequencies = frequencies;
     this.localDate = localDate;
 
@@ -165,25 +165,28 @@ public class TripPatternForDate {
 
   @Nullable
   public TripPatternForDate newWithFilteredTripTimes(Predicate<TripTimes> filter) {
-    ArrayList<TripTimes> filteredTripTimes = new ArrayList<>(tripTimes);
-    filteredTripTimes.removeIf(Predicate.not(filter));
-
-    List<FrequencyEntry> filteredFrequencies = frequencies
-      .stream()
-      .filter(frequencyEntry -> filter.test(frequencyEntry.tripTimes))
-      .collect(Collectors.toList());
-
-    if (filteredTripTimes.isEmpty()) {
-      if (hasFrequencies()) {
-        if (filteredFrequencies.isEmpty()) {
-          return null;
-        }
-      } else {
-        return null;
+    ArrayList<TripTimes> filteredTripTimes = new ArrayList<>(tripTimes.size());
+    for (TripTimes tripTimes : tripTimes) {
+      if (filter.test(tripTimes)) {
+        filteredTripTimes.add(tripTimes);
       }
     }
 
-    if (tripTimes.size() == filteredTripTimes.size()) {
+    List<FrequencyEntry> filteredFrequencies = new ArrayList<>(frequencies.size());
+    for (FrequencyEntry frequencyEntry : frequencies) {
+      if (filter.test(frequencyEntry.tripTimes)) {
+        filteredFrequencies.add(frequencyEntry);
+      }
+    }
+
+    if (filteredTripTimes.isEmpty() && filteredFrequencies.isEmpty()) {
+      return null;
+    }
+
+    if (
+      tripTimes.size() == filteredTripTimes.size() &&
+      frequencies.size() == filteredFrequencies.size()
+    ) {
       return this;
     }
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TripPatternForDateMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TripPatternForDateMapper.java
@@ -99,8 +99,8 @@ public class TripPatternForDateMapper {
 
     return new TripPatternForDate(
       timetable.getPattern().getRoutingTripPattern(),
-      List.copyOf(times),
-      List.copyOf(frequencies),
+      times,
+      frequencies,
       serviceDate
     );
   }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TripPatternForDateMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TripPatternForDateMapper.java
@@ -99,8 +99,8 @@ public class TripPatternForDateMapper {
 
     return new TripPatternForDate(
       timetable.getPattern().getRoutingTripPattern(),
-      times,
-      frequencies,
+      List.copyOf(times),
+      List.copyOf(frequencies),
       serviceDate
     );
   }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RaptorRoutingRequestTransitDataCreator.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RaptorRoutingRequestTransitDataCreator.java
@@ -2,6 +2,7 @@ package org.opentripplanner.routing.algorithm.raptoradapter.transit.request;
 
 import static org.opentripplanner.util.time.ServiceDateUtils.secondsSinceStartOfTime;
 
+import gnu.trove.list.TIntList;
 import gnu.trove.list.array.TIntArrayList;
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
@@ -110,7 +111,7 @@ class RaptorRoutingRequestTransitDataCreator {
       patternsSorted.sort(Comparator.comparing(TripPatternForDate::getLocalDate));
 
       // Calculate offsets per date
-      List<Integer> offsets = new ArrayList<>();
+      TIntList offsets = new TIntArrayList();
       for (TripPatternForDate tripPatternForDate : patternsSorted) {
         offsets.add(
           secondsSinceStartOfTime(transitSearchTimeZero, tripPatternForDate.getLocalDate())

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RoutingRequestTransitDataProviderFilter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RoutingRequestTransitDataProviderFilter.java
@@ -71,7 +71,7 @@ public class RoutingRequestTransitDataProviderFilter implements TransitDataProvi
 
   @Override
   public boolean tripPatternPredicate(TripPatternForDate tripPatternForDate) {
-    return routeIsNotBanned(tripPatternForDate);
+    return bannedRoutes.isEmpty() || routeIsNotBanned(tripPatternForDate);
   }
 
   @Override
@@ -81,7 +81,7 @@ public class RoutingRequestTransitDataProviderFilter implements TransitDataProvi
       return false;
     }
 
-    if (bannedTrips.contains(trip.getId())) {
+    if (!bannedTrips.isEmpty() && bannedTrips.contains(trip.getId())) {
       return false;
     }
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripPatternForDates.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripPatternForDates.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.routing.algorithm.raptoradapter.transit.request;
 
+import gnu.trove.list.TIntList;
 import java.util.BitSet;
 import java.util.List;
 import java.util.function.IntUnaryOperator;
@@ -62,13 +63,13 @@ public class TripPatternForDates
   TripPatternForDates(
     RoutingTripPattern tripPattern,
     List<TripPatternForDate> tripPatternForDates,
-    List<Integer> offsets,
+    TIntList offsets,
     BitSet boardingPossible,
     BitSet alightningPossible
   ) {
     this.tripPattern = tripPattern;
     this.tripPatternForDates = tripPatternForDates.toArray(new TripPatternForDate[] {});
-    this.offsets = offsets.stream().mapToInt(i -> i).toArray();
+    this.offsets = offsets.toArray();
     this.boardingPossible = boardingPossible;
     this.alightingPossible = alightningPossible;
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripPatternForDates.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TripPatternForDates.java
@@ -75,7 +75,7 @@ public class TripPatternForDates
 
     int numberOfTripSchedules = 0;
     boolean hasFrequencies = false;
-    for (TripPatternForDate tripPatternForDate : tripPatternForDates) {
+    for (TripPatternForDate tripPatternForDate : this.tripPatternForDates) {
       numberOfTripSchedules += tripPatternForDate.numberOfTripSchedules();
       if (tripPatternForDate.hasFrequencies()) {
         hasFrequencies = true;
@@ -90,9 +90,9 @@ public class TripPatternForDates
     this.arrivalTimes = new int[nStops * numberOfTripSchedules];
     this.departureTimes = new int[nStops * numberOfTripSchedules];
     int i = 0;
-    for (int d = 0; d < tripPatternForDates.size(); d++) {
+    for (int d = 0; d < this.tripPatternForDates.length; d++) {
       int offset = this.offsets[d];
-      for (var trip : tripPatternForDates.get(d).tripTimes()) {
+      for (var trip : this.tripPatternForDates[d].tripTimes()) {
         wheelchairBoardings[i] = trip.getWheelchairAccessibility();
         for (int s = 0; s < nStops; s++) {
           this.arrivalTimes[s * numberOfTripSchedules + i] = trip.getArrivalTime(s) + offset;

--- a/src/main/java/org/opentripplanner/routing/impl/StreetVertexIndex.java
+++ b/src/main/java/org/opentripplanner/routing/impl/StreetVertexIndex.java
@@ -207,7 +207,7 @@ public class StreetVertexIndex {
       // Check if Stop/StopCollection is found by FeedScopeId
       if (location.stopId != null) {
         Set<Vertex> transitStopVertices = getStopVerticesById(location.stopId);
-        if (transitStopVertices != null) {
+        if (transitStopVertices != null && !transitStopVertices.isEmpty()) {
           return transitStopVertices;
         }
       }

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/SystemErrDebugLogger.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/SystemErrDebugLogger.java
@@ -19,7 +19,7 @@ import org.opentripplanner.transit.raptor.api.request.DebugRequestBuilder;
 import org.opentripplanner.transit.raptor.api.view.ArrivalView;
 import org.opentripplanner.transit.raptor.api.view.PatternRideView;
 import org.opentripplanner.transit.raptor.rangeraptor.transit.TripTimesSearch;
-import org.opentripplanner.transit.raptor.util.IntUtils;
+import org.opentripplanner.util.lang.IntUtils;
 import org.opentripplanner.util.lang.OtpNumberFormat;
 import org.opentripplanner.util.lang.StringUtils;
 import org.opentripplanner.util.lang.TableFormatter;

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/besttimes/BestTimes.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/besttimes/BestTimes.java
@@ -1,6 +1,6 @@
 package org.opentripplanner.transit.raptor.rangeraptor.standard.besttimes;
 
-import static org.opentripplanner.transit.raptor.util.IntUtils.intArray;
+import static org.opentripplanner.util.lang.IntUtils.intArray;
 
 import java.util.BitSet;
 import org.opentripplanner.transit.raptor.rangeraptor.internalapi.WorkerLifeCycle;

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/besttimes/SimpleBestNumberOfTransfers.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/besttimes/SimpleBestNumberOfTransfers.java
@@ -2,7 +2,7 @@ package org.opentripplanner.transit.raptor.rangeraptor.standard.besttimes;
 
 import org.opentripplanner.transit.raptor.rangeraptor.internalapi.RoundProvider;
 import org.opentripplanner.transit.raptor.rangeraptor.standard.internalapi.BestNumberOfTransfers;
-import org.opentripplanner.transit.raptor.util.IntUtils;
+import org.opentripplanner.util.lang.IntUtils;
 
 /**
  * The responsibility for this class is to keep track of the best (minimun) number of transfers for

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/heuristics/HeuristicsAdapter.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/heuristics/HeuristicsAdapter.java
@@ -12,7 +12,7 @@ import org.opentripplanner.transit.raptor.rangeraptor.standard.besttimes.BestTim
 import org.opentripplanner.transit.raptor.rangeraptor.standard.internalapi.BestNumberOfTransfers;
 import org.opentripplanner.transit.raptor.rangeraptor.transit.EgressPaths;
 import org.opentripplanner.transit.raptor.rangeraptor.transit.TransitCalculator;
-import org.opentripplanner.transit.raptor.util.IntUtils;
+import org.opentripplanner.util.lang.IntUtils;
 import org.opentripplanner.util.lang.ToStringBuilder;
 import org.opentripplanner.util.time.TimeUtils;
 

--- a/src/main/java/org/opentripplanner/transit/raptor/service/DebugHeuristics.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/service/DebugHeuristics.java
@@ -9,7 +9,7 @@ import org.opentripplanner.transit.raptor.api.request.RaptorRequest;
 import org.opentripplanner.transit.raptor.api.transit.SearchDirection;
 import org.opentripplanner.transit.raptor.rangeraptor.internalapi.Heuristics;
 import org.opentripplanner.transit.raptor.util.CompareIntArrays;
-import org.opentripplanner.transit.raptor.util.IntUtils;
+import org.opentripplanner.util.lang.IntUtils;
 
 /**
  * Utility class to log computed heuristic data.

--- a/src/main/java/org/opentripplanner/util/lang/IntUtils.java
+++ b/src/main/java/org/opentripplanner/util/lang/IntUtils.java
@@ -1,8 +1,9 @@
-package org.opentripplanner.transit.raptor.util;
+package org.opentripplanner.util.lang;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.IntSummaryStatistics;
 import java.util.List;
 
 /**
@@ -37,5 +38,16 @@ public final class IntUtils {
     List<Integer> all = new ArrayList<>(a);
     all.addAll(b);
     return all.stream().mapToInt(it -> it).toArray();
+  }
+
+  public static double standardDeviation(List<Integer> v) {
+    double average = v.stream().mapToInt(it -> it).average().orElse(0d);
+
+    double sum = 0.0;
+    for (double num : v) {
+      sum += Math.pow(num - average, 2);
+    }
+
+    return Math.sqrt(sum / v.size());
   }
 }

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TestRouteData.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TestRouteData.java
@@ -3,6 +3,7 @@ package org.opentripplanner.routing.algorithm.raptoradapter.transit.request;
 import static org.opentripplanner.routing.algorithm.raptoradapter.transit.request.TestTransitCaseData.DATE;
 import static org.opentripplanner.routing.algorithm.raptoradapter.transit.request.TestTransitCaseData.OFFSET;
 
+import gnu.trove.list.array.TIntArrayList;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -69,7 +70,7 @@ public class TestRouteData {
     var patternForDates = new TripPatternForDates(
       routingTripPattern,
       listOfTripPatternForDates,
-      List.of(OFFSET),
+      new TIntArrayList(new int[] { OFFSET }),
       null,
       null
     );

--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/ResultPrinter.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/ResultPrinter.java
@@ -216,12 +216,10 @@ class ResultPrinter {
       standardDeviation = Math.sqrt(standardDeviation / v.size());
 
       System.err.printf(
-        " ==> %-" + labelMaxLen + "s : %s Avg: %4.1f Min: %4d Max: %4d Std dev: %4.1f%n",
+        " ==> %-" + labelMaxLen + "s : %s Avg: %4.1f  (σ=%.1f)%n",
         label,
         values,
         average,
-        statistics.getMin(),
-        statistics.getMax(),
         standardDeviation
       );
     }

--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/ResultPrinter.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/ResultPrinter.java
@@ -3,6 +3,7 @@ package org.opentripplanner.transit.raptor.speed_test;
 import static org.opentripplanner.util.time.DurationUtils.msToSecondsStr;
 
 import java.util.ArrayList;
+import java.util.IntSummaryStatistics;
 import java.util.List;
 import java.util.Map;
 import org.opentripplanner.transit.raptor.speed_test.model.SpeedTestProfile;
@@ -204,8 +205,25 @@ class ResultPrinter {
         "[ " +
         v.stream().map(it -> String.format("%4d", it)).reduce((a, b) -> a + ", " + b).orElse("") +
         " ]";
-      double avg = v.stream().mapToInt(it -> it).average().orElse(0d);
-      System.err.printf(" ==> %-" + labelMaxLen + "s : %s Avg: %4.1f%n", label, values, avg);
+      IntSummaryStatistics statistics = v.stream().mapToInt(it -> it).summaryStatistics();
+      double average = statistics.getAverage();
+      double standardDeviation = 0.0;
+
+      for (double num : v) {
+        standardDeviation += Math.pow(num - average, 2);
+      }
+
+      standardDeviation = Math.sqrt(standardDeviation / v.size());
+
+      System.err.printf(
+        " ==> %-" + labelMaxLen + "s : %s Avg: %4.1f Min: %4d Max: %4d Std dev: %4.1f%n",
+        label,
+        values,
+        average,
+        statistics.getMin(),
+        statistics.getMax(),
+        standardDeviation
+      );
     }
   }
 

--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/ResultPrinter.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/ResultPrinter.java
@@ -3,13 +3,13 @@ package org.opentripplanner.transit.raptor.speed_test;
 import static org.opentripplanner.util.time.DurationUtils.msToSecondsStr;
 
 import java.util.ArrayList;
-import java.util.IntSummaryStatistics;
 import java.util.List;
 import java.util.Map;
 import org.opentripplanner.transit.raptor.speed_test.model.SpeedTestProfile;
 import org.opentripplanner.transit.raptor.speed_test.model.testcase.TestCase;
 import org.opentripplanner.transit.raptor.speed_test.model.testcase.TestCaseFailedException;
 import org.opentripplanner.transit.raptor.speed_test.model.timer.SpeedTestTimer;
+import org.opentripplanner.util.lang.IntUtils;
 import org.opentripplanner.util.lang.TableFormatter;
 
 /**
@@ -205,22 +205,14 @@ class ResultPrinter {
         "[ " +
         v.stream().map(it -> String.format("%4d", it)).reduce((a, b) -> a + ", " + b).orElse("") +
         " ]";
-      IntSummaryStatistics statistics = v.stream().mapToInt(it -> it).summaryStatistics();
-      double average = statistics.getAverage();
-      double standardDeviation = 0.0;
-
-      for (double num : v) {
-        standardDeviation += Math.pow(num - average, 2);
-      }
-
-      standardDeviation = Math.sqrt(standardDeviation / v.size());
+      double avg = v.stream().mapToInt(it -> it).average().orElse(0d);
 
       System.err.printf(
         " ==> %-" + labelMaxLen + "s : %s Avg: %4.1f  (σ=%.1f)%n",
         label,
         values,
-        average,
-        standardDeviation
+        avg,
+        IntUtils.standardDeviation(v)
       );
     }
   }


### PR DESCRIPTION
### Summary

Even tough we are in process of moving to a new transit model, I noticed some possibilities of optimizing the RAPTOR adapter, after recent profiling. I also added some more statistics to be output from the SpeedTest

```
dev-2.x


Worker: 
 ==> mc_destination : [  478,  471,  470,  470,  470,  472,  470,  470,  470,  470 ] Avg: 471.1 Min:  470 Max:  478 Std dev:  2.4

Total:  
 ==> mc_destination : [  775,  753,  752,  751,  752,  754,  751,  751,  751,  751 ] Avg: 754.1 Min:  751 Max:  775 Std dev:  7.0


Use TIntList for offsets


Worker: 
 ==> mc_destination : [  475,  465,  462,  460,  476,  471,  466,  462,  460,  464 ] Avg: 466.1 Min:  460 Max:  476 Std dev:  5.6

Total:  
 ==> mc_destination : [  772,  729,  739,  737,  768,  757,  751,  738,  736,  744 ] Avg: 747.1 Min:  729 Max:  772 Std dev: 13.7


Cache offsets for service dates


Worker: 
 ==> mc_destination : [  479,  457,  454,  465,  459,  463,  456,  466,  461,  467 ] Avg: 462.7 Min:  454 Max:  479 Std dev:  6.9

Total:  
 ==> mc_destination : [  785,  713,  722,  721,  711,  735,  723,  742,  723,  740 ] Avg: 731.5 Min:  711 Max:  785 Std dev: 20.4


Filter by adding instead of removing entries 


Worker: 
 ==> mc_destination : [  463,  453,  447,  445,  453,  449,  446,  442,  446,  439 ] Avg: 448.3 Min:  439 Max:  463 Std dev:  6.4

Total:  
 ==> mc_destination : [  747,  717,  699,  708,  700,  717,  700,  690,  699,  691 ] Avg: 706.8 Min:  690 Max:  747 Std dev: 16.0


Skip checks if no banned routes/trips


Worker: 
 ==> mc_destination : [  447,  425,  424,  421,  422,  419,  420,  418,  424,  411 ] Avg: 423.1 Min:  411 Max:  447 Std dev:  8.8

Total:  
 ==> mc_destination : [  718,  673,  674,  674,  673,  672,  671,  662,  675,  652 ] Avg: 674.4 Min:  652 Max:  718 Std dev: 16.1
```