### PR TITLE
Fix newlines in Markdown generation, spelling

### DIFF
--- a/doc-templates/Configuration.md
+++ b/doc-templates/Configuration.md
@@ -107,9 +107,9 @@ version the configuration in a deployment pipeline. The `configVersion` is not u
 way, but is logged at startup and is available as part of the _server-info_ data in the REST API.
 The intended usage is to be able to check which version of the configuration the graph was build
 with and which version the router uses. In an deployment with many OTP instances it can be useful to
-ask an instance about the version, instead of tracking the deployment pipline backwards to find the
+ask an instance about the version, instead of tracking the deployment pipeline backwards to find the
 version used. How you inject a version into the configuration file is up to you, but you can do it
-in your build-pipline, at deployment time or use system environment variable substituton.
+in your build-pipeline, at deployment time or use system environment variable substitution.
 
 ## OTP Serialization version id and _Graph.obj_ file header
 
@@ -122,8 +122,8 @@ graph. The header info is available to configuration substitution:
 
 The intended usage is to be able to have a graph build pipeline which "knows" which graph that
 matches OTP planner instances. For example, you may build new graphs for every OTP serialization
-version id in use by the planning OPT instances you have deploied and plan to deploy. This way you
-can roll forward and backward new OTP instances without worring about building new graphs.
+version id in use by the planning OTP instances you have deployed and plan to deploy. This way you
+can roll forward and backward new OTP instances without worrying about building new graphs.
 
 There are various ways to access this information. To get the `Graph.obj` serialization version id
 you can run the following bash command:

--- a/doc-templates/VehicleParking.md
+++ b/doc-templates/VehicleParking.md
@@ -1,4 +1,4 @@
-# Vehicle Parking Updaters - OTP Sandbox Extension
+# Vehicle Parking Updaters
 
 ## Contact Info
 

--- a/docs/BuildConfiguration.md
+++ b/docs/BuildConfiguration.md
@@ -964,8 +964,8 @@ section, auto-scanning in the base directory for this feed type will be disabled
 
 <h3 id="tf_0_stationTransferPreference">stationTransferPreference</h3>
 
-**Since version:** `2.3` ∙ **Type:** `enum` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"allowed"`  \
-**Path:** /transitFeeds/[0]  \
+**Since version:** `2.3` ∙ **Type:** `enum` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"allowed"`   
+**Path:** /transitFeeds/[0]   
 **Enum values:** `discouraged` | `allowed` | `recommended` | `preferred`
 
 Should there be some preference or aversion for transfers at stops that are part of a station.

