### PR TITLE
Avoid creating unneeded objects in RAPTOR

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/RaptorTransferIndex.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/RaptorTransferIndex.java
@@ -12,20 +12,17 @@ import org.opentripplanner.transit.raptor.util.ReversedRaptorTransfer;
 
 public class RaptorTransferIndex {
 
-  private final List<List<RaptorTransfer>> forwardTransfers;
+  private final List<RaptorTransfer>[] forwardTransfers;
 
-  private final List<List<RaptorTransfer>> reversedTransfers;
+  private final List<RaptorTransfer>[] reversedTransfers;
 
   public RaptorTransferIndex(
     List<List<RaptorTransfer>> forwardTransfers,
     List<List<RaptorTransfer>> reversedTransfers
   ) {
     // Create immutable copies of the lists for each stop to make them immutable and faster to iterate
-    this.forwardTransfers =
-      forwardTransfers.stream().map(List::copyOf).collect(Collectors.toList());
-
-    this.reversedTransfers =
-      reversedTransfers.stream().map(List::copyOf).collect(Collectors.toList());
+    this.forwardTransfers = forwardTransfers.stream().map(List::copyOf).toArray(List[]::new);
+    this.reversedTransfers = reversedTransfers.stream().map(List::copyOf).toArray(List[]::new);
   }
 
   public static RaptorTransferIndex create(
@@ -68,11 +65,11 @@ public class RaptorTransferIndex {
     return new RaptorTransferIndex(forwardTransfers, reversedTransfers);
   }
 
-  public List<List<RaptorTransfer>> getForwardTransfers() {
-    return forwardTransfers;
+  public List<RaptorTransfer> getForwardTransfers(int stopIndex) {
+    return forwardTransfers[stopIndex];
   }
 
-  public List<List<RaptorTransfer>> getReversedTransfers() {
-    return reversedTransfers;
+  public List<RaptorTransfer> getReversedTransfers(int stopIndex) {
+    return reversedTransfers[stopIndex];
   }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/constrainedtransfer/ConstrainedBoardingSearch.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/constrainedtransfer/ConstrainedBoardingSearch.java
@@ -2,6 +2,8 @@ package org.opentripplanner.routing.algorithm.raptoradapter.transit.constrainedt
 
 import java.util.LinkedList;
 import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.opentripplanner.model.transfer.TransferConstraint;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripSchedule;
 import org.opentripplanner.transit.model.timetable.Trip;
@@ -28,6 +30,25 @@ public final class ConstrainedBoardingSearch
 
   private static final ConstrainedBoardingSearchStrategy FORWARD_STRATEGY = new ConstrainedBoardingSearchForward();
   private static final ConstrainedBoardingSearchStrategy REVERSE_STRATEGY = new ConstrainedBoardingSearchReverse();
+  public static final RaptorConstrainedTripScheduleBoardingSearch<TripSchedule> NOOP_SEARCH = new RaptorConstrainedTripScheduleBoardingSearch<>() {
+    @Override
+    public boolean transferExist(int targetStopPos) {
+      return false;
+    }
+
+    @Nullable
+    @Override
+    public RaptorTripScheduleBoardOrAlightEvent<TripSchedule> find(
+      RaptorTimeTable<TripSchedule> targetTimetable,
+      int transferSlack,
+      TripSchedule sourceTrip,
+      int sourceStopIndex,
+      int prevTransitArrivalTime,
+      int earliestBoardTime
+    ) {
+      return null;
+    }
+  };
 
   /** Handle forward and reverse specific tasks */
   private final ConstrainedBoardingSearchStrategy searchStrategy;
@@ -45,23 +66,23 @@ public final class ConstrainedBoardingSearch
   private int onTripIndex;
   private TransferConstraint onTripTxConstraint;
 
-  public ConstrainedBoardingSearch(boolean forwardSearch, TransferForPatternByStopPos transfers) {
+  public ConstrainedBoardingSearch(
+    boolean forwardSearch,
+    @Nonnull TransferForPatternByStopPos transfers
+  ) {
     this.transfers = transfers;
     this.searchStrategy = forwardSearch ? FORWARD_STRATEGY : REVERSE_STRATEGY;
   }
 
   @Override
   public boolean transferExist(int targetStopPos) {
-    if (transfers == null) {
-      return false;
-    }
-
     // Get all guaranteed transfers for the target pattern at the target stop position
     this.currentTransfers = transfers.get(targetStopPos);
     this.currentTargetStopPos = targetStopPos;
     return currentTransfers != null;
   }
 
+  @Nullable
   @Override
   public RaptorTripScheduleBoardOrAlightEvent<TripSchedule> find(
     RaptorTimeTable<TripSchedule> timetable,

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RaptorRoutingRequestTransitData.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RaptorRoutingRequestTransitData.java
@@ -210,7 +210,7 @@ public class RaptorRoutingRequestTransitData implements RaptorTransitDataProvide
   ) {
     TransferForPatternByStopPos transfers = forwardConstrainedTransfers.get(routeIndex);
     if (transfers == null) {
-      return null;
+      return ConstrainedBoardingSearch.NOOP_SEARCH;
     }
     return new ConstrainedBoardingSearch(true, transfers);
   }
@@ -221,7 +221,7 @@ public class RaptorRoutingRequestTransitData implements RaptorTransitDataProvide
   ) {
     TransferForPatternByStopPos transfers = reverseConstrainedTransfers.get(routeIndex);
     if (transfers == null) {
-      return null;
+      return ConstrainedBoardingSearch.NOOP_SEARCH;
     }
     return new ConstrainedBoardingSearch(false, transfers);
   }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RaptorRoutingRequestTransitData.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RaptorRoutingRequestTransitData.java
@@ -53,7 +53,7 @@ public class RaptorRoutingRequestTransitData implements RaptorTransitDataProvide
   /**
    * Transfers by stop index
    */
-  private final RaptorTransferIndex transfers;
+  private final RaptorTransferIndex transferIndex;
 
   private final List<TransferForPatternByStopPos> forwardConstrainedTransfers;
 
@@ -93,7 +93,7 @@ public class RaptorRoutingRequestTransitData implements RaptorTransitDataProvide
     );
     this.patternIndex = transitDataCreator.createPatternIndex(tripPatterns);
     this.activeTripPatternsPerStop = transitDataCreator.createTripPatternsPerStop(tripPatterns);
-    this.transfers = transitLayer.getRaptorTransfersForRequest(routingContext);
+    this.transferIndex = transitLayer.getRaptorTransfersForRequest(routingContext);
 
     this.forwardConstrainedTransfers = transitLayer.getForwardConstrainedTransfers();
     this.reverseConstrainedTransfers = transitLayer.getReverseConstrainedTransfers();
@@ -121,12 +121,12 @@ public class RaptorRoutingRequestTransitData implements RaptorTransitDataProvide
 
   @Override
   public Iterator<RaptorTransfer> getTransfersFromStop(int stopIndex) {
-    return transfers.getForwardTransfers().get(stopIndex).iterator();
+    return transferIndex.getForwardTransfers(stopIndex).iterator();
   }
 
   @Override
   public Iterator<? extends RaptorTransfer> getTransfersToStop(int stopIndex) {
-    return transfers.getReversedTransfers().get(stopIndex).iterator();
+    return transferIndex.getReversedTransfers(stopIndex).iterator();
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RaptorRoutingRequestTransitData.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RaptorRoutingRequestTransitData.java
@@ -208,13 +208,21 @@ public class RaptorRoutingRequestTransitData implements RaptorTransitDataProvide
   public RaptorConstrainedTripScheduleBoardingSearch<TripSchedule> transferConstraintsForwardSearch(
     int routeIndex
   ) {
-    return new ConstrainedBoardingSearch(true, forwardConstrainedTransfers.get(routeIndex));
+    TransferForPatternByStopPos transfers = forwardConstrainedTransfers.get(routeIndex);
+    if (transfers == null) {
+      return null;
+    }
+    return new ConstrainedBoardingSearch(true, transfers);
   }
 
   @Override
   public RaptorConstrainedTripScheduleBoardingSearch<TripSchedule> transferConstraintsReverseSearch(
     int routeIndex
   ) {
-    return new ConstrainedBoardingSearch(false, reverseConstrainedTransfers.get(routeIndex));
+    TransferForPatternByStopPos transfers = reverseConstrainedTransfers.get(routeIndex);
+    if (transfers == null) {
+      return null;
+    }
+    return new ConstrainedBoardingSearch(false, transfers);
   }
 }

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/RangeRaptorWorker.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/RangeRaptorWorker.java
@@ -242,8 +242,8 @@ public final class RangeRaptorWorker<T extends RaptorTripSchedule> implements Wo
             transitWorker.forEachBoarding(
               stopIndex,
               (int prevArrivalTime) -> {
-                boolean handled =
-                  txSearch != null &&
+                boolean boardedUsingConstrainedTransfer =
+                  enableTransferConstraints &&
                   boardWithConstrainedTransfer(
                     txSearch,
                     route.timetable(),
@@ -254,7 +254,7 @@ public final class RangeRaptorWorker<T extends RaptorTripSchedule> implements Wo
                   );
 
                 // Find the best trip and board [no guaranteed transfer exist]
-                if (!handled) {
+                if (!boardedUsingConstrainedTransfer) {
                   boardWithRegularTransfer(
                     tripSearch,
                     stopIndex,

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/RangeRaptorWorker.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/RangeRaptorWorker.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.transit.raptor.rangeraptor;
 
 import java.util.Collection;
+import javax.annotation.Nonnull;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.request.TripScheduleBoardSearch;
 import org.opentripplanner.transit.raptor.api.debug.RaptorTimers;
 import org.opentripplanner.transit.raptor.api.path.Path;
@@ -241,14 +242,16 @@ public final class RangeRaptorWorker<T extends RaptorTripSchedule> implements Wo
             transitWorker.forEachBoarding(
               stopIndex,
               (int prevArrivalTime) -> {
-                boolean handled = boardWithConstrainedTransfer(
-                  txSearch,
-                  route.timetable(),
-                  stopIndex,
-                  stopPos,
-                  prevArrivalTime,
-                  boardSlack
-                );
+                boolean handled =
+                  txSearch != null &&
+                  boardWithConstrainedTransfer(
+                    txSearch,
+                    route.timetable(),
+                    stopIndex,
+                    stopPos,
+                    prevArrivalTime,
+                    boardSlack
+                  );
 
                 // Find the best trip and board [no guaranteed transfer exist]
                 if (!handled) {
@@ -292,17 +295,13 @@ public final class RangeRaptorWorker<T extends RaptorTripSchedule> implements Wo
    * execution.
    */
   private boolean boardWithConstrainedTransfer(
-    RaptorConstrainedTripScheduleBoardingSearch<T> txSearch,
+    @Nonnull RaptorConstrainedTripScheduleBoardingSearch<T> txSearch,
     RaptorTimeTable<T> targetTimetable,
     int targetStopIndex,
     int targetStopPos,
     int prevArrivalTime,
     int boardSlack
   ) {
-    if (!enableTransferConstraints) {
-      return false;
-    }
-
     if (!txSearch.transferExist(targetStopPos)) {
       return false;
     }

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/McStopArrivals.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/McStopArrivals.java
@@ -1,7 +1,7 @@
 package org.opentripplanner.transit.raptor.rangeraptor.multicriteria;
 
 import java.util.BitSet;
-import java.util.List;
+import java.util.Collections;
 import org.opentripplanner.transit.raptor.api.response.StopArrivals;
 import org.opentripplanner.transit.raptor.api.transit.IntIterator;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTripSchedule;
@@ -107,7 +107,8 @@ public final class McStopArrivals<T extends RaptorTripSchedule> implements StopA
   Iterable<AbstractStopArrival<T>> listArrivalsAfterMarker(final int stop) {
     StopArrivalParetoSet<T> it = arrivals[stop];
     if (it == null) {
-      return List.of();
+      // Avoid creating new objects in a tight loop
+      return Collections::emptyIterator;
     }
     return it.elementsAfterMarker();
   }


### PR DESCRIPTION
### Summary

As with #4412, I noticed we spend quite lot of time in creating objects, which are not needed. This removes the instantiation of those objects.