### PR TITLE
Add deprecation tags, improve docs, update GraphiQL

### DIFF
--- a/docs/RouteRequest.md
+++ b/docs/RouteRequest.md
@@ -78,11 +78,11 @@ and in the [transferRequests in build-config.json](BuildConfiguration.md#transfe
 | [walkReluctance](#rd_walkReluctance)                                                                 |        `double`        | A multiplier for how bad walking is, compared to being in transit for equal lengths of time.                                       | *Optional* | `2.0`                    |  2.0  |
 | [walkSafetyFactor](#rd_walkSafetyFactor)                                                             |        `double`        | Factor for how much the walk safety is considered in routing.                                                                      | *Optional* | `1.0`                    |  2.2  |
 | walkSpeed                                                                                            |        `double`        | The user's walking speed in meters/second.                                                                                         | *Optional* | `1.33`                   |  2.0  |
-| [alightSlackForMode](#rd_alightSlackForMode)                                                         | `enum map of duration` | How much time alighting a vehicle takes for each given mode.                                                                       | *Optional* |                          |  2.0  |
+| [alightSlackForMode](#rd_alightSlackForMode)                                                         | `enum map of duration` | How much extra time should be given when alighting a vehicle for each given mode.                                                  | *Optional* |                          |  2.0  |
 | [allowedVehicleRentalNetworks](#rd_allowedVehicleRentalNetworks)                                     |       `string[]`       | The vehicle rental networks which may be used. If empty all networks may be used.                                                  | *Optional* |                          |  2.1  |
 | [bannedVehicleParkingTags](#rd_bannedVehicleParkingTags)                                             |       `string[]`       | Tags with which a vehicle parking will not be used. If empty, no tags are banned                                                   | *Optional* |                          |  2.1  |
 | [bannedVehicleRentalNetworks](#rd_bannedVehicleRentalNetworks)                                       |       `string[]`       | he vehicle rental networks which may not be used. If empty, no networks are banned.                                                | *Optional* |                          |  2.1  |
-| [boardSlackForMode](#rd_boardSlackForMode)                                                           | `enum map of duration` | How much time ride a vehicle takes for each given mode.                                                                            | *Optional* |                          |  2.0  |
+| [boardSlackForMode](#rd_boardSlackForMode)                                                           | `enum map of duration` | How much extra time should be given when boarding a vehicle for each given mode.                                                   | *Optional* |                          |  2.0  |
 | [itineraryFilters](#rd_itineraryFilters)                                                             |        `object`        | Configure itinerary filters that may modify itineraries, sort them, and filter away less preferable results.                       | *Optional* |                          |  2.0  |
 |    [accessibilityScore](#rd_if_accessibilityScore)                                                   |        `boolean`       | An experimental feature contributed by IBI which adds a sandbox accessibility *score* between 0 and 1 for each leg and itinerary.  | *Optional* | `false`                  |  2.2  |
 |    [bikeRentalDistanceRatio](#rd_if_bikeRentalDistanceRatio)                                         |        `double`        | Filter routes that consist of bike-rental and walking by the minimum fraction of the bike-rental leg using _distance_.             | *Optional* | `0.0`                    |  2.1  |
@@ -363,7 +363,7 @@ Value should be between 0 and 1. If the value is set to be 0, safety is ignored.
 **Path:** /routingDefaults   
 **Enum keys:** `rail` | `coach` | `subway` | `bus` | `tram` | `ferry` | `airplane` | `cable-car` | `gondola` | `funicular` | `trolleybus` | `monorail` | `carpool` | `taxi`
 
-How much time alighting a vehicle takes for each given mode.
+How much extra time should be given when alighting a vehicle for each given mode.
 
 Sometimes there is a need to configure a longer alighting times for specific modes, such as airplanes or ferries.
 
@@ -394,7 +394,7 @@ he vehicle rental networks which may not be used. If empty, no networks are bann
 **Path:** /routingDefaults   
 **Enum keys:** `rail` | `coach` | `subway` | `bus` | `tram` | `ferry` | `airplane` | `cable-car` | `gondola` | `funicular` | `trolleybus` | `monorail` | `carpool` | `taxi`
 
-How much time ride a vehicle takes for each given mode.
+How much extra time should be given when boarding a vehicle for each given mode.
 
 Sometimes there is a need to configure a board times for specific modes, such as airplanes or
 ferries, where the check-in process needs to be done in good time before ride.

--- a/docs/sandbox/LegacyGraphQLApi.md
+++ b/docs/sandbox/LegacyGraphQLApi.md
@@ -1,4 +1,4 @@
-# HSL Legacy GraphQL API - OTP Sandbox Extension
+# HSL Legacy GraphQL API
 
 ## Contact Info
 
@@ -9,7 +9,7 @@
 
 To enable this you need to add the feature `SandboxAPILegacyGraphQLApi`.
 
-```
+```json
 // otp-config.json
 {
   "otpFeatures" : {
@@ -40,7 +40,7 @@ curl --request POST \
 
 ## Built-in API client
 
-A browser based GraphQL API client is available at `http://localhost:8080/legacygraphql/graphiql` 
+A browser based GraphQL API client is available at [http://localhost:8080/legacygraphql/graphiql](http://localhost:8080/legacygraphql/graphiql)
 
 ![GraphiQL](../images/graphiql.png)
 

--- a/src/client/legacygraphql/graphiql/index.html
+++ b/src/client/legacygraphql/graphiql/index.html
@@ -21,27 +21,23 @@
     If you do not want to rely on a CDN, you can host these files locally or
     include them directly in your favored resource bundler.
   -->
-  <script
-          crossorigin
-          src="https://unpkg.com/react@17/umd/react.development.js"
-  ></script>
-  <script
-          crossorigin
-          src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"
-  ></script>
+
+  <script src="https://unpkg.com/react@17/umd/react.development.js" integrity="sha384-xQwCoNcK/7P3Lpv50IZSEbJdpqbToWEODAUyI/RECaRXmOE2apWt7htari8kvKa/" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js" integrity="sha384-E9IgxDsnjKgh0777N3lXen7NwXeTsOpLLJhI01SW7idG046SRqJpsW2rJwsOYk0L" crossorigin="anonymous"></script>
 
   <!--
     These two files can be found in the npm module, however you may wish to
     copy them directly into your environment, or perhaps include them in your
     favored resource bundler.
    -->
-  <link rel="stylesheet" href="https://unpkg.com/graphiql@2.0.8/graphiql.min.css" />
+  <link rel="stylesheet" href="https://unpkg.com/graphiql@2.3.0/graphiql.min.css" integrity="sha384-EoOkdc9Rm6XZNH221ekR+jbM2wvJymPzOr6o5VpjNG46Gk2iqK6SajJ+ryFEY5fq" crossorigin="anonymous">
   <title>OTP GraphQL Explorer</title>
 </head>
 
 <body>
 <div id="graphiql">Loading...</div>
-<script src="https://unpkg.com/graphiql@2.0.8/graphiql.min.js" type="application/javascript" ></script>
+<script src="https://unpkg.com/graphiql@2.3.0/graphiql.min.js" integrity="sha384-Loaau4qVSd26PmPWvZFVXEo55rVewsFamEjr5AJqoquYJCYamxP8p9RL+e91mAUb" crossorigin="anonymous"></script>
+
 <script>
   const defaultQuery = `
 # This is an example query for displaying all routes of your OTP deployment.

--- a/src/ext/resources/legacygraphqlapi/schema.graphqls
+++ b/src/ext/resources/legacygraphqlapi/schema.graphqls
@@ -2535,7 +2535,7 @@ type QueryType {
 
         Deprecated, not used, the timetable-view replaces this functionality.
         """
-        waitAtBeginningFactor: Float
+        waitAtBeginningFactor: Float @deprecated(reason: "Removed in OTP 2")
 
         """
         Max walk speed along streets, in meters per second. Default value: 1.33
@@ -2621,7 +2621,7 @@ type QueryType {
         This argument has no use for itinerary planning and will be removed later.
         ~~When true, do not use goal direction or stop at the target, build a full SPT. Default value: false.~~
         """
-        batch: Boolean
+        batch: Boolean @deprecated(reason: "Removed in OTP 2")
 
         """
         List of transportation modes that the user is willing to use. Default: `["WALK","TRANSIT"]`
@@ -2701,7 +2701,7 @@ type QueryType {
         No effect on itinerary planning, adjust argument `time` instead to get later departures.
         ~~The maximum wait time in seconds the user is willing to delay trip start. Only effective in Analyst.~~
         """
-        claimInitialWait: Long
+        claimInitialWait: Long @deprecated(reason: "Removed in OTP 2")
 
         """
         **Consider this argument experimental** – setting this argument to true
@@ -2711,7 +2711,7 @@ type QueryType {
         processing each transit leg, rather than reverse-optimizing the entire path
         when it's done. Default value: false.
         """
-        reverseOptimizeOnTheFly: Boolean
+        reverseOptimizeOnTheFly: Boolean @deprecated(reason: "Removed in OTP 2")
 
         """
         When false, return itineraries using canceled trips. Default value: true.
@@ -2751,14 +2751,14 @@ type QueryType {
         Whether legs should be compacted by performing a reversed search.
         **Experimental argument, will be removed!**
         """
-        compactLegsByReversedSearch: Boolean
+        compactLegsByReversedSearch: Boolean @deprecated(reason: "Removed in OTP 2")
 
         """
         Which vehicle rental networks can be used. By default, all networks are allowed.
 
         Deprecated: Use `allowedVehicleRentalNetworks` instead.
         """
-        allowedBikeRentalNetworks: [String] @deprecated(reason: "Use allowedBikeRentalNetworks instead")
+        allowedBikeRentalNetworks: [String] @deprecated(reason: "Use allowedVehicleRentalNetworks instead")
 
         """
         Which vehicle rental networks can be used. By default, all networks are allowed.

--- a/src/main/java/org/opentripplanner/standalone/config/routerequest/RouteRequestConfig.java
+++ b/src/main/java/org/opentripplanner/standalone/config/routerequest/RouteRequestConfig.java
@@ -249,7 +249,9 @@ travel time `x` (in seconds).
             c
               .of("alightSlackForMode")
               .since(V2_0)
-              .summary("How much time alighting a vehicle takes for each given mode.")
+              .summary(
+                "How much extra time should be given when alighting a vehicle for each given mode."
+              )
               .description(
                 "Sometimes there is a need to configure a longer alighting times for specific " +
                 "modes, such as airplanes or ferries."
@@ -281,7 +283,9 @@ transit leg in the trip. This is the default value used, if not overridden by th
             c
               .of("boardSlackForMode")
               .since(V2_0)
-              .summary("How much time ride a vehicle takes for each given mode.")
+              .summary(
+                "How much extra time should be given when boarding a vehicle for each given mode."
+              )
               .description(
                 """
 Sometimes there is a need to configure a board times for specific modes, such as airplanes or


### PR DESCRIPTION
### Summary

This PR achieves 3 things:

- updates the confusing documentation for board/alightSlackForMode
- updates the built-in GrapqhQL viewer to 2.3.0
- adds proper `@deprecated` tags to the input paramters of the `plan` resolver so that these don't show up in GraphiQL anymore