### PR TITLE
Introduce separate build step for windows

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -15,11 +15,8 @@ on:
       - dev-1.x
       - dev-2.x
 jobs:
-  build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ ubuntu-latest, windows-latest ]
+  build-linux:
+    runs-on: ubuntu-latest
     steps:
       # Starting in v2.2 checkout action fetches all tags when fetch-depth=0, for auto-versioning.
       - uses: actions/checkout@v3.1.0
@@ -34,12 +31,6 @@ jobs:
           distribution: temurin
           cache: maven
 
-      # on windows there are frequent failures caused by page files being too small
-      # https://github.com/actions/virtual-environments/issues/785
-      - name: Configure Windows Pagefile
-        if: matrix.os == 'windows-latest'
-        uses: al-cheb/configure-pagefile-action@v1.3
-
       - name: Prepare coverage agent, build and test
         run: mvn --batch-mode --update-snapshots jacoco:prepare-agent verify jacoco:report -P prettierCheck
 
@@ -50,10 +41,27 @@ jobs:
           files: target/site/jacoco/jacoco.xml
 
       - name: Deploy to Github Package Registry
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev-1.x' || github.ref == 'refs/heads/dev-2.x') && matrix.os == 'ubuntu-latest'
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev-1.x' || github.ref == 'refs/heads/dev-2.x')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: mvn --batch-mode deploy --settings maven-settings.xml -DskipTests -DGITHUB_REPOSITORY=$GITHUB_REPOSITORY -P prettierCheck -P deployGitHub
+
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: temurin
+          cache: maven
+      # on windows there are frequent failures caused by page files being too small
+      # https://github.com/actions/virtual-environments/issues/785
+      - name: Configure Windows Pagefile
+        uses: al-cheb/configure-pagefile-action@v1.3
+      - name: Run tests
+        run: mvn --batch-mode test -P prettierSkip
 
   docs:
     if: github.repository_owner == 'opentripplanner'
@@ -127,7 +135,9 @@ jobs:
   container-image:
     if: github.repository_owner == 'opentripplanner' && github.event_name == 'push' && github.ref == 'refs/heads/dev-2.x'
     runs-on: ubuntu-latest
-    needs: build
+    needs:
+      - build-windows
+      - build-linux
     env:
       CONTAINER_REPO: docker.io/opentripplanner/opentripplanner
       CONTAINER_REGISTRY_USER: otpbot

--- a/pom.xml
+++ b/pom.xml
@@ -960,11 +960,6 @@
         </profile>
         <profile>
             <id>prettierSkip</id>
-            <activation>
-                <os>
-                    <family>Windows</family>
-                </os>
-            </activation>
             <build>
                 <plugins>
                     <plugin>


### PR DESCRIPTION
### Summary

This PR refactors the CI steps from a Matrix build to two separate jobs for Windows and Linux for the following reasons:

- Lately the Windows CI runners have become quite slow and flaky. I want to do as little works as needed there. It speeds up the Windows build from 12 to 8 minutes.
- Prettier is disabled on Windows as it was crashing on the CI machines. This introduces confusion and friction for Windows developers.
- The Windows and Linux builds had drifted apart quite significantly so it's not even a lot of duplication to have two jobs.

### Issue

Fixes #4682 
