### PR TITLE
Remove filtering of flex patterns in NeTEX import

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/TimetabledPassingTimeType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/TimetabledPassingTimeType.java
@@ -10,6 +10,7 @@ import graphql.schema.GraphQLOutputType;
 import graphql.schema.GraphQLTypeReference;
 import org.opentripplanner.ext.transmodelapi.support.GqlUtil;
 import org.opentripplanner.model.PickDrop;
+import org.opentripplanner.model.StopTime;
 import org.opentripplanner.model.TripTimeOnDate;
 
 public class TimetabledPassingTimeType {
@@ -44,7 +45,7 @@ public class TimetabledPassingTimeType {
           .type(gqlUtil.timeScalar)
           .description("Scheduled time of arrival at quay")
           .dataFetcher(environment ->
-            ((TripTimeOnDate) environment.getSource()).getScheduledArrival()
+            missingValueToNull(((TripTimeOnDate) environment.getSource()).getScheduledArrival())
           )
           .build()
       )
@@ -55,7 +56,7 @@ public class TimetabledPassingTimeType {
           .type(gqlUtil.timeScalar)
           .description("Scheduled time of departure from quay")
           .dataFetcher(environment ->
-            ((TripTimeOnDate) environment.getSource()).getScheduledDeparture()
+            missingValueToNull(((TripTimeOnDate) environment.getSource()).getScheduledDeparture())
           )
           .build()
       )
@@ -144,5 +145,17 @@ public class TimetabledPassingTimeType {
           .build()
       )
       .build();
+  }
+
+  /**
+   * Generally the missing values are removed during the graph build. However, for flex trips they
+   * are not and have to be converted to null here.
+   */
+  private static Integer missingValueToNull(int value) {
+    if (value == StopTime.MISSING_VALUE) {
+      return null;
+    } else {
+      return value;
+    }
   }
 }

--- a/src/main/java/org/opentripplanner/netex/mapping/TripPatternMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/TripPatternMapper.java
@@ -204,17 +204,6 @@ class TripPatternMapper {
       return result;
     }
 
-    // TODO OTP2 - Trips containing AreaStops are not added to StopPatterns until support
-    //           - for this is added.
-    if (
-      result.tripStopTimes
-        .get(trips.get(0))
-        .stream()
-        .anyMatch(t -> t.getStop() instanceof AreaStop || t.getStop() instanceof GroupStop)
-    ) {
-      return result;
-    }
-
     // Create StopPattern from any trip (since they are part of the same JourneyPattern)
     StopPattern stopPattern = deduplicator.deduplicateObject(
       StopPattern.class,


### PR DESCRIPTION
### Summary

Currently we don't import `JourneyPattern`s with flex stops from NeTEx files. The support for adding these, as well as the corresponding change in GTFS handling was done in https://github.com/opentripplanner/OpenTripPlanner/pull/3757.
