### PR TITLE
Make Prometheus endpoint take Accept header into account

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/actuator/ActuatorAPI.java
+++ b/src/ext/java/org/opentripplanner/ext/actuator/ActuatorAPI.java
@@ -1,7 +1,11 @@
 package org.opentripplanner.ext.actuator;
 
+import static org.apache.http.HttpHeaders.ACCEPT;
+
 import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.prometheus.client.exporter.common.TextFormat;
 import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
@@ -15,7 +19,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Path("/actuators")
-@Produces(MediaType.APPLICATION_JSON) // One @Produces annotation for all endpoints.
 public class ActuatorAPI {
 
   private static final Logger LOG = LoggerFactory.getLogger(ActuatorAPI.class);
@@ -24,6 +27,7 @@ public class ActuatorAPI {
    * List the actuator endpoints available
    */
   @GET
+  @Produces(MediaType.APPLICATION_JSON)
   public Response actuator(@Context UriInfo uriInfo) {
     return Response
       .status(Response.Status.OK)
@@ -58,6 +62,7 @@ public class ActuatorAPI {
    */
   @GET
   @Path("/health")
+  @Produces(MediaType.APPLICATION_JSON)
   public Response health(@Context OtpServerRequestContext serverContext) {
     GraphUpdaterStatus updaterStatus = serverContext.transitService().getUpdaterStatus();
     if (updaterStatus != null) {
@@ -86,13 +91,20 @@ public class ActuatorAPI {
    * Returns micrometer metrics in a prometheus structured format.
    */
   @GET
-  @Produces
   @Path("/prometheus")
-  public Response prometheus(@Context PrometheusMeterRegistry prometheusRegistry) {
+  @Produces({ TextFormat.CONTENT_TYPE_004, TextFormat.CONTENT_TYPE_OPENMETRICS_100 })
+  public Response prometheus(
+    @Context final PrometheusMeterRegistry prometheusRegistry,
+    @HeaderParam(ACCEPT) final String acceptHeader
+  ) {
+    final var contentType = acceptHeader.contains("application/openmetrics-text")
+      ? TextFormat.CONTENT_TYPE_OPENMETRICS_100
+      : TextFormat.CONTENT_TYPE_004;
+
     return Response
       .status(Response.Status.OK)
-      .entity(prometheusRegistry.scrape())
-      .type("text/plain")
+      .entity(prometheusRegistry.scrape(contentType))
+      .type(contentType)
       .build();
   }
 }

--- a/src/ext/java/org/opentripplanner/ext/actuator/ActuatorAPI.java
+++ b/src/ext/java/org/opentripplanner/ext/actuator/ActuatorAPI.java
@@ -86,6 +86,7 @@ public class ActuatorAPI {
    * Returns micrometer metrics in a prometheus structured format.
    */
   @GET
+  @Produces
   @Path("/prometheus")
   public Response prometheus(@Context PrometheusMeterRegistry prometheusRegistry) {
     return Response

--- a/src/ext/java/org/opentripplanner/ext/actuator/ActuatorAPI.java
+++ b/src/ext/java/org/opentripplanner/ext/actuator/ActuatorAPI.java
@@ -4,6 +4,7 @@ import static org.apache.http.HttpHeaders.ACCEPT;
 
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.prometheus.client.exporter.common.TextFormat;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.Path;
@@ -95,7 +96,7 @@ public class ActuatorAPI {
   @Produces({ TextFormat.CONTENT_TYPE_004, TextFormat.CONTENT_TYPE_OPENMETRICS_100 })
   public Response prometheus(
     @Context final PrometheusMeterRegistry prometheusRegistry,
-    @HeaderParam(ACCEPT) final String acceptHeader
+    @HeaderParam(ACCEPT) @DefaultValue("*/*") final String acceptHeader
   ) {
     final var contentType = acceptHeader.contains("application/openmetrics-text")
       ? TextFormat.CONTENT_TYPE_OPENMETRICS_100


### PR DESCRIPTION
### Summary

closes #4673 by adding a wildcard `@Produces` on the `/otp/actuators/prometheus` endpoint method.