### PR TITLE
Re-enable copying of submode to trip from route

### DIFF
--- a/src/main/java/org/opentripplanner/transit/model/timetable/Trip.java
+++ b/src/main/java/org/opentripplanner/transit/model/timetable/Trip.java
@@ -46,7 +46,10 @@ public final class Trip extends AbstractTransitEntity<Trip, TripBuilder> impleme
     // Route is done first, it is used as a fallback for some fields
     this.route = requireNonNull(builder.getRoute());
     this.mode = requireNonNullElse(builder.getMode(), route.getMode());
-    this.netexSubmode = SubMode.getOrBuildAndCacheForever(builder.getNetexSubmode());
+    this.netexSubmode =
+      builder.getNetexSubmode() != null
+        ? SubMode.getOrBuildAndCacheForever(builder.getNetexSubmode())
+        : route.getNetexSubmode();
     this.direction = requireNonNullElse(builder.getDirection(), Direction.UNKNOWN);
     this.bikesAllowed = requireNonNullElse(builder.getBikesAllowed(), route.getBikesAllowed());
     this.wheelchairBoarding =

--- a/src/test/java/org/opentripplanner/transit/model/timetable/TripTest.java
+++ b/src/test/java/org/opentripplanner/transit/model/timetable/TripTest.java
@@ -57,6 +57,22 @@ class TripTest {
     .build();
 
   @Test
+  void shouldCopyFieldsFromRoute() {
+    var routeWithModes = ROUTE
+      .copy()
+      .withMode(TRANSIT_MODE)
+      .withNetexSubmode(NETEX_SUBMODE_NAME)
+      .withBikesAllowed(BIKE_ACCESS)
+      .build();
+
+    var subject = Trip.of(TransitModelForTest.id(ID)).withRoute(routeWithModes).build();
+
+    assertEquals(TRANSIT_MODE, subject.getMode());
+    assertEquals(NETEX_SUBMODE, subject.getNetexSubMode());
+    assertEquals(BIKE_ACCESS, subject.getBikesAllowed());
+  }
+
+  @Test
   void copy() {
     assertEquals(ID, subject.getId().getId());
 


### PR DESCRIPTION
### Summary

In https://github.com/opentripplanner/OpenTripPlanner/pull/4189, we accidentally removed the feature of copying the NeTEx submode from the route to the trip, if it is not set in the trip. Re-enable this feature.

### Unit tests

Added test for behaviour of copying all necessary fields from the route to the trip.
