### PR TITLE
Fix empty value management in GraphQL FeedScopeID mapping

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/mapping/TransitIdMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/mapping/TransitIdMapper.java
@@ -48,7 +48,7 @@ public class TransitIdMapper {
   }
 
   public static FeedScopedId mapIDToDomain(String id) {
-    if (id == null) {
+    if (id == null || id.isBlank()) {
       return null;
     }
     if (fixedFeedId != null) {


### PR DESCRIPTION
## PR Instructions

### Summary

As described in #4646, querying a line in the GraphQL API with an empty ID generates a confusing error message.
This PR handles the special case of an empty id so that GraphQL returns a "null" value for such queries.

### Issue

Fixes #4646

### Unit tests

:white_check_mark: 

### Documentation
No


