### PR TITLE
Pretty-print all JSON examples in docs

### DIFF
--- a/doc-templates/Flex.md
+++ b/doc-templates/Flex.md
@@ -15,6 +15,9 @@ the [GTFS-Flex v2.1 draft](https://github.com/MobilityData/gtfs-flex/blob/master
 
 ## Configuration
 
+This feature allows a limited number of config options. To change the configuration, add the 
+following to `router-config.json`.
+
 <!-- INSERT: config -->
 
 ## Changelog

--- a/docs/BuildConfiguration.md
+++ b/docs/BuildConfiguration.md
@@ -1095,25 +1095,32 @@ case where this is not the case.
     "timeZone" : "Europe/Rome",
     "osmTagMapping" : "default"
   },
-  "osm" : [ {
-    "source" : "gs://my-bucket/otp-work-dir/norway.osm.pbf",
-    "timeZone" : "Europe/Oslo",
-    "osmTagMapping" : "norway"
-  } ],
+  "osm" : [
+    {
+      "source" : "gs://my-bucket/otp-work-dir/norway.osm.pbf",
+      "timeZone" : "Europe/Oslo",
+      "osmTagMapping" : "norway"
+    }
+  ],
   "demDefaults" : {
     "elevationUnitMultiplier" : 1.0
   },
-  "dem" : [ {
-    "source" : "gs://my-bucket/otp-work-dir/norway.dem.tiff",
-    "elevationUnitMultiplier" : 2.5
-  } ],
+  "dem" : [
+    {
+      "source" : "gs://my-bucket/otp-work-dir/norway.dem.tiff",
+      "elevationUnitMultiplier" : 2.5
+    }
+  ],
   "netexDefaults" : {
     "feedId" : "EN",
     "sharedFilePattern" : "_stops.xml",
     "sharedGroupFilePattern" : "_(\\w{3})_shared_data.xml",
     "groupFilePattern" : "(\\w{3})_.*\\.xml",
     "ignoreFilePattern" : "(temp|tmp)",
-    "ferryIdsNotAllowedForBicycle" : [ "RUT:B107", "RUT:B209" ]
+    "ferryIdsNotAllowedForBicycle" : [
+      "RUT:B107",
+      "RUT:B209"
+    ]
   },
   "gtfsDefaults" : {
     "stationTransferPreference" : "recommended",
@@ -1122,27 +1129,33 @@ case where this is not the case.
     "blockBasedInterlining" : true,
     "maxInterlineDistance" : 200
   },
