### PR TITLE
Add Station Availability Information to VehicleStation Tile Layer

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/vectortiles/layers/vehiclerental/mapper/DigitransitVehicleRentalStationPropertyMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/layers/vehiclerental/mapper/DigitransitVehicleRentalStationPropertyMapper.java
@@ -21,6 +21,8 @@ public class DigitransitVehicleRentalStationPropertyMapper
       // to the response somehow.
       new T2<>("name", station.getName().toString()),
       new T2<>("network", station.getNetwork()),
+      new T2<>("vehiclesAvailable", station.getVehiclesAvailable()),
+      new T2<>("spacesAvailable", station.getSpacesAvailable()),
       // a station can potentially have multiple form factors that's why this is plural
       new T2<>(
         "formFactors",


### PR DESCRIPTION
### Summary

The VehicleStation tile layer currently does not contain vehicle availability information. This PR adds the vehicle availability count and the space availability count to the information returned for each station.

I'd like to add the IBI label to this PR, but don't think I have permissions to do so.