### PR TITLE
Skånetrafiken solution for correctly handling replaced trips

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/TripTimeShortHelper.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/TripTimeShortHelper.java
@@ -49,16 +49,28 @@ public class TripTimeShortHelper {
         }
          */
   }
+
   /**
    * Find trip time short for the from place in transit leg, or null. Use transitService.
    */
   @Nullable
-  public static TripTimeOnDate getTripTimeShortForFromPlace(Leg leg, TransitService transitService) {
-    if (!leg.isTransitLeg()) { return null; }
-    if (leg.isFlexibleTrip()) { return null; }
+  public static TripTimeOnDate getTripTimeShortForFromPlace(
+    Leg leg,
+    TransitService transitService
+  ) {
+    if (!leg.isTransitLeg()) {
+      return null;
+    }
+    if (leg.isFlexibleTrip()) {
+      return null;
+    }
 
     var serviceDate = leg.getServiceDate();
-    var tripTimes = TripTimesShortHelper.getTripTimesShort(transitService, leg.getTrip(), serviceDate);
+    var tripTimes = TripTimesShortHelper.getTripTimesShort(
+      transitService,
+      leg.getTrip(),
+      serviceDate
+    );
 
     return tripTimes.get(leg.getBoardStopPosInPattern());
   }
@@ -93,11 +105,19 @@ public class TripTimeShortHelper {
   }
 
   public static TripTimeOnDate getTripTimeShortForToPlace(Leg leg, TransitService transitService) {
-    if (!leg.isTransitLeg()) { return null; }
-    if (leg.isFlexibleTrip()) { return null; }
+    if (!leg.isTransitLeg()) {
+      return null;
+    }
+    if (leg.isFlexibleTrip()) {
+      return null;
+    }
 
     var serviceDate = leg.getServiceDate();
-    var tripTimes = TripTimesShortHelper.getTripTimesShort(transitService, leg.getTrip(), serviceDate);
+    var tripTimes = TripTimesShortHelper.getTripTimesShort(
+      transitService,
+      leg.getTrip(),
+      serviceDate
+    );
 
     return tripTimes.get(leg.getAlightStopPosInPattern());
   }
@@ -140,13 +160,24 @@ public class TripTimeShortHelper {
       .collect(Collectors.toList());
   }
 
-  public static List<TripTimeOnDate> getIntermediateTripTimeShortsForLeg(Leg leg, TransitService transitService) {
-    if (!leg.isTransitLeg()) { return List.of(); }
-    if (leg.isFlexibleTrip()) { return List.of(); }
+  public static List<TripTimeOnDate> getIntermediateTripTimeShortsForLeg(
+    Leg leg,
+    TransitService transitService
+  ) {
+    if (!leg.isTransitLeg()) {
+      return List.of();
+    }
+    if (leg.isFlexibleTrip()) {
+      return List.of();
+    }
 
     var serviceDate = leg.getServiceDate();
 
-    var tripTimes = TripTimesShortHelper.getTripTimesShort(transitService, leg.getTrip(), serviceDate);
+    var tripTimes = TripTimesShortHelper.getTripTimesShort(
+      transitService,
+      leg.getTrip(),
+      serviceDate
+    );
     return tripTimes.subList(leg.getBoardStopPosInPattern() + 1, leg.getAlightStopPosInPattern());
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/LegType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/LegType.java
@@ -269,7 +269,16 @@ public class LegType {
           .withDirective(gqlUtil.timingData)
           .description("EstimatedCall for the quay where the leg originates.")
           .type(estimatedCallType)
-          .dataFetcher(env -> TripTimeShortHelper.getTripTimeShortForFromPlace(env.getSource()))
+          .dataFetcher(env -> {
+            if (!((Leg) env.getSource()).getRealTime()) {
+              return TripTimeShortHelper.getTripTimeShortForFromPlace(
+                env.getSource(),
+                GqlUtil.getTransitService(env)
+              );
+            } else {
+              return TripTimeShortHelper.getTripTimeShortForFromPlace(env.getSource());
+            }
+          })
           .build()
       )
       .field(
@@ -279,7 +288,16 @@ public class LegType {
           .withDirective(gqlUtil.timingData)
           .description("EstimatedCall for the quay where the leg ends.")
           .type(estimatedCallType)
-          .dataFetcher(env -> TripTimeShortHelper.getTripTimeShortForToPlace(env.getSource()))
+          .dataFetcher(env -> {
+            if (!((Leg) env.getSource()).getRealTime()) {
+              return TripTimeShortHelper.getTripTimeShortForToPlace(
+                env.getSource(),
+                GqlUtil.getTransitService(env)
+              );
+            } else {
+              return TripTimeShortHelper.getTripTimeShortForToPlace(env.getSource());
+            }
+          })
           .build()
       )
       .field(
@@ -365,9 +383,16 @@ public class LegType {
             "For ride legs, estimated calls for quays between the Place where the leg originates and the Place where the leg ends. For non-ride legs, empty list."
           )
           .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(estimatedCallType))))
-          .dataFetcher(env ->
-            TripTimeShortHelper.getIntermediateTripTimeShortsForLeg((env.getSource()))
-          )
+          .dataFetcher(env -> {
+            if (!((Leg) env.getSource()).getRealTime()) {
+              return TripTimeShortHelper.getIntermediateTripTimeShortsForLeg(
+                env.getSource(),
+                GqlUtil.getTransitService(env)
+              );
+            } else {
+              return TripTimeShortHelper.getIntermediateTripTimeShortsForLeg(env.getSource());
+            }
+          })
           .build()
       )
       .field(

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TripPatternForDateMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TripPatternForDateMapper.java
@@ -75,6 +75,9 @@ public class TripPatternForDateMapper {
       if (tripTimes.getRealTimeState() == RealTimeState.CANCELED) {
         continue;
       }
+      if (tripTimes.replaced()) {
+        continue;
+      }
 
       times.add(tripTimes);
     }

--- a/src/main/java/org/opentripplanner/transit/model/timetable/TripTimes.java
+++ b/src/main/java/org/opentripplanner/transit/model/timetable/TripTimes.java
@@ -114,6 +114,12 @@ public class TripTimes implements Serializable, Comparable<TripTimes> {
   public Accessibility wheelchairAccessibility;
 
   /**
+   * This field is used to indicate that scheduled trip has been replaced by realtime trip
+   * and should not be used for routing anymore
+   */
+  private boolean replaced = false;
+
+  /**
    * The provided stopTimes are assumed to be pre-filtered, valid, and monotonically increasing. The
    * non-interpolated stoptimes should already be marked at timepoints by a previous filtering
    * step.
@@ -183,6 +189,7 @@ public class TripTimes implements Serializable, Comparable<TripTimes> {
     this.realTimeState = object.realTimeState;
     this.timepoints = object.timepoints;
     this.wheelchairAccessibility = object.wheelchairAccessibility;
+    this.replaced = object.replaced;
   }
 
   /**
@@ -468,6 +475,14 @@ public class TripTimes implements Serializable, Comparable<TripTimes> {
   /** The trips whose arrivals and departures are represented by this TripTimes */
   public Trip getTrip() {
     return trip;
+  }
+
+  public boolean replaced() {
+    return replaced;
+  }
+
+  public void setReplaced(boolean replaced) {
+    this.replaced = replaced;
   }
 
   /**

--- a/src/test/java/org/opentripplanner/updater/trip/TimetableSnapshotSourceTest.java
+++ b/src/test/java/org/opentripplanner/updater/trip/TimetableSnapshotSourceTest.java
@@ -555,10 +555,9 @@ public class TimetableSnapshotSourceTest {
         originalTripIndexForToday
       );
       assertTrue(
-        originalTripTimesForToday.isCanceled(),
-        "Original trip times should be canceled in time table for service date"
+        originalTripTimesForToday.replaced(),
+        "Original trip times should be marked as replaced in time table for service date"
       );
-      assertEquals(RealTimeState.CANCELED, originalTripTimesForToday.getRealTimeState());
     }
 
     // New trip pattern
@@ -834,7 +833,7 @@ public class TimetableSnapshotSourceTest {
         originalTripIndexForToday
       );
       // original trip should be canceled
-      assertEquals(RealTimeState.CANCELED, originalTripTimesForToday.getRealTimeState());
+      assertTrue(originalTripTimesForToday.replaced());
     }
 
     // New trip pattern
@@ -987,7 +986,7 @@ public class TimetableSnapshotSourceTest {
         originalTripIndexForToday
       );
       // original trip should be canceled
-      assertEquals(RealTimeState.CANCELED, originalTripTimesForToday.getRealTimeState());
+      assertTrue(originalTripTimesForToday.replaced());
     }
 
     // New trip pattern


### PR DESCRIPTION
## Summary
- When a scheduled trip is replaced by realtime update, do not set it as CANCELLED but use a new **replaced** flag

### Old solution

<img src="https://user-images.githubusercontent.com/98400292/200296624-492c450c-35ad-4d7d-9a86-37df27888da2.jpg" width="300">
<img src="https://user-images.githubusercontent.com/98400292/200296660-589b331f-ddc7-4cf8-8539-e2ac90337135.jpg" width="300">
<img src="https://user-images.githubusercontent.com/98400292/200296674-100a4a51-004f-4e68-980d-9b01ccb4daab.jpg" width="300">


### New solution

<img src="https://user-images.githubusercontent.com/98400292/200298722-771b12d1-ad2f-41d0-a160-268b6b5ea9d7.jpg" width="300">
<img src="https://user-images.githubusercontent.com/98400292/200298750-1c174f3a-a697-48df-ab5c-3aff82a2dd8c.jpg" width="300">
<img src="https://user-images.githubusercontent.com/98400292/200298766-9b899bb4-805c-4a34-a1e6-ca327be91ae9.jpg" width="300">


- When fetching trips through transmodel graphQL API use transitService to fetch realtime if search was performed with ignoreRealtimeUpdates=true

### Old solution
<img src="https://user-images.githubusercontent.com/98400292/200299276-ef745336-58f6-45c6-bd44-b857a290af1d.jpg" width="300">
### New Solution
<img src="https://user-images.githubusercontent.com/98400292/200299304-4c4c3d0c-5626-47d4-afb3-df5206aac583.jpg" width="300">


### Issue
N/A

### Unit tests
N/A

### Documentation
N/A
