### PR TITLE
Remove all edges from stop vertex in island pruning

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/module/islandpruning/PruneIslands.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/islandpruning/PruneIslands.java
@@ -495,9 +495,7 @@ public class PruneIslands implements GraphBuilderModule {
         Collection<Edge> edges = new ArrayList<>(v.getOutgoing());
         edges.addAll(v.getIncoming());
         for (Edge e : edges) {
-          if (e instanceof StreetTransitStopLink || e instanceof StreetTransitEntranceLink) {
-            graph.removeEdge(e);
-          }
+          graph.removeEdge(e);
         }
       }
       if (island.stopSize() > 0) {


### PR DESCRIPTION
### Summary

StreeLinkerModule  tests the sum of incoming and outgoing edges before relinking transit stops to the healthy part of the graph. Therefore, when island pruning removes an island with stops, all edges attached to transit stops of the island should be removed. 

Currently some transit stops (the ones linked with BoardingLocationToStopLink) remain unlinked after island pruning. This change fixes the problem. 