### PR TITLE
Fix TPoint generation for real-time generated patterns

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/constrainedtransfer/TransferIndexGenerator.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/constrainedtransfer/TransferIndexGenerator.java
@@ -26,8 +26,12 @@ import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.site.Station;
 import org.opentripplanner.transit.model.site.StopLocation;
 import org.opentripplanner.transit.model.timetable.Trip;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TransferIndexGenerator {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TransferIndexGenerator.class);
 
   private static final boolean BOARD = true;
   private static final boolean ALIGHT = false;
@@ -227,17 +231,69 @@ public class TransferIndexGenerator {
 
   private List<TPoint> findTPoints(TripTransferPoint point) {
     var trip = point.getTrip();
-    // All trips have at least one pattern, no need to chech for null here
+
+    // All trips have at least one pattern, no need to check for null here
     var patterns = patternsByTrip.get(trip);
-    int stopPosInPattern = point.getStopPositionInPattern();
-    return patterns
+    var groupedPatterns = patterns
       .stream()
-      .map(pattern -> {
-        int stopIndex = pattern.stopIndex(stopPosInPattern);
-        var sourcePoint = createTransferPointForPattern(trip, stopIndex);
-        return new TPoint(pattern, sourcePoint, trip, stopPosInPattern);
-      })
-      .toList();
+      .collect(Collectors.groupingBy(pattern -> pattern.getPattern().isCreatedByRealtimeUpdater()));
+
+    // Process first the pattern for which stopPosInPattern was calculated for
+    List<RoutingTripPattern> scheduledPatterns = groupedPatterns.get(Boolean.FALSE);
+    if (scheduledPatterns == null || scheduledPatterns.size() != 1) {
+      LOG.warn(
+        "Trip {} does not have exactly one scheduled trip pattern, found: {}. " +
+        "Skipping transfer generation.",
+        trip.getId(),
+        scheduledPatterns
+      );
+      return List.of();
+    }
+
+    int stopPosInPattern = point.getStopPositionInPattern();
+    var scheduledPattern = scheduledPatterns.get(0);
+    int stopIndex = scheduledPattern.stopIndex(stopPosInPattern);
+    var sourcePoint = createTransferPointForPattern(trip, stopIndex);
+    TPoint scheduledPoint = new TPoint(scheduledPattern, sourcePoint, trip, stopPosInPattern);
+
+    // Return early if only scheduled pattern exists
+    var realtimePatterns = groupedPatterns.get(Boolean.TRUE);
+    if (realtimePatterns == null || realtimePatterns.isEmpty()) {
+      return List.of(scheduledPoint);
+    }
+
+    // Process the other patterns based on the scheduled pattern
+    StopLocation scheduledStop = scheduledPattern.getPattern().getStop(stopPosInPattern);
+
+    List<TPoint> res = new ArrayList<>();
+    res.add(scheduledPoint);
+    for (RoutingTripPattern pattern : realtimePatterns) {
+      // Check if the same stop or its sibling is at the same position, if yes, generate a transfer point
+      if (stopPosInPattern < pattern.numberOfStopsInPattern()) {
+        StopLocation stop = pattern.getPattern().getStop(stopPosInPattern);
+        if (stop.equals(scheduledStop) || stop.isPartOfSameStationAs(scheduledStop)) {
+          res.add(
+            new TPoint(
+              pattern,
+              createTransferPointForPattern(trip, pattern.stopIndex(stopPosInPattern)),
+              trip,
+              stopPosInPattern
+            )
+          );
+          continue;
+        }
+      }
+      LOG.info(
+        "Updated pattern for trip {}, does not match original for stop {} at pos {}. " +
+        "Skipping transfer generation.",
+        trip,
+        scheduledStop,
+        stopPosInPattern
+      );
+      // TODO - Find the stop in the new pattern.
+    }
+
+    return List.copyOf(res);
   }
 
   private static class TPoint {

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TransitLayerUpdater.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/mappers/TransitLayerUpdater.java
@@ -121,10 +121,7 @@ public class TransitLayerUpdater {
         tripPatternsStartingOnDateMapCache.get(date).put(tripPattern, newTripPatternForDate);
         newTripPatternsForDate.put(tripPattern, newTripPatternForDate);
         datesToBeUpdated.addAll(newTripPatternForDate.getRunningPeriodDates());
-        if (
-          transferIndexGenerator != null &&
-          newTripPatternForDate.getTripPattern().getPattern().isCreatedByRealtimeUpdater()
-        ) {
+        if (transferIndexGenerator != null && tripPattern.isCreatedByRealtimeUpdater()) {
           transferIndexGenerator.addRealtimeTrip(
             tripPattern,
             timetable.getTripTimes().stream().map(TripTimes::getTrip).collect(Collectors.toList())


### PR DESCRIPTION
### Summary

Currently the generation crashes if the `TripTransferPoint#getStopPositionInPattern()` is greater than `RoutingTripPattern#numberOfStopsInPattern`, or it would create a transfer between the wrong stop, if the pattern changed. This changes the handling so that we check the index and compare the stop at that point, and generate a constrained transfer only if it is the same stop, or its sibling, at the specified stop point in pattern.
