### PR TITLE
Add support for HTTPS datasource for Graph Building

### DIFF
--- a/docs/BuildConfiguration.md
+++ b/docs/BuildConfiguration.md
@@ -125,8 +125,9 @@ different locations around the local filesystem.
 
 As a general rule, references to data files are specified as absolute URIs and must start with the protocol name.   
 Example:   
-Local files: `"file:///Users/kelvin/otp/streetGraph.obj"`   
-Google Cloud Storage files: `"gs://otp-test-bucket/a/b/graph.obj"`
+Local files: `"file:///Users/kelvin/otp/streetGraph.obj"`  
+HTTPS resources: `"https://download.geofabrik.de/europe/norway-latest.osm.pbf"`  
+Google Cloud Storage files: `"gs://otp-test-bucket/a/b/graph.obj"`  
 
 Alternatively if a relative URI can be provided, it is interpreted as a path relative to the [base directory](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/docs/Configuration.md#Base-Directory).
 Example:   

--- a/src/main/java/org/opentripplanner/datastore/api/DataSource.java
+++ b/src/main/java/org/opentripplanner/datastore/api/DataSource.java
@@ -143,7 +143,10 @@ public interface DataSource {
     return info;
   }
 
-  private String directory() {
+  /**
+   * Return the directory that contains the file.
+   */
+  default String directory() {
     int endIndex = path().length() - (name().length() + 1);
     return endIndex <= 0 ? "" : path().substring(0, endIndex);
   }

--- a/src/main/java/org/opentripplanner/datastore/configure/DataStoreModule.java
+++ b/src/main/java/org/opentripplanner/datastore/configure/DataStoreModule.java
@@ -14,6 +14,7 @@ import org.opentripplanner.datastore.api.GoogleStorageDSRepository;
 import org.opentripplanner.datastore.api.OtpDataStoreConfig;
 import org.opentripplanner.datastore.base.DataSourceRepository;
 import org.opentripplanner.datastore.file.FileDataSourceRepository;
+import org.opentripplanner.datastore.https.HttpsDataSourceRepository;
 import org.opentripplanner.standalone.config.api.OtpBaseDirectory;
 
 /**
@@ -57,6 +58,9 @@ public abstract class DataStoreModule {
     if (gsRepository != null) {
       repositories.add(gsRepository);
     }
+
+    repositories.add(new HttpsDataSourceRepository());
+
     // The file data storage repository should be last, to allow
     // other repositories to "override" and grab files analyzing the
     // datasource uri passed in

--- a/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceMetadata.java
+++ b/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceMetadata.java
@@ -1,0 +1,44 @@
+package org.opentripplanner.datastore.https;
+
+import java.util.Date;
+import java.util.Map;
+import org.apache.http.HttpHeaders;
+import org.apache.http.client.utils.DateUtils;
+
+/**
+ * HTTPS data source metadata returned by the HTTP server (HTTP headers).
+ */
+public class HttpsDataSourceMetadata {
+  private final String contentEncoding;
+  private final String contentType;
+  private final long lastModified;
+
+  public HttpsDataSourceMetadata(Map<String, String> headers) {
+    contentEncoding = headers.get(HttpHeaders.CONTENT_ENCODING);
+    contentType = headers.get(HttpHeaders.CONTENT_TYPE);
+    lastModified = parseDate(headers.get(HttpHeaders.LAST_MODIFIED));
+  }
+
+  public String contentEncoding() {
+    return contentEncoding;
+  }
+
+  public String contentType() {
+    return contentType;
+  }
+
+  public long lastModified() {
+    return lastModified;
+  }
+
+  private static long parseDate(String lastModifiedHeader) {
+    if (lastModifiedHeader != null) {
+      Date lastModifiedDate = DateUtils.parseDate(lastModifiedHeader);
+      if (lastModifiedDate != null) {
+        return lastModifiedDate.getTime();
+      }
+    }
+    return 0;
+  }
+
+}

--- a/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceMetadata.java
+++ b/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceMetadata.java
@@ -39,7 +39,7 @@ public class HttpsDataSourceMetadata {
 
   public HttpsDataSourceMetadata(Map<String, String> headers) {
     contentType = headers.get(HttpHeaders.CONTENT_TYPE);
-    contentLength = parseLong(headers);
+    contentLength = parseLong(headers.get(HttpHeaders.CONTENT_LENGTH));
     lastModified = parseDate(headers.get(HttpHeaders.LAST_MODIFIED));
   }
 
@@ -73,9 +73,9 @@ public class HttpsDataSourceMetadata {
     return 0;
   }
 
-  private static long parseLong(Map<String, String> headers) {
+  private static long parseLong(String header) {
     try {
-      return Long.parseLong(headers.get(HttpHeaders.CONTENT_LENGTH));
+      return Long.parseLong(header);
     } catch (Exception e) {
       return 0;
     }

--- a/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceMetadata.java
+++ b/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceMetadata.java
@@ -1,7 +1,11 @@
 package org.opentripplanner.datastore.https;
 
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.http.Header;
 import org.apache.http.HttpHeaders;
 import org.apache.http.client.utils.DateUtils;
 
@@ -10,26 +14,53 @@ import org.apache.http.client.utils.DateUtils;
  */
 public class HttpsDataSourceMetadata {
 
-  private final String contentEncoding;
+  private static final String CONTENT_TYPE_APPLICATION_GZIP = "application/gzip";
+  private static final String CONTENT_TYPE_APPLICATION_ZIP = "application/zip";
+
+  private static final Set<String> HTTP_HEADERS = Set.of(
+    HttpHeaders.CONTENT_TYPE,
+    HttpHeaders.CONTENT_LENGTH,
+    HttpHeaders.LAST_MODIFIED
+  );
+
   private final String contentType;
+
+  private final long contentLength;
   private final long lastModified;
 
-  public HttpsDataSourceMetadata(Map<String, String> headers) {
-    contentEncoding = headers.get(HttpHeaders.CONTENT_ENCODING);
-    contentType = headers.get(HttpHeaders.CONTENT_TYPE);
-    lastModified = parseDate(headers.get(HttpHeaders.LAST_MODIFIED));
+  public HttpsDataSourceMetadata(List<Header> headers) {
+    this(
+      headers
+        .stream()
+        .filter(header -> HTTP_HEADERS.contains(header.getName()))
+        .collect(Collectors.toUnmodifiableMap(Header::getName, Header::getValue))
+    );
   }
 
-  public String contentEncoding() {
-    return contentEncoding;
+  public HttpsDataSourceMetadata(Map<String, String> headers) {
+    contentType = headers.get(HttpHeaders.CONTENT_TYPE);
+    contentLength = parseLong(headers);
+    lastModified = parseDate(headers.get(HttpHeaders.LAST_MODIFIED));
   }
 
   public String contentType() {
     return contentType;
   }
 
+  public long contentLength() {
+    return contentLength;
+  }
+
   public long lastModified() {
     return lastModified;
+  }
+
+  public boolean isZipContentType() {
+    return CONTENT_TYPE_APPLICATION_ZIP.equalsIgnoreCase(contentType());
+  }
+
+  public boolean isGzipContentType() {
+    return CONTENT_TYPE_APPLICATION_GZIP.equalsIgnoreCase(contentType());
   }
 
   private static long parseDate(String lastModifiedHeader) {
@@ -40,5 +71,13 @@ public class HttpsDataSourceMetadata {
       }
     }
     return 0;
+  }
+
+  private static long parseLong(Map<String, String> headers) {
+    try {
+      return Long.parseLong(headers.get(HttpHeaders.CONTENT_LENGTH));
+    } catch (Exception e) {
+      return 0;
+    }
   }
 }

--- a/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceMetadata.java
+++ b/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceMetadata.java
@@ -9,6 +9,7 @@ import org.apache.http.client.utils.DateUtils;
  * HTTPS data source metadata returned by the HTTP server (HTTP headers).
  */
 public class HttpsDataSourceMetadata {
+
   private final String contentEncoding;
   private final String contentType;
   private final long lastModified;
@@ -40,5 +41,4 @@ public class HttpsDataSourceMetadata {
     }
     return 0;
   }
-
 }

--- a/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceMetadata.java
+++ b/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceMetadata.java
@@ -70,14 +70,14 @@ public class HttpsDataSourceMetadata {
         return lastModifiedDate.getTime();
       }
     }
-    return 0;
+    return -1;
   }
 
   private static long parseLong(String header) {
     try {
       return Long.parseLong(header);
     } catch (Exception e) {
-      return 0;
+      return -1;
     }
   }
 }

--- a/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceMetadata.java
+++ b/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceMetadata.java
@@ -14,8 +14,8 @@ import org.apache.http.client.utils.DateUtils;
  */
 public class HttpsDataSourceMetadata {
 
-  private static final String CONTENT_TYPE_APPLICATION_GZIP = "application/gzip";
-  private static final String CONTENT_TYPE_APPLICATION_ZIP = "application/zip";
+  static final String CONTENT_TYPE_APPLICATION_GZIP = "application/gzip";
+  static final String CONTENT_TYPE_APPLICATION_ZIP = "application/zip";
 
   private static final Set<String> HTTP_HEADERS = Set.of(
     HttpHeaders.CONTENT_TYPE,

--- a/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceMetadata.java
+++ b/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceMetadata.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 import org.apache.http.Header;
 import org.apache.http.HttpHeaders;
 import org.apache.http.client.utils.DateUtils;
+import org.opentripplanner.util.lang.ToStringBuilder;
 
 /**
  * HTTPS data source metadata returned by the HTTP server (HTTP headers).
@@ -24,7 +25,6 @@ public class HttpsDataSourceMetadata {
   );
 
   private final String contentType;
-
   private final long contentLength;
   private final long lastModified;
 
@@ -79,5 +79,15 @@ public class HttpsDataSourceMetadata {
     } catch (Exception e) {
       return -1;
     }
+  }
+
+  @Override
+  public String toString() {
+    return ToStringBuilder
+      .of(this.getClass())
+      .addObj("contentType", contentType)
+      .addObj("contentLength", contentLength)
+      .addObj("lastModified", lastModified)
+      .toString();
   }
 }

--- a/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceRepository.java
+++ b/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceRepository.java
@@ -1,7 +1,9 @@
 package org.opentripplanner.datastore.https;
 
 import java.net.URI;
+import java.util.List;
 import javax.annotation.Nonnull;
+import org.apache.http.Header;
 import org.opentripplanner.datastore.api.CompositeDataSource;
 import org.opentripplanner.datastore.api.DataSource;
 import org.opentripplanner.datastore.api.FileType;
@@ -46,14 +48,14 @@ public class HttpsDataSourceRepository implements DataSourceRepository {
 
   private DataSource createSource(URI uri, FileType type) {
     HttpsDataSourceMetadata httpsDataSourceMetadata = new HttpsDataSourceMetadata(
-      HttpUtils.getHeaders(uri)
+      getHttpHeaders(uri)
     );
     return new HttpsFileDataSource(uri, type, httpsDataSourceMetadata);
   }
 
   private CompositeDataSource createCompositeSource(URI uri, FileType type) {
     HttpsDataSourceMetadata httpsDataSourceMetadata = new HttpsDataSourceMetadata(
-      HttpUtils.getHeaders(uri)
+      getHttpHeaders(uri)
     );
 
     if (httpsDataSourceMetadata.isZipContentType() || uri.getPath().endsWith(".zip")) {
@@ -64,5 +66,9 @@ public class HttpsDataSourceRepository implements DataSourceRepository {
         "Only ZIP archives are supported as composite sources for the HTTPS data source"
       );
     }
+  }
+
+  protected List<Header> getHttpHeaders(URI uri) {
+    return HttpUtils.getHeaders(uri);
   }
 }

--- a/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceRepository.java
+++ b/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceRepository.java
@@ -2,9 +2,11 @@ package org.opentripplanner.datastore.https;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import org.apache.http.Header;
+import org.apache.http.HttpHeaders;
 import org.opentripplanner.datastore.api.CompositeDataSource;
 import org.opentripplanner.datastore.api.DataSource;
 import org.opentripplanner.datastore.api.FileType;
@@ -18,6 +20,12 @@ import org.opentripplanner.util.HttpUtils;
 public class HttpsDataSourceRepository implements DataSourceRepository {
 
   private static final String CONTENT_TYPE_APPLICATION_ZIP = "application/zip";
+
+  private static final Set<String> HTTP_HEADERS = Set.of(
+    HttpHeaders.CONTENT_ENCODING,
+    HttpHeaders.CONTENT_TYPE,
+    HttpHeaders.LAST_MODIFIED
+  );
 
   @Override
   public String description() {
@@ -73,7 +81,10 @@ public class HttpsDataSourceRepository implements DataSourceRepository {
   private static HttpsDataSourceMetadata getHttpsDataSourceMetadata(URI uri) {
     List<Header> headers = HttpUtils.getHeaders(uri);
     return new HttpsDataSourceMetadata(
-      headers.stream().collect(Collectors.toUnmodifiableMap(Header::getName, Header::getValue))
+      headers
+        .stream()
+        .filter(header -> HTTP_HEADERS.contains(header.getName()))
+        .collect(Collectors.toUnmodifiableMap(Header::getName, Header::getValue))
     );
   }
 }

--- a/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceRepository.java
+++ b/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceRepository.java
@@ -25,8 +25,7 @@ public class HttpsDataSourceRepository implements DataSourceRepository {
   }
 
   @Override
-  public void open() {
-  }
+  public void open() {}
 
   @Override
   public DataSource findSource(@Nonnull URI uri, @Nonnull FileType type) {
@@ -56,10 +55,12 @@ public class HttpsDataSourceRepository implements DataSourceRepository {
   }
 
   private CompositeDataSource createCompositeSource(URI uri, FileType type) {
-
     HttpsDataSourceMetadata httpsDataSourceMetadata = getHttpsDataSourceMetadata(uri);
 
-    if (CONTENT_TYPE_APPLICATION_ZIP.equalsIgnoreCase(httpsDataSourceMetadata.contentType()) || uri.getPath().endsWith(".zip")) {
+    if (
+      CONTENT_TYPE_APPLICATION_ZIP.equalsIgnoreCase(httpsDataSourceMetadata.contentType()) ||
+      uri.getPath().endsWith(".zip")
+    ) {
       DataSource httpsSource = new HttpsFileDataSource(uri, type, httpsDataSourceMetadata);
       return new ZipStreamDataSourceDecorator(httpsSource);
     } else {
@@ -70,9 +71,9 @@ public class HttpsDataSourceRepository implements DataSourceRepository {
   }
 
   private static HttpsDataSourceMetadata getHttpsDataSourceMetadata(URI uri) {
-      List<Header> headers = HttpUtils.getHeaders(uri);
-      return new HttpsDataSourceMetadata(headers.stream().collect(Collectors.toUnmodifiableMap(Header::getName, Header::getValue)));
+    List<Header> headers = HttpUtils.getHeaders(uri);
+    return new HttpsDataSourceMetadata(
+      headers.stream().collect(Collectors.toUnmodifiableMap(Header::getName, Header::getValue))
+    );
   }
-
-
 }

--- a/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceRepository.java
+++ b/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceRepository.java
@@ -1,0 +1,60 @@
+package org.opentripplanner.datastore.https;
+
+import java.net.URI;
+import javax.annotation.Nonnull;
+import org.opentripplanner.datastore.api.CompositeDataSource;
+import org.opentripplanner.datastore.api.DataSource;
+import org.opentripplanner.datastore.api.FileType;
+import org.opentripplanner.datastore.base.DataSourceRepository;
+import org.opentripplanner.datastore.base.ZipStreamDataSourceDecorator;
+
+/**
+ * This data store accesses files in read-only mode over HTTPS.
+ */
+public class HttpsDataSourceRepository implements DataSourceRepository {
+
+  @Override
+  public String description() {
+    return "HTTPS";
+  }
+
+  @Override
+  public void open() {}
+
+  @Override
+  public DataSource findSource(@Nonnull URI uri, @Nonnull FileType type) {
+    if (skipUri(uri)) {
+      return null;
+    }
+    return createSource(uri, type);
+  }
+
+  @Override
+  public CompositeDataSource findCompositeSource(@Nonnull URI uri, @Nonnull FileType type) {
+    if (skipUri(uri)) {
+      return null;
+    }
+    return createCompositeSource(uri, type);
+  }
+
+  /* private methods */
+
+  private static boolean skipUri(URI uri) {
+    return !"https".equals(uri.getScheme());
+  }
+
+  private DataSource createSource(URI uri, FileType type) {
+    return new HttpsFileDataSource(uri, type);
+  }
+
+  private CompositeDataSource createCompositeSource(URI uri, FileType type) {
+    if (uri.getPath().endsWith(".zip")) {
+      DataSource httpsSource = new HttpsFileDataSource(uri, type);
+      return new ZipStreamDataSourceDecorator(httpsSource);
+    } else {
+      throw new UnsupportedOperationException(
+        "Only ZIP archives are supported as composite sources for the HTTPS data source"
+      );
+    }
+  }
+}

--- a/src/main/java/org/opentripplanner/datastore/https/HttpsFileDataSource.java
+++ b/src/main/java/org/opentripplanner/datastore/https/HttpsFileDataSource.java
@@ -78,7 +78,7 @@ record HttpsFileDataSource(URI uri, FileType type, HttpsDataSourceMetadata https
 
   @Override
   public String name() {
-    return uri.getPath().substring(1);
+    return uri.getPath().substring(uri.getPath().lastIndexOf('/') + 1);
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/datastore/https/HttpsFileDataSource.java
+++ b/src/main/java/org/opentripplanner/datastore/https/HttpsFileDataSource.java
@@ -1,0 +1,87 @@
+package org.opentripplanner.datastore.https;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.util.zip.GZIPInputStream;
+import org.opentripplanner.datastore.api.DataSource;
+import org.opentripplanner.datastore.api.FileType;
+import org.opentripplanner.datastore.file.DirectoryDataSource;
+import org.opentripplanner.datastore.file.ZipFileDataSource;
+import org.opentripplanner.util.HttpUtils;
+
+/**
+ * This class is a wrapper around an HTTPS resource.
+ * <p>
+ * Reading compressed HTTPS resources is supported. The only format supported is gzip (extension
+ * .gz).
+ */
+record HttpsFileDataSource(URI uri, FileType type) implements DataSource {
+  /**
+   * Create a data source wrapper around an HTTPS resource. This wrapper handles GZIP(.gz)
+   * compressed files as well as normal files. It does not handle
+   * directories({@link DirectoryDataSource}) or zip-files {@link ZipFileDataSource} which contain
+   * multiple files.
+   */
+
+  @Override
+  public long size() {
+    return -1;
+  }
+
+  @Override
+  public long lastModified() {
+    return -1;
+  }
+
+  @Override
+  public boolean exists() {
+    return true;
+  }
+
+  @Override
+  public boolean isWritable() {
+    return false;
+  }
+
+  @Override
+  public InputStream asInputStream() {
+    InputStream in;
+
+    try {
+      in = HttpUtils.getData(uri);
+    } catch (IOException e) {
+      throw new IllegalStateException(e.getLocalizedMessage(), e);
+    }
+
+    // We support both gzip and unzipped files when reading.
+
+    if (uri.getPath().endsWith(".gz")) {
+      try {
+        return new GZIPInputStream(in);
+      } catch (IOException e) {
+        throw new IllegalStateException(e.getLocalizedMessage(), e);
+      }
+    } else {
+      return in;
+    }
+  }
+
+  @Override
+  public OutputStream asOutputStream() {
+    throw new UnsupportedOperationException(
+      "Write operations are not available for HTTPS data sources"
+    );
+  }
+
+  @Override
+  public String name() {
+    return uri.getPath().substring(1);
+  }
+
+  @Override
+  public String path() {
+    return uri.toString();
+  }
+}

--- a/src/main/java/org/opentripplanner/datastore/https/HttpsFileDataSource.java
+++ b/src/main/java/org/opentripplanner/datastore/https/HttpsFileDataSource.java
@@ -87,4 +87,10 @@ record HttpsFileDataSource(URI uri, FileType type, HttpsDataSourceMetadata https
   public String path() {
     return uri.toString();
   }
+
+  @Override
+  public String directory() {
+    int endIndex = path().lastIndexOf(name()) - 1;
+    return endIndex <= 0 ? "" : path().substring(0, endIndex);
+  }
 }

--- a/src/main/java/org/opentripplanner/datastore/https/HttpsFileDataSource.java
+++ b/src/main/java/org/opentripplanner/datastore/https/HttpsFileDataSource.java
@@ -17,9 +17,8 @@ import org.opentripplanner.util.HttpUtils;
  * Reading compressed HTTPS resources is supported. The only format supported is gzip (extension
  * .gz).
  */
-record HttpsFileDataSource(URI uri, FileType type, HttpsDataSourceMetadata httpsDataSourceMetadata) implements DataSource {
-
-
+record HttpsFileDataSource(URI uri, FileType type, HttpsDataSourceMetadata httpsDataSourceMetadata)
+  implements DataSource {
   private static final String CONTENT_ENCODING_GZIP = "gzip";
 
   /**

--- a/src/main/java/org/opentripplanner/datastore/https/HttpsFileDataSource.java
+++ b/src/main/java/org/opentripplanner/datastore/https/HttpsFileDataSource.java
@@ -19,8 +19,6 @@ import org.opentripplanner.util.HttpUtils;
  */
 record HttpsFileDataSource(URI uri, FileType type, HttpsDataSourceMetadata httpsDataSourceMetadata)
   implements DataSource {
-  private static final String CONTENT_ENCODING_GZIP = "gzip";
-
   /**
    * Create a data source wrapper around an HTTPS resource. This wrapper handles GZIP(.gz)
    * compressed files as well as normal files. It does not handle
@@ -30,7 +28,7 @@ record HttpsFileDataSource(URI uri, FileType type, HttpsDataSourceMetadata https
 
   @Override
   public long size() {
-    return -1;
+    return httpsDataSourceMetadata.contentLength();
   }
 
   @Override
@@ -60,7 +58,7 @@ record HttpsFileDataSource(URI uri, FileType type, HttpsDataSourceMetadata https
 
     // We support both gzip and unzipped files when reading.
 
-    if (CONTENT_ENCODING_GZIP.equalsIgnoreCase(httpsDataSourceMetadata.contentEncoding())) {
+    if (httpsDataSourceMetadata().isGzipContentType() || uri.getPath().endsWith(".gz")) {
       try {
         return new GZIPInputStream(in);
       } catch (IOException e) {

--- a/src/main/java/org/opentripplanner/datastore/https/HttpsFileDataSource.java
+++ b/src/main/java/org/opentripplanner/datastore/https/HttpsFileDataSource.java
@@ -17,7 +17,11 @@ import org.opentripplanner.util.HttpUtils;
  * Reading compressed HTTPS resources is supported. The only format supported is gzip (extension
  * .gz).
  */
-record HttpsFileDataSource(URI uri, FileType type) implements DataSource {
+record HttpsFileDataSource(URI uri, FileType type, HttpsDataSourceMetadata httpsDataSourceMetadata) implements DataSource {
+
+
+  private static final String CONTENT_ENCODING_GZIP = "gzip";
+
   /**
    * Create a data source wrapper around an HTTPS resource. This wrapper handles GZIP(.gz)
    * compressed files as well as normal files. It does not handle
@@ -32,7 +36,7 @@ record HttpsFileDataSource(URI uri, FileType type) implements DataSource {
 
   @Override
   public long lastModified() {
-    return -1;
+    return httpsDataSourceMetadata.lastModified();
   }
 
   @Override
@@ -57,7 +61,7 @@ record HttpsFileDataSource(URI uri, FileType type) implements DataSource {
 
     // We support both gzip and unzipped files when reading.
 
-    if (uri.getPath().endsWith(".gz")) {
+    if (CONTENT_ENCODING_GZIP.equalsIgnoreCase(httpsDataSourceMetadata.contentEncoding())) {
       try {
         return new GZIPInputStream(in);
       } catch (IOException e) {

--- a/src/main/java/org/opentripplanner/util/HttpUtils.java
+++ b/src/main/java/org/opentripplanner/util/HttpUtils.java
@@ -5,12 +5,16 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URL;
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
+import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
-import org.apache.http.client.HttpClient;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpHead;
+import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.impl.client.HttpClientBuilder;
 
 public class HttpUtils {
@@ -34,29 +38,10 @@ public class HttpUtils {
     Duration timeout,
     Map<String, String> requestHeaderValues
   ) throws IOException {
-    var to = (int) timeout.toMillis();
-    RequestConfig requestConfig = RequestConfig
-      .custom()
-      .setSocketTimeout(to)
-      .setConnectTimeout(to)
-      .setConnectionRequestTimeout(to)
-      .build();
-
-    HttpGet httpget = new HttpGet(uri);
-    httpget.setConfig(requestConfig);
-
-    if (requestHeaderValues != null) {
-      for (Map.Entry<String, String> entry : requestHeaderValues.entrySet()) {
-        httpget.addHeader(entry.getKey(), entry.getValue());
-      }
-    }
-
-    HttpClient httpclient = HttpClientBuilder.create().build();
-    HttpResponse response = httpclient.execute(httpget);
+    HttpResponse response = getResponse(new HttpGet(uri), timeout, requestHeaderValues);
     if (response.getStatusLine().getStatusCode() != 200) {
       return null;
     }
-
     HttpEntity entity = response.getEntity();
     if (entity == null) {
       return null;
@@ -67,6 +52,27 @@ public class HttpUtils {
   public static InputStream getData(URI uri, Map<String, String> requestHeaderValues)
     throws IOException {
     return getData(uri, DEFAULT_TIMEOUT, requestHeaderValues);
+  }
+
+  public static List<Header> getHeaders(URI uri) {
+    return getHeaders(uri, DEFAULT_TIMEOUT, null);
+  }
+
+  public static List<Header> getHeaders(
+    URI uri,
+    Duration timeout,
+    Map<String, String> requestHeaderValues
+  ) {
+    HttpResponse response;
+    try {
+      response = getResponse(new HttpHead(uri), timeout, requestHeaderValues);
+    } catch (IOException e) {
+      throw new RuntimeException(e.getLocalizedMessage(), e);
+    }
+    if (response.getStatusLine().getStatusCode() != 200) {
+      throw new RuntimeException("URI " + uri + " unavailable. HTTP error code " + response.getStatusLine().getStatusCode());
+    }
+    return Arrays.stream(response.getAllHeaders()).toList();
   }
 
   public static InputStream openInputStream(String url, Map<String, String> headers)
@@ -84,5 +90,29 @@ public class HttpUtils {
       // Local file probably, try standard java
       return downloadUrl.openStream();
     }
+  }
+
+  private static HttpResponse getResponse(
+    HttpRequestBase httpRequest,
+    Duration timeout,
+    Map<String, String> requestHeaderValues
+  ) throws IOException {
+    var to = (int) timeout.toMillis();
+    RequestConfig requestConfig = RequestConfig
+      .custom()
+      .setSocketTimeout(to)
+      .setConnectTimeout(to)
+      .setConnectionRequestTimeout(to)
+      .build();
+
+    httpRequest.setConfig(requestConfig);
+
+    if (requestHeaderValues != null) {
+      for (Map.Entry<String, String> entry : requestHeaderValues.entrySet()) {
+        httpRequest.addHeader(entry.getKey(), entry.getValue());
+      }
+    }
+
+    return HttpClientBuilder.create().build().execute(httpRequest);
   }
 }

--- a/src/main/java/org/opentripplanner/util/HttpUtils.java
+++ b/src/main/java/org/opentripplanner/util/HttpUtils.java
@@ -70,7 +70,9 @@ public class HttpUtils {
       throw new RuntimeException(e.getLocalizedMessage(), e);
     }
     if (response.getStatusLine().getStatusCode() != 200) {
-      throw new RuntimeException("URI " + uri + " unavailable. HTTP error code " + response.getStatusLine().getStatusCode());
+      throw new RuntimeException(
+        "URI " + uri + " unavailable. HTTP error code " + response.getStatusLine().getStatusCode()
+      );
     }
     return Arrays.stream(response.getAllHeaders()).toList();
   }

--- a/src/main/java/org/opentripplanner/util/HttpUtils.java
+++ b/src/main/java/org/opentripplanner/util/HttpUtils.java
@@ -70,8 +70,13 @@ public class HttpUtils {
       throw new RuntimeException(e.getLocalizedMessage(), e);
     }
     if (response.getStatusLine().getStatusCode() != 200) {
+      // remove the query part from the URI
+      String sanitizedUri = uri.toString().replace('?' + uri.getQuery(), "");
       throw new RuntimeException(
-        "URI " + uri + " unavailable. HTTP error code " + response.getStatusLine().getStatusCode()
+        "Resource " +
+        sanitizedUri +
+        " unavailable. HTTP error code " +
+        response.getStatusLine().getStatusCode()
       );
     }
     return Arrays.stream(response.getAllHeaders()).toList();

--- a/src/test/java/org/opentripplanner/datastore/https/HttpsDataSourceRepositoryTest.java
+++ b/src/test/java/org/opentripplanner/datastore/https/HttpsDataSourceRepositoryTest.java
@@ -1,0 +1,26 @@
+package org.opentripplanner.datastore.https;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.net.URI;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.datastore.api.FileType;
+
+class HttpsDataSourceRepositoryTest {
+
+  private final HttpsDataSourceRepository subject = new HttpsDataSourceRepository();
+
+  @Test
+  void testDescription() {
+    assertEquals("HTTPS", subject.description());
+  }
+
+  @Test
+  void testFindSource() throws Exception {
+    assertNull(
+      subject.findSource(new URI("file:/a.txt"), FileType.UNKNOWN),
+      "Expect to return null for unknown URI without connection to store"
+    );
+  }
+}

--- a/src/test/java/org/opentripplanner/datastore/https/HttpsDataSourceRepositoryTest.java
+++ b/src/test/java/org/opentripplanner/datastore/https/HttpsDataSourceRepositoryTest.java
@@ -1,10 +1,16 @@
 package org.opentripplanner.datastore.https;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import org.apache.http.Header;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.datastore.api.CompositeDataSource;
+import org.opentripplanner.datastore.api.DataSource;
 import org.opentripplanner.datastore.api.FileType;
 
 class HttpsDataSourceRepositoryTest {
@@ -17,10 +23,47 @@ class HttpsDataSourceRepositoryTest {
   }
 
   @Test
-  void testFindSource() throws Exception {
+  void testFindUnsupportedSource() throws Exception {
     assertNull(
       subject.findSource(new URI("file:/a.txt"), FileType.UNKNOWN),
-      "Expect to return null for unknown URI without connection to store"
+      "Expect to return null for unsupported URI"
     );
+  }
+
+  @Test
+  void testFindSupportedSource() throws Exception {
+    HttpsDataSourceRepository httpsDataSourceRepository = stubHttpsDataSourceRepository();
+    DataSource source = httpsDataSourceRepository.findSource(
+      new URI("https://server/path/to/dataset.xml"),
+      FileType.UNKNOWN
+    );
+    assertNotNull(source);
+  }
+
+  @Test
+  void testFindUnsupportedCompositeSource() throws Exception {
+    assertNull(
+      subject.findCompositeSource(new URI("file:/a.zip"), FileType.UNKNOWN),
+      "Expect to return null for unsupported URI"
+    );
+  }
+
+  @Test
+  void testFindSupportedCompositeSource() throws URISyntaxException {
+    HttpsDataSourceRepository httpsDataSourceRepository = stubHttpsDataSourceRepository();
+    CompositeDataSource compositeSource = httpsDataSourceRepository.findCompositeSource(
+      new URI("https://server/path/to/dataset.zip"),
+      FileType.UNKNOWN
+    );
+    assertNotNull(compositeSource);
+  }
+
+  private static HttpsDataSourceRepository stubHttpsDataSourceRepository() {
+    return new HttpsDataSourceRepository() {
+      @Override
+      protected List<Header> getHttpHeaders(URI uri) {
+        return List.of();
+      }
+    };
   }
 }

--- a/src/test/java/org/opentripplanner/datastore/https/HttpsFileDataSourceTest.java
+++ b/src/test/java/org/opentripplanner/datastore/https/HttpsFileDataSourceTest.java
@@ -1,0 +1,65 @@
+package org.opentripplanner.datastore.https;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.Map;
+import java.util.Set;
+import org.apache.http.HttpHeaders;
+import org.apache.http.client.utils.DateUtils;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.datastore.api.FileType;
+
+class HttpsFileDataSourceTest {
+
+  public static final String TEST_HOST = "https://localhost";
+  public static final String TEST_RELATIVE_PATH = "path/to";
+  public static final String TEST_NAME = "dataset.zip";
+  public static final String TEST_DIRECTORY = TEST_HOST + '/' + TEST_RELATIVE_PATH;
+  public static final String TEST_URI = TEST_DIRECTORY + '/' + TEST_NAME;
+
+  public static final String TEST_URI_WITH_PARAMETERS =
+    TEST_DIRECTORY + '/' + TEST_NAME + "?key=value";
+
+  @Test
+  void testHttpsFileDataSourceConstruction() throws URISyntaxException {
+    URI uri = new URI(TEST_URI);
+    FileType type = FileType.NETEX;
+    Instant now = Instant.now();
+    Map<String, String> headers = Map.of(
+      HttpHeaders.CONTENT_TYPE,
+      HttpsDataSourceMetadata.CONTENT_TYPE_APPLICATION_ZIP,
+      HttpHeaders.CONTENT_LENGTH,
+      "1024",
+      HttpHeaders.LAST_MODIFIED,
+      DateUtils.formatDate(Date.from(now))
+    );
+    HttpsDataSourceMetadata metadata = new HttpsDataSourceMetadata(headers);
+    HttpsFileDataSource httpsFileDataSource = new HttpsFileDataSource(uri, type, metadata);
+    assertEquals(TEST_NAME, httpsFileDataSource.name());
+    assertEquals(TEST_URI, httpsFileDataSource.path());
+    assertEquals(TEST_DIRECTORY, httpsFileDataSource.directory());
+    assertEquals(1024, httpsFileDataSource.size());
+    assertTrue(httpsFileDataSource.httpsDataSourceMetadata().isZipContentType());
+    assertEquals(
+      now.truncatedTo(ChronoUnit.SECONDS).toEpochMilli(),
+      httpsFileDataSource.lastModified()
+    );
+  }
+
+  @Test
+  void testUriWithParameters() throws URISyntaxException {
+    URI uri = new URI(TEST_URI_WITH_PARAMETERS);
+    FileType type = FileType.NETEX;
+    HttpsDataSourceMetadata metadata = new HttpsDataSourceMetadata(Map.of());
+    HttpsFileDataSource httpsFileDataSource = new HttpsFileDataSource(uri, type, metadata);
+    assertEquals(TEST_NAME, httpsFileDataSource.name());
+    assertEquals(TEST_URI_WITH_PARAMETERS, httpsFileDataSource.path());
+    assertEquals(TEST_DIRECTORY, httpsFileDataSource.directory());
+  }
+}

--- a/src/test/java/org/opentripplanner/datastore/https/HttpsFileDataSourceTest.java
+++ b/src/test/java/org/opentripplanner/datastore/https/HttpsFileDataSourceTest.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.datastore.https;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
@@ -9,7 +10,6 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.Map;
-import java.util.Set;
 import org.apache.http.HttpHeaders;
 import org.apache.http.client.utils.DateUtils;
 import org.junit.jupiter.api.Test;
@@ -22,14 +22,32 @@ class HttpsFileDataSourceTest {
   public static final String TEST_NAME = "dataset.zip";
   public static final String TEST_DIRECTORY = TEST_HOST + '/' + TEST_RELATIVE_PATH;
   public static final String TEST_URI = TEST_DIRECTORY + '/' + TEST_NAME;
-
   public static final String TEST_URI_WITH_PARAMETERS =
     TEST_DIRECTORY + '/' + TEST_NAME + "?key=value";
 
   @Test
+  void testNotWritable() throws URISyntaxException {
+    HttpsFileDataSource httpsFileDataSource = new HttpsFileDataSource(
+      new URI(TEST_URI),
+      FileType.UNKNOWN,
+      new HttpsDataSourceMetadata(Map.of())
+    );
+    assertFalse(httpsFileDataSource.isWritable());
+  }
+
+  @Test
+  void testExist() throws URISyntaxException {
+    HttpsFileDataSource httpsFileDataSource = new HttpsFileDataSource(
+      new URI(TEST_URI),
+      FileType.UNKNOWN,
+      new HttpsDataSourceMetadata(Map.of())
+    );
+    assertTrue(httpsFileDataSource.exists());
+  }
+
+  @Test
   void testHttpsFileDataSourceConstruction() throws URISyntaxException {
     URI uri = new URI(TEST_URI);
-    FileType type = FileType.NETEX;
     Instant now = Instant.now();
     Map<String, String> headers = Map.of(
       HttpHeaders.CONTENT_TYPE,
@@ -40,7 +58,11 @@ class HttpsFileDataSourceTest {
       DateUtils.formatDate(Date.from(now))
     );
     HttpsDataSourceMetadata metadata = new HttpsDataSourceMetadata(headers);
-    HttpsFileDataSource httpsFileDataSource = new HttpsFileDataSource(uri, type, metadata);
+    HttpsFileDataSource httpsFileDataSource = new HttpsFileDataSource(
+      uri,
+      FileType.UNKNOWN,
+      metadata
+    );
     assertEquals(TEST_NAME, httpsFileDataSource.name());
     assertEquals(TEST_URI, httpsFileDataSource.path());
     assertEquals(TEST_DIRECTORY, httpsFileDataSource.directory());
@@ -55,9 +77,12 @@ class HttpsFileDataSourceTest {
   @Test
   void testUriWithParameters() throws URISyntaxException {
     URI uri = new URI(TEST_URI_WITH_PARAMETERS);
-    FileType type = FileType.NETEX;
     HttpsDataSourceMetadata metadata = new HttpsDataSourceMetadata(Map.of());
-    HttpsFileDataSource httpsFileDataSource = new HttpsFileDataSource(uri, type, metadata);
+    HttpsFileDataSource httpsFileDataSource = new HttpsFileDataSource(
+      uri,
+      FileType.UNKNOWN,
+      metadata
+    );
     assertEquals(TEST_NAME, httpsFileDataSource.name());
     assertEquals(TEST_URI_WITH_PARAMETERS, httpsFileDataSource.path());
     assertEquals(TEST_DIRECTORY, httpsFileDataSource.directory());


### PR DESCRIPTION
### Summary

This PR implements support for reading data sources from an HTTPS resource.
The data source provides only read operations.

### Issue

Implements #4481

### Unit tests

Added unit tests

### Documentation

Updated BuildConfiguration.md

