### PR TITLE
Otp2 fix updater config

### DIFF
--- a/docs/OTP2-MigrationGuide.md
+++ b/docs/OTP2-MigrationGuide.md
@@ -286,4 +286,6 @@ The scripting API endpoint has been removed.
   citi-bike-nyc*, *jcdecaux*, *keolis-rennes*, *kml*, *next-bike*, *ov-fiets*, *sf-bay-area*, *
   share-bike*, *smoove*, *uip-bike*, and *vcub*. Use the standard *gtfs* updater instead, or
   reintroduce your custom updater as a Sandbox module.
+- The `logFrequency`, `maxSnapshotFrequency`, `purgeExpiredData` updater parameters are moved from 
+  the individual updaters to `timetableUpdates`(root level in the router config).  
 

--- a/src/ext-test/java/org/opentripplanner/ext/siri/SiriAlertsUpdateHandlerTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/siri/SiriAlertsUpdateHandlerTest.java
@@ -15,7 +15,6 @@ import java.util.Collection;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.GtfsTest;
-import org.opentripplanner.routing.RoutingService;
 import org.opentripplanner.routing.alertpatch.AlertSeverity;
 import org.opentripplanner.routing.alertpatch.AlertUrl;
 import org.opentripplanner.routing.alertpatch.EntitySelector;
@@ -143,7 +142,7 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
       transitAlertService = new TransitAlertServiceImpl(transitModel);
       alertsUpdateHandler.setTransitAlertService(transitAlertService);
 
