### PR TITLE
Add new fields to Transmodel API

### DIFF
--- a/src/ext/graphql/transmodelapi/schema.graphql
+++ b/src/ext/graphql/transmodelapi/schema.graphql
@@ -1009,6 +1009,8 @@ type StopPlace implements PlaceInterface {
     "If true only quays with at least one visiting line are included."
     filterByInUse: Boolean = false
   ): [Quay] @timingData
+  "Get all situations active for the stop place. Situations affecting individual quays are not returned, and should be fetched directly from the quay."
+  situations: [PtSituationElement!]!
   tariffZones: [TariffZone]!
   timeZone: String
   "The transport modes of quays under this stop place."

--- a/src/ext/graphql/transmodelapi/schema.graphql
+++ b/src/ext/graphql/transmodelapi/schema.graphql
@@ -1055,10 +1055,14 @@ type TimetabledPassingTime {
   "Scheduled time of departure from quay"
   departure: TimeAndDayOffset
   destinationDisplay: DestinationDisplay
+  "Earliest possible departure time for a service journey with a service window."
+  earliestDepartureTime: TimeAndDayOffset
   "Whether vehicle may be alighted at quay."
   forAlighting: Boolean
   "Whether vehicle may be boarded at quay."
   forBoarding: Boolean
+  "Latest possible (planned) arrival time for a service journey with a service window."
+  latestArrivalTime: TimeAndDayOffset
   notices: [Notice!]!
   quay: Quay
   "Whether vehicle will only stop on request."

--- a/src/ext/graphql/transmodelapi/schema.graphql
+++ b/src/ext/graphql/transmodelapi/schema.graphql
@@ -464,7 +464,7 @@ type PtSituationElement {
   lines: [Line]!
   "Priority of this situation "
   priority: Int
-  quays: [Quay]!
+  quays: [Quay!]!
   "Authority that reported this situation"
   reportAuthority: Authority @deprecated
   "ReportType of this situation"
@@ -474,6 +474,7 @@ type PtSituationElement {
   severity: Severity
   "Operator's internal id for this situation"
   situationNumber: String
+  stopPlaces: [StopPlace!]!
   "Summary of situation in all different translations available"
   summary: [MultilingualString!]!
   "Period this situation is in effect"

--- a/src/ext/graphql/transmodelapi/schema.graphql
+++ b/src/ext/graphql/transmodelapi/schema.graphql
@@ -162,7 +162,7 @@ type EstimatedCall {
   "Whether stop is cancelled. This means that either the ServiceJourney has a planned cancellation, the ServiceJourney has been cancelled by realtime data, or this particular StopPoint has been cancelled. This also means that both boarding and alighting has been cancelled."
   cancellation: Boolean!
   "The date the estimated call is valid for."
-  date: Date
+  date: Date!
   datedServiceJourney: DatedServiceJourney
   destinationDisplay: DestinationDisplay
   "Expected time of arrival at quay. Updated with real time information if available. Will be null if an actualArrivalTime exists"
@@ -177,13 +177,13 @@ type EstimatedCall {
   occupancyStatus: OccupancyStatus!
   "Whether the updated estimates are expected to be inaccurate."
   predictionInaccurate: Boolean!
-  quay: Quay
+  quay: Quay!
   "Whether this call has been updated with real time information."
   realtime: Boolean!
   realtimeState: RealtimeState!
   "Whether vehicle will only stop on request."
   requestStop: Boolean!
-  serviceJourney: ServiceJourney
+  serviceJourney: ServiceJourney!
   "Get all relevant situations for this EstimatedCall."
   situations: [PtSituationElement!]! @timingData
   stopPositionInPattern: Int!
@@ -1061,18 +1061,18 @@ type TimetabledPassingTime {
   "Earliest possible departure time for a service journey with a service window."
   earliestDepartureTime: TimeAndDayOffset
   "Whether vehicle may be alighted at quay."
-  forAlighting: Boolean
+  forAlighting: Boolean!
   "Whether vehicle may be boarded at quay."
-  forBoarding: Boolean
+  forBoarding: Boolean!
   "Latest possible (planned) arrival time for a service journey with a service window."
   latestArrivalTime: TimeAndDayOffset
   notices: [Notice!]!
-  quay: Quay
+  quay: Quay!
   "Whether vehicle will only stop on request."
-  requestStop: Boolean
-  serviceJourney: ServiceJourney
+  requestStop: Boolean!
+  serviceJourney: ServiceJourney!
   "Whether this is a timing point or not. Boarding and alighting is not allowed at timing points."
-  timingPoint: Boolean
+  timingPoint: Boolean!
 }
 
 "Used to specify board and alight slack for a given modes."

--- a/src/ext/java/org/opentripplanner/ext/flex/trip/FlexTrip.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/trip/FlexTrip.java
@@ -57,6 +57,10 @@ public abstract class FlexTrip<T extends FlexTrip<T, B>, B extends FlexTripBuild
     FlexConfig config
   );
 
+  /**
+   * Earliest departure time from fromStopIndex to toStopIndex, which departs after departureTime,
+   * and for which the flex trip has a duration of flexTime seconds.
+   */
   public abstract int earliestDepartureTime(
     int departureTime,
     int fromStopIndex,
@@ -64,12 +68,26 @@ public abstract class FlexTrip<T extends FlexTrip<T, B>, B extends FlexTripBuild
     int flexTime
   );
 
+  /**
+   * Earliest departure time from fromStopIndex.
+   */
+  public abstract int earliestDepartureTime(int stopIndex);
+
+  /**
+   * Latest arrival time to toStopIndex from fromStopIndex, which arrives before arrivalTime,
+   * and for which the flex trip has a duration of flexTime seconds.
+   */
   public abstract int latestArrivalTime(
     int arrivalTime,
     int fromStopIndex,
     int toStopIndex,
     int flexTime
   );
+
+  /**
+   * Latest arrival time to toStopIndex.
+   */
+  public abstract int latestArrivalTime(int stopIndex);
 
   /**
    * Returns all the stops that are in this trip.

--- a/src/ext/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTrip.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/trip/ScheduledDeviatedTrip.java
@@ -169,12 +169,22 @@ public class ScheduledDeviatedTrip
   }
 
   @Override
+  public int earliestDepartureTime(int stopIndex) {
+    return stopTimes[stopIndex].departureTime;
+  }
+
+  @Override
   public int latestArrivalTime(int arrivalTime, int fromStopIndex, int toStopIndex, int flexTime) {
     int stopTime = MISSING_VALUE;
     for (int i = toStopIndex; stopTime == MISSING_VALUE && i < stopTimes.length; i++) {
       stopTime = stopTimes[i].arrivalTime;
     }
     return stopTime != MISSING_VALUE && stopTime <= arrivalTime ? stopTime : -1;
+  }
+
+  @Override
+  public int latestArrivalTime(int stopIndex) {
+    return stopTimes[stopIndex].arrivalTime;
   }
 
   @Override

--- a/src/ext/java/org/opentripplanner/ext/flex/trip/UnscheduledTrip.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/trip/UnscheduledTrip.java
@@ -157,6 +157,11 @@ public class UnscheduledTrip extends FlexTrip<UnscheduledTrip, UnscheduledTripBu
   }
 
   @Override
+  public int earliestDepartureTime(int stopIndex) {
+    return stopTimes[stopIndex].flexWindowStart;
+  }
+
+  @Override
   public int latestArrivalTime(int arrivalTime, int fromStopIndex, int toStopIndex, int flexTime) {
     UnscheduledStopTime fromStopTime = stopTimes[fromStopIndex];
     UnscheduledStopTime toStopTime = stopTimes[toStopIndex];
@@ -168,6 +173,11 @@ public class UnscheduledTrip extends FlexTrip<UnscheduledTrip, UnscheduledTripBu
     }
 
     return Math.min(arrivalTime, toStopTime.flexWindowEnd);
+  }
+
+  @Override
+  public int latestArrivalTime(int stopIndex) {
+    return stopTimes[stopIndex].flexWindowEnd;
   }
 
   @Override

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
@@ -278,6 +278,7 @@ public class TransmodelGraphQLSchema {
     GraphQLNamedOutputType ptSituationElementType = PtSituationElementType.create(
       authorityType,
       quayType,
+      stopPlaceType,
       lineType,
       ServiceJourneyType.REF,
       multilingualStringType,

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
@@ -234,6 +234,7 @@ public class TransmodelGraphQLSchema {
       QuayType.REF,
       tariffZoneType,
       EstimatedCallType.REF,
+      PtSituationElementType.REF,
       gqlUtil
     );
     GraphQLOutputType quayType = QuayType.create(

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/et/EstimatedCallType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/et/EstimatedCallType.java
@@ -14,7 +14,6 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Optional;
 import java.util.Set;
 import org.opentripplanner.ext.transmodelapi.model.EnumTypes;
 import org.opentripplanner.ext.transmodelapi.support.GqlUtil;
@@ -53,7 +52,7 @@ public class EstimatedCallType {
         GraphQLFieldDefinition
           .newFieldDefinition()
           .name("quay")
-          .type(quayType)
+          .type(new GraphQLNonNull(quayType))
           .dataFetcher(environment -> ((TripTimeOnDate) environment.getSource()).getStop())
           .build()
       )
@@ -269,22 +268,16 @@ public class EstimatedCallType {
         GraphQLFieldDefinition
           .newFieldDefinition()
           .name("date")
-          .type(gqlUtil.dateScalar)
+          .type(new GraphQLNonNull(gqlUtil.dateScalar))
           .description("The date the estimated call is valid for.")
-          .dataFetcher(environment ->
-            Optional
-              .of(environment.getSource())
-              .map(TripTimeOnDate.class::cast)
-              .map(TripTimeOnDate::getServiceDay)
-              .orElse(null)
-          )
+          .dataFetcher(environment -> ((TripTimeOnDate) environment.getSource()).getServiceDay())
           .build()
       )
       .field(
         GraphQLFieldDefinition
           .newFieldDefinition()
           .name("serviceJourney")
-          .type(serviceJourneyType)
+          .type(new GraphQLNonNull(serviceJourneyType))
           .dataFetcher(environment -> ((TripTimeOnDate) environment.getSource()).getTrip())
           .build()
       )

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/StopPlaceType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/StopPlaceType.java
@@ -58,6 +58,7 @@ public class StopPlaceType {
     GraphQLOutputType quayType,
     GraphQLOutputType tariffZoneType,
     GraphQLOutputType estimatedCallType,
+    GraphQLOutputType ptSituationElementType,
     GqlUtil gqlUtil
   ) {
     return GraphQLObjectType
@@ -391,6 +392,22 @@ public class StopPlaceType {
               .limit(numberOfDepartures)
               .collect(Collectors.toList());
           })
+          .build()
+      )
+      .field(
+        GraphQLFieldDefinition
+          .newFieldDefinition()
+          .name("situations")
+          .description(
+            "Get all situations active for the stop place. Situations affecting individual quays are not returned, and should be fetched directly from the quay."
+          )
+          .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(ptSituationElementType))))
+          .dataFetcher(env ->
+            GqlUtil
+              .getTransitService(env)
+              .getTransitAlertService()
+              .getStopAlerts(((MonoOrMultiModalStation) env.getSource()).getId())
+          )
           .build()
       )
       .build();

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/StopPlaceType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/StopPlaceType.java
@@ -181,7 +181,7 @@ public class StopPlaceType {
               .map(StopLocation::getNetexVehicleSubmode)
               .filter(it -> it != SubMode.UNKNOWN)
               .map(TransmodelTransportSubmode::fromValue)
-              .collect(Collectors.toList())
+              .collect(Collectors.toSet())
           )
           .build()
       )

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/StopPlaceType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/stop/StopPlaceType.java
@@ -381,14 +381,14 @@ public class StopPlaceType {
                   transitModes,
                   environment
                 )
-              )
-              .sorted(TripTimeOnDate.compareByDeparture())
-              .distinct();
+              );
 
             return limitPerLineAndDestinationDisplay(
               tripTimeOnDateStream,
               departuresPerLineAndDestinationDisplay
             )
+              .sorted(TripTimeOnDate.compareByDeparture())
+              .distinct()
               .limit(numberOfDepartures)
               .collect(Collectors.toList());
           })

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/TimetabledPassingTimeType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/timetable/TimetabledPassingTimeType.java
@@ -36,7 +36,7 @@ public class TimetabledPassingTimeType {
         GraphQLFieldDefinition
           .newFieldDefinition()
           .name("quay")
-          .type(quayType)
+          .type(new GraphQLNonNull(quayType))
           .dataFetcher(environment -> ((TripTimeOnDate) environment.getSource()).getStop())
           .build()
       )
@@ -66,7 +66,7 @@ public class TimetabledPassingTimeType {
         GraphQLFieldDefinition
           .newFieldDefinition()
           .name("timingPoint")
-          .type(Scalars.GraphQLBoolean)
+          .type(new GraphQLNonNull(Scalars.GraphQLBoolean))
           .description(
             "Whether this is a timing point or not. Boarding and alighting is not allowed at timing points."
           )
@@ -77,7 +77,7 @@ public class TimetabledPassingTimeType {
         GraphQLFieldDefinition
           .newFieldDefinition()
           .name("forBoarding")
-          .type(Scalars.GraphQLBoolean)
+          .type(new GraphQLNonNull(Scalars.GraphQLBoolean))
           .description("Whether vehicle may be boarded at quay.")
           .dataFetcher(environment ->
             ((TripTimeOnDate) environment.getSource()).getPickupType() != PickDrop.NONE
@@ -88,7 +88,7 @@ public class TimetabledPassingTimeType {
         GraphQLFieldDefinition
           .newFieldDefinition()
           .name("forAlighting")
-          .type(Scalars.GraphQLBoolean)
+          .type(new GraphQLNonNull(Scalars.GraphQLBoolean))
           .description("Whether vehicle may be alighted at quay.")
           .dataFetcher(environment ->
             ((TripTimeOnDate) environment.getSource()).getDropoffType() != PickDrop.NONE
@@ -99,7 +99,7 @@ public class TimetabledPassingTimeType {
         GraphQLFieldDefinition
           .newFieldDefinition()
           .name("requestStop")
-          .type(Scalars.GraphQLBoolean)
+          .type(new GraphQLNonNull(Scalars.GraphQLBoolean))
           .description("Whether vehicle will only stop on request.")
           .dataFetcher(environment ->
             ((TripTimeOnDate) environment.getSource()).getDropoffType() ==
@@ -149,7 +149,7 @@ public class TimetabledPassingTimeType {
         GraphQLFieldDefinition
           .newFieldDefinition()
           .name("serviceJourney")
-          .type(serviceJourneyType)
+          .type(new GraphQLNonNull(serviceJourneyType))
           .dataFetcher(environment -> ((TripTimeOnDate) environment.getSource()).getTrip())
           .build()
       )


### PR DESCRIPTION
### Summary

Expose:
- Service window for flex in passing times
- StopPlace in SIRI-SX situation
- SIRI-SX situations in StopPlace

Fix two bugs:
- Sort estimated calls for stop place if `numberOfDeparturesPerLineAndDestinationDisplay` is used
- Deduplicate NeTEx submodes in stop places

Improvements
- Make non-nullable fields non-nullable in schema