### PR TITLE
Fix windows CI build by specifying resource encoding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -215,6 +215,14 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <propertiesEncoding>ISO-8859-1</propertiesEncoding>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <version>3.3.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@
                 <artifactId>maven-resources-plugin</artifactId>
                 <version>3.3.0</version>
                 <configuration>
-                    <propertiesEncoding>ISO-8859-1</propertiesEncoding>
+                    <propertiesEncoding>UTF-8</propertiesEncoding>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -214,6 +214,9 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- we are seeing random failures in Windows CI builds which appear related to the
+                 properties files: https://issues.apache.org/jira/browse/MRESOURCES-265
+            -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>

--- a/src/main/resources/Message_de.properties
+++ b/src/main/resources/Message_de.properties
@@ -1,18 +1,18 @@
 PLAN_OK      = Success
-SYSTEM_ERROR = Es tut uns leid, leider steht der Trip-Planer momentan nicht zur Verfügung. Bitte versuchen Sie es zu einem späteren Zeitpunkt nochmal.
+SYSTEM_ERROR = Es tut uns leid, leider steht der Trip-Planer momentan nicht zur VerfÃ¼gung. Bitte versuchen Sie es zu einem spÃ¤teren Zeitpunkt nochmal.
 
-OUTSIDE_BOUNDS   = Planung nicht möglich. Vielleicht versuchen sie einen Plan außerhalb der Kartengrenzen zu planen.
-REQUEST_TIMEOUT  = Der Trip-Planner braucht viel zu lange um die Anfrage zu bearbeiten. Bitte versuchen Sie es zu einem späteren Zeitpunkt nochmal.
-BOGUS_PARAMETER  = Die Anfrage ist fehlerhaft so dass sie der Server nicht bearbeiten möchte oder kann.
-PATH_NOT_FOUND   = Planung nicht möglich. Ihr Start- oder Endpunkt könnte nicht erreichbar sein. Bitte stellen sie sicher, dass ihre Anfrage innerhalb der Kartendaten ist.
-NO_TRANSIT_TIMES = Keine Fahrzeiten verfügbar. Das Datum kann zu weit in der Vergangenheit oder zu weit in der Zukunft liegen oder es gibt keinen Verkehrsbetrieb zu dem von Ihnen gewählten Zeitpunkt.
+OUTSIDE_BOUNDS   = Planung nicht mÃ¶glich. Vielleicht versuchen sie einen Plan auÃŸerhalb der Kartengrenzen zu planen.
+REQUEST_TIMEOUT  = Der Trip-Planner braucht viel zu lange um die Anfrage zu bearbeiten. Bitte versuchen Sie es zu einem spÃ¤teren Zeitpunkt nochmal.
+BOGUS_PARAMETER  = Die Anfrage ist fehlerhaft so dass sie der Server nicht bearbeiten mÃ¶chte oder kann.
+PATH_NOT_FOUND   = Planung nicht mÃ¶glich. Ihr Start- oder Endpunkt kÃ¶nnte nicht erreichbar sein. Bitte stellen sie sicher, dass ihre Anfrage innerhalb der Kartendaten ist.
+NO_TRANSIT_TIMES = Keine Fahrzeiten verfÃ¼gbar. Das Datum kann zu weit in der Vergangenheit oder zu weit in der Zukunft liegen oder es gibt keinen Verkehrsbetrieb zu dem von Ihnen gewÃ¤hlten Zeitpunkt.
 
