### PR TITLE
Remove unused heuristics fields

### DIFF
--- a/src/main/java/org/opentripplanner/transit/raptor/api/response/StopArrivals.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/response/StopArrivals.java
@@ -11,12 +11,6 @@ public interface StopArrivals {
   boolean reached(int stopIndex);
 
   /**
-   * The earliest arrival time at the given stop. If the stop is not reached, the behavior is
-   * undefined; It may return an arbitrary value or throw an exception.
-   */
-  int bestArrivalTime(int stopIndex);
-
-  /**
    * Returns {@code true} if the stop is reached.
    */
   boolean reachedByTransit(int stopIndex);
@@ -26,10 +20,4 @@ public interface StopArrivals {
    * the behavior is undefined; It may return an arbitrary value or throw an exception.
    */
   int bestTransitArrivalTime(int stopIndex);
-
-  /**
-   * The smallest number of transfers needed to reach the given stop. If the stop is not reached,
-   * the behavior is undefined; It may return an arbitrary value or throw an exception.
-   */
-  int smallestNumberOfTransfers(int stopIndex);
 }

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/internalapi/Heuristics.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/internalapi/Heuristics.java
@@ -46,11 +46,6 @@ public interface Heuristics {
   int bestOverallJourneyTravelDuration();
 
   /**
-   * Return the best/minimum required number of transfers from origin to destination.
-   */
-  int bestOverallJourneyNumOfTransfers();
-
-  /**
    * Return an estimate for the shortest possible wait-time needed across all journeys reaching the
    * destination given the iteration-start-time. Note! This can NOT be used for destination pruning,
    * because there most likely exist journeys with a lower wait-time. The access is NOT time-shift

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/McStopArrivals.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/McStopArrivals.java
@@ -14,7 +14,7 @@ import org.opentripplanner.transit.raptor.util.BitSetIterator;
 
 /**
  * This class serve as a wrapper for all stop arrival pareto set, one set for each stop. It also
- * keep track of stops visited since "last mark".
+ * keeps track of stops visited since "last mark".
  * <p>
  *
  * @param <T> The TripSchedule type defined by the user of the raptor API.
@@ -51,14 +51,6 @@ public final class McStopArrivals<T extends RaptorTripSchedule> implements StopA
   }
 
   @Override
-  public int bestArrivalTime(int stopIndex) {
-    return arrivals[stopIndex].stream()
-      .mapToInt(AbstractStopArrival::arrivalTime)
-      .min()
-      .orElseThrow();
-  }
-
-  @Override
   public boolean reachedByTransit(int stopIndex) {
     return (
       arrivals[stopIndex] != null &&
@@ -71,15 +63,6 @@ public final class McStopArrivals<T extends RaptorTripSchedule> implements StopA
     return arrivals[stopIndex].stream()
       .filter(ArrivalView::arrivedByTransit)
       .mapToInt(AbstractStopArrival::arrivalTime)
-      .min()
-      .orElseThrow();
-  }
-
-  @Override
-  public int smallestNumberOfTransfers(int stopIndex) {
-    return arrivals[stopIndex].stream()
-      .filter(ArrivalView::arrivedByTransit)
-      .mapToInt(AbstractStopArrival::numberOfTransfers)
       .min()
       .orElseThrow();
   }

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/StdRangeRaptorWorkerState.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/StdRangeRaptorWorkerState.java
@@ -23,7 +23,7 @@ import org.opentripplanner.transit.raptor.util.BitSetIterator;
  * This is grouped into a separate class (rather than just having the fields in the raptor worker
  * class) because we want to separate the logic of maintaining stop arrival state and performing the
  * steps of the algorithm. This also make it possible to have more than one state implementation,
- * which have ben used in the past to test different memory optimizations.
+ * which have been used in the past to test different memory optimizations.
  * <p>
  * Note that this represents the entire state of the Range Raptor search for all rounds. The {@code
  * stopArrivalsState} implementation can be swapped to achieve different results.
@@ -189,7 +189,7 @@ public final class StdRangeRaptorWorkerState<T extends RaptorTripSchedule>
 
   @Override
   public StopArrivals extractStopArrivals() {
-    return new StopArrivalsAdaptor(bestTimes, stopArrivalsState);
+    return new StopArrivalsAdaptor(bestTimes);
   }
 
   private void transferToStop(int arrivalTimeTransit, int fromStop, RaptorTransfer transfer) {

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/besttimes/StopArrivalsAdaptor.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/besttimes/StopArrivalsAdaptor.java
@@ -6,21 +6,14 @@ import org.opentripplanner.transit.raptor.rangeraptor.standard.internalapi.BestN
 public class StopArrivalsAdaptor implements StopArrivals {
 
   private final BestTimes bestTimes;
-  private final BestNumberOfTransfers nTransfers;
 
-  public StopArrivalsAdaptor(BestTimes bestTimes, BestNumberOfTransfers nTransfers) {
+  public StopArrivalsAdaptor(BestTimes bestTimes) {
     this.bestTimes = bestTimes;
-    this.nTransfers = nTransfers;
   }
 
   @Override
   public boolean reached(int stopIndex) {
     return bestTimes.isStopReached(stopIndex);
-  }
-
-  @Override
-  public int bestArrivalTime(int stopIndex) {
-    return bestTimes.time(stopIndex);
   }
 
   @Override
@@ -31,10 +24,5 @@ public class StopArrivalsAdaptor implements StopArrivals {
   @Override
   public int bestTransitArrivalTime(int stopIndex) {
     return bestTimes.transitArrivalTime(stopIndex);
-  }
-
-  @Override
-  public int smallestNumberOfTransfers(int stopIndex) {
-    return nTransfers.calculateMinNumberOfTransfers(stopIndex);
   }
 }

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/heuristics/HeuristicsAdapter.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/heuristics/HeuristicsAdapter.java
@@ -88,12 +88,6 @@ public class HeuristicsAdapter implements Heuristics {
   }
 
   @Override
-  public int bestOverallJourneyNumOfTransfers() {
-    calculateAggregatedResults();
-    return minJourneyNumOfTransfers;
-  }
-
-  @Override
   public int minWaitTimeForJourneysReachingDestination() {
     calculateAggregatedResults();
     return Math.abs(earliestArrivalTime - originDepartureTime) - minJourneyTravelDuration;


### PR DESCRIPTION
### Summary

While looking into doing something about #3748 I noticed that there are methods in the `StopArrivals` interface that are never used.

In order to make alternative implementations easier, I removed these unused methods.

Or would you like to keep them for future implementations?