### PR TITLE
Improve logging of Modes and SelectFilter with modes

### DIFF
--- a/src/main/java/org/opentripplanner/transit/model/basic/MainAndSubMode.java
+++ b/src/main/java/org/opentripplanner/transit/model/basic/MainAndSubMode.java
@@ -1,6 +1,8 @@
 package org.opentripplanner.transit.model.basic;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -20,5 +22,38 @@ public record MainAndSubMode(@Nonnull TransitMode mainMode, @Nullable SubMode su
 
   public static List<MainAndSubMode> all() {
     return ALL;
+  }
+
+  /**
+   * Return the complement of the given list of {@code modes} with {@link #all()} main modes
+   * as a starting point. Hence, take all main modes and remove all modes matching one of the
+   * given input {@code modes}. If one of the given modes is not a main mode
+   * ({@link #isMainModeOnly()}), then it is simply ignored.
+   */
+  public static List<MainAndSubMode> notMainModes(Collection<MainAndSubMode> modes) {
+    return MainAndSubMode.all().stream().filter(Predicate.not(modes::contains)).toList();
+  }
+
+  /** Return {@code true} if this only contains a main mode and the sub-mode is {@code null} */
+  public boolean isMainModeOnly() {
+    return subMode == null;
+  }
+
+  @Override
+  public String toString() {
+    if (subMode == null) {
+      return mainMode.name();
+    }
+    return mainMode.name() + "::" + subMode;
+  }
+
+  /**
+   * Make sure the String serialization is deterministic by sorting the elements in
+   * alphabetic order.
+   */
+  public static String toString(Collection<MainAndSubMode> modes) {
+    return modes != null
+      ? modes.stream().map(MainAndSubMode::toString).sorted().toList().toString()
+      : null;
   }
 }

--- a/src/test/java/org/opentripplanner/routing/api/request/request/filter/SelectRequestTest.java
+++ b/src/test/java/org/opentripplanner/routing/api/request/request/filter/SelectRequestTest.java
@@ -1,0 +1,69 @@
+package org.opentripplanner.routing.api.request.request.filter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.transit.model.basic.MainAndSubMode;
+import org.opentripplanner.transit.model.basic.SubMode;
+import org.opentripplanner.transit.model.basic.TransitMode;
+
+class SelectRequestTest {
+
+  static final MainAndSubMode TC_BUS = new MainAndSubMode(TransitMode.BUS);
+  static final MainAndSubMode TC_FERRY = new MainAndSubMode(TransitMode.FERRY);
+  static final MainAndSubMode TC_RAIL = new MainAndSubMode(TransitMode.RAIL);
+  static final MainAndSubMode TC_TRAM = new MainAndSubMode(TransitMode.TRAM);
+  static final MainAndSubMode TC_LOCAL_BUS = new MainAndSubMode(
+    TransitMode.BUS,
+    SubMode.of("LOCAL")
+  );
+  static final MainAndSubMode TC_LOCAL_TRAM = new MainAndSubMode(
+    TransitMode.TRAM,
+    SubMode.of("LOCAL")
+  );
+
+  @Test
+  void testModesToString() {
+    assertEquals("SelectRequest{transportModes: []}", modesSelect().toString());
+    assertEquals("SelectRequest{transportModes: [BUS]}", modesSelect(TC_BUS).toString());
+    assertEquals(
+      "SelectRequest{transportModes: [BUS::LOCAL, FERRY]}",
+      modesSelect(TC_FERRY, TC_LOCAL_BUS).toString()
+    );
+    assertEquals(
+      "SelectRequest{transportModes: ALL-MAIN-MODES}",
+      SelectRequest.of().withTransportModes(MainAndSubMode.all()).build().toString()
+    );
+    assertEquals("SelectRequest{transportModes: NOT [FERRY]}", notModesSelect(TC_FERRY).toString());
+    assertEquals(
+      "SelectRequest{transportModes: NOT [BUS, FERRY, TRAM]}",
+      notModesSelect(TC_BUS, TC_TRAM, TC_FERRY).toString()
+    );
+    assertEquals(
+      "SelectRequest{transportModes: [AIRPLANE, CABLE_CAR, CARPOOL, COACH, FUNICULAR, GONDOLA, MONORAIL, SUBWAY, TAXI, TROLLEYBUS]}",
+      notModesSelect(TC_BUS, TC_FERRY, TC_TRAM, TC_RAIL).toString()
+    );
+    var list = new ArrayList<>(
+      MainAndSubMode.notMainModes(List.of(TC_BUS, TC_TRAM, TC_LOCAL_TRAM))
+    );
+    list.add(TC_LOCAL_BUS);
+    assertEquals(
+      "SelectRequest{transportModes: [AIRPLANE, BUS::LOCAL, CABLE_CAR, CARPOOL, COACH, FERRY, FUNICULAR, GONDOLA, MONORAIL, RAIL, SUBWAY, TAXI, TROLLEYBUS]}",
+      SelectRequest.of().withTransportModes(list).build().toString()
+    );
+  }
+
+  static SelectRequest modesSelect(MainAndSubMode... modes) {
+    return SelectRequest.of().withTransportModes(Arrays.asList(modes)).build();
+  }
+
+  static SelectRequest notModesSelect(MainAndSubMode... modes) {
+    return SelectRequest
+      .of()
+      .withTransportModes(MainAndSubMode.notMainModes(Arrays.asList(modes)))
+      .build();
+  }
+}

