### PR TITLE
Advertise Gitter channel in documentation [ci skip]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,10 +7,10 @@ the contribution process and expectations.
 ## Primary Channels of Communication
 
 If you have any questions about problems you are encountering with code, deployment, documentation,
-or development coordination, please don't hesitate to post to the OpenTripPlanner discussion groups.
-These are Google Groups which can be accessed as web forums or as traditional email mailing lists:
+or development coordination, please don't hesitate to post to the [OpenTripPlanner Gitter chat](https://gitter.im/opentripplanner/OpenTripPlanner)
+or the mailing list. This is the Google Group which can be accessed as web forums or as traditional 
+email mailing lists:
 
-- https://groups.google.com/g/opentripplanner-dev (opentripplanner-dev@googlegroups.com)
 - https://groups.google.com/g/opentripplanner-users (opentripplanner-users@googlegroups.com)
 
 Any message posted there will be seen by most of the contributors, some of whom work on OTP full

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## Overview
 
+[![Join the chat at https://gitter.im/opentripplanner/OpenTripPLanner](https://badges.gitter.im/opentripplanner/OpenTripPlanner.svg)](https://gitter.im/opentripplanner/OpenTripPlanner)
+
 OpenTripPlanner (OTP) is an open source multi-modal trip planner, focusing on travel by scheduled
 public transportation in combination with bicycling, walking, and mobility services including bike
 share and ride hailing. Its server component runs on any platform with a Java virtual machine (

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,14 +57,14 @@ We encourage you to read the introductory sections of this documentation to fami
 with OpenTripPlanner use cases and configuration. But if you want to get started right away running
 your own OTP instance, the best place to start is the [Basic Tutorial](Basic-Tutorial.md) page.
 
-# Contact Info
+# Getting help
 
-Send questions and comments to
-the [user mailing list](http://groups.google.com/group/opentripplanner-users). Discuss internal
-development details on the [dev mailing list](http://groups.google.com/group/opentripplanner-dev).
-File bug reports via the Github [issue tracker](https://github.com/openplans/OpenTripPlanner/issues)
-. Note that the issue tracker is not intended for support questions or discussions. Please post them
-to one of the mailing lists instead.
+The fastest way to get help is to use our [Gitter chat room](https://gitter.im/opentripplanner/OpenTripPlanner)
+where most of the core developers are.
+You can also send questions and comments to the [mailing list](http://groups.google.com/group/opentripplanner-users)
+or file bug reports via the Github [issue tracker](https://github.com/openplans/OpenTripPlanner/issues). 
+Note that the issue tracker is not intended for support questions or discussions. Please use the
+chat or the mailing list instead.
 
 # Financial and In-Kind Support
 


### PR DESCRIPTION
Since we decided in the last PLC meeting that Gitter is now an official channel, we can add it to documentation and project Readme.
