### PR TITLE
test: Skip doc generation when the template file is not found.

### DIFF
--- a/src/test/java/org/opentripplanner/generate/doc/BuildConfigurationDocTest.java
+++ b/src/test/java/org/opentripplanner/generate/doc/BuildConfigurationDocTest.java
@@ -4,6 +4,8 @@ import static org.opentripplanner.framework.io.FileUtils.assertFileEquals;
 import static org.opentripplanner.framework.io.FileUtils.readFile;
 import static org.opentripplanner.framework.io.FileUtils.writeFile;
 import static org.opentripplanner.framework.text.MarkdownFormatter.HEADER_3;
+import static org.opentripplanner.generate.doc.framework.DocsTestConstants.DOCS_ROOT;
+import static org.opentripplanner.generate.doc.framework.DocsTestConstants.TEMPLATE_ROOT;
 import static org.opentripplanner.generate.doc.framework.TemplateUtil.replaceJsonExample;
 import static org.opentripplanner.generate.doc.framework.TemplateUtil.replaceParametersDetails;
 import static org.opentripplanner.generate.doc.framework.TemplateUtil.replaceParametersTable;
@@ -11,17 +13,19 @@ import static org.opentripplanner.standalone.config.framework.JsonSupport.jsonNo
 
 import java.io.File;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.generate.doc.framework.OnlyIfDocsExist;
 import org.opentripplanner.generate.doc.framework.ParameterDetailsList;
 import org.opentripplanner.generate.doc.framework.ParameterSummaryTable;
 import org.opentripplanner.generate.doc.framework.SkipNodes;
 import org.opentripplanner.standalone.config.BuildConfig;
 import org.opentripplanner.standalone.config.framework.json.NodeAdapter;
 
