### PR TITLE
Use placeholders in log messages

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
@@ -475,7 +475,7 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
     }
 
     if (!success) {
-      LOG.info("Pattern not updated for trip " + trip.getId());
+      LOG.info("Pattern not updated for trip {}", trip.getId());
     }
     return success;
   }

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETGooglePubsubUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETGooglePubsubUpdater.java
@@ -278,7 +278,7 @@ public class SiriETGooglePubsubUpdater implements GraphUpdater {
     EstimatedTimetableMessageReceiver receiver
   ) throws IOException {
     if (dataInitializationUrl != null) {
-      LOG.info("Fetching initial data from " + dataInitializationUrl);
+      LOG.info("Fetching initial data from {}", dataInitializationUrl);
       final long t1 = System.currentTimeMillis();
 
       final InputStream data = HttpUtils.getData(

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETHttpTripUpdateSource.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETHttpTripUpdateSource.java
@@ -86,7 +86,7 @@ public class SiriETHttpTripUpdateSource implements EstimatedTimetableSource {
       LOG.warn("Could not get SIRI-ET data from {}, caused by {}", url, e.getMessage());
     } catch (Exception e) {
       LOG.info("Failed after {} ms", (System.currentTimeMillis() - t1));
-      LOG.warn("Failed to parse SIRI-ET feed from " + url + ":", e);
+      LOG.warn("Failed to parse SIRI-ET feed from {}", url, e);
     } finally {
       LOG.info(
         "Updating ET [{}]: Create req: {}, Fetching data: {}, Unmarshalling: {}",

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriVMHttpTripUpdateSource.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriVMHttpTripUpdateSource.java
@@ -85,7 +85,7 @@ public class SiriVMHttpTripUpdateSource implements VehicleMonitoringSource {
       }
     } catch (IOException | JAXBException | XMLStreamException e) {
       LOG.info("Failed after {} ms", (System.currentTimeMillis() - t1));
-      LOG.warn("Failed to parse SIRI-VM feed from " + url + ":", e);
+      LOG.warn("Failed to parse SIRI-VM feed from {}", url, e);
 
       final long sleepTime = RETRY_INTERVAL_MILLIS + RETRY_INTERVAL_MILLIS * retryCount;
 

--- a/src/ext/java/org/opentripplanner/ext/smoovebikerental/SmooveBikeRentalDataSource.java
+++ b/src/ext/java/org/opentripplanner/ext/smoovebikerental/SmooveBikeRentalDataSource.java
@@ -64,7 +64,7 @@ public class SmooveBikeRentalDataSource extends GenericJsonDataSource<VehicleRen
       station.longitude = Double.parseDouble(coordinates[1].trim());
     } catch (NumberFormatException e) {
       // E.g. coordinates is empty
-      log.warn("Error parsing bike rental station " + station.id, e);
+      log.warn("Error parsing bike rental station {}", station.id, e);
       return null;
     }
     if (!node.path("operative").asText().equals("true")) {

--- a/src/ext/java/org/opentripplanner/ext/vehicleparking/hslpark/HslParkToVehicleParkingMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/vehicleparking/hslpark/HslParkToVehicleParkingMapper.java
@@ -129,7 +129,7 @@ public class HslParkToVehicleParkingMapper {
         )
         .build();
     } catch (Exception e) {
-      log.warn("Error parsing park " + vehicleParkId, e);
+      log.warn("Error parsing park {}", vehicleParkId, e);
       return null;
     }
   }

--- a/src/ext/java/org/opentripplanner/ext/vehicleparking/hslpark/HslParkUtilizationToPatchMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/vehicleparking/hslpark/HslParkUtilizationToPatchMapper.java
@@ -31,7 +31,7 @@ public class HslParkUtilizationToPatchMapper {
       );
       return new HslParkPatch(vehicleParkId, capacityType, spacesAvailable);
     } catch (Exception e) {
-      log.warn("Error parsing park utilization" + vehicleParkId, e);
+      log.warn("Error parsing park utilization {}", vehicleParkId, e);
       return null;
     }
   }

--- a/src/ext/java/org/opentripplanner/ext/vilkkubikerental/VilkkuBikeRentalDataSource.java
+++ b/src/ext/java/org/opentripplanner/ext/vilkkubikerental/VilkkuBikeRentalDataSource.java
@@ -50,7 +50,7 @@ public class VilkkuBikeRentalDataSource extends GenericXmlDataSource<VehicleRent
       station.latitude = getCoordinate(attributes.get("latitude"));
     } catch (NumberFormatException e) {
       // E.g. coordinates is empty
-      LOG.warn("Error parsing bike rental station location " + station.id, e);
+      LOG.warn("Error parsing bike rental station location {}", station.id, e);
       return null;
     }
 

