### PR TITLE
Use omitCanceled argument for stop times queries

### DIFF
--- a/docs/sandbox/LegacyGraphQLApi.md
+++ b/docs/sandbox/LegacyGraphQLApi.md
@@ -27,6 +27,7 @@
 - Implement allowedBikeRentalNetworks while deprecating it and add allowedVehicleRentalNetworks and bannedVehicleRentalNetworks. (July 2022, https://github.com/opentripplanner/OpenTripPlanner/pull/4279)
 - Filters place types in legacy GraphQL API so that a bike park type is not returned if a vehicle parking has no bicycle spaces and car park type is not returned if a parking has no car spaces. (July 2022, https://github.com/opentripplanner/OpenTripPlanner/pull/4296)
 - Include departures with skipped stops in the Stop type's stopTimesForPattern query. (July 2022, https://github.com/opentripplanner/OpenTripPlanner/pull/4299)
+- Implement support for omitCanceled parameter in some stop's stoptime queries (October 2023, https://github.com/opentripplanner/OpenTripPlanner/pull/4504)
 
 ## Documentation
 

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLStopImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLStopImpl.java
@@ -253,8 +253,6 @@ public class LegacyGraphQLStopImpl implements LegacyGraphQLDataFetchers.LegacyGr
             );
           }
 
-          // TODO: use args.getLegacyGraphQLOmitCanceled()
-
           return transitService.stopTimesForPatternAtStop(
             stop,
             pattern,
@@ -263,7 +261,8 @@ public class LegacyGraphQLStopImpl implements LegacyGraphQLDataFetchers.LegacyGr
             args.getLegacyGraphQLNumberOfDepartures(),
             args.getLegacyGraphQLOmitNonPickups()
               ? ArrivalDeparture.DEPARTURES
-              : ArrivalDeparture.BOTH
+              : ArrivalDeparture.BOTH,
+            !args.getLegacyGraphQLOmitCanceled()
           );
         },
         station -> null
@@ -288,8 +287,6 @@ public class LegacyGraphQLStopImpl implements LegacyGraphQLDataFetchers.LegacyGr
         environment.getArguments()
       );
 
-      // TODO: use args.getLegacyGraphQLOmitCanceled()
-
       Function<StopLocation, List<StopTimesInPattern>> stopTFunction = stop ->
         transitService.stopTimesForStop(
           stop,
@@ -299,7 +296,7 @@ public class LegacyGraphQLStopImpl implements LegacyGraphQLDataFetchers.LegacyGr
           args.getLegacyGraphQLOmitNonPickups()
             ? ArrivalDeparture.DEPARTURES
             : ArrivalDeparture.BOTH,
-          false
+          !args.getLegacyGraphQLOmitCanceled()
         );
 
       return getValue(
@@ -330,15 +327,14 @@ public class LegacyGraphQLStopImpl implements LegacyGraphQLDataFetchers.LegacyGr
         return null;
       }
 
-      // TODO: use args.getLegacyGraphQLOmitCanceled()
-
       Function<StopLocation, List<StopTimesInPattern>> stopTFunction = stop ->
         transitService.getStopTimesForStop(
           stop,
           date,
           args.getLegacyGraphQLOmitNonPickups()
             ? ArrivalDeparture.DEPARTURES
-            : ArrivalDeparture.BOTH
+            : ArrivalDeparture.BOTH,
+          !args.getLegacyGraphQLOmitCanceled()
         );
 
       return getValue(
@@ -363,8 +359,6 @@ public class LegacyGraphQLStopImpl implements LegacyGraphQLDataFetchers.LegacyGr
         environment.getArguments()
       );
 
-      // TODO: use args.getLegacyGraphQLOmitCanceled()
-
       Function<StopLocation, Stream<StopTimesInPattern>> stopTFunction = stop ->
         transitService
           .stopTimesForStop(
@@ -375,7 +369,7 @@ public class LegacyGraphQLStopImpl implements LegacyGraphQLDataFetchers.LegacyGr
             args.getLegacyGraphQLOmitNonPickups()
               ? ArrivalDeparture.DEPARTURES
               : ArrivalDeparture.BOTH,
-            false
+            !args.getLegacyGraphQLOmitCanceled()
           )
           .stream();
 
@@ -543,7 +537,8 @@ public class LegacyGraphQLStopImpl implements LegacyGraphQLDataFetchers.LegacyGr
             args.getLegacyGraphQLNumberOfDepartures(),
             args.getLegacyGraphQLOmitNonPickups()
               ? ArrivalDeparture.DEPARTURES
-              : ArrivalDeparture.BOTH
+              : ArrivalDeparture.BOTH,
+            false
           )
           .stream()
       )

--- a/src/main/java/org/opentripplanner/index/IndexAPI.java
+++ b/src/main/java/org/opentripplanner/index/IndexAPI.java
@@ -308,7 +308,8 @@ public class IndexAPI {
       .getStopTimesForStop(
         stop,
         serviceDate,
-        omitNonPickups ? ArrivalDeparture.DEPARTURES : ArrivalDeparture.BOTH
+        omitNonPickups ? ArrivalDeparture.DEPARTURES : ArrivalDeparture.BOTH,
+        true
       );
     return StopTimesInPatternMapper.mapToApi(stopTimes);
   }

