### PR TITLE
fix: TransmodelAPI fails to downcast board- and alight-slack

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/DefaultRoutingRequestType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/DefaultRoutingRequestType.java
@@ -58,8 +58,8 @@ public class DefaultRoutingRequestType {
             "This is a performance limit and should therefore be set high. " +
             "Use filters to limit what is presented to the client."
           )
-          .type(Scalars.GraphQLFloat)
-          .dataFetcher(env -> preferences.street().maxDirectDurationDefaultValue().toSeconds())
+          .type(Scalars.GraphQLInt)
+          .dataFetcher(env -> preferences.street().maxDirectDuration().defaultValueSeconds())
           .build()
       )
       .field(
@@ -315,7 +315,7 @@ public class DefaultRoutingRequestType {
           .name("boardSlackDefault")
           .description(TransportModeSlack.boardSlackDescription("boardSlackList"))
           .type(Scalars.GraphQLInt)
-          .dataFetcher(e -> preferences.transit().boardSlack().defaultValue().toSeconds())
+          .dataFetcher(e -> preferences.transit().boardSlack().defaultValueSeconds())
           .build()
       )
       .field(
@@ -333,7 +333,7 @@ public class DefaultRoutingRequestType {
           .name("alightSlackDefault")
           .description(TransportModeSlack.alightSlackDescription("alightSlackList"))
           .type(Scalars.GraphQLInt)
-          .dataFetcher(e -> preferences.transit().alightSlack().defaultValue().toSeconds())
+          .dataFetcher(e -> preferences.transit().alightSlack().defaultValueSeconds())
           .build()
       )
       .field(

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/TripQuery.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/TripQuery.java
@@ -355,7 +355,7 @@ public class TripQuery {
           .name("boardSlackDefault")
           .description(TransportModeSlack.boardSlackDescription("boardSlackList"))
           .type(Scalars.GraphQLInt)
-          .defaultValue(preferences.transit().boardSlack().defaultValue().toSeconds())
+          .defaultValue(preferences.transit().boardSlack().defaultValueSeconds())
           .build()
       )
       .argument(
@@ -377,7 +377,7 @@ public class TripQuery {
           .name("alightSlackDefault")
           .description(TransportModeSlack.alightSlackDescription("alightSlackList"))
           .type(Scalars.GraphQLInt)
-          .defaultValue(preferences.transit().alightSlack().defaultValue().toSeconds())
+          .defaultValue(preferences.transit().alightSlack().defaultValueSeconds())
           .build()
       )
       .argument(

--- a/src/ext/java/org/opentripplanner/ext/traveltime/TravelTimeResource.java
+++ b/src/ext/java/org/opentripplanner/ext/traveltime/TravelTimeResource.java
@@ -113,7 +113,8 @@ public class TravelTimeResource {
         routingRequest
           .preferences()
           .street()
-          .maxAccessEgressDuration(routingRequest.modes.accessMode)
+          .maxAccessEgressDuration()
+          .valueOf(routingRequest.modes.accessMode)
       );
 
     if (time != null) {

--- a/src/main/java/org/opentripplanner/api/common/RoutingResource.java
+++ b/src/main/java/org/opentripplanner/api/common/RoutingResource.java
@@ -930,8 +930,8 @@ public abstract class RoutingResource {
     if (minTransferTime != null) {
       int alightAndBoardSlack =
         (
-          (int) transitPref.boardSlack().defaultValue().toSeconds() +
-          (int) transitPref.alightSlack().defaultValue().toSeconds()
+          transitPref.boardSlack().defaultValueSeconds() +
+          transitPref.alightSlack().defaultValueSeconds()
         );
       if (alightAndBoardSlack > minTransferTime) {
         throw new IllegalArgumentException(

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/AccessEgressRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/AccessEgressRouter.java
@@ -43,7 +43,7 @@ public class AccessEgressRouter {
     NearbyStopFinder nearbyStopFinder = new NearbyStopFinder(
       rctx.graph,
       transitService,
-      nearbyRequest.preferences().street().maxAccessEgressDuration(streetMode),
+      nearbyRequest.preferences().street().maxAccessEgressDuration().valueOf(streetMode),
       true
     );
     List<NearbyStop> nearbyStopList = nearbyStopFinder.findNearbyStopsViaStreets(

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/DirectStreetRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/DirectStreetRouter.java
@@ -81,7 +81,7 @@ public class DirectStreetRouter {
     double distanceLimit;
     StreetMode mode = request.modes.directMode;
 
-    double durationLimit = preferences.street().maxDirectDuration(mode).toSeconds();
+    double durationLimit = preferences.street().maxDirectDuration().valueOf(mode).toSeconds();
 
     if (mode.includesDriving()) {
       distanceLimit = durationLimit * preferences.car().speed();

--- a/src/main/java/org/opentripplanner/routing/api/request/framework/DurationForEnum.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/framework/DurationForEnum.java
@@ -50,6 +50,15 @@ public class DurationForEnum<E extends Enum<?>> implements Serializable {
     return defaultValue;
   }
 
+  /**
+   * Utility method to get {@link #defaultValue} as an number in unit seconds. Equivalent to
+   * {@code (int) defaultValue.toSeconds()}. The downcast is safe since we only allow days, hours,
+   * and so on in the duration.
+   */
+  public int defaultValueSeconds() {
+    return (int) defaultValue.toSeconds();
+  }
+
   public Duration valueOf(E type) {
     return valueForEnum[type.ordinal()];
   }

--- a/src/main/java/org/opentripplanner/routing/api/request/preference/StreetPreferences.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/preference/StreetPreferences.java
@@ -74,21 +74,16 @@ public class StreetPreferences implements Cloneable, Serializable {
     this.elevatorHopCost = elevatorHopCost;
   }
 
-  /** @see #maxAccessEgressDuration(StreetMode) */
-  public Duration maxAccessEgressDurationDefaultValue() {
-    return maxAccessEgressDuration.defaultValue();
-  }
-
   /**
    * This is the maximum duration for access/egress per street mode for street searches. This is a
    * performance limit and should therefore be set high. Results close to the limit are not
-   * guaranteed to be optimal. Use* itinerary-filters to limit what is presented to the client.
+   * guaranteed to be optimal. Use itinerary-filters to limit what is presented to the client.
    * <p>
    * The duration can be set per mode, because some street modes searches are much more resource
-   * intensive than others.
+   * intensive than others. A default value is applied if the mode specific value do not exist.
    */
-  public Duration maxAccessEgressDuration(StreetMode mode) {
-    return maxAccessEgressDuration.valueOf(mode);
+  public DurationForEnum<StreetMode> maxAccessEgressDuration() {
+    return maxAccessEgressDuration;
   }
 
   public void initMaxAccessEgressDuration(Duration defaultValue, Map<StreetMode, Duration> values) {
@@ -107,13 +102,6 @@ public class StreetPreferences implements Cloneable, Serializable {
    */
   public DurationForEnum<StreetMode> maxDirectDuration() {
     return maxDirectDuration;
-  }
-
-  /**
-   * Utility method to get maxDirectDuration for a given mode. See {@link #maxDirectDuration()}.
-   */
-  public Duration maxDirectDuration(StreetMode mode) {
-    return maxDirectDuration.valueOf(mode);
   }
 
   public void initMaxDirectDuration(Duration defaultValue, Map<StreetMode, Duration> valuePerMode) {

--- a/src/main/java/org/opentripplanner/routing/api/request/preference/StreetPreferences.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/preference/StreetPreferences.java
@@ -103,12 +103,15 @@ public class StreetPreferences implements Cloneable, Serializable {
    * optimal. Use itinerary-filters to limit what is presented to the client.
    * <p>
    * The duration can be set per mode, because some street modes searches are much more resource
-   * intensive than others.
+   * intensive than others. A default value is applied if the mode specific value do not exist.
    */
-  public Duration maxDirectDurationDefaultValue() {
-    return maxDirectDuration.defaultValue();
+  public DurationForEnum<StreetMode> maxDirectDuration() {
+    return maxDirectDuration;
   }
 
+  /**
+   * Utility method to get maxDirectDuration for a given mode. See {@link #maxDirectDuration()}.
+   */
   public Duration maxDirectDuration(StreetMode mode) {
     return maxDirectDuration.valueOf(mode);
   }

--- a/src/main/java/org/opentripplanner/routing/impl/GraphPathFinder.java
+++ b/src/main/java/org/opentripplanner/routing/impl/GraphPathFinder.java
@@ -71,7 +71,9 @@ public class GraphPathFinder {
     }
 
     AStarBuilder aStar = AStarBuilder
-      .oneToOneMaxDuration(preferences.street().maxDirectDuration(options.modes.directMode))
+      .oneToOneMaxDuration(
+        preferences.street().maxDirectDuration().valueOf(options.modes.directMode)
+      )
       // FORCING the dominance function to weight only
       .setDominanceFunction(new DominanceFunction.MinimumWeight())
       .setContext(routingContext)

--- a/src/main/java/org/opentripplanner/standalone/config/RoutingRequestMapper.java
+++ b/src/main/java/org/opentripplanner/standalone/config/RoutingRequestMapper.java
@@ -161,7 +161,7 @@ public class RoutingRequestMapper {
       .initMaxDirectDuration(
         c.asDuration(
           "maxDirectStreetDuration",
-          preferences.street().maxDirectDurationDefaultValue()
+          preferences.street().maxDirectDuration().defaultValue()
         ),
         c.asEnumMap("maxDirectStreetDurationForMode", StreetMode.class, NodeAdapter::asDuration)
       );

--- a/src/main/java/org/opentripplanner/standalone/config/RoutingRequestMapper.java
+++ b/src/main/java/org/opentripplanner/standalone/config/RoutingRequestMapper.java
@@ -103,7 +103,7 @@ public class RoutingRequestMapper {
       .initMaxAccessEgressDuration(
         c.asDuration(
           "maxAccessEgressDuration",
-          preferences.street().maxAccessEgressDurationDefaultValue()
+          preferences.street().maxAccessEgressDuration().defaultValue()
         ),
         c.asEnumMap("maxAccessEgressDurationForMode", StreetMode.class, NodeAdapter::asDuration)
       );

--- a/src/test/java/org/opentripplanner/routing/api/request/framework/DurationForEnumTest.java
+++ b/src/test/java/org/opentripplanner/routing/api/request/framework/DurationForEnumTest.java
@@ -33,6 +33,7 @@ class DurationForEnumTest {
   @Test
   void defaultValue() {
     assertEquals(DEFAULT, subject.defaultValue());
+    assertEquals(DEFAULT.toSeconds(), subject.defaultValueSeconds());
   }
 
   @Test


### PR DESCRIPTION
### Summary

To fix this problem a utility method is added to the DurationForEnum witch does the downcast to int. To make the utility method available everywhere the StreetPreferences is changed, so it exposes the DurationForEnum type.

### Issue

No issue exist

### Unit tests

A unit tests is updated

### Documentation

Not changed
