### PR TITLE
Otp2 use optional in data source

### DIFF
--- a/src/main/java/org/opentripplanner/datastore/api/DataSource.java
+++ b/src/main/java/org/opentripplanner/datastore/api/DataSource.java
@@ -30,6 +30,9 @@ import org.opentripplanner.datastore.OtpDataStore;
  * these files.
  */
 public interface DataSource {
+  /** Used for returning unknown file size and unknown last modified time */
+  long UNKNOWN = -1;
+
   /**
    * @return the short name identifying the source within its scope (withing a {@link OtpDataStore}
    * or {@link CompositeDataSource}) Including the file extension.
@@ -60,14 +63,14 @@ public interface DataSource {
    * @return size in bytes, if unknown returns {@code -1}
    */
   default long size() {
-    return -1;
+    return UNKNOWN;
   }
 
   /**
    * @return last modified timestamp in ms, if unknown returns {@code -1}
    */
   default long lastModified() {
-    return -1;
+    return UNKNOWN;
   }
 
   /**

--- a/src/main/java/org/opentripplanner/datastore/file/AbstractFileDataSource.java
+++ b/src/main/java/org/opentripplanner/datastore/file/AbstractFileDataSource.java
@@ -46,12 +46,16 @@ public abstract class AbstractFileDataSource implements DataSource {
 
   @Override
   public final long size() {
-    return file.length();
+    // file.length() may return 0, map this to unknown
+    long value = file.length();
+    return value != 0L ? value : DataSource.UNKNOWN;
   }
 
   @Override
   public final long lastModified() {
-    return file.lastModified();
+    // file.lastModified() may return 0, map this to unknown
+    long value = file.lastModified();
+    return value != 0L ? value : DataSource.UNKNOWN;
   }
 
   @Override
@@ -62,8 +66,8 @@ public abstract class AbstractFileDataSource implements DataSource {
   @Override
   public boolean isWritable() {
     // We assume we can write to a file if the parent directory exist, and if the
-    // file it self exist then it must be writable. If the file do not exist
-    // we assume we can create a new file and write to it - there is no check on this.
+    // file exist then it must be writable. If the file do not exist we assume we
+    // can create a new file and write to it - there is no check on this.
     return file.getParentFile().exists() && (!file.exists() || file.canWrite());
   }
 

--- a/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceMetadata.java
+++ b/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceMetadata.java
@@ -8,12 +8,13 @@ import java.util.stream.Collectors;
 import org.apache.http.Header;
 import org.apache.http.HttpHeaders;
 import org.apache.http.client.utils.DateUtils;
+import org.opentripplanner.datastore.api.DataSource;
 import org.opentripplanner.util.lang.ToStringBuilder;
 
 /**
  * HTTPS data source metadata returned by the HTTP server (HTTP headers).
  */
-public class HttpsDataSourceMetadata {
+class HttpsDataSourceMetadata {
 
   static final String CONTENT_TYPE_APPLICATION_GZIP = "application/gzip";
   static final String CONTENT_TYPE_APPLICATION_ZIP = "application/zip";
@@ -28,7 +29,7 @@ public class HttpsDataSourceMetadata {
   private final long contentLength;
   private final long lastModified;
 
-  public HttpsDataSourceMetadata(List<Header> headers) {
+  HttpsDataSourceMetadata(List<Header> headers) {
     this(
       headers
         .stream()
@@ -37,29 +38,29 @@ public class HttpsDataSourceMetadata {
     );
   }
 
-  public HttpsDataSourceMetadata(Map<String, String> headers) {
+  HttpsDataSourceMetadata(Map<String, String> headers) {
     contentType = headers.get(HttpHeaders.CONTENT_TYPE);
     contentLength = parseLong(headers.get(HttpHeaders.CONTENT_LENGTH));
     lastModified = parseDate(headers.get(HttpHeaders.LAST_MODIFIED));
   }
 
-  public String contentType() {
+  String contentType() {
     return contentType;
   }
 
-  public long contentLength() {
+  long contentLength() {
     return contentLength;
   }
 
-  public long lastModified() {
+  long lastModified() {
     return lastModified;
   }
 
-  public boolean isZipContentType() {
+  boolean isZipContentType() {
     return CONTENT_TYPE_APPLICATION_ZIP.equalsIgnoreCase(contentType());
   }
 
-  public boolean isGzipContentType() {
+  boolean isGzipContentType() {
     return CONTENT_TYPE_APPLICATION_GZIP.equalsIgnoreCase(contentType());
   }
 
@@ -77,7 +78,7 @@ public class HttpsDataSourceMetadata {
     try {
       return Long.parseLong(header);
     } catch (Exception e) {
-      return -1;
+      return DataSource.UNKNOWN;
     }
   }
 

--- a/src/test/java/org/opentripplanner/datastore/file/DirectoryDataSourceTest.java
+++ b/src/test/java/org/opentripplanner/datastore/file/DirectoryDataSourceTest.java
@@ -47,8 +47,8 @@ public class DirectoryDataSourceTest {
     assertEquals(DIRNAME, subject.name());
     assertEquals(expectedPath, subject.path());
     assertEquals(REPORT, subject.type());
-    assertEquals(0L, subject.lastModified());
-    assertEquals(0L, subject.size());
+    assertEquals(DataSource.UNKNOWN, subject.lastModified());
+    assertEquals(DataSource.UNKNOWN, subject.size());
     assertFalse(subject.exists());
     assertTrue(subject.isWritable());
 
@@ -99,6 +99,6 @@ public class DirectoryDataSourceTest {
   }
 
   private String toString(Collection<DataSource> sources) {
-    return sources.stream().map(DataSource::name).collect(Collectors.toList()).toString();
+    return sources.stream().map(DataSource::name).sorted().toList().toString();
   }
 }

--- a/src/test/java/org/opentripplanner/datastore/file/FileDataSourceTest.java
+++ b/src/test/java/org/opentripplanner/datastore/file/FileDataSourceTest.java
@@ -15,6 +15,7 @@ import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.datastore.api.DataSource;
 
 public class FileDataSourceTest {
 
@@ -44,8 +45,8 @@ public class FileDataSourceTest {
     assertEquals(FILENAME, subject.name());
     assertEquals(expectedPath, subject.path());
     assertEquals(GRAPH, subject.type());
-    assertEquals(0L, subject.lastModified());
-    assertEquals(0L, subject.size());
+    assertEquals(DataSource.UNKNOWN, subject.lastModified());
+    assertEquals(DataSource.UNKNOWN, subject.size());
     assertFalse(subject.exists());
     assertTrue(subject.isWritable());
 


### PR DESCRIPTION
### Summary

This PR do a little cleanup of DataSource size and lastModified. It is based on #4482, and is a response to https://github.com/opentripplanner/OpenTripPlanner/pull/4482#discussion_r985545969. 

My original suggestion was to use `OptionalLong` to make the API safer, but that get a bit messy - mostly since most of the underlaying libraries already support returning `-1` as an `UNKNOW` value. So the changes I made are only to remove the `magic numbers`.

I also made on class in the http support package local.

### Issue

No issue


### Unit tests

Unit tests are updated.

### Documentation

JavaDoc ok.