--- a/src/main/java/org/opentripplanner/api/common/Message.java
+++ b/src/main/java/org/opentripplanner/api/common/Message.java
@@ -50,7 +50,7 @@ public enum Message {
     try {
       return config.get(name(), l);
     } catch (Exception e) {
-      LOG.warn("No entry in Message.properties file could be found for string " + name());
+      LOG.warn("No entry in Message.properties file could be found for string {}", name());
       return "";
     }
   }

--- a/src/main/java/org/opentripplanner/graph_builder/GraphBuilderDataSources.java
+++ b/src/main/java/org/opentripplanner/graph_builder/GraphBuilderDataSources.java
@@ -215,7 +215,7 @@ public class GraphBuilderDataSources {
     LOG.info("Existing files expected to be read or written:");
     for (FileType type : FileType.values()) {
       for (DataSource source : inputData.get(type)) {
-        LOG.info(BULLET_POINT + source.detailedInfo());
+        LOG.info(BULLET_POINT + "{}", source.detailedInfo());
       }
     }
 
@@ -223,7 +223,7 @@ public class GraphBuilderDataSources {
       LOG.info("Files excluded due to command line switches or unknown type:");
       for (FileType type : FileType.values()) {
         for (DataSource source : skipData.get(type)) {
-          LOG.info(BULLET_POINT + source.detailedInfo());
+          LOG.info(BULLET_POINT + "{}", source.detailedInfo());
         }
       }
     }

--- a/src/main/java/org/opentripplanner/graph_builder/module/GtfsModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/GtfsModule.java
@@ -281,10 +281,10 @@ public class GtfsModule implements GraphBuilderModule {
 
     for (Class<?> entityClass : reader.getEntityClasses()) {
       if (skipEntityClass(entityClass)) {
-        LOG.info("Skipping entity: " + entityClass.getName());
+        LOG.info("Skipping entity: {}", entityClass.getName());
         continue;
       }
-      LOG.info("Reading entity: " + entityClass.getName());
+      LOG.info("Reading entity: {}", entityClass.getName());
       reader.readEntities(entityClass);
       store.flush();
       // NOTE that agencies are first in the list and read before all other entity types, so it is effective to
@@ -470,7 +470,7 @@ public class GtfsModule implements GraphBuilderModule {
         String name = bean.getClass().getName();
         int index = name.lastIndexOf('.');
         if (index != -1) name = name.substring(index + 1);
-        LOG.debug("loading " + name + ": " + count);
+        LOG.debug("loading {}: {}", name, count);
       }
     }
 

--- a/src/main/java/org/opentripplanner/graph_builder/module/map/StreetMatcher.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/map/StreetMatcher.java
@@ -95,7 +95,7 @@ public class StreetMatcher {
       double k = states.peek_min_key();
       MatchState state = states.extract_min();
       if (++total % 50000 == 0) {
-        log.debug("seen / total: " + seen_count + " / " + total);
+        log.debug("seen / total: {} / {}", seen_count, total);
       }
       if (seen.contains(state)) {
         ++seen_count;

--- a/src/main/java/org/opentripplanner/graph_builder/module/ned/DegreeGridNEDTileSource.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/ned/DegreeGridNEDTileSource.java
@@ -101,7 +101,7 @@ public class DegreeGridNEDTileSource implements NEDTileSource {
           "Cannot download NED tiles from S3: awsAccessKey or awsSecretKey properties are not set"
         );
       }
-      log.info("Downloading NED degree tile " + path);
+      log.info("Downloading NED degree tile {}", path);
       // download the file from S3.
       AWSCredentials awsCredentials = new AWSCredentials(awsAccessKey, awsSecretKey);
       String key = formatLatLon(x, y) + ".tiff";

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/AreaGroup.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/AreaGroup.java
@@ -73,7 +73,7 @@ class AreaGroup {
       for (int i = 0; i < mp.getNumGeometries(); ++i) {
         Geometry poly = mp.getGeometryN(i);
         if (!(poly instanceof Polygon)) {
-          LOG.warn("Unexpected non-polygon when merging areas: " + poly);
+          LOG.warn("Unexpected non-polygon when merging areas: {}", poly);
           continue;
         }
         outermostRings.add(toRing((Polygon) poly, nodeMap));
@@ -81,7 +81,7 @@ class AreaGroup {
     } else if (u instanceof Polygon) {
       outermostRings.add(toRing((Polygon) u, nodeMap));
     } else {
-      LOG.warn("Unexpected non-polygon when merging areas: " + u);
+      LOG.warn("Unexpected non-polygon when merging areas: {}", u);
     }
   }
 

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/OSMDatabase.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/OSMDatabase.java
@@ -805,7 +805,7 @@ public class OSMDatabase {
         } else if (role.equals("outer")) {
           outerWays.add(way);
         } else {
-          LOG.warn("Unexpected role " + role + " in multipolygon");
+          LOG.warn("Unexpected role {} in multipolygon", role);
         }
       }
       processedAreas.add(relation);
@@ -1031,7 +1031,7 @@ public class OSMDatabase {
             relation.getOsmProvider()::getZoneId
           );
       } catch (NumberFormatException e) {
-        LOG.info("Unparseable turn restriction: " + relation.getId());
+        LOG.info("Unparseable turn restriction: {}", relation.getId());
       }
     }
 
@@ -1060,7 +1060,7 @@ public class OSMDatabase {
             if (levels.containsKey(role)) {
               wayLevels.put(way, levels.get(role));
             } else {
-              LOG.warn(member.getRef() + " has undefined level " + role);
+              LOG.warn("{} has undefined level {}", member.getRef(), role);
             }
           }
         }

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModule.java
@@ -187,7 +187,7 @@ public class OpenStreetMapModule implements GraphBuilderModule {
     OSMDatabase osmdb = new OSMDatabase(issueStore, boardingAreaRefTags);
     Handler handler = new Handler(graph, osmdb);
     for (OpenStreetMapProvider provider : providers) {
-      LOG.info("Gathering OSM from provider: " + provider);
+      LOG.info("Gathering OSM from provider: {}", provider);
       provider.readOSM(osmdb);
     }
     osmdb.postLoad();

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/WayPropertySet.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/WayPropertySet.java
@@ -124,7 +124,7 @@ public class WayPropertySet {
       (leftMixins.size() == 0 || rightMixins.size() == 0)
     ) {
       String all_tags = dumpTags(way);
-      LOG.debug("Used default permissions: " + all_tags);
+      LOG.debug("Used default permissions: {}", all_tags);
     }
     return result;
   }