-GEOCODE_FROM_NOT_FOUND    = Ausgangspunkt unbekannt. Können Sie bitte ein Wenig detailierter beschreiben?
-GEOCODE_TO_NOT_FOUND      = Fahrtziel unbekannt. Können Sie bitte ein Wenig detailierter beschreiben?
-GEOCODE_FROM_TO_NOT_FOUND = Ausgangspunkt und Fahrtziel unbekannt. Können Sie bitte ein Wenig detailierter beschreiben?
+GEOCODE_FROM_NOT_FOUND    = Ausgangspunkt unbekannt. KÃ¶nnen Sie bitte ein Wenig detailierter beschreiben?
+GEOCODE_TO_NOT_FOUND      = Fahrtziel unbekannt. KÃ¶nnen Sie bitte ein Wenig detailierter beschreiben?
+GEOCODE_FROM_TO_NOT_FOUND = Ausgangspunkt und Fahrtziel unbekannt. KÃ¶nnen Sie bitte ein Wenig detailierter beschreiben?
 TOO_CLOSE                 = Abstand zwischen Ausgangspunkt und Fahrtziel zu gering.
 
-UNDERSPECIFIED_TRIANGLE        = Wenn einer der Parameter triangleSafetyFactor, triangleSlopeFactor und triangleTimeFactor gesetzt ist müssen alle bestimmt sein.
+UNDERSPECIFIED_TRIANGLE        = Wenn einer der Parameter triangleSafetyFactor, triangleSlopeFactor und triangleTimeFactor gesetzt ist mÃ¼ssen alle bestimmt sein.
 TRIANGLE_NOT_AFFINE            = Die Summe von triangleSafetyFactor, triangleSlopeFactor, und triangleTimeFactor muss 1 betragen.
 TRIANGLE_OPTIMIZE_TYPE_NOT_SET = Wenn triangleSafetyFactor, triangleSlopeFactor und triangleTimeFactor gesetzt sind, dann muss OptimizeType gleich TRIANGLE sein.
-TRIANGLE_VALUES_NOT_SET        = Wenn OptimizeType gleich TRIANGLE ist, müssen triangleSafetyFactor, triangleSlopeFactor und triangleTimeFactor gesetzt sein.
+TRIANGLE_VALUES_NOT_SET        = Wenn OptimizeType gleich TRIANGLE ist, mÃ¼ssen triangleSafetyFactor, triangleSlopeFactor und triangleTimeFactor gesetzt sein.

--- a/src/main/resources/internals_hu.properties
+++ b/src/main/resources/internals_hu.properties
@@ -2,4 +2,4 @@ corner = %s \u00E9s %s sarok
 unnamedStreet = n\u00E9vtelen
 origin = Kiindul\u00E1si pont
 destination = C\u00E9lpont
-partOf = %s (%s része)
+partOf = %s (%s r\u00E9sze)

--- a/src/test/java/org/opentripplanner/framework/i18n/LocalizedStringTest.java
+++ b/src/test/java/org/opentripplanner/framework/i18n/LocalizedStringTest.java
@@ -50,4 +50,14 @@ class LocalizedStringTest {
   public void localeWithoutParams() {
     assertEquals("Destination", new LocalizedString("destination").toString());
   }
+
+  @Test
+  public void hungarianResource() {
+    assertEquals("névtelen", new LocalizedString("unnamedStreet").toString(new Locale("hu")));
+    assertEquals(
+      "A (B része)",
+      new LocalizedString("partOf", new NonLocalizedString("A"), new NonLocalizedString("B"))
+        .toString(new Locale("hu"))
+    );
+  }
 }

--- a/src/test/java/org/opentripplanner/framework/resources/ResourceBundleSingletonTest.java
+++ b/src/test/java/org/opentripplanner/framework/resources/ResourceBundleSingletonTest.java
@@ -1,0 +1,19 @@
+package org.opentripplanner.framework.resources;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Locale;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.api.common.Message;
+
+class ResourceBundleSingletonTest {
+
+  @Test
+  void localize() {
+    var msg = Message.SYSTEM_ERROR.get(Locale.GERMAN);
+    assertEquals(
+      "Es tut uns leid, leider steht der Trip-Planer momentan nicht zur Verfügung. Bitte versuchen Sie es zu einem späteren Zeitpunkt nochmal.",
+      msg
+    );
+  }
+}


### PR DESCRIPTION
We've seen random Windows ci build failures and I believe this will fix the problem, so lets test it.

## UTF-8

I have now converted all resources to UTF-8.