### PR TITLE
Use minimum diff of arrival/departure time in TransitGeneralizedCostFilter

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/filterchain/deletionflagger/TransitGeneralizedCostFilter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/filterchain/deletionflagger/TransitGeneralizedCostFilter.java
@@ -57,7 +57,7 @@ public class TransitGeneralizedCostFilter implements ItineraryDeletionFlagger {
   private double getWaitTimeCost(Itinerary a, Itinerary b) {
     return (
       intervalRelaxFactor *
-      Math.max(
+      Math.min(
         Math.abs(ChronoUnit.SECONDS.between(a.startTime(), b.startTime())),
         Math.abs(ChronoUnit.SECONDS.between(a.endTime(), b.endTime()))
       )


### PR DESCRIPTION
### Summary

We recently changed the filtering to include a "waiting time" between two itineraries. While testing, we found out that this change to be more aligned with user expectations

### Unit tests

Added test to differentiate between itineraries departing at the same time and at different times.