--- a/src/main/java/org/opentripplanner/model/calendar/impl/CalendarServiceDataFactoryImpl.java
+++ b/src/main/java/org/opentripplanner/model/calendar/impl/CalendarServiceDataFactoryImpl.java
@@ -68,7 +68,7 @@ public class CalendarServiceDataFactoryImpl {
     for (FeedScopedId serviceId : serviceIds) {
       index++;
 
-      LOG.debug("serviceId=" + serviceId + " (" + index + "/" + serviceIds.size() + ")");
+      LOG.debug("serviceId={} ({}/{})", serviceId, index, serviceIds.size());
 
       Set<LocalDate> activeDates = getServiceDatesForServiceId(serviceId);
       List<LocalDate> serviceDates = new ArrayList<>(activeDates);
@@ -139,7 +139,8 @@ public class CalendarServiceDataFactoryImpl {
       case ServiceCalendarDate.EXCEPTION_TYPE_ADD -> addServiceDate(activeDates, serviceDate);
       case ServiceCalendarDate.EXCEPTION_TYPE_REMOVE -> activeDates.remove(serviceDate);
       default -> LOG.warn(
-        "unknown CalendarDate exception type: " + calendarDate.getExceptionType()
+        "unknown CalendarDate exception type: {}",
+        calendarDate.getExceptionType()
       );
     }
   }

--- a/src/main/java/org/opentripplanner/model/projectinfo/OtpProjectInfoParser.java
+++ b/src/main/java/org/opentripplanner/model/projectinfo/OtpProjectInfoParser.java
@@ -27,7 +27,7 @@ class OtpProjectInfoParser {
           getBool(props, "git.dirty")
         )
       );
