### PR TITLE
Add error message for value assertion

### DIFF
--- a/src/main/java/org/opentripplanner/transit/model/framework/FeedScopedId.java
+++ b/src/main/java/org/opentripplanner/transit/model/framework/FeedScopedId.java
@@ -28,8 +28,8 @@ public final class FeedScopedId implements Serializable, Comparable<FeedScopedId
   private final String id;
 
   public FeedScopedId(@Nonnull String feedId, @Nonnull String id) {
-    this.feedId = assertHasValue(feedId);
-    this.id = assertHasValue(id);
+    this.feedId = assertHasValue(feedId, "Missing mandatory feedId on FeedScopeId");
+    this.id = assertHasValue(id, "Missing mandatory id on FeedScopeId");
   }
 
   /**

--- a/src/main/java/org/opentripplanner/transit/model/organization/Agency.java
+++ b/src/main/java/org/opentripplanner/transit/model/organization/Agency.java
@@ -27,8 +27,16 @@ public final class Agency extends AbstractTransitEntity<Agency, AgencyBuilder> i
   Agency(AgencyBuilder builder) {
     super(builder.getId());
     // Required fields
-    this.name = assertHasValue(builder.getName());
-    this.timezone = ZoneId.of(assertHasValue(builder.getTimezone()));
+    this.name =
+      assertHasValue(builder.getName(), "Missing mandatory name on Agency %s", builder.getId());
+    this.timezone =
+      ZoneId.of(
+        assertHasValue(
+          builder.getTimezone(),
+          "Missing mandatory time zone on Agency %s",
+          builder.getId()
+        )
+      );
 
     // Optional fields
     this.url = builder.getUrl();

--- a/src/main/java/org/opentripplanner/transit/model/organization/Operator.java
+++ b/src/main/java/org/opentripplanner/transit/model/organization/Operator.java
@@ -26,7 +26,8 @@ public class Operator extends AbstractTransitEntity<Operator, OperatorBuilder> i
   Operator(OperatorBuilder builder) {
     super(builder.getId());
     // Required fields
-    this.name = assertHasValue(builder.getName());
+    this.name =
+      assertHasValue(builder.getName(), "Missing mandatory name on Operator %s", builder.getId());
 
     // Optional fields
     this.url = builder.getUrl();

--- a/src/main/java/org/opentripplanner/util/lang/StringUtils.java
+++ b/src/main/java/org/opentripplanner/util/lang/StringUtils.java
@@ -18,10 +18,21 @@ public class StringUtils {
    * @throws IllegalArgumentException if given value is {@code null}, empty or only whitespace.
    */
   public static String assertHasValue(String value) {
+    return assertHasValue(value, "");
+  }
+
+  /**
+   * Verify String value is NOT {@code null}, empty or only whitespace.
+   * @param errorMessage optional custom message to be displayed as the exception message.
+   * @param placeholders optional placeholders used in the error message format.
+   * @throws IllegalArgumentException if given value is {@code null}, empty or only whitespace.
+   */
+  public static String assertHasValue(String value, String errorMessage, Object... placeholders) {
     if (value == null || value.isBlank()) {
       throw new IllegalArgumentException(
-        "Value can not be null, empty or just whitespace: " +
-        (value == null ? "null" : "'" + value + "'")
+        errorMessage.formatted(placeholders) +
+        " [Value cannot be null, empty or just whitespace: " +
+        (value == null ? "null]" : "'" + value + "']")
       );
     }
     return value;

--- a/src/test/java/org/opentripplanner/util/lang/StringUtilsTest.java
+++ b/src/test/java/org/opentripplanner/util/lang/StringUtilsTest.java
@@ -28,6 +28,12 @@ class StringUtilsTest {
 
     for (var it : illegalValues) {
       assertThrows(IllegalArgumentException.class, () -> StringUtils.assertHasValue(it));
+
+      Throwable thrown = assertThrows(
+        IllegalArgumentException.class,
+        () -> StringUtils.assertHasValue(it, "Illegal value %s", it)
+      );
+      assertTrue(thrown.getMessage().startsWith("Illegal value " + it));
     }
   }
 }


### PR DESCRIPTION
### Summary

This PR improves the error message that OTP produces when asserting that an input data field is neither null nor empty.
The StringUtils.assertHasValue() is overloaded with a new method that takes a message format and message placeholders as optional parameters. They can be used to provide context-specific information in the error message.

### Issue

No

### Unit tests

Updated StringUtilsTest.assertValueExist()

### Documentation

No
