### PR TITLE
Move all speed test data onto speed test server

### DIFF
--- a/.github/workflows/performance-test.yml
+++ b/.github/workflows/performance-test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - dev-2.x
-      - optional-transit-url
 
 jobs:
   perf-test:

--- a/.github/workflows/performance-test.yml
+++ b/.github/workflows/performance-test.yml
@@ -14,8 +14,6 @@ jobs:
         include:
 
           - location: germany # all of Germany (500k stops, 200k patterns) but no OSM
-            transit-url: https://leonard.io/otp/germany-2022-08-23.tidy.gtfs.zip
-            transit-filename: germany.gtfs.zip
             iterations: 1
             jfr-delay: "50s"
 
@@ -74,7 +72,12 @@ jobs:
           else
             wget ${{ matrix.osm-url }} -O graph/osm.pbf --no-clobber -q --show-progress --progress=bar:force || true
           fi
-          wget ${{ matrix.transit-url }} -O graph/${{ matrix.transit-filename }} --no-clobber -q --show-progress --progress=bar:force || true
+          if [ "${{ matrix.transit-url }}" = "" ];
+          then
+            echo "No transit download specified. Skipping..."
+          else
+            wget ${{ matrix.transit-url }} -O graph/${{ matrix.transit-filename }} --no-clobber -q --show-progress --progress=bar:force || true
+          fi
 
       - name: Build graph
         run: |

--- a/.github/workflows/performance-test.yml
+++ b/.github/workflows/performance-test.yml
@@ -52,6 +52,7 @@ jobs:
 
       - name: Build graph
         run: |
+          mkdir graph
           cp test/performance/${{ matrix.location }}/build-config.json graph/build-config.json
           cp target/otp-*-SNAPSHOT-shaded.jar otp.jar
           java -Xmx32G -jar otp.jar --build --save graph

--- a/.github/workflows/performance-test.yml
+++ b/.github/workflows/performance-test.yml
@@ -18,16 +18,10 @@ jobs:
             jfr-delay: "50s"
 
           - location: norway
-            osm-url: https://download.geofabrik.de/europe/norway-210101.osm.pbf
-            transit-url: https://leonard.io/otp/rb_norway-aggregated-netex-2021-12-11.zip
-            transit-filename: rb_norway-aggregated-netex.zip
             iterations: 4
             jfr-delay: "35s"
 
           - location: baden-wuerttemberg # German state of Baden-Württemberg: https://en.wikipedia.org/wiki/Baden-W%C3%BCrttemberg
-            osm-url: https://download.geofabrik.de/europe/germany/baden-wuerttemberg-220101.osm.pbf
-            transit-url: https://leonard.io/otp/baden-wuerttemberg-2022-07-25.gtfs.tidy.zip
-            transit-filename: baden-wuerttemberg.gtfs.zip
             iterations: 4
             jfr-delay: "50s"
 
@@ -52,32 +46,8 @@ jobs:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
 