-      LOG.debug("Parsed Maven artifact version: {}", version.toString());
+      LOG.debug("Parsed Maven artifact version: {}", version);
       return version;
     } catch (Exception e) {
       LOG.error("Error reading version from properties file: {}", e.getMessage());

--- a/src/main/java/org/opentripplanner/routing/algorithm/astar/AStar.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/astar/AStar.java
@@ -97,7 +97,7 @@ public class AStar {
     // print debug info
     if (verbose) {
       double w = pq.peek_min_key();
-      LOG.debug("pq min key = " + w);
+      LOG.debug("pq min key = {}", w);
     }
 
     // get the lowest-weight state in the queue
@@ -120,7 +120,7 @@ public class AStar {
     Vertex u_vertex = u.getVertex();
 
     if (verbose) {
-      LOG.debug("   vertex " + u_vertex);
+      LOG.debug("   vertex {}", u_vertex);
     }
 
     Collection<Edge> edges = arriveBy ? u_vertex.getIncoming() : u_vertex.getOutgoing();
@@ -146,17 +146,13 @@ public class AStar {
         double estimate = v.getWeight() + remaining_w;
 
         if (verbose) {
-          LOG.debug("      edge " + edge);
+          LOG.debug("      edge {}", edge);
           LOG.debug(
-            "      " +
-            u.getWeight() +
-            " -> " +
-            v.getWeight() +
-            "(w) + " +
-            remaining_w +
-            "(heur) = " +
-            estimate +
-            " vert = " +
+            "      {} -> {}(w) + {}(heur) = {} vert = {}",
+            u.getWeight(),
+            v.getWeight(),
+            remaining_w,
+            estimate,
             v.getVertex()
           );
         }

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/RoutingResponseMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/RoutingResponseMapper.java
@@ -137,9 +137,9 @@ public class RoutingResponseMapper {
     PageCursor nextPageCursor,
     Set<RoutingError> errors
   ) {
-    LOG.debug("PageCursor current  : " + currentPageCursor);
-    LOG.debug("PageCursor previous : " + prevPageCursor);
-    LOG.debug("PageCursor next ... : " + nextPageCursor);
-    LOG.debug("Errors ............ : " + errors);
+    LOG.debug("PageCursor current  : {}", currentPageCursor);
+    LOG.debug("PageCursor previous : {}", prevPageCursor);
+    LOG.debug("PageCursor next ... : {}", nextPageCursor);
+    LOG.debug("Errors ............ : {}", errors);
   }
 }

--- a/src/main/java/org/opentripplanner/routing/graph/SerializedGraphObject.java
+++ b/src/main/java/org/opentripplanner/routing/graph/SerializedGraphObject.java
@@ -222,7 +222,7 @@ public class SerializedGraphObject implements Serializable {
   }
 
   private void save(OutputStream outputStream, String graphName, long size) {
-    LOG.info("Writing graph " + graphName + " ...");
+    LOG.info("Writing graph {}  ...", graphName);
     outputStream = wrapOutputStreamWithProgressTracker(outputStream, size);
     Kryo kryo = KryoBuilder.create();
     Output output = new Output(outputStream);

--- a/src/main/java/org/opentripplanner/routing/impl/GraphPathFinder.java
+++ b/src/main/java/org/opentripplanner/routing/impl/GraphPathFinder.java
@@ -125,7 +125,7 @@ public class GraphPathFinder {
     }
 
     if (paths == null || paths.size() == 0) {
-      LOG.debug("Path not found: " + request.from() + " : " + request.to());
+      LOG.debug("Path not found: {} : {}", request.from(), request.to());
       throw new PathNotFoundException();
     }
 

--- a/src/main/java/org/opentripplanner/routing/spt/ShortestPathTree.java
+++ b/src/main/java/org/opentripplanner/routing/spt/ShortestPathTree.java
@@ -101,7 +101,7 @@ public class ShortestPathTree {
     List<Integer> nStates = new ArrayList<>(histogram.elementSet());
     Collections.sort(nStates);
     for (Integer nState : nStates) {
-      LOG.info(nState + " states: " + histogram.count(nState) + " vertices.");
+      LOG.info("{} states: {} vertices.", nState, histogram.count(nState));
     }
   }
 

--- a/src/main/java/org/opentripplanner/standalone/OtpStartupInfo.java
+++ b/src/main/java/org/opentripplanner/standalone/OtpStartupInfo.java
@@ -36,13 +36,13 @@ public class OtpStartupInfo {
   public static void logInfo() {
     // This is good when aggregating logs across multiple load balanced instances of OTP
     // Hint: a regexp filter like "^OTP (START|SHUTTING)" will list nodes going up/down
-    LOG.info("OTP STARTING UP (" + projectInfo().getVersionString() + ")");
+    LOG.info("OTP STARTING UP ({})", projectInfo().getVersionString());
     Runtime
       .getRuntime()
       .addShutdownHook(
-        new Thread(() -> LOG.info("OTP SHUTTING DOWN (" + projectInfo().getVersionString() + ")"))
+        new Thread(() -> LOG.info("OTP SHUTTING DOWN ({})", projectInfo().getVersionString()))
       );
-    LOG.info(NEW_LINE + info());
+    LOG.info(NEW_LINE + "{}", info());
   }
 
   /** Use this to do a manual test */

--- a/src/main/java/org/opentripplanner/transit/raptor/service/RangeRaptorDynamicSearch.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/service/RangeRaptorDynamicSearch.java
@@ -127,7 +127,7 @@ public class RangeRaptorDynamicSearch<T extends RaptorTripSchedule> {
   }
 
   private RaptorResponse<T> createAndRunDynamicRRWorker(RaptorRequest<T> request) {
-    LOG.debug("Main request: " + request.toString());
+    LOG.debug("Main request: {}", request);
     Worker<T> worker;
 
     // Create worker

--- a/src/main/java/org/opentripplanner/updater/GenericJsonDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/GenericJsonDataSource.java
@@ -33,7 +33,7 @@ public abstract class GenericJsonDataSource<T> implements DataSource<T> {
       }
       return true;
     }
-    LOG.info("Can't update entities from: " + url + ", keeping current list.");
+    LOG.info("Can't update entities from: {}, keeping current list.", url);
     return false;
   }
 

--- a/src/main/java/org/opentripplanner/updater/GenericXmlDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/GenericXmlDataSource.java
@@ -43,7 +43,7 @@ public abstract class GenericXmlDataSource<T> implements DataSource<T> {
       }
       return true;
     }
-    LOG.info("Can't update entities from: " + url + ", keeping current list.");
+    LOG.info("Can't update entities from: {}, keeping current list.", url);
     return false;
   }
 

--- a/src/main/java/org/opentripplanner/updater/alerts/GtfsRealtimeAlertsUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/alerts/GtfsRealtimeAlertsUpdater.java
@@ -95,11 +95,11 @@ public class GtfsRealtimeAlertsUpdater extends PollingGraphUpdater implements Tr
 
       long feedTimestamp = feed.getHeader().getTimestamp();
       if (feedTimestamp == lastTimestamp) {
-        LOG.debug("Ignoring feed with a timestamp that has not been updated from " + url);
+        LOG.debug("Ignoring feed with a timestamp that has not been updated from {}", url);
         return;
       }
       if (feedTimestamp < lastTimestamp) {
-        LOG.info("Ignoring feed with older than previous timestamp from " + url);
+        LOG.info("Ignoring feed with older than previous timestamp from {}", url);
         return;
       }
 

--- a/src/main/java/org/opentripplanner/updater/configure/UpdaterConfigurator.java
+++ b/src/main/java/org/opentripplanner/updater/configure/UpdaterConfigurator.java
@@ -94,7 +94,7 @@ public class UpdaterConfigurator {
   public static void shutdownGraph(TransitModel transitModel) {
     GraphUpdaterManager updaterManager = transitModel.getUpdaterManager();
     if (updaterManager != null) {
-      LOG.info("Stopping updater manager with " + updaterManager.numberOfUpdaters() + " updaters.");
+      LOG.info("Stopping updater manager with {} updaters.", updaterManager.numberOfUpdaters());
       updaterManager.stop();
     }
   }

--- a/src/main/java/org/opentripplanner/updater/stoptime/GtfsRealtimeFileTripUpdateSource.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/GtfsRealtimeFileTripUpdateSource.java
@@ -66,7 +66,7 @@ public class GtfsRealtimeFileTripUpdateSource implements TripUpdateSource {
         }
       }
     } catch (Exception e) {
-      LOG.warn("Failed to parse gtfs-rt feed at " + file + ":", e);
+      LOG.warn("Failed to parse gtfs-rt feed at {}", file, e);
     }
     return updates;
   }