--- a/src/main/java/org/opentripplanner/routing/graphfinder/PatternAtStop.java
+++ b/src/main/java/org/opentripplanner/routing/graphfinder/PatternAtStop.java
@@ -76,7 +76,8 @@ public class PatternAtStop {
       startTime,
       timeRange,
       numberOfDepartures,
-      arrivalDeparture
+      arrivalDeparture,
+      true
     );
   }
 

--- a/src/main/java/org/opentripplanner/routing/stoptimes/StopTimesHelper.java
+++ b/src/main/java/org/opentripplanner/routing/stoptimes/StopTimesHelper.java
@@ -87,7 +87,8 @@ public class StopTimesHelper {
     TransitService transitService,
     StopLocation stop,
     LocalDate serviceDate,
-    ArrivalDeparture arrivalDeparture
+    ArrivalDeparture arrivalDeparture,
+    boolean includeCancellations
   ) {
     List<StopTimesInPattern> ret = new ArrayList<>();
 
@@ -106,7 +107,13 @@ public class StopTimesHelper {
           if (skipByPickUpDropOff(pattern, arrivalDeparture, i)) {
             continue;
           }
+          if (skipByStopCancellation(pattern, includeCancellations, i)) {
+            continue;
+          }
           for (TripTimes t : tt.getTripTimes()) {
+            if (skipByTripCancellation(t, includeCancellations)) {
+              continue;
+            }
             if (servicesRunning.contains(t.getServiceCode())) {
               stopTimes.times.add(new TripTimeOnDate(t, i, pattern, serviceDate, midnight));
             }
@@ -140,7 +147,8 @@ public class StopTimesHelper {
     Instant startTime,
     Duration timeRange,
     int numberOfDepartures,
-    ArrivalDeparture arrivalDeparture
+    ArrivalDeparture arrivalDeparture,
+    boolean includeCancellations
   ) {
     Queue<TripTimeOnDate> pq = listTripTimeShortsForPatternAtStop(
       transitService,
@@ -150,7 +158,7 @@ public class StopTimesHelper {
       timeRange,
       numberOfDepartures,
       arrivalDeparture,
-      false,
+      includeCancellations,
       true
     );
 

--- a/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
+++ b/src/main/java/org/opentripplanner/transit/service/DefaultTransitService.java
@@ -309,9 +309,16 @@ public class DefaultTransitService implements TransitEditorService {
   public List<StopTimesInPattern> getStopTimesForStop(
     StopLocation stop,
     LocalDate serviceDate,
-    ArrivalDeparture arrivalDeparture
+    ArrivalDeparture arrivalDeparture,
+    boolean includeCancellations
   ) {
-    return StopTimesHelper.stopTimesForStop(this, stop, serviceDate, arrivalDeparture);
+    return StopTimesHelper.stopTimesForStop(
+      this,
+      stop,
+      serviceDate,
+      arrivalDeparture,
+      includeCancellations
+    );
   }
 
   /**
@@ -336,7 +343,8 @@ public class DefaultTransitService implements TransitEditorService {
     Instant startTime,
     Duration timeRange,
     int numberOfDepartures,
-    ArrivalDeparture arrivalDeparture
+    ArrivalDeparture arrivalDeparture,
+    boolean includeCancellations
   ) {
     return StopTimesHelper.stopTimesForPatternAtStop(
       this,
@@ -345,7 +353,8 @@ public class DefaultTransitService implements TransitEditorService {
       startTime,
       timeRange,
       numberOfDepartures,
-      arrivalDeparture
+      arrivalDeparture,
+      includeCancellations
     );
   }
 

--- a/src/main/java/org/opentripplanner/transit/service/TransitService.java
+++ b/src/main/java/org/opentripplanner/transit/service/TransitService.java
@@ -130,7 +130,8 @@ public interface TransitService {
   List<StopTimesInPattern> getStopTimesForStop(
     StopLocation stop,
     LocalDate serviceDate,
-    ArrivalDeparture arrivalDeparture
+    ArrivalDeparture arrivalDeparture,
+    boolean includeCancellations
   );
 
   List<TripTimeOnDate> stopTimesForPatternAtStop(
@@ -139,7 +140,8 @@ public interface TransitService {
     Instant startTime,
     Duration timeRange,
     int numberOfDepartures,
-    ArrivalDeparture arrivalDeparture
+    ArrivalDeparture arrivalDeparture,
+    boolean includeCancellations
   );
 
   Collection<GroupOfRoutes> getGroupsOfRoutes();

--- a/src/test/java/org/opentripplanner/routing/stoptimes/StopTimesHelperTest.java
+++ b/src/test/java/org/opentripplanner/routing/stoptimes/StopTimesHelperTest.java
@@ -1,14 +1,18 @@
 package org.opentripplanner.routing.stoptimes;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.Month;
+import java.util.List;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.ConstantsForTests;
 import org.opentripplanner.TestOtpModel;
+import org.opentripplanner.model.StopTimesInPattern;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.service.DefaultTransitService;
@@ -33,6 +37,8 @@ class StopTimesHelperTest {
       transitService.getPatternForTrip(
         transitService.getTripForId(new FeedScopedId(feedId, "5.1"))
       );
+    var tt = transitService.getTimetableForTripPattern(pattern, LocalDate.now());
+    tt.getTripTimes(0).cancelTrip();
   }
 
   /**
@@ -87,6 +93,23 @@ class StopTimesHelperTest {
     );
 
     assertEquals(5, result.stream().mapToLong(s -> s.times.size()).sum());
+    assertFalse(hasCancelledTrips(result));
+  }
+
+  @Test
+  void stopTimesForStop_noCanceledDepartures() {
+    var result = StopTimesHelper.stopTimesForStop(
+      transitService,
+      transitService.getRegularStop(stopId),
+      serviceDate.atStartOfDay(transitService.getTimeZone()).toInstant(),
+      Duration.ofHours(24),
+      10,
+      ArrivalDeparture.BOTH,
+      false
+    );
+
+    assertEquals(4, result.stream().mapToLong(s -> s.times.size()).sum());
+    assertTrue(hasCancelledTrips(result));
   }
 
   /**
@@ -260,5 +283,15 @@ class StopTimesHelperTest {
     assertEquals((8 * 60 + 10) * 60, stopTime.getScheduledArrival());
     assertEquals((8 * 60 + 10) * 60, stopTime.getScheduledDeparture());
     assertEquals(serviceDate, stopTime.getServiceDay());
+  }
+
+  boolean hasCancelledTrips(List<StopTimesInPattern> stopTimes) {
+    return stopTimes
+      .stream()
+      .filter(s ->
+        s.times.stream().anyMatch(tripTimeOnDate -> tripTimeOnDate.isCanceledEffectively())
+      )
+      .findAny()
+      .isEmpty();
   }
 }

--- a/src/test/java/org/opentripplanner/routing/stoptimes/StopTimesHelperTest.java
+++ b/src/test/java/org/opentripplanner/routing/stoptimes/StopTimesHelperTest.java
@@ -93,7 +93,7 @@ class StopTimesHelperTest {
     );
 
     assertEquals(5, result.stream().mapToLong(s -> s.times.size()).sum());
-    assertFalse(hasCancelledTrips(result));
+    assertTrue(hasCancelledTrips(result));
   }
 
   @Test
@@ -109,7 +109,7 @@ class StopTimesHelperTest {
     );
 
     assertEquals(4, result.stream().mapToLong(s -> s.times.size()).sum());
-    assertTrue(hasCancelledTrips(result));
+    assertFalse(hasCancelledTrips(result));
   }
 
   /**
@@ -286,7 +286,7 @@ class StopTimesHelperTest {
   }
 
   boolean hasCancelledTrips(List<StopTimesInPattern> stopTimes) {
-    return stopTimes
+    return !stopTimes
       .stream()
       .filter(s ->
         s.times.stream().anyMatch(tripTimeOnDate -> tripTimeOnDate.isCanceledEffectively())

--- a/src/test/java/org/opentripplanner/routing/stoptimes/StopTimesHelperTest.java
+++ b/src/test/java/org/opentripplanner/routing/stoptimes/StopTimesHelperTest.java
@@ -155,7 +155,8 @@ class StopTimesHelperTest {
       serviceDate.atStartOfDay(transitService.getTimeZone()).toInstant(),
       Duration.ofHours(24),
       2,
-      ArrivalDeparture.BOTH
+      ArrivalDeparture.BOTH,
+      true
     );
 
     assertEquals(1, stopTimes.size());
@@ -180,7 +181,8 @@ class StopTimesHelperTest {
       serviceDate.atStartOfDay(transitService.getTimeZone()).plusHours(12).toInstant(),
       Duration.ofHours(24),
       2,
-      ArrivalDeparture.BOTH
+      ArrivalDeparture.BOTH,
+      true
     );
 
     assertEquals(1, stopTimes.size());
@@ -206,7 +208,8 @@ class StopTimesHelperTest {
       serviceDate.atStartOfDay(transitService.getTimeZone()).toInstant(),
       Duration.ofHours(48),
       2,
-      ArrivalDeparture.BOTH
+      ArrivalDeparture.BOTH,
+      true
     );
 
     assertEquals(2, stopTimes.size());
@@ -235,7 +238,8 @@ class StopTimesHelperTest {
       transitService,
       transitService.getRegularStop(stopId),
       serviceDate,
-      ArrivalDeparture.BOTH
+      ArrivalDeparture.BOTH,
+      true
     );
 
     assertEquals(5, result.stream().mapToLong(s -> s.times.size()).sum());


### PR DESCRIPTION
### Summary

Implements omitCanceled argument for some legacy graphQL stop time queries. The behavior of other APIs should remain the same.

### Issue

Minor sandbox related change so no issue.

### Unit tests

Not sure how complicated it would be to create tests for this.

### Documentation

No updates needed

### Changelog

TODO update sandbox changelog