### PR TITLE
Add ETags handling to vector tile response

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/vectortiles/VectorTilesResource.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/VectorTilesResource.java
@@ -35,6 +35,7 @@ import org.opentripplanner.util.WorldEnvelope;
 @Path("/routers/{ignoreRouterId}/vectorTiles")
 public class VectorTilesResource {
 
+  public static final String APPLICATION_X_PROTOBUF = "application/x-protobuf";
   private static final Map<LayerType, LayerBuilderFactory> layers = new HashMap<>();
   private final OtpServerRequestContext serverContext;
   private final String ignoreRouterId;
@@ -60,7 +61,7 @@ public class VectorTilesResource {
 
   @GET
   @Path("/{layers}/{z}/{x}/{y}.pbf")
-  @Produces("application/x-protobuf")
+  @Produces(APPLICATION_X_PROTOBUF)
   public Response tileGet(
     @PathParam("x") int x,
     @PathParam("y") int y,

--- a/src/main/java/org/opentripplanner/standalone/server/EtagRequestFilter.java
+++ b/src/main/java/org/opentripplanner/standalone/server/EtagRequestFilter.java
@@ -17,6 +17,7 @@ public class EtagRequestFilter implements ContainerResponseFilter {
   public static final String HEADER_ETAG = "ETag";
   public static final String HEADER_IF_NONE_MATCH = "If-None-Match";
   public static final String HEADER_CONTENT_TYPE = "Content-Type";
+  public static final String HEADER_CACHE_CONTROL = "Cache-Control";
 
   @Override
   public void filter(ContainerRequestContext request, ContainerResponseContext response)
@@ -48,7 +49,7 @@ public class EtagRequestFilter implements ContainerResponseFilter {
   ) {
     var statusCode = response.getStatus();
     if (statusCode >= 200 && statusCode < 300 && HttpMethod.GET.matches(request.getMethod())) {
-      String cacheControl = response.getHeaderString("Cache-Control");
+      String cacheControl = response.getHeaderString(HEADER_CACHE_CONTROL);
       return (cacheControl == null || !cacheControl.contains(DIRECTIVE_NO_STORE));
     }
 
@@ -56,8 +57,8 @@ public class EtagRequestFilter implements ContainerResponseFilter {
   }
 
   private static String generateETagHeaderValue(byte[] input) {
-    StringBuilder builder = new StringBuilder(11);
-    builder.append("\"0");
+    StringBuilder builder = new StringBuilder(10);
+    builder.append('"');
     // according to https://softwareengineering.stackexchange.com/questions/49550
     // Murmur is the fastest hash algorithm and has an acceptable number of collisions.
     // (It doesn't need to be cryptographically secure.)

--- a/src/main/java/org/opentripplanner/standalone/server/EtagRequestFilter.java
+++ b/src/main/java/org/opentripplanner/standalone/server/EtagRequestFilter.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.standalone.server;
 
 import com.google.common.hash.Hashing;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import javax.ws.rs.HttpMethod;
 import javax.ws.rs.container.ContainerRequestContext;
@@ -34,6 +35,7 @@ public class EtagRequestFilter implements ContainerResponseFilter {
       // if the client's etag matches the generated one then send an empty response
       if (clientEtag != null && clientEtag.equals(etag)) {
         response.setEntity(null);
+        response.setEntityStream(new ByteArrayOutputStream());
         response.setStatus(HttpStatus.SC_NOT_MODIFIED);
       }
     }

--- a/src/main/java/org/opentripplanner/standalone/server/EtagRequestFilter.java
+++ b/src/main/java/org/opentripplanner/standalone/server/EtagRequestFilter.java
@@ -18,6 +18,7 @@ public class EtagRequestFilter implements ContainerResponseFilter {
   public static final String HEADER_IF_NONE_MATCH = "If-None-Match";
   public static final String HEADER_CONTENT_TYPE = "Content-Type";
   public static final String HEADER_CACHE_CONTROL = "Cache-Control";
+  public static final String HEADER_VARY = "Vary";
 
   @Override
   public void filter(ContainerRequestContext request, ContainerResponseContext response)
@@ -31,7 +32,7 @@ public class EtagRequestFilter implements ContainerResponseFilter {
       var clientEtag = request.getHeaderString(HEADER_IF_NONE_MATCH);
       var etag = generateETagHeaderValue(bytes);
       var headers = response.getHeaders();
-      headers.add("Vary", "Accept, Accept-Encoding, Accept-Language");
+      headers.add(HEADER_VARY, "Accept, Accept-Encoding, Accept-Language");
       headers.add(HEADER_ETAG, etag);
 
       // if the client's etag matches the generated one then send an empty response

--- a/src/main/java/org/opentripplanner/standalone/server/EtagRequestFilter.java
+++ b/src/main/java/org/opentripplanner/standalone/server/EtagRequestFilter.java
@@ -30,6 +30,7 @@ public class EtagRequestFilter implements ContainerResponseFilter {
       var clientEtag = request.getHeaderString(HEADER_IF_NONE_MATCH);
       var etag = generateETagHeaderValue(bytes);
       var headers = response.getHeaders();
+      headers.add("Vary", "Accept, Accept-Encoding, Accept-Language");
       headers.add(HEADER_ETAG, etag);
 
       // if the client's etag matches the generated one then send an empty response

--- a/src/main/java/org/opentripplanner/standalone/server/EtagRequestFilter.java
+++ b/src/main/java/org/opentripplanner/standalone/server/EtagRequestFilter.java
@@ -1,12 +1,12 @@
 package org.opentripplanner.standalone.server;
 
+import com.google.common.hash.Hashing;
 import java.io.IOException;
 import javax.ws.rs.HttpMethod;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
 import org.apache.commons.codec.binary.Hex;
-import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.http.HttpStatus;
 import org.opentripplanner.ext.vectortiles.VectorTilesResource;
 
@@ -42,7 +42,7 @@ public class EtagRequestFilter implements ContainerResponseFilter {
     ContainerRequestContext request,
     ContainerResponseContext response
   ) {
-    if (response.getLength() == 0) {
+    if (response.getLength() <= 0) {
       return false;
     }
     var statusCode = response.getStatus();
@@ -54,11 +54,10 @@ public class EtagRequestFilter implements ContainerResponseFilter {
     return false;
   }
 
-  private static String generateETagHeaderValue(byte[] output) {
-    // length of " + 0 + 32bits md5 hash + "
-    StringBuilder builder = new StringBuilder(37);
+  private static String generateETagHeaderValue(byte[] input) {
+    StringBuilder builder = new StringBuilder(11);
     builder.append("\"0");
-    var md5 = DigestUtils.getMd5Digest().digest(output);
+    var md5 = Hashing.murmur3_32_fixed().hashBytes(input).asBytes();
     var hex = Hex.encodeHex(md5);
     builder.append(hex);
     builder.append('"');

--- a/src/main/java/org/opentripplanner/standalone/server/EtagRequestFilter.java
+++ b/src/main/java/org/opentripplanner/standalone/server/EtagRequestFilter.java
@@ -55,8 +55,11 @@ public class EtagRequestFilter implements ContainerResponseFilter {
   private static String generateETagHeaderValue(byte[] input) {
     StringBuilder builder = new StringBuilder(11);
     builder.append("\"0");
-    var md5 = Hashing.murmur3_32_fixed().hashBytes(input).asBytes();
-    var hex = Hex.encodeHex(md5);
+    // according to https://softwareengineering.stackexchange.com/questions/49550
+    // Murmur is the fastest hash algorithm and has an acceptable number of collisions.
+    // (It doesn't need to be cryptographically secure.)
+    var hash = Hashing.murmur3_32_fixed().hashBytes(input).asBytes();
+    var hex = Hex.encodeHex(hash);
     builder.append(hex);
     builder.append('"');
     return builder.toString();

--- a/src/main/java/org/opentripplanner/standalone/server/EtagRequestFilter.java
+++ b/src/main/java/org/opentripplanner/standalone/server/EtagRequestFilter.java
@@ -1,0 +1,73 @@
+package org.opentripplanner.standalone.server;
+
+import java.io.IOException;
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.http.HttpStatus;
+import org.opentripplanner.ext.vectortiles.VectorTilesResource;
+
+public class EtagRequestFilter implements ContainerResponseFilter {
+
+  public static final String DIRECTIVE_NO_STORE = "no-store";
+  public static final String HEADER_ETAG = "ETag";
+  public static final String HEADER_IF_NONE_MATCH = "If-None-Match";
+  public static final String HEADER_CONTENT_TYPE = "Content-Type";
+
+  @Override
+  public void filter(ContainerRequestContext request, ContainerResponseContext response)
+    throws IOException {
+    if (
+      isEligibleForEtag(request, response) &&
+      hasAllowedContentType(response) &&
+      response.getEntity() instanceof byte[] bytes
+    ) {
+      var clientEtag = request.getHeaderString(HEADER_IF_NONE_MATCH);
+      var etag = generateETagHeaderValue(bytes);
+      var headers = response.getHeaders();
+      headers.add(HEADER_ETAG, etag);
+
+      // if the client's etag matches the generated one then send an empty response
+      if (clientEtag != null && clientEtag.equals(etag)) {
+        response.setEntity(null);
+        response.setStatus(HttpStatus.SC_NOT_MODIFIED);
+      }
+    }
+  }
+
+  private static boolean isEligibleForEtag(
+    ContainerRequestContext request,
+    ContainerResponseContext response
+  ) {
+    if (response.getLength() == 0) {
+      return false;
+    }
+    var statusCode = response.getStatus();
+    if (statusCode >= 200 && statusCode < 300 && HttpMethod.GET.matches(request.getMethod())) {
+      String cacheControl = response.getHeaderString("Cache-Control");
+      return (cacheControl == null || !cacheControl.contains(DIRECTIVE_NO_STORE));
+    }
+
+    return false;
+  }
+
+  private static String generateETagHeaderValue(byte[] output) {
+    // length of " + 0 + 32bits md5 hash + "
+    StringBuilder builder = new StringBuilder(37);
+    builder.append("\"0");
+    var md5 = DigestUtils.getMd5Digest().digest(output);
+    var hex = Hex.encodeHex(md5);
+    builder.append(hex);
+    builder.append('"');
+    return builder.toString();
+  }
+
+  private static boolean hasAllowedContentType(ContainerResponseContext response) {
+    return VectorTilesResource.APPLICATION_X_PROTOBUF.equals(
+      response.getStringHeaders().getFirst(HEADER_CONTENT_TYPE)
+    );
+  }
+}

--- a/src/main/java/org/opentripplanner/standalone/server/EtagRequestFilter.java
+++ b/src/main/java/org/opentripplanner/standalone/server/EtagRequestFilter.java
@@ -23,7 +23,8 @@ public class EtagRequestFilter implements ContainerResponseFilter {
     if (
       isEligibleForEtag(request, response) &&
       hasAllowedContentType(response) &&
-      response.getEntity() instanceof byte[] bytes
+      response.getEntity() instanceof byte[] bytes &&
+      bytes.length > 0
     ) {
       var clientEtag = request.getHeaderString(HEADER_IF_NONE_MATCH);
       var etag = generateETagHeaderValue(bytes);
@@ -42,9 +43,6 @@ public class EtagRequestFilter implements ContainerResponseFilter {
     ContainerRequestContext request,
     ContainerResponseContext response
   ) {
-    if (response.getLength() <= 0) {
-      return false;
-    }
     var statusCode = response.getStatus();
     if (statusCode >= 200 && statusCode < 300 && HttpMethod.GET.matches(request.getMethod())) {
       String cacheControl = response.getHeaderString("Cache-Control");

--- a/src/main/java/org/opentripplanner/standalone/server/EtagRequestFilter.java
+++ b/src/main/java/org/opentripplanner/standalone/server/EtagRequestFilter.java
@@ -18,7 +18,6 @@ public class EtagRequestFilter implements ContainerResponseFilter {
   public static final String HEADER_IF_NONE_MATCH = "If-None-Match";
   public static final String HEADER_CONTENT_TYPE = "Content-Type";
   public static final String HEADER_CACHE_CONTROL = "Cache-Control";
-  public static final String HEADER_VARY = "Vary";
 
   @Override
   public void filter(ContainerRequestContext request, ContainerResponseContext response)
@@ -32,7 +31,6 @@ public class EtagRequestFilter implements ContainerResponseFilter {
       var clientEtag = request.getHeaderString(HEADER_IF_NONE_MATCH);
       var etag = generateETagHeaderValue(bytes);
       var headers = response.getHeaders();
-      headers.add(HEADER_VARY, "Accept, Accept-Encoding, Accept-Language");
       headers.add(HEADER_ETAG, etag);
 
       // if the client's etag matches the generated one then send an empty response

--- a/src/main/java/org/opentripplanner/standalone/server/OTPWebApplication.java
+++ b/src/main/java/org/opentripplanner/standalone/server/OTPWebApplication.java
@@ -64,6 +64,7 @@ public class OTPWebApplication extends Application {
 
     /* Features and Filters: extend Jersey, manipulate requests and responses. */
     classes.add(CorsFilter.class);
+    classes.add(EtagRequestFilter.class);
 
     return classes;
   }

--- a/src/main/java/org/opentripplanner/standalone/server/OTPWebApplication.java
+++ b/src/main/java/org/opentripplanner/standalone/server/OTPWebApplication.java
@@ -63,8 +63,7 @@ public class OTPWebApplication extends Application {
     Set<Class<?>> classes = new HashSet<>(APIEndpoints.listAPIEndpoints());
 
     /* Features and Filters: extend Jersey, manipulate requests and responses. */
-    classes.add(CorsFilter.class);
-    classes.add(EtagRequestFilter.class);
+    classes.addAll(Set.of(CorsFilter.class, EtagRequestFilter.class, VaryRequestFilter.class));
 
     return classes;
   }
@@ -121,7 +120,8 @@ public class OTPWebApplication extends Application {
    * handlers, but in OTP we always just inject this OTP server context and grab anything else we
    * need (graph and other application components) from this single object.
    * <p>
-   * More on custom injection in Jersey 2: http://jersey.576304.n2.nabble.com/Custom-providers-in-Jersey-2-tp7580699p7580715.html
+   * More on custom injection in Jersey 2:
+   * http://jersey.576304.n2.nabble.com/Custom-providers-in-Jersey-2-tp7580699p7580715.html
    */
   private Binder makeBinder(Supplier<OtpServerRequestContext> contextProvider) {
     return new AbstractBinder() {

--- a/src/main/java/org/opentripplanner/standalone/server/VaryRequestFilter.java
+++ b/src/main/java/org/opentripplanner/standalone/server/VaryRequestFilter.java
@@ -1,0 +1,18 @@
+package org.opentripplanner.standalone.server;
+
+import java.io.IOException;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+
+public class VaryRequestFilter implements ContainerResponseFilter {
+
+  public static final String HEADER_VARY = "Vary";
+
+  @Override
+  public void filter(ContainerRequestContext request, ContainerResponseContext response)
+    throws IOException {
+    var headers = response.getHeaders();
+    headers.add(HEADER_VARY, "Accept, Accept-Encoding, Accept-Language");
+  }
+}

--- a/src/test/java/org/opentripplanner/standalone/server/EtagRequestFilterTest.java
+++ b/src/test/java/org/opentripplanner/standalone/server/EtagRequestFilterTest.java
@@ -1,39 +1,69 @@
 package org.opentripplanner.standalone.server;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.ext.vectortiles.VectorTilesResource.APPLICATION_X_PROTOBUF;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.stream.Stream;
+import javax.annotation.Nonnull;
 import org.glassfish.jersey.internal.MapPropertiesDelegate;
 import org.glassfish.jersey.message.internal.OutboundJaxrsResponse;
 import org.glassfish.jersey.message.internal.OutboundMessageContext;
 import org.glassfish.jersey.message.internal.Statuses;
 import org.glassfish.jersey.server.ContainerRequest;
 import org.glassfish.jersey.server.ContainerResponse;
-import org.junit.jupiter.api.Test;
-import org.opentripplanner.ext.vectortiles.VectorTilesResource;
+import org.jets3t.service.utils.Mimetypes;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.opentripplanner.test.support.VariableSource;
 
 class EtagRequestFilterTest {
 
-  @Test
-  void writeEtag() throws IOException {
-    var request = new ContainerRequest(null, null, "GET", null, new MapPropertiesDelegate(), null);
+  static Stream<Arguments> testCases = Stream.of(
+    Arguments.of("GET", 200, APPLICATION_X_PROTOBUF, bytes("hello123"), "\"0c8fc868b\""),
+    Arguments.of("GET", 404, APPLICATION_X_PROTOBUF, bytes("hello123"), null),
+    Arguments.of("GET", 200, "application/json", bytes("{}"), null),
+    Arguments.of("POST", 200, APPLICATION_X_PROTOBUF, bytes("hello123"), null),
+    Arguments.of("GET", 200, APPLICATION_X_PROTOBUF, bytes(""), null),
+    Arguments.of("POST", 200, Mimetypes.MIMETYPE_HTML, bytes("<body></body>"), null)
+  );
+
+  @ParameterizedTest(
+    name = "{0} request with response status={1} type={2}, entity={3} produces ETag header {4}"
+  )
+  @VariableSource("testCases")
+  void writeEtag(
+    String method,
+    int status,
+    String responseContentType,
+    byte[] entity,
+    String expectedEtag
+  ) throws IOException {
+    var request = request(method);
 
     var response = new ContainerResponse(
       request,
-      new OutboundJaxrsResponse(Statuses.from(200), new OutboundMessageContext())
+      new OutboundJaxrsResponse(Statuses.from(status), new OutboundMessageContext())
     );
-    response
-      .getHeaders()
-      .add(EtagRequestFilter.HEADER_CONTENT_TYPE, VectorTilesResource.APPLICATION_X_PROTOBUF);
-    response.setEntity("hello123".getBytes(StandardCharsets.UTF_8));
+    var headers = response.getHeaders();
+    headers.add(EtagRequestFilter.HEADER_CONTENT_TYPE, responseContentType);
+    headers.add("Content-Length", entity.length);
+    response.setEntity(entity);
 
     var filter = new EtagRequestFilter();
     filter.filter(request, response);
 
-    assertEquals(
-      "\"0f30aa7a662c728b7407c54ae6bfd27d1\"",
-      response.getHeaderString(EtagRequestFilter.HEADER_ETAG)
-    );
+    assertEquals(expectedEtag, response.getHeaderString(EtagRequestFilter.HEADER_ETAG));
+  }
+
+  @Nonnull
+  private static byte[] bytes(String input) {
+    return input.getBytes(StandardCharsets.UTF_8);
+  }
+
+  @Nonnull
+  private static ContainerRequest request(String method) {
+    return new ContainerRequest(null, null, method, null, new MapPropertiesDelegate(), null);
   }
 }

--- a/src/test/java/org/opentripplanner/standalone/server/EtagRequestFilterTest.java
+++ b/src/test/java/org/opentripplanner/standalone/server/EtagRequestFilterTest.java
@@ -1,0 +1,39 @@
+package org.opentripplanner.standalone.server;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.glassfish.jersey.internal.MapPropertiesDelegate;
+import org.glassfish.jersey.message.internal.OutboundJaxrsResponse;
+import org.glassfish.jersey.message.internal.OutboundMessageContext;
+import org.glassfish.jersey.message.internal.Statuses;
+import org.glassfish.jersey.server.ContainerRequest;
+import org.glassfish.jersey.server.ContainerResponse;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.ext.vectortiles.VectorTilesResource;
+
+class EtagRequestFilterTest {
+
+  @Test
+  void writeEtag() throws IOException {
+    var request = new ContainerRequest(null, null, "GET", null, new MapPropertiesDelegate(), null);
+
+    var response = new ContainerResponse(
+      request,
+      new OutboundJaxrsResponse(Statuses.from(200), new OutboundMessageContext())
+    );
+    response
+      .getHeaders()
+      .add(EtagRequestFilter.HEADER_CONTENT_TYPE, VectorTilesResource.APPLICATION_X_PROTOBUF);
+    response.setEntity("hello123".getBytes(StandardCharsets.UTF_8));
+
+    var filter = new EtagRequestFilter();
+    filter.filter(request, response);
+
+    assertEquals(
+      "\"0f30aa7a662c728b7407c54ae6bfd27d1\"",
+      response.getHeaderString(EtagRequestFilter.HEADER_ETAG)
+    );
+  }
+}

--- a/src/test/java/org/opentripplanner/standalone/server/EtagRequestFilterTest.java
+++ b/src/test/java/org/opentripplanner/standalone/server/EtagRequestFilterTest.java
@@ -22,7 +22,7 @@ import org.opentripplanner.test.support.VariableSource;
 class EtagRequestFilterTest {
 
   static final String vectorTilesResponse = "some vector tiles";
-  static final String vectorTilesEtag = "\"020c17790\"";
+  static final String vectorTilesEtag = "\"20c17790\"";
 
   static Stream<Arguments> etagCases = Stream.of(
     Arguments.of("GET", 200, APPLICATION_X_PROTOBUF, bytes(vectorTilesResponse), vectorTilesEtag),

--- a/src/test/java/org/opentripplanner/standalone/server/EtagRequestFilterTest.java
+++ b/src/test/java/org/opentripplanner/standalone/server/EtagRequestFilterTest.java
@@ -48,7 +48,6 @@ class EtagRequestFilterTest {
     var response = response(status, request);
     var headers = response.getHeaders();
     headers.add(EtagRequestFilter.HEADER_CONTENT_TYPE, responseContentType);
-    headers.add("Content-Length", entity.length);
     response.setEntity(entity);
 
     var filter = new EtagRequestFilter();
@@ -72,7 +71,6 @@ class EtagRequestFilterTest {
     var headers = response.getHeaders();
     headers.add(EtagRequestFilter.HEADER_CONTENT_TYPE, APPLICATION_X_PROTOBUF);
     var bytes = bytes(vectorTilesResponse);
-    headers.add("Content-Length", bytes.length);
     response.setEntity(bytes);
 
     var filter = new EtagRequestFilter();


### PR DESCRIPTION
### Summary

Improves the vector tile HTTP responses on slow network connections by adding ETag headers and honouring If-None-Match when sent by the client.

If anyone has an idea how I could add the filter to just the vector tile resource without checking for the content type, please let me know.

### Issue

#4469 

### Unit tests

Lots added.

cc @derhuerst