### PR TITLE
Handle cancelled trips correctly in SIRI ET module

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
@@ -988,9 +988,14 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
       Trip trip = tripTimes.getTrip();
       for (TripPattern pattern : patterns) {
         if (tripTimes.getNumStops() == pattern.numberOfStops()) {
-          // Check whether trip id has been used for previously ADDED/MODIFIED trip message and remove
-          // previously created trip
+          // All tripTimes should be handled the same way to always allow latest realtime-update to
+          // replace previous update regardless of realtimestate
+          cancelScheduledTrip(trip, serviceDate);
+
+          // Also check whether trip id has been used for previously ADDED/MODIFIED trip message and
+          // remove the previously created trip
           removePreviousRealtimeUpdate(trip, serviceDate);
+
           cancelScheduledTrip(trip, serviceDate);
           if (!tripTimes.isCanceled()) {
             // UPDATED and MODIFIED tripTimes should be handled the same way to always allow latest

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
@@ -1026,7 +1026,7 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
                 .ifFailure(errors::add);
             }
           } else {
-            buffer.update(pattern, tripTimes, serviceDate).ifFailure(errors::add);
+            cancelScheduledTrip(trip, serviceDate);
           }
 
           LOG.debug("Applied realtime data for trip {}", trip.getId().getId());

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
@@ -988,14 +988,13 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
       Trip trip = tripTimes.getTrip();
       for (TripPattern pattern : patterns) {
         if (tripTimes.getNumStops() == pattern.numberOfStops()) {
+          // Check whether trip id has been used for previously ADDED/MODIFIED trip message and remove
+          // previously created trip
+          removePreviousRealtimeUpdate(trip, serviceDate);
           if (!tripTimes.isCanceled()) {
             // UPDATED and MODIFIED tripTimes should be handled the same way to always allow latest
             // realtime-update to replace previous update regardless of realtimestate
             cancelScheduledTrip(trip, serviceDate);
-
-            // Check whether trip id has been used for previously ADDED/MODIFIED trip message and remove
-            // previously created trip
-            removePreviousRealtimeUpdate(trip, serviceDate);
 
             // Calculate modified stop-pattern
             var modifiedStops = createModifiedStops(
@@ -1027,7 +1026,6 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
                 .ifFailure(errors::add);
             }
           } else {
-            removePreviousRealtimeUpdate(trip, serviceDate);
             buffer.update(pattern, tripTimes, serviceDate).ifFailure(errors::add);
           }
 

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
@@ -1027,6 +1027,7 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
                 .ifFailure(errors::add);
             }
           } else {
+            removePreviousRealtimeUpdate(trip, serviceDate);
             buffer.update(pattern, tripTimes, serviceDate).ifFailure(errors::add);
           }
 

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
@@ -996,12 +996,7 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
           // remove the previously created trip
           removePreviousRealtimeUpdate(trip, serviceDate);
 
-          cancelScheduledTrip(trip, serviceDate);
           if (!tripTimes.isCanceled()) {
-            // UPDATED and MODIFIED tripTimes should be handled the same way to always allow latest
-            // realtime-update to replace previous update regardless of realtimestate
-            cancelScheduledTrip(trip, serviceDate);
-
             // Calculate modified stop-pattern
             var modifiedStops = createModifiedStops(
               pattern,

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
@@ -991,6 +991,7 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
           // Check whether trip id has been used for previously ADDED/MODIFIED trip message and remove
           // previously created trip
           removePreviousRealtimeUpdate(trip, serviceDate);
+          cancelScheduledTrip(trip, serviceDate);
           if (!tripTimes.isCanceled()) {
             // UPDATED and MODIFIED tripTimes should be handled the same way to always allow latest
             // realtime-update to replace previous update regardless of realtimestate
@@ -1025,8 +1026,6 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
               )
                 .ifFailure(errors::add);
             }
-          } else {
-            cancelScheduledTrip(trip, serviceDate);
           }
 
           LOG.debug("Applied realtime data for trip {}", trip.getId().getId());


### PR DESCRIPTION
### Summary
Ensure that previous real-time updates are removed when whole trip is cancelled.

### Issue
This PR takes care of following edge case:

1. real-time module receives ET message for a trip (no cancellations at this point) 
    new trip is create in real-time timetable.
2. real-time module receives another ET message, whole trip is cancelled
    trip from scheduled timetabled changes status to CANCELLED
    trip isn't removed from real-time timetable 
    OTP performs new search and cancelled trip comes up as a valid result since it isn't cancelled in real-time timetable. 

### Unit tests
- no new unit tests added

### Documentation
- no new documentation added
