### PR TITLE
Make Transmodel API accept timezones without colons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -327,6 +327,7 @@
                 </executions>
                 <configuration>
                     <verbose>false</verbose>
+                    <dateFormat>yyyy-MM-dd'T'HH:mm:ssXXX</dateFormat>
                     <includeOnlyProperties>
                         <!-- Including each property used reduce the plugin execution time. -->
                         <includeOnlyProperty>git.commit.id</includeOnlyProperty>

--- a/src/ext-test/java/org/opentripplanner/ext/transmodelapi/model/scalars/DateTimeScalarFactoryTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/transmodelapi/model/scalars/DateTimeScalarFactoryTest.java
@@ -1,0 +1,47 @@
+package org.opentripplanner.ext.transmodelapi.model.scalars;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner._support.time.ZoneIds.OSLO;
+
+import graphql.schema.GraphQLScalarType;
+import java.time.Instant;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.opentripplanner.test.support.VariableSource;
+
+class DateTimeScalarFactoryTest {
+
+  public static final String DATE_TIME = "2023-01-27T12:59:00+01:00";
+  public static final Long EPOCH_MILLIS = Instant.parse(DATE_TIME).toEpochMilli();
+  private static GraphQLScalarType subject;
+
+  @BeforeAll
+  static void setup() {
+    subject = DateTimeScalarFactory.createMillisecondsSinceEpochAsDateTimeStringScalar(OSLO);
+  }
+
+  @Test
+  void serialize() {
+    var result = subject.getCoercing().serialize(EPOCH_MILLIS);
+    assertEquals(DATE_TIME, result);
+  }
+
+  static Stream<Arguments> testCases = Stream.of(
+    Arguments.of(DATE_TIME),
+    Arguments.of("2023-01-27T12:59:00.000+01:00"),
+    Arguments.of("2023-01-27T12:59:00+0100"),
+    Arguments.of("2023-01-27T12:59:00+01"),
+    Arguments.of("2023-01-27T12:59:00"),
+    Arguments.of("2023-01-27T11:59:00Z")
+  );
+
+  @ParameterizedTest
+  @VariableSource("testCases")
+  void parse(String input) {
+    var result = subject.getCoercing().parseValue(input);
+    assertEquals(EPOCH_MILLIS, result);
+  }
+}


### PR DESCRIPTION
### Summary

Currently we can't parse times like `2023-01-27T12:59:00+0200`, which aren't technically ISO-8601 compatible, but widely enough used. Eg by RFC3339, see [errata](https://www.rfc-editor.org/errata/eid1584).

Also, it changes the timezone formatting used by `git-commit-id-maven-plugin` (see https://github.com/git-commit-id/git-commit-id-maven-plugin/issues/575#issuecomment-959879324) to match ISO-8601, and not the erroneous format.