### PR TITLE
Extract AbstractRaptorTransfer to improve performance

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/AccessEgress.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/AccessEgress.java
@@ -2,19 +2,10 @@ package org.opentripplanner.routing.algorithm.raptoradapter.transit;
 
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.cost.RaptorCostConverter;
 import org.opentripplanner.routing.core.State;
-import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
+import org.opentripplanner.transit.raptor.api.transit.AbstractRaptorTransfer;
 import org.opentripplanner.util.lang.ToStringBuilder;
 
-public class AccessEgress implements RaptorTransfer {
-
-  /**
-   * "To stop" in the case of access, "from stop" in the case of egress.
-   */
-  private final int toFromStop;
-
-  private final int durationInSeconds;
-
-  private final int generalizedCost;
+public class AccessEgress extends AbstractRaptorTransfer {
 
   /**
    * This should be the last state both in the case of access and egress.
@@ -22,25 +13,12 @@ public class AccessEgress implements RaptorTransfer {
   private final State lastState;
 
   public AccessEgress(int toFromStop, State lastState) {
-    this.toFromStop = toFromStop;
-    this.durationInSeconds = (int) lastState.getElapsedTimeSeconds();
-    this.generalizedCost = RaptorCostConverter.toRaptorCost(lastState.getWeight());
+    super(
+      toFromStop,
+      (int) lastState.getElapsedTimeSeconds(),
+      RaptorCostConverter.toRaptorCost(lastState.getWeight())
+    );
     this.lastState = lastState;
-  }
-
-  @Override
-  public int stop() {
-    return toFromStop;
-  }
-
-  @Override
-  public int generalizedCost() {
-    return generalizedCost;
-  }
-
-  @Override
-  public int durationInSeconds() {
-    return durationInSeconds;
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TransferWithDuration.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/TransferWithDuration.java
@@ -1,38 +1,19 @@
 package org.opentripplanner.routing.algorithm.raptoradapter.transit.request;
 
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.Transfer;
-import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
+import org.opentripplanner.transit.raptor.api.transit.AbstractRaptorTransfer;
 
-public class TransferWithDuration implements RaptorTransfer {
-
-  private final int durationSeconds;
-  private final int cost;
+public class TransferWithDuration extends AbstractRaptorTransfer {
 
   private final Transfer transfer;
 
   public TransferWithDuration(Transfer transfer, int durationSeconds, int cost) {
+    super(transfer.getToStop(), durationSeconds, cost);
     this.transfer = transfer;
-    this.durationSeconds = durationSeconds;
-    this.cost = cost;
   }
 
   public Transfer transfer() {
     return transfer;
-  }
-
-  @Override
-  public int stop() {
-    return transfer.getToStop();
-  }
-
-  @Override
-  public int generalizedCost() {
-    return cost;
-  }
-
-  @Override
-  public int durationInSeconds() {
-    return this.durationSeconds;
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/transit/raptor/api/transit/AbstractRaptorTransfer.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/api/transit/AbstractRaptorTransfer.java
@@ -1,0 +1,34 @@
+package org.opentripplanner.transit.raptor.api.transit;
+
+/**
+ * This class exists purely due to performance reasons. By declaring the getters as final, we avoid
+ * the itable stub to decide which RaptorTransfer implementation to use when fetching performance
+ * critical fields from an transfer.
+ */
+public abstract class AbstractRaptorTransfer implements RaptorTransfer {
+
+  private final int stop;
+  private final int durationInSeconds;
+  private final int generalizedCost;
+
+  protected AbstractRaptorTransfer(int stop, int durationInSeconds, int generalizedCost) {
+    this.stop = stop;
+    this.durationInSeconds = durationInSeconds;
+    this.generalizedCost = generalizedCost;
+  }
+
+  @Override
+  public final int stop() {
+    return stop;
+  }
+
+  @Override
+  public final int durationInSeconds() {
+    return durationInSeconds;
+  }
+
+  @Override
+  public final int generalizedCost() {
+    return generalizedCost;
+  }
+}

--- a/src/main/java/org/opentripplanner/transit/raptor/util/ReversedRaptorTransfer.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/util/ReversedRaptorTransfer.java
@@ -1,30 +1,15 @@
 package org.opentripplanner.transit.raptor.util;
 
+import org.opentripplanner.transit.raptor.api.transit.AbstractRaptorTransfer;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
 
-public class ReversedRaptorTransfer implements RaptorTransfer {
+public class ReversedRaptorTransfer extends AbstractRaptorTransfer {
 
-  private final int stopIndex;
   private final RaptorTransfer transfer;
 
   public ReversedRaptorTransfer(int fromStopIndex, RaptorTransfer transfer) {
-    this.stopIndex = fromStopIndex;
+    super(fromStopIndex, transfer.durationInSeconds(), transfer.generalizedCost());
     this.transfer = transfer;
-  }
-
-  @Override
-  public int stop() {
-    return stopIndex;
-  }
-
-  @Override
-  public int generalizedCost() {
-    return transfer.generalizedCost();
-  }
-
-  @Override
-  public int durationInSeconds() {
-    return transfer.durationInSeconds();
   }
 
   @Override


### PR DESCRIPTION
### Summary

While profiling, I noticed that we spend quite a lot of time querying three fields from `RaptorTransfer`s. Currently we have multiple implementations of this interface, which makes `itable stub` quite a prominent part of the profile. This PR extracts the three fields used into an abstract class, which defines the getters as final, making it possible for JDK to create optimized bytecode.

```
Before

Round 1

Worker: 
 ==> mc_destination : [  490,  478,  487,  473,  483,  472,  467,  469,  474,  478 ] Avg: 477.1  (σ=7.2)

Total:  
 ==> mc_destination : [  738,  709,  731,  694,  711,  711,  697,  683,  688,  700 ] Avg: 706.2  (σ=16.8)

Round 2

Worker: 
 ==> mc_destination : [  472,  471,  471,  472,  470,  471,  469,  470,  470,  470 ] Avg: 470.6  (σ=0.9)

Total:  
 ==> mc_destination : [  704,  687,  687,  688,  686,  686,  684,  685,  685,  685 ] Avg: 687.7  (σ=5.6)



After

Round 1

Worker: 
 ==> mc_destination : [  424,  406,  405,  404,  400,  405,  409,  403,  400,  405 ] Avg: 406.1  (σ=6.5)

Total:  
 ==> mc_destination : [  669,  635,  626,  630,  631,  627,  632,  628,  631,  627 ] Avg: 633.6  (σ=12.1)

Round 2

Worker: 
 ==> mc_destination : [  414,  414,  410,  412,  410,  409,  408,  412,  410,  413 ] Avg: 411.2  (σ=2.0)

Total:  
 ==> mc_destination : [  647,  631,  629,  631,  628,  628,  627,  628,  626,  629 ] Avg: 630.4  (σ=5.7)


```

