### PR TITLE
Add meta data to speed test results

### DIFF
--- a/.github/workflows/performance-test.yml
+++ b/.github/workflows/performance-test.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - dev-2.x
-
+      - speed-test-numbers
 jobs:
   perf-test:
     if: github.repository_owner == 'opentripplanner' && !startsWith(github.event.head_commit.message ,'Bump serialization version id for')

--- a/.github/workflows/performance-test.yml
+++ b/.github/workflows/performance-test.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - dev-2.x
-      - speed-test-numbers
+
 jobs:
   perf-test:
     if: github.repository_owner == 'opentripplanner' && !startsWith(github.event.head_commit.message ,'Bump serialization version id for')

--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTest.java
@@ -166,16 +166,29 @@ public class SpeedTest {
     printProfileStatistics();
 
     final var transitService = serverContext.transitService();
+<<<<<<< HEAD
     timer.globalUploadCount("transitdata_stops", transitService.listStopLocations().size());
     timer.globalUploadCount("transitdata_patterns", transitService.getAllTripPatterns().size());
     timer.globalUploadCount("transitdata_trips", transitService.getAllTrips().size());
+=======
+    timer.uploadGlobalCount("transitdata_stops", transitService.listStopLocations().size());
+    timer.uploadGlobalCount("transitdata_patterns", transitService.getAllTripPatterns().size());
+    timer.uploadGlobalCount("transitdata_trips", transitService.getAllTrips().size());
+>>>>>>> 576584011c (Use upload registry)
 
+    // we want to get the numbers after the garbage collection
     forceGCToAvoidGCLater();
 
     final var runtime = Runtime.getRuntime();
+<<<<<<< HEAD
     timer.globalUploadCount("jvm_free_memory", runtime.freeMemory());
     timer.globalUploadCount("jvm_max_memory", runtime.maxMemory());
     timer.globalUploadCount("jvm_total_memory", runtime.totalMemory());
+=======
+    timer.uploadGlobalCount("jvm_free_memory", runtime.freeMemory());
+    timer.uploadGlobalCount("jvm_max_memory", runtime.maxMemory());
+    timer.uploadGlobalCount("jvm_total_memory", runtime.totalMemory());
+>>>>>>> 576584011c (Use upload registry)
 
     timer.finishUp();
 

--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTest.java
@@ -166,29 +166,17 @@ public class SpeedTest {
     printProfileStatistics();
 
     final var transitService = serverContext.transitService();
-<<<<<<< HEAD
-    timer.globalUploadCount("transitdata_stops", transitService.listStopLocations().size());
-    timer.globalUploadCount("transitdata_patterns", transitService.getAllTripPatterns().size());
-    timer.globalUploadCount("transitdata_trips", transitService.getAllTrips().size());
-=======
     timer.uploadGlobalCount("transitdata_stops", transitService.listStopLocations().size());
     timer.uploadGlobalCount("transitdata_patterns", transitService.getAllTripPatterns().size());
     timer.uploadGlobalCount("transitdata_trips", transitService.getAllTrips().size());
->>>>>>> 576584011c (Use upload registry)
 
     // we want to get the numbers after the garbage collection
     forceGCToAvoidGCLater();
 
     final var runtime = Runtime.getRuntime();
-<<<<<<< HEAD
-    timer.globalUploadCount("jvm_free_memory", runtime.freeMemory());
-    timer.globalUploadCount("jvm_max_memory", runtime.maxMemory());
-    timer.globalUploadCount("jvm_total_memory", runtime.totalMemory());
-=======
     timer.uploadGlobalCount("jvm_free_memory", runtime.freeMemory());
     timer.uploadGlobalCount("jvm_max_memory", runtime.maxMemory());
     timer.uploadGlobalCount("jvm_total_memory", runtime.totalMemory());
->>>>>>> 576584011c (Use upload registry)
 
     timer.finishUp();
 

--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTest.java
@@ -166,16 +166,16 @@ public class SpeedTest {
     printProfileStatistics();
 
     final var transitService = serverContext.transitService();
-    timer.recordCount("transitdata_stops", transitService.listStopLocations().size());
-    timer.recordCount("transitdata_patterns", transitService.getAllTripPatterns().size());
-    timer.recordCount("transitdata_trips", transitService.getAllTrips().size());
+    timer.globalUploadCount("transitdata_stops", transitService.listStopLocations().size());
+    timer.globalUploadCount("transitdata_patterns", transitService.getAllTripPatterns().size());
+    timer.globalUploadCount("transitdata_trips", transitService.getAllTrips().size());
 
     forceGCToAvoidGCLater();
 
     final var runtime = Runtime.getRuntime();
-    timer.recordCount("jvm_free_memory", runtime.freeMemory());
-    timer.recordCount("jvm_max_memory", runtime.maxMemory());
-    timer.recordCount("jvm_total_memory", runtime.totalMemory());
+    timer.globalUploadCount("jvm_free_memory", runtime.freeMemory());
+    timer.globalUploadCount("jvm_max_memory", runtime.maxMemory());
+    timer.globalUploadCount("jvm_total_memory", runtime.totalMemory());
 
     timer.finishUp();
 

--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTest.java
@@ -165,6 +165,18 @@ public class SpeedTest {
     }
     printProfileStatistics();
 
+    final var transitService = serverContext.transitService();
+    timer.recordCount("transitdata_stops", transitService.listStopLocations().size());
+    timer.recordCount("transitdata_patterns", transitService.getAllTripPatterns().size());
+    timer.recordCount("transitdata_trips", transitService.getAllTrips().size());
+
+    forceGCToAvoidGCLater();
+
+    final var runtime = Runtime.getRuntime();
+    timer.recordCount("jvm_free_memory", runtime.freeMemory());
+    timer.recordCount("jvm_max_memory", runtime.maxMemory());
+    timer.recordCount("jvm_total_memory", runtime.totalMemory());
+
     timer.finishUp();
 
     System.err.println("\nSpeedTest done! " + projectInfo().getVersionString());

--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTest.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/SpeedTest.java
@@ -166,17 +166,17 @@ public class SpeedTest {
     printProfileStatistics();
 
     final var transitService = serverContext.transitService();
-    timer.uploadGlobalCount("transitdata_stops", transitService.listStopLocations().size());
-    timer.uploadGlobalCount("transitdata_patterns", transitService.getAllTripPatterns().size());
-    timer.uploadGlobalCount("transitdata_trips", transitService.getAllTrips().size());
+    timer.globalCount("transitdata_stops", transitService.listStopLocations().size());
+    timer.globalCount("transitdata_patterns", transitService.getAllTripPatterns().size());
+    timer.globalCount("transitdata_trips", transitService.getAllTrips().size());
 
     // we want to get the numbers after the garbage collection
     forceGCToAvoidGCLater();
 
     final var runtime = Runtime.getRuntime();
-    timer.uploadGlobalCount("jvm_free_memory", runtime.freeMemory());
-    timer.uploadGlobalCount("jvm_max_memory", runtime.maxMemory());
-    timer.uploadGlobalCount("jvm_total_memory", runtime.totalMemory());
+    timer.globalCount("jvm_free_memory", runtime.freeMemory());
+    timer.globalCount("jvm_max_memory", runtime.maxMemory());
+    timer.globalCount("jvm_total_memory", runtime.totalMemory());
 
     timer.finishUp();
 

--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/model/timer/MeterRegistrySetup.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/model/timer/MeterRegistrySetup.java
@@ -1,9 +1,11 @@
 package org.opentripplanner.transit.raptor.speed_test.model.timer;
 
 import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Meter.Id;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.cumulative.CumulativeCounter;
 import io.micrometer.core.instrument.cumulative.CumulativeTimer;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.core.instrument.distribution.HistogramGauges;
@@ -95,6 +97,11 @@ class MeterRegistrySetup {
       );
       HistogramGauges.registerWithCommonFormat(timer, this);
       return timer;
+    }
+
+    @Override
+    protected Counter newCounter(Id id) {
+      return new CumulativeCounter(id);
     }
   }
 }

--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/model/timer/SpeedTestTimer.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/model/timer/SpeedTestTimer.java
@@ -122,7 +122,7 @@ public class SpeedTestTimer {
     }
   }
 
