### PR TITLE
Upgrade to SLF4J 2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,8 +66,10 @@
         <micrometer.version>1.8.10</micrometer.version>
         <netcdf4.version>5.5.2</netcdf4.version>
         <netty.version>4.1.74.Final</netty.version>
+        <logback.version>1.3.4</logback.version>
         <lucene.version>9.1.0</lucene.version>
         <graphql.version>18.3</graphql.version>
+        <slf4j.version>2.0.3</slf4j.version>
         <!-- Other properties -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <GITHUB_REPOSITORY>opentripplanner/OpenTripPlanner</GITHUB_REPOSITORY>
@@ -265,13 +267,19 @@
                         --add-opens java.base/java.io=ALL-UNNAMED
                         --add-opens java.base/java.lang=ALL-UNNAMED
                         --add-opens java.base/java.lang.module=ALL-UNNAMED
+                        --add-opens java.base/java.lang.invoke=ALL-UNNAMED
+                        --add-opens java.base/java.lang.ref=ALL-UNNAMED
                         --add-opens java.base/java.math=ALL-UNNAMED
                         --add-opens java.base/java.net=ALL-UNNAMED
                         --add-opens java.base/java.text=ALL-UNNAMED
                         --add-opens java.base/java.time=ALL-UNNAMED
                         --add-opens java.base/java.time.zone=ALL-UNNAMED
+                        --add-opens java.base/java.time.format=ALL-UNNAMED
+                        --add-opens java.base/java.time.temporal=ALL-UNNAMED
+                        --add-opens java.base/java.time.chrono=ALL-UNNAMED
                         --add-opens java.base/java.util=ALL-UNNAMED
                         --add-opens java.base/java.util.concurrent.locks=ALL-UNNAMED
+                        --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED
                         --add-opens java.base/java.util.regex=ALL-UNNAMED
                         --add-opens java.base/jdk.internal.reflect=ALL-UNNAMED
                         --add-opens java.base/jdk.internal.misc=ALL-UNNAMED
@@ -280,6 +288,7 @@
                         --add-opens java.base/jdk.internal.util=ALL-UNNAMED
                         --add-opens java.base/jdk.internal.util.jar=ALL-UNNAMED
                         --add-opens java.base/jdk.internal.module=ALL-UNNAMED
+                        --add-opens java.base/sun.invoke.util=ALL-UNNAMED
                         --add-opens java.base/sun.net.www.protocol.http=ALL-UNNAMED
                         --add-opens java.base/sun.net.www.protocol.jar=ALL-UNNAMED
                         --add-opens java.base/sun.util.calendar=ALL-UNNAMED
@@ -521,17 +530,23 @@
     </dependencyManagement>
 
     <dependencies>
-        <!-- Logging library, implements slf4j logging API -->
+        <!-- Logging API -->
         <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>1.2.11</version>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
         </dependency>
         <!-- Jersey uses java.util logging, redirect it to slf4j API (we use the Logback implementation) -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jul-to-slf4j</artifactId>
-            <version>1.7.36</version>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <!-- Logging library, implements slf4j logging API -->
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.version}</version>
         </dependency>
 
         <!-- dependency injection -->


### PR DESCRIPTION
### Summary

This PR upgrades SLF4J to v2.
The SLF4J implementation Logback is upgraded to v1.3
Note:
- Logback 1.3 is compatible with SLF4J 2 and JavaEE8/JakartaEE8
- Logback 1.4 is compatible with SLF4J 2 and JakartaEE9


### Issue

No

### Unit tests

:white_check_mark: 

### Documentation

No.
