### PR TITLE
Add mapping for predictionInaccurate on RecordedCall

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/siri/TimetableHelper.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/TimetableHelper.java
@@ -194,9 +194,18 @@ public class TimetableHelper {
             realtimeDepartureTime = departureTime;
           }
 
+          boolean isCallPredictionInaccurate = Boolean.TRUE.equals(
+            recordedCall.isPredictionInaccurate()
+          );
+
           if (recordedCall.isCancellation() != null && recordedCall.isCancellation()) {
             modifiedStopTimes.get(callCounter).cancel();
             newTimes.setCancelled(callCounter);
+          } else if (isJourneyPredictionInaccurate | isCallPredictionInaccurate) {
+            // Set flag for inaccurate prediction if either call OR journey has inaccurate-flag
+            // set if stop is not cancelled. Setting recorded if stop is cancelled would
+            // override the cancellation information.
+            newTimes.setPredictionInaccurate(callCounter);
           } else if (
             recordedCall.getActualArrivalTime() != null ||
             recordedCall.getActualDepartureTime() != null


### PR DESCRIPTION
### Summary
Add mapping for `RecordedCall.PredictionInaccurate`

### Issue

closes #4434 

### Unit tests
N/A
### Documentation
N/A

