### PR TITLE
Enable fuzzyTripMatching in other SIRI-ET updaters

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/siri/SiriFuzzyTripMatcher.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriFuzzyTripMatcher.java
@@ -11,7 +11,6 @@ import java.util.Set;
 import org.opentripplanner.transit.model.basic.SubMode;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
-import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
@@ -47,7 +46,6 @@ public class SiriFuzzyTripMatcher {
 
   private final Map<String, Set<Trip>> mappedTripsCache = new HashMap<>();
   private final Map<String, Set<Trip>> internalPlanningCodeCache = new HashMap<>();
-  private final Map<String, Set<Route>> mappedRoutesCache = new HashMap<>();
   private final Map<String, Set<Trip>> startStopTripCache = new HashMap<>();
   private final Map<String, Trip> vehicleJourneyTripCache = new HashMap<>();
   private final Set<String> nonExistingStops = new HashSet<>();
@@ -159,11 +157,6 @@ public class SiriFuzzyTripMatcher {
     return trips;
   }
 
-  public Set<Route> getRoutesForStop(FeedScopedId siriStopId) {
-    var stop = transitService.getRegularStop(siriStopId);
-    return transitService.getRoutesForStop(stop);
-  }
-
   public FeedScopedId getStop(String siriStopId, String feedId) {
     if (nonExistingStops.contains(siriStopId)) {
       return null;
@@ -178,10 +171,6 @@ public class SiriFuzzyTripMatcher {
 
     nonExistingStops.add(siriStopId);
     return null;
-  }
-
-  public Set<Route> getRoutes(String lineRefValue) {
-    return mappedRoutesCache.getOrDefault(lineRefValue, new HashSet<>());
   }
 
   public FeedScopedId getTripId(String vehicleJourney, String feedId) {
@@ -307,18 +296,7 @@ public class SiriFuzzyTripMatcher {
           }
         }
       }
-      for (Route route : index.getAllRoutes()) {
-        String currentRouteId = getUnpaddedTripId(route.getId().getId());
-        if (mappedRoutesCache.containsKey(currentRouteId)) {
-          mappedRoutesCache.get(currentRouteId).add(route);
-        } else {
-          Set<Route> initialSet = new HashSet<>();
-          initialSet.add(route);
-          mappedRoutesCache.put(currentRouteId, initialSet);
-        }
-      }
 
-      LOG.info("Built route-cache [{}].", mappedRoutesCache.size());
       LOG.info("Built internalPlanningCode-cache [{}].", internalPlanningCodeCache.size());
       LOG.info("Built trips-cache [{}].", mappedTripsCache.size());
       LOG.info("Built start-stop-cache [{}].", startStopTripCache.size());

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriFuzzyTripMatcher.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriFuzzyTripMatcher.java
@@ -46,7 +46,6 @@ public class SiriFuzzyTripMatcher {
 
   private final Map<String, Set<Trip>> internalPlanningCodeCache = new HashMap<>();
   private final Map<String, Set<Trip>> startStopTripCache = new HashMap<>();
-  private final Set<String> nonExistingStops = new HashSet<>();
   private final TransitService transitService;
   private boolean initialized = false;
 
@@ -157,38 +156,6 @@ public class SiriFuzzyTripMatcher {
       }
     }
     return trips;
-  }
-
-  public FeedScopedId getStop(String siriStopId, String feedId) {
-    if (nonExistingStops.contains(siriStopId)) {
-      return null;
-    }
-
-    FeedScopedId id = new FeedScopedId(feedId, siriStopId);
-    if (transitService.getRegularStop(id) != null) {
-      return id;
-    } else if (transitService.getStationById(id) != null) {
-      return id;
-    }
-
-    nonExistingStops.add(siriStopId);
-    return null;
-  }
-
-  public FeedScopedId getTripId(String vehicleJourney, String feedId) {
-    //Attempt to find trip using datedServiceJourneys
-    TripOnServiceDate tripOnServiceDate = transitService.getTripOnServiceDateById(
-      new FeedScopedId(feedId, vehicleJourney)
-    );
-    if (tripOnServiceDate != null) {
-      return tripOnServiceDate.getTrip().getId();
-    }
-    //Fallback to handle extrajourneys
-    Trip trip = transitService.getTripForId(new FeedScopedId(feedId, vehicleJourney));
-    if (trip != null) {
-      return trip.getId();
-    }
-    return null;
   }
 
   /**

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriFuzzyTripMatcher.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriFuzzyTripMatcher.java
@@ -222,7 +222,11 @@ public class SiriFuzzyTripMatcher {
     return matches;
   }
 
-  Trip findTripByDatedVehicleJourneyRef(EstimatedVehicleJourney journey, String feedId) {
+  static Trip findTripByDatedVehicleJourneyRef(
+    EstimatedVehicleJourney journey,
+    String feedId,
+    TransitService transitService
+  ) {
     String serviceJourneyId = resolveDatedVehicleJourneyRef(journey);
     if (serviceJourneyId != null) {
       Trip trip = transitService.getTripForId(new FeedScopedId(feedId, serviceJourneyId));
@@ -290,7 +294,7 @@ public class SiriFuzzyTripMatcher {
     return lastStopId + ":" + lastStopArrivalTime;
   }
 
-  private String resolveDatedVehicleJourneyRef(EstimatedVehicleJourney journey) {
+  private static String resolveDatedVehicleJourneyRef(EstimatedVehicleJourney journey) {
     if (journey.getFramedVehicleJourneyRef() != null) {
       return journey.getFramedVehicleJourneyRef().getDatedVehicleJourneyRef();
     } else if (journey.getDatedVehicleJourneyRef() != null) {

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
@@ -420,7 +420,7 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
       return false;
     }
 
-    Set<Trip> trips = fuzzyTripMatcher.match(activity, feedId);
+    Set<Trip> trips = fuzzyTripMatcher.match(monitoredVehicleJourney, feedId);
 
     if (trips == null || trips.isEmpty()) {
       if (keepLogging) {
@@ -666,7 +666,9 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
     for (int i = 0; i < estimatedCalls.size(); i++) {
       EstimatedCall estimatedCall = estimatedCalls.get(i);
 
-      var stop = getStopForStopId(feedId, estimatedCall.getStopPointRef().getValue());
+      var stop = transitService.getRegularStop(
+        new FeedScopedId(feedId, estimatedCall.getStopPointRef().getValue())
+      );
 
       StopTime stopTime = new StopTime();
       stopTime.setStop(stop);
@@ -1554,16 +1556,5 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
     } else {
       return null;
     }
-  }
-
-  /**
-   * Retrieve stop given a feed id and stop id.
-   *
-   * @param feedId feed id for the stop id
-   * @param stopId trip id without the agency
-   * @return stop or null if stop doesn't exist
-   */
-  private StopLocation getStopForStopId(String feedId, String stopId) {
-    return transitService.getRegularStop(new FeedScopedId(feedId, stopId));
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
@@ -60,6 +60,7 @@ import uk.org.siri.siri20.EstimatedTimetableDeliveryStructure;
 import uk.org.siri.siri20.EstimatedVehicleJourney;
 import uk.org.siri.siri20.EstimatedVersionFrameStructure;
 import uk.org.siri.siri20.FramedVehicleJourneyRefStructure;
+import uk.org.siri.siri20.MonitoredVehicleJourneyStructure;
 import uk.org.siri.siri20.NaturalLanguageStringStructure;
 import uk.org.siri.siri20.RecordedCall;
 import uk.org.siri.siri20.VehicleActivityCancellationStructure;
@@ -403,16 +404,17 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
       return false;
     }
 
+    MonitoredVehicleJourneyStructure monitoredVehicleJourney = activity.getMonitoredVehicleJourney();
     if (
-      activity.getMonitoredVehicleJourney() == null ||
-      activity.getMonitoredVehicleJourney().getVehicleRef() == null ||
-      activity.getMonitoredVehicleJourney().getLineRef() == null
+      monitoredVehicleJourney == null ||
+      monitoredVehicleJourney.getVehicleRef() == null ||
+      monitoredVehicleJourney.getLineRef() == null
     ) {
       //No vehicle reference or line reference
       return false;
     }
 
-    Boolean isMonitored = activity.getMonitoredVehicleJourney().isMonitored();
+    Boolean isMonitored = monitoredVehicleJourney.isMonitored();
     if (isMonitored != null && !isMonitored) {
       //Vehicle is reported as NOT monitored
       return false;
@@ -424,20 +426,20 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
       if (keepLogging) {
         String lineRef =
           (
-            activity.getMonitoredVehicleJourney().getLineRef() != null
-              ? activity.getMonitoredVehicleJourney().getLineRef().getValue()
+            monitoredVehicleJourney.getLineRef() != null
+              ? monitoredVehicleJourney.getLineRef().getValue()
               : null
           );
         String vehicleRef =
           (
-            activity.getMonitoredVehicleJourney().getVehicleRef() != null
-              ? activity.getMonitoredVehicleJourney().getVehicleRef().getValue()
+            monitoredVehicleJourney.getVehicleRef() != null
+              ? monitoredVehicleJourney.getVehicleRef().getValue()
               : null
           );
         String tripId =
           (
-            activity.getMonitoredVehicleJourney().getCourseOfJourneyRef() != null
-              ? activity.getMonitoredVehicleJourney().getCourseOfJourneyRef().getValue()
+            monitoredVehicleJourney.getCourseOfJourneyRef() != null
+              ? monitoredVehicleJourney.getCourseOfJourneyRef().getValue()
               : null
           );
         LOG.debug(
@@ -453,16 +455,13 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
     }
 
     //Find the trip that best corresponds to MonitoredVehicleJourney
-    Trip trip = getTripForJourney(trips, activity.getMonitoredVehicleJourney());
+    Trip trip = getTripForJourney(trips, monitoredVehicleJourney);
 
     if (trip == null) {
       return false;
     }
 
-    final Set<TripPattern> patterns = getPatternsForTrip(
-      trips,
-      activity.getMonitoredVehicleJourney()
-    );
+    final Set<TripPattern> patterns = getPatternsForTrip(trips, monitoredVehicleJourney);
 
     if (patterns == null) {
       return false;
@@ -1250,7 +1249,7 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
 
   private Set<TripPattern> getPatternsForTrip(
     Set<Trip> matches,
-    VehicleActivityStructure.MonitoredVehicleJourney monitoredVehicleJourney
+    MonitoredVehicleJourneyStructure monitoredVehicleJourney
   ) {
     if (monitoredVehicleJourney.getOriginRef() == null) {
       return null;
@@ -1419,7 +1418,7 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
    */
   private Trip getTripForJourney(
     Set<Trip> trips,
-    VehicleActivityStructure.MonitoredVehicleJourney monitoredVehicleJourney
+    MonitoredVehicleJourneyStructure monitoredVehicleJourney
   ) {
     ZonedDateTime date = monitoredVehicleJourney.getOriginAimedDepartureTime();
     if (date == null) {

--- a/src/ext/java/org/opentripplanner/ext/siri/TimetableHelper.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/TimetableHelper.java
@@ -727,11 +727,10 @@ public class TimetableHelper {
       return Result.failure(new UpdateError(tripId, INVALID_INPUT_STRUCTURE));
     }
 
-    VehicleActivityStructure.MonitoredVehicleJourney monitoredVehicleJourney = activity.getMonitoredVehicleJourney();
+    MonitoredVehicleJourneyStructure monitoredVehicleJourney = activity.getMonitoredVehicleJourney();
 
-    Duration delay = null;
     if (monitoredVehicleJourney != null) {
-      delay = monitoredVehicleJourney.getDelay();
+      Duration delay = monitoredVehicleJourney.getDelay();
       int updatedDelay = 0;
       if (delay != null) {
         updatedDelay =

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETGooglePubsubUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETGooglePubsubUpdater.java
@@ -129,7 +129,10 @@ public class SiriETGooglePubsubUpdater implements GraphUpdater {
     this.subscriptionName = ProjectSubscriptionName.of(projectName, subscriptionId);
     this.topic = ProjectTopicName.of(projectName, topicName);
     this.pushConfig = PushConfig.getDefaultInstance();
-    this.fuzzyTripMatcher = SiriFuzzyTripMatcher.of(new DefaultTransitService(transitModel));
+    this.fuzzyTripMatcher =
+      config.fuzzyTripMatching()
+        ? SiriFuzzyTripMatcher.of(new DefaultTransitService(transitModel))
+        : null;
 
     try {
       if (

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETGooglePubsubUpdaterParameters.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETGooglePubsubUpdaterParameters.java
@@ -15,7 +15,8 @@ public record SiriETGooglePubsubUpdaterParameters(
   @Nullable String dataInitializationUrl,
   Duration reconnectPeriod,
   Duration initialGetDataTimeout,
-  boolean purgeExpiredData
+  boolean purgeExpiredData,
+  boolean fuzzyTripMatching
 ) {
   public static Duration RECONNECT_PERIOD = Duration.ofSeconds(30);
   public static Duration INITIAL_GET_DATA_TIMEOUT = Duration.ofSeconds(30);
@@ -41,6 +42,7 @@ public record SiriETGooglePubsubUpdaterParameters(
       .addDuration("reconnectPeriod", reconnectPeriod, RECONNECT_PERIOD)
       .addDuration("initialGetDataTimeout", initialGetDataTimeout, INITIAL_GET_DATA_TIMEOUT)
       .addBoolIfTrue("purgeExpiredData", purgeExpiredData)
+      .addBoolIfTrue("fuzzyTripMatching", fuzzyTripMatching)
       .addObj("dataInitializationUrl", dataInitializationUrl, null)
       .toString();
   }

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETUpdater.java
@@ -66,7 +66,10 @@ public class SiriETUpdater extends PollingGraphUpdater {
     this.snapshotSource = timetableSnapshot;
 
     this.blockReadinessUntilInitialized = config.blockReadinessUntilInitialized();
-    this.fuzzyTripMatcher = SiriFuzzyTripMatcher.of(new DefaultTransitService(transitModel));
+    this.fuzzyTripMatcher =
+      config.isFuzzyTripMatching()
+        ? SiriFuzzyTripMatcher.of(new DefaultTransitService(transitModel))
+        : null;
 
     LOG.info(
       "Creating stop time updater (SIRI ET) running every {} seconds : {}",

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETUpdaterParameters.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETUpdaterParameters.java
@@ -18,6 +18,7 @@ public class SiriETUpdaterParameters implements PollingGraphUpdaterParameters {
   private final String requestorRef;
   private final int timeoutSec;
   private final int previewIntervalMinutes;
+  private final boolean fuzzyTripMatching;
 
   public SiriETUpdaterParameters(
     String configRef,
@@ -30,7 +31,8 @@ public class SiriETUpdaterParameters implements PollingGraphUpdaterParameters {
     int frequencySec,
     String requestorRef,
     int timeoutSec,
-    int previewIntervalMinutes
+    int previewIntervalMinutes,
+    boolean fuzzyTripMatching
   ) {
     this.configRef = configRef;
     this.feedId = feedId;
@@ -43,6 +45,7 @@ public class SiriETUpdaterParameters implements PollingGraphUpdaterParameters {
     this.requestorRef = requestorRef;
     this.timeoutSec = timeoutSec;
     this.previewIntervalMinutes = previewIntervalMinutes;
+    this.fuzzyTripMatching = fuzzyTripMatching;
   }
 
   public String getFeedId() {
@@ -73,6 +76,10 @@ public class SiriETUpdaterParameters implements PollingGraphUpdaterParameters {
   @Override
   public String getConfigRef() {
     return configRef;
+  }
+
+  public boolean isFuzzyTripMatching() {
+    return fuzzyTripMatching;
   }
 
   public SiriETHttpTripUpdateSource.Parameters sourceParameters() {

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/azure/AbstractAzureSiriUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/azure/AbstractAzureSiriUpdater.java
@@ -42,8 +42,6 @@ public abstract class AbstractAzureSiriUpdater implements GraphUpdater {
   private boolean isPrimed = false;
   private String subscriptionName;
 
-  protected final boolean fuzzyTripMatching;
-
   protected String feedId;
 
   /**
@@ -62,8 +60,10 @@ public abstract class AbstractAzureSiriUpdater implements GraphUpdater {
     this.dataInitializationUrl = config.getDataInitializationUrl();
     this.timeout = config.getTimeout();
     this.feedId = config.getFeedId();
-    this.fuzzyTripMatcher = SiriFuzzyTripMatcher.of(new DefaultTransitService(transitModel));
-    this.fuzzyTripMatching = config.isFuzzyTripMatching();
+    this.fuzzyTripMatcher =
+      config.isFuzzyTripMatching()
+        ? SiriFuzzyTripMatcher.of(new DefaultTransitService(transitModel))
+        : null;
   }
 
   /**

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureETUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureETUpdater.java
@@ -119,8 +119,7 @@ public class SiriAzureETUpdater extends AbstractAzureSiriUpdater {
           fuzzyTripMatcher(),
           feedId,
           false,
-          updates,
-          fuzzyTripMatching
+          updates
         )
       );
     } catch (JAXBException | XMLStreamException e) {
@@ -144,8 +143,7 @@ public class SiriAzureETUpdater extends AbstractAzureSiriUpdater {
           fuzzyTripMatcher(),
           feedId,
           false,
-          updates,
-          fuzzyTripMatching
+          updates
         );
 
         setPrimed(true);

--- a/src/main/java/org/opentripplanner/standalone/config/updaters/SiriETGooglePubsubUpdaterConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/updaters/SiriETGooglePubsubUpdaterConfig.java
@@ -18,7 +18,8 @@ public class SiriETGooglePubsubUpdaterConfig {
       c.asText("dataInitializationUrl", null),
       c.asDuration("reconnectPeriod", RECONNECT_PERIOD),
       c.asDuration("initialGetDataTimeout", INITIAL_GET_DATA_TIMEOUT),
-      c.asBoolean("purgeExpiredData", false)
+      c.asBoolean("purgeExpiredData", false),
+      c.asBoolean("fuzzyTripMatching", false)
     );
   }
 }

--- a/src/main/java/org/opentripplanner/standalone/config/updaters/SiriETUpdaterConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/updaters/SiriETUpdaterConfig.java
@@ -18,7 +18,8 @@ public class SiriETUpdaterConfig {
       c.asInt("frequencySec", 60),
       c.asText("requestorRef", "otp-" + UUID.randomUUID()),
       c.asInt("timeoutSec", -1),
-      c.asInt("previewIntervalMinutes", -1)
+      c.asInt("previewIntervalMinutes", -1),
+      c.asBoolean("fuzzyTripMatching", false)
     );
   }
 }


### PR DESCRIPTION
### Summary

After #4347, the fuzzyTripMatching was set to false in all SIR-ET updaters-except in the Azure updater. This PR adds the config option to other SIRI-ET updater modules, and cleans up the implementation, so that a SiriFuzzyTripMatcher is created only when the config parameter is set to true. This required some clean-up of the matcher, which is included in the PR.