### PR TITLE
Specificity support for no-thru traffic restrictions

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/WayPropertySetSource.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/WayPropertySetSource.java
@@ -78,7 +78,7 @@ public interface WayPropertySetSource {
   default boolean isBicycleNoThroughTrafficExplicitlyDisallowed(OSMWithTags way) {
     String bicycle = way.getTag("bicycle");
     if (bicycle != null) {
-      return doesTagValueDisallowThroughTraffic(bicycle) || "dismount".equals(bicycle);
+      return doesTagValueDisallowThroughTraffic(bicycle);
     } else {
       return isVehicleThroughTrafficExplicitlyDisallowed(way);
     }

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/WayPropertySetSource.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/WayPropertySetSource.java
@@ -38,6 +38,7 @@ public interface WayPropertySetSource {
 
   default boolean doesTagValueDisallowThroughTraffic(String tagValue) {
     return (
+      "no".equals(tagValue) ||
       "destination".equals(tagValue) ||
       "private".equals(tagValue) ||
       "customers".equals(tagValue) ||
@@ -52,7 +53,11 @@ public interface WayPropertySetSource {
 
   default boolean isVehicleThroughTrafficExplicitlyDisallowed(OSMWithTags way) {
     String vehicle = way.getTag("vehicle");
-    return isGeneralNoThroughTraffic(way) || doesTagValueDisallowThroughTraffic(vehicle);
+    if (vehicle != null) {
+      return doesTagValueDisallowThroughTraffic(vehicle);
+    } else {
+      return isGeneralNoThroughTraffic(way);
+    }
   }
 
   /**
@@ -60,10 +65,11 @@ public interface WayPropertySetSource {
    */
   default boolean isMotorVehicleThroughTrafficExplicitlyDisallowed(OSMWithTags way) {
     String motorVehicle = way.getTag("motor_vehicle");
-    return (
-      isVehicleThroughTrafficExplicitlyDisallowed(way) ||
-      doesTagValueDisallowThroughTraffic(motorVehicle)
-    );
+    if (motorVehicle != null) {
+      return doesTagValueDisallowThroughTraffic(motorVehicle);
+    } else {
+      return isVehicleThroughTrafficExplicitlyDisallowed(way);
+    }
   }
 
   /**
@@ -71,10 +77,11 @@ public interface WayPropertySetSource {
    */
   default boolean isBicycleNoThroughTrafficExplicitlyDisallowed(OSMWithTags way) {
     String bicycle = way.getTag("bicycle");
-    return (
-      isVehicleThroughTrafficExplicitlyDisallowed(way) ||
-      doesTagValueDisallowThroughTraffic(bicycle)
-    );
+    if (bicycle != null) {
+      return doesTagValueDisallowThroughTraffic(bicycle) || "dismount".equals(bicycle);
+    } else {
+      return isVehicleThroughTrafficExplicitlyDisallowed(way);
+    }
   }
 
   /**
@@ -82,6 +89,10 @@ public interface WayPropertySetSource {
    */
   default boolean isWalkNoThroughTrafficExplicitlyDisallowed(OSMWithTags way) {
     String foot = way.getTag("foot");
-    return isGeneralNoThroughTraffic(way) || doesTagValueDisallowThroughTraffic(foot);
+    if (foot != null) {
+      return doesTagValueDisallowThroughTraffic(foot);
+    } else {
+      return isGeneralNoThroughTraffic(way);
+    }
   }
 }

--- a/src/main/java/org/opentripplanner/openstreetmap/model/OSMWithTags.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/model/OSMWithTags.java
@@ -287,7 +287,11 @@ public class OSMWithTags {
    * bicycle is denied if bicycle:no, bicycle:dismount, bicycle:license or bicycle:use_sidepath
    */
   public boolean isBicycleExplicitlyDenied() {
-    return isTagDeniedAccess("bicycle") || "dismount".equals(getTag("bicycle")) || "use_sidepath".equals(getTag("bicycle"));
+    return (
+      isTagDeniedAccess("bicycle") ||
+      "dismount".equals(getTag("bicycle")) ||
+      "use_sidepath".equals(getTag("bicycle"))
+    );
   }
 
   /**

--- a/src/main/java/org/opentripplanner/openstreetmap/model/OSMWithTags.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/model/OSMWithTags.java
@@ -284,10 +284,10 @@ public class OSMWithTags {
   /**
    * Returns true if bikes are explicitly denied access.
    * <p>
-   * bicycle is denied if bicycle:no, bicycle:license or bicycle:use_sidepath
+   * bicycle is denied if bicycle:no, bicycle:dismount, bicycle:license or bicycle:use_sidepath
    */
   public boolean isBicycleExplicitlyDenied() {
-    return isTagDeniedAccess("bicycle") || "use_sidepath".equals(getTag("bicycle"));
+    return isTagDeniedAccess("bicycle") || "dismount".equals(getTag("bicycle")) || "use_sidepath".equals(getTag("bicycle"));
   }
 
   /**

--- a/src/test/java/org/opentripplanner/graph_builder/module/osm/WayPropertySetSourceTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/osm/WayPropertySetSourceTest.java
@@ -157,18 +157,6 @@ public class WayPropertySetSourceTest {
     assertTrue(wayPropertySetSource.isWalkNoThroughTrafficExplicitlyDisallowed(tags));
   }
 
-  @Test
-  public void testBicycleDismount() {
-    OSMWithTags tags = new OSMWithTags();
-    WayPropertySetSource wayPropertySetSource = new DefaultWayPropertySetSource();
-
-    tags.addTag("bicycle", "dismount");
-
-    assertFalse(wayPropertySetSource.isMotorVehicleThroughTrafficExplicitlyDisallowed(tags));
-    assertTrue(wayPropertySetSource.isBicycleNoThroughTrafficExplicitlyDisallowed(tags));
-    assertFalse(wayPropertySetSource.isWalkNoThroughTrafficExplicitlyDisallowed(tags));
-  }
-
   public OSMWithTags way(String key, String value) {
     var way = new OSMWithTags();
     way.addTag(key, value);

--- a/src/test/java/org/opentripplanner/graph_builder/module/osm/WayPropertySetSourceTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/osm/WayPropertySetSourceTest.java
@@ -119,6 +119,44 @@ public class WayPropertySetSourceTest {
   }
 
   @Test
+  public void testVehicleDenied() {
+    OSMWithTags tags = new OSMWithTags();
+    WayPropertySetSource wayPropertySetSource = new DefaultWayPropertySetSource();
+
+    tags.addTag("vehicle", "destination");
+
+    assertTrue(wayPropertySetSource.isMotorVehicleThroughTrafficExplicitlyDisallowed(tags));
+    assertTrue(wayPropertySetSource.isBicycleNoThroughTrafficExplicitlyDisallowed(tags));
+    assertFalse(wayPropertySetSource.isWalkNoThroughTrafficExplicitlyDisallowed(tags));
+  }
+
+  @Test
+  public void testVehicleDeniedMotorVehiclePermissive() {
+    OSMWithTags tags = new OSMWithTags();
+    WayPropertySetSource wayPropertySetSource = new DefaultWayPropertySetSource();
+
+    tags.addTag("vehicle", "destination");
+    tags.addTag("motor_vehicle", "designated");
+
+    assertFalse(wayPropertySetSource.isMotorVehicleThroughTrafficExplicitlyDisallowed(tags));
+    assertTrue(wayPropertySetSource.isBicycleNoThroughTrafficExplicitlyDisallowed(tags));
+    assertFalse(wayPropertySetSource.isWalkNoThroughTrafficExplicitlyDisallowed(tags));
+  }
+
+  @Test
+  public void testVehicleDeniedBicyclePermissive() {
+    OSMWithTags tags = new OSMWithTags();
+    WayPropertySetSource wayPropertySetSource = new DefaultWayPropertySetSource();
+
+    tags.addTag("vehicle", "destination");
+    tags.addTag("bicycle", "designated");
+
+    assertTrue(wayPropertySetSource.isMotorVehicleThroughTrafficExplicitlyDisallowed(tags));
+    assertFalse(wayPropertySetSource.isBicycleNoThroughTrafficExplicitlyDisallowed(tags));
+    assertFalse(wayPropertySetSource.isWalkNoThroughTrafficExplicitlyDisallowed(tags));
+  }
+
+  @Test
   public void testMotorcycleModifier() {
     OSMWithTags tags = new OSMWithTags();
     WayPropertySetSource wayPropertySetSource = new DefaultWayPropertySetSource();

--- a/src/test/java/org/opentripplanner/graph_builder/module/osm/WayPropertySetSourceTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/osm/WayPropertySetSourceTest.java
@@ -82,6 +82,93 @@ public class WayPropertySetSourceTest {
     assertEquals(1, wps.getDataForWay(withFoo).getBicycleSafetyFeatures().back());
   }
 
+  public void testAccessNo() {
+    OSMWithTags tags = new OSMWithTags();
+    WayPropertySetSource wayPropertySetSource = new DefaultWayPropertySetSource();
+
+    tags.addTag("access", "no");
+
+    assertTrue(wayPropertySetSource.isMotorVehicleThroughTrafficExplicitlyDisallowed(tags));
+    assertTrue(wayPropertySetSource.isBicycleNoThroughTrafficExplicitlyDisallowed(tags));
+    assertTrue(wayPropertySetSource.isWalkNoThroughTrafficExplicitlyDisallowed(tags));
+  }
+
+  @Test
+  public void testAccessPrivate() {
+    OSMWithTags tags = new OSMWithTags();
+    WayPropertySetSource wayPropertySetSource = new DefaultWayPropertySetSource();
+
+    tags.addTag("access", "private");
+
+    assertTrue(wayPropertySetSource.isMotorVehicleThroughTrafficExplicitlyDisallowed(tags));
+    assertTrue(wayPropertySetSource.isBicycleNoThroughTrafficExplicitlyDisallowed(tags));
+    assertTrue(wayPropertySetSource.isWalkNoThroughTrafficExplicitlyDisallowed(tags));
+  }
+
+  @Test
+  public void testFootModifier() {
+    OSMWithTags tags = new OSMWithTags();
+    WayPropertySetSource wayPropertySetSource = new DefaultWayPropertySetSource();
+
+    tags.addTag("access", "private");
+    tags.addTag("foot", "yes");
+
+    assertTrue(wayPropertySetSource.isMotorVehicleThroughTrafficExplicitlyDisallowed(tags));
+    assertTrue(wayPropertySetSource.isBicycleNoThroughTrafficExplicitlyDisallowed(tags));
+    assertFalse(wayPropertySetSource.isWalkNoThroughTrafficExplicitlyDisallowed(tags));
+  }
+
+  @Test
+  public void testMotorcycleModifier() {
+    OSMWithTags tags = new OSMWithTags();
+    WayPropertySetSource wayPropertySetSource = new DefaultWayPropertySetSource();
+
+    tags.addTag("access", "private");
+    tags.addTag("motor_vehicle", "yes");
+
+    assertFalse(wayPropertySetSource.isMotorVehicleThroughTrafficExplicitlyDisallowed(tags));
+    assertTrue(wayPropertySetSource.isBicycleNoThroughTrafficExplicitlyDisallowed(tags));
+    assertTrue(wayPropertySetSource.isWalkNoThroughTrafficExplicitlyDisallowed(tags));
+  }
+
+  @Test
+  public void testBicycleModifier() {
+    OSMWithTags tags = new OSMWithTags();
+    WayPropertySetSource wayPropertySetSource = new DefaultWayPropertySetSource();
+
+    tags.addTag("access", "private");
+    tags.addTag("bicycle", "yes");
+
+    assertTrue(wayPropertySetSource.isMotorVehicleThroughTrafficExplicitlyDisallowed(tags));
+    assertFalse(wayPropertySetSource.isBicycleNoThroughTrafficExplicitlyDisallowed(tags));
+    assertTrue(wayPropertySetSource.isWalkNoThroughTrafficExplicitlyDisallowed(tags));
+  }
+
+  @Test
+  public void testBicyclePermissive() {
+    OSMWithTags tags = new OSMWithTags();
+    WayPropertySetSource wayPropertySetSource = new DefaultWayPropertySetSource();
+
+    tags.addTag("access", "private");
+    tags.addTag("bicycle", "permissive");
+
+    assertTrue(wayPropertySetSource.isMotorVehicleThroughTrafficExplicitlyDisallowed(tags));
+    assertFalse(wayPropertySetSource.isBicycleNoThroughTrafficExplicitlyDisallowed(tags));
+    assertTrue(wayPropertySetSource.isWalkNoThroughTrafficExplicitlyDisallowed(tags));
+  }
+
+  @Test
+  public void testBicycleDismount() {
+    OSMWithTags tags = new OSMWithTags();
+    WayPropertySetSource wayPropertySetSource = new DefaultWayPropertySetSource();
+
+    tags.addTag("bicycle", "dismount");
+
+    assertFalse(wayPropertySetSource.isMotorVehicleThroughTrafficExplicitlyDisallowed(tags));
+    assertTrue(wayPropertySetSource.isBicycleNoThroughTrafficExplicitlyDisallowed(tags));
+    assertFalse(wayPropertySetSource.isWalkNoThroughTrafficExplicitlyDisallowed(tags));
+  }
+
   public OSMWithTags way(String key, String value) {
     var way = new OSMWithTags();
     way.addTag(key, value);

--- a/src/test/java/org/opentripplanner/openstreetmap/model/OSMWithTagsTest.java
+++ b/src/test/java/org/opentripplanner/openstreetmap/model/OSMWithTagsTest.java
@@ -113,6 +113,22 @@ public class OSMWithTagsTest {
   }
 
   @Test
+  public void testBicycleDenied() {
+    OSMWithTags tags = new OSMWithTags();
+    assertFalse(tags.isBicycleExplicitlyDenied());
+
+    for (var allowedValue : List.of("yes", "unknown", "somevalue")) {
+      tags.addTag("bicycle", allowedValue);
+      assertFalse(tags.isBicycleExplicitlyDenied(), "bicycle=" + allowedValue);
+    }
+
+    for (var deniedValue : List.of("no", "dismount", "license", "use_sidepath")) {
+      tags.addTag("bicycle", deniedValue);
+      assertTrue(tags.isBicycleExplicitlyDenied(), "bicycle=" + deniedValue);
+    }
+  }
+
+  @Test
   public void getReferenceTags() {
     var osm = new OSMWithTags();
     osm.addTag("ref", "A");


### PR DESCRIPTION
### Summary

Support overriding general access restrictions (`access=private`) with more specific ones (`foot=yes`).

### Issue

closes #2669

### Unit tests

Unit tests are extended.

### Documentation

No changes.