### PR TITLE
Apply bike safety multiplier to cyclestreets and bicycle roads

### DIFF
--- a/src/main/java/org/opentripplanner/openstreetmap/tagmapping/DefaultMapper.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/tagmapping/DefaultMapper.java
@@ -502,8 +502,11 @@ class DefaultMapper implements OsmTagMapper {
 
     // We assume highway/cycleway of a cycle network to be safer (for bicycle network relations, their network is copied to way in postLoad)
     // this uses a OR since you don't want to apply the safety multiplier more than once.
+    // Cyclestreets where bicycles have priority or are the only permitted vehicles (a thing in traffic rules of
+    // some european countries) get an identical safety multiplier. See e.g. https://nl.wikipedia.org/wiki/Fietsstraat
+    // For simplicity these two concepts are handled together.
     props.setMixinProperties(
-      new LogicalOrSpecifier("lcn=yes", "rcn=yes", "ncn=yes"),
+      new LogicalOrSpecifier("lcn=yes", "rcn=yes", "ncn=yes", "bicycle_road=yes", "cyclestreet=yes"),
       ofBicycleSafety(0.7)
     );
 

--- a/src/main/java/org/opentripplanner/openstreetmap/tagmapping/DefaultMapper.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/tagmapping/DefaultMapper.java
@@ -506,7 +506,13 @@ class DefaultMapper implements OsmTagMapper {
     // some european countries) get an identical safety multiplier. See e.g. https://nl.wikipedia.org/wiki/Fietsstraat
     // For simplicity these two concepts are handled together.
     props.setMixinProperties(
-      new LogicalOrSpecifier("lcn=yes", "rcn=yes", "ncn=yes", "bicycle_road=yes", "cyclestreet=yes"),
+      new LogicalOrSpecifier(
+        "lcn=yes",
+        "rcn=yes",
+        "ncn=yes",
+        "bicycle_road=yes",
+        "cyclestreet=yes"
+      ),
       ofBicycleSafety(0.7)
     );
 

--- a/src/main/java/org/opentripplanner/openstreetmap/tagmapping/DefaultMapper.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/tagmapping/DefaultMapper.java
@@ -502,8 +502,9 @@ class DefaultMapper implements OsmTagMapper {
 
     // We assume highway/cycleway of a cycle network to be safer (for bicycle network relations, their network is copied to way in postLoad)
     // this uses a OR since you don't want to apply the safety multiplier more than once.
-    // Cyclestreets where bicycles have priority or are the only permitted vehicles (a thing in traffic rules of
-    // some european countries) get an identical safety multiplier. See e.g. https://nl.wikipedia.org/wiki/Fietsstraat
+    // Signed bicycle_roads and cyclestreets exist in traffic codes of some european countries.
+    // Tagging in OSM and on-the-ground use is varied, so just assume they are "somehow safer", too.
+    // In my test area ways often, but not always, have both tags.
     // For simplicity these two concepts are handled together.
     props.setMixinProperties(
       new LogicalOrSpecifier(

--- a/src/test/java/org/opentripplanner/openstreetmap/tagmapping/GermanyMapperTest.java
+++ b/src/test/java/org/opentripplanner/openstreetmap/tagmapping/GermanyMapperTest.java
@@ -122,7 +122,7 @@ public class GermanyMapperTest {
 
   @Test
   public void lcnAndRcnShouldNotBeAddedUp() {
-    // https://www.openstreetmap.org/way/26443041 is part of both an lcn and rnc but that shouldn't mean that
+    // https://www.openstreetmap.org/way/26443041 is part of both an lcn and rcn but that shouldn't mean that
     // it is to be more heavily favoured than other ways that are part of just one.
 
     var both = new OSMWithTags();
@@ -136,6 +136,65 @@ public class GermanyMapperTest {
 
     var residential = new OSMWithTags();
     residential.addTag("highway", "residential");
+
+    assertEquals(
+      wps.getDataForWay(both).getBicycleSafetyFeatures().forward(),
+      wps.getDataForWay(justLcn).getBicycleSafetyFeatures().forward(),
+      epsilon
+    );
+
+    assertEquals(wps.getDataForWay(both).getBicycleSafetyFeatures().forward(), 0.6859, epsilon);
+
+    assertEquals(
+      wps.getDataForWay(residential).getBicycleSafetyFeatures().forward(),
+      0.98,
+      epsilon
+    );
+  }
+
+  @Test
+  public void bicycleRoadAndLcnShouldNotBeAddedUp() {
+    // https://www.openstreetmap.org/way/22201321 was tagged as bicycle_road without lcn
+    // make it so all ways tagged as some kind of cyclestreets are considered as equally safe
+
+    var both = new OSMWithTags();
+    both.addTag("highway", "residential");
+    both.addTag("bicycle_road", "yes");
+    both.addTag("cyclestreet", "yes");
+    both.addTag("lcn", "yes");
+
+    var justBicycleRoad = new OSMWithTags();
+    justBicycleRoad.addTag("bicycle_road", "yes");
+    justBicycleRoad.addTag("highway", "residential");
+
+    var justCyclestreet = new OSMWithTags();
+    justCyclestreet.addTag("cyclestreet", "yes");
+    justCyclestreet.addTag("highway", "residential");
+
+    var justLcn = new OSMWithTags();
+    justLcn.addTag("lcn", "yes");
+    justLcn.addTag("highway", "residential");
+
+    var residential = new OSMWithTags();
+    residential.addTag("highway", "residential");
+
+    assertEquals(
+      wps.getDataForWay(justCyclestreet).getBicycleSafetyFeatures().forward(),
+      wps.getDataForWay(justLcn).getBicycleSafetyFeatures().forward(),
+      epsilon
+    );
+
+    assertEquals(
+      wps.getDataForWay(both).getBicycleSafetyFeatures().forward(),
+      wps.getDataForWay(justBicycleRoad).getBicycleSafetyFeatures().forward(),
+      epsilon
+    );
+
+    assertEquals(
+      wps.getDataForWay(both).getBicycleSafetyFeatures().forward(),
+      wps.getDataForWay(justCyclestreet).getBicycleSafetyFeatures().forward(),
+      epsilon
+    );
 
     assertEquals(
       wps.getDataForWay(both).getBicycleSafetyFeatures().forward(),


### PR DESCRIPTION
### Summary

Treat bicycle_rodas and cyclestreets as safe as cycle networks.

### Issue

The router currently does not prefer dedicated bicycle roads over other roads.

I followed the suggestion of @leonardehrenfried and just added the two tags to the existing three tags. https://github.com/opentripplanner/OpenTripPlanner/issues/3789#issuecomment-1008308140

Fixes #3789 (already closed as stale)

### Unit tests

I have verified the intended behaviour manually.
I'm currently upstreaming my local patches and catching up with a year of refactorings, so this was tested to have the intended function before merging the refactoring.

### Documentation

I have added documentation to the code outlining the rationale.

https://github.com/opentripplanner/OpenTripPlanner/labels/skip%20changelog