### PR TITLE
Configure the Germany speed test to download GTFS from the same server

### DIFF
--- a/.github/workflows/performance-test.yml
+++ b/.github/workflows/performance-test.yml
@@ -14,8 +14,6 @@ jobs:
         include:
 
           - location: germany # all of Germany (500k stops, 200k patterns) but no OSM
-            transit-url: https://leonard.io/otp/germany-2022-08-23.tidy.gtfs.zip
-            transit-filename: germany.gtfs.zip
             iterations: 1
             jfr-delay: "50s"
 
@@ -74,7 +72,12 @@ jobs:
           else
             wget ${{ matrix.osm-url }} -O graph/osm.pbf --no-clobber -q --show-progress --progress=bar:force || true
           fi
-          wget ${{ matrix.transit-url }} -O graph/${{ matrix.transit-filename }} --no-clobber -q --show-progress --progress=bar:force || true
+          if [ "${{ matrix.transit-url }}" = "" ];
+          then
+            echo "No transit download specified. Skipping..."
+          else
+            wget ${{ matrix.transit-url }} -O graph/${{ matrix.transit-filename }} --no-clobber -q --show-progress --progress=bar:force || true
+          fi
 
       - name: Build graph
         run: |

--- a/test/performance/README.md
+++ b/test/performance/README.md
@@ -32,8 +32,8 @@ that shows bottlenecks in the code.
 
 #### Norway
 
-- [Norwegian NeTEx data](https://leonard.io/otp/rb_norway-aggregated-netex-2021-12-11.zip)
-- [Norway OSM data](https://download.geofabrik.de/europe/norway-210101.osm.pbf)
+- [Norwegian NeTEx data](https://otp-performance.leonard.io/data/norway/rb_norway-aggregated-netex-2021-12-11.zip)
+- [Norway OSM data](https://otp-performance.leonard.io/data/norway/norway-210101.osm.pbf)
 
 If the link above do not work you should be able to find it on the ENTUR web:
 

--- a/test/performance/README.md
+++ b/test/performance/README.md
@@ -46,4 +46,4 @@ If the link above do not work you should be able to find it on the ENTUR web:
  
 #### Germany
 
-- [Tidied GTFS data](https://leonard.io/otp/germany-2022-08-23.tidy.gtfs.zip)
+- [Tidied GTFS data](https://otp-performance.leonard.io/data/germany/germany-2022-08-23.tidy.gtfs.zip)

--- a/test/performance/germany/build-config.json
+++ b/test/performance/germany/build-config.json
@@ -1,3 +1,8 @@
 {
-  "discardMinTransferTimes": true
+  "discardMinTransferTimes": true,
+  "transitFeeds": {
+    "type": "gtfs",
+    "source": "https://otp-performance.leonard.io/data/germany/germany-2022-08-23.tidy.gtfs.zip",
+    "feedId": "1"
+  }
 }

--- a/test/performance/norway/build-config.json
+++ b/test/performance/norway/build-config.json
@@ -1,5 +1,5 @@
 {
-  "transitServiceStart" : "2021-12-01",
+  "transitServiceStart": "2021-12-01",
   "transitServiceEnd": "2022-12-31",
   "dataImportReport": true,
   "transit": true,
@@ -31,11 +31,22 @@
     "sharedFilePattern": "_stops.xml",
     "sharedGroupFilePattern": "_(\\w{3})(_flexible)?_shared_data.xml",
     "groupFilePattern": "(\\w{3})_.*\\.xml",
-    "netexFeedId": "EN",
     "ferryIdsNotAllowedForBicycle": [
       "NYC:Line:1",
       "NYC:Line:012fc5c4-131b-4dfc-8160-4e49136e531a",
       "NYC:Line:8bfef12a-ac98-4376-8a2a-eb5a336d107b"
     ]
-  }
+  },
+  "transitFeeds": [
+    {
+      "type": "netex",
+      "source": "https://otp-performance.leonard.io/data/norway/rb_norway-aggregated-netex-2021-12-11.zip",
+      "feedId": "EN"
+    }
+  ],
+  "osm": [
+    {
+      "source": "https://otp-performance.leonard.io/data/norway/norway-210101.osm.pbf"
+    }
+  ]
 }


### PR DESCRIPTION
I've copied all the speed test input files onto the speed test server. They are all now available at: https://otp-performance.leonard.io/data/

This means that we can skip the caching and redownload the files for every run.

That's what I have moved the download of the German speed test file into its build-config.json