-      - name: Cache graph input files
-        uses: actions/cache@v2
-        with:
-          path: |
-            graph/*.pbf
-            graph/*.zip
-          key: graph-${{ matrix.transit-url}}-${{ matrix.osm-url}}
-
       - name: Build jar
         run: mvn -DskipTests --batch-mode package -P prettierSkip
-
-      - name: Download OSM & Netex data
-        run: |
-          mkdir -p graph
-          if [ "${{ matrix.osm-url }}" = "" ];
-          then
-            echo "No OSM download specified. Skipping..."
-          else
-            wget ${{ matrix.osm-url }} -O graph/osm.pbf --no-clobber -q --show-progress --progress=bar:force || true
-          fi
-          if [ "${{ matrix.transit-url }}" = "" ];
-          then
-            echo "No transit download specified. Skipping..."
-          else
-            wget ${{ matrix.transit-url }} -O graph/${{ matrix.transit-filename }} --no-clobber -q --show-progress --progress=bar:force || true
-          fi
 
       - name: Build graph
         run: |

--- a/.github/workflows/performance-test.yml
+++ b/.github/workflows/performance-test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - dev-2.x
+      - optional-transit-url
 
 jobs:
   perf-test:

--- a/test/performance/README.md
+++ b/test/performance/README.md
@@ -30,6 +30,8 @@ that shows bottlenecks in the code.
 
 ### Data files
 
+All data input files are located at https://otp-performance.leonard.io/data/
+
 #### Norway
 
 - [Norwegian NeTEx data](https://otp-performance.leonard.io/data/norway/rb_norway-aggregated-netex-2021-12-11.zip)
@@ -41,8 +43,8 @@ If the link above do not work you should be able to find it on the ENTUR web:
 
 #### Baden-Württemberg, Germany
 
-- [Tidied GTFS data](https://leonard.io/otp/baden-wuerttemberg-2022-07-25.gtfs.tidy.zip)
-- [BW OSM data](https://download.geofabrik.de/europe/germany/baden-wuerttemberg-220101.osm.pbf)
+- [Tidied GTFS data](https://otp-performance.leonard.io/data/baden-wuerttemberg/baden-wuerttemberg-2022-07-25.gtfs.tidy.zip)
+- [BW OSM data](https://otp-performance.leonard.io/data/baden-wuerttemberg/baden-wuerttemberg-220101.osm.pbf)
  
 #### Germany
 

--- a/test/performance/README.md
+++ b/test/performance/README.md
@@ -32,8 +32,8 @@ that shows bottlenecks in the code.
 
 #### Norway
 
-- [Norwegian NeTEx data](https://leonard.io/otp/rb_norway-aggregated-netex-2021-12-11.zip)
-- [Norway OSM data](https://download.geofabrik.de/europe/norway-210101.osm.pbf)
+- [Norwegian NeTEx data](https://otp-performance.leonard.io/data/norway/rb_norway-aggregated-netex-2021-12-11.zip)
+- [Norway OSM data](https://otp-performance.leonard.io/data/norway/norway-210101.osm.pbf)
 
 If the link above do not work you should be able to find it on the ENTUR web:
 

--- a/test/performance/README.md
+++ b/test/performance/README.md
@@ -46,4 +46,4 @@ If the link above do not work you should be able to find it on the ENTUR web:
  
 #### Germany
 
-- [Tidied GTFS data](https://leonard.io/otp/germany-2022-08-23.tidy.gtfs.zip)
+- [Tidied GTFS data](https://otp-performance.leonard.io/data/germany/germany-2022-08-23.tidy.gtfs.zip)

--- a/test/performance/baden-wuerttemberg/build-config.json
+++ b/test/performance/baden-wuerttemberg/build-config.json
@@ -5,5 +5,15 @@
   },
   "staticBikeParkAndRide": true,
   "discardMinTransferTimes": true,
-  "transitModelTimeZone": "Europe/Berlin"
+  "transitModelTimeZone": "Europe/Berlin",
+  "transitFeeds": {
+    "type": "gtfs",
+    "source": "https://otp-performance.leonard.io/data/baden-wuerttemberg/baden-wuerttemberg-2022-07-25.gtfs.tidy.zip",
+    "feedId": "1"
+  },
+  "osm": [
+    {
+      "source": "https://otp-performance.leonard.io/data/baden-wuerttemberg/baden-wuerttemberg-220101.osm.pbf"
+    }
+  ]
 }

--- a/test/performance/baden-wuerttemberg/build-config.json
+++ b/test/performance/baden-wuerttemberg/build-config.json
@@ -6,11 +6,13 @@
   "staticBikeParkAndRide": true,
   "discardMinTransferTimes": true,
   "transitModelTimeZone": "Europe/Berlin",
-  "transitFeeds": {
-    "type": "gtfs",
-    "source": "https://otp-performance.leonard.io/data/baden-wuerttemberg/baden-wuerttemberg-2022-07-25.gtfs.tidy.zip",
-    "feedId": "1"
-  },
+  "transitFeeds": [
+    {
+      "type": "gtfs",
+      "source": "https://otp-performance.leonard.io/data/baden-wuerttemberg/baden-wuerttemberg-2022-07-25.gtfs.tidy.zip",
+      "feedId": "1"
+    }
+  ],
   "osm": [
     {
       "source": "https://otp-performance.leonard.io/data/baden-wuerttemberg/baden-wuerttemberg-220101.osm.pbf"

--- a/test/performance/germany/build-config.json
+++ b/test/performance/germany/build-config.json
@@ -1,8 +1,10 @@
 {
   "discardMinTransferTimes": true,
-  "transitFeeds": {
-    "type": "gtfs",
-    "source": "https://otp-performance.leonard.io/data/germany/germany-2022-08-23.tidy.gtfs.zip",
-    "feedId": "1"
-  }
+  "transitFeeds": [
+    {
+      "type": "gtfs",
+      "source": "https://otp-performance.leonard.io/data/germany/germany-2022-08-23.tidy.gtfs.zip",
+      "feedId": "1"
+    }
+  ]
 }

--- a/test/performance/germany/build-config.json
+++ b/test/performance/germany/build-config.json
@@ -1,3 +1,8 @@
 {
-  "discardMinTransferTimes": true
+  "discardMinTransferTimes": true,
+  "transitFeeds": {
+    "type": "gtfs",
+    "source": "https://otp-performance.leonard.io/data/germany/germany-2022-08-23.tidy.gtfs.zip",
+    "feedId": "1"
+  }
 }

--- a/test/performance/norway/build-config.json
+++ b/test/performance/norway/build-config.json
@@ -1,5 +1,5 @@
 {
-  "transitServiceStart" : "2021-12-01",
+  "transitServiceStart": "2021-12-01",
   "transitServiceEnd": "2022-12-31",
   "dataImportReport": true,
   "transit": true,
@@ -37,5 +37,17 @@
       "NYC:Line:012fc5c4-131b-4dfc-8160-4e49136e531a",
       "NYC:Line:8bfef12a-ac98-4376-8a2a-eb5a336d107b"
     ]
-  }
+  },
+  "transitFeeds": [
+    {
+      "type": "netex",
+      "source": "https://otp-performance.leonard.io/data/norway/rb_norway-aggregated-netex-2021-12-11.zip",
+      "feedId": "EN"
+    }
+  ],
+  "osm": [
+    {
+      "source": "https://otp-performance.leonard.io/data/norway/norway-210101.osm.pbf"
+    }
+  ]
 }


### PR DESCRIPTION
I've copied all the speed test input files onto the speed test server. They are all now available at: https://otp-performance.leonard.io/data/

This means that we can skip the caching and redownload the files for every run.
