### PR TITLE
Add support for importing zip datasets containing large entries

### DIFF
--- a/src/main/java/org/opentripplanner/datastore/file/AbstractFileDataSource.java
+++ b/src/main/java/org/opentripplanner/datastore/file/AbstractFileDataSource.java
@@ -25,7 +25,7 @@ public abstract class AbstractFileDataSource implements DataSource {
   }
 
   @Override
-  public final String name() {
+  public String name() {
     return file.getName();
   }
 

--- a/src/main/java/org/opentripplanner/datastore/file/TemporaryFileDataSource.java
+++ b/src/main/java/org/opentripplanner/datastore/file/TemporaryFileDataSource.java
@@ -10,14 +10,21 @@ import org.slf4j.LoggerFactory;
 public class TemporaryFileDataSource extends FileDataSource {
 
   private static final Logger LOG = LoggerFactory.getLogger(TemporaryFileDataSource.class);
+  private final String originalName;
 
   /**
    * Create a data source wrapper around a temporary file. This wrapper handles GZIP(.gz) compressed
    * files as well as normal files. It does not handle directories({@link DirectoryDataSource}) or
    * zip-files {@link ZipFileDataSource} which contain multiple files.
    */
-  public TemporaryFileDataSource(File file, FileType type) {
+  public TemporaryFileDataSource(String originalName, File file, FileType type) {
     super(file, type);
+    this.originalName = originalName;
+  }
+
+  @Override
+  public String name() {
+    return originalName;
   }
 
   public void deleteFile() {

--- a/src/main/java/org/opentripplanner/datastore/file/TemporaryFileDataSource.java
+++ b/src/main/java/org/opentripplanner/datastore/file/TemporaryFileDataSource.java
@@ -1,0 +1,35 @@
+package org.opentripplanner.datastore.file;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import org.opentripplanner.datastore.api.FileType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TemporaryFileDataSource extends FileDataSource {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TemporaryFileDataSource.class);
+
+  /**
+   * Create a data source wrapper around a temporary file. This wrapper handles GZIP(.gz) compressed
+   * files as well as normal files. It does not handle directories({@link DirectoryDataSource}) or
+   * zip-files {@link ZipFileDataSource} which contain multiple files.
+   */
+  public TemporaryFileDataSource(File file, FileType type) {
+    super(file, type);
+  }
+
+  public void deleteFile() {
+    try {
+      Files.delete(file.toPath());
+    } catch (IOException e) {
+      LOG.warn(
+        "Could not delete temporary file {} for temporary file datasource {}",
+        file.getName(),
+        name(),
+        e
+      );
+    }
+  }
+}

--- a/src/test/java/org/opentripplanner/datastore/base/ZipStreamDataSourceDecoratorTest.java
+++ b/src/test/java/org/opentripplanner/datastore/base/ZipStreamDataSourceDecoratorTest.java
@@ -11,7 +11,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.ConstantsForTests;
@@ -20,11 +19,11 @@ import org.opentripplanner.datastore.api.DataSource;
 import org.opentripplanner.datastore.file.FileDataSource;
 import org.opentripplanner.datastore.file.TemporaryFileDataSource;
 
-public class ZipStreamDataSourceDecoratorTest {
+class ZipStreamDataSourceDecoratorTest {
 
   private static final long TIME = 30 * 365 * 24 * 60 * 60 * 1000L;
   private static final String FILENAME = ConstantsForTests.CALTRAIN_GTFS;
-  public static final List<String> EXPECTED_ZIP_ENTRIES = List.of(
+  static final List<String> EXPECTED_ZIP_ENTRIES = List.of(
     "trips.txt",
     "agency.txt",
     "calendar.txt",
@@ -37,7 +36,7 @@ public class ZipStreamDataSourceDecoratorTest {
     "stops.txt"
   );
 
-  public static final Map<String, Long> EXPECTED_FILE_SIZES = Map.of(
+  static final Map<String, Long> EXPECTED_FILE_SIZES = Map.of(
     "trips.txt",
     19406L,
     "agency.txt",
@@ -61,7 +60,7 @@ public class ZipStreamDataSourceDecoratorTest {
   );
 
   @Test
-  public void testAccessorsForNoneExistingFile() throws IOException {
+  void testAccessorsForNoneExistingFile() throws IOException {
     // Given:
     File target = new File(FILENAME);
     File copyTarget = new File(FILENAME);
@@ -93,7 +92,7 @@ public class ZipStreamDataSourceDecoratorTest {
   }
 
   @Test
-  public void testIO() throws IOException {
+  void testIO() throws IOException {
     // Given:
     File target = new File(FILENAME);
     CompositeDataSource subject = new ZipStreamDataSourceDecorator(
@@ -101,7 +100,7 @@ public class ZipStreamDataSourceDecoratorTest {
     );
 
     Collection<DataSource> content = subject.content();
-    Collection<String> names = content.stream().map(it -> it.name()).collect(Collectors.toList());
+    Collection<String> names = content.stream().map(DataSource::name).toList();
 
     System.out.println(names);
     assertTrue(names.containsAll(EXPECTED_ZIP_ENTRIES), names.toString());
@@ -132,14 +131,13 @@ public class ZipStreamDataSourceDecoratorTest {
         .allMatch(dataSource -> EXPECTED_FILE_SIZES.get(dataSource.name()) == dataSource.size())
     );
     assertTrue(content.stream().allMatch(TemporaryFileDataSource.class::isInstance));
-    assertTrue(content.stream().allMatch(dataSource -> dataSource.size() > 0));
     assertTrue(content.stream().allMatch(DataSource::exists));
     subject.close();
     assertTrue(content.stream().noneMatch(DataSource::exists));
   }
 
   @Test
-  public void testEntryProperties() {
+  void testEntryProperties() {
     // Given:
     File target = new File(FILENAME);
     CompositeDataSource subject = new ZipStreamDataSourceDecorator(

--- a/src/test/java/org/opentripplanner/datastore/base/ZipStreamDataSourceDecoratorTest.java
+++ b/src/test/java/org/opentripplanner/datastore/base/ZipStreamDataSourceDecoratorTest.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
@@ -34,6 +35,29 @@ public class ZipStreamDataSourceDecoratorTest {
     "shapes.txt",
     "stop_times.txt",
     "stops.txt"
+  );
+
+  public static final Map<String, Long> EXPECTED_FILE_SIZES = Map.of(
+    "trips.txt",
+    19406L,
+    "agency.txt",
+    113L,
+    "calendar.txt",
+    351L,
+    "calendar_dates.txt",
+    170L,
+    "fare_attributes.txt",
+    199L,
+    "fare_rules.txt",
+    487L,
+    "routes.txt",
+    228L,
+    "shapes.txt",
+    145880L,
+    "stop_times.txt",
+    269891L,
+    "stops.txt",
+    3141L
   );
 
   @Test
@@ -102,6 +126,11 @@ public class ZipStreamDataSourceDecoratorTest {
     Collection<DataSource> content = subject.content();
     Collection<String> names = content.stream().map(DataSource::name).toList();
     assertTrue(names.containsAll(EXPECTED_ZIP_ENTRIES));
+    assertTrue(
+      content
+        .stream()
+        .allMatch(dataSource -> EXPECTED_FILE_SIZES.get(dataSource.name()) == dataSource.size())
+    );
     assertTrue(content.stream().allMatch(TemporaryFileDataSource.class::isInstance));
     assertTrue(content.stream().allMatch(dataSource -> dataSource.size() > 0));
     assertTrue(content.stream().allMatch(DataSource::exists));


### PR DESCRIPTION
### Summary

This PR adds support for importing zip files that contain large entries ( > 2GB).
In the current implementation, zip entries are uncompressed in memory in a ByteArrayOutputStream. However ByteArrayOutputStream does not support arrays larger than MAX_INT bytes (~ 2GB).
This PR ensures that larger entries are offloaded to temporary files on disk.

### Issue
Fix #4507

### Unit tests

Added unit test.

### Documentation

No.

