### PR TITLE
Do not yet allow passthrough traffic by foot/bike=yes tags in Finland

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/FinlandWayPropertySetSource.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/FinlandWayPropertySetSource.java
@@ -8,6 +8,7 @@ import static org.opentripplanner.routing.edgetype.StreetTraversalPermission.PED
 import static org.opentripplanner.routing.edgetype.StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE;
 
 import java.util.function.BiFunction;
+import org.opentripplanner.openstreetmap.model.OSMWithTags;
 import org.opentripplanner.routing.edgetype.StreetTraversalPermission;
 
 /**
@@ -129,5 +130,20 @@ public class FinlandWayPropertySetSource implements WayPropertySetSource {
 
     // Read the rest from the default set
     new DefaultWayPropertySetSource().populateProperties(props);
+  }
+
+  @Override
+  public boolean isBicycleNoThroughTrafficExplicitlyDisallowed(OSMWithTags way) {
+    String bicycle = way.getTag("bicycle");
+    return (
+      isVehicleThroughTrafficExplicitlyDisallowed(way) ||
+      doesTagValueDisallowThroughTraffic(bicycle)
+    );
+  }
+
+  @Override
+  public boolean isWalkNoThroughTrafficExplicitlyDisallowed(OSMWithTags way) {
+    String foot = way.getTag("foot");
+    return isGeneralNoThroughTraffic(way) || doesTagValueDisallowThroughTraffic(foot);
   }
 }


### PR DESCRIPTION
### Summary

Pull request #4515 changed OSM processing so that tags foot=yes and bicycle=yes enable traversal along ways tagged with access=private. OSM data in Finland contains so much incorrectly modeled entities that we cannot adopt the change immediately. 

In this PR,  original logic of walk and bike nothrough tag processing is restored using FinlandWayPropertySetSource.java. 


