### PR TITLE
Make sure that we do not return realtime snapshot that is null

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
@@ -145,6 +145,11 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
       // Make a new snapshot if necessary
       try {
         snapshotToReturn = getTimetableSnapshot(false);
+        // Force commit so that we get non-null snapshot
+        // This should happen only once on startup
+        if (snapshotToReturn == null) {
+          snapshotToReturn = getTimetableSnapshot(true);
+        }
       } finally {
         bufferLock.unlock();
       }

--- a/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
+++ b/src/ext/java/org/opentripplanner/ext/siri/SiriTimetableSnapshotSource.java
@@ -129,6 +129,9 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
       new SiriTripPatternCache(tripPatternIdGenerator, transitService::getPatternForTrip);
 
     transitModel.initTimetableSnapshotProvider(this);
+
+    // Force commit so that snapshot initializes
+    getTimetableSnapshot(true);
   }
 
   /**
@@ -145,11 +148,6 @@ public class SiriTimetableSnapshotSource implements TimetableSnapshotProvider {
       // Make a new snapshot if necessary
       try {
         snapshotToReturn = getTimetableSnapshot(false);
-        // Force commit so that we get non-null snapshot
-        // This should happen only once on startup
-        if (snapshotToReturn == null) {
-          snapshotToReturn = getTimetableSnapshot(true);
-        }
       } finally {
         bufferLock.unlock();
       }


### PR DESCRIPTION
### Summary
Make sure that SiriTimetableSnapshotSource.getTimetableSnapshot does not return null

### Issue
N/A

### Unit tests
N/A

### Documentation
N/A
