### PR TITLE
Fix block-based interlining when importing several GTFS feeds

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/module/GtfsModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/GtfsModule.java
@@ -184,7 +184,7 @@ public class GtfsModule implements GraphBuilderModule {
             maxInterlineDistance,
             issueStore
           )
-            .run(transitModel.getAllTripPatterns());
+            .run(otpTransitService.getTripPatterns());
         }
 
         fareServiceFactory.processGtfs(fareRulesService, otpTransitService);

--- a/src/main/java/org/opentripplanner/graph_builder/module/interlining/InterlineProcessor.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/interlining/InterlineProcessor.java
@@ -79,7 +79,7 @@ public class InterlineProcessor {
     if (!transfers.isEmpty()) {
       LOG.info(
         "Found {} pairs of trips for which stay-seated (interlined) transfers were created",
-        interlinedTrips.keySet().size()
+        transfers.size()
       );
 
       transferService.addAll(transfers);

--- a/src/test/java/org/opentripplanner/graph_builder/module/GtfsModuleTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/GtfsModuleTest.java
@@ -5,11 +5,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.opentripplanner.ConstantsForTests;
 import org.opentripplanner.graph_builder.model.GtfsBundle;
 import org.opentripplanner.model.calendar.ServiceDateInterval;
 import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.test.support.VariableSource;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.service.StopModel;
 import org.opentripplanner.transit.service.TransitModel;
@@ -18,22 +24,19 @@ class GtfsModuleTest {
 
   @Test
   public void addShapesForFrequencyTrips() {
-    var deduplicator = new Deduplicator();
-    var stopModel = new StopModel();
-    var graph = new Graph(deduplicator);
-    var transitModel = new TransitModel(stopModel, deduplicator);
+    var model = buildTestModel();
 
     var bundle = new GtfsBundle(new File(ConstantsForTests.FAKE_GTFS));
     var module = new GtfsModule(
       List.of(bundle),
-      transitModel,
-      graph,
+      model.transitModel,
+      model.graph,
       ServiceDateInterval.unbounded()
     );
 
     module.buildGraph();
 
-    var frequencyTripPattern = transitModel
+    var frequencyTripPattern = model.transitModel
       .getAllTripPatterns()
       .stream()
       .filter(p -> !p.getScheduledTimetable().getFrequencyEntries().isEmpty())
@@ -45,8 +48,58 @@ class GtfsModuleTest {
     assertNotNull(tripPattern.getGeometry());
     assertNotNull(tripPattern.getHopGeometry(0));
 
-    var pattern = transitModel.getTripPatternForId(tripPattern.getId());
+    var pattern = model.transitModel.getTripPatternForId(tripPattern.getId());
     assertNotNull(pattern.getGeometry());
     assertNotNull(pattern.getHopGeometry(0));
+  }
+
+  private static TestModels buildTestModel() {
+    var deduplicator = new Deduplicator();
+    var stopModel = new StopModel();
+    var graph = new Graph(deduplicator);
+    var transitModel = new TransitModel(stopModel, deduplicator);
+    return new TestModels(graph, transitModel);
+  }
+
+  record TestModels(Graph graph, TransitModel transitModel) {}
+
+  @Nested
+  class Interlining {
+
+    static GtfsBundle bundle(String feedId) {
+      var b = new GtfsBundle(new File("src/test/resources/gtfs/interlining"));
+      b.setFeedId(new GtfsFeedId.Builder().id(feedId).build());
+      return b;
+    }
+
+    static Stream<Arguments> interliningCases = Stream.of(
+      Arguments.of(List.of(bundle("A")), 2),
+      Arguments.of(List.of(bundle("A"), bundle("B")), 4),
+      Arguments.of(List.of(bundle("A"), bundle("B"), bundle("C")), 6)
+    );
+
+    /**
+     * We test that the number of stay-seated transfers grows linearly (not exponentially) with the
+     * number of GTFS input feeds.
+     */
+    @ParameterizedTest(name = "Bundles {0} should generate {1} stay-seated transfers")
+    @VariableSource("interliningCases")
+    public void interline(List<GtfsBundle> bundles, int expectedTransfers) {
+      var model = buildTestModel();
+
+      var feedIds = bundles.stream().map(GtfsBundle::getFeedId).collect(Collectors.toSet());
+      assertEquals(bundles.size(), feedIds.size());
+
+      var module = new GtfsModule(
+        bundles,
+        model.transitModel,
+        model.graph,
+        ServiceDateInterval.unbounded()
+      );
+
+      module.buildGraph();
+
+      assertEquals(expectedTransfers, model.transitModel.getTransferService().listAll().size());
+    }
   }
 }


### PR DESCRIPTION
### Summary

When importing several GTFS feeds where one of them uses block-based interlining then all following imports regenerate the stay-seated transfers for all of the previous feeds. This leads to a huge number of constrained transfers which is terrible for performance.

### Issue

Fixes #4467.

### Unit tests

Test added.