### PR TITLE
Functionality for banned and whitelisted groups of routes

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLPlanner.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLPlanner.java
@@ -183,12 +183,14 @@ public class TransmodelGraphQLPlanner {
 
     callWith.argument(
       "whiteListed.groupsOfLines",
-      (List<String> groupsOfLines) -> request.journey().transit().setWhiteListedGroupsOfRoutes(mapIDsToDomain(groupsOfLines))
+      (List<String> groupsOfLines) ->
+        request.journey().transit().setWhiteListedGroupsOfRoutes(mapIDsToDomain(groupsOfLines))
     );
 
     callWith.argument(
       "banned.groupsOfLines",
-      (List<String> groupsOfLines) -> request.journey().transit().setBannedGroupsOfRoutes(mapIDsToDomain(groupsOfLines))
+      (List<String> groupsOfLines) ->
+        request.journey().transit().setBannedGroupsOfRoutes(mapIDsToDomain(groupsOfLines))
     );
 
     // callWith.argument("heuristicStepsPerMainStep", (Integer v) -> request.heuristicStepsPerMainStep = v);

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLPlanner.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLPlanner.java
@@ -181,6 +181,16 @@ public class TransmodelGraphQLPlanner {
       (List<String> networks) -> request.journey().rental().setBannedNetworks(Set.copyOf(networks))
     );
 
+    callWith.argument(
+      "whiteListed.groupsOfLines",
+      (List<String> groupsOfLines) -> request.journey().transit().setWhiteListedGroupsOfRoutes(mapIDsToDomain(groupsOfLines))
+    );
+
+    callWith.argument(
+      "banned.groupsOfLines",
+      (List<String> groupsOfLines) -> request.journey().transit().setBannedGroupsOfRoutes(mapIDsToDomain(groupsOfLines))
+    );
+
     // callWith.argument("heuristicStepsPerMainStep", (Integer v) -> request.heuristicStepsPerMainStep = v);
     // callWith.argument("compactLegsByReversedSearch", (Boolean v) -> { /* not used any more */ });
     // callWith.argument("banFirstServiceJourneysFromReuseNo", (Integer v) -> request.banFirstTripsFromReuseNo = v);

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/BannedInputType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/BannedInputType.java
@@ -46,5 +46,11 @@ public class BannedInputType {
         "Set of ids of rental networks that should not be allowed for renting vehicles."
       )
     )
+    .field(
+      GqlUtil.newIdListInputField(
+        "groupsOfLines",
+        "Set of ids of groups of lines that should not be used"
+      )
+    )
     .build();
 }

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/JourneyWhiteListed.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/JourneyWhiteListed.java
@@ -35,7 +35,9 @@ public class JourneyWhiteListed {
         "Set of ids of rental networks that should be used for renting vehicles."
       )
     )
-    .field(newIdListInputField("groupsOfLines", "Set of ids for groups of lines that should be used"))
+    .field(
+      newIdListInputField("groupsOfLines", "Set of ids for groups of lines that should be used")
+    )
     .build();
 
   public final Set<FeedScopedId> authorityIds;

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/JourneyWhiteListed.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/JourneyWhiteListed.java
@@ -35,6 +35,7 @@ public class JourneyWhiteListed {
         "Set of ids of rental networks that should be used for renting vehicles."
       )
     )
+    .field(newIdListInputField("groupsOfLines", "Set of ids for groups of lines that should be used"))
     .build();
 
   public final Set<FeedScopedId> authorityIds;

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RouteRequestTransitDataProviderFilter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RouteRequestTransitDataProviderFilter.java
@@ -3,6 +3,7 @@ package org.opentripplanner.routing.algorithm.raptoradapter.transit.request;
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import org.opentripplanner.model.modes.AllowTransitModeFilter;
@@ -222,12 +223,8 @@ public class RouteRequestTransitDataProviderFilter implements TransitDataProvide
       .map(AbstractTransitEntity::getId)
       .toList();
 
