### PR TITLE
Extract AStarRequest from RouteRequest

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/flex/ScheduledDeviatedTripTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/flex/ScheduledDeviatedTripTest.java
@@ -270,7 +270,7 @@ public class ScheduledDeviatedTripTest extends FlexTest {
       stopLocation,
       0,
       List.of(),
-      new State(
+      State.createState(
         new StreetLocation(id, new Coordinate(0, 0), id),
         new RouteRequest(),
         StreetMode.WALK

--- a/src/ext-test/java/org/opentripplanner/ext/flex/ScheduledDeviatedTripTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/flex/ScheduledDeviatedTripTest.java
@@ -270,7 +270,7 @@ public class ScheduledDeviatedTripTest extends FlexTest {
       stopLocation,
       0,
       List.of(),
-      State.createState(
+      State.create(
         new StreetLocation(id, new Coordinate(0, 0), id),
         new RouteRequest(),
         StreetMode.WALK

--- a/src/ext-test/java/org/opentripplanner/ext/flex/ScheduledDeviatedTripTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/flex/ScheduledDeviatedTripTest.java
@@ -27,7 +27,7 @@ import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.routing.algorithm.raptoradapter.router.AdditionalSearchDays;
 import org.opentripplanner.routing.algorithm.raptoradapter.router.TransitRouter;
 import org.opentripplanner.routing.api.request.RouteRequest;
-import org.opentripplanner.routing.api.request.StreetMode;
+import org.opentripplanner.routing.core.AStarRequest;
 import org.opentripplanner.routing.core.FareType;
 import org.opentripplanner.routing.core.Money;
 import org.opentripplanner.routing.core.State;
@@ -270,11 +270,7 @@ public class ScheduledDeviatedTripTest extends FlexTest {
       stopLocation,
       0,
       List.of(),
-      State.create(
-        new StreetLocation(id, new Coordinate(0, 0), id),
-        new RouteRequest(),
-        StreetMode.WALK
-      )
+      new State(new StreetLocation(id, new Coordinate(0, 0), id), AStarRequest.of().build())
     );
   }
 

--- a/src/ext/java/org/opentripplanner/ext/dataoverlay/DataOverlayStreetEdgeCostExtension.java
+++ b/src/ext/java/org/opentripplanner/ext/dataoverlay/DataOverlayStreetEdgeCostExtension.java
@@ -66,7 +66,7 @@ class DataOverlayStreetEdgeCostExtension implements StreetEdgeCostExtension, Ser
       return 0d;
     }
     double totalPenalty = 0d;
-    Instant requestInstant = s.getOptions().dateTime();
+    Instant requestInstant = s.getRequest().startTime();
     DataOverlayContext context = s.dataOverlayContext();
 
     for (Parameter parameter : context.getParameters()) {

--- a/src/ext/java/org/opentripplanner/ext/traveltime/TravelTimeResource.java
+++ b/src/ext/java/org/opentripplanner/ext/traveltime/TravelTimeResource.java
@@ -57,6 +57,7 @@ import org.opentripplanner.routing.algorithm.raptoradapter.transit.request.Rapto
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.request.RoutingRequestTransitDataProviderFilter;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
+import org.opentripplanner.routing.core.AStarRequest;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.core.StateData;
 import org.opentripplanner.routing.core.TemporaryVerticesContainer;
@@ -278,9 +279,15 @@ public class TravelTimeResource {
       routingRequest.journey().egress().mode()
     );
 
+    AStarRequest aStarRequest = new AStarRequest(
+      routingRequest.dateTime(),
+      routingRequest,
+      routingRequest.journey().egress().mode()
+    );
+
     for (var vertex : temporaryVertices.getFromVertices()) {
       // TODO StateData should be of direct mode here
-      initialStates.add(new State(vertex, startTime, stateData));
+      initialStates.add(new State(vertex, startTime, stateData, aStarRequest));
     }
 
     // TODO - Add a method to return all Stops, not StopLocations
@@ -291,7 +298,7 @@ public class TravelTimeResource {
         Vertex v = graph.getStopVertexForStopId(stop.getId());
         if (v != null) {
           Instant time = startOfTime.plusSeconds(arrivalTime).toInstant();
-          State s = new State(v, time, stateData.clone());
+          State s = new State(v, time, stateData.clone(), aStarRequest);
           s.weight = startTime.until(time, ChronoUnit.SECONDS);
           initialStates.add(s);
         }

--- a/src/ext/java/org/opentripplanner/ext/traveltime/TravelTimeResource.java
+++ b/src/ext/java/org/opentripplanner/ext/traveltime/TravelTimeResource.java
@@ -58,6 +58,7 @@ import org.opentripplanner.routing.algorithm.raptoradapter.transit.request.Routi
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.routing.core.AStarRequest;
+import org.opentripplanner.routing.core.AStarRequestMapper;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.core.StateData;
 import org.opentripplanner.routing.core.TemporaryVerticesContainer;
@@ -274,11 +275,10 @@ public class TravelTimeResource {
   ) {
     List<State> initialStates = new ArrayList<>();
 
-    AStarRequest aStarRequest = new AStarRequest(
-      routingRequest.dateTime(),
-      routingRequest,
-      routingRequest.journey().egress().mode()
-    );
+    AStarRequest aStarRequest = AStarRequestMapper
+      .map(routingRequest)
+      .setMode(routingRequest.journey().egress().mode())
+      .build();
 
     StateData stateData = StateData.getInitialStateData(aStarRequest);
 

--- a/src/ext/java/org/opentripplanner/ext/traveltime/TravelTimeResource.java
+++ b/src/ext/java/org/opentripplanner/ext/traveltime/TravelTimeResource.java
@@ -277,7 +277,7 @@ public class TravelTimeResource {
 
     AStarRequest aStarRequest = AStarRequestMapper
       .map(routingRequest)
-      .setMode(routingRequest.journey().egress().mode())
+      .withMode(routingRequest.journey().egress().mode())
       .build();
 
     StateData stateData = StateData.getInitialStateData(aStarRequest);

--- a/src/ext/java/org/opentripplanner/ext/traveltime/TravelTimeResource.java
+++ b/src/ext/java/org/opentripplanner/ext/traveltime/TravelTimeResource.java
@@ -123,6 +123,7 @@ public class TravelTimeResource {
       startTime = Instant.now();
     }
 
+    routingRequest.setDateTime(startTime);
     endTime = startTime.plus(traveltimeRequest.maxCutoff);
 
     ZoneId zoneId = transitService.getTimeZone();
@@ -292,8 +293,6 @@ public class TravelTimeResource {
           Instant time = startOfTime.plusSeconds(arrivalTime).toInstant();
           State s = new State(v, time, stateData.clone());
           s.weight = startTime.until(time, ChronoUnit.SECONDS);
-          // TODO: This shouldn't be overridden in state initialization
-          s.stateData.startTime = stateData.startTime;
           initialStates.add(s);
         }
       }

--- a/src/ext/java/org/opentripplanner/ext/traveltime/TravelTimeResource.java
+++ b/src/ext/java/org/opentripplanner/ext/traveltime/TravelTimeResource.java
@@ -274,16 +274,13 @@ public class TravelTimeResource {
   ) {
     List<State> initialStates = new ArrayList<>();
 
-    StateData stateData = StateData.getInitialStateData(
-      routingRequest,
-      routingRequest.journey().egress().mode()
-    );
-
     AStarRequest aStarRequest = new AStarRequest(
       routingRequest.dateTime(),
       routingRequest,
       routingRequest.journey().egress().mode()
     );
+
+    StateData stateData = StateData.getInitialStateData(aStarRequest);
 
     for (var vertex : temporaryVertices.getFromVertices()) {
       // TODO StateData should be of direct mode here

--- a/src/main/java/org/opentripplanner/graph_builder/module/NearbyStopFinder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/NearbyStopFinder.java
@@ -200,7 +200,7 @@ public class NearbyStopFinder {
             tsv.getStop(),
             0,
             Collections.emptyList(),
-            new State(vertex, request, streetRequest.mode())
+            State.createState(vertex, request, streetRequest.mode())
           )
         );
       }

--- a/src/main/java/org/opentripplanner/graph_builder/module/NearbyStopFinder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/NearbyStopFinder.java
@@ -24,6 +24,8 @@ import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.routing.api.request.preference.WalkPreferences;
 import org.opentripplanner.routing.api.request.request.StreetRequest;
+import org.opentripplanner.routing.core.AStarRequest;
+import org.opentripplanner.routing.core.AStarRequestMapper;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.core.TraverseMode;
 import org.opentripplanner.routing.edgetype.StreetEdge;
@@ -191,17 +193,16 @@ public class NearbyStopFinder {
     List<NearbyStop> stopsFound = new ArrayList<>();
 
     request.setArriveBy(reverseDirection);
+    AStarRequest aStarRequest = AStarRequestMapper
+      .map(request)
+      .setMode(streetRequest.mode())
+      .build();
 
     /* Add the origin vertices if they are stops */
     for (Vertex vertex : originVertices) {
       if (vertex instanceof TransitStopVertex tsv) {
         stopsFound.add(
-          new NearbyStop(
-            tsv.getStop(),
-            0,
-            Collections.emptyList(),
-            State.create(vertex, request, streetRequest.mode())
-          )
+          new NearbyStop(tsv.getStop(), 0, Collections.emptyList(), new State(vertex, aStarRequest))
         );
       }
     }

--- a/src/main/java/org/opentripplanner/graph_builder/module/NearbyStopFinder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/NearbyStopFinder.java
@@ -195,7 +195,7 @@ public class NearbyStopFinder {
     request.setArriveBy(reverseDirection);
     AStarRequest aStarRequest = AStarRequestMapper
       .map(request)
-      .setMode(streetRequest.mode())
+      .withMode(streetRequest.mode())
       .build();
 
     /* Add the origin vertices if they are stops */

--- a/src/main/java/org/opentripplanner/graph_builder/module/NearbyStopFinder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/NearbyStopFinder.java
@@ -200,7 +200,7 @@ public class NearbyStopFinder {
             tsv.getStop(),
             0,
             Collections.emptyList(),
-            State.createState(vertex, request, streetRequest.mode())
+            State.create(vertex, request, streetRequest.mode())
           )
         );
       }

--- a/src/main/java/org/opentripplanner/graph_builder/module/PruneNoThruIslands.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/PruneNoThruIslands.java
@@ -331,7 +331,7 @@ public class PruneNoThruIslands implements GraphBuilderModule {
       if (!(gv instanceof StreetVertex)) {
         continue;
       }
-      State s0 = new State(gv, options, streetMode);
+      State s0 = State.createState(gv, options, streetMode);
       for (Edge e : gv.getOutgoing()) {
         if (
           !(

--- a/src/main/java/org/opentripplanner/graph_builder/module/PruneNoThruIslands.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/PruneNoThruIslands.java
@@ -16,10 +16,8 @@ import org.opentripplanner.graph_builder.issues.IsolatedStop;
 import org.opentripplanner.graph_builder.issues.PrunedIslandStop;
 import org.opentripplanner.graph_builder.linking.VertexLinker;
 import org.opentripplanner.graph_builder.model.GraphBuilderModule;
-import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.routing.core.AStarRequest;
-import org.opentripplanner.routing.core.AStarRequestMapper;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.core.TraverseMode;
 import org.opentripplanner.routing.edgetype.ElevatorEdge;
@@ -327,7 +325,7 @@ public class PruneNoThruIslands implements GraphBuilderModule {
         default -> throw new IllegalArgumentException();
       };
 
-    AStarRequest request = AStarRequest.of().setMode(streetMode).build();
+    AStarRequest request = AStarRequest.of().withMode(streetMode).build();
 
     for (Vertex gv : graph.getVertices()) {
       if (!(gv instanceof StreetVertex)) {

--- a/src/main/java/org/opentripplanner/graph_builder/module/PruneNoThruIslands.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/PruneNoThruIslands.java
@@ -331,7 +331,7 @@ public class PruneNoThruIslands implements GraphBuilderModule {
       if (!(gv instanceof StreetVertex)) {
         continue;
       }
-      State s0 = State.createState(gv, options, streetMode);
+      State s0 = State.create(gv, options, streetMode);
       for (Edge e : gv.getOutgoing()) {
         if (
           !(

--- a/src/main/java/org/opentripplanner/graph_builder/module/PruneNoThruIslands.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/PruneNoThruIslands.java
@@ -18,6 +18,8 @@ import org.opentripplanner.graph_builder.linking.VertexLinker;
 import org.opentripplanner.graph_builder.model.GraphBuilderModule;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
+import org.opentripplanner.routing.core.AStarRequest;
+import org.opentripplanner.routing.core.AStarRequestMapper;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.core.TraverseMode;
 import org.opentripplanner.routing.edgetype.ElevatorEdge;
@@ -317,8 +319,6 @@ public class PruneNoThruIslands implements GraphBuilderModule {
     TraverseMode traverseMode,
     boolean shouldMatchNoThruType
   ) {
-    RouteRequest options = new RouteRequest();
-
     StreetMode streetMode =
       switch (traverseMode) {
         case WALK -> StreetMode.WALK;
@@ -327,11 +327,13 @@ public class PruneNoThruIslands implements GraphBuilderModule {
         default -> throw new IllegalArgumentException();
       };
 
+    AStarRequest request = AStarRequest.of().setMode(streetMode).build();
+
     for (Vertex gv : graph.getVertices()) {
       if (!(gv instanceof StreetVertex)) {
         continue;
       }
-      State s0 = State.create(gv, options, streetMode);
+      State s0 = new State(gv, request);
       for (Edge e : gv.getOutgoing()) {
         if (
           !(

--- a/src/main/java/org/opentripplanner/graph_builder/module/map/MatchState.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/map/MatchState.java
@@ -95,7 +95,7 @@ public abstract class MatchState {
 
   protected boolean carsCanTraverse(Edge edge) {
     // should be done with a method on edge (canTraverse already exists on turnEdge)
-    State s0 = State.createState(edge.getFromVertex(), traverseOptions, StreetMode.CAR);
+    State s0 = State.create(edge.getFromVertex(), traverseOptions, StreetMode.CAR);
     State s1 = edge.traverse(s0);
     return s1 != null;
   }

--- a/src/main/java/org/opentripplanner/graph_builder/module/map/MatchState.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/map/MatchState.java
@@ -95,7 +95,7 @@ public abstract class MatchState {
 
   protected boolean carsCanTraverse(Edge edge) {
     // should be done with a method on edge (canTraverse already exists on turnEdge)
-    State s0 = new State(edge.getFromVertex(), traverseOptions, StreetMode.CAR);
+    State s0 = State.createState(edge.getFromVertex(), traverseOptions, StreetMode.CAR);
     State s1 = edge.traverse(s0);
     return s1 != null;
   }

--- a/src/main/java/org/opentripplanner/graph_builder/module/map/MatchState.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/map/MatchState.java
@@ -6,8 +6,8 @@ import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.linearref.LinearLocation;
 import org.opentripplanner.common.geometry.SphericalDistanceLibrary;
-import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
+import org.opentripplanner.routing.core.AStarRequest;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.edgetype.StreetEdge;
 import org.opentripplanner.routing.graph.Edge;
@@ -15,7 +15,7 @@ import org.opentripplanner.routing.graph.Vertex;
 
 public abstract class MatchState {
 
-  private static final RouteRequest traverseOptions = new RouteRequest();
+  private static final AStarRequest REQUEST = AStarRequest.of().setMode(StreetMode.CAR).build();
 
   protected static final double NEW_SEGMENT_PENALTY = 0.1;
 
@@ -95,7 +95,7 @@ public abstract class MatchState {
 
   protected boolean carsCanTraverse(Edge edge) {
     // should be done with a method on edge (canTraverse already exists on turnEdge)
-    State s0 = State.create(edge.getFromVertex(), traverseOptions, StreetMode.CAR);
+    State s0 = new State(edge.getFromVertex(), REQUEST);
     State s1 = edge.traverse(s0);
     return s1 != null;
   }

--- a/src/main/java/org/opentripplanner/graph_builder/module/map/MatchState.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/map/MatchState.java
@@ -15,7 +15,7 @@ import org.opentripplanner.routing.graph.Vertex;
 
 public abstract class MatchState {
 
-  private static final AStarRequest REQUEST = AStarRequest.of().setMode(StreetMode.CAR).build();
+  private static final AStarRequest REQUEST = AStarRequest.of().withMode(StreetMode.CAR).build();
 
   protected static final double NEW_SEGMENT_PENALTY = 0.1;
 

--- a/src/main/java/org/opentripplanner/model/plan/Place.java
+++ b/src/main/java/org/opentripplanner/model/plan/Place.java
@@ -127,9 +127,9 @@ public class Place {
 
   public static Place forVehicleParkingEntrance(VehicleParkingEntranceVertex vertex, State state) {
     TraverseMode traverseMode = null;
-    if (state.getRequestMode().includesDriving()) {
+    if (state.getRequest().mode().includesDriving()) {
       traverseMode = TraverseMode.CAR;
-    } else if (state.getRequestMode().includesBiking()) {
+    } else if (state.getRequest().mode().includesBiking()) {
       traverseMode = TraverseMode.BICYCLE;
     }
 
@@ -139,7 +139,7 @@ public class Place {
       preferences.parking().useAvailabilityInformation() &&
       vertex
         .getVehicleParking()
-        .hasRealTimeDataForMode(traverseMode, state.getOptions().wheelchair());
+        .hasRealTimeDataForMode(traverseMode, state.getRequest().wheelchair());
     return new Place(
       vertex.getName(),
       WgsCoordinate.creatOptionalCoordinate(vertex.getLat(), vertex.getLon()),

--- a/src/main/java/org/opentripplanner/routing/algorithm/astar/AStarBuilder.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/astar/AStarBuilder.java
@@ -184,8 +184,8 @@ public class AStarBuilder {
     }
 
     for (var state : initialStates) {
-      state.stateData.intersectionTraversalCalculator = intersectionTraversalCalculator;
-      state.stateData.dataOverlayContext = dataOverlayContext;
+      state.getRequest().setIntersectionTraversalCalculator(intersectionTraversalCalculator);
+      state.getRequest().setDataOverlayContext(dataOverlayContext);
     }
 
     heuristic.initialize(routeRequest, streetRequest.mode(), origin, destination);

--- a/src/main/java/org/opentripplanner/routing/algorithm/astar/AStarBuilder.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/astar/AStarBuilder.java
@@ -169,7 +169,7 @@ public class AStarBuilder {
     } else {
       AStarRequest aStarRequest = AStarRequestMapper
         .map(routeRequest)
-        .setMode(streetRequest.mode())
+        .withMode(streetRequest.mode())
         .build();
 
       initialStates = State.getInitialStates(origin, aStarRequest);

--- a/src/main/java/org/opentripplanner/routing/algorithm/astar/AStarBuilder.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/astar/AStarBuilder.java
@@ -16,6 +16,8 @@ import org.opentripplanner.routing.algorithm.astar.strategies.TrivialRemainingWe
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.preference.StreetPreferences;
 import org.opentripplanner.routing.api.request.request.StreetRequest;
+import org.opentripplanner.routing.core.AStarRequest;
+import org.opentripplanner.routing.core.AStarRequestMapper;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.core.TemporaryVerticesContainer;
 import org.opentripplanner.routing.core.intersection_model.IntersectionTraversalCalculator;
@@ -165,7 +167,12 @@ public class AStarBuilder {
     if (this.initialStates != null) {
       initialStates = this.initialStates;
     } else {
-      initialStates = State.getInitialStates(routeRequest, streetRequest.mode(), origin);
+      AStarRequest aStarRequest = AStarRequestMapper
+        .map(routeRequest)
+        .setMode(streetRequest.mode())
+        .build();
+
+      initialStates = State.getInitialStates(origin, aStarRequest);
 
       if (originBackEdge != null) {
         for (var state : initialStates) {

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
@@ -20,6 +20,8 @@ import org.opentripplanner.routing.algorithm.raptoradapter.transit.request.Trans
 import org.opentripplanner.routing.algorithm.transferoptimization.api.OptimizedPath;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
+import org.opentripplanner.routing.core.AStarRequest;
+import org.opentripplanner.routing.core.AStarRequestMapper;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.core.StateEditor;
 import org.opentripplanner.routing.core.TraverseMode;
@@ -45,8 +47,8 @@ public class RaptorPathToItineraryMapper {
 
   private final TransitLayer transitLayer;
 
-  private final RouteRequest request;
-
+  private final AStarRequest request;
+  private final StreetMode transferMode;
   private final ZonedDateTime transitSearchTimeZero;
 
   private final GraphPathToItineraryMapper graphPathToItineraryMapper;
@@ -68,7 +70,13 @@ public class RaptorPathToItineraryMapper {
   ) {
     this.transitLayer = transitLayer;
     this.transitSearchTimeZero = transitSearchTimeZero;
-    this.request = request;
+    this.transferMode = request.journey().transfer().mode();
+    this.request =
+      AStarRequestMapper
+        .map(Transfer.prepareTransferRoutingRequest(request))
+        .setArriveBy(false)
+        .setMode(transferMode)
+        .build();
     this.graphPathToItineraryMapper =
       new GraphPathToItineraryMapper(
         transitService.getTimeZone(),
@@ -98,9 +106,7 @@ public class RaptorPathToItineraryMapper {
         legs.addAll(
           mapTransferLeg(
             pathLeg.asTransferLeg(),
-            request.journey().transfer().mode() == StreetMode.BIKE
-              ? TraverseMode.BICYCLE
-              : TraverseMode.WALK
+            transferMode == StreetMode.BIKE ? TraverseMode.BICYCLE : TraverseMode.WALK
           )
         );
       }
@@ -255,16 +261,7 @@ public class RaptorPathToItineraryMapper {
           .build()
       );
     } else {
-      // A RoutingRequest must be constructed so that the edges may be re-traversed to create the
-      // leg(s) from the list of edges.
-      RouteRequest traverseRequest = Transfer.prepareTransferRoutingRequest(request);
-      traverseRequest.setArriveBy(false);
-
-      StateEditor se = new StateEditor(
-        traverseRequest,
-        request.journey().transfer().mode(),
-        edges.get(0).getFromVertex()
-      );
+      StateEditor se = new StateEditor(edges.get(0).getFromVertex(), request);
       se.setTimeSeconds(createZonedDateTime(pathLeg.fromTime()).toEpochSecond());
 
       State s = se.makeState();

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
@@ -74,8 +74,8 @@ public class RaptorPathToItineraryMapper {
     this.request =
       AStarRequestMapper
         .map(Transfer.prepareTransferRoutingRequest(request))
-        .setArriveBy(false)
-        .setMode(transferMode)
+        .withArriveBy(false)
+        .withMode(transferMode)
         .build();
     this.graphPathToItineraryMapper =
       new GraphPathToItineraryMapper(

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/RaptorTransferIndex.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/RaptorTransferIndex.java
@@ -6,6 +6,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 import org.opentripplanner.routing.api.request.RouteRequest;
+import org.opentripplanner.routing.core.AStarRequest;
+import org.opentripplanner.routing.core.AStarRequestMapper;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
 import org.opentripplanner.transit.raptor.util.ReversedRaptorTransfer;
 
@@ -36,13 +38,18 @@ public class RaptorTransferIndex {
       reversedTransfers.add(new ArrayList<>());
     }
 
+    final AStarRequest aStarRequest = AStarRequestMapper
+      .map(request)
+      .setMode(request.journey().transfer().mode())
+      .build();
+
     for (int fromStop = 0; fromStop < transfersByStopIndex.size(); fromStop++) {
       // The transfers are filtered so that there is only one possible directional transfer
       // for a stop pair.
       var transfers = transfersByStopIndex
         .get(fromStop)
         .stream()
-        .flatMap(s -> s.asRaptorTransfer(request).stream())
+        .flatMap(s -> s.asRaptorTransfer(aStarRequest).stream())
         .collect(
           toMap(
             RaptorTransfer::stop,

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/RaptorTransferIndex.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/RaptorTransferIndex.java
@@ -40,7 +40,7 @@ public class RaptorTransferIndex {
 
     final AStarRequest aStarRequest = AStarRequestMapper
       .map(request)
-      .setMode(request.journey().transfer().mode())
+      .withMode(request.journey().transfer().mode())
       .build();
 
     for (int fromStop = 0; fromStop < transfersByStopIndex.size(); fromStop++) {

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/Transfer.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/Transfer.java
@@ -10,6 +10,7 @@ import org.opentripplanner.routing.algorithm.raptoradapter.transit.cost.RaptorCo
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.request.TransferWithDuration;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.preference.WalkPreferences;
+import org.opentripplanner.routing.core.AStarRequest;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.core.StateEditor;
 import org.opentripplanner.routing.graph.Edge;
@@ -103,7 +104,7 @@ public class Transfer {
     return edges;
   }
 
-  public Optional<RaptorTransfer> asRaptorTransfer(RouteRequest request) {
+  public Optional<RaptorTransfer> asRaptorTransfer(AStarRequest request) {
     WalkPreferences walkPreferences = request.preferences().walk();
     if (edges == null || edges.isEmpty()) {
       double durationSeconds = distanceMeters / walkPreferences.speed();
@@ -116,11 +117,7 @@ public class Transfer {
       );
     }
 
-    StateEditor se = new StateEditor(
-      request,
-      request.journey().transfer().mode(),
-      edges.get(0).getFromVertex()
-    );
+    StateEditor se = new StateEditor(edges.get(0).getFromVertex(), request);
     se.setTimeSeconds(0);
 
     State s = se.makeState();

--- a/src/main/java/org/opentripplanner/routing/api/request/RouteRequest.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/RouteRequest.java
@@ -8,18 +8,12 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Locale;
-import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.Envelope;
-import org.opentripplanner.common.geometry.SphericalDistanceLibrary;
 import org.opentripplanner.model.GenericLocation;
 import org.opentripplanner.model.plan.SortOrder;
 import org.opentripplanner.model.plan.pagecursor.PageCursor;
 import org.opentripplanner.model.plan.pagecursor.PageType;
 import org.opentripplanner.routing.api.request.preference.RoutingPreferences;
 import org.opentripplanner.routing.api.request.request.JourneyRequest;
-import org.opentripplanner.routing.core.State;
-import org.opentripplanner.routing.graph.Vertex;
-import org.opentripplanner.routing.spt.DominanceFunction;
 import org.opentripplanner.util.time.DateUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,14 +41,6 @@ public class RouteRequest implements Cloneable, Serializable {
 
   private static final long NOW_THRESHOLD_SEC = durationInSeconds("15h");
 
-  /**
-   * How close to do you have to be to the start or end to be considered "close".
-   *
-   * @see RouteRequest#isCloseToStartOrEnd(Vertex)
-   * @see DominanceFunction#betterOrEqualAndComparable(State, State)
-   */
-  private static final int MAX_CLOSENESS_METERS = 500;
-
   /* FIELDS UNIQUELY IDENTIFYING AN SPT REQUEST */
 
   private GenericLocation from;
@@ -80,10 +66,6 @@ public class RouteRequest implements Cloneable, Serializable {
   private JourneyRequest journey = new JourneyRequest();
 
   private boolean wheelchair = false;
-
-  private Envelope fromEnvelope;
-
-  private Envelope toEnvelope;
 
   /* CONSTRUCTORS */
 
@@ -246,36 +228,6 @@ public class RouteRequest implements Cloneable, Serializable {
     return ret;
   }
 
-  /**
-   * Returns if the vertex is considered "close" to the start or end point of the request. This is
-   * useful if you want to allow loops in car routes under certain conditions.
-   * <p>
-   * Note: If you are doing Raptor access/egress searches this method does not take the possible
-   * intermediate points (stations) into account. This means that stations might be skipped because
-   * a car route to it cannot be found and a suboptimal route to another station is returned
-   * instead.
-   * <p>
-   * If you encounter a case of this, you can adjust this code to take this into account.
-   *
-   * @see RouteRequest#MAX_CLOSENESS_METERS
-   * @see DominanceFunction#betterOrEqualAndComparable(State, State)
-   */
-  public boolean isCloseToStartOrEnd(Vertex vertex) {
-    if (from == null || to == null || from.getCoordinate() == null || to.getCoordinate() == null) {
-      return false;
-    }
-    if (fromEnvelope == null) {
-      fromEnvelope = getEnvelope(from.getCoordinate(), MAX_CLOSENESS_METERS);
-    }
-    if (toEnvelope == null) {
-      toEnvelope = getEnvelope(to.getCoordinate(), MAX_CLOSENESS_METERS);
-    }
-    return (
-      fromEnvelope.intersects(vertex.getCoordinate()) ||
-      toEnvelope.intersects(vertex.getCoordinate())
-    );
-  }
-
   /** The start location */
   public GenericLocation from() {
     return from;
@@ -407,15 +359,5 @@ public class RouteRequest implements Cloneable, Serializable {
 
   public void setNumItineraries(int numItineraries) {
     this.numItineraries = numItineraries;
-  }
-
-  private static Envelope getEnvelope(Coordinate c, int meters) {
-    double lat = SphericalDistanceLibrary.metersToDegrees(meters);
-    double lon = SphericalDistanceLibrary.metersToLonDegrees(meters, c.y);
-
-    Envelope env = new Envelope(c);
-    env.expandBy(lon, lat);
-
-    return env;
   }
 }

--- a/src/main/java/org/opentripplanner/routing/core/AStarRequest.java
+++ b/src/main/java/org/opentripplanner/routing/core/AStarRequest.java
@@ -1,26 +1,137 @@
 package org.opentripplanner.routing.core;
 
 import java.time.Instant;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Envelope;
+import org.opentripplanner.common.geometry.SphericalDistanceLibrary;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
+import org.opentripplanner.routing.api.request.preference.RoutingPreferences;
+import org.opentripplanner.routing.api.request.request.VehicleParkingRequest;
+import org.opentripplanner.routing.api.request.request.VehicleRentalRequest;
+import org.opentripplanner.routing.graph.Vertex;
+import org.opentripplanner.routing.spt.DominanceFunction;
 
 public class AStarRequest {
 
-  // the time at which the search started
-  public final Instant startTime;
+  /**
+   * How close to do you have to be to the start or end to be considered "close".
+   *
+   * @see AStarRequest#isCloseToStartOrEnd(Vertex)
+   * @see DominanceFunction#betterOrEqualAndComparable(State, State)
+   */
+  private static final int MAX_CLOSENESS_METERS = 500;
 
-  protected final RouteRequest opt;
+  // the time at which the search started
+  private final Instant startTime;
+  private final RoutingPreferences preferences;
+  private final StreetMode mode;
+  private final boolean arriveBy;
+  private final boolean wheelchair;
+  private final VehicleParkingRequest parking;
+  private final VehicleRentalRequest rental;
+
+  private final Envelope fromEnvelope;
+  private final Envelope toEnvelope;
+
+  public AStarRequest(Instant startTime, RouteRequest opt, StreetMode mode) {
+    this.startTime = startTime;
+    this.preferences = opt.preferences();
+    this.mode = mode;
+    this.arriveBy = opt.arriveBy();
+    this.wheelchair = opt.wheelchair();
+    this.parking = opt.journey().parking();
+    this.rental = opt.journey().rental();
+    this.fromEnvelope =
+      opt.from() != null && opt.from().getCoordinate() != null
+        ? getEnvelope(opt.from().getCoordinate())
+        : null;
+    this.toEnvelope =
+      opt.to() != null && opt.to().getCoordinate() != null
+        ? getEnvelope(opt.to().getCoordinate())
+        : null;
+  }
+
+  /**
+   * This constructor is only to be used from the copyOfReversed method
+   */
+  private AStarRequest(AStarRequest original, Instant time) {
+    this.startTime = time;
+    this.preferences = original.preferences.clone();
+    this.mode = original.mode;
+    this.arriveBy = !original.arriveBy;
+    this.wheelchair = original.wheelchair;
+    this.parking = original.parking.clone();
+    this.rental = original.rental.clone();
+    this.fromEnvelope = original.toEnvelope;
+    this.toEnvelope = original.fromEnvelope;
+  }
+
+  public Instant startTime() {
+    return startTime;
+  }
+
+  public RoutingPreferences preferences() {
+    return preferences;
+  }
 
   /**
    * The requested mode for the search. This contains information about all allowed transitions
    * between the different traverse modes, such as renting or parking a vehicle. Contrary to
    * currentMode, which can change when traversing edges, this is constant for a single search.
    */
-  protected final StreetMode requestMode;
+  public StreetMode mode() {
+    return mode;
+  }
 
-  public AStarRequest(Instant startTime, RouteRequest opt, StreetMode requestMode) {
-    this.startTime = startTime;
-    this.opt = opt;
-    this.requestMode = requestMode;
+  public boolean arriveBy() {
+    return arriveBy;
+  }
+
+  public boolean wheelchair() {
+    return wheelchair;
+  }
+
+  public VehicleParkingRequest parking() {
+    return parking;
+  }
+
+  public VehicleRentalRequest rental() {
+    return rental;
+  }
+
+  public AStarRequest copyOfReversed(Instant time) {
+    return new AStarRequest(this, time);
+  }
+
+  /**
+   * Returns if the vertex is considered "close" to the start or end point of the request. This is
+   * useful if you want to allow loops in car routes under certain conditions.
+   * <p>
+   * Note: If you are doing Raptor access/egress searches this method does not take the possible
+   * intermediate points (stations) into account. This means that stations might be skipped because
+   * a car route to it cannot be found and a suboptimal route to another station is returned
+   * instead.
+   * <p>
+   * If you encounter a case of this, you can adjust this code to take this into account.
+   *
+   * @see AStarRequest#MAX_CLOSENESS_METERS
+   * @see DominanceFunction#betterOrEqualAndComparable(State, State)
+   */
+  public boolean isCloseToStartOrEnd(Vertex vertex) {
+    return (
+      (fromEnvelope != null && fromEnvelope.intersects(vertex.getCoordinate())) ||
+      (toEnvelope != null && toEnvelope.intersects(vertex.getCoordinate()))
+    );
+  }
+
+  private static Envelope getEnvelope(Coordinate c) {
+    double lat = SphericalDistanceLibrary.metersToDegrees(MAX_CLOSENESS_METERS);
+    double lon = SphericalDistanceLibrary.metersToLonDegrees(MAX_CLOSENESS_METERS, c.y);
+
+    Envelope env = new Envelope(c);
+    env.expandBy(lon, lat);
+
+    return env;
   }
 }

--- a/src/main/java/org/opentripplanner/routing/core/AStarRequest.java
+++ b/src/main/java/org/opentripplanner/routing/core/AStarRequest.java
@@ -58,9 +58,9 @@ public class AStarRequest {
     this.parking = builder.parking();
     this.rental = builder.rental();
     this.from = builder.from();
-    this.fromEnvelope = getEnvelope(from);
+    this.fromEnvelope = createEnvelope(from);
     this.to = builder.to();
-    this.toEnvelope = getEnvelope(to);
+    this.toEnvelope = createEnvelope(to);
   }
 
   @Nonnull
@@ -115,7 +115,7 @@ public class AStarRequest {
   }
 
   public AStarRequest copyOfReversed(Instant time) {
-    return copyOf(this).setStartTime(time).setArriveBy(!arriveBy).build();
+    return copyOf(this).withStartTime(time).withArriveBy(!arriveBy).build();
   }
 
   public void setIntersectionTraversalCalculator(
@@ -150,7 +150,7 @@ public class AStarRequest {
   }
 
   @Nullable
-  private static Envelope getEnvelope(GenericLocation location) {
+  private static Envelope createEnvelope(GenericLocation location) {
     if (location == null) {
       return null;
     }

--- a/src/main/java/org/opentripplanner/routing/core/AStarRequest.java
+++ b/src/main/java/org/opentripplanner/routing/core/AStarRequest.java
@@ -12,9 +12,7 @@ import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.routing.api.request.preference.RoutingPreferences;
 import org.opentripplanner.routing.api.request.request.VehicleParkingRequest;
 import org.opentripplanner.routing.api.request.request.VehicleRentalRequest;
-import org.opentripplanner.routing.core.intersection_model.DrivingDirection;
 import org.opentripplanner.routing.core.intersection_model.IntersectionTraversalCalculator;
-import org.opentripplanner.routing.core.intersection_model.IntersectionTraversalModel;
 import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.routing.spt.DominanceFunction;
 
@@ -43,10 +41,8 @@ public class AStarRequest {
   private final Envelope fromEnvelope;
   private final Envelope toEnvelope;
 
-  protected IntersectionTraversalCalculator intersectionTraversalCalculator = IntersectionTraversalCalculator.create(
-    IntersectionTraversalModel.SIMPLE,
-    DrivingDirection.RIGHT
-  );
+  protected IntersectionTraversalCalculator intersectionTraversalCalculator =
+    IntersectionTraversalCalculator.DEFAULT;
 
   protected DataOverlayContext dataOverlayContext;
 

--- a/src/main/java/org/opentripplanner/routing/core/AStarRequest.java
+++ b/src/main/java/org/opentripplanner/routing/core/AStarRequest.java
@@ -4,11 +4,15 @@ import java.time.Instant;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Envelope;
 import org.opentripplanner.common.geometry.SphericalDistanceLibrary;
+import org.opentripplanner.ext.dataoverlay.routing.DataOverlayContext;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.routing.api.request.preference.RoutingPreferences;
 import org.opentripplanner.routing.api.request.request.VehicleParkingRequest;
 import org.opentripplanner.routing.api.request.request.VehicleRentalRequest;
+import org.opentripplanner.routing.core.intersection_model.DrivingDirection;
+import org.opentripplanner.routing.core.intersection_model.IntersectionTraversalCalculator;
+import org.opentripplanner.routing.core.intersection_model.IntersectionTraversalModel;
 import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.routing.spt.DominanceFunction;
 
@@ -33,6 +37,13 @@ public class AStarRequest {
 
   private final Envelope fromEnvelope;
   private final Envelope toEnvelope;
+
+  protected IntersectionTraversalCalculator intersectionTraversalCalculator = IntersectionTraversalCalculator.create(
+    IntersectionTraversalModel.SIMPLE,
+    DrivingDirection.RIGHT
+  );
+
+  protected DataOverlayContext dataOverlayContext;
 
   public AStarRequest(Instant startTime, RouteRequest opt, StreetMode mode) {
     this.startTime = startTime;
@@ -102,6 +113,16 @@ public class AStarRequest {
 
   public AStarRequest copyOfReversed(Instant time) {
     return new AStarRequest(this, time);
+  }
+
+  public void setIntersectionTraversalCalculator(
+    IntersectionTraversalCalculator intersectionTraversalCalculator
+  ) {
+    this.intersectionTraversalCalculator = intersectionTraversalCalculator;
+  }
+
+  public void setDataOverlayContext(DataOverlayContext dataOverlayContext) {
+    this.dataOverlayContext = dataOverlayContext;
   }
 
   /**

--- a/src/main/java/org/opentripplanner/routing/core/AStarRequest.java
+++ b/src/main/java/org/opentripplanner/routing/core/AStarRequest.java
@@ -16,6 +16,9 @@ import org.opentripplanner.routing.core.intersection_model.IntersectionTraversal
 import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.routing.spt.DominanceFunction;
 
+/**
+ * This class contains all information from the {@link RouteRequest} class required for an A* search
+ */
 public class AStarRequest {
 
   /**

--- a/src/main/java/org/opentripplanner/routing/core/AStarRequest.java
+++ b/src/main/java/org/opentripplanner/routing/core/AStarRequest.java
@@ -1,10 +1,12 @@
 package org.opentripplanner.routing.core;
 
 import java.time.Instant;
+import javax.annotation.Nullable;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Envelope;
 import org.opentripplanner.common.geometry.SphericalDistanceLibrary;
 import org.opentripplanner.ext.dataoverlay.routing.DataOverlayContext;
+import org.opentripplanner.model.GenericLocation;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.routing.api.request.preference.RoutingPreferences;
@@ -56,14 +58,8 @@ public class AStarRequest {
     this.wheelchair = opt.wheelchair();
     this.parking = opt.journey().parking();
     this.rental = opt.journey().rental();
-    this.fromEnvelope =
-      opt.from() != null && opt.from().getCoordinate() != null
-        ? getEnvelope(opt.from().getCoordinate())
-        : null;
-    this.toEnvelope =
-      opt.to() != null && opt.to().getCoordinate() != null
-        ? getEnvelope(opt.to().getCoordinate())
-        : null;
+    this.fromEnvelope = getEnvelope(opt.from());
+    this.toEnvelope = getEnvelope(opt.to());
   }
 
   /**
@@ -149,11 +145,21 @@ public class AStarRequest {
     );
   }
 
-  private static Envelope getEnvelope(Coordinate c) {
-    double lat = SphericalDistanceLibrary.metersToDegrees(MAX_CLOSENESS_METERS);
-    double lon = SphericalDistanceLibrary.metersToLonDegrees(MAX_CLOSENESS_METERS, c.y);
+  @Nullable
+  private static Envelope getEnvelope(GenericLocation location) {
+    if (location == null) {
+      return null;
+    }
 
-    Envelope env = new Envelope(c);
+    Coordinate coordinate = location.getCoordinate();
+    if (coordinate == null) {
+      return null;
+    }
+
+    double lat = SphericalDistanceLibrary.metersToDegrees(MAX_CLOSENESS_METERS);
+    double lon = SphericalDistanceLibrary.metersToLonDegrees(MAX_CLOSENESS_METERS, coordinate.y);
+
+    Envelope env = new Envelope(coordinate);
     env.expandBy(lon, lat);
 
     return env;

--- a/src/main/java/org/opentripplanner/routing/core/AStarRequest.java
+++ b/src/main/java/org/opentripplanner/routing/core/AStarRequest.java
@@ -22,6 +22,8 @@ import org.opentripplanner.routing.spt.DominanceFunction;
  */
 public class AStarRequest {
 
+  private static final AStarRequest DEFAULT = new AStarRequest();
+
   /**
    * How close to do you have to be to the start or end to be considered "close".
    *
@@ -49,23 +51,40 @@ public class AStarRequest {
 
   protected DataOverlayContext dataOverlayContext;
 
+  /**
+   * Constructor only used for creating a default instance.
+   */
+  private AStarRequest() {
+    this.startTime = Instant.now();
+    this.preferences = new RoutingPreferences();
+    this.mode = StreetMode.WALK;
+    this.arriveBy = false;
+    this.wheelchair = false;
+    this.parking = new VehicleParkingRequest();
+    this.rental = new VehicleRentalRequest();
+    this.from = null;
+    this.fromEnvelope = null;
+    this.to = null;
+    this.toEnvelope = null;
+  }
+
   AStarRequest(AStarRequestBuilder builder) {
-    this.startTime = builder.startTime();
+    this.startTime = builder.startTime;
     this.preferences = builder.preferences();
-    this.mode = builder.mode();
-    this.arriveBy = builder.arriveBy();
-    this.wheelchair = builder.wheelchair();
-    this.parking = builder.parking();
-    this.rental = builder.rental();
-    this.from = builder.from();
+    this.mode = builder.mode;
+    this.arriveBy = builder.arriveBy;
+    this.wheelchair = builder.wheelchair;
+    this.parking = builder.parking;
+    this.rental = builder.rental;
+    this.from = builder.from;
     this.fromEnvelope = createEnvelope(from);
-    this.to = builder.to();
+    this.to = builder.to;
     this.toEnvelope = createEnvelope(to);
   }
 
   @Nonnull
   public static AStarRequestBuilder of() {
-    return new AStarRequestBuilder();
+    return new AStarRequestBuilder(DEFAULT).withStartTime(Instant.now());
   }
 
   @Nonnull

--- a/src/main/java/org/opentripplanner/routing/core/AStarRequest.java
+++ b/src/main/java/org/opentripplanner/routing/core/AStarRequest.java
@@ -1,0 +1,26 @@
+package org.opentripplanner.routing.core;
+
+import java.time.Instant;
+import org.opentripplanner.routing.api.request.RouteRequest;
+import org.opentripplanner.routing.api.request.StreetMode;
+
+public class AStarRequest {
+
+  // the time at which the search started
+  public final Instant startTime;
+
+  protected final RouteRequest opt;
+
+  /**
+   * The requested mode for the search. This contains information about all allowed transitions
+   * between the different traverse modes, such as renting or parking a vehicle. Contrary to
+   * currentMode, which can change when traversing edges, this is constant for a single search.
+   */
+  protected final StreetMode requestMode;
+
+  public AStarRequest(Instant startTime, RouteRequest opt, StreetMode requestMode) {
+    this.startTime = startTime;
+    this.opt = opt;
+    this.requestMode = requestMode;
+  }
+}

--- a/src/main/java/org/opentripplanner/routing/core/AStarRequestBuilder.java
+++ b/src/main/java/org/opentripplanner/routing/core/AStarRequestBuilder.java
@@ -33,7 +33,7 @@ public class AStarRequestBuilder {
     this.to = original.to();
   }
 
-  public AStarRequestBuilder setStartTime(Instant startTime) {
+  public AStarRequestBuilder withStartTime(Instant startTime) {
     this.startTime = startTime;
     return this;
   }
@@ -42,7 +42,7 @@ public class AStarRequestBuilder {
     return startTime;
   }
 
-  public AStarRequestBuilder setMode(StreetMode mode) {
+  public AStarRequestBuilder withMode(StreetMode mode) {
     this.mode = mode;
     return this;
   }
@@ -51,7 +51,7 @@ public class AStarRequestBuilder {
     return mode;
   }
 
-  public AStarRequestBuilder setPreferences(RoutingPreferences preferences) {
+  public AStarRequestBuilder withPreferences(RoutingPreferences preferences) {
     this.preferences = preferences;
     return this;
   }
@@ -60,7 +60,7 @@ public class AStarRequestBuilder {
     return preferences;
   }
 
-  public AStarRequestBuilder setArriveBy(boolean arriveBy) {
+  public AStarRequestBuilder withArriveBy(boolean arriveBy) {
     this.arriveBy = arriveBy;
     return this;
   }
@@ -69,7 +69,7 @@ public class AStarRequestBuilder {
     return arriveBy;
   }
 
-  public AStarRequestBuilder setWheelchair(boolean wheelchair) {
+  public AStarRequestBuilder withWheelchair(boolean wheelchair) {
     this.wheelchair = wheelchair;
     return this;
   }
@@ -78,7 +78,7 @@ public class AStarRequestBuilder {
     return wheelchair;
   }
 
-  public AStarRequestBuilder setParking(VehicleParkingRequest parking) {
+  public AStarRequestBuilder withParking(VehicleParkingRequest parking) {
     this.parking = parking;
     return this;
   }
@@ -87,7 +87,7 @@ public class AStarRequestBuilder {
     return parking;
   }
 
-  public AStarRequestBuilder setRental(VehicleRentalRequest rental) {
+  public AStarRequestBuilder withRental(VehicleRentalRequest rental) {
     this.rental = rental;
     return this;
   }
@@ -96,7 +96,7 @@ public class AStarRequestBuilder {
     return rental;
   }
 
-  public AStarRequestBuilder setFrom(GenericLocation from) {
+  public AStarRequestBuilder withFrom(GenericLocation from) {
     this.from = from;
     return this;
   }
@@ -105,7 +105,7 @@ public class AStarRequestBuilder {
     return from;
   }
 
-  public AStarRequestBuilder setTo(GenericLocation to) {
+  public AStarRequestBuilder withTo(GenericLocation to) {
     this.to = to;
     return this;
   }

--- a/src/main/java/org/opentripplanner/routing/core/AStarRequestBuilder.java
+++ b/src/main/java/org/opentripplanner/routing/core/AStarRequestBuilder.java
@@ -9,17 +9,15 @@ import org.opentripplanner.routing.api.request.request.VehicleRentalRequest;
 
 public class AStarRequestBuilder {
 
-  private Instant startTime = Instant.now();
-  private StreetMode mode = StreetMode.WALK;
-  private RoutingPreferences preferences = new RoutingPreferences();
-  private boolean arriveBy = false;
-  private boolean wheelchair = false;
-  private VehicleParkingRequest parking = new VehicleParkingRequest();
-  private VehicleRentalRequest rental = new VehicleRentalRequest();
-  private GenericLocation from = null;
-  private GenericLocation to = null;
-
-  AStarRequestBuilder() {}
+  Instant startTime;
+  StreetMode mode;
+  RoutingPreferences preferences;
+  boolean arriveBy;
+  boolean wheelchair;
+  VehicleParkingRequest parking;
+  VehicleRentalRequest rental;
+  GenericLocation from;
+  GenericLocation to;
 
   AStarRequestBuilder(AStarRequest original) {
     this.startTime = original.startTime();
@@ -38,17 +36,9 @@ public class AStarRequestBuilder {
     return this;
   }
 
-  public Instant startTime() {
-    return startTime;
-  }
-
   public AStarRequestBuilder withMode(StreetMode mode) {
     this.mode = mode;
     return this;
-  }
-
-  public StreetMode mode() {
-    return mode;
   }
 
   public AStarRequestBuilder withPreferences(RoutingPreferences preferences) {
@@ -65,17 +55,9 @@ public class AStarRequestBuilder {
     return this;
   }
 
-  public boolean arriveBy() {
-    return arriveBy;
-  }
-
   public AStarRequestBuilder withWheelchair(boolean wheelchair) {
     this.wheelchair = wheelchair;
     return this;
-  }
-
-  public boolean wheelchair() {
-    return wheelchair;
   }
 
   public AStarRequestBuilder withParking(VehicleParkingRequest parking) {
@@ -83,17 +65,9 @@ public class AStarRequestBuilder {
     return this;
   }
 
-  public VehicleParkingRequest parking() {
-    return parking;
-  }
-
   public AStarRequestBuilder withRental(VehicleRentalRequest rental) {
     this.rental = rental;
     return this;
-  }
-
-  public VehicleRentalRequest rental() {
-    return rental;
   }
 
   public AStarRequestBuilder withFrom(GenericLocation from) {
@@ -101,17 +75,9 @@ public class AStarRequestBuilder {
     return this;
   }
 
-  public GenericLocation from() {
-    return from;
-  }
-
   public AStarRequestBuilder withTo(GenericLocation to) {
     this.to = to;
     return this;
-  }
-
-  public GenericLocation to() {
-    return to;
   }
 
   public AStarRequest build() {

--- a/src/main/java/org/opentripplanner/routing/core/AStarRequestBuilder.java
+++ b/src/main/java/org/opentripplanner/routing/core/AStarRequestBuilder.java
@@ -1,0 +1,120 @@
+package org.opentripplanner.routing.core;
+
+import java.time.Instant;
+import org.opentripplanner.model.GenericLocation;
+import org.opentripplanner.routing.api.request.StreetMode;
+import org.opentripplanner.routing.api.request.preference.RoutingPreferences;
+import org.opentripplanner.routing.api.request.request.VehicleParkingRequest;
+import org.opentripplanner.routing.api.request.request.VehicleRentalRequest;
+
+public class AStarRequestBuilder {
+
+  private Instant startTime = Instant.now();
+  private StreetMode mode = StreetMode.WALK;
+  private RoutingPreferences preferences = new RoutingPreferences();
+  private boolean arriveBy = false;
+  private boolean wheelchair = false;
+  private VehicleParkingRequest parking = new VehicleParkingRequest();
+  private VehicleRentalRequest rental = new VehicleRentalRequest();
+  private GenericLocation from = null;
+  private GenericLocation to = null;
+
+  AStarRequestBuilder() {}
+
+  AStarRequestBuilder(AStarRequest original) {
+    this.startTime = original.startTime();
+    this.mode = original.mode();
+    this.preferences = original.preferences().clone();
+    this.arriveBy = original.arriveBy();
+    this.wheelchair = original.wheelchair();
+    this.parking = original.parking().clone();
+    this.rental = original.rental();
+    this.from = original.from();
+    this.to = original.to();
+  }
+
+  public AStarRequestBuilder setStartTime(Instant startTime) {
+    this.startTime = startTime;
+    return this;
+  }
+
+  public Instant startTime() {
+    return startTime;
+  }
+
+  public AStarRequestBuilder setMode(StreetMode mode) {
+    this.mode = mode;
+    return this;
+  }
+
+  public StreetMode mode() {
+    return mode;
+  }
+
+  public AStarRequestBuilder setPreferences(RoutingPreferences preferences) {
+    this.preferences = preferences;
+    return this;
+  }
+
+  public RoutingPreferences preferences() {
+    return preferences;
+  }
+
+  public AStarRequestBuilder setArriveBy(boolean arriveBy) {
+    this.arriveBy = arriveBy;
+    return this;
+  }
+
+  public boolean arriveBy() {
+    return arriveBy;
+  }
+
+  public AStarRequestBuilder setWheelchair(boolean wheelchair) {
+    this.wheelchair = wheelchair;
+    return this;
+  }
+
+  public boolean wheelchair() {
+    return wheelchair;
+  }
+
+  public AStarRequestBuilder setParking(VehicleParkingRequest parking) {
+    this.parking = parking;
+    return this;
+  }
+
+  public VehicleParkingRequest parking() {
+    return parking;
+  }
+
+  public AStarRequestBuilder setRental(VehicleRentalRequest rental) {
+    this.rental = rental;
+    return this;
+  }
+
+  public VehicleRentalRequest rental() {
+    return rental;
+  }
+
+  public AStarRequestBuilder setFrom(GenericLocation from) {
+    this.from = from;
+    return this;
+  }
+
+  public GenericLocation from() {
+    return from;
+  }
+
+  public AStarRequestBuilder setTo(GenericLocation to) {
+    this.to = to;
+    return this;
+  }
+
+  public GenericLocation to() {
+    return to;
+  }
+
+  public AStarRequest build() {
+    return new AStarRequest(this);
+  }
+}

--- a/src/main/java/org/opentripplanner/routing/core/AStarRequestMapper.java
+++ b/src/main/java/org/opentripplanner/routing/core/AStarRequestMapper.java
@@ -7,13 +7,13 @@ public class AStarRequestMapper {
   public static AStarRequestBuilder map(RouteRequest opt) {
     return AStarRequest
       .of()
-      .setStartTime(opt.dateTime())
-      .setPreferences(opt.preferences())
-      .setArriveBy(opt.arriveBy())
-      .setWheelchair(opt.wheelchair())
-      .setParking(opt.journey().parking())
-      .setRental(opt.journey().rental())
-      .setFrom(opt.from())
-      .setTo(opt.to());
+      .withStartTime(opt.dateTime())
+      .withPreferences(opt.preferences())
+      .withArriveBy(opt.arriveBy())
+      .withWheelchair(opt.wheelchair())
+      .withParking(opt.journey().parking())
+      .withRental(opt.journey().rental())
+      .withFrom(opt.from())
+      .withTo(opt.to());
   }
 }

--- a/src/main/java/org/opentripplanner/routing/core/AStarRequestMapper.java
+++ b/src/main/java/org/opentripplanner/routing/core/AStarRequestMapper.java
@@ -1,0 +1,19 @@
+package org.opentripplanner.routing.core;
+
+import org.opentripplanner.routing.api.request.RouteRequest;
+
+public class AStarRequestMapper {
+
+  public static AStarRequestBuilder map(RouteRequest opt) {
+    return AStarRequest
+      .of()
+      .setStartTime(opt.dateTime())
+      .setPreferences(opt.preferences())
+      .setArriveBy(opt.arriveBy())
+      .setWheelchair(opt.wheelchair())
+      .setParking(opt.journey().parking())
+      .setRental(opt.journey().rental())
+      .setFrom(opt.from())
+      .setTo(opt.to());
+  }
+}

--- a/src/main/java/org/opentripplanner/routing/core/State.java
+++ b/src/main/java/org/opentripplanner/routing/core/State.java
@@ -66,7 +66,6 @@ public class State implements Cloneable {
     this.vertex = vertex;
     this.backState = null;
     this.stateData = stateData;
-    this.stateData.startTime = startTime;
     this.walkDistance = 0;
     this.time = startTime.getEpochSecond();
   }
@@ -415,7 +414,11 @@ public class State implements Cloneable {
     // It is distributed symmetrically over all preboard and prealight edges.
     var reversedRequest = stateData.opt.copyOfReversed();
     reversedRequest.preferences().rental().setUseAvailabilityInformation(false);
-    var newStateData = StateData.getInitialStateData(reversedRequest, stateData.requestMode);
+    var newStateData = StateData.getInitialStateData(
+      reversedRequest,
+      stateData.requestMode,
+      getTime()
+    );
     // TODO Check if those three lines are needed:
     // TODO Yes they are. We should instead pass the stateData as such after removing startTime, opt
     // and rctx from it.

--- a/src/main/java/org/opentripplanner/routing/core/State.java
+++ b/src/main/java/org/opentripplanner/routing/core/State.java
@@ -3,7 +3,6 @@ package org.opentripplanner.routing.core;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 import java.util.Set;
 import org.opentripplanner.ext.dataoverlay.routing.DataOverlayContext;
 import org.opentripplanner.routing.algorithm.astar.NegativeWeightException;
@@ -50,24 +49,6 @@ public class State implements Cloneable {
 
   /* CONSTRUCTORS */
 
-  /**
-   * Create an initial state, forcing vertex to the specified value. Useful for tests, etc.
-   */
-  public State(Vertex vertex, RouteRequest opt, StreetMode streetMode) {
-    // Since you explicitly specify, the vertex, we don't set the backEdge.
-    this(
-      vertex,
-      opt.dateTime(),
-      StateData.getInitialStateData(opt, streetMode),
-      new AStarRequest(opt.dateTime(), opt, streetMode)
-    );
-  }
-
-  /**
-   * Create an initial state, forcing vertex, back edge, time and start time to the specified
-   * values. Useful for starting a multiple initial state search, for example when propagating
-   * profile results to the street network in RoundBasedProfileRouter.
-   */
   public State(Vertex vertex, Instant startTime, StateData stateData, AStarRequest request) {
     this.request = request;
     this.weight = 0;
@@ -89,14 +70,26 @@ public class State implements Cloneable {
     Set<Vertex> vertices
   ) {
     Collection<State> states = new ArrayList<>();
-    List<StateData> initialStateDatas = StateData.getInitialStateDatas(request, streetMode);
     AStarRequest aStarRequest = new AStarRequest(request.dateTime(), request, streetMode);
     for (Vertex vertex : vertices) {
-      for (StateData stateData : initialStateDatas) {
+      for (StateData stateData : StateData.getInitialStateDatas(aStarRequest)) {
         states.add(new State(vertex, request.dateTime(), stateData, aStarRequest));
       }
     }
     return states;
+  }
+
+  /**
+   * Create an initial state, forcing vertex to the specified value. Useful for tests, etc.
+   */
+  public static State createState(Vertex vertex, RouteRequest opt, StreetMode streetMode) {
+    final AStarRequest aStarRequest = new AStarRequest(opt.dateTime(), opt, streetMode);
+    return new State(
+      vertex,
+      opt.dateTime(),
+      StateData.getInitialStateData(aStarRequest),
+      aStarRequest
+    );
   }
 
   /**

--- a/src/main/java/org/opentripplanner/routing/core/State.java
+++ b/src/main/java/org/opentripplanner/routing/core/State.java
@@ -364,11 +364,11 @@ public class State implements Cloneable {
   }
 
   public IntersectionTraversalCalculator intersectionTraversalCalculator() {
-    return stateData.intersectionTraversalCalculator;
+    return request.intersectionTraversalCalculator;
   }
 
   public DataOverlayContext dataOverlayContext() {
-    return stateData.dataOverlayContext;
+    return request.dataOverlayContext;
   }
 
   protected State clone() {

--- a/src/main/java/org/opentripplanner/routing/core/State.java
+++ b/src/main/java/org/opentripplanner/routing/core/State.java
@@ -6,8 +6,6 @@ import java.util.Collection;
 import java.util.Set;
 import org.opentripplanner.ext.dataoverlay.routing.DataOverlayContext;
 import org.opentripplanner.routing.algorithm.astar.NegativeWeightException;
-import org.opentripplanner.routing.api.request.RouteRequest;
-import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.routing.api.request.preference.RoutingPreferences;
 import org.opentripplanner.routing.core.intersection_model.IntersectionTraversalCalculator;
 import org.opentripplanner.routing.edgetype.VehicleRentalEdge;
@@ -49,6 +47,18 @@ public class State implements Cloneable {
 
   /* CONSTRUCTORS */
 
+  /**
+   * Create an initial state, forcing vertex to the specified value. Useful for tests, etc.
+   */
+  public State(Vertex vertex, AStarRequest aStarRequest) {
+    this(
+      vertex,
+      aStarRequest.startTime(),
+      StateData.getInitialStateData(aStarRequest),
+      aStarRequest
+    );
+  }
+
   public State(Vertex vertex, Instant startTime, StateData stateData, AStarRequest request) {
     this.request = request;
     this.weight = 0;
@@ -65,31 +75,16 @@ public class State implements Cloneable {
    * states must be created from a parent and associated with an edge.
    */
   public static Collection<State> getInitialStates(
-    RouteRequest request,
-    StreetMode streetMode,
-    Set<Vertex> vertices
+    Set<Vertex> vertices,
+    AStarRequest aStarRequest
   ) {
     Collection<State> states = new ArrayList<>();
-    AStarRequest aStarRequest = new AStarRequest(request.dateTime(), request, streetMode);
     for (Vertex vertex : vertices) {
       for (StateData stateData : StateData.getInitialStateDatas(aStarRequest)) {
-        states.add(new State(vertex, request.dateTime(), stateData, aStarRequest));
+        states.add(new State(vertex, aStarRequest.startTime(), stateData, aStarRequest));
       }
     }
     return states;
-  }
-
-  /**
-   * Create an initial state, forcing vertex to the specified value. Useful for tests, etc.
-   */
-  public static State create(Vertex vertex, RouteRequest opt, StreetMode streetMode) {
-    final AStarRequest aStarRequest = new AStarRequest(opt.dateTime(), opt, streetMode);
-    return new State(
-      vertex,
-      opt.dateTime(),
-      StateData.getInitialStateData(aStarRequest),
-      aStarRequest
-    );
   }
 
   /**

--- a/src/main/java/org/opentripplanner/routing/core/State.java
+++ b/src/main/java/org/opentripplanner/routing/core/State.java
@@ -82,7 +82,7 @@ public class State implements Cloneable {
   /**
    * Create an initial state, forcing vertex to the specified value. Useful for tests, etc.
    */
-  public static State createState(Vertex vertex, RouteRequest opt, StreetMode streetMode) {
+  public static State create(Vertex vertex, RouteRequest opt, StreetMode streetMode) {
     final AStarRequest aStarRequest = new AStarRequest(opt.dateTime(), opt, streetMode);
     return new State(
       vertex,

--- a/src/main/java/org/opentripplanner/routing/core/StateData.java
+++ b/src/main/java/org/opentripplanner/routing/core/StateData.java
@@ -2,7 +2,6 @@ package org.opentripplanner.routing.core;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.routing.vehicle_rental.RentalVehicleType.FormFactor;
 
@@ -60,11 +59,11 @@ public class StateData implements Cloneable {
   /**
    * Returns a set of initial StateDatas based on the options from the RoutingRequest
    */
-  public static List<StateData> getInitialStateDatas(RouteRequest options, StreetMode streetMode) {
+  public static List<StateData> getInitialStateDatas(AStarRequest request) {
     return getInitialStateDatas(
-      streetMode,
-      options.arriveBy(),
-      options.journey().rental().allowArrivingInRentedVehicleAtDestination(),
+      request.mode(),
+      request.arriveBy(),
+      request.rental().allowArrivingInRentedVehicleAtDestination(),
       false
     );
   }
@@ -73,11 +72,11 @@ public class StateData implements Cloneable {
    * Returns an initial StateData based on the options from the RoutingRequest. This returns always
    * only a single state, which is considered the "base case"
    */
-  public static StateData getInitialStateData(RouteRequest options, StreetMode streetMode) {
+  public static StateData getInitialStateData(AStarRequest request) {
     var stateDatas = getInitialStateDatas(
-      streetMode,
-      options.arriveBy(),
-      options.journey().rental().allowArrivingInRentedVehicleAtDestination(),
+      request.mode(),
+      request.arriveBy(),
+      request.rental().allowArrivingInRentedVehicleAtDestination(),
       true
     );
     if (stateDatas.size() != 1) {

--- a/src/main/java/org/opentripplanner/routing/core/StateData.java
+++ b/src/main/java/org/opentripplanner/routing/core/StateData.java
@@ -2,12 +2,8 @@ package org.opentripplanner.routing.core;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.opentripplanner.ext.dataoverlay.routing.DataOverlayContext;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
-import org.opentripplanner.routing.core.intersection_model.DrivingDirection;
-import org.opentripplanner.routing.core.intersection_model.IntersectionTraversalCalculator;
-import org.opentripplanner.routing.core.intersection_model.IntersectionTraversalModel;
 import org.opentripplanner.routing.vehicle_rental.RentalVehicleType.FormFactor;
 
 /**
@@ -26,12 +22,6 @@ public class StateData implements Cloneable {
   protected boolean mayKeepRentedVehicleAtDestination;
 
   protected CarPickupState carPickupState;
-
-  // TODO VIA - this will be folded into an AStarRequest in the future
-  public IntersectionTraversalCalculator intersectionTraversalCalculator = IntersectionTraversalCalculator.create(
-    IntersectionTraversalModel.SIMPLE,
-    DrivingDirection.RIGHT
-  );
 
   /**
    * The preferred mode, which may differ from backMode when for example walking with a bike. It may
@@ -53,8 +43,6 @@ public class StateData implements Cloneable {
 
   /** This boolean is set to true upon transition from a normal street to a no-through-traffic street. */
   protected boolean enteredNoThroughTrafficArea;
-
-  public DataOverlayContext dataOverlayContext;
 
   /** Private constructor, use static methods to get a set of initial states. */
   private StateData(StreetMode requestMode) {

--- a/src/main/java/org/opentripplanner/routing/core/StateEditor.java
+++ b/src/main/java/org/opentripplanner/routing/core/StateEditor.java
@@ -31,7 +31,7 @@ public class StateEditor {
   /* CONSTRUCTORS */
 
   public StateEditor(RouteRequest request, StreetMode streetMode, Vertex v) {
-    child = State.create(v, request, streetMode);
+    child = new State(v, AStarRequestMapper.map(request).setMode(streetMode).build());
   }
 
   public StateEditor(State parent, Edge e) {

--- a/src/main/java/org/opentripplanner/routing/core/StateEditor.java
+++ b/src/main/java/org/opentripplanner/routing/core/StateEditor.java
@@ -66,7 +66,7 @@ public class StateEditor {
       // from and to vertices are the same on eg. vehicle rental and parking vertices, thus, we
       // can't know the direction of travel from the above check. The expression below is simplified
       // fromVertex.equals(toVertex) ? parent.getOptions().arriveBy : false;
-      traversingBackward = fromVertex.equals(toVertex) && parent.getOptions().arriveBy();
+      traversingBackward = fromVertex.equals(toVertex) && parent.getRequest().arriveBy();
       child.vertex = toVertex;
     } else if (parentVertex.equals(toVertex)) {
       traversingBackward = true;
@@ -80,7 +80,7 @@ public class StateEditor {
       defectiveTraversal = true;
     }
 
-    if (traversingBackward != parent.getOptions().arriveBy()) {
+    if (traversingBackward != parent.getRequest().arriveBy()) {
       LOG.error(
         "Actual traversal direction does not match traversal direction in TraverseOptions."
       );

--- a/src/main/java/org/opentripplanner/routing/core/StateEditor.java
+++ b/src/main/java/org/opentripplanner/routing/core/StateEditor.java
@@ -1,7 +1,5 @@
 package org.opentripplanner.routing.core;
 
-import org.opentripplanner.routing.api.request.RouteRequest;
-import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.routing.vehicle_rental.RentalVehicleType.FormFactor;
@@ -30,8 +28,8 @@ public class StateEditor {
 
   /* CONSTRUCTORS */
 
-  public StateEditor(RouteRequest request, StreetMode streetMode, Vertex v) {
-    child = new State(v, AStarRequestMapper.map(request).setMode(streetMode).build());
+  public StateEditor(Vertex v, AStarRequest request) {
+    child = new State(v, request);
   }
 
   public StateEditor(State parent, Edge e) {

--- a/src/main/java/org/opentripplanner/routing/core/StateEditor.java
+++ b/src/main/java/org/opentripplanner/routing/core/StateEditor.java
@@ -31,7 +31,7 @@ public class StateEditor {
   /* CONSTRUCTORS */
 
   public StateEditor(RouteRequest request, StreetMode streetMode, Vertex v) {
-    child = new State(v, request, streetMode);
+    child = State.createState(v, request, streetMode);
   }
 
   public StateEditor(State parent, Edge e) {

--- a/src/main/java/org/opentripplanner/routing/core/StateEditor.java
+++ b/src/main/java/org/opentripplanner/routing/core/StateEditor.java
@@ -31,7 +31,7 @@ public class StateEditor {
   /* CONSTRUCTORS */
 
   public StateEditor(RouteRequest request, StreetMode streetMode, Vertex v) {
-    child = State.createState(v, request, streetMode);
+    child = State.create(v, request, streetMode);
   }
 
   public StateEditor(State parent, Edge e) {

--- a/src/main/java/org/opentripplanner/routing/core/intersection_model/IntersectionTraversalCalculator.java
+++ b/src/main/java/org/opentripplanner/routing/core/intersection_model/IntersectionTraversalCalculator.java
@@ -13,6 +13,11 @@ import org.opentripplanner.routing.vertextype.IntersectionVertex;
  * @author avi
  */
 public interface IntersectionTraversalCalculator {
+  IntersectionTraversalCalculator DEFAULT = create(
+    IntersectionTraversalModel.SIMPLE,
+    DrivingDirection.RIGHT
+  );
+
   /**
    * Compute the duration of turning onto "to" from "from".
    *

--- a/src/main/java/org/opentripplanner/routing/edgetype/CarPickupableEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/CarPickupableEdge.java
@@ -7,10 +7,10 @@ import org.opentripplanner.routing.core.StateEditor;
 public interface CarPickupableEdge {
   default boolean canPickupAndDrive(State state) {
     return (
-      state.getRequestMode().includesPickup() &&
+      state.getRequest().mode().includesPickup() &&
       state.getCarPickupState() ==
       (
-        state.getOptions().arriveBy()
+        state.getRequest().arriveBy()
           ? CarPickupState.WALK_FROM_DROP_OFF
           : CarPickupState.WALK_TO_PICKUP
       )
@@ -19,13 +19,14 @@ public interface CarPickupableEdge {
 
   default boolean canDropOffAfterDriving(State state) {
     return (
-      state.getRequestMode().includesPickup() && state.getCarPickupState() == CarPickupState.IN_CAR
+      state.getRequest().mode().includesPickup() &&
+      state.getCarPickupState() == CarPickupState.IN_CAR
     );
   }
 
   default void dropOffAfterDriving(State state, StateEditor editor) {
     editor.setCarPickupState(
-      state.getOptions().arriveBy()
+      state.getRequest().arriveBy()
         ? CarPickupState.WALK_TO_PICKUP
         : CarPickupState.WALK_FROM_DROP_OFF
     );

--- a/src/main/java/org/opentripplanner/routing/edgetype/ElevatorHopEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/ElevatorHopEdge.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.routing.edgetype;
 
 import org.locationtech.jts.geom.LineString;
-import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.preference.RoutingPreferences;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.core.StateEditor;
@@ -84,11 +83,10 @@ public class ElevatorHopEdge extends Edge implements ElevatorEdge, WheelchairTra
   @Override
   public State traverse(State s0) {
     RoutingPreferences preferences = s0.getPreferences();
-    RouteRequest request = s0.getOptions();
 
     StateEditor s1 = createEditorForDrivingOrWalking(s0, this);
 
-    if (request.wheelchair()) {
+    if (s0.getRequest().wheelchair()) {
       if (
         wheelchairAccessibility != Accessibility.POSSIBLE &&
         preferences.wheelchair().elevator().onlyConsiderAccessible()

--- a/src/main/java/org/opentripplanner/routing/edgetype/PathwayEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/PathwayEdge.java
@@ -3,7 +3,6 @@ package org.opentripplanner.routing.edgetype;
 import java.util.Objects;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.LineString;
-import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.preference.RoutingPreferences;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.core.StateEditor;
@@ -85,7 +84,6 @@ public class PathwayEdge extends Edge implements BikeWalkableEdge, WheelchairTra
     }
 
     RoutingPreferences preferences = s0.getPreferences();
-    RouteRequest request = s0.getOptions();
 
     /* TODO: Consider mode, so that passing through multiple fare gates is not possible */
     int time = traversalTime;
@@ -101,7 +99,7 @@ public class PathwayEdge extends Edge implements BikeWalkableEdge, WheelchairTra
 
     if (time > 0) {
       double weight = time;
-      if (request.wheelchair()) {
+      if (s0.getRequest().wheelchair()) {
         weight *=
           StreetEdgeReluctanceCalculator.computeWheelchairReluctance(
             preferences,

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetTransitEntityLink.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetTransitEntityLink.java
@@ -2,7 +2,6 @@ package org.opentripplanner.routing.edgetype;
 
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.LineString;
-import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.preference.RoutingPreferences;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.core.StateEditor;
@@ -60,7 +59,6 @@ public abstract class StreetTransitEntityLink<T extends Vertex>
       return null;
     }
 
-    RouteRequest req = s0.getOptions();
     RoutingPreferences pref = s0.getPreferences();
 
     // Do not check here whether any transit modes are selected. A check for the presence of
@@ -68,7 +66,7 @@ public abstract class StreetTransitEntityLink<T extends Vertex>
     // This allows searching for nearby transit stops using walk-only options.
     StateEditor s1 = s0.edit(this);
 
-    if (req.wheelchair()) {
+    if (s0.getRequest().wheelchair()) {
       var accessibility = pref.wheelchair();
       if (
         accessibility.stop().onlyConsiderAccessible() &&
@@ -85,7 +83,7 @@ public abstract class StreetTransitEntityLink<T extends Vertex>
     switch (s0.getNonTransitMode()) {
       case BICYCLE:
         // Forbid taking your own bike in the station if bike P+R activated.
-        if (s0.getRequestMode().includesParking() && !s0.isVehicleParked()) {
+        if (s0.getRequest().mode().includesParking() && !s0.isVehicleParked()) {
           return null;
         }
         // Forbid taking a (station) rental vehicle in the station. This allows taking along
@@ -94,7 +92,7 @@ public abstract class StreetTransitEntityLink<T extends Vertex>
           s0.isRentingVehicleFromStation() &&
           !(
             s0.mayKeepRentedVehicleAtDestination() &&
-            req.journey().rental().allowArrivingInRentedVehicleAtDestination()
+            s0.getRequest().rental().allowArrivingInRentedVehicleAtDestination()
           )
         ) {
           return null;
@@ -103,12 +101,12 @@ public abstract class StreetTransitEntityLink<T extends Vertex>
         break;
       case CAR:
         // Forbid taking your own car in the station if bike P+R activated.
-        if (s0.getRequestMode().includesParking() && !s0.isVehicleParked()) {
+        if (s0.getRequest().mode().includesParking() && !s0.isVehicleParked()) {
           return null;
         }
         // For Kiss & Ride allow dropping of the passenger before entering the station
         if (s0.getCarPickupState() != null) {
-          if (canDropOffAfterDriving(s0) && isLeavingStreetNetwork(req)) {
+          if (canDropOffAfterDriving(s0) && isLeavingStreetNetwork(s0.getRequest().arriveBy())) {
             dropOffAfterDriving(s0, s1);
           } else {
             return null;
@@ -126,7 +124,7 @@ public abstract class StreetTransitEntityLink<T extends Vertex>
     if (
       s0.isRentingVehicleFromStation() &&
       s0.mayKeepRentedVehicleAtDestination() &&
-      req.journey().rental().allowArrivingInRentedVehicleAtDestination()
+      s0.getRequest().rental().allowArrivingInRentedVehicleAtDestination()
     ) {
       s1.incrementWeight(pref.rental().arrivingInRentalVehicleAtDestinationCost());
     }
@@ -160,7 +158,7 @@ public abstract class StreetTransitEntityLink<T extends Vertex>
     return transitEntityVertex;
   }
 
-  boolean isLeavingStreetNetwork(RouteRequest req) {
-    return (req.arriveBy() ? fromv : tov) == getTransitEntityVertex();
+  boolean isLeavingStreetNetwork(boolean arriveBy) {
+    return (arriveBy ? fromv : tov) == getTransitEntityVertex();
   }
 }

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetVehicleRentalLink.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetVehicleRentalLink.java
@@ -37,9 +37,7 @@ public class StreetVehicleRentalLink extends Edge {
       return null;
     }
 
-    if (
-      vehicleRentalPlaceVertex.getStation().networkIsNotAllowed(s0.getOptions().journey().rental())
-    ) {
+    if (vehicleRentalPlaceVertex.getStation().networkIsNotAllowed(s0.getRequest().rental())) {
       return null;
     }
 

--- a/src/main/java/org/opentripplanner/routing/edgetype/TemporaryFreeEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/TemporaryFreeEdge.java
@@ -35,7 +35,7 @@ public class TemporaryFreeEdge extends FreeEdge implements TemporaryEdge {
     if (
       s0.isRentingVehicleFromStation() &&
       s0.mayKeepRentedVehicleAtDestination() &&
-      s0.getOptions().journey().rental().allowArrivingInRentedVehicleAtDestination()
+      s0.getRequest().rental().allowArrivingInRentedVehicleAtDestination()
     ) {
       s1.incrementWeight(s0.getPreferences().rental().arrivingInRentalVehicleAtDestinationCost());
     }

--- a/src/main/java/org/opentripplanner/routing/edgetype/VehicleParkingEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/VehicleParkingEdge.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.routing.edgetype;
 
 import org.locationtech.jts.geom.LineString;
-import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.routing.api.request.preference.BikePreferences;
 import org.opentripplanner.routing.api.request.preference.CarPreferences;
@@ -51,11 +50,11 @@ public class VehicleParkingEdge extends Edge {
 
   @Override
   public State traverse(State s0) {
-    if (!s0.getRequestMode().includesParking()) {
+    if (!s0.getRequest().mode().includesParking()) {
       return null;
     }
 
-    if (s0.getOptions().arriveBy()) {
+    if (s0.getRequest().arriveBy()) {
       return traverseUnPark(s0);
     } else {
       return traversePark(s0);
@@ -87,7 +86,7 @@ public class VehicleParkingEdge extends Edge {
       return null;
     }
 
-    StreetMode streetMode = s0.getRequestMode();
+    StreetMode streetMode = s0.getRequest().mode();
 
     if (streetMode.includesBiking()) {
       final BikePreferences bike = s0.getPreferences().bike();
@@ -101,14 +100,11 @@ public class VehicleParkingEdge extends Edge {
   }
 
   private State traverseUnPark(State s0, int parkingCost, int parkingTime, TraverseMode mode) {
-    RoutingPreferences preferences = s0.getPreferences();
-    RouteRequest request = s0.getOptions();
-
     if (
       !vehicleParking.hasSpacesAvailable(
         mode,
-        request.wheelchair(),
-        preferences.parking().useAvailabilityInformation()
+        s0.getRequest().wheelchair(),
+        s0.getPreferences().parking().useAvailabilityInformation()
       )
     ) {
       return null;
@@ -122,7 +118,7 @@ public class VehicleParkingEdge extends Edge {
   }
 
   private State traversePark(State s0) {
-    StreetMode streetMode = s0.getRequestMode();
+    StreetMode streetMode = s0.getRequest().mode();
     RoutingPreferences preferences = s0.getPreferences();
 
     if (!streetMode.includesWalking() || s0.isVehicleParked()) {
@@ -144,14 +140,11 @@ public class VehicleParkingEdge extends Edge {
   }
 
   private State traversePark(State s0, int parkingCost, int parkingTime) {
-    RoutingPreferences preferences = s0.getPreferences();
-    RouteRequest request = s0.getOptions();
-
     if (
       !vehicleParking.hasSpacesAvailable(
         s0.getNonTransitMode(),
-        request.wheelchair(),
-        preferences.parking().useAvailabilityInformation()
+        s0.getRequest().wheelchair(),
+        s0.getPreferences().parking().useAvailabilityInformation()
       )
     ) {
       return null;

--- a/src/main/java/org/opentripplanner/routing/edgetype/VehicleRentalEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/VehicleRentalEdge.java
@@ -27,11 +27,11 @@ public class VehicleRentalEdge extends Edge {
   }
 
   public State traverse(State s0) {
-    if (!s0.getRequestMode().includesRenting()) {
+    if (!s0.getRequest().mode().includesRenting()) {
       return null;
     }
 
-    var allowedRentalFormFactors = allowedModes(s0.getRequestMode());
+    var allowedRentalFormFactors = allowedModes(s0.getRequest().mode());
     if (!allowedRentalFormFactors.isEmpty() && !allowedRentalFormFactors.contains(formFactor)) {
       return null;
     }
@@ -43,15 +43,13 @@ public class VehicleRentalEdge extends Edge {
     String network = station.getNetwork();
     var preferences = s0.getPreferences();
     boolean realtimeAvailability = preferences.rental().useAvailabilityInformation();
-    var options = s0.getOptions();
-    var vehicleRental = options.journey().rental();
 
-    if (station.networkIsNotAllowed(vehicleRental)) {
+    if (station.networkIsNotAllowed(s0.getRequest().rental())) {
       return null;
     }
 
     boolean pickedUp;
-    if (options.arriveBy()) {
+    if (s0.getRequest().arriveBy()) {
       switch (s0.getVehicleRentalState()) {
         case BEFORE_RENTING:
           return null;
@@ -125,7 +123,7 @@ public class VehicleRentalEdge extends Edge {
             s1.beginFloatingVehicleRenting(formFactor, network, false);
           } else {
             boolean mayKeep =
-              vehicleRental.allowArrivingInRentedVehicleAtDestination() &&
+              s0.getRequest().rental().allowArrivingInRentedVehicleAtDestination() &&
               station.isArrivingInRentalVehicleAtDestinationAllowed();
             s1.beginVehicleRentingAtStation(formFactor, network, mayKeep, false);
           }

--- a/src/main/java/org/opentripplanner/routing/services/notes/StreetNotesService.java
+++ b/src/main/java/org/opentripplanner/routing/services/notes/StreetNotesService.java
@@ -44,7 +44,7 @@ public class StreetNotesService implements Serializable {
 
     @Override
     public boolean matches(State state) {
-      return state.getOptions().wheelchair();
+      return state.getRequest().wheelchair();
     }
   };
 

--- a/src/main/java/org/opentripplanner/routing/spt/DominanceFunction.java
+++ b/src/main/java/org/opentripplanner/routing/spt/DominanceFunction.java
@@ -89,7 +89,7 @@ public abstract class DominanceFunction implements Serializable {
       (a.backEdge instanceof StreetEdge) &&
       a.getBackMode() != null &&
       a.getBackMode().isDriving() &&
-      a.getOptions().isCloseToStartOrEnd(a.getVertex())
+      a.getRequest().isCloseToStartOrEnd(a.getVertex())
     ) {
       return false;
     }

--- a/src/main/java/org/opentripplanner/routing/spt/GraphPath.java
+++ b/src/main/java/org/opentripplanner/routing/spt/GraphPath.java
@@ -36,7 +36,7 @@ public class GraphPath {
     /* Put path in chronological order */
     State lastState;
     // needed to track repeat invocations of path-reversing methods
-    if (s.getOptions().arriveBy()) {
+    if (s.getRequest().arriveBy()) {
       lastState = s.reverse();
     } else {
       lastState = s;

--- a/src/test/java/org/opentripplanner/graph_builder/module/map/StreetMatcherTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/map/StreetMatcherTest.java
@@ -192,7 +192,7 @@ public class StreetMatcherTest {
     public State traverse(State s0) {
       double d = getDistanceMeters();
       TraverseMode mode = s0.getNonTransitMode();
-      int t = (int) (d / s0.getOptions().preferences().getSpeed(mode, false));
+      int t = (int) (d / s0.getRequest().preferences().getSpeed(mode, false));
       StateEditor s1 = s0.edit(this);
       s1.incrementTimeInSeconds(t);
       s1.incrementWeight(d);

--- a/src/test/java/org/opentripplanner/routing/TestHalfEdges.java
+++ b/src/test/java/org/opentripplanner/routing/TestHalfEdges.java
@@ -513,7 +513,7 @@ public class TestHalfEdges {
     // The alert should be preserved
     // traverse the FreeEdge from the StreetLocation to the new IntersectionVertex
     RouteRequest req = new RouteRequest();
-    State traversedOne = State.createState(start, req, req.journey().direct().mode());
+    State traversedOne = State.create(start, req, req.journey().direct().mode());
     State currentState;
     for (Edge e : start.getOutgoing()) {
       currentState = e.traverse(traversedOne);
@@ -557,7 +557,7 @@ public class TestHalfEdges {
         tempEdges
       );
 
-    traversedOne = State.createState(start, req, req.journey().direct().mode());
+    traversedOne = State.create(start, req, req.journey().direct().mode());
     for (Edge e : start.getOutgoing()) {
       currentState = e.traverse(traversedOne);
       if (currentState != null) {

--- a/src/test/java/org/opentripplanner/routing/TestHalfEdges.java
+++ b/src/test/java/org/opentripplanner/routing/TestHalfEdges.java
@@ -547,7 +547,7 @@ public class TestHalfEdges {
       StreetNotesService.WHEELCHAIR_MATCHER
     );
 
-    req.setWheelchair(true);
+    req.withWheelchair(true);
 
     start =
       StreetVertexIndex.createTemporaryStreetLocationForTest(

--- a/src/test/java/org/opentripplanner/routing/TestHalfEdges.java
+++ b/src/test/java/org/opentripplanner/routing/TestHalfEdges.java
@@ -513,7 +513,7 @@ public class TestHalfEdges {
     // The alert should be preserved
     // traverse the FreeEdge from the StreetLocation to the new IntersectionVertex
     RouteRequest req = new RouteRequest();
-    State traversedOne = new State(start, req, req.journey().direct().mode());
+    State traversedOne = State.createState(start, req, req.journey().direct().mode());
     State currentState;
     for (Edge e : start.getOutgoing()) {
       currentState = e.traverse(traversedOne);
@@ -557,7 +557,7 @@ public class TestHalfEdges {
         tempEdges
       );
 
-    traversedOne = new State(start, req, req.journey().direct().mode());
+    traversedOne = State.createState(start, req, req.journey().direct().mode());
     for (Edge e : start.getOutgoing()) {
       currentState = e.traverse(traversedOne);
       if (currentState != null) {

--- a/src/test/java/org/opentripplanner/routing/TestHalfEdges.java
+++ b/src/test/java/org/opentripplanner/routing/TestHalfEdges.java
@@ -24,6 +24,8 @@ import org.opentripplanner.model.StreetNote;
 import org.opentripplanner.routing.algorithm.astar.AStarBuilder;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
+import org.opentripplanner.routing.core.AStarRequest;
+import org.opentripplanner.routing.core.AStarRequestBuilder;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.core.TemporaryVerticesContainer;
 import org.opentripplanner.routing.edgetype.StreetEdge;
@@ -512,8 +514,8 @@ public class TestHalfEdges {
 
     // The alert should be preserved
     // traverse the FreeEdge from the StreetLocation to the new IntersectionVertex
-    RouteRequest req = new RouteRequest();
-    State traversedOne = State.create(start, req, req.journey().direct().mode());
+    AStarRequestBuilder req = AStarRequest.of();
+    State traversedOne = new State(start, req.build());
     State currentState;
     for (Edge e : start.getOutgoing()) {
       currentState = e.traverse(traversedOne);
@@ -557,7 +559,7 @@ public class TestHalfEdges {
         tempEdges
       );
 
-    traversedOne = State.create(start, req, req.journey().direct().mode());
+    traversedOne = new State(start, req.build());
     for (Edge e : start.getOutgoing()) {
       currentState = e.traverse(traversedOne);
       if (currentState != null) {

--- a/src/test/java/org/opentripplanner/routing/algorithm/DominanceFunctionTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/DominanceFunctionTest.java
@@ -8,6 +8,7 @@ import java.time.Instant;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
+import org.opentripplanner.routing.core.AStarRequest;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.core.StateData;
 import org.opentripplanner.routing.graph.Vertex;
@@ -28,12 +29,14 @@ public class DominanceFunctionTest {
     State stateA = new State(
       fromVertex,
       Instant.EPOCH,
-      StateData.getInitialStateData(request, StreetMode.WALK)
+      StateData.getInitialStateData(request, StreetMode.WALK),
+      new AStarRequest(request.dateTime(), request, StreetMode.WALK)
     );
     State stateB = new State(
       toVertex,
       Instant.EPOCH,
-      StateData.getInitialStateData(request, StreetMode.WALK)
+      StateData.getInitialStateData(request, StreetMode.WALK),
+      new AStarRequest(request.dateTime(), request, StreetMode.WALK)
     );
     stateA.weight = 1;
     stateB.weight = 2;

--- a/src/test/java/org/opentripplanner/routing/algorithm/DominanceFunctionTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/DominanceFunctionTest.java
@@ -26,18 +26,10 @@ public class DominanceFunctionTest {
 
     // Test if domination works in the general case
 
-    State stateA = new State(
-      fromVertex,
-      Instant.EPOCH,
-      StateData.getInitialStateData(request, StreetMode.WALK),
-      new AStarRequest(request.dateTime(), request, StreetMode.WALK)
-    );
-    State stateB = new State(
-      toVertex,
-      Instant.EPOCH,
-      StateData.getInitialStateData(request, StreetMode.WALK),
-      new AStarRequest(request.dateTime(), request, StreetMode.WALK)
-    );
+    AStarRequest aStarRequest = new AStarRequest(request.dateTime(), request, StreetMode.WALK);
+    StateData stateData = StateData.getInitialStateData(aStarRequest);
+    State stateA = new State(fromVertex, Instant.EPOCH, stateData, aStarRequest);
+    State stateB = new State(toVertex, Instant.EPOCH, stateData, aStarRequest);
     stateA.weight = 1;
     stateB.weight = 2;
 

--- a/src/test/java/org/opentripplanner/routing/algorithm/DominanceFunctionTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/DominanceFunctionTest.java
@@ -6,8 +6,6 @@ import static org.mockito.Mockito.mock;
 
 import java.time.Instant;
 import org.junit.jupiter.api.Test;
-import org.opentripplanner.routing.api.request.RouteRequest;
-import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.routing.core.AStarRequest;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.core.StateData;
@@ -22,11 +20,10 @@ public class DominanceFunctionTest {
     DominanceFunction minimumWeightDominanceFunction = new DominanceFunction.MinimumWeight();
     Vertex fromVertex = mock(TransitStopVertex.class);
     Vertex toVertex = mock(TransitStopVertex.class);
-    RouteRequest request = new RouteRequest();
 
     // Test if domination works in the general case
 
-    AStarRequest aStarRequest = new AStarRequest(request.dateTime(), request, StreetMode.WALK);
+    AStarRequest aStarRequest = AStarRequest.of().build();
     StateData stateData = StateData.getInitialStateData(aStarRequest);
     State stateA = new State(fromVertex, Instant.EPOCH, stateData, aStarRequest);
     State stateB = new State(toVertex, Instant.EPOCH, stateData, aStarRequest);

--- a/src/test/java/org/opentripplanner/routing/core/StateEditorTest.java
+++ b/src/test/java/org/opentripplanner/routing/core/StateEditorTest.java
@@ -5,14 +5,12 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.Test;
-import org.opentripplanner.routing.api.request.RouteRequest;
-import org.opentripplanner.routing.api.request.StreetMode;
 
 public class StateEditorTest {
 
   @Test
   public final void testIncrementTimeInSeconds() {
-    StateEditor stateEditor = new StateEditor(new RouteRequest(), StreetMode.WALK, null);
+    StateEditor stateEditor = new StateEditor(null, AStarRequest.of().build());
 
     stateEditor.setTimeSeconds(0);
     stateEditor.incrementTimeInSeconds(999999999);
@@ -22,7 +20,7 @@ public class StateEditorTest {
 
   @Test
   public final void testWeightIncrement() {
-    StateEditor stateEditor = new StateEditor(new RouteRequest(), StreetMode.WALK, null);
+    StateEditor stateEditor = new StateEditor(null, AStarRequest.of().build());
 
     stateEditor.setTimeSeconds(0);
     stateEditor.incrementWeight(10);
@@ -32,7 +30,7 @@ public class StateEditorTest {
 
   @Test
   public final void testNanWeightIncrement() {
-    StateEditor stateEditor = new StateEditor(new RouteRequest(), StreetMode.WALK, null);
+    StateEditor stateEditor = new StateEditor(null, AStarRequest.of().build());
 
     stateEditor.setTimeSeconds(0);
     stateEditor.incrementWeight(Double.NaN);
@@ -42,7 +40,7 @@ public class StateEditorTest {
 
   @Test
   public final void testInfinityWeightIncrement() {
-    StateEditor stateEditor = new StateEditor(new RouteRequest(), StreetMode.WALK, null);
+    StateEditor stateEditor = new StateEditor(null, AStarRequest.of().build());
 
     stateEditor.setTimeSeconds(0);
     stateEditor.incrementWeight(Double.NEGATIVE_INFINITY);

--- a/src/test/java/org/opentripplanner/routing/core/TraverseResultTest.java
+++ b/src/test/java/org/opentripplanner/routing/core/TraverseResultTest.java
@@ -16,11 +16,13 @@ public class TraverseResultTest {
 
     /* note: times are rounded to seconds toward zero */
 
+    final RouteRequest request = new RouteRequest();
     for (int i = 0; i < 4; i++) {
       State r = new State(
         null,
         Instant.ofEpochSecond(i * 1000),
-        StateData.getInitialStateData(new RouteRequest(), StreetMode.WALK)
+        StateData.getInitialStateData(request, StreetMode.WALK),
+        new AStarRequest(request.dateTime(), request, StreetMode.WALK)
       );
       resultChain = r.addToExistingResultChain(resultChain);
     }

--- a/src/test/java/org/opentripplanner/routing/core/TraverseResultTest.java
+++ b/src/test/java/org/opentripplanner/routing/core/TraverseResultTest.java
@@ -18,12 +18,9 @@ public class TraverseResultTest {
 
     final RouteRequest request = new RouteRequest();
     for (int i = 0; i < 4; i++) {
-      State r = new State(
-        null,
-        Instant.ofEpochSecond(i * 1000),
-        StateData.getInitialStateData(request, StreetMode.WALK),
-        new AStarRequest(request.dateTime(), request, StreetMode.WALK)
-      );
+      AStarRequest aStarRequest = new AStarRequest(request.dateTime(), request, StreetMode.WALK);
+      StateData stateData = StateData.getInitialStateData(aStarRequest);
+      State r = new State(null, Instant.ofEpochSecond(i * 1000), stateData, aStarRequest);
       resultChain = r.addToExistingResultChain(resultChain);
     }
 

--- a/src/test/java/org/opentripplanner/routing/core/TraverseResultTest.java
+++ b/src/test/java/org/opentripplanner/routing/core/TraverseResultTest.java
@@ -5,8 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.time.Instant;
 import org.junit.jupiter.api.Test;
-import org.opentripplanner.routing.api.request.RouteRequest;
-import org.opentripplanner.routing.api.request.StreetMode;
 
 public class TraverseResultTest {
 
@@ -16,9 +14,8 @@ public class TraverseResultTest {
 
     /* note: times are rounded to seconds toward zero */
 
-    final RouteRequest request = new RouteRequest();
+    AStarRequest aStarRequest = AStarRequest.of().build();
     for (int i = 0; i < 4; i++) {
-      AStarRequest aStarRequest = new AStarRequest(request.dateTime(), request, StreetMode.WALK);
       StateData stateData = StateData.getInitialStateData(aStarRequest);
       State r = new State(null, Instant.ofEpochSecond(i * 1000), stateData, aStarRequest);
       resultChain = r.addToExistingResultChain(resultChain);

--- a/src/test/java/org/opentripplanner/routing/edgetype/ElevatorHopEdgeTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/ElevatorHopEdgeTest.java
@@ -67,7 +67,7 @@ class ElevatorHopEdgeTest {
 
   private State traverse(Accessibility wheelchair, RouteRequest req) {
     var edge = new ElevatorHopEdge(from, to, StreetTraversalPermission.ALL, wheelchair);
-    var state = new State(from, req, StreetMode.WALK);
+    var state = State.createState(from, req, StreetMode.WALK);
 
     return edge.traverse(state);
   }

--- a/src/test/java/org/opentripplanner/routing/edgetype/ElevatorHopEdgeTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/ElevatorHopEdgeTest.java
@@ -8,11 +8,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.routing.api.request.preference.AccessibilityPreferences;
 import org.opentripplanner.routing.api.request.preference.WheelchairPreferences;
 import org.opentripplanner.routing.core.AStarRequest;
-import org.opentripplanner.routing.core.AStarRequestBuilder;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
@@ -35,7 +33,7 @@ class ElevatorHopEdgeTest {
   public void shouldNotTraverse(Accessibility wheelchair) {
     var req = AStarRequest.of();
     AccessibilityPreferences feature = AccessibilityPreferences.ofOnlyAccessible();
-    req.setWheelchair(true);
+    req.withWheelchair(true);
     req
       .preferences()
       .setWheelchair(new WheelchairPreferences(feature, feature, feature, 25, 8, 10, 25));
@@ -60,7 +58,7 @@ class ElevatorHopEdgeTest {
     assertNotNull(result);
     assertTrue(result.weight > 1);
 
-    req = AStarRequest.copyOf(req).setWheelchair(true).build();
+    req = AStarRequest.copyOf(req).withWheelchair(true).build();
     var wheelchairResult = traverse(wheelchair, req);
     assertNotNull(wheelchairResult);
     assertEquals(expectedCost, wheelchairResult.weight);

--- a/src/test/java/org/opentripplanner/routing/edgetype/ElevatorHopEdgeTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/ElevatorHopEdgeTest.java
@@ -8,10 +8,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.routing.api.request.preference.AccessibilityPreferences;
 import org.opentripplanner.routing.api.request.preference.WheelchairPreferences;
+import org.opentripplanner.routing.core.AStarRequest;
+import org.opentripplanner.routing.core.AStarRequestBuilder;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
@@ -32,13 +33,13 @@ class ElevatorHopEdgeTest {
   @ParameterizedTest(name = "{0} should be allowed to traverse when requesting onlyAccessible")
   @VariableSource("noTraverse")
   public void shouldNotTraverse(Accessibility wheelchair) {
-    var req = new RouteRequest();
+    var req = AStarRequest.of();
     AccessibilityPreferences feature = AccessibilityPreferences.ofOnlyAccessible();
     req.setWheelchair(true);
     req
       .preferences()
       .setWheelchair(new WheelchairPreferences(feature, feature, feature, 25, 8, 10, 25));
-    State result = traverse(wheelchair, req);
+    State result = traverse(wheelchair, req.build());
     assertNull(result);
   }
 
@@ -54,20 +55,20 @@ class ElevatorHopEdgeTest {
   @ParameterizedTest(name = "{0} should allowed to traverse with a cost of {1}")
   @VariableSource("all")
   public void allowByDefault(Accessibility wheelchair, double expectedCost) {
-    var req = new RouteRequest();
+    var req = AStarRequest.of().build();
     var result = traverse(wheelchair, req);
     assertNotNull(result);
     assertTrue(result.weight > 1);
 
-    req.setWheelchair(true);
+    req = AStarRequest.copyOf(req).setWheelchair(true).build();
     var wheelchairResult = traverse(wheelchair, req);
     assertNotNull(wheelchairResult);
     assertEquals(expectedCost, wheelchairResult.weight);
   }
 
-  private State traverse(Accessibility wheelchair, RouteRequest req) {
+  private State traverse(Accessibility wheelchair, AStarRequest req) {
     var edge = new ElevatorHopEdge(from, to, StreetTraversalPermission.ALL, wheelchair);
-    var state = State.create(from, req, StreetMode.WALK);
+    var state = new State(from, req);
 
     return edge.traverse(state);
   }

--- a/src/test/java/org/opentripplanner/routing/edgetype/ElevatorHopEdgeTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/ElevatorHopEdgeTest.java
@@ -67,7 +67,7 @@ class ElevatorHopEdgeTest {
 
   private State traverse(Accessibility wheelchair, RouteRequest req) {
     var edge = new ElevatorHopEdge(from, to, StreetTraversalPermission.ALL, wheelchair);
-    var state = State.createState(from, req, StreetMode.WALK);
+    var state = State.create(from, req, StreetMode.WALK);
 
     return edge.traverse(state);
   }

--- a/src/test/java/org/opentripplanner/routing/edgetype/PathwayEdgeTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/PathwayEdgeTest.java
@@ -194,7 +194,7 @@ class PathwayEdgeTest {
   }
 
   private State assertThatEdgeIsTraversable(PathwayEdge edge, boolean wheelchair) {
-    var req = AStarRequest.of().setWheelchair(wheelchair).setMode(StreetMode.WALK);
+    var req = AStarRequest.of().withWheelchair(wheelchair).withMode(StreetMode.WALK);
 
     req
       .preferences()

--- a/src/test/java/org/opentripplanner/routing/edgetype/PathwayEdgeTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/PathwayEdgeTest.java
@@ -209,7 +209,7 @@ class PathwayEdgeTest {
           25
         )
       );
-    var state = new State(from, req, StreetMode.WALK);
+    var state = State.createState(from, req, StreetMode.WALK);
 
     var afterTraversal = edge.traverse(state);
     assertNotNull(afterTraversal);

--- a/src/test/java/org/opentripplanner/routing/edgetype/PathwayEdgeTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/PathwayEdgeTest.java
@@ -9,9 +9,9 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.routing.api.request.preference.WheelchairPreferences;
+import org.opentripplanner.routing.core.AStarRequest;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
@@ -194,8 +194,8 @@ class PathwayEdgeTest {
   }
 
   private State assertThatEdgeIsTraversable(PathwayEdge edge, boolean wheelchair) {
-    var req = new RouteRequest();
-    req.setWheelchair(wheelchair);
+    var req = AStarRequest.of().setWheelchair(wheelchair).setMode(StreetMode.WALK);
+
     req
       .preferences()
       .setWheelchair(
@@ -209,9 +209,8 @@ class PathwayEdgeTest {
           25
         )
       );
-    var state = State.create(from, req, StreetMode.WALK);
 
-    var afterTraversal = edge.traverse(state);
+    var afterTraversal = edge.traverse(new State(from, req.build()));
     assertNotNull(afterTraversal);
 
     assertTrue(afterTraversal.getWeight() > 0);

--- a/src/test/java/org/opentripplanner/routing/edgetype/PathwayEdgeTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/PathwayEdgeTest.java
@@ -209,7 +209,7 @@ class PathwayEdgeTest {
           25
         )
       );
-    var state = State.createState(from, req, StreetMode.WALK);
+    var state = State.create(from, req, StreetMode.WALK);
 
     var afterTraversal = edge.traverse(state);
     assertNotNull(afterTraversal);

--- a/src/test/java/org/opentripplanner/routing/edgetype/StreetEdgeCostTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/StreetEdgeCostTest.java
@@ -45,7 +45,7 @@ class StreetEdgeCostTest extends GraphRoutingTest {
 
     var req = AStarRequest.of();
     req.preferences().withWalk(w -> w.setReluctance(walkReluctance));
-    State result = traverse(edge, req.setMode(StreetMode.WALK).build());
+    State result = traverse(edge, req.withMode(StreetMode.WALK).build());
     assertNotNull(result);
     assertEquals(expectedCost, (long) result.weight);
 
@@ -68,7 +68,7 @@ class StreetEdgeCostTest extends GraphRoutingTest {
     var req = AStarRequest.of();
     req.preferences().withBike(bike -> bike.setReluctance(bikeReluctance));
 
-    State result = traverse(edge, req.setMode(StreetMode.BIKE).build());
+    State result = traverse(edge, req.withMode(StreetMode.BIKE).build());
     assertNotNull(result);
     assertEquals(expectedCost, (long) result.weight);
 
@@ -91,7 +91,7 @@ class StreetEdgeCostTest extends GraphRoutingTest {
     var req = AStarRequest.of();
     req.preferences().car().setReluctance(carReluctance);
 
-    State result = traverse(edge, req.setMode(StreetMode.CAR).build());
+    State result = traverse(edge, req.withMode(StreetMode.CAR).build());
     assertNotNull(result);
     assertEquals(expectedCost, (long) result.weight);
 
@@ -113,7 +113,7 @@ class StreetEdgeCostTest extends GraphRoutingTest {
 
     var req = AStarRequest.of();
     req.preferences().withWalk(w -> w.setStairsReluctance(stairsReluctance));
-    req.setMode(StreetMode.WALK);
+    req.withMode(StreetMode.WALK);
     var result = traverse(edge, req.build());
     assertEquals(expectedCost, (long) result.weight);
 
@@ -147,7 +147,7 @@ class StreetEdgeCostTest extends GraphRoutingTest {
 
     var req = AStarRequest.of();
     req.preferences().withWalk(w -> w.setSafetyFactor(walkSafetyFactor));
-    req.setMode(StreetMode.WALK);
+    req.withMode(StreetMode.WALK);
     var result = traverse(edge, req.build());
     assertEquals(expectedCost, (long) result.weight);
 

--- a/src/test/java/org/opentripplanner/routing/edgetype/StreetEdgeCostTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/StreetEdgeCostTest.java
@@ -159,7 +159,7 @@ class StreetEdgeCostTest extends GraphRoutingTest {
   }
 
   private State traverse(StreetEdge edge, RouteRequest req, StreetMode streetMode) {
-    var state = new State(V1, req, streetMode);
+    var state = State.createState(V1, req, streetMode);
 
     assertEquals(0, state.weight);
     return edge.traverse(state);

--- a/src/test/java/org/opentripplanner/routing/edgetype/StreetEdgeCostTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/StreetEdgeCostTest.java
@@ -159,7 +159,7 @@ class StreetEdgeCostTest extends GraphRoutingTest {
   }
 
   private State traverse(StreetEdge edge, RouteRequest req, StreetMode streetMode) {
-    var state = State.createState(V1, req, streetMode);
+    var state = State.create(V1, req, streetMode);
 
     assertEquals(0, state.weight);
     return edge.traverse(state);

--- a/src/test/java/org/opentripplanner/routing/edgetype/StreetEdgeCostTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/StreetEdgeCostTest.java
@@ -7,8 +7,8 @@ import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.opentripplanner.routing.algorithm.GraphRoutingTest;
-import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
+import org.opentripplanner.routing.core.AStarRequest;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.vertextype.StreetVertex;
 import org.opentripplanner.test.support.VariableSource;
@@ -43,9 +43,9 @@ class StreetEdgeCostTest extends GraphRoutingTest {
     double length = 100;
     var edge = new StreetEdge(V1, V2, null, "edge", length, StreetTraversalPermission.ALL, false);
 
-    var req = new RouteRequest();
+    var req = AStarRequest.of();
     req.preferences().withWalk(w -> w.setReluctance(walkReluctance));
-    State result = traverse(edge, req, StreetMode.WALK);
+    State result = traverse(edge, req.setMode(StreetMode.WALK).build());
     assertNotNull(result);
     assertEquals(expectedCost, (long) result.weight);
 
@@ -65,10 +65,10 @@ class StreetEdgeCostTest extends GraphRoutingTest {
     double length = 100;
     var edge = new StreetEdge(V1, V2, null, "edge", length, StreetTraversalPermission.ALL, false);
 
-    var req = new RouteRequest();
+    var req = AStarRequest.of();
     req.preferences().withBike(bike -> bike.setReluctance(bikeReluctance));
 
-    State result = traverse(edge, req, StreetMode.BIKE);
+    State result = traverse(edge, req.setMode(StreetMode.BIKE).build());
     assertNotNull(result);
     assertEquals(expectedCost, (long) result.weight);
 
@@ -88,10 +88,10 @@ class StreetEdgeCostTest extends GraphRoutingTest {
     double length = 100;
     var edge = new StreetEdge(V1, V2, null, "edge", length, StreetTraversalPermission.ALL, false);
 
-    var req = new RouteRequest();
+    var req = AStarRequest.of();
     req.preferences().car().setReluctance(carReluctance);
 
-    State result = traverse(edge, req, StreetMode.CAR);
+    State result = traverse(edge, req.setMode(StreetMode.CAR).build());
     assertNotNull(result);
     assertEquals(expectedCost, (long) result.weight);
 
@@ -111,16 +111,16 @@ class StreetEdgeCostTest extends GraphRoutingTest {
     var edge = new StreetEdge(V1, V2, null, "stairs", length, StreetTraversalPermission.ALL, false);
     edge.setStairs(true);
 
-    var req = new RouteRequest();
+    var req = AStarRequest.of();
     req.preferences().withWalk(w -> w.setStairsReluctance(stairsReluctance));
-
-    var result = traverse(edge, req, StreetMode.WALK);
+    req.setMode(StreetMode.WALK);
+    var result = traverse(edge, req.build());
     assertEquals(expectedCost, (long) result.weight);
 
     assertEquals(23, result.getElapsedTimeSeconds());
 
     edge.setStairs(false);
-    var notStairsResult = traverse(edge, req, StreetMode.WALK);
+    var notStairsResult = traverse(edge, req.build());
     assertEquals(15, (long) notStairsResult.weight);
   }
 
@@ -145,21 +145,21 @@ class StreetEdgeCostTest extends GraphRoutingTest {
     );
     edge.setWalkSafetyFactor(2);
 
-    var req = new RouteRequest();
+    var req = AStarRequest.of();
     req.preferences().withWalk(w -> w.setSafetyFactor(walkSafetyFactor));
-
-    var result = traverse(edge, req, StreetMode.WALK);
+    req.setMode(StreetMode.WALK);
+    var result = traverse(edge, req.build());
     assertEquals(expectedCost, (long) result.weight);
 
     assertEquals(8, result.getElapsedTimeSeconds());
 
     edge.setWalkSafetyFactor(1);
-    var defaultSafetyResult = traverse(edge, req, StreetMode.WALK);
+    var defaultSafetyResult = traverse(edge, req.build());
     assertEquals(15, (long) defaultSafetyResult.weight);
   }
 
-  private State traverse(StreetEdge edge, RouteRequest req, StreetMode streetMode) {
-    var state = State.create(V1, req, streetMode);
+  private State traverse(StreetEdge edge, AStarRequest request) {
+    var state = new State(V1, request);
 
     assertEquals(0, state.weight);
     return edge.traverse(state);

--- a/src/test/java/org/opentripplanner/routing/edgetype/StreetEdgeTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/StreetEdgeTest.java
@@ -86,7 +86,7 @@ public class StreetEdgeTest {
 
     AStarRequestBuilder options = AStarRequest.copyOf(proto);
 
-    State s0 = new State(v1, options.setMode(StreetMode.WALK).build());
+    State s0 = new State(v1, options.withMode(StreetMode.WALK).build());
     State s1 = e1.traverse(s0);
 
     // Should use the speed on the edge.
@@ -101,7 +101,7 @@ public class StreetEdgeTest {
     StreetEdge e1 = edge(v1, v2, 100.0, StreetTraversalPermission.ALL);
     e1.setCarSpeed(10.0f);
 
-    State s0 = new State(v1, AStarRequest.copyOf(proto).setMode(StreetMode.CAR).build());
+    State s0 = new State(v1, AStarRequest.copyOf(proto).withMode(StreetMode.CAR).build());
     State s1 = e1.traverse(s0);
 
     // Should use the speed on the edge.
@@ -145,15 +145,15 @@ public class StreetEdgeTest {
     AStarRequestBuilder forward = AStarRequest.copyOf(proto);
     forward.preferences().withBike(it -> it.setSpeed(3.0f));
 
-    State s0 = new State(v0, forward.setMode(StreetMode.BIKE).build());
+    State s0 = new State(v0, forward.withMode(StreetMode.BIKE).build());
     State s1 = e0.traverse(s0);
     State s2 = e1.traverse(s1);
 
     AStarRequestBuilder reverse = AStarRequest.copyOf(proto);
-    reverse.setArriveBy(true);
+    reverse.withArriveBy(true);
     reverse.preferences().withBike(it -> it.setSpeed(3.0f));
 
-    State s3 = new State(v2, reverse.setMode(StreetMode.BIKE).build());
+    State s3 = new State(v2, reverse.withMode(StreetMode.BIKE).build());
     State s4 = e1.traverse(s3);
     State s5 = e0.traverse(s4);
 
@@ -177,14 +177,14 @@ public class StreetEdgeTest {
 
     AStarRequestBuilder forward = AStarRequest.copyOf(proto);
 
-    State s0 = new State(v0, forward.setMode(StreetMode.BIKE).build());
+    State s0 = new State(v0, forward.withMode(StreetMode.BIKE).build());
     State s1 = e0.traverse(s0);
     State s2 = e1.traverse(s1);
 
     AStarRequestBuilder reverse = AStarRequest.copyOf(proto);
-    reverse.setArriveBy(true);
+    reverse.withArriveBy(true);
 
-    State s3 = new State(v2, reverse.setMode(StreetMode.BIKE).build());
+    State s3 = new State(v2, reverse.withMode(StreetMode.BIKE).build());
     State s4 = e1.traverse(s3);
     State s5 = e0.traverse(s4);
 
@@ -204,7 +204,7 @@ public class StreetEdgeTest {
     AStarRequestBuilder noPenalty = AStarRequest.copyOf(proto);
     noPenalty.preferences().withBike(it -> it.setSwitchTime(0).setSwitchCost(0));
 
-    State s0 = new State(v0, noPenalty.setMode(StreetMode.BIKE).build());
+    State s0 = new State(v0, noPenalty.withMode(StreetMode.BIKE).build());
     State s1 = e0.traverse(s0);
     State s2 = e1.traverse(s1);
     State s3 = e2.traverse(s2);
@@ -212,7 +212,7 @@ public class StreetEdgeTest {
     AStarRequestBuilder withPenalty = AStarRequest.copyOf(proto);
     withPenalty.preferences().withBike(it -> it.setSwitchTime(42).setSwitchCost(23));
 
-    State s4 = new State(v0, withPenalty.setMode(StreetMode.BIKE).build());
+    State s4 = new State(v0, withPenalty.withMode(StreetMode.BIKE).build());
     State s5 = e0.traverse(s4);
     State s6 = e1.traverse(s5);
     State s7 = e2.traverse(s6);
@@ -253,8 +253,8 @@ public class StreetEdgeTest {
     StreetEdge e0 = edge(v0, v1, 50.0, StreetTraversalPermission.ALL);
     StreetEdge e1 = edge(v1, v2, 18.4, StreetTraversalPermission.ALL);
     AStarRequestBuilder aStarRequestBuilder = AStarRequest.copyOf(proto);
-    aStarRequestBuilder.setArriveBy(true);
-    AStarRequest request = aStarRequestBuilder.setMode(StreetMode.WALK).build();
+    aStarRequestBuilder.withArriveBy(true);
+    AStarRequest request = aStarRequestBuilder.withMode(StreetMode.WALK).build();
     State state = new State(v2, Instant.EPOCH, StateData.getInitialStateData(request), request);
 
     e1.addTurnRestriction(new TurnRestriction(e1, e0, null, TraverseModeSet.allModes(), null));
@@ -364,7 +364,7 @@ public class StreetEdgeTest {
     double slopeWorkLength = testStreet.getEffectiveBikeDistanceForWorkCost();
     double slopeSpeedLength = testStreet.getEffectiveBikeDistance();
 
-    var request = AStarRequest.of().setMode(StreetMode.BIKE);
+    var request = AStarRequest.of().withMode(StreetMode.BIKE);
 
     request
       .preferences()

--- a/src/test/java/org/opentripplanner/routing/edgetype/StreetEdgeTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/StreetEdgeTest.java
@@ -254,6 +254,7 @@ public class StreetEdgeTest {
     StreetEdge e0 = edge(v0, v1, 50.0, StreetTraversalPermission.ALL);
     StreetEdge e1 = edge(v1, v2, 18.4, StreetTraversalPermission.ALL);
     RouteRequest routingRequest = proto.clone();
+    routingRequest.setArriveBy(true);
     State state = new State(
       v2,
       Instant.EPOCH,
@@ -261,7 +262,6 @@ public class StreetEdgeTest {
       new AStarRequest(routingRequest.dateTime(), routingRequest, StreetMode.WALK)
     );
 
-    state.getOptions().setArriveBy(true);
     e1.addTurnRestriction(new TurnRestriction(e1, e0, null, TraverseModeSet.allModes(), null));
 
     assertNotNull(e0.traverse(e1.traverse(state)));

--- a/src/test/java/org/opentripplanner/routing/edgetype/StreetEdgeTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/StreetEdgeTest.java
@@ -85,7 +85,7 @@ public class StreetEdgeTest {
 
     RouteRequest options = proto.clone();
 
-    State s0 = State.createState(v1, options, StreetMode.WALK);
+    State s0 = State.create(v1, options, StreetMode.WALK);
     State s1 = e1.traverse(s0);
 
     // Should use the speed on the edge.
@@ -102,7 +102,7 @@ public class StreetEdgeTest {
 
     RouteRequest options = proto.clone();
 
-    State s0 = State.createState(v1, options, StreetMode.CAR);
+    State s0 = State.create(v1, options, StreetMode.CAR);
     State s1 = e1.traverse(s0);
 
     // Should use the speed on the edge.
@@ -146,7 +146,7 @@ public class StreetEdgeTest {
     RouteRequest forward = proto.clone();
     forward.preferences().withBike(it -> it.setSpeed(3.0f));
 
-    State s0 = State.createState(v0, forward, StreetMode.BIKE);
+    State s0 = State.create(v0, forward, StreetMode.BIKE);
     State s1 = e0.traverse(s0);
     State s2 = e1.traverse(s1);
 
@@ -154,7 +154,7 @@ public class StreetEdgeTest {
     reverse.setArriveBy(true);
     reverse.preferences().withBike(it -> it.setSpeed(3.0f));
 
-    State s3 = State.createState(v2, reverse, StreetMode.BIKE);
+    State s3 = State.create(v2, reverse, StreetMode.BIKE);
     State s4 = e1.traverse(s3);
     State s5 = e0.traverse(s4);
 
@@ -178,14 +178,14 @@ public class StreetEdgeTest {
 
     RouteRequest forward = proto.clone();
 
-    State s0 = State.createState(v0, forward, StreetMode.BIKE);
+    State s0 = State.create(v0, forward, StreetMode.BIKE);
     State s1 = e0.traverse(s0);
     State s2 = e1.traverse(s1);
 
     RouteRequest reverse = proto.clone();
     reverse.setArriveBy(true);
 
-    State s3 = State.createState(v2, reverse, StreetMode.BIKE);
+    State s3 = State.create(v2, reverse, StreetMode.BIKE);
     State s4 = e1.traverse(s3);
     State s5 = e0.traverse(s4);
 
@@ -205,7 +205,7 @@ public class StreetEdgeTest {
     RouteRequest noPenalty = proto.clone();
     noPenalty.preferences().withBike(it -> it.setSwitchTime(0).setSwitchCost(0));
 
-    State s0 = State.createState(v0, noPenalty, StreetMode.BIKE);
+    State s0 = State.create(v0, noPenalty, StreetMode.BIKE);
     State s1 = e0.traverse(s0);
     State s2 = e1.traverse(s1);
     State s3 = e2.traverse(s2);
@@ -213,7 +213,7 @@ public class StreetEdgeTest {
     RouteRequest withPenalty = proto.clone();
     withPenalty.preferences().withBike(it -> it.setSwitchTime(42).setSwitchCost(23));
 
-    State s4 = State.createState(v0, withPenalty, StreetMode.BIKE);
+    State s4 = State.create(v0, withPenalty, StreetMode.BIKE);
     State s5 = e0.traverse(s4);
     State s6 = e1.traverse(s5);
     State s7 = e2.traverse(s6);
@@ -381,14 +381,14 @@ public class StreetEdgeTest {
       );
     request.preferences().setAllStreetReluctance(1);
 
-    State startState = State.createState(v1, request, StreetMode.BIKE);
+    State startState = State.create(v1, request, StreetMode.BIKE);
     State result = testStreet.traverse(startState);
     double timeWeight = result.getWeight();
     double expectedTimeWeight = slopeSpeedLength / SPEED;
     assertEquals(expectedTimeWeight, result.getWeight(), DELTA);
 
     request.preferences().withBike(bike -> bike.withOptimizeTriangle(it -> it.withSlope(1)));
-    startState = State.createState(v1, request, StreetMode.BIKE);
+    startState = State.create(v1, request, StreetMode.BIKE);
     result = testStreet.traverse(startState);
     double slopeWeight = result.getWeight();
     double expectedSlopeWeight = slopeWorkLength / SPEED;
@@ -397,7 +397,7 @@ public class StreetEdgeTest {
     assertTrue(length * 1.5 * 10 / SPEED > slopeWeight);
 
     request.preferences().withBike(bike -> bike.withOptimizeTriangle(it -> it.withSafety(1)));
-    startState = State.createState(v1, request, StreetMode.BIKE);
+    startState = State.create(v1, request, StreetMode.BIKE);
     result = testStreet.traverse(startState);
     double slopeSafety = costs.slopeSafetyCost;
     double safetyWeight = result.getWeight();
@@ -407,7 +407,7 @@ public class StreetEdgeTest {
     request
       .preferences()
       .withBike(bike -> bike.withOptimizeTriangle(it -> it.withTime(1).withSlope(1).withSafety(1)));
-    startState = State.createState(v1, request, StreetMode.BIKE);
+    startState = State.create(v1, request, StreetMode.BIKE);
     result = testStreet.traverse(startState);
     double expectedWeight = timeWeight * 0.33 + slopeWeight * 0.33 + safetyWeight * 0.34;
     assertEquals(expectedWeight, result.getWeight(), DELTA);

--- a/src/test/java/org/opentripplanner/routing/edgetype/StreetEdgeTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/StreetEdgeTest.java
@@ -85,7 +85,7 @@ public class StreetEdgeTest {
 
     RouteRequest options = proto.clone();
 
-    State s0 = new State(v1, options, StreetMode.WALK);
+    State s0 = State.createState(v1, options, StreetMode.WALK);
     State s1 = e1.traverse(s0);
 
     // Should use the speed on the edge.
@@ -102,7 +102,7 @@ public class StreetEdgeTest {
 
     RouteRequest options = proto.clone();
 
-    State s0 = new State(v1, options, StreetMode.CAR);
+    State s0 = State.createState(v1, options, StreetMode.CAR);
     State s1 = e1.traverse(s0);
 
     // Should use the speed on the edge.
@@ -146,7 +146,7 @@ public class StreetEdgeTest {
     RouteRequest forward = proto.clone();
     forward.preferences().withBike(it -> it.setSpeed(3.0f));
 
-    State s0 = new State(v0, forward, StreetMode.BIKE);
+    State s0 = State.createState(v0, forward, StreetMode.BIKE);
     State s1 = e0.traverse(s0);
     State s2 = e1.traverse(s1);
 
@@ -154,7 +154,7 @@ public class StreetEdgeTest {
     reverse.setArriveBy(true);
     reverse.preferences().withBike(it -> it.setSpeed(3.0f));
 
-    State s3 = new State(v2, reverse, StreetMode.BIKE);
+    State s3 = State.createState(v2, reverse, StreetMode.BIKE);
     State s4 = e1.traverse(s3);
     State s5 = e0.traverse(s4);
 
@@ -178,14 +178,14 @@ public class StreetEdgeTest {
 
     RouteRequest forward = proto.clone();
 
-    State s0 = new State(v0, forward, StreetMode.BIKE);
+    State s0 = State.createState(v0, forward, StreetMode.BIKE);
     State s1 = e0.traverse(s0);
     State s2 = e1.traverse(s1);
 
     RouteRequest reverse = proto.clone();
     reverse.setArriveBy(true);
 
-    State s3 = new State(v2, reverse, StreetMode.BIKE);
+    State s3 = State.createState(v2, reverse, StreetMode.BIKE);
     State s4 = e1.traverse(s3);
     State s5 = e0.traverse(s4);
 
@@ -205,7 +205,7 @@ public class StreetEdgeTest {
     RouteRequest noPenalty = proto.clone();
     noPenalty.preferences().withBike(it -> it.setSwitchTime(0).setSwitchCost(0));
 
-    State s0 = new State(v0, noPenalty, StreetMode.BIKE);
+    State s0 = State.createState(v0, noPenalty, StreetMode.BIKE);
     State s1 = e0.traverse(s0);
     State s2 = e1.traverse(s1);
     State s3 = e2.traverse(s2);
@@ -213,7 +213,7 @@ public class StreetEdgeTest {
     RouteRequest withPenalty = proto.clone();
     withPenalty.preferences().withBike(it -> it.setSwitchTime(42).setSwitchCost(23));
 
-    State s4 = new State(v0, withPenalty, StreetMode.BIKE);
+    State s4 = State.createState(v0, withPenalty, StreetMode.BIKE);
     State s5 = e0.traverse(s4);
     State s6 = e1.traverse(s5);
     State s7 = e2.traverse(s6);
@@ -255,12 +255,12 @@ public class StreetEdgeTest {
     StreetEdge e1 = edge(v1, v2, 18.4, StreetTraversalPermission.ALL);
     RouteRequest routingRequest = proto.clone();
     routingRequest.setArriveBy(true);
-    State state = new State(
-      v2,
-      Instant.EPOCH,
-      StateData.getInitialStateData(routingRequest, StreetMode.WALK),
-      new AStarRequest(routingRequest.dateTime(), routingRequest, StreetMode.WALK)
+    AStarRequest request = new AStarRequest(
+      routingRequest.dateTime(),
+      routingRequest,
+      StreetMode.WALK
     );
+    State state = new State(v2, Instant.EPOCH, StateData.getInitialStateData(request), request);
 
     e1.addTurnRestriction(new TurnRestriction(e1, e0, null, TraverseModeSet.allModes(), null));
 
@@ -381,14 +381,14 @@ public class StreetEdgeTest {
       );
     request.preferences().setAllStreetReluctance(1);
 
-    State startState = new State(v1, request, StreetMode.BIKE);
+    State startState = State.createState(v1, request, StreetMode.BIKE);
     State result = testStreet.traverse(startState);
     double timeWeight = result.getWeight();
     double expectedTimeWeight = slopeSpeedLength / SPEED;
     assertEquals(expectedTimeWeight, result.getWeight(), DELTA);
 
     request.preferences().withBike(bike -> bike.withOptimizeTriangle(it -> it.withSlope(1)));
-    startState = new State(v1, request, StreetMode.BIKE);
+    startState = State.createState(v1, request, StreetMode.BIKE);
     result = testStreet.traverse(startState);
     double slopeWeight = result.getWeight();
     double expectedSlopeWeight = slopeWorkLength / SPEED;
@@ -397,7 +397,7 @@ public class StreetEdgeTest {
     assertTrue(length * 1.5 * 10 / SPEED > slopeWeight);
 
     request.preferences().withBike(bike -> bike.withOptimizeTriangle(it -> it.withSafety(1)));
-    startState = new State(v1, request, StreetMode.BIKE);
+    startState = State.createState(v1, request, StreetMode.BIKE);
     result = testStreet.traverse(startState);
     double slopeSafety = costs.slopeSafetyCost;
     double safetyWeight = result.getWeight();
@@ -407,7 +407,7 @@ public class StreetEdgeTest {
     request
       .preferences()
       .withBike(bike -> bike.withOptimizeTriangle(it -> it.withTime(1).withSlope(1).withSafety(1)));
-    startState = new State(v1, request, StreetMode.BIKE);
+    startState = State.createState(v1, request, StreetMode.BIKE);
     result = testStreet.traverse(startState);
     double expectedWeight = timeWeight * 0.33 + slopeWeight * 0.33 + safetyWeight * 0.34;
     assertEquals(expectedWeight, result.getWeight(), DELTA);

--- a/src/test/java/org/opentripplanner/routing/edgetype/StreetEdgeTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/StreetEdgeTest.java
@@ -17,6 +17,7 @@ import org.locationtech.jts.geom.impl.PackedCoordinateSequence;
 import org.opentripplanner.common.TurnRestriction;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
+import org.opentripplanner.routing.core.AStarRequest;
 import org.opentripplanner.routing.core.BicycleOptimizeType;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.core.StateData;
@@ -256,7 +257,8 @@ public class StreetEdgeTest {
     State state = new State(
       v2,
       Instant.EPOCH,
-      StateData.getInitialStateData(routingRequest, StreetMode.WALK)
+      StateData.getInitialStateData(routingRequest, StreetMode.WALK),
+      new AStarRequest(routingRequest.dateTime(), routingRequest, StreetMode.WALK)
     );
 
     state.getOptions().setArriveBy(true);

--- a/src/test/java/org/opentripplanner/routing/edgetype/StreetEdgeTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/StreetEdgeTest.java
@@ -15,9 +15,9 @@ import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.impl.PackedCoordinateSequence;
 import org.opentripplanner.common.TurnRestriction;
-import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.routing.core.AStarRequest;
+import org.opentripplanner.routing.core.AStarRequestBuilder;
 import org.opentripplanner.routing.core.BicycleOptimizeType;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.core.StateData;
@@ -38,7 +38,7 @@ public class StreetEdgeTest {
 
   private Graph graph;
   private IntersectionVertex v0, v1, v2;
-  private RouteRequest proto;
+  private AStarRequest proto;
 
   @BeforeEach
   public void before() {
@@ -48,13 +48,14 @@ public class StreetEdgeTest {
     v1 = vertex("maple_1st", 2.0, 2.0);
     v2 = vertex("maple_2nd", 1.0, 2.0);
 
-    proto = new RouteRequest();
-    var pref = proto.preferences();
+    var req = AStarRequest.of();
+    var pref = req.preferences();
     pref.street().setTurnReluctance(1.0);
     pref.withWalk(it -> it.setSpeed(1.0).setReluctance(1.0).setStairsReluctance(1.0));
     pref.withBike(it -> it.setSpeed(5.0f).setReluctance(1.0).setWalkingSpeed(0.8));
     pref.car().setSpeed(15.0f);
     pref.car().setReluctance(1.0);
+    this.proto = req.build();
   }
 
   @Test
@@ -83,9 +84,9 @@ public class StreetEdgeTest {
     StreetEdge e1 = edge(v1, v2, 100.0, StreetTraversalPermission.ALL);
     e1.setCarSpeed(10.0f);
 
-    RouteRequest options = proto.clone();
+    AStarRequestBuilder options = AStarRequest.copyOf(proto);
 
-    State s0 = State.create(v1, options, StreetMode.WALK);
+    State s0 = new State(v1, options.setMode(StreetMode.WALK).build());
     State s1 = e1.traverse(s0);
 
     // Should use the speed on the edge.
@@ -100,9 +101,7 @@ public class StreetEdgeTest {
     StreetEdge e1 = edge(v1, v2, 100.0, StreetTraversalPermission.ALL);
     e1.setCarSpeed(10.0f);
 
-    RouteRequest options = proto.clone();
-
-    State s0 = State.create(v1, options, StreetMode.CAR);
+    State s0 = new State(v1, AStarRequest.copyOf(proto).setMode(StreetMode.CAR).build());
     State s1 = e1.traverse(s0);
 
     // Should use the speed on the edge.
@@ -143,18 +142,18 @@ public class StreetEdgeTest {
 
     v1.trafficLight = true;
 
-    RouteRequest forward = proto.clone();
+    AStarRequestBuilder forward = AStarRequest.copyOf(proto);
     forward.preferences().withBike(it -> it.setSpeed(3.0f));
 
-    State s0 = State.create(v0, forward, StreetMode.BIKE);
+    State s0 = new State(v0, forward.setMode(StreetMode.BIKE).build());
     State s1 = e0.traverse(s0);
     State s2 = e1.traverse(s1);
 
-    RouteRequest reverse = proto.clone();
+    AStarRequestBuilder reverse = AStarRequest.copyOf(proto);
     reverse.setArriveBy(true);
     reverse.preferences().withBike(it -> it.setSpeed(3.0f));
 
-    State s3 = State.create(v2, reverse, StreetMode.BIKE);
+    State s3 = new State(v2, reverse.setMode(StreetMode.BIKE).build());
     State s4 = e1.traverse(s3);
     State s5 = e0.traverse(s4);
 
@@ -176,16 +175,16 @@ public class StreetEdgeTest {
 
     v1.trafficLight = true;
 
-    RouteRequest forward = proto.clone();
+    AStarRequestBuilder forward = AStarRequest.copyOf(proto);
 
-    State s0 = State.create(v0, forward, StreetMode.BIKE);
+    State s0 = new State(v0, forward.setMode(StreetMode.BIKE).build());
     State s1 = e0.traverse(s0);
     State s2 = e1.traverse(s1);
 
-    RouteRequest reverse = proto.clone();
+    AStarRequestBuilder reverse = AStarRequest.copyOf(proto);
     reverse.setArriveBy(true);
 
-    State s3 = State.create(v2, reverse, StreetMode.BIKE);
+    State s3 = new State(v2, reverse.setMode(StreetMode.BIKE).build());
     State s4 = e1.traverse(s3);
     State s5 = e0.traverse(s4);
 
@@ -202,18 +201,18 @@ public class StreetEdgeTest {
     StreetEdge e1 = edge(v1, v2, 0.0, StreetTraversalPermission.BICYCLE);
     StreetEdge e2 = edge(v2, v0, 0.0, StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE);
 
-    RouteRequest noPenalty = proto.clone();
+    AStarRequestBuilder noPenalty = AStarRequest.copyOf(proto);
     noPenalty.preferences().withBike(it -> it.setSwitchTime(0).setSwitchCost(0));
 
-    State s0 = State.create(v0, noPenalty, StreetMode.BIKE);
+    State s0 = new State(v0, noPenalty.setMode(StreetMode.BIKE).build());
     State s1 = e0.traverse(s0);
     State s2 = e1.traverse(s1);
     State s3 = e2.traverse(s2);
 
-    RouteRequest withPenalty = proto.clone();
+    AStarRequestBuilder withPenalty = AStarRequest.copyOf(proto);
     withPenalty.preferences().withBike(it -> it.setSwitchTime(42).setSwitchCost(23));
 
-    State s4 = State.create(v0, withPenalty, StreetMode.BIKE);
+    State s4 = new State(v0, withPenalty.setMode(StreetMode.BIKE).build());
     State s5 = e0.traverse(s4);
     State s6 = e1.traverse(s5);
     State s7 = e2.traverse(s6);
@@ -253,13 +252,9 @@ public class StreetEdgeTest {
   public void testTurnRestriction() {
     StreetEdge e0 = edge(v0, v1, 50.0, StreetTraversalPermission.ALL);
     StreetEdge e1 = edge(v1, v2, 18.4, StreetTraversalPermission.ALL);
-    RouteRequest routingRequest = proto.clone();
-    routingRequest.setArriveBy(true);
-    AStarRequest request = new AStarRequest(
-      routingRequest.dateTime(),
-      routingRequest,
-      StreetMode.WALK
-    );
+    AStarRequestBuilder aStarRequestBuilder = AStarRequest.copyOf(proto);
+    aStarRequestBuilder.setArriveBy(true);
+    AStarRequest request = aStarRequestBuilder.setMode(StreetMode.WALK).build();
     State state = new State(v2, Instant.EPOCH, StateData.getInitialStateData(request), request);
 
     e1.addTurnRestriction(new TurnRestriction(e1, e0, null, TraverseModeSet.allModes(), null));
@@ -369,7 +364,7 @@ public class StreetEdgeTest {
     double slopeWorkLength = testStreet.getEffectiveBikeDistanceForWorkCost();
     double slopeSpeedLength = testStreet.getEffectiveBikeDistance();
 
-    var request = new RouteRequest();
+    var request = AStarRequest.of().setMode(StreetMode.BIKE);
 
     request
       .preferences()
@@ -381,14 +376,14 @@ public class StreetEdgeTest {
       );
     request.preferences().setAllStreetReluctance(1);
 
-    State startState = State.create(v1, request, StreetMode.BIKE);
+    State startState = new State(v1, request.build());
     State result = testStreet.traverse(startState);
     double timeWeight = result.getWeight();
     double expectedTimeWeight = slopeSpeedLength / SPEED;
     assertEquals(expectedTimeWeight, result.getWeight(), DELTA);
 
     request.preferences().withBike(bike -> bike.withOptimizeTriangle(it -> it.withSlope(1)));
-    startState = State.create(v1, request, StreetMode.BIKE);
+    startState = new State(v1, request.build());
     result = testStreet.traverse(startState);
     double slopeWeight = result.getWeight();
     double expectedSlopeWeight = slopeWorkLength / SPEED;
@@ -397,7 +392,7 @@ public class StreetEdgeTest {
     assertTrue(length * 1.5 * 10 / SPEED > slopeWeight);
 
     request.preferences().withBike(bike -> bike.withOptimizeTriangle(it -> it.withSafety(1)));
-    startState = State.create(v1, request, StreetMode.BIKE);
+    startState = new State(v1, request.build());
     result = testStreet.traverse(startState);
     double slopeSafety = costs.slopeSafetyCost;
     double safetyWeight = result.getWeight();
@@ -407,7 +402,7 @@ public class StreetEdgeTest {
     request
       .preferences()
       .withBike(bike -> bike.withOptimizeTriangle(it -> it.withTime(1).withSlope(1).withSafety(1)));
-    startState = State.create(v1, request, StreetMode.BIKE);
+    startState = new State(v1, request.build());
     result = testStreet.traverse(startState);
     double expectedWeight = timeWeight * 0.33 + slopeWeight * 0.33 + safetyWeight * 0.34;
     assertEquals(expectedWeight, result.getWeight(), DELTA);

--- a/src/test/java/org/opentripplanner/routing/edgetype/StreetEdgeWheelchairCostTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/StreetEdgeWheelchairCostTest.java
@@ -10,9 +10,8 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.impl.PackedCoordinateSequence;
 import org.opentripplanner.routing.algorithm.GraphRoutingTest;
-import org.opentripplanner.routing.api.request.RouteRequest;
-import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.routing.api.request.preference.WheelchairPreferences;
+import org.opentripplanner.routing.core.AStarRequest;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.vertextype.StreetVertex;
 import org.opentripplanner.test.support.VariableSource;
@@ -88,7 +87,7 @@ class StreetEdgeWheelchairCostTest extends GraphRoutingTest {
 
     assertEquals(slope, edge.getMaxSlope(), 0.0001);
 
-    var req = new RouteRequest();
+    var req = AStarRequest.of();
     req.setWheelchair(true);
     req
       .preferences()
@@ -103,7 +102,7 @@ class StreetEdgeWheelchairCostTest extends GraphRoutingTest {
           10
         )
       );
-    State result = traverse(edge, req);
+    State result = traverse(edge, req.build());
     assertNotNull(result);
     assertEquals(expectedCost, (long) result.weight);
   }
@@ -123,7 +122,7 @@ class StreetEdgeWheelchairCostTest extends GraphRoutingTest {
     var edge = new StreetEdge(V1, V2, null, "stairs", length, StreetTraversalPermission.ALL, false);
     edge.setStairs(true);
 
-    var req = new RouteRequest();
+    var req = AStarRequest.of();
     req.setWheelchair(true);
     req
       .preferences()
@@ -141,11 +140,11 @@ class StreetEdgeWheelchairCostTest extends GraphRoutingTest {
 
     req.preferences().withWalk(w -> w.setReluctance(1.0));
 
-    var result = traverse(edge, req);
+    var result = traverse(edge, req.build());
     assertEquals(expectedCost, (long) result.weight);
 
     edge.setStairs(false);
-    var notStairsResult = traverse(edge, req);
+    var notStairsResult = traverse(edge, req.build());
     assertEquals(7, (long) notStairsResult.weight);
   }
 
@@ -164,7 +163,7 @@ class StreetEdgeWheelchairCostTest extends GraphRoutingTest {
     var edge = new StreetEdge(V1, V2, null, "stairs", length, StreetTraversalPermission.ALL, false);
     edge.setWheelchairAccessible(false);
 
-    var req = new RouteRequest();
+    var req = AStarRequest.of();
     req.setWheelchair(true);
     req
       .preferences()
@@ -180,12 +179,12 @@ class StreetEdgeWheelchairCostTest extends GraphRoutingTest {
         )
       );
 
-    var result = traverse(edge, req);
+    var result = traverse(edge, req.build());
     assertEquals(expectedCost, (long) result.weight);
 
     // reluctance should have no effect when the edge is accessible
     edge.setWheelchairAccessible(true);
-    var accessibleResult = traverse(edge, req);
+    var accessibleResult = traverse(edge, req.build());
     assertEquals(15, (long) accessibleResult.weight);
   }
 
@@ -204,18 +203,18 @@ class StreetEdgeWheelchairCostTest extends GraphRoutingTest {
     double length = 10;
     var edge = new StreetEdge(V1, V2, null, "stairs", length, StreetTraversalPermission.ALL, false);
 
-    var req = new RouteRequest();
+    var req = AStarRequest.of();
     req.preferences().withWalk(w -> w.setReluctance(walkReluctance));
     req.setWheelchair(true);
 
-    var result = traverse(edge, req);
+    var result = traverse(edge, req.build());
     assertEquals(expectedCost, (long) result.weight);
 
     assertEquals(8, result.getElapsedTimeSeconds());
   }
 
-  private State traverse(StreetEdge edge, RouteRequest req) {
-    var state = State.create(V1, req, StreetMode.WALK);
+  private State traverse(StreetEdge edge, AStarRequest req) {
+    var state = new State(V1, req);
 
     assertEquals(0, state.weight);
     return edge.traverse(state);

--- a/src/test/java/org/opentripplanner/routing/edgetype/StreetEdgeWheelchairCostTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/StreetEdgeWheelchairCostTest.java
@@ -215,7 +215,7 @@ class StreetEdgeWheelchairCostTest extends GraphRoutingTest {
   }
 
   private State traverse(StreetEdge edge, RouteRequest req) {
-    var state = State.createState(V1, req, StreetMode.WALK);
+    var state = State.create(V1, req, StreetMode.WALK);
 
     assertEquals(0, state.weight);
     return edge.traverse(state);

--- a/src/test/java/org/opentripplanner/routing/edgetype/StreetEdgeWheelchairCostTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/StreetEdgeWheelchairCostTest.java
@@ -88,7 +88,7 @@ class StreetEdgeWheelchairCostTest extends GraphRoutingTest {
     assertEquals(slope, edge.getMaxSlope(), 0.0001);
 
     var req = AStarRequest.of();
-    req.setWheelchair(true);
+    req.withWheelchair(true);
     req
       .preferences()
       .setWheelchair(
@@ -123,7 +123,7 @@ class StreetEdgeWheelchairCostTest extends GraphRoutingTest {
     edge.setStairs(true);
 
     var req = AStarRequest.of();
-    req.setWheelchair(true);
+    req.withWheelchair(true);
     req
       .preferences()
       .setWheelchair(
@@ -164,7 +164,7 @@ class StreetEdgeWheelchairCostTest extends GraphRoutingTest {
     edge.setWheelchairAccessible(false);
 
     var req = AStarRequest.of();
-    req.setWheelchair(true);
+    req.withWheelchair(true);
     req
       .preferences()
       .setWheelchair(
@@ -205,7 +205,7 @@ class StreetEdgeWheelchairCostTest extends GraphRoutingTest {
 
     var req = AStarRequest.of();
     req.preferences().withWalk(w -> w.setReluctance(walkReluctance));
-    req.setWheelchair(true);
+    req.withWheelchair(true);
 
     var result = traverse(edge, req.build());
     assertEquals(expectedCost, (long) result.weight);

--- a/src/test/java/org/opentripplanner/routing/edgetype/StreetEdgeWheelchairCostTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/StreetEdgeWheelchairCostTest.java
@@ -215,7 +215,7 @@ class StreetEdgeWheelchairCostTest extends GraphRoutingTest {
   }
 
   private State traverse(StreetEdge edge, RouteRequest req) {
-    var state = new State(V1, req, StreetMode.WALK);
+    var state = State.createState(V1, req, StreetMode.WALK);
 
     assertEquals(0, state.weight);
     return edge.traverse(state);

--- a/src/test/java/org/opentripplanner/routing/edgetype/StreetTransitEntityLinkTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/StreetTransitEntityLinkTest.java
@@ -94,6 +94,6 @@ class StreetTransitEntityLinkTest {
       .setWheelchair(new WheelchairPreferences(feature, feature, feature, 25, 8, 10, 25));
 
     var edge = new StreetTransitStopLink(from, to);
-    return edge.traverse(new State(from, req, StreetMode.BIKE));
+    return edge.traverse(State.createState(from, req, StreetMode.BIKE));
   }
 }

--- a/src/test/java/org/opentripplanner/routing/edgetype/StreetTransitEntityLinkTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/StreetTransitEntityLinkTest.java
@@ -81,14 +81,14 @@ class StreetTransitEntityLinkTest {
       .withModes(Set.of(TransitMode.RAIL))
       .build();
 
-    var req = AStarRequest.of().setMode(StreetMode.BIKE);
+    var req = AStarRequest.of().withMode(StreetMode.BIKE);
     AccessibilityPreferences feature;
     if (onlyAccessible) {
       feature = AccessibilityPreferences.ofOnlyAccessible();
     } else {
       feature = AccessibilityPreferences.ofCost(100, 100);
     }
-    req.setWheelchair(true);
+    req.withWheelchair(true);
     req
       .preferences()
       .setWheelchair(new WheelchairPreferences(feature, feature, feature, 25, 8, 10, 25));

--- a/src/test/java/org/opentripplanner/routing/edgetype/StreetTransitEntityLinkTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/StreetTransitEntityLinkTest.java
@@ -8,10 +8,10 @@ import static org.opentripplanner.transit.model.basic.Accessibility.POSSIBLE;
 
 import java.util.Set;
 import org.junit.jupiter.api.Test;
-import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.routing.api.request.preference.AccessibilityPreferences;
 import org.opentripplanner.routing.api.request.preference.WheelchairPreferences;
+import org.opentripplanner.routing.core.AStarRequest;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.vertextype.SimpleVertex;
@@ -81,7 +81,7 @@ class StreetTransitEntityLinkTest {
       .withModes(Set.of(TransitMode.RAIL))
       .build();
 
-    var req = new RouteRequest();
+    var req = AStarRequest.of().setMode(StreetMode.BIKE);
     AccessibilityPreferences feature;
     if (onlyAccessible) {
       feature = AccessibilityPreferences.ofOnlyAccessible();
@@ -94,6 +94,6 @@ class StreetTransitEntityLinkTest {
       .setWheelchair(new WheelchairPreferences(feature, feature, feature, 25, 8, 10, 25));
 
     var edge = new StreetTransitStopLink(from, to);
-    return edge.traverse(State.create(from, req, StreetMode.BIKE));
+    return edge.traverse(new State(from, req.build()));
   }
 }

--- a/src/test/java/org/opentripplanner/routing/edgetype/StreetTransitEntityLinkTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/StreetTransitEntityLinkTest.java
@@ -94,6 +94,6 @@ class StreetTransitEntityLinkTest {
       .setWheelchair(new WheelchairPreferences(feature, feature, feature, 25, 8, 10, 25));
 
     var edge = new StreetTransitStopLink(from, to);
-    return edge.traverse(State.createState(from, req, StreetMode.BIKE));
+    return edge.traverse(State.create(from, req, StreetMode.BIKE));
   }
 }

--- a/src/test/java/org/opentripplanner/routing/edgetype/TemporaryPartialStreetEdgeTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/TemporaryPartialStreetEdgeTest.java
@@ -144,7 +144,7 @@ public class TemporaryPartialStreetEdgeTest {
 
     StreetMode streetMode = options.journey().direct().mode();
     State s0 = new State(v1, options, streetMode);
-    s0.stateData.intersectionTraversalCalculator = calculator;
+    s0.getRequest().setIntersectionTraversalCalculator(calculator);
     State s1 = e1.traverse(s0);
     State s2 = e2.traverse(s1);
     State s3 = e3.traverse(s2);
@@ -153,7 +153,7 @@ public class TemporaryPartialStreetEdgeTest {
     Edge partialE2Second = start.getOutgoing().iterator().next();
 
     State partialS0 = new State(v1, options, streetMode);
-    partialS0.stateData.intersectionTraversalCalculator = calculator;
+    partialS0.getRequest().setIntersectionTraversalCalculator(calculator);
     State partialS1 = e1.traverse(partialS0);
     State partialS2A = partialE2First.traverse(partialS1);
     State partialS2B = partialE2Second.traverse(partialS2A);
@@ -171,13 +171,13 @@ public class TemporaryPartialStreetEdgeTest {
     calculator = new ConstantIntersectionTraversalCalculator();
 
     State s0NoCost = new State(v1, options, streetMode);
-    s0NoCost.stateData.intersectionTraversalCalculator = calculator;
+    s0NoCost.getRequest().setIntersectionTraversalCalculator(calculator);
     State s1NoCost = e1.traverse(s0NoCost);
     State s2NoCost = e2.traverse(s1NoCost);
     State s3NoCost = e3.traverse(s2NoCost);
 
     State partialS0NoCost = new State(v1, options, streetMode);
-    partialS0NoCost.stateData.intersectionTraversalCalculator = calculator;
+    partialS0NoCost.getRequest().setIntersectionTraversalCalculator(calculator);
     State partialS1NoCost = e1.traverse(partialS0NoCost);
     State partialS2ANoCost = partialE2First.traverse(partialS1NoCost);
     State partialS2BNoCost = partialE2Second.traverse(partialS2ANoCost);

--- a/src/test/java/org/opentripplanner/routing/edgetype/TemporaryPartialStreetEdgeTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/TemporaryPartialStreetEdgeTest.java
@@ -90,10 +90,10 @@ public class TemporaryPartialStreetEdgeTest {
 
     // Traverse both the partial and parent edges.
     StreetMode streetMode = options.journey().direct().mode();
-    State s0 = State.createState(v1, options, streetMode);
+    State s0 = State.create(v1, options, streetMode);
     State s1 = e1.traverse(s0);
 
-    State partialS0 = State.createState(v1, options, streetMode);
+    State partialS0 = State.create(v1, options, streetMode);
     State partialS1 = pEdge1.traverse(partialS0);
 
     // Traversal of original and partial edges should yield the same results.
@@ -143,7 +143,7 @@ public class TemporaryPartialStreetEdgeTest {
     options.preferences().street().setTurnReluctance(1.0);
 
     StreetMode streetMode = options.journey().direct().mode();
-    State s0 = State.createState(v1, options, streetMode);
+    State s0 = State.create(v1, options, streetMode);
     s0.getRequest().setIntersectionTraversalCalculator(calculator);
     State s1 = e1.traverse(s0);
     State s2 = e2.traverse(s1);
@@ -152,7 +152,7 @@ public class TemporaryPartialStreetEdgeTest {
     Edge partialE2First = end.getIncoming().iterator().next();
     Edge partialE2Second = start.getOutgoing().iterator().next();
 
-    State partialS0 = State.createState(v1, options, streetMode);
+    State partialS0 = State.create(v1, options, streetMode);
     partialS0.getRequest().setIntersectionTraversalCalculator(calculator);
     State partialS1 = e1.traverse(partialS0);
     State partialS2A = partialE2First.traverse(partialS1);
@@ -170,13 +170,13 @@ public class TemporaryPartialStreetEdgeTest {
     // All intersections take 0 seconds now.
     calculator = new ConstantIntersectionTraversalCalculator();
 
-    State s0NoCost = State.createState(v1, options, streetMode);
+    State s0NoCost = State.create(v1, options, streetMode);
     s0NoCost.getRequest().setIntersectionTraversalCalculator(calculator);
     State s1NoCost = e1.traverse(s0NoCost);
     State s2NoCost = e2.traverse(s1NoCost);
     State s3NoCost = e3.traverse(s2NoCost);
 
-    State partialS0NoCost = State.createState(v1, options, streetMode);
+    State partialS0NoCost = State.create(v1, options, streetMode);
     partialS0NoCost.getRequest().setIntersectionTraversalCalculator(calculator);
     State partialS1NoCost = e1.traverse(partialS0NoCost);
     State partialS2ANoCost = partialE2First.traverse(partialS1NoCost);

--- a/src/test/java/org/opentripplanner/routing/edgetype/TemporaryPartialStreetEdgeTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/TemporaryPartialStreetEdgeTest.java
@@ -90,10 +90,10 @@ public class TemporaryPartialStreetEdgeTest {
 
     // Traverse both the partial and parent edges.
     StreetMode streetMode = options.journey().direct().mode();
-    State s0 = new State(v1, options, streetMode);
+    State s0 = State.createState(v1, options, streetMode);
     State s1 = e1.traverse(s0);
 
-    State partialS0 = new State(v1, options, streetMode);
+    State partialS0 = State.createState(v1, options, streetMode);
     State partialS1 = pEdge1.traverse(partialS0);
 
     // Traversal of original and partial edges should yield the same results.
@@ -143,7 +143,7 @@ public class TemporaryPartialStreetEdgeTest {
     options.preferences().street().setTurnReluctance(1.0);
 
     StreetMode streetMode = options.journey().direct().mode();
-    State s0 = new State(v1, options, streetMode);
+    State s0 = State.createState(v1, options, streetMode);
     s0.getRequest().setIntersectionTraversalCalculator(calculator);
     State s1 = e1.traverse(s0);
     State s2 = e2.traverse(s1);
@@ -152,7 +152,7 @@ public class TemporaryPartialStreetEdgeTest {
     Edge partialE2First = end.getIncoming().iterator().next();
     Edge partialE2Second = start.getOutgoing().iterator().next();
 
-    State partialS0 = new State(v1, options, streetMode);
+    State partialS0 = State.createState(v1, options, streetMode);
     partialS0.getRequest().setIntersectionTraversalCalculator(calculator);
     State partialS1 = e1.traverse(partialS0);
     State partialS2A = partialE2First.traverse(partialS1);
@@ -170,13 +170,13 @@ public class TemporaryPartialStreetEdgeTest {
     // All intersections take 0 seconds now.
     calculator = new ConstantIntersectionTraversalCalculator();
 
-    State s0NoCost = new State(v1, options, streetMode);
+    State s0NoCost = State.createState(v1, options, streetMode);
     s0NoCost.getRequest().setIntersectionTraversalCalculator(calculator);
     State s1NoCost = e1.traverse(s0NoCost);
     State s2NoCost = e2.traverse(s1NoCost);
     State s3NoCost = e3.traverse(s2NoCost);
 
-    State partialS0NoCost = new State(v1, options, streetMode);
+    State partialS0NoCost = State.createState(v1, options, streetMode);
     partialS0NoCost.getRequest().setIntersectionTraversalCalculator(calculator);
     State partialS1NoCost = e1.traverse(partialS0NoCost);
     State partialS2ANoCost = partialE2First.traverse(partialS1NoCost);

--- a/src/test/java/org/opentripplanner/routing/edgetype/TemporaryPartialStreetEdgeTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/TemporaryPartialStreetEdgeTest.java
@@ -67,7 +67,7 @@ public class TemporaryPartialStreetEdgeTest {
 
   @Test
   public void testTraversal() {
-    AStarRequest request = AStarRequest.of().setMode(StreetMode.CAR).build();
+    AStarRequest request = AStarRequest.of().withMode(StreetMode.CAR).build();
 
     // Partial edge with same endpoints as the parent.
     TemporaryPartialStreetEdge pEdge1 = newTemporaryPartialStreetEdge(
@@ -132,7 +132,7 @@ public class TemporaryPartialStreetEdgeTest {
       tempEdges
     );
 
-    AStarRequest request = AStarRequest.of().setMode(StreetMode.CAR).build();
+    AStarRequest request = AStarRequest.of().withMode(StreetMode.CAR).build();
 
     // All intersections take 10 minutes - we'll notice if one isn't counted.
     double turnDurationSecs = 10.0 * 60.0;

--- a/src/test/java/org/opentripplanner/routing/edgetype/TemporaryPartialStreetEdgeTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/TemporaryPartialStreetEdgeTest.java
@@ -11,8 +11,8 @@ import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.graph_builder.linking.DisposableEdgeCollection;
-import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
+import org.opentripplanner.routing.core.AStarRequest;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.core.intersection_model.ConstantIntersectionTraversalCalculator;
 import org.opentripplanner.routing.graph.Edge;
@@ -67,8 +67,7 @@ public class TemporaryPartialStreetEdgeTest {
 
   @Test
   public void testTraversal() {
-    RouteRequest options = new RouteRequest();
-    options.journey().direct().setMode(StreetMode.CAR);
+    AStarRequest request = AStarRequest.of().setMode(StreetMode.CAR).build();
 
     // Partial edge with same endpoints as the parent.
     TemporaryPartialStreetEdge pEdge1 = newTemporaryPartialStreetEdge(
@@ -89,11 +88,10 @@ public class TemporaryPartialStreetEdgeTest {
     );
 
     // Traverse both the partial and parent edges.
-    StreetMode streetMode = options.journey().direct().mode();
-    State s0 = State.create(v1, options, streetMode);
+    State s0 = new State(v1, request);
     State s1 = e1.traverse(s0);
 
-    State partialS0 = State.create(v1, options, streetMode);
+    State partialS0 = new State(v1, request);
     State partialS1 = pEdge1.traverse(partialS0);
 
     // Traversal of original and partial edges should yield the same results.
@@ -134,16 +132,14 @@ public class TemporaryPartialStreetEdgeTest {
       tempEdges
     );
 
-    RouteRequest options = new RouteRequest();
-    options.journey().direct().setMode(StreetMode.CAR);
+    AStarRequest request = AStarRequest.of().setMode(StreetMode.CAR).build();
 
     // All intersections take 10 minutes - we'll notice if one isn't counted.
     double turnDurationSecs = 10.0 * 60.0;
     var calculator = new ConstantIntersectionTraversalCalculator(turnDurationSecs);
-    options.preferences().street().setTurnReluctance(1.0);
+    request.preferences().street().setTurnReluctance(1.0);
 
-    StreetMode streetMode = options.journey().direct().mode();
-    State s0 = State.create(v1, options, streetMode);
+    State s0 = new State(v1, request);
     s0.getRequest().setIntersectionTraversalCalculator(calculator);
     State s1 = e1.traverse(s0);
     State s2 = e2.traverse(s1);
@@ -152,7 +148,7 @@ public class TemporaryPartialStreetEdgeTest {
     Edge partialE2First = end.getIncoming().iterator().next();
     Edge partialE2Second = start.getOutgoing().iterator().next();
 
-    State partialS0 = State.create(v1, options, streetMode);
+    State partialS0 = new State(v1, request);
     partialS0.getRequest().setIntersectionTraversalCalculator(calculator);
     State partialS1 = e1.traverse(partialS0);
     State partialS2A = partialE2First.traverse(partialS1);
@@ -170,13 +166,13 @@ public class TemporaryPartialStreetEdgeTest {
     // All intersections take 0 seconds now.
     calculator = new ConstantIntersectionTraversalCalculator();
 
-    State s0NoCost = State.create(v1, options, streetMode);
+    State s0NoCost = new State(v1, request);
     s0NoCost.getRequest().setIntersectionTraversalCalculator(calculator);
     State s1NoCost = e1.traverse(s0NoCost);
     State s2NoCost = e2.traverse(s1NoCost);
     State s3NoCost = e3.traverse(s2NoCost);
 
-    State partialS0NoCost = State.create(v1, options, streetMode);
+    State partialS0NoCost = new State(v1, request);
     partialS0NoCost.getRequest().setIntersectionTraversalCalculator(calculator);
     State partialS1NoCost = e1.traverse(partialS0NoCost);
     State partialS2ANoCost = partialE2First.traverse(partialS1NoCost);

--- a/src/test/java/org/opentripplanner/routing/edgetype/VehicleParkingEdgeTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/VehicleParkingEdgeTest.java
@@ -28,7 +28,7 @@ class VehicleParkingEdgeTest extends GraphRoutingTest {
   public void availableCarPlacesTest() {
     initEdgeAndRequest(StreetMode.CAR_TO_PARK, false, true);
 
-    State s0 = new State(vertex, request, streetMode);
+    State s0 = State.createState(vertex, request, streetMode);
 
     State s1 = vehicleParkingEdge.traverse(s0);
 
@@ -39,7 +39,7 @@ class VehicleParkingEdgeTest extends GraphRoutingTest {
   public void notAvailableCarPlacesTest() {
     initEdgeAndRequest(StreetMode.CAR_TO_PARK, false, false);
 
-    State s0 = new State(vertex, request, streetMode);
+    State s0 = State.createState(vertex, request, streetMode);
 
     State s1 = vehicleParkingEdge.traverse(s0);
 
@@ -56,7 +56,7 @@ class VehicleParkingEdgeTest extends GraphRoutingTest {
       true
     );
 
-    State s0 = new State(vertex, request, streetMode);
+    State s0 = State.createState(vertex, request, streetMode);
 
     State s1 = vehicleParkingEdge.traverse(s0);
 
@@ -67,7 +67,7 @@ class VehicleParkingEdgeTest extends GraphRoutingTest {
   public void realtimeAvailableCarPlacesFallbackTest() {
     initEdgeAndRequest(StreetMode.CAR_TO_PARK, false, true, null, true);
 
-    State s0 = new State(vertex, request, streetMode);
+    State s0 = State.createState(vertex, request, streetMode);
 
     State s1 = vehicleParkingEdge.traverse(s0);
 
@@ -84,7 +84,7 @@ class VehicleParkingEdgeTest extends GraphRoutingTest {
       true
     );
 
-    State s0 = new State(vertex, request, streetMode);
+    State s0 = State.createState(vertex, request, streetMode);
 
     State s1 = vehicleParkingEdge.traverse(s0);
 
@@ -95,7 +95,7 @@ class VehicleParkingEdgeTest extends GraphRoutingTest {
   public void availableBicyclePlacesTest() {
     initEdgeAndRequest(StreetMode.BIKE_TO_PARK, true, false);
 
-    State s0 = new State(vertex, request, streetMode);
+    State s0 = State.createState(vertex, request, streetMode);
 
     State s1 = vehicleParkingEdge.traverse(s0);
 
@@ -106,7 +106,7 @@ class VehicleParkingEdgeTest extends GraphRoutingTest {
   public void notAvailableBicyclePlacesTest() {
     initEdgeAndRequest(StreetMode.BIKE_TO_PARK, false, false);
 
-    State s0 = new State(vertex, request, streetMode);
+    State s0 = State.createState(vertex, request, streetMode);
 
     State s1 = vehicleParkingEdge.traverse(s0);
 
@@ -123,7 +123,7 @@ class VehicleParkingEdgeTest extends GraphRoutingTest {
       true
     );
 
-    State s0 = new State(vertex, request, streetMode);
+    State s0 = State.createState(vertex, request, streetMode);
 
     State s1 = vehicleParkingEdge.traverse(s0);
 
@@ -134,7 +134,7 @@ class VehicleParkingEdgeTest extends GraphRoutingTest {
   public void realtimeAvailableBicyclePlacesFallbackTest() {
     initEdgeAndRequest(StreetMode.BIKE_TO_PARK, true, false, null, true);
 
-    State s0 = new State(vertex, request, streetMode);
+    State s0 = State.createState(vertex, request, streetMode);
 
     State s1 = vehicleParkingEdge.traverse(s0);
 
@@ -151,7 +151,7 @@ class VehicleParkingEdgeTest extends GraphRoutingTest {
       true
     );
 
-    State s0 = new State(vertex, request, streetMode);
+    State s0 = State.createState(vertex, request, streetMode);
 
     State s1 = vehicleParkingEdge.traverse(s0);
 

--- a/src/test/java/org/opentripplanner/routing/edgetype/VehicleParkingEdgeTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/VehicleParkingEdgeTest.java
@@ -160,7 +160,7 @@ class VehicleParkingEdgeTest extends GraphRoutingTest {
     vehicleParkingEdge = new VehicleParkingEdge(vertex);
 
     var builder = AStarRequest.of();
-    builder.setMode(parkingMode);
+    builder.withMode(parkingMode);
     builder.preferences().parking().setUseAvailabilityInformation(realtime);
     this.request = builder.build();
   }

--- a/src/test/java/org/opentripplanner/routing/edgetype/VehicleParkingEdgeTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/VehicleParkingEdgeTest.java
@@ -28,7 +28,7 @@ class VehicleParkingEdgeTest extends GraphRoutingTest {
   public void availableCarPlacesTest() {
     initEdgeAndRequest(StreetMode.CAR_TO_PARK, false, true);
 
-    State s0 = State.createState(vertex, request, streetMode);
+    State s0 = State.create(vertex, request, streetMode);
 
     State s1 = vehicleParkingEdge.traverse(s0);
 
@@ -39,7 +39,7 @@ class VehicleParkingEdgeTest extends GraphRoutingTest {
   public void notAvailableCarPlacesTest() {
     initEdgeAndRequest(StreetMode.CAR_TO_PARK, false, false);
 
-    State s0 = State.createState(vertex, request, streetMode);
+    State s0 = State.create(vertex, request, streetMode);
 
     State s1 = vehicleParkingEdge.traverse(s0);
 
@@ -56,7 +56,7 @@ class VehicleParkingEdgeTest extends GraphRoutingTest {
       true
     );
 
-    State s0 = State.createState(vertex, request, streetMode);
+    State s0 = State.create(vertex, request, streetMode);
 
     State s1 = vehicleParkingEdge.traverse(s0);
 
@@ -67,7 +67,7 @@ class VehicleParkingEdgeTest extends GraphRoutingTest {
   public void realtimeAvailableCarPlacesFallbackTest() {
     initEdgeAndRequest(StreetMode.CAR_TO_PARK, false, true, null, true);
 
-    State s0 = State.createState(vertex, request, streetMode);
+    State s0 = State.create(vertex, request, streetMode);
 
     State s1 = vehicleParkingEdge.traverse(s0);
 
@@ -84,7 +84,7 @@ class VehicleParkingEdgeTest extends GraphRoutingTest {
       true
     );
 
-    State s0 = State.createState(vertex, request, streetMode);
+    State s0 = State.create(vertex, request, streetMode);
 
     State s1 = vehicleParkingEdge.traverse(s0);
 
@@ -95,7 +95,7 @@ class VehicleParkingEdgeTest extends GraphRoutingTest {
   public void availableBicyclePlacesTest() {
     initEdgeAndRequest(StreetMode.BIKE_TO_PARK, true, false);
 
-    State s0 = State.createState(vertex, request, streetMode);
+    State s0 = State.create(vertex, request, streetMode);
 
     State s1 = vehicleParkingEdge.traverse(s0);
 
@@ -106,7 +106,7 @@ class VehicleParkingEdgeTest extends GraphRoutingTest {
   public void notAvailableBicyclePlacesTest() {
     initEdgeAndRequest(StreetMode.BIKE_TO_PARK, false, false);
 
-    State s0 = State.createState(vertex, request, streetMode);
+    State s0 = State.create(vertex, request, streetMode);
 
     State s1 = vehicleParkingEdge.traverse(s0);
 
@@ -123,7 +123,7 @@ class VehicleParkingEdgeTest extends GraphRoutingTest {
       true
     );
 
-    State s0 = State.createState(vertex, request, streetMode);
+    State s0 = State.create(vertex, request, streetMode);
 
     State s1 = vehicleParkingEdge.traverse(s0);
 
@@ -134,7 +134,7 @@ class VehicleParkingEdgeTest extends GraphRoutingTest {
   public void realtimeAvailableBicyclePlacesFallbackTest() {
     initEdgeAndRequest(StreetMode.BIKE_TO_PARK, true, false, null, true);
 
-    State s0 = State.createState(vertex, request, streetMode);
+    State s0 = State.create(vertex, request, streetMode);
 
     State s1 = vehicleParkingEdge.traverse(s0);
 
@@ -151,7 +151,7 @@ class VehicleParkingEdgeTest extends GraphRoutingTest {
       true
     );
 
-    State s0 = State.createState(vertex, request, streetMode);
+    State s0 = State.create(vertex, request, streetMode);
 
     State s1 = vehicleParkingEdge.traverse(s0);
 

--- a/src/test/java/org/opentripplanner/routing/edgetype/VehicleParkingEdgeTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/VehicleParkingEdgeTest.java
@@ -6,8 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.routing.algorithm.GraphRoutingTest;
-import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
+import org.opentripplanner.routing.core.AStarRequest;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.vehicle_parking.VehicleParking;
@@ -20,17 +20,14 @@ class VehicleParkingEdgeTest extends GraphRoutingTest {
 
   Graph graph;
   VehicleParkingEdge vehicleParkingEdge;
-  RouteRequest request;
-  StreetMode streetMode;
+  AStarRequest request;
   VehicleParkingEntranceVertex vertex;
 
   @Test
   public void availableCarPlacesTest() {
     initEdgeAndRequest(StreetMode.CAR_TO_PARK, false, true);
 
-    State s0 = State.create(vertex, request, streetMode);
-
-    State s1 = vehicleParkingEdge.traverse(s0);
+    State s1 = traverse();
 
     assertNotNull(s1);
   }
@@ -39,9 +36,7 @@ class VehicleParkingEdgeTest extends GraphRoutingTest {
   public void notAvailableCarPlacesTest() {
     initEdgeAndRequest(StreetMode.CAR_TO_PARK, false, false);
 
-    State s0 = State.create(vertex, request, streetMode);
-
-    State s1 = vehicleParkingEdge.traverse(s0);
+    State s1 = traverse();
 
     assertNull(s1);
   }
@@ -56,9 +51,7 @@ class VehicleParkingEdgeTest extends GraphRoutingTest {
       true
     );
 
-    State s0 = State.create(vertex, request, streetMode);
-
-    State s1 = vehicleParkingEdge.traverse(s0);
+    State s1 = traverse();
 
     assertNotNull(s1);
   }
@@ -67,9 +60,7 @@ class VehicleParkingEdgeTest extends GraphRoutingTest {
   public void realtimeAvailableCarPlacesFallbackTest() {
     initEdgeAndRequest(StreetMode.CAR_TO_PARK, false, true, null, true);
 
-    State s0 = State.create(vertex, request, streetMode);
-
-    State s1 = vehicleParkingEdge.traverse(s0);
+    State s1 = traverse();
 
     assertNotNull(s1);
   }
@@ -84,9 +75,7 @@ class VehicleParkingEdgeTest extends GraphRoutingTest {
       true
     );
 
-    State s0 = State.create(vertex, request, streetMode);
-
-    State s1 = vehicleParkingEdge.traverse(s0);
+    State s1 = traverse();
 
     assertNull(s1);
   }
@@ -95,9 +84,7 @@ class VehicleParkingEdgeTest extends GraphRoutingTest {
   public void availableBicyclePlacesTest() {
     initEdgeAndRequest(StreetMode.BIKE_TO_PARK, true, false);
 
-    State s0 = State.create(vertex, request, streetMode);
-
-    State s1 = vehicleParkingEdge.traverse(s0);
+    State s1 = traverse();
 
     assertNotNull(s1);
   }
@@ -106,9 +93,7 @@ class VehicleParkingEdgeTest extends GraphRoutingTest {
   public void notAvailableBicyclePlacesTest() {
     initEdgeAndRequest(StreetMode.BIKE_TO_PARK, false, false);
 
-    State s0 = State.create(vertex, request, streetMode);
-
-    State s1 = vehicleParkingEdge.traverse(s0);
+    State s1 = traverse();
 
     assertNull(s1);
   }
@@ -123,9 +108,7 @@ class VehicleParkingEdgeTest extends GraphRoutingTest {
       true
     );
 
-    State s0 = State.create(vertex, request, streetMode);
-
-    State s1 = vehicleParkingEdge.traverse(s0);
+    State s1 = traverse();
 
     assertNotNull(s1);
   }
@@ -134,9 +117,7 @@ class VehicleParkingEdgeTest extends GraphRoutingTest {
   public void realtimeAvailableBicyclePlacesFallbackTest() {
     initEdgeAndRequest(StreetMode.BIKE_TO_PARK, true, false, null, true);
 
-    State s0 = State.create(vertex, request, streetMode);
-
-    State s1 = vehicleParkingEdge.traverse(s0);
+    State s1 = traverse();
 
     assertNotNull(s1);
   }
@@ -151,9 +132,7 @@ class VehicleParkingEdgeTest extends GraphRoutingTest {
       true
     );
 
-    State s0 = State.create(vertex, request, streetMode);
-
-    State s1 = vehicleParkingEdge.traverse(s0);
+    State s1 = traverse();
 
     assertNull(s1);
   }
@@ -180,10 +159,10 @@ class VehicleParkingEdgeTest extends GraphRoutingTest {
 
     vehicleParkingEdge = new VehicleParkingEdge(vertex);
 
-    this.request = new RouteRequest();
-    request.journey().direct().setMode(parkingMode);
-    request.preferences().parking().setUseAvailabilityInformation(realtime);
-    this.streetMode = request.journey().direct().mode();
+    var builder = AStarRequest.of();
+    builder.setMode(parkingMode);
+    builder.preferences().parking().setUseAvailabilityInformation(realtime);
+    this.request = builder.build();
   }
 
   private VehicleParking createVehicleParking(
@@ -205,5 +184,9 @@ class VehicleParkingEdgeTest extends GraphRoutingTest {
     String id = "Entrance";
     return builder ->
       builder.entranceId(TransitModelForTest.id(id)).name(new NonLocalizedString(id)).x(0).y(0);
+  }
+
+  private State traverse() {
+    return vehicleParkingEdge.traverse(new State(vertex, request));
   }
 }


### PR DESCRIPTION
### Summary

As suggested in https://github.com/opentripplanner/OpenTripPlanner/pull/4432#discussion_r983425903, I split out an `AStarRequest` from `RouteRequest`, which is used internally by the A*-router.

At a later stage, we might want to add an `AStarRequestBuilder` and use it in places where `State.createState` is used today, so that we wouldn't need to create a `RouteRequest` just to initialize the `AStarRequest`.
