### PR TITLE
Fix direct transfer analyzer

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/transferanalyzer/DirectTransferAnalyzer.java
+++ b/src/ext/java/org/opentripplanner/ext/transferanalyzer/DirectTransferAnalyzer.java
@@ -3,6 +3,7 @@ package org.opentripplanner.ext.transferanalyzer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -86,12 +87,15 @@ public class DirectTransferAnalyzer implements GraphBuilderModule {
         .filter(t -> t.stop instanceof RegularStop)
         .collect(Collectors.toMap(t -> (RegularStop) t.stop, t -> t));
 
-      /* Find nearby stops by street distance */
-      Map<RegularStop, NearbyStop> stopsStreets = nearbyStopFinderStreets
-        .findClosestStops(c0, radiusMeters * RADIUS_MULTIPLIER)
-        .stream()
-        .filter(t -> t.stop instanceof RegularStop)
-        .collect(Collectors.toMap(t -> (RegularStop) t.stop, t -> t));
+      Map<RegularStop, NearbyStop> stopsStreets = new HashMap<>();
+      try {
+        /* Find nearby stops by street distance */
+        nearbyStopFinderStreets
+          .findClosestStops(c0, radiusMeters * RADIUS_MULTIPLIER)
+          .stream()
+          .filter(t -> t.stop instanceof RegularStop)
+          .forEach(t -> stopsStreets.putIfAbsent((RegularStop) t.stop, t));
+      } catch (Exception ignored) {}
 
       RegularStop originStop = originStopVertex.getStop();
 

--- a/src/ext/java/org/opentripplanner/ext/transferanalyzer/annotations/TransferCouldNotBeRouted.java
+++ b/src/ext/java/org/opentripplanner/ext/transferanalyzer/annotations/TransferCouldNotBeRouted.java
@@ -52,4 +52,9 @@ public class TransferCouldNotBeRouted implements DataImportIssue {
       directDistance
     );
   }
+
+  @Override
+  public int getPriority() {
+    return (int) -directDistance;
+  }
 }

--- a/src/ext/java/org/opentripplanner/ext/transferanalyzer/annotations/TransferRoutingDistanceTooLong.java
+++ b/src/ext/java/org/opentripplanner/ext/transferanalyzer/annotations/TransferRoutingDistanceTooLong.java
@@ -61,4 +61,9 @@ public class TransferRoutingDistanceTooLong implements DataImportIssue {
       directDistance
     );
   }
+
+  @Override
+  public int getPriority() {
+    return (int) (ratio * 1000);
+  }
 }

--- a/src/main/java/org/opentripplanner/graph_builder/issue/api/DataImportIssue.java
+++ b/src/main/java/org/opentripplanner/graph_builder/issue/api/DataImportIssue.java
@@ -27,7 +27,7 @@ public interface DataImportIssue {
   String getMessage();
 
   /**
-   * Priority for issue sorting. The issue with the highhest priority will appear first in its class.
+   * Priority for issue sorting. The issue with the highest priority will appear first in its class.
    */
   default int getPriority() {
     return 0;

--- a/src/main/java/org/opentripplanner/graph_builder/issues/HopSpeedSlow.java
+++ b/src/main/java/org/opentripplanner/graph_builder/issues/HopSpeedSlow.java
@@ -31,6 +31,6 @@ public class HopSpeedSlow implements DataImportIssue {
 
   @Override
   public int getPriority() {
-    return (int) metersPerSecond;
+    return (int) metersPerSecond * -100;
   }
 }

--- a/src/main/java/org/opentripplanner/graph_builder/issues/HopZeroDistance.java
+++ b/src/main/java/org/opentripplanner/graph_builder/issues/HopZeroDistance.java
@@ -1,11 +1,12 @@
 package org.opentripplanner.graph_builder.issues;
 
+import org.opentripplanner.framework.time.DurationUtils;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssue;
 import org.opentripplanner.transit.model.timetable.Trip;
 
 public class HopZeroDistance implements DataImportIssue {
 
-  public static final String FMT = "Zero-distance hop in %d seconds on trip %s stop sequence %d.";
+  public static final String FMT = "Zero-distance hop in %s on trip %s stop sequence %d.";
 
   final int sec;
   final Trip trip;
@@ -19,6 +20,11 @@ public class HopZeroDistance implements DataImportIssue {
 
   @Override
   public String getMessage() {
-    return String.format(FMT, sec, trip, seq);
+    return String.format(FMT, DurationUtils.durationToStr(sec), trip, seq);
+  }
+
+  @Override
+  public int getPriority() {
+    return sec;
   }
 }

--- a/src/main/java/org/opentripplanner/graph_builder/issues/HopZeroTime.java
+++ b/src/main/java/org/opentripplanner/graph_builder/issues/HopZeroTime.java
@@ -23,4 +23,9 @@ public class HopZeroTime implements DataImportIssue {
   public String getMessage() {
     return String.format(FMT, dist, trip.getRoute().getId(), trip.getId(), seq);
   }
+
+  @Override
+  public int getPriority() {
+    return (int) dist;
+  }
 }

--- a/src/main/java/org/opentripplanner/graph_builder/issues/InterliningTeleport.java
+++ b/src/main/java/org/opentripplanner/graph_builder/issues/InterliningTeleport.java
@@ -25,6 +25,6 @@ public class InterliningTeleport implements DataImportIssue {
 
   @Override
   public int getPriority() {
-    return 10000000 - distance;
+    return -distance;
   }
 }

--- a/src/main/java/org/opentripplanner/graph_builder/issues/RepeatedStops.java
+++ b/src/main/java/org/opentripplanner/graph_builder/issues/RepeatedStops.java
@@ -22,4 +22,9 @@ public class RepeatedStops implements DataImportIssue {
   public String getMessage() {
     return String.format(FMT, trip.getId(), removedStopSequences);
   }
+
+  @Override
+  public int getPriority() {
+    return removedStopSequences.size();
+  }
 }


### PR DESCRIPTION
### Summary

Direct transfer analyzer crashed if it couldn't link a stop to the street network. Fix that and add a couple of priorities to the data import issues