### PR TITLE
Do not run forward heuristic to calculate LAT, it is calculated from data already

### DIFF
--- a/src/main/java/org/opentripplanner/transit/raptor/service/HeuristicToRunResolver.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/service/HeuristicToRunResolver.java
@@ -38,11 +38,6 @@ class HeuristicToRunResolver {
       reverse = true;
     }
 
-    // Use FWD heuristics to find LAT(latest arrival time) if REV heuristics is enabled
-    if (!s.isLatestArrivalTimeSet() && reverse) {
-      forward = true;
-    }
-
     // Use either REV/FWD heuristics to calculate search window
     if (!s.isSearchWindowSet() && !reverse) {
       forward = true;

--- a/src/main/java/org/opentripplanner/transit/raptor/service/RangeRaptorDynamicSearch.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/service/RangeRaptorDynamicSearch.java
@@ -192,22 +192,25 @@ public class RangeRaptorDynamicSearch<T extends RaptorTripSchedule> {
     }
 
     // Run the first heuristic search
-    HeuristicSearchTask<T> task;
-    task = tasks.get(0);
-    task.withRequest(originalRequest).run();
-    calculateDynamicSearchParametersFromHeuristics(task.result());
+    Heuristics result = runHeuristicSearchTask(tasks.get(0));
+    calculateDynamicSearchParametersFromHeuristics(result);
 
     if (tasks.size() == 1) {
       return;
     }
 
     // Run the second heuristic search
-    task = tasks.get(1);
+    runHeuristicSearchTask(tasks.get(1));
+  }
+
+  private Heuristics runHeuristicSearchTask(HeuristicSearchTask<T> task) {
     RaptorRequest<T> request = task.getDirection().isForward()
       ? requestForForwardHeurSearchWithDynamicSearchParams()
       : requestForReverseHeurSearchWithDynamicSearchParams();
 
     task.withRequest(request).run();
+
+    return task.result();
   }
 
   /**

--- a/src/test/java/org/opentripplanner/transit/raptor/service/HeuristicToRunResolverTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/service/HeuristicToRunResolverTest.java
@@ -37,8 +37,8 @@ public class HeuristicToRunResolverTest {
 
     given(DEST, EDT, LAT, WIN).expect(_x_, REV);
     given(DEST, EDT, LAT, _x_).expect(_x_, REV);
-    given(DEST, EDT, _x_, WIN).expect(FWD, REV);
-    given(DEST, EDT, _x_, _x_).expect(FWD, REV);
+    given(DEST, EDT, _x_, WIN).expect(_x_, REV);
+    given(DEST, EDT, _x_, _x_).expect(_x_, REV);
     given(DEST, _x_, LAT, WIN).expect(_x_, REV);
     given(DEST, _x_, LAT, _x_).expect(_x_, REV);
     // Skip alternatives with both EAT & LAT off.


### PR DESCRIPTION
### Summary

Currently we run a forward heuristic search, if either EDT or LAT is not defined in the request. In https://github.com/opentripplanner/OpenTripPlanner/pull/3664, we changed the behaviour, so that the reverse heuristic doesn't require the LAT to be set anymore. However, we missed changing the criteria of when the search should be done. This PR changes that, so that LAT is not required anymore when the reverse heuristic search is done. Also the `RangeRaptorDynamicSearch` is fixed, as it previously expected the first search to always be the forward heuristic search.
