### PR TITLE
Fix initialization order of FlexConfig

### DIFF
--- a/src/ext-test/java/org/opentripplanner/standalone/config/sandbox/FlexConfigTest.java
+++ b/src/ext-test/java/org/opentripplanner/standalone/config/sandbox/FlexConfigTest.java
@@ -1,0 +1,14 @@
+package org.opentripplanner.standalone.config.sandbox;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class FlexConfigTest {
+
+  @Test
+  void initializationOrder() {
+    assertNotNull(FlexConfig.DEFAULT.maxTransferDuration());
+    assertNotNull(FlexConfig.DEFAULT.maxFlexTripDuration());
+  }
+}

--- a/src/main/java/org/opentripplanner/standalone/config/sandbox/FlexConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/sandbox/FlexConfig.java
@@ -5,17 +5,14 @@ import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2
 
 import java.time.Duration;
 import org.opentripplanner.standalone.config.framework.json.NodeAdapter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class FlexConfig {
-
-  public static final FlexConfig DEFAULT = new FlexConfig();
 
   private static final Duration MAX_TRANSFER_DURATION = Duration.ofMinutes(5);
   private static final Duration MAX_FLEX_TRIP_DURATION = Duration.ofMinutes(45);
 
-  private static final Logger LOG = LoggerFactory.getLogger(FlexConfig.class);
+  // this needs to be instantiated _after_ the defaults are initialized!
+  public static final FlexConfig DEFAULT = new FlexConfig();
 
   private final Duration maxTransferDuration;
   private final Duration maxFlexTripDuration;


### PR DESCRIPTION
### Summary

After #4642 has been merged I started seeing the following error in the newly added flex speed test:

```
 - - - - - - - - - - - - - - - - - - - - - - - - - - [ #37 Des Moines to Hilshire Terrace (transit) ]
- - - - - - - - - - - - - - - - - - - - - - - - - - -  [ #38 Des Moines to Hilshire Terrace (flex) ]
TC 38   FAILED      0 ms  #38 Des Moines - Hilshire Terrace, (-122.30898, 47.3978844, NaN) - (-122.18101501, 47.40648236, NaN), 10:00-()  - Cannot invoke "java.time.Duration.getSeconds()" because the return value of "org.opentripplanner.standalone.config.sandbox.FlexConfig.maxTransferDuration()" is null  (NullPointerException) 
java.lang.NullPointerException: Cannot invoke "java.time.Duration.getSeconds()" because the return value of "org.opentripplanner.standalone.config.sandbox.FlexConfig.maxTransferDuration()" is null
	at org.opentripplanner.ext.flex.template.FlexAccessEgressTemplate.createFlexAccessEgressStream(FlexAccessEgressTemplate.java:98)
	at org.opentripplanner.ext.flex.FlexRouter.lambda$createFlexAccesses$2(FlexRouter.java:152)
	at java.base/java.util.stream.ReferencePipeline$7$1.accept(ReferencePipeline.java:273)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1625)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
	at org.opentripplanner.ext.flex.FlexRouter.createFlexAccesses(FlexRouter.java:153)
	at org.opentripplanner.routing.algorithm.raptoradapter.router.street.FlexAccessEgressRouter.routeAccessEgress(FlexAccessEgressRouter.java:67)
	at org.opentripplanner.routing.algorithm.raptoradapter.router.TransitRouter.getAccessEgresses(TransitRouter.java:228)
	at org.opentripplanner.routing.algorithm.raptoradapter.router.TransitRouter.lambda$getAccessEgresses$0(TransitRouter.java:169)
	at org.opentripplanner.routing.algorithm.raptoradapter.router.TransitRouter.getAccessEgresses(TransitRouter.java:191)
	at org.opentripplanner.routing.algorithm.raptoradapter.router.TransitRouter.route(TransitRouter.java:95)
	at org.opentripplanner.routing.algorithm.raptoradapter.router.TransitRouter.route(TransitRouter.java:73)
	at org.opentripplanner.routing.algorithm.RoutingWorker.routeTransit(RoutingWorker.java:255)
	at org.opentripplanner.routing.algorithm.RoutingWorker.route(RoutingWorker.java:121)
	at org.opentripplanner.routing.RoutingService.route(RoutingService.java:48)
	at org.opentripplanner.transit.speed_test.SpeedTest.runSingleTestCase(SpeedTest.java:252)
	at org.opentripplanner.transit.speed_test.SpeedTest.runSingleTest(SpeedTest.java:219)
	at org.opentripplanner.transit.speed_test.SpeedTest.runTest(SpeedTest.java:172)
	at org.opentripplanner.transit.speed_test.SpeedTest.main(SpeedTest.java:111)
	at org.codehaus.mojo.exec.ExecJavaMojo$1.run(ExecJavaMojo.java:254)
	at java.base/java.lang.Thread.run(Thread.java:833)
```

This is due to a nasty static initialization order bug: the default instance is created before the default variables are initialized.


### Unit tests

Added.