### PR TITLE
Rename VehicleRentalStationService and PollingStoptimeUpdaterConfig

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
@@ -221,7 +221,7 @@ public class LegacyGraphQLQueryTypeImpl
       );
 
       VehicleRentalService vehicleRentalStationService = getRoutingService(environment)
-        .getVehicleRentalStationService();
+        .getVehicleRentalService();
 
       if (vehicleRentalStationService == null) {
         return null;
@@ -242,7 +242,7 @@ public class LegacyGraphQLQueryTypeImpl
   public DataFetcher<Iterable<VehicleRentalPlace>> bikeRentalStations() {
     return environment -> {
       VehicleRentalService vehicleRentalStationService = getRoutingService(environment)
-        .getVehicleRentalStationService();
+        .getVehicleRentalService();
 
       if (vehicleRentalStationService == null) {
         return null;
@@ -479,7 +479,7 @@ public class LegacyGraphQLQueryTypeImpl
         .<LegacyGraphQLRequestContext>getContext()
         .getTransitService();
       VehicleParkingService vehicleParkingService = routingService.getVehicleParkingService();
-      VehicleRentalService vehicleRentalStationService = routingService.getVehicleRentalStationService();
+      VehicleRentalService vehicleRentalStationService = routingService.getVehicleRentalService();
 
       switch (type) {
         case "Agency":
@@ -809,7 +809,7 @@ public class LegacyGraphQLQueryTypeImpl
       );
 
       VehicleRentalService vehicleRentalStationService = getRoutingService(environment)
-        .getVehicleRentalStationService();
+        .getVehicleRentalService();
 
       if (vehicleRentalStationService == null) {
         return null;
@@ -830,7 +830,7 @@ public class LegacyGraphQLQueryTypeImpl
   public DataFetcher<Iterable<VehicleRentalVehicle>> rentalVehicles() {
     return environment -> {
       VehicleRentalService vehicleRentalStationService = getRoutingService(environment)
-        .getVehicleRentalStationService();
+        .getVehicleRentalService();
 
       if (vehicleRentalStationService == null) {
         return null;
@@ -1180,7 +1180,7 @@ public class LegacyGraphQLQueryTypeImpl
       );
 
       VehicleRentalService vehicleRentalStationService = getRoutingService(environment)
-        .getVehicleRentalStationService();
+        .getVehicleRentalService();
 
       if (vehicleRentalStationService == null) {
         return null;
@@ -1201,7 +1201,7 @@ public class LegacyGraphQLQueryTypeImpl
   public DataFetcher<Iterable<VehicleRentalStation>> vehicleRentalStations() {
     return environment -> {
       VehicleRentalService vehicleRentalStationService = getRoutingService(environment)
-        .getVehicleRentalStationService();
+        .getVehicleRentalService();
 
       if (vehicleRentalStationService == null) {
         return null;

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
@@ -59,8 +59,8 @@ import org.opentripplanner.routing.graphfinder.PlaceType;
 import org.opentripplanner.routing.vehicle_parking.VehicleParking;
 import org.opentripplanner.routing.vehicle_parking.VehicleParkingService;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalPlace;
+import org.opentripplanner.routing.vehicle_rental.VehicleRentalService;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalStation;
-import org.opentripplanner.routing.vehicle_rental.VehicleRentalStationService;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalVehicle;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
@@ -220,7 +220,7 @@ public class LegacyGraphQLQueryTypeImpl
         environment.getArguments()
       );
 
-      VehicleRentalStationService vehicleRentalStationService = getRoutingService(environment)
+      VehicleRentalService vehicleRentalStationService = getRoutingService(environment)
         .getVehicleRentalStationService();
 
       if (vehicleRentalStationService == null) {
@@ -241,7 +241,7 @@ public class LegacyGraphQLQueryTypeImpl
   @Override
   public DataFetcher<Iterable<VehicleRentalPlace>> bikeRentalStations() {
     return environment -> {
-      VehicleRentalStationService vehicleRentalStationService = getRoutingService(environment)
+      VehicleRentalService vehicleRentalStationService = getRoutingService(environment)
         .getVehicleRentalStationService();
 
       if (vehicleRentalStationService == null) {
@@ -479,7 +479,7 @@ public class LegacyGraphQLQueryTypeImpl
         .<LegacyGraphQLRequestContext>getContext()
         .getTransitService();
       VehicleParkingService vehicleParkingService = routingService.getVehicleParkingService();
-      VehicleRentalStationService vehicleRentalStationService = routingService.getVehicleRentalStationService();
+      VehicleRentalService vehicleRentalStationService = routingService.getVehicleRentalStationService();
 
       switch (type) {
         case "Agency":
@@ -808,7 +808,7 @@ public class LegacyGraphQLQueryTypeImpl
         environment.getArguments()
       );
 
-      VehicleRentalStationService vehicleRentalStationService = getRoutingService(environment)
+      VehicleRentalService vehicleRentalStationService = getRoutingService(environment)
         .getVehicleRentalStationService();
 
       if (vehicleRentalStationService == null) {
@@ -829,7 +829,7 @@ public class LegacyGraphQLQueryTypeImpl
   @Override
   public DataFetcher<Iterable<VehicleRentalVehicle>> rentalVehicles() {
     return environment -> {
-      VehicleRentalStationService vehicleRentalStationService = getRoutingService(environment)
+      VehicleRentalService vehicleRentalStationService = getRoutingService(environment)
         .getVehicleRentalStationService();
 
       if (vehicleRentalStationService == null) {
@@ -1179,7 +1179,7 @@ public class LegacyGraphQLQueryTypeImpl
         environment.getArguments()
       );
 
-      VehicleRentalStationService vehicleRentalStationService = getRoutingService(environment)
+      VehicleRentalService vehicleRentalStationService = getRoutingService(environment)
         .getVehicleRentalStationService();
 
       if (vehicleRentalStationService == null) {
@@ -1200,7 +1200,7 @@ public class LegacyGraphQLQueryTypeImpl
   @Override
   public DataFetcher<Iterable<VehicleRentalStation>> vehicleRentalStations() {
     return environment -> {
-      VehicleRentalStationService vehicleRentalStationService = getRoutingService(environment)
+      VehicleRentalService vehicleRentalStationService = getRoutingService(environment)
         .getVehicleRentalStationService();
 
       if (vehicleRentalStationService == null) {

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
@@ -1336,7 +1336,7 @@ public class TransmodelGraphQLSchema {
             Collection<VehicleRentalPlace> all = new ArrayList<>(
               GqlUtil
                 .getRoutingService(environment)
-                .getVehicleRentalStationService()
+                .getVehicleRentalService()
                 .getVehicleRentalStations()
             );
             List<String> filterByIds = environment.getArgument("ids");
@@ -1367,7 +1367,7 @@ public class TransmodelGraphQLSchema {
           .dataFetcher(environment -> {
             return GqlUtil
               .getRoutingService(environment)
-              .getVehicleRentalStationService()
+              .getVehicleRentalService()
               .getVehicleRentalStations()
               .stream()
               .filter(bikeRentalStation ->
@@ -1408,7 +1408,7 @@ public class TransmodelGraphQLSchema {
           .dataFetcher(environment ->
             GqlUtil
               .getRoutingService(environment)
-              .getVehicleRentalStationService()
+              .getVehicleRentalService()
               .getVehicleRentalStationForEnvelope(
                 environment.getArgument("minimumLongitude"),
                 environment.getArgument("minimumLatitude"),

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/VectorTilesResource.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/VectorTilesResource.java
@@ -60,7 +60,7 @@ public class VectorTilesResource {
       LayerType.VehicleRental,
       (graph, transitService, layerParameters, locale) ->
         new VehicleRentalPlacesLayerBuilder(
-          graph.getVehicleRentalStationService(),
+          graph.getVehicleRentalService(),
           layerParameters,
           locale
         )
@@ -69,7 +69,7 @@ public class VectorTilesResource {
       LayerType.VehicleRentalStation,
       (graph, transitService, layerParameters, locale) ->
         new VehicleRentalStationsLayerBuilder(
-          graph.getVehicleRentalStationService(),
+          graph.getVehicleRentalService(),
           layerParameters,
           locale
         )
@@ -77,10 +77,7 @@ public class VectorTilesResource {
     layers.put(
       LayerType.VehicleRentalVehicle,
       (graph, transitService, layerParameters, locale) ->
-        new VehicleRentalVehiclesLayerBuilder(
-          graph.getVehicleRentalStationService(),
-          layerParameters
-        )
+        new VehicleRentalVehiclesLayerBuilder(graph.getVehicleRentalService(), layerParameters)
     );
     layers.put(
       LayerType.VehicleParking,

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/layers/vehiclerental/VehicleRentalLayerBuilder.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/layers/vehiclerental/VehicleRentalLayerBuilder.java
@@ -11,15 +11,15 @@ import org.opentripplanner.ext.vectortiles.LayerBuilder;
 import org.opentripplanner.ext.vectortiles.PropertyMapper;
 import org.opentripplanner.ext.vectortiles.VectorTilesResource;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalPlace;
-import org.opentripplanner.routing.vehicle_rental.VehicleRentalStationService;
+import org.opentripplanner.routing.vehicle_rental.VehicleRentalService;
 import org.opentripplanner.util.geometry.GeometryUtils;
 
 abstract class VehicleRentalLayerBuilder<T extends VehicleRentalPlace> extends LayerBuilder<T> {
 
-  private final VehicleRentalStationService service;
+  private final VehicleRentalService service;
 
   public VehicleRentalLayerBuilder(
-    VehicleRentalStationService service,
+    VehicleRentalService service,
     Map<MapperType, PropertyMapper<T>> mappers,
     VectorTilesResource.LayerParameters layerParameters
   ) {
@@ -43,7 +43,7 @@ abstract class VehicleRentalLayerBuilder<T extends VehicleRentalPlace> extends L
       .toList();
   }
 
-  protected abstract Collection<T> getVehicleRentalPlaces(VehicleRentalStationService service);
+  protected abstract Collection<T> getVehicleRentalPlaces(VehicleRentalService service);
 
   enum MapperType {
     Digitransit,

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/layers/vehiclerental/VehicleRentalPlacesLayerBuilder.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/layers/vehiclerental/VehicleRentalPlacesLayerBuilder.java
@@ -6,12 +6,12 @@ import java.util.Map;
 import org.opentripplanner.ext.vectortiles.VectorTilesResource;
 import org.opentripplanner.ext.vectortiles.layers.vehiclerental.mapper.DigitransitVehicleRentalPropertyMapper;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalPlace;
-import org.opentripplanner.routing.vehicle_rental.VehicleRentalStationService;
+import org.opentripplanner.routing.vehicle_rental.VehicleRentalService;
 
 public class VehicleRentalPlacesLayerBuilder extends VehicleRentalLayerBuilder<VehicleRentalPlace> {
 
   public VehicleRentalPlacesLayerBuilder(
-    VehicleRentalStationService service,
+    VehicleRentalService service,
     VectorTilesResource.LayerParameters layerParameters,
     Locale locale
   ) {
@@ -23,9 +23,7 @@ public class VehicleRentalPlacesLayerBuilder extends VehicleRentalLayerBuilder<V
   }
 
   @Override
-  protected Collection<VehicleRentalPlace> getVehicleRentalPlaces(
-    VehicleRentalStationService service
-  ) {
+  protected Collection<VehicleRentalPlace> getVehicleRentalPlaces(VehicleRentalService service) {
     return service.getVehicleRentalPlaces();
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/layers/vehiclerental/VehicleRentalStationsLayerBuilder.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/layers/vehiclerental/VehicleRentalStationsLayerBuilder.java
@@ -8,14 +8,14 @@ import java.util.Map;
 import org.opentripplanner.ext.vectortiles.VectorTilesResource;
 import org.opentripplanner.ext.vectortiles.layers.vehiclerental.mapper.DigitransitRealtimeVehicleRentalStationPropertyMapper;
 import org.opentripplanner.ext.vectortiles.layers.vehiclerental.mapper.DigitransitVehicleRentalStationPropertyMapper;
+import org.opentripplanner.routing.vehicle_rental.VehicleRentalService;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalStation;
-import org.opentripplanner.routing.vehicle_rental.VehicleRentalStationService;
 
 public class VehicleRentalStationsLayerBuilder
   extends VehicleRentalLayerBuilder<VehicleRentalStation> {
 
   public VehicleRentalStationsLayerBuilder(
-    VehicleRentalStationService service,
+    VehicleRentalService service,
     VectorTilesResource.LayerParameters layerParameters,
     Locale locale
   ) {
@@ -33,9 +33,7 @@ public class VehicleRentalStationsLayerBuilder
   }
 
   @Override
-  protected Collection<VehicleRentalStation> getVehicleRentalPlaces(
-    VehicleRentalStationService service
-  ) {
+  protected Collection<VehicleRentalStation> getVehicleRentalPlaces(VehicleRentalService service) {
     return service.getVehicleRentalStations();
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/layers/vehiclerental/VehicleRentalVehiclesLayerBuilder.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/layers/vehiclerental/VehicleRentalVehiclesLayerBuilder.java
@@ -6,16 +6,14 @@ import java.util.Collection;
 import java.util.Map;
 import org.opentripplanner.ext.vectortiles.VectorTilesResource;
 import org.opentripplanner.ext.vectortiles.layers.vehiclerental.mapper.DigitransitRentalVehiclePropertyMapper;
-import org.opentripplanner.ext.vectortiles.layers.vehiclerental.mapper.DigitransitVehicleRentalPropertyMapper;
-import org.opentripplanner.routing.vehicle_rental.VehicleRentalPlace;
-import org.opentripplanner.routing.vehicle_rental.VehicleRentalStationService;
+import org.opentripplanner.routing.vehicle_rental.VehicleRentalService;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalVehicle;
 
 public class VehicleRentalVehiclesLayerBuilder
   extends VehicleRentalLayerBuilder<VehicleRentalVehicle> {
 
   public VehicleRentalVehiclesLayerBuilder(
-    VehicleRentalStationService service,
+    VehicleRentalService service,
     VectorTilesResource.LayerParameters layerParameters
   ) {
     super(
@@ -29,9 +27,7 @@ public class VehicleRentalVehiclesLayerBuilder
   }
 
   @Override
-  protected Collection<VehicleRentalVehicle> getVehicleRentalPlaces(
-    VehicleRentalStationService service
-  ) {
+  protected Collection<VehicleRentalVehicle> getVehicleRentalPlaces(VehicleRentalService service) {
     return service.getVehicleRentalVehicles();
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/vehiclerentalservicedirectory/VehicleRentalServiceDirectoryFetcher.java
+++ b/src/ext/java/org/opentripplanner/ext/vehiclerentalservicedirectory/VehicleRentalServiceDirectoryFetcher.java
@@ -7,7 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.opentripplanner.ext.vehiclerentalservicedirectory.api.VehicleRentalServiceDirectoryFetcherParameters;
 import org.opentripplanner.graph_builder.linking.VertexLinker;
-import org.opentripplanner.routing.vehicle_rental.VehicleRentalStationService;
+import org.opentripplanner.routing.vehicle_rental.VehicleRentalService;
 import org.opentripplanner.updater.GraphUpdater;
 import org.opentripplanner.updater.vehicle_rental.VehicleRentalUpdater;
 import org.opentripplanner.updater.vehicle_rental.datasources.VehicleRentalDataSourceFactory;
@@ -30,7 +30,7 @@ public class VehicleRentalServiceDirectoryFetcher {
   public static List<GraphUpdater> createUpdatersFromEndpoint(
     VehicleRentalServiceDirectoryFetcherParameters parameters,
     VertexLinker vertexLinker,
-    VehicleRentalStationService vehicleRentalStationService
+    VehicleRentalService vehicleRentalStationService
   ) {
     LOG.info("Fetching list of updaters from {}", parameters.getUrl());
 

--- a/src/main/java/org/opentripplanner/api/model/ApiRouterInfo.java
+++ b/src/main/java/org/opentripplanner/api/model/ApiRouterInfo.java
@@ -7,7 +7,7 @@ import org.locationtech.jts.geom.Geometry;
 import org.opentripplanner.api.mapping.ModeMapper;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.vehicle_parking.VehicleParkingService;
-import org.opentripplanner.routing.vehicle_rental.VehicleRentalStationService;
+import org.opentripplanner.routing.vehicle_rental.VehicleRentalService;
 import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.transit.service.TransitService;
 import org.opentripplanner.util.TravelOption;
@@ -34,7 +34,7 @@ public class ApiRouterInfo {
 
   /** TODO: Do not pass in the graph here, do this in a mapper instead. */
   public ApiRouterInfo(String routerId, Graph graph, TransitService transitService) {
-    VehicleRentalStationService vehicleRentalService = graph.getVehicleRentalStationService();
+    VehicleRentalService vehicleRentalService = graph.getVehicleRentalService();
     VehicleParkingService vehicleParkingService = graph.getVehicleParkingService();
 
     this.routerId = routerId;
@@ -53,7 +53,7 @@ public class ApiRouterInfo {
     transitService.getCenter().ifPresentOrElse(this::setCenter, this::calculateCenter);
   }
 
-  public boolean mapHasBikeSharing(VehicleRentalStationService service) {
+  public boolean mapHasBikeSharing(VehicleRentalService service) {
     if (service == null) {
       return false;
     }

--- a/src/main/java/org/opentripplanner/api/resource/BikeRental.java
+++ b/src/main/java/org/opentripplanner/api/resource/BikeRental.java
@@ -16,7 +16,7 @@ import org.opentripplanner.api.mapping.VehicleRentalStationMapper;
 import org.opentripplanner.api.model.ApiVehicleRentalStation;
 import org.opentripplanner.api.model.ApiVehicleRentalStationList;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalPlace;
-import org.opentripplanner.routing.vehicle_rental.VehicleRentalStationService;
+import org.opentripplanner.routing.vehicle_rental.VehicleRentalService;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
 
 @Path("/routers/{ignoreRouterId}/bike_rental")
@@ -57,9 +57,7 @@ public class BikeRental {
   ) {
     OtpServerRequestContext serverContext = this.serverContext;
 
-    VehicleRentalStationService vehicleRentalService = serverContext
-      .graph()
-      .getVehicleRentalStationService();
+    VehicleRentalService vehicleRentalService = serverContext.graph().getVehicleRentalService();
     Locale locale = locale_param != null && !locale_param.isBlank()
       ? Locale.forLanguageTag(locale_param.replaceAll("-", "_"))
       : Locale.ENGLISH;

--- a/src/main/java/org/opentripplanner/routing/RoutingService.java
+++ b/src/main/java/org/opentripplanner/routing/RoutingService.java
@@ -22,7 +22,7 @@ import org.opentripplanner.routing.graphfinder.PlaceType;
 import org.opentripplanner.routing.impl.StreetVertexIndex;
 import org.opentripplanner.routing.services.RealtimeVehiclePositionService;
 import org.opentripplanner.routing.vehicle_parking.VehicleParkingService;
-import org.opentripplanner.routing.vehicle_rental.VehicleRentalStationService;
+import org.opentripplanner.routing.vehicle_rental.VehicleRentalService;
 import org.opentripplanner.standalone.api.OtpServerRequestContext;
 import org.opentripplanner.transit.model.basic.TransitMode;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
@@ -134,9 +134,9 @@ public class RoutingService implements org.opentripplanner.routing.api.request.R
     return this.graph.getVehiclePositionService();
   }
 
-  /** {@link Graph#getVehicleRentalStationService()} */
-  public VehicleRentalStationService getVehicleRentalStationService() {
-    return this.graph.getVehicleRentalStationService();
+  /** {@link Graph#getVehicleRentalService()} */
+  public VehicleRentalService getVehicleRentalStationService() {
+    return this.graph.getVehicleRentalService();
   }
 
   /** {@link Graph#getVehicleParkingService()} */

--- a/src/main/java/org/opentripplanner/routing/RoutingService.java
+++ b/src/main/java/org/opentripplanner/routing/RoutingService.java
@@ -135,7 +135,7 @@ public class RoutingService implements org.opentripplanner.routing.api.request.R
   }
 
   /** {@link Graph#getVehicleRentalService()} */
-  public VehicleRentalService getVehicleRentalStationService() {
+  public VehicleRentalService getVehicleRentalService() {
     return this.graph.getVehicleRentalService();
   }
 

--- a/src/main/java/org/opentripplanner/routing/graph/Graph.java
+++ b/src/main/java/org/opentripplanner/routing/graph/Graph.java
@@ -29,7 +29,7 @@ import org.opentripplanner.routing.impl.StreetVertexIndex;
 import org.opentripplanner.routing.services.RealtimeVehiclePositionService;
 import org.opentripplanner.routing.services.notes.StreetNotesService;
 import org.opentripplanner.routing.vehicle_parking.VehicleParkingService;
-import org.opentripplanner.routing.vehicle_rental.VehicleRentalStationService;
+import org.opentripplanner.routing.vehicle_rental.VehicleRentalService;
 import org.opentripplanner.routing.vertextype.TransitStopVertex;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
@@ -105,7 +105,7 @@ public class Graph implements Serializable {
   private double distanceBetweenElevationSamples;
 
   private transient RealtimeVehiclePositionService vehiclePositionService;
-  private final VehicleRentalStationService vehicleRentalStationService = new VehicleRentalStationService();
+  private final VehicleRentalService vehicleRentalStationService = new VehicleRentalService();
 
   private final VehicleParkingService vehicleParkingService = new VehicleParkingService();
   private FareService fareService;
@@ -432,7 +432,7 @@ public class Graph implements Serializable {
     return vehiclePositionService;
   }
 
-  public VehicleRentalStationService getVehicleRentalStationService() {
+  public VehicleRentalService getVehicleRentalService() {
     return vehicleRentalStationService;
   }
 

--- a/src/main/java/org/opentripplanner/routing/vehicle_rental/VehicleRentalService.java
+++ b/src/main/java/org/opentripplanner/routing/vehicle_rental/VehicleRentalService.java
@@ -12,43 +12,43 @@ import org.opentripplanner.transit.model.framework.FeedScopedId;
 
 public class VehicleRentalService implements Serializable {
 
-  private final Map<FeedScopedId, VehicleRentalPlace> vehicleRentalStations = new HashMap<>();
+  private final Map<FeedScopedId, VehicleRentalPlace> rentalPlaces = new HashMap<>();
 
   public Collection<VehicleRentalPlace> getVehicleRentalPlaces() {
-    return vehicleRentalStations.values();
+    return rentalPlaces.values();
   }
 
   public VehicleRentalPlace getVehicleRentalPlace(FeedScopedId id) {
-    return vehicleRentalStations.get(id);
+    return rentalPlaces.get(id);
   }
 
   public List<VehicleRentalVehicle> getVehicleRentalVehicles() {
-    return vehicleRentalStations
+    return rentalPlaces
       .values()
       .stream()
       .filter(vehicleRentalPlace -> vehicleRentalPlace instanceof VehicleRentalVehicle)
       .map(VehicleRentalVehicle.class::cast)
-      .collect(Collectors.toList());
+      .toList();
   }
 
   public VehicleRentalVehicle getVehicleRentalVehicle(FeedScopedId id) {
-    VehicleRentalPlace vehicleRentalPlace = vehicleRentalStations.get(id);
+    VehicleRentalPlace vehicleRentalPlace = rentalPlaces.get(id);
     return vehicleRentalPlace instanceof VehicleRentalVehicle
       ? (VehicleRentalVehicle) vehicleRentalPlace
       : null;
   }
 
   public List<VehicleRentalStation> getVehicleRentalStations() {
-    return vehicleRentalStations
+    return rentalPlaces
       .values()
       .stream()
       .filter(vehicleRentalPlace -> vehicleRentalPlace instanceof VehicleRentalStation)
       .map(VehicleRentalStation.class::cast)
-      .collect(Collectors.toList());
+      .toList();
   }
 
   public VehicleRentalStation getVehicleRentalStation(FeedScopedId id) {
-    VehicleRentalPlace vehicleRentalPlace = vehicleRentalStations.get(id);
+    VehicleRentalPlace vehicleRentalPlace = rentalPlaces.get(id);
     return vehicleRentalPlace instanceof VehicleRentalStation
       ? (VehicleRentalStation) vehicleRentalPlace
       : null;
@@ -56,12 +56,12 @@ public class VehicleRentalService implements Serializable {
 
   public void addVehicleRentalStation(VehicleRentalPlace vehicleRentalStation) {
     // Remove old reference first, as adding will be a no-op if already present
-    vehicleRentalStations.remove(vehicleRentalStation.getId());
-    vehicleRentalStations.put(vehicleRentalStation.getId(), vehicleRentalStation);
+    rentalPlaces.remove(vehicleRentalStation.getId());
+    rentalPlaces.put(vehicleRentalStation.getId(), vehicleRentalStation);
   }
 
   public void removeVehicleRentalStation(FeedScopedId vehicleRentalStationId) {
-    vehicleRentalStations.remove(vehicleRentalStationId);
+    rentalPlaces.remove(vehicleRentalStationId);
   }
 
   /**
@@ -80,10 +80,10 @@ public class VehicleRentalService implements Serializable {
       new Coordinate(maxLon, maxLat)
     );
 
-    return vehicleRentalStations
+    return rentalPlaces
       .values()
       .stream()
       .filter(b -> envelope.contains(new Coordinate(b.getLongitude(), b.getLatitude())))
-      .collect(Collectors.toList());
+      .toList();
   }
 }

--- a/src/main/java/org/opentripplanner/routing/vehicle_rental/VehicleRentalService.java
+++ b/src/main/java/org/opentripplanner/routing/vehicle_rental/VehicleRentalService.java
@@ -10,7 +10,7 @@ import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Envelope;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 
-public class VehicleRentalStationService implements Serializable {
+public class VehicleRentalService implements Serializable {
 
   private final Map<FeedScopedId, VehicleRentalPlace> vehicleRentalStations = new HashMap<>();
 

--- a/src/main/java/org/opentripplanner/standalone/config/routerconfig/UpdatersConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/routerconfig/UpdatersConfig.java
@@ -35,7 +35,7 @@ import org.opentripplanner.ext.vehiclerentalservicedirectory.api.VehicleRentalSe
 import org.opentripplanner.standalone.config.framework.json.NodeAdapter;
 import org.opentripplanner.standalone.config.routerconfig.updaters.GtfsRealtimeAlertsUpdaterConfig;
 import org.opentripplanner.standalone.config.routerconfig.updaters.MqttGtfsRealtimeUpdaterConfig;
-import org.opentripplanner.standalone.config.routerconfig.updaters.PollingStoptimeUpdaterConfig;
+import org.opentripplanner.standalone.config.routerconfig.updaters.PollingTripUpdaterConfig;
 import org.opentripplanner.standalone.config.routerconfig.updaters.SiriETGooglePubsubUpdaterConfig;
 import org.opentripplanner.standalone.config.routerconfig.updaters.SiriETUpdaterConfig;
 import org.opentripplanner.standalone.config.routerconfig.updaters.SiriSXUpdaterConfig;
@@ -233,7 +233,7 @@ public class UpdatersConfig implements UpdatersParameters {
     // TODO: deprecated, remove in next major version
     BIKE_RENTAL(VehicleRentalUpdaterConfig::create),
     VEHICLE_RENTAL(VehicleRentalUpdaterConfig::create),
-    STOP_TIME_UPDATER(PollingStoptimeUpdaterConfig::create),
+    STOP_TIME_UPDATER(PollingTripUpdaterConfig::create),
     WEBSOCKET_GTFS_RT_UPDATER(WebsocketGtfsRealtimeUpdaterConfig::create),
     MQTT_GTFS_RT_UPDATER(MqttGtfsRealtimeUpdaterConfig::create),
     REAL_TIME_ALERTS(GtfsRealtimeAlertsUpdaterConfig::create),

--- a/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/PollingTripUpdaterConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/PollingTripUpdaterConfig.java
@@ -8,7 +8,7 @@ import org.opentripplanner.updater.trip.BackwardsDelayPropagationType;
 import org.opentripplanner.updater.trip.PollingTripUpdaterParameters;
 import org.opentripplanner.util.OtpAppException;
 
-public class PollingStoptimeUpdaterConfig {
+public class PollingTripUpdaterConfig {
 
   public static PollingTripUpdaterParameters create(String configRef, NodeAdapter c) {
     String file = null;

--- a/src/main/java/org/opentripplanner/updater/configure/UpdaterConfigurator.java
+++ b/src/main/java/org/opentripplanner/updater/configure/UpdaterConfigurator.java
@@ -113,7 +113,7 @@ public class UpdaterConfigurator {
     return VehicleRentalServiceDirectoryFetcher.createUpdatersFromEndpoint(
       parameters,
       graph.getLinker(),
-      graph.getVehicleRentalStationService()
+      graph.getVehicleRentalService()
     );
   }
 
@@ -132,7 +132,7 @@ public class UpdaterConfigurator {
           configItem,
           source,
           graph.getLinker(),
-          graph.getVehicleRentalStationService()
+          graph.getVehicleRentalService()
         )
       );
     }

--- a/src/main/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/vehicle_rental/VehicleRentalUpdater.java
@@ -19,7 +19,7 @@ import org.opentripplanner.routing.edgetype.VehicleRentalEdge;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.vehicle_rental.RentalVehicleType.FormFactor;
 import org.opentripplanner.routing.vehicle_rental.VehicleRentalPlace;
-import org.opentripplanner.routing.vehicle_rental.VehicleRentalStationService;
+import org.opentripplanner.routing.vehicle_rental.VehicleRentalService;
 import org.opentripplanner.routing.vertextype.VehicleRentalPlaceVertex;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.service.TransitModel;
@@ -45,13 +45,13 @@ public class VehicleRentalUpdater extends PollingGraphUpdater {
   Map<FeedScopedId, DisposableEdgeCollection> tempEdgesByStation = new HashMap<>();
   private VertexLinker linker;
 
-  private VehicleRentalStationService service;
+  private VehicleRentalService service;
 
   public VehicleRentalUpdater(
     VehicleRentalUpdaterParameters parameters,
     DataSource<VehicleRentalPlace> source,
     VertexLinker vertexLinker,
-    VehicleRentalStationService vehicleRentalStationService
+    VehicleRentalService vehicleRentalStationService
   ) throws IllegalArgumentException {
     super(parameters);
     // Configure updater


### PR DESCRIPTION
### Summary

This renames two classes that have a name which doesn't correctly reflect their purpose:

- `VehicleRentalStationService` is renamed to `VehicleRentalService`
- `PorllingStoptimeUpdaterConfig` is renames to `PollingTripUpdaterConfig`