-      alertsUpdateHandler.setSiriFuzzyTripMatcher(new SiriFuzzyTripMatcher(transitService));
+      alertsUpdateHandler.setSiriFuzzyTripMatcher(SiriFuzzyTripMatcher.of(transitService));
     }
   }
 

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriFuzzyTripMatcher.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriFuzzyTripMatcher.java
@@ -54,7 +54,7 @@ public class SiriFuzzyTripMatcher {
   private final TransitService transitService;
 
   /**
-   * Factory method used to crete only one instance.
+   * Factory method used to create only one instance.
    * <p>
    * THIS METHOD IS NOT THREAD-SAFE AND SHOULD BE CALLED DURING THE
    * INITIALIZATION PROCESS.

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriFuzzyTripMatcher.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriFuzzyTripMatcher.java
@@ -36,23 +36,37 @@ import uk.org.siri.siri20.VehicleModesEnumeration;
  * process will always be applied even in places where you have good quality IDs in SIRI data and
  * don't need it - we'd have to add a way to disable it.
  * <p>
- * Several instances of this SiriFuzzyTripMatcher may appear in different SIRI updaters, but they
- * all share a common set of static Map fields. We generally don't advocate using static fields in
- * this way, but as part of a sandbox contribution we are maintaining this implementation.
+ * The same instance of this SiriFuzzyTripMatcher may appear in different SIRI updaters. Be sure
+ * to fetch the instance at during the setup of the updaters, the initialization is not thread-safe.
  */
 public class SiriFuzzyTripMatcher {
 
   private static final Logger LOG = LoggerFactory.getLogger(SiriFuzzyTripMatcher.class);
-  private static final Map<String, Set<Trip>> mappedTripsCache = new HashMap<>();
-  private static final Map<String, Set<Trip>> mappedVehicleRefCache = new HashMap<>();
-  private static final Map<String, Set<Route>> mappedRoutesCache = new HashMap<>();
-  private static final Map<String, Set<Trip>> start_stop_tripCache = new HashMap<>();
-  private static final Map<String, Trip> vehicleJourneyTripCache = new HashMap<>();
-  private static final Set<String> nonExistingStops = new HashSet<>();
 
+  private static SiriFuzzyTripMatcher instance;
+
+  private final Map<String, Set<Trip>> mappedTripsCache = new HashMap<>();
+  private final Map<String, Set<Trip>> mappedVehicleRefCache = new HashMap<>();
+  private final Map<String, Set<Route>> mappedRoutesCache = new HashMap<>();
+  private final Map<String, Set<Trip>> start_stop_tripCache = new HashMap<>();
+  private final Map<String, Trip> vehicleJourneyTripCache = new HashMap<>();
+  private final Set<String> nonExistingStops = new HashSet<>();
   private final TransitService transitService;
 
-  public SiriFuzzyTripMatcher(TransitService transitService) {
+  /**
+   * Factory method used to crete only one instance.
+   * <p>
+   * THIS METHOD IS NOT THREAD-SAFE AND SHOULD BE CALLED DURING THE
+   * INITIALIZATION PROCESS.
+   */
+  public static SiriFuzzyTripMatcher of(TransitService transitService) {
+    if (instance == null) {
+      instance = new SiriFuzzyTripMatcher(transitService);
+    }
+    return instance;
+  }
+
+  private SiriFuzzyTripMatcher(TransitService transitService) {
     this.transitService = transitService;
     initCache(this.transitService);
   }
@@ -246,7 +260,7 @@ public class SiriFuzzyTripMatcher {
     return null;
   }
 
-  private static void initCache(TransitService index) {
+  private void initCache(TransitService index) {
     if (mappedTripsCache.isEmpty()) {
       for (Trip trip : index.getAllTrips()) {
         TripPattern tripPattern = index.getPatternForTrip(trip);

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
@@ -98,19 +98,23 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
   private final TransitLayerUpdater transitLayerUpdater;
 
   public int logFrequency = 2000;
+
   /**
    * If a timetable snapshot is requested less than this number of milliseconds after the previous
    * snapshot, just return the same one. Throttles the potentially resource-consuming task of
    * duplicating a TripPattern -> Timetable map and indexing the new Timetables.
    */
-  public int maxSnapshotFrequency = 1000; // msec
+  public int maxSnapshotFrequency = 1000;
+
   /**
    * The last committed snapshot that was handed off to a routing thread. This snapshot may be given
    * to more than one routing thread if the maximum snapshot frequency is exceeded.
    */
   private volatile TimetableSnapshot snapshot = null;
+
   /** Should expired realtime data be purged from the graph. */
   public boolean purgeExpiredData = true;
+
   protected LocalDate lastPurgeDate = null;
   protected long lastSnapshotTime = -1;
 

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETGooglePubsubUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETGooglePubsubUpdater.java
@@ -25,8 +25,10 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.entur.protobuf.mapper.SiriMapper;
+import org.opentripplanner.ext.siri.SiriFuzzyTripMatcher;
 import org.opentripplanner.ext.siri.SiriTimetableSnapshotSource;
 import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.updater.GraphUpdater;
 import org.opentripplanner.updater.WriteToGraphCallback;
@@ -62,9 +64,9 @@ public class SiriETGooglePubsubUpdater implements GraphUpdater {
 
   private static final Logger LOG = LoggerFactory.getLogger(SiriETGooglePubsubUpdater.class);
 
-  private static final transient AtomicLong messageCounter = new AtomicLong(0);
-  private static final transient AtomicLong updateCounter = new AtomicLong(0);
-  private static final transient AtomicLong sizeCounter = new AtomicLong(0);
+  private static final AtomicLong MESSAGE_COUNTER = new AtomicLong(0);
+  private static final AtomicLong UPDATE_COUNTER = new AtomicLong(0);
+  private static final AtomicLong SIZE_COUNTER = new AtomicLong(0);
   /**
    * The URL used to fetch all initial updates
    */
@@ -87,6 +89,8 @@ public class SiriETGooglePubsubUpdater implements GraphUpdater {
    */
   private WriteToGraphCallback saveResultOnGraph;
   private SiriTimetableSnapshotSource snapshotSource;
+  private SiriFuzzyTripMatcher fuzzyTripMatcher;
+
   private transient long startTime;
   private boolean primed;
 
@@ -118,10 +122,8 @@ public class SiriETGooglePubsubUpdater implements GraphUpdater {
         System.getenv("GOOGLE_APPLICATION_CREDENTIALS") != null &&
         !System.getenv("GOOGLE_APPLICATION_CREDENTIALS").isEmpty()
       ) {
-        /*
-                  Google libraries expects path to credentials json-file is stored in environment variable "GOOGLE_APPLICATION_CREDENTIALS"
-                  Ref.: https://cloud.google.com/docs/authentication/getting-started
-                 */
+        // Google libraries expects path to credentials json-file is stored in environment variable "GOOGLE_APPLICATION_CREDENTIALS"
+        // Ref.: https://cloud.google.com/docs/authentication/getting-started
 
         subscriptionAdminClient = SubscriptionAdminClient.create();
 
@@ -146,8 +148,10 @@ public class SiriETGooglePubsubUpdater implements GraphUpdater {
   public void setup(Graph graph, TransitModel transitModel) throws Exception {
     // TODO OTP2 - This is thread safe, but only because updater setup methods are called sequentially.
     //           - Ideally we should inject the snapshotSource on this class.
-    snapshotSource =
+    this.snapshotSource =
       transitModel.getOrSetupTimetableSnapshotProvider(SiriTimetableSnapshotSource::new);
+
+    this.fuzzyTripMatcher = SiriFuzzyTripMatcher.of(new DefaultTransitService(transitModel));
   }
 
   @Override
@@ -306,9 +310,9 @@ public class SiriETGooglePubsubUpdater implements GraphUpdater {
             LOG.info(
               "Pubsub updater initialized after {} ms: [messages: {},  updates: {}, total size: {}, time since startup: {}]",
               (System.currentTimeMillis() - t2),
-              messageCounter.get(),
-              updateCounter.get(),
-              FileUtils.byteCountToDisplaySize(sizeCounter.get()),
+              MESSAGE_COUNTER.get(),
+              UPDATE_COUNTER.get(),
+              FileUtils.byteCountToDisplaySize(SIZE_COUNTER.get()),
               getTimeSinceStartupString()
             );
           }
@@ -326,7 +330,7 @@ public class SiriETGooglePubsubUpdater implements GraphUpdater {
     public void receiveMessage(PubsubMessage message, AckReplyConsumer consumer) {
       Siri siri;
       try {
-        sizeCounter.addAndGet(message.getData().size());
+        SIZE_COUNTER.addAndGet(message.getData().size());
 
         final ByteString data = message.getData();
 
@@ -354,15 +358,15 @@ public class SiriETGooglePubsubUpdater implements GraphUpdater {
         } catch (Throwable t) {
           //ignore
         }
-        long numberOfUpdates = updateCounter.addAndGet(numberOfUpdatedTrips);
-        long numberOfMessages = messageCounter.incrementAndGet();
+        long numberOfUpdates = UPDATE_COUNTER.addAndGet(numberOfUpdatedTrips);
+        long numberOfMessages = MESSAGE_COUNTER.incrementAndGet();
 
         if (numberOfMessages % 1000 == 0) {
           LOG.info(
             "Pubsub stats: [messages: {}, updates: {}, total size: {}, current delay {} ms, time since startup: {}]",
             numberOfMessages,
             numberOfUpdates,
-            FileUtils.byteCountToDisplaySize(sizeCounter.get()),
+            FileUtils.byteCountToDisplaySize(SIZE_COUNTER.get()),
             (now() - siri.getServiceDelivery().getResponseTimestamp().toInstant().toEpochMilli()),
             getTimeSinceStartupString()
           );
@@ -371,6 +375,7 @@ public class SiriETGooglePubsubUpdater implements GraphUpdater {
         var f = saveResultOnGraph.execute((graph, transitModel) ->
           snapshotSource.applyEstimatedTimetable(
             transitModel,
+            fuzzyTripMatcher,
             feedId,
             false,
             estimatedTimetableDeliveries

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETGooglePubsubUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETGooglePubsubUpdater.java
@@ -94,7 +94,10 @@ public class SiriETGooglePubsubUpdater implements GraphUpdater {
   private transient long startTime;
   private boolean primed;
 
-  public SiriETGooglePubsubUpdater(SiriETGooglePubsubUpdaterParameters config) {
+  public SiriETGooglePubsubUpdater(
+    SiriETGooglePubsubUpdaterParameters config,
+    SiriTimetableSnapshotSource timetableSnapshot
+  ) {
     this.configRef = config.getConfigRef();
     /*
            URL that responds to HTTP GET which returns all initial data in protobuf-format.
@@ -103,6 +106,7 @@ public class SiriETGooglePubsubUpdater implements GraphUpdater {
     this.dataInitializationUrl = URI.create(config.getDataInitializationUrl());
     this.feedId = config.getFeedId();
     this.reconnectPeriodSec = config.getReconnectPeriodSec();
+    this.snapshotSource = timetableSnapshot;
 
     // set subscriber
     String subscriptionId = System.getenv("HOSTNAME");
@@ -146,11 +150,6 @@ public class SiriETGooglePubsubUpdater implements GraphUpdater {
 
   @Override
   public void setup(Graph graph, TransitModel transitModel) throws Exception {
-    // TODO OTP2 - This is thread safe, but only because updater setup methods are called sequentially.
-    //           - Ideally we should inject the snapshotSource on this class.
-    this.snapshotSource =
-      transitModel.getOrSetupTimetableSnapshotProvider(SiriTimetableSnapshotSource::new);
-
     this.fuzzyTripMatcher = SiriFuzzyTripMatcher.of(new DefaultTransitService(transitModel));
   }
 

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETUpdater.java
@@ -2,8 +2,10 @@ package org.opentripplanner.ext.siri.updater;
 
 import java.util.List;
 import org.apache.commons.lang3.BooleanUtils;
+import org.opentripplanner.ext.siri.SiriFuzzyTripMatcher;
 import org.opentripplanner.ext.siri.SiriTimetableSnapshotSource;
 import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.updater.PollingGraphUpdater;
 import org.opentripplanner.updater.WriteToGraphCallback;
@@ -59,6 +61,8 @@ public class SiriETUpdater extends PollingGraphUpdater {
    */
   private SiriTimetableSnapshotSource snapshotSource;
 
+  private SiriFuzzyTripMatcher fuzzyTripMatcher;
+
   public SiriETUpdater(SiriETUpdaterParameters config) {
     super(config);
     // Create update streamer from preferences
@@ -95,20 +99,22 @@ public class SiriETUpdater extends PollingGraphUpdater {
     // Only create a realtime data snapshot source if none exists already
     // TODO OTP2 - This is thread safe, but only because updater setup methods are called sequentially.
     //           - Ideally we should inject the snapshotSource on this class.
-    snapshotSource =
+    this.snapshotSource =
       transitModel.getOrSetupTimetableSnapshotProvider(SiriTimetableSnapshotSource::new);
+
+    this.fuzzyTripMatcher = SiriFuzzyTripMatcher.of(new DefaultTransitService(transitModel));
 
     // Set properties of realtime data snapshot source.
     // TODO OTP2 - this is overwriting these properties if they were specified by other updaters.
     //           - These should not be specified at a per-updater level, but at a per-router level.
-    if (logFrequency != null) {
-      snapshotSource.logFrequency = logFrequency;
+    if (this.logFrequency != null) {
+      this.snapshotSource.logFrequency = logFrequency;
     }
-    if (maxSnapshotFrequency != null) {
-      snapshotSource.maxSnapshotFrequency = maxSnapshotFrequency;
+    if (this.maxSnapshotFrequency != null) {
+      this.snapshotSource.maxSnapshotFrequency = maxSnapshotFrequency;
     }
-    if (purgeExpiredData != null) {
-      snapshotSource.purgeExpiredData = purgeExpiredData;
+    if (this.purgeExpiredData != null) {
+      this.snapshotSource.purgeExpiredData = purgeExpiredData;
     }
   }
 
@@ -134,7 +140,13 @@ public class SiriETUpdater extends PollingGraphUpdater {
         List<EstimatedTimetableDeliveryStructure> etds = serviceDelivery.getEstimatedTimetableDeliveries();
         if (etds != null) {
           saveResultOnGraph.execute((graph, transitModel) -> {
-            snapshotSource.applyEstimatedTimetable(transitModel, feedId, fullDataset, etds);
+            snapshotSource.applyEstimatedTimetable(
+              transitModel,
+              fuzzyTripMatcher,
+              feedId,
+              fullDataset,
+              etds
+            );
             if (markPrimed) primed = true;
           });
         }

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETUpdater.java
@@ -4,7 +4,6 @@ import java.util.List;
 import org.apache.commons.lang3.BooleanUtils;
 import org.opentripplanner.ext.siri.SiriFuzzyTripMatcher;
 import org.opentripplanner.ext.siri.SiriTimetableSnapshotSource;
-import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.updater.PollingGraphUpdater;
@@ -51,10 +50,11 @@ public class SiriETUpdater extends PollingGraphUpdater {
    */
   private final SiriTimetableSnapshotSource snapshotSource;
 
-  private SiriFuzzyTripMatcher fuzzyTripMatcher;
+  private final SiriFuzzyTripMatcher fuzzyTripMatcher;
 
   public SiriETUpdater(
     SiriETUpdaterParameters config,
+    TransitModel transitModel,
     SiriTimetableSnapshotSource timetableSnapshot
   ) {
     super(config);
@@ -65,7 +65,8 @@ public class SiriETUpdater extends PollingGraphUpdater {
 
     this.snapshotSource = timetableSnapshot;
 
-    blockReadinessUntilInitialized = config.blockReadinessUntilInitialized();
+    this.blockReadinessUntilInitialized = config.blockReadinessUntilInitialized();
+    this.fuzzyTripMatcher = SiriFuzzyTripMatcher.of(new DefaultTransitService(transitModel));
 
     LOG.info(
       "Creating stop time updater (SIRI ET) running every {} seconds : {}",
@@ -78,14 +79,6 @@ public class SiriETUpdater extends PollingGraphUpdater {
   public void setGraphUpdaterManager(WriteToGraphCallback saveResultOnGraph) {
     this.saveResultOnGraph = saveResultOnGraph;
   }
-
-  @Override
-  public void setup(Graph graph, TransitModel transitModel) {
-    this.fuzzyTripMatcher = SiriFuzzyTripMatcher.of(new DefaultTransitService(transitModel));
-  }
-
-  @Override
-  public void teardown() {}
 
   /**
    * Repeatedly makes blocking calls to an UpdateStreamer to retrieve new stop time updates, and

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriSXUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriSXUpdater.java
@@ -10,7 +10,6 @@ import org.apache.commons.lang3.BooleanUtils;
 import org.opentripplanner.ext.siri.SiriAlertsUpdateHandler;
 import org.opentripplanner.ext.siri.SiriFuzzyTripMatcher;
 import org.opentripplanner.ext.siri.SiriHttpUtils;
-import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
 import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.transit.service.DefaultTransitService;
@@ -29,24 +28,20 @@ public class SiriSXUpdater extends PollingGraphUpdater implements TransitAlertPr
   private static final long RETRY_INTERVAL_MILLIS = 5000;
   private static final Map<String, String> requestHeaders = new HashMap<>();
   private final String url;
-  private final String feedId;
-  private final long earlyStart;
   private final String originalRequestorRef;
+  private final TransitAlertService transitAlertService;
+  private final SiriAlertsUpdateHandler updateHandler;
   private WriteToGraphCallback saveResultOnGraph;
   private ZonedDateTime lastTimestamp = ZonedDateTime.now().minusWeeks(1);
-  private TransitAlertService transitAlertService;
-  private SiriAlertsUpdateHandler updateHandler = null;
   private String requestorRef;
   private int timeout;
   private int retryCount = 0;
 
-  public SiriSXUpdater(SiriSXUpdaterParameters config) {
+  public SiriSXUpdater(SiriSXUpdaterParameters config, TransitModel transitModel) {
     super(config);
     // TODO: add options to choose different patch services
     this.url = config.getUrl();
     this.requestorRef = config.getRequestorRef();
-    this.earlyStart = config.getEarlyStartSec();
-    this.feedId = config.getFeedId();
 
     if (requestorRef == null || requestorRef.isEmpty()) {
       requestorRef = "otp-" + UUID.randomUUID().toString();
@@ -61,8 +56,15 @@ public class SiriSXUpdater extends PollingGraphUpdater implements TransitAlertPr
     }
 
     blockReadinessUntilInitialized = config.blockReadinessUntilInitialized();
-
     requestHeaders.put("ET-Client-Name", SiriHttpUtils.getUniqueETClientName("-SX"));
+
+    this.transitAlertService = new TransitAlertServiceImpl(transitModel);
+    this.updateHandler = new SiriAlertsUpdateHandler(config.getFeedId(), transitModel);
+    this.updateHandler.setEarlyStart(config.getEarlyStartSec());
+    this.updateHandler.setTransitAlertService(transitAlertService);
+    this.updateHandler.setSiriFuzzyTripMatcher(
+        SiriFuzzyTripMatcher.of(new DefaultTransitService(transitModel))
+      );
 
     LOG.info(
       "Creating real-time alert updater (SIRI SX) running every {} seconds : {}",
@@ -75,22 +77,6 @@ public class SiriSXUpdater extends PollingGraphUpdater implements TransitAlertPr
   public void setGraphUpdaterManager(WriteToGraphCallback saveResultOnGraph) {
     this.saveResultOnGraph = saveResultOnGraph;
   }
-
-  @Override
-  public void setup(Graph graph, TransitModel transitModel) {
-    this.transitAlertService = new TransitAlertServiceImpl(transitModel);
-    if (updateHandler == null) {
-      updateHandler = new SiriAlertsUpdateHandler(feedId, transitModel);
-    }
-    updateHandler.setEarlyStart(earlyStart);
-    updateHandler.setTransitAlertService(transitAlertService);
-    updateHandler.setSiriFuzzyTripMatcher(
-      SiriFuzzyTripMatcher.of(new DefaultTransitService(transitModel))
-    );
-  }
-
-  @Override
-  public void teardown() {}
 
   public TransitAlertService getTransitAlertService() {
     return transitAlertService;

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriSXUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriSXUpdater.java
@@ -66,7 +66,7 @@ public class SiriSXUpdater extends PollingGraphUpdater implements TransitAlertPr
 
     LOG.info(
       "Creating real-time alert updater (SIRI SX) running every {} seconds : {}",
-      pollingPeriodSeconds,
+      pollingPeriodSeconds(),
       url
     );
   }

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriSXUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriSXUpdater.java
@@ -79,15 +79,14 @@ public class SiriSXUpdater extends PollingGraphUpdater implements TransitAlertPr
   @Override
   public void setup(Graph graph, TransitModel transitModel) {
     this.transitAlertService = new TransitAlertServiceImpl(transitModel);
-    SiriFuzzyTripMatcher fuzzyTripMatcher = new SiriFuzzyTripMatcher(
-      new DefaultTransitService(transitModel)
-    );
     if (updateHandler == null) {
       updateHandler = new SiriAlertsUpdateHandler(feedId, transitModel);
     }
     updateHandler.setEarlyStart(earlyStart);
     updateHandler.setTransitAlertService(transitAlertService);
-    updateHandler.setSiriFuzzyTripMatcher(fuzzyTripMatcher);
+    updateHandler.setSiriFuzzyTripMatcher(
+      SiriFuzzyTripMatcher.of(new DefaultTransitService(transitModel))
+    );
   }
 
   @Override

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriVMUpdaterParameters.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriVMUpdaterParameters.java
@@ -9,7 +9,6 @@ public class SiriVMUpdaterParameters implements PollingGraphUpdaterParameters {
   private final int logFrequency;
   private final int maxSnapshotFrequencyMs;
   private final boolean purgeExpiredData;
-  private final boolean fuzzyTripMatching;
   private final boolean blockReadinessUntilInitialized;
 
   // Source parameters
@@ -24,7 +23,6 @@ public class SiriVMUpdaterParameters implements PollingGraphUpdaterParameters {
     int logFrequency,
     int maxSnapshotFrequencyMs,
     boolean purgeExpiredData,
-    boolean fuzzyTripMatching,
     boolean blockReadinessUntilInitialized,
     String url,
     String requestorRef,
@@ -36,7 +34,6 @@ public class SiriVMUpdaterParameters implements PollingGraphUpdaterParameters {
     this.logFrequency = logFrequency;
     this.maxSnapshotFrequencyMs = maxSnapshotFrequencyMs;
     this.purgeExpiredData = purgeExpiredData;
-    this.fuzzyTripMatching = fuzzyTripMatching;
     this.blockReadinessUntilInitialized = blockReadinessUntilInitialized;
     this.url = url;
     this.requestorRef = requestorRef;
@@ -68,10 +65,6 @@ public class SiriVMUpdaterParameters implements PollingGraphUpdaterParameters {
 
   public boolean purgeExpiredData() {
     return purgeExpiredData;
-  }
-
-  public boolean fuzzyTripMatching() {
-    return fuzzyTripMatching;
   }
 
   public boolean blockReadinessUntilInitialized() {

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/azure/AbstractAzureSiriUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/azure/AbstractAzureSiriUpdater.java
@@ -33,7 +33,7 @@ public abstract class AbstractAzureSiriUpdater implements GraphUpdater {
   private final Logger LOG = LoggerFactory.getLogger(getClass());
   private boolean isPrimed = false;
   protected WriteToGraphCallback saveResultOnGraph;
-  protected SiriTimetableSnapshotSource snapshotSource;
+  protected final SiriTimetableSnapshotSource snapshotSource;
 
   private SiriFuzzyTripMatcher fuzzyTripMatcher;
   private final String configRef;
@@ -56,15 +56,19 @@ public abstract class AbstractAzureSiriUpdater implements GraphUpdater {
    */
   protected int timeout;
 
-  public AbstractAzureSiriUpdater(SiriAzureUpdaterParameters config) {
+  public AbstractAzureSiriUpdater(
+    SiriAzureUpdaterParameters config,
+    TransitModel transitModel,
+    SiriTimetableSnapshotSource snapshotSource
+  ) {
     this.configRef = config.getConfigRef();
-
     this.serviceBusUrl = config.getServiceBusUrl();
     this.topicName = config.getTopicName();
-
     this.dataInitializationUrl = config.getDataInitializationUrl();
     this.timeout = config.getTimeout();
     this.feedId = config.getFeedId();
+    this.snapshotSource = snapshotSource;
+    this.fuzzyTripMatcher = SiriFuzzyTripMatcher.of(new DefaultTransitService(transitModel));
   }
 
   /**
@@ -85,11 +89,7 @@ public abstract class AbstractAzureSiriUpdater implements GraphUpdater {
   }
 
   @Override
-  public void setup(Graph graph, TransitModel transitModel) throws Exception {
-    snapshotSource =
-      transitModel.getOrSetupTimetableSnapshotProvider(SiriTimetableSnapshotSource::new);
-    this.fuzzyTripMatcher = SiriFuzzyTripMatcher.of(new DefaultTransitService(transitModel));
-  }
+  public void setup(Graph graph, TransitModel transitModel) throws Exception {}
 
   @Override
   public void run() throws Exception {

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/azure/AbstractAzureSiriUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/azure/AbstractAzureSiriUpdater.java
@@ -18,8 +18,10 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import org.opentripplanner.ext.siri.SiriFuzzyTripMatcher;
 import org.opentripplanner.ext.siri.SiriTimetableSnapshotSource;
 import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.updater.GraphUpdater;
 import org.opentripplanner.updater.WriteToGraphCallback;
@@ -32,6 +34,8 @@ public abstract class AbstractAzureSiriUpdater implements GraphUpdater {
   private boolean isPrimed = false;
   protected WriteToGraphCallback saveResultOnGraph;
   protected SiriTimetableSnapshotSource snapshotSource;
+
+  private SiriFuzzyTripMatcher fuzzyTripMatcher;
   private final String configRef;
 
   private ServiceBusProcessorClient eventProcessor;
@@ -84,6 +88,7 @@ public abstract class AbstractAzureSiriUpdater implements GraphUpdater {
   public void setup(Graph graph, TransitModel transitModel) throws Exception {
     snapshotSource =
       transitModel.getOrSetupTimetableSnapshotProvider(SiriTimetableSnapshotSource::new);
+    this.fuzzyTripMatcher = SiriFuzzyTripMatcher.of(new DefaultTransitService(transitModel));
   }
 
   @Override
@@ -170,6 +175,10 @@ public abstract class AbstractAzureSiriUpdater implements GraphUpdater {
   @Override
   public String getConfigRef() {
     return this.configRef;
+  }
+
+  SiriFuzzyTripMatcher fuzzyTripMatcher() {
+    return fuzzyTripMatcher;
   }
 
   /**

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureETUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureETUpdater.java
@@ -35,6 +35,8 @@ public class SiriAzureETUpdater extends AbstractAzureSiriUpdater {
   private static final AtomicLong MESSAGE_COUNTER = new AtomicLong(0);
 
   private final LocalDate fromDateTime;
+  private final SiriTimetableSnapshotSource snapshotSource;
+
   private long startTime;
 
   public SiriAzureETUpdater(
@@ -42,8 +44,9 @@ public class SiriAzureETUpdater extends AbstractAzureSiriUpdater {
     TransitModel transitModel,
     SiriTimetableSnapshotSource snapshotSource
   ) {
-    super(config, transitModel, snapshotSource);
+    super(config, transitModel);
     this.fromDateTime = config.getFromDateTime();
+    this.snapshotSource = snapshotSource;
   }
 
   @Override

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureETUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureETUpdater.java
@@ -20,6 +20,8 @@ import javax.xml.bind.JAXBException;
 import javax.xml.stream.XMLStreamException;
 import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.apache.http.client.utils.URIBuilder;
+import org.opentripplanner.ext.siri.SiriTimetableSnapshotSource;
+import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.util.HttpUtils;
 import org.rutebanken.siri20.util.SiriXml;
 import org.slf4j.Logger;
@@ -35,8 +37,12 @@ public class SiriAzureETUpdater extends AbstractAzureSiriUpdater {
   private final LocalDate fromDateTime;
   private long startTime;
 
-  public SiriAzureETUpdater(SiriAzureETUpdaterParameters config) {
-    super(config);
+  public SiriAzureETUpdater(
+    SiriAzureETUpdaterParameters config,
+    TransitModel transitModel,
+    SiriTimetableSnapshotSource snapshotSource
+  ) {
+    super(config, transitModel, snapshotSource);
     this.fromDateTime = config.getFromDateTime();
   }
 

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureSXUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureSXUpdater.java
@@ -19,6 +19,7 @@ import javax.xml.stream.XMLStreamException;
 import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.apache.http.client.utils.URIBuilder;
 import org.opentripplanner.ext.siri.SiriAlertsUpdateHandler;
+import org.opentripplanner.ext.siri.SiriTimetableSnapshotSource;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
 import org.opentripplanner.routing.services.TransitAlertService;
@@ -41,8 +42,12 @@ public class SiriAzureSXUpdater extends AbstractAzureSiriUpdater implements Tran
   private final LocalDate toDateTime;
   private long startTime;
 
-  public SiriAzureSXUpdater(SiriAzureSXUpdaterParameters config) {
-    super(config);
+  public SiriAzureSXUpdater(
+    SiriAzureSXUpdaterParameters config,
+    TransitModel transitModel,
+    SiriTimetableSnapshotSource snapshotSource
+  ) {
+    super(config, transitModel, snapshotSource);
     this.fromDateTime = config.getFromDateTime();
     this.toDateTime = config.getToDateTime();
   }

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureSXUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureSXUpdater.java
@@ -19,11 +19,9 @@ import javax.xml.stream.XMLStreamException;
 import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.apache.http.client.utils.URIBuilder;
 import org.opentripplanner.ext.siri.SiriAlertsUpdateHandler;
-import org.opentripplanner.ext.siri.SiriFuzzyTripMatcher;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
 import org.opentripplanner.routing.services.TransitAlertService;
-import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.updater.alerts.TransitAlertProvider;
 import org.opentripplanner.util.HttpUtils;
@@ -53,14 +51,12 @@ public class SiriAzureSXUpdater extends AbstractAzureSiriUpdater implements Tran
   public void setup(Graph graph, TransitModel transitModel) throws Exception {
     super.setup(graph, transitModel);
     this.transitAlertService = new TransitAlertServiceImpl(transitModel);
-    SiriFuzzyTripMatcher fuzzyTripMatcher = new SiriFuzzyTripMatcher(
-      new DefaultTransitService(transitModel)
-    );
+
     if (updateHandler == null) {
       updateHandler = new SiriAlertsUpdateHandler(feedId, transitModel);
     }
     updateHandler.setTransitAlertService(transitAlertService);
-    updateHandler.setSiriFuzzyTripMatcher(fuzzyTripMatcher);
+    updateHandler.setSiriFuzzyTripMatcher(fuzzyTripMatcher());
   }
 
   @Override

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureSXUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureSXUpdater.java
@@ -19,8 +19,6 @@ import javax.xml.stream.XMLStreamException;
 import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.apache.http.client.utils.URIBuilder;
 import org.opentripplanner.ext.siri.SiriAlertsUpdateHandler;
-import org.opentripplanner.ext.siri.SiriTimetableSnapshotSource;
-import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
 import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.transit.service.TransitModel;
@@ -34,34 +32,22 @@ import uk.org.siri.siri20.Siri;
 public class SiriAzureSXUpdater extends AbstractAzureSiriUpdater implements TransitAlertProvider {
 
   private final Logger LOG = LoggerFactory.getLogger(getClass());
-  private SiriAlertsUpdateHandler updateHandler;
-  private TransitAlertService transitAlertService;
+  private final SiriAlertsUpdateHandler updateHandler;
+  private final TransitAlertService transitAlertService;
 
   private static final transient AtomicLong messageCounter = new AtomicLong(0);
   private final LocalDate fromDateTime;
   private final LocalDate toDateTime;
   private long startTime;
 
-  public SiriAzureSXUpdater(
-    SiriAzureSXUpdaterParameters config,
-    TransitModel transitModel,
-    SiriTimetableSnapshotSource snapshotSource
-  ) {
-    super(config, transitModel, snapshotSource);
+  public SiriAzureSXUpdater(SiriAzureSXUpdaterParameters config, TransitModel transitModel) {
+    super(config, transitModel);
     this.fromDateTime = config.getFromDateTime();
     this.toDateTime = config.getToDateTime();
-  }
-
-  @Override
-  public void setup(Graph graph, TransitModel transitModel) throws Exception {
-    super.setup(graph, transitModel);
     this.transitAlertService = new TransitAlertServiceImpl(transitModel);
-
-    if (updateHandler == null) {
-      updateHandler = new SiriAlertsUpdateHandler(feedId, transitModel);
-    }
-    updateHandler.setTransitAlertService(transitAlertService);
-    updateHandler.setSiriFuzzyTripMatcher(fuzzyTripMatcher());
+    this.updateHandler = new SiriAlertsUpdateHandler(feedId, transitModel);
+    this.updateHandler.setTransitAlertService(transitAlertService);
+    this.updateHandler.setSiriFuzzyTripMatcher(fuzzyTripMatcher());
   }
 
   @Override

--- a/src/ext/java/org/opentripplanner/ext/vehiclerentalservicedirectory/VehicleRentalServiceDirectoryFetcher.java
+++ b/src/ext/java/org/opentripplanner/ext/vehiclerentalservicedirectory/VehicleRentalServiceDirectoryFetcher.java
@@ -6,6 +6,8 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import org.opentripplanner.ext.vehiclerentalservicedirectory.api.VehicleRentalServiceDirectoryFetcherParameters;
+import org.opentripplanner.graph_builder.linking.VertexLinker;
+import org.opentripplanner.routing.vehicle_rental.VehicleRentalStationService;
 import org.opentripplanner.updater.GraphUpdater;
 import org.opentripplanner.updater.vehicle_rental.VehicleRentalUpdater;
 import org.opentripplanner.updater.vehicle_rental.datasources.VehicleRentalDataSourceFactory;
@@ -26,7 +28,9 @@ public class VehicleRentalServiceDirectoryFetcher {
   private static final int DEFAULT_FREQUENCY_SEC = 15;
 
   public static List<GraphUpdater> createUpdatersFromEndpoint(
-    VehicleRentalServiceDirectoryFetcherParameters parameters
+    VehicleRentalServiceDirectoryFetcherParameters parameters,
+    VertexLinker vertexLinker,
+    VehicleRentalStationService vehicleRentalStationService
   ) {
     LOG.info("Fetching list of updaters from {}", parameters.getUrl());
 
@@ -73,7 +77,12 @@ public class VehicleRentalServiceDirectoryFetcher {
         var dataSource = VehicleRentalDataSourceFactory.create(
           vehicleRentalParameters.sourceParameters()
         );
-        GraphUpdater updater = new VehicleRentalUpdater(vehicleRentalParameters, dataSource);
+        GraphUpdater updater = new VehicleRentalUpdater(
+          vehicleRentalParameters,
+          dataSource,
+          vertexLinker,
+          vehicleRentalStationService
+        );
         updaters.add(updater);
       }
     } catch (java.io.IOException e) {

--- a/src/ext/java/org/opentripplanner/ext/vilkkubikerental/VilkkuBikeRentalDataSource.java
+++ b/src/ext/java/org/opentripplanner/ext/vilkkubikerental/VilkkuBikeRentalDataSource.java
@@ -24,7 +24,7 @@ public class VilkkuBikeRentalDataSource extends GenericXmlDataSource<VehicleRent
     "longitude"
   );
 
-  private String network;
+  private final String network;
 
   /**
    * Initialize VilkkuBikeRentalDataSource.

--- a/src/main/java/org/opentripplanner/model/TimetableSnapshot.java
+++ b/src/main/java/org/opentripplanner/model/TimetableSnapshot.java
@@ -18,7 +18,6 @@ import org.opentripplanner.routing.algorithm.raptoradapter.transit.mappers.Trans
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.site.StopLocation;
-import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripIdAndServiceDate;
 import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
 import org.opentripplanner.transit.model.timetable.TripTimes;
@@ -44,11 +43,13 @@ import org.slf4j.LoggerFactory;
 public class TimetableSnapshot {
 
   private static final Logger LOG = LoggerFactory.getLogger(TimetableSnapshot.class);
+
   /**
    * A set of all timetables which have been modified and are waiting to be indexed. When
    * <code>dirty</code> is <code>null</code>, it indicates that the snapshot is read-only.
    */
   private final Set<Timetable> dirtyTimetables = new HashSet<>();
+
   /**
    * The timetables for different days, for each TripPattern (each sequence of stops on a particular
    * Route) for which we have an updated Timetable. The keys include both TripPatterns from the
@@ -60,6 +61,7 @@ public class TimetableSnapshot {
    * FIXME: this could be made into a flat hashtable with compound keys.
    */
   private HashMap<TripPattern, SortedSet<Timetable>> timetables = new HashMap();
+
   /**
    * <p>
    * Map containing the current trip pattern given a trip id and a service date, if it has been
@@ -69,8 +71,10 @@ public class TimetableSnapshot {
    * This is a HashMap and not a Map so the clone function is available.
    */
   private HashMap<TripIdAndServiceDate, TripPattern> realtimeAddedTripPattern = new HashMap<>();
+
   private HashMap<FeedScopedId, TripOnServiceDate> realtimeAddedTripOnServiceDate = new HashMap<>();
   private HashMap<TripIdAndServiceDate, TripOnServiceDate> realtimeAddedTripOnServiceDateByTripIdAndServiceDate = new HashMap<>();
+
   /**
    * This maps contains all of the new or updated TripPatterns added by realtime data indexed on
    * stop. This has to be kept in order for them to be included in the stop times api call on a
@@ -81,11 +85,13 @@ public class TimetableSnapshot {
    * TODO Find a generic way to keep all realtime indexes.
    */
   private SetMultimap<StopLocation, TripPattern> patternsForStop = HashMultimap.create();
+
   /**
    * Boolean value indicating that timetable snapshot is read only if true. Once it is true, it
    * shouldn't be possible to change it to false anymore.
    */
   private boolean readOnly = false;
+
   /**
    * Boolean value indicating that this timetable snapshot contains changes compared to the state of
    * the last commit if true.

--- a/src/main/java/org/opentripplanner/standalone/OTPMain.java
+++ b/src/main/java/org/opentripplanner/standalone/OTPMain.java
@@ -14,7 +14,7 @@ import org.opentripplanner.standalone.configure.LoadApplication;
 import org.opentripplanner.standalone.server.GrizzlyServer;
 import org.opentripplanner.transit.raptor.configure.RaptorConfig;
 import org.opentripplanner.transit.service.TransitModel;
-import org.opentripplanner.updater.GraphUpdaterConfigurator;
+import org.opentripplanner.updater.configure.UpdaterConfigurator;
 import org.opentripplanner.util.OtpAppException;
 import org.opentripplanner.util.ThrowableUtils;
 import org.slf4j.Logger;
@@ -218,7 +218,7 @@ public class OTPMain {
   ) {
     var hook = new Thread(() -> {
       LOG.info("OTP shutdown started...");
-      GraphUpdaterConfigurator.shutdownGraph(transitModel);
+      UpdaterConfigurator.shutdownGraph(transitModel);
       raptorConfig.shutdown();
       WeakCollectionCleaner.DEFAULT.exit();
       DeferredAuthorityFactory.exit();

--- a/src/main/java/org/opentripplanner/standalone/config/updaters/SiriVMUpdaterConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/updaters/SiriVMUpdaterConfig.java
@@ -13,7 +13,6 @@ public class SiriVMUpdaterConfig {
       c.asInt("logFrequency", -1),
       c.asInt("maxSnapshotFrequencyMs", -1),
       c.asBoolean("purgeExpiredData", false),
-      c.asBoolean("fuzzyTripMatching", false),
       c.asBoolean("blockReadinessUntilInitialized", false),
       c.asText("url"),
       c.asText("requestorRef", "otp-" + UUID.randomUUID()),

--- a/src/main/java/org/opentripplanner/standalone/config/updaters/WebsocketGtfsRealtimeUpdaterConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/updaters/WebsocketGtfsRealtimeUpdaterConfig.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.standalone.config.updaters;
 
 import org.opentripplanner.standalone.config.NodeAdapter;
+import org.opentripplanner.updater.stoptime.BackwardsDelayPropagationType;
 import org.opentripplanner.updater.stoptime.WebsocketGtfsRealtimeUpdaterParameters;
 
 public class WebsocketGtfsRealtimeUpdaterConfig {
@@ -10,7 +11,8 @@ public class WebsocketGtfsRealtimeUpdaterConfig {
       configRef,
       c.asText("feedId", null),
       c.asText("url", null),
-      c.asInt("reconnectPeriodSec", 60)
+      c.asInt("reconnectPeriodSec", 60),
+      c.asEnum("backwardsDelayPropagationType", BackwardsDelayPropagationType.REQUIRED_NO_DATA)
     );
   }
 }

--- a/src/main/java/org/opentripplanner/standalone/configure/ConstructApplication.java
+++ b/src/main/java/org/opentripplanner/standalone/configure/ConstructApplication.java
@@ -22,7 +22,7 @@ import org.opentripplanner.standalone.server.GrizzlyServer;
 import org.opentripplanner.standalone.server.OTPWebApplication;
 import org.opentripplanner.transit.raptor.configure.RaptorConfig;
 import org.opentripplanner.transit.service.TransitModel;
-import org.opentripplanner.updater.GraphUpdaterConfigurator;
+import org.opentripplanner.updater.configure.UpdaterConfigurator;
 import org.opentripplanner.util.OTPFeature;
 import org.opentripplanner.visualizer.GraphVisualizer;
 import org.slf4j.Logger;
@@ -131,8 +131,8 @@ public class ConstructApplication {
 
     creatTransitLayerForRaptor(transitModel(), routerConfig());
 
-    /* Create Graph updater modules from JSON config. */
-    GraphUpdaterConfigurator.setupGraph(graph(), transitModel(), routerConfig().updaterConfig());
+    /* Create updater modules from JSON config. */
+    UpdaterConfigurator.configure(graph(), transitModel(), routerConfig().updaterConfig());
 
     graph().initEllipsoidToGeoidDifference();
 

--- a/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
+++ b/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
@@ -11,7 +11,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Function;
 import javax.inject.Inject;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Envelope;
@@ -21,7 +20,6 @@ import org.opentripplanner.model.PathTransfer;
 import org.opentripplanner.model.StopTimesInPattern;
 import org.opentripplanner.model.Timetable;
 import org.opentripplanner.model.TimetableSnapshot;
-import org.opentripplanner.model.TimetableSnapshotProvider;
 import org.opentripplanner.model.TripTimeOnDate;
 import org.opentripplanner.model.calendar.CalendarService;
 import org.opentripplanner.model.transfer.TransferService;
@@ -471,13 +469,6 @@ public class DefaultTransitService implements TransitEditorService {
   @Override
   public Collection<PathTransfer> getTransfersByStop(StopLocation stop) {
     return this.transitModel.getTransfersByStop(stop);
-  }
-
-  @Override
-  public <T extends TimetableSnapshotProvider> T getOrSetupTimetableSnapshotProvider(
-    Function<TransitModel, T> creator
-  ) {
-    return this.transitModel.getOrSetupTimetableSnapshotProvider(creator);
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/transit/service/TransitEditorService.java
+++ b/src/main/java/org/opentripplanner/transit/service/TransitEditorService.java
@@ -1,8 +1,6 @@
 package org.opentripplanner.transit.service;
 
-import java.util.function.Function;
 import org.opentripplanner.model.FeedInfo;
-import org.opentripplanner.model.TimetableSnapshotProvider;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TransitLayer;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.network.Route;
@@ -19,10 +17,6 @@ public interface TransitEditorService extends TransitService {
   void addRoutes(Route route);
 
   void addTransitMode(TransitMode mode);
-
-  <T extends TimetableSnapshotProvider> T getOrSetupTimetableSnapshotProvider(
-    Function<TransitModel, T> creator
-  );
 
   void setTransitLayer(TransitLayer transitLayer);
 }

--- a/src/main/java/org/opentripplanner/transit/service/TransitModel.java
+++ b/src/main/java/org/opentripplanner/transit/service/TransitModel.java
@@ -15,7 +15,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.Function;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import org.opentripplanner.ext.flex.trip.FlexTrip;
@@ -44,8 +43,8 @@ import org.opentripplanner.transit.model.organization.Agency;
 import org.opentripplanner.transit.model.organization.Operator;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
-import org.opentripplanner.updater.GraphUpdaterConfigurator;
 import org.opentripplanner.updater.GraphUpdaterManager;
+import org.opentripplanner.updater.configure.UpdaterConfigurator;
 import org.opentripplanner.util.lang.ObjectUtils;
 import org.opentripplanner.util.time.ServiceDateUtils;
 import org.slf4j.Logger;
@@ -135,26 +134,15 @@ public class TransitModel implements Serializable {
       : timetableSnapshotProvider.getTimetableSnapshot();
   }
 
-  /**
-   * TODO OTP2 - This should be replaced by proper dependency injection
-   */
-  @SuppressWarnings("unchecked")
-  public <T extends TimetableSnapshotProvider> T getOrSetupTimetableSnapshotProvider(
-    Function<TransitModel, T> creator
-  ) {
-    if (timetableSnapshotProvider == null) {
-      timetableSnapshotProvider = creator.apply(this);
-    }
-    try {
-      return (T) timetableSnapshotProvider;
-    } catch (ClassCastException e) {
+  public void initTimetableSnapshotProvider(TimetableSnapshotProvider timetableSnapshotProvider) {
+    if (this.timetableSnapshotProvider != null) {
       throw new IllegalArgumentException(
-        "We support only one timetableSnapshotSource, there are two implementation; one for GTFS and one " +
-        "for Netex/Siri. They need to be refactored to work together. This cast will fail if updaters " +
-        "try setup both.",
-        e
+        "We support only one timetableSnapshotSource, there are two implementation; one for " +
+        "GTFS and one for Netex/Siri. They need to be refactored to work together. This cast " +
+        "will fail if updaters try setup both."
       );
     }
+    this.timetableSnapshotProvider = timetableSnapshotProvider;
   }
 
   /** Data model for Raptor routing, with realtime updates applied (if any). */
@@ -426,7 +414,7 @@ public class TransitModel implements Serializable {
    * Manages all updaters of this graph. Is created by the GraphUpdaterConfigurator when there are
    * graph updaters defined in the configuration.
    *
-   * @see GraphUpdaterConfigurator
+   * @see UpdaterConfigurator
    */
   public GraphUpdaterManager getUpdaterManager() {
     return updaterManager;

--- a/src/main/java/org/opentripplanner/updater/GraphUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/GraphUpdater.java
@@ -1,8 +1,5 @@
 package org.opentripplanner.updater;
 
-import org.opentripplanner.routing.graph.Graph;
-import org.opentripplanner.transit.service.TransitModel;
-
 /**
  * Interface for graph updaters. Objects that implement this interface should always be configured
  * via PreferencesConfigurable.configure after creating the object. GraphUpdaterConfigurator should
@@ -25,7 +22,7 @@ public interface GraphUpdater {
    * method won't be called). All updaters' setup methods will be run sequentially in a
    * single-threaded manner before updates begin, in order to avoid concurrent reads/writes.
    */
-  void setup(Graph graph, TransitModel transitModel) throws Exception;
+  //void setup(Graph graph, TransitModel transitModel) throws Exception;
 
   /**
    * This method will run in its own thread. It pulls or receives updates and applies them to the
@@ -38,7 +35,7 @@ public interface GraphUpdater {
   /**
    * Here the updater can clean up after itself.
    */
-  void teardown();
+  default void teardown() {}
 
   /**
    * Allow clients to wait for all realtime data to be loaded before submitting any travel plan

--- a/src/main/java/org/opentripplanner/updater/PollingGraphUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/PollingGraphUpdater.java
@@ -20,7 +20,7 @@ public abstract class PollingGraphUpdater implements GraphUpdater {
   private static final Logger LOG = LoggerFactory.getLogger(PollingGraphUpdater.class);
   private final String configRef;
   /** How long to wait after polling to poll again. */
-  protected Integer pollingPeriodSeconds;
+  private Integer pollingPeriodSeconds;
 
   // TODO OTP2 eliminate this field for reasons in "primed" javadoc; also "initialized" is not a clear term.
   protected boolean blockReadinessUntilInitialized;
@@ -37,6 +37,10 @@ public abstract class PollingGraphUpdater implements GraphUpdater {
   public PollingGraphUpdater(PollingGraphUpdaterParameters config) {
     this.pollingPeriodSeconds = config.getFrequencySec();
     this.configRef = config.getConfigRef();
+  }
+
+  public Integer pollingPeriodSeconds() {
+    return pollingPeriodSeconds;
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/updater/TimetableSnapshotSourceParameters.java
+++ b/src/main/java/org/opentripplanner/updater/TimetableSnapshotSourceParameters.java
@@ -1,0 +1,42 @@
+package org.opentripplanner.updater;
+
+/**
+ * @param logFrequency           Log a status message for every successfully applied trip updates.
+ *                               Apply to GTFS-RT updates only.
+ * @param maxSnapshotFrequencyMs If a timetable snapshot is requested less than this number of
+ *                               milliseconds after the previous snapshot, then return the same
+ *                               instance. Throttles the potentially resource-consuming task of
+ *                               duplicating a TripPattern → Timetable map and indexing the new
+ *                               Timetables. Apply to GTFS-RT and Siri updates.
+ * @param purgeExpiredData       Should expired realtime data be purged from the graph. Apply to
+ *                               GTFS-RT and Siri updates.
+ */
+public record TimetableSnapshotSourceParameters(
+  int logFrequency,
+  int maxSnapshotFrequencyMs,
+  boolean purgeExpiredData
+) {
+  public static final TimetableSnapshotSourceParameters DEFAULT = new TimetableSnapshotSourceParameters(
+    2000,
+    1000,
+    true
+  );
+
+  /* Factory functions, used instead of a builder - useful in tests. */
+
+  public TimetableSnapshotSourceParameters withMaxSnapshotFrequencyMs(int maxSnapshotFrequencyMs) {
+    return new TimetableSnapshotSourceParameters(
+      this.logFrequency,
+      maxSnapshotFrequencyMs,
+      this.purgeExpiredData
+    );
+  }
+
+  public TimetableSnapshotSourceParameters withPurgeExpiredData(boolean purgeExpiredData) {
+    return new TimetableSnapshotSourceParameters(
+      this.logFrequency,
+      this.maxSnapshotFrequencyMs,
+      purgeExpiredData
+    );
+  }
+}

--- a/src/main/java/org/opentripplanner/updater/UpdatersParameters.java
+++ b/src/main/java/org/opentripplanner/updater/UpdatersParameters.java
@@ -18,6 +18,8 @@ import org.opentripplanner.updater.vehicle_positions.VehiclePositionsUpdaterPara
 import org.opentripplanner.updater.vehicle_rental.VehicleRentalUpdaterParameters;
 
 public interface UpdatersParameters {
+  TimetableSnapshotSourceParameters timetableSnapshotParameters();
+
   VehicleRentalServiceDirectoryFetcherParameters getVehicleRentalServiceDirectoryFetcherParameters();
 
   List<VehicleRentalUpdaterParameters> getVehicleRentalParameters();

--- a/src/main/java/org/opentripplanner/updater/alerts/GtfsRealtimeAlertsUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/alerts/GtfsRealtimeAlertsUpdater.java
@@ -51,7 +51,7 @@ public class GtfsRealtimeAlertsUpdater extends PollingGraphUpdater implements Tr
 
     LOG.info(
       "Creating real-time alert updater running every {} seconds : {}",
-      pollingPeriodSeconds,
+      pollingPeriodSeconds(),
       url
     );
   }

--- a/src/main/java/org/opentripplanner/updater/alerts/GtfsRealtimeAlertsUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/alerts/GtfsRealtimeAlertsUpdater.java
@@ -4,7 +4,6 @@ import com.google.transit.realtime.GtfsRealtime.FeedMessage;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.Map;
-import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
 import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.transit.service.DefaultTransitService;
@@ -33,21 +32,30 @@ public class GtfsRealtimeAlertsUpdater extends PollingGraphUpdater implements Tr
 
   private static final Logger LOG = LoggerFactory.getLogger(GtfsRealtimeAlertsUpdater.class);
   private final String url;
-  private final String feedId;
-  private final long earlyStart;
-  private final boolean fuzzyTripMatching;
+  private final AlertsUpdateHandler updateHandler;
+  private final TransitAlertService transitAlertService;
   private WriteToGraphCallback saveResultOnGraph;
   private Long lastTimestamp = Long.MIN_VALUE;
-  private GtfsRealtimeFuzzyTripMatcher fuzzyTripMatcher;
-  private AlertsUpdateHandler updateHandler = null;
-  private TransitAlertService transitAlertService;
 
-  public GtfsRealtimeAlertsUpdater(GtfsRealtimeAlertsUpdaterParameters config) {
+  public GtfsRealtimeAlertsUpdater(
+    GtfsRealtimeAlertsUpdaterParameters config,
+    TransitModel transitModel
+  ) {
     super(config);
     this.url = config.getUrl();
-    this.earlyStart = config.getEarlyStartSec();
-    this.feedId = config.getFeedId();
-    this.fuzzyTripMatching = config.fuzzyTripMatching();
+    TransitAlertService transitAlertService = new TransitAlertServiceImpl(transitModel);
+
+    var fuzzyTripMatcher = config.fuzzyTripMatching()
+      ? new GtfsRealtimeFuzzyTripMatcher(new DefaultTransitService(transitModel))
+      : null;
+
+    this.transitAlertService = transitAlertService;
+
+    this.updateHandler = new AlertsUpdateHandler();
+    this.updateHandler.setEarlyStart(config.getEarlyStartSec());
+    this.updateHandler.setFeedId(config.getFeedId());
+    this.updateHandler.setTransitAlertService(transitAlertService);
+    this.updateHandler.setFuzzyTripMatcher(fuzzyTripMatcher);
 
     LOG.info(
       "Creating real-time alert updater running every {} seconds : {}",
@@ -60,26 +68,6 @@ public class GtfsRealtimeAlertsUpdater extends PollingGraphUpdater implements Tr
   public void setGraphUpdaterManager(WriteToGraphCallback saveResultOnGraph) {
     this.saveResultOnGraph = saveResultOnGraph;
   }
-
-  @Override
-  public void setup(Graph graph, TransitModel transitModel) {
-    TransitAlertService transitAlertService = new TransitAlertServiceImpl(transitModel);
-    if (fuzzyTripMatching) {
-      this.fuzzyTripMatcher =
-        new GtfsRealtimeFuzzyTripMatcher(new DefaultTransitService(transitModel));
-    }
-    this.transitAlertService = transitAlertService;
-    if (updateHandler == null) {
-      updateHandler = new AlertsUpdateHandler();
-    }
-    updateHandler.setEarlyStart(earlyStart);
-    updateHandler.setFeedId(feedId);
-    updateHandler.setTransitAlertService(transitAlertService);
-    updateHandler.setFuzzyTripMatcher(fuzzyTripMatcher);
-  }
-
-  @Override
-  public void teardown() {}
 
   public TransitAlertService getTransitAlertService() {
     return transitAlertService;

--- a/src/main/java/org/opentripplanner/updater/configure/UpdaterConfigurator.java
+++ b/src/main/java/org/opentripplanner/updater/configure/UpdaterConfigurator.java
@@ -40,6 +40,7 @@ import org.slf4j.LoggerFactory;
  * GraphUpdaterManager.
  */
 public class UpdaterConfigurator {
+
   private static final Logger LOG = LoggerFactory.getLogger(UpdaterConfigurator.class);
 
   private final Graph graph;

--- a/src/main/java/org/opentripplanner/updater/configure/UpdaterConfigurator.java
+++ b/src/main/java/org/opentripplanner/updater/configure/UpdaterConfigurator.java
@@ -1,41 +1,33 @@
-package org.opentripplanner.updater;
+package org.opentripplanner.updater.configure;
 
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
+import org.opentripplanner.ext.siri.SiriTimetableSnapshotSource;
 import org.opentripplanner.ext.siri.updater.SiriETGooglePubsubUpdater;
-import org.opentripplanner.ext.siri.updater.SiriETGooglePubsubUpdaterParameters;
 import org.opentripplanner.ext.siri.updater.SiriETUpdater;
-import org.opentripplanner.ext.siri.updater.SiriETUpdaterParameters;
 import org.opentripplanner.ext.siri.updater.SiriSXUpdater;
-import org.opentripplanner.ext.siri.updater.SiriSXUpdaterParameters;
 import org.opentripplanner.ext.siri.updater.SiriVMUpdater;
-import org.opentripplanner.ext.siri.updater.SiriVMUpdaterParameters;
 import org.opentripplanner.ext.siri.updater.azure.SiriAzureETUpdater;
-import org.opentripplanner.ext.siri.updater.azure.SiriAzureETUpdaterParameters;
 import org.opentripplanner.ext.siri.updater.azure.SiriAzureSXUpdater;
-import org.opentripplanner.ext.siri.updater.azure.SiriAzureSXUpdaterParameters;
 import org.opentripplanner.ext.vehiclerentalservicedirectory.VehicleRentalServiceDirectoryFetcher;
 import org.opentripplanner.ext.vehiclerentalservicedirectory.api.VehicleRentalServiceDirectoryFetcherParameters;
 import org.opentripplanner.model.calendar.openinghours.OpeningHoursCalendarService;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.transit.service.TransitModel;
+import org.opentripplanner.updater.GraphUpdater;
+import org.opentripplanner.updater.GraphUpdaterManager;
+import org.opentripplanner.updater.UpdatersParameters;
 import org.opentripplanner.updater.alerts.GtfsRealtimeAlertsUpdater;
-import org.opentripplanner.updater.alerts.GtfsRealtimeAlertsUpdaterParameters;
 import org.opentripplanner.updater.stoptime.MqttGtfsRealtimeUpdater;
-import org.opentripplanner.updater.stoptime.MqttGtfsRealtimeUpdaterParameters;
 import org.opentripplanner.updater.stoptime.PollingStoptimeUpdater;
-import org.opentripplanner.updater.stoptime.PollingStoptimeUpdaterParameters;
+import org.opentripplanner.updater.stoptime.TimetableSnapshotSource;
 import org.opentripplanner.updater.stoptime.WebsocketGtfsRealtimeUpdater;
-import org.opentripplanner.updater.stoptime.WebsocketGtfsRealtimeUpdaterParameters;
-import org.opentripplanner.updater.street_notes.WFSNotePollingGraphUpdaterParameters;
 import org.opentripplanner.updater.street_notes.WinkkiPollingGraphUpdater;
 import org.opentripplanner.updater.vehicle_parking.VehicleParkingDataSourceFactory;
 import org.opentripplanner.updater.vehicle_parking.VehicleParkingUpdater;
-import org.opentripplanner.updater.vehicle_parking.VehicleParkingUpdaterParameters;
 import org.opentripplanner.updater.vehicle_positions.PollingVehiclePositionUpdater;
 import org.opentripplanner.updater.vehicle_rental.VehicleRentalUpdater;
-import org.opentripplanner.updater.vehicle_rental.VehicleRentalUpdaterParameters;
 import org.opentripplanner.updater.vehicle_rental.datasources.VehicleRentalDataSourceFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,24 +39,38 @@ import org.slf4j.LoggerFactory;
  * are then setup by providing the graph as a parameter. Finally, the updaters are added to the
  * GraphUpdaterManager.
  */
-public abstract class GraphUpdaterConfigurator {
+public class UpdaterConfigurator {
+  private static final Logger LOG = LoggerFactory.getLogger(UpdaterConfigurator.class);
 
-  private static final Logger LOG = LoggerFactory.getLogger(GraphUpdaterConfigurator.class);
+  private final Graph graph;
+  private final TransitModel transitModel;
+  private final UpdatersParameters updatersParameters;
+  private SiriTimetableSnapshotSource siriTimetableSnapshotSource = null;
+  private TimetableSnapshotSource gtfsTimetableSnapshotSource = null;
 
-  public static void setupGraph(
+  private UpdaterConfigurator(
     Graph graph,
     TransitModel transitModel,
     UpdatersParameters updatersParameters
   ) {
+    this.graph = graph;
+    this.transitModel = transitModel;
+    this.updatersParameters = updatersParameters;
+  }
+
+  public static void configure(
+    Graph graph,
+    TransitModel transitModel,
+    UpdatersParameters updatersParameters
+  ) {
+    new UpdaterConfigurator(graph, transitModel, updatersParameters).configure();
+  }
+
+  private void configure() {
     List<GraphUpdater> updaters = new ArrayList<>();
 
-    updaters.addAll(
-      createUpdatersFromConfig(
-        updatersParameters,
-        graph.getOpeningHoursCalendarService(),
-        transitModel.getTimeZone()
-      )
-    );
+    updaters.addAll(createUpdatersFromConfig());
+
     updaters.addAll(
       // Setup updaters using the VehicleRentalServiceDirectoryFetcher(Sandbox)
       fetchVehicleRentalServicesFromOnlineDirectory(
@@ -94,11 +100,7 @@ public abstract class GraphUpdaterConfigurator {
     }
   }
 
-  public static void setupUpdaters(
-    Graph graph,
-    TransitModel transitModel,
-    List<GraphUpdater> updaters
-  ) {
+  private void setupUpdaters(Graph graph, TransitModel transitModel, List<GraphUpdater> updaters) {
     for (GraphUpdater updater : updaters) {
       try {
         updater.setup(graph, transitModel);
@@ -125,45 +127,44 @@ public abstract class GraphUpdaterConfigurator {
   /**
    * @return a list of GraphUpdaters created from the configuration
    */
-  private static List<GraphUpdater> createUpdatersFromConfig(
-    UpdatersParameters config,
-    OpeningHoursCalendarService openingHoursCalendarService,
-    ZoneId zoneId
-  ) {
+  private List<GraphUpdater> createUpdatersFromConfig() {
+    OpeningHoursCalendarService openingHoursCalendarService = graph.getOpeningHoursCalendarService();
+    ZoneId zoneId = transitModel.getTimeZone();
+
     List<GraphUpdater> updaters = new ArrayList<>();
 
-    for (VehicleRentalUpdaterParameters configItem : config.getVehicleRentalParameters()) {
+    for (var configItem : updatersParameters.getVehicleRentalParameters()) {
       var source = VehicleRentalDataSourceFactory.create(configItem.sourceParameters());
       updaters.add(new VehicleRentalUpdater(configItem, source));
     }
-    for (GtfsRealtimeAlertsUpdaterParameters configItem : config.getGtfsRealtimeAlertsUpdaterParameters()) {
+    for (var configItem : updatersParameters.getGtfsRealtimeAlertsUpdaterParameters()) {
       updaters.add(new GtfsRealtimeAlertsUpdater(configItem));
     }
-    for (PollingStoptimeUpdaterParameters configItem : config.getPollingStoptimeUpdaterParameters()) {
-      updaters.add(new PollingStoptimeUpdater(configItem));
+    for (var configItem : updatersParameters.getPollingStoptimeUpdaterParameters()) {
+      updaters.add(new PollingStoptimeUpdater(configItem, provideGtfsTimetableSnapshot()));
     }
-    for (var configItem : config.getVehiclePositionsUpdaterParameters()) {
+    for (var configItem : updatersParameters.getVehiclePositionsUpdaterParameters()) {
       updaters.add(new PollingVehiclePositionUpdater(configItem));
     }
-    for (SiriETUpdaterParameters configItem : config.getSiriETUpdaterParameters()) {
-      updaters.add(new SiriETUpdater(configItem));
+    for (var configItem : updatersParameters.getSiriETUpdaterParameters()) {
+      updaters.add(new SiriETUpdater(configItem, provideSiriTimetableSnapshot()));
     }
-    for (SiriETGooglePubsubUpdaterParameters configItem : config.getSiriETGooglePubsubUpdaterParameters()) {
-      updaters.add(new SiriETGooglePubsubUpdater(configItem));
+    for (var configItem : updatersParameters.getSiriETGooglePubsubUpdaterParameters()) {
+      updaters.add(new SiriETGooglePubsubUpdater(configItem, provideSiriTimetableSnapshot()));
     }
-    for (SiriSXUpdaterParameters configItem : config.getSiriSXUpdaterParameters()) {
+    for (var configItem : updatersParameters.getSiriSXUpdaterParameters()) {
       updaters.add(new SiriSXUpdater(configItem));
     }
-    for (SiriVMUpdaterParameters configItem : config.getSiriVMUpdaterParameters()) {
-      updaters.add(new SiriVMUpdater(configItem));
+    for (var configItem : updatersParameters.getSiriVMUpdaterParameters()) {
+      updaters.add(new SiriVMUpdater(provideSiriTimetableSnapshot(), configItem));
     }
-    for (WebsocketGtfsRealtimeUpdaterParameters configItem : config.getWebsocketGtfsRealtimeUpdaterParameters()) {
-      updaters.add(new WebsocketGtfsRealtimeUpdater(configItem));
+    for (var configItem : updatersParameters.getWebsocketGtfsRealtimeUpdaterParameters()) {
+      updaters.add(new WebsocketGtfsRealtimeUpdater(configItem, provideGtfsTimetableSnapshot()));
     }
-    for (MqttGtfsRealtimeUpdaterParameters configItem : config.getMqttGtfsRealtimeUpdaterParameters()) {
-      updaters.add(new MqttGtfsRealtimeUpdater(configItem));
+    for (var configItem : updatersParameters.getMqttGtfsRealtimeUpdaterParameters()) {
+      updaters.add(new MqttGtfsRealtimeUpdater(configItem, provideGtfsTimetableSnapshot()));
     }
-    for (VehicleParkingUpdaterParameters configItem : config.getVehicleParkingUpdaterParameters()) {
+    for (var configItem : updatersParameters.getVehicleParkingUpdaterParameters()) {
       var source = VehicleParkingDataSourceFactory.create(
         configItem,
         openingHoursCalendarService,
@@ -171,16 +172,40 @@ public abstract class GraphUpdaterConfigurator {
       );
       updaters.add(new VehicleParkingUpdater(configItem, source));
     }
-    for (WFSNotePollingGraphUpdaterParameters configItem : config.getWinkkiPollingGraphUpdaterParameters()) {
+    for (var configItem : updatersParameters.getWinkkiPollingGraphUpdaterParameters()) {
       updaters.add(new WinkkiPollingGraphUpdater(configItem));
     }
-    for (SiriAzureETUpdaterParameters configItem : config.getSiriAzureETUpdaterParameters()) {
-      updaters.add(new SiriAzureETUpdater(configItem));
+    for (var configItem : updatersParameters.getSiriAzureETUpdaterParameters()) {
+      updaters.add(
+        new SiriAzureETUpdater(configItem, transitModel, provideSiriTimetableSnapshot())
+      );
     }
-    for (SiriAzureSXUpdaterParameters configItem : config.getSiriAzureSXUpdaterParameters()) {
-      updaters.add(new SiriAzureSXUpdater(configItem));
+    for (var configItem : updatersParameters.getSiriAzureSXUpdaterParameters()) {
+      updaters.add(
+        new SiriAzureSXUpdater(configItem, transitModel, provideSiriTimetableSnapshot())
+      );
     }
 
     return updaters;
+  }
+
+  private SiriTimetableSnapshotSource provideSiriTimetableSnapshot() {
+    if (siriTimetableSnapshotSource == null) {
+      this.siriTimetableSnapshotSource =
+        new SiriTimetableSnapshotSource(
+          updatersParameters.timetableSnapshotParameters(),
+          transitModel
+        );
+    }
+
+    return siriTimetableSnapshotSource;
+  }
+
+  private TimetableSnapshotSource provideGtfsTimetableSnapshot() {
+    if (gtfsTimetableSnapshotSource == null) {
+      this.gtfsTimetableSnapshotSource =
+        new TimetableSnapshotSource(updatersParameters.timetableSnapshotParameters(), transitModel);
+    }
+    return gtfsTimetableSnapshotSource;
   }
 }

--- a/src/main/java/org/opentripplanner/updater/stoptime/MqttGtfsRealtimeUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/MqttGtfsRealtimeUpdater.java
@@ -84,9 +84,6 @@ public class MqttGtfsRealtimeUpdater implements GraphUpdater {
       this.fuzzyTripMatcher =
         new GtfsRealtimeFuzzyTripMatcher(new DefaultTransitService(transitModel));
     }
-    if (backwardsDelayPropagationType != null) {
-      snapshotSource.backwardsDelayPropagationType = backwardsDelayPropagationType;
-    }
   }
 
   @Override
@@ -175,7 +172,7 @@ public class MqttGtfsRealtimeUpdater implements GraphUpdater {
       if (updates != null) {
         // Handle trip updates via graph writer runnable
         saveResultOnGraph.execute(
-          new TripUpdateGraphWriterRunnable(fuzzyTripMatcher, fullDataset, updates, feedId)
+          new TripUpdateGraphWriterRunnable(fuzzyTripMatcher, backwardsDelayPropagationType, fullDataset, updates, feedId)
         );
       }
     }

--- a/src/main/java/org/opentripplanner/updater/stoptime/MqttGtfsRealtimeUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/MqttGtfsRealtimeUpdater.java
@@ -51,7 +51,9 @@ public class MqttGtfsRealtimeUpdater implements GraphUpdater {
   private final String clientId = "OpenTripPlanner-" + MqttClient.generateClientId();
   private final String configRef;
   private WriteToGraphCallback saveResultOnGraph;
-  MemoryPersistence persistence = new MemoryPersistence();
+  private final MemoryPersistence persistence = new MemoryPersistence();
+
+  private GtfsRealtimeFuzzyTripMatcher fuzzyTripMatcher = null;
 
   private MqttClient client;
 
@@ -79,7 +81,7 @@ public class MqttGtfsRealtimeUpdater implements GraphUpdater {
 
     // Set properties of realtime data snapshot source
     if (fuzzyTripMatching) {
-      snapshotSource.fuzzyTripMatcher =
+      this.fuzzyTripMatcher =
         new GtfsRealtimeFuzzyTripMatcher(new DefaultTransitService(transitModel));
     }
     if (backwardsDelayPropagationType != null) {
@@ -172,7 +174,9 @@ public class MqttGtfsRealtimeUpdater implements GraphUpdater {
 
       if (updates != null) {
         // Handle trip updates via graph writer runnable
-        saveResultOnGraph.execute(new TripUpdateGraphWriterRunnable(fullDataset, updates, feedId));
+        saveResultOnGraph.execute(
+          new TripUpdateGraphWriterRunnable(fuzzyTripMatcher, fullDataset, updates, feedId)
+        );
       }
     }
 

--- a/src/main/java/org/opentripplanner/updater/stoptime/PollingStoptimeUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/PollingStoptimeUpdater.java
@@ -28,36 +28,45 @@ import org.slf4j.LoggerFactory;
 public class PollingStoptimeUpdater extends PollingGraphUpdater {
 
   private static final Logger LOG = LoggerFactory.getLogger(PollingStoptimeUpdater.class);
+
   /**
    * Update streamer
    */
   private final TripUpdateSource updateSource;
+
   /**
    * Property to set on the RealtimeDataSnapshotSource
    */
   private final Boolean purgeExpiredData;
+
   /**
    * Feed id that is used for the trip ids in the TripUpdates
    */
   private final String feedId;
+
   private final boolean fuzzyTripMatching;
+
   /**
    * Defines when delays are propagated to previous stops and if these stops are given
    * the NO_DATA flag.
    */
   private final BackwardsDelayPropagationType backwardsDelayPropagationType;
+
   /**
    * Parent update manager. Is used to execute graph writer runnables.
    */
   private WriteToGraphCallback saveResultOnGraph;
+
   /**
    * Property to set on the RealtimeDataSnapshotSource
    */
   private Integer logFrequency;
+
   /**
    * Property to set on the RealtimeDataSnapshotSource
    */
   private Integer maxSnapshotFrequency;
+
   /**
    * Set only if we should attempt to match the trip_id from other data in TripDescriptor
    */
@@ -116,9 +125,6 @@ public class PollingStoptimeUpdater extends PollingGraphUpdater {
     if (purgeExpiredData != null) {
       snapshotSource.purgeExpiredData = purgeExpiredData;
     }
-    if (backwardsDelayPropagationType != null) {
-      snapshotSource.backwardsDelayPropagationType = backwardsDelayPropagationType;
-    }
   }
 
   @Override
@@ -138,6 +144,7 @@ public class PollingStoptimeUpdater extends PollingGraphUpdater {
       // Handle trip updates via graph writer runnable
       TripUpdateGraphWriterRunnable runnable = new TripUpdateGraphWriterRunnable(
         fuzzyTripMatcher,
+        backwardsDelayPropagationType,
         fullDataset,
         updates,
         feedId

--- a/src/main/java/org/opentripplanner/updater/stoptime/PollingStoptimeUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/PollingStoptimeUpdater.java
@@ -116,9 +116,6 @@ public class PollingStoptimeUpdater extends PollingGraphUpdater {
     if (purgeExpiredData != null) {
       snapshotSource.purgeExpiredData = purgeExpiredData;
     }
-    if (fuzzyTripMatcher != null) {
-      snapshotSource.fuzzyTripMatcher = fuzzyTripMatcher;
-    }
     if (backwardsDelayPropagationType != null) {
       snapshotSource.backwardsDelayPropagationType = backwardsDelayPropagationType;
     }
@@ -140,6 +137,7 @@ public class PollingStoptimeUpdater extends PollingGraphUpdater {
     if (updates != null) {
       // Handle trip updates via graph writer runnable
       TripUpdateGraphWriterRunnable runnable = new TripUpdateGraphWriterRunnable(
+        fuzzyTripMatcher,
         fullDataset,
         updates,
         feedId

--- a/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
@@ -55,52 +55,63 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
    * Maximum time in seconds since midnight for arrivals and departures
    */
   private static final long MAX_ARRIVAL_DEPARTURE_TIME = 48 * 60 * 60;
+
   /**
    * The working copy of the timetable snapshot. Should not be visible to routing threads. Should
    * only be modified by a thread that holds a lock on {@link #bufferLock}. All public methods that
    * might modify this buffer will correctly acquire the lock.
    */
   private final TimetableSnapshot buffer = new TimetableSnapshot();
+
   /**
    * Lock to indicate that buffer is in use
    */
   private final ReentrantLock bufferLock = new ReentrantLock(true);
+
   /**
    * A synchronized cache of trip patterns that are added to the graph due to GTFS-realtime
    * messages.
    */
-  private final TripPatternCache tripPatternCache = new TripPatternCache();
-  private final ZoneId timeZone;
 
+  private final TripPatternCache tripPatternCache = new TripPatternCache();
+
+  private final ZoneId timeZone;
   private final TransitService transitService;
   private final TransitLayerUpdater transitLayerUpdater;
 
   public int logFrequency = 2000;
   private int totalSuccessfullyApplied = 0;
+
   /**
    * If a timetable snapshot is requested less than this number of milliseconds after the previous
    * snapshot, just return the same one. Throttles the potentially resource-consuming task of
    * duplicating a TripPattern → Timetable map and indexing the new Timetables.
    */
   public int maxSnapshotFrequency = 1000; // msec
+
   /**
    * The last committed snapshot that was handed off to a routing thread. This snapshot may be given
    * to more than one routing thread if the maximum snapshot frequency is exceeded.
    */
   private volatile TimetableSnapshot snapshot = null;
+
   /** Should expired realtime data be purged from the graph. */
   public boolean purgeExpiredData = true;
+
   protected LocalDate lastPurgeDate = null;
+
   /** Epoch time in milliseconds at which the last snapshot was generated. */
   protected long lastSnapshotTime = -1;
-  public GtfsRealtimeFuzzyTripMatcher fuzzyTripMatcher;
+
   /**
    * Defines when delays are propagated to previous stops and if these stops are given
    * the NO_DATA flag.
    */
   BackwardsDelayPropagationType backwardsDelayPropagationType =
     BackwardsDelayPropagationType.REQUIRED_NO_DATA;
+
   private final Deduplicator deduplicator;
+
   private final Map<FeedScopedId, Integer> serviceCodes;
 
   public static TimetableSnapshotSource ofTransitModel(final TransitModel transitModel) {
@@ -165,6 +176,7 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
    * @param updates     GTFS-RT TripUpdate's that should be applied atomically
    */
   public void applyTripUpdates(
+    GtfsRealtimeFuzzyTripMatcher fuzzyTripMatcher,
     final boolean fullDataset,
     final List<TripUpdate> updates,
     final String feedId

--- a/src/main/java/org/opentripplanner/updater/stoptime/TripUpdateGraphWriterRunnable.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/TripUpdateGraphWriterRunnable.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.updater.GraphWriterRunnable;
+import org.opentripplanner.updater.GtfsRealtimeFuzzyTripMatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,21 +25,20 @@ class TripUpdateGraphWriterRunnable implements GraphWriterRunnable {
    */
   private final List<TripUpdate> updates;
 
+  private final GtfsRealtimeFuzzyTripMatcher fuzzyTripMatcher;
+
   private final String feedId;
 
   TripUpdateGraphWriterRunnable(
-    final boolean fullDataset,
-    final List<TripUpdate> updates,
-    final String feedId
+    GtfsRealtimeFuzzyTripMatcher fuzzyTripMatcher,
+    boolean fullDataset,
+    List<TripUpdate> updates,
+    String feedId
   ) {
-    // Preconditions
-    Objects.requireNonNull(updates);
-    Objects.requireNonNull(feedId);
-
-    // Set fields
+    this.fuzzyTripMatcher = fuzzyTripMatcher;
     this.fullDataset = fullDataset;
-    this.updates = updates;
-    this.feedId = feedId;
+    this.updates = Objects.requireNonNull(updates);
+    this.feedId = Objects.requireNonNull(feedId);
   }
 
   @Override
@@ -48,7 +48,7 @@ class TripUpdateGraphWriterRunnable implements GraphWriterRunnable {
     // TimetableSnapshotSource should already be set up
     TimetableSnapshotSource snapshotSource = transitModel.getOrSetupTimetableSnapshotProvider(null);
     if (snapshotSource != null) {
-      snapshotSource.applyTripUpdates(fullDataset, updates, feedId);
+      snapshotSource.applyTripUpdates(fuzzyTripMatcher, fullDataset, updates, feedId);
     } else {
       LOG.error(
         "Could not find realtime data snapshot source in graph." +

--- a/src/main/java/org/opentripplanner/updater/stoptime/TripUpdateGraphWriterRunnable.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/TripUpdateGraphWriterRunnable.java
@@ -27,15 +27,19 @@ class TripUpdateGraphWriterRunnable implements GraphWriterRunnable {
 
   private final GtfsRealtimeFuzzyTripMatcher fuzzyTripMatcher;
 
+  private final BackwardsDelayPropagationType backwardsDelayPropagationType;
+
   private final String feedId;
 
   TripUpdateGraphWriterRunnable(
     GtfsRealtimeFuzzyTripMatcher fuzzyTripMatcher,
+    BackwardsDelayPropagationType backwardsDelayPropagationType,
     boolean fullDataset,
     List<TripUpdate> updates,
     String feedId
   ) {
     this.fuzzyTripMatcher = fuzzyTripMatcher;
+    this.backwardsDelayPropagationType = backwardsDelayPropagationType;
     this.fullDataset = fullDataset;
     this.updates = Objects.requireNonNull(updates);
     this.feedId = Objects.requireNonNull(feedId);
@@ -48,7 +52,13 @@ class TripUpdateGraphWriterRunnable implements GraphWriterRunnable {
     // TimetableSnapshotSource should already be set up
     TimetableSnapshotSource snapshotSource = transitModel.getOrSetupTimetableSnapshotProvider(null);
     if (snapshotSource != null) {
-      snapshotSource.applyTripUpdates(fuzzyTripMatcher, fullDataset, updates, feedId);
+      snapshotSource.applyTripUpdates(
+        fuzzyTripMatcher,
+        backwardsDelayPropagationType,
+        fullDataset,
+        updates,
+        feedId
+      );
     } else {
       LOG.error(
         "Could not find realtime data snapshot source in graph." +

--- a/src/main/java/org/opentripplanner/updater/stoptime/TripUpdateGraphWriterRunnable.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/TripUpdateGraphWriterRunnable.java
@@ -7,12 +7,8 @@ import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.updater.GraphWriterRunnable;
 import org.opentripplanner.updater.GtfsRealtimeFuzzyTripMatcher;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 class TripUpdateGraphWriterRunnable implements GraphWriterRunnable {
-
-  private static final Logger LOG = LoggerFactory.getLogger(TripUpdateGraphWriterRunnable.class);
 
   /**
    * True iff the list with updates represent all updates that are active right now, i.e. all
@@ -30,14 +26,17 @@ class TripUpdateGraphWriterRunnable implements GraphWriterRunnable {
   private final BackwardsDelayPropagationType backwardsDelayPropagationType;
 
   private final String feedId;
+  private final TimetableSnapshotSource snapshotSource;
 
   TripUpdateGraphWriterRunnable(
+    TimetableSnapshotSource snapshotSource,
     GtfsRealtimeFuzzyTripMatcher fuzzyTripMatcher,
     BackwardsDelayPropagationType backwardsDelayPropagationType,
     boolean fullDataset,
     List<TripUpdate> updates,
     String feedId
   ) {
+    this.snapshotSource = snapshotSource;
     this.fuzzyTripMatcher = fuzzyTripMatcher;
     this.backwardsDelayPropagationType = backwardsDelayPropagationType;
     this.fullDataset = fullDataset;
@@ -47,24 +46,12 @@ class TripUpdateGraphWriterRunnable implements GraphWriterRunnable {
 
   @Override
   public void run(Graph graph, TransitModel transitModel) {
-    // Apply updates to graph using realtime snapshot source. The source is retrieved from the graph using the
-    // setup method which return the instance, we do not need to provide any creator because the
-    // TimetableSnapshotSource should already be set up
-    TimetableSnapshotSource snapshotSource = transitModel.getOrSetupTimetableSnapshotProvider(null);
-    if (snapshotSource != null) {
-      snapshotSource.applyTripUpdates(
-        fuzzyTripMatcher,
-        backwardsDelayPropagationType,
-        fullDataset,
-        updates,
-        feedId
-      );
-    } else {
-      LOG.error(
-        "Could not find realtime data snapshot source in graph." +
-        " The following updates are not applied: {}",
-        updates
-      );
-    }
+    snapshotSource.applyTripUpdates(
+      fuzzyTripMatcher,
+      backwardsDelayPropagationType,
+      fullDataset,
+      updates,
+      feedId
+    );
   }
 }

--- a/src/main/java/org/opentripplanner/updater/stoptime/WebsocketGtfsRealtimeUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/WebsocketGtfsRealtimeUpdater.java
@@ -61,6 +61,8 @@ public class WebsocketGtfsRealtimeUpdater implements GraphUpdater {
 
   private final String configRef;
 
+  private final BackwardsDelayPropagationType backwardsDelayPropagationType;
+
   /**
    * Parent update manager. Is used to execute graph writer runnables.
    */
@@ -73,6 +75,7 @@ public class WebsocketGtfsRealtimeUpdater implements GraphUpdater {
     this.url = parameters.getUrl();
     this.feedId = parameters.getFeedId();
     this.reconnectPeriodSec = parameters.getReconnectPeriodSec();
+    this.backwardsDelayPropagationType = parameters.getBackwardsDelayPropagationType();
   }
 
   @Override
@@ -191,6 +194,7 @@ public class WebsocketGtfsRealtimeUpdater implements GraphUpdater {
         // Handle trip updates via graph writer runnable
         TripUpdateGraphWriterRunnable runnable = new TripUpdateGraphWriterRunnable(
           fuzzyTripMatcher,
+          backwardsDelayPropagationType,
           fullDataset,
           updates,
           feedId

--- a/src/main/java/org/opentripplanner/updater/stoptime/WebsocketGtfsRealtimeUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/WebsocketGtfsRealtimeUpdater.java
@@ -15,7 +15,6 @@ import org.asynchttpclient.AsyncHttpClient;
 import org.asynchttpclient.ws.WebSocket;
 import org.asynchttpclient.ws.WebSocketListener;
 import org.asynchttpclient.ws.WebSocketUpgradeHandler;
-import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.updater.GraphUpdater;
@@ -74,7 +73,8 @@ public class WebsocketGtfsRealtimeUpdater implements GraphUpdater {
 
   public WebsocketGtfsRealtimeUpdater(
     WebsocketGtfsRealtimeUpdaterParameters parameters,
-    TimetableSnapshotSource snapshotSource
+    TimetableSnapshotSource snapshotSource,
+    TransitModel transitModel
   ) {
     this.configRef = parameters.getConfigRef();
     this.url = parameters.getUrl();
@@ -82,17 +82,13 @@ public class WebsocketGtfsRealtimeUpdater implements GraphUpdater {
     this.reconnectPeriodSec = parameters.getReconnectPeriodSec();
     this.backwardsDelayPropagationType = parameters.getBackwardsDelayPropagationType();
     this.snapshotSource = snapshotSource;
+    this.fuzzyTripMatcher =
+      new GtfsRealtimeFuzzyTripMatcher(new DefaultTransitService(transitModel));
   }
 
   @Override
   public void setGraphUpdaterManager(WriteToGraphCallback saveResultOnGraph) {
     this.saveResultOnGraph = saveResultOnGraph;
-  }
-
-  @Override
-  public void setup(Graph graph, TransitModel transitModel) {
-    this.fuzzyTripMatcher =
-      new GtfsRealtimeFuzzyTripMatcher(new DefaultTransitService(transitModel));
   }
 
   @Override
@@ -137,9 +133,6 @@ public class WebsocketGtfsRealtimeUpdater implements GraphUpdater {
       client.close();
     }
   }
-
-  @Override
-  public void teardown() {}
 
   @Override
   public String getConfigRef() {

--- a/src/main/java/org/opentripplanner/updater/stoptime/WebsocketGtfsRealtimeUpdaterParameters.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/WebsocketGtfsRealtimeUpdaterParameters.java
@@ -8,7 +8,6 @@ public class WebsocketGtfsRealtimeUpdaterParameters {
   private final int reconnectPeriodSec;
   private final BackwardsDelayPropagationType backwardsDelayPropagationType;
 
-
   public WebsocketGtfsRealtimeUpdaterParameters(
     String configRef,
     String feedId,

--- a/src/main/java/org/opentripplanner/updater/stoptime/WebsocketGtfsRealtimeUpdaterParameters.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/WebsocketGtfsRealtimeUpdaterParameters.java
@@ -6,17 +6,21 @@ public class WebsocketGtfsRealtimeUpdaterParameters {
   private final String feedId;
   private final String url;
   private final int reconnectPeriodSec;
+  private final BackwardsDelayPropagationType backwardsDelayPropagationType;
+
 
   public WebsocketGtfsRealtimeUpdaterParameters(
     String configRef,
     String feedId,
     String url,
-    int reconnectPeriodSec
+    int reconnectPeriodSec,
+    BackwardsDelayPropagationType backwardsDelayPropagationType
   ) {
     this.configRef = configRef;
     this.feedId = feedId;
     this.url = url;
     this.reconnectPeriodSec = reconnectPeriodSec;
+    this.backwardsDelayPropagationType = backwardsDelayPropagationType;
   }
 
   String getUrl() {
@@ -34,5 +38,9 @@ public class WebsocketGtfsRealtimeUpdaterParameters {
   /** The config name/type for the updater. Used to reference the configuration element. */
   String getConfigRef() {
     return configRef;
+  }
+
+  public BackwardsDelayPropagationType getBackwardsDelayPropagationType() {
+    return backwardsDelayPropagationType;
   }
 }

--- a/src/main/java/org/opentripplanner/updater/street_notes/WFSNotePollingGraphUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/street_notes/WFSNotePollingGraphUpdater.java
@@ -3,7 +3,6 @@ package org.opentripplanner.updater.street_notes;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.SetMultimap;
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Collection;
 import java.util.HashMap;
@@ -43,50 +42,66 @@ import org.slf4j.LoggerFactory;
  * Classes that extend this class should provide getNote which parses the WFS features into notes.
  * Also the implementing classes should be added to the GraphUpdaterConfigurator
  *
- * @author hannesj
  * @see WinkkiPollingGraphUpdater
  */
 public abstract class WFSNotePollingGraphUpdater extends PollingGraphUpdater {
 
-  // How much should the geometries be padded with in order to be sure they intersect with graph edges
+  private static final Logger LOG = LoggerFactory.getLogger(WFSNotePollingGraphUpdater.class);
+
+  /**
+   * How much should the geometries be padded with in order to be sure they intersect with
+   * graph edges
+   */
   private static final double SEARCH_RADIUS_M = 1;
   private static final double SEARCH_RADIUS_DEG = SphericalDistanceLibrary.metersToDegrees(
     SEARCH_RADIUS_M
   );
-  // Set the matcher type for the notes, can be overridden in extending classes
+
+  /** Set the matcher type for the notes */
   private static final NoteMatcher NOTE_MATCHER = StreetNotesService.ALWAYS_MATCHER;
-  private static final Logger LOG = LoggerFactory.getLogger(WFSNotePollingGraphUpdater.class);
+
   private final DynamicStreetNotesSource notesSource = new DynamicStreetNotesSource();
-  protected Graph graph;
+  private final FeatureSource<SimpleFeatureType, SimpleFeature> featureSource;
+  private final Query query;
+  private final Graph graph;
   private WriteToGraphCallback saveResultOnGraph;
   private SetMultimap<Edge, MatcherAndStreetNote> notesForEdge;
+
   /**
    * Set of unique matchers, kept during building phase, used for interning (lots of note/matchers
    * are identical).
    */
   private Map<T2<NoteMatcher, StreetNote>, MatcherAndStreetNote> uniqueMatchers;
-  private URL url;
-  private String featureType;
-  private Query query;
-  private FeatureSource<SimpleFeatureType, SimpleFeature> featureSource;
 
   /**
    * The property 'frequencySec' is already read and used by the abstract base class.
    */
-  public WFSNotePollingGraphUpdater(WFSNotePollingGraphUpdaterParameters config) {
+  public WFSNotePollingGraphUpdater(WFSNotePollingGraphUpdaterParameters config, Graph graph) {
     super(config);
     try {
-      url = new URL(config.getUrl());
-      featureType = config.getFeatureType();
+      LOG.info("Setup WFS polling updater");
+      URL url = new URL(config.getUrl());
+      String featureType = config.getFeatureType();
+
+      this.graph = graph;
+
+      HashMap<String, Object> connectionParameters = new HashMap<>();
+      connectionParameters.put(WFSDataStoreFactory.URL.key, url);
+      WFSDataStore data = (new WFSDataStoreFactory()).createDataStore(connectionParameters);
+
+      this.query = new Query(featureType); // Read only single feature type from the source
+      this.query.setCoordinateSystem(CRS.decode("EPSG:4326", true)); // Get coordinates in WGS-84
+      this.featureSource = data.getFeatureSource(featureType);
+      graph.streetNotesService.addNotesSource(notesSource);
+
       LOG.info(
         "Configured WFS polling updater: frequencySec={}, url={} and featureType={}",
         pollingPeriodSeconds(),
         url.toString(),
         featureType
       );
-    } catch (MalformedURLException e) {
-      // TODO Handle this in config loading
-      LOG.warn(e.toString());
+    } catch (FactoryException | IOException e) {
+      throw new RuntimeException(e.getMessage(), e);
     }
   }
 
@@ -96,27 +111,6 @@ public abstract class WFSNotePollingGraphUpdater extends PollingGraphUpdater {
   @Override
   public void setGraphUpdaterManager(WriteToGraphCallback saveResultOnGraph) {
     this.saveResultOnGraph = saveResultOnGraph;
-  }
-
-  /**
-   * Setup the WFS data source and add the DynamicStreetNotesSource to the graph
-   */
-  @Override
-  public void setup(Graph graph, TransitModel transitModel) throws IOException, FactoryException {
-    this.graph = graph;
-    LOG.info("Setup WFS polling updater");
-    HashMap<String, Object> connectionParameters = new HashMap<>();
-    connectionParameters.put(WFSDataStoreFactory.URL.key, url);
-    WFSDataStore data = (new WFSDataStoreFactory()).createDataStore(connectionParameters);
-    query = new Query(featureType); // Read only single feature type from the source
-    query.setCoordinateSystem(CRS.decode("EPSG:4326", true)); // Get coordinates in WGS-84
-    featureSource = data.getFeatureSource(featureType);
-    graph.streetNotesService.addNotesSource(notesSource);
-  }
-
-  @Override
-  public void teardown() {
-    LOG.info("Teardown WFS polling updater");
   }
 
   /**

--- a/src/main/java/org/opentripplanner/updater/street_notes/WFSNotePollingGraphUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/street_notes/WFSNotePollingGraphUpdater.java
@@ -80,7 +80,7 @@ public abstract class WFSNotePollingGraphUpdater extends PollingGraphUpdater {
       featureType = config.getFeatureType();
       LOG.info(
         "Configured WFS polling updater: frequencySec={}, url={} and featureType={}",
-        pollingPeriodSeconds,
+        pollingPeriodSeconds(),
         url.toString(),
         featureType
       );

--- a/src/main/java/org/opentripplanner/updater/street_notes/WinkkiPollingGraphUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/street_notes/WinkkiPollingGraphUpdater.java
@@ -3,6 +3,7 @@ package org.opentripplanner.updater.street_notes;
 import java.util.Date;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opentripplanner.model.StreetNote;
+import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.transit.model.basic.NonLocalizedString;
 
 /**
@@ -22,8 +23,8 @@ import org.opentripplanner.transit.model.basic.NonLocalizedString;
 
 public class WinkkiPollingGraphUpdater extends WFSNotePollingGraphUpdater {
 
-  public WinkkiPollingGraphUpdater(WFSNotePollingGraphUpdaterParameters config) {
-    super(config);
+  public WinkkiPollingGraphUpdater(WFSNotePollingGraphUpdaterParameters config, Graph graph) {
+    super(config, graph);
   }
 
   protected StreetNote getNote(SimpleFeature feature) {

--- a/src/main/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingUpdater.java
@@ -55,7 +55,7 @@ public class VehicleParkingUpdater extends PollingGraphUpdater {
 
     LOG.info(
       "Creating vehicle-parking updater running every {} seconds : {}",
-      pollingPeriodSeconds,
+      pollingPeriodSeconds(),
       source
     );
   }

--- a/src/main/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingUpdater.java
@@ -48,10 +48,16 @@ public class VehicleParkingUpdater extends PollingGraphUpdater {
 
   public VehicleParkingUpdater(
     VehicleParkingUpdaterParameters parameters,
-    DataSource<VehicleParking> source
+    DataSource<VehicleParking> source,
+    VertexLinker vertexLinker,
+    VehicleParkingService vehicleParkingService
   ) {
     super(parameters);
     this.source = source;
+    // Creation of network linker library will not modify the graph
+    this.linker = vertexLinker;
+    // Adding a vehicle parking station service needs a graph writer runnable
+    this.vehicleParkingService = vehicleParkingService;
 
     LOG.info(
       "Creating vehicle-parking updater running every {} seconds : {}",
@@ -64,17 +70,6 @@ public class VehicleParkingUpdater extends PollingGraphUpdater {
   public void setGraphUpdaterManager(WriteToGraphCallback saveResultOnGraph) {
     this.saveResultOnGraph = saveResultOnGraph;
   }
-
-  @Override
-  public void setup(Graph graph, TransitModel transitModel) {
-    // Creation of network linker library will not modify the graph
-    linker = graph.getLinker();
-    // Adding a vehicle parking station service needs a graph writer runnable
-    vehicleParkingService = graph.getVehicleParkingService();
-  }
-
-  @Override
-  public void teardown() {}
 
   @Override
   protected void runPolling() throws Exception {

--- a/src/main/java/org/opentripplanner/updater/vehicle_positions/PollingVehiclePositionUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_positions/PollingVehiclePositionUpdater.java
@@ -4,7 +4,7 @@ import com.google.transit.realtime.GtfsRealtime.VehiclePosition;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
-import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.routing.services.RealtimeVehiclePositionService;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.service.TransitModel;
@@ -26,51 +26,48 @@ import org.slf4j.LoggerFactory;
 public class PollingVehiclePositionUpdater extends PollingGraphUpdater {
 
   private static final Logger LOG = LoggerFactory.getLogger(PollingVehiclePositionUpdater.class);
+
   /**
    * Update streamer
    */
   private final VehiclePositionSource vehiclePositionSource;
-  private final String feedId;
+
+  private final VehiclePositionPatternMatcher vehiclePositionPatternMatcher;
+
   /**
    * Parent update manager. Is used to execute graph writer runnables.
    */
   private WriteToGraphCallback saveResultOnGraph;
-  private VehiclePositionPatternMatcher vehiclePositionPatternMatcher;
 
-  public PollingVehiclePositionUpdater(VehiclePositionsUpdaterParameters params) {
+  public PollingVehiclePositionUpdater(
+    VehiclePositionsUpdaterParameters params,
+    RealtimeVehiclePositionService vehiclePositionService,
+    TransitModel transitModel
+  ) {
     super(params);
-    var p = (VehiclePositionsUpdaterParameters) params;
-    vehiclePositionSource = new GtfsRealtimeHttpVehiclePositionSource(p.url());
+    this.vehiclePositionSource = new GtfsRealtimeHttpVehiclePositionSource(params.url());
+    var index = transitModel.getTransitModelIndex();
+    this.vehiclePositionPatternMatcher =
+      new VehiclePositionPatternMatcher(
+        params.feedId(),
+        tripId -> index.getTripForId().get(tripId),
+        trip -> index.getPatternForTrip().get(trip),
+        (trip, date) -> getPatternIncludingRealtime(transitModel, trip, date),
+        vehiclePositionService,
+        transitModel.getTimeZone()
+      );
 
     LOG.info(
       "Creating vehicle position updater running every {} seconds : {}",
       pollingPeriodSeconds(),
       vehiclePositionSource
     );
-    feedId = params.feedId();
   }
 
   @Override
   public void setGraphUpdaterManager(WriteToGraphCallback saveResultOnGraph) {
     this.saveResultOnGraph = saveResultOnGraph;
   }
-
-  @Override
-  public void setup(Graph graph, TransitModel transitModel) {
-    var index = transitModel.getTransitModelIndex();
-    vehiclePositionPatternMatcher =
-      new VehiclePositionPatternMatcher(
-        feedId,
-        tripId -> index.getTripForId().get(tripId),
-        trip -> index.getPatternForTrip().get(trip),
-        (trip, date) -> getPatternIncludingRealtime(transitModel, trip, date),
-        graph.getVehiclePositionService(),
-        transitModel.getTimeZone()
-      );
-  }
-
-  @Override
-  public void teardown() {}
 
   /**
    * Repeatedly makes blocking calls to an UpdateStreamer to retrieve new stop time updates, and

--- a/src/main/java/org/opentripplanner/updater/vehicle_positions/PollingVehiclePositionUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_positions/PollingVehiclePositionUpdater.java
@@ -44,7 +44,7 @@ public class PollingVehiclePositionUpdater extends PollingGraphUpdater {
 
     LOG.info(
       "Creating vehicle position updater running every {} seconds : {}",
-      pollingPeriodSeconds,
+      pollingPeriodSeconds(),
       vehiclePositionSource
     );
     feedId = params.feedId();

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdater.java
@@ -55,12 +55,12 @@ public class VehicleRentalUpdater extends PollingGraphUpdater {
     LOG.info("Setting up vehicle rental updater.");
 
     this.source = source;
-    if (pollingPeriodSeconds <= 0) {
+    if (pollingPeriodSeconds() <= 0) {
       LOG.info("Creating vehicle-rental updater running once only (non-polling): {}", source);
     } else {
       LOG.info(
         "Creating vehicle-rental updater running every {} seconds: {}",
-        pollingPeriodSeconds,
+        pollingPeriodSeconds(),
         source
       );
     }

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdater.java
@@ -48,13 +48,25 @@ public class VehicleRentalUpdater extends PollingGraphUpdater {
 
   public VehicleRentalUpdater(
     VehicleRentalUpdaterParameters parameters,
-    DataSource<VehicleRentalPlace> source
+    DataSource<VehicleRentalPlace> source,
+    VertexLinker vertexLinker,
+    VehicleRentalStationService vehicleRentalStationService
   ) throws IllegalArgumentException {
     super(parameters);
     // Configure updater
     LOG.info("Setting up vehicle rental updater.");
 
     this.source = source;
+
+    // Creation of network linker library will not modify the graph
+    this.linker = vertexLinker;
+
+    // Adding a vehicle rental station service needs a graph writer runnable
+    this.service = vehicleRentalStationService;
+
+    // Do any setup if needed
+    source.setup();
+
     if (pollingPeriodSeconds() <= 0) {
       LOG.info("Creating vehicle-rental updater running once only (non-polling): {}", source);
     } else {
@@ -70,19 +82,6 @@ public class VehicleRentalUpdater extends PollingGraphUpdater {
   public void setGraphUpdaterManager(WriteToGraphCallback saveResultOnGraph) {
     this.saveResultOnGraph = saveResultOnGraph;
   }
-
-  @Override
-  public void setup(Graph graph, TransitModel transitModel) {
-    // Creation of network linker library will not modify the graph
-    linker = graph.getLinker();
-    // Adding a vehicle rental station service needs a graph writer runnable
-    service = graph.getVehicleRentalStationService();
-    // Do any setup if needed
-    source.setup();
-  }
-
-  @Override
-  public void teardown() {}
 
   @Override
   public String toString() {

--- a/src/test/java/org/opentripplanner/GtfsTest.java
+++ b/src/test/java/org/opentripplanner/GtfsTest.java
@@ -32,7 +32,6 @@ import org.opentripplanner.routing.impl.TransitAlertServiceImpl;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
-import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.StopModel;
 import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.updater.TimetableSnapshotSourceParameters;
@@ -164,12 +163,8 @@ public abstract class GtfsTest {
     serverContext = TestServerContext.createServerContext(graph, transitModel);
     timetableSnapshotSource =
       new TimetableSnapshotSource(
-        transitModel.getTimeZone(),
-        new DefaultTransitService(transitModel),
-        transitModel.getTransitLayerUpdater(),
-        transitModel.getDeduplicator(),
-        transitModel.getServiceCodes(),
-        TimetableSnapshotSourceParameters.DEFAULT.withPurgeExpiredData(false)
+        TimetableSnapshotSourceParameters.DEFAULT.withPurgeExpiredData(false),
+        transitModel
       );
     alertPatchServiceImpl = new TransitAlertServiceImpl(transitModel);
     alertsUpdateHandler.setTransitAlertService(alertPatchServiceImpl);

--- a/src/test/java/org/opentripplanner/GtfsTest.java
+++ b/src/test/java/org/opentripplanner/GtfsTest.java
@@ -3,6 +3,7 @@ package org.opentripplanner;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.opentripplanner.updater.stoptime.BackwardsDelayPropagationType.REQUIRED_NO_DATA;
 
 import com.google.transit.realtime.GtfsRealtime.FeedEntity;
 import com.google.transit.realtime.GtfsRealtime.FeedMessage;
@@ -175,7 +176,13 @@ public abstract class GtfsTest {
       for (FeedEntity feedEntity : feedEntityList) {
         updates.add(feedEntity.getTripUpdate());
       }
-      timetableSnapshotSource.applyTripUpdates(null, fullDataset, updates, feedId.getId());
+      timetableSnapshotSource.applyTripUpdates(
+        null,
+        REQUIRED_NO_DATA,
+        fullDataset,
+        updates,
+        feedId.getId()
+      );
       alertsUpdateHandler.update(feedMessage);
     } catch (Exception exception) {}
   }

--- a/src/test/java/org/opentripplanner/GtfsTest.java
+++ b/src/test/java/org/opentripplanner/GtfsTest.java
@@ -175,7 +175,7 @@ public abstract class GtfsTest {
       for (FeedEntity feedEntity : feedEntityList) {
         updates.add(feedEntity.getTripUpdate());
       }
-      timetableSnapshotSource.applyTripUpdates(fullDataset, updates, feedId.getId());
+      timetableSnapshotSource.applyTripUpdates(null, fullDataset, updates, feedId.getId());
       alertsUpdateHandler.update(feedMessage);
     } catch (Exception exception) {}
   }

--- a/src/test/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSourceTest.java
+++ b/src/test/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSourceTest.java
@@ -30,11 +30,15 @@ import org.opentripplanner.transit.model.timetable.RealTimeState;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripTimes;
 import org.opentripplanner.transit.service.TransitModel;
+import org.opentripplanner.updater.GtfsRealtimeFuzzyTripMatcher;
 import org.opentripplanner.util.time.ServiceDateUtils;
 
 public class TimetableSnapshotSourceTest {
 
-  static TransitModel transitModel;
+  private static TransitModel transitModel;
+
+  private static final GtfsRealtimeFuzzyTripMatcher TRIP_MATCHER_NOOP = null;
+
   private static final boolean fullDataset = false;
   private static LocalDate serviceDate;
   private static byte[] cancellation;
@@ -46,6 +50,7 @@ public class TimetableSnapshotSourceTest {
   public static void setUpClass() {
     TestOtpModel model = ConstantsForTests.buildGtfsGraph(ConstantsForTests.FAKE_GTFS);
     transitModel = model.transitModel();
+    // fuzzyTripMatcher = new GtfsRealtimeFuzzyTripMatcher(new DefaultTransitService(transitModel));
 
     feedId = transitModel.getFeedIds().stream().findFirst().get();
 
@@ -70,13 +75,23 @@ public class TimetableSnapshotSourceTest {
 
   @Test
   public void testGetSnapshot() throws InvalidProtocolBufferException {
-    updater.applyTripUpdates(fullDataset, List.of(TripUpdate.parseFrom(cancellation)), feedId);
+    updater.applyTripUpdates(
+      TRIP_MATCHER_NOOP,
+      fullDataset,
+      List.of(TripUpdate.parseFrom(cancellation)),
+      feedId
+    );
 
     final TimetableSnapshot snapshot = updater.getTimetableSnapshot();
     assertNotNull(snapshot);
     assertSame(snapshot, updater.getTimetableSnapshot());
 
-    updater.applyTripUpdates(fullDataset, List.of(TripUpdate.parseFrom(cancellation)), feedId);
+    updater.applyTripUpdates(
+      TRIP_MATCHER_NOOP,
+      fullDataset,
+      List.of(TripUpdate.parseFrom(cancellation)),
+      feedId
+    );
     assertSame(snapshot, updater.getTimetableSnapshot());
 
     updater.maxSnapshotFrequency = (-1);
@@ -94,7 +109,12 @@ public class TimetableSnapshotSourceTest {
     final int tripIndex = pattern.getScheduledTimetable().getTripIndex(tripId);
     final int tripIndex2 = pattern.getScheduledTimetable().getTripIndex(tripId2);
 
-    updater.applyTripUpdates(fullDataset, List.of(TripUpdate.parseFrom(cancellation)), feedId);
+    updater.applyTripUpdates(
+      TRIP_MATCHER_NOOP,
+      fullDataset,
+      List.of(TripUpdate.parseFrom(cancellation)),
+      feedId
+    );
 
     final TimetableSnapshot snapshot = updater.getTimetableSnapshot();
     final Timetable forToday = snapshot.resolve(pattern, serviceDate);
@@ -139,7 +159,7 @@ public class TimetableSnapshotSourceTest {
 
     final TripUpdate tripUpdate = tripUpdateBuilder.build();
 
-    updater.applyTripUpdates(fullDataset, List.of(tripUpdate), feedId);
+    updater.applyTripUpdates(TRIP_MATCHER_NOOP, fullDataset, List.of(tripUpdate), feedId);
 
     final TimetableSnapshot snapshot = updater.getTimetableSnapshot();
     final Timetable forToday = snapshot.resolve(pattern, serviceDate);
@@ -175,7 +195,7 @@ public class TimetableSnapshotSourceTest {
         tripUpdateBuilder.setTrip(tripDescriptorBuilder);
         var tripUpdate = tripUpdateBuilder.build();
 
-        updater.applyTripUpdates(fullDataset, List.of(tripUpdate), feedId);
+        updater.applyTripUpdates(TRIP_MATCHER_NOOP, fullDataset, List.of(tripUpdate), feedId);
 
         var snapshot = updater.getTimetableSnapshot();
         assertNull(snapshot);
@@ -271,7 +291,7 @@ public class TimetableSnapshotSourceTest {
     }
 
     // WHEN
-    updater.applyTripUpdates(fullDataset, List.of(tripUpdate), feedId);
+    updater.applyTripUpdates(TRIP_MATCHER_NOOP, fullDataset, List.of(tripUpdate), feedId);
 
     // THEN
     // Find new pattern in graph starting from stop A
@@ -413,7 +433,7 @@ public class TimetableSnapshotSourceTest {
     }
 
     // WHEN
-    updater.applyTripUpdates(fullDataset, List.of(tripUpdate), feedId);
+    updater.applyTripUpdates(TRIP_MATCHER_NOOP, fullDataset, List.of(tripUpdate), feedId);
 
     // THEN
     final TimetableSnapshot snapshot = updater.getTimetableSnapshot();
@@ -576,7 +596,7 @@ public class TimetableSnapshotSourceTest {
     }
 
     // WHEN
-    updater.applyTripUpdates(fullDataset, List.of(tripUpdate), feedId);
+    updater.applyTripUpdates(TRIP_MATCHER_NOOP, fullDataset, List.of(tripUpdate), feedId);
 
     // THEN
     final TimetableSnapshot snapshot = updater.getTimetableSnapshot();
@@ -672,7 +692,7 @@ public class TimetableSnapshotSourceTest {
     }
 
     // WHEN
-    updater.applyTripUpdates(fullDataset, List.of(tripUpdate), feedId);
+    updater.applyTripUpdates(TRIP_MATCHER_NOOP, fullDataset, List.of(tripUpdate), feedId);
 
     // THEN
     final TimetableSnapshot snapshot = updater.getTimetableSnapshot();
@@ -832,7 +852,7 @@ public class TimetableSnapshotSourceTest {
     }
 
     // WHEN
-    updater.applyTripUpdates(fullDataset, List.of(tripUpdate), feedId);
+    updater.applyTripUpdates(TRIP_MATCHER_NOOP, fullDataset, List.of(tripUpdate), feedId);
 
     // THEN
     final TimetableSnapshot snapshot = updater.getTimetableSnapshot();
@@ -913,7 +933,12 @@ public class TimetableSnapshotSourceTest {
     updater.maxSnapshotFrequency = 0;
     updater.purgeExpiredData = false;
 
-    updater.applyTripUpdates(fullDataset, List.of(TripUpdate.parseFrom(cancellation)), feedId);
+    updater.applyTripUpdates(
+      TRIP_MATCHER_NOOP,
+      fullDataset,
+      List.of(TripUpdate.parseFrom(cancellation)),
+      feedId
+    );
     final TimetableSnapshot snapshotA = updater.getTimetableSnapshot();
 
     updater.purgeExpiredData = true;
@@ -930,7 +955,7 @@ public class TimetableSnapshotSourceTest {
 
     final TripUpdate tripUpdate = tripUpdateBuilder.build();
 
-    updater.applyTripUpdates(fullDataset, List.of(tripUpdate), feedId);
+    updater.applyTripUpdates(TRIP_MATCHER_NOOP, fullDataset, List.of(tripUpdate), feedId);
     final TimetableSnapshot snapshotB = updater.getTimetableSnapshot();
 
     assertNotSame(snapshotA, snapshotB);

--- a/src/test/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSourceTest.java
+++ b/src/test/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSourceTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.opentripplanner.updater.stoptime.BackwardsDelayPropagationType.REQUIRED_NO_DATA;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.transit.realtime.GtfsRealtime.TripDescriptor;
@@ -77,6 +78,7 @@ public class TimetableSnapshotSourceTest {
   public void testGetSnapshot() throws InvalidProtocolBufferException {
     updater.applyTripUpdates(
       TRIP_MATCHER_NOOP,
+      REQUIRED_NO_DATA,
       fullDataset,
       List.of(TripUpdate.parseFrom(cancellation)),
       feedId
@@ -88,6 +90,7 @@ public class TimetableSnapshotSourceTest {
 
     updater.applyTripUpdates(
       TRIP_MATCHER_NOOP,
+      REQUIRED_NO_DATA,
       fullDataset,
       List.of(TripUpdate.parseFrom(cancellation)),
       feedId
@@ -111,6 +114,7 @@ public class TimetableSnapshotSourceTest {
 
     updater.applyTripUpdates(
       TRIP_MATCHER_NOOP,
+      REQUIRED_NO_DATA,
       fullDataset,
       List.of(TripUpdate.parseFrom(cancellation)),
       feedId
@@ -159,7 +163,13 @@ public class TimetableSnapshotSourceTest {
 
     final TripUpdate tripUpdate = tripUpdateBuilder.build();
 
-    updater.applyTripUpdates(TRIP_MATCHER_NOOP, fullDataset, List.of(tripUpdate), feedId);
+    updater.applyTripUpdates(
+      TRIP_MATCHER_NOOP,
+      REQUIRED_NO_DATA,
+      fullDataset,
+      List.of(tripUpdate),
+      feedId
+    );
 
     final TimetableSnapshot snapshot = updater.getTimetableSnapshot();
     final Timetable forToday = snapshot.resolve(pattern, serviceDate);
@@ -195,7 +205,13 @@ public class TimetableSnapshotSourceTest {
         tripUpdateBuilder.setTrip(tripDescriptorBuilder);
         var tripUpdate = tripUpdateBuilder.build();
 
-        updater.applyTripUpdates(TRIP_MATCHER_NOOP, fullDataset, List.of(tripUpdate), feedId);
+        updater.applyTripUpdates(
+          TRIP_MATCHER_NOOP,
+          REQUIRED_NO_DATA,
+          fullDataset,
+          List.of(tripUpdate),
+          feedId
+        );
 
         var snapshot = updater.getTimetableSnapshot();
         assertNull(snapshot);
@@ -291,7 +307,13 @@ public class TimetableSnapshotSourceTest {
     }
 
     // WHEN
-    updater.applyTripUpdates(TRIP_MATCHER_NOOP, fullDataset, List.of(tripUpdate), feedId);
+    updater.applyTripUpdates(
+      TRIP_MATCHER_NOOP,
+      REQUIRED_NO_DATA,
+      fullDataset,
+      List.of(tripUpdate),
+      feedId
+    );
 
     // THEN
     // Find new pattern in graph starting from stop A
@@ -433,7 +455,13 @@ public class TimetableSnapshotSourceTest {
     }
 
     // WHEN
-    updater.applyTripUpdates(TRIP_MATCHER_NOOP, fullDataset, List.of(tripUpdate), feedId);
+    updater.applyTripUpdates(
+      TRIP_MATCHER_NOOP,
+      REQUIRED_NO_DATA,
+      fullDataset,
+      List.of(tripUpdate),
+      feedId
+    );
 
     // THEN
     final TimetableSnapshot snapshot = updater.getTimetableSnapshot();
@@ -596,7 +624,13 @@ public class TimetableSnapshotSourceTest {
     }
 
     // WHEN
-    updater.applyTripUpdates(TRIP_MATCHER_NOOP, fullDataset, List.of(tripUpdate), feedId);
+    updater.applyTripUpdates(
+      TRIP_MATCHER_NOOP,
+      REQUIRED_NO_DATA,
+      fullDataset,
+      List.of(tripUpdate),
+      feedId
+    );
 
     // THEN
     final TimetableSnapshot snapshot = updater.getTimetableSnapshot();
@@ -692,7 +726,13 @@ public class TimetableSnapshotSourceTest {
     }
 
     // WHEN
-    updater.applyTripUpdates(TRIP_MATCHER_NOOP, fullDataset, List.of(tripUpdate), feedId);
+    updater.applyTripUpdates(
+      TRIP_MATCHER_NOOP,
+      REQUIRED_NO_DATA,
+      fullDataset,
+      List.of(tripUpdate),
+      feedId
+    );
 
     // THEN
     final TimetableSnapshot snapshot = updater.getTimetableSnapshot();
@@ -852,7 +892,13 @@ public class TimetableSnapshotSourceTest {
     }
 
     // WHEN
-    updater.applyTripUpdates(TRIP_MATCHER_NOOP, fullDataset, List.of(tripUpdate), feedId);
+    updater.applyTripUpdates(
+      TRIP_MATCHER_NOOP,
+      REQUIRED_NO_DATA,
+      fullDataset,
+      List.of(tripUpdate),
+      feedId
+    );
 
     // THEN
     final TimetableSnapshot snapshot = updater.getTimetableSnapshot();
@@ -935,6 +981,7 @@ public class TimetableSnapshotSourceTest {
 
     updater.applyTripUpdates(
       TRIP_MATCHER_NOOP,
+      REQUIRED_NO_DATA,
       fullDataset,
       List.of(TripUpdate.parseFrom(cancellation)),
       feedId
@@ -955,7 +1002,13 @@ public class TimetableSnapshotSourceTest {
 
     final TripUpdate tripUpdate = tripUpdateBuilder.build();
 
-    updater.applyTripUpdates(TRIP_MATCHER_NOOP, fullDataset, List.of(tripUpdate), feedId);
+    updater.applyTripUpdates(
+      TRIP_MATCHER_NOOP,
+      REQUIRED_NO_DATA,
+      fullDataset,
+      List.of(tripUpdate),
+      feedId
+    );
     final TimetableSnapshot snapshotB = updater.getTimetableSnapshot();
 
     assertNotSame(snapshotA, snapshotB);

--- a/src/test/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingUpdaterTest.java
+++ b/src/test/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingUpdaterTest.java
@@ -43,13 +43,17 @@ class VehicleParkingUpdaterTest {
     dataSource = (DataSource<VehicleParking>) Mockito.mock(DataSource.class);
     when(dataSource.update()).thenReturn(true);
 
-    var parameters = new VehicleParkingUpdaterParameters(null, -1, null);
-    vehicleParkingUpdater = new VehicleParkingUpdater(parameters, dataSource);
-
     transitModel.index();
     graph.index(transitModel.getStopModel());
 
-    vehicleParkingUpdater.setup(graph, transitModel);
+    var parameters = new VehicleParkingUpdaterParameters(null, -1, null);
+    vehicleParkingUpdater =
+      new VehicleParkingUpdater(
+        parameters,
+        dataSource,
+        graph.getLinker(),
+        graph.getVehicleParkingService()
+      );
   }
 
   @Test


### PR DESCRIPTION
### Summary

- refactor: Keep the fuzzyTripMatcher in updaters, allow for customizations. The SiriVMUpdater had a config parameter for using the fuzzyTripMatcher with no effect.
- refactor: Move the GTFS fuzzyTripMatcher to updaters from snapshot source, this allows for customizations.
- refactor: Move the GTFS backwardsDelayPropagationType to updaters from snapshot source, this allows for customizations.
- refactor: Move logFrequency, maxSnapshotFrequency, purgeExpiredData to timetableUpdates in config

These parameters are not updater parameters and configure the realtime updates in general. Currently,
OTP can run with either a Siri or a GTFS SnapshotProvider. These parameters are passed to the
provider. This enables us to inject the correct provider into the injector instead of duplicating
the snapshot provider creation logic in every updater.

### Issue

part of #4002


### Unit tests

Updated.

- [ ] The `TimetableSnapshotSourceTest.testPurgeExpiredData` needs some care - the `purgeExpiredData` does not have any effect. Tip on how to improve this test is appreciated. 


### Documentation

- The router configuration is changed, this is documented in the migration guide.
