### PR TITLE
Replace 'developer mailing list' with 'Gitter chat' in doc

### DIFF
--- a/ISSUE_TEMPLATE
+++ b/ISSUE_TEMPLATE
@@ -1,6 +1,8 @@
-**NOTE:** this issue system is intended for reporting bugs and tracking progress in software development. For all other usage and software development questions or discussion, please write to one of the mailing lists (Google groups):
-https://groups.google.com/forum/#!forum/opentripplanner-dev
-https://groups.google.com/forum/#!forum/opentripplanner-users
+**NOTE:** this issue system is intended for reporting bugs and tracking progress in software
+development. For all other usage and software development questions or discussion, please write to
+the user mailing list(https://groups.google.com/forum/#!forum/opentripplanner-users) or post a
+question in the developer chat: https://gitter.im/opentripplanner/OpenTripPlanner.
+
 
 ## Expected behavior
 

--- a/README.md
+++ b/README.md
@@ -57,11 +57,13 @@ the world.
 
 ## Mailing Lists
 
-The main forums through which the OpenTripPlanner community organizes development and provides
-mutual assistance are our two Google discussion groups. Changes and extensions to OTP are debated on
-the [opentripplanner-dev](https://groups.google.com/forum/#!forum/opentripplanner-dev) developers'
-list. More general questions and announcements of interest to non-developer OTP users should be
-directed to
+The fastest way to get help is to use our [Gitter chat room](https://gitter.im/opentripplanner/OpenTripPlanner)
+where most of the core developers are. You can also send questions and comments to the 
+[mailing list](http://groups.google.com/group/opentripplanner-users).
+
+Changes and extensions to OTP are debated in issues on [GitHub](https://github.com/opentripplanner/OpenTripPlanner/issues)
+and in the  [Gitter chat room](https://gitter.im/opentripplanner/OpenTripPlanner). More general 
+questions and announcements of interest to non-developer OTP users should be directed to
 the [opentripplanner-users](https://groups.google.com/forum/#!forum/opentripplanner-users) list.
 Other details of [project governance](http://docs.opentripplanner.org/en/dev-2.x/Governance/) can be
 found in the main documentation.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ of [OTP history](http://docs.opentripplanner.org/en/dev-2.x/History/) and a list
 of [cities and regions using OTP](http://docs.opentripplanner.org/en/dev-2.x/Deployments/) around
 the world.
 
-## Mailing Lists
+## Getting in touch
 
 The fastest way to get help is to use our [Gitter chat room](https://gitter.im/opentripplanner/OpenTripPlanner)
 where most of the core developers are. You can also send questions and comments to the 

--- a/docs/Developers-Guide.md
+++ b/docs/Developers-Guide.md
@@ -53,7 +53,8 @@ like "program arguments".
 OpenTripPlanner is a community based open source project, and we welcome all who wish to contribute.
 There are several ways to get involved:
 
-* Join the [developer mailing list](http://groups.google.com/group/opentripplanner-dev)
+* Join the [Gitter chat room](https://gitter.im/opentripplanner/OpenTripPlanner) and the 
+  [user mailing list](http://groups.google.com/group/opentripplanner-users).
 
 * Fix typos and improve the documentation within the `/docs` directory of the project (details
   below).

--- a/docs/Localization.md
+++ b/docs/Localization.md
@@ -153,8 +153,8 @@ translation library. After you rebuild OTP, all new strings should be visible in
 ## For Translators: Creating New Translations
 
 The following can get a bit technical. If you want to do a translation but don't want to / know how
-to install all this software, post to the `opentripplanner-dev` mailing list stating what language
-you want to translate, and someone will make you a corresponding `.po` file.
+to install all this software, post to the [Gitter chat room](https://gitter.im/opentripplanner/OpenTripPlanner) 
+stating what language you want to translate, and someone will make you a corresponding `.po` file.
 
 ### Creating a New Translation File
 


### PR DESCRIPTION
### Summary

Update documentation to point to Gitter chat room and not old dev mailing list.


### Documentation

Updated

