### PR TITLE
Increase connection timeout for HTTPS datasources

### DIFF
--- a/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceRepository.java
+++ b/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceRepository.java
@@ -73,6 +73,6 @@ public class HttpsDataSourceRepository implements DataSourceRepository {
   }
 
   protected List<Header> getHttpHeaders(URI uri) {
-    return HttpUtils.getHeaders(uri, HTTP_HEADERS_REQUEST_TIMEOUT, Map.of());
+    return HttpUtils.getHeaders(uri, HTTP_HEAD_REQUEST_TIMEOUT, Map.of());
   }
 }

--- a/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceRepository.java
+++ b/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceRepository.java
@@ -18,7 +18,7 @@ import org.opentripplanner.util.HttpUtils;
  */
 public class HttpsDataSourceRepository implements DataSourceRepository {
 
-  private static final Duration HTTP_HEADERS_REQUEST_TIMEOUT = Duration.ofSeconds(20);
+  private static final Duration HTTP_HEAD_REQUEST_TIMEOUT = Duration.ofSeconds(20);
 
   @Override
   public String description() {

--- a/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceRepository.java
+++ b/src/main/java/org/opentripplanner/datastore/https/HttpsDataSourceRepository.java
@@ -1,7 +1,9 @@
 package org.opentripplanner.datastore.https;
 
 import java.net.URI;
+import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import javax.annotation.Nonnull;
 import org.apache.http.Header;
 import org.opentripplanner.datastore.api.CompositeDataSource;
@@ -15,6 +17,8 @@ import org.opentripplanner.util.HttpUtils;
  * This data store accesses files in read-only mode over HTTPS.
  */
 public class HttpsDataSourceRepository implements DataSourceRepository {
+
+  private static final Duration HTTP_HEADERS_REQUEST_TIMEOUT = Duration.ofSeconds(20);
 
   @Override
   public String description() {
@@ -69,6 +73,6 @@ public class HttpsDataSourceRepository implements DataSourceRepository {
   }
 
   protected List<Header> getHttpHeaders(URI uri) {
-    return HttpUtils.getHeaders(uri);
+    return HttpUtils.getHeaders(uri, HTTP_HEADERS_REQUEST_TIMEOUT, Map.of());
   }
 }

--- a/src/main/java/org/opentripplanner/datastore/https/HttpsFileDataSource.java
+++ b/src/main/java/org/opentripplanner/datastore/https/HttpsFileDataSource.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
+import java.time.Duration;
+import java.util.Map;
 import java.util.zip.GZIPInputStream;
 import org.opentripplanner.datastore.api.DataSource;
 import org.opentripplanner.datastore.api.FileType;
@@ -19,6 +21,8 @@ import org.opentripplanner.util.HttpUtils;
  */
 record HttpsFileDataSource(URI uri, FileType type, HttpsDataSourceMetadata httpsDataSourceMetadata)
   implements DataSource {
+  private static final Duration HTTP_GET_REQUEST_TIMEOUT = Duration.ofSeconds(20);
+
   /**
    * Create a data source wrapper around an HTTPS resource. This wrapper handles GZIP(.gz)
    * compressed files as well as normal files. It does not handle
@@ -51,7 +55,7 @@ record HttpsFileDataSource(URI uri, FileType type, HttpsDataSourceMetadata https
     InputStream in;
 
     try {
-      in = HttpUtils.getData(uri);
+      in = HttpUtils.getData(uri, HTTP_GET_REQUEST_TIMEOUT, Map.of());
     } catch (IOException e) {
       throw new IllegalStateException(e.getLocalizedMessage(), e);
     }

--- a/src/main/java/org/opentripplanner/util/HttpUtils.java
+++ b/src/main/java/org/opentripplanner/util/HttpUtils.java
@@ -64,22 +64,31 @@ public class HttpUtils {
     Map<String, String> requestHeaderValues
   ) {
     HttpResponse response;
+    //
     try {
       response = getResponse(new HttpHead(uri), timeout, requestHeaderValues);
     } catch (IOException e) {
-      throw new RuntimeException(e.getLocalizedMessage(), e);
+      throw new RuntimeException(
+        "Network error while querying headers for resource " + sanitizeUri(uri),
+        e
+      );
     }
     if (response.getStatusLine().getStatusCode() != 200) {
-      // remove the query part from the URI
-      String sanitizedUri = uri.toString().replace('?' + uri.getQuery(), "");
       throw new RuntimeException(
         "Resource " +
-        sanitizedUri +
+        sanitizeUri(uri) +
         " unavailable. HTTP error code " +
         response.getStatusLine().getStatusCode()
       );
     }
     return Arrays.stream(response.getAllHeaders()).toList();
+  }
+
+  /**
+   * Remove the query part from the URI.
+   */
+  private static String sanitizeUri(URI uri) {
+    return uri.toString().replace('?' + uri.getQuery(), "");
   }
 
   public static InputStream openInputStream(String url, Map<String, String> headers)


### PR DESCRIPTION

### Summary

As reported in #4552, the graph builder may fail at startup due to a read timeout while downloading from a HTTPS data source.
The default timeout, that is also used by the real time updaters, is 5s.
Testing with a real HTTPS data source shows that the latency could be up to 8s.
While it is desirable to have a short timeout for the real time updaters, this timeout can be relaxed for the graph builder where data sources are loaded only once and a timeout error would result in failing the build.
The timeout could be exposed as a configuration parameter. For simplicity, this PR simply extends the timeout for the HTTPS data sources to 20s.


### Issue
Fix #4552

### Unit tests

:white_check_mark: 
### Documentation

No
