### PR TITLE
Hardcode initial capacities for a* search

### DIFF
--- a/src/main/java/org/opentripplanner/common/pqueue/BinHeap.java
+++ b/src/main/java/org/opentripplanner/common/pqueue/BinHeap.java
@@ -135,4 +135,8 @@ public class BinHeap<T> {
     prio = Arrays.copyOf(prio, capacity + 1);
     elem = Arrays.copyOf(elem, capacity + 1);
   }
+
+  public int getCapacity() {
+    return capacity;
+  }
 }

--- a/src/main/java/org/opentripplanner/routing/algorithm/astar/AStar.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/astar/AStar.java
@@ -66,13 +66,8 @@ public class AStar {
     this.spt = new ShortestPathTree(dominanceFunction);
     this.heuristic.initialize(rctx);
 
-    // Priority Queue.
-    // The queue is self-resizing, so we initialize it to have size = O(sqrt(|V|)) << |V|.
-    // For reference, a random, undirected search on a uniform 2d grid will examine roughly sqrt(|V|) vertices
-    // before reaching its target.
-    int initialSize = rctx.graph.getVertices().size();
-    initialSize = (int) Math.ceil(2 * (Math.sqrt((double) initialSize + 1)));
-    this.pq = new BinHeap<>(initialSize);
+    // Initialized with a reasonable size, see #4445
+    this.pq = new BinHeap<>(1000);
     this.nVisited = 0;
     this.targetAcceptedStates = new ArrayList<>();
 

--- a/src/main/java/org/opentripplanner/routing/spt/ShortestPathTree.java
+++ b/src/main/java/org/opentripplanner/routing/spt/ShortestPathTree.java
@@ -45,8 +45,8 @@ public class ShortestPathTree {
 
   public ShortestPathTree(DominanceFunction dominanceFunction) {
     this.dominanceFunction = dominanceFunction;
-    // TODO: Calculate the initial size based on the search properties
-    stateSets = new IdentityHashMap<>();
+    // Initialized with a reasonable size, see #4445
+    stateSets = new IdentityHashMap<>(10_000);
   }
 
   /** @return a list of GraphPaths, sometimes empty but never null. */


### PR DESCRIPTION
### Summary

Currently the A* priority queue is always initialized to the same size, depending on the graph. We should set it differently depending on the context (access/egress or direct search). This PR makes that possible by moving the parameter from being hardcode to setting it in the SystemPreferences.

Also, we want to remove the RoutingContext (done in https://github.com/opentripplanner/OpenTripPlanner/pull/4432), so the property needs to be accessible form the routing request.