### PR TITLE
fix: relaxGeneralizedCostAtDestination leaks Raptor internal NOT_SET

### DIFF
--- a/docs/RouteRequest.md
+++ b/docs/RouteRequest.md
@@ -63,7 +63,7 @@ and in the [transferRequests in build-config.json](BuildConfiguration.md#transfe
 | numItineraries                                                                                       |        `integer`       | The maximum number of itineraries to return.                                                                                       | *Optional* | `50`                     |  2.0  |
 | [optimize](#rd_optimize)                                                                             |         `enum`         | The set of characteristics that the user wants to optimize for.                                                                    | *Optional* | `"safe"`                 |  2.0  |
 | [otherThanPreferredRoutesPenalty](#rd_otherThanPreferredRoutesPenalty)                               |        `integer`       | Penalty added for using every route that is not preferred if user set any route as preferred.                                      | *Optional* | `300`                    |  2.0  |
-| [relaxTransitSearchGeneralizedCostAtDestination](#rd_relaxTransitSearchGeneralizedCostAtDestination) |        `double`        | Whether non-optimal transit paths at the destination should be returned                                                            | *Optional* | `-1.0`                   |  2.3  |
+| [relaxTransitSearchGeneralizedCostAtDestination](#rd_relaxTransitSearchGeneralizedCostAtDestination) |        `double`        | Whether non-optimal transit paths at the destination should be returned                                                            | *Optional* |                          |  2.3  |
 | [searchWindow](#rd_searchWindow)                                                                     |       `duration`       | The duration of the search-window.                                                                                                 | *Optional* |                          |  2.0  |
 | stairsReluctance                                                                                     |        `double`        | Used instead of walkReluctance for stairs.                                                                                         | *Optional* | `2.0`                    |  2.0  |
 | [stairsTimeFactor](#rd_stairsTimeFactor)                                                             |        `double`        | How much more time does it take to walk a flight of stairs compared to walking a similar horizontal length.                        | *Optional* | `3.0`                    |  2.1  |
@@ -243,7 +243,7 @@ We return number of seconds that we are willing to wait for preferred route.
 
 <h3 id="rd_relaxTransitSearchGeneralizedCostAtDestination">relaxTransitSearchGeneralizedCostAtDestination</h3>
 
-**Since version:** `2.3` ∙ **Type:** `double` ∙ **Cardinality:** `Optional` ∙ **Default value:** `-1.0`   
+**Since version:** `2.3` ∙ **Type:** `double` ∙ **Cardinality:** `Optional`   
 **Path:** /routingDefaults 
 
 Whether non-optimal transit paths at the destination should be returned
@@ -252,9 +252,10 @@ Let c be the existing minimum pareto optimal generalized cost to beat. Then a tr
 with cost c' is accepted if the following is true:
 `c' < Math.round(c * relaxRaptorCostCriteria)`.
 
-If the value is less than 0.0 a normal '<' comparison is performed.
+The parameter is optional. If not set a normal comparison is performed.
 
-Values greater than 2.0 are not supported, due to performance reasons.
+Values equals or less than zero is not allowed. Values greater than 2.0 are not
+supported, due to performance reasons.
 
 
 <h3 id="rd_searchWindow">searchWindow</h3>

--- a/src/ext/graphql/transmodelapi/schema.graphql
+++ b/src/ext/graphql/transmodelapi/schema.graphql
@@ -738,15 +738,18 @@ type QueryType {
     "Use the cursor to go to the next \"page\" of itineraries. Copy the cursor from the last response and keep the original request as is. This will enable you to search for itineraries in the next or previous time-window."
     pageCursor: String,
     """
-    Whether non-optimal transit paths at the destination should be returned.
-    Let c be the existing minimum pareto optimal generalized-cost to beat. Then a trip with
-    cost c' is accepted if the following is true:
-    `c' < Math.round(c * relaxTransitSearchGeneralizedCostAtDestination)`.
+    Whether non-optimal transit paths at the destination should be returned. Let c be the
+    existing minimum pareto optimal generalized-cost to beat. Then a trip with cost c' is
+    accepted if the following is true:
     
-    If the value is less than 0.0 a normal '<' comparison is performed.
-    Values greater than 2.0 are not supported, due to performance reasons.
+    `c' < Math.round(c * relaxTransitSearchGeneralizedCostAtDestination)`
+    
+    The parameter is optional. If not set, a normal comparison is performed.
+    
+    Values less than 1.0 is not allowed, and values greater than 2.0 are not
+    supported, due to performance reasons.
     """
-    relaxTransitSearchGeneralizedCostAtDestination: Float = -1.0,
+    relaxTransitSearchGeneralizedCostAtDestination: Float = null,
     """
     The length of the search-window in minutes. This parameter is optional.
     

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLPlanner.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLPlanner.java
@@ -26,7 +26,6 @@ import org.opentripplanner.routing.api.request.RequestModes;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.routing.api.request.preference.RoutingPreferences;
-import org.opentripplanner.routing.api.request.request.filter.AllowAllTransitFilter;
 import org.opentripplanner.routing.api.request.request.filter.SelectRequest;
 import org.opentripplanner.routing.api.request.request.filter.TransitFilter;
 import org.opentripplanner.routing.api.request.request.filter.TransitFilterRequest;
@@ -442,8 +441,7 @@ public class TransmodelGraphQLPlanner {
       callWith.argument("includePlannedCancellations", tr::setIncludePlannedCancellations);
       callWith.argument(
         "relaxTransitSearchGeneralizedCostAtDestination",
-        (Double value) ->
-          tr.withRaptor(it -> it.withRelaxTransitSearchGeneralizedCostAtDestination(value))
+        (Double value) -> tr.withRaptor(it -> it.withRelaxGeneralizedCostAtDestination(value))
       );
     });
     preferences.withItineraryFilter(itineraryFilter -> {

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/TripQuery.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/TripQuery.java
@@ -465,18 +465,21 @@ public class TripQuery {
           .name("relaxTransitSearchGeneralizedCostAtDestination")
           .description(
             """
-            Whether non-optimal transit paths at the destination should be returned.
-            Let c be the existing minimum pareto optimal generalized-cost to beat. Then a trip with
-            cost c' is accepted if the following is true:
-            `c' < Math.round(c * relaxTransitSearchGeneralizedCostAtDestination)`.
-            
-            If the value is less than 0.0 a normal '<' comparison is performed.
-            Values greater than 2.0 are not supported, due to performance reasons.
-            """
+              Whether non-optimal transit paths at the destination should be returned. Let c be the
+              existing minimum pareto optimal generalized-cost to beat. Then a trip with cost c' is
+              accepted if the following is true:
+              
+              `c' < Math.round(c * relaxTransitSearchGeneralizedCostAtDestination)`
+                          
+              The parameter is optional. If not set, a normal comparison is performed.
+              
+              Values less than 1.0 is not allowed, and values greater than 2.0 are not
+              supported, due to performance reasons.
+              """
           )
           .type(Scalars.GraphQLFloat)
-          .defaultValue(
-            preferences.transit().raptor().relaxTransitSearchGeneralizedCostAtDestination()
+          .defaultValueProgrammatic(
+            preferences.transit().raptor().relaxGeneralizedCostAtDestination().orElse(null)
           )
           .build()
       )

--- a/src/main/java/org/opentripplanner/api/common/RequestToPreferencesMapper.java
+++ b/src/main/java/org/opentripplanner/api/common/RequestToPreferencesMapper.java
@@ -88,7 +88,7 @@ class RequestToPreferencesMapper {
       setIfNotNull(req.ignoreRealtimeUpdates, tr::setIgnoreRealtimeUpdates);
       setIfNotNull(
         req.relaxTransitSearchGeneralizedCostAtDestination,
-        value -> tr.withRaptor(it -> it.withRelaxTransitSearchGeneralizedCostAtDestination(value))
+        value -> tr.withRaptor(it -> it.withRelaxGeneralizedCostAtDestination(value))
       );
     });
 

--- a/src/main/java/org/opentripplanner/api/common/RoutingResource.java
+++ b/src/main/java/org/opentripplanner/api/common/RoutingResource.java
@@ -652,7 +652,7 @@ public abstract class RoutingResource {
 
   /**
    * Whether non-optimal transit paths at the destination should be returned.
-   * If the value is less than 0.0 a normal '<' comparison is performed.
+   * This is optional. Use values between 1.0 and 2.0. For example to relax 10% use 1.1.
    * Values greater than 2.0 are not supported, due to performance reasons.
    * {@link SearchParams#relaxCostAtDestination()}
    */

--- a/src/main/java/org/opentripplanner/raptor/api/request/SearchParams.java
+++ b/src/main/java/org/opentripplanner/raptor/api/request/SearchParams.java
@@ -5,6 +5,8 @@ import static org.opentripplanner.raptor.api.request.RaptorRequest.assertPropert
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
+import javax.annotation.Nullable;
 import org.opentripplanner.framework.tostring.ToStringBuilder;
 import org.opentripplanner.raptor.api.model.RaptorAccessEgress;
 import org.opentripplanner.raptor.api.model.RaptorTransfer;
@@ -36,7 +38,10 @@ public class SearchParams {
   private final boolean preferLateArrival;
   private final int numberOfAdditionalTransfers;
   private final int maxNumberOfTransfers;
-  private final double relaxCostAtDestination;
+
+  @Nullable
+  private final Double relaxCostAtDestination;
+
   private final boolean timetable;
   private final boolean constrainedTransfers;
   private final Collection<RaptorAccessEgress> accessPaths;
@@ -53,7 +58,7 @@ public class SearchParams {
     preferLateArrival = false;
     numberOfAdditionalTransfers = 5;
     maxNumberOfTransfers = NOT_SET;
-    relaxCostAtDestination = NOT_SET;
+    relaxCostAtDestination = null;
     timetable = false;
     constrainedTransfers = false;
     accessPaths = List.of();
@@ -176,21 +181,18 @@ public class SearchParams {
    * Whether to accept non-optimal trips if they are close enough - if and only if they represent an
    * optimal path for their given iteration. In other words this slack only relaxes the pareto
    * comparison at the destination.
-   * <p/>
+   * <p>
    * Let {@code c} be the existing minimum pareto optimal cost to beat. Then a trip with cost
    * {@code c'} is accepted if the following is true:
    * <pre>
    * c' < Math.round(c * relaxCostAtDestination)
    * </pre>
-   * If the value is less than 0.0 a normal '<' comparison is performed.
-   * <p/>
-   * TODO - When setting this above 1.0, we get some unwanted results. We should have a filter to remove those
-   * TODO - results. See issue https://github.com/entur/r5/issues/28
-   * <p/>
-   * The default value is -1.0 (disabled)
+   * If the value is less than 1.0 a normal '<' comparison is performed.
+   * <p>
+   * The default is not set.
    */
-  public double relaxCostAtDestination() {
-    return relaxCostAtDestination;
+  public Optional<Double> relaxCostAtDestination() {
+    return Optional.ofNullable(relaxCostAtDestination);
   }
 
   /**
@@ -264,9 +266,10 @@ public class SearchParams {
       latestArrivalTime,
       searchWindowInSeconds,
       preferLateArrival,
+      numberOfAdditionalTransfers,
+      relaxCostAtDestination,
       accessPaths,
-      egressPaths,
-      numberOfAdditionalTransfers
+      egressPaths
     );
   }
 
@@ -285,6 +288,7 @@ public class SearchParams {
       searchWindowInSeconds == that.searchWindowInSeconds &&
       preferLateArrival == that.preferLateArrival &&
       numberOfAdditionalTransfers == that.numberOfAdditionalTransfers &&
+      Objects.equals(relaxCostAtDestination, that.relaxCostAtDestination) &&
       accessPaths.equals(that.accessPaths) &&
       egressPaths.equals(that.egressPaths)
     );
@@ -299,6 +303,7 @@ public class SearchParams {
       .addDurationSec("searchWindow", searchWindowInSeconds)
       .addBoolIfTrue("departAsLateAsPossible", preferLateArrival)
       .addNum("numberOfAdditionalTransfers", numberOfAdditionalTransfers)
+      .addNum("relaxCostAtDestination", relaxCostAtDestination)
       .addCollection("accessPaths", accessPaths, 5)
       .addCollection("egressPaths", egressPaths, 5)
       .toString();

--- a/src/main/java/org/opentripplanner/raptor/api/request/SearchParamsBuilder.java
+++ b/src/main/java/org/opentripplanner/raptor/api/request/SearchParamsBuilder.java
@@ -26,7 +26,7 @@ public class SearchParamsBuilder<T extends RaptorTripSchedule> {
   private boolean preferLateArrival;
   private int numberOfAdditionalTransfers;
   private int maxNumberOfTransfers;
-  private double relaxCostAtDestination;
+  private Double relaxCostAtDestination;
   private boolean timetable;
   private boolean constrainedTransfers;
   private boolean allowEmptyEgressPaths;
@@ -39,7 +39,7 @@ public class SearchParamsBuilder<T extends RaptorTripSchedule> {
     this.preferLateArrival = defaults.preferLateArrival();
     this.numberOfAdditionalTransfers = defaults.numberOfAdditionalTransfers();
     this.maxNumberOfTransfers = defaults.maxNumberOfTransfers();
-    this.relaxCostAtDestination = defaults.relaxCostAtDestination();
+    this.relaxCostAtDestination = defaults.relaxCostAtDestination().orElse(null);
     this.timetable = defaults.timetable();
     this.constrainedTransfers = defaults.constrainedTransfers();
     this.accessPaths.addAll(defaults.accessPaths());
@@ -115,11 +115,11 @@ public class SearchParamsBuilder<T extends RaptorTripSchedule> {
     return this;
   }
 
-  public double relaxCostAtDestination() {
+  public Double relaxCostAtDestination() {
     return relaxCostAtDestination;
   }
 
-  public SearchParamsBuilder<T> relaxCostAtDestination(double relaxCostAtDestination) {
+  public SearchParamsBuilder<T> relaxCostAtDestination(Double relaxCostAtDestination) {
     this.relaxCostAtDestination = relaxCostAtDestination;
     return this;
   }
@@ -199,6 +199,7 @@ public class SearchParamsBuilder<T extends RaptorTripSchedule> {
       .addDurationSec("searchWindow", searchWindowInSeconds)
       .addBoolIfTrue("departAsLateAsPossible", preferLateArrival)
       .addNum("numberOfAdditionalTransfers", numberOfAdditionalTransfers)
+      .addNum("relaxCostAtDestination", relaxCostAtDestination)
       .addCollection("accessPaths", accessPaths, 5)
       .addCollection("egressPaths", egressPaths, 5)
       .toString();

--- a/src/main/java/org/opentripplanner/raptor/rangeraptor/path/configure/PathConfig.java
+++ b/src/main/java/org/opentripplanner/raptor/rangeraptor/path/configure/PathConfig.java
@@ -60,31 +60,35 @@ public class PathConfig<T extends RaptorTripSchedule> {
   }
 
   private ParetoComparator<RaptorPath<T>> paretoComparator(boolean includeCost) {
-    double relaxedCost = ctx.searchParams().relaxCostAtDestination();
-    boolean includeRelaxedCost = includeCost && relaxedCost > 0.0;
+    boolean includeRelaxedCost =
+      includeCost && ctx.searchParams().relaxCostAtDestination().isPresent();
     boolean includeTimetable = ctx.searchParams().timetable();
     boolean preferLateArrival = ctx.searchParams().preferLateArrival();
 
-    if (includeTimetable && includeRelaxedCost) {
-      return comparatorWithTimetableAndRelaxedCost(relaxedCost);
-    }
-    if (includeTimetable && includeCost) {
-      return comparatorWithTimetableAndCost();
-    }
-    if (includeTimetable) {
-      return comparatorWithTimetable();
-    }
-    if (includeRelaxedCost && preferLateArrival) {
-      return comparatorWithRelaxedCostAndLatestDeparture(relaxedCost);
-    }
     if (includeRelaxedCost) {
+      double relaxedCost = ctx.searchParams().relaxCostAtDestination().get();
+
+      if (includeTimetable) {
+        return comparatorWithTimetableAndRelaxedCost(relaxedCost);
+      }
+      if (preferLateArrival) {
+        return comparatorWithRelaxedCostAndLatestDeparture(relaxedCost);
+      }
       return comparatorWithRelaxedCost(relaxedCost);
     }
-    if (includeCost && preferLateArrival) {
-      return comparatorWithCostAndLatestDeparture();
-    }
+
     if (includeCost) {
+      if (includeTimetable) {
+        return comparatorWithTimetableAndCost();
+      }
+      if (preferLateArrival) {
+        return comparatorWithCostAndLatestDeparture();
+      }
       return comparatorWithCost();
+    }
+
+    if (includeTimetable) {
+      return comparatorWithTimetable();
     }
     if (preferLateArrival) {
       return comparatorStandardAndLatestDepature();

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/RaptorRequestMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/RaptorRequestMapper.java
@@ -100,9 +100,11 @@ public class RaptorRequestMapper {
       searchParams.numberOfAdditionalTransfers(preferences.transfer().maxAdditionalTransfers());
     }
 
-    searchParams.relaxCostAtDestination(
-      preferences.transit().raptor().relaxTransitSearchGeneralizedCostAtDestination()
-    );
+    preferences
+      .transit()
+      .raptor()
+      .relaxGeneralizedCostAtDestination()
+      .ifPresent(searchParams::relaxCostAtDestination);
 
     for (Optimization optimization : preferences.transit().raptor().optimizations()) {
       if (optimization.is(PARALLEL)) {

--- a/src/main/java/org/opentripplanner/routing/api/request/framework/Units.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/framework/Units.java
@@ -70,6 +70,14 @@ public class Units {
   }
 
   /**
+   * If given input value is {@code null}, then return {@code null}, if not
+   * verify value, see {@link #reluctance(double, double, double)}.
+   */
+  public static Double reluctanceOptional(Double value, double minValue, double maxValue) {
+    return (value == null) ? null : reluctance(value, minValue, maxValue);
+  }
+
+  /**
    * Amount of time/slack/duration in seconds - A constant amount of time.
    */
   public static int duration(int seconds) {

--- a/src/main/java/org/opentripplanner/routing/api/request/framework/Units.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/framework/Units.java
@@ -43,17 +43,21 @@ public class Units {
    * Unit: Human cost per second of actual time (scalar)
    */
   public static double reluctance(double value) {
-    return reluctance(value, 0.0, Double.MAX_VALUE);
+    return normalizedFactor(value, 0.0, Double.MAX_VALUE);
   }
 
   /**
-   * Reluctance of factor between {@param minValue} and {@param maxValue}.
-   * Number of decimals used are: 2 for absolute value less than 2.0, 1 for absolute value less than
-   * 10.0, and zero for absolute values above 10.0.
+   * Normalized factor in given range between {@param minValue} and {@param maxValue}.
+   * Number of decimals used are:
+   * <ul>
+   *   <li>2 decimals for absolute value less than 2. Example: -1.99 and 0.01</li>
+   *   <li>1 decimal for absolute value less than 10. Example: 2.0 and 9.9</li>
+   *   <li>zero decimals for absolute values above 10.  Example: -10 and 10</li>
+   * </ul>
    * <p>
-   * Unit: Human cost per second of actual time (scalar)
+   * Unit: scalar
    */
-  public static double reluctance(double value, double minValue, double maxValue) {
+  public static double normalizedFactor(double value, double minValue, double maxValue) {
     if (value < minValue) {
       throw new IllegalArgumentException("Min limit(" + minValue + ") exceeded: " + value);
     }
@@ -71,10 +75,10 @@ public class Units {
 
   /**
    * If given input value is {@code null}, then return {@code null}, if not
-   * verify value, see {@link #reluctance(double, double, double)}.
+   * verify value, see {@link #normalizedFactor(double, double, double)}.
    */
-  public static Double reluctanceOptional(Double value, double minValue, double maxValue) {
-    return (value == null) ? null : reluctance(value, minValue, maxValue);
+  public static Double normalizedOptionalFactor(Double value, double minValue, double maxValue) {
+    return (value == null) ? null : normalizedFactor(value, minValue, maxValue);
   }
 
   /**

--- a/src/main/java/org/opentripplanner/routing/api/request/preference/RaptorPreferences.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/preference/RaptorPreferences.java
@@ -53,13 +53,11 @@ public final class RaptorPreferences implements Serializable {
     this.timeLimit = builder.timeLimit;
 
     this.relaxGeneralizedCostAtDestination =
-      builder.relaxGeneralizedCostAtDestination == null
-        ? null
-        : Units.reluctance(
-          builder.relaxGeneralizedCostAtDestination,
-          MIN_RELAX_COST_AT_DESTINATION,
-          MAX_RELAX_COST_AT_DESTINATION
-        );
+      Units.normalizedOptionalFactor(
+        builder.relaxGeneralizedCostAtDestination,
+        MIN_RELAX_COST_AT_DESTINATION,
+        MAX_RELAX_COST_AT_DESTINATION
+      );
   }
 
   public static Builder of() {

--- a/src/main/java/org/opentripplanner/routing/api/request/preference/RaptorPreferences.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/preference/RaptorPreferences.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
@@ -24,7 +25,8 @@ import org.opentripplanner.routing.api.request.framework.Units;
 public final class RaptorPreferences implements Serializable {
 
   public static final RaptorPreferences DEFAULT = new RaptorPreferences();
-  public static final double MAX_RELAX_COST_AT_DESTINATION_VALUE = 2.0;
+  private static final double MIN_RELAX_COST_AT_DESTINATION = 1.0;
+  private static final double MAX_RELAX_COST_AT_DESTINATION = 2.0;
 
   private final Set<Optimization> optimizations;
 
@@ -34,14 +36,14 @@ public final class RaptorPreferences implements Serializable {
 
   private final Instant timeLimit;
 
-  private final double relaxTransitSearchGeneralizedCostAtDestination;
+  private final Double relaxGeneralizedCostAtDestination;
 
   private RaptorPreferences() {
     this.optimizations = EnumSet.of(Optimization.PARETO_CHECK_AGAINST_DESTINATION);
     this.profile = RaptorProfile.MULTI_CRITERIA;
     this.searchDirection = SearchDirection.FORWARD;
     this.timeLimit = null;
-    this.relaxTransitSearchGeneralizedCostAtDestination = SearchParams.NOT_SET;
+    this.relaxGeneralizedCostAtDestination = null;
   }
 
   private RaptorPreferences(RaptorPreferences.Builder builder) {
@@ -49,12 +51,15 @@ public final class RaptorPreferences implements Serializable {
     this.profile = Objects.requireNonNull(builder.profile);
     this.searchDirection = Objects.requireNonNull(builder.searchDirection);
     this.timeLimit = builder.timeLimit;
-    this.relaxTransitSearchGeneralizedCostAtDestination =
-      Units.reluctance(
-        builder.relaxTransitSearchGeneralizedCostAtDestination,
-        Double.NEGATIVE_INFINITY,
-        MAX_RELAX_COST_AT_DESTINATION_VALUE
-      );
+
+    this.relaxGeneralizedCostAtDestination =
+      builder.relaxGeneralizedCostAtDestination == null
+        ? null
+        : Units.reluctance(
+          builder.relaxGeneralizedCostAtDestination,
+          MIN_RELAX_COST_AT_DESTINATION,
+          MAX_RELAX_COST_AT_DESTINATION
+        );
   }
 
   public static Builder of() {
@@ -86,22 +91,29 @@ public final class RaptorPreferences implements Serializable {
     return timeLimit;
   }
 
-  public double relaxTransitSearchGeneralizedCostAtDestination() {
-    return relaxTransitSearchGeneralizedCostAtDestination;
+  /**
+   * See {@link SearchParams#relaxCostAtDestination()} for documentation.
+   */
+  public Optional<Double> relaxGeneralizedCostAtDestination() {
+    return Optional.ofNullable(relaxGeneralizedCostAtDestination);
   }
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
     RaptorPreferences that = (RaptorPreferences) o;
+
     return (
       optimizations.equals(that.optimizations) &&
       profile == that.profile &&
       searchDirection == that.searchDirection &&
       Objects.equals(timeLimit, that.timeLimit) &&
-      relaxTransitSearchGeneralizedCostAtDestination ==
-      that.relaxTransitSearchGeneralizedCostAtDestination
+      Objects.equals(relaxGeneralizedCostAtDestination, that.relaxGeneralizedCostAtDestination)
     );
   }
 
@@ -112,7 +124,7 @@ public final class RaptorPreferences implements Serializable {
       profile,
       searchDirection,
       timeLimit,
-      relaxTransitSearchGeneralizedCostAtDestination
+      relaxGeneralizedCostAtDestination
     );
   }
 
@@ -126,9 +138,9 @@ public final class RaptorPreferences implements Serializable {
       // Ignore time limit if null (default value)
       .addDateTime("timeLimit", timeLimit)
       .addNum(
-        "relaxTransitSearchGeneralizedCostAtDestination",
-        relaxTransitSearchGeneralizedCostAtDestination,
-        DEFAULT.relaxTransitSearchGeneralizedCostAtDestination
+        "relaxGeneralizedCostAtDestination",
+        relaxGeneralizedCostAtDestination,
+        DEFAULT.relaxGeneralizedCostAtDestination
       )
       .toString();
   }
@@ -141,7 +153,7 @@ public final class RaptorPreferences implements Serializable {
     private SearchDirection searchDirection;
     private Set<Optimization> optimizations;
     private Instant timeLimit;
-    private double relaxTransitSearchGeneralizedCostAtDestination;
+    private Double relaxGeneralizedCostAtDestination;
 
     public Builder(RaptorPreferences original) {
       this.original = original;
@@ -149,12 +161,7 @@ public final class RaptorPreferences implements Serializable {
       this.searchDirection = original.searchDirection;
       this.optimizations = null;
       this.timeLimit = original.timeLimit;
-      this.relaxTransitSearchGeneralizedCostAtDestination =
-        original.relaxTransitSearchGeneralizedCostAtDestination;
-    }
-
-    public RaptorPreferences original() {
-      return original;
+      this.relaxGeneralizedCostAtDestination = original.relaxGeneralizedCostAtDestination;
     }
 
     public Builder withOptimizations(Collection<Optimization> optimizations) {
@@ -180,11 +187,10 @@ public final class RaptorPreferences implements Serializable {
       return this;
     }
 
-    public Builder withRelaxTransitSearchGeneralizedCostAtDestination(
-      double relaxTransitSearchGeneralizedCostAtDestination
+    public Builder withRelaxGeneralizedCostAtDestination(
+      @Nullable Double relaxGeneralizedCostAtDestination
     ) {
-      this.relaxTransitSearchGeneralizedCostAtDestination =
-        relaxTransitSearchGeneralizedCostAtDestination;
+      this.relaxGeneralizedCostAtDestination = relaxGeneralizedCostAtDestination;
       return this;
     }
 

--- a/src/main/java/org/opentripplanner/standalone/config/routerequest/RouteRequestConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/routerequest/RouteRequestConfig.java
@@ -331,24 +331,24 @@ ferries, where the check-in process needs to be done in good time before ride.
           .asLinearFunction(dft.unpreferredCost())
       )
       .withRaptor(it ->
-        it.withRelaxTransitSearchGeneralizedCostAtDestination(
-          c
-            .of("relaxTransitSearchGeneralizedCostAtDestination")
-            .since(V2_3)
-            .summary("Whether non-optimal transit paths at the destination should be returned")
-            .description(
-              """
-              Let c be the existing minimum pareto optimal generalized cost to beat. Then a trip
-              with cost c' is accepted if the following is true:
-              `c' < Math.round(c * relaxRaptorCostCriteria)`.
-              
-              If the value is less than 0.0 a normal '<' comparison is performed.
-              
-              Values greater than 2.0 are not supported, due to performance reasons.
-              """
-            )
-            .asDouble(dft.raptor().relaxTransitSearchGeneralizedCostAtDestination())
-        )
+        c
+          .of("relaxTransitSearchGeneralizedCostAtDestination")
+          .since(V2_3)
+          .summary("Whether non-optimal transit paths at the destination should be returned")
+          .description(
+            """
+                Let c be the existing minimum pareto optimal generalized cost to beat. Then a trip
+                with cost c' is accepted if the following is true:
+                `c' < Math.round(c * relaxRaptorCostCriteria)`.
+                              
+                The parameter is optional. If not set a normal comparison is performed.
+                              
+                Values equals or less than zero is not allowed. Values greater than 2.0 are not
+                supported, due to performance reasons.
+                """
+          )
+          .asDoubleOptional()
+          .ifPresent(it::withRelaxGeneralizedCostAtDestination)
       );
   }
 

--- a/src/test/java/org/opentripplanner/raptor/util/paretoset/ParetoSetTest.java
+++ b/src/test/java/org/opentripplanner/raptor/util/paretoset/ParetoSetTest.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.raptor.util.paretoset;
 
+import static java.lang.Math.round;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -236,6 +237,21 @@ public class ParetoSetTest {
 
     // Expect all vectors with v1=4 or v2 in [1,2]
     assertEquals("{V1[4, 4], V4[5, 2], V5[5, 1], V6[5, 2]}", set.toString());
+  }
+
+  @Test
+  public void testRelaxedCriteriaAcceptingTenPercentExtra() {
+    // Given a set and function
+    ParetoSet<Vector> set = new ParetoSet<>((l, r) -> l.v1 < r.v1 || l.v2 <= round(r.v2 * 1.1));
+
+    // Add some values
+    set.add(new Vector("a", 1, 110));
+    set.add(new Vector("a", 1, 111));
+    set.add(new Vector("d", 1, 100));
+    set.add(new Vector("g", 1, 111));
+    set.add(new Vector("g", 1, 110));
+
+    assertEquals("{a[1, 110], d[1, 100], g[1, 110]}", set.toString());
   }
 
   @Test

--- a/src/test/java/org/opentripplanner/routing/api/request/framework/UnitsTest.java
+++ b/src/test/java/org/opentripplanner/routing/api/request/framework/UnitsTest.java
@@ -24,6 +24,12 @@ class UnitsTest {
   }
 
   @Test
+  void reluctanceWithMinMax() {
+    assertEquals(0.0, Units.reluctance(0.0, 0.0, 8.0));
+    assertThrows(IllegalArgumentException.class, () -> Units.reluctance(0.999, 1.0, 8.0));
+  }
+
+  @Test
   void duration() {
     assertEquals(0, Units.duration(0));
     assertEquals(10_000, Units.duration(10_000));

--- a/src/test/java/org/opentripplanner/routing/api/request/framework/UnitsTest.java
+++ b/src/test/java/org/opentripplanner/routing/api/request/framework/UnitsTest.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.routing.api.request.framework;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -24,9 +25,15 @@ class UnitsTest {
   }
 
   @Test
-  void reluctanceWithMinMax() {
-    assertEquals(0.0, Units.reluctance(0.0, 0.0, 8.0));
-    assertThrows(IllegalArgumentException.class, () -> Units.reluctance(0.999, 1.0, 8.0));
+  void normalizedFactor() {
+    assertEquals(0.0, Units.normalizedFactor(0.0, 0.0, 8.0));
+    assertThrows(IllegalArgumentException.class, () -> Units.normalizedFactor(0.999, 1.0, 8.0));
+  }
+
+  @Test
+  void normalizedOptionalFactor() {
+    assertNull(Units.normalizedOptionalFactor(null, 0.0, 8.0));
+    assertEquals(1.0, Units.normalizedOptionalFactor(1.0, 0.0, 8.0));
   }
 
   @Test

--- a/src/test/java/org/opentripplanner/routing/api/request/preference/RaptorPreferencesTest.java
+++ b/src/test/java/org/opentripplanner/routing/api/request/preference/RaptorPreferencesTest.java
@@ -3,6 +3,7 @@ package org.opentripplanner.routing.api.request.preference;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.routing.api.request.preference.ImmutablePreferencesAsserts.assertEqualsAndHashCode;
 
 import java.time.Instant;
@@ -27,12 +28,15 @@ class RaptorPreferencesTest {
     .atStartOfDay(ZoneIds.UTC)
     .toInstant();
 
+  private static final double RELAX_GENERALIZED_COST_AT_DESTINATION = 1.2;
+
   private final RaptorPreferences subject = RaptorPreferences
     .of()
     .withSearchDirection(SEARCH_DIRECTION)
     .withProfile(PROFILE)
     .withOptimizations(OPTIMIZATIONS)
     .withTimeLimit(TIME_LIMIT)
+    .withRelaxGeneralizedCostAtDestination(RELAX_GENERALIZED_COST_AT_DESTINATION)
     .build();
 
   @Test
@@ -81,6 +85,33 @@ class RaptorPreferencesTest {
   }
 
   @Test
+  void relaxGeneralizedCostAtDestination() {
+    // Default is not set (null)
+    assertTrue(RaptorPreferences.of().build().relaxGeneralizedCostAtDestination().isEmpty());
+    assertEquals(
+      RELAX_GENERALIZED_COST_AT_DESTINATION,
+      subject.relaxGeneralizedCostAtDestination().orElseThrow()
+    );
+    assertEquals(
+      1.0,
+      RaptorPreferences
+        .of()
+        .withRelaxGeneralizedCostAtDestination(1.0)
+        .build()
+        .relaxGeneralizedCostAtDestination()
+        .orElseThrow()
+    );
+    assertThrows(
+      IllegalArgumentException.class,
+      () -> RaptorPreferences.of().withRelaxGeneralizedCostAtDestination(0.99).build()
+    );
+    assertThrows(
+      IllegalArgumentException.class,
+      () -> RaptorPreferences.of().withRelaxGeneralizedCostAtDestination(2.01).build()
+    );
+  }
+
+  @Test
   void testEqualsAndHashCode() {
     // Return same object if no value is set
     assertSame(RaptorPreferences.DEFAULT, RaptorPreferences.of().build());
@@ -100,7 +131,8 @@ class RaptorPreferencesTest {
       "optimizations: [PARALLEL], " +
       "profile: STANDARD, " +
       "searchDirection: REVERSE, " +
-      "timeLimit: 2020-06-09T00:00:00Z" +
+      "timeLimit: 2020-06-09T00:00:00Z, " +
+      "relaxGeneralizedCostAtDestination: 1.2" +
       "}",
       subject.toString()
     );


### PR DESCRIPTION
### Summary

The RaptorPreferences was representing *not set* with any negative value instead of using `null`. A magic number from the Raptor internal model was leaked in the API and when this value was changed, the API changed. In addition, the RaptorPreferences `equals(..)` and `hashCode()` was implemented incorrect.

The `relaxGeneralizedCostAtDestination` allowed values should be: `null`(not set), `1.0 to 2.0` (0% to 100% relaxation). 


### Unit tests

New unit tests on `RaptorPreferences` are added.
