### PR TITLE
Add Houston WayPropertySet

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/reportapi/model/BicycleSafetyReport.java
+++ b/src/ext/java/org/opentripplanner/ext/reportapi/model/BicycleSafetyReport.java
@@ -28,11 +28,11 @@ public class BicycleSafetyReport {
     wayPropertySet
       .getWayProperties()
       .forEach(p -> {
-        buf.addText(p.getSpecifier().toString());
-        buf.addBoolean(p.isSafetyMixin());
-        buf.addText(p.getProperties().getPermission().toString());
+        buf.addText(p.specifier().toString());
+        buf.addBoolean(p.safetyMixin());
+        buf.addText(p.properties().getPermission().toString());
 
-        var safetyProps = p.getProperties().getBicycleSafetyFeatures();
+        var safetyProps = p.properties().getBicycleSafetyFeatures();
         buf.addNumber(safetyProps.forward());
         buf.addNumber(safetyProps.back());
         buf.newLine();

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/HoustonWayPropertySetSource.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/HoustonWayPropertySetSource.java
@@ -25,6 +25,14 @@ public class HoustonWayPropertySetSource implements WayPropertySetSource {
       "highway=footway;layer=-1;tunnel=yes;indoor=yes",
       withModes(StreetTraversalPermission.NONE)
     );
+    props.setProperties(
+      "highway=*;layer=-1;tunnel=yes;indoor=yes",
+      withModes(StreetTraversalPermission.ALL)
+    );
+    props.setProperties(
+      "highway=footway;tunnel=yes;indoor=yes",
+      withModes(StreetTraversalPermission.PEDESTRIAN)
+    );
 
     // Read the rest from the default set
     new DefaultWayPropertySetSource().populateProperties(props);

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/HoustonWayPropertySetSource.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/HoustonWayPropertySetSource.java
@@ -1,8 +1,10 @@
 package org.opentripplanner.graph_builder.module.osm;
 
 import static org.opentripplanner.graph_builder.module.osm.WayPropertiesBuilder.withModes;
-
-import org.opentripplanner.routing.edgetype.StreetTraversalPermission;
+import static org.opentripplanner.routing.edgetype.StreetTraversalPermission.ALL;
+import static org.opentripplanner.routing.edgetype.StreetTraversalPermission.BICYCLE;
+import static org.opentripplanner.routing.edgetype.StreetTraversalPermission.NONE;
+import static org.opentripplanner.routing.edgetype.StreetTraversalPermission.PEDESTRIAN;
 
 /**
  * OSM way properties for the Houston, Texas, USA area.
@@ -20,20 +22,16 @@ public class HoustonWayPropertySetSource implements WayPropertySetSource {
 
   @Override
   public void populateProperties(WayPropertySet props) {
-    // Disallow any use of underground indoor pedestrian tunnels
-    props.setProperties(
-      "highway=footway;layer=-1;tunnel=yes;indoor=yes",
-      withModes(StreetTraversalPermission.NONE)
-    );
-    props.setProperties(
-      "highway=*;layer=-1;tunnel=yes;indoor=yes",
-      withModes(StreetTraversalPermission.ALL)
-    );
-    props.setProperties(
-      "highway=footway;tunnel=yes;indoor=yes",
-      withModes(StreetTraversalPermission.PEDESTRIAN)
-    );
+    props.setProperties("highway=*;layer=-1;tunnel=yes;indoor=yes", withModes(ALL));
+    props.setProperties("highway=cycleway;tunnel=yes;indoor=yes", withModes(BICYCLE));
+    // sadly we need these permutations since otherwise they would match with the final props
+    // I'm not sure if this is a bug or working as intended
+    props.setProperties("highway=footway;tunnel=yes;indoor=yes", withModes(PEDESTRIAN));
+    props.setProperties("highway=footway;tunnel=yes;layer=-1", withModes(PEDESTRIAN));
+    props.setProperties("highway=footway", withModes(PEDESTRIAN));
 
+    // Disallow any use of underground indoor pedestrian tunnels
+    props.setProperties("highway=footway;layer=-1;tunnel=yes;indoor=yes", withModes(NONE));
     // Read the rest from the default set
     new DefaultWayPropertySetSource().populateProperties(props);
   }

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/HoustonWayPropertySetSource.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/HoustonWayPropertySetSource.java
@@ -1,0 +1,32 @@
+package org.opentripplanner.graph_builder.module.osm;
+
+import static org.opentripplanner.graph_builder.module.osm.WayPropertiesBuilder.withModes;
+
+import org.opentripplanner.routing.edgetype.StreetTraversalPermission;
+
+/**
+ * OSM way properties for the Houston, Texas, USA area.
+ * <p>
+ * The differences compared to the default property set are:
+ * <p>
+ * 1. In Houston we want to disallow usage of downtown pedestrian tunnel system.
+ *
+ * @author demory
+ * @see WayPropertySetSource
+ * @see DefaultWayPropertySetSource
+ */
+
+public class HoustonWayPropertySetSource implements WayPropertySetSource {
+
+  @Override
+  public void populateProperties(WayPropertySet props) {
+    // Disallow any use of underground indoor pedestrian tunnels
+    props.setProperties(
+      "highway=footway;layer=-1;tunnel=yes;indoor=yes",
+      withModes(StreetTraversalPermission.NONE)
+    );
+
+    // Read the rest from the default set
+    new DefaultWayPropertySetSource().populateProperties(props);
+  }
+}

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/WayProperties.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/WayProperties.java
@@ -37,8 +37,7 @@ public class WayProperties {
   }
 
   public boolean equals(Object o) {
-    if (o instanceof WayProperties) {
-      WayProperties other = (WayProperties) o;
+    if (o instanceof WayProperties other) {
       return (
         bicycleSafetyFeatures.equals(other.bicycleSafetyFeatures) &&
         walkSafetyFeatures.equals(other.walkSafetyFeatures) &&

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/WayPropertyPicker.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/WayPropertyPicker.java
@@ -6,49 +6,13 @@ package org.opentripplanner.graph_builder.module.osm;
  * WayPropertyPickers may be mixins, in which case they do not need to beat out all the other
  * WayPropertyPickers. Instead, their safety values will be applied to all ways that they match
  * multiplicatively.
+ *
+ * @param safetyMixin If this value is true, and this picker's specifier applies to a given way,
+ *                    then this picker is never chosen as the most applicable value, and the final
+ *                    safety will be multiplied by this value. More than one mixin may apply.
  */
-public class WayPropertyPicker {
-
-  private OSMSpecifier specifier;
-
-  private WayProperties properties;
-
-  private boolean safetyMixin;
-
-  public WayPropertyPicker() {}
-
-  public WayPropertyPicker(OSMSpecifier specifier, WayProperties properties, boolean mixin) {
-    this.specifier = specifier;
-    this.properties = properties;
-    this.safetyMixin = mixin;
-  }
-
-  public OSMSpecifier getSpecifier() {
-    return specifier;
-  }
-
-  public void setSpecifier(OSMSpecifier specifier) {
-    this.specifier = specifier;
-  }
-
-  public WayProperties getProperties() {
-    return properties;
-  }
-
-  public void setProperties(WayProperties properties) {
-    this.properties = properties;
-  }
-
-  /**
-   * If this value is true, and this picker's specifier applies to a given way, then this picker is
-   * never chosen as the most applicable value, and the final safety will be multiplied by this
-   * value. More than one mixin may apply.
-   */
-  public boolean isSafetyMixin() {
-    return safetyMixin;
-  }
-
-  public void setSafetyMixin(boolean mixin) {
-    this.safetyMixin = mixin;
-  }
-}
+public record WayPropertyPicker(
+  OSMSpecifier specifier,
+  WayProperties properties,
+  boolean safetyMixin
+) {}

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/WayPropertySet.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/WayPropertySet.java
@@ -96,12 +96,12 @@ public class WayPropertySet {
     List<WayProperties> leftMixins = new ArrayList<>();
     List<WayProperties> rightMixins = new ArrayList<>();
     for (WayPropertyPicker picker : wayProperties) {
-      OSMSpecifier specifier = picker.getSpecifier();
-      WayProperties wayProperties = picker.getProperties();
+      OSMSpecifier specifier = picker.specifier();
+      WayProperties wayProperties = picker.properties();
       P2<Integer> score = specifier.matchScores(way);
       int leftScore = score.first;
       int rightScore = score.second;
-      if (picker.isSafetyMixin()) {
+      if (picker.safetyMixin()) {
         if (leftScore > 0) {
           leftMixins.add(wayProperties);
         }

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/WayPropertySetSource.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/WayPropertySetSource.java
@@ -20,21 +20,18 @@ public interface WayPropertySetSource {
   static WayPropertySetSource fromConfig(String type) {
     // type is set to "default" by GraphBuilderParameters if not provided in
     // build-config.json
-    if ("default".equals(type)) {
-      return new DefaultWayPropertySetSource();
-    } else if ("norway".equals(type)) {
-      return new NorwayWayPropertySetSource();
-    } else if ("uk".equals(type)) {
-      return new UKWayPropertySetSource();
-    } else if ("finland".equals(type)) {
-      return new FinlandWayPropertySetSource();
-    } else if ("germany".equals(type)) {
-      return new GermanyWayPropertySetSource();
-    } else if ("atlanta".equals(type)) {
-      return new AtlantaWayPropertySetSource();
-    } else {
-      throw new IllegalArgumentException(String.format("Unknown osmWayPropertySet: '%s'", type));
-    }
+    return switch (type) {
+      case "default" -> new DefaultWayPropertySetSource();
+      case "norway" -> new NorwayWayPropertySetSource();
+      case "uk" -> new UKWayPropertySetSource();
+      case "finland" -> new FinlandWayPropertySetSource();
+      case "germany" -> new GermanyWayPropertySetSource();
+      case "atlanta" -> new AtlantaWayPropertySetSource();
+      case "houston" -> new HoustonWayPropertySetSource();
+      default -> throw new IllegalArgumentException(
+        "Unknown osmWayPropertySet: '%s'".formatted(type)
+      );
+    };
   }
 
   void populateProperties(WayPropertySet wayPropertySet);

--- a/src/main/java/org/opentripplanner/openstreetmap/model/OSMWithTags.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/model/OSMWithTags.java
@@ -13,6 +13,7 @@ import org.opentripplanner.transit.model.basic.Accessibility;
 import org.opentripplanner.transit.model.basic.I18NString;
 import org.opentripplanner.transit.model.basic.NonLocalizedString;
 import org.opentripplanner.transit.model.basic.TranslatedString;
+import org.opentripplanner.util.lang.ToStringBuilder;
 
 /**
  * A base class for OSM entities containing common methods.
@@ -396,5 +397,10 @@ public class OSMWithTags {
   private boolean isTagDeniedAccess(String tagName) {
     String tagValue = getTag(tagName);
     return "no".equals(tagValue) || "license".equals(tagValue);
+  }
+
+  @Override
+  public String toString() {
+    return ToStringBuilder.of(this.getClass()).addObj("tags", tags).toString();
   }
 }

--- a/src/test/java/org/opentripplanner/graph_builder/module/osm/HoustonWayPropertySetSourceTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/osm/HoustonWayPropertySetSourceTest.java
@@ -1,0 +1,49 @@
+package org.opentripplanner.graph_builder.module.osm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.openstreetmap.model.OSMWithTags;
+import org.opentripplanner.routing.edgetype.StreetTraversalPermission;
+
+class HoustonWayPropertySetSourceTest {
+
+  static WayPropertySet wps = new WayPropertySet();
+
+  static {
+    var source = new HoustonWayPropertySetSource();
+    source.populateProperties(wps);
+  }
+
+  @Test
+  public void lamarTunnel() {
+    // https://www.openstreetmap.org/way/127288293
+    OSMWithTags lamarTunnel = new OSMWithTags();
+    lamarTunnel.addTag("highway", "footway");
+    lamarTunnel.addTag("indoor", "yes");
+    lamarTunnel.addTag("lit", "yes");
+    lamarTunnel.addTag("name", "Lamar Tunnel");
+    lamarTunnel.addTag("tunnel", "yes");
+
+    assertEquals(StreetTraversalPermission.NONE, wps.getDataForWay(lamarTunnel).getPermission());
+  }
+
+  @Test
+  public void carTunnel() {
+    // https://www.openstreetmap.org/way/598694756
+    OSMWithTags tunnel = new OSMWithTags();
+    tunnel.addTag("highway", "primary");
+    tunnel.addTag("hov", "lane");
+    tunnel.addTag("lanes", "4");
+    tunnel.addTag("layer", "-1");
+    tunnel.addTag("lit", "yes");
+    tunnel.addTag("maxspeed", "30 mph");
+    tunnel.addTag("nam", "San Jacinto Street");
+    tunnel.addTag("note:lanes", "right lane is hov");
+    tunnel.addTag("oneway", "yes");
+    tunnel.addTag("surface", "concrete");
+    tunnel.addTag("tunnel", "yes");
+
+    assertEquals(StreetTraversalPermission.CAR, wps.getDataForWay(tunnel).getPermission());
+  }
+}

--- a/src/test/java/org/opentripplanner/graph_builder/module/osm/HoustonWayPropertySetSourceTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/osm/HoustonWayPropertySetSourceTest.java
@@ -1,10 +1,13 @@
 package org.opentripplanner.graph_builder.module.osm;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.routing.edgetype.StreetTraversalPermission.ALL;
+import static org.opentripplanner.routing.edgetype.StreetTraversalPermission.BICYCLE;
+import static org.opentripplanner.routing.edgetype.StreetTraversalPermission.NONE;
+import static org.opentripplanner.routing.edgetype.StreetTraversalPermission.PEDESTRIAN;
 
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.openstreetmap.model.OSMWithTags;
-import org.opentripplanner.routing.edgetype.StreetTraversalPermission;
 
 class HoustonWayPropertySetSourceTest {
 
@@ -26,7 +29,7 @@ class HoustonWayPropertySetSourceTest {
     tunnel.addTag("name", "Lamar Tunnel");
     tunnel.addTag("tunnel", "yes");
 
-    assertEquals(StreetTraversalPermission.NONE, wps.getDataForWay(tunnel).getPermission());
+    assertEquals(NONE, wps.getDataForWay(tunnel).getPermission());
   }
 
   @Test
@@ -38,7 +41,40 @@ class HoustonWayPropertySetSourceTest {
     tunnel.addTag("name", "Harris County Tunnel");
     tunnel.addTag("tunnel", "yes");
 
-    assertEquals(StreetTraversalPermission.PEDESTRIAN, wps.getDataForWay(tunnel).getPermission());
+    assertEquals(PEDESTRIAN, wps.getDataForWay(tunnel).getPermission());
+  }
+
+  @Test
+  public void pedestrianUnderpass() {
+    // https://www.openstreetmap.org/way/783648925
+    OSMWithTags tunnel = new OSMWithTags();
+    tunnel.addTag("highway", "footway");
+    tunnel.addTag("layer", "-1");
+    tunnel.addTag("tunnel", "yes");
+
+    assertEquals(PEDESTRIAN, wps.getDataForWay(tunnel).getPermission());
+  }
+
+  @Test
+  public void cyclingTunnel() {
+    // https://www.openstreetmap.org/way/220484967
+    OSMWithTags tunnel = new OSMWithTags();
+    tunnel.addTag("bicycle", "designated");
+    tunnel.addTag("foot", "designated");
+    tunnel.addTag("highway", "cycleway");
+    tunnel.addTag("segregated", "no");
+    tunnel.addTag("surface", "concrete");
+    tunnel.addTag("tunnel", "yes");
+
+    assertEquals(BICYCLE, wps.getDataForWay(tunnel).getPermission());
+
+    // https://www.openstreetmap.org/way/101884176
+    tunnel = new OSMWithTags();
+    tunnel.addTag("highway", "cycleway");
+    tunnel.addTag("layer", "-1");
+    tunnel.addTag("name", "Hogg Woods Trail");
+    tunnel.addTag("tunnel", "yes");
+    assertEquals(ALL, wps.getDataForWay(tunnel).getPermission());
   }
 
   @Test
@@ -57,7 +93,7 @@ class HoustonWayPropertySetSourceTest {
     tunnel.addTag("surface", "concrete");
     tunnel.addTag("tunnel", "yes");
 
-    assertEquals(StreetTraversalPermission.ALL, wps.getDataForWay(tunnel).getPermission());
+    assertEquals(ALL, wps.getDataForWay(tunnel).getPermission());
   }
 
   @Test
@@ -70,6 +106,29 @@ class HoustonWayPropertySetSourceTest {
     tunnel.addTag("oneway", "yes");
     tunnel.addTag("tunnel", "yes");
 
-    assertEquals(StreetTraversalPermission.ALL, wps.getDataForWay(tunnel).getPermission());
+    assertEquals(ALL, wps.getDataForWay(tunnel).getPermission());
+  }
+
+  @Test
+  public void serviceTunnel() {
+    // https://www.openstreetmap.org/way/15334550
+    OSMWithTags tunnel = new OSMWithTags();
+    tunnel.addTag("highway", "service");
+    tunnel.addTag("layer", "-1");
+    tunnel.addTag("tunnel", "yes");
+
+    assertEquals(ALL, wps.getDataForWay(tunnel).getPermission());
+  }
+
+  @Test
+  public void unclassified() {
+    // https://www.openstreetmap.org/way/44896136
+    OSMWithTags tunnel = new OSMWithTags();
+    tunnel.addTag("highway", "unclassified");
+    tunnel.addTag("name", "Ross Sterling Street");
+    tunnel.addTag("layer", "-1");
+    tunnel.addTag("tunnel", "yes");
+
+    assertEquals(ALL, wps.getDataForWay(tunnel).getPermission());
   }
 }

--- a/src/test/java/org/opentripplanner/graph_builder/module/osm/HoustonWayPropertySetSourceTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/osm/HoustonWayPropertySetSourceTest.java
@@ -44,6 +44,6 @@ class HoustonWayPropertySetSourceTest {
     tunnel.addTag("surface", "concrete");
     tunnel.addTag("tunnel", "yes");
 
-    assertEquals(StreetTraversalPermission.CAR, wps.getDataForWay(tunnel).getPermission());
+    assertEquals(StreetTraversalPermission.ALL, wps.getDataForWay(tunnel).getPermission());
   }
 }

--- a/src/test/java/org/opentripplanner/graph_builder/module/osm/HoustonWayPropertySetSourceTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/osm/HoustonWayPropertySetSourceTest.java
@@ -18,14 +18,27 @@ class HoustonWayPropertySetSourceTest {
   @Test
   public void lamarTunnel() {
     // https://www.openstreetmap.org/way/127288293
-    OSMWithTags lamarTunnel = new OSMWithTags();
-    lamarTunnel.addTag("highway", "footway");
-    lamarTunnel.addTag("indoor", "yes");
-    lamarTunnel.addTag("lit", "yes");
-    lamarTunnel.addTag("name", "Lamar Tunnel");
-    lamarTunnel.addTag("tunnel", "yes");
+    OSMWithTags tunnel = new OSMWithTags();
+    tunnel.addTag("highway", "footway");
+    tunnel.addTag("indoor", "yes");
+    tunnel.addTag("layer", "-1");
+    tunnel.addTag("lit", "yes");
+    tunnel.addTag("name", "Lamar Tunnel");
+    tunnel.addTag("tunnel", "yes");
 
-    assertEquals(StreetTraversalPermission.NONE, wps.getDataForWay(lamarTunnel).getPermission());
+    assertEquals(StreetTraversalPermission.NONE, wps.getDataForWay(tunnel).getPermission());
+  }
+
+  @Test
+  public void harrisCountyTunnel() {
+    // https://www.openstreetmap.org/way/127288288
+    OSMWithTags tunnel = new OSMWithTags();
+    tunnel.addTag("highway", "footway");
+    tunnel.addTag("indoor", "yes");
+    tunnel.addTag("name", "Harris County Tunnel");
+    tunnel.addTag("tunnel", "yes");
+
+    assertEquals(StreetTraversalPermission.PEDESTRIAN, wps.getDataForWay(tunnel).getPermission());
   }
 
   @Test
@@ -42,6 +55,19 @@ class HoustonWayPropertySetSourceTest {
     tunnel.addTag("note:lanes", "right lane is hov");
     tunnel.addTag("oneway", "yes");
     tunnel.addTag("surface", "concrete");
+    tunnel.addTag("tunnel", "yes");
+
+    assertEquals(StreetTraversalPermission.ALL, wps.getDataForWay(tunnel).getPermission());
+  }
+
+  @Test
+  public void carUnderpass() {
+    // https://www.openstreetmap.org/way/102925214
+    OSMWithTags tunnel = new OSMWithTags();
+    tunnel.addTag("highway", "motorway_link");
+    tunnel.addTag("lanes", "2");
+    tunnel.addTag("layer", "-1");
+    tunnel.addTag("oneway", "yes");
     tunnel.addTag("tunnel", "yes");
 
     assertEquals(StreetTraversalPermission.ALL, wps.getDataForWay(tunnel).getPermission());


### PR DESCRIPTION
### Summary

This adds a custom way property set for Houston where we want to remove indoor tunnels that connect buildings. These are rarely public and cause issues when a stop is linked to them.

I noticed a problem (?) where the specifier `highway=footway;layer=-1;tunnel=yes;indoor=yes` is quite greedy and matches things that are not footways so I had to add other permutations which, in my view, should not be necessary. I will investigate more and open an issue if I think it's a bug.

I also did some gentle refactoring. 

### Unit tests

Added.

### Documentation

Added.