### PR TITLE
Add timeZone parameter to hsl and parkapi vehicle parking updaters

### DIFF
--- a/docs/sandbox/VehicleParking.md
+++ b/docs/sandbox/VehicleParking.md
@@ -8,6 +8,7 @@
 
 - Create initial sandbox implementation (January
   2022, https://github.com/opentripplanner/OpenTripPlanner/pull/3796)
+- Add timeZone parameter to hsl and parkapi updaters (September 2022, https://github.com/opentripplanner/OpenTripPlanner/pull/4427)
 
 ## Documentation
 

--- a/docs/sandbox/VehicleParking.md
+++ b/docs/sandbox/VehicleParking.md
@@ -37,6 +37,7 @@ All updaters have the following parameters in common:
     "type": "vehicle-parking",
     "sourceType": "hsl-park",
     "feedId": "hslpark",
+    "timeZone": "Europe/Helsinki",
     "facilitiesFrequencySec": 3600,
     "facilitiesUrl": "https://p.hsl.fi/api/v1/facilities.json?limit=-1",
     "utilizationsFrequencySec": 600,
@@ -45,6 +46,8 @@ All updaters have the following parameters in common:
 ```
 
 - `sourceType`: needs to be `"hsl-park"`
+- `timeZone`: must be configured to parse opening hours.
+  The value can be given either as a zone id, or an UTC offset.
 - `facilitiesUrl`: URL that contains the basic information for the parks
 - `facilitiesFrequencySec`: how often should the basic information for parks be refetched. Should be
   more than `utilizationsFrequencySec` and if it's <= 0, parks are only fetched once. Default `600`.
@@ -80,6 +83,7 @@ All updaters have the following parameters in common:
     "type": "vehicle-parking",
     "sourceType": "park-api",
     "feedId": "parkapi",
+    "timeZone": "Europe/Berlin",
     "frequencySec": 600,
     "url": "https://foo.bar",
     "headers": {"Cache-Control": "max-age=604800"},
@@ -89,6 +93,8 @@ All updaters have the following parameters in common:
 
 - `sourceType`: needs to be `"park-api"` if car parks are fetched, `"bicycle-park-api"` if bicycle
   parks.
+- `timeZone`: must be configured to parse opening hours.
+  The value can be given either as a zone id, or an UTC offset.
 - `url`: URL that contains the park data in KML format
 - `frequencySec`: how often park data is refetched. Default `60`.
 - `headers`: Use these headers for requests

--- a/src/ext-test/java/org/opentripplanner/ext/vehicleparking/hslpark/HslParkUpdaterTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/vehicleparking/hslpark/HslParkUpdaterTest.java
@@ -20,6 +20,7 @@ public class HslParkUpdaterTest {
   void parseParks() {
     var facilitiesUrl = "file:src/ext-test/resources/vehicleparking/hslpark/facilities.json";
     var utilizationsUrl = "file:src/ext-test/resources/vehicleparking/hslpark/utilizations.json";
+    var timeZone = ZoneId.of("Europe/Helsinki");
 
     var parameters = new HslParkUpdaterParameters(
       "",
@@ -28,18 +29,15 @@ public class HslParkUpdaterTest {
       "hslpark",
       null,
       30,
-      utilizationsUrl
+      utilizationsUrl,
+      timeZone
     );
     var openingHoursCalendarService = new OpeningHoursCalendarService(
       new Deduplicator(),
       LocalDate.of(2022, Month.JANUARY, 1),
       LocalDate.of(2023, Month.JANUARY, 1)
     );
-    var updater = new HslParkUpdater(
-      parameters,
-      openingHoursCalendarService,
-      ZoneId.of("Europe/Helsinki")
-    );
+    var updater = new HslParkUpdater(parameters, openingHoursCalendarService);
 
     assertTrue(updater.update());
     var parkingLots = updater.getUpdates();

--- a/src/ext-test/java/org/opentripplanner/ext/vehicleparking/hslpark/HslParkUpdaterTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/vehicleparking/hslpark/HslParkUpdaterTest.java
@@ -126,4 +126,40 @@ public class HslParkUpdaterTest {
       fourth.getOpeningHours().toString()
     );
   }
+
+  @Test
+  void parseParksWithoutTimeZone() {
+    var facilitiesUrl = "file:src/ext-test/resources/vehicleparking/hslpark/facilities.json";
+    var utilizationsUrl = "file:src/ext-test/resources/vehicleparking/hslpark/utilizations.json";
+    ZoneId timeZone = null;
+
+    var parameters = new HslParkUpdaterParameters(
+      "",
+      3000,
+      facilitiesUrl,
+      "hslpark",
+      null,
+      30,
+      utilizationsUrl,
+      timeZone
+    );
+    var openingHoursCalendarService = new OpeningHoursCalendarService(
+      new Deduplicator(),
+      LocalDate.of(2022, Month.JANUARY, 1),
+      LocalDate.of(2023, Month.JANUARY, 1)
+    );
+    var updater = new HslParkUpdater(parameters, openingHoursCalendarService);
+
+    assertTrue(updater.update());
+    var parkingLots = updater.getUpdates();
+
+    assertEquals(4, parkingLots.size());
+
+    var first = parkingLots.get(0);
+    assertEquals("Tapiola Park", first.getName().toString());
+    assertEquals("hslpark:990", first.getId().toString());
+    assertEquals(24.804713028552346, first.getX());
+    assertEquals(60.176018858575354, first.getY());
+    assertNull(first.getOpeningHours());
+  }
 }

--- a/src/ext-test/java/org/opentripplanner/ext/vehicleparking/parkapi/ParkAPIUpdaterTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/vehicleparking/parkapi/ParkAPIUpdaterTest.java
@@ -56,4 +56,37 @@ public class ParkAPIUpdaterTest {
     assertTrue(last.hasWheelchairAccessibleCarPlaces());
     assertEquals(1, last.getCapacity().getWheelchairAccessibleCarSpaces());
   }
+
+  @Test
+  void parseCarsWithoutTimeZone() {
+    var url = "file:src/ext-test/resources/vehicleparking/parkapi/parkapi-reutlingen.json";
+    ZoneId timeZone = null;
+    var parameters = new ParkAPIUpdaterParameters(
+      "",
+      url,
+      "park-api",
+      30,
+      null,
+      List.of(),
+      null,
+      timeZone
+    );
+    var openingHoursCalendarService = new OpeningHoursCalendarService(
+      new Deduplicator(),
+      LocalDate.of(2022, Month.JANUARY, 1),
+      LocalDate.of(2023, Month.JANUARY, 1)
+    );
+    var updater = new CarParkAPIUpdater(parameters, openingHoursCalendarService);
+
+    assertTrue(updater.update());
+    var parkingLots = updater.getUpdates();
+
+    assertEquals(30, parkingLots.size());
+
+    var first = parkingLots.get(0);
+    assertEquals("Parkplatz Alenberghalle", first.getName().toString());
+    assertNull(first.getOpeningHours());
+    assertTrue(first.hasAnyCarPlaces());
+    assertNull(first.getCapacity());
+  }
 }

--- a/src/ext-test/java/org/opentripplanner/ext/vehicleparking/parkapi/ParkAPIUpdaterTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/vehicleparking/parkapi/ParkAPIUpdaterTest.java
@@ -17,18 +17,23 @@ public class ParkAPIUpdaterTest {
   @Test
   void parseCars() {
     var url = "file:src/ext-test/resources/vehicleparking/parkapi/parkapi-reutlingen.json";
-
-    var parameters = new ParkAPIUpdaterParameters("", url, "park-api", 30, null, List.of(), null);
+    var timeZone = ZoneId.of("Europe/Berlin");
+    var parameters = new ParkAPIUpdaterParameters(
+      "",
+      url,
+      "park-api",
+      30,
+      null,
+      List.of(),
+      null,
+      timeZone
+    );
     var openingHoursCalendarService = new OpeningHoursCalendarService(
       new Deduplicator(),
       LocalDate.of(2022, Month.JANUARY, 1),
       LocalDate.of(2023, Month.JANUARY, 1)
     );
-    var updater = new CarParkAPIUpdater(
-      parameters,
-      openingHoursCalendarService,
-      ZoneId.of("Europe/Berlin")
-    );
+    var updater = new CarParkAPIUpdater(parameters, openingHoursCalendarService);
 
     assertTrue(updater.update());
     var parkingLots = updater.getUpdates();

--- a/src/ext/java/org/opentripplanner/ext/vehicleparking/hslpark/HslParkToVehicleParkingMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/vehicleparking/hslpark/HslParkToVehicleParkingMapper.java
@@ -223,6 +223,9 @@ public class HslParkToVehicleParkingMapper {
   );
 
   private OHCalendar parseOpeningHours(JsonNode openingHoursByDayType) {
+    if (zoneId == null) {
+      return null;
+    }
     var calendarBuilder = openingHoursCalendarService.newBuilder(zoneId);
     for (DayTypeAndDays dayTypeAndDays : DAYS_FOR_DAY_TYPES) {
       String key = dayTypeAndDays.typeKey();

--- a/src/ext/java/org/opentripplanner/ext/vehicleparking/hslpark/HslParkUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/vehicleparking/hslpark/HslParkUpdater.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.ext.vehicleparking.hslpark;
 
-import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -33,12 +32,15 @@ public class HslParkUpdater implements DataSource<VehicleParking> {
 
   public HslParkUpdater(
     HslParkUpdaterParameters parameters,
-    OpeningHoursCalendarService openingHoursCalendarService,
-    ZoneId zoneId
+    OpeningHoursCalendarService openingHoursCalendarService
   ) {
     String feedId = parameters.getFeedId();
     vehicleParkingMapper =
-      new HslParkToVehicleParkingMapper(feedId, openingHoursCalendarService, zoneId);
+      new HslParkToVehicleParkingMapper(
+        feedId,
+        openingHoursCalendarService,
+        parameters.getTimeZone()
+      );
     parkPatchMapper = new HslParkUtilizationToPatchMapper(feedId);
     facilitiesDownloader =
       new JsonDataListDownloader<>(

--- a/src/ext/java/org/opentripplanner/ext/vehicleparking/hslpark/HslParkUpdaterParameters.java
+++ b/src/ext/java/org/opentripplanner/ext/vehicleparking/hslpark/HslParkUpdaterParameters.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.ext.vehicleparking.hslpark;
 
+import java.time.ZoneId;
 import org.opentripplanner.updater.DataSourceType;
 import org.opentripplanner.updater.vehicle_parking.VehicleParkingUpdaterParameters;
 
@@ -13,6 +14,7 @@ public class HslParkUpdaterParameters extends VehicleParkingUpdaterParameters {
   private final String facilitiesUrl;
   private final String feedId;
   private final String utilizationsUrl;
+  private final ZoneId timeZone;
 
   public HslParkUpdaterParameters(
     String configRef,
@@ -21,13 +23,15 @@ public class HslParkUpdaterParameters extends VehicleParkingUpdaterParameters {
     String feedId,
     DataSourceType sourceType,
     int utilizationsFrequencySec,
-    String utilizationsUrl
+    String utilizationsUrl,
+    ZoneId timeZone
   ) {
     super(configRef, utilizationsFrequencySec, sourceType);
     this.facilitiesFrequencySec = facilitiesFrequencySec;
     this.facilitiesUrl = facilitiesUrl;
     this.feedId = feedId;
     this.utilizationsUrl = utilizationsUrl;
+    this.timeZone = timeZone;
   }
 
   public int getFacilitiesFrequencySec() {
@@ -44,5 +48,9 @@ public class HslParkUpdaterParameters extends VehicleParkingUpdaterParameters {
 
   public String getUtilizationsUrl() {
     return utilizationsUrl;
+  }
+
+  public ZoneId getTimeZone() {
+    return timeZone;
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/vehicleparking/parkapi/BicycleParkAPIUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/vehicleparking/parkapi/BicycleParkAPIUpdater.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.ext.vehicleparking.parkapi;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import java.time.ZoneId;
 import org.opentripplanner.model.calendar.openinghours.OpeningHoursCalendarService;
 import org.opentripplanner.routing.vehicle_parking.VehicleParkingSpaces;
 
@@ -13,10 +12,9 @@ public class BicycleParkAPIUpdater extends ParkAPIUpdater {
 
   public BicycleParkAPIUpdater(
     ParkAPIUpdaterParameters parameters,
-    OpeningHoursCalendarService openingHoursCalendarService,
-    ZoneId zoneId
+    OpeningHoursCalendarService openingHoursCalendarService
   ) {
-    super(parameters, openingHoursCalendarService, zoneId);
+    super(parameters, openingHoursCalendarService);
   }
 
   @Override

--- a/src/ext/java/org/opentripplanner/ext/vehicleparking/parkapi/CarParkAPIUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/vehicleparking/parkapi/CarParkAPIUpdater.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.ext.vehicleparking.parkapi;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import java.time.ZoneId;
 import org.opentripplanner.model.calendar.openinghours.OpeningHoursCalendarService;
 import org.opentripplanner.routing.vehicle_parking.VehicleParkingSpaces;
 
@@ -13,10 +12,9 @@ public class CarParkAPIUpdater extends ParkAPIUpdater {
 
   public CarParkAPIUpdater(
     ParkAPIUpdaterParameters parameters,
-    OpeningHoursCalendarService openingHoursCalendarService,
-    ZoneId zoneId
+    OpeningHoursCalendarService openingHoursCalendarService
   ) {
-    super(parameters, openingHoursCalendarService, zoneId);
+    super(parameters, openingHoursCalendarService);
   }
 
   @Override

--- a/src/ext/java/org/opentripplanner/ext/vehicleparking/parkapi/ParkAPIUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/vehicleparking/parkapi/ParkAPIUpdater.java
@@ -2,7 +2,6 @@ package org.opentripplanner.ext.vehicleparking.parkapi;
 
 import ch.poole.openinghoursparser.OpeningHoursParseException;
 import com.fasterxml.jackson.databind.JsonNode;
-import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -39,13 +38,13 @@ abstract class ParkAPIUpdater extends GenericJsonDataSource<VehicleParking> {
 
   public ParkAPIUpdater(
     ParkAPIUpdaterParameters parameters,
-    OpeningHoursCalendarService openingHoursCalendarService,
-    ZoneId zoneId
+    OpeningHoursCalendarService openingHoursCalendarService
   ) {
     super(parameters.getUrl(), JSON_PARSE_PATH, parameters.getHttpHeaders());
     this.feedId = parameters.getFeedId();
     this.staticTags = parameters.getTags();
-    this.osmOpeningHoursParser = new OSMOpeningHoursParser(openingHoursCalendarService, zoneId);
+    this.osmOpeningHoursParser =
+      new OSMOpeningHoursParser(openingHoursCalendarService, parameters.getTimeZone());
   }
 
   @Override

--- a/src/ext/java/org/opentripplanner/ext/vehicleparking/parkapi/ParkAPIUpdaterParameters.java
+++ b/src/ext/java/org/opentripplanner/ext/vehicleparking/parkapi/ParkAPIUpdaterParameters.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.ext.vehicleparking.parkapi;
 
+import java.time.ZoneId;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -17,6 +18,7 @@ public class ParkAPIUpdaterParameters extends VehicleParkingUpdaterParameters {
   private final String feedId;
   private final Map<String, String> httpHeaders;
   private final List<String> tags;
+  private final ZoneId timeZone;
 
   public ParkAPIUpdaterParameters(
     String configRef,
@@ -25,13 +27,15 @@ public class ParkAPIUpdaterParameters extends VehicleParkingUpdaterParameters {
     int frequencySec,
     @Nonnull Map<String, String> httpHeaders,
     List<String> tags,
-    DataSourceType sourceType
+    DataSourceType sourceType,
+    ZoneId timeZone
   ) {
     super(configRef, frequencySec, sourceType);
     this.url = url;
     this.feedId = feedId;
     this.httpHeaders = httpHeaders;
     this.tags = tags;
+    this.timeZone = timeZone;
   }
 
   public String getFeedId() {
@@ -48,5 +52,9 @@ public class ParkAPIUpdaterParameters extends VehicleParkingUpdaterParameters {
 
   public Collection<String> getTags() {
     return tags;
+  }
+
+  public ZoneId getTimeZone() {
+    return timeZone;
   }
 }

--- a/src/main/java/org/opentripplanner/standalone/config/updaters/VehicleParkingUpdaterConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/updaters/VehicleParkingUpdaterConfig.java
@@ -26,6 +26,7 @@ public class VehicleParkingUpdaterConfig {
   public static VehicleParkingUpdaterParameters create(String updaterRef, NodeAdapter c) {
     var sourceType = mapStringToSourceType(c.asText("sourceType"));
     var feedId = c.asText("feedId", null);
+    var timeZone = c.asZoneId("timeZone", null);
     switch (sourceType) {
       case HSL_PARK:
         return new HslParkUpdaterParameters(
@@ -35,7 +36,8 @@ public class VehicleParkingUpdaterConfig {
           feedId,
           sourceType,
           c.asInt("utilizationsFrequencySec", 600),
-          c.asText("utilizationsUrl", null)
+          c.asText("utilizationsUrl", null),
+          timeZone
         );
       case KML:
         return new KmlUpdaterParameters(
@@ -56,7 +58,8 @@ public class VehicleParkingUpdaterConfig {
           c.asInt("frequencySec", 60),
           c.asMap("headers", NodeAdapter::asText),
           new ArrayList<>(c.asTextSet("tags", Set.of())),
-          sourceType
+          sourceType,
+          timeZone
         );
       default:
         throw new OtpAppException("The updater source type is unhandled: " + sourceType);

--- a/src/main/java/org/opentripplanner/updater/configure/UpdaterConfigurator.java
+++ b/src/main/java/org/opentripplanner/updater/configure/UpdaterConfigurator.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.updater.configure;
 
-import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import org.opentripplanner.ext.siri.SiriTimetableSnapshotSource;
@@ -123,7 +122,6 @@ public class UpdaterConfigurator {
    */
   private List<GraphUpdater> createUpdatersFromConfig() {
     OpeningHoursCalendarService openingHoursCalendarService = graph.getOpeningHoursCalendarService();
-    ZoneId zoneId = transitModel.getTimeZone();
 
     List<GraphUpdater> updaters = new ArrayList<>();
 
@@ -180,11 +178,7 @@ public class UpdaterConfigurator {
       );
     }
     for (var configItem : updatersParameters.getVehicleParkingUpdaterParameters()) {
-      var source = VehicleParkingDataSourceFactory.create(
-        configItem,
-        openingHoursCalendarService,
-        zoneId
-      );
+      var source = VehicleParkingDataSourceFactory.create(configItem, openingHoursCalendarService);
       updaters.add(
         new VehicleParkingUpdater(
           configItem,

--- a/src/main/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingDataSourceFactory.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingDataSourceFactory.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.updater.vehicle_parking;
 
-import java.time.ZoneId;
 import org.opentripplanner.ext.vehicleparking.hslpark.HslParkUpdater;
 import org.opentripplanner.ext.vehicleparking.hslpark.HslParkUpdaterParameters;
 import org.opentripplanner.ext.vehicleparking.kml.KmlBikeParkDataSource;
@@ -21,29 +20,25 @@ public class VehicleParkingDataSourceFactory {
 
   public static DataSource<VehicleParking> create(
     VehicleParkingUpdaterParameters parameters,
-    OpeningHoursCalendarService openingHoursCalendarService,
-    ZoneId zoneId
+    OpeningHoursCalendarService openingHoursCalendarService
   ) {
     switch (parameters.getSourceType()) {
       case HSL_PARK:
         return new HslParkUpdater(
           (HslParkUpdaterParameters) parameters,
-          openingHoursCalendarService,
-          zoneId
+          openingHoursCalendarService
         );
       case KML:
         return new KmlBikeParkDataSource((KmlUpdaterParameters) parameters);
       case PARK_API:
         return new CarParkAPIUpdater(
           (ParkAPIUpdaterParameters) parameters,
-          openingHoursCalendarService,
-          zoneId
+          openingHoursCalendarService
         );
       case BICYCLE_PARK_API:
         return new BicycleParkAPIUpdater(
           (ParkAPIUpdaterParameters) parameters,
-          openingHoursCalendarService,
-          zoneId
+          openingHoursCalendarService
         );
     }
     throw new IllegalArgumentException(


### PR DESCRIPTION
### Summary

Adds `timeZone` parameter to HSL and parkapi updaters to determine the time zone for the opening hours. 

### Issue

fixes #4428 

### Unit tests

Updated tests.

### Documentation

Updated sandbox documentation.

### Changelog

Added for sandbox

