### PR TITLE
Always check allowed modes in VehicleRentalEdge

### DIFF
--- a/src/main/java/org/opentripplanner/street/model/edge/VehicleRentalEdge.java
+++ b/src/main/java/org/opentripplanner/street/model/edge/VehicleRentalEdge.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.street.model.edge;
 
+import java.util.Collections;
 import java.util.Set;
 import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.framework.i18n.I18NString;
@@ -49,9 +50,10 @@ public class VehicleRentalEdge extends Edge {
     boolean pickedUp;
     if (s0.getRequest().arriveBy()) {
       switch (s0.getVehicleRentalState()) {
-        case BEFORE_RENTING:
+        case BEFORE_RENTING -> {
           return null;
-        case HAVE_RENTED:
+        }
+        case HAVE_RENTED -> {
           if (
             (realtimeAvailability && !station.allowDropoffNow()) ||
             !station.getAvailableDropoffFormFactors(realtimeAvailability).contains(formFactor)
@@ -60,8 +62,8 @@ public class VehicleRentalEdge extends Edge {
           }
           s1.dropOffRentedVehicleAtStation(formFactor, network, true);
           pickedUp = false;
-          break;
-        case RENTING_FLOATING:
+        }
+        case RENTING_FLOATING -> {
           if (!station.getAvailablePickupFormFactors(realtimeAvailability).contains(formFactor)) {
             return null;
           }
@@ -71,8 +73,8 @@ public class VehicleRentalEdge extends Edge {
           } else {
             return null;
           }
-          break;
-        case RENTING_FROM_STATION:
+        }
+        case RENTING_FROM_STATION -> {
           if (
             (realtimeAvailability && !station.allowPickupNow()) ||
             !station.getAvailablePickupFormFactors(realtimeAvailability).contains(formFactor)
@@ -92,13 +94,12 @@ public class VehicleRentalEdge extends Edge {
           }
           s1.beginVehicleRentingAtStation(formFactor, network, false, true);
           pickedUp = true;
-          break;
-        default:
-          throw new IllegalStateException();
+        }
+        default -> throw new IllegalStateException();
       }
     } else {
       switch (s0.getVehicleRentalState()) {
-        case BEFORE_RENTING:
+        case BEFORE_RENTING -> {
           if (
             (realtimeAvailability && !station.allowPickupNow()) ||
             !station.getAvailablePickupFormFactors(realtimeAvailability).contains(formFactor)
@@ -114,34 +115,31 @@ public class VehicleRentalEdge extends Edge {
             s1.beginVehicleRentingAtStation(formFactor, network, mayKeep, false);
           }
           pickedUp = true;
-          break;
-        case HAVE_RENTED:
+        }
+        case HAVE_RENTED -> {
           return null;
-        case RENTING_FLOATING:
-        case RENTING_FROM_STATION:
+        }
+        case RENTING_FLOATING, RENTING_FROM_STATION -> {
           if (!hasCompatibleNetworks(network, s0.getVehicleRentalNetwork())) {
             return null;
           }
+          var formFactors = station.getAvailableDropoffFormFactors(realtimeAvailability);
           if (
             (realtimeAvailability && !station.allowDropoffNow()) ||
-            !station.getAvailableDropoffFormFactors(realtimeAvailability).contains(formFactor)
+            !formFactors.contains(formFactor)
           ) {
             return null;
           }
           if (
             !allowedRentalFormFactors.isEmpty() &&
-            station
-              .getAvailableDropoffFormFactors(realtimeAvailability)
-              .stream()
-              .noneMatch(allowedRentalFormFactors::contains)
+            Collections.disjoint(allowedRentalFormFactors, formFactors)
           ) {
             return null;
           }
           s1.dropOffRentedVehicleAtStation(formFactor, network, false);
           pickedUp = false;
-          break;
-        default:
-          throw new IllegalStateException();
+        }
+        default -> throw new IllegalStateException();
       }
     }
 

--- a/src/main/java/org/opentripplanner/street/model/edge/VehicleRentalEdge.java
+++ b/src/main/java/org/opentripplanner/street/model/edge/VehicleRentalEdge.java
@@ -53,11 +53,8 @@ public class VehicleRentalEdge extends Edge {
           return null;
         case HAVE_RENTED:
           if (
-            realtimeAvailability &&
-            (
-              !station.allowDropoffNow() ||
-              !station.getAvailableDropoffFormFactors(true).contains(formFactor)
-            )
+            (realtimeAvailability && !station.allowDropoffNow()) ||
+            !station.getAvailableDropoffFormFactors(realtimeAvailability).contains(formFactor)
           ) {
             return null;
           }
@@ -65,10 +62,7 @@ public class VehicleRentalEdge extends Edge {
           pickedUp = false;
           break;
         case RENTING_FLOATING:
-          if (
-            realtimeAvailability &&
-            !station.getAvailablePickupFormFactors(true).contains(formFactor)
-          ) {
+          if (!station.getAvailablePickupFormFactors(realtimeAvailability).contains(formFactor)) {
             return null;
           }
           if (station.isFloatingVehicle()) {
@@ -80,11 +74,8 @@ public class VehicleRentalEdge extends Edge {
           break;
         case RENTING_FROM_STATION:
           if (
-            realtimeAvailability &&
-            (
-              !station.allowPickupNow() ||
-              !station.getAvailablePickupFormFactors(true).contains(formFactor)
-            )
+            (realtimeAvailability && !station.allowPickupNow()) ||
+            !station.getAvailablePickupFormFactors(realtimeAvailability).contains(formFactor)
           ) {
             return null;
           }
@@ -109,11 +100,8 @@ public class VehicleRentalEdge extends Edge {
       switch (s0.getVehicleRentalState()) {
         case BEFORE_RENTING:
           if (
-            realtimeAvailability &&
-            (
-              !station.allowPickupNow() ||
-              !station.getAvailablePickupFormFactors(true).contains(formFactor)
-            )
+            (realtimeAvailability && !station.allowPickupNow()) ||
+            !station.getAvailablePickupFormFactors(realtimeAvailability).contains(formFactor)
           ) {
             return null;
           }
@@ -135,11 +123,8 @@ public class VehicleRentalEdge extends Edge {
             return null;
           }
           if (
-            realtimeAvailability &&
-            (
-              !station.allowDropoffNow() ||
-              !station.getAvailableDropoffFormFactors(true).contains(formFactor)
-            )
+            (realtimeAvailability && !station.allowDropoffNow()) ||
+            !station.getAvailableDropoffFormFactors(realtimeAvailability).contains(formFactor)
           ) {
             return null;
           }


### PR DESCRIPTION
### Summary

Currently we do not check available types when `realtimeAvailability` is false. This might produce wrong results, if the form factors allowed differ between pickup and drop off.