--- a/src/main/java/org/opentripplanner/updater/stoptime/GtfsRealtimeHttpTripUpdateSource.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/GtfsRealtimeHttpTripUpdateSource.java
@@ -71,7 +71,7 @@ public class GtfsRealtimeHttpTripUpdateSource implements TripUpdateSource {
         }
       }
     } catch (Exception e) {
-      LOG.warn("Failed to parse gtfs-rt feed from " + url + ":", e);
+      LOG.warn("Failed to parse gtfs-rt feed from {}", url, e);
     }
     return updates;
   }

--- a/src/main/java/org/opentripplanner/updater/stoptime/MqttGtfsRealtimeUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/MqttGtfsRealtimeUpdater.java
@@ -94,7 +94,7 @@ public class MqttGtfsRealtimeUpdater implements GraphUpdater {
     }
     client.setCallback(new Callback());
 
-    LOG.debug("Connecting to broker: " + url);
+    LOG.debug("Connecting to broker: {}", url);
     client.connect(connOpts);
   }
 
@@ -120,7 +120,7 @@ public class MqttGtfsRealtimeUpdater implements GraphUpdater {
         LOG.debug("Connected");
         client.subscribe(topic, qos);
       } catch (MqttException e) {
-        LOG.warn("Could not subscribe to: " + topic);
+        LOG.warn("Could not subscribe to: {}", topic);
       }
     }
 

