### PR TITLE
Add more module tests to Raptor for all relevant profiles

### DIFF
--- a/src/test/java/org/opentripplanner/raptor/moduletests/A01_SingeRouteTest.java
+++ b/src/test/java/org/opentripplanner/raptor/moduletests/A01_SingeRouteTest.java
@@ -5,31 +5,29 @@ import static org.opentripplanner.raptor._data.api.PathUtils.pathsToString;
 import static org.opentripplanner.raptor._data.transit.TestRoute.route;
 import static org.opentripplanner.raptor._data.transit.TestTripPattern.pattern;
 import static org.opentripplanner.raptor._data.transit.TestTripSchedule.schedule;
+import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.multiCriteria;
+import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.standard;
 
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner.raptor.RaptorService;
 import org.opentripplanner.raptor._data.RaptorTestConstants;
 import org.opentripplanner.raptor._data.transit.TestAccessEgress;
 import org.opentripplanner.raptor._data.transit.TestTransitData;
 import org.opentripplanner.raptor._data.transit.TestTripSchedule;
-import org.opentripplanner.raptor.api.model.SearchDirection;
-import org.opentripplanner.raptor.api.request.RaptorProfile;
 import org.opentripplanner.raptor.api.request.RaptorRequestBuilder;
 import org.opentripplanner.raptor.configure.RaptorConfig;
