### PR TITLE
Digitransit stop vector layer updates

### DIFF
--- a/docs/sandbox/MapboxVectorTilesApi.md
+++ b/docs/sandbox/MapboxVectorTilesApi.md
@@ -15,6 +15,7 @@
   name [#3648](https://github.com/opentripplanner/OpenTripPlanner/pull/3648)
 - 2022-01-03: Add support for VehicleParking entities
 - 2022-04-27: Read the headsign for frequency-only patterns correctly [#4122](https://github.com/opentripplanner/OpenTripPlanner/pull/4122)
+- 2022-08-23: Remove patterns and add route gtfsTypes to stop layer [#4404](https://github.com/opentripplanner/OpenTripPlanner/pull/4404)
 
 ## Documentation
 

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/DigitransitStopPropertyMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/DigitransitStopPropertyMapper.java
@@ -50,7 +50,7 @@ public class DigitransitStopPropertyMapper extends PropertyMapper<RegularStop> {
           routeObject.put("gtfsType", route.getGtfsType());
           return routeObject;
         })
-        .collect(Collectors.toList())
+        .toList()
     );
     String desc = stop.getDescription() != null ? stop.getDescription().toString() : null;
     return List.of(

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/DigitransitStopPropertyMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/DigitransitStopPropertyMapper.java
@@ -50,6 +50,7 @@ public class DigitransitStopPropertyMapper extends PropertyMapper<RegularStop> {
           pattern.put("headsign", Optional.ofNullable(headsign).orElse(""));
           pattern.put("type", tripPattern.getRoute().getMode().name());
           pattern.put("shortName", tripPattern.getRoute().getShortName());
+          pattern.put("gtfsType", tripPattern.getRoute().getGtfsType());
           return pattern;
         })
         .collect(Collectors.toList())

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/DigitransitStopPropertyMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/DigitransitStopPropertyMapper.java
@@ -50,8 +50,18 @@ public class DigitransitStopPropertyMapper extends PropertyMapper<RegularStop> {
           pattern.put("headsign", Optional.ofNullable(headsign).orElse(""));
           pattern.put("type", tripPattern.getRoute().getMode().name());
           pattern.put("shortName", tripPattern.getRoute().getShortName());
-          pattern.put("gtfsType", tripPattern.getRoute().getGtfsType());
           return pattern;
+        })
+        .collect(Collectors.toList())
+    );
+    String routes = JSONArray.toJSONString(
+      transitService
+        .getRoutesForStop(stop)
+        .stream()
+        .map(route -> {
+          JSONObject routeObject = new JSONObject();
+          routeObject.put("gtfsType", route.getGtfsType());
+          return routeObject;
         })
         .collect(Collectors.toList())
     );
@@ -68,7 +78,8 @@ public class DigitransitStopPropertyMapper extends PropertyMapper<RegularStop> {
         stop.getParentStation() != null ? stop.getParentStation().getId() : "null"
       ),
       new T2<>("type", type),
-      new T2<>("patterns", patterns)
+      new T2<>("patterns", patterns),
+      new T2<>("routes", routes)
     );
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/DigitransitStopPropertyMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/DigitransitStopPropertyMapper.java
@@ -41,19 +41,6 @@ public class DigitransitStopPropertyMapper extends PropertyMapper<RegularStop> {
       .map(Enum::name)
       .orElse(null);
 
-    String patterns = JSONArray.toJSONString(
-      patternsForStop
-        .stream()
-        .map(tripPattern -> {
-          String headsign = tripPattern.getStopHeadsign(tripPattern.findStopPosition(stop));
-          JSONObject pattern = new JSONObject();
-          pattern.put("headsign", Optional.ofNullable(headsign).orElse(""));
-          pattern.put("type", tripPattern.getRoute().getMode().name());
-          pattern.put("shortName", tripPattern.getRoute().getShortName());
-          return pattern;
-        })
-        .collect(Collectors.toList())
-    );
     String routes = JSONArray.toJSONString(
       transitService
         .getRoutesForStop(stop)
@@ -78,7 +65,6 @@ public class DigitransitStopPropertyMapper extends PropertyMapper<RegularStop> {
         stop.getParentStation() != null ? stop.getParentStation().getId() : "null"
       ),
       new T2<>("type", type),
-      new T2<>("patterns", patterns),
       new T2<>("routes", routes)
     );
   }


### PR DESCRIPTION
### Summary

* Adds routes' gtfsType to stop vector tiles so we can draw stops differently when routes with certain submodes go through them
* Removed patterns from stop vector tiles

### Issue

Sandbox changes so not needed.

### Unit tests

We don't have tests for this?

### Documentation

Not needed

### Changelog

Updated sandbox documentation

