### PR TITLE
Add translation support for parks in legacy GraphQL API

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLBikeParkImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLBikeParkImpl.java
@@ -3,6 +3,7 @@ package org.opentripplanner.ext.legacygraphqlapi.datafetchers;
 import graphql.relay.Relay;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
+import org.opentripplanner.ext.legacygraphqlapi.LegacyGraphQLUtils;
 import org.opentripplanner.ext.legacygraphqlapi.generated.LegacyGraphQLDataFetchers;
 import org.opentripplanner.routing.vehicle_parking.VehicleParking;
 
@@ -31,7 +32,8 @@ public class LegacyGraphQLBikeParkImpl implements LegacyGraphQLDataFetchers.Lega
 
   @Override
   public DataFetcher<String> name() {
-    return environment -> getSource(environment).getName().toString();
+    return environment ->
+      LegacyGraphQLUtils.getTranslation(getSource(environment).getName(), environment);
   }
 
   // TODO

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLCarParkImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLCarParkImpl.java
@@ -3,6 +3,7 @@ package org.opentripplanner.ext.legacygraphqlapi.datafetchers;
 import graphql.relay.Relay;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
+import org.opentripplanner.ext.legacygraphqlapi.LegacyGraphQLUtils;
 import org.opentripplanner.ext.legacygraphqlapi.generated.LegacyGraphQLDataFetchers;
 import org.opentripplanner.routing.vehicle_parking.VehicleParking;
 
@@ -42,7 +43,8 @@ public class LegacyGraphQLCarParkImpl implements LegacyGraphQLDataFetchers.Legac
 
   @Override
   public DataFetcher<String> name() {
-    return environment -> getSource(environment).getName().toString();
+    return environment ->
+      LegacyGraphQLUtils.getTranslation(getSource(environment).getName(), environment);
   }
 
   // TODO

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLVehicleParkingImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLVehicleParkingImpl.java
@@ -3,6 +3,7 @@ package org.opentripplanner.ext.legacygraphqlapi.datafetchers;
 import graphql.relay.Relay;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
+import org.opentripplanner.ext.legacygraphqlapi.LegacyGraphQLUtils;
 import org.opentripplanner.ext.legacygraphqlapi.generated.LegacyGraphQLDataFetchers;
 import org.opentripplanner.routing.vehicle_parking.VehicleParking;
 import org.opentripplanner.routing.vehicle_parking.VehicleParkingSpaces;
@@ -64,15 +65,14 @@ public class LegacyGraphQLVehicleParkingImpl
 
   @Override
   public DataFetcher<String> name() {
-    return environment -> getSource(environment).getName().toString();
+    return environment ->
+      LegacyGraphQLUtils.getTranslation(getSource(environment).getName(), environment);
   }
 
   @Override
   public DataFetcher<String> note() {
-    return environment -> {
-      var note = getSource(environment).getNote();
-      return note != null ? note.toString() : null;
-    };
+    return environment ->
+      LegacyGraphQLUtils.getTranslation(getSource(environment).getNote(), environment);
   }
 
   @Override

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/LegacyGraphQLTypes.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/LegacyGraphQLTypes.java
@@ -82,6 +82,25 @@ public class LegacyGraphQLTypes {
     WARNING,
   }
 
+  public static class LegacyGraphQLBikeParkNameArgs {
+
+    private String language;
+
+    public LegacyGraphQLBikeParkNameArgs(Map<String, Object> args) {
+      if (args != null) {
+        this.language = (String) args.get("language");
+      }
+    }
+
+    public String getLegacyGraphQLLanguage() {
+      return this.language;
+    }
+
+    public void setLegacyGraphQLLanguage(String language) {
+      this.language = language;
+    }
+  }
+
   public static class LegacyGraphQLBikeParkOpeningHoursArgs {
 
     private Iterable<String> dates;
@@ -105,6 +124,25 @@ public class LegacyGraphQLTypes {
     ALLOWED,
     NOT_ALLOWED,
     NO_INFORMATION,
+  }
+
+  public static class LegacyGraphQLCarParkNameArgs {
+
+    private String language;
+
+    public LegacyGraphQLCarParkNameArgs(Map<String, Object> args) {
+      if (args != null) {
+        this.language = (String) args.get("language");
+      }
+    }
+
+    public String getLegacyGraphQLLanguage() {
+      return this.language;
+    }
+
+    public void setLegacyGraphQLLanguage(String language) {
+      this.language = language;
+    }
   }
 
   public static class LegacyGraphQLCarParkOpeningHoursArgs {
@@ -3099,6 +3137,44 @@ public class LegacyGraphQLTypes {
     ROUTE_TYPE,
     STOPS_ON_TRIP,
     TRIP,
+  }
+
+  public static class LegacyGraphQLVehicleParkingNameArgs {
+
+    private String language;
+
+    public LegacyGraphQLVehicleParkingNameArgs(Map<String, Object> args) {
+      if (args != null) {
+        this.language = (String) args.get("language");
+      }
+    }
+
+    public String getLegacyGraphQLLanguage() {
+      return this.language;
+    }
+
+    public void setLegacyGraphQLLanguage(String language) {
+      this.language = language;
+    }
+  }
+
+  public static class LegacyGraphQLVehicleParkingNoteArgs {
+
+    private String language;
+
+    public LegacyGraphQLVehicleParkingNoteArgs(Map<String, Object> args) {
+      if (args != null) {
+        this.language = (String) args.get("language");
+      }
+    }
+
+    public String getLegacyGraphQLLanguage() {
+      return this.language;
+    }
+
+    public void setLegacyGraphQLLanguage(String language) {
+      this.language = language;
+    }
   }
 
   /**

--- a/src/ext/resources/legacygraphqlapi/schema.graphqls
+++ b/src/ext/resources/legacygraphqlapi/schema.graphqls
@@ -274,7 +274,9 @@ type BikePark implements Node & PlaceInterface {
     bikeParkId: String
 
     """Name of the bike park"""
-    name: String!
+    name(
+        """Returns name with the specified language, if found, otherwise returns with some default language."""
+        language: String): String!
 
     """Number of spaces available for bikes"""
     spacesAvailable: Int
@@ -318,7 +320,9 @@ type VehicleParking implements Node & PlaceInterface {
     vehicleParkingId: String
 
     """Name of the park"""
-    name: String!
+    name(
+        """Returns name with the specified language, if found, otherwise returns with some default language."""
+        language: String): String!
 
     """
     If true, value of `spacesAvailable` is updated from a real-time source.
@@ -350,7 +354,9 @@ type VehicleParking implements Node & PlaceInterface {
     """
     A short translatable note containing details of this vehicle parking.
     """
-    note: String
+    note(
+        """Returns note with the specified language, if found, otherwise returns with some default language."""
+        language: String): String
 
     """
     The state of this vehicle parking.
@@ -722,7 +728,9 @@ type CarPark implements Node & PlaceInterface {
     carParkId: String
 
     """Name of the car park"""
-    name: String!
+    name(
+        """Returns name with the specified language, if found, otherwise returns with some default language."""
+        language: String): String!
 
     """Number of parking spaces at the car park"""
     maxCapacity: Int


### PR DESCRIPTION
### Summary

Add translation support for parking in the legacy graphQL API.

### Issue

No issue as minor sandbox change

### Unit tests

None

### Documentation

Not needed

### Changelog

Maybe we should add a generic note to sandbox changelog about translation support?