-  "transitFeeds" : [ {
-    "type" : "gtfs",
-    "feedId" : "SE",
-    "source" : "gs://BUCKET/OTP_GCS_WORK_DIR/sweeden-gtfs.obj"
-  }, {
-    "type" : "netex",
-    "feedId" : "NO",
-    "source" : "gs://BUCKET/OTP_GCS_WORK_DIR/norway-netex.obj",
-    "sharedFilePattern" : "_stops.xml",
-    "sharedGroupFilePattern" : "_(\\w{3})_shared_data.xml",
-    "groupFilePattern" : "(\\w{3})_.*\\.xml",
-    "ignoreFilePattern" : "(temp|tmp)"
-  } ],
-  "transferRequests" : [ {
-    "modes" : "WALK"
-  }, {
-    "modes" : "WALK",
-    "wheelchairAccessibility" : {
-      "enabled" : true
+  "transitFeeds" : [
+    {
+      "type" : "gtfs",
+      "feedId" : "SE",
+      "source" : "gs://BUCKET/OTP_GCS_WORK_DIR/sweeden-gtfs.obj"
+    },
+    {
+      "type" : "netex",
+      "feedId" : "NO",
+      "source" : "gs://BUCKET/OTP_GCS_WORK_DIR/norway-netex.obj",
+      "sharedFilePattern" : "_stops.xml",
+      "sharedGroupFilePattern" : "_(\\w{3})_shared_data.xml",
+      "groupFilePattern" : "(\\w{3})_.*\\.xml",
+      "ignoreFilePattern" : "(temp|tmp)"
     }
-  } ]
+  ],
+  "transferRequests" : [
+    {
+      "modes" : "WALK"
+    },
+    {
+      "modes" : "WALK",
+      "wheelchairAccessibility" : {
+        "enabled" : true
+      }
+    }
+  ]
 }
 ```
 

--- a/docs/RouterConfiguration.md
+++ b/docs/RouterConfiguration.md
@@ -492,133 +492,152 @@ Http headers.
   "transmodelApi" : {
     "hideFeedId" : true
   },
-  "vectorTileLayers" : [ {
-    "name" : "stops",
-    "type" : "Stop",
-    "mapper" : "Digitransit",
-    "maxZoom" : 20,
-    "minZoom" : 14,
-    "cacheMaxSeconds" : 600
-  }, {
-    "name" : "stations",
-    "type" : "Station",
-    "mapper" : "Digitransit",
-    "maxZoom" : 20,
-    "minZoom" : 12,
-    "cacheMaxSeconds" : 600
-  }, {
-    "name" : "rentalPlaces",
-    "type" : "VehicleRental",
-    "mapper" : "Digitransit",
-    "maxZoom" : 20,
-    "minZoom" : 14,
-    "cacheMaxSeconds" : 60,
-    "expansionFactor" : 0.25
-  }, {
-    "name" : "rentalVehicle",
-    "type" : "VehicleRentalVehicle",
-    "mapper" : "Digitransit",
-    "maxZoom" : 20,
-    "minZoom" : 14,
-    "cacheMaxSeconds" : 60
-  }, {
-    "name" : "rentalStation",
-    "type" : "VehicleRentalStation",
-    "mapper" : "Digitransit",
-    "maxZoom" : 20,
-    "minZoom" : 14,
-    "cacheMaxSeconds" : 600
-  }, {
-    "name" : "vehicleParking",
-    "type" : "VehicleParking",
-    "mapper" : "Digitransit",
-    "maxZoom" : 20,
-    "minZoom" : 14,
-    "cacheMaxSeconds" : 60,
-    "expansionFactor" : 0.25
-  } ],
-  "updaters" : [ {
-    "type" : "real-time-alerts",
-    "frequencySec" : 30,
-    "url" : "http://developer.trimet.org/ws/V1/FeedSpecAlerts/appID/0123456789ABCDEF",
-    "feedId" : "TriMet",
-    "headers" : {
-      "Some-Header" : "A-Value"
-    }
-  }, {
-    "type" : "vehicle-rental",
-    "network" : "socialbicycles_coast",
-    "sourceType" : "gbfs",
-    "language" : "en",
-    "frequencySec" : 60,
-    "allowKeepingRentedBicycleAtDestination" : true,
-    "url" : "http://coast.socialbicycles.com/opendata/gbfs.json",
-    "headers" : {
-      "Auth" : "<any-token>",
-      "<key>" : "<value>"
-    }
-  }, {
-    "type" : "vehicle-parking",
-    "sourceType" : "hsl-park",
-    "feedId" : "hslpark",
-    "timeZone" : "Europe/Helsinki",
-    "facilitiesFrequencySec" : 3600,
-    "facilitiesUrl" : "https://p.hsl.fi/api/v1/facilities.json?limit=-1",
-    "utilizationsFrequencySec" : 600,
-    "utilizationsUrl" : "https://p.hsl.fi/api/v1/utilizations.json?limit=-1",
-    "hubsUrl" : "https://p.hsl.fi/api/v1/hubs.json?limit=-1"
-  }, {
-    "type" : "vehicle-parking",
-    "sourceType" : "park-api",
-    "feedId" : "parkapi",
-    "timeZone" : "Europe/Berlin",
-    "frequencySec" : 600,
-    "url" : "https://foo.bar",
-    "headers" : {
-      "Cache-Control" : "max-age=604800"
+  "vectorTileLayers" : [
+    {
+      "name" : "stops",
+      "type" : "Stop",
+      "mapper" : "Digitransit",
+      "maxZoom" : 20,
+      "minZoom" : 14,
+      "cacheMaxSeconds" : 600
     },
-    "tags" : [ "source:parkapi" ]
-  }, {
-    "type" : "vehicle-parking",
-    "feedId" : "bikely",
-    "sourceType" : "bikely",
-    "url" : "https://api.safebikely.com/api/v1/s/locations",
-    "headers" : {
-      "X-Bikely-Token" : "${BIKELY_TOKEN}",
-      "Authorization" : "${BIKELY_AUTHORIZATION}"
+    {
+      "name" : "stations",
+      "type" : "Station",
+      "mapper" : "Digitransit",
+      "maxZoom" : 20,
+      "minZoom" : 12,
+      "cacheMaxSeconds" : 600
+    },
+    {
+      "name" : "rentalPlaces",
+      "type" : "VehicleRental",
+      "mapper" : "Digitransit",
+      "maxZoom" : 20,
+      "minZoom" : 14,
+      "cacheMaxSeconds" : 60,
+      "expansionFactor" : 0.25
+    },
+    {
+      "name" : "rentalVehicle",
+      "type" : "VehicleRentalVehicle",
+      "mapper" : "Digitransit",
+      "maxZoom" : 20,
+      "minZoom" : 14,
+      "cacheMaxSeconds" : 60
+    },
+    {
+      "name" : "rentalStation",
+      "type" : "VehicleRentalStation",
+      "mapper" : "Digitransit",
+      "maxZoom" : 20,
+      "minZoom" : 14,
+      "cacheMaxSeconds" : 600
+    },
+    {
+      "name" : "vehicleParking",
+      "type" : "VehicleParking",
+      "mapper" : "Digitransit",
+      "maxZoom" : 20,
+      "minZoom" : 14,
+      "cacheMaxSeconds" : 60,
+      "expansionFactor" : 0.25
     }
-  }, {
-    "type" : "stop-time-updater",
-    "frequencySec" : 60,
-    "backwardsDelayPropagationType" : "REQUIRED_NO_DATA",
-    "url" : "http://developer.trimet.org/ws/V1/TripUpdate/appID/0123456789ABCDEF",
-    "feedId" : "TriMet",
-    "headers" : {
-      "Authorization" : "A-Token"
+  ],
+  "updaters" : [
+    {
+      "type" : "real-time-alerts",
+      "frequencySec" : 30,
+      "url" : "http://developer.trimet.org/ws/V1/FeedSpecAlerts/appID/0123456789ABCDEF",
+      "feedId" : "TriMet",
+      "headers" : {
+        "Some-Header" : "A-Value"
+      }
+    },
+    {
+      "type" : "vehicle-rental",
+      "network" : "socialbicycles_coast",
+      "sourceType" : "gbfs",
+      "language" : "en",
+      "frequencySec" : 60,
+      "allowKeepingRentedBicycleAtDestination" : true,
+      "url" : "http://coast.socialbicycles.com/opendata/gbfs.json",
+      "headers" : {
+        "Auth" : "<any-token>",
+        "<key>" : "<value>"
+      }
+    },
+    {
+      "type" : "vehicle-parking",
+      "sourceType" : "hsl-park",
+      "feedId" : "hslpark",
+      "timeZone" : "Europe/Helsinki",
+      "facilitiesFrequencySec" : 3600,
+      "facilitiesUrl" : "https://p.hsl.fi/api/v1/facilities.json?limit=-1",
+      "utilizationsFrequencySec" : 600,
+      "utilizationsUrl" : "https://p.hsl.fi/api/v1/utilizations.json?limit=-1",
+      "hubsUrl" : "https://p.hsl.fi/api/v1/hubs.json?limit=-1"
+    },
+    {
+      "type" : "vehicle-parking",
+      "sourceType" : "park-api",
+      "feedId" : "parkapi",
+      "timeZone" : "Europe/Berlin",
+      "frequencySec" : 600,
+      "url" : "https://foo.bar",
+      "headers" : {
+        "Cache-Control" : "max-age=604800"
+      },
+      "tags" : [
+        "source:parkapi"
+      ]
+    },
+    {
+      "type" : "vehicle-parking",
+      "feedId" : "bikely",
+      "sourceType" : "bikely",
+      "url" : "https://api.safebikely.com/api/v1/s/locations",
+      "headers" : {
+        "X-Bikely-Token" : "${BIKELY_TOKEN}",
+        "Authorization" : "${BIKELY_AUTHORIZATION}"
+      }
+    },
+    {
+      "type" : "stop-time-updater",
+      "frequencySec" : 60,
+      "backwardsDelayPropagationType" : "REQUIRED_NO_DATA",
+      "url" : "http://developer.trimet.org/ws/V1/TripUpdate/appID/0123456789ABCDEF",
+      "feedId" : "TriMet",
+      "headers" : {
+        "Authorization" : "A-Token"
+      }
+    },
+    {
+      "type" : "vehicle-positions",
+      "url" : "https://s3.amazonaws.com/kcm-alerts-realtime-prod/vehiclepositions.pb",
+      "feedId" : "1",
+      "frequencySec" : 60,
+      "headers" : {
+        "Header-Name" : "Header-Value"
+      }
+    },
+    {
+      "type" : "websocket-gtfs-rt-updater"
+    },
+    {
+      "type" : "siri-azure-sx-updater",
+      "topic" : "some_topic",
+      "servicebus-url" : "service_bus_url",
+      "feedId" : "feed_id",
+      "customMidnight" : 4,
+      "history" : {
+        "url" : "endpoint_url",
+        "fromDateTime" : "-P1D",
+        "toDateTime" : "P1D",
+        "timeout" : 300000
+      }
     }
-  }, {
-    "type" : "vehicle-positions",
-    "url" : "https://s3.amazonaws.com/kcm-alerts-realtime-prod/vehiclepositions.pb",
-    "feedId" : "1",
-    "frequencySec" : 60,
-    "headers" : {
-      "Header-Name" : "Header-Value"
-    }
-  }, {
-    "type" : "websocket-gtfs-rt-updater"
-  }, {
-    "type" : "siri-azure-sx-updater",
-    "topic" : "some_topic",
-    "servicebus-url" : "service_bus_url",
-    "feedId" : "feed_id",
-    "customMidnight" : 4,
-    "history" : {
-      "url" : "endpoint_url",
-      "fromDateTime" : "-P1D",
-      "toDateTime" : "P1D",
-      "timeout" : 300000
-    }
-  } ]
+  ]
 }
 ```
 

