### PR TITLE
Add detailed graph statistics report

### DIFF
--- a/docs/sandbox/ReportApi.md
+++ b/docs/sandbox/ReportApi.md
@@ -22,6 +22,8 @@ Feel free to add more reports and to add your organization to the contact info l
 This module mounts an endpoint for generating reports under `otp/report`. Available reports:
 
 - [/otp/report/transfers.csv](http://localhost:8080/otp/report/transfers.csv)
+- [/otp/report/graph.json](http://localhost:8080/otp/report/graph.json)
+  Detailed numbers of transit and street entities in the graph
 - [/otp/report/bicycle-safety.html](http://localhost:8080/otp/report/bicycle-safety.html):
   Interactive viewer of the rules that determine how bicycle safety factors are calculated.
 - [/otp/report/bicycle-safety.csv](http://localhost:8080/otp/report/bicycle-safety.csv): Raw CSV

--- a/src/ext/java/org/opentripplanner/ext/reportapi/model/GraphReportBuilder.java
+++ b/src/ext/java/org/opentripplanner/ext/reportapi/model/GraphReportBuilder.java
@@ -1,0 +1,78 @@
+package org.opentripplanner.ext.reportapi.model;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import org.opentripplanner.standalone.api.OtpServerRequestContext;
+
+public class GraphReportBuilder {
+
+  public static GraphStats build(OtpServerRequestContext context) {
+    var transitService = context.transitService();
+    var graph = context.graph();
+    var constrainedTransfers = transitService.getTransferService().listAll();
+
+    var constrainedTransfersByType = constrainedTransfers
+      .stream()
+      .collect(
+        Collectors.groupingBy(transfer -> {
+          var transferConstraint = transfer.getTransferConstraint();
+          if (transferConstraint.isMinTransferTimeSet()) {
+            return "minTransferTime";
+          } else if (transferConstraint.isStaySeated()) {
+            return "staySeated";
+          } else if (transferConstraint.isGuaranteed()) {
+            return "guaranteed";
+          } else if (transferConstraint.isNotAllowed()) {
+            return "notAllowed";
+          } else return "unknown";
+        })
+      );
+
+    var stopsByType = transitService
+      .listStopLocations()
+      .stream()
+      .collect(
+        Collectors.groupingBy(stop -> {
+          var className = stop.getClass().getSimpleName();
+          // lower case first letter
+          return Character.toLowerCase(className.charAt(0)) + className.substring(1);
+        })
+      );
+
+    Map<String, Integer> constrainedTransferCounts = countMapValues(constrainedTransfersByType);
+    Map<String, Integer> stopCounts = countMapValues(stopsByType);
+
+    return new GraphStats(
+      new StreetStats(graph.countEdges(), graph.countVertices()),
+      new TransitStats(
+        stopCounts,
+        transitService.getAllTripPatterns().size(),
+        transitService.getAllRoutes().size(),
+        new ConstrainedTransferStats(constrainedTransfers.size(), constrainedTransferCounts)
+      )
+    );
+  }
+
+  @Nonnull
+  private static <T> Map<String, Integer> countMapValues(Map<String, List<T>> input) {
+    Map<String, Integer> result = new HashMap<>();
+    input.forEach((key, value) -> result.put(key, value.size()));
+    return result;
+  }
+
+  record GraphStats(StreetStats street, TransitStats transit) {}
+
+  record StreetStats(int edges, int vertices) {}
+
+  record TransitStats(
+    Map<String, Integer> stops,
+    int patterns,
+    int routes,
+    ConstrainedTransferStats constrainedTransfers
+  ) {}
+
+  record ConstrainedTransferStats(int total, Map<String, Integer> types) {}
+}

--- a/src/ext/java/org/opentripplanner/ext/reportapi/model/GraphReportBuilder.java
+++ b/src/ext/java/org/opentripplanner/ext/reportapi/model/GraphReportBuilder.java
@@ -42,6 +42,7 @@ public class GraphReportBuilder {
       new StreetStats(edgeTypes, vertexTypes),
       new TransitStats(
         stopCounts,
+        transitService.getAllTrips().size(),
         transitService.getAllTripPatterns().size(),
         transitService.getAllRoutes().size(),
         constrainedTransferCounts
@@ -71,7 +72,13 @@ public class GraphReportBuilder {
 
   record StreetStats(TypeStats edges, TypeStats vertices) {}
 
-  record TransitStats(TypeStats stops, int patterns, int routes, TypeStats constrainedTransfers) {}
+  record TransitStats(
+    TypeStats stops,
+    int trips,
+    int tripPatterns,
+    int routes,
+    TypeStats constrainedTransfers
+  ) {}
 
   record TypeStats(int total, Map<String, Integer> types) {}
 }

--- a/src/ext/java/org/opentripplanner/ext/reportapi/model/GraphReportBuilder.java
+++ b/src/ext/java/org/opentripplanner/ext/reportapi/model/GraphReportBuilder.java
@@ -67,7 +67,7 @@ public class GraphReportBuilder {
     return new TypeStats(input.size(), result);
   }
 
-  record GraphStats(StreetStats street, TransitStats transit) {}
+  public record GraphStats(StreetStats street, TransitStats transit) {}
 
   record StreetStats(TypeStats edges, TypeStats vertices) {}
 

--- a/src/ext/java/org/opentripplanner/ext/reportapi/resource/ReportResource.java
+++ b/src/ext/java/org/opentripplanner/ext/reportapi/resource/ReportResource.java
@@ -11,6 +11,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.opentripplanner.ext.reportapi.model.BicycleSafetyReport;
+import org.opentripplanner.ext.reportapi.model.GraphReportBuilder;
 import org.opentripplanner.ext.reportapi.model.TransfersReport;
 import org.opentripplanner.model.transfer.TransferService;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
@@ -60,6 +61,16 @@ public class ReportResource {
         "Content-Disposition",
         "attachment; filename=\"" + osmWayPropertySet + "-bicycle-safety.csv\""
       )
+      .build();
+  }
+
+  @GET
+  @Path("/graph.json")
+  public Response stats(@Context OtpServerRequestContext serverRequestContext) {
+    return Response
+      .status(Response.Status.OK)
+      .entity(GraphReportBuilder.build(serverRequestContext))
+      .type("application/json")
       .build();
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/reportapi/resource/ReportResource.java
+++ b/src/ext/java/org/opentripplanner/ext/reportapi/resource/ReportResource.java
@@ -3,8 +3,6 @@ package org.opentripplanner.ext.reportapi.resource;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.function.Supplier;
-import javax.annotation.Nullable;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -26,9 +24,10 @@ import org.opentripplanner.transit.service.TransitService;
 @Produces(MediaType.TEXT_PLAIN)
 public class ReportResource {
 
-  @Nullable
-/** Since the computation is pretty expensive only allow it every 5 minutes */
-  private static CachedValue<GraphStats> cachedStats = new CachedValue<>(Duration.ofMinutes(5));;
+  /** Since the computation is pretty expensive only allow it every 5 minutes */
+  private static final CachedValue<GraphStats> cachedStats = new CachedValue<>(
+    Duration.ofMinutes(5)
+  );
 
   private final TransferService transferService;
   private final TransitService transitService;
@@ -76,7 +75,6 @@ public class ReportResource {
   @GET
   @Path("/graph.json")
   public Response stats(@Context OtpServerRequestContext serverRequestContext) {
-
     return Response
       .status(Response.Status.OK)
       .entity(cachedStats.get(() -> GraphReportBuilder.build(serverRequestContext)))

--- a/src/main/java/org/opentripplanner/common/model/CachedValue.java
+++ b/src/main/java/org/opentripplanner/common/model/CachedValue.java
@@ -13,12 +13,11 @@ import javax.annotation.Nonnull;
  */
 public class CachedValue<T> {
 
-  private final Supplier<T> supplier;
   private final Duration cacheInterval;
   private T value;
   private Instant timeout;
 
-  public CachedValue(@Nonnull Supplier<T> supplier, @Nonnull Duration cacheInterval) {
+  public CachedValue(@Nonnull Duration cacheInterval) {
     this.supplier = Objects.requireNonNull(supplier);
     this.value = null;
     this.cacheInterval = cacheInterval;
@@ -30,7 +29,7 @@ public class CachedValue<T> {
    * <p>
    * Otherwise, recompute and return it.
    */
-  public T get() {
+  public T get(@Nonnull Supplier<T> supplier) {
     synchronized (this) {
       if (hasExpired()) {
         this.value = supplier.get();

--- a/src/main/java/org/opentripplanner/common/model/CachedValue.java
+++ b/src/main/java/org/opentripplanner/common/model/CachedValue.java
@@ -20,7 +20,7 @@ public class CachedValue<T> {
 
   public CachedValue(@Nonnull Supplier<T> supplier, @Nonnull Duration cacheInterval) {
     this.supplier = Objects.requireNonNull(supplier);
-    this.value = supplier.get();
+    this.value = null;
     this.cacheInterval = cacheInterval;
     this.timeout = calculateTimeout();
   }
@@ -45,6 +45,6 @@ public class CachedValue<T> {
   }
 
   private boolean hasExpired() {
-    return timeout.isBefore(Instant.now());
+    return value == null || timeout.isBefore(Instant.now());
   }
 }

--- a/src/main/java/org/opentripplanner/common/model/CachedValue.java
+++ b/src/main/java/org/opentripplanner/common/model/CachedValue.java
@@ -18,7 +18,6 @@ public class CachedValue<T> {
   private Instant timeout;
 
   public CachedValue(@Nonnull Duration cacheInterval) {
-    this.supplier = Objects.requireNonNull(supplier);
     this.value = null;
     this.cacheInterval = cacheInterval;
     this.timeout = calculateTimeout();

--- a/src/main/java/org/opentripplanner/common/model/CachedValue.java
+++ b/src/main/java/org/opentripplanner/common/model/CachedValue.java
@@ -1,0 +1,50 @@
+package org.opentripplanner.common.model;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.function.Supplier;
+import javax.annotation.Nonnull;
+
+/**
+ * The purpose of this class is to be a generic container for caching expensive computations.
+ * <p>
+ * THIS CLASS IS THREAD-SAFE.
+ */
+public class CachedValue<T> {
+
+  private final Supplier<T> supplier;
+  private final Duration cacheInterval;
+  private T value;
+  private Instant timeout;
+
+  public CachedValue(@Nonnull Supplier<T> supplier, @Nonnull Duration cacheInterval) {
+    this.supplier = Objects.requireNonNull(supplier);
+    this.value = supplier.get();
+    this.cacheInterval = cacheInterval;
+    this.timeout = calculateTimeout();
+  }
+
+  /**
+   * If the cached value has not expired, then return it.
+   * <p>
+   * Otherwise, recompute and return it.
+   */
+  public T get() {
+    synchronized (this) {
+      if (hasExpired()) {
+        this.value = supplier.get();
+        this.timeout = calculateTimeout();
+      }
+    }
+    return value;
+  }
+
+  private Instant calculateTimeout() {
+    return Instant.now().plus(cacheInterval);
+  }
+
+  private boolean hasExpired() {
+    return timeout.isBefore(Instant.now());
+  }
+}


### PR DESCRIPTION
### Summary

This adds a JSON endpoint which contains detailed statistics for the graph.

The output looks like this:

```
{
  "street": {
    "edges": {
      "total": 7943430,
      "types": {
        "vehicleParkingEdge": 8014,
        "streetTransitStopLink": 253432,
        "areaEdge": 118628,
        "elevatorHopEdge": 132,
        "streetVehicleParkingLink": 1372,
        "boardingLocationToStopLink": 36,
        "streetEdge": 7561098,
        "streetTransitEntranceLink": 82,
        "elevatorAlightEdge": 159,
        "freeEdge": 318,
        "elevatorBoardEdge": 159
      }
    },
    "vertices": {
      "total": 3154188,
      "types": {
        "vehicleParkingEntranceVertex": 681,
        "osmBoardingLocationVertex": 44,
        "transitStopVertex": 76573,
        "elevatorOffboardVertex": 159,
        "exitVertex": 3212,
        "barrierVertex": 1247,
        "splitterVertex": 94660,
        "osmVertex": 2977431,
        "elevatorOnboardVertex": 159,
        "transitEntranceVertex": 22
      }
    }
  },
  "transit": {
    "stops": {
      "total": 76573,
      "types": {
        "regularStop": 76573
      }
    },
    "patterns": 9930,
    "routes": 1939,
    "constrainedTransfers": {
      "total": 207782,
      "types": {
        "minTransferTime": 1853,
        "guaranteed": 10234,
        "notAllowed": 1648,
        "staySeated": 194029,
        "unknown": 18
      }
    }
  }
}
```

It's in the ReportApi sandbox so it's off by default. Since computing this information is somewhat expensive it's also cached for 5 minutes.

It also fixes the transfers endpoint for GTFS sources, which don't have an operator.