### PR TITLE
Remove configuration params of German speed tests

### DIFF
--- a/test/performance/baden-wuerttemberg/speed-test-config.json
+++ b/test/performance/baden-wuerttemberg/speed-test-config.json
@@ -5,35 +5,6 @@
 
   // Relative paths supported like "../../data/otp-ci/graph-${otp.serialization.version.id}.obj"
   // Default: "graph.obj"
-  "graph": "graph.obj",
+  "graph": "graph.obj"
 
-  // OTP Default is 45 minutes (2700 seconds)
-  // maxWalkDurationSeconds: 2700,
-
-  "tuningParameters": {
-    // maxNumberOfTransfers: 12,
-
-    // scheduledTripBinarySearchThreshold: 50,
-
-    // iterationDepartureStepInSeconds: 60,
-
-    // searchThreadPoolSize: 0,
-
-    "dynamicSearchWindow": {
-      "minTransitTimeCoefficient": 0.75,
-      "minWaitTimeCoefficient": 0.0
-      // minTimeMinutes: 30,
-      // minTimeMinutes: 40,
-
-      // default is 180 minutes (3 hours)
-      // maxLengthMinutes : 360,
-
-      // stepMinutes: 10
-      // stepMinutes: 10
-    }
-  },
-  "routingDefaults": {
-    // Default is 1.4 m/s = ~ 5.0 km/t
-    "walkSpeed": 1.4
-  }
 }

--- a/test/performance/germany/speed-test-config.json
+++ b/test/performance/germany/speed-test-config.json
@@ -5,35 +5,6 @@
 
   // Relative paths supported like "../../data/otp-ci/graph-${otp.serialization.version.id}.obj"
   // Default: "graph.obj"
-  "graph": "graph.obj",
+  "graph": "graph.obj"
 
-  // OTP Default is 45 minutes (2700 seconds)
-  // maxWalkDurationSeconds: 2700,
-
-  "tuningParameters": {
-    // maxNumberOfTransfers: 12,
-
-    // scheduledTripBinarySearchThreshold: 50,
-
-    // iterationDepartureStepInSeconds: 60,
-
-    // searchThreadPoolSize: 0,
-
-    "dynamicSearchWindow": {
-      "minTransitTimeCoefficient": 0.75,
-      "minWaitTimeCoefficient": 0.0
-      // minTimeMinutes: 30,
-      // minTimeMinutes: 40,
-
-      // default is 180 minutes (3 hours)
-      // maxLengthMinutes : 360,
-
-      // stepMinutes: 10
-      // stepMinutes: 10
-    }
-  },
-  "routingDefaults": {
-    // Default is 1.4 m/s = ~ 5.0 km/t
-    "walkSpeed": 1.4
-  }
 }


### PR DESCRIPTION
@hannesj fixed the configuration in a previous PR but that actually led to some tests not returning results. This restores the behaviour from before that PR.