### PR TITLE
Upgrade dependencies to take newest GTFS Flex spec into account

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,6 @@
         <!-- Lib versions - keep list sorted on property name -->
         <geotools.version>27.1</geotools.version>
         <google.dagger.version>2.44.2</google.dagger.version>
-        <!-- Cannot update Jackson until this is merged: https://github.com/OneBusAway/onebusaway-gtfs-modules/pull/206 -->
         <jackson.version>2.14.0</jackson.version>
         <jersey.version>3.0.9</jersey.version>
         <junit.version>5.9.1</junit.version>
@@ -839,7 +838,7 @@
         <dependency>
             <groupId>org.onebusaway</groupId>
             <artifactId>onebusaway-gtfs</artifactId>
-            <version>1.3.116-SNAPSHOT</version>
+            <version>1.3.116</version>
         </dependency>
         <!-- Processing is used for the debug GUI (though we could probably use just Java2D) -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -872,12 +872,12 @@
         <dependency>
             <groupId>com.graphql-java</groupId>
             <artifactId>graphql-java-extended-scalars</artifactId>
-            <version>19.1</version>
+            <version>${graphql.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.13</version>
+            <version>4.5.14</version>
         </dependency>
         <dependency>
             <groupId>commons-cli</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -742,7 +742,7 @@
             <artifactId>guava</artifactId>
             <version>31.1-jre</version>
         </dependency>
-        <!-- Jersey annontation-driven REST web services (JAX-RS implementation) -->
+        <!-- Jersey annotation-driven REST web services (JAX-RS implementation) -->
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-server</artifactId>
@@ -795,6 +795,15 @@
             <artifactId>jackson-datatype-jsr310</artifactId>
             <version>${jackson.version}</version>
         </dependency>
+        <!--
+            jersey pulls in older versions of this dependency which are binary-incompatible
+            with the latest jackson version, so we need to explicitly define them here
+         -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
 
         <!--
           Google library imports
@@ -830,7 +839,7 @@
         <dependency>
             <groupId>org.onebusaway</groupId>
             <artifactId>onebusaway-gtfs</artifactId>
-            <version>1.3.114</version>
+            <version>1.3.116-SNAPSHOT</version>
         </dependency>
         <!-- Processing is used for the debug GUI (though we could probably use just Java2D) -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -59,18 +59,18 @@
         <otp.serialization.version.id>81</otp.serialization.version.id>
         <!-- Lib versions - keep list sorted on property name -->
         <geotools.version>27.1</geotools.version>
-        <google.dagger.version>2.44</google.dagger.version>
+        <google.dagger.version>2.44.2</google.dagger.version>
         <!-- Cannot update Jackson until this is merged: https://github.com/OneBusAway/onebusaway-gtfs-modules/pull/206 -->
-        <jackson.version>2.13.3</jackson.version>
+        <jackson.version>2.14.0</jackson.version>
         <jersey.version>3.0.9</jersey.version>
         <junit.version>5.9.1</junit.version>
-        <micrometer.version>1.9.5</micrometer.version>
+        <micrometer.version>1.10.2</micrometer.version>
         <netcdf4.version>5.5.2</netcdf4.version>
         <netty.version>4.1.74.Final</netty.version>
         <logback.version>1.4.5</logback.version>
-        <lucene.version>9.4.1</lucene.version>
-        <graphql.version>19.2</graphql.version>
-        <slf4j.version>2.0.3</slf4j.version>
+        <lucene.version>9.4.2</lucene.version>
+        <graphql.version>20.0</graphql.version>
+        <slf4j.version>2.0.5</slf4j.version>
         <netex-java-model.version>2.0.14</netex-java-model.version>
         <siri-java-model.version>1.21</siri-java-model.version>
         <jaxb-runtime.version>3.0.2</jaxb-runtime.version>
@@ -864,7 +864,7 @@
         <dependency>
             <groupId>com.graphql-java</groupId>
             <artifactId>graphql-java-extended-scalars</artifactId>
-            <version>19.0</version>
+            <version>19.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
### Summary

The primary change of this PR is the upgrade of the OneBusAway GTFS import library to take into account a change in the GTFS flex: https://github.com/MobilityData/gtfs-flex/commit/547200dfb580771265ae14b07d9bfd7b91c16ed2

However, since I was working on the POM anyways, I upgraded the other libraries as well. The Jackson update fixes a security warning.

I've run this PR with IBI's smoke test suit and it passes.

cc @miles-grant-ibigroup @demory 