### PR TITLE
Update GH Actions versions

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -38,7 +38,7 @@ jobs:
       # https://github.com/actions/virtual-environments/issues/785
       - name: Configure Windows Pagefile
         if: matrix.os == 'windows-latest'
-        uses: al-cheb/configure-pagefile-action@v1.2
+        uses: al-cheb/configure-pagefile-action@v1.3
 
       - name: Prepare coverage agent, build and test
         run: mvn --batch-mode --update-snapshots jacoco:prepare-agent verify jacoco:report -P prettierCheck

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 17
+          distribution: adopt
       - name: Cache local Maven repository
         uses: actions/cache@v3
         with:
@@ -75,6 +76,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 17
+          distribution: adopt
       - name: Cache local Maven repository
         uses: actions/cache@v3
         with:

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 17
-          distribution: adopt
+          distribution: temurin
       - name: Cache local Maven repository
         uses: actions/cache@v3
         with:
@@ -76,7 +76,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 17
-          distribution: adopt
+          distribution: temurin
       - name: Cache local Maven repository
         uses: actions/cache@v3
         with:

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -25,19 +25,14 @@ jobs:
       - uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
+          
       # Java setup step completes very fast, no need to run in a preconfigured docker container
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           java-version: 17
           distribution: temurin
-      - name: Cache local Maven repository
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+          cache: maven
 
       # on windows there are frequent failures caused by page files being too small
       # https://github.com/actions/virtual-environments/issues/785
@@ -77,12 +72,6 @@ jobs:
         with:
           java-version: 17
           distribution: temurin
-      - name: Cache local Maven repository
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+          cache: maven
       - name: Build container image with Jib, push to Dockerhub
         run: mvn --batch-mode compile com.google.cloud.tools:jib-maven-plugin:build -Djib.to.tags=latest,${{ github.sha }}

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -22,16 +22,16 @@ jobs:
         os: [ ubuntu-latest, windows-latest ]
     steps:
       # Starting in v2.2 checkout action fetches all tags when fetch-depth=0, for auto-versioning.
-      - uses: actions/checkout@v2.3.2
+      - uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
       # Java setup step completes very fast, no need to run in a preconfigured docker container
       - name: Set up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 17
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -68,15 +68,15 @@ jobs:
       CONTAINER_REGISTRY_USER: otpbot
       CONTAINER_REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
     steps:
-      - uses: actions/checkout@v2.3.2
+      - uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
       - name: Set up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 17
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/close_stale_pr_and_issues.yml
+++ b/.github/workflows/close_stale_pr_and_issues.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.repository_owner == 'opentripplanner'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v5.0.0
+      - uses: actions/stale@v6.0.1
         id: stale
         with:
           stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 30 days'

--- a/.github/workflows/performance-test.yml
+++ b/.github/workflows/performance-test.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 17
-          distribution: adopt
+          distribution: temurin
 
       - name: Set up Maven
         uses: stCarolas/setup-maven@v4.5

--- a/.github/workflows/performance-test.yml
+++ b/.github/workflows/performance-test.yml
@@ -35,17 +35,12 @@ jobs:
         with:
           java-version: 17
           distribution: temurin
+          cache: maven
 
       - name: Set up Maven
         uses: stCarolas/setup-maven@v4.5
         with:
           maven-version: 3.8.2
-
-      - name: Cache local Maven repository
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
 
       - name: Build jar
         run: mvn -DskipTests --batch-mode package -P prettierSkip

--- a/.github/workflows/performance-test.yml
+++ b/.github/workflows/performance-test.yml
@@ -34,6 +34,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 17
+          distribution: adopt
 
       - name: Set up Maven
         uses: stCarolas/setup-maven@v4.5

--- a/.github/workflows/performance-test.yml
+++ b/.github/workflows/performance-test.yml
@@ -26,22 +26,22 @@ jobs:
             jfr-delay: "50s"
 
     steps:
-      - uses: actions/checkout@v2.3.2
+      - uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 17
 
       - name: Set up Maven
-        uses: stCarolas/setup-maven@v4.2
+        uses: stCarolas/setup-maven@v4.5
         with:
           maven-version: 3.8.2
 
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           token: ${{ secrets.CHANGELOG_TOKEN }}
 
@@ -57,7 +57,7 @@ jobs:
           git config --global user.email 'serialization-version-bot@opentripplanner.org'
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           token: ${{ secrets.CHANGELOG_TOKEN }}
 


### PR DESCRIPTION
Github Actions is updating their node runtime version, so you see a large number of warnings to update to Actions version. Example: https://github.com/opentripplanner/OpenTripPlanner/actions/runs/3313424495

This PR updates the Actions that will stop working in the future.