### PR TITLE
Ignore logger in graph serialization test in order to fix flaky test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -282,7 +282,6 @@
                         --add-opens java.base/java.util.concurrent.locks=ALL-UNNAMED
                         --add-opens java.base/java.util.regex=ALL-UNNAMED
                         --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED
-                        --add-opens java.base/java.util.logging=ALL-UNNAMED
                         --add-opens java.base/jdk.internal.reflect=ALL-UNNAMED
                         --add-opens java.base/jdk.internal.misc=ALL-UNNAMED
                         --add-opens java.base/jdk.internal.loader=ALL-UNNAMED

--- a/src/test/java/org/opentripplanner/routing/graph/GraphSerializationTest.java
+++ b/src/test/java/org/opentripplanner/routing/graph/GraphSerializationTest.java
@@ -24,7 +24,6 @@ import org.opentripplanner.standalone.config.BuildConfig;
 import org.opentripplanner.standalone.config.RouterConfig;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.service.TransitModel;
-import org.slf4j.Logger;
 
 /**
  * Tests that saving a graph and reloading it (round trip through serialization and deserialization)
@@ -45,7 +44,8 @@ public class GraphSerializationTest {
       JarFile.class,
       SoftReference.class,
       Class.class,
-      Logger.class,
+      org.slf4j.Logger.class,
+      ch.qos.logback.classic.Logger.class,
       HashGridSpatialIndex.class,
       Deduplicator.class
     )

--- a/src/test/java/org/opentripplanner/routing/graph/GraphSerializationTest.java
+++ b/src/test/java/org/opentripplanner/routing/graph/GraphSerializationTest.java
@@ -7,6 +7,7 @@ import java.io.File;
 import java.lang.ref.SoftReference;
 import java.lang.reflect.Method;
 import java.util.BitSet;
+import java.util.Set;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.jar.JarFile;
 import org.geotools.util.WeakValueHashMap;
@@ -23,6 +24,7 @@ import org.opentripplanner.standalone.config.BuildConfig;
 import org.opentripplanner.standalone.config.RouterConfig;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.service.TransitModel;
+import org.slf4j.Logger;
 
 /**
  * Tests that saving a graph and reloading it (round trip through serialization and deserialization)
@@ -34,6 +36,20 @@ import org.opentripplanner.transit.service.TransitModel;
  * Created by abyrd on 2018-10-26
  */
 public class GraphSerializationTest {
+
+  static Class<?>[] IGNORED_CLASSES = Set
+    .of(
+      ThreadPoolExecutor.class,
+      WeakValueHashMap.class,
+      Method.class,
+      JarFile.class,
+      SoftReference.class,
+      Class.class,
+      Logger.class,
+      HashGridSpatialIndex.class,
+      Deduplicator.class
+    )
+    .toArray(Class[]::new);
 
   /**
    * Tests GTFS based graph serialization to file.
@@ -79,7 +95,6 @@ public class GraphSerializationTest {
       .getCachedPortlandGraph()
       .index();
     Graph originalGraph = cachedPortlandGraph.graph();
-    TransitModel originalTransitModel = cachedPortlandGraph.transitModel();
 
     // We can exclude relatively few classes here, because the object trees are of course perfectly identical.
     // We do skip edge lists - otherwise we trigger a depth-first search of the graph causing a stack overflow.
@@ -89,14 +104,8 @@ public class GraphSerializationTest {
     objectDiffer.useEquals(BitSet.class, LineString.class, Polygon.class);
     // ThreadPoolExecutor contains a weak reference to a very deep chain of Finalizer instances.
     // Method instances usually are part of a proxy which are totally un-reflectable in Java 11.
-    objectDiffer.ignoreClasses(
-      ThreadPoolExecutor.class,
-      WeakValueHashMap.class,
-      Method.class,
-      JarFile.class,
-      SoftReference.class,
-      Class.class
-    );
+
+    objectDiffer.ignoreClasses(IGNORED_CLASSES);
     // This setting is critical to perform a deep test of an object against itself.
     objectDiffer.enableComparingIdenticalObjects();
     objectDiffer.compareTwoObjects(originalGraph, originalGraph);
@@ -136,21 +145,12 @@ public class GraphSerializationTest {
       "uniqueMatchers"
     );
     // Edges have very detailed String representation including lat/lon coordinates and OSM IDs. They should be unique.
-    objectDiffer.setKeyExtractor("turnRestrictions", edge -> edge.toString());
+    objectDiffer.setKeyExtractor("turnRestrictions", Object::toString);
     objectDiffer.useEquals(BitSet.class, LineString.class, Polygon.class);
     // HashGridSpatialIndex contains unordered lists in its bins. This is rebuilt after deserialization anyway.
     // The deduplicator in the loaded graph will be empty, because it is transient and only fills up when items
     // are deduplicated.
-    objectDiffer.ignoreClasses(
-      HashGridSpatialIndex.class,
-      ThreadPoolExecutor.class,
-      Deduplicator.class,
-      WeakValueHashMap.class,
-      Method.class,
-      JarFile.class,
-      SoftReference.class,
-      Class.class
-    );
+    objectDiffer.ignoreClasses(IGNORED_CLASSES);
     objectDiffer.compareTwoObjects(g1, g2);
     objectDiffer.printSummary();
     // Print differences before assertion so we can see what went wrong.


### PR DESCRIPTION
### Summary

Recently we've seen random failures in the graph serialization test which started after the upgrade to slf4j 2. It seems that the internals of that library have changed and this trips up the object differ.

I think the fix would simply be to ignore the logger during the graph comparision. This is the right thing to do even if there wasn't a flaky test.