### PR TITLE
Read service date from ET messages

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/siri/TimetableHelper.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/TimetableHelper.java
@@ -9,8 +9,10 @@ import static org.opentripplanner.model.UpdateError.UpdateErrorType.TOO_FEW_STOP
 import static org.opentripplanner.model.UpdateError.UpdateErrorType.TRIP_NOT_FOUND_IN_PATTERN;
 import static org.opentripplanner.model.UpdateError.UpdateErrorType.UNKNOWN;
 
+import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -121,7 +123,8 @@ public class TimetableHelper {
     OccupancyEnumeration journeyOccupancy = journey.getOccupancy();
 
     int callCounter = 0;
-    ZonedDateTime departureDate = null;
+
+    ZonedDateTime serviceDate = getServiceDate(journey, zoneId, oldTimes);
     Set<Object> alreadyVisited = new HashSet<>();
 
     boolean isJourneyPredictionInaccurate =
@@ -151,16 +154,8 @@ public class TimetableHelper {
         }
 
         if (foundMatch) {
-          if (departureDate == null) {
-            departureDate = recordedCall.getAimedDepartureTime();
-            if (departureDate == null) {
-              departureDate = recordedCall.getAimedArrivalTime();
-            }
-            departureDate = departureDate.minusDays(calculateDayOffset(oldTimes));
-          }
-
           ZonedDateTime startOfService = ServiceDateUtils.asStartOfService(
-            departureDate.toLocalDate(),
+            serviceDate.toLocalDate(),
             zoneId
           );
 
@@ -260,14 +255,6 @@ public class TimetableHelper {
           }
 
           if (foundMatch) {
-            if (departureDate == null) {
-              departureDate = estimatedCall.getAimedDepartureTime();
-              if (departureDate == null) {
-                departureDate = estimatedCall.getAimedArrivalTime();
-              }
-              departureDate = departureDate.minusDays(calculateDayOffset(oldTimes));
-            }
-
             boolean isCallPredictionInaccurate =
               estimatedCall.isPredictionInaccurate() != null &&
               estimatedCall.isPredictionInaccurate();
@@ -294,7 +281,7 @@ public class TimetableHelper {
             }
 
             ZonedDateTime startOfService = ServiceDateUtils.asStartOfService(
-              departureDate.toLocalDate(),
+              serviceDate.toLocalDate(),
               zoneId
             );
 
@@ -554,7 +541,6 @@ public class TimetableHelper {
 
     List<StopTime> modifiedStops = new ArrayList<>();
 
-    ZonedDateTime departureDate = null;
     int numberOfRecordedCalls = recordedCalls.size();
     Set<Object> alreadyVisited = new HashSet<>();
     // modify updated stop-times
@@ -613,14 +599,6 @@ public class TimetableHelper {
         for (EstimatedCall estimatedCall : estimatedCalls) {
           if (alreadyVisited.contains(estimatedCall)) {
             continue;
-          }
-          if (departureDate == null) {
-            departureDate =
-              (
-                estimatedCall.getAimedDepartureTime() != null
-                  ? estimatedCall.getAimedDepartureTime()
-                  : estimatedCall.getAimedArrivalTime()
-              );
           }
 
           //Current stop is being updated
@@ -894,5 +872,36 @@ public class TimetableHelper {
       case NO_BOARDING -> Optional.of(NONE);
       case PASS_THRU -> Optional.of(CANCELLED);
     };
+  }
+
+  private static ZonedDateTime getServiceDate(
+    EstimatedVehicleJourney journey,
+    ZoneId zoneId,
+    TripTimes oldTimes
+  ) {
+    if (
+      journey.getFramedVehicleJourneyRef() != null &&
+      journey.getFramedVehicleJourneyRef().getDataFrameRef() != null
+    ) {
+      var dataFrame = journey.getFramedVehicleJourneyRef().getDataFrameRef();
+      if (dataFrame != null) {
+        try {
+          return LocalDate.parse(dataFrame.getValue()).atStartOfDay(zoneId);
+        } catch (DateTimeParseException ignored) {
+          LOG.warn("Invalid dataFrame format: {}", dataFrame.getValue());
+        }
+      }
+    }
+
+    var recordedCalls = journey.getRecordedCalls();
+    var estimatedCalls = journey.getEstimatedCalls();
+    ZonedDateTime firstDeparture;
+    if (recordedCalls.getRecordedCalls().isEmpty()) {
+      firstDeparture = estimatedCalls.getEstimatedCalls().get(0).getAimedDepartureTime();
+    } else {
+      firstDeparture = recordedCalls.getRecordedCalls().get(0).getAimedDepartureTime();
+    }
+
+    return firstDeparture.minusDays(calculateDayOffset(oldTimes)).withZoneSameInstant(zoneId);
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/siri/TimetableHelper.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/TimetableHelper.java
@@ -124,7 +124,7 @@ public class TimetableHelper {
 
     int callCounter = 0;
 
-    ZonedDateTime serviceDate = getServiceDate(journey, zoneId, oldTimes);
+    LocalDate serviceDate = getServiceDate(journey, zoneId, oldTimes);
     Set<Object> alreadyVisited = new HashSet<>();
 
     boolean isJourneyPredictionInaccurate =
@@ -154,10 +154,7 @@ public class TimetableHelper {
         }
 
         if (foundMatch) {
-          ZonedDateTime startOfService = ServiceDateUtils.asStartOfService(
-            serviceDate.toLocalDate(),
-            zoneId
-          );
+          ZonedDateTime startOfService = ServiceDateUtils.asStartOfService(serviceDate, zoneId);
 
           int arrivalTime = newTimes.getArrivalTime(callCounter);
 
@@ -280,10 +277,7 @@ public class TimetableHelper {
               modifiedStopTimes.get(callCounter).cancelPickup();
             }
 
-            ZonedDateTime startOfService = ServiceDateUtils.asStartOfService(
-              serviceDate.toLocalDate(),
-              zoneId
-            );
+            ZonedDateTime startOfService = ServiceDateUtils.asStartOfService(serviceDate, zoneId);
 
             int arrivalTime = newTimes.getArrivalTime(callCounter);
 
@@ -874,7 +868,7 @@ public class TimetableHelper {
     };
   }
 
-  private static ZonedDateTime getServiceDate(
+  private static LocalDate getServiceDate(
     EstimatedVehicleJourney journey,
     ZoneId zoneId,
     TripTimes oldTimes
@@ -902,6 +896,9 @@ public class TimetableHelper {
       firstDeparture = recordedCalls.getRecordedCalls().get(0).getAimedDepartureTime();
     }
 
-    return firstDeparture.minusDays(calculateDayOffset(oldTimes)).withZoneSameInstant(zoneId);
+    return firstDeparture
+      .minusDays(calculateDayOffset(oldTimes))
+      .withZoneSameInstant(zoneId)
+      .toLocalDate();
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/siri/TimetableHelper.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/TimetableHelper.java
@@ -125,6 +125,7 @@ public class TimetableHelper {
     int callCounter = 0;
 
     LocalDate serviceDate = getServiceDate(journey, zoneId, oldTimes);
+    ZonedDateTime startOfService = ServiceDateUtils.asStartOfService(serviceDate, zoneId);
     Set<Object> alreadyVisited = new HashSet<>();
 
     boolean isJourneyPredictionInaccurate =
@@ -154,8 +155,6 @@ public class TimetableHelper {
         }
 
         if (foundMatch) {
-          ZonedDateTime startOfService = ServiceDateUtils.asStartOfService(serviceDate, zoneId);
-
           int arrivalTime = newTimes.getArrivalTime(callCounter);
 
           Integer realtimeArrivalTime = getAvailableTime(
@@ -276,8 +275,6 @@ public class TimetableHelper {
             if (departureStatus == CallStatusEnumeration.CANCELLED) {
               modifiedStopTimes.get(callCounter).cancelPickup();
             }
-
-            ZonedDateTime startOfService = ServiceDateUtils.asStartOfService(serviceDate, zoneId);
 
             int arrivalTime = newTimes.getArrivalTime(callCounter);
 

--- a/src/ext/java/org/opentripplanner/ext/siri/TimetableHelper.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/TimetableHelper.java
@@ -886,7 +886,7 @@ public class TimetableHelper {
       var dataFrame = journey.getFramedVehicleJourneyRef().getDataFrameRef();
       if (dataFrame != null) {
         try {
-          return LocalDate.parse(dataFrame.getValue()).atStartOfDay(zoneId);
+          return LocalDate.parse(dataFrame.getValue());
         } catch (DateTimeParseException ignored) {
           LOG.warn("Invalid dataFrame format: {}", dataFrame.getValue());
         }


### PR DESCRIPTION
### Summary

If service date is present in ET message, use that data instead on calculating it based on first departure.

```
<FramedVehicleJourneyRef>
    <DataFrameRef>2022-10-12</DataFrameRef>                        
    <DatedVehicleJourneyRef>....</DatedVehicleJourneyRef>
</FramedVehicleJourneyRef>
```
In example above, service date should be **2022-10-12** as that's what is defined in message. We do not need to explicitly calculate it.

### Issue
N/A

### Unit tests
N/A

### Documentation
N/A
