### PR TITLE
OSMway in defaultSafetyForPermission function

### DIFF
--- a/src/main/java/org/opentripplanner/framework/functional/FunctionUtils.java
+++ b/src/main/java/org/opentripplanner/framework/functional/FunctionUtils.java
@@ -1,0 +1,17 @@
+package org.opentripplanner.framework.functional;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+public class FunctionUtils {
+
+  @FunctionalInterface
+  public interface TriFunction<A, B, C, R> {
+    R apply(A a, B b, C c);
+
+    default <V> TriFunction<A, B, C, V> andThen(Function<? super R, ? extends V> after) {
+      Objects.requireNonNull(after);
+      return (A a, B b, C c) -> after.apply(apply(a, b, c));
+    }
+  }
+}

--- a/src/main/java/org/opentripplanner/openstreetmap/tagmapping/FinlandMapper.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/tagmapping/FinlandMapper.java
@@ -7,7 +7,7 @@ import static org.opentripplanner.street.model.StreetTraversalPermission.NONE;
 import static org.opentripplanner.street.model.StreetTraversalPermission.PEDESTRIAN;
 import static org.opentripplanner.street.model.StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE;
 
-import java.util.function.BiFunction;
+import org.opentripplanner.framework.functional.FunctionUtils.TriFunction;
 import org.opentripplanner.openstreetmap.model.OSMWithTags;
 import org.opentripplanner.openstreetmap.wayproperty.WayPropertySet;
 import org.opentripplanner.street.model.StreetTraversalPermission;
@@ -28,9 +28,10 @@ class FinlandMapper implements OsmTagMapper {
 
   @Override
   public void populateProperties(WayPropertySet props) {
-    BiFunction<StreetTraversalPermission, Float, Double> defaultWalkSafetyForPermission = (
+    TriFunction<StreetTraversalPermission, Float, OSMWithTags, Double> defaultWalkSafetyForPermission = (
         permission,
-        speedLimit
+        speedLimit,
+        way
       ) ->
       switch (permission) {
         case ALL, PEDESTRIAN_AND_CAR -> {


### PR DESCRIPTION
I will like too hear if it is a good idea to pass `OSMway` along with permission and speed in the `defaultWalkSafetyForPermission` and `defaultBicycleSafetyForPermission` functions.
This allows me to set a flat value for roads with sidewalks not mapped separately, without listing all permutations of sidewalks and cycleway tags, using a condition directly in the `defaultWalkSafetyForPermission`  function.
It also allows using `isMotorVehicleThroughTrafficExplicitlyDisallowed` in `defaultBicycleSafetyForPermission`.
Both are useful, but it comes with the cost of passing yet another parameter through `defaultWalkSafetyForPermission` and `defaultBicycleSafetyForPermission`, and the name of the function implies that it may not be what these functions were intended for.