-  public void globalUploadCount(String meterName, Number count) {
+  public void uploadGlobalCount(String meterName, Number count) {
     var counter = uploadRegistry.counter(meterName);
     counter.increment(count.doubleValue());
   }

--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/model/timer/SpeedTestTimer.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/model/timer/SpeedTestTimer.java
@@ -67,18 +67,13 @@ public class SpeedTestTimer {
 
   public void setUp(boolean logResultsByTestCaseCategory) {
     this.groupResultByTestCaseCategory = logResultsByTestCaseCategory;
-    var measurementEnv = Optional
-      .ofNullable(System.getenv("MEASUREMENT_ENVIRONMENT"))
-      .orElse("local");
     var location = Optional.ofNullable(System.getenv("SPEEDTEST_LOCATION")).orElse("unknown");
     registry
       .config()
       .commonTags(
         List.of(
-          Tag.of("measurement.environment", measurementEnv),
           Tag.of("git.commit", projectInfo().versionControl.commit),
           Tag.of("git.branch", projectInfo().versionControl.branch),
-          Tag.of("git.buildtime", projectInfo().versionControl.buildTime),
           Tag.of("location", location)
         )
       );
@@ -125,6 +120,11 @@ public class SpeedTestTimer {
     if (uploadRegistry != null) {
       uploadRegistry.close();
     }
+  }
+
+  public void recordCount(String meterName, Number count) {
+    var counter = registry.counter(meterName);
+    counter.increment(count.doubleValue());
   }
 
   public int totalTimerMean(String timerName) {

--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/model/timer/SpeedTestTimer.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/model/timer/SpeedTestTimer.java
@@ -122,11 +122,11 @@ public class SpeedTestTimer {
     }
   }
 
-  public void uploadGlobalCount(String meterName, Number count) {
+  public void globalCount(String meterName, long count) {
     if (uploadRegistry != null) {
       registry.add(uploadRegistry);
       var counter = registry.counter(meterName);
-      counter.increment(count.doubleValue());
+      counter.increment(count);
       registry.remove(uploadRegistry);
     }
   }

--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/model/timer/SpeedTestTimer.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/model/timer/SpeedTestTimer.java
@@ -123,8 +123,12 @@ public class SpeedTestTimer {
   }
 
   public void uploadGlobalCount(String meterName, Number count) {
-    var counter = uploadRegistry.counter(meterName);
-    counter.increment(count.doubleValue());
+    if (uploadRegistry != null) {
+      registry.add(uploadRegistry);
+      var counter = registry.counter(meterName);
+      counter.increment(count.doubleValue());
+      registry.remove(uploadRegistry);
+    }
   }
 
   public int totalTimerMean(String timerName) {

--- a/src/test/java/org/opentripplanner/transit/raptor/speed_test/model/timer/SpeedTestTimer.java
+++ b/src/test/java/org/opentripplanner/transit/raptor/speed_test/model/timer/SpeedTestTimer.java
@@ -122,8 +122,8 @@ public class SpeedTestTimer {
     }
   }
 
-  public void recordCount(String meterName, Number count) {
-    var counter = registry.counter(meterName);
+  public void globalUploadCount(String meterName, Number count) {
+    var counter = uploadRegistry.counter(meterName);
     counter.increment(count.doubleValue());
   }
 

--- a/test/performance/README.md
+++ b/test/performance/README.md
@@ -1,4 +1,4 @@
-## Speed test
+# Speed test
 
 This folder contains configuration and expectations to run the OTP speed test. The test runs 
 automatically after each merged PR and the results are visualised on a [Grafana instance](https://otp-performance.leonard.io).
@@ -17,22 +17,25 @@ mvn exec:java -Dexec.mainClass="org.opentripplanner.transit.raptor.speed_test.Sp
 
 The results will be displayed on the console.
 
-### Instrumentation
+## Instrumentation
 
 Each run on CI is instrumented with Java Flight Recorder. The results are then saved as an artifact
 and can be downloaded. IntelliJ for example can display a very useful flame graph from those jrf files
 that shows bottlenecks in the code.
 
-### Configure the test
+## Configure the test
 
 - Pick a valid "testDate" for your data set and set it in the speed-test-config.json.
 - Make sure build-config "transitServiceStart" and "transitServiceEnd" include the "testDate".
 
-### Data files
+## Data files
 
 All data input files are located at https://otp-performance.leonard.io/data/
 
-#### Norway
+### Norway
+
+[📊 Dashboard](https://otp-performance.leonard.io/) 
+
 Data used:
 - Norwegian NeTEx data
 - Norway OSM data
@@ -43,20 +46,29 @@ If the link above do not work you should be able to find it on the ENTUR web:
 
 - https://www.entur.org/
 
-#### Baden-Württemberg, Germany
+### Baden-Württemberg, Germany
+
+[📊 Dashboard](https://otp-performance.leonard.io/d/9sXJ43gVk/otp-performance?orgId=1&var-category=transit&var-branch_fixed=dev-2.x&var-location=baden-wuerttemberg&var-branch=dev-2.x&from=1658872800000&to=now)
+
 Data used:
 - Tidied GTFS data
 - BW OSM data
 
 [build-config](baden-wuerttemberg/build-config.json)
  
-#### Germany
+### Germany
+
+[📊 Dashboard](https://otp-performance.leonard.io/d/9sXJ43gVk/otp-performance?orgId=1&var-category=transit&var-branch_fixed=dev-2.x&var-location=germany&var-branch=dev-2.x&from=1661292000000&to=now)
+
 Data used:
 - Tidied GTFS data
 
 [build-config](germany/build-config.json)
 
-#### Skånetrafiken
+### Skånetrafiken
+
+[📊 Dashboard](https://otp-performance.leonard.io/d/9sXJ43gVk/otp-performance?orgId=1&var-category=top-5000&var-branch_fixed=dev-2.x&var-location=skanetrafiken&var-branch=dev-2.x&from=1666965240000&to=now)
+
 Data used:
 - Skånetrafiken NeTEx data
 - Sweden OSM data


### PR DESCRIPTION
### Summary

Since the input data is the major factor on how fast the speed test is expected to run, I'm adding the follwoing numbers of the data set to the speed test results:

- number of stops
- trips
- patterns

and the JVM memory metrics.

Once we have that I will add it to Grafana.

