### PR TITLE
feature: Add a short git commit hash to MetricsLogging

### DIFF
--- a/src/main/java/org/opentripplanner/framework/lang/IntUtils.java
+++ b/src/main/java/org/opentripplanner/framework/lang/IntUtils.java
@@ -49,4 +49,35 @@ public final class IntUtils {
 
     return Math.sqrt(sum / v.size());
   }
+
+  /**
+   * Convert a hex string to a human-readable decimal number like this:
+   * <pre>
+   *    '0'  ->  0
+   *    '1'  ->  1
+   *    'f'  ->  15
+   *   '10'  ->  100
+   *   'f0'  ->  1500
+   *   'ff'  ->  1515
+   * 'a3f7'  ->  10031507
+   * </pre>
+   * @throws NullPointerException if the given value is {@code null}
+   * @throws IllegalArgumentException if the value is more than 4 characters or not a hex number.
+   */
+  public static int hexToReadableInt(String value) {
+    if (value.length() > 4) {
+      throw new IllegalArgumentException(
+        "The value have too many characters(max 4): '" + value + "'"
+      );
+    }
+    if (!value.matches("^[\\da-fA-F]+$")) {
+      throw new IllegalArgumentException("The value is not a hex string: '" + value + "'");
+    }
+    int r = 0;
+    for (int i = 0; i < value.length(); ++i) {
+      r *= 100;
+      r += Integer.parseInt(value.substring(i, i + 1), 16);
+    }
+    return r;
+  }
 }

--- a/src/main/java/org/opentripplanner/model/projectinfo/OtpProjectInfo.java
+++ b/src/main/java/org/opentripplanner/model/projectinfo/OtpProjectInfo.java
@@ -1,11 +1,16 @@
 package org.opentripplanner.model.projectinfo;
 
 import java.io.Serializable;
+import org.opentripplanner.framework.lang.IntUtils;
 import org.opentripplanner.standalone.config.BuildConfig;
 import org.opentripplanner.standalone.config.OtpConfig;
 import org.opentripplanner.standalone.config.RouterConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class OtpProjectInfo implements Serializable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(OtpProjectInfo.class);
 
   static final String UNKNOWN = "UNKNOWN";
   private static final OtpProjectInfo INSTANCE = OtpProjectInfoParser.loadFromProperties();
@@ -88,6 +93,24 @@ public class OtpProjectInfo implements Serializable {
       versionControl.commit,
       versionControl.branch
     );
+  }
+
+  /**
+   * Return to last characters in the git hash as a 4 digit integer. Examples:
+   * "01" -> 1, "0F" -> 15, "1F" -> 115, "AF" -> 1015, "FF" -> 1515.
+   * <p>
+   * Return a negative value on errors.
+   */
+  public int getShortCommitHashAsInt() {
+    try {
+      String value = versionControl.commit;
+      return (value != null && value.length() >= 2)
+        ? IntUtils.hexToReadableInt(value.substring(value.length() - 2))
+        : -1;
+    } catch (IllegalArgumentException e) {
+      LOG.warn("OTP git commit hash is not valid: {}", e.getMessage(), e);
+      return -2;
+    }
   }
 
   /**

--- a/src/main/java/org/opentripplanner/standalone/server/MetricsLogging.java
+++ b/src/main/java/org/opentripplanner/standalone/server/MetricsLogging.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.standalone.server;
 
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.binder.cache.GuavaCacheMetrics;
@@ -18,6 +19,7 @@ import io.micrometer.core.instrument.binder.system.UptimeMetrics;
 import jakarta.inject.Inject;
 import java.util.List;
 import java.util.concurrent.ForkJoinPool;
+import org.opentripplanner.model.projectinfo.OtpProjectInfo;
 import org.opentripplanner.raptor.configure.RaptorConfig;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripSchedule;
 import org.opentripplanner.transit.service.TransitModel;
@@ -27,6 +29,10 @@ import org.opentripplanner.transit.service.TransitModel;
  * performance logging, through the Actuator API.
  */
 public class MetricsLogging {
+
+  private static final int GIT_COMMIT_HASH_SHORT = OtpProjectInfo
+    .projectInfo()
+    .getShortCommitHashAsInt();
 
   @Inject
   public MetricsLogging(TransitModel transitModel, RaptorConfig<TripSchedule> raptorConfig) {
@@ -81,5 +87,13 @@ public class MetricsLogging {
       )
         .bindTo(Metrics.globalRegistry);
     }
+    // Log Git commit (2 last digits)
+    Gauge
+      .builder("otp.git.commit.hash.short", () -> GIT_COMMIT_HASH_SHORT)
+      .description(
+        "A four decimal representation of the last two HEX digits in the git commit hash. " +
+        "Example: f9 -> 1509"
+      )
+      .register(Metrics.globalRegistry);
   }
 }

--- a/src/test/java/org/opentripplanner/framework/lang/IntUtilsTest.java
+++ b/src/test/java/org/opentripplanner/framework/lang/IntUtilsTest.java
@@ -2,6 +2,7 @@ package org.opentripplanner.framework.lang;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -28,5 +29,23 @@ class IntUtilsTest {
   void standardDeviation() {
     assertEquals(0.0, IntUtils.standardDeviation(List.of(7)));
     assertEquals(2.0, IntUtils.standardDeviation(List.of(9, 2, 4, 4, 5, 4, 7, 5)), 0.01);
+  }
+
+  @Test
+  void hexToReadableInt() {
+    assertEquals(0, IntUtils.hexToReadableInt("0"));
+    assertEquals(1, IntUtils.hexToReadableInt("1"));
+    assertEquals(10, IntUtils.hexToReadableInt("a"));
+    assertEquals(15, IntUtils.hexToReadableInt("F"));
+    assertEquals(100, IntUtils.hexToReadableInt("10"));
+    assertEquals(1000000, IntUtils.hexToReadableInt("1000"));
+    assertEquals(15071001, IntUtils.hexToReadableInt("F7a1"));
+
+    // 5 digits is too long
+    assertThrows(IllegalArgumentException.class, () -> IntUtils.hexToReadableInt("10000"));
+
+    // None HEX character error
+    assertThrows(IllegalArgumentException.class, () -> IntUtils.hexToReadableInt(""));
+    assertThrows(IllegalArgumentException.class, () -> IntUtils.hexToReadableInt("G"));
   }
 }


### PR DESCRIPTION
### Summary

This adds a Gauge(`otp.git.commit.hash.short`) with the git commit hash as a 4 digit decimal number. Only the 2 last characters in the hash is added, like 03 -> 3, 1a -> 110, ff -> 1515.

This is an experimental feature to let us easier identify each build in the performance monitor. The idea is to add a graph with the Gauge, values from 0(`00`) to 1515(`ff`). The number is hence easy to convert to hex and can be used together with the timestamp to identify the corresponding git commit. Collisions are possible since only the 2 last hex digits of the commit hash is included. In practice this is easy to detect and solve by just look at the previous/next sample.
