### PR TITLE
Fix batch queries in legacy graphql API

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
@@ -587,6 +587,8 @@ public class LegacyGraphQLQueryTypeImpl
   public DataFetcher<DataFetcherResult<RoutingResponse>> plan() {
     return environment -> {
       LegacyGraphQLRequestContext context = environment.<LegacyGraphQLRequestContext>getContext();
+      // we need to clone the default request as it is request-scoped and this method
+      // can be used by a batch query, causing several invocations to use the same instance
       RouteRequest request = context.getServerContext().defaultRouteRequest().clone();
 
       CallerWithEnvironment callWith = new CallerWithEnvironment(environment);


### PR DESCRIPTION
### Summary

This fixes an issue in the legacy graphql API where batch requests were using the same routingRequest instance.

This happened because the server context is request-scoped but we are creating multiple routing requests per HTTP request.

There is possibly a more robust way of doing that. Lets discuss it.

### Issue

Closes #4496