### PR TITLE
Add support for Deduplicator generic object arrays

### DIFF
--- a/src/main/java/org/opentripplanner/transit/model/basic/NonLocalizedString.java
+++ b/src/main/java/org/opentripplanner/transit/model/basic/NonLocalizedString.java
@@ -88,9 +88,7 @@ public class NonLocalizedString implements I18NString, Serializable {
 
   @Override
   public boolean equals(Object other) {
-    return (
-      other instanceof NonLocalizedString && this.name.equals(((NonLocalizedString) other).name)
-    );
+    return (other instanceof NonLocalizedString that && this.name.equals(that.name));
   }
 
   @Override


### PR DESCRIPTION
### Summary

This PR add support for generic type arrays to the Deduplicator. This is needed in the #4450 


### Unit tests

The Deduplicator unit test is updated.


### Documentation
No doc added.