--- a/src/test/java/org/opentripplanner/transit/model/basic/MainAndSubModeTest.java
+++ b/src/test/java/org/opentripplanner/transit/model/basic/MainAndSubModeTest.java
@@ -1,0 +1,45 @@
+package org.opentripplanner.transit.model.basic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class MainAndSubModeTest {
+
+  public static final MainAndSubMode BUS = new MainAndSubMode(TransitMode.BUS);
+  public static final MainAndSubMode LOCAL_BUS = new MainAndSubMode(
+    TransitMode.BUS,
+    SubMode.of("LOCAL")
+  );
+
+  @Test
+  public void testToString() {
+    assertEquals("BUS", BUS.toString());
+    assertEquals("BUS::LOCAL", LOCAL_BUS.toString());
+  }
+
+  @Test
+  public void mainModeOnly() {
+    assertTrue(BUS.isMainModeOnly(), BUS.toString());
+    assertFalse(LOCAL_BUS.isMainModeOnly(), LOCAL_BUS.toString());
+  }
+
+  @Test
+  public void notMainModes() {
+    assertEquals(MainAndSubMode.all(), MainAndSubMode.notMainModes(List.of()));
+    assertEquals(
+      MainAndSubMode.all().stream().filter(m -> !BUS.equals(m)).toList(),
+      MainAndSubMode.notMainModes(List.of(BUS))
+    );
+  }
+
+  @Test
+  public void listToString() {
+    assertEquals("[]", MainAndSubMode.toString(List.of()));
+    assertEquals("[BUS]", MainAndSubMode.toString(List.of(BUS)));
+    assertEquals("[BUS, BUS::LOCAL]", MainAndSubMode.toString(List.of(LOCAL_BUS, BUS)));
+  }
+}


### PR DESCRIPTION
### Summary

Value types like `MainAndSubMode` in the internal OTP model should have short easy to read `toString()` implementations. These types are frequently read while debugging and in loggs, so less "stuff" printed means faster and easier reading. 

The `subMode` is optional, so I did the following 

 - MainMode=BUS, SubMode=null  ==> `"BUS"`
 - MainMode=BUS, SubMode=LOCAL  ==> `"BUS::LOCAL"`

We could use something like `BUS+LOCAL`, `BUS&LOCAL`, `BUS(LOCAL)`, or `BUS[LOCAL]`, but I think the `::` works fine - there is no change of collisions with real values, and we already use `:` as a separator in the `FeedScopedId` - this is kind of similar.

### Unit tests

Several unit tests are added, I also added a few utility methods, which lead to DRY/easier readable code like the 
`MainAndSubMode#toString(List<MainAndSubMode>)` used in `SelectRequest`.
