### PR TITLE
Small cleanup ItineraryListFilterChainBuilder

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/filterchain/ItineraryListFilterChainBuilder.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/filterchain/ItineraryListFilterChainBuilder.java
@@ -281,7 +281,9 @@ public class ItineraryListFilterChainBuilder {
 
     filters.addAll(buildGroupByTripIdAndDistanceFilters());
 
-    filters.addAll(buildGroupBySameRoutesAndStopsFilter());
+    if (removeItinerariesWithSameRoutesAndStops) {
+      filters.addAll(buildGroupBySameRoutesAndStopsFilter());
+    }
 
     if (sameFirstOrLastTripFilter) {
       filters.add(new SortingFilter(generalizedCostComparator()));
@@ -402,7 +404,6 @@ public class ItineraryListFilterChainBuilder {
    * meanings we chose to use a long, but descriptive name instead.
    */
   private List<ItineraryListFilter> buildGroupBySameRoutesAndStopsFilter() {
-    if (removeItinerariesWithSameRoutesAndStops) {
       return List.of(
         new GroupByFilter<>(
           GroupBySameRoutesAndStops::new,
@@ -412,9 +413,6 @@ public class ItineraryListFilterChainBuilder {
           )
         )
       );
-    } else {
-      return List.of();
-    }
   }
 
   /**

--- a/src/main/java/org/opentripplanner/routing/algorithm/filterchain/ItineraryListFilterChainBuilder.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/filterchain/ItineraryListFilterChainBuilder.java
@@ -404,15 +404,15 @@ public class ItineraryListFilterChainBuilder {
    * meanings we chose to use a long, but descriptive name instead.
    */
   private List<ItineraryListFilter> buildGroupBySameRoutesAndStopsFilter() {
-      return List.of(
-        new GroupByFilter<>(
-          GroupBySameRoutesAndStops::new,
-          List.of(
-            new SortingFilter(SortOrderComparator.comparator(sortOrder)),
-            new DeletionFlaggingFilter(new MaxLimitFilter(GroupBySameRoutesAndStops.TAG, 1))
-          )
+    return List.of(
+      new GroupByFilter<>(
+        GroupBySameRoutesAndStops::new,
+        List.of(
+          new SortingFilter(SortOrderComparator.comparator(sortOrder)),
+          new DeletionFlaggingFilter(new MaxLimitFilter(GroupBySameRoutesAndStops.TAG, 1))
         )
-      );
+      )
+    );
   }
 
   /**


### PR DESCRIPTION
### Summary

Fix: All optional filters is added in the same place, except `removeItinerariesWithSameRoutesAndStops`.


### Issue

No.

### Unit tests

No functionallity  is changed.

### Documentation

No.