--- a/docs/sandbox/Flex.md
+++ b/docs/sandbox/Flex.md
@@ -15,21 +15,21 @@ the [GTFS-Flex v2.1 draft](https://github.com/MobilityData/gtfs-flex/blob/master
 
 ## Configuration
 
+This feature allows a limited number of config options. To change the configuration, add the 
+following to `router-config.json`.
+
 <!-- config BEGIN -->
 <!-- NOTE! This section is auto-generated. Do not change, change doc in code instead. -->
 
 ### Example configuration
 
 ```JSON
-// This feature allows a limited number of config options. To change the configuration, add the following to `router-config.json`.
+// router-config.json
 {
-    "flex": {
-      "maxTransferDuration" : "5m",
-      "maxFlexTripDuration" : "45m",
-      "maxAccessWalkDuration" : "15m",
-      "maxEgressWalkDuration" : "15m"
-    }
-
+  "maxTransferDuration" : "5m",
+  "maxFlexTripDuration" : "45m",
+  "maxAccessWalkDuration" : "15m",
+  "maxEgressWalkDuration" : "15m"
 }
 ```
 ### Overview

--- a/docs/sandbox/Flex.md
+++ b/docs/sandbox/Flex.md
@@ -26,10 +26,12 @@ following to `router-config.json`.
 ```JSON
 // router-config.json
 {
-  "maxTransferDuration" : "5m",
-  "maxFlexTripDuration" : "45m",
-  "maxAccessWalkDuration" : "15m",
-  "maxEgressWalkDuration" : "15m"
+  "flex" : {
+    "maxTransferDuration" : "5m",
+    "maxFlexTripDuration" : "45m",
+    "maxAccessWalkDuration" : "15m",
+    "maxEgressWalkDuration" : "15m"
+  }
 }
 ```
 ### Overview

--- a/docs/sandbox/VehicleParking.md
+++ b/docs/sandbox/VehicleParking.md
@@ -80,7 +80,7 @@ Used for converting abstract opening hours into concrete points in time.
 ```JSON
 // router-config.json
 {
-    "updaters": [
+  "updaters" : [
     {
       "type" : "vehicle-parking",
       "sourceType" : "hsl-park",
@@ -93,7 +93,6 @@ Used for converting abstract opening hours into concrete points in time.
       "hubsUrl" : "https://p.hsl.fi/api/v1/hubs.json?limit=-1"
     }
   ]
-
 }
 ```
 
@@ -165,7 +164,7 @@ Tags to add to the parking lots.
 ```JSON
 // router-config.json
 {
-    "updaters": [
+  "updaters" : [
     {
       "type" : "vehicle-parking",
       "sourceType" : "park-api",
@@ -176,10 +175,11 @@ Tags to add to the parking lots.
       "headers" : {
         "Cache-Control" : "max-age=604800"
       },
-      "tags" : [ "source:parkapi" ]
+      "tags" : [
+        "source:parkapi"
+      ]
     }
   ]
-
 }
 ```
 
@@ -233,7 +233,7 @@ HTTP headers to add.
 ```JSON
 // router-config.json
 {
-    "updaters": [
+  "updaters" : [
     {
       "type" : "vehicle-parking",
       "feedId" : "bikely",
@@ -245,7 +245,6 @@ HTTP headers to add.
       }
     }
   ]
-
 }
 ```
 

--- a/src/test/java/org/opentripplanner/generate/doc/BuildConfigurationDocTest.java
+++ b/src/test/java/org/opentripplanner/generate/doc/BuildConfigurationDocTest.java
@@ -12,6 +12,7 @@ import static org.opentripplanner.generate.doc.framework.TemplateUtil.replacePar
 import static org.opentripplanner.standalone.config.framework.JsonSupport.jsonNodeFromResource;
 
 import java.io.File;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.framework.application.OtpFileNames;
 import org.opentripplanner.generate.doc.framework.OnlyIfDocsExist;
@@ -22,6 +23,7 @@ import org.opentripplanner.standalone.config.BuildConfig;
 import org.opentripplanner.standalone.config.framework.json.NodeAdapter;
 
 @OnlyIfDocsExist
+@Tag("docs")
 public class BuildConfigurationDocTest {
 
   private static final String CONFIG_JSON = OtpFileNames.BUILD_CONFIG_FILENAME;

--- a/src/test/java/org/opentripplanner/generate/doc/ConfigurationDocTest.java
+++ b/src/test/java/org/opentripplanner/generate/doc/ConfigurationDocTest.java
@@ -10,10 +10,12 @@ import static org.opentripplanner.generate.doc.support.ConfigTypeTable.configTyp
 import static org.opentripplanner.generate.doc.support.OTPFeatureTable.otpFeaturesTable;
 
 import java.io.File;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.generate.doc.framework.OnlyIfDocsExist;
 
 @OnlyIfDocsExist
+@Tag("docs")
 public class ConfigurationDocTest {
 
   private static final File TEMPLATE = new File(TEMPLATE_ROOT, "Configuration.md");

--- a/src/test/java/org/opentripplanner/generate/doc/FlexConfigurationDocTest.java
+++ b/src/test/java/org/opentripplanner/generate/doc/FlexConfigurationDocTest.java
@@ -6,7 +6,6 @@ import static org.opentripplanner.framework.io.FileUtils.writeFile;
 import static org.opentripplanner.framework.text.MarkdownFormatter.HEADER_4;
 import static org.opentripplanner.generate.doc.framework.DocsTestConstants.DOCS_ROOT;
 import static org.opentripplanner.generate.doc.framework.DocsTestConstants.TEMPLATE_ROOT;
-import static org.opentripplanner.generate.doc.framework.TemplateUtil.MAPPER;
 import static org.opentripplanner.generate.doc.framework.TemplateUtil.replaceSection;
 import static org.opentripplanner.standalone.config.framework.JsonSupport.jsonNodeFromResource;
 
@@ -17,6 +16,7 @@ import org.opentripplanner.generate.doc.framework.OnlyIfDocsExist;
 import org.opentripplanner.generate.doc.framework.ParameterDetailsList;
 import org.opentripplanner.generate.doc.framework.ParameterSummaryTable;
 import org.opentripplanner.generate.doc.framework.SkipNodes;
+import org.opentripplanner.generate.doc.framework.TemplateUtil;
 import org.opentripplanner.standalone.config.RouterConfig;
 import org.opentripplanner.standalone.config.framework.json.NodeAdapter;
 
@@ -70,8 +70,7 @@ public class FlexConfigurationDocTest {
   }
 
   private void addExample(DocBuilder buf, NodeAdapter node) {
-    var root = MAPPER.createObjectNode();
-    root.set("flex", node.rawNode());
+    var root = TemplateUtil.jsonExampleBuilder(node.rawNode()).wrapInObject("flex").build();
     buf.header(3, "Example configuration", null).addExample("router-config.json", root);
   }
 }

--- a/src/test/java/org/opentripplanner/generate/doc/FlexConfigurationDocTest.java
+++ b/src/test/java/org/opentripplanner/generate/doc/FlexConfigurationDocTest.java
@@ -4,9 +4,9 @@ import static org.opentripplanner.framework.io.FileUtils.assertFileEquals;
 import static org.opentripplanner.framework.io.FileUtils.readFile;
 import static org.opentripplanner.framework.io.FileUtils.writeFile;
 import static org.opentripplanner.framework.text.MarkdownFormatter.HEADER_4;
-import static org.opentripplanner.generate.doc.framework.DocBuilder.MAPPER;
 import static org.opentripplanner.generate.doc.framework.DocsTestConstants.DOCS_ROOT;
 import static org.opentripplanner.generate.doc.framework.DocsTestConstants.TEMPLATE_ROOT;
+import static org.opentripplanner.generate.doc.framework.TemplateUtil.MAPPER;
 import static org.opentripplanner.generate.doc.framework.TemplateUtil.replaceSection;
 import static org.opentripplanner.standalone.config.framework.JsonSupport.jsonNodeFromResource;
 
@@ -72,6 +72,6 @@ public class FlexConfigurationDocTest {
   private void addExample(DocBuilder buf, NodeAdapter node) {
     var root = MAPPER.createObjectNode();
     root.set("flex", node.rawNode());
-    buf.header(3, "Example configuration", null).addExample("router-config.json", node.rawNode());
+    buf.header(3, "Example configuration", null).addExample("router-config.json", root);
   }
 }

--- a/src/test/java/org/opentripplanner/generate/doc/FlexConfigurationDocTest.java
+++ b/src/test/java/org/opentripplanner/generate/doc/FlexConfigurationDocTest.java
@@ -4,6 +4,7 @@ import static org.opentripplanner.framework.io.FileUtils.assertFileEquals;
 import static org.opentripplanner.framework.io.FileUtils.readFile;
 import static org.opentripplanner.framework.io.FileUtils.writeFile;
 import static org.opentripplanner.framework.text.MarkdownFormatter.HEADER_4;
+import static org.opentripplanner.generate.doc.framework.DocBuilder.MAPPER;
 import static org.opentripplanner.generate.doc.framework.DocsTestConstants.DOCS_ROOT;
 import static org.opentripplanner.generate.doc.framework.DocsTestConstants.TEMPLATE_ROOT;
 import static org.opentripplanner.generate.doc.framework.TemplateUtil.replaceSection;
@@ -69,12 +70,8 @@ public class FlexConfigurationDocTest {
   }
 
   private void addExample(DocBuilder buf, NodeAdapter node) {
-    buf
-      .header(3, "Example configuration", null)
-      .addExample(
-        "This feature allows a limited number of config options. To change the " +
-        "configuration, add the following to `router-config.json`.",
-        "\"flex\": %s".formatted(node.toPrettyString().indent(node.level() + 1).trim())
-      );
+    var root = MAPPER.createObjectNode();
+    root.set("flex", node.rawNode());
+    buf.header(3, "Example configuration", null).addExample("router-config.json", node.rawNode());
   }
 }

--- a/src/test/java/org/opentripplanner/generate/doc/RouteRequestDocTest.java
+++ b/src/test/java/org/opentripplanner/generate/doc/RouteRequestDocTest.java
@@ -12,6 +12,7 @@ import static org.opentripplanner.generate.doc.framework.TemplateUtil.replacePar
 import static org.opentripplanner.standalone.config.framework.JsonSupport.jsonNodeFromResource;
 
 import java.io.File;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.generate.doc.framework.OnlyIfDocsExist;
 import org.opentripplanner.generate.doc.framework.ParameterDetailsList;
@@ -21,6 +22,7 @@ import org.opentripplanner.standalone.config.RouterConfig;
 import org.opentripplanner.standalone.config.framework.json.NodeAdapter;
 
 @OnlyIfDocsExist
+@Tag("docs")
 public class RouteRequestDocTest {
 
   private static final File TEMPLATE = new File(TEMPLATE_ROOT, "RouteRequest.md");

--- a/src/test/java/org/opentripplanner/generate/doc/RouterConfigurationDocTest.java
+++ b/src/test/java/org/opentripplanner/generate/doc/RouterConfigurationDocTest.java
@@ -46,7 +46,7 @@ public class RouterConfigurationDocTest {
    */
   @Test
   public void updateBuildConfigurationDoc() {
-    NodeAdapter node = readBuildConfig();
+    NodeAdapter node = readRouterConfig();
 
     // Read and close inout file (same as output file)
     String doc = readFile(TEMPLATE);
@@ -61,7 +61,7 @@ public class RouterConfigurationDocTest {
     assertFileEquals(original, OUT_FILE);
   }
 
-  private NodeAdapter readBuildConfig() {
+  private NodeAdapter readRouterConfig() {
     var json = jsonNodeFromResource(CONFIG_PATH);
     var conf = new RouterConfig(json, CONFIG_PATH, true);
     return conf.asNodeAdapter();

--- a/src/test/java/org/opentripplanner/generate/doc/RouterConfigurationDocTest.java
+++ b/src/test/java/org/opentripplanner/generate/doc/RouterConfigurationDocTest.java
@@ -13,6 +13,7 @@ import static org.opentripplanner.generate.doc.framework.TemplateUtil.replacePar
 import static org.opentripplanner.standalone.config.framework.JsonSupport.jsonNodeFromResource;
 
 import java.io.File;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.generate.doc.framework.OnlyIfDocsExist;
 import org.opentripplanner.generate.doc.framework.ParameterDetailsList;
@@ -22,6 +23,7 @@ import org.opentripplanner.standalone.config.RouterConfig;
 import org.opentripplanner.standalone.config.framework.json.NodeAdapter;
 
 @OnlyIfDocsExist
+@Tag("docs")
 public class RouterConfigurationDocTest {
 
   private static final File TEMPLATE = new File(TEMPLATE_ROOT, "RouterConfiguration.md");

--- a/src/test/java/org/opentripplanner/generate/doc/UpdaterConfigDocTest.java
+++ b/src/test/java/org/opentripplanner/generate/doc/UpdaterConfigDocTest.java
@@ -13,6 +13,7 @@ import static org.opentripplanner.standalone.config.framework.JsonSupport.jsonNo
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
 import java.util.Set;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.generate.doc.framework.DocBuilder;
 import org.opentripplanner.generate.doc.framework.OnlyIfDocsExist;
@@ -23,6 +24,7 @@ import org.opentripplanner.standalone.config.RouterConfig;
 import org.opentripplanner.standalone.config.framework.json.NodeAdapter;
 
 @OnlyIfDocsExist
+@Tag("docs")
 public class UpdaterConfigDocTest {
 
   private static final File TEMPLATE = new File(TEMPLATE_ROOT, "UpdaterConfig.md");

--- a/src/test/java/org/opentripplanner/generate/doc/UpdaterConfigDocTest.java
+++ b/src/test/java/org/opentripplanner/generate/doc/UpdaterConfigDocTest.java
@@ -97,12 +97,6 @@ public class UpdaterConfigDocTest {
 
   private void addExample(DocBuilder buf, NodeAdapter node) {
     buf.addSection("##### Example configuration");
-
-    var updaters = mapper.createArrayNode();
-    updaters.add(node.rawNode());
-    var root = mapper.createObjectNode();
-    root.set("updaters", updaters);
-
-    buf.addExample(ROUTER_CONFIG_FILENAME, root);
+    buf.addUpdaterExample(ROUTER_CONFIG_FILENAME, node.rawNode());
   }
 }

--- a/src/test/java/org/opentripplanner/generate/doc/VehicleParkingDocTest.java
+++ b/src/test/java/org/opentripplanner/generate/doc/VehicleParkingDocTest.java
@@ -11,6 +11,7 @@ import static org.opentripplanner.generate.doc.framework.TemplateUtil.replaceSec
 import static org.opentripplanner.standalone.config.framework.JsonSupport.jsonNodeFromResource;
 
 import java.io.File;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.generate.doc.framework.DocBuilder;
 import org.opentripplanner.generate.doc.framework.OnlyIfDocsExist;
@@ -21,6 +22,7 @@ import org.opentripplanner.standalone.config.RouterConfig;
 import org.opentripplanner.standalone.config.framework.json.NodeAdapter;
 
 @OnlyIfDocsExist
+@Tag("docs")
 public class VehicleParkingDocTest {
 
   private static final File TEMPLATE = new File(TEMPLATE_ROOT, "VehicleParking.md");

--- a/src/test/java/org/opentripplanner/generate/doc/VehicleParkingDocTest.java
+++ b/src/test/java/org/opentripplanner/generate/doc/VehicleParkingDocTest.java
@@ -82,15 +82,6 @@ public class VehicleParkingDocTest {
 
   private void addExample(DocBuilder buf, NodeAdapter node) {
     buf.addSection("##### Example configuration");
-    buf.addExample(
-      ROUTER_CONFIG_FILENAME,
-      """
-      "updaters": [
-        %s
-      ]
-      """.formatted(
-          node.toPrettyString().indent(node.level()).trim()
-        )
-    );
+    buf.addUpdaterExample(ROUTER_CONFIG_FILENAME, node.rawNode());
   }
 }

--- a/src/test/java/org/opentripplanner/generate/doc/framework/DocBuilder.java
+++ b/src/test/java/org/opentripplanner/generate/doc/framework/DocBuilder.java
@@ -100,14 +100,7 @@ public class DocBuilder {
   }
 
   public void addExample(String comment, JsonNode body) {
-    String json = TemplateUtil.prettyPrintJson(body);
-
-    buffer.append("""
-      ```JSON
-      // %s
-      %s
-      ```
-      """.formatted(comment, json));
+    buffer.append(TemplateUtil.jsonExample(body, comment));
   }
 
   public void addUpdaterExample(String comment, JsonNode node) {

--- a/src/test/java/org/opentripplanner/generate/doc/framework/DocBuilder.java
+++ b/src/test/java/org/opentripplanner/generate/doc/framework/DocBuilder.java
@@ -1,14 +1,9 @@
 package org.opentripplanner.generate.doc.framework;
 
 import static org.opentripplanner.framework.text.MarkdownFormatter.NEW_LINE;
+import static org.opentripplanner.generate.doc.framework.TemplateUtil.MAPPER;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.util.DefaultIndenter;
-import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.opentripplanner.framework.text.MarkdownFormatter;
@@ -19,16 +14,6 @@ import org.opentripplanner.standalone.config.framework.json.EnumMapper;
  */
 @SuppressWarnings("UnusedReturnValue")
 public class DocBuilder {
-
-  public static final ObjectMapper MAPPER = new ObjectMapper();
-  public static final ObjectWriter PRETTY_PRINTER;
-
-  static {
-    MAPPER.enable(SerializationFeature.INDENT_OUTPUT);
-    var pp = new DefaultPrettyPrinter();
-    pp.indentArraysWith(DefaultIndenter.SYSTEM_LINEFEED_INSTANCE);
-    PRETTY_PRINTER = MAPPER.writer(pp);
-  }
 
   private final StringBuilder buffer = new StringBuilder();
 
@@ -116,7 +101,7 @@ public class DocBuilder {
   }
 
   public void addExample(String comment, JsonNode body) {
-    String json = prettyPrintJson(body);
+    String json = TemplateUtil.prettyPrintJson(body);
 
     buffer.append("""
       ```JSON
@@ -132,14 +117,6 @@ public class DocBuilder {
     var root = MAPPER.createObjectNode();
     root.set("updaters", updaters);
     addExample(comment, root);
-  }
-
-  private static String prettyPrintJson(JsonNode body) {
-    try {
-      return PRETTY_PRINTER.writeValueAsString(body);
-    } catch (JsonProcessingException e) {
-      throw new RuntimeException(e);
-    }
   }
 
   /**

--- a/src/test/java/org/opentripplanner/generate/doc/framework/DocBuilder.java
+++ b/src/test/java/org/opentripplanner/generate/doc/framework/DocBuilder.java
@@ -20,7 +20,7 @@ import org.opentripplanner.standalone.config.framework.json.EnumMapper;
 @SuppressWarnings("UnusedReturnValue")
 public class DocBuilder {
 
-  private static final ObjectMapper MAPPER = new ObjectMapper();
+  public static final ObjectMapper MAPPER = new ObjectMapper();
   public static final ObjectWriter PRETTY_PRINTER;
 
   static {
@@ -115,22 +115,6 @@ public class DocBuilder {
     return endParagraph();
   }
 
-  public void addExample(String comment, String body) {
-    buffer.append(
-      """
-      ```JSON
-      // %s
-      {
-        %s
-      }
-      ```
-      """.formatted(
-          comment,
-          body.indent(2)
-        )
-    );
-  }
-
   public void addExample(String comment, JsonNode body) {
     String json = prettyPrintJson(body);
 
@@ -140,6 +124,14 @@ public class DocBuilder {
       %s
       ```
       """.formatted(comment, json));
+  }
+
+  public void addUpdaterExample(String comment, JsonNode node) {
+    var updaters = MAPPER.createArrayNode();
+    updaters.add(node);
+    var root = MAPPER.createObjectNode();
+    root.set("updaters", updaters);
+    addExample(comment, root);
   }
 
   private static String prettyPrintJson(JsonNode body) {

--- a/src/test/java/org/opentripplanner/generate/doc/framework/DocBuilder.java
+++ b/src/test/java/org/opentripplanner/generate/doc/framework/DocBuilder.java
@@ -20,14 +20,14 @@ import org.opentripplanner.standalone.config.framework.json.EnumMapper;
 @SuppressWarnings("UnusedReturnValue")
 public class DocBuilder {
 
+  private static final ObjectMapper MAPPER = new ObjectMapper();
   public static final ObjectWriter PRETTY_PRINTER;
 
   static {
-    var mapper = new ObjectMapper();
-    mapper.enable(SerializationFeature.INDENT_OUTPUT);
+    MAPPER.enable(SerializationFeature.INDENT_OUTPUT);
     var pp = new DefaultPrettyPrinter();
     pp.indentArraysWith(DefaultIndenter.SYSTEM_LINEFEED_INSTANCE);
-    PRETTY_PRINTER = mapper.writer(pp);
+    PRETTY_PRINTER = MAPPER.writer(pp);
   }
 
   private final StringBuilder buffer = new StringBuilder();

--- a/src/test/java/org/opentripplanner/generate/doc/framework/DocBuilder.java
+++ b/src/test/java/org/opentripplanner/generate/doc/framework/DocBuilder.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.generate.doc.framework;
 
 import static org.opentripplanner.framework.text.MarkdownFormatter.NEW_LINE;
-import static org.opentripplanner.generate.doc.framework.TemplateUtil.MAPPER;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.List;
@@ -112,10 +111,7 @@ public class DocBuilder {
   }
 
   public void addUpdaterExample(String comment, JsonNode node) {
-    var updaters = MAPPER.createArrayNode();
-    updaters.add(node);
-    var root = MAPPER.createObjectNode();
-    root.set("updaters", updaters);
+    var root = TemplateUtil.jsonExampleBuilder(node).wrapInArray().wrapInObject("updaters").build();
     addExample(comment, root);
   }
 

--- a/src/test/java/org/opentripplanner/generate/doc/framework/JsonExampleBuilder.java
+++ b/src/test/java/org/opentripplanner/generate/doc/framework/JsonExampleBuilder.java
@@ -1,0 +1,38 @@
+package org.opentripplanner.generate.doc.framework;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Objects;
+
+/**
+ * Helper class to build up JSON nodes that can be pretty-printed and inserted into the documentation.
+ *
+ */
+public class JsonExampleBuilder {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private JsonNode node;
+
+  public JsonExampleBuilder(JsonNode node) {
+    Objects.requireNonNull(node);
+    this.node = node;
+  }
+
+  public JsonExampleBuilder wrapInObject(String propName) {
+    var obj = MAPPER.createObjectNode();
+    obj.put(propName, node);
+    node = obj;
+    return this;
+  }
+
+  public JsonExampleBuilder wrapInArray() {
+    var array = MAPPER.createArrayNode();
+    array.add(node);
+    node = array;
+    return this;
+  }
+
+  public JsonNode build() {
+    return node;
+  }
+}

--- a/src/test/java/org/opentripplanner/generate/doc/framework/TemplateUtil.java
+++ b/src/test/java/org/opentripplanner/generate/doc/framework/TemplateUtil.java
@@ -14,8 +14,8 @@ import org.opentripplanner.standalone.config.framework.json.NodeAdapter;
  */
 public class TemplateUtil {
 
-  public static final ObjectMapper MAPPER = new ObjectMapper();
-  public static final ObjectWriter PRETTY_PRINTER;
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final ObjectWriter PRETTY_PRINTER;
 
   static {
     MAPPER.enable(SerializationFeature.INDENT_OUTPUT);
@@ -59,6 +59,10 @@ public class TemplateUtil {
         .formatted(token, replacement, token);
 
     return doc.replace(replaceToken, replacementText);
+  }
+
+  public static JsonExampleBuilder jsonExampleBuilder(JsonNode node) {
+    return new JsonExampleBuilder(node);
   }
 
   private static String replaceToken(String token) {

--- a/src/test/java/org/opentripplanner/generate/doc/framework/TemplateUtil.java
+++ b/src/test/java/org/opentripplanner/generate/doc/framework/TemplateUtil.java
@@ -1,11 +1,28 @@
 package org.opentripplanner.generate.doc.framework;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.util.DefaultIndenter;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import org.opentripplanner.standalone.config.framework.json.NodeAdapter;
 
 /**
  * Replace a text in a file wrapped using HTML comments
  */
 public class TemplateUtil {
+
+  public static final ObjectMapper MAPPER = new ObjectMapper();
+  public static final ObjectWriter PRETTY_PRINTER;
+
+  static {
+    MAPPER.enable(SerializationFeature.INDENT_OUTPUT);
+    var pp = new DefaultPrettyPrinter();
+    pp.indentArraysWith(DefaultIndenter.SYSTEM_LINEFEED_INSTANCE);
+    PRETTY_PRINTER = MAPPER.writer(pp);
+  }
 
   private static final String PARAMETERS_TABLE = "PARAMETERS-TABLE";
   private static final String PARAMETERS_DETAILS = "PARAMETERS-DETAILS";
@@ -59,7 +76,15 @@ public class TemplateUtil {
       ```
       """.formatted(
         source,
-        nodeAdapter.toPrettyString()
+        prettyPrintJson(nodeAdapter.rawNode())
       );
+  }
+
+  public static String prettyPrintJson(JsonNode body) {
+    try {
+      return PRETTY_PRINTER.writeValueAsString(body);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/src/test/java/org/opentripplanner/generate/doc/framework/TemplateUtil.java
+++ b/src/test/java/org/opentripplanner/generate/doc/framework/TemplateUtil.java
@@ -70,18 +70,25 @@ public class TemplateUtil {
   }
 
   /**
-   * Create a JSON example for the node. The given source  from the node
+   * Create a JSON example for an arbitrary JSON node.
    */
-  public static String jsonExample(NodeAdapter nodeAdapter, String source) {
+  public static String jsonExample(JsonNode json, String comment) {
     return """
       ```JSON
       // %s
       %s
       ```
       """.formatted(
-        source,
-        prettyPrintJson(nodeAdapter.rawNode())
+        comment,
+        prettyPrintJson(json)
       );
+  }
+
+  /**
+   * Create a JSON example for the node. The given source  from the node
+   */
+  public static String jsonExample(NodeAdapter nodeAdapter, String source) {
+    return jsonExample(nodeAdapter.rawNode(), source);
   }
 
   public static String prettyPrintJson(JsonNode body) {


### PR DESCRIPTION
### Summary

Pretty-prints all JSON examples when generating the docs.

What has mainly changed is the formatting of arrays which were a little too compact before. Now, every array element starts on a new line.

#### Before
![Screenshot from 2023-01-16 12-51-14](https://user-images.githubusercontent.com/151346/212672827-98ffc9ef-e263-40eb-a77f-fd99a48c39bb.png)

#### After
![Screenshot from 2023-01-16 12-47-43](https://user-images.githubusercontent.com/151346/212672894-ad557f77-b527-42c5-9290-64c23d14aaae.png)