-    if (!bannedGroupsOfRoutes.isEmpty()) {
-      for (var id : groupOfRoutesIDs) {
-        if (bannedGroupsOfRoutes.contains(id)) {
-          return true;
-        }
-      }
+    if (!bannedGroupsOfRoutes.isEmpty() && !Collections.disjoint(bannedGroupsOfRoutes, groupOfRoutesIDs)) {
+      return true;
     }
 
     boolean whiteListed = false;

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RouteRequestTransitDataProviderFilter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RouteRequestTransitDataProviderFilter.java
@@ -223,7 +223,10 @@ public class RouteRequestTransitDataProviderFilter implements TransitDataProvide
       .map(AbstractTransitEntity::getId)
       .toList();
 
-    if (!bannedGroupsOfRoutes.isEmpty() && !Collections.disjoint(bannedGroupsOfRoutes, groupOfRoutesIDs)) {
+    if (
+      !bannedGroupsOfRoutes.isEmpty() &&
+      !Collections.disjoint(bannedGroupsOfRoutes, groupOfRoutesIDs)
+    ) {
       return true;
     }
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RouteRequestTransitDataProviderFilter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RouteRequestTransitDataProviderFilter.java
@@ -157,8 +157,8 @@ public class RouteRequestTransitDataProviderFilter implements TransitDataProvide
       bannedAgenciesCollection.isEmpty() &&
       whiteListedRoutes.isEmpty() &&
       whiteListedAgenciesCollection.isEmpty() &&
-        whiteListedGroupsOfRoutesCollection.isEmpty() &&
-        bannedGroupsOfRoutesCollection.isEmpty()
+      whiteListedGroupsOfRoutesCollection.isEmpty() &&
+      bannedGroupsOfRoutesCollection.isEmpty()
     ) {
       return List.of();
     }
@@ -171,7 +171,15 @@ public class RouteRequestTransitDataProviderFilter implements TransitDataProvide
     List<FeedScopedId> ret = new ArrayList<>();
     for (Route route : routes) {
       if (
-        routeIsBanned(bannedAgencies, bannedRoutes, whiteListedAgencies, whiteListedRoutes, whiteListedGroupsOfRoutes, bannedGroupOfRoutes, route)
+        routeIsBanned(
+          bannedAgencies,
+          bannedRoutes,
+          whiteListedAgencies,
+          whiteListedRoutes,
+          whiteListedGroupsOfRoutes,
+          bannedGroupOfRoutes,
+          route
+        )
       ) {
         ret.add(route.getId());
       }
@@ -194,7 +202,6 @@ public class RouteRequestTransitDataProviderFilter implements TransitDataProvide
     Set<FeedScopedId> bannedGroupsOfRoutes,
     Route route
   ) {
-
     /* check if agency is banned for this plan */
     if (!bannedAgencies.isEmpty()) {
       if (bannedAgencies.contains(route.getAgency().getId())) {
@@ -209,7 +216,11 @@ public class RouteRequestTransitDataProviderFilter implements TransitDataProvide
       }
     }
 
-    var groupOfRoutesIDs = route.getGroupsOfRoutes().stream().map(AbstractTransitEntity::getId).toList();
+    var groupOfRoutesIDs = route
+      .getGroupsOfRoutes()
+      .stream()
+      .map(AbstractTransitEntity::getId)
+      .toList();
 
     if (!bannedGroupsOfRoutes.isEmpty()) {
       for (var id : groupOfRoutesIDs) {

--- a/src/main/java/org/opentripplanner/routing/api/request/request/TransitRequest.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/request/TransitRequest.java
@@ -22,6 +22,8 @@ public class TransitRequest implements Cloneable, Serializable {
   private List<FeedScopedId> unpreferredAgencies = List.of();
   private RouteMatcher whiteListedRoutes = RouteMatcher.emptyMatcher();
   private RouteMatcher bannedRoutes = RouteMatcher.emptyMatcher();
+  private List<FeedScopedId> whiteListedGroupsOfRoutes = List.of();
+  private List<FeedScopedId> bannedGroupsOfRoutes = List.of();
 
   /**
    * @deprecated TODO OTP2 Needs to be implemented
@@ -233,6 +235,22 @@ public class TransitRequest implements Cloneable, Serializable {
 
   public DebugRaptor raptorDebugging() {
     return raptorDebugging;
+  }
+
+  public void setWhiteListedGroupsOfRoutes(List<FeedScopedId> whiteListedGroupsOfRoutes) {
+    this.whiteListedGroupsOfRoutes = whiteListedGroupsOfRoutes;
+  }
+
+  public List<FeedScopedId> whiteListedGroupsOfRoutes() {
+    return whiteListedGroupsOfRoutes;
+  }
+
+  public void setBannedGroupsOfRoutes(List<FeedScopedId> bannedGroupsOfRoutes) {
+    this.bannedGroupsOfRoutes = bannedGroupsOfRoutes;
+  }
+
+  public List<FeedScopedId> bannedGroupsOfRoutes() {
+    return bannedGroupsOfRoutes;
   }
 
   public TransitRequest clone() {

--- a/src/main/java/org/opentripplanner/transit/model/network/RouteBuilder.java
+++ b/src/main/java/org/opentripplanner/transit/model/network/RouteBuilder.java
@@ -198,6 +198,11 @@ public final class RouteBuilder extends AbstractEntityBuilder<Route, RouteBuilde
     return this;
   }
 
+  public RouteBuilder withGroupOfRoutes(List<GroupOfRoutes> groupsOfRoutes) {
+    this.groupsOfRoutes = groupsOfRoutes;
+    return this;
+  }
+
   public List<GroupOfRoutes> getGroupsOfRoutes() {
     if (groupsOfRoutes == null) {
       groupsOfRoutes = new ArrayList<>();

--- a/src/test/java/org/opentripplanner/routing/algorithm/TestBanning.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/TestBanning.java
@@ -13,6 +13,8 @@ import org.opentripplanner.routing.api.request.request.TransitRequest;
 import org.opentripplanner.routing.core.RouteMatcher;
 import org.opentripplanner.transit.model._data.TransitModelForTest;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.model.network.GroupOfRoutes;
+import org.opentripplanner.transit.model.network.GroupOfRoutesBuilder;
 import org.opentripplanner.transit.model.network.Route;
 import org.opentripplanner.transit.model.organization.Agency;
 
@@ -35,6 +37,8 @@ public class TestBanning {
       transit.bannedRoutes(),
       Set.copyOf(transit.whiteListedAgencies()),
       transit.whiteListedRoutes(),
+      transit.whiteListedGroupsOfRoutes(),
+      transit.bannedGroupsOfRoutes(),
       routes
     );
 
@@ -56,6 +60,8 @@ public class TestBanning {
       transit.bannedRoutes(),
       Set.copyOf(transit.whiteListedAgencies()),
       transit.whiteListedRoutes(),
+      transit.whiteListedGroupsOfRoutes(),
+      transit.bannedGroupsOfRoutes(),
       routes
     );
 
@@ -63,14 +69,104 @@ public class TestBanning {
     assertTrue(bannedRoutes.contains(id("RUT:Route:2")));
   }
 
+  @Test
+  public void testWhitelistedGroupsOfRoutes() {
+    Collection<Route> routes = getTestRoutes();
+    TransitRequest transitRequest = new TransitRequest();
+    Collection<FeedScopedId> bannedRoutes;
+
+    transitRequest.setWhiteListedGroupsOfRoutes(List.of(id("RUT:GroupOfRoutes:1")));
+
+    bannedRoutes = RouteRequestTransitDataProviderFilter.bannedRoutes(
+      Set.copyOf(transitRequest.bannedAgencies()),
+      transitRequest.bannedRoutes(),
+      Set.copyOf(transitRequest.whiteListedAgencies()),
+      transitRequest.whiteListedRoutes(),
+      transitRequest.whiteListedGroupsOfRoutes(),
+      transitRequest.bannedGroupsOfRoutes(),
+      routes
+    );
+
+    assertEquals(1, bannedRoutes.size());
+    assertTrue(bannedRoutes.contains(id("RUT:Route:2")));
+
+
+    transitRequest.setWhiteListedGroupsOfRoutes(List.of(id("RUT:GroupOfRoutes:2")));
+
+    bannedRoutes = RouteRequestTransitDataProviderFilter.bannedRoutes(
+      Set.copyOf(transitRequest.bannedAgencies()),
+      transitRequest.bannedRoutes(),
+      Set.copyOf(transitRequest.whiteListedAgencies()),
+      transitRequest.whiteListedRoutes(),
+      transitRequest.whiteListedGroupsOfRoutes(),
+      transitRequest.bannedGroupsOfRoutes(),
+      routes
+    );
+
+    assertEquals(1, bannedRoutes.size());
+    assertTrue(bannedRoutes.contains(id("RUT:Route:1")));
+  }
+
+  @Test
+  public void testBannedGroupsOfRoutes() {
+    Collection<Route> routes = getTestRoutes();
+    TransitRequest transitRequest = new TransitRequest();
+    Collection<FeedScopedId> bannedRoutes;
+
+    transitRequest.setBannedGroupsOfRoutes(List.of(id("RUT:GroupOfRoutes:1")));
+
+    bannedRoutes = RouteRequestTransitDataProviderFilter.bannedRoutes(
+      Set.copyOf(transitRequest.bannedAgencies()),
+      transitRequest.bannedRoutes(),
+      Set.copyOf(transitRequest.whiteListedAgencies()),
+      transitRequest.whiteListedRoutes(),
+      transitRequest.whiteListedGroupsOfRoutes(),
+      transitRequest.bannedGroupsOfRoutes(),
+      routes
+    );
+
+    assertEquals(2, bannedRoutes.size());
+    assertTrue(bannedRoutes.contains(id("RUT:Route:1")));
+    assertTrue(bannedRoutes.contains(id("RUT:Route:3")));
+
+
+    transitRequest.setBannedGroupsOfRoutes(List.of(id("RUT:GroupOfRoutes:2")));
+
+    bannedRoutes = RouteRequestTransitDataProviderFilter.bannedRoutes(
+      Set.copyOf(transitRequest.bannedAgencies()),
+      transitRequest.bannedRoutes(),
+      Set.copyOf(transitRequest.whiteListedAgencies()),
+      transitRequest.whiteListedRoutes(),
+      transitRequest.whiteListedGroupsOfRoutes(),
+      transitRequest.bannedGroupsOfRoutes(),
+      routes
+    );
+
+    assertEquals(2, bannedRoutes.size());
+    assertTrue(bannedRoutes.contains(id("RUT:Route:2")));
+    assertTrue(bannedRoutes.contains(id("RUT:Route:3")));
+  }
+
   private List<Route> getTestRoutes() {
     Agency agency1 = TransitModelForTest.agency("A").copy().withId(id("RUT:Agency:1")).build();
     Agency agency2 = TransitModelForTest.agency("B").copy().withId(id("RUT:Agency:2")).build();
 
+    GroupOfRoutes groupOfRoutes1 = GroupOfRoutes.of(id("RUT:GroupOfRoutes:1")).build();
+    GroupOfRoutes groupOfRoutes2 = GroupOfRoutes.of(id("RUT:GroupOfRoutes:2")).build();
+
     return List.of(
-      TransitModelForTest.route("RUT:Route:1").withAgency(agency1).build(),
-      TransitModelForTest.route("RUT:Route:2").withAgency(agency1).build(),
-      TransitModelForTest.route("RUT:Route:3").withAgency(agency2).build()
+      TransitModelForTest.route("RUT:Route:1")
+        .withAgency(agency1)
+        .withGroupOfRoutes(List.of(groupOfRoutes1))
+        .build(),
+      TransitModelForTest.route("RUT:Route:2")
+        .withGroupOfRoutes(List.of(groupOfRoutes2))
+        .withAgency(agency1)
+        .build(),
+      TransitModelForTest.route("RUT:Route:3")
+        .withGroupOfRoutes(List.of(groupOfRoutes1, groupOfRoutes2))
+        .withAgency(agency2)
+        .build()
     );
   }
 }

--- a/src/test/java/org/opentripplanner/routing/algorithm/TestBanning.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/TestBanning.java
@@ -77,31 +77,32 @@ public class TestBanning {
 
     transitRequest.setWhiteListedGroupsOfRoutes(List.of(id("RUT:GroupOfRoutes:1")));
 
-    bannedRoutes = RouteRequestTransitDataProviderFilter.bannedRoutes(
-      Set.copyOf(transitRequest.bannedAgencies()),
-      transitRequest.bannedRoutes(),
-      Set.copyOf(transitRequest.whiteListedAgencies()),
-      transitRequest.whiteListedRoutes(),
-      transitRequest.whiteListedGroupsOfRoutes(),
-      transitRequest.bannedGroupsOfRoutes(),
-      routes
-    );
+    bannedRoutes =
+      RouteRequestTransitDataProviderFilter.bannedRoutes(
+        Set.copyOf(transitRequest.bannedAgencies()),
+        transitRequest.bannedRoutes(),
+        Set.copyOf(transitRequest.whiteListedAgencies()),
+        transitRequest.whiteListedRoutes(),
+        transitRequest.whiteListedGroupsOfRoutes(),
+        transitRequest.bannedGroupsOfRoutes(),
+        routes
+      );
 
     assertEquals(1, bannedRoutes.size());
     assertTrue(bannedRoutes.contains(id("RUT:Route:2")));
 
-
     transitRequest.setWhiteListedGroupsOfRoutes(List.of(id("RUT:GroupOfRoutes:2")));
 
-    bannedRoutes = RouteRequestTransitDataProviderFilter.bannedRoutes(
-      Set.copyOf(transitRequest.bannedAgencies()),
-      transitRequest.bannedRoutes(),
-      Set.copyOf(transitRequest.whiteListedAgencies()),
-      transitRequest.whiteListedRoutes(),
-      transitRequest.whiteListedGroupsOfRoutes(),
-      transitRequest.bannedGroupsOfRoutes(),
-      routes
-    );
+    bannedRoutes =
+      RouteRequestTransitDataProviderFilter.bannedRoutes(
+        Set.copyOf(transitRequest.bannedAgencies()),
+        transitRequest.bannedRoutes(),
+        Set.copyOf(transitRequest.whiteListedAgencies()),
+        transitRequest.whiteListedRoutes(),
+        transitRequest.whiteListedGroupsOfRoutes(),
+        transitRequest.bannedGroupsOfRoutes(),
+        routes
+      );
 
     assertEquals(1, bannedRoutes.size());
     assertTrue(bannedRoutes.contains(id("RUT:Route:1")));
@@ -115,32 +116,33 @@ public class TestBanning {
 
     transitRequest.setBannedGroupsOfRoutes(List.of(id("RUT:GroupOfRoutes:1")));
 
-    bannedRoutes = RouteRequestTransitDataProviderFilter.bannedRoutes(
-      Set.copyOf(transitRequest.bannedAgencies()),
-      transitRequest.bannedRoutes(),
-      Set.copyOf(transitRequest.whiteListedAgencies()),
-      transitRequest.whiteListedRoutes(),
-      transitRequest.whiteListedGroupsOfRoutes(),
-      transitRequest.bannedGroupsOfRoutes(),
-      routes
-    );
+    bannedRoutes =
+      RouteRequestTransitDataProviderFilter.bannedRoutes(
+        Set.copyOf(transitRequest.bannedAgencies()),
+        transitRequest.bannedRoutes(),
+        Set.copyOf(transitRequest.whiteListedAgencies()),
+        transitRequest.whiteListedRoutes(),
+        transitRequest.whiteListedGroupsOfRoutes(),
+        transitRequest.bannedGroupsOfRoutes(),
+        routes
+      );
 
     assertEquals(2, bannedRoutes.size());
     assertTrue(bannedRoutes.contains(id("RUT:Route:1")));
     assertTrue(bannedRoutes.contains(id("RUT:Route:3")));
 
-
     transitRequest.setBannedGroupsOfRoutes(List.of(id("RUT:GroupOfRoutes:2")));
 
-    bannedRoutes = RouteRequestTransitDataProviderFilter.bannedRoutes(
-      Set.copyOf(transitRequest.bannedAgencies()),
-      transitRequest.bannedRoutes(),
-      Set.copyOf(transitRequest.whiteListedAgencies()),
-      transitRequest.whiteListedRoutes(),
-      transitRequest.whiteListedGroupsOfRoutes(),
-      transitRequest.bannedGroupsOfRoutes(),
-      routes
-    );
+    bannedRoutes =
+      RouteRequestTransitDataProviderFilter.bannedRoutes(
+        Set.copyOf(transitRequest.bannedAgencies()),
+        transitRequest.bannedRoutes(),
+        Set.copyOf(transitRequest.whiteListedAgencies()),
+        transitRequest.whiteListedRoutes(),
+        transitRequest.whiteListedGroupsOfRoutes(),
+        transitRequest.bannedGroupsOfRoutes(),
+        routes
+      );
 
     assertEquals(2, bannedRoutes.size());
     assertTrue(bannedRoutes.contains(id("RUT:Route:2")));
@@ -155,15 +157,18 @@ public class TestBanning {
     GroupOfRoutes groupOfRoutes2 = GroupOfRoutes.of(id("RUT:GroupOfRoutes:2")).build();
 
     return List.of(
-      TransitModelForTest.route("RUT:Route:1")
+      TransitModelForTest
+        .route("RUT:Route:1")
         .withAgency(agency1)
         .withGroupOfRoutes(List.of(groupOfRoutes1))
         .build(),
-      TransitModelForTest.route("RUT:Route:2")
+      TransitModelForTest
+        .route("RUT:Route:2")
         .withGroupOfRoutes(List.of(groupOfRoutes2))
         .withAgency(agency1)
         .build(),
-      TransitModelForTest.route("RUT:Route:3")
+      TransitModelForTest
+        .route("RUT:Route:3")
         .withGroupOfRoutes(List.of(groupOfRoutes1, groupOfRoutes2))
         .withAgency(agency2)
         .build()


### PR DESCRIPTION
### Summary
This adds functionality together with transmodel api mapping for groups of lines that should be whitelisted or banned during search.

### Issue
closes #4628 

### Unit tests
- Unit tests for new filters

### Documentation
- Transmodel GraphQL documentation for new filters.
