### PR TITLE
Do not allow boarding/alighting at GroupStops in RAPTOR

### DIFF
--- a/src/main/java/org/opentripplanner/transit/model/network/StopPattern.java
+++ b/src/main/java/org/opentripplanner/transit/model/network/StopPattern.java
@@ -11,6 +11,7 @@ import javax.annotation.Nonnull;
 import org.opentripplanner.model.PickDrop;
 import org.opentripplanner.model.StopTime;
 import org.opentripplanner.transit.model.site.AreaStop;
+import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
 import org.opentripplanner.transit.model.site.StopLocation;
 
@@ -220,10 +221,10 @@ public final class StopPattern implements Serializable {
    * (centroids) and might not have times.
    */
   private static PickDrop computePickDrop(StopLocation stop, PickDrop pickDrop) {
-    if (stop instanceof AreaStop) {
-      return PickDrop.NONE;
-    } else {
+    if (stop instanceof RegularStop) {
       return pickDrop;
+    } else {
+      return PickDrop.NONE;
     }
   }
 

--- a/src/test/java/org/opentripplanner/transit/model/_data/TransitModelForTest.java
+++ b/src/test/java/org/opentripplanner/transit/model/_data/TransitModelForTest.java
@@ -2,6 +2,8 @@ package org.opentripplanner.transit.model._data;
 
 import static org.opentripplanner.transit.model.basic.Accessibility.NO_INFORMATION;
 
+import java.util.List;
+import org.locationtech.jts.geom.Geometry;
 import org.opentripplanner.model.PickDrop;
 import org.opentripplanner.model.StopTime;
 import org.opentripplanner.transit.model.basic.Accessibility;
@@ -13,10 +15,13 @@ import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.network.RouteBuilder;
 import org.opentripplanner.transit.model.network.StopPattern;
 import org.opentripplanner.transit.model.organization.Agency;
+import org.opentripplanner.transit.model.site.AreaStop;
+import org.opentripplanner.transit.model.site.GroupStop;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.RegularStopBuilder;
 import org.opentripplanner.transit.model.site.Station;
 import org.opentripplanner.transit.model.site.StationBuilder;
+import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.site.StopTransferPriority;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripBuilder;
@@ -128,12 +133,37 @@ public class TransitModelForTest {
       .withPriority(StopTransferPriority.ALLOWED);
   }
 
+  public static GroupStop groupStopForTest(String idAndName, List<RegularStop> stops) {
+    var builder = GroupStop.of(id(idAndName)).withName(new NonLocalizedString(idAndName));
+
+    stops.forEach(builder::addLocation);
+
+    return builder.build();
+  }
+
+  public static AreaStop areaStopForTest(String idAndName, Geometry geometry) {
+    return AreaStop
+      .of(id(idAndName))
+      .withName(new NonLocalizedString(idAndName))
+      .withGeometry(geometry)
+      .build();
+  }
+
   public static StopTime stopTime(Trip trip, int seq) {
     var stopTime = new StopTime();
     stopTime.setTrip(trip);
     stopTime.setStopSequence(seq);
 
     var stop = TransitModelForTest.stopForTest("stop-" + seq, 0, 0);
+    stopTime.setStop(stop);
+
+    return stopTime;
+  }
+
+  public static StopTime stopTime(Trip trip, int seq, StopLocation stop) {
+    var stopTime = new StopTime();
+    stopTime.setTrip(trip);
+    stopTime.setStopSequence(seq);
     stopTime.setStop(stop);
 
     return stopTime;

--- a/src/test/java/org/opentripplanner/transit/model/network/StopPatternTest.java
+++ b/src/test/java/org/opentripplanner/transit/model/network/StopPatternTest.java
@@ -1,0 +1,61 @@
+package org.opentripplanner.transit.model.network;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.opentripplanner.transit.model._data.TransitModelForTest;
+import org.opentripplanner.transit.model.timetable.Trip;
+import org.opentripplanner.util.geometry.GeometryUtils;
+
+class StopPatternTest {
+
+  @Test
+  void boardingAlightingConditions() {
+    // We have different types of stops, of which only regular stops should allow boarding/alighting
+    var s1 = TransitModelForTest.stopForTest("1", 60.0, 11.0);
+    var s2 = TransitModelForTest.stopForTest("2", 61.0, 11.0);
+    var s3 = TransitModelForTest.stopForTest("3", 62.0, 11.0);
+    var s4 = TransitModelForTest.stopForTest("4", 62.1, 11.0);
+
+    var s34 = TransitModelForTest.groupStopForTest("3_4", List.of(s3, s4));
+
+    var areaStop = TransitModelForTest.areaStopForTest(
+      "area",
+      GeometryUtils
+        .getGeometryFactory()
+        .createPolygon(
+          new Coordinate[] {
+            new Coordinate(11.0, 63.0),
+            new Coordinate(11.5, 63.0),
+            new Coordinate(11.5, 63.5),
+            new Coordinate(11.0, 63.5),
+            new Coordinate(11.0, 63.0),
+          }
+        )
+    );
+
+    Trip t = TransitModelForTest.trip("trip").build();
+
+    StopPattern stopPattern = new StopPattern(
+      List.of(
+        TransitModelForTest.stopTime(t, 0, s1),
+        TransitModelForTest.stopTime(t, 1, s2),
+        TransitModelForTest.stopTime(t, 2, s34),
+        TransitModelForTest.stopTime(t, 3, areaStop)
+      )
+    );
+
+    assertTrue(stopPattern.canAlight(0), "Allowed at RegularStop");
+    assertTrue(stopPattern.canAlight(1), "Allowed at RegularStop");
+    assertFalse(stopPattern.canAlight(2), "Forbidden at GroupStop");
+    assertFalse(stopPattern.canAlight(3), "Forbidden at AreaStop");
+
+    assertTrue(stopPattern.canBoard(0), "Allowed at RegularStop");
+    assertTrue(stopPattern.canBoard(1), "Allowed at RegularStop");
+    assertFalse(stopPattern.canBoard(2), "Forbidden at GroupStop");
+    assertFalse(stopPattern.canBoard(3), "Forbidden at AreaStop");
+  }
+}


### PR DESCRIPTION
### Summary

In https://github.com/opentripplanner/OpenTripPlanner/pull/3757 all `StopLocation`s were added to patterns. It works with RAPTOR, as area stops were always set as not allowed for boarding/alighting. The same should be done also for `GroupStops`. This changes that and adds a test to validate the behaviour
