### PR TITLE
Update heuristic profile name in performanceTimers

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/performance/PerformanceTimersForRaptor.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/performance/PerformanceTimersForRaptor.java
@@ -1,8 +1,10 @@
 package org.opentripplanner.routing.algorithm.raptoradapter.router.performance;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Timer;
 import java.util.Collection;
+import java.util.List;
 import org.opentripplanner.routing.api.request.RoutingTag;
 import org.opentripplanner.routing.framework.MicrometerUtils;
 import org.opentripplanner.transit.raptor.api.debug.RaptorTimers;
@@ -13,12 +15,16 @@ public class PerformanceTimersForRaptor implements RaptorTimers {
   private final Timer timerRoute;
   private final Timer findTransitPerRound;
   private final Timer findTransfersPerRound;
+  private final MeterRegistry registry;
+  private final Collection<RoutingTag> routingTags;
 
   public PerformanceTimersForRaptor(
     String namePrefix,
     Collection<RoutingTag> routingTags,
     MeterRegistry registry
   ) {
+    this.registry = registry;
+    this.routingTags = routingTags;
     var tags = MicrometerUtils.mapTimingTags(routingTags);
     timerRoute = Timer.builder("raptor." + namePrefix + ".route").tags(tags).register(registry);
     findTransitPerRound =
@@ -52,5 +58,10 @@ public class PerformanceTimersForRaptor implements RaptorTimers {
   @Override
   public void findTransfersForRound(Runnable body) {
     findTransfersPerRound.record(body);
+  }
+
+  @Override
+  public RaptorTimers withNamePrefix(String namePrefix) {
+    return new PerformanceTimersForRaptor(namePrefix, routingTags, registry);
   }
 }

--- a/src/main/java/org/opentripplanner/transit/raptor/api/debug/RaptorTimers.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/debug/RaptorTimers.java
@@ -24,6 +24,11 @@ public interface RaptorTimers {
     public void findTransfersForRound(Runnable body) {
       body.run();
     }
+
+    @Override
+    public RaptorTimers withNamePrefix(String namePrefix) {
+      return this;
+    }
   };
 
   /**
@@ -44,4 +49,9 @@ public interface RaptorTimers {
    * for a Range-Raptor round.
    */
   void findTransfersForRound(Runnable body);
+
+  /**
+   * Create a new instance with a new name prefix. Useful when creating a new request for heuristic.
+   */
+  RaptorTimers withNamePrefix(String namePrefix);
 }


### PR DESCRIPTION
### Summary

We need to modify the `PerformanceTimersForRaptor` in `HeuristicSearchTask` in order to contain the proper name for the search profile. 

### Issue

Fixes #4302
