### PR TITLE
Improve error log message for I/O Exception during graph loading

### DIFF
--- a/src/main/java/org/opentripplanner/routing/graph/SerializedGraphObject.java
+++ b/src/main/java/org/opentripplanner/routing/graph/SerializedGraphObject.java
@@ -171,11 +171,15 @@ public class SerializedGraphObject implements Serializable {
       logSerializationCompleteStatus(serObj.graph, serObj.transitModel);
       return serObj;
     } catch (IOException e) {
-      LOG.error("Exception while loading graph: {}", e.getLocalizedMessage(), e);
+      LOG.error("IO exception while loading graph: {}", e.getLocalizedMessage(), e);
       return null;
     } catch (KryoException ke) {
+      if (ke.getCause() instanceof IOException) {
+        LOG.error("IO exception while loading graph: {}", ke.getLocalizedMessage(), ke);
+        return null;
+      }
       LOG.warn(
-        "Exception while loading graph: {}\n{}",
+        "Deserialization exception while loading graph: {}\n{}",
         sourceDescription,
         ke.getLocalizedMessage()
       );


### PR DESCRIPTION
### Summary

When an I/O exception occurs while Kryo loads a serialized graph over a network connection, the error log message incorrectly suggests that the graph is binary incompatible with the current version of OTP:

`Unable to load graph. The deserialization failed. Is the loaded graph build with the same OTP version as you are using to load it? Graph: gs://marduk-production/graphs/streetGraph-otp2.obj org.opentripplanner.util.OtpAppException: Unable to load graph. The deserialization failed. Is the loaded graph build with the same OTP version as you are using to load it? Graph: gs://marduk-production/graphs/streetGraph-otp2.obj`

This PR improves the exception management by producing a specific log message for network errors.

Resulting message:
```
12:17:06.592 ERROR (SerializedGraphObject.java:178) IO exception while loading graph: java.io.IOException: com.google.cloud.RetryHelper$RetryHelperException: com.google.cloud.storage.StorageException: storage.googleapis.com
com.esotericsoftware.kryo.KryoException: java.io.IOException: com.google.cloud.RetryHelper$RetryHelperException: com.google.cloud.storage.StorageException: storage.googleapis.com
	at com.esotericsoftware.kryo.io.Input.fill(Input.java:186)
	at com.esotericsoftware.kryo.io.Input.require(Input.java:218)
	at com.esotericsoftware.kryo.io.Input.readBytes(Input.java:372)
	at com.esotericsoftware.kryo.io.Input.readBytes(Input.java:352)
	at org.opentripplanner.routing.graph.SerializedGraphObject.load(SerializedGraphObject.java:155)
	at org.opentripplanner.routing.graph.SerializedGraphObject.load(SerializedGraphObject.java:106)
	at org.opentripplanner.standalone.OTPMain.startOTPServer(OTPMain.java:122)
	at org.opentripplanner.standalone.OTPMain.main(OTPMain.java:53)
	at org.opentripplanner.ext.interactivelauncher.InteractiveOtpMain.startOtp(InteractiveOtpMain.java:38)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.io.IOException: com.google.cloud.RetryHelper$RetryHelperException: com.google.cloud.storage.StorageException: storage.googleapis.com
	at com.google.cloud.storage.BlobReadChannel.read(BlobReadChannel.java:140)
	at java.base/sun.nio.ch.ChannelInputStream.read(ChannelInputStream.java:65)
	at java.base/sun.nio.ch.ChannelInputStream.read(ChannelInputStream.java:107)
	at java.base/sun.nio.ch.ChannelInputStream.read(ChannelInputStream.java:101)
	at com.esotericsoftware.kryo.io.Input.fill(Input.java:184)
	... 9 common frames omitted
Caused by: com.google.cloud.RetryHelper$RetryHelperException: com.google.cloud.storage.StorageException: storage.googleapis.com
	at com.google.cloud.RetryHelper.runWithRetries(RetryHelper.java:54)
	at com.google.cloud.storage.BlobReadChannel.read(BlobReadChannel.java:127)
	... 13 common frames omitted
Caused by: com.google.cloud.storage.StorageException: storage.googleapis.com
	at com.google.cloud.storage.StorageException.translate(StorageException.java:116)
	at com.google.cloud.storage.spi.v1.HttpStorageRpc.read(HttpStorageRpc.java:741)
	at com.google.cloud.storage.BlobReadChannel.lambda$read$0(BlobReadChannel.java:128)
	at com.google.api.gax.retrying.DirectRetryingExecutor.submit(DirectRetryingExecutor.java:105)
	at com.google.cloud.RetryHelper.run(RetryHelper.java:76)
	at com.google.cloud.RetryHelper.runWithRetries(RetryHelper.java:50)
	... 14 common frames omitted
Caused by: java.net.UnknownHostException: storage.googleapis.com
```

### Issue
No


### Unit tests

:white_check_mark: 

### Documentation
No

