### PR TITLE
Simplify TransferRequest by using AStarRequest

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/traveltime/TravelTimeResource.java
+++ b/src/ext/java/org/opentripplanner/ext/traveltime/TravelTimeResource.java
@@ -132,8 +132,6 @@ public class TravelTimeResource {
     LocalDate endDate = LocalDate.ofInstant(endTime, zoneId);
     startOfTime = ServiceDateUtils.asStartOfService(startDate, zoneId);
 
-    RouteRequest transferRouteRequest = routingRequest.copyAndPrepareForTransferRouting();
-
     requestTransitDataProvider =
       new RaptorRoutingRequestTransitData(
         transitService.getRealtimeTransitLayer(),
@@ -141,7 +139,7 @@ public class TravelTimeResource {
         0,
         (int) Period.between(startDate, endDate).get(ChronoUnit.DAYS),
         new RouteRequestTransitDataProviderFilter(routingRequest, transitService),
-        transferRouteRequest
+        routingRequest
       );
 
     raptorService = new RaptorService<>(serverContext.raptorConfig());

--- a/src/ext/java/org/opentripplanner/ext/traveltime/TravelTimeResource.java
+++ b/src/ext/java/org/opentripplanner/ext/traveltime/TravelTimeResource.java
@@ -279,6 +279,7 @@ public class TravelTimeResource {
     AStarRequest aStarRequest = AStarRequestMapper
       .map(routingRequest)
       .withMode(routingRequest.journey().egress().mode())
+      .withArriveBy(false)
       .build();
 
     StateData stateData = StateData.getInitialStateData(aStarRequest);

--- a/src/main/java/org/opentripplanner/graph_builder/module/DirectTransferGenerator.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/DirectTransferGenerator.java
@@ -116,13 +116,7 @@ public class DirectTransferGenerator implements GraphBuilderModule {
         LOG.debug("Linking stop '{}' {}", stop, ts0);
 
         for (RouteRequest transferProfile : transferRequests) {
-          var streetRequest = transferProfile.clone();
-
-          // Make sure we use a generic request, without any specific fields set
-          streetRequest.setArriveBy(false);
-          streetRequest.setDateTime(Instant.ofEpochSecond(0));
-          streetRequest.setFrom(null);
-          streetRequest.setTo(null);
+          RouteRequest streetRequest = prepareTransferRequest(transferProfile);
 
           for (NearbyStop sd : findNearbyStops(
             nearbyStopFinder,
@@ -201,6 +195,17 @@ public class DirectTransferGenerator implements GraphBuilderModule {
   @Override
   public void checkInputs() {
     // No inputs
+  }
+
+  private static RouteRequest prepareTransferRequest(RouteRequest transferProfile) {
+    var streetRequest = transferProfile.clone();
+
+    // Make sure we use a generic request, without any specific fields set
+    streetRequest.setArriveBy(false);
+    streetRequest.setDateTime(Instant.ofEpochSecond(0));
+    streetRequest.setFrom(null);
+    streetRequest.setTo(null);
+    return streetRequest;
   }
 
   private static Iterable<NearbyStop> findNearbyStops(

--- a/src/main/java/org/opentripplanner/graph_builder/module/DirectTransferGenerator.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/DirectTransferGenerator.java
@@ -3,6 +3,7 @@ package org.opentripplanner.graph_builder.module;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimaps;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -115,7 +116,13 @@ public class DirectTransferGenerator implements GraphBuilderModule {
         LOG.debug("Linking stop '{}' {}", stop, ts0);
 
         for (RouteRequest transferProfile : transferRequests) {
-          RouteRequest streetRequest = transferProfile.copyAndPrepareForTransferRouting();
+          var streetRequest = transferProfile.clone();
+
+          // Make sure we use a generic request, without any specific fields set
+          streetRequest.setArriveBy(false);
+          streetRequest.setDateTime(Instant.ofEpochSecond(0));
+          streetRequest.setFrom(null);
+          streetRequest.setTo(null);
 
           for (NearbyStop sd : findNearbyStops(
             nearbyStopFinder,

--- a/src/main/java/org/opentripplanner/graph_builder/module/DirectTransferGenerator.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/DirectTransferGenerator.java
@@ -3,11 +3,9 @@ package org.opentripplanner.graph_builder.module;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimaps;
 import java.time.Duration;
-import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.opentripplanner.graph_builder.DataImportIssueStore;
 import org.opentripplanner.graph_builder.issues.StopNotLinkedForTransfers;
@@ -116,12 +114,10 @@ public class DirectTransferGenerator implements GraphBuilderModule {
         LOG.debug("Linking stop '{}' {}", stop, ts0);
 
         for (RouteRequest transferProfile : transferRequests) {
-          RouteRequest streetRequest = prepareTransferRequest(transferProfile);
-
           for (NearbyStop sd : findNearbyStops(
             nearbyStopFinder,
             ts0,
-            streetRequest,
+            transferProfile,
             transferProfile.journey().transfer(),
             false
           )) {
@@ -143,7 +139,7 @@ public class DirectTransferGenerator implements GraphBuilderModule {
             for (NearbyStop sd : findNearbyStops(
               nearbyStopFinder,
               ts0,
-              streetRequest,
+              transferProfile,
               transferProfile.journey().transfer(),
               true
             )) {
@@ -197,17 +193,6 @@ public class DirectTransferGenerator implements GraphBuilderModule {
     // No inputs
   }
 
-  private static RouteRequest prepareTransferRequest(RouteRequest transferProfile) {
-    var streetRequest = transferProfile.clone();
-
-    // Make sure we use a generic request, without any specific fields set
-    streetRequest.setArriveBy(false);
-    streetRequest.setDateTime(Instant.ofEpochSecond(0));
-    streetRequest.setFrom(null);
-    streetRequest.setTo(null);
-    return streetRequest;
-  }
-
   private static Iterable<NearbyStop> findNearbyStops(
     NearbyStopFinder nearbyStopFinder,
     Vertex vertex,
@@ -225,37 +210,5 @@ public class DirectTransferGenerator implements GraphBuilderModule {
       : nearbyStopFinder.findNearbyStops(vertex, request, streetRequest, reverseDirection);
   }
 
-  private static class TransferKey {
-
-    private final StopLocation source;
-    private final StopLocation target;
-    private final List<Edge> edges;
-
-    private TransferKey(StopLocation source, StopLocation target, List<Edge> edges) {
-      this.source = source;
-      this.target = target;
-      this.edges = edges;
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(source, target, edges);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      final TransferKey that = (TransferKey) o;
-      return (
-        source.equals(that.source) &&
-        target.equals(that.target) &&
-        Objects.equals(edges, that.edges)
-      );
-    }
-  }
+  private record TransferKey(StopLocation source, StopLocation target, List<Edge> edges) {}
 }

--- a/src/main/java/org/opentripplanner/graph_builder/module/NearbyStopFinder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/NearbyStopFinder.java
@@ -186,26 +186,15 @@ public class NearbyStopFinder {
   public List<NearbyStop> findNearbyStopsViaStreets(
     Set<Vertex> originVertices,
     boolean reverseDirection,
-    RouteRequest originalRequest,
+    RouteRequest request,
     StreetRequest streetRequest
   ) {
-    RouteRequest request = originalRequest.clone();
-    List<NearbyStop> stopsFound = new ArrayList<>();
-
-    request.setArriveBy(reverseDirection);
-    AStarRequest aStarRequest = AStarRequestMapper
-      .map(request)
-      .withMode(streetRequest.mode())
-      .build();
-
-    /* Add the origin vertices if they are stops */
-    for (Vertex vertex : originVertices) {
-      if (vertex instanceof TransitStopVertex tsv) {
-        stopsFound.add(
-          new NearbyStop(tsv.getStop(), 0, Collections.emptyList(), new State(vertex, aStarRequest))
-        );
-      }
-    }
+    List<NearbyStop> stopsFound = createDirectlyConnectedStops(
+      originVertices,
+      reverseDirection,
+      request,
+      streetRequest
+    );
 
     // Return only the origin vertices if there are no valid street modes
     if (streetRequest.mode() == StreetMode.NOT_SET) {
@@ -216,6 +205,7 @@ public class NearbyStopFinder {
       .allDirections(getSkipEdgeStrategy(reverseDirection, request))
       .setDominanceFunction(new DominanceFunction.MinimumWeight())
       .setRequest(request)
+      .setArriveBy(reverseDirection)
       .setStreetRequest(streetRequest)
       .setFrom(reverseDirection ? null : originVertices)
       .setTo(reverseDirection ? originVertices : null)
@@ -315,6 +305,32 @@ public class NearbyStopFinder {
     } else {
       return durationSkipEdgeStrategy;
     }
+  }
+
+  private static List<NearbyStop> createDirectlyConnectedStops(
+    Set<Vertex> originVertices,
+    boolean reverseDirection,
+    RouteRequest request,
+    StreetRequest streetRequest
+  ) {
+    List<NearbyStop> stopsFound = new ArrayList<>();
+
+    AStarRequest aStarRequest = AStarRequestMapper
+      .mapToTransferRequest(request)
+      .withArriveBy(reverseDirection)
+      .withMode(streetRequest.mode())
+      .build();
+
+    /* Add the origin vertices if they are stops */
+    for (Vertex vertex : originVertices) {
+      if (vertex instanceof TransitStopVertex tsv) {
+        stopsFound.add(
+          new NearbyStop(tsv.getStop(), 0, Collections.emptyList(), new State(vertex, aStarRequest))
+        );
+      }
+    }
+
+    return stopsFound;
   }
 
   private boolean canBoardFlex(State state, boolean reverse) {

--- a/src/main/java/org/opentripplanner/routing/algorithm/astar/strategies/EuclideanRemainingWeightHeuristic.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/astar/strategies/EuclideanRemainingWeightHeuristic.java
@@ -2,7 +2,6 @@ package org.opentripplanner.routing.algorithm.astar.strategies;
 
 import java.util.Set;
 import org.opentripplanner.common.geometry.SphericalDistanceLibrary;
-import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.routing.api.request.preference.RoutingPreferences;
 import org.opentripplanner.routing.core.State;
@@ -26,15 +25,16 @@ public class EuclideanRemainingWeightHeuristic implements RemainingWeightHeurist
   //      not work correctly.
   @Override
   public void initialize(
-    RouteRequest request,
     StreetMode streetMode,
     Set<Vertex> fromVertices,
-    Set<Vertex> toVertices
+    Set<Vertex> toVertices,
+    boolean arriveBy,
+    RoutingPreferences preferences
   ) {
     Vertex target = toVertices.iterator().next();
-    maxStreetSpeed = getStreetSpeedUpperBound(request.preferences(), streetMode);
-    walkingSpeed = request.preferences().walk().speed();
-    arriveBy = request.arriveBy();
+    maxStreetSpeed = getStreetSpeedUpperBound(preferences, streetMode);
+    walkingSpeed = preferences.walk().speed();
+    this.arriveBy = arriveBy;
 
     if (target.getDegreeIn() == 1) {
       Edge edge = target.getIncoming().iterator().next();

--- a/src/main/java/org/opentripplanner/routing/algorithm/astar/strategies/RemainingWeightHeuristic.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/astar/strategies/RemainingWeightHeuristic.java
@@ -2,8 +2,8 @@ package org.opentripplanner.routing.algorithm.astar.strategies;
 
 import java.io.Serializable;
 import java.util.Set;
-import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
+import org.opentripplanner.routing.api.request.preference.RoutingPreferences;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.graph.Vertex;
 
@@ -18,10 +18,11 @@ public interface RemainingWeightHeuristic extends Serializable {
    * initialization cannot depend on the origin vertex or state.
    */
   void initialize(
-    RouteRequest request,
     StreetMode streetMode,
     Set<Vertex> fromVertices,
-    Set<Vertex> toVertices
+    Set<Vertex> toVertices,
+    boolean arriveBy,
+    RoutingPreferences preferences
   );
 
   double estimateRemainingWeight(State s);

--- a/src/main/java/org/opentripplanner/routing/algorithm/astar/strategies/TrivialRemainingWeightHeuristic.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/astar/strategies/TrivialRemainingWeightHeuristic.java
@@ -1,8 +1,8 @@
 package org.opentripplanner.routing.algorithm.astar.strategies;
 
 import java.util.Set;
-import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
+import org.opentripplanner.routing.api.request.preference.RoutingPreferences;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.graph.Vertex;
 
@@ -14,10 +14,11 @@ public class TrivialRemainingWeightHeuristic implements RemainingWeightHeuristic
 
   @Override
   public void initialize(
-    RouteRequest request,
     StreetMode streetMode,
     Set<Vertex> fromVertices,
-    Set<Vertex> toVertices
+    Set<Vertex> toVertices,
+    boolean arriveBy,
+    RoutingPreferences preferences
   ) {}
 
   @Override

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/RaptorPathToItineraryMapper.java
@@ -72,12 +72,7 @@ public class RaptorPathToItineraryMapper<T extends TripSchedule> {
     this.transitLayer = transitLayer;
     this.transitSearchTimeZero = transitSearchTimeZero;
     this.transferMode = request.journey().transfer().mode();
-    this.request =
-      AStarRequestMapper
-        .map(request.copyAndPrepareForTransferRouting())
-        .withArriveBy(false)
-        .withMode(transferMode)
-        .build();
+    this.request = AStarRequestMapper.mapToTransferRequest(request).build();
     this.graphPathToItineraryMapper =
       new GraphPathToItineraryMapper(
         transitService.getTimeZone(),

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/TransitRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/TransitRouter.java
@@ -244,15 +244,13 @@ public class TransitRouter {
   private RaptorRoutingRequestTransitData createRequestTransitDataProvider(
     TransitLayer transitLayer
   ) {
-    RouteRequest transferRequest = request.copyAndPrepareForTransferRouting();
-
     return new RaptorRoutingRequestTransitData(
       transitLayer,
       transitSearchTimeZero,
       additionalSearchDays.additionalSearchDaysInPast(),
       additionalSearchDays.additionalSearchDaysInFuture(),
       new RouteRequestTransitDataProviderFilter(request, serverContext.transitService()),
-      transferRequest
+      request
     );
   }
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/RaptorTransferIndex.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/RaptorTransferIndex.java
@@ -5,9 +5,7 @@ import static java.util.stream.Collectors.toMap;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
-import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.core.AStarRequest;
-import org.opentripplanner.routing.core.AStarRequestMapper;
 import org.opentripplanner.transit.raptor.api.transit.RaptorTransfer;
 
 public class RaptorTransferIndex {
@@ -27,7 +25,7 @@ public class RaptorTransferIndex {
 
   public static RaptorTransferIndex create(
     List<List<Transfer>> transfersByStopIndex,
-    RouteRequest request
+    AStarRequest request
   ) {
     var forwardTransfers = new ArrayList<List<RaptorTransfer>>(transfersByStopIndex.size());
     var reversedTransfers = new ArrayList<List<RaptorTransfer>>(transfersByStopIndex.size());
@@ -37,18 +35,13 @@ public class RaptorTransferIndex {
       reversedTransfers.add(new ArrayList<>());
     }
 
-    final AStarRequest aStarRequest = AStarRequestMapper
-      .map(request)
-      .withMode(request.journey().transfer().mode())
-      .build();
-
     for (int fromStop = 0; fromStop < transfersByStopIndex.size(); fromStop++) {
       // The transfers are filtered so that there is only one possible directional transfer
       // for a stop pair.
       var transfers = transfersByStopIndex
         .get(fromStop)
         .stream()
-        .flatMap(s -> s.asRaptorTransfer(aStarRequest).stream())
+        .flatMap(s -> s.asRaptorTransfer(request).stream())
         .collect(
           toMap(
             RaptorTransfer::stop,

--- a/src/main/java/org/opentripplanner/routing/api/request/RouteRequest.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/RouteRequest.java
@@ -195,15 +195,6 @@ public class RouteRequest implements Cloneable, Serializable {
 
   /* INSTANCE METHODS */
 
-  public RouteRequest copyAndPrepareForTransferRouting() {
-    var rr = clone();
-    rr.setArriveBy(false);
-    rr.setDateTime(Instant.ofEpochSecond(0));
-    rr.setFrom(null);
-    rr.setTo(null);
-    return rr;
-  }
-
   /**
    * This method is used to clone the default message, and insert a current time. A typical use-case
    * is to copy the default request(from router-config), and then set all user specified parameters

--- a/src/main/java/org/opentripplanner/routing/core/AStarRequestMapper.java
+++ b/src/main/java/org/opentripplanner/routing/core/AStarRequestMapper.java
@@ -10,7 +10,6 @@ public class AStarRequestMapper {
       .of()
       .withStartTime(opt.dateTime())
       .withPreferences(opt.preferences())
-      .withArriveBy(opt.arriveBy())
       .withWheelchair(opt.wheelchair())
       .withParking(opt.journey().parking())
       .withRental(opt.journey().rental())

--- a/src/main/java/org/opentripplanner/routing/core/AStarRequestMapper.java
+++ b/src/main/java/org/opentripplanner/routing/core/AStarRequestMapper.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.routing.core;
 
+import java.time.Instant;
 import org.opentripplanner.routing.api.request.RouteRequest;
 
 public class AStarRequestMapper {
@@ -15,5 +16,16 @@ public class AStarRequestMapper {
       .withRental(opt.journey().rental())
       .withFrom(opt.from())
       .withTo(opt.to());
+  }
+
+  public static AStarRequestBuilder mapToTransferRequest(RouteRequest opt) {
+    return AStarRequest
+      .of()
+      .withStartTime(Instant.ofEpochSecond(0))
+      .withPreferences(opt.preferences())
+      .withWheelchair(opt.wheelchair())
+      .withParking(opt.journey().parking())
+      .withRental(opt.journey().rental())
+      .withMode(opt.journey().transfer().mode());
   }
 }

--- a/src/test/java/org/opentripplanner/routing/core/AStarRequestMapperTest.java
+++ b/src/test/java/org/opentripplanner/routing/core/AStarRequestMapperTest.java
@@ -1,0 +1,62 @@
+package org.opentripplanner.routing.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.model.GenericLocation;
+import org.opentripplanner.routing.api.request.RequestModes;
+import org.opentripplanner.routing.api.request.RouteRequest;
+import org.opentripplanner.routing.api.request.StreetMode;
+import org.opentripplanner.transit.model._data.TransitModelForTest;
+
+class AStarRequestMapperTest {
+
+  @Test
+  void map() {
+    RouteRequest routeRequest = new RouteRequest();
+
+    Instant dateTime = Instant.parse("2022-11-10T10:00:00Z");
+    routeRequest.setDateTime(dateTime);
+    var from = new GenericLocation(null, TransitModelForTest.id("STOP"), null, null);
+    routeRequest.setFrom(from);
+    var to = new GenericLocation(60.0, 20.0);
+    routeRequest.setTo(to);
+    routeRequest.withPreferences(it -> it.withWalk(walk -> walk.withSpeed(2.4)));
+    routeRequest.setWheelchair(true);
+    var modes = RequestModes.of().withAllStreetModes(StreetMode.BIKE).build();
+    routeRequest.journey().setModes(modes);
+
+    var subject = AStarRequestMapper.map(routeRequest).build();
+
+    assertEquals(dateTime, subject.startTime());
+    assertEquals(from, subject.from());
+    assertEquals(to, subject.to());
+    assertEquals(routeRequest.preferences(), subject.preferences());
+    assertTrue(subject.wheelchair());
+  }
+
+  @Test
+  void mapToTransferRequest() {
+    RouteRequest routeRequest = new RouteRequest();
+
+    Instant dateTime = Instant.parse("2022-11-10T10:00:00Z");
+    routeRequest.setDateTime(dateTime);
+    var from = new GenericLocation(null, TransitModelForTest.id("STOP"), null, null);
+    routeRequest.setFrom(from);
+    var to = new GenericLocation(60.0, 20.0);
+    routeRequest.setTo(to);
+    routeRequest.withPreferences(it -> it.withWalk(walk -> walk.withSpeed(2.4)));
+    routeRequest.setWheelchair(true);
+
+    var subject = AStarRequestMapper.mapToTransferRequest(routeRequest).build();
+
+    assertEquals(Instant.EPOCH, subject.startTime());
+    assertNull(subject.from());
+    assertNull(subject.to());
+    assertEquals(routeRequest.preferences(), subject.preferences());
+    assertTrue(subject.wheelchair());
+  }
+}


### PR DESCRIPTION
### Summary

The recent move to separate `AStarRequest` and individual preference classes helps us to clean up code related to transfer requests.