+import org.opentripplanner.raptor.moduletests.support.RaptorModuleTestCase;
 
 /**
  * FEATURE UNDER TEST
  * <p>
- * Raptor should return a path if it exist for the most basic case with one route with one trip, an
+ * Raptor should return a path if it exists for the most basic case with one route with one trip, an
  * access and an egress path.
  */
 public class A01_SingeRouteTest implements RaptorTestConstants {
-
-  private static final String EXP_PATH =
-    "Walk 30s ~ B ~ BUS R1 0:01 0:05 ~ D ~ Walk 20s " + "[0:00:30 0:05:20 4m50s 0tx";
-  private static final String EXP_PATH_NO_COST = EXP_PATH + "]";
-  private static final String EXP_PATH_WITH_COST = EXP_PATH + " $940]";
 
   private final TestTransitData data = new TestTransitData();
   private final RaptorRequestBuilder<TestTripSchedule> requestBuilder = new RaptorRequestBuilder<>();
@@ -53,7 +51,7 @@ public class A01_SingeRouteTest implements RaptorTestConstants {
    *   3  20s
    */
   @BeforeEach
-  public void setup() {
+  void setup() {
     data.withRoute(
       route(pattern("R1", STOP_B, STOP_C, STOP_D)).withTimetable(schedule("00:01, 00:03, 00:05"))
     );
@@ -68,37 +66,22 @@ public class A01_SingeRouteTest implements RaptorTestConstants {
     ModuleTestDebugLogging.setupDebugLogging(data, requestBuilder);
   }
 
-  @Test
-  public void standardOneIteration() {
-    var request = requestBuilder
-      .profile(RaptorProfile.STANDARD)
-      .searchParams()
-      .searchOneIterationOnly()
+  static List<RaptorModuleTestCase> testCases() {
+    return RaptorModuleTestCase
+      .of()
+      .add(standard(), "Walk 30s ~ B ~ BUS R1 0:01 0:05 ~ D ~ Walk 20s [0:00:30 0:05:20 4m50s 0tx]")
+      .add(
+        multiCriteria(),
+        "Walk 30s ~ B ~ BUS R1 0:01 0:05 ~ D ~ Walk 20s [0:00:30 0:05:20 4m50s 0tx $940]"
+      )
       .build();
-
-    var response = raptorService.route(request, data);
-
-    assertEquals(EXP_PATH_NO_COST, pathsToString(response));
   }
 
-  @Test
-  public void standardReverseWithoutSearchWindow() {
-    var request = requestBuilder
-      .searchDirection(SearchDirection.REVERSE)
-      .profile(RaptorProfile.STANDARD)
-      .build();
-
+  @ParameterizedTest
+  @MethodSource("testCases")
+  void testRaptor(RaptorModuleTestCase testCase) {
+    var request = testCase.withConfig(requestBuilder);
     var response = raptorService.route(request, data);
-
-    assertEquals(EXP_PATH_NO_COST, pathsToString(response));
-  }
-
-  @Test
-  public void multiCriteria() {
-    var request = requestBuilder.profile(RaptorProfile.MULTI_CRITERIA).build();
-
-    var response = raptorService.route(request, data);
-
-    assertEquals(EXP_PATH_WITH_COST, pathsToString(response));
+    assertEquals(testCase.expected(), pathsToString(response));
   }
 }

--- a/src/test/java/org/opentripplanner/raptor/moduletests/A02_SingeRouteRestrictionsTest.java
+++ b/src/test/java/org/opentripplanner/raptor/moduletests/A02_SingeRouteRestrictionsTest.java
@@ -5,19 +5,22 @@ import static org.opentripplanner.raptor._data.api.PathUtils.pathsToString;
 import static org.opentripplanner.raptor._data.transit.TestRoute.route;
 import static org.opentripplanner.raptor._data.transit.TestTripPattern.pattern;
 import static org.opentripplanner.raptor._data.transit.TestTripSchedule.schedule;
+import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.multiCriteria;
+import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.standard;
 
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner.raptor.RaptorService;
 import org.opentripplanner.raptor._data.RaptorTestConstants;
 import org.opentripplanner.raptor._data.transit.TestAccessEgress;
 import org.opentripplanner.raptor._data.transit.TestTransitData;
 import org.opentripplanner.raptor._data.transit.TestTripPattern;
 import org.opentripplanner.raptor._data.transit.TestTripSchedule;
-import org.opentripplanner.raptor.api.model.SearchDirection;
-import org.opentripplanner.raptor.api.request.RaptorProfile;
 import org.opentripplanner.raptor.api.request.RaptorRequestBuilder;
 import org.opentripplanner.raptor.configure.RaptorConfig;
+import org.opentripplanner.raptor.moduletests.support.RaptorModuleTestCase;
 
 /**
  * FEATURE UNDER TEST
@@ -52,7 +55,7 @@ public class A02_SingeRouteRestrictionsTest implements RaptorTestConstants {
    *
    */
   @BeforeEach
-  public void setup() {
+  void setup() {
     TestTripPattern pattern = pattern("R1", STOP_B, STOP_C, STOP_D);
     pattern.restrictions("BW BA AW");
     data.withRoute(route(pattern).withTimetable(schedule("00:01, 00:03, 00:05")));
@@ -67,42 +70,22 @@ public class A02_SingeRouteRestrictionsTest implements RaptorTestConstants {
     ModuleTestDebugLogging.setupDebugLogging(data, requestBuilder);
   }
 
-  @Test
-  public void standard() {
-    var request = requestBuilder.profile(RaptorProfile.STANDARD).build();
-
-    var response = raptorService.route(request, data);
-
-    assertEquals(
-      "Walk 30s ~ B ~ BUS R1 0:01 0:05 ~ D ~ Walk 20s [0:00:30 0:05:20 4m50s 0tx]",
-      pathsToString(response)
-    );
-  }
-
-  @Test
-  public void standardReverse() {
-    var request = requestBuilder
-      .searchDirection(SearchDirection.REVERSE)
-      .profile(RaptorProfile.STANDARD)
+  static List<RaptorModuleTestCase> testCases() {
+    return RaptorModuleTestCase
+      .of()
+      .add(standard(), "Walk 30s ~ B ~ BUS R1 0:01 0:05 ~ D ~ Walk 20s [0:00:30 0:05:20 4m50s 0tx]")
+      .add(
+        multiCriteria(),
+        "Walk 30s ~ B ~ BUS R1 0:01 0:05 ~ D ~ Walk 20s [0:00:30 0:05:20 4m50s 0tx $940]"
+      )
       .build();
-
-    var response = raptorService.route(request, data);
-
-    assertEquals(
-      "Walk 30s ~ B ~ BUS R1 0:01 0:05 ~ D ~ Walk 20s [0:00:30 0:05:20 4m50s 0tx]",
-      pathsToString(response)
-    );
   }
 
-  @Test
-  public void multiCriteria() {
-    var request = requestBuilder.profile(RaptorProfile.MULTI_CRITERIA).build();
-
+  @ParameterizedTest
+  @MethodSource("testCases")
+  void testRaptor(RaptorModuleTestCase testCase) {
+    var request = testCase.withConfig(requestBuilder);
     var response = raptorService.route(request, data);
-
-    assertEquals(
-      "Walk 30s ~ B ~ BUS R1 0:01 0:05 ~ D ~ Walk 20s [0:00:30 0:05:20 4m50s 0tx $940]",
-      pathsToString(response)
-    );
+    assertEquals(testCase.expected(), pathsToString(response));
   }
 }

--- a/src/test/java/org/opentripplanner/raptor/moduletests/A04_BoardingTest.java
+++ b/src/test/java/org/opentripplanner/raptor/moduletests/A04_BoardingTest.java
@@ -1,23 +1,25 @@
 package org.opentripplanner.raptor.moduletests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.raptor._data.api.PathUtils.pathsToString;
 import static org.opentripplanner.raptor._data.transit.TestRoute.route;
 import static org.opentripplanner.raptor._data.transit.TestTripSchedule.schedule;
-import static org.opentripplanner.raptor.api.model.SearchDirection.REVERSE;
-import static org.opentripplanner.raptor.api.request.RaptorProfile.MIN_TRAVEL_DURATION;
-import static org.opentripplanner.raptor.api.request.RaptorProfile.MULTI_CRITERIA;
-import static org.opentripplanner.raptor.api.request.RaptorProfile.STANDARD;
+import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.minDuration;
+import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.multiCriteria;
 
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner.raptor.RaptorService;
 import org.opentripplanner.raptor._data.RaptorTestConstants;
-import org.opentripplanner.raptor._data.api.PathUtils;
 import org.opentripplanner.raptor._data.transit.TestAccessEgress;
 import org.opentripplanner.raptor._data.transit.TestTransitData;
 import org.opentripplanner.raptor._data.transit.TestTripSchedule;
 import org.opentripplanner.raptor.api.request.RaptorRequestBuilder;
 import org.opentripplanner.raptor.configure.RaptorConfig;
+import org.opentripplanner.raptor.moduletests.support.RaptorModuleTestCase;
+import org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig;
 
 /**
  * FEATURE UNDER TEST
@@ -72,7 +74,14 @@ public class A04_BoardingTest implements RaptorTestConstants {
     "~ Walk 1m [0:13 0:41 28m 2tx";
 
   /** Expect the optimal path to be found. */
-  private final String EXP_PATH_MIN_TRAVEL_DURATION = OPTIMAL_PATH + "]";
+  private static final String EXP_PATH_MIN_TRAVEL_DURATION = OPTIMAL_PATH + "]";
+
+  /**
+   * The multi-criteria search should find the best alternative, because it looks at the
+   * arrival-time, generalized-cost, and departure-time(travel-time). In this case the same path as
+   * the min-travel-duration will find.
+   */
+  private static final String EXP_PATH_MC = OPTIMAL_PATH + " $3600]";
 
   private final TestTransitData data = new TestTransitData();
   private final RaptorRequestBuilder<TestTripSchedule> requestBuilder = new RaptorRequestBuilder<>();
@@ -80,15 +89,8 @@ public class A04_BoardingTest implements RaptorTestConstants {
     RaptorConfig.defaultConfigForTest()
   );
 
-  /**
-   * The multi-criteria search should find the best alternative, because it looks at the
-   * arrival-time, generalized-cost, and departure-time(travel-time). In this case the same path as
-   * the min-travel-duration will find.
-   */
-  private final String EXP_PATH_MC = OPTIMAL_PATH + " $3600]";
-
   @BeforeEach
-  public void setup() {
+  void setup() {
     // There is three possible paths before boarding trip L2
     data.withRoute(route("L1_1", STOP_A, STOP_B).withTimetable(schedule("0:10 0:18")));
     data.withRoute(route("L1_2", STOP_A, STOP_C).withTimetable(schedule("0:14 0:18")));
@@ -115,47 +117,27 @@ public class A04_BoardingTest implements RaptorTestConstants {
     ModuleTestDebugLogging.setupDebugLogging(data, requestBuilder);
   }
 
-  /**
-   * A test on the standard profile is included to demonstrate that the min-travel-duration and the
-   * standard give different results. The L2 boarding stop is different.
-   */
-  @Test
-  public void standard() {
-    requestBuilder.profile(STANDARD);
-    var response = raptorService.route(requestBuilder.build(), data);
-    assertEquals(EXP_PATH_BEST_ARRIVAL_TIME, PathUtils.pathsToString(response));
+  static List<RaptorModuleTestCase> testCases() {
+    return RaptorModuleTestCase
+      .of()
+      // A test on the standard profile is included to demonstrate that the
+      // min-travel-duration and the standard give different results. The L2
+      // boarding stop is different.
+      .add(RaptorModuleTestConfig.standard().forwardOnly(), EXP_PATH_BEST_ARRIVAL_TIME)
+      // A reverse test on the standard profile is included to demonstrate
+      // that the min-travel-duration and the standard give different results
+      // when searching in reverse. The L2 alight stop is different.
+      .add(RaptorModuleTestConfig.standard().reverseOnly(), EXP_PATH_BEST_ARRIVAL_TIME_REVERSE)
+      .add(minDuration(), EXP_PATH_MIN_TRAVEL_DURATION)
+      .add(multiCriteria(), EXP_PATH_MC)
+      .build();
   }
 
-  @Test
-  public void minTravelDuration() {
-    requestBuilder.profile(MIN_TRAVEL_DURATION);
-    var response = raptorService.route(requestBuilder.build(), data);
-    assertEquals(EXP_PATH_MIN_TRAVEL_DURATION, PathUtils.pathsToString(response));
-  }
-
-  /**
-   * A reverse test on the standard profile is included to demonstrate that the min-travel-duration
-   * and the standard give different results when searching in reverse. The L2 alight stop is
-   * different.
-   */
-  @Test
-  public void standardReverse() {
-    requestBuilder.profile(STANDARD).searchDirection(REVERSE);
-    var response = raptorService.route(requestBuilder.build(), data);
-    assertEquals(EXP_PATH_BEST_ARRIVAL_TIME_REVERSE, PathUtils.pathsToString(response));
-  }
-
-  @Test
-  public void minTravelDurationReverse() {
-    requestBuilder.profile(MIN_TRAVEL_DURATION).searchDirection(REVERSE);
-    var response = raptorService.route(requestBuilder.build(), data);
-    assertEquals(EXP_PATH_MIN_TRAVEL_DURATION, PathUtils.pathsToString(response));
-  }
-
-  @Test
-  public void multiCriteria() {
-    requestBuilder.profile(MULTI_CRITERIA);
-    var response = raptorService.route(requestBuilder.build(), data);
-    assertEquals(EXP_PATH_MC, PathUtils.pathsToString(response));
+  @ParameterizedTest
+  @MethodSource("testCases")
+  void testRaptor(RaptorModuleTestCase testCase) {
+    var request = testCase.withConfig(requestBuilder);
+    var response = raptorService.route(request, data);
+    assertEquals(testCase.expected(), pathsToString(response));
   }
 }

--- a/src/test/java/org/opentripplanner/raptor/moduletests/A04_BoardingTest.java
+++ b/src/test/java/org/opentripplanner/raptor/moduletests/A04_BoardingTest.java
@@ -6,6 +6,7 @@ import static org.opentripplanner.raptor._data.transit.TestRoute.route;
 import static org.opentripplanner.raptor._data.transit.TestTripSchedule.schedule;
 import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.minDuration;
 import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.multiCriteria;
+import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.standard;
 
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,7 +20,6 @@ import org.opentripplanner.raptor._data.transit.TestTripSchedule;
 import org.opentripplanner.raptor.api.request.RaptorRequestBuilder;
 import org.opentripplanner.raptor.configure.RaptorConfig;
 import org.opentripplanner.raptor.moduletests.support.RaptorModuleTestCase;
-import org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig;
 
 /**
  * FEATURE UNDER TEST
@@ -123,11 +123,11 @@ public class A04_BoardingTest implements RaptorTestConstants {
       // A test on the standard profile is included to demonstrate that the
       // min-travel-duration and the standard give different results. The L2
       // boarding stop is different.
-      .add(RaptorModuleTestConfig.standard().forwardOnly(), EXP_PATH_BEST_ARRIVAL_TIME)
+      .add(standard().forwardOnly(), EXP_PATH_BEST_ARRIVAL_TIME)
       // A reverse test on the standard profile is included to demonstrate
       // that the min-travel-duration and the standard give different results
       // when searching in reverse. The L2 alight stop is different.
-      .add(RaptorModuleTestConfig.standard().reverseOnly(), EXP_PATH_BEST_ARRIVAL_TIME_REVERSE)
+      .add(standard().reverseOnly(), EXP_PATH_BEST_ARRIVAL_TIME_REVERSE)
       .add(minDuration(), EXP_PATH_MIN_TRAVEL_DURATION)
       .add(multiCriteria(), EXP_PATH_MC)
       .build();

--- a/src/test/java/org/opentripplanner/raptor/moduletests/B01_AccessTest.java
+++ b/src/test/java/org/opentripplanner/raptor/moduletests/B01_AccessTest.java
@@ -1,25 +1,27 @@
 package org.opentripplanner.raptor.moduletests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.opentripplanner.raptor._data.api.PathUtils.join;
+import static org.opentripplanner.raptor._data.api.PathUtils.pathsToStringDetailed;
 import static org.opentripplanner.raptor._data.transit.TestRoute.route;
 import static org.opentripplanner.raptor._data.transit.TestTripSchedule.schedule;
-import static org.opentripplanner.raptor.api.model.SearchDirection.REVERSE;
-import static org.opentripplanner.raptor.api.request.RaptorProfile.MULTI_CRITERIA;
-import static org.opentripplanner.raptor.api.request.RaptorProfile.STANDARD;
+import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.TC_STANDARD_ONE;
+import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.multiCriteria;
 
 import java.time.Duration;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner.framework.time.DurationUtils;
 import org.opentripplanner.raptor.RaptorService;
 import org.opentripplanner.raptor._data.RaptorTestConstants;
-import org.opentripplanner.raptor._data.api.PathUtils;
 import org.opentripplanner.raptor._data.transit.TestAccessEgress;
 import org.opentripplanner.raptor._data.transit.TestTransitData;
 import org.opentripplanner.raptor._data.transit.TestTripSchedule;
 import org.opentripplanner.raptor.api.request.RaptorRequestBuilder;
 import org.opentripplanner.raptor.configure.RaptorConfig;
+import org.opentripplanner.raptor.moduletests.support.RaptorModuleTestCase;
+import org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig;
 
 /**
  * FEATURE UNDER TEST
@@ -36,7 +38,7 @@ public class B01_AccessTest implements RaptorTestConstants {
   );
 
   @BeforeEach
-  public void setup() {
+  void setup() {
     data.withRoute(
       route("R1", STOP_B, STOP_C, STOP_D, STOP_E, STOP_F)
         .withTimetable(schedule("0:10 0:14 0:18 0:22 0:25"))
@@ -59,46 +61,33 @@ public class B01_AccessTest implements RaptorTestConstants {
     ModuleTestDebugLogging.setupDebugLogging(data, requestBuilder);
   }
 
-  @Test
-  public void standard() {
-    requestBuilder.profile(STANDARD);
-
-    var response = raptorService.route(requestBuilder.build(), data);
-
-    // expect: one path with the latest departure time.
-    assertEquals(
-      "Walk 7m ~ D ~ BUS R1 0:18 0:25 ~ F ~ Walk 1s [0:11 0:25:01 14m1s 0tx]",
-      PathUtils.pathsToString(response)
-    );
-  }
-
-  @Test
-  public void standardReverse() {
-    requestBuilder.profile(STANDARD).searchDirection(REVERSE);
-
-    var response = raptorService.route(requestBuilder.build(), data);
-
-    // expect: one path with the latest departure time, same as found in the forward search.
-    assertEquals(
-      "Walk 7m ~ D ~ BUS R1 0:18 0:25 ~ F ~ Walk 1s [0:11 0:25:01 14m1s 0tx]",
-      PathUtils.pathsToString(response)
-    );
-  }
-
-  @Test
-  public void multiCriteria() {
-    requestBuilder.profile(MULTI_CRITERIA).searchParams().timetable(true);
-
-    var response = raptorService.route(requestBuilder.build(), data);
-
-    // expect: All pareto optimal paths
-    assertEquals(
-      join(
+  static List<RaptorModuleTestCase> testCases() {
+    return RaptorModuleTestCase
+      .of()
+      .add(
+        RaptorModuleTestConfig.standard().not(TC_STANDARD_ONE),
+        "Walk 7m 0:11 0:18 ~ D 0s ~ BUS R1 0:18 0:25 7m ~ F 0s ~ Walk 1s 0:25 0:25:01 [0:11 0:25:01 14m1s 0tx]"
+      )
+      .add(
+        // When we run one iteration the access boarding first is used as long as it
+        // arrives at the origin at the same time. In this case the "worst" path is kept.
+        TC_STANDARD_ONE,
+        "Walk 1s 0:09:59 0:10 ~ B 0s ~ BUS R1 0:10 0:25 15m ~ F 0s ~ Walk 1s 0:25 0:25:01 [0:09:59 0:25:01 15m2s 0tx]"
+      )
+      .add(
+        multiCriteria(),
         "Walk 7m 0:11 0:18 $840 ~ D 0s ~ BUS R1 0:18 0:25 7m $1020 ~ F 0s ~ Walk 1s 0:25 0:25:01 $2 [0:11 0:25:01 14m1s 0tx $1862]",
         "Walk 4m 0:10 0:14 $480 ~ C 0s ~ BUS R1 0:14 0:25 11m $1260 ~ F 0s ~ Walk 1s 0:25 0:25:01 $2 [0:10 0:25:01 15m1s 0tx $1742]",
         "Walk 1s 0:09:59 0:10 $2 ~ B 0s ~ BUS R1 0:10 0:25 15m $1500 ~ F 0s ~ Walk 1s 0:25 0:25:01 $2 [0:09:59 0:25:01 15m2s 0tx $1504]"
-      ),
-      PathUtils.pathsToStringDetailed(response)
-    );
+      )
+      .build();
+  }
+
+  @ParameterizedTest
+  @MethodSource("testCases")
+  void testRaptor(RaptorModuleTestCase testCase) {
+    var request = testCase.withConfig(requestBuilder);
+    var response = raptorService.route(request, data);
+    assertEquals(testCase.expected(), pathsToStringDetailed(response));
   }
 }

--- a/src/test/java/org/opentripplanner/raptor/moduletests/B02_EgressTest.java
+++ b/src/test/java/org/opentripplanner/raptor/moduletests/B02_EgressTest.java
@@ -5,6 +5,7 @@ import static org.opentripplanner.raptor._data.api.PathUtils.pathsToString;
 import static org.opentripplanner.raptor._data.transit.TestRoute.route;
 import static org.opentripplanner.raptor._data.transit.TestTripSchedule.schedule;
 import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.TC_STANDARD_REV_ONE;
+import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.multiCriteria;
 import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.standard;
 
 import java.util.List;
@@ -19,7 +20,6 @@ import org.opentripplanner.raptor._data.transit.TestTripSchedule;
 import org.opentripplanner.raptor.api.request.RaptorRequestBuilder;
 import org.opentripplanner.raptor.configure.RaptorConfig;
 import org.opentripplanner.raptor.moduletests.support.RaptorModuleTestCase;
-import org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig;
 
 /**
  * FEATURE UNDER TEST
@@ -71,7 +71,7 @@ public class B02_EgressTest implements RaptorTestConstants {
         "Walk 20s ~ B ~ BUS R1 0:10 0:28 ~ G ~ Walk 1s [0:09:40 0:28:01 18m21s 0tx]"
       )
       .add(
-        RaptorModuleTestConfig.multiCriteria(),
+        multiCriteria(),
         "Walk 20s ~ B ~ BUS R1 0:10 0:20 ~ E ~ Walk 7m [0:09:40 0:27 17m20s 0tx $2080]",
         "Walk 20s ~ B ~ BUS R1 0:10 0:24 ~ F ~ Walk 4m [0:09:40 0:28 18m20s 0tx $1960]",
         "Walk 20s ~ B ~ BUS R1 0:10 0:28 ~ G ~ Walk 1s [0:09:40 0:28:01 18m21s 0tx $1722]"

--- a/src/test/java/org/opentripplanner/raptor/moduletests/B03_AccessEgressTest.java
+++ b/src/test/java/org/opentripplanner/raptor/moduletests/B03_AccessEgressTest.java
@@ -1,23 +1,27 @@
 package org.opentripplanner.raptor.moduletests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.opentripplanner.raptor._data.api.PathUtils.join;
+import static org.opentripplanner.raptor._data.api.PathUtils.pathsToString;
 import static org.opentripplanner.raptor._data.transit.TestRoute.route;
 import static org.opentripplanner.raptor._data.transit.TestTripSchedule.schedule;
-import static org.opentripplanner.raptor.api.model.SearchDirection.REVERSE;
-import static org.opentripplanner.raptor.api.request.RaptorProfile.MULTI_CRITERIA;
-import static org.opentripplanner.raptor.api.request.RaptorProfile.STANDARD;
+import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.TC_STANDARD_ONE;
+import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.TC_STANDARD_REV_ONE;
+import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.multiCriteria;
+import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.standard;
 
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner.raptor.RaptorService;
 import org.opentripplanner.raptor._data.RaptorTestConstants;
-import org.opentripplanner.raptor._data.api.PathUtils;
 import org.opentripplanner.raptor._data.transit.TestAccessEgress;
 import org.opentripplanner.raptor._data.transit.TestTransitData;
 import org.opentripplanner.raptor._data.transit.TestTripSchedule;
 import org.opentripplanner.raptor.api.request.RaptorRequestBuilder;
 import org.opentripplanner.raptor.configure.RaptorConfig;
+import org.opentripplanner.raptor.moduletests.support.RaptorModuleTestCase;
+import org.opentripplanner.raptor.moduletests.support.RaptorModuleTestCaseBuilder;
 
 /**
  * FEATURE UNDER TEST
@@ -61,43 +65,25 @@ public class B03_AccessEgressTest implements RaptorTestConstants {
     ModuleTestDebugLogging.setupDebugLogging(data, requestBuilder);
   }
 
-  @Test
-  public void standard() {
-    requestBuilder.profile(STANDARD);
-
-    var response = raptorService.route(requestBuilder.build(), data);
-
-    // expect: The latest departure combined with the earliest arrival is expected
-    assertEquals(
-      "Walk 7m ~ C ~ BUS R1 0:18 0:32 ~ F ~ Walk 7m [0:11 0:39 28m 0tx]",
-      PathUtils.pathsToString(response)
-    );
+  /** Only the multi-criteria test-cases differ for timetableView on/off */
+  private static RaptorModuleTestCaseBuilder standardTestCases() {
+    return RaptorModuleTestCase
+      .of()
+      .add(
+        standard().manyIterationOnly(),
+        "Walk 7m ~ C ~ BUS R1 0:18 0:32 ~ F ~ Walk 7m [0:11 0:39 28m 0tx]"
+      )
+      .add(TC_STANDARD_ONE, "Walk 1s ~ A ~ BUS R1 0:10 0:32 ~ F ~ Walk 7m [0:09:59 0:39 29m1s 0tx]")
+      .add(
+        TC_STANDARD_REV_ONE,
+        "Walk 7m ~ C ~ BUS R1 0:18 0:40 ~ H ~ Walk 1s [0:11 0:40:01 29m1s 0tx]"
+      );
   }
 
-  @Test
-  public void standardReverse() {
-    requestBuilder.profile(STANDARD).searchDirection(REVERSE);
-
-    var response = raptorService.route(requestBuilder.build(), data);
-
-    // expect: The latest departure combined with the earliest arrival is expected - same as
-    //         the forward search above
-    assertEquals(
-      "Walk 7m ~ C ~ BUS R1 0:18 0:32 ~ F ~ Walk 7m [0:11 0:39 28m 0tx]",
-      PathUtils.pathsToString(response)
-    );
-  }
-
-  @Test
-  public void multiCriteriaWithTimetable() {
-    requestBuilder.profile(MULTI_CRITERIA).searchParams().timetable(true);
-
-    var response = raptorService.route(requestBuilder.build(), data);
-
-    // expect: With 3 optimal solutions for both access and egress we get 3 x 3 = 9 optimal
-    //         alternatives then timetable is enabled.
-    assertEquals(
-      join(
+  static List<RaptorModuleTestCase> testCases() {
+    return standardTestCases()
+      .add(
+        multiCriteria(),
         "Walk 7m ~ C ~ BUS R1 0:18 0:32 ~ F ~ Walk 7m [0:11 0:39 28m 0tx $3120]",
         "Walk 4m ~ B ~ BUS R1 0:14 0:32 ~ F ~ Walk 7m [0:10 0:39 29m 0tx $3000]",
         "Walk 1s ~ A ~ BUS R1 0:10 0:32 ~ F ~ Walk 7m [0:09:59 0:39 29m1s 0tx $2762]",
@@ -107,32 +93,38 @@ public class B03_AccessEgressTest implements RaptorTestConstants {
         "Walk 7m ~ C ~ BUS R1 0:18 0:40 ~ H ~ Walk 1s [0:11 0:40:01 29m1s 0tx $2762]",
         "Walk 4m ~ B ~ BUS R1 0:14 0:40 ~ H ~ Walk 1s [0:10 0:40:01 30m1s 0tx $2642]",
         "Walk 1s ~ A ~ BUS R1 0:10 0:40 ~ H ~ Walk 1s [0:09:59 0:40:01 30m2s 0tx $2404]"
-      ),
-      PathUtils.pathsToString(response)
-    );
+      )
+      .build();
   }
 
-  /**
-   * This test turn timetable "off", this is the same as {@code arriveBy=false}. There is no support
-   * for {@code arriveBy=true}, which would prioritize the latest arrival if cost is the same.
-   */
-  @Test
-  public void multiCriteriaWithoutTimetable() {
-    requestBuilder.profile(MULTI_CRITERIA).searchParams().timetable(false);
+  @ParameterizedTest
+  @MethodSource("testCases")
+  void testRaptorWithTimeTable(RaptorModuleTestCase testCase) {
+    requestBuilder.searchParams().timetable(true);
+    var request = testCase.withConfig(requestBuilder);
+    var response = raptorService.route(request, data);
+    assertEquals(testCase.expected(), pathsToString(response));
+  }
 
-    var response = raptorService.route(requestBuilder.build(), data);
-
-    // expect: Expect pareto optimal results with earliest-arrival-time and cost as the criteria,
-    //         but not departure-time.
-    assertEquals(
-      join(
+  static List<RaptorModuleTestCase> noTimetableTestCases() {
+    return standardTestCases()
+      .add(
+        multiCriteria(),
         "Walk 7m ~ C ~ BUS R1 0:18 0:32 ~ F ~ Walk 7m [0:11 0:39 28m 0tx $3120]",
         "Walk 4m ~ B ~ BUS R1 0:14 0:32 ~ F ~ Walk 7m [0:10 0:39 29m 0tx $3000]",
         "Walk 1s ~ A ~ BUS R1 0:10 0:32 ~ F ~ Walk 7m [0:09:59 0:39 29m1s 0tx $2762]",
         "Walk 1s ~ A ~ BUS R1 0:10 0:36 ~ G ~ Walk 4m [0:09:59 0:40 30m1s 0tx $2642]",
         "Walk 1s ~ A ~ BUS R1 0:10 0:40 ~ H ~ Walk 1s [0:09:59 0:40:01 30m2s 0tx $2404]"
-      ),
-      PathUtils.pathsToString(response)
-    );
+      )
+      .build();
+  }
+
+  @ParameterizedTest
+  @MethodSource("noTimetableTestCases")
+  void testRaptorWithoutTimetable(RaptorModuleTestCase testCase) {
+    requestBuilder.searchParams().timetable(false);
+    var request = testCase.withConfig(requestBuilder);
+    var response = raptorService.route(request, data);
+    assertEquals(testCase.expected(), pathsToString(response));
   }
 }

--- a/src/test/java/org/opentripplanner/raptor/moduletests/B04_AccessEgressBoardingTest.java
+++ b/src/test/java/org/opentripplanner/raptor/moduletests/B04_AccessEgressBoardingTest.java
@@ -1,23 +1,25 @@
 package org.opentripplanner.raptor.moduletests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.raptor._data.api.PathUtils.pathsToString;
 import static org.opentripplanner.raptor._data.transit.TestRoute.route;
 import static org.opentripplanner.raptor._data.transit.TestTripSchedule.schedule;
-import static org.opentripplanner.raptor.api.model.SearchDirection.REVERSE;
-import static org.opentripplanner.raptor.api.request.RaptorProfile.MIN_TRAVEL_DURATION;
-import static org.opentripplanner.raptor.api.request.RaptorProfile.MULTI_CRITERIA;
-import static org.opentripplanner.raptor.api.request.RaptorProfile.STANDARD;
+import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.minDuration;
+import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.multiCriteria;
+import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.standard;
 
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner.raptor.RaptorService;
 import org.opentripplanner.raptor._data.RaptorTestConstants;
-import org.opentripplanner.raptor._data.api.PathUtils;
 import org.opentripplanner.raptor._data.transit.TestAccessEgress;
 import org.opentripplanner.raptor._data.transit.TestTransitData;
 import org.opentripplanner.raptor._data.transit.TestTripSchedule;
 import org.opentripplanner.raptor.api.request.RaptorRequestBuilder;
 import org.opentripplanner.raptor.configure.RaptorConfig;
+import org.opentripplanner.raptor.moduletests.support.RaptorModuleTestCase;
 
 /**
  * FEATURE UNDER TEST
@@ -53,21 +55,21 @@ public class B04_AccessEgressBoardingTest implements RaptorTestConstants {
   );
 
   /** Board R1 at stop B and alight at stop E */
-  private final String OPTIMAL_PATH =
+  private static final String OPTIMAL_PATH =
     "Walk 10s ~ B ~ BUS R1 0:14 0:34 ~ E ~ Walk 10s [0:13:50 0:34:10 20m20s 0tx";
 
   /** Expect the optimal path to be found. */
-  private final String EXP_PATH_MIN_TRAVEL_DURATION = OPTIMAL_PATH + "]";
+  private static final String EXP_PATH_MIN_TRAVEL_DURATION = OPTIMAL_PATH + "]";
 
   /**
    * The multi-criteria search should find the best alternative, because it looks at the
    * arrival-time, generalized-cost, and departure-time(travel-time). In this case the same path as
    * the min-travel-duration will find.
    */
-  private final String EXP_PATH_MC = OPTIMAL_PATH + " $1840]";
+  private static final String EXP_PATH_MC = OPTIMAL_PATH + " $1840]";
 
   @BeforeEach
-  public void setup() {
+  void setup() {
     data.withRoute(
       route("R1", STOP_A, STOP_B, STOP_C, STOP_D, STOP_E, STOP_F)
         .withTimetable(schedule("0:10 0:14 0:18 0:30 0:34 0:38"))
@@ -91,47 +93,26 @@ public class B04_AccessEgressBoardingTest implements RaptorTestConstants {
     ModuleTestDebugLogging.setupDebugLogging(data, requestBuilder);
   }
 
-  /**
-   * A test on the standard profile is included to demonstrate that the min-travel-duration and the
-   * standard give different results. The boarding stop is different.
-   */
-  @Test
-  public void standard() {
-    requestBuilder.profile(STANDARD);
-    var response = raptorService.route(requestBuilder.build(), data);
-    assertEquals(EXP_PATH_BEST_ARRIVAL_TIME, PathUtils.pathsToString(response));
+  static List<RaptorModuleTestCase> testCases() {
+    return RaptorModuleTestCase
+      .of()
+      // A test on the standard profile is included to demonstrate that the min-travel-duration
+      // and the standard give different results. The boarding stop is different.
+      .add(standard().forwardOnly(), EXP_PATH_BEST_ARRIVAL_TIME)
+      // A reverse test on the standard profile is included to demonstrate that the
+      // min-travel-duration and the standard give different results when searching
+      // in reverse. The alight stop is different.
+      .add(standard().reverseOnly(), EXP_PATH_BEST_ARRIVAL_TIME_REVERSE)
+      .add(minDuration(), EXP_PATH_MIN_TRAVEL_DURATION)
+      .add(multiCriteria(), EXP_PATH_MC)
+      .build();
   }
 
-  @Test
-  public void minTravelDuration() {
-    requestBuilder.profile(MIN_TRAVEL_DURATION);
-    var response = raptorService.route(requestBuilder.build(), data);
-    assertEquals(EXP_PATH_MIN_TRAVEL_DURATION, PathUtils.pathsToString(response));
-  }
-
-  /**
-   * A reverse test on the standard profile is included to demonstrate that the min-travel-duration
-   * and the standard give different results when searching in reverse. The alight stop is
-   * different.
-   */
-  @Test
-  public void standardReverse() {
-    requestBuilder.profile(STANDARD).searchDirection(REVERSE);
-    var response = raptorService.route(requestBuilder.build(), data);
-    assertEquals(EXP_PATH_BEST_ARRIVAL_TIME_REVERSE, PathUtils.pathsToString(response));
-  }
-
-  @Test
-  public void minTravelDurationReverse() {
-    requestBuilder.profile(MIN_TRAVEL_DURATION).searchDirection(REVERSE);
-    var response = raptorService.route(requestBuilder.build(), data);
-    assertEquals(EXP_PATH_MIN_TRAVEL_DURATION, PathUtils.pathsToString(response));
-  }
-
-  @Test
-  public void multiCriteria() {
-    requestBuilder.profile(MULTI_CRITERIA);
-    var response = raptorService.route(requestBuilder.build(), data);
-    assertEquals(EXP_PATH_MC, PathUtils.pathsToString(response));
+  @ParameterizedTest
+  @MethodSource("testCases")
+  void testRaptor(RaptorModuleTestCase testCase) {
+    var request = testCase.withConfig(requestBuilder);
+    var response = raptorService.route(request, data);
+    assertEquals(testCase.expected(), pathsToString(response));
   }
 }

--- a/src/test/java/org/opentripplanner/raptor/moduletests/B10_FlexAccessTest.java
+++ b/src/test/java/org/opentripplanner/raptor/moduletests/B10_FlexAccessTest.java
@@ -1,24 +1,27 @@
 package org.opentripplanner.raptor.moduletests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.opentripplanner.raptor._data.api.PathUtils.join;
 import static org.opentripplanner.raptor._data.api.PathUtils.pathsToString;
 import static org.opentripplanner.raptor._data.transit.TestAccessEgress.flex;
 import static org.opentripplanner.raptor._data.transit.TestAccessEgress.flexAndWalk;
 import static org.opentripplanner.raptor._data.transit.TestRoute.route;
 import static org.opentripplanner.raptor._data.transit.TestTripSchedule.schedule;
+import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.TC_STANDARD_ONE;
+import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.multiCriteria;
+import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.standard;
 
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner.raptor.RaptorService;
 import org.opentripplanner.raptor._data.RaptorTestConstants;
 import org.opentripplanner.raptor._data.transit.TestAccessEgress;
 import org.opentripplanner.raptor._data.transit.TestTransitData;
 import org.opentripplanner.raptor._data.transit.TestTripSchedule;
-import org.opentripplanner.raptor.api.model.SearchDirection;
-import org.opentripplanner.raptor.api.request.RaptorProfile;
 import org.opentripplanner.raptor.api.request.RaptorRequestBuilder;
 import org.opentripplanner.raptor.configure.RaptorConfig;
+import org.opentripplanner.raptor.moduletests.support.RaptorModuleTestCase;
 import org.opentripplanner.raptor.spi.DefaultSlackProvider;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.cost.RaptorCostConverter;
 
@@ -43,7 +46,7 @@ public class B10_FlexAccessTest implements RaptorTestConstants {
   );
 
   @BeforeEach
-  public void setup() {
+  void setup() {
     data.withRoute(
       route("R1", STOP_B, STOP_C, STOP_D, STOP_E, STOP_F)
         .withTimetable(schedule("0:10, 0:12, 0:14, 0:16, 0:20"))
@@ -71,44 +74,30 @@ public class B10_FlexAccessTest implements RaptorTestConstants {
     ModuleTestDebugLogging.setupDebugLogging(data, requestBuilder);
   }
 
-  @Test
-  public void standard() {
-    requestBuilder.profile(RaptorProfile.STANDARD);
-
-    var response = raptorService.route(requestBuilder.build(), data);
-
-    assertEquals(
-      "Flex 3m 2x ~ D ~ BUS R1 0:14 0:20 ~ F ~ Walk 1m [0:10 0:21 11m 2tx]",
-      pathsToString(response)
-    );
-  }
-
-  @Test
-  public void standardReverse() {
-    requestBuilder.profile(RaptorProfile.STANDARD).searchDirection(SearchDirection.REVERSE);
-
-    var response = raptorService.route(requestBuilder.build(), data);
-
-    assertEquals(
-      "Flex 3m 2x ~ D ~ BUS R1 0:14 0:20 ~ F ~ Walk 1m [0:10 0:21 11m 2tx]",
-      pathsToString(response)
-    );
-  }
-
-  @Test
-  public void multiCriteria() {
-    requestBuilder.profile(RaptorProfile.MULTI_CRITERIA);
-
-    var response = raptorService.route(requestBuilder.build(), data);
-
-    assertEquals(
-      join(
+  static List<RaptorModuleTestCase> testCases() {
+    return RaptorModuleTestCase
+      .of()
+      .add(
+        standard().not(TC_STANDARD_ONE),
+        "Flex 3m 2x ~ D ~ BUS R1 0:14 0:20 ~ F ~ Walk 1m [0:10 0:21 11m 2tx]"
+      )
+      // First boarding wins with one-iteration
+      .add(TC_STANDARD_ONE, "Walk 10m ~ B ~ BUS R1 0:10 0:20 ~ F ~ Walk 1m [0:00 0:21 21m 0tx]")
+      .add(
+        multiCriteria(),
         "Flex 3m 2x ~ D ~ BUS R1 0:14 0:20 ~ F ~ Walk 1m [0:10 0:21 11m 2tx $1500]", // ldt
         "Flex 2m 2x ~ C ~ BUS R1 0:12 0:20 ~ F ~ Walk 1m [0:09 0:21 12m 2tx $1499]", // cost
         "Flex 7m 1x ~ E ~ BUS R1 0:16 0:20 ~ F ~ Walk 1m [0:08 0:21 13m 1tx $1500]", // tx+time
         "Walk 10m ~ B ~ BUS R1 0:10 0:20 ~ F ~ Walk 1m [0:00 0:21 21m 0tx $1500]" // tx
-      ),
-      pathsToString(response)
-    );
+      )
+      .build();
+  }
+
+  @ParameterizedTest
+  @MethodSource("testCases")
+  void testRaptor(RaptorModuleTestCase testCase) {
+    var request = testCase.withConfig(requestBuilder);
+    var response = raptorService.route(request, data);
+    assertEquals(testCase.expected(), pathsToString(response));
   }
 }

--- a/src/test/java/org/opentripplanner/raptor/moduletests/B11_FlexEgressTest.java
+++ b/src/test/java/org/opentripplanner/raptor/moduletests/B11_FlexEgressTest.java
@@ -1,25 +1,28 @@
 package org.opentripplanner.raptor.moduletests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.opentripplanner.raptor._data.api.PathUtils.join;
 import static org.opentripplanner.raptor._data.api.PathUtils.pathsToString;
 import static org.opentripplanner.raptor._data.transit.TestAccessEgress.flex;
 import static org.opentripplanner.raptor._data.transit.TestAccessEgress.flexAndWalk;
 import static org.opentripplanner.raptor._data.transit.TestRoute.route;
 import static org.opentripplanner.raptor._data.transit.TestTripSchedule.schedule;
+import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.TC_STANDARD_REV_ONE;
+import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.multiCriteria;
+import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.standard;
 
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner.framework.time.DurationUtils;
 import org.opentripplanner.raptor.RaptorService;
 import org.opentripplanner.raptor._data.RaptorTestConstants;
 import org.opentripplanner.raptor._data.transit.TestAccessEgress;
 import org.opentripplanner.raptor._data.transit.TestTransitData;
 import org.opentripplanner.raptor._data.transit.TestTripSchedule;
-import org.opentripplanner.raptor.api.model.SearchDirection;
-import org.opentripplanner.raptor.api.request.RaptorProfile;
 import org.opentripplanner.raptor.api.request.RaptorRequestBuilder;
 import org.opentripplanner.raptor.configure.RaptorConfig;
+import org.opentripplanner.raptor.moduletests.support.RaptorModuleTestCase;
 import org.opentripplanner.raptor.spi.DefaultSlackProvider;
 
 /**
@@ -40,7 +43,7 @@ public class B11_FlexEgressTest implements RaptorTestConstants {
   );
 
   @BeforeEach
-  public void setup() {
+  void setup() {
     data.withRoute(
       route("R1", STOP_B, STOP_C, STOP_D, STOP_E, STOP_F)
         .withTimetable(schedule("0:10, 0:12, 0:14, 0:16, 0:18"))
@@ -63,44 +66,30 @@ public class B11_FlexEgressTest implements RaptorTestConstants {
     ModuleTestDebugLogging.setupDebugLogging(data, requestBuilder);
   }
 
-  @Test
-  public void standard() {
-    requestBuilder.profile(RaptorProfile.STANDARD);
-
-    var response = raptorService.route(requestBuilder.build(), data);
-
-    assertEquals(
-      "Walk 1m ~ B ~ BUS R1 0:10 0:14 ~ D ~ Flex 3m 2x [0:09 0:18 9m 2tx]",
-      pathsToString(response)
-    );
-  }
-
-  @Test
-  public void standardReverse() {
-    requestBuilder.profile(RaptorProfile.STANDARD).searchDirection(SearchDirection.REVERSE);
-
-    var response = raptorService.route(requestBuilder.build(), data);
-
-    assertEquals(
-      "Walk 1m ~ B ~ BUS R1 0:10 0:14 ~ D ~ Flex 3m 2x [0:09 0:18 9m 2tx]",
-      pathsToString(response)
-    );
-  }
-
-  @Test
-  public void multiCriteria() {
-    requestBuilder.profile(RaptorProfile.MULTI_CRITERIA);
-
-    var response = raptorService.route(requestBuilder.build(), data);
-
-    assertEquals(
-      join(
+  static List<RaptorModuleTestCase> testCases() {
+    return RaptorModuleTestCase
+      .of()
+      .add(
+        standard().not(TC_STANDARD_REV_ONE),
+        "Walk 1m ~ B ~ BUS R1 0:10 0:14 ~ D ~ Flex 3m 2x [0:09 0:18 9m 2tx]"
+      )
+      // "First"(in reverse) alighting wins
+      .add(TC_STANDARD_REV_ONE, "Walk 1m ~ B ~ BUS R1 0:10 0:18 ~ F ~ Walk 10m [0:09 0:28 19m 0tx]")
+      .add(
+        multiCriteria(),
         "Walk 1m ~ B ~ BUS R1 0:10 0:14 ~ D ~ Flex 3m 2x [0:09 0:18 9m 2tx $1380]",
         "Walk 1m ~ B ~ BUS R1 0:10 0:16 ~ E ~ Flex 1m59s 2x [0:09 0:18:59 9m59s 2tx $1378]",
         "Walk 1m ~ B ~ BUS R1 0:10 0:12 ~ C ~ Flex 7m 1x [0:09 0:20 11m 1tx $1740]",
         "Walk 1m ~ B ~ BUS R1 0:10 0:18 ~ F ~ Walk 10m [0:09 0:28 19m 0tx $2400]"
-      ),
-      pathsToString(response)
-    );
+      )
+      .build();
+  }
+
+  @ParameterizedTest
+  @MethodSource("testCases")
+  void testRaptor(RaptorModuleTestCase testCase) {
+    var request = testCase.withConfig(requestBuilder);
+    var response = raptorService.route(request, data);
+    assertEquals(testCase.expected(), pathsToString(response));
   }
 }

--- a/src/test/java/org/opentripplanner/raptor/moduletests/C01_TransferBoardAndAlightSlackTest.java
+++ b/src/test/java/org/opentripplanner/raptor/moduletests/C01_TransferBoardAndAlightSlackTest.java
@@ -5,18 +5,21 @@ import static org.opentripplanner.raptor._data.api.PathUtils.pathsToString;
 import static org.opentripplanner.raptor._data.transit.TestRoute.route;
 import static org.opentripplanner.raptor._data.transit.TestTripPattern.pattern;
 import static org.opentripplanner.raptor._data.transit.TestTripSchedule.schedule;
+import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.multiCriteria;
+import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.standard;
 
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner.raptor.RaptorService;
 import org.opentripplanner.raptor._data.RaptorTestConstants;
 import org.opentripplanner.raptor._data.transit.TestAccessEgress;
 import org.opentripplanner.raptor._data.transit.TestTransitData;
 import org.opentripplanner.raptor._data.transit.TestTripSchedule;
-import org.opentripplanner.raptor.api.model.SearchDirection;
-import org.opentripplanner.raptor.api.request.RaptorProfile;
 import org.opentripplanner.raptor.api.request.RaptorRequestBuilder;
 import org.opentripplanner.raptor.configure.RaptorConfig;
+import org.opentripplanner.raptor.moduletests.support.RaptorModuleTestCase;
 import org.opentripplanner.raptor.spi.DefaultSlackProvider;
 
 /**
@@ -47,7 +50,7 @@ public class C01_TransferBoardAndAlightSlackTest implements RaptorTestConstants 
   );
 
   @BeforeEach
-  public void setup() {
+  void setup() {
     //Given slack: transfer 1m, board 30s, alight 10s
     data.withSlackProvider(new DefaultSlackProvider(D1m, D30s, D10s));
 
@@ -75,29 +78,19 @@ public class C01_TransferBoardAndAlightSlackTest implements RaptorTestConstants 
     ModuleTestDebugLogging.setupDebugLogging(data, requestBuilder);
   }
 
-  @Test
-  public void standard() {
-    var request = requestBuilder.profile(RaptorProfile.STANDARD).build();
-    var response = raptorService.route(request, data);
-    assertEquals(EXPECTED_RESULT, pathsToString(response));
-  }
-
-  @Test
-  public void standardReverse() {
-    var request = requestBuilder
-      .searchDirection(SearchDirection.REVERSE)
-      .profile(RaptorProfile.STANDARD)
+  static List<RaptorModuleTestCase> testCases() {
+    return RaptorModuleTestCase
+      .of()
+      .add(standard(), EXPECTED_RESULT)
+      .add(multiCriteria(), EXPECTED_RESULT.replace("]", " $1510]"))
       .build();
-    var response = raptorService.route(request, data);
-    assertEquals(EXPECTED_RESULT, pathsToString(response));
   }
 
-  @Test
-  public void multiCriteria() {
-    // Add cost to result string
-    String expected = EXPECTED_RESULT.replace("]", " $1510]");
-    var request = requestBuilder.profile(RaptorProfile.MULTI_CRITERIA).build();
+  @ParameterizedTest
+  @MethodSource("testCases")
+  void testRaptor(RaptorModuleTestCase testCase) {
+    var request = testCase.withConfig(requestBuilder);
     var response = raptorService.route(request, data);
-    assertEquals(expected, pathsToString(response));
+    assertEquals(testCase.expected(), pathsToString(response));
   }
 }

--- a/src/test/java/org/opentripplanner/raptor/moduletests/C02_BoardAndAlightSlackWithFlexAccessEgressTest.java
+++ b/src/test/java/org/opentripplanner/raptor/moduletests/C02_BoardAndAlightSlackWithFlexAccessEgressTest.java
@@ -7,17 +7,21 @@ import static org.opentripplanner.raptor._data.transit.TestAccessEgress.flexAndW
 import static org.opentripplanner.raptor._data.transit.TestRoute.route;
 import static org.opentripplanner.raptor._data.transit.TestTripPattern.pattern;
 import static org.opentripplanner.raptor._data.transit.TestTripSchedule.schedule;
+import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.TC_STANDARD_REV;
+import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.multiCriteria;
+import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.standard;
 
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner.raptor.RaptorService;
 import org.opentripplanner.raptor._data.RaptorTestConstants;
 import org.opentripplanner.raptor._data.transit.TestTransitData;
 import org.opentripplanner.raptor._data.transit.TestTripSchedule;
-import org.opentripplanner.raptor.api.model.SearchDirection;
-import org.opentripplanner.raptor.api.request.RaptorProfile;
 import org.opentripplanner.raptor.api.request.RaptorRequestBuilder;
 import org.opentripplanner.raptor.configure.RaptorConfig;
+import org.opentripplanner.raptor.moduletests.support.RaptorModuleTestCase;
 import org.opentripplanner.raptor.spi.DefaultSlackProvider;
 
 /**
@@ -51,7 +55,7 @@ public class C02_BoardAndAlightSlackWithFlexAccessEgressTest implements RaptorTe
           schedule().departures("0:03:29, 0:05:29"),
           // This is the trip we expect to board
           schedule().departures("0:04:00, 0:10:00").arrivals("0, 00:06:00"),
-          // REVERSE SEARCH: The last trip arrives to late: It takes 1m40s to get to the
+          // REVERSE SEARCH: The last trip arrives too late: It takes 1m40s to get to the
           // point of "boarding" in the reverse search:
           // --> 00:10:00 - (flex 20s + slack(1m + 10s)) = 00:08:30  (arrival time)
           schedule().arrivals("0:04:51, 0:06:51")
@@ -71,36 +75,20 @@ public class C02_BoardAndAlightSlackWithFlexAccessEgressTest implements RaptorTe
     ModuleTestDebugLogging.setupDebugLogging(data, requestBuilder);
   }
 
-  @Test
-  public void standard() {
-    var request = requestBuilder
-      .profile(RaptorProfile.STANDARD)
-      .searchParams()
-      .searchOneIterationOnly()
+  static List<RaptorModuleTestCase> testCases() {
+    return RaptorModuleTestCase
+      .of()
+      // TODO - TC_STANDARD_REV does not give tha same results - why?
+      .add(standard().not(TC_STANDARD_REV), EXPECTED_RESULT)
+      .add(multiCriteria(), EXPECTED_RESULT.replace("]", " $1840]"))
       .build();
-
-    var response = raptorService.route(request, data);
-    assertEquals(EXPECTED_RESULT, pathsToString(response));
   }
 
-  @Test
-  public void standardReverse() {
-    var request = requestBuilder
-      .profile(RaptorProfile.STANDARD)
-      .searchDirection(SearchDirection.REVERSE)
-      .searchParams()
-      .searchOneIterationOnly()
-      .build();
+  @ParameterizedTest
+  @MethodSource("testCases")
+  void testRaptor(RaptorModuleTestCase testCase) {
+    var request = testCase.withConfig(requestBuilder);
     var response = raptorService.route(request, data);
-    assertEquals(EXPECTED_RESULT, pathsToString(response));
-  }
-
-  @Test
-  public void multiCriteria() {
-    // Add cost to result string
-    String expected = EXPECTED_RESULT.replace("]", " $1840]");
-    var request = requestBuilder.profile(RaptorProfile.MULTI_CRITERIA).build();
-    var response = raptorService.route(request, data);
-    assertEquals(expected, pathsToString(response));
+    assertEquals(testCase.expected(), pathsToString(response));
   }
 }

--- a/src/test/java/org/opentripplanner/raptor/moduletests/E01_GuaranteedTransferTest.java
+++ b/src/test/java/org/opentripplanner/raptor/moduletests/E01_GuaranteedTransferTest.java
@@ -4,19 +4,21 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.raptor._data.api.PathUtils.pathsToString;
 import static org.opentripplanner.raptor._data.transit.TestRoute.route;
 import static org.opentripplanner.raptor._data.transit.TestTripSchedule.schedule;
+import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.multiCriteria;
+import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.standard;
 
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner.raptor.RaptorService;
 import org.opentripplanner.raptor._data.RaptorTestConstants;
 import org.opentripplanner.raptor._data.transit.TestAccessEgress;
 import org.opentripplanner.raptor._data.transit.TestTransitData;
 import org.opentripplanner.raptor._data.transit.TestTripSchedule;
-import org.opentripplanner.raptor.api.model.SearchDirection;
-import org.opentripplanner.raptor.api.request.Optimization;
-import org.opentripplanner.raptor.api.request.RaptorProfile;
 import org.opentripplanner.raptor.api.request.RaptorRequestBuilder;
 import org.opentripplanner.raptor.configure.RaptorConfig;
+import org.opentripplanner.raptor.moduletests.support.RaptorModuleTestCase;
 import org.opentripplanner.raptor.spi.DefaultSlackProvider;
 
 /**
@@ -57,6 +59,7 @@ public class E01_GuaranteedTransferTest implements RaptorTestConstants {
     data.withGuaranteedTransfer(tripA, STOP_B, tripB, STOP_B);
     data.mcCostParamsBuilder().transferCost(100);
 
+    // NOTE! No search-window is set.
     requestBuilder
       .searchParams()
       .constrainedTransfers(true)
@@ -73,45 +76,19 @@ public class E01_GuaranteedTransferTest implements RaptorTestConstants {
     ModuleTestDebugLogging.setupDebugLogging(data, requestBuilder);
   }
 
-  @Test
-  public void standardOneIteration() {
-    var request = requestBuilder
-      .profile(RaptorProfile.STANDARD)
-      .searchParams()
-      .searchOneIterationOnly()
+  static List<RaptorModuleTestCase> testCases() {
+    return RaptorModuleTestCase
+      .of()
+      .add(standard(), EXP_PATH_NO_COST)
+      .add(multiCriteria(), EXP_PATH_WITH_COST)
       .build();
-    var response = raptorService.route(request, data);
-    assertEquals(EXP_PATH_NO_COST, pathsToString(response));
   }
 
-  @Test
-  public void standardDynamicSearchWindow() {
-    var request = requestBuilder.profile(RaptorProfile.STANDARD).build();
+  @ParameterizedTest
+  @MethodSource("testCases")
+  void testRaptor(RaptorModuleTestCase testCase) {
+    var request = testCase.withConfig(requestBuilder);
     var response = raptorService.route(request, data);
-    assertEquals(EXP_PATH_NO_COST, pathsToString(response));
-  }
-
-  @Test
-  public void standardReverseOneIteration() {
-    var request = requestBuilder
-      .searchDirection(SearchDirection.REVERSE)
-      .profile(RaptorProfile.STANDARD)
-      .searchParams()
-      .searchOneIterationOnly()
-      .build();
-
-    var response = raptorService.route(request, data);
-
-    assertEquals(EXP_PATH_NO_COST, pathsToString(response));
-  }
-
-  @Test
-  public void multiCriteria() {
-    requestBuilder.optimizations().add(Optimization.PARETO_CHECK_AGAINST_DESTINATION);
-    var request = requestBuilder.profile(RaptorProfile.MULTI_CRITERIA).build();
-
-    var response = raptorService.route(request, data);
-
-    assertEquals(EXP_PATH_WITH_COST, pathsToString(response));
+    assertEquals(testCase.expected(), pathsToString(response));
   }
 }

--- a/src/test/java/org/opentripplanner/raptor/moduletests/E02_NotAllowedConstrainedTransferTest.java
+++ b/src/test/java/org/opentripplanner/raptor/moduletests/E02_NotAllowedConstrainedTransferTest.java
@@ -4,19 +4,22 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.raptor._data.api.PathUtils.pathsToString;
 import static org.opentripplanner.raptor._data.transit.TestRoute.route;
 import static org.opentripplanner.raptor._data.transit.TestTripSchedule.schedule;
+import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.TC_STANDARD_REV;
+import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.multiCriteria;
+import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.standard;
 
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner.raptor.RaptorService;
 import org.opentripplanner.raptor._data.RaptorTestConstants;
 import org.opentripplanner.raptor._data.transit.TestAccessEgress;
 import org.opentripplanner.raptor._data.transit.TestTransitData;
 import org.opentripplanner.raptor._data.transit.TestTripSchedule;
-import org.opentripplanner.raptor.api.model.SearchDirection;
-import org.opentripplanner.raptor.api.request.Optimization;
-import org.opentripplanner.raptor.api.request.RaptorProfile;
 import org.opentripplanner.raptor.api.request.RaptorRequestBuilder;
 import org.opentripplanner.raptor.configure.RaptorConfig;
+import org.opentripplanner.raptor.moduletests.support.RaptorModuleTestCase;
 
 /**
  * FEATURE UNDER TEST
@@ -55,8 +58,8 @@ public class E02_NotAllowedConstrainedTransferTest implements RaptorTestConstant
       );
     var r3 = route("R3", STOP_B, STOP_C).withTimetable(schedule("0:15 0:20"));
 
-    var tripA = r1.timetable().getTripSchedule(0);
-    var tripB = r2.timetable().getTripSchedule(0);
+    var tripR1a = r1.timetable().getTripSchedule(0);
+    var tripR2a = r2.timetable().getTripSchedule(0);
 
     data.withRoutes(r1, r2, r3);
 
@@ -64,9 +67,10 @@ public class E02_NotAllowedConstrainedTransferTest implements RaptorTestConstant
     // the second trip in R2 as well. This is of cause not a correct way to implement the
     // transit model, a not-allowed transfer should apply to ALL trips if constraint is passed
     // to raptor.
-    data.withConstrainedTransfer(tripA, STOP_B, tripB, STOP_B, TestTransitData.TX_NOT_ALLOWED);
+    data.withConstrainedTransfer(tripR1a, STOP_B, tripR2a, STOP_B, TestTransitData.TX_NOT_ALLOWED);
     data.mcCostParamsBuilder().transferCost(100);
 
+    // NOTE! No search-window set
     requestBuilder
       .searchParams()
       .constrainedTransfers(true)
@@ -79,45 +83,21 @@ public class E02_NotAllowedConstrainedTransferTest implements RaptorTestConstant
     ModuleTestDebugLogging.setupDebugLogging(data, requestBuilder);
   }
 
-  @Test
-  public void standardOneIteration() {
-    var request = requestBuilder
-      .profile(RaptorProfile.STANDARD)
-      .searchParams()
-      .searchOneIterationOnly()
+  static List<RaptorModuleTestCase> testCases() {
+    // TODO - This is a bug - the reverse search should not allow the forbidden boarding
+    //      - TC_STANDARD_REV is excluded since the test fails
+    return RaptorModuleTestCase
+      .of()
+      .add(standard().not(TC_STANDARD_REV), EXP_PATH_NO_COST)
+      .add(multiCriteria(), EXP_PATH_WITH_COST)
       .build();
-    var response = raptorService.route(request, data);
-    assertEquals(EXP_PATH_NO_COST, pathsToString(response));
   }
 
-  @Test
-  public void standardDynamicSearchWindow() {
-    var request = requestBuilder.profile(RaptorProfile.STANDARD).build();
+  @ParameterizedTest
+  @MethodSource("testCases")
+  void testRaptor(RaptorModuleTestCase testCase) {
+    var request = testCase.withConfig(requestBuilder);
     var response = raptorService.route(request, data);
-    assertEquals(EXP_PATH_NO_COST, pathsToString(response));
-  }
-
-  @Test
-  public void standardReverseOneIteration() {
-    var request = requestBuilder
-      .searchDirection(SearchDirection.REVERSE)
-      .profile(RaptorProfile.STANDARD)
-      .searchParams()
-      .searchOneIterationOnly()
-      .build();
-
-    var response = raptorService.route(request, data);
-
-    assertEquals(EXP_PATH_NO_COST, pathsToString(response));
-  }
-
-  @Test
-  public void multiCriteria() {
-    requestBuilder.optimizations().add(Optimization.PARETO_CHECK_AGAINST_DESTINATION);
-    var request = requestBuilder.profile(RaptorProfile.MULTI_CRITERIA).build();
-
-    var response = raptorService.route(request, data);
-
-    assertEquals(EXP_PATH_WITH_COST, pathsToString(response));
+    assertEquals(testCase.expected(), pathsToString(response));
   }
 }

--- a/src/test/java/org/opentripplanner/raptor/moduletests/F01_TransitModeReluctanceTest.java
+++ b/src/test/java/org/opentripplanner/raptor/moduletests/F01_TransitModeReluctanceTest.java
@@ -5,9 +5,14 @@ import static org.opentripplanner.raptor._data.api.PathUtils.pathsToString;
 import static org.opentripplanner.raptor._data.transit.TestRoute.route;
 import static org.opentripplanner.raptor._data.transit.TestTripPattern.pattern;
 import static org.opentripplanner.raptor._data.transit.TestTripSchedule.schedule;
+import static org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig.multiCriteria;
 
+import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner.raptor.RaptorService;
 import org.opentripplanner.raptor._data.RaptorTestConstants;
 import org.opentripplanner.raptor._data.transit.TestAccessEgress;
@@ -16,6 +21,8 @@ import org.opentripplanner.raptor._data.transit.TestTripSchedule;
 import org.opentripplanner.raptor.api.request.RaptorProfile;
 import org.opentripplanner.raptor.api.request.RaptorRequestBuilder;
 import org.opentripplanner.raptor.configure.RaptorConfig;
+import org.opentripplanner.raptor.moduletests.support.RaptorModuleTestCase;
+import org.opentripplanner.raptor.moduletests.support.RaptorModuleTestConfig;
 
 /**
  * FEATURE UNDER TEST
@@ -27,6 +34,8 @@ public class F01_TransitModeReluctanceTest implements RaptorTestConstants {
 
   private static final String EXPECTED =
     "Walk 30s ~ A ~ BUS %s 0:01 0:02:40 ~ B ~ Walk 20s " + "[0:00:30 0:03 2m30s 0tx $%d]";
+  public static final double[] PREFER_R1 = { 0.99, 1.0 };
+  public static final double[] PREFER_R2 = { 0.9, 0.89 };
   private final TestTransitData data = new TestTransitData();
   private final RaptorRequestBuilder<TestTripSchedule> requestBuilder = new RaptorRequestBuilder<>();
   private final RaptorService<TestTripSchedule> raptorService = new RaptorService<>(
@@ -58,24 +67,49 @@ public class F01_TransitModeReluctanceTest implements RaptorTestConstants {
     ModuleTestDebugLogging.setupDebugLogging(data, requestBuilder);
   }
 
-  @Test
-  public void preferR1() {
-    // Give R1 a slightly smaller(0.01 less then R2) transit reluctance factor
-    data.mcCostParamsBuilder().transitReluctanceFactors(new double[] { 0.99, 1.0 });
-    var request = requestBuilder.build();
-    var response = raptorService.route(request, data);
-
-    // Verify R1 is preferred and the cost is correct
-    assertEquals(expected("R1", 799), pathsToString(response));
+  static List<RaptorModuleTestCase> testCasesPreferR1() {
+    return RaptorModuleTestCase.of().add(multiCriteria(), expected("R1", 799)).build();
   }
 
-  @Test
-  public void preferR2() {
-    data.mcCostParamsBuilder().transitReluctanceFactors(new double[] { 0.9, 0.89 });
-    var request = requestBuilder.build();
+  @ParameterizedTest
+  @MethodSource("testCasesPreferR1")
+  void testPreferR1(RaptorModuleTestCase testCase) {
+    // Give R1 a slightly smaller(0.01 less then R2) transit reluctance factor
+    data.mcCostParamsBuilder().transitReluctanceFactors(new double[] { 0.99, 1.0 });
+    var request = testCase.withConfig(requestBuilder);
     var response = raptorService.route(request, data);
+    assertEquals(testCase.expected(), pathsToString(response));
+  }
 
-    assertEquals(expected("R2", 789), pathsToString(response));
+  static List<RaptorModuleTestCase> testCasesPreferR2() {
+    return RaptorModuleTestCase.of().add(multiCriteria(), expected("R2", 789)).build();
+  }
+
+  static Stream<Arguments> testCases() {
+    return RaptorModuleTestConfig
+      .multiCriteria()
+      .build()
+      .stream()
+      .flatMap(config ->
+        Stream.of(
+          Arguments.of(PREFER_R1, config, "R1", 799),
+          Arguments.of(PREFER_R2, config, "R2", 789)
+        )
+      );
+  }
+
+  @ParameterizedTest(name = "Transit reluctance {0} should prefer {2} and give cost {3}")
+  @MethodSource("testCases")
+  void testPreferR2(
+    double[] transitReluctance,
+    RaptorModuleTestConfig testConfig,
+    String expRoute,
+    int expCost
+  ) {
+    data.mcCostParamsBuilder().transitReluctanceFactors(transitReluctance);
+    var request = testConfig.apply(requestBuilder).build();
+    var response = raptorService.route(request, data);
+    assertEquals(expected(expRoute, expCost), pathsToString(response));
   }
 
   private static String expected(String route, int cost) {

--- a/src/test/java/org/opentripplanner/raptor/moduletests/support/RaptorModuleTestCase.java
+++ b/src/test/java/org/opentripplanner/raptor/moduletests/support/RaptorModuleTestCase.java
@@ -1,0 +1,35 @@
+package org.opentripplanner.raptor.moduletests.support;
+
+import org.opentripplanner.raptor.api.model.RaptorTripSchedule;
+import org.opentripplanner.raptor.api.request.RaptorRequest;
+import org.opentripplanner.raptor.api.request.RaptorRequestBuilder;
+
+/**
+ * The given Raptor module-test configuration should result in the given expected path string,
+ * when calling Raptor. Se one of the module test on how to use this.
+ */
+public record RaptorModuleTestCase(RaptorModuleTestConfig config, String expected) {
+  public static RaptorModuleTestCaseBuilder of() {
+    return new RaptorModuleTestCaseBuilder();
+  }
+
+  /**
+   * Configure the Raptor request according to the embedded config.
+   */
+  public <T extends RaptorTripSchedule> RaptorRequest<T> withConfig(
+    RaptorRequestBuilder<T> builder
+  ) {
+    return config.apply(builder).build();
+  }
+
+  @Override
+  public String toString() {
+    String profile = config.profile().name().toLowerCase();
+    String optimizations = config == RaptorModuleTestConfig.TC_MULTI_CRITERIA_DEST_PRUNING
+      ? " w/dest-pruning"
+      : "";
+    String oneIteration = config.withOneIteration() ? " one-iteration" : "";
+    String reverse = config.isReverse() ? " reverse" : "";
+    return profile + optimizations + reverse + oneIteration;
+  }
+}

--- a/src/test/java/org/opentripplanner/raptor/moduletests/support/RaptorModuleTestCaseBuilder.java
+++ b/src/test/java/org/opentripplanner/raptor/moduletests/support/RaptorModuleTestCaseBuilder.java
@@ -1,0 +1,35 @@
+package org.opentripplanner.raptor.moduletests.support;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Builder for {@link RaptorModuleTestConfig}.
+ */
+public class RaptorModuleTestCaseBuilder {
+
+  private final List<RaptorModuleTestCase> cases = new ArrayList<>();
+
+  public RaptorModuleTestCaseBuilder add(RaptorModuleTestConfig config, String... expected) {
+    return add(config, Arrays.asList(expected));
+  }
+
+  public RaptorModuleTestCaseBuilder add(RaptorModuleTestConfig config, List<String> expected) {
+    cases.add(new RaptorModuleTestCase(config, String.join("\n", expected)));
+    return this;
+  }
+
+  public RaptorModuleTestCaseBuilder add(
+    RaptorModuleTestConfigSetBuilder configs,
+    String... expected
+  ) {
+    List<String> expList = Arrays.asList(expected);
+    configs.build().forEach(c -> add(c, expList));
+    return this;
+  }
+
+  public List<RaptorModuleTestCase> build() {
+    return cases;
+  }
+}

--- a/src/test/java/org/opentripplanner/raptor/moduletests/support/RaptorModuleTestConfig.java
+++ b/src/test/java/org/opentripplanner/raptor/moduletests/support/RaptorModuleTestConfig.java
@@ -1,0 +1,106 @@
+package org.opentripplanner.raptor.moduletests.support;
+
+import static org.opentripplanner.raptor.api.request.RaptorProfile.MIN_TRAVEL_DURATION;
+import static org.opentripplanner.raptor.api.request.RaptorProfile.MULTI_CRITERIA;
+import static org.opentripplanner.raptor.api.request.RaptorProfile.STANDARD;
+
+import java.util.List;
+import org.opentripplanner.raptor.api.model.RaptorTripSchedule;
+import org.opentripplanner.raptor.api.model.SearchDirection;
+import org.opentripplanner.raptor.api.request.Optimization;
+import org.opentripplanner.raptor.api.request.RaptorProfile;
+import org.opentripplanner.raptor.api.request.RaptorRequestBuilder;
+
+/**
+ * This enum is a list of all relevant ways to configure Raptor with
+ * <ol>
+ *   <li>{@link RaptorProfile}</li>
+ *   <li>Run one iteration(just Raptor) or many iterations(Range Raptor)</li>
+ *   <li>Search forward from origin to destination, or in reverse from destination to origin</li>
+ *   <li>Optimization (Multi-criteria destination pruning only)</li>
+ * </ol>
+ * Not all combinations are allowed, and this list only contains allowed configurations.
+ */
+public enum RaptorModuleTestConfig {
+  TC_STANDARD(STANDARD, false, false),
+  TC_STANDARD_ONE(STANDARD, true, false),
+  TC_STANDARD_REV(STANDARD, false, true),
+  TC_STANDARD_REV_ONE(STANDARD, true, true),
+  TC_MIN_DURATION(MIN_TRAVEL_DURATION, true, false),
+  TC_MIN_DURATION_REV(MIN_TRAVEL_DURATION, true, true),
+  TC_MULTI_CRITERIA(MULTI_CRITERIA, false, false),
+  TC_MULTI_CRITERIA_DEST_PRUNING(MULTI_CRITERIA, false, false);
+
+  private final RaptorProfile profile;
+  private final boolean oneIteration;
+  private final boolean reverse;
+
+  public static final List<RaptorModuleTestConfig> STANDARD_LIST = List.of(
+    TC_STANDARD,
+    TC_STANDARD_ONE,
+    TC_STANDARD_REV,
+    TC_STANDARD_REV_ONE
+  );
+  public static final List<RaptorModuleTestConfig> MIN_DURATION_LIST = List.of(
+    TC_MIN_DURATION,
+    TC_MIN_DURATION_REV
+  );
+  public static final List<RaptorModuleTestConfig> MULTI_CRITERIA_LIST = List.of(
+    TC_MULTI_CRITERIA,
+    TC_MULTI_CRITERIA_DEST_PRUNING
+  );
+
+  RaptorModuleTestConfig(RaptorProfile profile, boolean oneIteration, boolean reverse) {
+    this.profile = profile;
+    this.oneIteration = oneIteration;
+    this.reverse = reverse;
+  }
+
+  RaptorProfile profile() {
+    return profile;
+  }
+
+  boolean withOneIteration() {
+    return oneIteration;
+  }
+
+  boolean withManyIterations() {
+    return !oneIteration;
+  }
+
+  boolean isReverse() {
+    return reverse;
+  }
+
+  boolean isForward() {
+    return !isReverse();
+  }
+
+  public static RaptorModuleTestConfigSetBuilder standard() {
+    return new RaptorModuleTestConfigSetBuilder(STANDARD_LIST);
+  }
+
+  public static RaptorModuleTestConfigSetBuilder minDuration() {
+    return new RaptorModuleTestConfigSetBuilder(MIN_DURATION_LIST);
+  }
+
+  public static RaptorModuleTestConfigSetBuilder multiCriteria() {
+    return new RaptorModuleTestConfigSetBuilder(MULTI_CRITERIA_LIST);
+  }
+
+  public <T extends RaptorTripSchedule> RaptorRequestBuilder<T> apply(
+    RaptorRequestBuilder<T> builder
+  ) {
+    builder.profile(profile);
+    if (oneIteration) {
+      builder.searchParams().searchOneIterationOnly();
+    }
+    if (reverse) {
+      builder.searchDirection(SearchDirection.REVERSE);
+    }
+    if (this == TC_MULTI_CRITERIA_DEST_PRUNING) {
+      builder.enableOptimization(Optimization.PARETO_CHECK_AGAINST_DESTINATION);
+    }
+    return builder;
+  }
+}

--- a/src/test/java/org/opentripplanner/raptor/moduletests/support/RaptorModuleTestConfigSetBuilder.java
+++ b/src/test/java/org/opentripplanner/raptor/moduletests/support/RaptorModuleTestConfigSetBuilder.java
@@ -1,0 +1,51 @@
+package org.opentripplanner.raptor.moduletests.support;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+
+/**
+ * A builder that is used to filter down the set of configurations to the desired set. Note! You
+ * always start with a set, and then remove elements.
+ */
+public class RaptorModuleTestConfigSetBuilder {
+
+  private final Set<RaptorModuleTestConfig> configs = EnumSet.noneOf(RaptorModuleTestConfig.class);
+
+  public RaptorModuleTestConfigSetBuilder(Collection<RaptorModuleTestConfig> initSet) {
+    configs.addAll(initSet);
+  }
+
+  public RaptorModuleTestConfigSetBuilder forwardOnly() {
+    return remove(RaptorModuleTestConfig::isReverse);
+  }
+
+  public RaptorModuleTestConfigSetBuilder reverseOnly() {
+    return remove(RaptorModuleTestConfig::isForward);
+  }
+
+  public RaptorModuleTestConfigSetBuilder oneIterationOnly() {
+    return remove(RaptorModuleTestConfig::withManyIterations);
+  }
+
+  public RaptorModuleTestConfigSetBuilder manyIterationOnly() {
+    return remove(RaptorModuleTestConfig::withOneIteration);
+  }
+
+  public RaptorModuleTestConfigSetBuilder not(RaptorModuleTestConfig config) {
+    return remove(config::equals);
+  }
+
+  public RaptorModuleTestConfigSetBuilder remove(Predicate<RaptorModuleTestConfig> remove) {
+    Arrays.stream(RaptorModuleTestConfig.values()).filter(remove).forEach(configs::remove);
+    return this;
+  }
+
+  public List<RaptorModuleTestConfig> build() {
+    return configs.stream().sorted(Comparator.comparingInt(Enum::ordinal)).toList();
+  }
+}


### PR DESCRIPTION
### Summary

- This adds tests on several missed cases for raptor profiles
- It also make it much easier to add min_duration tests later(low coverage)
- The new builders make the expectations for each profile much more visible,
   this is important - because we want to highlight the differences. It
   illustrates well when a profile can be used and what you sacrifice.

