### PR TITLE
Add support for deleted trips & including real-time cancelations in trip search

### DIFF
--- a/src/ext/graphql/transmodelapi/schema.graphql
+++ b/src/ext/graphql/transmodelapi/schema.graphql
@@ -723,6 +723,8 @@ type QueryType {
     ignoreRealtimeUpdates: Boolean = false,
     "When true, service journeys cancelled in scheduled route data will be included during this search."
     includePlannedCancellations: Boolean = false,
+    "When true, service journeys cancelled by real-time updates will be included during this search."
+    includeRealtimeCancellations: Boolean = false,
     "Configure the itinerary-filter-chain. NOTE! THESE PARAMETERS ARE USED FOR SERVER-SIDE TUNING AND IS AVAILABLE HERE FOR TESTING ONLY."
     itineraryFilters: ItineraryFilters,
     "The preferable language to use for text targeted the end user. Note! The data quality is limited, only stop and quay names are translates, and not in all places of the API."

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
@@ -1027,7 +1027,7 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
           // remove the previously created trip
           removePreviousRealtimeUpdate(trip, serviceDate);
 
-          if (!tripTimes.isCanceledOrDeleted()) {
+          if (!tripTimes.isDeleted()) {
             // Calculate modified stop-pattern
             var modifiedStops = createModifiedStops(
               pattern,

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
@@ -1021,13 +1021,13 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
         if (tripTimes.getNumStops() == pattern.numberOfStops()) {
           // All tripTimes should be handled the same way to always allow latest realtime-update to
           // replace previous update regardless of realtimestate
-          cancelScheduledTrip(trip, serviceDate);
+          markScheduledTripAsDeleted(trip, serviceDate);
 
           // Also check whether trip id has been used for previously ADDED/MODIFIED trip message and
           // remove the previously created trip
           removePreviousRealtimeUpdate(trip, serviceDate);
 
-          if (!tripTimes.isCanceled()) {
+          if (!tripTimes.isCanceledOrDeleted()) {
             // Calculate modified stop-pattern
             var modifiedStops = createModifiedStops(
               pattern,
@@ -1042,6 +1042,7 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
             );
 
             if (modifiedStops != null && modifiedStops.isEmpty()) {
+              // Empty modified stops means that there is no calls for the trip, cancel it
               tripTimes.cancelTrip();
             } else {
               // Add new trip
@@ -1219,26 +1220,26 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
   }
 
   /**
-   * Cancel scheduled trip in buffer given trip on service date
+   * Mark the scheduled trip in the buffer as deleted, given trip on service date
    *
    * @param serviceDate service date
-   * @return true if scheduled trip was cancelled
+   * @return true if scheduled trip was marked as deleted
    */
-  private boolean cancelScheduledTrip(Trip trip, final LocalDate serviceDate) {
+  private boolean markScheduledTripAsDeleted(Trip trip, final LocalDate serviceDate) {
     boolean success = false;
 
     final TripPattern pattern = transitService.getPatternForTrip(trip);
 
     if (pattern != null) {
-      // Cancel scheduled trip times for this trip in this pattern
+      // Mark scheduled trip times for this trip in this pattern as deleted
       final Timetable timetable = pattern.getScheduledTimetable();
       final TripTimes tripTimes = timetable.getTripTimes(trip);
 
       if (tripTimes == null) {
-        LOG.warn("Could not cancel scheduled trip {}", trip.getId());
+        LOG.warn("Could not mark scheduled trip as deleted {}", trip.getId());
       } else {
         final TripTimes newTripTimes = new TripTimes(tripTimes);
-        newTripTimes.cancelTrip();
+        newTripTimes.deleteTrip();
         buffer.update(pattern, newTripTimes, serviceDate);
         success = true;
       }

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLPlanner.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLPlanner.java
@@ -26,7 +26,6 @@ import org.opentripplanner.routing.api.request.RequestModes;
 import org.opentripplanner.routing.api.request.RouteRequest;
 import org.opentripplanner.routing.api.request.StreetMode;
 import org.opentripplanner.routing.api.request.preference.RoutingPreferences;
-import org.opentripplanner.routing.api.request.request.filter.AllowAllTransitFilter;
 import org.opentripplanner.routing.api.request.request.filter.SelectRequest;
 import org.opentripplanner.routing.api.request.request.filter.TransitFilter;
 import org.opentripplanner.routing.api.request.request.filter.TransitFilterRequest;
@@ -440,6 +439,7 @@ public class TransmodelGraphQLPlanner {
       });
       callWith.argument("ignoreRealtimeUpdates", tr::setIgnoreRealtimeUpdates);
       callWith.argument("includePlannedCancellations", tr::setIncludePlannedCancellations);
+      callWith.argument("includeRealtimeCancellations", tr::setIncludeRealtimeCancellations);
       callWith.argument(
         "relaxTransitSearchGeneralizedCostAtDestination",
         (Double value) ->

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/TripQuery.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/TripQuery.java
@@ -187,6 +187,17 @@ public class TripQuery {
       .argument(
         GraphQLArgument
           .newArgument()
+          .name("includeRealtimeCancellations")
+          .description(
+            "When true, service journeys cancelled by real-time updates will be included during this search."
+          )
+          .type(Scalars.GraphQLBoolean)
+          .defaultValue(preferences.transit().includeRealtimeCancellations())
+          .build()
+      )
+      .argument(
+        GraphQLArgument
+          .newArgument()
           .name("locale")
           .description(
             "The preferable language to use for text targeted the end user. Note! The data " +

--- a/src/main/java/org/opentripplanner/model/TripTimeOnDate.java
+++ b/src/main/java/org/opentripplanner/model/TripTimeOnDate.java
@@ -169,7 +169,7 @@ public class TripTimeOnDate {
   public boolean isCanceledEffectively() {
     return (
       isCancelledStop() ||
-      tripTimes.isCanceled() ||
+      tripTimes.isCanceledOrDeleted() ||
       tripTimes.getTrip().getNetexAlteration().isCanceledOrReplaced()
     );
   }
@@ -213,13 +213,13 @@ public class TripTimeOnDate {
   }
 
   public PickDrop getPickupType() {
-    return tripTimes.isCanceled() || tripTimes.isCancelledStop(stopIndex)
+    return tripTimes.isCanceledOrDeleted() || tripTimes.isCancelledStop(stopIndex)
       ? PickDrop.CANCELLED
       : tripPattern.getBoardType(stopIndex);
   }
 
   public PickDrop getDropoffType() {
-    return tripTimes.isCanceled() || tripTimes.isCancelledStop(stopIndex)
+    return tripTimes.isCanceledOrDeleted() || tripTimes.isCancelledStop(stopIndex)
       ? PickDrop.CANCELLED
       : tripPattern.getAlightType(stopIndex);
   }

--- a/src/main/java/org/opentripplanner/model/TripTimeOnDate.java
+++ b/src/main/java/org/opentripplanner/model/TripTimeOnDate.java
@@ -13,12 +13,16 @@ import org.opentripplanner.transit.model.timetable.RealTimeState;
 import org.opentripplanner.transit.model.timetable.StopTimeKey;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripTimes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Represents a Trip at a specific stop index and on a specific service day. This is a read-only
  * data transfer object used to pass information from the OTP internal model to the APIs.
  */
 public class TripTimeOnDate {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TripTimeOnDate.class);
 
   public static final int UNDEFINED = -1;
 
@@ -213,13 +217,35 @@ public class TripTimeOnDate {
   }
 
   public PickDrop getPickupType() {
-    return tripTimes.isCanceledOrDeleted() || tripTimes.isCancelledStop(stopIndex)
+    if (tripTimes.isDeleted()) {
+      LOG.warn(
+        "Returning pickup type for a deleted trip {} on pattern {} on date {}. This indicates a bug.",
+        tripTimes.getTrip().getId(),
+        tripPattern.getId(),
+        serviceDate
+      );
+
+      return tripPattern.getBoardType(stopIndex);
+    }
+
+    return tripTimes.isCanceled() || tripTimes.isCancelledStop(stopIndex)
       ? PickDrop.CANCELLED
       : tripPattern.getBoardType(stopIndex);
   }
 
   public PickDrop getDropoffType() {
-    return tripTimes.isCanceledOrDeleted() || tripTimes.isCancelledStop(stopIndex)
+    if (tripTimes.isDeleted()) {
+      LOG.warn(
+        "Returning dropoff type for a deleted trip {} on pattern {} on date {}. This indicates a bug.",
+        tripTimes.getTrip().getId(),
+        tripPattern.getId(),
+        serviceDate
+      );
+
+      return tripPattern.getAlightType(stopIndex);
+    }
+
+    return tripTimes.isCanceled() || tripTimes.isCancelledStop(stopIndex)
       ? PickDrop.CANCELLED
       : tripPattern.getAlightType(stopIndex);
   }

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TripPatternForDateMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TripPatternForDateMapper.java
@@ -13,7 +13,6 @@ import java.util.stream.Collectors;
 import org.opentripplanner.model.Timetable;
 import org.opentripplanner.routing.algorithm.raptoradapter.transit.TripPatternForDate;
 import org.opentripplanner.transit.model.timetable.FrequencyEntry;
-import org.opentripplanner.transit.model.timetable.RealTimeState;
 import org.opentripplanner.transit.model.timetable.TripTimes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -72,7 +71,7 @@ public class TripPatternForDateMapper {
       if (!serviceCodesRunning.contains(tripTimes.getServiceCode())) {
         continue;
       }
-      if (tripTimes.getRealTimeState() == RealTimeState.CANCELED) {
+      if (tripTimes.isCanceledOrDeleted()) {
         continue;
       }
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TripPatternForDateMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TripPatternForDateMapper.java
@@ -71,7 +71,7 @@ public class TripPatternForDateMapper {
       if (!serviceCodesRunning.contains(tripTimes.getServiceCode())) {
         continue;
       }
-      if (tripTimes.isCanceledOrDeleted()) {
+      if (tripTimes.isDeleted()) {
         continue;
       }
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RouteRequestTransitDataProviderFilter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RouteRequestTransitDataProviderFilter.java
@@ -29,6 +29,8 @@ public class RouteRequestTransitDataProviderFilter implements TransitDataProvide
 
   private final boolean includePlannedCancellations;
 
+  private final boolean includeRealtimeCancellations;
+
   private final List<TransitFilter> filters;
 
   private final Set<FeedScopedId> bannedTrips;
@@ -46,6 +48,7 @@ public class RouteRequestTransitDataProviderFilter implements TransitDataProvide
       request.wheelchair(),
       request.preferences().wheelchair(),
       request.preferences().transit().includePlannedCancellations(),
+      request.preferences().transit().includeRealtimeCancellations(),
       Set.copyOf(request.journey().transit().bannedTrips()),
       bannedRoutes(request.journey().transit().filters(), transitService.getAllRoutes()),
       request.journey().transit().filters()
@@ -58,6 +61,7 @@ public class RouteRequestTransitDataProviderFilter implements TransitDataProvide
     boolean wheelchairEnabled,
     WheelchairPreferences wheelchairPreferences,
     boolean includePlannedCancellations,
+    boolean includeRealtimeCancellations,
     Set<FeedScopedId> bannedTrips,
     Set<FeedScopedId> bannedRoutes,
     List<TransitFilter> filters
@@ -66,6 +70,7 @@ public class RouteRequestTransitDataProviderFilter implements TransitDataProvide
     this.wheelchairEnabled = wheelchairEnabled;
     this.wheelchairPreferences = wheelchairPreferences;
     this.includePlannedCancellations = includePlannedCancellations;
+    this.includeRealtimeCancellations = includeRealtimeCancellations;
     this.bannedRoutes = Set.copyOf(bannedRoutes);
     this.bannedTrips = bannedTrips;
     this.filters = filters;
@@ -110,8 +115,13 @@ public class RouteRequestTransitDataProviderFilter implements TransitDataProvide
     }
 
     if (!includePlannedCancellations) {
-      //noinspection RedundantIfStatement
       if (trip.getNetexAlteration().isCanceledOrReplaced()) {
+        return false;
+      }
+    }
+
+    if (!includeRealtimeCancellations) {
+      if (tripTimes.isCanceled()) {
         return false;
       }
     }

--- a/src/main/java/org/opentripplanner/routing/api/request/preference/TransitPreferences.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/preference/TransitPreferences.java
@@ -31,6 +31,7 @@ public final class TransitPreferences implements Serializable {
   private final DoubleAlgorithmFunction unpreferredCost;
   private final boolean ignoreRealtimeUpdates;
   private final boolean includePlannedCancellations;
+  private final boolean includeRealtimeCancellations;
   private final RaptorPreferences raptor;
 
   private TransitPreferences() {
@@ -40,6 +41,7 @@ public final class TransitPreferences implements Serializable {
     this.unpreferredCost = createLinearFunction(0.0, DEFAULT_ROUTE_RELUCTANCE);
     this.ignoreRealtimeUpdates = false;
     this.includePlannedCancellations = false;
+    this.includeRealtimeCancellations = false;
     this.raptor = RaptorPreferences.DEFAULT;
   }
 
@@ -51,6 +53,7 @@ public final class TransitPreferences implements Serializable {
     this.unpreferredCost = requireNonNull(builder.unpreferredCost);
     this.ignoreRealtimeUpdates = builder.ignoreRealtimeUpdates;
     this.includePlannedCancellations = builder.includePlannedCancellations;
+    this.includeRealtimeCancellations = builder.includeRealtimeCancellations;
     this.raptor = requireNonNull(builder.raptor);
   }
 
@@ -139,6 +142,13 @@ public final class TransitPreferences implements Serializable {
   }
 
   /**
+   * When true, trips cancelled in by real-time updates are included in this search.
+   */
+  public boolean includeRealtimeCancellations() {
+    return includeRealtimeCancellations;
+  }
+
+  /**
    * Set of options to use with Raptor. These are available here for testing purposes.
    */
   public RaptorPreferences raptor() {
@@ -154,6 +164,7 @@ public final class TransitPreferences implements Serializable {
       otherThanPreferredRoutesPenalty == that.otherThanPreferredRoutesPenalty &&
       ignoreRealtimeUpdates == that.ignoreRealtimeUpdates &&
       includePlannedCancellations == that.includePlannedCancellations &&
+      includeRealtimeCancellations == that.includeRealtimeCancellations &&
       boardSlack.equals(that.boardSlack) &&
       alightSlack.equals(that.alightSlack) &&
       reluctanceForMode.equals(that.reluctanceForMode) &&
@@ -172,6 +183,7 @@ public final class TransitPreferences implements Serializable {
       unpreferredCost,
       ignoreRealtimeUpdates,
       includePlannedCancellations,
+      includeRealtimeCancellations,
       raptor
     );
   }
@@ -197,6 +209,10 @@ public final class TransitPreferences implements Serializable {
         "includePlannedCancellations",
         includePlannedCancellations != DEFAULT.includePlannedCancellations
       )
+      .addBoolIfTrue(
+        "includeRealtimeCancellations",
+        includeRealtimeCancellations != DEFAULT.includeRealtimeCancellations
+      )
       .addObj("raptor", raptor, DEFAULT.raptor)
       .toString();
   }
@@ -213,6 +229,7 @@ public final class TransitPreferences implements Serializable {
     private DoubleAlgorithmFunction unpreferredCost;
     private boolean ignoreRealtimeUpdates;
     private boolean includePlannedCancellations;
+    private boolean includeRealtimeCancellations;
     private RaptorPreferences raptor;
 
     public Builder(TransitPreferences original) {
@@ -224,6 +241,7 @@ public final class TransitPreferences implements Serializable {
       this.unpreferredCost = original.unpreferredCost;
       this.ignoreRealtimeUpdates = original.ignoreRealtimeUpdates;
       this.includePlannedCancellations = original.includePlannedCancellations;
+      this.includeRealtimeCancellations = original.includeRealtimeCancellations;
       this.raptor = original.raptor;
     }
 
@@ -276,6 +294,11 @@ public final class TransitPreferences implements Serializable {
 
     public Builder setIncludePlannedCancellations(boolean includePlannedCancellations) {
       this.includePlannedCancellations = includePlannedCancellations;
+      return this;
+    }
+
+    public Builder setIncludeRealtimeCancellations(boolean includeRealtimeCancellations) {
+      this.includeRealtimeCancellations = includeRealtimeCancellations;
       return this;
     }
 

--- a/src/main/java/org/opentripplanner/routing/stoptimes/StopTimesHelper.java
+++ b/src/main/java/org/opentripplanner/routing/stoptimes/StopTimesHelper.java
@@ -295,6 +295,10 @@ public class StopTimesHelper {
   }
 
   public static boolean skipByTripCancellation(TripTimes tripTimes, boolean includeCancellations) {
+    if (tripTimes.isDeleted()) {
+      return true;
+    }
+
     return (
       (tripTimes.isCanceled() || tripTimes.getTrip().getNetexAlteration().isCanceledOrReplaced()) &&
       !includeCancellations

--- a/src/main/java/org/opentripplanner/transit/model/timetable/RealTimeState.java
+++ b/src/main/java/org/opentripplanner/transit/model/timetable/RealTimeState.java
@@ -33,7 +33,8 @@ public enum RealTimeState {
   MODIFIED,
 
   /**
-   * The trip has been canceled, and should not be visible to the end user
+   * The trip should not be visible to the end user. Either it has been set as deleted in the
+   * real-time feed, or it has been replaced by another trip on another pattern.
    */
   DELETED,
 }

--- a/src/main/java/org/opentripplanner/transit/model/timetable/RealTimeState.java
+++ b/src/main/java/org/opentripplanner/transit/model/timetable/RealTimeState.java
@@ -31,4 +31,9 @@ public enum RealTimeState {
    * trip pattern of the scheduled trip.
    */
   MODIFIED,
+
+  /**
+   * The trip has been canceled, and should not be visible to the end user
+   */
+  DELETED,
 }

--- a/src/main/java/org/opentripplanner/transit/model/timetable/TripTimes.java
+++ b/src/main/java/org/opentripplanner/transit/model/timetable/TripTimes.java
@@ -337,10 +337,24 @@ public class TripTimes implements Serializable, Comparable<TripTimes> {
   }
 
   /**
+   * @return true if this TripTimes is canceled or soft-deleted
+   */
+  public boolean isCanceledOrDeleted() {
+    return isCanceled() || isDeleted();
+  }
+
+  /**
    * @return true if this TripTimes is canceled
    */
   public boolean isCanceled() {
     return realTimeState == RealTimeState.CANCELED;
+  }
+
+  /**
+   * @return true if this TripTimes is soft-deleted, and should not be visible to the user
+   */
+  public boolean isDeleted() {
+    return realTimeState == RealTimeState.DELETED;
   }
 
   /**
@@ -382,6 +396,11 @@ public class TripTimes implements Serializable, Comparable<TripTimes> {
   /** Cancel this entire trip */
   public void cancelTrip() {
     realTimeState = RealTimeState.CANCELED;
+  }
+
+  /** Soft delete the entire trip */
+  public void deleteTrip() {
+    realTimeState = RealTimeState.DELETED;
   }
 
   public void updateDepartureTime(final int stop, final int time) {

--- a/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotSource.java
+++ b/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotSource.java
@@ -291,8 +291,8 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
               tripId,
               serviceDate
             );
-            case CANCELED -> handleCanceledTrip(tripId, serviceDate);
-            case DELETED -> handleCanceledTrip(tripId, serviceDate);
+            case CANCELED -> handleCanceledTrip(tripId, serviceDate, false);
+            case DELETED -> handleCanceledTrip(tripId, serviceDate, true);
             case REPLACEMENT -> validateAndHandleModifiedTrip(
               tripUpdate,
               tripDescriptor,
@@ -430,9 +430,10 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
       return UpdateError.result(tripId, NO_UPDATES);
     }
 
-    // If this trip_id has been used for previously ADDED/MODIFIED trip message (e.g. when the sequence of stops has
-    // changed, and is now changing back to the originally scheduled one) cancel that previously created trip.
-    cancelPreviouslyAddedTrip(tripId, serviceDate);
+    // If this trip_id has been used for previously ADDED/MODIFIED trip message (e.g. when the
+    // sequence of stops has changed, and is now changing back to the originally scheduled one),
+    // mark that previously created trip as DELETED.
+    cancelPreviouslyAddedTrip(tripId, serviceDate, true);
 
     // Get new TripTimes based on scheduled timetable
     var result = pattern
@@ -469,7 +470,7 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
         pattern
       );
 
-      cancelScheduledTrip(tripId, serviceDate);
+      cancelScheduledTrip(tripId, serviceDate, true);
       return buffer.update(newPattern, updatedTripTimes, serviceDate);
     } else {
       // Set the updated trip times in the buffer
@@ -676,9 +677,9 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
       "number of stop should match the number of stop time updates"
     );
 
-    // Check whether trip id has been used for previously ADDED trip message and cancel
-    // previously created trip
-    cancelPreviouslyAddedTrip(tripId, serviceDate);
+    // Check whether trip id has been used for previously ADDED trip message and mark previously
+    // created trip as DELETED
+    cancelPreviouslyAddedTrip(tripId, serviceDate, true);
 
     Route route = getOrCreateRoute(tripDescriptor, tripId);
 
@@ -926,7 +927,11 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
    * @param serviceDate service date
    * @return true if scheduled trip was cancelled
    */
-  private boolean cancelScheduledTrip(final FeedScopedId tripId, final LocalDate serviceDate) {
+  private boolean cancelScheduledTrip(
+    final FeedScopedId tripId,
+    final LocalDate serviceDate,
+    boolean markAsDeleted
+  ) {
     boolean success = false;
 
     final TripPattern pattern = getPatternForTripId(tripId);
@@ -939,7 +944,11 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
         debug(tripId, "Could not cancel scheduled trip because it's not in the timetable");
       } else {
         final TripTimes newTripTimes = new TripTimes(timetable.getTripTimes(tripIndex));
-        newTripTimes.cancelTrip();
+        if (markAsDeleted) {
+          newTripTimes.deleteTrip();
+        } else {
+          newTripTimes.cancelTrip();
+        }
         buffer.update(pattern, newTripTimes, serviceDate);
         success = true;
       }
@@ -962,7 +971,8 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
    */
   private boolean cancelPreviouslyAddedTrip(
     final FeedScopedId tripId,
-    final LocalDate serviceDate
+    final LocalDate serviceDate,
+    boolean markAsDeleted
   ) {
     boolean success = false;
 
@@ -975,7 +985,11 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
         debug(tripId, "Could not cancel previously added trip on {}", serviceDate);
       } else {
         final TripTimes newTripTimes = new TripTimes(timetable.getTripTimes(tripIndex));
-        newTripTimes.cancelTrip();
+        if (markAsDeleted) {
+          newTripTimes.deleteTrip();
+        } else {
+          newTripTimes.cancelTrip();
+        }
         buffer.update(pattern, newTripTimes, serviceDate);
         success = true;
       }
@@ -1072,13 +1086,13 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
       "number of stop should match the number of stop time updates"
     );
 
-    // Cancel scheduled trip
+    // Mark scheduled trip as DELETED
     var tripId = trip.getId();
-    cancelScheduledTrip(tripId, serviceDate);
+    cancelScheduledTrip(tripId, serviceDate, true);
 
-    // Check whether trip id has been used for previously ADDED/REPLACEMENT trip message and cancel
-    // previously created trip
-    cancelPreviouslyAddedTrip(tripId, serviceDate);
+    // Check whether trip id has been used for previously ADDED/REPLACEMENT trip message and mark it
+    // as DELETED
+    cancelPreviouslyAddedTrip(tripId, serviceDate, true);
 
     // Add new trip
     return addTripToGraphAndBuffer(
@@ -1093,13 +1107,18 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
 
   private Result<UpdateSuccess, UpdateError> handleCanceledTrip(
     FeedScopedId tripId,
-    final LocalDate serviceDate
+    final LocalDate serviceDate,
+    boolean markAsDeleted
   ) {
     // Try to cancel scheduled trip
-    final boolean cancelScheduledSuccess = cancelScheduledTrip(tripId, serviceDate);
+    final boolean cancelScheduledSuccess = cancelScheduledTrip(tripId, serviceDate, markAsDeleted);
 
     // Try to cancel previously added trip
-    final boolean cancelPreviouslyAddedSuccess = cancelPreviouslyAddedTrip(tripId, serviceDate);
+    final boolean cancelPreviouslyAddedSuccess = cancelPreviouslyAddedTrip(
+      tripId,
+      serviceDate,
+      markAsDeleted
+    );
 
     if (!cancelScheduledSuccess && !cancelPreviouslyAddedSuccess) {
       debug(tripId, "No pattern found for tripId. Skipping cancellation.");

--- a/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotSource.java
+++ b/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotSource.java
@@ -291,8 +291,8 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
               tripId,
               serviceDate
             );
-            case CANCELED -> handleCanceledTrip(tripId, serviceDate, false);
-            case DELETED -> handleCanceledTrip(tripId, serviceDate, true);
+            case CANCELED -> handleCanceledTrip(tripId, serviceDate, CancelationType.CANCEL);
+            case DELETED -> handleCanceledTrip(tripId, serviceDate, CancelationType.DELETE);
             case REPLACEMENT -> validateAndHandleModifiedTrip(
               tripUpdate,
               tripDescriptor,
@@ -433,7 +433,7 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
     // If this trip_id has been used for previously ADDED/MODIFIED trip message (e.g. when the
     // sequence of stops has changed, and is now changing back to the originally scheduled one),
     // mark that previously created trip as DELETED.
-    cancelPreviouslyAddedTrip(tripId, serviceDate, true);
+    cancelPreviouslyAddedTrip(tripId, serviceDate, CancelationType.DELETE);
 
     // Get new TripTimes based on scheduled timetable
     var result = pattern
@@ -470,7 +470,7 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
         pattern
       );
 
-      cancelScheduledTrip(tripId, serviceDate, true);
+      cancelScheduledTrip(tripId, serviceDate, CancelationType.DELETE);
       return buffer.update(newPattern, updatedTripTimes, serviceDate);
     } else {
       // Set the updated trip times in the buffer
@@ -679,7 +679,7 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
 
     // Check whether trip id has been used for previously ADDED trip message and mark previously
     // created trip as DELETED
-    cancelPreviouslyAddedTrip(tripId, serviceDate, true);
+    cancelPreviouslyAddedTrip(tripId, serviceDate, CancelationType.DELETE);
 
     Route route = getOrCreateRoute(tripDescriptor, tripId);
 
@@ -930,7 +930,7 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
   private boolean cancelScheduledTrip(
     final FeedScopedId tripId,
     final LocalDate serviceDate,
-    boolean markAsDeleted
+    CancelationType cancelationType
   ) {
     boolean success = false;
 
@@ -944,10 +944,9 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
         debug(tripId, "Could not cancel scheduled trip because it's not in the timetable");
       } else {
         final TripTimes newTripTimes = new TripTimes(timetable.getTripTimes(tripIndex));
-        if (markAsDeleted) {
-          newTripTimes.deleteTrip();
-        } else {
-          newTripTimes.cancelTrip();
+        switch (cancelationType) {
+          case CANCEL -> newTripTimes.cancelTrip();
+          case DELETE -> newTripTimes.deleteTrip();
         }
         buffer.update(pattern, newTripTimes, serviceDate);
         success = true;
@@ -972,7 +971,7 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
   private boolean cancelPreviouslyAddedTrip(
     final FeedScopedId tripId,
     final LocalDate serviceDate,
-    boolean markAsDeleted
+    CancelationType cancelationType
   ) {
     boolean success = false;
 
@@ -985,10 +984,9 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
         debug(tripId, "Could not cancel previously added trip on {}", serviceDate);
       } else {
         final TripTimes newTripTimes = new TripTimes(timetable.getTripTimes(tripIndex));
-        if (markAsDeleted) {
-          newTripTimes.deleteTrip();
-        } else {
-          newTripTimes.cancelTrip();
+        switch (cancelationType) {
+          case CANCEL -> newTripTimes.cancelTrip();
+          case DELETE -> newTripTimes.deleteTrip();
         }
         buffer.update(pattern, newTripTimes, serviceDate);
         success = true;
@@ -1088,11 +1086,11 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
 
     // Mark scheduled trip as DELETED
     var tripId = trip.getId();
-    cancelScheduledTrip(tripId, serviceDate, true);
+    cancelScheduledTrip(tripId, serviceDate, CancelationType.DELETE);
 
     // Check whether trip id has been used for previously ADDED/REPLACEMENT trip message and mark it
     // as DELETED
-    cancelPreviouslyAddedTrip(tripId, serviceDate, true);
+    cancelPreviouslyAddedTrip(tripId, serviceDate, CancelationType.DELETE);
 
     // Add new trip
     return addTripToGraphAndBuffer(
@@ -1108,7 +1106,7 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
   private Result<UpdateSuccess, UpdateError> handleCanceledTrip(
     FeedScopedId tripId,
     final LocalDate serviceDate,
-    boolean markAsDeleted
+    CancelationType markAsDeleted
   ) {
     // Try to cancel scheduled trip
     final boolean cancelScheduledSuccess = cancelScheduledTrip(tripId, serviceDate, markAsDeleted);
@@ -1162,5 +1160,10 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
   private static void debug(String feedId, String tripId, String message, Object... params) {
     String m = "[feedId: %s, tripId: %s] %s".formatted(feedId, tripId, message);
     LOG.debug(m, params);
+  }
+
+  private enum CancelationType {
+    CANCEL,
+    DELETE,
   }
 }

--- a/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotSource.java
+++ b/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotSource.java
@@ -292,6 +292,7 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
               serviceDate
             );
             case CANCELED -> handleCanceledTrip(tripId, serviceDate);
+            case DELETED -> handleCanceledTrip(tripId, serviceDate);
             case REPLACEMENT -> validateAndHandleModifiedTrip(
               tripUpdate,
               tripDescriptor,

--- a/src/main/proto/gtfs-realtime.proto
+++ b/src/main/proto/gtfs-realtime.proto
@@ -216,9 +216,9 @@ message TripUpdate {
     // Expected occupancy after departure from the given stop.
     // Should be provided only for future stops.
     // In order to provide departure_occupancy_status without either arrival or
-    // departure StopTimeEvents, ScheduleRelationship should be set to NO_DATA. 
+    // departure StopTimeEvents, ScheduleRelationship should be set to NO_DATA.
     optional VehiclePosition.OccupancyStatus departure_occupancy_status = 7;
-    
+
     // The relation between the StopTimeEvents and the static schedule.
     enum ScheduleRelationship {
       // The vehicle is proceeding in accordance with its static schedule of
@@ -250,7 +250,7 @@ message TripUpdate {
       UNSCHEDULED = 3;
     }
     optional ScheduleRelationship schedule_relationship = 5
-        [default = SCHEDULED];
+    [default = SCHEDULED];
 
     // Provides the updated values for the stop time.
     // NOTE: This message is still experimental, and subject to change. It may be formally adopted in the future.
@@ -340,7 +340,7 @@ message TripUpdate {
   optional int32 delay = 5;
 
   // Defines updated properties of the trip, such as a new shape_id when there is a detour. Or defines the
-  // trip_id, start_date, and start_time of a DUPLICATED trip. 
+  // trip_id, start_date, and start_time of a DUPLICATED trip.
   // NOTE: This message is still experimental, and subject to change. It may be formally adopted in the future.
   message TripProperties {
     // Defines the identifier of a new trip that is a duplicate of an existing trip defined in (CSV) GTFS trips.txt
@@ -374,7 +374,7 @@ message TripUpdate {
     // or a Shape in the (protobuf) real-time feed. The order of stops (stop sequences) for this trip must remain the same as
     // (CSV) GTFS. Stops that are a part of the original trip but will no longer be made, such as when a detour occurs, should
     // be marked as schedule_relationship=SKIPPED.
-    // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future. 
+    // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
     optional string shape_id = 4;
 
     // The extensions namespace allows 3rd-party developers to extend the
@@ -450,7 +450,7 @@ message VehiclePosition {
   // The state of passenger occupancy for the vehicle or carriage.
   // Individual producers may not publish all OccupancyStatus values. Therefore, consumers
   // must not assume that the OccupancyStatus values follow a linear scale.
-  // Consumers should represent OccupancyStatus values as the state indicated 
+  // Consumers should represent OccupancyStatus values as the state indicated
   // and intended by the producer. Likewise, producers must use OccupancyStatus values that
   // correspond to actual vehicle occupancy states.
   // For describing passenger occupancy levels on a linear scale, see `occupancy_percentage`.
@@ -504,7 +504,7 @@ message VehiclePosition {
   // including both seated and standing capacity, and current operating regulations allow.
   // The value may exceed 100 if there are more passengers than the maximum designed capacity.
   // The precision of occupancy_percentage should be low enough that individual passengers cannot be tracked boarding or alighting the vehicle.
-  // If multi_carriage_status is populated with per-carriage occupancy_percentage, 
+  // If multi_carriage_status is populated with per-carriage occupancy_percentage,
   // then this field should describe the entire vehicle with all carriages accepting passengers considered.
   // This field is still experimental, and subject to change. It may be formally adopted in the future.
   optional uint32 occupancy_percentage = 10;
@@ -539,7 +539,7 @@ message VehiclePosition {
     // For example, the first carriage in the direction of travel has a value of 1.
     // If the second carriage in the direction of travel has a value of 3,
     // consumers will discard data for all carriages (i.e., the multi_carriage_details field).
-    // Carriages without data must be represented with a valid carriage_sequence number and the fields 
+    // Carriages without data must be represented with a valid carriage_sequence number and the fields
     // without data should be omitted (alternately, those fields could also be included and set to the "no data" values).
     // This message/field is still experimental, and subject to change. It may be formally adopted in the future.
     optional uint32 carriage_sequence = 5;
@@ -554,12 +554,12 @@ message VehiclePosition {
   }
 
   // Details of the multiple carriages of this given vehicle.
-  // The first occurrence represents the first carriage of the vehicle, 
-  // given the current direction of travel. 
-  // The number of occurrences of the multi_carriage_details 
+  // The first occurrence represents the first carriage of the vehicle,
+  // given the current direction of travel.
+  // The number of occurrences of the multi_carriage_details
   // field represents the number of carriages of the vehicle.
-  // It also includes non boardable carriages, 
-  // like engines, maintenance carriages, etc… as they provide valuable 
+  // It also includes non boardable carriages,
+  // like engines, maintenance carriages, etc… as they provide valuable
   // information to passengers about where to stand on a platform.
   // This message/field is still experimental, and subject to change. It may be formally adopted in the future.
   repeated CarriageDetails multi_carriage_details = 11;
@@ -583,7 +583,7 @@ message Alert {
   // Entities whose users we should notify of this alert.
   repeated EntitySelector informed_entity = 5;
 
-  // Cause of this alert.
+  // Cause of this alert. If cause_detail is included, then Cause must also be included.
   enum Cause {
     UNKNOWN_CAUSE = 1;
     OTHER_CAUSE = 2;        // Not machine-representable.
@@ -600,7 +600,7 @@ message Alert {
   }
   optional Cause cause = 6 [default = UNKNOWN_CAUSE];
 
-  // What is the effect of this problem on the affected entity.
+  // What is the effect of this problem on the affected entity. If effect_detail is included, then Effect must also be included.
   enum Effect {
     NO_SERVICE = 1;
     REDUCED_SERVICE = 2;
@@ -639,23 +639,32 @@ message Alert {
 
   // Severity of this alert.
   enum SeverityLevel {
-	UNKNOWN_SEVERITY = 1;
-	INFO = 2;
-	WARNING = 3;
-	SEVERE = 4;
+    UNKNOWN_SEVERITY = 1;
+    INFO = 2;
+    WARNING = 3;
+    SEVERE = 4;
   }
 
   optional SeverityLevel severity_level = 14 [default = UNKNOWN_SEVERITY];
 
   // TranslatedImage to be displayed along the alert text. Used to explain visually the alert effect of a detour, station closure, etc. The image must enhance the understanding of the alert. Any essential information communicated within the image must also be contained in the alert text.
-  // The following types of images are discouraged : image containing mainly text, marketing or branded images that add no additional information. 
+  // The following types of images are discouraged : image containing mainly text, marketing or branded images that add no additional information.
   // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
-  optional TranslatedImage image = 15; 
+  optional TranslatedImage image = 15;
 
   // Text describing the appearance of the linked image in the `image` field (e.g., in case the image can't be displayed
   // or the user can't see the image for accessibility reasons). See the HTML spec for alt image text - https://html.spec.whatwg.org/#alt.
   // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
   optional TranslatedString image_alternative_text = 16;
+
+
+  // Description of the cause of the alert that allows for agency-specific language; more specific than the Cause. If cause_detail is included, then Cause must also be included.
+  // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
+  optional TranslatedString cause_detail = 17;
+
+  // Description of the effect of the alert that allows for agency-specific language; more specific than the Effect. If effect_detail is included, then Effect must also be included.
+  // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
+  optional TranslatedString effect_detail = 18;
 
   // The extensions namespace allows 3rd-party developers to extend the
   // GTFS Realtime Specification in order to add and evaluate new features
@@ -799,7 +808,7 @@ message TripDescriptor {
     CANCELED = 3;
 
     // Should not be used - for backwards-compatibility only.
-    REPLACEMENT = 5 [deprecated=true];
+    REPLACEMENT = 5 [deprecated = true];
 
     // An extra trip that was added in addition to a running schedule, for example, to replace a broken vehicle or to
     // respond to sudden passenger load. Used with TripUpdate.TripProperties.trip_id, TripUpdate.TripProperties.start_date,
@@ -808,8 +817,8 @@ message TripDescriptor {
     // (in calendar.txt or calendar_dates.txt) is operating within the next 30 days. The trip to be duplicated is
     // identified via TripUpdate.TripDescriptor.trip_id. This enumeration does not modify the existing trip referenced by
     // TripUpdate.TripDescriptor.trip_id - if a producer wants to cancel the original trip, it must publish a separate
-    // TripUpdate with the value of CANCELED. Trips defined in GTFS frequencies.txt with exact_times that is empty or
-    // equal to 0 cannot be duplicated. The VehiclePosition.TripDescriptor.trip_id for the new trip must contain
+    // TripUpdate with the value of CANCELED or DELETED. Trips defined in GTFS frequencies.txt with exact_times that is
+    // empty or equal to 0 cannot be duplicated. The VehiclePosition.TripDescriptor.trip_id for the new trip must contain
     // the matching value from TripUpdate.TripProperties.trip_id and VehiclePosition.TripDescriptor.ScheduleRelationship
     // must also be set to DUPLICATED.
     // Existing producers and consumers that were using the ADDED enumeration to represent duplicated trips must follow
@@ -817,6 +826,17 @@ message TripDescriptor {
     // to transition to the DUPLICATED enumeration.
     // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
     DUPLICATED = 6;
+
+
+    // A trip that existed in the schedule but was removed and must not be shown to users.
+    // DELETED should be used instead of CANCELED to indicate that a transit provider would like to entirely remove
+    // information about the corresponding trip from consuming applications, so the trip is not shown as cancelled to
+    // riders, e.g. a trip that is entirely being replaced by another trip.
+    // This designation becomes particularly important if several trips are cancelled and replaced with substitute service.
+    // If consumers were to show explicit information about the cancellations it would distract from the more important
+    // real-time predictions.
+    // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
+    DELETED = 7;
   }
   optional ScheduleRelationship schedule_relationship = 4;
 
@@ -950,12 +970,12 @@ message TranslatedString {
 message TranslatedImage {
   message LocalizedImage {
     // String containing an URL linking to an image
-    // The image linked must be less than 2MB. 
+    // The image linked must be less than 2MB.
     // If an image changes in a significant enough way that an update is required on the consumer side, the producer must update the URL to a new one.
-    // The URL should be a fully qualified URL that includes http:// or https://, and any special characters in the URL must be correctly escaped. See the following http://www.w3.org/Addressing/URL/4_URI_Recommentations.html for a description of how to create fully qualified URL values.
+    // The URL should be a fully qualified URL that includes http:// or https://, and any special characters in the URL must be correctly escaped. See the following http://www.w3.org/Addressing/URL/4_URI_Recommentations.html for a description of how to create fully qualified URL values.
     required string url = 1;
 
-    // IANA media type as to specify the type of image to be displayed. 
+    // IANA media type as to specify the type of image to be displayed.
     // The type must start with "image/"
     required string media_type = 2;
 
@@ -997,7 +1017,7 @@ message Shape {
   // See https://developers.google.com/protocol-buffers/docs/proto#specifying_field_rules
   // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
   optional string shape_id = 1;
-  
+
   // Encoded polyline representation of the shape. This polyline must contain at least two points.
   // For more information about encoded polylines, see https://developers.google.com/maps/documentation/utilities/polylinealgorithm
   // This field is required as per reference.md, but needs to be specified here optional because "Required is Forever"

--- a/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RouteRequestTransitDataProviderFilterTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/RouteRequestTransitDataProviderFilterTest.java
@@ -86,6 +86,7 @@ public class RouteRequestTransitDataProviderFilterTest {
       true,
       DEFAULT_ACCESSIBILITY,
       false,
+      false,
       Set.of(),
       Set.of(),
       List.of(AllowAllTransitFilter.of())
@@ -110,6 +111,7 @@ public class RouteRequestTransitDataProviderFilterTest {
       false,
       DEFAULT_ACCESSIBILITY,
       false,
+      false,
       Set.of(),
       Set.of(),
       filterForMode(TransitMode.BUS)
@@ -128,6 +130,7 @@ public class RouteRequestTransitDataProviderFilterTest {
       false,
       false,
       DEFAULT_ACCESSIBILITY,
+      false,
       false,
       Set.of(),
       Set.of(ROUTE.getId()),
@@ -155,6 +158,7 @@ public class RouteRequestTransitDataProviderFilterTest {
       false,
       false,
       DEFAULT_ACCESSIBILITY,
+      false,
       false,
       Set.of(TRIP_ID),
       Set.of(),
@@ -209,6 +213,7 @@ public class RouteRequestTransitDataProviderFilterTest {
       false,
       DEFAULT_ACCESSIBILITY,
       false,
+      false,
       Set.of(),
       Set.of(),
       filterForMode(TransitMode.BUS)
@@ -235,6 +240,7 @@ public class RouteRequestTransitDataProviderFilterTest {
       true,
       true,
       WheelchairPreferences.DEFAULT,
+      false,
       false,
       Set.of(),
       Set.of(),
@@ -263,6 +269,7 @@ public class RouteRequestTransitDataProviderFilterTest {
       true,
       WheelchairPreferences.DEFAULT,
       false,
+      false,
       Set.of(),
       Set.of(),
       List.of(AllowAllTransitFilter.of())
@@ -290,6 +297,7 @@ public class RouteRequestTransitDataProviderFilterTest {
       true,
       WheelchairPreferences.DEFAULT,
       false,
+      false,
       Set.of(),
       Set.of(),
       filterForMode(TransitMode.BUS)
@@ -316,6 +324,7 @@ public class RouteRequestTransitDataProviderFilterTest {
       false,
       true,
       WheelchairPreferences.DEFAULT,
+      false,
       false,
       Set.of(),
       Set.of(),
@@ -356,6 +365,7 @@ public class RouteRequestTransitDataProviderFilterTest {
       false,
       WheelchairPreferences.DEFAULT,
       true,
+      false,
       Set.of(),
       Set.of(),
       filterForMode(TransitMode.BUS)
@@ -377,6 +387,7 @@ public class RouteRequestTransitDataProviderFilterTest {
       false,
       DEFAULT_ACCESSIBILITY,
       false,
+      false,
       Set.of(),
       Set.of(),
       List.of(AllowAllTransitFilter.of())
@@ -389,6 +400,74 @@ public class RouteRequestTransitDataProviderFilterTest {
 
     // When
     boolean valid4 = filter2.tripTimesPredicate(tripTimesWithReplaced, true);
+    // Then
+    assertFalse(valid4);
+  }
+
+  @Test
+  public void includeRealtimeCancellationsTest() {
+    TripTimes tripTimes = createTestTripTimes(
+      TRIP_ID,
+      ROUTE,
+      BikeAccess.NOT_ALLOWED,
+      TransitMode.BUS,
+      null,
+      Accessibility.NOT_POSSIBLE,
+      TripAlteration.PLANNED
+    );
+
+    TripTimes tripTimesWithCancellation = createTestTripTimes(
+      TRIP_ID,
+      ROUTE,
+      BikeAccess.NOT_ALLOWED,
+      TransitMode.BUS,
+      null,
+      Accessibility.NOT_POSSIBLE,
+      TripAlteration.PLANNED
+    );
+    tripTimesWithCancellation.cancelTrip();
+
+    // Given
+    var filter1 = new RouteRequestTransitDataProviderFilter(
+      false,
+      false,
+      WheelchairPreferences.DEFAULT,
+      false,
+      true,
+      Set.of(),
+      Set.of(),
+      filterForMode(TransitMode.BUS)
+    );
+
+    // When
+    boolean valid1 = filter1.tripTimesPredicate(tripTimes, true);
+    // Then
+    assertTrue(valid1);
+
+    // When
+    boolean valid2 = filter1.tripTimesPredicate(tripTimesWithCancellation, true);
+    // Then
+    assertTrue(valid2);
+
+    // Given
+    var filter2 = new RouteRequestTransitDataProviderFilter(
+      false,
+      false,
+      DEFAULT_ACCESSIBILITY,
+      false,
+      false,
+      Set.of(),
+      Set.of(),
+      List.of(AllowAllTransitFilter.of())
+    );
+
+    // When
+    boolean valid3 = filter2.tripTimesPredicate(tripTimes, true);
+    // Then
+    assertTrue(valid3);
+
+    // When
+    boolean valid4 = filter2.tripTimesPredicate(tripTimesWithCancellation, true);
     // Then
     assertFalse(valid4);
   }
@@ -491,6 +570,7 @@ public class RouteRequestTransitDataProviderFilterTest {
       true,
       DEFAULT_ACCESSIBILITY,
       false,
+      false,
       Set.of(),
       Set.of(),
       filterForMode(TransitMode.BUS)
@@ -513,6 +593,7 @@ public class RouteRequestTransitDataProviderFilterTest {
       false,
       false,
       DEFAULT_ACCESSIBILITY,
+      false,
       false,
       Set.of(),
       Set.of(),

--- a/src/test/java/org/opentripplanner/routing/api/request/preference/TransitPreferencesTest.java
+++ b/src/test/java/org/opentripplanner/routing/api/request/preference/TransitPreferencesTest.java
@@ -31,6 +31,7 @@ class TransitPreferencesTest {
   private static final SearchDirection RAPTOR_SEARCH_DIRECTION = SearchDirection.REVERSE;
   private static final boolean IGNORE_REALTIME_UPDATES = true;
   private static final boolean INCLUDE_PLANNED_CANCELLATIONS = true;
+  private static final boolean INCLUDE_REALTIME_CANCELLATIONS = true;
 
   private final TransitPreferences subject = TransitPreferences
     .of()
@@ -41,6 +42,7 @@ class TransitPreferencesTest {
     .withAlightSlack(b -> b.withDefault(D15s).with(TransitMode.AIRPLANE, D25m))
     .setIgnoreRealtimeUpdates(IGNORE_REALTIME_UPDATES)
     .setIncludePlannedCancellations(INCLUDE_PLANNED_CANCELLATIONS)
+    .setIncludeRealtimeCancellations(INCLUDE_REALTIME_CANCELLATIONS)
     .withRaptor(b -> b.withSearchDirection(RAPTOR_SEARCH_DIRECTION))
     .build();
 
@@ -84,6 +86,12 @@ class TransitPreferencesTest {
   }
 
   @Test
+  void includeRealtimeCancellations() {
+    assertFalse(TransitPreferences.DEFAULT.includeRealtimeCancellations());
+    assertTrue(subject.includeRealtimeCancellations());
+  }
+
+  @Test
   void raptorOptions() {
     assertEquals(RAPTOR_SEARCH_DIRECTION, subject.raptor().searchDirection());
   }
@@ -111,6 +119,7 @@ class TransitPreferencesTest {
       "unpreferredCost: f(x) = 300 + 1.15 x, " +
       "ignoreRealtimeUpdates, " +
       "includePlannedCancellations, " +
+      "includeRealtimeCancellations, " +
       "raptor: RaptorPreferences{searchDirection: REVERSE}" +
       "}",
       subject.toString()

--- a/src/test/java/org/opentripplanner/updater/trip/TimetableSnapshotSourceTest.java
+++ b/src/test/java/org/opentripplanner/updater/trip/TimetableSnapshotSourceTest.java
@@ -357,7 +357,7 @@ public class TimetableSnapshotSourceTest {
         originalTripIndexScheduled
       );
       assertFalse(
-        originalTripTimesScheduled.isCanceled(),
+        originalTripTimesScheduled.isCanceledOrDeleted(),
         "Original trip times should not be canceled in scheduled time table"
       );
       assertEquals(RealTimeState.SCHEDULED, originalTripTimesScheduled.getRealTimeState());
@@ -371,10 +371,10 @@ public class TimetableSnapshotSourceTest {
         originalTripIndexForToday
       );
       assertTrue(
-        originalTripTimesForToday.isCanceled(),
-        "Original trip times should be canceled in time table for service date"
+        originalTripTimesForToday.isDeleted(),
+        "Original trip times should be deleted in time table for service date"
       );
-      assertEquals(RealTimeState.CANCELED, originalTripTimesForToday.getRealTimeState());
+      assertEquals(RealTimeState.DELETED, originalTripTimesForToday.getRealTimeState());
     }
 
     // New trip pattern
@@ -525,7 +525,7 @@ public class TimetableSnapshotSourceTest {
         originalTripIndexScheduled
       );
       assertFalse(
-        originalTripTimesScheduled.isCanceled(),
+        originalTripTimesScheduled.isCanceledOrDeleted(),
         "Original trip times should not be canceled in scheduled time table"
       );
       assertEquals(RealTimeState.SCHEDULED, originalTripTimesScheduled.getRealTimeState());
@@ -610,7 +610,7 @@ public class TimetableSnapshotSourceTest {
           originalTripIndexScheduled
         );
         assertFalse(
-          originalTripTimesScheduled.isCanceled(),
+          originalTripTimesScheduled.isCanceledOrDeleted(),
           "Original trip times should not be canceled in scheduled time table"
         );
         assertEquals(RealTimeState.SCHEDULED, originalTripTimesScheduled.getRealTimeState());
@@ -623,8 +623,12 @@ public class TimetableSnapshotSourceTest {
         final TripTimes originalTripTimesForToday = originalTimetableForToday.getTripTimes(
           originalTripIndexForToday
         );
-        // original trip should be canceled
-        assertEquals(RealTimeState.CANCELED, originalTripTimesForToday.getRealTimeState());
+        assertTrue(
+          originalTripTimesForToday.isDeleted(),
+          "Original trip times should be deleted in time table for service date"
+        );
+        // original trip should be deleted
+        assertEquals(RealTimeState.DELETED, originalTripTimesForToday.getRealTimeState());
       }
 
       // New trip pattern
@@ -731,8 +735,12 @@ public class TimetableSnapshotSourceTest {
         final TripTimes originalTripTimesForToday = originalTimetableForToday.getTripTimes(
           originalTripIndexForToday
         );
+        assertTrue(
+          originalTripTimesForToday.isDeleted(),
+          "Original trip times should be deleted in time table for service date"
+        );
         // original trip should be canceled
-        assertEquals(RealTimeState.CANCELED, originalTripTimesForToday.getRealTimeState());
+        assertEquals(RealTimeState.DELETED, originalTripTimesForToday.getRealTimeState());
       }
 
       // New trip pattern


### PR DESCRIPTION
### Summary

GTFS-RT recently added a `DELETED` real-time state in https://github.com/google/transit/pull/352. Add support for this, as well as refactoring the internals of OTP, so that trips replaced by other patterns are marked as `DELETED`, while only real cancellations are marked as `CANCELED`. This also enables us to add a field `includeRealtimeCancellations` in the Transmodel API
