### PR TITLE
Replace surface=cobblestone:flattened with surface=set as a mixin spec in default OsmTagMapper

### DIFF
--- a/src/main/java/org/opentripplanner/openstreetmap/tagmapping/DefaultMapper.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/tagmapping/DefaultMapper.java
@@ -569,7 +569,8 @@ class DefaultMapper implements OsmTagMapper {
     props.setMixinProperties("surface=wood", ofBicycleSafety(1.18));
 
     props.setMixinProperties("surface=cobblestone", ofBicycleSafety(1.3));
-    props.setMixinProperties("surface=cobblestone:flattened", ofBicycleSafety(1.3));
+    props.setMixinProperties("surface=sett", ofBicycleSafety(1.3));
+    props.setMixinProperties("surface=unhewn_cobblestone", ofBicycleSafety(1.5));
     props.setMixinProperties("surface=grass_paver", ofBicycleSafety(1.3));
     props.setMixinProperties("surface=pebblestone", ofBicycleSafety(1.3));
     // Can be slick if wet, but otherwise not unfavorable to bikes


### PR DESCRIPTION
### Summary

DefaultMapper use the tag `surface=cobblestone:flattened`. OpenStreetMap wiki sites `surface=cobblestone:flattened` as a possible mistagging of [`surface=sett`](https://wiki.openstreetmap.org/wiki/Tag:surface=sett).
`surface=sett` is used 310 650 times, while `surface=cobblestone:flattened` is only used 5 431 times world wide.

This PR suggest to replace `surface=cobblestone:flattened` with `surface=sett` as a mixin spec, and to add a mixin spec for [`surface=unhewn_cobblestone`](https://wiki.openstreetmap.org/wiki/Tag:surface=unhewn_cobblestone).

Both are tags are already in use in NorwayMapper.