### PR TITLE
Do not override network name in the vehicle rental service directory service

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/vehiclerentalservicedirectory/VehicleRentalServiceDirectoryFetcher.java
+++ b/src/ext/java/org/opentripplanner/ext/vehiclerentalservicedirectory/VehicleRentalServiceDirectoryFetcher.java
@@ -71,7 +71,7 @@ public class VehicleRentalServiceDirectoryFetcher {
             parameters.getLanguage(),
             false,
             parameters.getHeaders(),
-            parameters.getSourceNetworkName(),
+            null,
             false
           )
         );


### PR DESCRIPTION
### Summary

In https://github.com/opentripplanner/OpenTripPlanner/pull/4147 code was added to always override the network name in the vehicle rental service directory service. This was not correct, instead the id should be read from the feed.