### PR TITLE
fix: forBoarding and forAlighting on cancelled calls in transmodel api

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/et/EstimatedCallType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/et/EstimatedCallType.java
@@ -221,13 +221,9 @@ public class EstimatedCallType {
           .newFieldDefinition()
           .name("forBoarding")
           .type(new GraphQLNonNull(Scalars.GraphQLBoolean))
-          .description(
-            "Whether vehicle may be boarded at quay according to the planned data. " +
-            "If the cancellation flag is set, boarding is not possible, even if this field " +
-            "is set to true."
-          )
+          .description("Whether vehicle may be boarded at quay.")
           .dataFetcher(environment ->
-            ((TripTimeOnDate) environment.getSource()).getPickupType() != NONE
+            ((TripTimeOnDate) environment.getSource()).getPickupType().isRoutable()
           )
           .build()
       )
@@ -236,13 +232,9 @@ public class EstimatedCallType {
           .newFieldDefinition()
           .name("forAlighting")
           .type(new GraphQLNonNull(Scalars.GraphQLBoolean))
-          .description(
-            "Whether vehicle may be alighted at quay according to the planned data. " +
-            "If the cancellation flag is set, alighting is not possible, even if this field " +
-            "is set to true."
-          )
+          .description("Whether vehicle may be alighted at quay.")
           .dataFetcher(environment ->
-            ((TripTimeOnDate) environment.getSource()).getDropoffType() != NONE
+            ((TripTimeOnDate) environment.getSource()).getDropoffType().isRoutable()
           )
           .build()
       )


### PR DESCRIPTION
### Summary

This is essentially a partial revert of the following commit: https://github.com/opentripplanner/OpenTripPlanner/commit/0afeae15b3a68ff94f49e30733ef5fffb1febdd0. In particular, forBoarding and forAlighting on estimated calls in the transmodel API were forced to be true for cancelled calls. The result is that the values do not reflect the planned data (despite what the documentation said) nor the realtime data (which we would expect from the data in estimated calls). 
