### PR TITLE
Reduce the number of calls to Heuristics#reached

### DIFF
--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/internalapi/HeuristicAtStop.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/internalapi/HeuristicAtStop.java
@@ -6,6 +6,15 @@ import java.time.Duration;
  * Heuristic data for a given stop.
  */
 public record HeuristicAtStop(int minTravelDuration, int minNumTransfers, int minCost) {
+  /**
+   * Representation for a stop, which has not been reached by the heuristic search
+   */
+  public static final HeuristicAtStop UNREACHED = new HeuristicAtStop(
+    Integer.MAX_VALUE,
+    Integer.MAX_VALUE,
+    Integer.MAX_VALUE
+  );
+
   @Override
   public String toString() {
     return (

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/internalapi/Heuristics.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/internalapi/Heuristics.java
@@ -1,7 +1,5 @@
 package org.opentripplanner.transit.raptor.rangeraptor.internalapi;
 
-import javax.annotation.Nullable;
-
 /**
  * The heuristics are used in the multi-criteria search and can be generated using the standard
  * search. This interface decouple these two implementations and make it possible to implement more
@@ -9,14 +7,10 @@ import javax.annotation.Nullable;
  */
 public interface Heuristics {
   /**
-   * Is the stop reached by the heuristic search?
+   * The heuristic from the origin to the given stop. Returns {@link HeuristicAtStop#UNREACHED} if
+   * the stop is not reached.
    */
-  boolean reached(int stop);
-
-  /**
-   * The best overall travel duration from origin to the given stop.
-   */
-  int bestTravelDuration(int stop);
+  HeuristicAtStop createHeuristicAtStop(int stop);
 
   /**
    * To plot or debug the travel duration.
@@ -26,11 +20,6 @@ public interface Heuristics {
   int[] bestTravelDurationToIntArray(int unreached);
 
   /**
-   * The best number of transfers to reach the given stop.
-   */
-  int bestNumOfTransfers(int stop);
-
-  /**
    * To plot or debug the number of transfers.
    *
    * @param unreached set all unreached values to this value
@@ -38,23 +27,11 @@ public interface Heuristics {
   int[] bestNumOfTransfersToIntArray(int unreached);
 
   /**
-   * The best overall generalized cost from origin to the given stop.
-   */
-  int bestGeneralizedCost(int stop);
-
-  /**
    * To plot or debug the generalized cost.
    *
    * @param unreached set all unreached values to this value
    */
   int[] bestGeneralizedCostToIntArray(int unreached);
-
-  /**
-   * The heuristic from the origin to the given stop. Returns {@link HeuristicAtStop#UNREACHED} if
-   * the stop is not reached.
-   */
-  @Nullable
-  HeuristicAtStop createHeuristicAtStop(int stop);
 
   /**
    * The number of stops in the heuristics. This includes all stops also stops not reached.

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/internalapi/Heuristics.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/internalapi/Heuristics.java
@@ -50,7 +50,8 @@ public interface Heuristics {
   int[] bestGeneralizedCostToIntArray(int unreached);
 
   /**
-   * The heuristic from the origin to the given stop.
+   * The heuristic from the origin to the given stop. Returns {@link HeuristicAtStop#UNREACHED} if
+   * the stop is not reached.
    */
   @Nullable
   HeuristicAtStop createHeuristicAtStop(int stop);

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/heuristic/HeuristicsProvider.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/heuristic/HeuristicsProvider.java
@@ -84,7 +84,7 @@ public final class HeuristicsProvider<T extends RaptorTripSchedule> {
   private boolean qualify(int stop, int arrivalTime, int travelDuration, int cost) {
     HeuristicAtStop h = get(stop);
 
-    if (h == null) {
+    if (h == HeuristicAtStop.UNREACHED) {
       return false;
     }
     int minArrivalTime = arrivalTime + h.minTravelDuration();
@@ -96,13 +96,13 @@ public final class HeuristicsProvider<T extends RaptorTripSchedule> {
   }
 
   private String rejectErrorMessage(int stop) {
-    return get(stop) == null
+    return get(stop) == HeuristicAtStop.UNREACHED
       ? "The stop was not reached in the heuristic calculation."
       : get(stop).toString();
   }
 
   private HeuristicAtStop get(int stop) {
-    if (stops[stop] == null && heuristics.reached(stop)) {
+    if (stops[stop] == null) {
       stops[stop] = heuristics.createHeuristicAtStop(stop);
     }
     return stops[stop];

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/heuristics/HeuristicsAdapter.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/heuristics/HeuristicsAdapter.java
@@ -5,7 +5,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.IntUnaryOperator;
 import java.util.stream.Collectors;
-import javax.annotation.Nullable;
 import org.opentripplanner.transit.raptor.api.transit.CostCalculator;
 import org.opentripplanner.transit.raptor.api.transit.RaptorAccessEgress;
 import org.opentripplanner.transit.raptor.rangeraptor.internalapi.HeuristicAtStop;
@@ -62,9 +61,14 @@ public class HeuristicsAdapter implements Heuristics {
   @Override
   public int bestTravelDuration(int stop) {
     if (reached(stop)) {
-      return calculator.duration(originDepartureTime, times.time(stop));
+      return bestTravelDurationInternal(stop);
     }
     return NOT_SET;
+  }
+
+  /** This method should be used only when it has been established that the stop has been reached */
+  private int bestTravelDurationInternal(int stop) {
+    return calculator.duration(originDepartureTime, times.time(stop));
   }
 
   @Override
@@ -85,9 +89,14 @@ public class HeuristicsAdapter implements Heuristics {
   @Override
   public int bestGeneralizedCost(int stop) {
     if (reached(stop)) {
-      return costCalculator.calculateMinCost(bestTravelDuration(stop), bestNumOfTransfers(stop));
+      return bestGeneralizedCostInternal(stop);
     }
     return NOT_SET;
+  }
+
+  /** This method should be used only when it has been established that the stop has been reached */
+  private int bestGeneralizedCostInternal(int stop) {
+    return costCalculator.calculateMinCost(bestTravelDuration(stop), bestNumOfTransfers(stop));
   }
 
   @Override
@@ -96,15 +105,14 @@ public class HeuristicsAdapter implements Heuristics {
   }
 
   @Override
-  @Nullable
   public HeuristicAtStop createHeuristicAtStop(int stop) {
     return reached(stop)
       ? new HeuristicAtStop(
-        bestTravelDuration(stop),
+        bestTravelDurationInternal(stop),
         bestNumOfTransfers(stop),
-        bestGeneralizedCost(stop)
+        bestGeneralizedCostInternal(stop)
       )
-      : null;
+      : HeuristicAtStop.UNREACHED;
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/heuristics/HeuristicsAdapter.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/heuristics/HeuristicsAdapter.java
@@ -53,30 +53,14 @@ public class HeuristicsAdapter implements Heuristics {
     lifeCycle.onSetupIteration(this::setUpIteration);
   }
 
-  public boolean reached(int stop) {
-    return times.isStopReached(stop);
-  }
-
-  private int bestTravelDuration(int stop) {
-    return calculator.duration(originDepartureTime, times.time(stop));
-  }
-
   @Override
   public int[] bestTravelDurationToIntArray(int unreached) {
     return toIntArray(size(), unreached, this::bestTravelDuration);
   }
 
-  public int bestNumOfTransfers(int stop) {
-    return transfers.calculateMinNumberOfTransfers(stop);
-  }
-
   @Override
   public int[] bestNumOfTransfersToIntArray(int unreached) {
     return toIntArray(size(), unreached, this::bestNumOfTransfers);
-  }
-
-  private int bestGeneralizedCost(int stop) {
-    return costCalculator.calculateMinCost(bestTravelDuration(stop), bestNumOfTransfers(stop));
   }
 
   @Override
@@ -144,6 +128,22 @@ public class HeuristicsAdapter implements Heuristics {
         20
       )
       .toString();
+  }
+
+  private boolean reached(int stop) {
+    return times.isStopReached(stop);
+  }
+
+  private int bestTravelDuration(int stop) {
+    return calculator.duration(originDepartureTime, times.time(stop));
+  }
+
+  private int bestNumOfTransfers(int stop) {
+    return transfers.calculateMinNumberOfTransfers(stop);
+  }
+
+  private int bestGeneralizedCost(int stop) {
+    return costCalculator.calculateMinCost(bestTravelDuration(stop), bestNumOfTransfers(stop));
   }
 
   private void setUpIteration(int departureTime) {

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/heuristics/HeuristicsAdapter.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/standard/heuristics/HeuristicsAdapter.java
@@ -53,21 +53,11 @@ public class HeuristicsAdapter implements Heuristics {
     lifeCycle.onSetupIteration(this::setUpIteration);
   }
 
-  @Override
   public boolean reached(int stop) {
     return times.isStopReached(stop);
   }
 
-  @Override
-  public int bestTravelDuration(int stop) {
-    if (reached(stop)) {
-      return bestTravelDurationInternal(stop);
-    }
-    return NOT_SET;
-  }
-
-  /** This method should be used only when it has been established that the stop has been reached */
-  private int bestTravelDurationInternal(int stop) {
+  private int bestTravelDuration(int stop) {
     return calculator.duration(originDepartureTime, times.time(stop));
   }
 
@@ -76,7 +66,6 @@ public class HeuristicsAdapter implements Heuristics {
     return toIntArray(size(), unreached, this::bestTravelDuration);
   }
 
-  @Override
   public int bestNumOfTransfers(int stop) {
     return transfers.calculateMinNumberOfTransfers(stop);
   }
@@ -86,16 +75,7 @@ public class HeuristicsAdapter implements Heuristics {
     return toIntArray(size(), unreached, this::bestNumOfTransfers);
   }
 
-  @Override
-  public int bestGeneralizedCost(int stop) {
-    if (reached(stop)) {
-      return bestGeneralizedCostInternal(stop);
-    }
-    return NOT_SET;
-  }
-
-  /** This method should be used only when it has been established that the stop has been reached */
-  private int bestGeneralizedCostInternal(int stop) {
+  private int bestGeneralizedCost(int stop) {
     return costCalculator.calculateMinCost(bestTravelDuration(stop), bestNumOfTransfers(stop));
   }
 
@@ -108,9 +88,9 @@ public class HeuristicsAdapter implements Heuristics {
   public HeuristicAtStop createHeuristicAtStop(int stop) {
     return reached(stop)
       ? new HeuristicAtStop(
-        bestTravelDurationInternal(stop),
+        bestTravelDuration(stop),
         bestNumOfTransfers(stop),
-        bestGeneralizedCostInternal(stop)
+        bestGeneralizedCost(stop)
       )
       : HeuristicAtStop.UNREACHED;
   }


### PR DESCRIPTION
### Summary

Currently we call `Heuristics#reached` multiple times when calculating a heuristic at a stop. Optimize the creation by extracting internal versions without the check, and only do it once at the top level. Also cache the unreached stops in the array by using a static value.