--- a/docs/BuildConfiguration.md
+++ b/docs/BuildConfiguration.md
@@ -75,7 +75,7 @@ Sections follow that describe particular settings in more depth.
 |    noTransfersOnIsolatedStops                                            |  `boolean`  | Whether we should allow transfers to and from StopPlaces marked with LimitedUse.ISOLATED                                    | *Optional* | `false`                           |  2.2  |
 |    [sharedFilePattern](#nd_sharedFilePattern)                            |   `regexp`  | Pattern for matching shared NeTEx files in a NeTEx bundle.                                                                  | *Optional* | `"shared-data\.xml"`              |  2.0  |
 |    [sharedGroupFilePattern](#nd_sharedGroupFilePattern)                  |   `regexp`  | Pattern for matching shared group NeTEx files in a NeTEx bundle.                                                            | *Optional* | `"(\w{3})-.*-shared\.xml"`        |  2.0  |
-|    [ferryIdsNotAllowedForBicycle](#nd_ferryIdsNotAllowedForBicycle)      |  `string[]` | List ferries witch do not allow bikes.                                                                                      | *Optional* |                                   |  2.0  |
+|    [ferryIdsNotAllowedForBicycle](#nd_ferryIdsNotAllowedForBicycle)      |  `string[]` | List ferries which do not allow bikes.                                                                                      | *Optional* |                                   |  2.0  |
 | [osm](#osm)                                                              |  `object[]` | Configure properties for a given OpenStreetMap feed.                                                                        | *Optional* |                                   |  2.2  |
 |       [osmTagMapping](#osm_0_osmTagMapping)                              |    `enum`   | The named set of mapping rules applied when parsing OSM tags.                                                               | *Optional* | `"default"`                       |  2.2  |
 |       source                                                             |    `uri`    | The unique URI pointing to the data file.                                                                                   | *Required* |                                   |  2.2  |
@@ -102,7 +102,7 @@ Sections follow that describe particular settings in more depth.
 |       [sharedFilePattern](#tf_1_sharedFilePattern)                       |   `regexp`  | Pattern for matching shared NeTEx files in a NeTEx bundle.                                                                  | *Optional* | `"_stops.xml"`                    |  2.0  |
 |       [sharedGroupFilePattern](#tf_1_sharedGroupFilePattern)             |   `regexp`  | Pattern for matching shared group NeTEx files in a NeTEx bundle.                                                            | *Optional* | `"_(\w{3})_shared_data.xml"`      |  2.0  |
 |       source                                                             |    `uri`    | The unique URI pointing to the data file.                                                                                   | *Required* |                                   |  2.2  |
-|       [ferryIdsNotAllowedForBicycle](#tf_1_ferryIdsNotAllowedForBicycle) |  `string[]` | List ferries witch do not allow bikes.                                                                                      | *Optional* |                                   |  2.0  |
+|       [ferryIdsNotAllowedForBicycle](#tf_1_ferryIdsNotAllowedForBicycle) |  `string[]` | List ferries which do not allow bikes.                                                                                      | *Optional* |                                   |  2.0  |
 
 <!-- PARAMETERS-TABLE END -->
 
@@ -412,7 +412,7 @@ See [writeCachedElevations](#writeCachedElevations) for details.
 
 <h3 id="areaVisibility">areaVisibility</h3>
 
-**Since version:** `1.5` ∙ **Type:** `boolean` ∙ **Cardinality:** `Optional` ∙ **Default value:** `false`  \
+**Since version:** `1.5` ∙ **Type:** `boolean` ∙ **Cardinality:** `Optional` ∙ **Default value:** `false`   
 **Path:** / 
 
 Perform visibility calculations.
@@ -423,7 +423,7 @@ shortest way rather than around the edge of it. (These calculations can be time 
 
 <h3 id="buildReportDir">buildReportDir</h3>
 
-**Since version:** `2.0` ∙ **Type:** `uri` ∙ **Cardinality:** `Optional`  \
+**Since version:** `2.0` ∙ **Type:** `uri` ∙ **Cardinality:** `Optional`   
 **Path:** / 
 
 URI to the directory where the graph build report should be written to.
@@ -434,7 +434,7 @@ If it does not exist, it is created.
 
 <h3 id="configVersion">configVersion</h3>
 
-**Since version:** `2.1` ∙ **Type:** `string` ∙ **Cardinality:** `Optional`  \
+**Since version:** `2.1` ∙ **Type:** `string` ∙ **Cardinality:** `Optional`   
 **Path:** / 
 
 Deployment version of the *build-config.json*.
@@ -452,7 +452,7 @@ Be aware that OTP uses the config embedded in the loaded graph if no new config 
 
 <h3 id="dataImportReport">dataImportReport</h3>
 
-**Since version:** `2.0` ∙ **Type:** `boolean` ∙ **Cardinality:** `Optional` ∙ **Default value:** `false`  \
+**Since version:** `2.0` ∙ **Type:** `boolean` ∙ **Cardinality:** `Optional` ∙ **Default value:** `false`   
 **Path:** / 
 
 Generate nice HTML report of Graph errors/warnings
@@ -461,7 +461,7 @@ The reports are stored in the same location as the graph.
 
 <h3 id="discardMinTransferTimes">discardMinTransferTimes</h3>
 
-**Since version:** `2.2` ∙ **Type:** `boolean` ∙ **Cardinality:** `Optional` ∙ **Default value:** `false`  \
+**Since version:** `2.2` ∙ **Type:** `boolean` ∙ **Cardinality:** `Optional` ∙ **Default value:** `false`   
 **Path:** / 
 
 Should minimum transfer times in GTFS files be discarded.
@@ -472,7 +472,7 @@ but we want to calculate the transfers always from OSM data.
 
 <h3 id="distanceBetweenElevationSamples">distanceBetweenElevationSamples</h3>
 
-**Since version:** `2.0` ∙ **Type:** `double` ∙ **Cardinality:** `Optional` ∙ **Default value:** `10.0`  \
+**Since version:** `2.0` ∙ **Type:** `double` ∙ **Cardinality:** `Optional` ∙ **Default value:** `10.0`   
 **Path:** / 
 
 The distance between elevation samples in meters.
@@ -481,7 +481,7 @@ The default is the approximate resolution of 1/3 arc-second NED data. This shoul
 
 <h3 id="elevationUnitMultiplier">elevationUnitMultiplier</h3>
 
-**Since version:** `2.0` ∙ **Type:** `double` ∙ **Cardinality:** `Optional` ∙ **Default value:** `1.0`  \
+**Since version:** `2.0` ∙ **Type:** `double` ∙ **Cardinality:** `Optional` ∙ **Default value:** `1.0`   
 **Path:** / 
 
 Specify a multiplier to convert elevation units from source to meters.
@@ -493,7 +493,7 @@ in the source data, this should be set to 0.1.
 
 <h3 id="graph">graph</h3>
 
-**Since version:** `2.0` ∙ **Type:** `uri` ∙ **Cardinality:** `Optional`  \
+**Since version:** `2.0` ∙ **Type:** `uri` ∙ **Cardinality:** `Optional`   
 **Path:** / 
 
 URI to the graph object file for reading and writing.
@@ -502,7 +502,7 @@ The file is created or overwritten if OTP saves the graph to the file.
 
 <h3 id="gsCredentials">gsCredentials</h3>
 
-**Since version:** `2.0` ∙ **Type:** `string` ∙ **Cardinality:** `Optional`  \
+**Since version:** `2.0` ∙ **Type:** `string` ∙ **Cardinality:** `Optional`   
 **Path:** / 
 
 Local file system path to Google Cloud Platform service accounts credentials file.
@@ -516,7 +516,7 @@ This is a path to a file on the local file system, not an URI.
 
 <h3 id="includeEllipsoidToGeoidDifference">includeEllipsoidToGeoidDifference</h3>
 
-**Since version:** `2.0` ∙ **Type:** `boolean` ∙ **Cardinality:** `Optional` ∙ **Default value:** `false`  \
+**Since version:** `2.0` ∙ **Type:** `boolean` ∙ **Cardinality:** `Optional` ∙ **Default value:** `false`   
 **Path:** / 
 
 Include the Ellipsoid to Geoid difference in the calculations of every point along every StreetWithElevationEdge.
@@ -532,7 +532,7 @@ all of the elevation values in the street edges.
 
 <h3 id="islandWithStopsMaxSize">islandWithStopsMaxSize</h3>
 
-**Since version:** `2.1` ∙ **Type:** `integer` ∙ **Cardinality:** `Optional` ∙ **Default value:** `5`  \
+**Since version:** `2.1` ∙ **Type:** `integer` ∙ **Cardinality:** `Optional` ∙ **Default value:** `5`   
 **Path:** / 
 
 When a graph island with stops in it should be pruned.
@@ -543,7 +543,7 @@ size will be pruned.
 
 <h3 id="islandWithoutStopsMaxSize">islandWithoutStopsMaxSize</h3>
 
-**Since version:** `2.1` ∙ **Type:** `integer` ∙ **Cardinality:** `Optional` ∙ **Default value:** `40`  \
+**Since version:** `2.1` ∙ **Type:** `integer` ∙ **Cardinality:** `Optional` ∙ **Default value:** `40`   
 **Path:** / 
 
 When a graph island without stops should be pruned.
@@ -554,7 +554,7 @@ this size will be pruned.
 
 <h3 id="maxDataImportIssuesPerFile">maxDataImportIssuesPerFile</h3>
 
-**Since version:** `2.0` ∙ **Type:** `integer` ∙ **Cardinality:** `Optional` ∙ **Default value:** `1000`  \
+**Since version:** `2.0` ∙ **Type:** `integer` ∙ **Cardinality:** `Optional` ∙ **Default value:** `1000`   
 **Path:** / 
 
 When to split the import report.
@@ -565,7 +565,7 @@ When to split the import report.
 
 <h3 id="maxStopToShapeSnapDistance">maxStopToShapeSnapDistance</h3>
 
-**Since version:** `2.1` ∙ **Type:** `double` ∙ **Cardinality:** `Optional` ∙ **Default value:** `150.0`  \
+**Since version:** `2.1` ∙ **Type:** `double` ∙ **Cardinality:** `Optional` ∙ **Default value:** `150.0`   
 **Path:** / 
 
 Maximum distance between route shapes and their stops.
@@ -577,7 +577,7 @@ default to simple stop-to-stop geometry instead.
 
 <h3 id="multiThreadElevationCalculations">multiThreadElevationCalculations</h3>
 
-**Since version:** `2.0` ∙ **Type:** `boolean` ∙ **Cardinality:** `Optional` ∙ **Default value:** `false`  \
+**Since version:** `2.0` ∙ **Type:** `boolean` ∙ **Cardinality:** `Optional` ∙ **Default value:** `false`   
 **Path:** / 
 
 Configuring multi-threading during elevation calculations.
@@ -589,7 +589,7 @@ Configuring multi-threading during elevation calculations.
 
 <h3 id="osmCacheDataInMem">osmCacheDataInMem</h3>
 
-**Since version:** `2.0` ∙ **Type:** `boolean` ∙ **Cardinality:** `Optional` ∙ **Default value:** `false`  \
+**Since version:** `2.0` ∙ **Type:** `boolean` ∙ **Cardinality:** `Optional` ∙ **Default value:** `false`   
 **Path:** / 
 
 If OSM data should be cached in memory during processing.
@@ -604,7 +604,7 @@ data, and to `false` to read the stream from the source each time.
 
 <h3 id="readCachedElevations">readCachedElevations</h3>
 
-**Since version:** `2.0` ∙ **Type:** `boolean` ∙ **Cardinality:** `Optional` ∙ **Default value:** `true`  \
+**Since version:** `2.0` ∙ **Type:** `boolean` ∙ **Cardinality:** `Optional` ∙ **Default value:** `true`   
 **Path:** / 
 
 Whether to read cached elevation data.
@@ -616,7 +616,7 @@ recalculating them all over again.
 
 <h3 id="streetGraph">streetGraph</h3>
 
-**Since version:** `2.0` ∙ **Type:** `uri` ∙ **Cardinality:** `Optional`  \
+**Since version:** `2.0` ∙ **Type:** `uri` ∙ **Cardinality:** `Optional`   
 **Path:** / 
 
 URI to the street graph object file for reading and writing.
@@ -625,7 +625,7 @@ The file is created or overwritten if OTP saves the graph to the file
 
 <h3 id="subwayAccessTime">subwayAccessTime</h3>
 
-**Since version:** `1.5` ∙ **Type:** `double` ∙ **Cardinality:** `Optional` ∙ **Default value:** `2.0`  \
+**Since version:** `1.5` ∙ **Type:** `double` ∙ **Cardinality:** `Optional` ∙ **Default value:** `2.0`   
 **Path:** / 
 
 Minutes necessary to reach stops served by trips on routes of route_type=1 (subway) from the street.
@@ -646,7 +646,7 @@ to check in to a flight (2-3 hours for international flights) than to alight and
 
 <h3 id="transitModelTimeZone">transitModelTimeZone</h3>
 
-**Since version:** `2.2` ∙ **Type:** `time-zone` ∙ **Cardinality:** `Optional`  \
+**Since version:** `2.2` ∙ **Type:** `time-zone` ∙ **Cardinality:** `Optional`   
 **Path:** / 
 
 Time zone for the graph.
@@ -655,7 +655,7 @@ This is used to store the timetables in the transit model, and to interpret time
 
 <h3 id="transitServiceEnd">transitServiceEnd</h3>
 
-**Since version:** `2.0` ∙ **Type:** `duration` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"P3Y"`  \
+**Since version:** `2.0` ∙ **Type:** `duration` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"P3Y"`   
 **Path:** / 
 
 Limit the import of transit services to the given end date.
@@ -671,7 +671,7 @@ Use an empty string to make it unbounded.
 
 <h3 id="transitServiceStart">transitServiceStart</h3>
 
-**Since version:** `2.0` ∙ **Type:** `duration` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"-P1Y"`  \
+**Since version:** `2.0` ∙ **Type:** `duration` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"-P1Y"`   
 **Path:** / 
 
 Limit the import of transit services to the given START date.
@@ -687,7 +687,7 @@ Use an empty string to make unbounded.
 
 <h3 id="writeCachedElevations">writeCachedElevations</h3>
 
-**Since version:** `2.0` ∙ **Type:** `boolean` ∙ **Cardinality:** `Optional` ∙ **Default value:** `false`  \
+**Since version:** `2.0` ∙ **Type:** `boolean` ∙ **Cardinality:** `Optional` ∙ **Default value:** `false`   
 **Path:** / 
 
 Reusing elevation data from previous builds
@@ -717,7 +717,7 @@ recommended.
 
 <h3 id="boardingLocationTags">boardingLocationTags</h3>
 
-**Since version:** `2.2` ∙ **Type:** `string[]` ∙ **Cardinality:** `Optional`  \
+**Since version:** `2.2` ∙ **Type:** `string[]` ∙ **Cardinality:** `Optional`   
 **Path:** / 
 
 What OSM tags should be looked on for the source of matching stops to platforms and stops.
@@ -726,7 +726,7 @@ What OSM tags should be looked on for the source of matching stops to platforms 
 
 <h3 id="dem">dem</h3>
 
-**Since version:** `2.2` ∙ **Type:** `object[]` ∙ **Cardinality:** `Optional`  \
+**Since version:** `2.2` ∙ **Type:** `object[]` ∙ **Cardinality:** `Optional`   
 **Path:** / 
 
 Specify parameters for DEM extracts.
@@ -742,7 +742,7 @@ the command line.
 
 <h3 id="dem_0_elevationUnitMultiplier">elevationUnitMultiplier</h3>
 
-**Since version:** `2.2` ∙ **Type:** `double` ∙ **Cardinality:** `Optional`  \
+**Since version:** `2.2` ∙ **Type:** `double` ∙ **Cardinality:** `Optional`   
 **Path:** /dem/[0] 
 
 Specify a multiplier to convert elevation units from source to meters.
@@ -755,7 +755,7 @@ Specify a multiplier to convert elevation units from source to meters.
 
 <h3 id="elevationBucket">elevationBucket</h3>
 
-**Since version:** `na` ∙ **Type:** `object` ∙ **Cardinality:** `Optional`  \
+**Since version:** `na` ∙ **Type:** `object` ∙ **Cardinality:** `Optional`   
 **Path:** / 
 
 Used to download NED elevation tiles from the given AWS S3 bucket.
@@ -781,7 +781,7 @@ to specify your NED tile cache location.
 
 <h3 id="localFileNamePatterns">localFileNamePatterns</h3>
 
-**Since version:** `2.0` ∙ **Type:** `object` ∙ **Cardinality:** `Optional`  \
+**Since version:** `2.0` ∙ **Type:** `object` ∙ **Cardinality:** `Optional`   
 **Path:** / 
 
 Patterns for matching OTP file types in the base directory
@@ -798,7 +798,7 @@ Netex data is also often supplied in a ZIP file.
 
 <h3 id="lfp_dem">dem</h3>
 
-**Since version:** `2.0` ∙ **Type:** `regexp` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"(?i)\.tiff?$"`  \
+**Since version:** `2.0` ∙ **Type:** `regexp` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"(?i)\.tiff?$"`   
 **Path:** /localFileNamePatterns 
 
 Pattern for matching elevation DEM files.
@@ -809,7 +809,7 @@ considered a match. Any legal Java Regular expression is allowed.
 
 <h3 id="lfp_gtfs">gtfs</h3>
 
-**Since version:** `2.0` ∙ **Type:** `regexp` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"(?i)gtfs"`  \
+**Since version:** `2.0` ∙ **Type:** `regexp` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"(?i)gtfs"`   
 **Path:** /localFileNamePatterns 
 
 Patterns for matching GTFS zip-files or directories.
@@ -820,7 +820,7 @@ Any legal Java Regular expression is allowed.
 
 <h3 id="lfp_netex">netex</h3>
 
-**Since version:** `2.0` ∙ **Type:** `regexp` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"(?i)netex"`  \
+**Since version:** `2.0` ∙ **Type:** `regexp` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"(?i)netex"`   
 **Path:** /localFileNamePatterns 
 
 Patterns for matching NeTEx zip files or directories.
@@ -831,7 +831,7 @@ pattern it is considered a match. Any legal Java Regular expression is allowed.
 
 <h3 id="lfp_osm">osm</h3>
 
-**Since version:** `2.0` ∙ **Type:** `regexp` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"(?i)(\.pbf|\.osm|\.osm\.xml)$"`  \
+**Since version:** `2.0` ∙ **Type:** `regexp` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"(?i)(\.pbf|\.osm|\.osm\.xml)$"`   
 **Path:** /localFileNamePatterns 
 
 Pattern for matching Open Street Map input files.
@@ -842,7 +842,7 @@ it is considered a match. Any legal Java Regular expression is allowed.
 
 <h3 id="nd_groupFilePattern">groupFilePattern</h3>
 
-**Since version:** `2.0` ∙ **Type:** `regexp` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"(\w{3})-.*\.xml"`  \
+**Since version:** `2.0` ∙ **Type:** `regexp` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"(\w{3})-.*\.xml"`   
 **Path:** /netexDefaults 
 
 Pattern for matching group NeTEx files.
@@ -856,7 +856,7 @@ with group `"RUT"`.
 
 <h3 id="nd_ignoreFilePattern">ignoreFilePattern</h3>
 
-**Since version:** `2.0` ∙ **Type:** `regexp` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"$^"`  \
+**Since version:** `2.0` ∙ **Type:** `regexp` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"$^"`   
 **Path:** /netexDefaults 
 
 Pattern for matching ignored files in a NeTEx bundle.
@@ -867,7 +867,7 @@ The *ignored* files are *not* loaded.
 
 <h3 id="nd_sharedFilePattern">sharedFilePattern</h3>
 
-**Since version:** `2.0` ∙ **Type:** `regexp` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"shared-data\.xml"`  \
+**Since version:** `2.0` ∙ **Type:** `regexp` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"shared-data\.xml"`   
 **Path:** /netexDefaults 
 
 Pattern for matching shared NeTEx files in a NeTEx bundle.
@@ -887,7 +887,7 @@ File names are matched in the following order - and treated accordingly to the f
 
 <h3 id="nd_sharedGroupFilePattern">sharedGroupFilePattern</h3>
 
-**Since version:** `2.0` ∙ **Type:** `regexp` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"(\w{3})-.*-shared\.xml"`  \
+**Since version:** `2.0` ∙ **Type:** `regexp` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"(\w{3})-.*-shared\.xml"`   
 **Path:** /netexDefaults 
 
 Pattern for matching shared group NeTEx files in a NeTEx bundle.
@@ -905,12 +905,12 @@ The pattern `"(\w{3})-.*-shared\.xml"` matches `"RUT-shared.xml"` with group `"R
 
 <h3 id="nd_ferryIdsNotAllowedForBicycle">ferryIdsNotAllowedForBicycle</h3>
 
-**Since version:** `2.0` ∙ **Type:** `string[]` ∙ **Cardinality:** `Optional`  \
+**Since version:** `2.0` ∙ **Type:** `string[]` ∙ **Cardinality:** `Optional`   
 **Path:** /netexDefaults 
 
-List ferries witch do not allow bikes.
+List ferries which do not allow bikes.
 
-Bicycles are allowed on most ferries however Nordic profile doesn't contain a place
+Bicycles are allowed on most ferries however the Nordic profile doesn't contain a place
 where bicycle conveyance can be defined.
 
 For this reason we allow bicycles on ferries by default and allow to override the rare
@@ -919,7 +919,7 @@ case where this is not the case.
 
 <h3 id="osm">osm</h3>
 
-**Since version:** `2.2` ∙ **Type:** `object[]` ∙ **Cardinality:** `Optional`  \
+**Since version:** `2.2` ∙ **Type:** `object[]` ∙ **Cardinality:** `Optional`   
 **Path:** / 
 
 Configure properties for a given OpenStreetMap feed.
@@ -932,23 +932,23 @@ the local filesystem.
 
 <h3 id="osm_0_osmTagMapping">osmTagMapping</h3>
 
-**Since version:** `2.2` ∙ **Type:** `enum` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"default"`  \
-**Path:** /osm/[0]  \
+**Since version:** `2.2` ∙ **Type:** `enum` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"default"`   
+**Path:** /osm/[0]   
 **Enum values:** `default` | `norway` | `uk` | `finland` | `germany` | `atlanta` | `houston`
 
 The named set of mapping rules applied when parsing OSM tags.
 
 <h3 id="od_osmTagMapping">osmTagMapping</h3>
 
-**Since version:** `2.2` ∙ **Type:** `enum` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"default"`  \
-**Path:** /osmDefaults  \
+**Since version:** `2.2` ∙ **Type:** `enum` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"default"`   
+**Path:** /osmDefaults   
 **Enum values:** `default` | `norway` | `uk` | `finland` | `germany` | `atlanta` | `houston`
 
 The named set of mapping rules applied when parsing OSM tags.
 
 <h3 id="transitFeeds">transitFeeds</h3>
 
-**Since version:** `2.2` ∙ **Type:** `object[]` ∙ **Cardinality:** `Optional`  \
+**Since version:** `2.2` ∙ **Type:** `object[]` ∙ **Cardinality:** `Optional`   
 **Path:** / 
 
 Scan for transit data files
@@ -976,7 +976,7 @@ with the `stopTransferCost` parameter in the router configuration.
 
 <h3 id="tf_1_groupFilePattern">groupFilePattern</h3>
 
-**Since version:** `2.0` ∙ **Type:** `regexp` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"(\w{3})_.*\.xml"`  \
+**Since version:** `2.0` ∙ **Type:** `regexp` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"(\w{3})_.*\.xml"`   
 **Path:** /transitFeeds/[1] 
 
 Pattern for matching group NeTEx files.
@@ -990,7 +990,7 @@ with group `"RUT"`.
 
 <h3 id="tf_1_ignoreFilePattern">ignoreFilePattern</h3>
 
-**Since version:** `2.0` ∙ **Type:** `regexp` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"(temp|tmp)"`  \
+**Since version:** `2.0` ∙ **Type:** `regexp` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"(temp|tmp)"`   
 **Path:** /transitFeeds/[1] 
 
 Pattern for matching ignored files in a NeTEx bundle.
@@ -1001,7 +1001,7 @@ The *ignored* files are *not* loaded.
 
 <h3 id="tf_1_sharedFilePattern">sharedFilePattern</h3>
 
-**Since version:** `2.0` ∙ **Type:** `regexp` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"_stops.xml"`  \
+**Since version:** `2.0` ∙ **Type:** `regexp` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"_stops.xml"`   
 **Path:** /transitFeeds/[1] 
 
 Pattern for matching shared NeTEx files in a NeTEx bundle.
@@ -1021,7 +1021,7 @@ File names are matched in the following order - and treated accordingly to the f
 
 <h3 id="tf_1_sharedGroupFilePattern">sharedGroupFilePattern</h3>
 
-**Since version:** `2.0` ∙ **Type:** `regexp` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"_(\w{3})_shared_data.xml"`  \
+**Since version:** `2.0` ∙ **Type:** `regexp` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"_(\w{3})_shared_data.xml"`   
 **Path:** /transitFeeds/[1] 
 
 Pattern for matching shared group NeTEx files in a NeTEx bundle.
@@ -1039,12 +1039,12 @@ The pattern `"(\w{3})-.*-shared\.xml"` matches `"RUT-shared.xml"` with group `"R
 
 <h3 id="tf_1_ferryIdsNotAllowedForBicycle">ferryIdsNotAllowedForBicycle</h3>
 
-**Since version:** `2.0` ∙ **Type:** `string[]` ∙ **Cardinality:** `Optional`  \
+**Since version:** `2.0` ∙ **Type:** `string[]` ∙ **Cardinality:** `Optional`   
 **Path:** /transitFeeds/[1] 
 
-List ferries witch do not allow bikes.
+List ferries which do not allow bikes.
 
-Bicycles are allowed on most ferries however Nordic profile doesn't contain a place
+Bicycles are allowed on most ferries however the Nordic profile doesn't contain a place
 where bicycle conveyance can be defined.
 
 For this reason we allow bicycles on ferries by default and allow to override the rare

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -133,9 +133,9 @@ version the configuration in a deployment pipeline. The `configVersion` is not u
 way, but is logged at startup and is available as part of the _server-info_ data in the REST API.
 The intended usage is to be able to check which version of the configuration the graph was build
 with and which version the router uses. In an deployment with many OTP instances it can be useful to
-ask an instance about the version, instead of tracking the deployment pipline backwards to find the
+ask an instance about the version, instead of tracking the deployment pipeline backwards to find the
 version used. How you inject a version into the configuration file is up to you, but you can do it
-in your build-pipline, at deployment time or use system environment variable substituton.
+in your build-pipeline, at deployment time or use system environment variable substitution.
 
 ## OTP Serialization version id and _Graph.obj_ file header
 
@@ -148,8 +148,8 @@ graph. The header info is available to configuration substitution:
 
 The intended usage is to be able to have a graph build pipeline which "knows" which graph that
 matches OTP planner instances. For example, you may build new graphs for every OTP serialization
-version id in use by the planning OPT instances you have deploied and plan to deploy. This way you
-can roll forward and backward new OTP instances without worring about building new graphs.
+version id in use by the planning OTP instances you have deployed and plan to deploy. This way you
+can roll forward and backward new OTP instances without worrying about building new graphs.
 
 There are various ways to access this information. To get the `Graph.obj` serialization version id
 you can run the following bash command:

--- a/docs/RouteRequest.md
+++ b/docs/RouteRequest.md
@@ -129,7 +129,7 @@ and in the [transferRequests in build-config.json](BuildConfiguration.md#transfe
 
 <h3 id="rd_alightSlack">alightSlack</h3>
 
-**Since version:** `2.0` ∙ **Type:** `duration` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"PT0S"`  \
+**Since version:** `2.0` ∙ **Type:** `duration` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"PT0S"`   
 **Path:** /routingDefaults 
 
 The minimum extra time after exiting a public transport vehicle.
@@ -138,7 +138,7 @@ The slack is added to the time when going from the transit vehicle to the stop.
 
 <h3 id="rd_bikeBoardCost">bikeBoardCost</h3>
 
-**Since version:** `2.0` ∙ **Type:** `integer` ∙ **Cardinality:** `Optional` ∙ **Default value:** `600`  \
+**Since version:** `2.0` ∙ **Type:** `integer` ∙ **Cardinality:** `Optional` ∙ **Default value:** `600`   
 **Path:** /routingDefaults 
 
 Prevents unnecessary transfers by adding a cost for boarding a vehicle.
@@ -147,7 +147,7 @@ This is the cost that is used when boarding while cycling.This is usually higher
 
 <h3 id="rd_boardSlack">boardSlack</h3>
 
-**Since version:** `2.0` ∙ **Type:** `duration` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"PT0S"`  \
+**Since version:** `2.0` ∙ **Type:** `duration` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"PT0S"`   
 **Path:** /routingDefaults 
 
 The boardSlack is the minimum extra time to board a public transport vehicle.
@@ -161,23 +161,23 @@ transit leg in the trip. This is the default value used, if not overridden by th
 
 <h3 id="rd_drivingDirection">drivingDirection</h3>
 
-**Since version:** `2.2` ∙ **Type:** `enum` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"right"`  \
-**Path:** /routingDefaults  \
+**Since version:** `2.2` ∙ **Type:** `enum` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"right"`   
+**Path:** /routingDefaults   
 **Enum values:** `right` | `left`
 
 The driving direction to use in the intersection traversal calculation
 
 <h3 id="rd_intersectionTraversalModel">intersectionTraversalModel</h3>
 
-**Since version:** `2.2` ∙ **Type:** `enum` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"simple"`  \
-**Path:** /routingDefaults  \
+**Since version:** `2.2` ∙ **Type:** `enum` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"simple"`   
+**Path:** /routingDefaults   
 **Enum values:** `norway` | `simple`
 
 The model that computes the costs of turns.
 
 <h3 id="rd_maxAccessEgressDuration">maxAccessEgressDuration</h3>
 
-**Since version:** `2.1` ∙ **Type:** `duration` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"PT45M"`  \
+**Since version:** `2.1` ∙ **Type:** `duration` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"PT45M"`   
 **Path:** /routingDefaults 
 
 This is the maximum duration for access/egress for street searches.
@@ -191,7 +191,7 @@ do not exist.
 
 <h3 id="rd_maxDirectStreetDuration">maxDirectStreetDuration</h3>
 
-**Since version:** `2.1` ∙ **Type:** `duration` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"PT4H"`  \
+**Since version:** `2.1` ∙ **Type:** `duration` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"PT4H"`   
 **Path:** /routingDefaults 
 
 This is the maximum duration for a direct street search for each mode.
@@ -205,7 +205,7 @@ do not exist."
 
 <h3 id="rd_maxJourneyDuration">maxJourneyDuration</h3>
 
-**Since version:** `2.1` ∙ **Type:** `duration` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"PT24H"`  \
+**Since version:** `2.1` ∙ **Type:** `duration` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"PT24H"`   
 **Path:** /routingDefaults 
 
 The expected maximum time a journey can last across all possible journeys for the current deployment.
@@ -223,15 +223,15 @@ search, hence, making it a bit slower. Recommended values would be from 12 hours
 
 <h3 id="rd_optimize">optimize</h3>
 
-**Since version:** `2.0` ∙ **Type:** `enum` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"safe"`  \
-**Path:** /routingDefaults  \
+**Since version:** `2.0` ∙ **Type:** `enum` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"safe"`   
+**Path:** /routingDefaults   
 **Enum values:** `quick` | `safe` | `flat` | `greenways` | `triangle`
 
 The set of characteristics that the user wants to optimize for.
 
 <h3 id="rd_otherThanPreferredRoutesPenalty">otherThanPreferredRoutesPenalty</h3>
 
-**Since version:** `2.0` ∙ **Type:** `integer` ∙ **Cardinality:** `Optional` ∙ **Default value:** `300`  \
+**Since version:** `2.0` ∙ **Type:** `integer` ∙ **Cardinality:** `Optional` ∙ **Default value:** `300`   
 **Path:** /routingDefaults 
 
 Penalty added for using every route that is not preferred if user set any route as preferred.
@@ -240,7 +240,7 @@ We return number of seconds that we are willing to wait for preferred route.
 
 <h3 id="rd_searchWindow">searchWindow</h3>
 
-**Since version:** `2.0` ∙ **Type:** `duration` ∙ **Cardinality:** `Optional`  \
+**Since version:** `2.0` ∙ **Type:** `duration` ∙ **Cardinality:** `Optional`   
 **Path:** /routingDefaults 
 
 The duration of the search-window.
@@ -267,7 +267,7 @@ increase/decrease the search-window when paging to match the requested number of
 
 <h3 id="rd_stairsTimeFactor">stairsTimeFactor</h3>
 
-**Since version:** `2.1` ∙ **Type:** `double` ∙ **Cardinality:** `Optional` ∙ **Default value:** `3.0`  \
+**Since version:** `2.1` ∙ **Type:** `double` ∙ **Cardinality:** `Optional` ∙ **Default value:** `3.0`   
 **Path:** /routingDefaults 
 
 How much more time does it take to walk a flight of stairs compared to walking a similar horizontal length.
@@ -278,7 +278,7 @@ speed of pedestrians on stairs. Transportation Planning and Technology, 33(2), 1
 
 <h3 id="rd_transferPenalty">transferPenalty</h3>
 
-**Since version:** `2.0` ∙ **Type:** `integer` ∙ **Cardinality:** `Optional` ∙ **Default value:** `0`  \
+**Since version:** `2.0` ∙ **Type:** `integer` ∙ **Cardinality:** `Optional` ∙ **Default value:** `0`   
 **Path:** /routingDefaults 
 
 An additional penalty added to boardings after the first.
@@ -290,7 +290,7 @@ significant time or walking will still be taken.
 
 <h3 id="rd_transferSlack">transferSlack</h3>
 
-**Since version:** `2.0` ∙ **Type:** `integer` ∙ **Cardinality:** `Optional` ∙ **Default value:** `120`  \
+**Since version:** `2.0` ∙ **Type:** `integer` ∙ **Cardinality:** `Optional` ∙ **Default value:** `120`   
 **Path:** /routingDefaults 
 
 The extra time needed to make a safe transfer in seconds.
@@ -303,7 +303,7 @@ alight-slack."
 
 <h3 id="rd_unpreferredCost">unpreferredCost</h3>
 
-**Since version:** `2.2` ∙ **Type:** `linear-function` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"f(x) = 0 + 1.0 x"`  \
+**Since version:** `2.2` ∙ **Type:** `linear-function` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"f(x) = 0 + 1.0 x"`   
 **Path:** /routingDefaults 
 
 A cost function used to calculate penalty for an unpreferred route.
@@ -314,7 +314,7 @@ or for an unpreferred agency's departure. For example, 600 + 2.0 x
 
 <h3 id="rd_walkReluctance">walkReluctance</h3>
 
-**Since version:** `2.0` ∙ **Type:** `double` ∙ **Cardinality:** `Optional` ∙ **Default value:** `2.0`  \
+**Since version:** `2.0` ∙ **Type:** `double` ∙ **Cardinality:** `Optional` ∙ **Default value:** `2.0`   
 **Path:** /routingDefaults 
 
 A multiplier for how bad walking is, compared to being in transit for equal lengths of time.
@@ -328,7 +328,7 @@ high values.
 
 <h3 id="rd_walkSafetyFactor">walkSafetyFactor</h3>
 
-**Since version:** `2.2` ∙ **Type:** `double` ∙ **Cardinality:** `Optional` ∙ **Default value:** `1.0`  \
+**Since version:** `2.2` ∙ **Type:** `double` ∙ **Cardinality:** `Optional` ∙ **Default value:** `1.0`   
 **Path:** /routingDefaults 
 
 Factor for how much the walk safety is considered in routing.
@@ -337,8 +337,8 @@ Value should be between 0 and 1. If the value is set to be 0, safety is ignored.
 
 <h3 id="rd_alightSlackForMode">alightSlackForMode</h3>
 
-**Since version:** `2.0` ∙ **Type:** `enum map of duration` ∙ **Cardinality:** `Optional`  \
-**Path:** /routingDefaults  \
+**Since version:** `2.0` ∙ **Type:** `enum map of duration` ∙ **Cardinality:** `Optional`   
+**Path:** /routingDefaults   
 **Enum keys:** `rail` | `coach` | `subway` | `bus` | `tram` | `ferry` | `airplane` | `cable-car` | `gondola` | `funicular` | `trolleybus` | `monorail`
 
 How much time alighting a vehicle takes for each given mode.
@@ -347,29 +347,29 @@ Sometimes there is a need to configure a longer alighting times for specific mod
 
 <h3 id="rd_allowedVehicleRentalNetworks">allowedVehicleRentalNetworks</h3>
 
-**Since version:** `2.1` ∙ **Type:** `string[]` ∙ **Cardinality:** `Optional`  \
+**Since version:** `2.1` ∙ **Type:** `string[]` ∙ **Cardinality:** `Optional`   
 **Path:** /routingDefaults 
 
 The vehicle rental networks which may be used. If empty all networks may be used.
 
 <h3 id="rd_bannedVehicleParkingTags">bannedVehicleParkingTags</h3>
 
-**Since version:** `2.1` ∙ **Type:** `string[]` ∙ **Cardinality:** `Optional`  \
+**Since version:** `2.1` ∙ **Type:** `string[]` ∙ **Cardinality:** `Optional`   
 **Path:** /routingDefaults 
 
 Tags with which a vehicle parking will not be used. If empty, no tags are banned
 
 <h3 id="rd_bannedVehicleRentalNetworks">bannedVehicleRentalNetworks</h3>
 
-**Since version:** `2.1` ∙ **Type:** `string[]` ∙ **Cardinality:** `Optional`  \
+**Since version:** `2.1` ∙ **Type:** `string[]` ∙ **Cardinality:** `Optional`   
 **Path:** /routingDefaults 
 
 he vehicle rental networks which may not be used. If empty, no networks are banned.
 
 <h3 id="rd_boardSlackForMode">boardSlackForMode</h3>
 
-**Since version:** `2.0` ∙ **Type:** `enum map of duration` ∙ **Cardinality:** `Optional`  \
-**Path:** /routingDefaults  \
+**Since version:** `2.0` ∙ **Type:** `enum map of duration` ∙ **Cardinality:** `Optional`   
+**Path:** /routingDefaults   
 **Enum keys:** `rail` | `coach` | `subway` | `bus` | `tram` | `ferry` | `airplane` | `cable-car` | `gondola` | `funicular` | `trolleybus` | `monorail`
 
 How much time ride a vehicle takes for each given mode.
@@ -380,7 +380,7 @@ ferries, where the check-in process needs to be done in good time before ride.
 
 <h3 id="rd_itineraryFilters">itineraryFilters</h3>
 
-**Since version:** `2.0` ∙ **Type:** `object` ∙ **Cardinality:** `Optional`  \
+**Since version:** `2.0` ∙ **Type:** `object` ∙ **Cardinality:** `Optional`   
 **Path:** /routingDefaults 
 
 Configure itinerary filters that may modify itineraries, sort them, and filter away less preferable results.
@@ -418,7 +418,7 @@ itineraries that are at least double in cost for the non-grouped legs.
 
 <h3 id="rd_if_accessibilityScore">accessibilityScore</h3>
 
-**Since version:** `2.2` ∙ **Type:** `boolean` ∙ **Cardinality:** `Optional` ∙ **Default value:** `false`  \
+**Since version:** `2.2` ∙ **Type:** `boolean` ∙ **Cardinality:** `Optional` ∙ **Default value:** `false`   
 **Path:** /routingDefaults/itineraryFilters 
 
 An experimental feature contributed by IBI which adds a sandbox accessibility *score* between 0 and 1 for each leg and itinerary.
@@ -427,7 +427,7 @@ This can be used by frontend developers to implement a simple traffic light UI.
 
 <h3 id="rd_if_bikeRentalDistanceRatio">bikeRentalDistanceRatio</h3>
 
-**Since version:** `2.1` ∙ **Type:** `double` ∙ **Cardinality:** `Optional` ∙ **Default value:** `0.0`  \
+**Since version:** `2.1` ∙ **Type:** `double` ∙ **Cardinality:** `Optional` ∙ **Default value:** `0.0`   
 **Path:** /routingDefaults/itineraryFilters 
 
 Filter routes that consist of bike-rental and walking by the minimum fraction of the bike-rental leg using _distance_.
@@ -439,7 +439,7 @@ for the result to be included.
 
 <h3 id="rd_if_filterItinerariesWithSameFirstOrLastTrip">filterItinerariesWithSameFirstOrLastTrip</h3>
 
-**Since version:** `2.2` ∙ **Type:** `boolean` ∙ **Cardinality:** `Optional` ∙ **Default value:** `false`  \
+**Since version:** `2.2` ∙ **Type:** `boolean` ∙ **Cardinality:** `Optional` ∙ **Default value:** `false`   
 **Path:** /routingDefaults/itineraryFilters 
 
 If more than one itinerary begins or ends with same trip, filter out one of those itineraries so that only one remains.
@@ -452,7 +452,7 @@ removed from list.
 
 <h3 id="rd_if_groupedOtherThanSameLegsMaxCostMultiplier">groupedOtherThanSameLegsMaxCostMultiplier</h3>
 
-**Since version:** `2.1` ∙ **Type:** `double` ∙ **Cardinality:** `Optional` ∙ **Default value:** `2.0`  \
+**Since version:** `2.1` ∙ **Type:** `double` ∙ **Cardinality:** `Optional` ∙ **Default value:** `2.0`   
 **Path:** /routingDefaults/itineraryFilters 
 
 Filter grouped itineraries, where the non-grouped legs are more expensive than in the lowest cost one.
@@ -464,7 +464,7 @@ having a higher cost will be filtered.
 
 <h3 id="rd_if_nonTransitGeneralizedCostLimit">nonTransitGeneralizedCostLimit</h3>
 
-**Since version:** `2.1` ∙ **Type:** `linear-function` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"f(x) = 3,600 + 2.0 x"`  \
+**Since version:** `2.1` ∙ **Type:** `linear-function` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"f(x) = 3,600 + 2.0 x"`   
 **Path:** /routingDefaults/itineraryFilters 
 
 The function define a max-limit for generalized-cost for non-transit itineraries.
@@ -482,7 +482,7 @@ non-transit itineraries with a cost larger than `1800 + 2 * 5000 = 11 800` are d
 
 <h3 id="rd_if_parkAndRideDurationRatio">parkAndRideDurationRatio</h3>
 
-**Since version:** `2.1` ∙ **Type:** `double` ∙ **Cardinality:** `Optional` ∙ **Default value:** `0.0`  \
+**Since version:** `2.1` ∙ **Type:** `double` ∙ **Cardinality:** `Optional` ∙ **Default value:** `0.0`   
 **Path:** /routingDefaults/itineraryFilters 
 
 Filter P+R routes that consist of driving and walking by the minimum fraction of the driving using of _time_.
@@ -494,7 +494,7 @@ result to be included. However, if there is only a single result, it is never fi
 
 <h3 id="rd_if_removeItinerariesWithSameRoutesAndStops">removeItinerariesWithSameRoutesAndStops</h3>
 
-**Since version:** `2.2` ∙ **Type:** `boolean` ∙ **Cardinality:** `Optional` ∙ **Default value:** `false`  \
+**Since version:** `2.2` ∙ **Type:** `boolean` ∙ **Cardinality:** `Optional` ∙ **Default value:** `false`   
 **Path:** /routingDefaults/itineraryFilters 
 
 Set to true if you want to list only the first itinerary  which goes through the same stops and routes.
@@ -503,7 +503,7 @@ Itineraries visiting the same set of stops and riding the exact same routes, dep
 
 <h3 id="rd_if_transitGeneralizedCostLimit">transitGeneralizedCostLimit</h3>
 
-**Since version:** `2.1` ∙ **Type:** `object` ∙ **Cardinality:** `Optional`  \
+**Since version:** `2.1` ∙ **Type:** `object` ∙ **Cardinality:** `Optional`   
 **Path:** /routingDefaults/itineraryFilters 
 
 A relative limit for the generalized-cost for transit itineraries.
@@ -518,8 +518,8 @@ _1 hour plus 2 times cost_ use: `3600 + 2.0 x`. To set an absolute value(3000s) 
 
 <h3 id="rd_maxAccessEgressDurationForMode">maxAccessEgressDurationForMode</h3>
 
-**Since version:** `2.1` ∙ **Type:** `enum map of duration` ∙ **Cardinality:** `Optional`  \
-**Path:** /routingDefaults  \
+**Since version:** `2.1` ∙ **Type:** `enum map of duration` ∙ **Cardinality:** `Optional`   
+**Path:** /routingDefaults   
 **Enum keys:** `not-set` | `walk` | `bike` | `bike-to-park` | `bike-rental` | `scooter-rental` | `car` | `car-to-park` | `car-pickup` | `car-rental` | `flexible`
 
 Limit access/egress per street mode.
@@ -530,8 +530,8 @@ done because some street modes searches are much more resource intensive than ot
 
 <h3 id="rd_maxDirectStreetDurationForMode">maxDirectStreetDurationForMode</h3>
 
-**Since version:** `2.2` ∙ **Type:** `enum map of duration` ∙ **Cardinality:** `Optional`  \
-**Path:** /routingDefaults  \
+**Since version:** `2.2` ∙ **Type:** `enum map of duration` ∙ **Cardinality:** `Optional`   
+**Path:** /routingDefaults   
 **Enum keys:** `not-set` | `walk` | `bike` | `bike-to-park` | `bike-rental` | `scooter-rental` | `car` | `car-to-park` | `car-pickup` | `car-rental` | `flexible`
 
 Limit direct route duration per street mode.
@@ -542,14 +542,14 @@ done because some street modes searches are much more resource intensive than ot
 
 <h3 id="rd_requiredVehicleParkingTags">requiredVehicleParkingTags</h3>
 
-**Since version:** `2.1` ∙ **Type:** `string[]` ∙ **Cardinality:** `Optional`  \
+**Since version:** `2.1` ∙ **Type:** `string[]` ∙ **Cardinality:** `Optional`   
 **Path:** /routingDefaults 
 
 Tags which are required to use a vehicle parking. If empty, no tags are required.
 
 <h3 id="rd_transferOptimization">transferOptimization</h3>
 
-**Since version:** `2.1` ∙ **Type:** `object` ∙ **Cardinality:** `Optional`  \
+**Since version:** `2.1` ∙ **Type:** `object` ∙ **Cardinality:** `Optional`   
 **Path:** /routingDefaults 
 
 Optimize where a transfer between to trip happens. 
@@ -587,7 +587,7 @@ package documentation.
 
 <h3 id="rd_to_backTravelWaitTimeFactor">backTravelWaitTimeFactor</h3>
 
-**Since version:** `2.1` ∙ **Type:** `double` ∙ **Cardinality:** `Optional` ∙ **Default value:** `1.0`  \
+**Since version:** `2.1` ∙ **Type:** `double` ∙ **Cardinality:** `Optional` ∙ **Default value:** `1.0`   
 **Path:** /routingDefaults/transferOptimization 
 
 To reduce back-travel we favor waiting, this reduces the cost of waiting.
@@ -596,7 +596,7 @@ The wait time is used to prevent *back-travel*, the `backTravelWaitTimeFactor` i
 
 <h3 id="rd_to_extraStopBoardAlightCostsFactor">extraStopBoardAlightCostsFactor</h3>
 
-**Since version:** `2.1` ∙ **Type:** `double` ∙ **Cardinality:** `Optional` ∙ **Default value:** `0.0`  \
+**Since version:** `2.1` ∙ **Type:** `double` ∙ **Cardinality:** `Optional` ∙ **Default value:** `0.0`   
 **Path:** /routingDefaults/transferOptimization 
 
 Add an extra board- and alight-cost for prioritized stops.
@@ -613,7 +613,7 @@ doubled. Stop priority is only supported by the NeTEx import, not GTFS.
 
 <h3 id="rd_to_minSafeWaitTimeFactor">minSafeWaitTimeFactor</h3>
 
-**Since version:** `2.1` ∙ **Type:** `double` ∙ **Cardinality:** `Optional` ∙ **Default value:** `5.0`  \
+**Since version:** `2.1` ∙ **Type:** `double` ∙ **Cardinality:** `Optional` ∙ **Default value:** `5.0`   
 **Path:** /routingDefaults/transferOptimization 
 
 Used to set a maximum wait-time cost, base on min-safe-transfer-time.
@@ -622,7 +622,7 @@ This defines the maximum cost for the logarithmic function relative to the min-s
 
 <h3 id="rd_to_optimizeTransferWaitTime">optimizeTransferWaitTime</h3>
 
-**Since version:** `2.1` ∙ **Type:** `boolean` ∙ **Cardinality:** `Optional` ∙ **Default value:** `true`  \
+**Since version:** `2.1` ∙ **Type:** `boolean` ∙ **Cardinality:** `Optional` ∙ **Default value:** `true`   
 **Path:** /routingDefaults/transferOptimization 
 
 This enables the transfer wait time optimization.
@@ -631,15 +631,15 @@ If not enabled generalizedCost function is used to pick the optimal transfer poi
 
 <h3 id="rd_transitReluctanceForMode">transitReluctanceForMode</h3>
 
-**Since version:** `2.1` ∙ **Type:** `enum map of double` ∙ **Cardinality:** `Optional`  \
-**Path:** /routingDefaults  \
+**Since version:** `2.1` ∙ **Type:** `enum map of double` ∙ **Cardinality:** `Optional`   
+**Path:** /routingDefaults   
 **Enum keys:** `rail` | `coach` | `subway` | `bus` | `tram` | `ferry` | `airplane` | `cable-car` | `gondola` | `funicular` | `trolleybus` | `monorail`
 
 Transit reluctance for a given transport mode
 
 <h3 id="rd_unpreferred">unpreferred</h3>
 
-**Since version:** `2.2` ∙ **Type:** `object` ∙ **Cardinality:** `Optional`  \
+**Since version:** `2.2` ∙ **Type:** `object` ∙ **Cardinality:** `Optional`   
 **Path:** /routingDefaults 
 
 Parameters listing authorities or lines that preferably should not be used in trip patters.
@@ -654,7 +654,7 @@ travel time `x` (in seconds).
 
 <h3 id="rd_wheelchairAccessibility_maxSlope">maxSlope</h3>
 
-**Since version:** `2.0` ∙ **Type:** `double` ∙ **Cardinality:** `Optional` ∙ **Default value:** `0.083`  \
+**Since version:** `2.0` ∙ **Type:** `double` ∙ **Cardinality:** `Optional` ∙ **Default value:** `0.083`   
 **Path:** /routingDefaults/wheelchairAccessibility 
 
 The maximum slope as a fraction of 1.
@@ -663,7 +663,7 @@ The maximum slope as a fraction of 1.
 
 <h3 id="rd_wheelchairAccessibility_slopeExceededReluctance">slopeExceededReluctance</h3>
 
-**Since version:** `2.2` ∙ **Type:** `double` ∙ **Cardinality:** `Optional` ∙ **Default value:** `1.0`  \
+**Since version:** `2.2` ∙ **Type:** `double` ∙ **Cardinality:** `Optional` ∙ **Default value:** `1.0`   
 **Path:** /routingDefaults/wheelchairAccessibility 
 
 How much streets with high slope should be avoided.
@@ -676,7 +676,7 @@ too steep edges.
 
 <h3 id="rd_wheelchairAccessibility_stairsReluctance">stairsReluctance</h3>
 
-**Since version:** `2.2` ∙ **Type:** `double` ∙ **Cardinality:** `Optional` ∙ **Default value:** `100.0`  \
+**Since version:** `2.2` ∙ **Type:** `double` ∙ **Cardinality:** `Optional` ∙ **Default value:** `100.0`   
 **Path:** /routingDefaults/wheelchairAccessibility 
 
 How much stairs should be avoided.

--- a/docs/RouterConfiguration.md
+++ b/docs/RouterConfiguration.md
@@ -77,7 +77,7 @@ A full list of them can be found in the [RouteRequest](RouteRequest.md).
 
 <h3 id="configVersion">configVersion</h3>
 
-**Since version:** `2.1` ∙ **Type:** `string` ∙ **Cardinality:** `Optional`  \
+**Since version:** `2.1` ∙ **Type:** `string` ∙ **Cardinality:** `Optional`   
 **Path:** / 
 
 Deployment version of the *router-config.json*.
@@ -95,7 +95,7 @@ Be aware that OTP uses the config embedded in the loaded graph if no new config 
 
 <h3 id="requestLogFile">requestLogFile</h3>
 
-**Since version:** `2.0` ∙ **Type:** `string` ∙ **Cardinality:** `Optional`  \
+**Since version:** `2.0` ∙ **Type:** `string` ∙ **Cardinality:** `Optional`   
 **Path:** / 
 
 The path of the log file for the requests.
@@ -127,7 +127,7 @@ number of transit vehicles used in that itinerary.
 
 <h3 id="streetRoutingTimeout">streetRoutingTimeout</h3>
 
-**Since version:** `na` ∙ **Type:** `duration` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"PT5S"`  \
+**Since version:** `na` ∙ **Type:** `duration` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"PT5S"`   
 **Path:** / 
 
 The maximum time a street routing request is allowed to take before returning a timeout.
@@ -146,7 +146,7 @@ The search aborts after this duration and any paths found are returned to the cl
 
 <h3 id="flex_maxTransferDurationSeconds">maxTransferDurationSeconds</h3>
 
-**Since version:** `2.1` ∙ **Type:** `integer` ∙ **Cardinality:** `Optional` ∙ **Default value:** `300`  \
+**Since version:** `2.1` ∙ **Type:** `integer` ∙ **Cardinality:** `Optional` ∙ **Default value:** `300`   
 **Path:** /flex 
 
 How long should you be allowed to walk from a flex vehicle to a transit one.
@@ -155,7 +155,7 @@ How long should a passenger be allowed to walk after getting out of a flex vehic
 
 <h3 id="transit">transit</h3>
 
-**Since version:** `na` ∙ **Type:** `object` ∙ **Cardinality:** `Optional`  \
+**Since version:** `na` ∙ **Type:** `object` ∙ **Cardinality:** `Optional`   
 **Path:** / 
 
 Configuration for transit searches with RAPTOR.
@@ -167,7 +167,7 @@ request and the actual routing request.
 
 <h3 id="transit_iterationDepartureStepInSeconds">iterationDepartureStepInSeconds</h3>
 
-**Since version:** `na` ∙ **Type:** `integer` ∙ **Cardinality:** `Optional` ∙ **Default value:** `60`  \
+**Since version:** `na` ∙ **Type:** `integer` ∙ **Cardinality:** `Optional` ∙ **Default value:** `60`   
 **Path:** /transit 
 
 Step for departure times between each RangeRaptor iterations.
@@ -180,7 +180,7 @@ but you might get a slack of 60 seconds somewhere in the result.
 
 <h3 id="transit_maxNumberOfTransfers">maxNumberOfTransfers</h3>
 
-**Since version:** `na` ∙ **Type:** `integer` ∙ **Cardinality:** `Optional` ∙ **Default value:** `12`  \
+**Since version:** `na` ∙ **Type:** `integer` ∙ **Cardinality:** `Optional` ∙ **Default value:** `12`   
 **Path:** /transit 
 
 This parameter is used to allocate enough memory space for Raptor.
@@ -192,7 +192,7 @@ transfers is very little so it is better to set it too high than to low.
 
 <h3 id="transit_scheduledTripBinarySearchThreshold">scheduledTripBinarySearchThreshold</h3>
 
-**Since version:** `na` ∙ **Type:** `integer` ∙ **Cardinality:** `Optional` ∙ **Default value:** `50`  \
+**Since version:** `na` ∙ **Type:** `integer` ∙ **Cardinality:** `Optional` ∙ **Default value:** `50`   
 **Path:** /transit 
 
 This threshold is used to determine when to perform a binary trip schedule search.
@@ -205,7 +205,7 @@ few percents.
 
 <h3 id="transit_searchThreadPoolSize">searchThreadPoolSize</h3>
 
-**Since version:** `na` ∙ **Type:** `integer` ∙ **Cardinality:** `Optional` ∙ **Default value:** `0`  \
+**Since version:** `na` ∙ **Type:** `integer` ∙ **Cardinality:** `Optional` ∙ **Default value:** `0`   
 **Path:** /transit 
 
 Split a travel search in smaller jobs and run them in parallel to improve performance.
@@ -217,7 +217,7 @@ no extra threads are started and the search is done in one thread.
 
 <h3 id="transit_transferCacheMaxSize">transferCacheMaxSize</h3>
 
-**Since version:** `na` ∙ **Type:** `integer` ∙ **Cardinality:** `Optional` ∙ **Default value:** `25`  \
+**Since version:** `na` ∙ **Type:** `integer` ∙ **Cardinality:** `Optional` ∙ **Default value:** `25`   
 **Path:** /transit 
 
 The maximum number of distinct transfers parameters to cache pre-calculated transfers for.
@@ -226,7 +226,7 @@ The maximum number of distinct transfers parameters to cache pre-calculated tran
 
 <h3 id="transit_dynamicSearchWindow">dynamicSearchWindow</h3>
 
-**Since version:** `na` ∙ **Type:** `object` ∙ **Cardinality:** `Optional`  \
+**Since version:** `na` ∙ **Type:** `object` ∙ **Cardinality:** `Optional`   
 **Path:** /transit 
 
 The dynamic search window coefficients used to calculate the EDT, LAT and SW.
@@ -264,7 +264,7 @@ In addition there is an upper bound on the calculation of the search window:
 
 <h3 id="transit_dynamicSearchWindow_maxWinTimeMinutes">maxWinTimeMinutes</h3>
 
-**Since version:** `na` ∙ **Type:** `integer` ∙ **Cardinality:** `Optional` ∙ **Default value:** `180`  \
+**Since version:** `na` ∙ **Type:** `integer` ∙ **Cardinality:** `Optional` ∙ **Default value:** `180`   
 **Path:** /transit/dynamicSearchWindow 
 
 Upper limit for the search-window calculation.
@@ -280,7 +280,7 @@ The default is 3 hours. The unit is minutes.
 
 <h3 id="transit_dynamicSearchWindow_minTransitTimeCoefficient">minTransitTimeCoefficient</h3>
 
-**Since version:** `na` ∙ **Type:** `double` ∙ **Cardinality:** `Optional` ∙ **Default value:** `0.5`  \
+**Since version:** `na` ∙ **Type:** `double` ∙ **Cardinality:** `Optional` ∙ **Default value:** `0.5`   
 **Path:** /transit/dynamicSearchWindow 
 
 The coefficient to multiply with `minTransitTime`.
@@ -289,7 +289,7 @@ Use a value between `0.0` and `3.0`. Using `0.0` will eliminate the `minTransitT
 
 <h3 id="transit_dynamicSearchWindow_minWaitTimeCoefficient">minWaitTimeCoefficient</h3>
 
-**Since version:** `na` ∙ **Type:** `double` ∙ **Cardinality:** `Optional` ∙ **Default value:** `0.5`  \
+**Since version:** `na` ∙ **Type:** `double` ∙ **Cardinality:** `Optional` ∙ **Default value:** `0.5`   
 **Path:** /transit/dynamicSearchWindow 
 
 The coefficient to multiply with `minWaitTime`.
@@ -298,7 +298,7 @@ Use a value between `0.0` and `1.0`. Using `0.0` will eliminate the `minWaitTime
 
 <h3 id="transit_dynamicSearchWindow_minWinTimeMinutes">minWinTimeMinutes</h3>
 
-**Since version:** `na` ∙ **Type:** `integer` ∙ **Cardinality:** `Optional` ∙ **Default value:** `40`  \
+**Since version:** `na` ∙ **Type:** `integer` ∙ **Cardinality:** `Optional` ∙ **Default value:** `40`   
 **Path:** /transit/dynamicSearchWindow 
 
 The constant minimum number of minutes for a raptor-search-window. 
@@ -307,7 +307,7 @@ Use a value between 20 and 180 minutes in a normal deployment.
 
 <h3 id="transit_dynamicSearchWindow_stepMinutes">stepMinutes</h3>
 
-**Since version:** `na` ∙ **Type:** `integer` ∙ **Cardinality:** `Optional` ∙ **Default value:** `10`  \
+**Since version:** `na` ∙ **Type:** `integer` ∙ **Cardinality:** `Optional` ∙ **Default value:** `10`   
 **Path:** /transit/dynamicSearchWindow 
 
 Used to set the steps the search-window is rounded to.
@@ -323,7 +323,7 @@ coefficient.
 
 <h3 id="transit_pagingSearchWindowAdjustments">pagingSearchWindowAdjustments</h3>
 
-**Since version:** `na` ∙ **Type:** `duration[]` ∙ **Cardinality:** `Optional`  \
+**Since version:** `na` ∙ **Type:** `duration[]` ∙ **Cardinality:** `Optional`   
 **Path:** /transit 
 
 The provided array of durations is used to increase the search-window for the next/previous page.
@@ -337,8 +337,8 @@ for more info."
 
 <h3 id="transit_stopTransferCost">stopTransferCost</h3>
 
-**Since version:** `na` ∙ **Type:** `enum map of integer` ∙ **Cardinality:** `Optional`  \
-**Path:** /transit  \
+**Since version:** `na` ∙ **Type:** `enum map of integer` ∙ **Cardinality:** `Optional`   
+**Path:** /transit   
 **Enum keys:** `discouraged` | `allowed` | `recommended` | `preferred`
 
 Use this to set a stop transfer cost for the given transfer priority
@@ -364,7 +364,7 @@ Use values in a range from `0` to `100 000`. **All key/value pairs are required 
 
 <h3 id="transmodelApi_hideFeedId">hideFeedId</h3>
 
-**Since version:** `na` ∙ **Type:** `boolean` ∙ **Cardinality:** `Optional` ∙ **Default value:** `false`  \
+**Since version:** `na` ∙ **Type:** `boolean` ∙ **Cardinality:** `Optional` ∙ **Default value:** `false`   
 **Path:** /transmodelApi 
 
 Hide the FeedId in all API output, and add it to input.
@@ -373,14 +373,14 @@ Only turn this feature on if you have unique ids across all feeds, without the f
 
 <h3 id="transmodelApi_tracingHeaderTags">tracingHeaderTags</h3>
 
-**Since version:** `na` ∙ **Type:** `string[]` ∙ **Cardinality:** `Optional`  \
+**Since version:** `na` ∙ **Type:** `string[]` ∙ **Cardinality:** `Optional`   
 **Path:** /transmodelApi 
 
 Used to group requests when monitoring OTP.
 
 <h3 id="vehicleRentalServiceDirectory_headers">headers</h3>
 
-**Since version:** `na` ∙ **Type:** `map of string` ∙ **Cardinality:** `Optional`  \
+**Since version:** `na` ∙ **Type:** `map of string` ∙ **Cardinality:** `Optional`   
 **Path:** /vehicleRentalServiceDirectory 
 
 Http headers.

--- a/docs/UpdaterConfig.md
+++ b/docs/UpdaterConfig.md
@@ -98,8 +98,8 @@ predicted arrival and departure times for the remainder of the trip.
 
 <h4 id="u__5__backwardsDelayPropagationType">backwardsDelayPropagationType</h4>
 
-**Since version:** `2.2` ∙ **Type:** `enum` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"required-no-data"`  \
-**Path:** /updaters/[5]  \
+**Since version:** `2.2` ∙ **Type:** `enum` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"required-no-data"`   
+**Path:** /updaters/[5]   
 **Enum values:** `required-no-data` | `required` | `always`
 
 How backwards propagation should be handled.
@@ -157,8 +157,8 @@ How backwards propagation should be handled.
 
 <h4 id="u__7__backwardsDelayPropagationType">backwardsDelayPropagationType</h4>
 
-**Since version:** `na` ∙ **Type:** `enum` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"required-no-data"`  \
-**Path:** /updaters/[7]  \
+**Since version:** `na` ∙ **Type:** `enum` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"required-no-data"`   
+**Path:** /updaters/[7]   
 **Enum values:** `required-no-data` | `required` | `always`
 
 TODO
@@ -266,7 +266,7 @@ can be configured as a json. Any header key, value can be inserted.
 
 <h4 id="u_1_allowKeepingRentedBicycleAtDestination">allowKeepingRentedBicycleAtDestination</h4>
 
-**Since version:** `na` ∙ **Type:** `boolean` ∙ **Cardinality:** `Optional` ∙ **Default value:** `false`  \
+**Since version:** `na` ∙ **Type:** `boolean` ∙ **Cardinality:** `Optional` ∙ **Default value:** `false`   
 **Path:** /updaters/[1] 
 
 If a vehicle should be allowed to be kept at the end of a station-based rental.
@@ -275,7 +275,7 @@ This behaviour is useful in towns that have only a single rental station. Withou
 
 <h4 id="u_1_network">network</h4>
 
-**Since version:** `na` ∙ **Type:** `string` ∙ **Cardinality:** `Optional`  \
+**Since version:** `na` ∙ **Type:** `string` ∙ **Cardinality:** `Optional`   
 **Path:** /updaters/[1] 
 
 The name of the network to override the one derived from the source data.
@@ -284,15 +284,15 @@ GBFS feeds must include a system_id which will be used as the default `network`.
 
 <h4 id="u_1_sourceType">sourceType</h4>
 
-**Since version:** `na` ∙ **Type:** `enum` ∙ **Cardinality:** `Required`  \
-**Path:** /updaters/[1]  \
+**Since version:** `na` ∙ **Type:** `enum` ∙ **Cardinality:** `Required`   
+**Path:** /updaters/[1]   
 **Enum values:** `gbfs` | `smoove` | `vilkku`
 
 What source of vehicle rental updater to use.
 
 <h4 id="u_1_headers">headers</h4>
 
-**Since version:** `na` ∙ **Type:** `map of string` ∙ **Cardinality:** `Optional`  \
+**Since version:** `na` ∙ **Type:** `map of string` ∙ **Cardinality:** `Optional`   
 **Path:** /updaters/[1] 
 
 HTTP headers to add to the request. Any header key, value can be inserted.

--- a/docs/sandbox/VehicleParking.md
+++ b/docs/sandbox/VehicleParking.md
@@ -1,4 +1,4 @@
-# Vehicle Parking Updaters - OTP Sandbox Extension
+# Vehicle Parking Updaters
 
 ## Contact Info
 
@@ -49,7 +49,7 @@ All updaters have the following parameters in common:
 
 <h4 id="u__2__feedId">feedId</h4>
 
-**Since version:** `2.2` ∙ **Type:** `string` ∙ **Cardinality:** `Optional`  \
+**Since version:** `2.2` ∙ **Type:** `string` ∙ **Cardinality:** `Optional`   
 **Path:** /updaters/[2] 
 
 The name of the data source.
@@ -58,15 +58,15 @@ This will end up in the API responses as the feed id of of the parking lot.
 
 <h4 id="u__2__sourceType">sourceType</h4>
 
-**Since version:** `2.2` ∙ **Type:** `enum` ∙ **Cardinality:** `Required`  \
-**Path:** /updaters/[2]  \
+**Since version:** `2.2` ∙ **Type:** `enum` ∙ **Cardinality:** `Required`   
+**Path:** /updaters/[2]   
 **Enum values:** `park-api` | `bicycle-park-api` | `hsl-park` | `bikely`
 
 The source of the vehicle updates.
 
 <h4 id="u__2__timeZone">timeZone</h4>
 
-**Since version:** `2.2` ∙ **Type:** `time-zone` ∙ **Cardinality:** `Optional`  \
+**Since version:** `2.2` ∙ **Type:** `time-zone` ∙ **Cardinality:** `Optional`   
 **Path:** /updaters/[2] 
 
 The time zone of the feed.
@@ -120,7 +120,7 @@ Used for converting abstract opening hours into concrete points in time.
 
 <h4 id="u__3__feedId">feedId</h4>
 
-**Since version:** `2.2` ∙ **Type:** `string` ∙ **Cardinality:** `Optional`  \
+**Since version:** `2.2` ∙ **Type:** `string` ∙ **Cardinality:** `Optional`   
 **Path:** /updaters/[3] 
 
 The name of the data source.
@@ -129,15 +129,15 @@ This will end up in the API responses as the feed id of of the parking lot.
 
 <h4 id="u__3__sourceType">sourceType</h4>
 
-**Since version:** `2.2` ∙ **Type:** `enum` ∙ **Cardinality:** `Required`  \
-**Path:** /updaters/[3]  \
+**Since version:** `2.2` ∙ **Type:** `enum` ∙ **Cardinality:** `Required`   
+**Path:** /updaters/[3]   
 **Enum values:** `park-api` | `bicycle-park-api` | `hsl-park` | `bikely`
 
 The source of the vehicle updates.
 
 <h4 id="u__3__timeZone">timeZone</h4>
 
-**Since version:** `2.2` ∙ **Type:** `time-zone` ∙ **Cardinality:** `Optional`  \
+**Since version:** `2.2` ∙ **Type:** `time-zone` ∙ **Cardinality:** `Optional`   
 **Path:** /updaters/[3] 
 
 The time zone of the feed.
@@ -146,14 +146,14 @@ Used for converting abstract opening hours into concrete points in time.
 
 <h4 id="u__3__headers">headers</h4>
 
-**Since version:** `2.2` ∙ **Type:** `map of string` ∙ **Cardinality:** `Optional`  \
+**Since version:** `2.2` ∙ **Type:** `map of string` ∙ **Cardinality:** `Optional`   
 **Path:** /updaters/[3] 
 
 HTTP headers to add.
 
 <h4 id="u__3__tags">tags</h4>
 
-**Since version:** `2.2` ∙ **Type:** `string[]` ∙ **Cardinality:** `Optional`  \
+**Since version:** `2.2` ∙ **Type:** `string[]` ∙ **Cardinality:** `Optional`   
 **Path:** /updaters/[3] 
 
 Tags to add to the parking lots.
@@ -204,7 +204,7 @@ Tags to add to the parking lots.
 
 <h4 id="u__4__feedId">feedId</h4>
 
-**Since version:** `2.2` ∙ **Type:** `string` ∙ **Cardinality:** `Optional`  \
+**Since version:** `2.2` ∙ **Type:** `string` ∙ **Cardinality:** `Optional`   
 **Path:** /updaters/[4] 
 
 The name of the data source.
@@ -213,15 +213,15 @@ This will end up in the API responses as the feed id of of the parking lot.
 
 <h4 id="u__4__sourceType">sourceType</h4>
 
-**Since version:** `2.2` ∙ **Type:** `enum` ∙ **Cardinality:** `Required`  \
-**Path:** /updaters/[4]  \
+**Since version:** `2.2` ∙ **Type:** `enum` ∙ **Cardinality:** `Required`   
+**Path:** /updaters/[4]   
 **Enum values:** `park-api` | `bicycle-park-api` | `hsl-park` | `bikely`
 
 The source of the vehicle updates.
 
 <h4 id="u__4__headers">headers</h4>
 
-**Since version:** `2.3` ∙ **Type:** `map of string` ∙ **Cardinality:** `Optional`  \
+**Since version:** `2.3` ∙ **Type:** `map of string` ∙ **Cardinality:** `Optional`   
 **Path:** /updaters/[4] 
 
 HTTP headers to add.

--- a/src/main/java/org/opentripplanner/framework/text/MarkdownFormatter.java
+++ b/src/main/java/org/opentripplanner/framework/text/MarkdownFormatter.java
@@ -79,7 +79,7 @@ public class MarkdownFormatter {
   }
 
   public static String lineBreak() {
-    return " \\";
+    return "  ";
   }
 
   private static String normalizeAnchor(String anchor) {

--- a/src/main/java/org/opentripplanner/framework/text/MarkdownFormatter.java
+++ b/src/main/java/org/opentripplanner/framework/text/MarkdownFormatter.java
@@ -79,10 +79,10 @@ public class MarkdownFormatter {
   }
 
   /**
-   * Line-breaks in markdown is a bit problematic, we should avoid mixing HTML tags and markdown since not all 
+   * Line-breaks in markdown is a bit problematic, we should avoid mixing HTML tags and markdown since not all
    * Markdown applications support it, the same goes for ending the line with {@code \}. The best alternative
    * seams to be using two trailing spaces {@code "  "} followed by a line-break, even if this is error-prune.
-   * This method does not add the line-break, just the trailing spaces. 
+   * This method does not add the line-break, just the trailing spaces.
    * <p>
    * For more info see https://www.markdownguide.org/basic-syntax/#line-breaks
    */

--- a/src/main/java/org/opentripplanner/framework/text/MarkdownFormatter.java
+++ b/src/main/java/org/opentripplanner/framework/text/MarkdownFormatter.java
@@ -78,6 +78,14 @@ public class MarkdownFormatter {
     return level <= 0 ? "" : NBSP.repeat(3 * level);
   }
 
+  /**
+   * Line-breaks in markdown is a bit problematic, we should avoid mixing HTML tags and markdown since not all 
+   * Markdown applications support it, the same goes for ending the line with {@code \}. The best alternative
+   * seams to be using two trailing spaces {@code "  "} followed by a line-break, even if this is error-prune.
+   * This method does not add the line-break, just the trailing spaces. 
+   * <p>
+   * For more info see https://www.markdownguide.org/basic-syntax/#line-breaks
+   */
   public static String lineBreak() {
     return "  ";
   }

--- a/src/main/java/org/opentripplanner/standalone/config/buildconfig/NetexConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/buildconfig/NetexConfig.java
@@ -138,10 +138,10 @@ public class NetexConfig {
         config
           .of("ferryIdsNotAllowedForBicycle")
           .since(V2_0)
-          .summary("List ferries witch do not allow bikes.")
+          .summary("List ferries which do not allow bikes.")
           .description(
             """
-            Bicycles are allowed on most ferries however Nordic profile doesn't contain a place
+            Bicycles are allowed on most ferries however the Nordic profile doesn't contain a place
             where bicycle conveyance can be defined.
             
             For this reason we allow bicycles on ferries by default and allow to override the rare

--- a/src/test/java/org/opentripplanner/generate/doc/framework/DocBuilderTest.java
+++ b/src/test/java/org/opentripplanner/generate/doc/framework/DocBuilderTest.java
@@ -29,7 +29,7 @@ class DocBuilderTest {
       """
       Section
          
-      **Label** `code` ∙ Text  \\
+      **Label** `code` ∙ Text\s\s\s
       More text\s
       
       <h1 id="anchor">Header</h1>


### PR DESCRIPTION
### Summary

This fixes an issue where the markdown generator doesn't correctly build line breaks.

The markdown syntax for this is two trailing spaces.

#### Before
![Screenshot from 2022-11-22 14-19-11](https://user-images.githubusercontent.com/151346/203326551-1d22af07-8430-454d-ba7f-0ccf0821288b.png)

#### After
![Screenshot from 2022-11-22 14-18-30](https://user-images.githubusercontent.com/151346/203326638-e9c0e907-a4b9-48a7-a159-bed63b234fba.png)


The PR also fixes a handfull of spelling errors.