### PR TITLE
Date-based tag for container image

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -117,13 +117,13 @@ jobs:
       - name: Build container image with Jib, push to Dockerhub
         run: |
           # we give the container three tags
-          #   - latest
+          #   - "latest"
           #   - the git SHA1
-          #   - a string like "2.3-2022-12-12-21_38"
+          #   - a string like "v2.3_2022-12-12T21-38"
           
           version_with_snapshot=`mvn -q help:evaluate -Dexpression=project.version -q -DforceStdout`
           version=${version_with_snapshot/-SNAPSHOT/}
-          docker_date=`date +%Y-%m-%d-%H_%M`
-          docker_version="$version-$docker_date"
+          image_date=`date +%Y-%m-%dT%H-%M`
+          image_version="v$version-$image_date"
           
-          mvn --batch-mode compile com.google.cloud.tools:jib-maven-plugin:build -Djib.to.tags=latest,${{ github.sha }},$docker_version
+          mvn --batch-mode compile com.google.cloud.tools:jib-maven-plugin:build -Djib.to.tags=latest,${{ github.sha }},$image_version

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -115,4 +115,15 @@ jobs:
           distribution: temurin
           cache: maven
       - name: Build container image with Jib, push to Dockerhub
-        run: mvn --batch-mode compile com.google.cloud.tools:jib-maven-plugin:build -Djib.to.tags=latest,${{ github.sha }}
+        run: |
+          # we give the container three tags
+          #   - latest
+          #   - the git SHA1
+          #   - a string like "2.3-2022-12-12-21_38"
+          
+          version_with_snapshot=`mvn -q help:evaluate -Dexpression=project.version -q -DforceStdout`
+          version=${version_with_snapshot/-SNAPSHOT/}
+          docker_date=`date +%Y-%m-%d-%H_%M`
+          docker_version="$version-$docker_date"
+          
+          mvn --batch-mode compile com.google.cloud.tools:jib-maven-plugin:build -Djib.to.tags=latest,${{ github.sha }},$docker_version


### PR DESCRIPTION
### Summary

This adds a date based tag to the container image uploaded to Dockerhub. It makes it easier to spot from a single glance how old the version is.

An example of the new tag is `v2.3_2022-12-12T21-38`.

Note that this doesn't upload extra images, just extra tags to the registry.