### PR TITLE
Add entrances to parking lots that are unconnected in OSM

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/issues/ParkAndRideUnlinked.java
+++ b/src/main/java/org/opentripplanner/graph_builder/issues/ParkAndRideUnlinked.java
@@ -6,9 +6,9 @@ import org.opentripplanner.openstreetmap.model.OSMWithTags;
 public class ParkAndRideUnlinked implements DataImportIssue {
 
   public static final String FMT =
-    "Park and ride '%s' (%s) not linked to any streets; it will not be usable.";
+    "Park and ride '%s' (%s) not linked to any streets in OSM; entrance might not be placed correctly.";
   public static final String HTMLFMT =
-    "Park and ride <a href='%s'>'%s' (%s)</a> not linked to any streets; it will not be usable.";
+    "Park and ride <a href='%s'>'%s' (%s)</a> not linked to any streets in OSM; entrance might not be placed correctly.";
 
   final String name;
   final OSMWithTags entity;

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/AreaGroup.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/AreaGroup.java
@@ -71,18 +71,18 @@ class AreaGroup {
     );
     this.union = allPolygons.union();
 
-    if (this.union instanceof GeometryCollection) {
-      GeometryCollection mp = (GeometryCollection) this.union;
+    if (this.union instanceof GeometryCollection coll) {
+      GeometryCollection mp = coll;
       for (int i = 0; i < mp.getNumGeometries(); ++i) {
-        Geometry poly = mp.getGeometryN(i);
-        if (!(poly instanceof Polygon)) {
-          LOG.warn("Unexpected non-polygon when merging areas: {}", poly);
-          continue;
+        Geometry geom = mp.getGeometryN(i);
+        if (geom instanceof Polygon polygon) {
+          outermostRings.add(toRing(polygon, nodeMap));
+        } else {
+          LOG.warn("Unexpected non-polygon when merging areas: {}", geom);
         }
-        outermostRings.add(toRing((Polygon) poly, nodeMap));
       }
-    } else if (this.union instanceof Polygon) {
-      outermostRings.add(toRing((Polygon) this.union, nodeMap));
+    } else if (this.union instanceof Polygon polygon) {
+      outermostRings.add(toRing(polygon, nodeMap));
     } else {
       LOG.warn("Unexpected non-polygon when merging areas: {}", this.union);
     }

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/AreaGroup.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/AreaGroup.java
@@ -40,6 +40,8 @@ class AreaGroup {
    */
   List<Ring> outermostRings = new ArrayList<>();
 
+  public final Geometry union;
+
   public AreaGroup(Collection<Area> areas) {
     this.areas = areas;
 
@@ -64,11 +66,13 @@ class AreaGroup {
       }
     }
     GeometryFactory geometryFactory = GeometryUtils.getGeometryFactory();
-    Geometry u = geometryFactory.createMultiPolygon(allRings.toArray(new Polygon[allRings.size()]));
-    u = u.union();
+    Geometry allPolygons = geometryFactory.createMultiPolygon(
+      allRings.toArray(new Polygon[allRings.size()])
+    );
+    this.union = allPolygons.union();
 
-    if (u instanceof GeometryCollection) {
-      GeometryCollection mp = (GeometryCollection) u;
+    if (this.union instanceof GeometryCollection) {
+      GeometryCollection mp = (GeometryCollection) this.union;
       for (int i = 0; i < mp.getNumGeometries(); ++i) {
         Geometry poly = mp.getGeometryN(i);
         if (!(poly instanceof Polygon)) {
@@ -77,10 +81,10 @@ class AreaGroup {
         }
         outermostRings.add(toRing((Polygon) poly, nodeMap));
       }
-    } else if (u instanceof Polygon) {
-      outermostRings.add(toRing((Polygon) u, nodeMap));
+    } else if (this.union instanceof Polygon) {
+      outermostRings.add(toRing((Polygon) this.union, nodeMap));
     } else {
-      LOG.warn("Unexpected non-polygon when merging areas: {}", u);
+      LOG.warn("Unexpected non-polygon when merging areas: {}", this.union);
     }
   }
 

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/ParkingProcessor.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/ParkingProcessor.java
@@ -12,8 +12,6 @@ import java.util.Set;
 import java.util.function.BiFunction;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Envelope;
-import org.locationtech.jts.geom.Geometry;
-import org.opentripplanner.framework.geometry.GeometryUtils;
 import org.opentripplanner.framework.geometry.WgsCoordinate;
 import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.framework.i18n.LocalizedStringFormat;
@@ -291,12 +289,6 @@ public class ParkingProcessor {
     OSMWithTags entity,
     boolean isCarPark
   ) {
-    var geoms = group.areas.stream().map(a -> a.jtsMultiPolygon).toArray(Geometry[]::new);
-    var centroid = GeometryUtils
-      .getGeometryFactory()
-      .createGeometryCollection(geoms)
-      .getInteriorPoint();
-
     LOG.debug(
       "Creating an artificial entrance for {} as it's not linked to the street network",
       entity.getOpenStreetMapLink()
@@ -310,7 +302,7 @@ public class ParkingProcessor {
           )
         )
         .name(vehicleParkingName)
-        .coordinate(new WgsCoordinate(centroid))
+        .coordinate(new WgsCoordinate(group.union.getInteriorPoint()))
         // setting the vertex to null signals the rest of the build process that this needs to be linked to the street network
         .vertex(null)
         .walkAccessible(true)

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/ParkingProcessor.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/ParkingProcessor.java
@@ -246,13 +246,11 @@ public class ParkingProcessor {
       if (!walkAccessibleOut || !carAccessibleIn || !walkAccessibleIn || !carAccessibleOut) {
         // This will prevent the P+R to be useful.
         issueStore.add(new ParkAndRideUnlinked(creativeName.toString(), entity));
-        return null;
       }
     } else {
       if (!walkAccessibleOut || !walkAccessibleIn) {
         // This will prevent the P+R to be useful.
         issueStore.add(new ParkAndRideUnlinked(creativeName.toString(), entity));
-        return null;
       }
     }
 
@@ -287,6 +285,10 @@ public class ParkingProcessor {
   ) {
     var centroid = area.outermostRings.get(0).jtsPolygon.getCentroid();
 
+    LOG.debug(
+      "Creating an artificial entrance for {} as it's not linked to the street network",
+      entity.getOpenStreetMapLink()
+    );
     return List.of(builder ->
       builder
         .entranceId(

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/ParkingProcessor.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/ParkingProcessor.java
@@ -277,6 +277,12 @@ public class ParkingProcessor {
     return vehicleParking;
   }
 
+  /**
+   * Creates an artificial entrance to a parking facility's centroid.
+   * <p>
+   * This is useful if the facility is not linked to the street network in OSM. Without this method
+   * it would not be usable by the routing algorithm as it's unreachable.
+   */
   private List<VehicleParking.VehicleParkingEntranceCreator> createArtificialEntrances(
     AreaGroup area,
     I18NString vehicleParkingName,

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/ParkingProcessor.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/ParkingProcessor.java
@@ -262,6 +262,10 @@ public class ParkingProcessor {
       entity
     );
 
+    if (entrances.isEmpty()) {
+      entrances = createArtificialEntrances(group, creativeName, entity, isCarParkAndRide);
+    }
+
     var vehicleParking = createVehicleParkingObjectFromOsmEntity(
       isCarParkAndRide,
       envelope.centre(),
@@ -273,6 +277,31 @@ public class ParkingProcessor {
     VehicleParkingHelper.linkVehicleParkingToGraph(graph, vehicleParking);
 
     return vehicleParking;
+  }
+
+  private List<VehicleParking.VehicleParkingEntranceCreator> createArtificialEntrances(
+    AreaGroup area,
+    I18NString vehicleParkingName,
+    OSMWithTags entity,
+    boolean isCarPark
+  ) {
+    var centroid = area.outermostRings.get(0).jtsPolygon.getCentroid();
+
+    return List.of(builder ->
+      builder
+        .entranceId(
+          new FeedScopedId(
+            VEHICLE_PARKING_OSM_FEED_ID,
+            String.format("%s/%d/centroid", entity.getClass().getSimpleName(), entity.getId())
+          )
+        )
+        .name(vehicleParkingName)
+        .coordinate(new WgsCoordinate(centroid))
+        // setting the vertex to null signals the rest of the build process that this needs to be linked to the street network
+        .vertex(null)
+        .walkAccessible(true)
+        .carAccessible(isCarPark)
+    );
   }
 
   private VehicleParking createVehicleParkingObjectFromOsmEntity(

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/ParkingProcessor.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/ParkingProcessor.java
@@ -289,7 +289,7 @@ public class ParkingProcessor {
     OSMWithTags entity,
     boolean isCarPark
   ) {
-    var centroid = area.outermostRings.get(0).jtsPolygon.getCentroid();
+    var centroid = area.jtsMultiPolygon.getInteriorPoint();
 
     LOG.debug(
       "Creating an artificial entrance for {} as it's not linked to the street network",

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/ParkingProcessor.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/ParkingProcessor.java
@@ -12,6 +12,8 @@ import java.util.Set;
 import java.util.function.BiFunction;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Envelope;
+import org.locationtech.jts.geom.Geometry;
+import org.opentripplanner.framework.geometry.GeometryUtils;
 import org.opentripplanner.framework.geometry.WgsCoordinate;
 import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.framework.i18n.LocalizedStringFormat;
@@ -284,12 +286,16 @@ public class ParkingProcessor {
    * it would not be usable by the routing algorithm as it's unreachable.
    */
   private List<VehicleParking.VehicleParkingEntranceCreator> createArtificialEntrances(
-    AreaGroup area,
+    AreaGroup group,
     I18NString vehicleParkingName,
     OSMWithTags entity,
     boolean isCarPark
   ) {
-    var centroid = area.jtsMultiPolygon.getInteriorPoint();
+    var geoms = group.areas.stream().map(a -> a.jtsMultiPolygon).toArray(Geometry[]::new);
+    var centroid = GeometryUtils
+      .getGeometryFactory()
+      .createGeometryCollection(geoms)
+      .getInteriorPoint();
 
     LOG.debug(
       "Creating an artificial entrance for {} as it's not linked to the street network",

--- a/src/test/java/org/opentripplanner/graph_builder/module/osm/UnconnectedAreasTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/osm/UnconnectedAreasTest.java
@@ -45,9 +45,9 @@ public class UnconnectedAreasTest {
     int nParkAndRideLink = gg.getEdgesOfType(StreetVehicleParkingLink.class).size();
     int nParkAndRideEdge = gg.getEdgesOfType(VehicleParkingEdge.class).size();
 
-    assertEquals(11, nParkAndRide);
-    assertEquals(30, nParkAndRideLink);
-    assertEquals(41, nParkAndRideEdge);
+    assertEquals(12, nParkAndRide);
+    assertEquals(38, nParkAndRideLink);
+    assertEquals(42, nParkAndRideEdge);
   }
 
   @Test
@@ -62,9 +62,9 @@ public class UnconnectedAreasTest {
     int nParkAndRideLink = gg.getEdgesOfType(StreetVehicleParkingLink.class).size();
     int nParkAndRideEdge = gg.getEdgesOfType(VehicleParkingEdge.class).size();
 
-    assertEquals(11, nParkAndRideEntrances);
-    assertEquals(24, nParkAndRideLink);
-    assertEquals(31, nParkAndRideEdge);
+    assertEquals(13, nParkAndRideEntrances);
+    assertEquals(32, nParkAndRideLink);
+    assertEquals(33, nParkAndRideEdge);
   }
 
   /**


### PR DESCRIPTION
### Summary

Right now if a parking area is not linked to the street network OTP discards it. However, it's a pretty common occurrence that no entrance ways are mapped.

This PR adds an artificial entrance vertex if none exists in OSM and then lets the street linker do the link to the centroid of the parking facility.

If it turns out that this is an unwanted default I can add a build config parameter.

### Issue

Closes #1562

### Unit tests

Added.