### PR TITLE
Only index instances of RegularStop

### DIFF
--- a/src/main/java/org/opentripplanner/transit/service/StopModelIndex.java
+++ b/src/main/java/org/opentripplanner/transit/service/StopModelIndex.java
@@ -38,8 +38,10 @@ class StopModelIndex {
 
     var allStops = new CollectionsView<StopLocation>(stops, flexStops, groupStops);
     for (StopLocation it : allStops) {
-      Envelope envelope = new Envelope(it.getCoordinate().asJtsCoordinate());
-      regularStopSpatialIndex.insert(envelope, it);
+      if (it instanceof RegularStop regularStop) {
+        var envelope = new Envelope(it.getCoordinate().asJtsCoordinate());
+        regularStopSpatialIndex.insert(envelope, regularStop);
+      }
       stopsByIndex[it.getIndex()] = it;
     }
 


### PR DESCRIPTION
### Summary

The spatial index for `RegularStops` also contains other types of stops which causes `ClassCastExceptions` when you try to use the index. This fixes that.