### PR TITLE
Expose original trip pattern in pattern

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLPatternImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLPatternImpl.java
@@ -173,6 +173,11 @@ public class LegacyGraphQLPatternImpl implements LegacyGraphQLDataFetchers.Legac
   }
 
   @Override
+  public DataFetcher<TripPattern> originalTripPattern() {
+    return environment -> getSource(environment).getOriginalTripPattern();
+  }
+
+  @Override
   public DataFetcher<Geometry> patternGeometry() {
     return environment -> getSource(environment).getGeometry();
   }

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/LegacyGraphQLDataFetchers.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/LegacyGraphQLDataFetchers.java
@@ -448,6 +448,8 @@ public class LegacyGraphQLDataFetchers {
 
     public DataFetcher<String> name();
 
+    public DataFetcher<TripPattern> originalTripPattern();
+
     public DataFetcher<Geometry> patternGeometry();
 
     public DataFetcher<Route> route();

--- a/src/ext/resources/legacygraphqlapi/schema.graphqls
+++ b/src/ext/resources/legacygraphqlapi/schema.graphqls
@@ -1705,6 +1705,9 @@ type Pattern implements Node {
     Realtime-updated position of vehicles that are serving this pattern.
     """
     vehiclePositions: [VehiclePosition!]
+
+    """Original Trip pattern for changed patterns"""
+    originalTripPattern: Pattern
 }
 
 """Entities, which are relevant for a pattern and can contain alerts"""


### PR DESCRIPTION
### Summary

This PR exposes a originalTripPattern field in Pattern in graphql api. 
We have identified a need for this field in other project. 

### Unit tests

This is tested locally and is working as expected.


