### PR TITLE
Backport deployment of docs to master

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -55,6 +55,45 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: mvn --batch-mode deploy --settings maven-settings.xml -DskipTests -DGITHUB_REPOSITORY=$GITHUB_REPOSITORY -P prettierCheck -P deployGitHub
 
+  docs:
+    if: github.repository_owner == 'opentripplanner' && github.event_name == 'push' && (github.ref == 'refs/heads/dev-2.x' || github.ref == 'refs/heads/master')
+    runs-on: ubuntu-latest
+    needs: build
+    env:
+      REMOTE: docs
+      LOCAL_BRANCH: local-pages
+      REMOTE_BRANCH: main
+      TOKEN: ${{ secrets.CHANGELOG_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v3.1.0
+        with:
+          token: ${{ secrets.CHANGELOG_TOKEN }}
+      - name: Install Python dependencies
+        run: pip install -r docs/requirements.txt
+      - name: Deploy docs to Github pages
+        run: |
+          git config --global user.name 'OTP Bot'
+          git config --global user.email 'bot@opentripplanner.org'
+
+          # mike, the versioning plugin for mkdocs, expects there to be a local branch to push to so
+          # we are cloning one here and commit to it
+          # mike has support for specifing the origin but then it tries to rebase the _local_ gh-pages
+          # branch onto the remote which fails. that's the reason for this git hackery.
+          
+          deploy_version = "dev-2.x"
+          if [ ${{ github.ref }} = 'refs/heads/master' ]; 
+          then
+            deploy_version = "latest"
+          fi
+
+          git remote add $REMOTE https://$TOKEN@github.com/opentripplanner/docs.git 
+          git fetch $REMOTE $REMOTE_BRANCH:$LOCAL_BRANCH
+          # prefix is the root folder where to deploy the HTML, we use 'en' to emulate the URL
+          # structure of readthedocs
+          mike deploy --branch $LOCAL_BRANCH --prefix en ${deploy_version}
+          git push $REMOTE $LOCAL_BRANCH:$REMOTE_BRANCH
+
   container-image:
     if: github.repository_owner == 'opentripplanner' && github.event_name == 'push' && github.ref == 'refs/heads/dev-2.x'
     runs-on: ubuntu-latest

--- a/doc-templates/Configuration.md
+++ b/doc-templates/Configuration.md
@@ -141,7 +141,7 @@ possible to keep parts of the configuration in separate files. To include the co
 use
 `${includeFile:FILE_NAME}`. The `FILE_NAME` must be the name of a file in the configuration
 directory. Relative paths are not supported.
-<p>
+
 To allow both files (the configuration file and the injected file) to be valid JSON files, a special
 case is supported. If the include file directive is quoted, then the quotes are removed, if the 
 text inserted is valid JSON (starts with `{` and ends with `}`). 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -167,7 +167,7 @@ possible to keep parts of the configuration in separate files. To include the co
 use
 `${includeFile:FILE_NAME}`. The `FILE_NAME` must be the name of a file in the configuration
 directory. Relative paths are not supported.
-<p>
+
 To allow both files (the configuration file and the injected file) to be valid JSON files, a special
 case is supported. If the include file directive is quoted, then the quotes are removed, if the 
 text inserted is valid JSON (starts with `{` and ends with `}`). 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,11 +9,31 @@ repo_url: https://github.com/opentripplanner/OpenTripPlanner
 docs_dir: docs
 site_dir: target/mkdocs
 
+theme:
+    name: material
+    features:
+        - toc.integrate
+    palette:
+        primary: blue
+        accent: blue
+        scheme: default
+
+extra:
+    version:
+        provider: mike
+
+markdown_extensions:
+    - pymdownx.highlight:
+          anchor_linenums: true
+    - pymdownx.inlinehilite
+    - pymdownx.snippets
+    - pymdownx.superfences
+
 # MkDocs will automatically discover pages if you don't list them here.
 # In that case subdirectories can be used to organize pages.
 # The list below organizes them into categories and controls the order.
 
-pages:
+nav:
 - Home: 'index.md'
 - About:
     - Governance: 'Governance.md'


### PR DESCRIPTION
This adds the CI configuration to deploy the docs from the master branch. The selected version to deploy it to is `latest` so it will end up at https://docs.opentripplanner.org/en/latest/.

After we have merged this we should also merge it back to dev-2.x.