### PR TITLE
Add amenity=ferry terminal to boarding locations

### DIFF
--- a/src/main/java/org/opentripplanner/openstreetmap/model/OSMWithTags.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/model/OSMWithTags.java
@@ -406,6 +406,7 @@ public class OSMWithTags {
       "station".equals(getTag("railway")) ||
       "halt".equals(getTag("railway")) ||
       "bus_station".equals(getTag("amenity")) ||
+      "ferry_terminal".equals(getTag("amenity")) ||
       isPlatform()
     );
   }


### PR DESCRIPTION
### Summary

OSM wiki says: amenity=ferry_terminal is a place where people, cars etc. can board and leave a ferry. This is exactly the purpose of boarding locations in OTP.