### PR TITLE
Use information about maxRounds to prune multi-criteria RAPTOR search

### DIFF
--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/internalapi/RoundProvider.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/internalapi/RoundProvider.java
@@ -16,4 +16,9 @@ public interface RoundProvider {
    * The current Raptor round.
    */
   int round();
+
+  /**
+   * Maximum limit of rounds. This number can decrease during the search.
+   */
+  int roundMaxLimit();
 }

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/heuristic/HeuristicsProvider.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/multicriteria/heuristic/HeuristicsProvider.java
@@ -89,6 +89,9 @@ public final class HeuristicsProvider<T extends RaptorTripSchedule> {
     }
     int minArrivalTime = arrivalTime + h.minTravelDuration();
     int minNumberOfTransfers = roundProvider.round() - 1 + h.minNumTransfers();
+    if (minNumberOfTransfers >= roundProvider.roundMaxLimit()) {
+      return false;
+    }
     int minTravelDuration = travelDuration + h.minTravelDuration();
     int minCost = cost + h.minCost();
     int departureTime = minArrivalTime - minTravelDuration;

--- a/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/transit/RoundTracker.java
+++ b/src/main/java/org/opentripplanner/transit/raptor/rangeraptor/transit/RoundTracker.java
@@ -28,7 +28,7 @@ public class RoundTracker implements RoundProvider {
    * This is default set to the maximum number of rounds limit, but as soon as the destination is
    * reach the {@link #numberOfAdditionalTransfers} is used to update the limit.
    * <p/>
-   * The limit is inclusive, indicating the the last round to process.
+   * The limit is inclusive, indicating the last round to process.
    */
   private int roundMaxLimit;
 
@@ -53,8 +53,14 @@ public class RoundTracker implements RoundProvider {
   /**
    * Return the current round, the round in process.
    */
+  @Override
   public int round() {
     return round;
+  }
+
+  @Override
+  public int roundMaxLimit() {
+    return roundMaxLimit;
   }
 
   /**


### PR DESCRIPTION
### Summary

After reaching the destination we lower the number of transfers allowed. It might make sense to use this information together with the heuristic to prune the path, even tough it might be optimal in terms of cost or duration, but will not be reached, as the minimum rounds allowed is too small. Also calculating this one condition should be faster than qualifying the whole path. In the future, it might make sense to do this even before any paths to the destination are reached.
