### PR TITLE
Expose more data from SIRI-SX messages in the Transmodel API

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/legacygraphqlapi/LegacyGraphQLstepImplTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/legacygraphqlapi/LegacyGraphQLstepImplTest.java
@@ -30,9 +30,9 @@ class LegacyGraphQLstepImplTest {
     note.effectiveEndDate = Date.from(endInstant);
 
     TransitAlert alert = LegacyGraphQLstepImpl.mapStreetNoteToAlert(note);
-    assertEquals(TEST_STREET_NOTE_HEADER, alert.alertHeaderText.toString(Locale.ROOT));
-    assertEquals(TEST_STREET_NOTE_DESCRIPTION, alert.alertDescriptionText.toString(Locale.ROOT));
-    assertEquals(TEST_STREET_NOTE_URL, alert.alertUrl.toString(Locale.ROOT));
+    assertEquals(TEST_STREET_NOTE_HEADER, alert.headerText().toString(Locale.ROOT));
+    assertEquals(TEST_STREET_NOTE_DESCRIPTION, alert.descriptionText().toString(Locale.ROOT));
+    assertEquals(TEST_STREET_NOTE_URL, alert.url().toString(Locale.ROOT));
     assertEquals(startInstant, alert.getEffectiveStartDate());
     assertEquals(endInstant, alert.getEffectiveEndDate());
   }

--- a/src/ext-test/java/org/opentripplanner/ext/siri/SiriAlertsUpdateHandlerTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/siri/SiriAlertsUpdateHandlerTest.java
@@ -176,12 +176,15 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
       transitAlertService.getAllAlerts().clear();
     }
     if (alertsUpdateHandler == null) {
-      alertsUpdateHandler = new SiriAlertsUpdateHandler(FEED_ID, transitModel);
-
       transitAlertService = new TransitAlertServiceImpl(transitModel);
-      alertsUpdateHandler.setTransitAlertService(transitAlertService);
-
-      alertsUpdateHandler.setSiriFuzzyTripMatcher(SiriFuzzyTripMatcher.of(transitService));
+      alertsUpdateHandler =
+        new SiriAlertsUpdateHandler(
+          FEED_ID,
+          transitModel,
+          transitAlertService,
+          SiriFuzzyTripMatcher.of(transitService),
+          0
+        );
     }
   }
 

--- a/src/ext-test/java/org/opentripplanner/ext/siri/SiriAlertsUpdateHandlerTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/siri/SiriAlertsUpdateHandlerTest.java
@@ -109,16 +109,16 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
     assertEquals(1, stopPatches.size());
     final TransitAlert transitAlert = stopPatches.iterator().next();
 
-    assertEquals(situationNumber, transitAlert.getId());
-    assertEquals(reportType, transitAlert.alertType);
-    assertEquals(AlertSeverity.SEVERE, transitAlert.severity);
-    assertEquals(priorityValue, transitAlert.priority);
+    assertEquals(situationNumber, transitAlert.getId().getId());
+    assertEquals(reportType, transitAlert.type());
+    assertEquals(AlertSeverity.SEVERE, transitAlert.severity());
+    assertEquals(priorityValue, transitAlert.priority());
 
     assertTrue(containsOnlyEntitiesOfClass(transitAlert, EntitySelector.Stop.class));
     assertTrue(matchesEntity(transitAlert, stopId));
 
-    assertEquals(1, transitAlert.getEntities().size());
-    EntitySelector entitySelector = transitAlert.getEntities().iterator().next();
+    assertEquals(1, transitAlert.entities().size());
+    EntitySelector entitySelector = transitAlert.entities().iterator().next();
     assertTrue(
       ((EntitySelector.Stop) entitySelector).stopConditions().contains(StopCondition.DESTINATION)
     );
@@ -159,10 +159,10 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
       )
     );
 
-    assertNotNull(transitAlert.getAlertUrlList());
-    assertFalse(transitAlert.getAlertUrlList().isEmpty());
+    assertNotNull(transitAlert.siriUrls());
+    assertFalse(transitAlert.siriUrls().isEmpty());
 
-    final List<AlertUrl> alertUrlList = transitAlert.getAlertUrlList();
+    final List<AlertUrl> alertUrlList = transitAlert.siriUrls();
     AlertUrl alertUrl = alertUrlList.get(0);
     assertEquals(infoLinkUri, alertUrl.uri);
     assertEquals(infoLinkLabel, alertUrl.label);
@@ -282,7 +282,7 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
 
     boolean foundStartPointStopCondition = false;
     boolean foundDestinationStopCondition = false;
