### PR TITLE
Improve resiliency of the Transmodel API

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/PlanPlaceType.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/model/plan/PlanPlaceType.java
@@ -60,7 +60,15 @@ public class PlanPlaceType {
           .name("latitude")
           .description("The latitude of the place.")
           .type(new GraphQLNonNull(Scalars.GraphQLFloat))
-          .dataFetcher(environment -> ((Place) environment.getSource()).coordinate.latitude())
+          .dataFetcher(environment -> {
+            var coordinate = ((Place) environment.getSource()).coordinate;
+            if (coordinate == null) {
+              // TODO: Technically this is wrong, we should not return the place the user sends to
+              //  us, as that is the only place the value can be null
+              return 0;
+            }
+            return coordinate.latitude();
+          })
           .build()
       )
       .field(
@@ -69,7 +77,15 @@ public class PlanPlaceType {
           .name("longitude")
           .description("The longitude of the place.")
           .type(new GraphQLNonNull(Scalars.GraphQLFloat))
-          .dataFetcher(environment -> ((Place) environment.getSource()).coordinate.longitude())
+          .dataFetcher(environment -> {
+            var coordinate = ((Place) environment.getSource()).coordinate;
+            if (coordinate == null) {
+              // TODO: Technically this is wrong, we should not return the place the user sends to
+              //  us, as that is the only place the value can be null
+              return 0;
+            }
+            return coordinate.longitude();
+          })
           .build()
       )
       .field(

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/TripPlanMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/TripPlanMapper.java
@@ -21,8 +21,16 @@ public class TripPlanMapper {
     Place to;
 
     if (itineraries.isEmpty()) {
-      from = placeFromGeoLocation(request.from(), new LocalizedString("origin"));
-      to = placeFromGeoLocation(request.to(), new LocalizedString("destination"));
+      from =
+        placeFromGeoLocation(
+          request != null ? request.from() : null,
+          new LocalizedString("origin")
+        );
+      to =
+        placeFromGeoLocation(
+          request != null ? request.to() : null,
+          new LocalizedString("destination")
+        );
     } else {
       List<Leg> legs = itineraries.get(0).getLegs();
       from = legs.get(0).getFrom();
@@ -32,6 +40,10 @@ public class TripPlanMapper {
   }
 
   private static Place placeFromGeoLocation(GenericLocation location, I18NString defaultName) {
+    if (location == null) {
+      return Place.normal(null, null, defaultName);
+    }
+
     return Place.normal(
       location.lat,
       location.lng,


### PR DESCRIPTION
### Summary

This PR contains ~two~ one improvement:
- If an error is thrown from the parsing of the request, we generate a `TripPlan`, which we can show to the user together with the error. In this we include coordinates, which might be null, which will lead to an NPE. Instead pass in null all the way, and serialize it as 0 in the API, as it is a non-nullable type.
- ~Validation was made stricter to relaxGeneralizedCostAtDestination recently, which will throw an error if an invalid value is specified. Instead pre-validate the value and only set it if valid.~ Removed, as all clients are now fixed. However we should improve validation somehow already when parsing the value.