### PR TITLE
Remove unused SIRI parameters from config

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETUpdaterParameters.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriETUpdaterParameters.java
@@ -8,9 +8,6 @@ public class SiriETUpdaterParameters
 
   private final String configRef;
   private final String feedId;
-  private final int logFrequency;
-  private final int maxSnapshotFrequencyMs;
-  private final boolean purgeExpiredData;
   private final boolean blockReadinessUntilInitialized;
 
   private final String url;
@@ -25,9 +22,6 @@ public class SiriETUpdaterParameters
   public SiriETUpdaterParameters(
     String configRef,
     String feedId,
-    int logFrequency,
-    int maxSnapshotFrequencyMs,
-    boolean purgeExpiredData,
     boolean blockReadinessUntilInitialized,
     String url,
     int frequencySec,
@@ -38,9 +32,6 @@ public class SiriETUpdaterParameters
   ) {
     this.configRef = configRef;
     this.feedId = feedId;
-    this.logFrequency = logFrequency;
-    this.maxSnapshotFrequencyMs = maxSnapshotFrequencyMs;
-    this.purgeExpiredData = purgeExpiredData;
     this.blockReadinessUntilInitialized = blockReadinessUntilInitialized;
     this.url = url;
     this.frequencySec = frequencySec;
@@ -52,18 +43,6 @@ public class SiriETUpdaterParameters
 
   public String getFeedId() {
     return feedId;
-  }
-
-  public int getLogFrequency() {
-    return logFrequency;
-  }
-
-  public int getMaxSnapshotFrequencyMs() {
-    return maxSnapshotFrequencyMs;
-  }
-
-  public boolean purgeExpiredData() {
-    return purgeExpiredData;
   }
 
   public boolean blockReadinessUntilInitialized() {

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriVMUpdaterParameters.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriVMUpdaterParameters.java
@@ -6,9 +6,6 @@ public class SiriVMUpdaterParameters implements PollingGraphUpdaterParameters {
 
   private final String configRef;
   private final String feedId;
-  private final int logFrequency;
-  private final int maxSnapshotFrequencyMs;
-  private final boolean purgeExpiredData;
   private final boolean blockReadinessUntilInitialized;
 
   // Source parameters
@@ -20,9 +17,6 @@ public class SiriVMUpdaterParameters implements PollingGraphUpdaterParameters {
   public SiriVMUpdaterParameters(
     String configRef,
     String feedId,
-    int logFrequency,
-    int maxSnapshotFrequencyMs,
-    boolean purgeExpiredData,
     boolean blockReadinessUntilInitialized,
     String url,
     String requestorRef,
@@ -31,9 +25,6 @@ public class SiriVMUpdaterParameters implements PollingGraphUpdaterParameters {
   ) {
     this.configRef = configRef;
     this.feedId = feedId;
-    this.logFrequency = logFrequency;
-    this.maxSnapshotFrequencyMs = maxSnapshotFrequencyMs;
-    this.purgeExpiredData = purgeExpiredData;
     this.blockReadinessUntilInitialized = blockReadinessUntilInitialized;
     this.url = url;
     this.requestorRef = requestorRef;
@@ -53,18 +44,6 @@ public class SiriVMUpdaterParameters implements PollingGraphUpdaterParameters {
 
   public String getFeedId() {
     return feedId;
-  }
-
-  public int getLogFrequency() {
-    return logFrequency;
-  }
-
-  public int getMaxSnapshotFrequencyMs() {
-    return maxSnapshotFrequencyMs;
-  }
-
-  public boolean purgeExpiredData() {
-    return purgeExpiredData;
   }
 
   public boolean blockReadinessUntilInitialized() {

--- a/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/SiriETUpdaterConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/SiriETUpdaterConfig.java
@@ -12,9 +12,6 @@ public class SiriETUpdaterConfig {
     return new SiriETUpdaterParameters(
       configRef,
       c.of("feedId").since(NA).summary("TODO").asString(null),
-      c.of("logFrequency").since(NA).summary("TODO").asInt(-1),
-      c.of("maxSnapshotFrequencyMs").since(NA).summary("TODO").asInt(-1),
-      c.of("purgeExpiredData").since(NA).summary("TODO").asBoolean(false),
       c.of("blockReadinessUntilInitialized").since(NA).summary("TODO").asBoolean(false),
       c.of("url").since(NA).summary("TODO").asString(),
       c.of("frequencySec").since(NA).summary("TODO").asInt(60),

--- a/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/SiriVMUpdaterConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/routerconfig/updaters/SiriVMUpdaterConfig.java
@@ -12,9 +12,6 @@ public class SiriVMUpdaterConfig {
     return new SiriVMUpdaterParameters(
       configRef,
       c.of("feedId").since(NA).summary("TODO").asString(null),
-      c.of("logFrequency").since(NA).summary("TODO").asInt(-1),
-      c.of("maxSnapshotFrequencyMs").since(NA).summary("TODO").asInt(-1),
-      c.of("purgeExpiredData").since(NA).summary("TODO").asBoolean(false),
       c.of("blockReadinessUntilInitialized").since(NA).summary("TODO").asBoolean(false),
       c.of("url").since(NA).summary("TODO").asString(),
       c.of("requestorRef").since(NA).summary("TODO").asString("otp-" + UUID.randomUUID()),


### PR DESCRIPTION
### Summary

We recently moved some parameters to be on the timetable snapshot source, rather than the individual updaters. These parameters still existed on the config mappers. Remove those.
