### PR TITLE
Add initial get data timeout to SiriETGooglePubsubUpdater

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETGooglePubsubUpdaterParameters.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETGooglePubsubUpdaterParameters.java
@@ -1,65 +1,47 @@
 package org.opentripplanner.ext.siri.updater;
 
-public class SiriETGooglePubsubUpdaterParameters {
+import java.time.Duration;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.opentripplanner.util.lang.ToStringBuilder;
 
-  private final String configRef;
-  private final String feedId;
-  private final String type;
-  private final String projectName;
-  private final String topicName;
-  private final String dataInitializationUrl;
-  private final int reconnectPeriodSec;
-  private final boolean purgeExpiredData;
+public record SiriETGooglePubsubUpdaterParameters(
+  @Nonnull String configRef,
+  @Nullable String feedId,
+  String type,
+  String projectName,
+  String topicName,
+  @Nullable String dataInitializationUrl,
+  Duration reconnectPeriod,
+  Duration initialGetDataTimeout,
+  boolean purgeExpiredData
+) {
+  public static Duration RECONNECT_PERIOD = Duration.ofSeconds(30);
+  public static Duration INITIAL_GET_DATA_TIMEOUT = Duration.ofSeconds(30);
 
-  public SiriETGooglePubsubUpdaterParameters(
-    String configRef,
-    String feedId,
-    String type,
-    String projectName,
-    String topicName,
-    String dataInitializationUrl,
-    int reconnectPeriodSec,
-    boolean purgeExpiredData
-  ) {
-    this.configRef = configRef;
-    this.feedId = feedId;
-    this.type = type;
-    this.projectName = projectName;
-    this.topicName = topicName;
-    this.dataInitializationUrl = dataInitializationUrl;
-    this.reconnectPeriodSec = reconnectPeriodSec;
-    this.purgeExpiredData = purgeExpiredData;
+  public SiriETGooglePubsubUpdaterParameters {
+    Objects.requireNonNull(type);
+    Objects.requireNonNull(projectName);
+    Objects.requireNonNull(topicName);
+    Objects.requireNonNull(reconnectPeriod);
+    Objects.requireNonNull(initialGetDataTimeout);
+    Objects.requireNonNull(reconnectPeriod);
   }
 
-  String getConfigRef() {
-    return configRef;
-  }
-
-  String getFeedId() {
-    return feedId;
-  }
-
-  String getType() {
-    return this.type;
-  }
-
-  String getProjectName() {
-    return this.projectName;
-  }
-
-  String getTopicName() {
-    return this.topicName;
-  }
-
-  String getDataInitializationUrl() {
-    return this.dataInitializationUrl;
-  }
-
-  boolean purgeExpiredData() {
-    return this.purgeExpiredData;
-  }
-
-  int getReconnectPeriodSec() {
-    return this.reconnectPeriodSec;
+  @Override
+  public String toString() {
+    return ToStringBuilder
+      .of(SiriETGooglePubsubUpdaterParameters.class)
+      .addObj("configRef", configRef, null)
+      .addObj("feedId", feedId, null)
+      .addObj("type", type)
+      .addObj("projectName", projectName)
+      .addObj("topicName", topicName)
+      .addDuration("reconnectPeriod", reconnectPeriod, RECONNECT_PERIOD)
+      .addDuration("initialGetDataTimeout", initialGetDataTimeout, INITIAL_GET_DATA_TIMEOUT)
+      .addBoolIfTrue("purgeExpiredData", purgeExpiredData)
+      .addObj("dataInitializationUrl", dataInitializationUrl, null)
+      .toString();
   }
 }

--- a/src/main/java/org/opentripplanner/standalone/config/updaters/SiriETGooglePubsubUpdaterConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/updaters/SiriETGooglePubsubUpdaterConfig.java
@@ -1,5 +1,8 @@
 package org.opentripplanner.standalone.config.updaters;
 
+import static org.opentripplanner.ext.siri.updater.SiriETGooglePubsubUpdaterParameters.INITIAL_GET_DATA_TIMEOUT;
+import static org.opentripplanner.ext.siri.updater.SiriETGooglePubsubUpdaterParameters.RECONNECT_PERIOD;
+
 import org.opentripplanner.ext.siri.updater.SiriETGooglePubsubUpdaterParameters;
 import org.opentripplanner.standalone.config.NodeAdapter;
 
@@ -13,7 +16,8 @@ public class SiriETGooglePubsubUpdaterConfig {
       c.asText("projectName"),
       c.asText("topicName"),
       c.asText("dataInitializationUrl", null),
-      c.asInt("reconnectPeriodSec", 30),
+      c.asDuration("reconnectPeriod", RECONNECT_PERIOD),
+      c.asDuration("initialGetDataTimeout", INITIAL_GET_DATA_TIMEOUT),
       c.asBoolean("purgeExpiredData", false)
     );
   }

--- a/src/main/java/org/opentripplanner/util/lang/ToStringBuilder.java
+++ b/src/main/java/org/opentripplanner/util/lang/ToStringBuilder.java
@@ -268,12 +268,12 @@ public class ToStringBuilder {
   }
 
   public ToStringBuilder addDuration(String name, Duration duration) {
-    return addIfNotIgnored(
-      name,
-      duration,
-      null,
-      d -> DurationUtils.durationToStr((int) d.toSeconds())
-    );
+    return addDuration(name, duration, null);
+  }
+
+  public ToStringBuilder addDuration(String name, Duration duration, Duration ignoreValue) {
+    Function<Duration, String> toStringOp = d -> DurationUtils.durationToStr((int) d.toSeconds());
+    return addIfNotIgnored(name, duration, ignoreValue, toStringOp);
   }
 
   @Override

--- a/src/test/java/org/opentripplanner/util/lang/ToStringBuilderTest.java
+++ b/src/test/java/org/opentripplanner/util/lang/ToStringBuilderTest.java
@@ -269,16 +269,18 @@ public class ToStringBuilderTest {
 
   @Test
   public void addDuration() {
+    var D2m5s = Duration.ofSeconds(125);
+    var D1d2h50m45s = Duration.parse("P1dT2h50m45s");
+
     assertEquals("ToStringBuilderTest{d: 35s}", subject().addDurationSec("d", 35).toString());
     assertEquals(
       "ToStringBuilderTest{d: 1d2h50m45s}",
-      subject().addDurationSec("d", (26 * 60 + 50) * 60 + 45).toString()
+      subject().addDurationSec("d", (int) D1d2h50m45s.toSeconds()).toString()
     );
-    assertEquals(
-      "ToStringBuilderTest{d: 2m5s}",
-      subject().addDuration("d", Duration.ofSeconds(125)).toString()
-    );
+    assertEquals("ToStringBuilderTest{d: 2m5s}", subject().addDuration("d", D2m5s).toString());
     assertEquals("ToStringBuilderTest{}", subject().addDurationSec("d", 12, 12).toString());
+    assertEquals("ToStringBuilderTest{}", subject().addDuration("d", null, null).toString());
+    assertEquals("ToStringBuilderTest{}", subject().addDuration("d", D2m5s, D2m5s).toString());
   }
 
   @Test


### PR DESCRIPTION
### Summary

This PR enable us to configure the initial timeout for fetching Siri-ET Google Pubsub messages. The default is 30 seconds.


### Issue

No issue for this.


### Unit tests

Unit tests updated.

### Documentation

These parameters are not documented.

