### PR TITLE
docs: Add transitGeneralizedCostLimit fields in documentation

### DIFF
--- a/docs/RouteRequest.md
+++ b/docs/RouteRequest.md
@@ -96,6 +96,8 @@ and in the [transferRequests in build-config.json](BuildConfiguration.md#transfe
 |    [parkAndRideDurationRatio](#rd_if_parkAndRideDurationRatio)                                       |        `double`        | Filter P+R routes that consist of driving and walking by the minimum fraction of the driving using of _time_.                      | *Optional* | `0.0`                    |  2.1  |
 |    [removeItinerariesWithSameRoutesAndStops](#rd_if_removeItinerariesWithSameRoutesAndStops)         |        `boolean`       | Set to true if you want to list only the first itinerary  which goes through the same stops and routes.                            | *Optional* | `false`                  |  2.2  |
 |    [transitGeneralizedCostLimit](#rd_if_transitGeneralizedCostLimit)                                 |        `object`        | A relative limit for the generalized-cost for transit itineraries.                                                                 | *Optional* |                          |  2.1  |
+|       [costLimitFunction](#rd_if_transitGeneralizedCostLimit_costLimitFunction)                      |    `linear-function`   | The base function used by the filter.                                                                                              | *Optional* | `"f(x) = 900 + 1.5 x"`   |  2.2  |
+|       [intervalRelaxFactor](#rd_if_transitGeneralizedCostLimit_intervalRelaxFactor)                  |        `double`        | How much the filter should be relaxed for itineraries that do not overlap in time.                                                 | *Optional* | `0.4`                    |  2.2  |
 | [maxAccessEgressDurationForMode](#rd_maxAccessEgressDurationForMode)                                 | `enum map of duration` | Limit access/egress per street mode.                                                                                               | *Optional* |                          |  2.1  |
 | [maxDirectStreetDurationForMode](#rd_maxDirectStreetDurationForMode)                                 | `enum map of duration` | Limit direct route duration per street mode.                                                                                       | *Optional* |                          |  2.2  |
 | [requiredVehicleParkingTags](#rd_requiredVehicleParkingTags)                                         |       `string[]`       | Tags which are required to use a vehicle parking. If empty, no tags are required.                                                  | *Optional* |                          |  2.1  |
@@ -544,6 +546,27 @@ dropped. The `transitGeneralizedCostLimit` is calculated using the `costLimitFun
 `intervalRelaxFactor` multiplied with the interval in seconds. To set the `costLimitFunction` to be
 _1 hour plus 2 times cost_ use: `3600 + 2.0 x`. To set an absolute value(3000s) use: `3000 + 0x`
 
+
+<h3 id="rd_if_transitGeneralizedCostLimit_costLimitFunction">costLimitFunction</h3>
+
+**Since version:** `2.2` ∙ **Type:** `linear-function` ∙ **Cardinality:** `Optional` ∙ **Default value:** `"f(x) = 900 + 1.5 x"`   
+**Path:** /routingDefaults/itineraryFilters/transitGeneralizedCostLimit 
+
+The base function used by the filter.
+
+This function calculates the threshold for the filter, when the itineraries have exactly the same arrival and departure times.
+
+<h3 id="rd_if_transitGeneralizedCostLimit_intervalRelaxFactor">intervalRelaxFactor</h3>
+
+**Since version:** `2.2` ∙ **Type:** `double` ∙ **Cardinality:** `Optional` ∙ **Default value:** `0.4`   
+**Path:** /routingDefaults/itineraryFilters/transitGeneralizedCostLimit 
+
+How much the filter should be relaxed for itineraries that do not overlap in time.
+
+This value is used to increase the filter threshold for itineraries further away in
+time, compared to those, that have exactly the same arrival and departure times.
+
+The unit is cost unit per second of time difference.
 
 <h3 id="rd_maxAccessEgressDurationForMode">maxAccessEgressDurationForMode</h3>
 

--- a/docs/RouterConfiguration.md
+++ b/docs/RouterConfiguration.md
@@ -430,7 +430,10 @@ Http headers.
       "BIKE_RENTAL" : "20m"
     },
     "itineraryFilters" : {
-      "transitGeneralizedCostLimit" : "3600 + 2.5 x",
+      "transitGeneralizedCostLimit" : {
+        "costLimitFunction" : "900 + 1.5 x",
+        "intervalRelaxFactor" : 0.4
+      },
       "bikeRentalDistanceRatio" : 0.3,
       "accessibilityScore" : true,
       "minBikeParkingDistance" : 300

--- a/src/main/java/org/opentripplanner/standalone/config/routerequest/ItineraryFiltersConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/routerequest/ItineraryFiltersConfig.java
@@ -261,12 +261,25 @@ removed from list.
         node
           .of("costLimitFunction")
           .since(V2_2)
-          .summary("TODO")
+          .summary("The base function used by the filter.")
+          .description(
+            "This function calculates the threshold for the filter, when the itineraries have " +
+            "exactly the same arrival and departure times."
+          )
           .asLinearFunction(transitGeneralizedCostLimit.costLimitFunction()),
         node
           .of("intervalRelaxFactor")
           .since(V2_2)
-          .summary("TODO")
+          .summary(
+            "How much the filter should be relaxed for itineraries that do not overlap in time."
+          )
+          .description(
+            """
+            This value is used to increase the filter threshold for itineraries further away in
+            time, compared to those, that have exactly the same arrival and departure times.
+
+            The unit is cost unit per second of time difference."""
+          )
           .asDouble(transitGeneralizedCostLimit.intervalRelaxFactor())
       );
     }

--- a/src/test/resources/standalone/config/router-config.json
+++ b/src/test/resources/standalone/config/router-config.json
@@ -43,7 +43,10 @@
       "BIKE_RENTAL": "20m"
     },
     "itineraryFilters": {
-      "transitGeneralizedCostLimit": "3600 + 2.5 x",
+      "transitGeneralizedCostLimit": {
+        "costLimitFunction": "900 + 1.5 x",
+        "intervalRelaxFactor": 0.4
+      },
       "bikeRentalDistanceRatio": 0.3,
       "accessibilityScore": true,
       "minBikeParkingDistance": 300


### PR DESCRIPTION
### Summary

It seems these were missed in https://github.com/opentripplanner/OpenTripPlanner/pull/4188 due to simultaneus upgrade to the new documentation generation.
