### PR TITLE
Merge @Tag("docs") and @OnlyIfDocsExist into @GeneratesDocumentation

### DIFF
--- a/src/test/java/org/opentripplanner/generate/doc/BuildConfigurationDocTest.java
+++ b/src/test/java/org/opentripplanner/generate/doc/BuildConfigurationDocTest.java
@@ -12,18 +12,16 @@ import static org.opentripplanner.generate.doc.framework.TemplateUtil.replacePar
 import static org.opentripplanner.standalone.config.framework.JsonSupport.jsonNodeFromResource;
 
 import java.io.File;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.framework.application.OtpFileNames;
-import org.opentripplanner.generate.doc.framework.OnlyIfDocsExist;
+import org.opentripplanner.generate.doc.framework.GeneratesDocumentation;
 import org.opentripplanner.generate.doc.framework.ParameterDetailsList;
 import org.opentripplanner.generate.doc.framework.ParameterSummaryTable;
 import org.opentripplanner.generate.doc.framework.SkipNodes;
 import org.opentripplanner.standalone.config.BuildConfig;
 import org.opentripplanner.standalone.config.framework.json.NodeAdapter;
 
-@OnlyIfDocsExist
-@Tag("docs")
+@GeneratesDocumentation
 public class BuildConfigurationDocTest {
 
   private static final String CONFIG_JSON = OtpFileNames.BUILD_CONFIG_FILENAME;

--- a/src/test/java/org/opentripplanner/generate/doc/ConfigurationDocTest.java
+++ b/src/test/java/org/opentripplanner/generate/doc/ConfigurationDocTest.java
@@ -10,12 +10,10 @@ import static org.opentripplanner.generate.doc.support.ConfigTypeTable.configTyp
 import static org.opentripplanner.generate.doc.support.OTPFeatureTable.otpFeaturesTable;
 
 import java.io.File;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.opentripplanner.generate.doc.framework.OnlyIfDocsExist;
+import org.opentripplanner.generate.doc.framework.GeneratesDocumentation;
 
-@OnlyIfDocsExist
-@Tag("docs")
+@GeneratesDocumentation
 public class ConfigurationDocTest {
 
   private static final File TEMPLATE = new File(TEMPLATE_ROOT, "Configuration.md");

--- a/src/test/java/org/opentripplanner/generate/doc/FlexConfigurationDocTest.java
+++ b/src/test/java/org/opentripplanner/generate/doc/FlexConfigurationDocTest.java
@@ -12,7 +12,7 @@ import static org.opentripplanner.standalone.config.framework.JsonSupport.jsonNo
 import java.io.File;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.generate.doc.framework.DocBuilder;
-import org.opentripplanner.generate.doc.framework.OnlyIfDocsExist;
+import org.opentripplanner.generate.doc.framework.GeneratesDocumentation;
 import org.opentripplanner.generate.doc.framework.ParameterDetailsList;
 import org.opentripplanner.generate.doc.framework.ParameterSummaryTable;
 import org.opentripplanner.generate.doc.framework.SkipNodes;
@@ -20,7 +20,7 @@ import org.opentripplanner.generate.doc.framework.TemplateUtil;
 import org.opentripplanner.standalone.config.RouterConfig;
 import org.opentripplanner.standalone.config.framework.json.NodeAdapter;
 
-@OnlyIfDocsExist
+@GeneratesDocumentation
 public class FlexConfigurationDocTest {
 
   private static final File TEMPLATE = new File(TEMPLATE_ROOT, "Flex.md");

--- a/src/test/java/org/opentripplanner/generate/doc/RouteRequestDocTest.java
+++ b/src/test/java/org/opentripplanner/generate/doc/RouteRequestDocTest.java
@@ -12,17 +12,15 @@ import static org.opentripplanner.generate.doc.framework.TemplateUtil.replacePar
 import static org.opentripplanner.standalone.config.framework.JsonSupport.jsonNodeFromResource;
 
 import java.io.File;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.opentripplanner.generate.doc.framework.OnlyIfDocsExist;
+import org.opentripplanner.generate.doc.framework.GeneratesDocumentation;
 import org.opentripplanner.generate.doc.framework.ParameterDetailsList;
 import org.opentripplanner.generate.doc.framework.ParameterSummaryTable;
 import org.opentripplanner.generate.doc.framework.SkipNodes;
 import org.opentripplanner.standalone.config.RouterConfig;
 import org.opentripplanner.standalone.config.framework.json.NodeAdapter;
 
-@OnlyIfDocsExist
-@Tag("docs")
+@GeneratesDocumentation
 public class RouteRequestDocTest {
 
   private static final File TEMPLATE = new File(TEMPLATE_ROOT, "RouteRequest.md");

--- a/src/test/java/org/opentripplanner/generate/doc/RouterConfigurationDocTest.java
+++ b/src/test/java/org/opentripplanner/generate/doc/RouterConfigurationDocTest.java
@@ -13,17 +13,15 @@ import static org.opentripplanner.generate.doc.framework.TemplateUtil.replacePar
 import static org.opentripplanner.standalone.config.framework.JsonSupport.jsonNodeFromResource;
 
 import java.io.File;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.opentripplanner.generate.doc.framework.OnlyIfDocsExist;
+import org.opentripplanner.generate.doc.framework.GeneratesDocumentation;
 import org.opentripplanner.generate.doc.framework.ParameterDetailsList;
 import org.opentripplanner.generate.doc.framework.ParameterSummaryTable;
 import org.opentripplanner.generate.doc.framework.SkipNodes;
 import org.opentripplanner.standalone.config.RouterConfig;
 import org.opentripplanner.standalone.config.framework.json.NodeAdapter;
 
-@OnlyIfDocsExist
-@Tag("docs")
+@GeneratesDocumentation
 public class RouterConfigurationDocTest {
 
   private static final File TEMPLATE = new File(TEMPLATE_ROOT, "RouterConfiguration.md");

--- a/src/test/java/org/opentripplanner/generate/doc/UpdaterConfigDocTest.java
+++ b/src/test/java/org/opentripplanner/generate/doc/UpdaterConfigDocTest.java
@@ -13,18 +13,16 @@ import static org.opentripplanner.standalone.config.framework.JsonSupport.jsonNo
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
 import java.util.Set;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.generate.doc.framework.DocBuilder;
-import org.opentripplanner.generate.doc.framework.OnlyIfDocsExist;
+import org.opentripplanner.generate.doc.framework.GeneratesDocumentation;
 import org.opentripplanner.generate.doc.framework.ParameterDetailsList;
 import org.opentripplanner.generate.doc.framework.ParameterSummaryTable;
 import org.opentripplanner.generate.doc.framework.SkipNodes;
 import org.opentripplanner.standalone.config.RouterConfig;
 import org.opentripplanner.standalone.config.framework.json.NodeAdapter;
 
-@OnlyIfDocsExist
-@Tag("docs")
+@GeneratesDocumentation
 public class UpdaterConfigDocTest {
 
   private static final File TEMPLATE = new File(TEMPLATE_ROOT, "UpdaterConfig.md");

--- a/src/test/java/org/opentripplanner/generate/doc/VehicleParkingDocTest.java
+++ b/src/test/java/org/opentripplanner/generate/doc/VehicleParkingDocTest.java
@@ -11,18 +11,16 @@ import static org.opentripplanner.generate.doc.framework.TemplateUtil.replaceSec
 import static org.opentripplanner.standalone.config.framework.JsonSupport.jsonNodeFromResource;
 
 import java.io.File;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.generate.doc.framework.DocBuilder;
-import org.opentripplanner.generate.doc.framework.OnlyIfDocsExist;
+import org.opentripplanner.generate.doc.framework.GeneratesDocumentation;
 import org.opentripplanner.generate.doc.framework.ParameterDetailsList;
 import org.opentripplanner.generate.doc.framework.ParameterSummaryTable;
 import org.opentripplanner.generate.doc.framework.SkipNodes;
 import org.opentripplanner.standalone.config.RouterConfig;
 import org.opentripplanner.standalone.config.framework.json.NodeAdapter;
 
-@OnlyIfDocsExist
-@Tag("docs")
+@GeneratesDocumentation
 public class VehicleParkingDocTest {
 
   private static final File TEMPLATE = new File(TEMPLATE_ROOT, "VehicleParking.md");

--- a/src/test/java/org/opentripplanner/generate/doc/framework/DocsTestConstants.java
+++ b/src/test/java/org/opentripplanner/generate/doc/framework/DocsTestConstants.java
@@ -14,7 +14,7 @@ public interface DocsTestConstants {
 
   /**
    * This method return {@code true} if the /docs directory is available. If not, a warning is
-   * logged and the method returns {@code false}. This is used by the {@link OnlyIfDocsExist}
+   * logged and the method returns {@code false}. This is used by the {@link GeneratesDocumentation}
    * annotation.
    */
   static boolean docsExistOrWarn() {

--- a/src/test/java/org/opentripplanner/generate/doc/framework/GeneratesDocumentation.java
+++ b/src/test/java/org/opentripplanner/generate/doc/framework/GeneratesDocumentation.java
@@ -4,18 +4,28 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.condition.EnabledIf;
 
 /**
- * Use this annotation on tests that access the /docs folder outside the source/resource.
+ * Use this annotation on tests that generate(access) the /docs directory outside the
+ * source/resource.
+ * <p>
+ * All tests annotated with this annotation is tagged with "docs". You may include or exclude
+ * these when running the tests. To only run doc generation use:
+ * <pre>
+ *   mvn test -Dgroups=docs
+ * </pre>
+ * <p>
  * Accessing files that are not on class-path is error prune and should be avoided. This
- * annotation is used to prevent the test from failing and log a WARNING when the test are run
+ * annotation will prevent the test from failing and only log a WARNING if the test is run
  * in a different environment.
  * <p>
  * See {@link DocsTestConstants#docsExistOrWarn}
  */
+@Tag("docs")
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @EnabledIf("org.opentripplanner.generate.doc.framework.DocsTestConstants#docsExistOrWarn")
-public @interface OnlyIfDocsExist {
+public @interface GeneratesDocumentation {
 }

--- a/src/test/java/org/opentripplanner/standalone/config/ExampleConfigTest.java
+++ b/src/test/java/org/opentripplanner/standalone/config/ExampleConfigTest.java
@@ -11,14 +11,14 @@ import java.util.function.Consumer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.opentest4j.AssertionFailedError;
-import org.opentripplanner.generate.doc.framework.OnlyIfDocsExist;
+import org.opentripplanner.generate.doc.framework.GeneratesDocumentation;
 import org.opentripplanner.standalone.config.framework.JsonSupport;
 import org.opentripplanner.standalone.config.framework.json.NodeAdapter;
 import org.opentripplanner.standalone.config.framework.project.EnvironmentVariableReplacer;
 import org.opentripplanner.test.support.FilePatternSource;
 import org.opentripplanner.transit.speed_test.options.SpeedTestConfig;
 
-@OnlyIfDocsExist
+@GeneratesDocumentation
 public class ExampleConfigTest {
 
   @FilePatternSource(pattern = "docs/examples/**/" + ROUTER_CONFIG_FILENAME)


### PR DESCRIPTION
### Summary

This is just a small cleanup, merging the `@Tag("docs")` and `@OnlyIfDocsExist` into one annotation `@GeneratesDocumentation`. This make it a bit more robust since we want to tag ALL doc generating tests with "docs" and make sure they are safe - do not fail if run without the docs folder present.

### Documentation

JavaDoc is updated, tests run as before - also with filtering on `docs`.