--- a/src/main/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingUpdater.java
@@ -73,7 +73,7 @@ public class VehicleParkingUpdater extends PollingGraphUpdater {
 
   @Override
   protected void runPolling() throws Exception {
-    LOG.debug("Updating vehicle parkings from " + source);
+    LOG.debug("Updating vehicle parkings from {}", source);
     if (!source.update()) {
       LOG.debug("No updates");
       return;

--- a/src/main/java/org/opentripplanner/updater/vehicle_positions/GtfsRealtimeHttpVehiclePositionSource.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_positions/GtfsRealtimeHttpVehiclePositionSource.java
@@ -40,12 +40,12 @@ public class GtfsRealtimeHttpVehiclePositionSource implements VehiclePositionSou
   public List<VehiclePosition> getPositions() {
     try (InputStream is = HttpUtils.openInputStream(url.toString(), defaultHeaders)) {
       if (is == null) {
-        LOG.warn("Failed to get data from url " + url);
+        LOG.warn("Failed to get data from url {}", url);
         return List.of();
       }
       return this.getPositions(is);
     } catch (IOException e) {
-      LOG.warn("Error reading vehicle positions from " + url, e);
+      LOG.warn("Error reading vehicle positions from {}", url, e);
     }
     return List.of();
   }

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdater.java
@@ -100,7 +100,7 @@ public class VehicleRentalUpdater extends PollingGraphUpdater {
 
   @Override
   protected void runPolling() {
-    LOG.debug("Updating vehicle rental stations from " + source);
+    LOG.debug("Updating vehicle rental stations from {}", source);
     if (!source.update()) {
       LOG.debug("No updates");
       return;

--- a/src/main/java/org/opentripplanner/util/OTPFeature.java
+++ b/src/main/java/org/opentripplanner/util/OTPFeature.java
@@ -67,8 +67,8 @@ public enum OTPFeature {
   }
 
   public static void logFeatureSetup() {
-    LOG.info("Features turned on: \n\t" + valuesAsString(true));
-    LOG.info("Features turned off: \n\t" + valuesAsString(false));
+    LOG.info("Features turned on: \n\t{}", valuesAsString(true));
+    LOG.info("Features turned off: \n\t{}", valuesAsString(false));
   }
 
   /**

--- a/src/main/java/org/opentripplanner/util/resources/ResourceBundleSingleton.java
+++ b/src/main/java/org/opentripplanner/util/resources/ResourceBundleSingleton.java
@@ -40,7 +40,7 @@ public enum ResourceBundleSingleton {
       //LOG.debug(String.format("Localized '%s' using '%s'", key, retval));
       return resourceBundle.getString(key);
     } catch (MissingResourceException e) {
-      //LOG.debug("Missing translation for key: " + key);
+      //LOG.debug("Missing translation for key: {}", key);
       return key;
     }
   }

--- a/src/main/java/org/opentripplanner/util/xml/JsonDataListDownloader.java
+++ b/src/main/java/org/opentripplanner/util/xml/JsonDataListDownloader.java
@@ -41,16 +41,16 @@ public class JsonDataListDownloader<T> {
 
     try (InputStream data = HttpUtils.openInputStream(url, headers)) {
       if (data == null) {
-        log.warn("Failed to get data from url " + url);
+        log.warn("Failed to get data from url {}", url);
         return null;
       }
       return parseJSON(data);
     } catch (IllegalArgumentException e) {
-      log.warn("Error parsing bike rental feed from " + url, e);
+      log.warn("Error parsing bike rental feed from {}", url, e);
     } catch (JsonProcessingException e) {
-      log.warn("Error parsing bike rental feed from " + url + "(bad JSON of some sort)", e);
+      log.warn("Error parsing bike rental feed from {} (bad JSON of some sort)", url, e);
     } catch (IOException e) {
-      log.warn("Error reading bike rental feed from " + url, e);
+      log.warn("Error reading bike rental feed from {}", url, e);
     }
     return null;
   }

--- a/src/main/java/org/opentripplanner/util/xml/XmlDataListDownloader.java
+++ b/src/main/java/org/opentripplanner/util/xml/XmlDataListDownloader.java
@@ -72,7 +72,7 @@ public class XmlDataListDownloader<T> {
         inputStream = url2.openStream();
       }
       if (inputStream == null) {
-        LOG.warn("Failed to get data from url " + url);
+        LOG.warn("Failed to get data from url {}", url);
         return null;
       } else if (zip) {
         ZipInputStream zipInputStream = new ZipInputStream(inputStream);
@@ -81,12 +81,12 @@ public class XmlDataListDownloader<T> {
       }
       return parseXML(inputStream);
     } catch (IOException e) {
-      LOG.warn("Error reading XML feed from " + url, e);
+      LOG.warn("Error reading XML feed from {}", url, e);
       return null;
     } catch (ParserConfigurationException e) {
       throw new RuntimeException(e);
     } catch (SAXException e) {
-      LOG.warn("Error parsing XML feed from " + url + "(bad XML of some sort)", e);
+      LOG.warn("Error parsing XML feed from {} (bad XML of some sort)", url, e);
       return null;
     }
   }

--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/options/SpeedTestConfig.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/options/SpeedTestConfig.java
@@ -46,7 +46,7 @@ public class SpeedTestConfig {
   public static SpeedTestConfig config(File dir) {
     var json = new ConfigLoader(dir).loadJsonByFilename(FILE_NAME);
     SpeedTestConfig config = new SpeedTestConfig(json);
-    LOG.info("SpeedTest config loaded: " + config);
+    LOG.info("SpeedTest config loaded: {}", config);
     return config;
   }
 


### PR DESCRIPTION
### Summary

This PR uses placeholders in log messages instead of string concatenation. This reduces unnecessary object creation and garbage collection.
Message with a higher verbosity level - typically debug level - may be filtered out by configuration, but the parameters of the log.debug() methods are still evaluated. When using placeholders  this does not result in object creation.

Note: SLF4J 2 allows to use lambdas as values for message placeholders, which can further reduce logging overhead when evaluating placeholder values triggers a method invocation.

### Unit tests

:white_check_mark: 

### Documentation
No
