### PR TITLE
Add fallback for missing operator name

### DIFF
--- a/src/main/java/org/opentripplanner/netex/mapping/NetexMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/NetexMapper.java
@@ -277,7 +277,7 @@ public class NetexMapper {
   }
 
   private void mapOperators() {
-    OperatorToAgencyMapper mapper = new OperatorToAgencyMapper(idFactory);
+    OperatorToAgencyMapper mapper = new OperatorToAgencyMapper(issueStore, idFactory);
     for (org.rutebanken.netex.model.Operator operator : currentNetexIndex
       .getOperatorsById()
       .localValues()) {

--- a/src/main/java/org/opentripplanner/netex/mapping/OperatorToAgencyMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/OperatorToAgencyMapper.java
@@ -21,13 +21,14 @@ class OperatorToAgencyMapper {
   }
 
   Operator mapOperator(org.rutebanken.netex.model.Operator source) {
-    String name = source.getName().getValue();
-    if (!StringUtils.hasValue(name)) {
+    final String name;
+    if (source.getName() == null || !StringUtils.hasValue(source.getName().getValue())) {
       issueStore.add("MissingOperatorName", "Missing name for operator %s", source.getId());
       // fall back to NeTEx id when the operator name is missing
       name = source.getId();
+    } else {
+      name = source.getName().getValue();
     }
-
     var target = Operator.of(idFactory.createId(source.getId())).withName(name);
 
     mapContactDetails(source.getContactDetails(), target);

--- a/src/test/java/org/opentripplanner/netex/mapping/OperatorToAgencyMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/OperatorToAgencyMapperTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.graph_builder.DataImportIssueStore;
 import org.rutebanken.netex.model.ContactStructure;
 import org.rutebanken.netex.model.MultilingualString;
 import org.rutebanken.netex.model.Operator;
@@ -25,7 +26,9 @@ public class OperatorToAgencyMapperTest {
 
     // When mapped
     org.opentripplanner.transit.model.organization.Operator o;
-    o = new OperatorToAgencyMapper(MappingSupport.ID_FACTORY).mapOperator(operator);
+    o =
+      new OperatorToAgencyMapper(DataImportIssueStore.noopIssueStore(), MappingSupport.ID_FACTORY)
+        .mapOperator(operator);
 
     // Then expect
     assertEquals(ID, o.getId().getId());
@@ -43,7 +46,9 @@ public class OperatorToAgencyMapperTest {
 
     // When mapped
     org.opentripplanner.transit.model.organization.Operator o;
-    o = new OperatorToAgencyMapper(MappingSupport.ID_FACTORY).mapOperator(operator);
+    o =
+      new OperatorToAgencyMapper(DataImportIssueStore.noopIssueStore(), MappingSupport.ID_FACTORY)
+        .mapOperator(operator);
 
     // Then expect
     assertEquals(ID, o.getId().getId());

--- a/src/test/java/org/opentripplanner/netex/mapping/OperatorToAgencyMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/OperatorToAgencyMapperTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.graph_builder.DataImportIssue;
 import org.opentripplanner.graph_builder.DataImportIssueStore;
 import org.rutebanken.netex.model.ContactStructure;
 import org.rutebanken.netex.model.MultilingualString;
@@ -55,5 +56,25 @@ public class OperatorToAgencyMapperTest {
     assertEquals(NAME, o.getName());
     assertNull(o.getUrl());
     assertNull(o.getPhone());
+  }
+
+  @Test
+  public void mapOperatorWithMissingName() {
+    // Given
+    Operator operator = new Operator().withId(ID);
+
+    // When mapped
+    org.opentripplanner.transit.model.organization.Operator o;
+    DataImportIssueStore issueStore = new DataImportIssueStore();
+    o = new OperatorToAgencyMapper(issueStore, MappingSupport.ID_FACTORY).mapOperator(operator);
+
+    // Then expect
+    assertEquals(ID, o.getId().getId());
+    assertEquals(ID, o.getName());
+    assertNull(o.getUrl());
+    assertNull(o.getPhone());
+    assertEquals(1, issueStore.getIssues().size());
+    DataImportIssue dataImportIssue = issueStore.getIssues().get(0);
+    assertEquals("MissingOperatorName", dataImportIssue.getType());
   }
 }


### PR DESCRIPTION
### Summary

This PR fixes #4587: when the name of an Operator is missing in a NeTEx dataset, the graph builder fails.
Since this field is not critical to journey planning, this should not prevent the graph building from completing.
This PR:
- adds an issue in the issue store when an operator name is missing.
- uses the NeTEx id of the operator as a substitute for the missing operator name.

### Issue

fixes #4587

### Unit tests

Added unit test.

### Documentation

No