-    for (EntitySelector entity : transitAlert.getEntities()) {
+    for (EntitySelector entity : transitAlert.entities()) {
       if (((EntitySelector.Stop) entity).stopConditions().contains(StopCondition.START_POINT)) {
         foundStartPointStopCondition = true;
       }
@@ -310,7 +310,7 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
 
     foundStartPointStopCondition = false;
     foundDestinationStopCondition = false;
-    for (EntitySelector entity : transitAlert.getEntities()) {
+    for (EntitySelector entity : transitAlert.entities()) {
       if (((EntitySelector.Stop) entity).stopConditions().contains(StopCondition.START_POINT)) {
         foundStartPointStopCondition = true;
       }
@@ -364,7 +364,7 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
     assertTrue(containsOnlyEntitiesOfClass(transitAlert, EntitySelector.Trip.class));
     assertTrue(matchesEntity(transitAlert, tripId));
 
-    assertEquals(situationNumber, transitAlert.getId());
+    assertEquals(situationNumber, transitAlert.getId().getId());
 
     // Effective validity should be calculated based on the actual departures when Operating dat/service date is provided
     final ZonedDateTime effectiveStartDate = ZonedDateTime.ofInstant(
@@ -424,7 +424,7 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
     assertTrue(containsOnlyEntitiesOfClass(transitAlert, EntitySelector.Trip.class));
     assertTrue(matchesEntity(transitAlert, tripId));
 
-    assertEquals(situationNumber, transitAlert.getId());
+    assertEquals(situationNumber, transitAlert.getId().getId());
 
     // Effective validity should be calculated based on the actual departures when Operating dat/service date is provided
     final ZonedDateTime effectiveStartDate = ZonedDateTime.ofInstant(
@@ -472,7 +472,7 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
     assertEquals(1, tripPatches.size());
     final TransitAlert transitAlert = tripPatches.iterator().next();
 
-    assertEquals(situationNumber, transitAlert.getId());
+    assertEquals(situationNumber, transitAlert.getId().getId());
     assertTrue(containsOnlyEntitiesOfClass(transitAlert, EntitySelector.Trip.class));
     assertTrue(matchesEntity(transitAlert, tripId));
   }
@@ -513,7 +513,7 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
     assertNotNull(tripPatches);
     assertEquals(1, tripPatches.size());
     TransitAlert transitAlert = tripPatches.iterator().next();
-    assertEquals(situationNumber, transitAlert.getId());
+    assertEquals(situationNumber, transitAlert.getId().getId());
     assertTrue(matchesEntity(transitAlert, stopId0, tripId, serviceDate));
 
     tripPatches = transitAlertService.getStopAndTripAlerts(stopId1, tripId, serviceDate);
@@ -521,7 +521,7 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
     assertEquals(1, tripPatches.size());
     transitAlert = tripPatches.iterator().next();
 
-    assertEquals(situationNumber, transitAlert.getId());
+    assertEquals(situationNumber, transitAlert.getId().getId());
     assertTrue(containsOnlyEntitiesOfClass(transitAlert, EntitySelector.StopAndTrip.class));
     assertTrue(matchesEntity(transitAlert, stopId1, tripId, serviceDate));
   }
@@ -557,7 +557,7 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
 
     assertTrue(containsOnlyEntitiesOfClass(transitAlert, EntitySelector.Route.class));
     assertTrue(matchesEntity(transitAlert, lineRef));
-    assertEquals(situationNumber, transitAlert.getId());
+    assertEquals(situationNumber, transitAlert.getId().getId());
 
     // Effective validity should be calculated based on the actual departures when Operating dat/service date is provided
     final ZonedDateTime effectiveStartDate = ZonedDateTime.ofInstant(
@@ -602,7 +602,7 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
     final TransitAlert transitAlert = tripPatches.iterator().next();
     assertTrue(containsOnlyEntitiesOfClass(transitAlert, EntitySelector.Route.class));
     assertTrue(matchesEntity(transitAlert, lineRef));
-    assertEquals(situationNumber, transitAlert.getId());
+    assertEquals(situationNumber, transitAlert.getId().getId());
 
     ptSituation =
       createPtSituationElement(
@@ -665,7 +665,7 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
     assertEquals(1, tripPatches.size());
     TransitAlert transitAlert = tripPatches.iterator().next();
 
-    assertEquals(situationNumber, transitAlert.getId());
+    assertEquals(situationNumber, transitAlert.getId().getId());
     assertTrue(containsOnlyEntitiesOfClass(transitAlert, EntitySelector.StopAndTrip.class));
     assertTrue(matchesEntity(transitAlert, stopId0, tripId, serviceDate));
 
@@ -674,7 +674,7 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
     assertNotNull(tripPatches);
     assertEquals(1, tripPatches.size());
     transitAlert = tripPatches.iterator().next();
-    assertEquals(situationNumber, transitAlert.getId());
+    assertEquals(situationNumber, transitAlert.getId().getId());
     assertTrue(containsOnlyEntitiesOfClass(transitAlert, EntitySelector.StopAndTrip.class));
     assertTrue(matchesEntity(transitAlert, stopId1, tripId, serviceDate));
   }
@@ -773,7 +773,7 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
     assertNotNull(tripPatches);
     assertEquals(1, tripPatches.size());
     TransitAlert transitAlert = tripPatches.iterator().next();
-    assertEquals(situationNumber, transitAlert.getId());
+    assertEquals(situationNumber, transitAlert.getId().getId());
 
     assertNotNull(transitAlert.getEffectiveStartDate());
 
@@ -902,14 +902,14 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
   }
 
   private boolean containsOnlyEntitiesOfClass(TransitAlert transitAlert, Class<?> cls) {
-    long totalEntityCount = transitAlert.getEntities().size();
-    long clsEntityCount = transitAlert.getEntities().stream().filter(cls::isInstance).count();
+    long totalEntityCount = transitAlert.entities().size();
+    long clsEntityCount = transitAlert.entities().stream().filter(cls::isInstance).count();
     return clsEntityCount > 0 && clsEntityCount == totalEntityCount;
   }
 
   private boolean matchesEntity(TransitAlert transitAlert, FeedScopedId feedScopedEntityId) {
     boolean foundMatch = false;
-    for (EntitySelector entity : transitAlert.getEntities()) {
+    for (EntitySelector entity : transitAlert.entities()) {
       if (!foundMatch) {
         if (entity instanceof EntitySelector.Stop entitySelector) {
           foundMatch = entitySelector.stopId().equals(feedScopedEntityId);
@@ -1070,7 +1070,7 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
     LocalDate serviceDate
   ) {
     boolean foundMatch = false;
-    for (EntitySelector entity : transitAlert.getEntities()) {
+    for (EntitySelector entity : transitAlert.entities()) {
       if (!foundMatch) {
         if (entity.key() instanceof EntityKey.StopAndRoute stopAndRoute) {
           foundMatch = stopAndRoute.equals((new EntityKey.StopAndRoute(stopId, routeOrTripId)));
@@ -1133,7 +1133,7 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
     assertEquals(1, tripPatches.size());
     TransitAlert transitAlert = tripPatches.iterator().next();
 
-    assertEquals(situationNumber, transitAlert.getId());
+    assertEquals(situationNumber, transitAlert.getId().getId());
 
     assertTrue(containsOnlyEntitiesOfClass(transitAlert, EntitySelector.StopAndRoute.class));
     assertTrue(matchesEntity(transitAlert, feedStop_0_id, feedRouteId));
@@ -1145,7 +1145,7 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
     assertEquals(1, tripPatches.size());
     transitAlert = tripPatches.iterator().next();
 
-    assertEquals(situationNumber, transitAlert.getId());
+    assertEquals(situationNumber, transitAlert.getId().getId());
 
     assertTrue(containsOnlyEntitiesOfClass(transitAlert, EntitySelector.StopAndRoute.class));
     assertTrue(matchesEntity(transitAlert, feedStop_1_id, feedRouteId));
@@ -1198,7 +1198,7 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
     assertNotNull(tripPatches);
     assertEquals(1, tripPatches.size());
     TransitAlert transitAlert = tripPatches.iterator().next();
-    assertEquals(situationNumber, transitAlert.getId());
+    assertEquals(situationNumber, transitAlert.getId().getId());
     assertTrue(matchesEntity(transitAlert, feedRouteId));
 
     FeedScopedId feedStopId = new FeedScopedId(FEED_ID, stopId0);
@@ -1207,7 +1207,7 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
     assertNotNull(tripPatches);
     assertEquals(1, tripPatches.size());
     transitAlert = tripPatches.iterator().next();
-    assertEquals(situationNumber, transitAlert.getId());
+    assertEquals(situationNumber, transitAlert.getId().getId());
     assertTrue(matchesEntity(transitAlert, feedStopId));
 
     feedStopId = new FeedScopedId(FEED_ID, stopId1);
@@ -1216,7 +1216,7 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
     assertNotNull(tripPatches);
     assertEquals(1, tripPatches.size());
     transitAlert = tripPatches.iterator().next();
-    assertEquals(situationNumber, transitAlert.getId());
+    assertEquals(situationNumber, transitAlert.getId().getId());
     assertTrue(matchesEntity(transitAlert, feedStopId));
   }
 

--- a/src/ext/graphql/transmodelapi/schema.graphql
+++ b/src/ext/graphql/transmodelapi/schema.graphql
@@ -36,6 +36,44 @@ interface PlaceInterface {
   longitude: Float
 }
 
+union Affects = AffectedLine | AffectedServiceJourney | AffectedStopPlace | AffectedStopPlaceOnLine | AffectedStopPlaceOnServiceJourney | AffectedUnknown
+
+type AffectedLine {
+  line: Line
+}
+
+type AffectedServiceJourney {
+  datedServiceJourney: DatedServiceJourney
+  operatingDay: Date
+  serviceJourney: ServiceJourney
+}
+
+type AffectedStopPlace {
+  quay: Quay
+  stopConditions: [StopCondition!]!
+  stopPlace: StopPlace
+}
+
+type AffectedStopPlaceOnLine {
+  line: Line
+  quay: Quay
+  stopConditions: [StopCondition!]!
+  stopPlace: StopPlace
+}
+
+type AffectedStopPlaceOnServiceJourney {
+  datedServiceJourney: DatedServiceJourney
+  operatingDay: Date
+  quay: Quay
+  serviceJourney: ServiceJourney
+  stopConditions: [StopCondition!]!
+  stopPlace: StopPlace
+}
+
+type AffectedUnknown {
+  description: String
+}
+
 "Authority involved in public transportation. An organisation under which the responsibility of organising the transport service in a certain area is placed."
 type Authority {
   fareUrl: String
@@ -454,31 +492,39 @@ type Presentation {
 type PtSituationElement {
   "Advice of situation in all different translations available"
   advice: [MultilingualString!]!
+  "Get all affected entities for the situation"
+  affects: [Affects!]!
   "Get affected authority for this situation element"
-  authority: Authority
+  authority: Authority @deprecated
+  "Timestamp for when the situation was created."
+  creationTime: DateTime
   "Description of situation in all different translations available"
   description: [MultilingualString!]!
   id: ID!
   "Optional links to more information."
   infoLinks: [infoLink!]
-  lines: [Line]!
+  lines: [Line]! @deprecated
+  "Codespace of the data source."
+  participant: String
   "Priority of this situation "
   priority: Int
-  quays: [Quay!]!
-  "Authority that reported this situation"
+  quays: [Quay!]! @deprecated
+  "Authority that reported this situation. Always returns the first agency in the codespace"
   reportAuthority: Authority @deprecated
   "ReportType of this situation"
   reportType: ReportType
-  serviceJourneys: [ServiceJourney]!
+  serviceJourneys: [ServiceJourney]! @deprecated
   "Severity of this situation "
   severity: Severity
   "Operator's internal id for this situation"
   situationNumber: String
-  stopPlaces: [StopPlace!]!
+  stopPlaces: [StopPlace!]! @deprecated
   "Summary of situation in all different translations available"
   summary: [MultilingualString!]!
   "Period this situation is in effect"
   validityPeriod: ValidityPeriod
+  "Timestamp when the situation element was updated."
+  versionedAtTime: DateTime
 }
 
 "A place such as platform, stance, or quayside where passengers have access to PT vehicles."
@@ -674,6 +720,8 @@ type QueryType {
   situations(
     "Filter by reporting authorities."
     authorities: [String],
+    "Filter by reporting source."
+    codespaces: [String],
     "Filter by severity."
     severities: [Severity]
   ): [PtSituationElement!]! @timingData
@@ -1443,6 +1491,19 @@ enum Severity {
   verySevere
   "Situation has a very slight impact on trips."
   verySlight
+}
+
+enum StopCondition {
+  "Situation applies when stop is the destination of the leg."
+  destination
+  "Situation applies when transfering to another leg at the stop."
+  exceptionalStop
+  "Situation applies when passing the stop, without stopping."
+  notStopping
+  "Situation applies when at the stop, and the stop requires a request to stop."
+  requestStop
+  "Situation applies when stop is the startpoint of the leg."
+  startPoint
 }
 
 enum StreetMode {

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLAgencyImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLAgencyImpl.java
@@ -38,7 +38,7 @@ public class LegacyGraphQLAgencyImpl implements LegacyGraphQLDataFetchers.Legacy
                 .stream()
                 .filter(alert ->
                   alert
-                    .getEntities()
+                    .entities()
                     .stream()
                     .filter(EntitySelector.RouteTypeAndAgency.class::isInstance)
                     .map(EntitySelector.RouteTypeAndAgency.class::cast)

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLAlertImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLAlertImpl.java
@@ -40,7 +40,7 @@ public class LegacyGraphQLAlertImpl implements LegacyGraphQLDataFetchers.LegacyG
   public DataFetcher<Agency> agency() {
     return environment ->
       getSource(environment)
-        .getEntities()
+        .entities()
         .stream()
         .filter(EntitySelector.Agency.class::isInstance)
         .findAny()
@@ -53,26 +53,26 @@ public class LegacyGraphQLAlertImpl implements LegacyGraphQLDataFetchers.LegacyG
 
   @Override
   public DataFetcher<String> alertCause() {
-    return environment -> getLegacyGraphQLCause(getSource(environment).cause);
+    return environment -> getLegacyGraphQLCause(getSource(environment).cause());
   }
 
   @Override
   public DataFetcher<String> alertDescriptionText() {
     return environment ->
-      getSource(environment).alertDescriptionText.toString(environment.getLocale());
+      getSource(environment).descriptionText().toString(environment.getLocale());
   }
 
   @Override
   public DataFetcher<Iterable<Map.Entry<String, String>>> alertDescriptionTextTranslations() {
     return environment -> {
-      var text = getSource(environment).alertDescriptionText;
+      var text = getSource(environment).descriptionText();
       return getTranslations(text);
     };
   }
 
   @Override
   public DataFetcher<String> alertEffect() {
-    return environment -> getLegacyGraphQLEffect(getSource(environment).effect);
+    return environment -> getLegacyGraphQLEffect(getSource(environment).effect());
   }
 
   @Override
@@ -80,38 +80,38 @@ public class LegacyGraphQLAlertImpl implements LegacyGraphQLDataFetchers.LegacyG
     return environment -> {
       TransitAlert alert = getSource(environment);
       return Objects.hash(
-        alert.alertDescriptionText,
-        alert.alertHeaderText,
-        alert.alertUrl,
-        alert.cause,
-        alert.effect,
-        alert.severity
+        alert.descriptionText(),
+        alert.headerText(),
+        alert.url(),
+        alert.cause(),
+        alert.effect(),
+        alert.severity()
       );
     };
   }
 
   @Override
   public DataFetcher<String> alertHeaderText() {
-    return environment -> getSource(environment).alertHeaderText.toString(environment.getLocale());
+    return environment -> getSource(environment).headerText().toString(environment.getLocale());
   }
 
   @Override
   public DataFetcher<Iterable<Map.Entry<String, String>>> alertHeaderTextTranslations() {
     return environment -> {
-      var text = getSource(environment).alertHeaderText;
+      var text = getSource(environment).headerText();
       return getTranslations(text);
     };
   }
 
   @Override
   public DataFetcher<String> alertSeverityLevel() {
-    return environment -> getLegacyGraphQLSeverity(getSource(environment).severity);
+    return environment -> getLegacyGraphQLSeverity(getSource(environment).severity());
   }
 
   @Override
   public DataFetcher<String> alertUrl() {
     return environment -> {
-      var alertUrl = getSource(environment).alertUrl;
+      var alertUrl = getSource(environment).url();
       return alertUrl == null ? null : alertUrl.toString(environment.getLocale());
     };
   }
@@ -119,7 +119,7 @@ public class LegacyGraphQLAlertImpl implements LegacyGraphQLDataFetchers.LegacyG
   @Override
   public DataFetcher<Iterable<Map.Entry<String, String>>> alertUrlTranslations() {
     return environment -> {
-      var url = getSource(environment).alertUrl;
+      var url = getSource(environment).url();
       return getTranslations(url);
     };
   }
@@ -150,7 +150,7 @@ public class LegacyGraphQLAlertImpl implements LegacyGraphQLDataFetchers.LegacyG
   public DataFetcher<Iterable<Object>> entities() {
     return environment ->
       getSource(environment)
-        .getEntities()
+        .entities()
         .stream()
         .map(entitySelector -> {
           if (entitySelector instanceof EntitySelector.Stop) {
@@ -266,12 +266,13 @@ public class LegacyGraphQLAlertImpl implements LegacyGraphQLDataFetchers.LegacyG
 
   @Override
   public DataFetcher<String> feed() {
-    return environment -> getSource(environment).getFeedId();
+    return environment -> getSource(environment).getId().getFeedId();
   }
 
   @Override
   public DataFetcher<Relay.ResolvedGlobalId> id() {
-    return environment -> new Relay.ResolvedGlobalId("Alert", getSource(environment).getId());
+    return environment ->
+      new Relay.ResolvedGlobalId("Alert", getSource(environment).getId().toString());
   }
 
   // This is deprecated
@@ -284,7 +285,7 @@ public class LegacyGraphQLAlertImpl implements LegacyGraphQLDataFetchers.LegacyG
   public DataFetcher<Route> route() {
     return environment ->
       getSource(environment)
-        .getEntities()
+        .entities()
         .stream()
         .filter(entitySelector -> entitySelector instanceof EntitySelector.Route)
         .findAny()
@@ -299,7 +300,7 @@ public class LegacyGraphQLAlertImpl implements LegacyGraphQLDataFetchers.LegacyG
   public DataFetcher<Object> stop() {
     return environment ->
       getSource(environment)
-        .getEntities()
+        .entities()
         .stream()
         .filter(entitySelector -> entitySelector instanceof EntitySelector.Stop)
         .findAny()
@@ -314,7 +315,7 @@ public class LegacyGraphQLAlertImpl implements LegacyGraphQLDataFetchers.LegacyG
   public DataFetcher<Trip> trip() {
     return environment ->
       getSource(environment)
-        .getEntities()
+        .entities()
         .stream()
         .filter(entitySelector -> entitySelector instanceof EntitySelector.Trip)
         .findAny()

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLFeedImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLFeedImpl.java
@@ -43,7 +43,7 @@ public class LegacyGraphQLFeedImpl implements LegacyGraphQLDataFetchers.LegacyGr
                 .stream()
                 .filter(alert ->
                   alert
-                    .getEntities()
+                    .entities()
                     .stream()
                     .filter(EntitySelector.RouteType.class::isInstance)
                     .map(EntitySelector.RouteType.class::cast)

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLPatternImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLPatternImpl.java
@@ -81,7 +81,7 @@ public class LegacyGraphQLPatternImpl implements LegacyGraphQLDataFetchers.Legac
                   .stream()
                   .filter(alert ->
                     alert
-                      .getEntities()
+                      .entities()
                       .stream()
                       .anyMatch(entity ->
                         (
@@ -108,7 +108,7 @@ public class LegacyGraphQLPatternImpl implements LegacyGraphQLDataFetchers.Legac
                     .stream()
                     .filter(alert ->
                       alert
-                        .getEntities()
+                        .entities()
                         .stream()
                         .anyMatch(entity ->
                           (

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
@@ -137,17 +137,18 @@ public class LegacyGraphQLQueryTypeImpl
         .stream()
         .filter(alert ->
           args.getLegacyGraphQLFeeds() == null ||
-          ((List<String>) args.getLegacyGraphQLFeeds()).contains(alert.getFeedId())
+          ((List<String>) args.getLegacyGraphQLFeeds()).contains(alert.getId().getFeedId())
         )
         .filter(alert ->
-          severities == null || severities.contains(getLegacyGraphQLSeverity(alert.severity))
+          severities == null || severities.contains(getLegacyGraphQLSeverity(alert.severity()))
         )
-        .filter(alert -> effects == null || effects.contains(getLegacyGraphQLEffect(alert.effect)))
-        .filter(alert -> causes == null || causes.contains(getLegacyGraphQLCause(alert.cause)))
+        .filter(alert -> effects == null || effects.contains(getLegacyGraphQLEffect(alert.effect()))
+        )
+        .filter(alert -> causes == null || causes.contains(getLegacyGraphQLCause(alert.cause())))
         .filter(alert ->
           args.getLegacyGraphQLRoute() == null ||
           alert
-            .getEntities()
+            .entities()
             .stream()
             .filter(entitySelector -> entitySelector instanceof EntitySelector.Route)
             .map(EntitySelector.Route.class::cast)
@@ -158,7 +159,7 @@ public class LegacyGraphQLQueryTypeImpl
         .filter(alert ->
           args.getLegacyGraphQLStop() == null ||
           alert
-            .getEntities()
+            .entities()
             .stream()
             .filter(entitySelector -> entitySelector instanceof EntitySelector.Stop)
             .map(EntitySelector.Stop.class::cast)

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLRouteImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLRouteImpl.java
@@ -71,7 +71,7 @@ public class LegacyGraphQLRouteImpl implements LegacyGraphQLDataFetchers.LegacyG
                   .stream()
                   .filter(alert ->
                     alert
-                      .getEntities()
+                      .entities()
                       .stream()
                       .anyMatch(entity ->
                         entity instanceof EntitySelector.StopAndRoute stopAndRoute &&
@@ -94,7 +94,7 @@ public class LegacyGraphQLRouteImpl implements LegacyGraphQLDataFetchers.LegacyG
                     .stream()
                     .filter(alert ->
                       alert
-                        .getEntities()
+                        .entities()
                         .stream()
                         .anyMatch(entity ->
                           entity instanceof EntitySelector.StopAndTrip stopAndTrip &&

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLStopImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLStopImpl.java
@@ -63,7 +63,7 @@ public class LegacyGraphQLStopImpl implements LegacyGraphQLDataFetchers.LegacyGr
               .stream()
               .filter(alert ->
                 alert
-                  .getEntities()
+                  .entities()
                   .stream()
                   .anyMatch(entity ->
                     (

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLTripImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLTripImpl.java
@@ -96,7 +96,7 @@ public class LegacyGraphQLTripImpl implements LegacyGraphQLDataFetchers.LegacyGr
                   .stream()
                   .filter(alert ->
                     alert
-                      .getEntities()
+                      .entities()
                       .stream()
                       .anyMatch(entity ->
                         (

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLstepImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLstepImpl.java
@@ -2,7 +2,6 @@ package org.opentripplanner.ext.legacygraphqlapi.datafetchers;
 
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
-import java.util.List;
 import org.opentripplanner.api.mapping.StreetNoteMaperMapper;
 import org.opentripplanner.ext.legacygraphqlapi.generated.LegacyGraphQLDataFetchers;
 import org.opentripplanner.ext.legacygraphqlapi.generated.LegacyGraphQLTypes.LegacyGraphQLAbsoluteDirection;
@@ -12,7 +11,9 @@ import org.opentripplanner.model.plan.ElevationProfile.Step;
 import org.opentripplanner.model.plan.WalkStep;
 import org.opentripplanner.routing.alertpatch.TimePeriod;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
+import org.opentripplanner.routing.alertpatch.TransitAlertBuilder;
 import org.opentripplanner.street.model.note.StreetNote;
+import org.opentripplanner.transit.model.framework.FeedScopedId;
 
 public class LegacyGraphQLstepImpl implements LegacyGraphQLDataFetchers.LegacyGraphQLStep {
 
@@ -20,19 +21,20 @@ public class LegacyGraphQLstepImpl implements LegacyGraphQLDataFetchers.LegacyGr
    * Similar to {@link StreetNoteMaperMapper::mapToApi}.
    */
   public static TransitAlert mapStreetNoteToAlert(StreetNote note) {
-    TransitAlert alert = new TransitAlert();
-    alert.alertHeaderText = note.note;
-    alert.alertDescriptionText = note.descriptionText;
-    alert.alertUrl = new NonLocalizedString(note.url);
-    alert.setTimePeriods(
-      List.of(
-        new TimePeriod(
-          note.effectiveStartDate.getTime() / 1000,
-          note.effectiveEndDate.getTime() / 1000
-        )
+    // TODO: The ID is used only in the mapping, we should instead have two mappers for the fields
+    TransitAlertBuilder alert = TransitAlert.of(
+      new FeedScopedId("StreetNote", Integer.toString(note.hashCode()))
+    );
+    alert.withHeaderText(note.note);
+    alert.withDescriptionText(note.descriptionText);
+    alert.withUrl(new NonLocalizedString(note.url));
+    alert.addTimePeriod(
+      new TimePeriod(
+        note.effectiveStartDate.getTime() / 1000,
+        note.effectiveEndDate.getTime() / 1000
       )
     );
-    return alert;
+    return alert.build();
   }
 
   @Override

--- a/src/ext/java/org/opentripplanner/ext/siri/AffectsMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/AffectsMapper.java
@@ -1,0 +1,416 @@
+package org.opentripplanner.ext.siri;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.opentripplanner.framework.time.ServiceDateUtils;
+import org.opentripplanner.routing.alertpatch.EntitySelector;
+import org.opentripplanner.routing.alertpatch.StopCondition;
+import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.model.timetable.Trip;
+import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
+import org.opentripplanner.transit.service.TransitService;
+import uk.org.ifopt.siri20.StopPlaceRef;
+import uk.org.siri.siri20.AffectedLineStructure;
+import uk.org.siri.siri20.AffectedOperatorStructure;
+import uk.org.siri.siri20.AffectedRouteStructure;
+import uk.org.siri.siri20.AffectedStopPlaceStructure;
+import uk.org.siri.siri20.AffectedStopPointStructure;
+import uk.org.siri.siri20.AffectedVehicleJourneyStructure;
+import uk.org.siri.siri20.AffectsScopeStructure;
+import uk.org.siri.siri20.DataFrameRefStructure;
+import uk.org.siri.siri20.FramedVehicleJourneyRefStructure;
+import uk.org.siri.siri20.LineRef;
+import uk.org.siri.siri20.NetworkRefStructure;
+import uk.org.siri.siri20.OperatorRefStructure;
+import uk.org.siri.siri20.RoutePointTypeEnumeration;
+import uk.org.siri.siri20.StopPointRef;
+import uk.org.siri.siri20.VehicleJourneyRef;
+
+/**
+ * Maps a {@link AffectsScopeStructure} to a list of {@link EntitySelector}s
+ */
+public class AffectsMapper {
+
+  private final String feedId;
+  private final SiriFuzzyTripMatcher siriFuzzyTripMatcher;
+  private final TransitService transitService;
+
+  public AffectsMapper(
+    String feedId,
+    SiriFuzzyTripMatcher siriFuzzyTripMatcher,
+    TransitService transitService
+  ) {
+    this.feedId = feedId;
+    this.siriFuzzyTripMatcher = siriFuzzyTripMatcher;
+    this.transitService = transitService;
+  }
+
+  List<EntitySelector> mapAffects(AffectsScopeStructure affectsStructure) {
+    if (affectsStructure == null) {
+      return List.of();
+    }
+
+    List<EntitySelector> selectors = new ArrayList<>();
+    selectors.addAll(mapOperators(affectsStructure.getOperators()));
+    selectors.addAll(mapStopPoints(affectsStructure.getStopPoints()));
+    selectors.addAll(mapStopPlaces(affectsStructure.getStopPlaces()));
+    selectors.addAll(mapNetworks(affectsStructure.getNetworks()));
+    selectors.addAll(mapVehicleJourneys(affectsStructure.getVehicleJourneys()));
+
+    return selectors;
+  }
+
+  private List<EntitySelector> mapVehicleJourneys(AffectsScopeStructure.VehicleJourneys vjs) {
+    if (vjs == null || isEmpty(vjs.getAffectedVehicleJourneies())) {
+      return List.of();
+    }
+
+    List<EntitySelector> selectors = new ArrayList<>();
+    for (AffectedVehicleJourneyStructure affectedVehicleJourney : vjs.getAffectedVehicleJourneies()) {
+      List<AffectedStopPointStructure> affectedStops = new ArrayList<>();
+
+      List<AffectedRouteStructure> routes = affectedVehicleJourney.getRoutes();
+      // Resolve AffectedStop-ids
+      if (routes != null) {
+        for (AffectedRouteStructure route : routes) {
+          if (route.getStopPoints() != null) {
+            List<Serializable> stopPointsList = route
+              .getStopPoints()
+              .getAffectedStopPointsAndLinkProjectionToNextStopPoints();
+            for (Serializable serializable : stopPointsList) {
+              if (serializable instanceof AffectedStopPointStructure stopPointStructure) {
+                affectedStops.add(stopPointStructure);
+              }
+            }
+          }
+        }
+      }
+
+      List<VehicleJourneyRef> vehicleJourneyReves = affectedVehicleJourney.getVehicleJourneyReves();
+
+      if (isNotEmpty(vehicleJourneyReves)) {
+        for (VehicleJourneyRef vehicleJourneyRef : vehicleJourneyReves) {
+          List<FeedScopedId> tripIds = new ArrayList<>();
+
+          FeedScopedId tripIdFromVehicleJourney = getTripId(
+            vehicleJourneyRef.getValue(),
+            feedId,
+            transitService
+          );
+
+          ZonedDateTime originAimedDepartureTime = affectedVehicleJourney.getOriginAimedDepartureTime() !=
+            null
+            ? affectedVehicleJourney.getOriginAimedDepartureTime()
+            : ZonedDateTime.now();
+
+          ZonedDateTime startOfService = ServiceDateUtils.asStartOfService(
+            originAimedDepartureTime
+          );
+
+          LocalDate serviceDate = startOfService.toLocalDate();
+
+          if (tripIdFromVehicleJourney != null) {
+            tripIds.add(tripIdFromVehicleJourney);
+          } else if (siriFuzzyTripMatcher != null) {
+            tripIds =
+              siriFuzzyTripMatcher.getTripIdForInternalPlanningCodeServiceDate(
+                vehicleJourneyRef.getValue(),
+                serviceDate
+              );
+          }
+
+          for (FeedScopedId tripId : tripIds) {
+            if (!affectedStops.isEmpty()) {
+              for (AffectedStopPointStructure affectedStop : affectedStops) {
+                FeedScopedId stop = getStop(
+                  affectedStop.getStopPointRef().getValue(),
+                  feedId,
+                  transitService
+                );
+                if (stop == null) {
+                  stop = new FeedScopedId(feedId, affectedStop.getStopPointRef().getValue());
+                }
+                // Creating unique, deterministic id for the alert
+                EntitySelector.StopAndTrip entitySelector = new EntitySelector.StopAndTrip(
+                  stop,
+                  tripId,
+                  serviceDate,
+                  resolveStopConditions(affectedStop.getStopConditions())
+                );
+                selectors.add(entitySelector);
+              }
+            } else {
+              selectors.add(new EntitySelector.Trip(tripId, serviceDate));
+            }
+          }
+        }
+      }
+
+      final FramedVehicleJourneyRefStructure framedVehicleJourneyRef = affectedVehicleJourney.getFramedVehicleJourneyRef();
+      if (framedVehicleJourneyRef != null) {
+        final DataFrameRefStructure dataFrameRef = framedVehicleJourneyRef.getDataFrameRef();
+        final String datedVehicleJourneyRef = framedVehicleJourneyRef.getDatedVehicleJourneyRef();
+
+        FeedScopedId tripId = getTripId(datedVehicleJourneyRef, feedId, transitService);
+
+        if (tripId != null) {
+          LocalDate serviceDate = null;
+          if (dataFrameRef != null && dataFrameRef.getValue() != null) {
+            serviceDate = LocalDate.parse(dataFrameRef.getValue());
+          }
+
+          if (!affectedStops.isEmpty()) {
+            for (AffectedStopPointStructure affectedStop : affectedStops) {
+              FeedScopedId stop = getStop(
+                affectedStop.getStopPointRef().getValue(),
+                feedId,
+                transitService
+              );
+              if (stop == null) {
+                stop = new FeedScopedId(feedId, affectedStop.getStopPointRef().getValue());
+              }
+
+              selectors.add(
+                new EntitySelector.StopAndTrip(
+                  stop,
+                  tripId,
+                  serviceDate,
+                  resolveStopConditions(affectedStop.getStopConditions())
+                )
+              );
+            }
+          } else {
+            selectors.add(new EntitySelector.Trip(tripId, serviceDate));
+          }
+        }
+      }
+    }
+    return selectors;
+  }
+
+  private List<EntitySelector> mapNetworks(AffectsScopeStructure.Networks networks) {
+    if (networks == null || isEmpty(networks.getAffectedNetworks())) {
+      return List.of();
+    }
+
+    List<EntitySelector> selectors = new ArrayList<>();
+
+    for (AffectsScopeStructure.Networks.AffectedNetwork affectedNetwork : networks.getAffectedNetworks()) {
+      List<AffectedLineStructure> affectedLines = affectedNetwork.getAffectedLines();
+      if (isNotEmpty(affectedLines)) {
+        for (AffectedLineStructure line : affectedLines) {
+          LineRef lineRef = line.getLineRef();
+
+          if (lineRef == null || lineRef.getValue() == null) {
+            continue;
+          }
+
+          List<AffectedStopPointStructure> affectedStops = new ArrayList<>();
+
+          AffectedLineStructure.Routes routes = line.getRoutes();
+
+          // Resolve AffectedStop-ids
+          if (routes != null) {
+            for (AffectedRouteStructure route : routes.getAffectedRoutes()) {
+              if (route.getStopPoints() != null) {
+                List<Serializable> stopPointsList = route
+                  .getStopPoints()
+                  .getAffectedStopPointsAndLinkProjectionToNextStopPoints();
+                for (Serializable serializable : stopPointsList) {
+                  if (serializable instanceof AffectedStopPointStructure stopPointStructure) {
+                    affectedStops.add(stopPointStructure);
+                  }
+                }
+              }
+            }
+          }
+          FeedScopedId affectedRoute = new FeedScopedId(feedId, lineRef.getValue());
+
+          if (!affectedStops.isEmpty()) {
+            for (AffectedStopPointStructure affectedStop : affectedStops) {
+              FeedScopedId stop = getStop(
+                affectedStop.getStopPointRef().getValue(),
+                feedId,
+                transitService
+              );
+              if (stop == null) {
+                stop = new FeedScopedId(feedId, affectedStop.getStopPointRef().getValue());
+              }
+              EntitySelector.StopAndRoute entitySelector = new EntitySelector.StopAndRoute(
+                stop,
+                resolveStopConditions(affectedStop.getStopConditions()),
+                affectedRoute
+              );
+              selectors.add(entitySelector);
+            }
+          } else {
+            selectors.add(new EntitySelector.Route(affectedRoute));
+          }
+        }
+      } else {
+        NetworkRefStructure networkRef = affectedNetwork.getNetworkRef();
+        if (networkRef == null || networkRef.getValue() == null) {
+          continue;
+        }
+        String networkId = networkRef.getValue();
+        // TODO: What to do here - We need to store network on route and add new EntitySelector
+        selectors.add(new EntitySelector.Unknown("Alert affects network %s".formatted(networkId)));
+      }
+    }
+    return selectors;
+  }
+
+  private List<EntitySelector> mapStopPoints(AffectsScopeStructure.StopPoints stopPoints) {
+    if (stopPoints == null || isEmpty(stopPoints.getAffectedStopPoints())) {
+      return List.of();
+    }
+
+    List<EntitySelector> selectors = new ArrayList<>();
+
+    for (AffectedStopPointStructure stopPoint : stopPoints.getAffectedStopPoints()) {
+      StopPointRef stopPointRef = stopPoint.getStopPointRef();
+      if (stopPointRef == null || stopPointRef.getValue() == null) {
+        continue;
+      }
+
+      FeedScopedId stopId = getStop(stopPointRef.getValue(), feedId, transitService);
+
+      if (stopId == null) {
+        stopId = new FeedScopedId(feedId, stopPointRef.getValue());
+      }
+
+      EntitySelector.Stop entitySelector = new EntitySelector.Stop(
+        stopId,
+        resolveStopConditions(stopPoint.getStopConditions())
+      );
+
+      selectors.add(entitySelector);
+    }
+
+    return selectors;
+  }
+
+  private List<EntitySelector> mapStopPlaces(AffectsScopeStructure.StopPlaces stopPlaces) {
+    if (stopPlaces == null || isEmpty(stopPlaces.getAffectedStopPlaces())) {
+      return List.of();
+    }
+    List<EntitySelector> selectors = new ArrayList<>();
+
+    for (AffectedStopPlaceStructure stopPlace : stopPlaces.getAffectedStopPlaces()) {
+      StopPlaceRef stopPlaceRef = stopPlace.getStopPlaceRef();
+      if (stopPlaceRef == null || stopPlaceRef.getValue() == null) {
+        continue;
+      }
+
+      FeedScopedId stopId = getStop(stopPlaceRef.getValue(), feedId, transitService);
+
+      if (stopId == null) {
+        stopId = new FeedScopedId(feedId, stopPlaceRef.getValue());
+      }
+
+      selectors.add(new EntitySelector.Stop(stopId));
+    }
+
+    return selectors;
+  }
+
+  private List<EntitySelector> mapOperators(AffectsScopeStructure.Operators operators) {
+    if (operators == null || isEmpty(operators.getAffectedOperators())) {
+      return List.of();
+    }
+
+    List<EntitySelector> selectors = new ArrayList<>();
+
+    for (AffectedOperatorStructure affectedOperator : operators.getAffectedOperators()) {
+      OperatorRefStructure operatorRef = affectedOperator.getOperatorRef();
+      if (operatorRef == null || operatorRef.getValue() == null) {
+        continue;
+      }
+
+      // SIRI Operators are mapped to OTP Agency, this is probably wrong - but
+      // I leave this for now.
+      String agencyId = operatorRef.getValue();
+
+      selectors.add(new EntitySelector.Agency(new FeedScopedId(feedId, agencyId)));
+    }
+
+    return selectors;
+  }
+
+  private static FeedScopedId getStop(
+    String siriStopId,
+    String feedId,
+    TransitService transitService
+  ) {
+    FeedScopedId id = new FeedScopedId(feedId, siriStopId);
+    if (transitService.getRegularStop(id) != null) {
+      return id;
+    } else if (transitService.getStationById(id) != null) {
+      return id;
+    }
+
+    return null;
+  }
+
+  private static FeedScopedId getTripId(
+    String vehicleJourney,
+    String feedId,
+    TransitService transitService
+  ) {
+    Trip trip = transitService.getTripForId(new FeedScopedId(feedId, vehicleJourney));
+    if (trip != null) {
+      return trip.getId();
+    }
+    //Attempt to find trip using datedServiceJourneys
+    TripOnServiceDate tripOnServiceDate = transitService.getTripOnServiceDateById(
+      new FeedScopedId(feedId, vehicleJourney)
+    );
+    if (tripOnServiceDate != null) {
+      return tripOnServiceDate.getTrip().getId();
+    }
+    return null;
+  }
+
+  private static Set<StopCondition> resolveStopConditions(
+    List<RoutePointTypeEnumeration> stopConditions
+  ) {
+    Set<StopCondition> alertStopConditions = new HashSet<>();
+    if (stopConditions != null) {
+      for (RoutePointTypeEnumeration stopCondition : stopConditions) {
+        switch (stopCondition) {
+          case EXCEPTIONAL_STOP -> alertStopConditions.add(StopCondition.EXCEPTIONAL_STOP);
+          case DESTINATION -> alertStopConditions.add(StopCondition.DESTINATION);
+          case NOT_STOPPING -> alertStopConditions.add(StopCondition.NOT_STOPPING);
+          case REQUEST_STOP -> alertStopConditions.add(StopCondition.REQUEST_STOP);
+          case START_POINT -> alertStopConditions.add(StopCondition.START_POINT);
+        }
+      }
+    }
+    if (alertStopConditions.isEmpty()) {
+      //No StopConditions are set - set default
+      alertStopConditions.add(StopCondition.START_POINT);
+      alertStopConditions.add(StopCondition.DESTINATION);
+    }
+    return alertStopConditions;
+  }
+
+  /**
+   * @return True if list is null or is empty.
+   */
+  private static boolean isEmpty(List<?> list) {
+    return list == null || list.isEmpty();
+  }
+
+  /**
+   * @return True if list have at least one element. {@code false} is returned if the given list is
+   * empty or {@code null}.
+   */
+  private static boolean isNotEmpty(List<?> list) {
+    return list != null && !list.isEmpty();
+  }
+}

--- a/src/ext/java/org/opentripplanner/ext/siri/AffectsMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/AffectsMapper.java
@@ -124,6 +124,14 @@ public class AffectsMapper {
               );
           }
 
+          if (tripIds.isEmpty()) {
+            selectors.add(
+              new EntitySelector.Unknown(
+                "Alert affects unknown vehicle journey %s".formatted(vehicleJourneyRef.getValue())
+              )
+            );
+          }
+
           for (FeedScopedId tripId : tripIds) {
             if (!affectedStops.isEmpty()) {
               for (AffectedStopPointStructure affectedStop : affectedStops) {
@@ -187,6 +195,12 @@ public class AffectsMapper {
           } else {
             selectors.add(new EntitySelector.Trip(tripId, serviceDate));
           }
+        } else {
+          selectors.add(
+            new EntitySelector.Unknown(
+              "Alert affects unknown framed vehicle journey %s".formatted(datedVehicleJourneyRef)
+            )
+          );
         }
       }
     }

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriAlertsUpdateHandler.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriAlertsUpdateHandler.java
@@ -161,6 +161,13 @@ public class SiriAlertsUpdateHandler {
       return null;
     }
 
+    if (situation.getCreationTime() != null) {
+      alert.withCreationTime(situation.getCreationTime());
+    }
+    if (situation.getVersionedAtTime() != null) {
+      alert.withUpdatedTime(situation.getVersionedAtTime());
+    }
+
     ArrayList<TimePeriod> periods = new ArrayList<>();
     if (situation.getValidityPeriods().size() > 0) {
       for (HalfOpenTimestampOutputRangeStructure activePeriod : situation.getValidityPeriods()) {
@@ -439,7 +446,7 @@ public class SiriAlertsUpdateHandler {
     if (alert.entities().isEmpty()) {
       LOG.info(
         "No match found for Alert - setting Unknown entity for situation with situationNumber {}",
-        situation.getSituationNumber()
+        alert.getId()
       );
       alert.addEntity(new EntitySelector.Unknown("Alert had no entities that could be handled"));
     }
@@ -448,11 +455,9 @@ public class SiriAlertsUpdateHandler {
 
     alert.withSeverity(SiriSeverityMapper.getAlertSeverityForSiriSeverity(situation.getSeverity()));
 
-    // TODO: Add field for codespace
-    //    if (situation.getParticipantRef() != null) {
-    //      String codespace = situation.getParticipantRef().getValue();
-    //      alert.setFeedId(codespace + ":Authority:" + codespace); //TODO - SIRI: Should probably not assume this codespace -> authority rule
-    //    }
+    if (situation.getParticipantRef() != null) {
+      alert.withSiriCodespace(situation.getParticipantRef().getValue());
+    }
 
     return alert.build();
   }

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriAlertsUpdateHandler.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriAlertsUpdateHandler.java
@@ -1,7 +1,5 @@
 package org.opentripplanner.ext.siri;
 
-import java.io.Serializable;
-import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -12,45 +10,25 @@ import java.util.Set;
 import org.opentripplanner.framework.i18n.I18NString;
 import org.opentripplanner.framework.i18n.NonLocalizedString;
 import org.opentripplanner.framework.i18n.TranslatedString;
-import org.opentripplanner.framework.time.ServiceDateUtils;
 import org.opentripplanner.routing.alertpatch.AlertUrl;
 import org.opentripplanner.routing.alertpatch.EntitySelector;
-import org.opentripplanner.routing.alertpatch.StopCondition;
 import org.opentripplanner.routing.alertpatch.TimePeriod;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.routing.alertpatch.TransitAlertBuilder;
 import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
-import org.opentripplanner.transit.model.timetable.Trip;
-import org.opentripplanner.transit.model.timetable.TripOnServiceDate;
 import org.opentripplanner.transit.service.DefaultTransitService;
 import org.opentripplanner.transit.service.TransitModel;
 import org.opentripplanner.transit.service.TransitService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.org.ifopt.siri20.StopPlaceRef;
-import uk.org.siri.siri20.AffectedLineStructure;
-import uk.org.siri.siri20.AffectedOperatorStructure;
-import uk.org.siri.siri20.AffectedRouteStructure;
-import uk.org.siri.siri20.AffectedStopPlaceStructure;
-import uk.org.siri.siri20.AffectedStopPointStructure;
-import uk.org.siri.siri20.AffectedVehicleJourneyStructure;
-import uk.org.siri.siri20.AffectsScopeStructure;
-import uk.org.siri.siri20.DataFrameRefStructure;
 import uk.org.siri.siri20.DefaultedTextStructure;
-import uk.org.siri.siri20.FramedVehicleJourneyRefStructure;
 import uk.org.siri.siri20.HalfOpenTimestampOutputRangeStructure;
 import uk.org.siri.siri20.InfoLinkStructure;
-import uk.org.siri.siri20.LineRef;
 import uk.org.siri.siri20.NaturalLanguageStringStructure;
-import uk.org.siri.siri20.NetworkRefStructure;
-import uk.org.siri.siri20.OperatorRefStructure;
 import uk.org.siri.siri20.PtSituationElement;
-import uk.org.siri.siri20.RoutePointTypeEnumeration;
 import uk.org.siri.siri20.ServiceDelivery;
 import uk.org.siri.siri20.SituationExchangeDeliveryStructure;
-import uk.org.siri.siri20.StopPointRef;
-import uk.org.siri.siri20.VehicleJourneyRef;
 import uk.org.siri.siri20.WorkflowStatusEnumeration;
 
 /**
@@ -62,16 +40,25 @@ public class SiriAlertsUpdateHandler {
 
   private static final Logger LOG = LoggerFactory.getLogger(SiriAlertsUpdateHandler.class);
   private final String feedId;
-  private final TransitService transitService;
   private final Set<TransitAlert> alerts = new HashSet<>();
-  private TransitAlertService transitAlertService;
+  private final TransitAlertService transitAlertService;
   /** How long before the posted start of an event it should be displayed to users */
-  private long earlyStart;
-  private SiriFuzzyTripMatcher siriFuzzyTripMatcher;
+  private final long earlyStart;
+  private final AffectsMapper affectsMapper;
 
-  public SiriAlertsUpdateHandler(String feedId, TransitModel transitModel) {
+  public SiriAlertsUpdateHandler(
+    String feedId,
+    TransitModel transitModel,
+    TransitAlertService transitAlertService,
+    SiriFuzzyTripMatcher siriFuzzyTripMatcher,
+    long earlyStart
+  ) {
     this.feedId = feedId;
-    this.transitService = new DefaultTransitService(transitModel);
+    this.transitAlertService = transitAlertService;
+    this.earlyStart = earlyStart;
+
+    TransitService transitService = new DefaultTransitService(transitModel);
+    this.affectsMapper = new AffectsMapper(feedId, siriFuzzyTripMatcher, transitService);
   }
 
   public void update(ServiceDelivery delivery) {
@@ -130,22 +117,6 @@ public class SiriAlertsUpdateHandler {
     }
   }
 
-  public void setTransitAlertService(TransitAlertService transitAlertService) {
-    this.transitAlertService = transitAlertService;
-  }
-
-  public long getEarlyStart() {
-    return earlyStart;
-  }
-
-  public void setEarlyStart(long earlyStart) {
-    this.earlyStart = earlyStart;
-  }
-
-  public void setSiriFuzzyTripMatcher(SiriFuzzyTripMatcher siriFuzzyTripMatcher) {
-    this.siriFuzzyTripMatcher = siriFuzzyTripMatcher;
-  }
-
   private TransitAlert handleAlert(PtSituationElement situation) {
     TransitAlertBuilder alert = createAlertWithTexts(situation);
 
@@ -194,254 +165,7 @@ public class SiriAlertsUpdateHandler {
       alert.withPriority(situation.getPriority().intValue());
     }
 
-    AffectsScopeStructure affectsStructure = situation.getAffects();
-
-    if (affectsStructure != null) {
-      AffectsScopeStructure.Operators operators = affectsStructure.getOperators();
-
-      if (operators != null && isNotEmpty(operators.getAffectedOperators())) {
-        for (AffectedOperatorStructure affectedOperator : operators.getAffectedOperators()) {
-          OperatorRefStructure operatorRef = affectedOperator.getOperatorRef();
-          if (operatorRef == null || operatorRef.getValue() == null) {
-            continue;
-          }
-
-          // SIRI Operators are mapped to OTP Agency, this i probably wrong - but
-          // I leave this for now.
-          String agencyId = operatorRef.getValue();
-
-          alert.addEntity(new EntitySelector.Agency(new FeedScopedId(feedId, agencyId)));
-        }
-      }
-
-      AffectsScopeStructure.StopPoints stopPoints = affectsStructure.getStopPoints();
-      AffectsScopeStructure.StopPlaces stopPlaces = affectsStructure.getStopPlaces();
-
-      if (stopPoints != null && isNotEmpty(stopPoints.getAffectedStopPoints())) {
-        for (AffectedStopPointStructure stopPoint : stopPoints.getAffectedStopPoints()) {
-          StopPointRef stopPointRef = stopPoint.getStopPointRef();
-          if (stopPointRef == null || stopPointRef.getValue() == null) {
-            continue;
-          }
-
-          FeedScopedId stopId = getStop(stopPointRef.getValue(), feedId, transitService);
-
-          if (stopId == null) {
-            stopId = new FeedScopedId(feedId, stopPointRef.getValue());
-          }
-
-          EntitySelector.Stop entitySelector = new EntitySelector.Stop(
-            stopId,
-            resolveStopConditions(stopPoint.getStopConditions())
-          );
-
-          alert.addEntity(entitySelector);
-        }
-      } else if (stopPlaces != null && isNotEmpty(stopPlaces.getAffectedStopPlaces())) {
-        for (AffectedStopPlaceStructure stopPoint : stopPlaces.getAffectedStopPlaces()) {
-          StopPlaceRef stopPlace = stopPoint.getStopPlaceRef();
-          if (stopPlace == null || stopPlace.getValue() == null) {
-            continue;
-          }
-
-          FeedScopedId stopId = getStop(stopPlace.getValue(), feedId, transitService);
-
-          if (stopId == null) {
-            stopId = new FeedScopedId(feedId, stopPlace.getValue());
-          }
-
-          alert.addEntity(new EntitySelector.Stop(stopId));
-        }
-      }
-
-      AffectsScopeStructure.Networks networks = affectsStructure.getNetworks();
-      if (networks != null && isNotEmpty(networks.getAffectedNetworks())) {
-        for (AffectsScopeStructure.Networks.AffectedNetwork affectedNetwork : networks.getAffectedNetworks()) {
-          List<AffectedLineStructure> affectedLines = affectedNetwork.getAffectedLines();
-          if (isNotEmpty(affectedLines)) {
-            for (AffectedLineStructure line : affectedLines) {
-              LineRef lineRef = line.getLineRef();
-
-              if (lineRef == null || lineRef.getValue() == null) {
-                continue;
-              }
-
-              List<AffectedStopPointStructure> affectedStops = new ArrayList<>();
-
-              AffectedLineStructure.Routes routes = line.getRoutes();
-
-              // Resolve AffectedStop-ids
-              if (routes != null) {
-                for (AffectedRouteStructure route : routes.getAffectedRoutes()) {
-                  if (route.getStopPoints() != null) {
-                    List<Serializable> stopPointsList = route
-                      .getStopPoints()
-                      .getAffectedStopPointsAndLinkProjectionToNextStopPoints();
-                    for (Serializable serializable : stopPointsList) {
-                      if (serializable instanceof AffectedStopPointStructure stopPointStructure) {
-                        affectedStops.add(stopPointStructure);
-                      }
-                    }
-                  }
-                }
-              }
-              FeedScopedId affectedRoute = new FeedScopedId(feedId, lineRef.getValue());
-
-              if (!affectedStops.isEmpty()) {
-                for (AffectedStopPointStructure affectedStop : affectedStops) {
-                  FeedScopedId stop = getStop(
-                    affectedStop.getStopPointRef().getValue(),
-                    feedId,
-                    transitService
-                  );
-                  if (stop == null) {
-                    stop = new FeedScopedId(feedId, affectedStop.getStopPointRef().getValue());
-                  }
-                  EntitySelector.StopAndRoute entitySelector = new EntitySelector.StopAndRoute(
-                    stop,
-                    resolveStopConditions(affectedStop.getStopConditions()),
-                    affectedRoute
-                  );
-                  alert.addEntity(entitySelector);
-                }
-              } else {
-                alert.addEntity(new EntitySelector.Route(affectedRoute));
-              }
-            }
-          } else {
-            NetworkRefStructure networkRef = affectedNetwork.getNetworkRef();
-            if (networkRef == null || networkRef.getValue() == null) {
-              continue;
-            }
-            String networkId = networkRef.getValue();
-            // TODO: What to do here?
-          }
-        }
-      }
-
-      AffectsScopeStructure.VehicleJourneys vjs = affectsStructure.getVehicleJourneys();
-      if (vjs != null && isNotEmpty(vjs.getAffectedVehicleJourneies())) {
-        for (AffectedVehicleJourneyStructure affectedVehicleJourney : vjs.getAffectedVehicleJourneies()) {
-          List<AffectedStopPointStructure> affectedStops = new ArrayList<>();
-
-          List<AffectedRouteStructure> routes = affectedVehicleJourney.getRoutes();
-          // Resolve AffectedStop-ids
-          if (routes != null) {
-            for (AffectedRouteStructure route : routes) {
-              if (route.getStopPoints() != null) {
-                List<Serializable> stopPointsList = route
-                  .getStopPoints()
-                  .getAffectedStopPointsAndLinkProjectionToNextStopPoints();
-                for (Serializable serializable : stopPointsList) {
-                  if (serializable instanceof AffectedStopPointStructure stopPointStructure) {
-                    affectedStops.add(stopPointStructure);
-                  }
-                }
-              }
-            }
-          }
-
-          List<VehicleJourneyRef> vehicleJourneyReves = affectedVehicleJourney.getVehicleJourneyReves();
-
-          if (isNotEmpty(vehicleJourneyReves)) {
-            for (VehicleJourneyRef vehicleJourneyRef : vehicleJourneyReves) {
-              List<FeedScopedId> tripIds = new ArrayList<>();
-
-              FeedScopedId tripIdFromVehicleJourney = getTripId(
-                vehicleJourneyRef.getValue(),
-                feedId,
-                transitService
-              );
-
-              ZonedDateTime originAimedDepartureTime = affectedVehicleJourney.getOriginAimedDepartureTime() !=
-                null
-                ? affectedVehicleJourney.getOriginAimedDepartureTime()
-                : ZonedDateTime.now();
-
-              ZonedDateTime startOfService = ServiceDateUtils.asStartOfService(
-                originAimedDepartureTime
-              );
-
-              LocalDate serviceDate = startOfService.toLocalDate();
-
-              if (tripIdFromVehicleJourney != null) {
-                tripIds.add(tripIdFromVehicleJourney);
-              } else if (siriFuzzyTripMatcher != null) {
-                tripIds =
-                  siriFuzzyTripMatcher.getTripIdForInternalPlanningCodeServiceDate(
-                    vehicleJourneyRef.getValue(),
-                    serviceDate
-                  );
-              }
-
-              for (FeedScopedId tripId : tripIds) {
-                if (!affectedStops.isEmpty()) {
-                  for (AffectedStopPointStructure affectedStop : affectedStops) {
-                    FeedScopedId stop = getStop(
-                      affectedStop.getStopPointRef().getValue(),
-                      feedId,
-                      transitService
-                    );
-                    if (stop == null) {
-                      stop = new FeedScopedId(feedId, affectedStop.getStopPointRef().getValue());
-                    }
-                    // Creating unique, deterministic id for the alert
-                    EntitySelector.StopAndTrip entitySelector = new EntitySelector.StopAndTrip(
-                      stop,
-                      tripId,
-                      serviceDate,
-                      resolveStopConditions(affectedStop.getStopConditions())
-                    );
-                    alert.addEntity(entitySelector);
-                  }
-                } else {
-                  alert.addEntity(new EntitySelector.Trip(tripId, serviceDate));
-                }
-              }
-            }
-          }
-
-          final FramedVehicleJourneyRefStructure framedVehicleJourneyRef = affectedVehicleJourney.getFramedVehicleJourneyRef();
-          if (framedVehicleJourneyRef != null) {
-            final DataFrameRefStructure dataFrameRef = framedVehicleJourneyRef.getDataFrameRef();
-            final String datedVehicleJourneyRef = framedVehicleJourneyRef.getDatedVehicleJourneyRef();
-
-            FeedScopedId tripId = getTripId(datedVehicleJourneyRef, feedId, transitService);
-
-            if (tripId != null) {
-              LocalDate serviceDate = null;
-              if (dataFrameRef != null && dataFrameRef.getValue() != null) {
-                serviceDate = LocalDate.parse(dataFrameRef.getValue());
-              }
-
-              if (!affectedStops.isEmpty()) {
-                for (AffectedStopPointStructure affectedStop : affectedStops) {
-                  FeedScopedId stop = getStop(
-                    affectedStop.getStopPointRef().getValue(),
-                    feedId,
-                    transitService
-                  );
-                  if (stop == null) {
-                    stop = new FeedScopedId(feedId, affectedStop.getStopPointRef().getValue());
-                  }
-
-                  alert.addEntity(
-                    new EntitySelector.StopAndTrip(
-                      stop,
-                      tripId,
-                      serviceDate,
-                      resolveStopConditions(affectedStop.getStopConditions())
-                    )
-                  );
-                }
-              } else {
-                alert.addEntity(new EntitySelector.Trip(tripId, serviceDate));
-              }
-            }
-          }
-        }
-      }
-    }
+    alert.addEntites(affectsMapper.mapAffects(situation.getAffects()));
 
     if (alert.entities().isEmpty()) {
       LOG.info(
@@ -460,40 +184,6 @@ public class SiriAlertsUpdateHandler {
     }
 
     return alert.build();
-  }
-
-  private static FeedScopedId getStop(
-    String siriStopId,
-    String feedId,
-    TransitService transitService
-  ) {
-    FeedScopedId id = new FeedScopedId(feedId, siriStopId);
-    if (transitService.getRegularStop(id) != null) {
-      return id;
-    } else if (transitService.getStationById(id) != null) {
-      return id;
-    }
-
-    return null;
-  }
-
-  private static FeedScopedId getTripId(
-    String vehicleJourney,
-    String feedId,
-    TransitService transitService
-  ) {
-    Trip trip = transitService.getTripForId(new FeedScopedId(feedId, vehicleJourney));
-    if (trip != null) {
-      return trip.getId();
-    }
-    //Attempt to find trip using datedServiceJourneys
-    TripOnServiceDate tripOnServiceDate = transitService.getTripOnServiceDateById(
-      new FeedScopedId(feedId, vehicleJourney)
-    );
-    if (tripOnServiceDate != null) {
-      return tripOnServiceDate.getTrip().getId();
-    }
-    return null;
   }
 
   private long getEpochSecond(ZonedDateTime startTime) {
@@ -551,37 +241,6 @@ public class SiriAlertsUpdateHandler {
       }
     }
     return alertUrls;
-  }
-
-  private Set<StopCondition> resolveStopConditions(List<RoutePointTypeEnumeration> stopConditions) {
-    Set<StopCondition> alertStopConditions = new HashSet<>();
-    if (stopConditions != null) {
-      for (RoutePointTypeEnumeration stopCondition : stopConditions) {
-        switch (stopCondition) {
-          case EXCEPTIONAL_STOP:
-            alertStopConditions.add(StopCondition.EXCEPTIONAL_STOP);
-            break;
-          case DESTINATION:
-            alertStopConditions.add(StopCondition.DESTINATION);
-            break;
-          case NOT_STOPPING:
-            alertStopConditions.add(StopCondition.NOT_STOPPING);
-            break;
-          case REQUEST_STOP:
-            alertStopConditions.add(StopCondition.REQUEST_STOP);
-            break;
-          case START_POINT:
-            alertStopConditions.add(StopCondition.START_POINT);
-            break;
-        }
-      }
-    }
-    if (alertStopConditions.isEmpty()) {
-      //No StopConditions are set - set default
-      alertStopConditions.add(StopCondition.START_POINT);
-      alertStopConditions.add(StopCondition.DESTINATION);
-    }
-    return alertStopConditions;
   }
 
   /**

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/SiriSXUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/SiriSXUpdater.java
@@ -59,13 +59,14 @@ public class SiriSXUpdater extends PollingGraphUpdater implements TransitAlertPr
     requestHeaders.put("ET-Client-Name", SiriHttpUtils.getUniqueETClientName("-SX"));
 
     this.transitAlertService = new TransitAlertServiceImpl(transitModel);
-    this.updateHandler = new SiriAlertsUpdateHandler(config.getFeedId(), transitModel);
-    this.updateHandler.setEarlyStart(config.getEarlyStartSec());
-    this.updateHandler.setTransitAlertService(transitAlertService);
-    this.updateHandler.setSiriFuzzyTripMatcher(
-        SiriFuzzyTripMatcher.of(new DefaultTransitService(transitModel))
+    this.updateHandler =
+      new SiriAlertsUpdateHandler(
+        config.getFeedId(),
+        transitModel,
+        transitAlertService,
+        SiriFuzzyTripMatcher.of(new DefaultTransitService(transitModel)),
+        config.getEarlyStartSec()
       );
-
     LOG.info(
       "Creating real-time alert updater (SIRI SX) running every {} seconds : {}",
       pollingPeriodSeconds(),

--- a/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureSXUpdater.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/updater/azure/SiriAzureSXUpdater.java
@@ -45,9 +45,8 @@ public class SiriAzureSXUpdater extends AbstractAzureSiriUpdater implements Tran
     this.fromDateTime = config.getFromDateTime();
     this.toDateTime = config.getToDateTime();
     this.transitAlertService = new TransitAlertServiceImpl(transitModel);
-    this.updateHandler = new SiriAlertsUpdateHandler(feedId, transitModel);
-    this.updateHandler.setTransitAlertService(transitAlertService);
-    this.updateHandler.setSiriFuzzyTripMatcher(fuzzyTripMatcher());
+    this.updateHandler =
+      new SiriAlertsUpdateHandler(feedId, transitModel, transitAlertService, fuzzyTripMatcher(), 0);
   }
 
   @Override

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
@@ -73,6 +73,7 @@ import org.opentripplanner.ext.transmodelapi.model.plan.TripPatternType;
 import org.opentripplanner.ext.transmodelapi.model.plan.TripQuery;
 import org.opentripplanner.ext.transmodelapi.model.plan.TripType;
 import org.opentripplanner.ext.transmodelapi.model.siri.et.EstimatedCallType;
+import org.opentripplanner.ext.transmodelapi.model.siri.sx.AffectsType;
 import org.opentripplanner.ext.transmodelapi.model.siri.sx.PtSituationElementType;
 import org.opentripplanner.ext.transmodelapi.model.stop.BikeParkType;
 import org.opentripplanner.ext.transmodelapi.model.stop.BikeRentalStationType;
@@ -278,6 +279,15 @@ public class TransmodelGraphQLSchema {
     );
     GraphQLOutputType interchangeType = InterchangeType.create(lineType, ServiceJourneyType.REF);
 
+    GraphQLOutputType affectsType = AffectsType.create(
+      quayType,
+      stopPlaceType,
+      lineType,
+      ServiceJourneyType.REF,
+      DatedServiceJourneyType.REF,
+      gqlUtil
+    );
+
     // Timetable
     GraphQLNamedOutputType ptSituationElementType = PtSituationElementType.create(
       authorityType,
@@ -288,6 +298,7 @@ public class TransmodelGraphQLSchema {
       multilingualStringType,
       validityPeriodType,
       infoLinkType,
+      affectsType,
       gqlUtil,
       relay
     );

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLSchema.java
@@ -1505,7 +1505,8 @@ public class TransmodelGraphQLSchema {
               alerts =
                 alerts
                   .stream()
-                  .filter(alert -> authorities.contains(alert.getFeedId()))
+                  // TODO: We need to store the reporting authority in a field
+                  .filter(alert -> authorities.contains(alert.getId().getFeedId()))
                   .collect(Collectors.toSet());
             }
             if ((environment.getArgument("severities") instanceof List)) {
@@ -1513,7 +1514,7 @@ public class TransmodelGraphQLSchema {
               alerts =
                 alerts
                   .stream()
-                  .filter(alert -> severities.contains(getTransmodelSeverity(alert.severity)))
+                  .filter(alert -> severities.contains(getTransmodelSeverity(alert.severity())))
                   .collect(Collectors.toSet());
             }
             return alerts;

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/framework/ValidityPeriodType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/framework/ValidityPeriodType.java
@@ -7,7 +7,7 @@ import org.opentripplanner.ext.transmodelapi.support.GqlUtil;
 
 public class ValidityPeriodType {
 
-  public static GraphQLObjectType create(GqlUtil qglUtil) {
+  public static GraphQLObjectType create(GqlUtil gqlUtil) {
     return GraphQLObjectType
       .newObject()
       .name("ValidityPeriod")
@@ -15,7 +15,7 @@ public class ValidityPeriodType {
         GraphQLFieldDefinition
           .newFieldDefinition()
           .name("startTime")
-          .type(qglUtil.dateTimeScalar)
+          .type(gqlUtil.dateTimeScalar)
           .description("Start of validity period")
           .dataFetcher(environment -> {
             Pair<Long, Long> period = environment.getSource();
@@ -27,7 +27,7 @@ public class ValidityPeriodType {
         GraphQLFieldDefinition
           .newFieldDefinition()
           .name("endTime")
-          .type(qglUtil.dateTimeScalar)
+          .type(gqlUtil.dateTimeScalar)
           .description("End of validity period. Will return 'null' if validity is open-ended.")
           .dataFetcher(environment -> {
             Pair<Long, Long> period = environment.getSource();

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/sx/AffectsType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/sx/AffectsType.java
@@ -1,0 +1,284 @@
+package org.opentripplanner.ext.transmodelapi.model.siri.sx;
+
+import static org.opentripplanner.ext.transmodelapi.model.EnumTypes.stopConditionEnum;
+
+import graphql.Scalars;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLList;
+import graphql.schema.GraphQLNonNull;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLOutputType;
+import graphql.schema.GraphQLUnionType;
+import org.opentripplanner.ext.transmodelapi.model.stop.StopPlaceType;
+import org.opentripplanner.ext.transmodelapi.support.GqlUtil;
+import org.opentripplanner.routing.alertpatch.EntitySelector;
+import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.model.timetable.TripIdAndServiceDate;
+
+public class AffectsType {
+
+  private static final String NAME = "Affects";
+
+  public static GraphQLOutputType create(
+    GraphQLOutputType quayType,
+    GraphQLOutputType stopPlaceType,
+    GraphQLOutputType lineType,
+    GraphQLOutputType serviceJourneyType,
+    GraphQLOutputType datedServiceJourneyType,
+    GqlUtil gqlUtil
+  ) {
+    GraphQLObjectType affectedStopPlace = GraphQLObjectType
+      .newObject()
+      .name("AffectedStopPlace")
+      .field(
+        GraphQLFieldDefinition
+          .newFieldDefinition()
+          .name("quay")
+          .type(quayType)
+          .dataFetcher(environment -> {
+            FeedScopedId stopId = environment.<EntitySelector.Stop>getSource().stopId();
+            return GqlUtil.getTransitService(environment).getRegularStop(stopId);
+          })
+          .build()
+      )
+      .field(
+        GraphQLFieldDefinition
+          .newFieldDefinition()
+          .name("stopPlace")
+          .type(stopPlaceType)
+          .dataFetcher(environment -> {
+            FeedScopedId stopId = environment.<EntitySelector.Stop>getSource().stopId();
+            return StopPlaceType.fetchStopPlaceById(stopId, environment);
+          })
+          .build()
+      )
+      .field(
+        GraphQLFieldDefinition
+          .newFieldDefinition()
+          .name("stopConditions")
+          .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(stopConditionEnum))))
+          .build()
+      )
+      .build();
+
+    GraphQLObjectType affectedLine = GraphQLObjectType
+      .newObject()
+      .name("AffectedLine")
+      .field(
+        GraphQLFieldDefinition
+          .newFieldDefinition()
+          .name("line")
+          .type(lineType)
+          .dataFetcher(environment -> {
+            var routeId = environment.<EntitySelector.Route>getSource().routeId();
+            return GqlUtil.getTransitService(environment).getRouteForId(routeId);
+          })
+          .build()
+      )
+      .build();
+
+    GraphQLObjectType affectedServiceJourney = GraphQLObjectType
+      .newObject()
+      .name("AffectedServiceJourney")
+      .field(
+        GraphQLFieldDefinition
+          .newFieldDefinition()
+          .name("serviceJourney")
+          .type(serviceJourneyType)
+          .dataFetcher(environment -> {
+            var tripId = environment.<EntitySelector.Trip>getSource().tripId();
+            return GqlUtil.getTransitService(environment).getTripForId(tripId);
+          })
+          .build()
+      )
+      .field(
+        GraphQLFieldDefinition
+          .newFieldDefinition()
+          .name("operatingDay")
+          .type(gqlUtil.dateScalar)
+          .dataFetcher(environment -> environment.<EntitySelector.Trip>getSource().serviceDate())
+          .build()
+      )
+      .field(
+        GraphQLFieldDefinition
+          .newFieldDefinition()
+          .name("datedServiceJourney")
+          .type(datedServiceJourneyType)
+          .dataFetcher(environment -> {
+            EntitySelector.Trip entitySelector = environment.getSource();
+            return GqlUtil
+              .getTransitService(environment)
+              .getTripOnServiceDateForTripAndDay(
+                new TripIdAndServiceDate(entitySelector.tripId(), entitySelector.serviceDate())
+              );
+          })
+          .build()
+      )
+      .build();
+
+    GraphQLObjectType affectedStopPlaceOnLine = GraphQLObjectType
+      .newObject()
+      .name("AffectedStopPlaceOnLine")
+      .field(
+        GraphQLFieldDefinition
+          .newFieldDefinition()
+          .name("quay")
+          .type(quayType)
+          .dataFetcher(environment -> {
+            FeedScopedId stopId = environment.<EntitySelector.StopAndRoute>getSource().stopId();
+            return GqlUtil.getTransitService(environment).getRegularStop(stopId);
+          })
+          .build()
+      )
+      .field(
+        GraphQLFieldDefinition
+          .newFieldDefinition()
+          .name("stopPlace")
+          .type(stopPlaceType)
+          .dataFetcher(environment -> {
+            FeedScopedId stopId = environment.<EntitySelector.StopAndRoute>getSource().stopId();
+            return StopPlaceType.fetchStopPlaceById(stopId, environment);
+          })
+          .build()
+      )
+      .field(
+        GraphQLFieldDefinition
+          .newFieldDefinition()
+          .name("line")
+          .type(lineType)
+          .dataFetcher(environment -> {
+            var routeId = environment.<EntitySelector.StopAndRoute>getSource().routeId();
+            return GqlUtil.getTransitService(environment).getRouteForId(routeId);
+          })
+          .build()
+      )
+      .field(
+        GraphQLFieldDefinition
+          .newFieldDefinition()
+          .name("stopConditions")
+          .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(stopConditionEnum))))
+          .build()
+      )
+      .build();
+
+    GraphQLObjectType affectedStopPlaceOnServiceJourney = GraphQLObjectType
+      .newObject()
+      .name("AffectedStopPlaceOnServiceJourney")
+      .field(
+        GraphQLFieldDefinition
+          .newFieldDefinition()
+          .name("quay")
+          .type(quayType)
+          .dataFetcher(environment -> {
+            FeedScopedId stopId = environment.<EntitySelector.StopAndTrip>getSource().stopId();
+            return GqlUtil.getTransitService(environment).getRegularStop(stopId);
+          })
+          .build()
+      )
+      .field(
+        GraphQLFieldDefinition
+          .newFieldDefinition()
+          .name("stopPlace")
+          .type(stopPlaceType)
+          .dataFetcher(environment -> {
+            FeedScopedId stopId = environment.<EntitySelector.StopAndTrip>getSource().stopId();
+            return StopPlaceType.fetchStopPlaceById(stopId, environment);
+          })
+          .build()
+      )
+      .field(
+        GraphQLFieldDefinition
+          .newFieldDefinition()
+          .name("serviceJourney")
+          .type(serviceJourneyType)
+          .dataFetcher(environment -> {
+            var tripId = environment.<EntitySelector.StopAndTrip>getSource().tripId();
+            return GqlUtil.getTransitService(environment).getTripForId(tripId);
+          })
+          .build()
+      )
+      .field(
+        GraphQLFieldDefinition
+          .newFieldDefinition()
+          .name("operatingDay")
+          .type(gqlUtil.dateScalar)
+          .dataFetcher(environment ->
+            environment.<EntitySelector.StopAndTrip>getSource().serviceDate()
+          )
+          .build()
+      )
+      .field(
+        GraphQLFieldDefinition
+          .newFieldDefinition()
+          .name("datedServiceJourney")
+          .type(datedServiceJourneyType)
+          .dataFetcher(environment -> {
+            EntitySelector.StopAndTrip entitySelector = environment.getSource();
+            return GqlUtil
+              .getTransitService(environment)
+              .getTripOnServiceDateForTripAndDay(
+                new TripIdAndServiceDate(entitySelector.tripId(), entitySelector.serviceDate())
+              );
+          })
+          .build()
+      )
+      .field(
+        GraphQLFieldDefinition
+          .newFieldDefinition()
+          .name("stopConditions")
+          .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(stopConditionEnum))))
+          .build()
+      )
+      .build();
+
+    GraphQLObjectType affectedUnknown = GraphQLObjectType
+      .newObject()
+      .name("AffectedUnknown")
+      .field(
+        GraphQLFieldDefinition
+          .newFieldDefinition()
+          .name("description")
+          .type(Scalars.GraphQLString)
+          .dataFetcher(environment -> {
+            var object = environment.getSource();
+
+            if (object instanceof EntitySelector.Unknown unknownEntitySelector) {
+              return unknownEntitySelector.description();
+            }
+
+            // Fallback to toString
+            return object.toString();
+          })
+          .build()
+      )
+      .build();
+
+    return GraphQLUnionType
+      .newUnionType()
+      .name(NAME)
+      .possibleType(affectedStopPlace)
+      .possibleType(affectedLine)
+      .possibleType(affectedServiceJourney)
+      .possibleType(affectedStopPlaceOnLine)
+      .possibleType(affectedStopPlaceOnServiceJourney)
+      .possibleType(affectedUnknown)
+      .typeResolver(env -> {
+        var object = env.getObject();
+
+        if (object instanceof EntitySelector.Stop) {
+          return affectedStopPlace;
+        } else if (object instanceof EntitySelector.Route) {
+          return affectedLine;
+        } else if (object instanceof EntitySelector.Trip) {
+          return affectedServiceJourney;
+        } else if (object instanceof EntitySelector.StopAndRoute) {
+          return affectedStopPlaceOnLine;
+        } else if (object instanceof EntitySelector.StopAndTrip) {
+          return affectedStopPlaceOnServiceJourney;
+        }
+
+        return affectedUnknown;
+      })
+      .build();
+  }
+}

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/sx/PtSituationElementType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/siri/sx/PtSituationElementType.java
@@ -41,6 +41,7 @@ public class PtSituationElementType {
     GraphQLOutputType multilingualStringType,
     GraphQLObjectType validityPeriodType,
     GraphQLObjectType infoLinkType,
+    GraphQLOutputType affectsType,
     GqlUtil gqlUtil,
     Relay relay
   ) {
@@ -64,6 +65,7 @@ public class PtSituationElementType {
           .name("authority")
           .type(authorityType)
           .description("Get affected authority for this situation element")
+          .deprecate("Use affects instead")
           .dataFetcher(environment ->
             GqlUtil
               .getTransitService(environment)
@@ -84,6 +86,7 @@ public class PtSituationElementType {
           .newFieldDefinition()
           .name("lines")
           .type(new GraphQLNonNull(new GraphQLList(lineType)))
+          .deprecate("Use affects instead")
           .dataFetcher(environment -> {
             TransitService transitService = GqlUtil.getTransitService(environment);
             return ((TransitAlert) environment.getSource()).entities()
@@ -101,6 +104,7 @@ public class PtSituationElementType {
           .newFieldDefinition()
           .name("serviceJourneys")
           .type(new GraphQLNonNull(new GraphQLList(serviceJourneyType)))
+          .deprecate("Use affects instead")
           .dataFetcher(environment -> {
             TransitService transitService = GqlUtil.getTransitService(environment);
             return ((TransitAlert) environment.getSource()).entities()
@@ -118,6 +122,7 @@ public class PtSituationElementType {
           .newFieldDefinition()
           .name("quays")
           .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(quayType))))
+          .deprecate("Use affects instead")
           .dataFetcher(environment -> {
             TransitService transitService = GqlUtil.getTransitService(environment);
             return ((TransitAlert) environment.getSource()).entities()
@@ -136,6 +141,7 @@ public class PtSituationElementType {
           .newFieldDefinition()
           .name("stopPlaces")
           .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(stopPlaceType))))
+          .deprecate("Use affects instead")
           .dataFetcher(environment -> {
             TransitService transitService = GqlUtil.getTransitService(environment);
             return ((TransitAlert) environment.getSource()).entities()
@@ -155,12 +161,15 @@ public class PtSituationElementType {
           })
           .build()
       )
-      //                .field(GraphQLFieldDefinition.newFieldDefinition()
-      //                        .name("journeyPatterns")
-      //                        .description("Get all journey patterns for this situation element")
-      //                        .type(new GraphQLNonNull(new GraphQLList(journeyPatternType)))
-      //                        .dataFetcher(environment -> ((AlertPatch) environment.getSource()).getTripPatterns())
-      //                        .build())
+      .field(
+        GraphQLFieldDefinition
+          .newFieldDefinition()
+          .name("affects")
+          .description("Get all affected entities for the situation")
+          .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(affectsType))))
+          .dataFetcher(environment -> ((TransitAlert) environment.getSource()).entities())
+          .build()
+      )
       .field(
         GraphQLFieldDefinition
           .newFieldDefinition()

--- a/src/main/java/org/opentripplanner/api/mapping/AlertMapper.java
+++ b/src/main/java/org/opentripplanner/api/mapping/AlertMapper.java
@@ -30,16 +30,16 @@ public class AlertMapper {
 
   ApiAlert mapToApi(TransitAlert domain) {
     ApiAlert api = new ApiAlert();
-    if (domain.alertHeaderText != null) {
-      api.alertHeaderText = domain.alertHeaderText.toString(locale);
+    if (domain.headerText() != null) {
+      api.alertHeaderText = domain.headerText().toString(locale);
     }
 
-    if (domain.alertDescriptionText != null) {
-      api.alertDescriptionText = domain.alertDescriptionText.toString(locale);
+    if (domain.descriptionText() != null) {
+      api.alertDescriptionText = domain.descriptionText().toString(locale);
     }
 
-    if (domain.alertUrl != null) {
-      api.alertUrl = domain.alertUrl.toString(locale);
+    if (domain.url() != null) {
+      api.alertUrl = domain.url().toString(locale);
     }
 
     api.effectiveStartDate = ofNullableInstant(domain.getEffectiveStartDate());

--- a/src/main/java/org/opentripplanner/routing/alertpatch/EntityKey.java
+++ b/src/main/java/org/opentripplanner/routing/alertpatch/EntityKey.java
@@ -3,7 +3,7 @@ package org.opentripplanner.routing.alertpatch;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.timetable.Direction;
 
-public interface EntityKey {
+public sealed interface EntityKey {
   record Agency(FeedScopedId agencyId) implements EntityKey {}
 
   record Stop(FeedScopedId stopId) implements EntityKey {}

--- a/src/main/java/org/opentripplanner/routing/alertpatch/EntitySelector.java
+++ b/src/main/java/org/opentripplanner/routing/alertpatch/EntitySelector.java
@@ -5,7 +5,7 @@ import java.util.Set;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.model.timetable.Direction;
 
-public interface EntitySelector {
+public sealed interface EntitySelector {
   EntityKey key();
 
   default boolean matches(EntitySelector other) {

--- a/src/main/java/org/opentripplanner/routing/alertpatch/TransitAlert.java
+++ b/src/main/java/org/opentripplanner/routing/alertpatch/TransitAlert.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.routing.alertpatch;
 
 import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
@@ -30,6 +31,9 @@ public class TransitAlert extends AbstractTransitEntity<TransitAlert, TransitAle
   private final AlertEffect effect;
   //null means unknown
   private final Integer priority;
+  private final ZonedDateTime creationTime;
+  private final ZonedDateTime updatedTime;
+  private final String siriCodespace;
   private final Set<EntitySelector> entities;
   private final List<TimePeriod> timePeriods;
 
@@ -46,6 +50,9 @@ public class TransitAlert extends AbstractTransitEntity<TransitAlert, TransitAle
     this.cause = builder.cause();
     this.effect = builder.effect();
     this.priority = builder.priority();
+    this.creationTime = builder.creationTime();
+    this.updatedTime = builder.updatedTime();
+    this.siriCodespace = builder.siriCodespace();
     this.entities = Set.copyOf(builder.entities());
     this.timePeriods = List.copyOf(builder.timePeriods());
   }
@@ -105,6 +112,18 @@ public class TransitAlert extends AbstractTransitEntity<TransitAlert, TransitAle
 
   public Integer priority() {
     return priority;
+  }
+
+  public ZonedDateTime creationTime() {
+    return creationTime;
+  }
+
+  public ZonedDateTime updatedTime() {
+    return updatedTime;
+  }
+
+  public String siriCodespace() {
+    return siriCodespace;
   }
 
   public Set<EntitySelector> entities() {
@@ -174,6 +193,9 @@ public class TransitAlert extends AbstractTransitEntity<TransitAlert, TransitAle
       Objects.equals(cause, other.cause) &&
       Objects.equals(effect, other.effect) &&
       Objects.equals(priority, other.priority) &&
+      Objects.equals(creationTime, other.creationTime) &&
+      Objects.equals(updatedTime, other.updatedTime) &&
+      Objects.equals(siriCodespace, other.siriCodespace) &&
       Objects.equals(entities, other.entities) &&
       Objects.equals(timePeriods, other.timePeriods)
     );

--- a/src/main/java/org/opentripplanner/routing/alertpatch/TransitAlert.java
+++ b/src/main/java/org/opentripplanner/routing/alertpatch/TransitAlert.java
@@ -1,60 +1,118 @@
 package org.opentripplanner.routing.alertpatch;
 
-import java.io.Serializable;
 import java.time.Instant;
-import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.opentripplanner.framework.i18n.I18NString;
+import org.opentripplanner.transit.model.framework.AbstractTransitEntity;
+import org.opentripplanner.transit.model.framework.FeedScopedId;
+import org.opentripplanner.transit.model.framework.TransitBuilder;
 
-public class TransitAlert implements Serializable {
+public class TransitAlert extends AbstractTransitEntity<TransitAlert, TransitAlertBuilder> {
 
-  private final Set<EntitySelector> entities = new HashSet<>();
-  private String id;
-  public I18NString alertHeaderText;
-  public I18NString alertDescriptionText;
-  public I18NString alertDetailText;
-  public I18NString alertAdviceText;
+  private final I18NString headerText;
+  private final I18NString descriptionText;
+  private final I18NString detailText;
+  private final I18NString adviceText;
   // TODO OTP2 we wanted to merge the GTFS single alertUrl and the SIRI multiple URLs.
   //      However, GTFS URLs are one-per-language in a single object, and SIRI URLs are N objects with no translation.
-  public I18NString alertUrl;
-  private List<AlertUrl> alertUrlList = new ArrayList<>();
+  private final I18NString url;
+  private final List<AlertUrl> siriUrls;
   //null means unknown
-  public String alertType;
+  private final String type;
+  private final AlertSeverity severity;
+  private final AlertCause cause;
+  private final AlertEffect effect;
+  //null means unknown
+  private final Integer priority;
+  private final Set<EntitySelector> entities;
+  private final List<TimePeriod> timePeriods;
+
+  TransitAlert(TransitAlertBuilder builder) {
+    super(builder.getId());
+    this.headerText = builder.headerText();
+    this.descriptionText = builder.descriptionText();
+    this.detailText = builder.detailText();
+    this.adviceText = builder.adviceText();
+    this.url = builder.url();
+    this.siriUrls = List.copyOf(builder.siriUrls());
+    this.type = builder.type();
+    this.severity = builder.severity();
+    this.cause = builder.cause();
+    this.effect = builder.effect();
+    this.priority = builder.priority();
+    this.entities = Set.copyOf(builder.entities());
+    this.timePeriods = List.copyOf(builder.timePeriods());
+  }
+
+  public static TransitAlertBuilder of(FeedScopedId id) {
+    return new TransitAlertBuilder(id);
+  }
+
+  public I18NString headerText() {
+    return headerText;
+  }
+
+  public I18NString descriptionText() {
+    return descriptionText;
+  }
+
+  public I18NString detailText() {
+    return detailText;
+  }
+
+  public I18NString adviceText() {
+    return adviceText;
+  }
+
+  public I18NString url() {
+    return url;
+  }
+
+  public List<AlertUrl> siriUrls() {
+    return siriUrls;
+  }
+
+  public String type() {
+    return type;
+  }
+
   /**
    * The severity of the alert.
    */
-  public AlertSeverity severity;
+  public AlertSeverity severity() {
+    return severity;
+  }
+
   /**
    * The cause of the disruption.
    */
-  public AlertCause cause;
+  public AlertCause cause() {
+    return cause;
+  }
+
   /**
    * The effect of the disruption.
    */
-  public AlertEffect effect;
-  //null means unknown
-  public Integer priority;
-  private List<TimePeriod> timePeriods = new ArrayList<>();
-  private String feedId;
-
-  public String getId() {
-    return id;
+  public AlertEffect effect() {
+    return effect;
   }
 
-  public void setId(String id) {
-    this.id = id;
+  public Integer priority() {
+    return priority;
   }
 
-  public List<AlertUrl> getAlertUrlList() {
-    return alertUrlList;
+  public Set<EntitySelector> entities() {
+    return entities;
   }
 
-  public void setAlertUrlList(List<AlertUrl> alertUrlList) {
-    this.alertUrlList = alertUrlList;
+  public Collection<TimePeriod> timePeriods() {
+    return timePeriods;
   }
 
   public boolean displayDuring(long startTimeSeconds, long endTimeSeconds) {
@@ -66,26 +124,6 @@ public class TransitAlert implements Serializable {
       }
     }
     return false;
-  }
-
-  public void setTimePeriods(List<TimePeriod> periods) {
-    timePeriods = periods;
-  }
-
-  public void addEntity(EntitySelector entitySelector) {
-    entities.add(entitySelector);
-  }
-
-  public Set<EntitySelector> getEntities() {
-    return entities;
-  }
-
-  public String getFeedId() {
-    return feedId;
-  }
-
-  public void setFeedId(String feedId) {
-    this.feedId = feedId;
   }
 
   /**
@@ -122,19 +160,28 @@ public class TransitAlert implements Serializable {
   }
 
   @Override
-  public String toString() {
+  public boolean sameAs(@Nonnull TransitAlert other) {
     return (
-      "Alert('" +
-      (
-        alertHeaderText != null
-          ? alertHeaderText.toString()
-          : alertDescriptionText != null
-            ? alertDescriptionText.toString()
-            : alertDetailText != null
-              ? alertDetailText.toString()
-              : alertAdviceText != null ? alertAdviceText.toString() : "?"
-      ) +
-      "')"
+      getId().equals(other.getId()) &&
+      Objects.equals(headerText, other.headerText) &&
+      Objects.equals(descriptionText, other.descriptionText) &&
+      Objects.equals(detailText, other.detailText) &&
+      Objects.equals(adviceText, other.adviceText) &&
+      Objects.equals(url, other.url) &&
+      Objects.equals(siriUrls, other.siriUrls) &&
+      Objects.equals(type, other.type) &&
+      Objects.equals(severity, other.severity) &&
+      Objects.equals(cause, other.cause) &&
+      Objects.equals(effect, other.effect) &&
+      Objects.equals(priority, other.priority) &&
+      Objects.equals(entities, other.entities) &&
+      Objects.equals(timePeriods, other.timePeriods)
     );
+  }
+
+  @Nonnull
+  @Override
+  public TransitBuilder<TransitAlert, TransitAlertBuilder> copy() {
+    return new TransitAlertBuilder(this);
   }
 }

--- a/src/main/java/org/opentripplanner/routing/alertpatch/TransitAlertBuilder.java
+++ b/src/main/java/org/opentripplanner/routing/alertpatch/TransitAlertBuilder.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.routing.alertpatch;
 
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -23,6 +24,9 @@ public class TransitAlertBuilder extends AbstractEntityBuilder<TransitAlert, Tra
   private AlertEffect effect;
   //null means unknown
   private Integer priority;
+  private ZonedDateTime creationTime;
+  private ZonedDateTime updatedTime;
+  private String siriCodespace;
   private final Set<EntitySelector> entities = new HashSet<>();
   private final List<TimePeriod> timePeriods = new ArrayList<>();
 
@@ -43,6 +47,9 @@ public class TransitAlertBuilder extends AbstractEntityBuilder<TransitAlert, Tra
     this.cause = original.cause();
     this.effect = original.effect();
     this.priority = original.priority();
+    this.creationTime = original.creationTime();
+    this.updatedTime = original.updatedTime();
+    this.siriCodespace = original.siriCodespace();
     this.entities.addAll(original.entities());
     this.timePeriods.addAll(original.timePeriods());
   }
@@ -148,6 +155,33 @@ public class TransitAlertBuilder extends AbstractEntityBuilder<TransitAlert, Tra
 
   public TransitAlertBuilder withPriority(Integer priority) {
     this.priority = priority;
+    return this;
+  }
+
+  public ZonedDateTime creationTime() {
+    return creationTime;
+  }
+
+  public TransitAlertBuilder withCreationTime(ZonedDateTime creationTime) {
+    this.creationTime = creationTime;
+    return this;
+  }
+
+  public ZonedDateTime updatedTime() {
+    return updatedTime;
+  }
+
+  public TransitAlertBuilder withUpdatedTime(ZonedDateTime updatedTime) {
+    this.updatedTime = updatedTime;
+    return this;
+  }
+
+  public String siriCodespace() {
+    return siriCodespace;
+  }
+
+  public TransitAlertBuilder withSiriCodespace(String siriCodespace) {
+    this.siriCodespace = siriCodespace;
     return this;
   }
 

--- a/src/main/java/org/opentripplanner/routing/alertpatch/TransitAlertBuilder.java
+++ b/src/main/java/org/opentripplanner/routing/alertpatch/TransitAlertBuilder.java
@@ -1,0 +1,185 @@
+package org.opentripplanner.routing.alertpatch;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.opentripplanner.framework.i18n.I18NString;
+import org.opentripplanner.transit.model.framework.AbstractEntityBuilder;
+import org.opentripplanner.transit.model.framework.FeedScopedId;
+
+public class TransitAlertBuilder extends AbstractEntityBuilder<TransitAlert, TransitAlertBuilder> {
+
+  private I18NString headerText;
+  private I18NString descriptionText;
+  private I18NString detailText;
+  private I18NString adviceText;
+  private I18NString url;
+  private final List<AlertUrl> siriUrls = new ArrayList<>();
+  private String type;
+  private AlertSeverity severity;
+  private AlertCause cause;
+  private AlertEffect effect;
+  //null means unknown
+  private Integer priority;
+  private final Set<EntitySelector> entities = new HashSet<>();
+  private final List<TimePeriod> timePeriods = new ArrayList<>();
+
+  TransitAlertBuilder(FeedScopedId id) {
+    super(id);
+  }
+
+  TransitAlertBuilder(TransitAlert original) {
+    super(original);
+    this.headerText = original.headerText();
+    this.descriptionText = original.descriptionText();
+    this.detailText = original.detailText();
+    this.adviceText = original.adviceText();
+    this.url = original.url();
+    this.siriUrls.addAll(original.siriUrls());
+    this.type = original.type();
+    this.severity = original.severity();
+    this.cause = original.cause();
+    this.effect = original.effect();
+    this.priority = original.priority();
+    this.entities.addAll(original.entities());
+    this.timePeriods.addAll(original.timePeriods());
+  }
+
+  public I18NString headerText() {
+    return headerText;
+  }
+
+  public TransitAlertBuilder withHeaderText(I18NString headerText) {
+    this.headerText = headerText;
+    return this;
+  }
+
+  public I18NString descriptionText() {
+    return descriptionText;
+  }
+
+  public TransitAlertBuilder withDescriptionText(I18NString descriptionText) {
+    this.descriptionText = descriptionText;
+    return this;
+  }
+
+  public I18NString detailText() {
+    return detailText;
+  }
+
+  public TransitAlertBuilder withDetailText(I18NString detailText) {
+    this.detailText = detailText;
+    return this;
+  }
+
+  public I18NString adviceText() {
+    return adviceText;
+  }
+
+  public TransitAlertBuilder withAdviceText(I18NString adviceText) {
+    this.adviceText = adviceText;
+    return this;
+  }
+
+  public I18NString url() {
+    return url;
+  }
+
+  public TransitAlertBuilder withUrl(I18NString gtfsUrl) {
+    this.url = gtfsUrl;
+    return this;
+  }
+
+  public List<AlertUrl> siriUrls() {
+    return siriUrls;
+  }
+
+  public TransitAlertBuilder addSiriUrl(AlertUrl alertUrl) {
+    siriUrls.add(alertUrl);
+    return this;
+  }
+
+  public TransitAlertBuilder addSiriUrls(Collection<AlertUrl> alertUrls) {
+    siriUrls.addAll(alertUrls);
+    return this;
+  }
+
+  public String type() {
+    return type;
+  }
+
+  public TransitAlertBuilder withType(String type) {
+    this.type = type;
+    return this;
+  }
+
+  public AlertSeverity severity() {
+    return severity;
+  }
+
+  public TransitAlertBuilder withSeverity(AlertSeverity severity) {
+    this.severity = severity;
+    return this;
+  }
+
+  public AlertCause cause() {
+    return cause;
+  }
+
+  public TransitAlertBuilder withCause(AlertCause cause) {
+    this.cause = cause;
+    return this;
+  }
+
+  public AlertEffect effect() {
+    return effect;
+  }
+
+  public TransitAlertBuilder withEffect(AlertEffect effect) {
+    this.effect = effect;
+    return this;
+  }
+
+  public Integer priority() {
+    return priority;
+  }
+
+  public TransitAlertBuilder withPriority(Integer priority) {
+    this.priority = priority;
+    return this;
+  }
+
+  public Set<EntitySelector> entities() {
+    return entities;
+  }
+
+  public boolean hasEntities() {
+    return !entities.isEmpty();
+  }
+
+  public TransitAlertBuilder addEntity(EntitySelector entitySelector) {
+    entities.add(entitySelector);
+    return this;
+  }
+
+  public Collection<TimePeriod> timePeriods() {
+    return timePeriods;
+  }
+
+  public TransitAlertBuilder addTimePeriod(TimePeriod timePeriod) {
+    timePeriods.add(timePeriod);
+    return this;
+  }
+
+  public TransitAlertBuilder addTimePeriods(Collection<TimePeriod> periods) {
+    timePeriods.addAll(periods);
+    return this;
+  }
+
+  @Override
+  protected TransitAlert buildFromValues() {
+    return new TransitAlert(this);
+  }
+}

--- a/src/main/java/org/opentripplanner/routing/alertpatch/TransitAlertBuilder.java
+++ b/src/main/java/org/opentripplanner/routing/alertpatch/TransitAlertBuilder.java
@@ -198,6 +198,11 @@ public class TransitAlertBuilder extends AbstractEntityBuilder<TransitAlert, Tra
     return this;
   }
 
+  public TransitAlertBuilder addEntites(List<EntitySelector> entitySelectors) {
+    entities.addAll(entitySelectors);
+    return this;
+  }
+
   public Collection<TimePeriod> timePeriods() {
     return timePeriods;
   }

--- a/src/main/java/org/opentripplanner/routing/impl/DelegatingTransitAlertServiceImpl.java
+++ b/src/main/java/org/opentripplanner/routing/impl/DelegatingTransitAlertServiceImpl.java
@@ -51,7 +51,7 @@ public class DelegatingTransitAlertServiceImpl implements TransitAlertService {
   }
 
   @Override
-  public TransitAlert getAlertById(String id) {
+  public TransitAlert getAlertById(FeedScopedId id) {
     return transitAlertServices
       .stream()
       .map(transitAlertService -> transitAlertService.getAlertById(id))

--- a/src/main/java/org/opentripplanner/routing/impl/TransitAlertServiceImpl.java
+++ b/src/main/java/org/opentripplanner/routing/impl/TransitAlertServiceImpl.java
@@ -48,7 +48,7 @@ public class TransitAlertServiceImpl implements TransitAlertService {
   }
 
   @Override
-  public TransitAlert getAlertById(String id) {
+  public TransitAlert getAlertById(FeedScopedId id) {
     return alerts
       .values()
       .stream()

--- a/src/main/java/org/opentripplanner/routing/impl/TransitAlertServiceImpl.java
+++ b/src/main/java/org/opentripplanner/routing/impl/TransitAlertServiceImpl.java
@@ -4,14 +4,11 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import java.time.LocalDate;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.opentripplanner.routing.alertpatch.EntityKey;
 import org.opentripplanner.routing.alertpatch.EntitySelector;
 import org.opentripplanner.routing.alertpatch.StopCondition;
-import org.opentripplanner.routing.alertpatch.StopConditionsHelper;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
@@ -37,7 +34,7 @@ public class TransitAlertServiceImpl implements TransitAlertService {
   public void setAlerts(Collection<TransitAlert> alerts) {
     Multimap<EntityKey, TransitAlert> newAlerts = HashMultimap.create();
     for (TransitAlert alert : alerts) {
-      for (EntitySelector entity : alert.getEntities()) {
+      for (EntitySelector entity : alert.entities()) {
         newAlerts.put(entity.key(), alert);
       }
     }
@@ -68,7 +65,7 @@ public class TransitAlertServiceImpl implements TransitAlertService {
     Set<TransitAlert> result = new HashSet<>();
     EntitySelector.Stop entitySelector = new EntitySelector.Stop(stopId, stopConditions);
     for (TransitAlert alert : alerts.get(entitySelector.key())) {
-      if (alert.getEntities().stream().anyMatch(selector -> selector.matches(entitySelector))) {
+      if (alert.entities().stream().anyMatch(selector -> selector.matches(entitySelector))) {
         result.add(alert);
       }
     }
@@ -104,7 +101,7 @@ public class TransitAlertServiceImpl implements TransitAlertService {
     Set<TransitAlert> result = new HashSet<>();
     EntitySelector.Trip entitySelector = new EntitySelector.Trip(trip, serviceDate);
     for (TransitAlert alert : alerts.get(entitySelector.key())) {
-      if (alert.getEntities().stream().anyMatch(selector -> selector.matches(entitySelector))) {
+      if (alert.entities().stream().anyMatch(selector -> selector.matches(entitySelector))) {
         result.add(alert);
       }
     }
@@ -129,7 +126,7 @@ public class TransitAlertServiceImpl implements TransitAlertService {
       stopConditions
     );
     for (TransitAlert alert : alerts.get(entitySelector.key())) {
-      if (alert.getEntities().stream().anyMatch(selector -> selector.matches(entitySelector))) {
+      if (alert.entities().stream().anyMatch(selector -> selector.matches(entitySelector))) {
         result.add(alert);
       }
     }
@@ -151,7 +148,7 @@ public class TransitAlertServiceImpl implements TransitAlertService {
       stopConditions
     );
     for (TransitAlert alert : alerts.get(entitySelector.key())) {
-      if (alert.getEntities().stream().anyMatch(selector -> selector.matches(entitySelector))) {
+      if (alert.entities().stream().anyMatch(selector -> selector.matches(entitySelector))) {
         result.add(alert);
       }
     }

--- a/src/main/java/org/opentripplanner/routing/services/TransitAlertService.java
+++ b/src/main/java/org/opentripplanner/routing/services/TransitAlertService.java
@@ -13,7 +13,7 @@ public interface TransitAlertService {
 
   Collection<TransitAlert> getAllAlerts();
 
-  TransitAlert getAlertById(String id);
+  TransitAlert getAlertById(FeedScopedId id);
 
   default Collection<TransitAlert> getStopAlerts(FeedScopedId stop) {
     return getStopAlerts(stop, Set.of());

--- a/src/test/java/org/opentripplanner/routing/algorithm/filterchain/filter/TransitAlertFilterTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/filterchain/filter/TransitAlertFilterTest.java
@@ -1,6 +1,6 @@
 package org.opentripplanner.routing.algorithm.filterchain.filter;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.model.plan.TestItineraryBuilder.BUS_ROUTE;
 import static org.opentripplanner.model.plan.TestItineraryBuilder.newItinerary;
 
@@ -16,6 +16,8 @@ import org.opentripplanner.routing.services.TransitAlertService;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 
 class TransitAlertFilterTest implements PlanTestConstants {
+
+  private static final FeedScopedId ID = new FeedScopedId("FEED", "BUS");
 
   @Test
   void testFilter() {
@@ -38,18 +40,16 @@ class TransitAlertFilterTest implements PlanTestConstants {
     // Then: expect correct alerts to be added
     Itinerary first = list.get(0);
     assertEquals(1, first.getLegs().get(0).getTransitAlerts().size());
-    assertEquals("BUS", first.getLegs().get(0).getTransitAlerts().iterator().next().getId());
+    assertEquals(ID, first.getLegs().get(0).getTransitAlerts().iterator().next().getId());
     assertEquals(0, list.get(1).getLegs().get(0).getTransitAlerts().size());
   }
 
   abstract static class TestTransitAlertService implements TransitAlertService {
 
-    public static final TransitAlert BUS_ALERT = new TransitAlert();
-
-    static {
-      BUS_ALERT.setId("BUS");
-      BUS_ALERT.setTimePeriods(List.of(new TimePeriod(0, TimePeriod.OPEN_ENDED)));
-    }
+    public static final TransitAlert BUS_ALERT = TransitAlert
+      .of(ID)
+      .addTimePeriod(new TimePeriod(0, TimePeriod.OPEN_ENDED))
+      .build();
 
     @Override
     public Collection<TransitAlert> getRouteAlerts(FeedScopedId route) {

--- a/src/test/java/org/opentripplanner/updater/alert/AlertsUpdateHandlerTest.java
+++ b/src/test/java/org/opentripplanner/updater/alert/AlertsUpdateHandlerTest.java
@@ -85,7 +85,7 @@ public class AlertsUpdateHandlerTest {
       .addInformedEntity(GtfsRealtime.EntitySelector.newBuilder().setAgencyId("1"))
       .build();
     TransitAlert transitAlert = processOneAlert(alert);
-    assertNull(transitAlert.alertUrl);
+    assertNull(transitAlert.url());
   }
 
   @Test
@@ -104,7 +104,7 @@ public class AlertsUpdateHandlerTest {
       )
       .build();
     TransitAlert transitAlert = processOneAlert(alert);
-    assertEquals("https://www.opentripplanner.org/", transitAlert.alertUrl.toString());
+    assertEquals("https://www.opentripplanner.org/", transitAlert.url().toString());
   }
 
   @Test
@@ -137,7 +137,7 @@ public class AlertsUpdateHandlerTest {
     TransitAlert transitAlert = processOneAlert(alert);
 
     List<Entry<String, String>> translations =
-      ((TranslatedString) transitAlert.alertUrl).getTranslations();
+      ((TranslatedString) transitAlert.url()).getTranslations();
     assertEquals(2, translations.size());
     assertEquals("en", translations.get(0).getKey());
     assertEquals("https://www.opentripplanner.org/", translations.get(0).getValue());
@@ -158,7 +158,7 @@ public class AlertsUpdateHandlerTest {
       )
       .build();
     TransitAlert transitAlert = processOneAlert(alert);
-    assertEquals("Title", transitAlert.alertHeaderText.toString());
+    assertEquals("Title", transitAlert.headerText().toString());
   }
 
   @Test
@@ -177,7 +177,7 @@ public class AlertsUpdateHandlerTest {
     TransitAlert transitAlert = processOneAlert(alert);
 
     List<Entry<String, String>> translations =
-      ((TranslatedString) transitAlert.alertHeaderText).getTranslations();
+      ((TranslatedString) transitAlert.headerText()).getTranslations();
     assertEquals(2, translations.size());
     assertEquals("en", translations.get(0).getKey());
     assertEquals("Title", translations.get(0).getValue());
@@ -198,7 +198,7 @@ public class AlertsUpdateHandlerTest {
       )
       .build();
     TransitAlert transitAlert = processOneAlert(alert);
-    assertEquals("Description", transitAlert.alertDescriptionText.toString());
+    assertEquals("Description", transitAlert.descriptionText().toString());
   }
 
   @Test
@@ -223,7 +223,7 @@ public class AlertsUpdateHandlerTest {
     TransitAlert transitAlert = processOneAlert(alert);
 
     List<Entry<String, String>> translations =
-      ((TranslatedString) transitAlert.alertDescriptionText).getTranslations();
+      ((TranslatedString) transitAlert.descriptionText()).getTranslations();
     assertEquals(2, translations.size());
     assertEquals("en", translations.get(0).getKey());
     assertEquals("Description", translations.get(0).getValue());
@@ -238,7 +238,7 @@ public class AlertsUpdateHandlerTest {
       .addInformedEntity(GtfsRealtime.EntitySelector.newBuilder().setAgencyId("1"))
       .build();
     TransitAlert transitAlert = processOneAlert(alert);
-    assertEquals(AlertSeverity.UNKNOWN_SEVERITY, transitAlert.severity);
+    assertEquals(AlertSeverity.UNKNOWN_SEVERITY, transitAlert.severity());
   }
 
   @Test
@@ -249,7 +249,7 @@ public class AlertsUpdateHandlerTest {
       .setSeverityLevel(SeverityLevel.SEVERE)
       .build();
     TransitAlert transitAlert = processOneAlert(alert);
-    assertEquals(AlertSeverity.SEVERE, transitAlert.severity);
+    assertEquals(AlertSeverity.SEVERE, transitAlert.severity());
   }
 
   @Test
@@ -259,7 +259,7 @@ public class AlertsUpdateHandlerTest {
       .addInformedEntity(GtfsRealtime.EntitySelector.newBuilder().setAgencyId("1"))
       .build();
     TransitAlert transitAlert = processOneAlert(alert);
-    assertEquals(AlertCause.UNKNOWN_CAUSE, transitAlert.cause);
+    assertEquals(AlertCause.UNKNOWN_CAUSE, transitAlert.cause());
   }
 
   @Test
@@ -270,7 +270,7 @@ public class AlertsUpdateHandlerTest {
       .setCause(Cause.MAINTENANCE)
       .build();
     TransitAlert transitAlert = processOneAlert(alert);
-    assertEquals(AlertCause.MAINTENANCE, transitAlert.cause);
+    assertEquals(AlertCause.MAINTENANCE, transitAlert.cause());
   }
 
   @Test
@@ -280,7 +280,7 @@ public class AlertsUpdateHandlerTest {
       .addInformedEntity(GtfsRealtime.EntitySelector.newBuilder().setAgencyId("1"))
       .build();
     TransitAlert transitAlert = processOneAlert(alert);
-    assertEquals(AlertEffect.UNKNOWN_EFFECT, transitAlert.effect);
+    assertEquals(AlertEffect.UNKNOWN_EFFECT, transitAlert.effect());
   }
 
   @Test
@@ -291,7 +291,7 @@ public class AlertsUpdateHandlerTest {
       .setEffect(Effect.MODIFIED_SERVICE)
       .build();
     TransitAlert transitAlert = processOneAlert(alert);
-    assertEquals(AlertEffect.MODIFIED_SERVICE, transitAlert.effect);
+    assertEquals(AlertEffect.MODIFIED_SERVICE, transitAlert.effect());
   }
 
   @Test
@@ -301,10 +301,10 @@ public class AlertsUpdateHandlerTest {
       .addInformedEntity(GtfsRealtime.EntitySelector.newBuilder().setAgencyId("1"))
       .build();
     TransitAlert transitAlert = processOneAlert(alert);
-    long totalSelectorCount = transitAlert.getEntities().size();
+    long totalSelectorCount = transitAlert.entities().size();
     assertEquals(1l, totalSelectorCount);
     long agencySelectorCount = transitAlert
-      .getEntities()
+      .entities()
       .stream()
       .filter(entitySelector -> entitySelector instanceof EntitySelector.Agency)
       .count();
@@ -318,10 +318,10 @@ public class AlertsUpdateHandlerTest {
       .addInformedEntity(GtfsRealtime.EntitySelector.newBuilder().setRouteId("1"))
       .build();
     TransitAlert transitAlert = processOneAlert(alert);
-    long totalSelectorCount = transitAlert.getEntities().size();
+    long totalSelectorCount = transitAlert.entities().size();
     assertEquals(1l, totalSelectorCount);
     long routeSelectorCount = transitAlert
-      .getEntities()
+      .entities()
       .stream()
       .filter(entitySelector -> entitySelector instanceof EntitySelector.Route)
       .count();
@@ -339,10 +339,10 @@ public class AlertsUpdateHandlerTest {
       )
       .build();
     TransitAlert transitAlert = processOneAlert(alert);
-    long totalSelectorCount = transitAlert.getEntities().size();
+    long totalSelectorCount = transitAlert.entities().size();
     assertEquals(1l, totalSelectorCount);
     long tripSelectorCount = transitAlert
-      .getEntities()
+      .entities()
       .stream()
       .filter(entitySelector -> entitySelector instanceof EntitySelector.Trip)
       .count();
@@ -356,10 +356,10 @@ public class AlertsUpdateHandlerTest {
       .addInformedEntity(GtfsRealtime.EntitySelector.newBuilder().setStopId("1"))
       .build();
     TransitAlert transitAlert = processOneAlert(alert);
-    long totalSelectorCount = transitAlert.getEntities().size();
+    long totalSelectorCount = transitAlert.entities().size();
     assertEquals(1l, totalSelectorCount);
     long stopSelectorCount = transitAlert
-      .getEntities()
+      .entities()
       .stream()
       .filter(entitySelector -> entitySelector instanceof EntitySelector.Stop)
       .count();
@@ -373,10 +373,10 @@ public class AlertsUpdateHandlerTest {
       .addInformedEntity(0, GtfsRealtime.EntitySelector.newBuilder().setStopId("1").setRouteId("1"))
       .build();
     TransitAlert transitAlert = processOneAlert(alert);
-    long totalSelectorCount = transitAlert.getEntities().size();
+    long totalSelectorCount = transitAlert.entities().size();
     assertEquals(1l, totalSelectorCount);
     long stopAndRouteSelectorCount = transitAlert
-      .getEntities()
+      .entities()
       .stream()
       .filter(entitySelector -> entitySelector instanceof EntitySelector.StopAndRoute)
       .count();
@@ -396,10 +396,10 @@ public class AlertsUpdateHandlerTest {
       )
       .build();
     TransitAlert transitAlert = processOneAlert(alert);
-    long totalSelectorCount = transitAlert.getEntities().size();
+    long totalSelectorCount = transitAlert.entities().size();
     assertEquals(1l, totalSelectorCount);
     long stopAndTripSelectorCount = transitAlert
-      .getEntities()
+      .entities()
       .stream()
       .filter(entitySelector -> entitySelector instanceof EntitySelector.StopAndTrip)
       .count();
@@ -415,16 +415,16 @@ public class AlertsUpdateHandlerTest {
       .addInformedEntity(GtfsRealtime.EntitySelector.newBuilder().setRouteId("1"))
       .build();
     TransitAlert transitAlert = processOneAlert(alert);
-    long totalSelectorCount = transitAlert.getEntities().size();
+    long totalSelectorCount = transitAlert.entities().size();
     assertEquals(3l, totalSelectorCount);
     long agencySelectorCount = transitAlert
-      .getEntities()
+      .entities()
       .stream()
       .filter(entitySelector -> entitySelector instanceof EntitySelector.Agency)
       .count();
     assertEquals(2l, agencySelectorCount);
     long routeSelectorCount = transitAlert
-      .getEntities()
+      .entities()
       .stream()
       .filter(entitySelector -> entitySelector instanceof EntitySelector.Route)
       .count();
@@ -435,10 +435,10 @@ public class AlertsUpdateHandlerTest {
   public void testMissingSelector() {
     GtfsRealtime.Alert alert = Alert.newBuilder().build();
     TransitAlert transitAlert = processOneAlert(alert);
-    long totalSelectorCount = transitAlert.getEntities().size();
+    long totalSelectorCount = transitAlert.entities().size();
     assertEquals(1l, totalSelectorCount);
     List<EntitySelector> selectors = transitAlert
-      .getEntities()
+      .entities()
       .stream()
       .filter(entitySelector -> entitySelector instanceof EntitySelector.Unknown)
       .toList();
@@ -457,10 +457,10 @@ public class AlertsUpdateHandlerTest {
       .addInformedEntity(GtfsRealtime.EntitySelector.newBuilder().setDirectionId(1).build())
       .build();
     TransitAlert transitAlert = processOneAlert(alert);
-    long totalSelectorCount = transitAlert.getEntities().size();
+    long totalSelectorCount = transitAlert.entities().size();
     assertEquals(1l, totalSelectorCount);
     List<EntitySelector> selectors = transitAlert
-      .getEntities()
+      .entities()
       .stream()
       .filter(entitySelector -> entitySelector instanceof EntitySelector.Unknown)
       .toList();
@@ -480,10 +480,10 @@ public class AlertsUpdateHandlerTest {
       )
       .build();
     TransitAlert transitAlert = processOneAlert(alert);
-    long totalSelectorCount = transitAlert.getEntities().size();
+    long totalSelectorCount = transitAlert.entities().size();
     assertEquals(1l, totalSelectorCount);
     long directionAndRouteSelectorCount = transitAlert
-      .getEntities()
+      .entities()
       .stream()
       .filter(entitySelector -> entitySelector instanceof EntitySelector.DirectionAndRoute)
       .count();
@@ -497,10 +497,10 @@ public class AlertsUpdateHandlerTest {
       .addInformedEntity(GtfsRealtime.EntitySelector.newBuilder().setRouteType(1).build())
       .build();
     TransitAlert transitAlert = processOneAlert(alert);
-    long totalSelectorCount = transitAlert.getEntities().size();
+    long totalSelectorCount = transitAlert.entities().size();
     assertEquals(1l, totalSelectorCount);
     long RouteTypeSelectorCount = transitAlert
-      .getEntities()
+      .entities()
       .stream()
       .filter(entitySelector -> entitySelector instanceof EntitySelector.RouteType)
       .count();
@@ -516,10 +516,10 @@ public class AlertsUpdateHandlerTest {
       )
       .build();
     TransitAlert transitAlert = processOneAlert(alert);
-    long totalSelectorCount = transitAlert.getEntities().size();
+    long totalSelectorCount = transitAlert.entities().size();
     assertEquals(1l, totalSelectorCount);
     long RouteTypeAndAgencySelectorCount = transitAlert
-      .getEntities()
+      .entities()
       .stream()
       .filter(entitySelector -> entitySelector instanceof EntitySelector.RouteTypeAndAgency)
       .count();
@@ -546,7 +546,7 @@ public class AlertsUpdateHandlerTest {
     public void setAlerts(Collection<TransitAlert> alerts) {
       Multimap<EntitySelector, TransitAlert> newAlerts = HashMultimap.create();
       for (TransitAlert alert : alerts) {
-        for (EntitySelector entity : alert.getEntities()) {
+        for (EntitySelector entity : alert.entities()) {
           newAlerts.put(entity, alert);
         }
       }


### PR DESCRIPTION
### Summary

This PR converts the `TransitAlert` to a `TransitEntity`, simplifies the handling of SIRI-SX and exposes various new fields to the transmodel API 

