### PR TITLE
Refactor of wayproperty.specifier.Condition

### DIFF
--- a/src/main/java/org/opentripplanner/openstreetmap/model/OSMWay.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/model/OSMWay.java
@@ -92,7 +92,8 @@ public class OSMWay extends OSMWithTags {
    * Returns true if bikes can only go in the reverse direction.
    */
   public boolean isOneWayReverseBicycle() {
-    return "-1".equals(getTag("oneway:bicycle"));
+    String oneWayBicycle = getTag("oneway:bicycle");
+    return "-1".equals(oneWayBicycle) || isTagFalse("bicycle:forward");
   }
 
   /**

--- a/src/main/java/org/opentripplanner/openstreetmap/wayproperty/WayPropertySet.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/wayproperty/WayPropertySet.java
@@ -120,6 +120,7 @@ public class WayPropertySet {
     float forwardSpeed = getCarSpeedForWay(way, false);
     float backSpeed = getCarSpeedForWay(way, true);
     StreetTraversalPermission permission = forwardResult.getPermission();
+    StreetTraversalPermission backwardPermission = backwardResult.getPermission();
 
     WayProperties result = forwardResult
       .mutate()
@@ -129,7 +130,7 @@ public class WayPropertySet {
           : defaultBicycleSafetyForPermission.apply(permission, forwardSpeed),
         backwardResult.getBicycleSafetyFeatures() != null
           ? backwardResult.getBicycleSafetyFeatures().back()
-          : defaultBicycleSafetyForPermission.apply(permission, backSpeed)
+          : defaultBicycleSafetyForPermission.apply(backwardPermission, backSpeed)
       )
       .walkSafety(
         forwardResult.getWalkSafetyFeatures() != null
@@ -137,7 +138,7 @@ public class WayPropertySet {
           : defaultWalkSafetyForPermission.apply(permission, forwardSpeed),
         backwardResult.getWalkSafetyFeatures() != null
           ? backwardResult.getWalkSafetyFeatures().back()
-          : defaultWalkSafetyForPermission.apply(permission, backSpeed)
+          : defaultWalkSafetyForPermission.apply(backwardPermission, backSpeed)
       )
       .build();
 

--- a/src/main/java/org/opentripplanner/openstreetmap/wayproperty/WayPropertySet.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/wayproperty/WayPropertySet.java
@@ -121,6 +121,7 @@ public class WayPropertySet {
     float backSpeed = getCarSpeedForWay(way, true);
     StreetTraversalPermission permission = rightResult.getPermission();
 
+    // TODO: Seems to assume right hand traffic
     WayProperties result = rightResult
       .mutate()
       .bicycleSafety(
@@ -179,7 +180,7 @@ public class WayPropertySet {
   /**
    * Calculate the automobile speed, in meters per second, for this way.
    */
-  public float getCarSpeedForWay(OSMWithTags way, boolean back) {
+  public float getCarSpeedForWay(OSMWithTags way, boolean backward) {
     // first, check for maxspeed tags
     Float speed = null;
     Float currentSpeed;
@@ -187,11 +188,11 @@ public class WayPropertySet {
     if (way.hasTag("maxspeed:motorcar")) speed =
       getMetersSecondFromSpeed(way.getTag("maxspeed:motorcar"));
 
-    if (speed == null && !back && way.hasTag("maxspeed:forward")) speed =
+    if (speed == null && !backward && way.hasTag("maxspeed:forward")) speed =
       getMetersSecondFromSpeed(way.getTag("maxspeed:forward"));
 
-    if (speed == null && back && way.hasTag("maxspeed:reverse")) speed =
-      getMetersSecondFromSpeed(way.getTag("maxspeed:reverse"));
+    if (speed == null && backward && way.hasTag("maxspeed:backward")) speed =
+      getMetersSecondFromSpeed(way.getTag("maxspeed:backward"));
 
     if (speed == null && way.hasTag("maxspeed:lanes")) {
       for (String lane : way.getTag("maxspeed:lanes").split("\\|")) {

--- a/src/main/java/org/opentripplanner/openstreetmap/wayproperty/WayPropertySet.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/wayproperty/WayPropertySet.java
@@ -112,7 +112,7 @@ public class WayPropertySet {
       if (score.backward() > 0) {
         backwardMixins.add(mixin);
       }
-      if (score.backward() > 0) {
+      if (score.forward() > 0) {
         forwardMixins.add(mixin);
       }
     }
@@ -143,10 +143,10 @@ public class WayPropertySet {
 
     /* apply mixins */
     if (backwardMixins.size() > 0) {
-      result = applyMixins(result, backwardMixins, false);
+      result = applyMixins(result, backwardMixins, true);
     }
     if (forwardMixins.size() > 0) {
-      result = applyMixins(result, forwardMixins, true);
+      result = applyMixins(result, forwardMixins, false);
     }
     if (
       (bestBackwardScore == 0 || bestForwardScore == 0) &&
@@ -449,7 +449,7 @@ public class WayPropertySet {
   private WayProperties applyMixins(
     WayProperties result,
     List<MixinProperties> mixins,
-    boolean back
+    boolean backward
   ) {
     SafetyFeatures bicycleSafetyFeatures = result.getBicycleSafetyFeatures();
     double forwardBicycle = bicycleSafetyFeatures.forward();
@@ -458,7 +458,7 @@ public class WayPropertySet {
     double forwardWalk = walkSafetyFeatures.forward();
     double backWalk = walkSafetyFeatures.back();
     for (var mixin : mixins) {
-      if (back) {
+      if (backward) {
         if (mixin.bicycleSafety() != null) {
           backBicycle *= mixin.bicycleSafety().back();
         }

--- a/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/BestMatchSpecifier.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/BestMatchSpecifier.java
@@ -25,7 +25,7 @@ public class BestMatchSpecifier implements OsmSpecifier {
   private final Condition[] conditions;
 
   public BestMatchSpecifier(String spec) {
-    conditions = OsmSpecifier.parseEqualsTests(spec, ";");
+    conditions = OsmSpecifier.parseConditions(spec, ";");
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/BestMatchSpecifier.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/BestMatchSpecifier.java
@@ -30,34 +30,30 @@ public class BestMatchSpecifier implements OsmSpecifier {
 
   @Override
   public Scores matchScores(OSMWithTags way) {
-    int leftScore = 0, rightScore = 0;
-    int leftMatches = 0, rightMatches = 0;
+    int backwardScore = 0, forwardScore = 0;
+    int backwardMatches = 0, forwardMatches = 0;
 
     for (var test : conditions) {
-      var leftMatch = test.matchLeft(way);
-      var rightMatch = test.matchRight(way);
+      var forwardMatch = test.matchForward(way);
+      var backwardMatch = test.matchBackward(way);
 
-      // TODO: Assumes right hand traffic for now, because upstream code does
-      var forwardMatch = leftMatch == Condition.MatchResult.NONE ? test.matchBackward(way) : leftMatch;
-      var backwardMatch = rightMatch == Condition.MatchResult.NONE ? test.matchForward(way) : rightMatch;
-
-      int leftTagScore = toTagScore(forwardMatch);
-      leftScore += leftTagScore;
-      if (leftTagScore > 0) {
-        leftMatches++;
+      int backwardTagScore = toTagScore(backwardMatch);
+      backwardScore += backwardTagScore;
+      if (backwardTagScore > 0) {
+        backwardMatches++;
       }
-      int rightTagScore = toTagScore(backwardMatch);
-      rightScore += rightTagScore;
-      if (rightTagScore > 0) {
-        rightMatches++;
+      int forwardTagScore = toTagScore(forwardMatch);
+      forwardScore += forwardTagScore;
+      if (forwardTagScore > 0) {
+        forwardMatches++;
       }
     }
 
-    int allMatchLeftBonus = (leftMatches == conditions.length) ? 10 : 0;
-    leftScore += allMatchLeftBonus;
-    int allMatchRightBonus = (rightMatches == conditions.length) ? 10 : 0;
-    rightScore += allMatchRightBonus;
-    return new Scores(leftScore, rightScore);
+    int allMatchBackwardBonus = (backwardMatches == conditions.length) ? 10 : 0;
+    backwardScore += allMatchBackwardBonus;
+    int allMatchForwardBonus = (forwardMatches == conditions.length) ? 10 : 0;
+    forwardScore += allMatchForwardBonus;
+    return new Scores(forwardScore, backwardScore);
   }
 
   @Override

--- a/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/BestMatchSpecifier.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/BestMatchSpecifier.java
@@ -21,7 +21,6 @@ public class BestMatchSpecifier implements OsmSpecifier {
    */
   public static final int EXACT_MATCH_SCORE = 100;
   public static final int WILDCARD_MATCH_SCORE = 1;
-  public static final int PREFIX_MATCH_SCORE = 75;
   public static final int NO_MATCH_SCORE = 0;
   private final Condition[] conditions;
 
@@ -89,8 +88,6 @@ public class BestMatchSpecifier implements OsmSpecifier {
       case EXACT -> EXACT_MATCH_SCORE;
       // wildcard matches are basically tiebreakers
       case WILDCARD -> WILDCARD_MATCH_SCORE;
-      // if the test says surface=cobblestone:flattened but the way has surface=cobblestone
-      case PREFIX -> PREFIX_MATCH_SCORE;
       // no match means no score
       case NONE -> NO_MATCH_SCORE;
     };

--- a/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/BestMatchSpecifier.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/BestMatchSpecifier.java
@@ -37,12 +37,16 @@ public class BestMatchSpecifier implements OsmSpecifier {
       var leftMatch = test.matchLeft(way);
       var rightMatch = test.matchRight(way);
 
-      int leftTagScore = toTagScore(leftMatch);
+      // TODO: Assumes right hand traffic for now, because upstream code does
+      var forwardMatch = leftMatch == Condition.MatchResult.NONE ? test.matchBackward(way) : leftMatch;
+      var backwardMatch = rightMatch == Condition.MatchResult.NONE ? test.matchForward(way) : rightMatch;
+
+      int leftTagScore = toTagScore(forwardMatch);
       leftScore += leftTagScore;
       if (leftTagScore > 0) {
         leftMatches++;
       }
-      int rightTagScore = toTagScore(rightMatch);
+      int rightTagScore = toTagScore(backwardMatch);
       rightScore += rightTagScore;
       if (rightTagScore > 0) {
         rightMatches++;

--- a/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/Condition.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/Condition.java
@@ -169,4 +169,17 @@ public sealed interface Condition {
       return Arrays.stream(values).anyMatch(value -> way.matchesKeyValue(opKey, value));
     }
   }
+  record EqualsAnyInOrAbsent(String key, String... values) implements Condition {
+
+    /* A use case for this is to detect the absence of a sidewalk, cycle lane or verge*/
+    public EqualsAnyInOrAbsent(String key) {
+      this(key, "no", "none");
+    }
+    
+    @Override
+    public boolean getMatches(OSMWithTags way, String opKey) {
+      return !way.hasTag(opKey) ||
+        Arrays.stream(values).anyMatch(value -> way.matchesKeyValue(opKey, value));
+    }
+  }
 }

--- a/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/Condition.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/Condition.java
@@ -13,15 +13,6 @@ public sealed interface Condition {
       return MatchResult.WILDCARD;
     } else if (way.matchesKeyValue(opKey, opValue)) {
       return EXACT;
-    } else if (opValue.contains(":")) {
-      // treat cases like cobblestone:flattened as cobblestone if a more-specific match
-      // does not apply
-      var splitValue = opValue.split(":", 2)[0];
-      if (way.matchesKeyValue(opKey, splitValue)) {
-        return MatchResult.PREFIX;
-      } else {
-        return NONE;
-      }
     } else {
       return NONE;
     }
@@ -61,7 +52,6 @@ public sealed interface Condition {
 
   enum MatchResult {
     EXACT,
-    PREFIX,
     WILDCARD,
     NONE;
 

--- a/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/Condition.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/Condition.java
@@ -14,6 +14,9 @@ public sealed interface Condition {
     return getMatches(way, this.key());
   }
 
+  default MatchResult matchType() {
+    return EXACT;
+  }
   String key();
 
   /**
@@ -41,7 +44,7 @@ public sealed interface Condition {
    * required but `cycleway:left=lane` should match.
    */
   default MatchResult matchLeft(OSMWithTags way) {
-    return matchesLeft(way) ? EXACT : NONE;
+    return matchesLeft(way) ? matchType() : NONE;
   }
 
   default boolean matchesRight(OSMWithTags way) {
@@ -61,7 +64,7 @@ public sealed interface Condition {
    * required but `cycleway:right=lane` should match.
    */
   default MatchResult matchRight(OSMWithTags way) {
-    return matchesRight(way) ? EXACT: NONE;
+    return matchesRight(way) ? matchType(): NONE;
   }
 
   /**
@@ -75,6 +78,25 @@ public sealed interface Condition {
     } else {
       return matches(way);
     }
+  }
+
+  default boolean matchesForward(OSMWithTags way) {
+    var forwardKey = this.key() + ":forward";
+    return getMatches(way, forwardKey);
+  }
+
+  default MatchResult matchForward(OSMWithTags way) {
+    return matchesForward(way) ? matchType(): NONE;
+  }
+
+
+  default boolean matchesBackward(OSMWithTags way) {
+    var BackwardKey = this.key() + ":backward";
+    return getMatches(way, BackwardKey);
+  }
+
+  default MatchResult matchBackward(OSMWithTags way) {
+    return matchesBackward(way) ? matchType(): NONE;
   }
 
   enum MatchResult {
@@ -92,19 +114,9 @@ public sealed interface Condition {
 
   record Present(String key) implements Condition {
     @Override
-    public MatchResult match(OSMWithTags way) {
-      return matches(way) ? WILDCARD : NONE;
+    public MatchResult matchType() {
+      return WILDCARD;
     }
-    @Override
-    public MatchResult matchLeft(OSMWithTags way) {
-      return matchesLeft(way) ? WILDCARD : NONE;
-    }
-
-    @Override
-    public MatchResult matchRight(OSMWithTags way) {
-      return matchesRight(way) ? WILDCARD : NONE;
-    }
-
     @Override
     public boolean getMatches(OSMWithTags way, String opKey) {
       return way.hasTag(opKey);

--- a/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/Condition.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/Condition.java
@@ -8,24 +8,24 @@ import java.util.Arrays;
 import org.opentripplanner.openstreetmap.model.OSMWithTags;
 
 public sealed interface Condition {
-  boolean getMatches(OSMWithTags way, String opKey);
-
-  default boolean matches(OSMWithTags way) {
-    return getMatches(way, this.key());
-  }
+  String key();
 
   default MatchResult matchType() {
     return EXACT;
   }
 
-  String key();
+  boolean isExtendedKeyMatch(OSMWithTags way, String exKey);
 
   /**
    * Test to what degree the OSM entity matches with this operation when taking the regular tag keys
    * into account.
    */
+  default boolean isMatch(OSMWithTags way) {
+    return isExtendedKeyMatch(way, this.key());
+  }
+
   default MatchResult match(OSMWithTags way) {
-    return matches(way) ? EXACT : NONE;
+    return isMatch(way) ? matchType() : NONE;
   }
 
   /**
@@ -35,12 +35,12 @@ public sealed interface Condition {
    * For example, it should not match a way with `cycleway:right=lane` when the `cycleway=lane` was
    * required but `cycleway:left=lane` should match.
    */
-  default boolean matchesLeft(OSMWithTags way) {
+  default boolean isLeftMatch(OSMWithTags way) {
     var leftKey = this.key() + ":left";
     if (way.hasTag(leftKey)) {
-      return getMatches(way, leftKey);
+      return isExtendedKeyMatch(way, leftKey);
     } else {
-      return matchesExplicitBoth(way);
+      return isExplicitBothMatch(way);
     }
   }
 
@@ -51,12 +51,12 @@ public sealed interface Condition {
    * For example, it should not match a way with `cycleway:left=lane` when the `cycleway=lane` was
    * required but `cycleway:right=lane` should match.
    */
-  default boolean matchesRight(OSMWithTags way) {
+  default boolean isRightMatch(OSMWithTags way) {
     var rightKey = this.key() + ":right";
     if (way.hasTag(rightKey)) {
-      return getMatches(way, rightKey);
+      return isExtendedKeyMatch(way, rightKey);
     } else {
-      return matchesExplicitBoth(way);
+      return isExplicitBothMatch(way);
     }
   }
 
@@ -64,41 +64,41 @@ public sealed interface Condition {
    * Test to what degree the OSM entity matches with this operation when taking the ':both' key
    * suffixes into account.
    */
-  default boolean matchesExplicitBoth(OSMWithTags way) {
+  default boolean isExplicitBothMatch(OSMWithTags way) {
     var bothKey = this.key() + ":both";
     if (way.hasTag(bothKey)) {
-      return getMatches(way, bothKey);
+      return isExtendedKeyMatch(way, bothKey);
     } else {
-      return matches(way);
+      return isMatch(way);
     }
   }
 
-  default boolean matchesForward(OSMWithTags way) {
+  default boolean isForwardMatch(OSMWithTags way) {
     var forwardKey = this.key() + ":forward";
     if (way.hasTag(forwardKey)) {
-      return getMatches(way, forwardKey);
+      return isExtendedKeyMatch(way, forwardKey);
     } else {
       /* Assumes right hand traffic */
-      return matchesRight(way);
+      return isRightMatch(way);
     }
   }
 
   default MatchResult matchForward(OSMWithTags way) {
-    return matchesForward(way) ? matchType() : NONE;
+    return isForwardMatch(way) ? matchType() : NONE;
   }
 
-  default boolean matchesBackward(OSMWithTags way) {
+  default boolean isBackwardMatch(OSMWithTags way) {
     var backwardKey = this.key() + ":backward";
     if (way.hasTag(backwardKey)) {
-      return getMatches(way, backwardKey);
+      return isExtendedKeyMatch(way, backwardKey);
     } else {
       /* Assumes right hand traffic */
-      return matchesLeft(way);
+      return isLeftMatch(way);
     }
   }
 
   default MatchResult matchBackward(OSMWithTags way) {
-    return matchesBackward(way) ? matchType() : NONE;
+    return isBackwardMatch(way) ? matchType() : NONE;
   }
 
   enum MatchResult {
@@ -109,8 +109,8 @@ public sealed interface Condition {
 
   record Equals(String key, String value) implements Condition {
     @Override
-    public boolean getMatches(OSMWithTags way, String opKey) {
-      return way.hasTag(opKey) && way.matchesKeyValue(opKey, value);
+    public boolean isExtendedKeyMatch(OSMWithTags way, String exKey) {
+      return way.hasTag(exKey) && way.matchesKeyValue(exKey, value);
     }
   }
 
@@ -120,33 +120,30 @@ public sealed interface Condition {
       return WILDCARD;
     }
     @Override
-    public boolean getMatches(OSMWithTags way, String opKey) {
-      return way.hasTag(opKey);
+    public boolean isExtendedKeyMatch(OSMWithTags way, String exKey) {
+      return way.hasTag(exKey);
     }
   }
 
   record Absent(String key) implements Condition {
-    public MatchResult matchType() {
-      return WILDCARD;
-    }
     @Override
-    public boolean getMatches(OSMWithTags way, String opKey) {
-      return !way.hasTag(opKey);
+    public boolean isExtendedKeyMatch(OSMWithTags way, String exKey) {
+      return !way.hasTag(exKey);
     }
   }
 
   record GreaterThan(String key, int value) implements Condition {
     @Override
-    public boolean getMatches(OSMWithTags way, String opKey) {
-      var maybeInt = way.getTagAsInt(opKey, ignored -> {});
+    public boolean isExtendedKeyMatch(OSMWithTags way, String exKey) {
+      var maybeInt = way.getTagAsInt(exKey, ignored -> {});
       return maybeInt.isPresent() && maybeInt.getAsInt() > value;
     }
   }
 
   record LessThan(String key, int value) implements Condition {
     @Override
-    public boolean getMatches(OSMWithTags way, String opKey) {
-      var maybeInt = way.getTagAsInt(opKey, ignored -> {});
+    public boolean isExtendedKeyMatch(OSMWithTags way, String exKey) {
+      var maybeInt = way.getTagAsInt(exKey, ignored -> {});
       return maybeInt.isPresent() && maybeInt.getAsInt() < value;
     }
   }
@@ -159,16 +156,16 @@ public sealed interface Condition {
     }
 
     @Override
-    public boolean getMatches(OSMWithTags way, String opKey) {
-      var maybeInt = way.getTagAsInt(opKey, ignored -> {});
+    public boolean isExtendedKeyMatch(OSMWithTags way, String exKey) {
+      var maybeInt = way.getTagAsInt(exKey, ignored -> {});
       return maybeInt.isPresent() && maybeInt.getAsInt() >= lower && maybeInt.getAsInt() <= upper;
     }
   }
 
   record EqualsAnyIn(String key, String... values) implements Condition {
     @Override
-    public boolean getMatches(OSMWithTags way, String opKey) {
-      return Arrays.stream(values).anyMatch(value -> way.matchesKeyValue(opKey, value));
+    public boolean isExtendedKeyMatch(OSMWithTags way, String exKey) {
+      return Arrays.stream(values).anyMatch(value -> way.matchesKeyValue(exKey, value));
     }
   }
 
@@ -179,10 +176,10 @@ public sealed interface Condition {
     }
 
     @Override
-    public boolean getMatches(OSMWithTags way, String opKey) {
+    public boolean isExtendedKeyMatch(OSMWithTags way, String exKey) {
       return (
-        !way.hasTag(opKey) ||
-        Arrays.stream(values).anyMatch(value -> way.matchesKeyValue(opKey, value))
+        !way.hasTag(exKey) ||
+        Arrays.stream(values).anyMatch(value -> way.matchesKeyValue(exKey, value))
       );
     }
   }

--- a/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/Condition.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/Condition.java
@@ -124,6 +124,9 @@ public sealed interface Condition {
   }
 
   record Absent(String key) implements Condition {
+    public MatchResult matchType() {
+      return WILDCARD;
+    }
     @Override
     public boolean getMatches(OSMWithTags way, String opKey) {
       return !way.hasTag(opKey);

--- a/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/Condition.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/Condition.java
@@ -88,9 +88,9 @@ public sealed interface Condition {
   }
 
   default boolean matchesBackward(OSMWithTags way) {
-    var BackwardKey = this.key() + ":backward";
-    if (way.hasTag(BackwardKey)) {
-      return getMatches(way, BackwardKey);
+    var backwardKey = this.key() + ":backward";
+    if (way.hasTag(backwardKey)) {
+      return getMatches(way, backwardKey);
     } else {
       /* Assumes right hand traffic */
       return matchesLeft(way);

--- a/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/Condition.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/Condition.java
@@ -27,15 +27,6 @@ public sealed interface Condition {
     return matches(way) ? EXACT : NONE;
   }
 
-  default boolean matchesLeft(OSMWithTags way) {
-    var leftKey = this.key() + ":left";
-    if (way.hasTag(leftKey)) {
-      return getMatches(way, leftKey);
-    } else {
-      return matchesExplicitBoth(way);
-    }
-  }
-
   /**
    * Test to what degree the OSM entity matches with this operation when taking the ':left' key
    * suffixes into account.
@@ -43,14 +34,10 @@ public sealed interface Condition {
    * For example, it should not match a way with `cycleway:right=lane` when the `cycleway=lane` was
    * required but `cycleway:left=lane` should match.
    */
-  default MatchResult matchLeft(OSMWithTags way) {
-    return matchesLeft(way) ? matchType() : NONE;
-  }
-
-  default boolean matchesRight(OSMWithTags way) {
-    var rightKey = this.key() + ":right";
-    if (way.hasTag(rightKey)) {
-      return getMatches(way, rightKey);
+  default boolean matchesLeft(OSMWithTags way) {
+    var leftKey = this.key() + ":left";
+    if (way.hasTag(leftKey)) {
+      return getMatches(way, leftKey);
     } else {
       return matchesExplicitBoth(way);
     }
@@ -63,8 +50,13 @@ public sealed interface Condition {
    * For example, it should not match a way with `cycleway:left=lane` when the `cycleway=lane` was
    * required but `cycleway:right=lane` should match.
    */
-  default MatchResult matchRight(OSMWithTags way) {
-    return matchesRight(way) ? matchType(): NONE;
+  default boolean matchesRight(OSMWithTags way) {
+    var rightKey = this.key() + ":right";
+    if (way.hasTag(rightKey)) {
+      return getMatches(way, rightKey);
+    } else {
+      return matchesExplicitBoth(way);
+    }
   }
 
   /**
@@ -82,17 +74,26 @@ public sealed interface Condition {
 
   default boolean matchesForward(OSMWithTags way) {
     var forwardKey = this.key() + ":forward";
-    return getMatches(way, forwardKey);
+    if (way.hasTag(forwardKey)) {
+      return getMatches(way, forwardKey);
+    } else {
+      /* Assumes right hand traffic */
+      return matchesRight(way);
+    }
   }
 
   default MatchResult matchForward(OSMWithTags way) {
     return matchesForward(way) ? matchType(): NONE;
   }
 
-
   default boolean matchesBackward(OSMWithTags way) {
     var BackwardKey = this.key() + ":backward";
-    return getMatches(way, BackwardKey);
+    if (way.hasTag(BackwardKey)) {
+      return getMatches(way, BackwardKey);
+    } else {
+      /* Assumes right hand traffic */
+      return matchesLeft(way);
+    }
   }
 
   default MatchResult matchBackward(OSMWithTags way) {

--- a/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/Condition.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/Condition.java
@@ -17,6 +17,7 @@ public sealed interface Condition {
   default MatchResult matchType() {
     return EXACT;
   }
+
   String key();
 
   /**
@@ -83,7 +84,7 @@ public sealed interface Condition {
   }
 
   default MatchResult matchForward(OSMWithTags way) {
-    return matchesForward(way) ? matchType(): NONE;
+    return matchesForward(way) ? matchType() : NONE;
   }
 
   default boolean matchesBackward(OSMWithTags way) {
@@ -97,13 +98,13 @@ public sealed interface Condition {
   }
 
   default MatchResult matchBackward(OSMWithTags way) {
-    return matchesBackward(way) ? matchType(): NONE;
+    return matchesBackward(way) ? matchType() : NONE;
   }
 
   enum MatchResult {
     EXACT,
     WILDCARD,
-    NONE
+    NONE,
   }
 
   record Equals(String key, String value) implements Condition {
@@ -170,17 +171,19 @@ public sealed interface Condition {
       return Arrays.stream(values).anyMatch(value -> way.matchesKeyValue(opKey, value));
     }
   }
-  record EqualsAnyInOrAbsent(String key, String... values) implements Condition {
 
+  record EqualsAnyInOrAbsent(String key, String... values) implements Condition {
     /* A use case for this is to detect the absence of a sidewalk, cycle lane or verge*/
     public EqualsAnyInOrAbsent(String key) {
       this(key, "no", "none");
     }
-    
+
     @Override
     public boolean getMatches(OSMWithTags way, String opKey) {
-      return !way.hasTag(opKey) ||
-        Arrays.stream(values).anyMatch(value -> way.matchesKeyValue(opKey, value));
+      return (
+        !way.hasTag(opKey) ||
+        Arrays.stream(values).anyMatch(value -> way.matchesKeyValue(opKey, value))
+      );
     }
   }
 }

--- a/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/Condition.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/Condition.java
@@ -16,10 +16,6 @@ public sealed interface Condition {
 
   String key();
 
-  default boolean isWildcard() {
-    return false;
-  }
-
   /**
    * Test to what degree the OSM entity matches with this operation when taking the regular tag keys
    * into account.
@@ -95,8 +91,6 @@ public sealed interface Condition {
   }
 
   record Present(String key) implements Condition {
-    public boolean isWildcard() {return true;}
-
     @Override
     public MatchResult match(OSMWithTags way) {
       return matches(way) ? WILDCARD : NONE;

--- a/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/Condition.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/Condition.java
@@ -4,6 +4,7 @@ import static org.opentripplanner.openstreetmap.wayproperty.specifier.Condition.
 import static org.opentripplanner.openstreetmap.wayproperty.specifier.Condition.MatchResult.NONE;
 import static org.opentripplanner.openstreetmap.wayproperty.specifier.Condition.MatchResult.WILDCARD;
 
+import java.util.Arrays;
 import org.opentripplanner.openstreetmap.model.OSMWithTags;
 
 public sealed interface Condition {
@@ -136,6 +137,27 @@ public sealed interface Condition {
     public boolean getMatches(OSMWithTags way, String opKey) {
       var maybeInt = way.getTagAsInt(opKey, ignored -> {});
       return maybeInt.isPresent() && maybeInt.getAsInt() < value;
+    }
+  }
+
+  record InclusiveRange(String key, int upper, int lower) implements Condition {
+    public InclusiveRange {
+      if (upper < lower) {
+        throw new IllegalArgumentException("Upper bound is lower than lower bound");
+      }
+    }
+
+    @Override
+    public boolean getMatches(OSMWithTags way, String opKey) {
+      var maybeInt = way.getTagAsInt(opKey, ignored -> {});
+      return maybeInt.isPresent() && maybeInt.getAsInt() >= lower && maybeInt.getAsInt() <= upper;
+    }
+  }
+
+  record EqualsAnyIn(String key, String... values) implements Condition {
+    @Override
+    public boolean getMatches(OSMWithTags way, String opKey) {
+      return Arrays.stream(values).anyMatch(value -> way.matchesKeyValue(opKey, value));
     }
   }
 }

--- a/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/ExactMatchSpecifier.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/ExactMatchSpecifier.java
@@ -34,11 +34,6 @@ public class ExactMatchSpecifier implements OsmSpecifier {
 
   public ExactMatchSpecifier(Condition... conditions) {
     this.conditions = Arrays.asList(conditions);
-    if (this.conditions.stream().anyMatch(Condition::isWildcard)) {
-      throw new IllegalArgumentException(
-        "Wildcards are not allowed in %s".formatted(this.getClass().getSimpleName())
-      );
-    }
     bestMatchScore = this.conditions.size() * MATCH_MULTIPLIER;
   }
 

--- a/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/ExactMatchSpecifier.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/ExactMatchSpecifier.java
@@ -44,7 +44,11 @@ public class ExactMatchSpecifier implements OsmSpecifier {
 
   @Override
   public Scores matchScores(OSMWithTags way) {
-    return Scores.of(matchScore(way));
+
+    return new Scores(
+      allLeftSidedTagsMatch(way) ? bestMatchScore : NO_MATCH_SCORE,
+      allRightSidedTagsMatch(way) ? bestMatchScore : NO_MATCH_SCORE
+    );
   }
 
   @Override
@@ -58,6 +62,14 @@ public class ExactMatchSpecifier implements OsmSpecifier {
 
   public boolean allTagsMatch(OSMWithTags way) {
     return conditions.stream().allMatch(o -> o.matches(way));
+  }
+
+  public boolean allLeftSidedTagsMatch(OSMWithTags way) {
+    return conditions.stream().allMatch(c -> c.matchesLeft(way));
+  }
+
+  public boolean allRightSidedTagsMatch(OSMWithTags way) {
+    return conditions.stream().allMatch(c -> c.matchesRight(way));
   }
 
   public static ExactMatchSpecifier exact(String spec) {

--- a/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/ExactMatchSpecifier.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/ExactMatchSpecifier.java
@@ -29,7 +29,7 @@ public class ExactMatchSpecifier implements OsmSpecifier {
   private final int bestMatchScore;
 
   public ExactMatchSpecifier(String spec) {
-    this(OsmSpecifier.parseEqualsTests(spec, ";"));
+    this(OsmSpecifier.parseConditions(spec, ";"));
   }
 
   public ExactMatchSpecifier(Condition... conditions) {

--- a/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/ExactMatchSpecifier.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/ExactMatchSpecifier.java
@@ -41,8 +41,8 @@ public class ExactMatchSpecifier implements OsmSpecifier {
   public Scores matchScores(OSMWithTags way) {
 
     return new Scores(
-      allLeftSidedTagsMatch(way) ? bestMatchScore : NO_MATCH_SCORE,
-      allRightSidedTagsMatch(way) ? bestMatchScore : NO_MATCH_SCORE
+      allForwardTagsMatch(way) ? bestMatchScore : NO_MATCH_SCORE,
+      allBackwardTagsMatch(way) ? bestMatchScore : NO_MATCH_SCORE
     );
   }
 
@@ -59,14 +59,12 @@ public class ExactMatchSpecifier implements OsmSpecifier {
     return conditions.stream().allMatch(o -> o.matches(way));
   }
 
-  public boolean allLeftSidedTagsMatch(OSMWithTags way) {
-    // TODO: Assumes right hand traffic for now, because upstream code does
-    return conditions.stream().allMatch(c -> c.matchesLeft(way) || c.matchesBackward(way));
+  public boolean allBackwardTagsMatch(OSMWithTags way) {
+    return conditions.stream().allMatch(c -> c.matchesBackward(way));
   }
 
-  public boolean allRightSidedTagsMatch(OSMWithTags way) {
-    // TODO: Assumes right hand traffic for now, because upstream code does
-    return conditions.stream().allMatch(c -> c.matchesRight(way) || c.matchesForward(way));
+  public boolean allForwardTagsMatch(OSMWithTags way) {
+    return conditions.stream().allMatch(c -> c.matchesForward(way));
   }
 
   public static ExactMatchSpecifier exact(String spec) {

--- a/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/ExactMatchSpecifier.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/ExactMatchSpecifier.java
@@ -55,15 +55,15 @@ public class ExactMatchSpecifier implements OsmSpecifier {
   }
 
   public boolean allTagsMatch(OSMWithTags way) {
-    return conditions.stream().allMatch(o -> o.matches(way));
+    return conditions.stream().allMatch(o -> o.isMatch(way));
   }
 
   public boolean allBackwardTagsMatch(OSMWithTags way) {
-    return conditions.stream().allMatch(c -> c.matchesBackward(way));
+    return conditions.stream().allMatch(c -> c.isBackwardMatch(way));
   }
 
   public boolean allForwardTagsMatch(OSMWithTags way) {
-    return conditions.stream().allMatch(c -> c.matchesForward(way));
+    return conditions.stream().allMatch(c -> c.isForwardMatch(way));
   }
 
   public static ExactMatchSpecifier exact(String spec) {

--- a/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/ExactMatchSpecifier.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/ExactMatchSpecifier.java
@@ -60,11 +60,13 @@ public class ExactMatchSpecifier implements OsmSpecifier {
   }
 
   public boolean allLeftSidedTagsMatch(OSMWithTags way) {
-    return conditions.stream().allMatch(c -> c.matchesLeft(way));
+    // TODO: Assumes right hand traffic for now, because upstream code does
+    return conditions.stream().allMatch(c -> c.matchesLeft(way) || c.matchesBackward(way));
   }
 
   public boolean allRightSidedTagsMatch(OSMWithTags way) {
-    return conditions.stream().allMatch(c -> c.matchesRight(way));
+    // TODO: Assumes right hand traffic for now, because upstream code does
+    return conditions.stream().allMatch(c -> c.matchesRight(way) || c.matchesForward(way));
   }
 
   public static ExactMatchSpecifier exact(String spec) {

--- a/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/ExactMatchSpecifier.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/ExactMatchSpecifier.java
@@ -39,7 +39,6 @@ public class ExactMatchSpecifier implements OsmSpecifier {
 
   @Override
   public Scores matchScores(OSMWithTags way) {
-
     return new Scores(
       allForwardTagsMatch(way) ? bestMatchScore : NO_MATCH_SCORE,
       allBackwardTagsMatch(way) ? bestMatchScore : NO_MATCH_SCORE

--- a/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/OsmSpecifier.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/OsmSpecifier.java
@@ -10,15 +10,19 @@ import org.opentripplanner.openstreetmap.model.OSMWithTags;
  * How the scoring logic is implemented is the responsibility of the implementations.
  */
 public interface OsmSpecifier {
-  static Condition.Equals[] parseEqualsTests(String spec, String separator) {
+  static Condition[] parseEqualsTests(String spec, String separator) {
     return Arrays
       .stream(spec.split(separator))
       .filter(p -> !p.isEmpty())
       .map(pair -> {
         var kv = pair.split("=");
-        return new Condition.Equals(kv[0].toLowerCase(), kv[1].toLowerCase());
+        if (kv[1].equals("*")) {
+          return new Condition.Present(kv[0].toLowerCase());
+        } else {
+          return new Condition.Equals(kv[0].toLowerCase(), kv[1].toLowerCase());
+        }
       })
-      .toArray(Condition.Equals[]::new);
+      .toArray(Condition[]::new);
   }
 
   /**

--- a/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/OsmSpecifier.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/OsmSpecifier.java
@@ -28,7 +28,7 @@ public interface OsmSpecifier {
   /**
    * Calculates a pair of scores expressing how well an OSM entity's tags match this specifier.
    * <p>
-   * Tags in this specifier are matched against those for the left and right side of the OSM way
+   * Tags in this specifier are matched against those for the forward and backward direction of the OSM way
    * separately. See: http://wiki.openstreetmap.org/wiki/Forward_%26_backward,_left_%26_right
    *
    * @param way an OSM tagged object to compare to this specifier
@@ -38,11 +38,11 @@ public interface OsmSpecifier {
   /**
    * Calculates a score expressing how well an OSM entity's tags match this specifier. This does
    * exactly the same thing as {@link OsmSpecifier#matchScores(OSMWithTags)} but without regard for
-   * :left and :right.
+   * :left, :right, :forward, :backward and :both.
    */
   int matchScore(OSMWithTags way);
 
-  record Scores(int left, int right) {
+  record Scores(int forward, int backward) {
     public static Scores of(int s) {
       return new Scores(s, s);
     }

--- a/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/OsmSpecifier.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/wayproperty/specifier/OsmSpecifier.java
@@ -10,7 +10,7 @@ import org.opentripplanner.openstreetmap.model.OSMWithTags;
  * How the scoring logic is implemented is the responsibility of the implementations.
  */
 public interface OsmSpecifier {
-  static Condition[] parseEqualsTests(String spec, String separator) {
+  static Condition[] parseConditions(String spec, String separator) {
     return Arrays
       .stream(spec.split(separator))
       .filter(p -> !p.isEmpty())

--- a/src/test/java/org/opentripplanner/openstreetmap/tagmapping/DefaultMapperTest.java
+++ b/src/test/java/org/opentripplanner/openstreetmap/tagmapping/DefaultMapperTest.java
@@ -35,7 +35,7 @@ public class DefaultMapperTest {
 
     way = new OSMWithTags();
     way.addTag("maxspeed:forward", "80");
-    way.addTag("maxspeed:reverse", "20");
+    way.addTag("maxspeed:backward", "20");
     way.addTag("maxspeed", "40");
     assertTrue(within(kmhAsMs(80), wps.getCarSpeedForWay(way, false), epsilon));
     assertTrue(within(kmhAsMs(20), wps.getCarSpeedForWay(way, true), epsilon));

--- a/src/test/java/org/opentripplanner/openstreetmap/wayproperty/WayPropertySetTest.java
+++ b/src/test/java/org/opentripplanner/openstreetmap/wayproperty/WayPropertySetTest.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.openstreetmap.wayproperty;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.openstreetmap.wayproperty.MixinPropertiesBuilder.ofBicycleSafety;
 import static org.opentripplanner.openstreetmap.wayproperty.WayPropertiesBuilder.withModes;
 import static org.opentripplanner.street.model.StreetTraversalPermission.CAR;
 import static org.opentripplanner.street.model.StreetTraversalPermission.NONE;
@@ -28,6 +29,14 @@ class WayPropertySetTest {
     assertEquals(NONE, wps.getDataForWay(tunnel).getPermission());
   }
 
+  @Test
+  void mixinLeftSide() {
+    var cycleway = WayTestData.cyclewayLeft();
+    WayPropertySet wps = wps();
+    SafetyFeatures expected = new SafetyFeatures(1, 5);
+    assertEquals(expected, wps.getDataForWay(cycleway).getBicycleSafetyFeatures());
+  }
+
   @Nonnull
   private static WayPropertySet wps() {
     var wps = new WayPropertySet();
@@ -39,6 +48,7 @@ class WayPropertySetTest {
           new ExactMatchSpecifier("highway=footway;layer=-1;tunnel=yes;indoor=yes"),
           withModes(NONE)
         );
+        props.setMixinProperties("cycleway=lane", ofBicycleSafety(5));
       }
     };
     source.populateProperties(wps);

--- a/src/test/java/org/opentripplanner/openstreetmap/wayproperty/specifier/BestMatchSpecifierTest.java
+++ b/src/test/java/org/opentripplanner/openstreetmap/wayproperty/specifier/BestMatchSpecifierTest.java
@@ -44,8 +44,8 @@ class BestMatchSpecifierTest extends SpecifierTest {
   void leftRightMatch() {
     var way = WayTestData.cyclewayLeft();
     var result = bikeLane.matchScores(way);
-    assertEquals(210, result.left());
-    assertEquals(100, result.right());
+    assertEquals(210, result.backward());
+    assertEquals(100, result.forward());
   }
 
   static Stream<Arguments> leftRightTestCases = Stream.of(
@@ -56,12 +56,12 @@ class BestMatchSpecifierTest extends SpecifierTest {
   );
 
   @ParameterizedTest(
-    name = "way {0} with specifier {1} should have a left score {2} and right score {3}"
+    name = "way {0} with specifier {1} should have a backward score {2} and forward score {3}"
   )
   @VariableSource("leftRightTestCases")
-  void leftRight(OSMWithTags way, OsmSpecifier spec, int expectedLeft, int expectedRight) {
+  void leftRight(OSMWithTags way, OsmSpecifier spec, int expectedBackward, int expectedForward) {
     var result = spec.matchScores(way);
-    assertEquals(expectedLeft, result.left());
-    assertEquals(expectedRight, result.right());
+    assertEquals(expectedBackward, result.backward());
+    assertEquals(expectedForward, result.forward());
   }
 }

--- a/src/test/java/org/opentripplanner/openstreetmap/wayproperty/specifier/BestMatchSpecifierTest.java
+++ b/src/test/java/org/opentripplanner/openstreetmap/wayproperty/specifier/BestMatchSpecifierTest.java
@@ -19,9 +19,6 @@ class BestMatchSpecifierTest extends SpecifierTest {
   );
 
   static OsmSpecifier bikeLane = new BestMatchSpecifier("highway=residential;cycleway=lane");
-  static OsmSpecifier regularCobblestones = new BestMatchSpecifier(
-    "highway=residential;surface=cobblestones"
-  );
   static OsmSpecifier cyclewayTrack = new BestMatchSpecifier("highway=footway;cycleway=track");
   static OsmSpecifier highwayFootwayCyclewayLane = new BestMatchSpecifier(
     "highway=footway;cycleway=lane"

--- a/src/test/java/org/opentripplanner/openstreetmap/wayproperty/specifier/BestMatchSpecifierTest.java
+++ b/src/test/java/org/opentripplanner/openstreetmap/wayproperty/specifier/BestMatchSpecifierTest.java
@@ -1,10 +1,8 @@
 package org.opentripplanner.openstreetmap.wayproperty.specifier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.opentripplanner.openstreetmap.wayproperty.specifier.WayTestData.cobblestones;
 import static org.opentripplanner.openstreetmap.wayproperty.specifier.WayTestData.cyclewayLaneTrack;
 import static org.opentripplanner.openstreetmap.wayproperty.specifier.WayTestData.cyclewayLeft;
-import static org.opentripplanner.openstreetmap.wayproperty.specifier.WayTestData.flattenedCobblestones;
 
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -24,10 +22,6 @@ class BestMatchSpecifierTest extends SpecifierTest {
   static OsmSpecifier regularCobblestones = new BestMatchSpecifier(
     "highway=residential;surface=cobblestones"
   );
-  static OsmSpecifier cobblestonesFlattened = new BestMatchSpecifier(
-    "highway=residential;surface=cobblestones:flattened"
-  );
-
   static OsmSpecifier cyclewayTrack = new BestMatchSpecifier("highway=footway;cycleway=track");
   static OsmSpecifier highwayFootwayCyclewayLane = new BestMatchSpecifier(
     "highway=footway;cycleway=lane"
@@ -55,21 +49,6 @@ class BestMatchSpecifierTest extends SpecifierTest {
     var result = bikeLane.matchScores(way);
     assertEquals(210, result.left());
     assertEquals(100, result.right());
-  }
-
-  static Stream<Arguments> testCases = Stream.of(
-    Arguments.of(flattenedCobblestones(), regularCobblestones, 100),
-    Arguments.of(flattenedCobblestones(), cobblestonesFlattened, 210),
-    Arguments.of(cobblestones(), regularCobblestones, 210),
-    Arguments.of(cobblestones(), cobblestonesFlattened, 185)
-  );
-
-  @ParameterizedTest(name = "way {0} with specifier {1} should have a score of {2}")
-  @VariableSource("testCases")
-  void cobblestonesFlattened(OSMWithTags way, OsmSpecifier spec, int expectedScore) {
-    var result = spec.matchScores(way);
-    assertEquals(expectedScore, result.left());
-    assertEquals(expectedScore, result.right());
   }
 
   static Stream<Arguments> leftRightTestCases = Stream.of(

--- a/src/test/java/org/opentripplanner/openstreetmap/wayproperty/specifier/ConditionTest.java
+++ b/src/test/java/org/opentripplanner/openstreetmap/wayproperty/specifier/ConditionTest.java
@@ -42,7 +42,9 @@ class ConditionTest {
     Arguments.of(tramsForward(), embeddedTrams, NONE, EXACT)
   );
 
-  @ParameterizedTest(name = "way {0} with op {1} should have a backward result {2}, forward result {3}")
+  @ParameterizedTest(
+    name = "way {0} with op {1} should have a backward result {2}, forward result {3}"
+  )
   @VariableSource("equalsCases")
   void leftRight(
     OSMWithTags way,

--- a/src/test/java/org/opentripplanner/openstreetmap/wayproperty/specifier/ConditionTest.java
+++ b/src/test/java/org/opentripplanner/openstreetmap/wayproperty/specifier/ConditionTest.java
@@ -3,41 +3,63 @@ package org.opentripplanner.openstreetmap.wayproperty.specifier;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.openstreetmap.wayproperty.specifier.Condition.MatchResult.EXACT;
 import static org.opentripplanner.openstreetmap.wayproperty.specifier.Condition.MatchResult.NONE;
+import static org.opentripplanner.openstreetmap.wayproperty.specifier.Condition.MatchResult.WILDCARD;
 import static org.opentripplanner.openstreetmap.wayproperty.specifier.WayTestData.carTunnel;
 import static org.opentripplanner.openstreetmap.wayproperty.specifier.WayTestData.cobblestones;
 import static org.opentripplanner.openstreetmap.wayproperty.specifier.WayTestData.cycleway;
+import static org.opentripplanner.openstreetmap.wayproperty.specifier.WayTestData.cyclewayBoth;
 import static org.opentripplanner.openstreetmap.wayproperty.specifier.WayTestData.cyclewayLaneTrack;
 import static org.opentripplanner.openstreetmap.wayproperty.specifier.WayTestData.cyclewayLeft;
+import static org.opentripplanner.openstreetmap.wayproperty.specifier.WayTestData.excellentSmoothness;
 import static org.opentripplanner.openstreetmap.wayproperty.specifier.WayTestData.fiveLanes;
+import static org.opentripplanner.openstreetmap.wayproperty.specifier.WayTestData.highwayTertiary;
+import static org.opentripplanner.openstreetmap.wayproperty.specifier.WayTestData.noSidewalk;
 import static org.opentripplanner.openstreetmap.wayproperty.specifier.WayTestData.pedestrianTunnel;
+import static org.opentripplanner.openstreetmap.wayproperty.specifier.WayTestData.sidewalkBoth;
 import static org.opentripplanner.openstreetmap.wayproperty.specifier.WayTestData.threeLanes;
 import static org.opentripplanner.openstreetmap.wayproperty.specifier.WayTestData.tramsForward;
+import static org.opentripplanner.openstreetmap.wayproperty.specifier.WayTestData.veryBadSmoothness;
 
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.opentripplanner.openstreetmap.model.OSMWithTags;
 import org.opentripplanner.openstreetmap.wayproperty.specifier.Condition.Absent;
 import org.opentripplanner.openstreetmap.wayproperty.specifier.Condition.Equals;
+import org.opentripplanner.openstreetmap.wayproperty.specifier.Condition.EqualsAnyIn;
 import org.opentripplanner.openstreetmap.wayproperty.specifier.Condition.GreaterThan;
+import org.opentripplanner.openstreetmap.wayproperty.specifier.Condition.InclusiveRange;
 import org.opentripplanner.openstreetmap.wayproperty.specifier.Condition.LessThan;
 import org.opentripplanner.openstreetmap.wayproperty.specifier.Condition.MatchResult;
+import org.opentripplanner.openstreetmap.wayproperty.specifier.Condition.Present;
 import org.opentripplanner.test.support.VariableSource;
 
 class ConditionTest {
 
   static Condition cyclewayLane = new Equals("cycleway", "lane");
   static Condition cyclewayTrack = new Equals("cycleway", "track");
-
+  static Condition embeddedTrams = new Equals("embedded_rails", "tram");
+  static Condition cyclewayPresent = new Present("cycleway");
   static Condition cyclewayAbsent = new Absent("cycleway");
   static Condition moreThanFourLanes = new GreaterThan("lanes", 4);
   static Condition lessThanFourLanes = new LessThan("lanes", 4);
-
-  static Condition embeddedTrams = new Equals("embedded_rails", "tram");
+  static Condition betweenFiveAndThreeLanes = new InclusiveRange("lanes", 5, 3);
+  static Condition smoothnessBadAndWorseThanBad = new EqualsAnyIn(
+    "smoothness",
+    "bad",
+    "very_bad",
+    "horrible",
+    "very_horrible",
+    "impassable"
+  );
+  static Condition noSidewalk = new Condition.EqualsAnyInOrAbsent("sidewalk");
 
   static Stream<Arguments> equalsCases = Stream.of(
     Arguments.of(cyclewayLeft(), cyclewayLane, EXACT, NONE),
     Arguments.of(cyclewayLaneTrack(), cyclewayLane, EXACT, NONE),
+    Arguments.of(cyclewayBoth(), cyclewayLane, EXACT, EXACT),
     Arguments.of(cyclewayLaneTrack(), cyclewayTrack, NONE, EXACT),
     Arguments.of(tramsForward(), embeddedTrams, NONE, EXACT)
   );
@@ -57,6 +79,8 @@ class ConditionTest {
   }
 
   static Stream<Arguments> otherCases = Stream.of(
+    Arguments.of(cycleway(), cyclewayPresent, WILDCARD),
+    Arguments.of(carTunnel(), cyclewayPresent, NONE),
     Arguments.of(carTunnel(), cyclewayAbsent, EXACT),
     Arguments.of(cobblestones(), cyclewayAbsent, EXACT),
     Arguments.of(cycleway(), cyclewayAbsent, NONE),
@@ -67,12 +91,28 @@ class ConditionTest {
     Arguments.of(fiveLanes(), lessThanFourLanes, NONE),
     Arguments.of(threeLanes(), lessThanFourLanes, EXACT),
     Arguments.of(carTunnel(), lessThanFourLanes, NONE),
-    Arguments.of(cycleway(), lessThanFourLanes, NONE)
+    Arguments.of(cycleway(), lessThanFourLanes, NONE),
+    Arguments.of(fiveLanes(), betweenFiveAndThreeLanes, EXACT),
+    Arguments.of(threeLanes(), betweenFiveAndThreeLanes, EXACT),
+    Arguments.of(veryBadSmoothness(), smoothnessBadAndWorseThanBad, EXACT),
+    Arguments.of(cobblestones(), smoothnessBadAndWorseThanBad, NONE),
+    Arguments.of(excellentSmoothness(), smoothnessBadAndWorseThanBad, NONE),
+    Arguments.of(noSidewalk(), noSidewalk, EXACT),
+    Arguments.of(highwayTertiary(), noSidewalk, EXACT),
+    Arguments.of(sidewalkBoth(), noSidewalk, NONE)
   );
 
   @ParameterizedTest(name = "way {0} with op {1} should have a result {2}")
   @VariableSource("otherCases")
   void otherTests(OSMWithTags way, Condition op, MatchResult expectation) {
     assertEquals(expectation, op.match(way));
+  }
+
+  @Test
+  void assertThrowsOnLowerLowerThanUpperLimit() {
+    Assertions.assertThrows(
+      IllegalArgumentException.class,
+      () -> new InclusiveRange("lanes", 4, 6)
+    );
   }
 }

--- a/src/test/java/org/opentripplanner/openstreetmap/wayproperty/specifier/ConditionTest.java
+++ b/src/test/java/org/opentripplanner/openstreetmap/wayproperty/specifier/ConditionTest.java
@@ -38,16 +38,16 @@ class ConditionTest {
     Arguments.of(cyclewayLaneTrack(), cyclewayTrack, NONE, EXACT)
   );
 
-  @ParameterizedTest(name = "way {0} with op {1} should have a left result {2}, right result {3}")
+  @ParameterizedTest(name = "way {0} with op {1} should have a backward result {2}, forward result {3}")
   @VariableSource("equalsCases")
   void leftRight(
     OSMWithTags way,
     Condition op,
-    MatchResult leftExpectation,
-    MatchResult rightExpectation
+    MatchResult backwardExpectation,
+    MatchResult forwardExpectation
   ) {
-    assertEquals(leftExpectation, op.matchLeft(way));
-    assertEquals(rightExpectation, op.matchRight(way));
+    assertEquals(backwardExpectation, op.matchBackward(way));
+    assertEquals(forwardExpectation, op.matchForward(way));
   }
 
   static Stream<Arguments> otherCases = Stream.of(

--- a/src/test/java/org/opentripplanner/openstreetmap/wayproperty/specifier/ConditionTest.java
+++ b/src/test/java/org/opentripplanner/openstreetmap/wayproperty/specifier/ConditionTest.java
@@ -11,6 +11,7 @@ import static org.opentripplanner.openstreetmap.wayproperty.specifier.WayTestDat
 import static org.opentripplanner.openstreetmap.wayproperty.specifier.WayTestData.fiveLanes;
 import static org.opentripplanner.openstreetmap.wayproperty.specifier.WayTestData.pedestrianTunnel;
 import static org.opentripplanner.openstreetmap.wayproperty.specifier.WayTestData.threeLanes;
+import static org.opentripplanner.openstreetmap.wayproperty.specifier.WayTestData.tramsForward;
 
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -32,10 +33,13 @@ class ConditionTest {
   static Condition moreThanFourLanes = new GreaterThan("lanes", 4);
   static Condition lessThanFourLanes = new LessThan("lanes", 4);
 
+  static Condition embeddedTrams = new Equals("embedded_rails", "tram");
+
   static Stream<Arguments> equalsCases = Stream.of(
     Arguments.of(cyclewayLeft(), cyclewayLane, EXACT, NONE),
     Arguments.of(cyclewayLaneTrack(), cyclewayLane, EXACT, NONE),
-    Arguments.of(cyclewayLaneTrack(), cyclewayTrack, NONE, EXACT)
+    Arguments.of(cyclewayLaneTrack(), cyclewayTrack, NONE, EXACT),
+    Arguments.of(tramsForward(), embeddedTrams, NONE, EXACT)
   );
 
   @ParameterizedTest(name = "way {0} with op {1} should have a backward result {2}, forward result {3}")

--- a/src/test/java/org/opentripplanner/openstreetmap/wayproperty/specifier/ExactMatchSpecifierTest.java
+++ b/src/test/java/org/opentripplanner/openstreetmap/wayproperty/specifier/ExactMatchSpecifierTest.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.openstreetmap.wayproperty.specifier;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.openstreetmap.model.OSMWithTags;
 
@@ -28,13 +27,5 @@ class ExactMatchSpecifierTest extends SpecifierTest {
     assertScore(0, highwayPrimarySpec, tunnel);
     assertScore(600, pedestrianUndergroundTunnelSpec, tunnel);
     assertScore(800, pedestrianUndergroundIndoorTunnelSpec, tunnel);
-  }
-
-  @Test
-  public void throwOnWildcard() {
-    Assertions.assertThrows(
-      IllegalArgumentException.class,
-      () -> new ExactMatchSpecifier("highway=*")
-    );
   }
 }

--- a/src/test/java/org/opentripplanner/openstreetmap/wayproperty/specifier/OsmSpecifierTest.java
+++ b/src/test/java/org/opentripplanner/openstreetmap/wayproperty/specifier/OsmSpecifierTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test;
 
 public class OsmSpecifierTest extends SpecifierTest {
 
-  Condition[] wildcardSpec = OsmSpecifier.parseEqualsTests("highway=*", ";");
+  Condition[] wildcardSpec = OsmSpecifier.parseConditions("highway=*", ";");
 
   @Test
   public void parseWildcardAsPresent() {

--- a/src/test/java/org/opentripplanner/openstreetmap/wayproperty/specifier/OsmSpecifierTest.java
+++ b/src/test/java/org/opentripplanner/openstreetmap/wayproperty/specifier/OsmSpecifierTest.java
@@ -1,13 +1,15 @@
 package org.opentripplanner.openstreetmap.wayproperty.specifier;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class OsmSpecifierTest extends SpecifierTest {
+
   Condition[] wildcardSpec = OsmSpecifier.parseEqualsTests("highway=*", ";");
+
   @Test
   public void parseWildcardAsPresent() {
-    var expected = new Condition[]{new Condition.Present("highway")};
+    var expected = new Condition[] { new Condition.Present("highway") };
     Assertions.assertArrayEquals(expected, wildcardSpec);
   }
 }

--- a/src/test/java/org/opentripplanner/openstreetmap/wayproperty/specifier/OsmSpecifierTest.java
+++ b/src/test/java/org/opentripplanner/openstreetmap/wayproperty/specifier/OsmSpecifierTest.java
@@ -1,0 +1,13 @@
+package org.opentripplanner.openstreetmap.wayproperty.specifier;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
+
+public class OsmSpecifierTest extends SpecifierTest {
+  Condition[] wildcardSpec = OsmSpecifier.parseEqualsTests("highway=*", ";");
+  @Test
+  public void parseWildcardAsPresent() {
+    var expected = new Condition[]{new Condition.Present("highway")};
+    Assertions.assertArrayEquals(expected, wildcardSpec);
+  }
+}

--- a/src/test/java/org/opentripplanner/openstreetmap/wayproperty/specifier/SpecifierTest.java
+++ b/src/test/java/org/opentripplanner/openstreetmap/wayproperty/specifier/SpecifierTest.java
@@ -8,8 +8,8 @@ public class SpecifierTest {
 
   protected void assertScore(int expectedScore, OsmSpecifier spec, OSMWithTags tunnel) {
     var result = spec.matchScores(tunnel);
-    assertEquals(expectedScore, result.left());
-    assertEquals(expectedScore, result.right());
+    assertEquals(expectedScore, result.backward());
+    assertEquals(expectedScore, result.forward());
     var score = spec.matchScore(tunnel);
     assertEquals(expectedScore, score);
   }

--- a/src/test/java/org/opentripplanner/openstreetmap/wayproperty/specifier/WayTestData.java
+++ b/src/test/java/org/opentripplanner/openstreetmap/wayproperty/specifier/WayTestData.java
@@ -113,6 +113,13 @@ public class WayTestData {
     return way;
   }
 
+  public static OSMWithTags cyclewayBoth() {
+    var way = new OSMWithTags();
+    way.addTag("highway", "residential");
+    way.addTag("cycleway:both", "lane");
+    return way;
+  }
+
   public static OSMWithTags footwaySidewalk() {
     var way = new OSMWithTags();
     way.addTag("footway", "sidewalk");
@@ -176,9 +183,29 @@ public class WayTestData {
   }
 
   public static OSMWithTags tramsForward() {
+    // https://www.openstreetmap.org/way/108037345
     var way = new OSMWithTags();
     way.addTag("highway", "tertiary");
     way.addTag("embedded_rails:forward", "tram");
+    return way;
+  }
+
+  public static OSMWithTags veryBadSmoothness() {
+    // https://www.openstreetmap.org/way/11402648
+    var way = new OSMWithTags();
+    way.addTag("highway", "footway");
+    way.addTag("surface", "sett");
+    way.addTag("smoothness", "very_bad");
+    return way;
+  }
+
+  public static OSMWithTags excellentSmoothness() {
+    // https://www.openstreetmap.org/way/437167371
+    var way = new OSMWithTags();
+    way.addTag("highway", "cycleway");
+    way.addTag("segregated", "no");
+    way.addTag("surface", "asphalt");
+    way.addTag("smoothness", "excellent");
     return way;
   }
 }

--- a/src/test/java/org/opentripplanner/openstreetmap/wayproperty/specifier/WayTestData.java
+++ b/src/test/java/org/opentripplanner/openstreetmap/wayproperty/specifier/WayTestData.java
@@ -160,13 +160,6 @@ public class WayTestData {
     return way;
   }
 
-  public static OSMWithTags flattenedCobblestones() {
-    var way = new OSMWithTags();
-    way.addTag("highway", "residential");
-    way.addTag("surface", "cobblestones:flattened");
-    return way;
-  }
-
   public static OSMWithTags cobblestones() {
     var way = new OSMWithTags();
     way.addTag("highway", "residential");

--- a/src/test/java/org/opentripplanner/openstreetmap/wayproperty/specifier/WayTestData.java
+++ b/src/test/java/org/opentripplanner/openstreetmap/wayproperty/specifier/WayTestData.java
@@ -174,4 +174,11 @@ public class WayTestData {
     way.addTag("cycleway:right", "track");
     return way;
   }
+
+  public static OSMWithTags tramsForward() {
+    var way = new OSMWithTags();
+    way.addTag("highway", "tertiary");
+    way.addTag("embedded_rails:forward", "tram");
+    return way;
+  }
 }


### PR DESCRIPTION
This PR both refactors wayproperty.specifier.Condition, to make it easer to make more conditions, and adds more conditions.

* The «Equals» condition now does what it says. Functionality for matching prefixed values like surface=cobblestone:flatten is removed and «wildcard» matching are moved to a new condition called «Present». 
* The assumption of right hand driving is removed from «WayPropertiesBuilder.getDataForWay», but there is still no support for left hand side driving when `:right` and `:left` postfixes are evaluated.
*  Support for matching of `:forward`, `:backward` and `:both` postfixes are added.

This PR also fix the to small following bugs:
* `maxspeed:reverse` should be `maxspeed:backward`
* #4695 
### Issue
closes  #4695

### Unit tests
Test concerning cobblestones:flattened is removed.
A testcase for :forward postfix, «tramsForward» is added.
A test for directional safety mixin is also added.
