### PR TITLE
Take into account null values for fare details

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/fares/impl/HighestFareInFreeTransferWindowFareServiceTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/fares/impl/HighestFareInFreeTransferWindowFareServiceTest.java
@@ -1,6 +1,6 @@
 package org.opentripplanner.ext.fares.impl;
 
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.model.plan.TestItineraryBuilder.newItinerary;
 import static org.opentripplanner.transit.model._data.TransitModelForTest.FEED_ID;
 import static org.opentripplanner.transit.model._data.TransitModelForTest.id;
@@ -8,18 +8,14 @@ import static org.opentripplanner.transit.model._data.TransitModelForTest.id;
 import java.time.Duration;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Locale;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.opentripplanner.api.mapping.FareMapper;
 import org.opentripplanner.ext.fares.model.FareAttribute;
 import org.opentripplanner.ext.fares.model.FareRuleSet;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.PlanTestConstants;
 import org.opentripplanner.routing.core.FareType;
-import org.opentripplanner.routing.core.ItineraryFares;
 import org.opentripplanner.routing.core.Money;
 import org.opentripplanner.routing.fares.FareService;
 import org.opentripplanner.transit.model.basic.NonLocalizedString;
@@ -45,14 +41,9 @@ class HighestFareInFreeTransferWindowFareServiceTest implements PlanTestConstant
     float expectedFare
   ) {
     var fares = fareService.getCost(i);
-    Assertions.assertEquals(
-      Money.usDollars(Math.round(expectedFare * 100)),
-      fares.getFare(FareType.regular)
-    );
+    assertEquals(Money.usDollars(Math.round(expectedFare * 100)), fares.getFare(FareType.regular));
 
-    // i think that returning an empty list would be the better option but it's here for backwards
-    // compat
-    fares.getTypes().forEach(t -> assertNull(fares.getDetails(t)));
+    fares.getTypes().forEach(t -> assertEquals(List.of(), fares.getDetails(t)));
   }
 
   private static List<Arguments> createTestCases() {

--- a/src/ext-test/java/org/opentripplanner/ext/fares/impl/HighestFareInFreeTransferWindowFareServiceTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/fares/impl/HighestFareInFreeTransferWindowFareServiceTest.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.ext.fares.impl;
 
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.opentripplanner.model.plan.TestItineraryBuilder.newItinerary;
 import static org.opentripplanner.transit.model._data.TransitModelForTest.FEED_ID;
 import static org.opentripplanner.transit.model._data.TransitModelForTest.id;
@@ -7,15 +8,18 @@ import static org.opentripplanner.transit.model._data.TransitModelForTest.id;
 import java.time.Duration;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.opentripplanner.api.mapping.FareMapper;
 import org.opentripplanner.ext.fares.model.FareAttribute;
 import org.opentripplanner.ext.fares.model.FareRuleSet;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.PlanTestConstants;
 import org.opentripplanner.routing.core.FareType;
+import org.opentripplanner.routing.core.ItineraryFares;
 import org.opentripplanner.routing.core.Money;
 import org.opentripplanner.routing.fares.FareService;
 import org.opentripplanner.transit.model.basic.NonLocalizedString;
@@ -40,10 +44,15 @@ class HighestFareInFreeTransferWindowFareServiceTest implements PlanTestConstant
     Itinerary i,
     float expectedFare
   ) {
+    var fares = fareService.getCost(i);
     Assertions.assertEquals(
       Money.usDollars(Math.round(expectedFare * 100)),
-      fareService.getCost(i).getFare(FareType.regular)
+      fares.getFare(FareType.regular)
     );
+
+    // i think that returning an empty list would be the better option but it's here for backwards
+    // compat
+    fares.getTypes().forEach(t -> assertNull(fares.getDetails(t)));
   }
 
   private static List<Arguments> createTestCases() {

--- a/src/ext/java/org/opentripplanner/ext/fares/impl/HighestFareInFreeTransferWindowFareService.java
+++ b/src/ext/java/org/opentripplanner/ext/fares/impl/HighestFareInFreeTransferWindowFareService.java
@@ -14,8 +14,6 @@ import org.opentripplanner.routing.core.ItineraryFares;
  */
 public class HighestFareInFreeTransferWindowFareService extends DefaultFareServiceImpl {
 
-  private static final long serialVersionUID = 20120229L;
-
   private final boolean analyzeInterlinedTransfers;
   private final Duration freeTransferWindow;
 

--- a/src/main/java/org/opentripplanner/api/mapping/FareMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/FareMapper.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -103,14 +102,9 @@ public class FareMapper {
       .getTypes()
       .stream()
       .map(key -> {
-        var details = fare.getDetails(key);
-        if (details == null) {
-          return null;
-        }
-        var money = details.stream().map(this::toApiFareComponent).toList();
+        var money = fare.getDetails(key).stream().map(this::toApiFareComponent).toList();
         return new SimpleEntry<>(key, money);
       })
-      .filter(Objects::nonNull)
       .collect(Collectors.toMap(e -> e.getKey().name(), Entry::getValue));
   }
 

--- a/src/main/java/org/opentripplanner/api/mapping/FareMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/FareMapper.java
@@ -3,11 +3,11 @@ package org.opentripplanner.api.mapping;
 import com.google.common.collect.Multimap;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -103,9 +103,14 @@ public class FareMapper {
       .getTypes()
       .stream()
       .map(key -> {
-        var money = fare.getDetails(key).stream().map(this::toApiFareComponent).toList();
+        var details = fare.getDetails(key);
+        if (details == null) {
+          return null;
+        }
+        var money = details.stream().map(this::toApiFareComponent).toList();
         return new SimpleEntry<>(key, money);
       })
+      .filter(Objects::nonNull)
       .collect(Collectors.toMap(e -> e.getKey().name(), Entry::getValue));
   }
 

--- a/src/main/java/org/opentripplanner/routing/core/ItineraryFares.java
+++ b/src/main/java/org/opentripplanner/routing/core/ItineraryFares.java
@@ -69,7 +69,7 @@ public class ItineraryFares {
   }
 
   public List<FareComponent> getDetails(FareType type) {
-    return details.get(type);
+    return details.getOrDefault(type, List.of());
   }
 
   public Set<FareType> getTypes() {

--- a/src/test/java/org/opentripplanner/api/mapping/FareMapperTest.java
+++ b/src/test/java/org/opentripplanner/api/mapping/FareMapperTest.java
@@ -1,9 +1,9 @@
 package org.opentripplanner.api.mapping;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.opentripplanner.model.plan.TestItineraryBuilder.newItinerary;
 
+import java.util.List;
 import java.util.Locale;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.model.plan.Itinerary;
@@ -29,6 +29,6 @@ class FareMapperTest implements PlanTestConstants {
     var apiMoney = apiFare.fare().get(FareType.regular.name());
     assertEquals(500, apiMoney.cents());
     assertEquals("USD", apiMoney.currency().currency());
-    assertNull(apiFare.details().get(FareType.regular.name()));
+    assertEquals(List.of(), apiFare.details().get(FareType.regular.name()));
   }
 }

--- a/src/test/java/org/opentripplanner/api/mapping/FareMapperTest.java
+++ b/src/test/java/org/opentripplanner/api/mapping/FareMapperTest.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.api.mapping;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.opentripplanner.model.plan.TestItineraryBuilder.newItinerary;
 
@@ -16,7 +17,7 @@ class FareMapperTest implements PlanTestConstants {
   @Test
   public void emptyDetails() {
     var fare = new ItineraryFares();
-    fare.addFare(FareType.regular, Money.usDollars(5));
+    fare.addFare(FareType.regular, Money.usDollars(500));
 
     Itinerary itinerary = newItinerary(A, 30).bus(1, 30, 60, B).bus(2, 90, 120, C).build();
 
@@ -25,6 +26,9 @@ class FareMapperTest implements PlanTestConstants {
     var mapper = new FareMapper(Locale.US);
     var apiFare = mapper.mapFare(itinerary);
 
-    assertNull(apiFare.details().get("regular"));
+    var apiMoney = apiFare.fare().get(FareType.regular.name());
+    assertEquals(500, apiMoney.cents());
+    assertEquals("USD", apiMoney.currency().currency());
+    assertNull(apiFare.details().get(FareType.regular.name()));
   }
 }

--- a/src/test/java/org/opentripplanner/api/mapping/FareMapperTest.java
+++ b/src/test/java/org/opentripplanner/api/mapping/FareMapperTest.java
@@ -1,0 +1,30 @@
+package org.opentripplanner.api.mapping;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.opentripplanner.model.plan.TestItineraryBuilder.newItinerary;
+
+import java.util.Locale;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.model.plan.Itinerary;
+import org.opentripplanner.model.plan.PlanTestConstants;
+import org.opentripplanner.routing.core.FareType;
+import org.opentripplanner.routing.core.ItineraryFares;
+import org.opentripplanner.routing.core.Money;
+
+class FareMapperTest implements PlanTestConstants {
+
+  @Test
+  public void emptyDetails() {
+    var fare = new ItineraryFares();
+    fare.addFare(FareType.regular, Money.usDollars(5));
+
+    Itinerary itinerary = newItinerary(A, 30).bus(1, 30, 60, B).bus(2, 90, 120, C).build();
+
+    itinerary.setFare(fare);
+
+    var mapper = new FareMapper(Locale.US);
+    var apiFare = mapper.mapFare(itinerary);
+
+    assertNull(apiFare.details().get("regular"));
+  }
+}


### PR DESCRIPTION
### Issue

The Houston fare calculator in OTP1 produces fares that returned `null` instead of the empty list for the `fareConponents` object. Together with the rewrite of the API mapper code this led to an NPE when writing out the API response.

This PR deals with the null (as opposed to the empty list).

@miles-grant-ibigroup @optionsome This PR restores the `null` output but if we could return the empty list instead the code could be streamlined. Would that cause problems in your frontends?

### Unit tests

Tests added.

### Documentation

n/a