### PR TITLE
Remove micrometer-jersey2 module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -624,11 +624,6 @@
         </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>
-            <artifactId>micrometer-jersey2</artifactId>
-            <version>1.8.11</version>
-        </dependency>
-        <dependency>
-            <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-influx</artifactId>
             <version>${micrometer.version}</version>
             <scope>test</scope>

--- a/src/main/java/org/opentripplanner/standalone/server/OTPWebApplication.java
+++ b/src/main/java/org/opentripplanner/standalone/server/OTPWebApplication.java
@@ -1,8 +1,8 @@
 package org.opentripplanner.standalone.server;
 
 import io.micrometer.core.instrument.Metrics;
-import io.micrometer.jersey2.server.DefaultJerseyTagsProvider;
-import io.micrometer.jersey2.server.MetricsApplicationEventListener;
+import io.micrometer.core.instrument.binder.jersey.server.DefaultJerseyTagsProvider;
+import io.micrometer.core.instrument.binder.jersey.server.MetricsApplicationEventListener;
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import java.util.HashMap;


### PR DESCRIPTION
As of https://github.com/micrometer-metrics/micrometer/commit/e7b03bcb13ee747cd3a1b7964c63dad8e4fa245a this has been moved into micrometer-core.