### PR TITLE
Move scripts filtering to test-resource-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,15 +106,6 @@
                 <targetPath>client</targetPath>
                 <filtering>false</filtering>
             </resource>
-            <resource>
-                <!-- Shell scripts to start up OTP, need to be filtered to insert the JAR file name. -->
-                <!-- These are treated as testResources rather than resources to keep them out of the JAR. -->
-                <!-- The staging repo will reject a JAR containing them as they use traversal paths (../..). -->
-                <directory>src/scripts</directory>
-                <filtering>true</filtering>
-                <!-- Copy the scripts up into the root of the repo, not /target/classes -->
-                <targetPath>../..</targetPath>
-            </resource>
         </resources>
         <testResources>
             <testResource>
@@ -122,6 +113,15 @@
             </testResource>
             <testResource>
                 <directory>src/ext-test/resources</directory>
+            </testResource>
+            <testResource>
+                <!-- Shell scripts to start up OTP, need to be filtered to insert the JAR file name. -->
+                <!-- These are treated as testResources rather than resources to keep them out of the JAR. -->
+                <!-- The staging repo will reject a JAR containing them as they use traversal paths (../..). -->
+                <directory>src/scripts</directory>
+                <filtering>true</filtering>
+                <!-- Copy the scripts up into the root of the repo, not /target/classes -->
+                <targetPath>../..</targetPath>
             </testResource>
         </testResources>
         <extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -954,7 +954,7 @@
             </distributionManagement>
         </profile>
         <profile>
-            <id>releaseMavenCentral</id>
+            <id>release</id>
             <build>
                 <plugins>
                     <plugin>


### PR DESCRIPTION
### Summary

The scripts can not be in the main jar file. If included, we would not be able to release to mvn central.

This PR also rename the Maven profile `releaseMavenCentral` to `release` to be consistent with the doc and defacto naming standard. 

### Issue

fixes #2634


### Documentation

Is up to date.


**NOTE!** This merges to `master`, so `master` MUST be merged to `dev-2.x` after this is merged. The reason we merge this to `master` and not `dev-2.x` is to be prepared to if we need to make a bugfix release.
