### PR TITLE
Setting transportmode on added Trip 

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
@@ -613,11 +613,9 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
     var tripBuilder = Trip.of(tripId);
     tripBuilder.withRoute(route);
 
-    if (!route.getMode().equals(transitMode.first)) {
-      // Trip overrides default TransitMode specified in the Route - needs to be set on Trip
-      tripBuilder.withMode(transitMode.first);
-      tripBuilder.withNetexSubmode(transitMode.second);
-    }
+    // Explicitly set TransitMode on Trip - in case it differs from Route
+    tripBuilder.withMode(transitMode.first);
+    tripBuilder.withNetexSubmode(transitMode.second);
 
     LocalDate serviceDate = getServiceDateForEstimatedVehicleJourney(estimatedVehicleJourney);
 

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
@@ -571,12 +571,13 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
     FeedScopedId routeId = new FeedScopedId(feedId, lineRef);
     Route route = transitModel.getTransitModelIndex().getRouteForId(routeId);
 
+    T2<TransitMode, String> transitMode = getTransitMode(
+      estimatedVehicleJourney.getVehicleModes(),
+      replacedRoute
+    );
+
     if (route == null) { // Route is unknown - create new
       var routeBuilder = Route.of(routeId);
-      T2<TransitMode, String> transitMode = getTransitMode(
-        estimatedVehicleJourney.getVehicleModes(),
-        replacedRoute
-      );
       routeBuilder.withMode(transitMode.first);
       routeBuilder.withNetexSubmode(transitMode.second);
       routeBuilder.withOperator(operator);
@@ -611,6 +612,12 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
 
     var tripBuilder = Trip.of(tripId);
     tripBuilder.withRoute(route);
+
+    if (!route.getMode().equals(transitMode.first)) {
+      // Trip overrides default TransitMode specified in the Route - needs to be set on Trip
+      tripBuilder.withMode(transitMode.first);
+      tripBuilder.withNetexSubmode(transitMode.second);
+    }
 
     LocalDate serviceDate = getServiceDateForEstimatedVehicleJourney(estimatedVehicleJourney);
 


### PR DESCRIPTION
When an added trip specifies a different TransportMode than its referenced Line/Route, TransportMode needs to be set on the Trip-object.
