### PR TITLE
Remove unused StreetClasses from StreetEdge

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/OSMFilter.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/OSMFilter.java
@@ -209,32 +209,9 @@ public class OSMFilter {
     return new P2<>(permissionsFront, permissionsBack);
   }
 
-  public static int getStreetClasses(OSMWithTags way) {
-    int link = 0;
+  public static boolean isLink(OSMWithTags way) {
     String highway = way.getTag("highway");
-    if (highway != null && highway.endsWith(("_link"))) {
-      link = StreetEdge.CLASS_LINK;
-    }
-    return getPlatformClass(way) | link;
-  }
-
-  public static int getPlatformClass(OSMWithTags way) {
-    String highway = way.getTag("highway");
-    if ("platform".equals(way.getTag("railway"))) {
-      return StreetEdge.CLASS_TRAIN_PLATFORM;
-    }
-    if ("platform".equals(highway) || "platform".equals(way.getTag("public_transport"))) {
-      if (
-        way.isTagTrue("train") ||
-        way.isTagTrue("subway") ||
-        way.isTagTrue("tram") ||
-        way.isTagTrue("monorail")
-      ) {
-        return StreetEdge.CLASS_TRAIN_PLATFORM;
-      }
-      return StreetEdge.CLASS_OTHER_PLATFORM;
-    }
-    return 0;
+    return highway != null && highway.endsWith(("_link"));
   }
 
   /**

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModule.java
@@ -1569,34 +1569,7 @@ public class OpenStreetMapModule implements GraphBuilderModule {
         back
       );
       street.setCarSpeed(carSpeed);
-
-      String highway = way.getTag("highway");
-      int cls;
-      if ("crossing".equals(highway) && !way.isTag("bicycle", "designated")) {
-        cls = StreetEdge.CLASS_CROSSING;
-      } else if (
-        "footway".equals(highway) &&
-        way.isTag("footway", "crossing") &&
-        !way.isTag("bicycle", "designated")
-      ) {
-        cls = StreetEdge.CLASS_CROSSING;
-      } else if (
-        "residential".equals(highway) ||
-        "tertiary".equals(highway) ||
-        "secondary".equals(highway) ||
-        "secondary_link".equals(highway) ||
-        "primary".equals(highway) ||
-        "primary_link".equals(highway) ||
-        "trunk".equals(highway) ||
-        "trunk_link".equals(highway)
-      ) {
-        cls = StreetEdge.CLASS_STREET;
-      } else {
-        cls = StreetEdge.CLASS_OTHERPATH;
-      }
-
-      cls |= OSMFilter.getStreetClasses(way);
-      street.setStreetClass(cls);
+      street.setLink(OSMFilter.isLink(way));
 
       if (!way.hasTag("name") && !way.hasTag("ref")) {
         street.setHasBogusName(true);

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilder.java
@@ -33,7 +33,6 @@ import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.routing.api.request.request.StreetRequest;
 import org.opentripplanner.routing.core.State;
-import org.opentripplanner.routing.core.TraverseMode;
 import org.opentripplanner.routing.edgetype.AreaEdge;
 import org.opentripplanner.routing.edgetype.AreaEdgeList;
 import org.opentripplanner.routing.edgetype.NamedArea;
@@ -487,9 +486,6 @@ public class WalkableAreaBuilder {
         endEndpoint.getCoordinate()
       );
 
-      int cls = StreetEdge.CLASS_OTHERPATH;
-      cls |= OSMFilter.getStreetClasses(areaEntity);
-
       String label =
         "way (area) " +
         areaEntity.getId() +
@@ -519,7 +515,7 @@ public class WalkableAreaBuilder {
         street.setWheelchairAccessible(false);
       }
 
-      street.setStreetClass(cls);
+      street.setLink(OSMFilter.isLink(areaEntity));
 
       label =
         "way (area) " +
@@ -550,7 +546,7 @@ public class WalkableAreaBuilder {
         backStreet.setWheelchairAccessible(false);
       }
 
-      backStreet.setStreetClass(cls);
+      backStreet.setLink(OSMFilter.isLink(areaEntity));
 
       if (!wayPropertiesCache.containsKey(areaEntity)) {
         WayProperties wayData = areaEntity
@@ -633,9 +629,6 @@ public class WalkableAreaBuilder {
       }
       NamedArea namedArea = new NamedArea();
       OSMWithTags areaEntity = area.parent;
-      int cls = StreetEdge.CLASS_OTHERPATH;
-      cls |= OSMFilter.getStreetClasses(areaEntity);
-      namedArea.setStreetClass(cls);
 
       String id = "way (area) " + areaEntity.getId() + " (splitter linking)";
       I18NString name = handler.getNameForWay(areaEntity, id);

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/StatesToWalkStepsMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/StatesToWalkStepsMapper.java
@@ -139,10 +139,7 @@ public class StatesToWalkStepsMapper {
   }
 
   private static boolean isLink(Edge edge) {
-    return (
-      edge instanceof StreetEdge &&
-      (((StreetEdge) edge).getStreetClass() & StreetEdge.CLASS_LINK) == StreetEdge.CLASS_LINK
-    );
+    return (edge instanceof StreetEdge streetEdge && streetEdge.isLink());
   }
 
   private static List<P2<Double>> encodeElevationProfile(

--- a/src/main/java/org/opentripplanner/routing/edgetype/AreaEdgeList.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/AreaEdgeList.java
@@ -123,18 +123,8 @@ public class AreaEdgeList implements Serializable {
 
       double length = SphericalDistanceLibrary.distance(to.getCoordinate(), from.getCoordinate());
 
-      AreaEdge forward = new AreaEdge(
-        from,
-        to,
-        line,
-        area.getName(),
-        length,
-        area.getPermission(),
-        false,
-        this
-      );
-      forward.setStreetClass(area.getStreetClass());
-      AreaEdge backward = new AreaEdge(
+      new AreaEdge(from, to, line, area.getName(), length, area.getPermission(), false, this);
+      new AreaEdge(
         to,
         from,
         line.reverse(),
@@ -144,7 +134,6 @@ public class AreaEdgeList implements Serializable {
         true,
         this
       );
-      backward.setStreetClass(area.getStreetClass());
     }
   }
 }

--- a/src/main/java/org/opentripplanner/routing/edgetype/NamedArea.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/NamedArea.java
@@ -19,8 +19,6 @@ public class NamedArea implements Serializable {
 
   private double walkSafetyMultiplier;
 
-  private int streetClass;
-
   private StreetTraversalPermission permission;
 
   public I18NString getName() {
@@ -61,13 +59,5 @@ public class NamedArea implements Serializable {
 
   public void setPermission(StreetTraversalPermission permission) {
     this.permission = permission;
-  }
-
-  public int getStreetClass() {
-    return streetClass;
-  }
-
-  public void setStreetClass(int streetClass) {
-    this.streetClass = streetClass;
   }
 }

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
@@ -48,17 +48,11 @@ public class StreetEdge
   implements BikeWalkableEdge, Cloneable, CarPickupableEdge, WheelchairTraversalInformation {
 
   private static final Logger LOG = LoggerFactory.getLogger(StreetEdge.class);
-  /* TODO combine these with OSM highway= flags? */
-  public static final int CLASS_STREET = 3;
-  public static final int CLASS_CROSSING = 4;
-  public static final int CLASS_OTHERPATH = 5;
-  public static final int CLASS_OTHER_PLATFORM = 8;
-  public static final int CLASS_TRAIN_PLATFORM = 16;
-  public static final int CLASS_LINK = 32; // on/offramps; OSM calls them "links"
+
   private static final double GREENWAY_SAFETY_FACTOR = 0.1;
   // TODO(flamholz): do something smarter with the car speed here.
   public static final float DEFAULT_CAR_SPEED = 11.2f;
-  /** If you have more than 8 flags, increase flags to short or int */
+  /** If you have more than 16 flags, increase flags to short or int */
   private static final int BACK_FLAG_INDEX = 0;
   private static final int ROUNDABOUT_FLAG_INDEX = 1;
   private static final int HASBOGUSNAME_FLAG_INDEX = 2;
@@ -68,6 +62,7 @@ public class StreetEdge
   private static final int WHEELCHAIR_ACCESSIBLE_FLAG_INDEX = 6;
   private static final int BICYCLE_NOTHRUTRAFFIC = 7;
   private static final int WALK_NOTHRUTRAFFIC = 8;
+  private static final int CLASS_LINK = 9;
   private StreetEdgeCostExtension costExtension;
   /** back, roundabout, stairs, ... */
   private short flags;
@@ -99,8 +94,6 @@ public class StreetEdge
   private I18NString name;
 
   private StreetTraversalPermission permission;
-
-  private int streetClass = CLASS_OTHERPATH;
 
   /**
    * The speed (meters / sec) at which an automobile can traverse this street segment.
@@ -567,14 +560,6 @@ public class StreetEdge
     this.permission = permission;
   }
 
-  public int getStreetClass() {
-    return streetClass;
-  }
-
-  public void setStreetClass(int streetClass) {
-    this.streetClass = streetClass;
-  }
-
   /**
    * Marks that this edge is the reverse of the one defined in the source data. Does NOT mean
    * fromv/tov are reversed.
@@ -624,6 +609,17 @@ public class StreetEdge
 
   public void setStairs(boolean stairs) {
     flags = BitSetUtils.set(flags, STAIRS_FLAG_INDEX, stairs);
+  }
+
+  /**
+   * The edge is part of an osm way, which is of type link
+   */
+  public boolean isLink() {
+    return BitSetUtils.get(flags, CLASS_LINK);
+  }
+
+  public void setLink(boolean link) {
+    flags = BitSetUtils.set(flags, CLASS_LINK, link);
   }
 
   public float getCarSpeed() {
@@ -889,7 +885,7 @@ public class StreetEdge
     splitEdge.flags = this.flags;
     splitEdge.setBicycleSafetyFactor(bicycleSafetyFactor);
     splitEdge.setWalkSafetyFactor(walkSafetyFactor);
-    splitEdge.setStreetClass(getStreetClass());
+    splitEdge.setLink(isLink());
     splitEdge.setCarSpeed(getCarSpeed());
     splitEdge.setElevationExtensionUsingParent(this, fromDistance, toDistance);
   }

--- a/src/main/java/org/opentripplanner/routing/impl/StreetVertexIndex.java
+++ b/src/main/java/org/opentripplanner/routing/impl/StreetVertexIndex.java
@@ -300,7 +300,7 @@ public class StreetVertexIndex {
       temporaryPartialStreetEdge.setMotorVehicleNoThruTraffic(street.isMotorVehicleNoThruTraffic());
       temporaryPartialStreetEdge.setBicycleNoThruTraffic(street.isBicycleNoThruTraffic());
       temporaryPartialStreetEdge.setWalkNoThruTraffic(street.isWalkNoThruTraffic());
-      temporaryPartialStreetEdge.setStreetClass(street.getStreetClass());
+      temporaryPartialStreetEdge.setLink(street.isLink());
       tempEdges.addEdge(temporaryPartialStreetEdge);
     } else {
       TemporaryPartialStreetEdge temporaryPartialStreetEdge = new TemporaryPartialStreetEdge(
@@ -312,7 +312,7 @@ public class StreetVertexIndex {
         lengthOut
       );
 
-      temporaryPartialStreetEdge.setStreetClass(street.getStreetClass());
+      temporaryPartialStreetEdge.setLink(street.isLink());
       temporaryPartialStreetEdge.setMotorVehicleNoThruTraffic(street.isMotorVehicleNoThruTraffic());
       temporaryPartialStreetEdge.setBicycleNoThruTraffic(street.isBicycleNoThruTraffic());
       temporaryPartialStreetEdge.setWalkNoThruTraffic(street.isWalkNoThruTraffic());

--- a/src/test/java/org/opentripplanner/graph_builder/module/map/StreetMatcherTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/map/StreetMatcherTest.java
@@ -228,11 +228,6 @@ public class StreetMatcherTest {
     }
 
     @Override
-    public int getStreetClass() {
-      return StreetEdge.CLASS_STREET;
-    }
-
-    @Override
     public boolean isMotorVehicleNoThruTraffic() {
       return false;
     }


### PR DESCRIPTION
### Summary

Remove unused StreetClasses from StreetEdge. The only class in use is the `link`, which was moved to be part of the flags