+@OnlyIfDocsExist
 public class BuildConfigurationDocTest {
 
   private static final String CONFIG_JSON = "build-config.json";
-  private static final File TEMPLATE = new File("doc-templates", "BuildConfiguration.md");
-  private static final File OUT_FILE = new File("docs", "BuildConfiguration.md");
+  private static final File TEMPLATE = new File(TEMPLATE_ROOT, "BuildConfiguration.md");
+  private static final File OUT_FILE = new File(DOCS_ROOT, "BuildConfiguration.md");
 
   private static final String CONFIG_PATH = "standalone/config/" + CONFIG_JSON;
   private static final SkipNodes SKIP_NODES = SkipNodes

--- a/src/test/java/org/opentripplanner/generate/doc/ConfigurationDocTest.java
+++ b/src/test/java/org/opentripplanner/generate/doc/ConfigurationDocTest.java
@@ -3,18 +3,22 @@ package org.opentripplanner.generate.doc;
 import static org.opentripplanner.framework.io.FileUtils.assertFileEquals;
 import static org.opentripplanner.framework.io.FileUtils.readFile;
 import static org.opentripplanner.framework.io.FileUtils.writeFile;
+import static org.opentripplanner.generate.doc.framework.DocsTestConstants.DOCS_ROOT;
+import static org.opentripplanner.generate.doc.framework.DocsTestConstants.TEMPLATE_ROOT;
 import static org.opentripplanner.generate.doc.framework.TemplateUtil.replaceSection;
 import static org.opentripplanner.generate.doc.support.ConfigTypeTable.configTypeTable;
 import static org.opentripplanner.generate.doc.support.OTPFeatureTable.otpFeaturesTable;
 
 import java.io.File;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.generate.doc.framework.OnlyIfDocsExist;
 
+@OnlyIfDocsExist
 public class ConfigurationDocTest {
 
-  private static final File TEMPLATE = new File("doc-templates", "Configuration.md");
+  private static final File TEMPLATE = new File(TEMPLATE_ROOT, "Configuration.md");
 
-  private static final File OUT_FILE = new File("docs", "Configuration.md");
+  private static final File OUT_FILE = new File(DOCS_ROOT, "Configuration.md");
 
   private static final String CONFIG_TYPE_PLACEHOLDER = "CONFIGURATION-TYPES-TABLE";
   private static final String OTP_FEATURE_PLACEHOLDER = "OTP-FEATURE-TABLE";

--- a/src/test/java/org/opentripplanner/generate/doc/RouteRequestDocTest.java
+++ b/src/test/java/org/opentripplanner/generate/doc/RouteRequestDocTest.java
@@ -4,22 +4,26 @@ import static org.opentripplanner.framework.io.FileUtils.assertFileEquals;
 import static org.opentripplanner.framework.io.FileUtils.readFile;
 import static org.opentripplanner.framework.io.FileUtils.writeFile;
 import static org.opentripplanner.framework.text.MarkdownFormatter.HEADER_3;
+import static org.opentripplanner.generate.doc.framework.DocsTestConstants.DOCS_ROOT;
+import static org.opentripplanner.generate.doc.framework.DocsTestConstants.TEMPLATE_ROOT;
 import static org.opentripplanner.generate.doc.framework.TemplateUtil.replaceParametersDetails;
 import static org.opentripplanner.generate.doc.framework.TemplateUtil.replaceParametersTable;
 import static org.opentripplanner.standalone.config.framework.JsonSupport.jsonNodeFromResource;
 
 import java.io.File;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.generate.doc.framework.OnlyIfDocsExist;
 import org.opentripplanner.generate.doc.framework.ParameterDetailsList;
 import org.opentripplanner.generate.doc.framework.ParameterSummaryTable;
 import org.opentripplanner.generate.doc.framework.SkipNodes;
 import org.opentripplanner.standalone.config.RouterConfig;
 import org.opentripplanner.standalone.config.framework.json.NodeAdapter;
 
+@OnlyIfDocsExist
 public class RouteRequestDocTest {
 
-  private static final File TEMPLATE = new File("doc-templates", "RouteRequest.md");
-  private static final File OUT_FILE = new File("docs", "RouteRequest.md");
+  private static final File TEMPLATE = new File(TEMPLATE_ROOT, "RouteRequest.md");
+  private static final File OUT_FILE = new File(DOCS_ROOT, "RouteRequest.md");
   private static final String BUILD_CONFIG_FILENAME = "standalone/config/router-config.json";
   private static final SkipNodes SKIP_NODES = SkipNodes
     .of()

--- a/src/test/java/org/opentripplanner/generate/doc/RouterConfigurationDocTest.java
+++ b/src/test/java/org/opentripplanner/generate/doc/RouterConfigurationDocTest.java
@@ -4,6 +4,8 @@ import static org.opentripplanner.framework.io.FileUtils.assertFileEquals;
 import static org.opentripplanner.framework.io.FileUtils.readFile;
 import static org.opentripplanner.framework.io.FileUtils.writeFile;
 import static org.opentripplanner.framework.text.MarkdownFormatter.HEADER_3;
+import static org.opentripplanner.generate.doc.framework.DocsTestConstants.DOCS_ROOT;
+import static org.opentripplanner.generate.doc.framework.DocsTestConstants.TEMPLATE_ROOT;
 import static org.opentripplanner.generate.doc.framework.TemplateUtil.replaceJsonExample;
 import static org.opentripplanner.generate.doc.framework.TemplateUtil.replaceParametersDetails;
 import static org.opentripplanner.generate.doc.framework.TemplateUtil.replaceParametersTable;
@@ -11,18 +13,20 @@ import static org.opentripplanner.standalone.config.framework.JsonSupport.jsonNo
 
 import java.io.File;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.generate.doc.framework.OnlyIfDocsExist;
 import org.opentripplanner.generate.doc.framework.ParameterDetailsList;
 import org.opentripplanner.generate.doc.framework.ParameterSummaryTable;
 import org.opentripplanner.generate.doc.framework.SkipNodes;
 import org.opentripplanner.standalone.config.RouterConfig;
 import org.opentripplanner.standalone.config.framework.json.NodeAdapter;
 
+@OnlyIfDocsExist
 public class RouterConfigurationDocTest {
 
   private static final String CONFIG_JSON = "router-config.json";
 
-  private static final File TEMPLATE = new File("doc-templates", "RouterConfiguration.md");
-  private static final File OUT_FILE = new File("docs", "RouterConfiguration.md");
+  private static final File TEMPLATE = new File(TEMPLATE_ROOT, "RouterConfiguration.md");
+  private static final File OUT_FILE = new File(DOCS_ROOT, "RouterConfiguration.md");
 
   private static final String CONFIG_PATH = "standalone/config/" + CONFIG_JSON;
   private static final SkipNodes SKIP_NODES = SkipNodes

--- a/src/test/java/org/opentripplanner/generate/doc/UpdaterConfigDocTest.java
+++ b/src/test/java/org/opentripplanner/generate/doc/UpdaterConfigDocTest.java
@@ -4,6 +4,8 @@ import static org.opentripplanner.framework.io.FileUtils.assertFileEquals;
 import static org.opentripplanner.framework.io.FileUtils.readFile;
 import static org.opentripplanner.framework.io.FileUtils.writeFile;
 import static org.opentripplanner.framework.text.MarkdownFormatter.HEADER_4;
+import static org.opentripplanner.generate.doc.framework.DocsTestConstants.DOCS_ROOT;
+import static org.opentripplanner.generate.doc.framework.DocsTestConstants.TEMPLATE_ROOT;
 import static org.opentripplanner.generate.doc.framework.TemplateUtil.replaceSection;
 import static org.opentripplanner.standalone.config.framework.JsonSupport.jsonNodeFromResource;
 
@@ -11,16 +13,18 @@ import java.io.File;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.generate.doc.framework.DocBuilder;
+import org.opentripplanner.generate.doc.framework.OnlyIfDocsExist;
 import org.opentripplanner.generate.doc.framework.ParameterDetailsList;
 import org.opentripplanner.generate.doc.framework.ParameterSummaryTable;
 import org.opentripplanner.generate.doc.framework.SkipNodes;
 import org.opentripplanner.standalone.config.RouterConfig;
 import org.opentripplanner.standalone.config.framework.json.NodeAdapter;
 
+@OnlyIfDocsExist
 public class UpdaterConfigDocTest {
 
-  private static final File TEMPLATE = new File("doc-templates", "UpdaterConfig.md");
-  private static final File OUT_FILE = new File("docs", "UpdaterConfig.md");
+  private static final File TEMPLATE = new File(TEMPLATE_ROOT, "UpdaterConfig.md");
+  private static final File OUT_FILE = new File(DOCS_ROOT, "UpdaterConfig.md");
 
   private static final String BUILD_CONFIG_FILENAME = "standalone/config/router-config.json";
   private static final Set<String> SKIP_UPDATERS = Set.of("siri-azure-sx-updater");

--- a/src/test/java/org/opentripplanner/generate/doc/framework/DocsTestConstants.java
+++ b/src/test/java/org/opentripplanner/generate/doc/framework/DocsTestConstants.java
@@ -1,0 +1,33 @@
+package org.opentripplanner.generate.doc.framework;
+
+import java.io.File;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public interface DocsTestConstants {
+  Logger LOG = LoggerFactory.getLogger(DocsTestConstants.class);
+  File TEMPLATE_ROOT = new File("doc-templates");
+  File DOCS_ROOT = new File("docs");
+
+  /**
+   * This method return {@code true} if the /docs directory is available. If not, a warning is
+   * logged and the method returns {@code false}. This is used by the {@link OnlyIfDocsExist}
+   * annotation.
+   */
+  static boolean docsExistOrWarn() {
+    if (DOCS_ROOT.exists()) {
+      return true;
+    }
+    LOG.warn(
+      """
+      SKIP TEST - '/docs' NOT FOUND
+      
+          The docs/doc-templates directory might not be available if you run the tests outside the
+          root of the projects. This may happen if the project root is not the working directory,
+          if you run tests using jar files or in a Maven multi-module project.
+          
+      """
+    );
+    return false;
+  }
+}

--- a/src/test/java/org/opentripplanner/generate/doc/framework/DocsTestConstants.java
+++ b/src/test/java/org/opentripplanner/generate/doc/framework/DocsTestConstants.java
@@ -4,6 +4,9 @@ import java.io.File;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Define a few constants used by most of the doc generating tests.
+ */
 public interface DocsTestConstants {
   Logger LOG = LoggerFactory.getLogger(DocsTestConstants.class);
   File TEMPLATE_ROOT = new File("doc-templates");

--- a/src/test/java/org/opentripplanner/generate/doc/framework/OnlyIfDocsExist.java
+++ b/src/test/java/org/opentripplanner/generate/doc/framework/OnlyIfDocsExist.java
@@ -1,0 +1,16 @@
+package org.opentripplanner.generate.doc.framework;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.condition.EnabledIf;
+
+/**
+ * See {@link DocsTestConstants#docsExistOrWarn}
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@EnabledIf("org.opentripplanner.generate.doc.framework.DocsTestConstants#docsExistOrWarn")
+public @interface OnlyIfDocsExist {
+}

--- a/src/test/java/org/opentripplanner/generate/doc/framework/OnlyIfDocsExist.java
+++ b/src/test/java/org/opentripplanner/generate/doc/framework/OnlyIfDocsExist.java
@@ -7,6 +7,11 @@ import java.lang.annotation.Target;
 import org.junit.jupiter.api.condition.EnabledIf;
 
 /**
+ * Use this annotation on tests that access the /docs folder outside the source/resource.
+ * Accessing files that are not on class-path is error prune and should be avoided. This
+ * annotation is used to prevent the test from failing and log a WARNING when the test are run
+ * in a different environment.
+ * <p>
  * See {@link DocsTestConstants#docsExistOrWarn}
  */
 @Target(ElementType.TYPE)

--- a/src/test/java/org/opentripplanner/generate/doc/framework/TemplateUtil.java
+++ b/src/test/java/org/opentripplanner/generate/doc/framework/TemplateUtil.java
@@ -1,19 +1,20 @@
 package org.opentripplanner.generate.doc.framework;
 
 import org.opentripplanner.standalone.config.framework.json.NodeAdapter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Replace a text in a file wrapped using HTML comments
  */
-@SuppressWarnings("NewClassNamingConvention")
 public class TemplateUtil {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TemplateUtil.class);
 
   private static final String PARAMETERS_TABLE = "PARAMETERS-TABLE";
   private static final String PARAMETERS_DETAILS = "PARAMETERS-DETAILS";
 
   private static final String EXAMPLE = "JSON-EXAMPLE";
-
-  private static final String NEW_LINE = "\n";
   private static final String COMMENT_OPEN = "<!-- ";
   private static final String COMMENT_CLOSE = " -->";
 
@@ -46,10 +47,6 @@ public class TemplateUtil {
         .formatted(token, replacement, token);
 
     return doc.replace(replaceToken, replacementText);
-  }
-
-  private static String air(String section) {
-    return NEW_LINE + section + NEW_LINE;
   }
 
   private static String replaceToken(String token) {

--- a/src/test/java/org/opentripplanner/standalone/config/ExampleConfigTest.java
+++ b/src/test/java/org/opentripplanner/standalone/config/ExampleConfigTest.java
@@ -9,11 +9,13 @@ import java.util.function.Consumer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.opentest4j.AssertionFailedError;
+import org.opentripplanner.generate.doc.framework.OnlyIfDocsExist;
 import org.opentripplanner.standalone.config.framework.JsonSupport;
 import org.opentripplanner.standalone.config.framework.json.NodeAdapter;
 import org.opentripplanner.standalone.config.framework.project.EnvironmentVariableReplacer;
 import org.opentripplanner.test.support.FilePatternSource;
 
+@OnlyIfDocsExist
 public class ExampleConfigTest {
 
   @FilePatternSource(pattern = "docs/examples/**/router-config.json")


### PR DESCRIPTION
### Summary

When the unit-tests are run using the jar file, not a checked out project, then the doc folder might not be present. In this case we want to skip the doc generation, and not fail.

When fixing this I considered 3 different ways to do it:
 1. Use JUnit tags, and exclude tests using Maven profile
 2. Use annotation to include/exclude test
 3. Check if the docs folder exist, if not exit test

I went for option 3 - the least complex one. It has the downside that you need to include
```
    if(skipDocGeneration(BuildConfigurationDocTest.class)) {
      return;
    }
```
in every doc test (currently 5 places), but this is just slightly more code than using an JUnit annotation. There is no Maven config involved or build CI environment setup/changes needed. 