### PR TITLE
Do not return a leg from a leg reference, if trip does not exist on date

### DIFF
--- a/src/main/java/org/opentripplanner/model/plan/legreference/ScheduledTransitLegReference.java
+++ b/src/main/java/org/opentripplanner/model/plan/legreference/ScheduledTransitLegReference.java
@@ -42,6 +42,14 @@ public record ScheduledTransitLegReference(
 
     TripTimes tripTimes = timetable.getTripTimes(trip);
 
+    if (
+      !transitService
+        .getServiceCodesRunningForDate(serviceDate)
+        .contains(tripTimes.getServiceCode())
+    ) {
+      return null;
+    }
+
     // TODO: What should we have here
     ZoneId timeZone = transitService.getTimeZone();
 


### PR DESCRIPTION
### Summary

Currently we return a leg from a leg reference irrespective of whether the trip is actually running on the date in the reference. Check this when reconstructing the leg and return null, if the trip is not in service on the date.

This problem occurs, when the underlying transit data changes, and a specific trip does not run anymore on the service date. This currently only affects the `leg` query in the Transmodel API.
