### PR TITLE
Remove unnecessary sourceType attribute from GTFS-RT configuration 

### DIFF
--- a/docs/RouterConfiguration.md
+++ b/docs/RouterConfiguration.md
@@ -427,8 +427,6 @@ Common to all updater entries that connect to a network resource is the `url` fi
         {
             "type": "stop-time-updater",
             "frequencySec": 60,
-            // this is either http or file... shouldn't it default to http or guess from the presence of a URL?
-            "sourceType": "gtfs-http",
             // Optional parameter for defining behaviour for propagating delays to previous stops.
             // Default value is "REQUIRED_NO_DATA" which only propagates delays backwards when it is required
             // to ensure that the times are increasing and it sets the NO_DATA flag on the stops so these
@@ -445,7 +443,6 @@ Common to all updater entries that connect to a network resource is the `url` fi
         // Polling for GTFS-RT Vehicle Positions - output can be fetched via trip pattern GraphQL APIs 
         {
             "type": "vehicle-positions",
-            "sourceType": "gtfs-rt-http",
             "url": "https://s3.amazonaws.com/kcm-alerts-realtime-prod/vehiclepositions.pb",
             "feedId": "1",
             "frequencySec": 60

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETUpdater.java
@@ -25,7 +25,6 @@ import uk.org.siri.siri20.Siri;
  * <pre>
  * rt.type = stop-time-updater
  * rt.frequencySec = 60
- * rt.sourceType = gtfs-http
  * rt.url = http://host.tld/path
  * rt.feedId = TA
  * </pre>

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriVMUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriVMUpdater.java
@@ -22,7 +22,6 @@ import uk.org.siri.siri20.VehicleMonitoringDeliveryStructure;
  * <pre>
  * rt.type = stop-time-updater
  * rt.frequencySec = 60
- * rt.sourceType = gtfs-http
  * rt.url = http://host.tld/path
  * rt.feedId = TA
  * </pre>

--- a/src/main/java/org/opentripplanner/standalone/config/updaters/PollingStoptimeUpdaterConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/updaters/PollingStoptimeUpdaterConfig.java
@@ -13,28 +13,25 @@ public class PollingStoptimeUpdaterConfig {
   public static PollingTripUpdaterParameters create(String configRef, NodeAdapter c) {
     String file = null;
     String url = null;
-    var sourceType = c
-      .of("sourceType")
-      .withDoc(NA, /*TODO DOC*/"TODO")
-      .withExample(/*TODO DOC*/"TODO")
-      .asEnum(DataSourceType.class);
 
-    if (sourceType == DataSourceType.GTFS_RT_FILE) {
+    if (c.exist("file")) {
       file =
         c.of("file").withDoc(NA, /*TODO DOC*/"TODO").withExample(/*TODO DOC*/"TODO").asString();
-    } else if (sourceType == DataSourceType.GTFS_RT_HTTP) {
+    } else if (c.exist("url")) {
       url = c.of("url").withDoc(NA, /*TODO DOC*/"TODO").withExample(/*TODO DOC*/"TODO").asString();
     } else {
       throw new OtpAppException(
-        "Polling-stoptime-updater sourece-type is not valid: {}",
-        sourceType
+        "Need either 'url' or 'file' properties to configure " +
+        configRef +
+        " but received: " +
+        c.asText()
       );
     }
 
     // TODO DOC: Deprecate  c.of("logFrequency").withDoc(NA, /*TODO DOC*/"TODO").asInt(-1)
 
     return new PollingTripUpdaterParameters(
-      configRef + ":" + sourceType,
+      configRef,
       c.of("frequencySec").withDoc(NA, /*TODO DOC*/"TODO").asInt(60),
       c.of("maxSnapshotFrequencyMs").withDoc(NA, /*TODO DOC*/"TODO").asInt(-1),
       c.of("purgeExpiredData").withDoc(NA, /*TODO DOC*/"TODO").asBoolean(false),
@@ -43,7 +40,6 @@ public class PollingStoptimeUpdaterConfig {
         .of("backwardsDelayPropagationType")
         .withDoc(NA, /*TODO DOC*/"TODO")
         .asEnum(BackwardsDelayPropagationType.REQUIRED_NO_DATA),
-      sourceType,
       c.of("feedId").withDoc(NA, /*TODO DOC*/"TODO").withExample(/*TODO DOC*/"TODO").asString(null),
       url,
       file

--- a/src/main/java/org/opentripplanner/standalone/config/updaters/VehiclePositionsUpdaterConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/updaters/VehiclePositionsUpdaterConfig.java
@@ -10,10 +10,6 @@ import org.opentripplanner.util.OtpAppException;
 public class VehiclePositionsUpdaterConfig {
 
   public static VehiclePositionsUpdaterParameters create(String updaterRef, NodeAdapter c) {
-    var sourceType = c
-      .of("sourceType")
-      .withDoc(NA, /*TODO DOC*/"TODO")
-      .asEnum(DataSourceType.class);
     var feedId = c
       .of("feedId")
       .withDoc(NA, /*TODO DOC*/"TODO")
@@ -21,18 +17,7 @@ public class VehiclePositionsUpdaterConfig {
       .asString();
     var frequencySec = c.of("frequencySec").withDoc(NA, /*TODO DOC*/"TODO").asInt(60);
 
-    switch (sourceType) {
-      // TODO: We should probably only allow one of these?
-      case GTFS_RT_HTTP:
-      case GTFS_RT_VEHICLE_POSITIONS:
-        var url = c
-          .of("url")
-          .withDoc(NA, /*TODO DOC*/"TODO")
-          .withExample(/*TODO DOC*/"TODO")
-          .asUri();
-        return new VehiclePositionsUpdaterParameters(updaterRef, feedId, url, frequencySec);
-      default:
-        throw new OtpAppException("The updater source type is unhandled: " + sourceType);
-    }
+    var url = c.of("url").withDoc(NA, /*TODO DOC*/"TODO").withExample(/*TODO DOC*/"TODO").asUri();
+    return new VehiclePositionsUpdaterParameters(updaterRef, feedId, url, frequencySec);
   }
 }

--- a/src/main/java/org/opentripplanner/updater/DataSourceType.java
+++ b/src/main/java/org/opentripplanner/updater/DataSourceType.java
@@ -11,11 +11,4 @@ public enum DataSourceType {
   PARK_API,
   BICYCLE_PARK_API,
   HSL_PARK,
-
-  // GTFS RT
-  GTFS_RT_HTTP,
-  GTFS_RT_FILE,
-
-  // GTFS-RT Vehicle Positions
-  GTFS_RT_VEHICLE_POSITIONS,
 }

--- a/src/main/java/org/opentripplanner/updater/trip/PollingTripUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/trip/PollingTripUpdater.java
@@ -21,7 +21,6 @@ import org.slf4j.LoggerFactory;
  * <pre>
  * rt.type = stop-time-updater
  * rt.frequencySec = 60
- * rt.sourceType = gtfs-http
  * rt.url = http://host.tld/path
  * rt.feedId = TA
  * </pre>

--- a/src/main/java/org/opentripplanner/updater/trip/PollingTripUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/trip/PollingTripUpdater.java
@@ -120,14 +120,15 @@ public class PollingTripUpdater extends PollingGraphUpdater {
   }
 
   private static TripUpdateSource createSource(PollingTripUpdaterParameters parameters) {
-    switch (parameters.getSourceType()) {
-      case GTFS_RT_HTTP:
-        return new GtfsRealtimeHttpTripUpdateSource(parameters.httpSourceParameters());
-      case GTFS_RT_FILE:
-        return new GtfsRealtimeFileTripUpdateSource(parameters.fileSourceParameters());
+    if (parameters.httpSourceParameters().getUrl() != null) {
+      return new GtfsRealtimeHttpTripUpdateSource(parameters.httpSourceParameters());
+    } else if (parameters.fileSourceParameters().getFile() != null) {
+      return new GtfsRealtimeFileTripUpdateSource(parameters.fileSourceParameters());
+    } else {
+      throw new IllegalArgumentException(
+        "Need either a url or file argument to construct a" +
+        PollingTripUpdater.class.getSimpleName()
+      );
     }
-    throw new IllegalArgumentException(
-      "Unknown update streamer source type: " + parameters.getSourceType()
-    );
   }
 }

--- a/src/main/java/org/opentripplanner/updater/trip/PollingTripUpdaterParameters.java
+++ b/src/main/java/org/opentripplanner/updater/trip/PollingTripUpdaterParameters.java
@@ -14,7 +14,6 @@ public class PollingTripUpdaterParameters
   private final BackwardsDelayPropagationType backwardsDelayPropagationType;
 
   // Source
-  private final DataSourceType sourceType;
   private final String feedId;
   private final String httpSourceUrl;
   private final String fileSource;
@@ -26,7 +25,6 @@ public class PollingTripUpdaterParameters
     boolean purgeExpiredData,
     boolean fuzzyTripMatching,
     BackwardsDelayPropagationType backwardsDelayPropagationType,
-    DataSourceType sourceType,
     String feedId,
     String httpSourceUrl,
     String fileSource
@@ -37,7 +35,6 @@ public class PollingTripUpdaterParameters
     this.purgeExpiredData = purgeExpiredData;
     this.fuzzyTripMatching = fuzzyTripMatching;
     this.backwardsDelayPropagationType = backwardsDelayPropagationType;
-    this.sourceType = sourceType;
     this.feedId = feedId;
     this.httpSourceUrl = httpSourceUrl;
     this.fileSource = fileSource;
@@ -58,16 +55,8 @@ public class PollingTripUpdaterParameters
     return configRef;
   }
 
-  public DataSourceType getSourceType() {
-    return sourceType;
-  }
-
   public String getFeedId() {
     return feedId;
-  }
-
-  boolean purgeExpiredData() {
-    return purgeExpiredData;
   }
 
   boolean fuzzyTripMatching() {

--- a/src/main/java/org/opentripplanner/updater/trip/PollingTripUpdaterParameters.java
+++ b/src/main/java/org/opentripplanner/updater/trip/PollingTripUpdaterParameters.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.updater.trip;
 
-import org.opentripplanner.updater.DataSourceType;
 import org.opentripplanner.updater.PollingGraphUpdaterParameters;
 
 public class PollingTripUpdaterParameters
@@ -13,7 +12,6 @@ public class PollingTripUpdaterParameters
   private final boolean fuzzyTripMatching;
   private final BackwardsDelayPropagationType backwardsDelayPropagationType;
 
-  // Source
   private final String feedId;
   private final String httpSourceUrl;
   private final String fileSource;

--- a/src/main/java/org/opentripplanner/updater/vehicle_position/PollingVehiclePositionUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_position/PollingVehiclePositionUpdater.java
@@ -19,7 +19,6 @@ import org.slf4j.LoggerFactory;
  * <pre>
  * rt.type = vehicle-positions
  * rt.frequencySec = 60
- * rt.sourceType = gtfs-http
  * rt.url = http://host.tld/path
  * rt.feedId = TA
  * </pre>

--- a/src/test/resources/standalone/config/router-config.json
+++ b/src/test/resources/standalone/config/router-config.json
@@ -179,8 +179,6 @@
     {
       "type": "stop-time-updater",
       "frequencySec": 60,
-      // this is either http or file... shouldn't it default to http or guess from the presence of a URL?
-      "sourceType": "gtfs-rt-http",
       // Optional parameter for defining behaviour for propagating delays to previous stops.
       // Default value is "REQUIRED_NO_DATA" which only propagates delays backwards when it is required
       // to ensure that the times are increasing and it sets the NO_DATA flag on the stops so these
@@ -197,7 +195,6 @@
     // Polling for GTFS-RT Vehicle Positions - output can be fetched via trip pattern GraphQL APIss
     {
       "type": "vehicle-positions",
-      "sourceType": "gtfs-rt-http",
       "url": "https://s3.amazonaws.com/kcm-alerts-realtime-prod/vehiclepositions.pb",
       "feedId": "1",
       "frequencySec": 60


### PR DESCRIPTION
### Summary

In #4517 the field configType for GTFS-RT updaters was changed leading to users having to update their config files. This led me to investigate if the field is actually necessary and it turns out that it isn't!

Removing this field resolves a couple of long standing TODOs and will make configuration easier.

### Documentation

Updated.