### PR TITLE
More graph stats, better exception message

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
@@ -213,11 +213,17 @@ public class GraphBuilder implements Runnable {
     var f = new OtpNumberFormat();
     var nStops = f.formatNumber(transitModel.getStopModel().stopIndexSize());
     var nPatterns = f.formatNumber(transitModel.getAllTripPatterns().size());
+    var nTransfers = f.formatNumber(transitModel.getTransferService().listAll().size());
     var nVertices = f.formatNumber(graph.countVertices());
     var nEdges = f.formatNumber(graph.countEdges());
 
     LOG.info("Graph building took {}.", time);
     LOG.info("Graph built.   |V|={} |E|={}", nVertices, nEdges);
-    LOG.info("Transit built. |Stops|={} |Patterns|={}", nStops, nPatterns);
+    LOG.info(
+      "Transit built. |Stops|={} |Patterns|={} |ConstrainedTransfers|={}",
+      nStops,
+      nPatterns,
+      nTransfers
+    );
   }
 }

--- a/src/main/java/org/opentripplanner/routing/graph/SerializedGraphObject.java
+++ b/src/main/java/org/opentripplanner/routing/graph/SerializedGraphObject.java
@@ -237,11 +237,18 @@ public class SerializedGraphObject implements Serializable {
   private static void logSerializationCompleteStatus(Graph graph, TransitModel transitModel) {
     var f = new OtpNumberFormat();
     var nStops = f.formatNumber(transitModel.getStopModel().stopIndexSize());
+    var nTransfers = f.formatNumber(transitModel.getTransferService().listAll().size());
     var nPatterns = f.formatNumber(transitModel.getAllTripPatterns().size());
     var nVertices = f.formatNumber(graph.countVertices());
     var nEdges = f.formatNumber(graph.countEdges());
 
     LOG.info("Graph loaded.   |V|={} |E|={}", nVertices, nEdges);
     LOG.info("Transit loaded. |Stops|={} |Patterns|={}", nStops, nPatterns);
+    LOG.info(
+      "Transit loaded. |Stops|={} |Patterns|={} |ConstrainedTransfers|={}",
+      nStops,
+      nPatterns,
+      nTransfers
+    );
   }
 }

--- a/src/main/java/org/opentripplanner/transit/service/TransitModel.java
+++ b/src/main/java/org/opentripplanner/transit/service/TransitModel.java
@@ -324,7 +324,9 @@ public class TransitModel implements Serializable {
       Collection<ZoneId> zones = getAgencyTimeZones();
       if (zones.size() > 1) {
         throw new IllegalStateException(
-          "The graph contains agencies with different time zones. Please configure the one to be used in the build-config.json"
+          "The graph contains agencies with different time zones: %s. Please configure the one to be used in the build-config.json".formatted(
+              zones
+            )
         );
       }
     }


### PR DESCRIPTION
This is a very simple PR that improves the error message when you have multiple time zones in your transit data. 

This makes it easy to figure out if there is a real problem or just a superficial like using both `America/New_York` and `US/Eastern`.

It also adds the number of constrained transfers to the graph entity size output, as this is important when debugging performance problems.